### PR TITLE
[JSC] Optimize `String.prototype.at` like `String.prototype.charAt`

### DIFF
--- a/JSTests/microbenchmarks/string-prototype-at-negative-index.js
+++ b/JSTests/microbenchmarks/string-prototype-at-negative-index.js
@@ -1,0 +1,12 @@
+function test(string) {
+    var result;
+    for (let i = 0; i < 1e6; i++) {
+        result = string.at(-4);
+    }
+    return result;
+}
+
+var string = "hello, world!";
+var result = test(string);
+if (result != "r")
+    throw "Bad result: " + result;

--- a/JSTests/microbenchmarks/string-prototype-at-out-of-bounds.js
+++ b/JSTests/microbenchmarks/string-prototype-at-out-of-bounds.js
@@ -1,0 +1,12 @@
+function test(string) {
+    var result;
+    for (let i = 0; i < 1e6; i++) {
+        result = string.at(20);
+    }
+    return result;
+}
+
+var string = "hello, world!";
+var result = test(string);
+if (result != undefined)
+    throw "Bad result: " + result;

--- a/JSTests/microbenchmarks/string-prototype-at-positive-index.js
+++ b/JSTests/microbenchmarks/string-prototype-at-positive-index.js
@@ -1,0 +1,12 @@
+function test(string) {
+    var result;
+    for (let i = 0; i < 1e6; i++) {
+        result = string.at(4);
+    }
+    return result;
+}
+
+var string = "hello, world!";
+var result = test(string);
+if (result != "o")
+    throw "Bad result: " + result;

--- a/JSTests/stress/string-prototype-at.js
+++ b/JSTests/stress/string-prototype-at.js
@@ -1,0 +1,71 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected) {
+        throw new Error('bad value: ' + actual);
+    }
+}
+
+const runs = 1e6;
+
+function testZeroIndex(str) {
+    let count = 0;
+    for (let i = 0; i < runs; i++) {
+        const maybeH = str.at(0);
+        if (maybeH === str[0]) {
+            count++;
+        }
+    }
+    return count;
+}
+
+function testPositiveIndex(str) {
+    let count = 0;
+    for (let i = 0; i < runs; i++) {
+        const index = 3;
+        const value = str.at(index);
+        if (value === str[index]) {
+            count++;
+        }
+    }
+    return count;
+}
+
+function testOutOfBounds(str) {
+    let count = 0;
+    for (let i = 0; i < runs; i++) {
+        const index = 20;
+        const value = str.at(index);
+        if (value === undefined) {
+            count++;
+        }
+    }
+    return count;
+}
+
+noInline(testOutOfBounds);
+
+function testNegativeIndex(str) {
+    let count = 0;
+    for (let i = 0; i < runs; i++) {
+        const index = -3;
+        const value = str.at(index);
+        if (value === str[str.length + index]) {
+            count++;
+        }
+    }
+    return count;
+}
+
+noInline(testNegativeIndex);
+
+const string8 = "hello, world";
+const string16 = "こんにちは、世界";
+
+shouldBe(testZeroIndex(string16), runs);
+shouldBe(testPositiveIndex(string16), runs);
+shouldBe(testOutOfBounds(string16), runs);
+shouldBe(testNegativeIndex(string16), runs);
+
+shouldBe(testZeroIndex(string8), runs);
+shouldBe(testPositiveIndex(string8), runs);
+shouldBe(testOutOfBounds(string8), runs);
+shouldBe(testNegativeIndex(string8), runs);

--- a/Source/JavaScriptCore/builtins/StringPrototype.js
+++ b/Source/JavaScriptCore/builtins/StringPrototype.js
@@ -344,25 +344,6 @@ function concat(arg /* ... */)
     return @tailCallForwardArguments(@stringConcatSlowPath, this);
 }
 
-// FIXME: This is extremely similar to charAt, so we should optimize it accordingly.    
-//        https://bugs.webkit.org/show_bug.cgi?id=217139    
-function at(index)    
-{   
-    "use strict";   
-
-    if (@isUndefinedOrNull(this))   
-        @throwTypeError("String.prototype.at requires that |this| not be null or undefined"); 
-
-    var string = @toString(this);   
-    var length = string.length; 
-
-    var k = @toIntegerOrInfinity(index);  
-    if (k < 0)  
-        k += length;    
-
-    return (k >= 0 && k < length) ? string[k] : @undefined; 
-}
-
 @linkTimeConstant
 function createHTML(func, string, tag, attribute, value)
 {

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2321,6 +2321,15 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         setForNode(node, m_vm.stringStructure.get());
         break;
 
+    case StringAt: {
+        ArrayMode arrayMode = node->arrayMode();
+        if (arrayMode.isOutOfBounds())
+            setTypeForNode(node, SpecString | SpecOther);
+        else
+            setForNode(node, m_vm.stringStructure.get());
+        break;
+    }
+
     case StringLocaleCompare:
         setNonCellTypeForNode(node, SpecInt32Only);
         break;

--- a/Source/JavaScriptCore/dfg/DFGArrayMode.h
+++ b/Source/JavaScriptCore/dfg/DFGArrayMode.h
@@ -143,7 +143,18 @@ public:
         u.asBytes.mayBeLargeTypedArray = false;
         u.asBytes.mayBeResizableOrGrowableSharedTypedArray = false;
     }
-    
+
+    ArrayMode(Array::Type type, Array::Action action, Array::Speculation speculation)
+    {
+        u.asBytes.type = type;
+        u.asBytes.arrayClass = Array::NonArray;
+        u.asBytes.speculation = speculation;
+        u.asBytes.conversion = Array::AsIs;
+        u.asBytes.action = action;
+        u.asBytes.mayBeLargeTypedArray = false;
+        u.asBytes.mayBeResizableOrGrowableSharedTypedArray = false;
+    }
+
     ArrayMode(Array::Type type, Array::Class arrayClass, Array::Action action)
     {
         u.asBytes.type = type;

--- a/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
@@ -336,7 +336,8 @@ private:
             
         case StringCharAt:
         case StringCharCodeAt:
-        case StringCodePointAt: {
+        case StringCodePointAt:
+        case StringAt: {
             node->child1()->mergeFlags(NodeBytecodeUsesAsValue);
             node->child2()->mergeFlags(NodeBytecodeUsesAsValue | NodeBytecodeUsesAsInt | NodeBytecodePrefersArrayIndex);
             break;

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -2968,6 +2968,23 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             return CallOptimizationResult::Inlined;
         }
 
+        case StringPrototypeAtIntrinsic: {
+            if (argumentCountIncludingThis < 2)
+                return CallOptimizationResult::DidNothing;
+
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType))
+                return CallOptimizationResult::DidNothing;
+
+            insertChecks();
+            VirtualRegister thisOperand = virtualRegisterForArgumentIncludingThis(0, registerOffset);
+            VirtualRegister indexOperand = virtualRegisterForArgumentIncludingThis(1, registerOffset);
+            bool hasOutOfBoundsExitSite = m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, OutOfBounds);
+            Node* node = addToGraph(StringAt, OpInfo(ArrayMode(Array::String, Array::Read, hasOutOfBoundsExitSite ? Array::OutOfBounds : Array::InBounds).asWord()), get(thisOperand), get(indexOperand));
+
+            setResult(node);
+            return CallOptimizationResult::Inlined;
+        }
+
         case StringPrototypeLocaleCompareIntrinsic: {
             // Currently, only handling default locale case.
             if (argumentCountIncludingThis != 2)

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -170,6 +170,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         case StringCharAt:
         case StringCharCodeAt:
         case StringCodePointAt:
+        case StringAt:
         case Arrayify:
         case ArrayifyToStructure:
         case ArrayPush:
@@ -1996,6 +1997,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         return;
 
     case StringCharAt:
+    case StringAt:
         def(PureValue(node));
         return;
 

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -356,6 +356,7 @@ bool doesGC(Graph& graph, Node* node)
     case ResolveScopeForHoistingFuncDeclInEval:
     case Return:
     case StringCharAt:
+    case StringAt:
     case StringLocaleCompare:
     case TailCall:
     case TailCallForwardVarargs:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1075,11 +1075,15 @@ private:
                 fixEdge<UntypedUse>(node->child1());
             break;
 
+        case StringAt:
         case StringCharAt:
         case StringCharCodeAt:
         case StringCodePointAt: {
             // Currently we have no good way of refining these.
-            ASSERT(node->arrayMode() == ArrayMode(Array::String, Array::Read));
+            if (op == StringAt)
+                ASSERT(node->arrayMode() == ArrayMode(Array::String, Array::Read, Array::OutOfBounds) || node->arrayMode() == ArrayMode(Array::String, Array::Read, Array::InBounds));
+            else
+                ASSERT(node->arrayMode() == ArrayMode(Array::String, Array::Read));
             blessArrayOperation(node->child1(), node->child2(), node->child1()); // Rewrite child1 with ResolveRope.
             fixEdge<KnownStringUse>(node->child1());
             fixEdge<Int32Use>(node->child2());

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -2495,6 +2495,7 @@ public:
         case StringCharAt:
         case StringCharCodeAt:
         case StringCodePointAt:
+        case StringAt:
         case CheckArray:
         case CheckArrayOrEmpty:
         case Arrayify:

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -351,6 +351,7 @@ namespace JSC { namespace DFG {
     macro(StringCodePointAt, NodeResultInt32) \
     macro(StringCharAt, NodeResultJS) \
     macro(StringFromCharCode, NodeResultJS | NodeMustGenerate) \
+    macro(StringAt, NodeResultJS) \
     \
     /* Nodes for comparison operations. */\
     macro(CompareLess, NodeResultBoolean | NodeMustGenerate) \

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -639,7 +639,16 @@ private:
             }
             break;
         }
-            
+
+        case StringAt: {
+            ArrayMode arrayMode = node->arrayMode();
+            if (arrayMode.isOutOfBounds())
+                changed |= mergePrediction(SpecString | SpecOther);
+            else
+                changed |= mergePrediction(SpecString);
+            break;
+        }
+
         case ToThis: {
             // ToThis in methods for primitive types should speculate primitive types in strict mode.
             bool isStrictMode = node->ecmaMode().isStrict();
@@ -1506,7 +1515,8 @@ private:
         case AtomicsOr:
         case AtomicsStore:
         case AtomicsSub:
-        case AtomicsXor: {
+        case AtomicsXor:
+        case StringAt: {
             m_dependentNodes.append(m_currentNode);
             break;
         }

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -395,6 +395,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case StringCharAt:
     case StringCharCodeAt:
     case StringCodePointAt:
+    case StringAt:
         return node->arrayMode().alreadyChecked(graph, node, state.forNode(graph.child(node, 0)));
 
     case ArrayPush:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -2598,6 +2598,7 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case StringAt:
     case StringCharAt: {
         // Relies on StringCharAt node having same basic layout as GetByVal
         JSValueRegsTemporary result;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -3569,6 +3569,7 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case StringAt:
     case StringCharAt: {
         // Relies on StringCharAt node having same basic layout as GetByVal
         JSValueRegsTemporary result;

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -159,6 +159,7 @@ inline CapabilityLevel canCompile(Node* node)
     case GetArgument:
     case InvalidationPoint:
     case StringCharAt:
+    case StringAt:
     case StringLocaleCompare:
     case CheckIsConstant:
     case CheckBadValue:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1293,6 +1293,9 @@ private:
         case MakeAtomString:
             compileMakeAtomString();
             break;
+        case StringAt:
+            compileStringAt();
+            break;
         case StringCharAt:
             compileStringCharAt();
             break;
@@ -9975,16 +9978,19 @@ IGNORE_CLANG_WARNINGS_END
     LValue compileStringCharAtImpl()
     {
         LValue base = lowString(m_graph.child(m_node, 0));
-        LValue index = lowInt32(m_graph.child(m_node, 1));
+        LValue originalIndex = lowInt32(m_graph.child(m_node, 1));
+
+        LValue stringImpl = m_out.loadPtr(base, m_heaps.JSString_value);
+        LValue stringLength = m_out.load32NonNegative(stringImpl, m_heaps.StringImpl_length);
+
+        LValue index = m_node->op() == StringAt ? m_out.select(m_out.lessThan(originalIndex, m_out.int32Zero), m_out.add(originalIndex, stringLength), originalIndex) : originalIndex;
 
         LBasicBlock fastPath = m_out.newBlock();
         LBasicBlock slowPath = m_out.newBlock();
         LBasicBlock continuation = m_out.newBlock();
 
-        LValue stringImpl = m_out.loadPtr(base, m_heaps.JSString_value);
         m_out.branch(
-            m_out.aboveOrEqual(
-                index, m_out.load32NonNegative(stringImpl, m_heaps.StringImpl_length)),
+            m_out.aboveOrEqual(index, stringLength),
             rarely(slowPath), usually(fastPath));
 
         LBasicBlock lastNext = m_out.appendTo(fastPath, slowPath);
@@ -10004,18 +10010,19 @@ IGNORE_CLANG_WARNINGS_END
 
         // FIXME: Need to cage strings!
         // https://bugs.webkit.org/show_bug.cgi?id=174924
-        ValueFromBlock char8Bit = m_out.anchor(
-            m_out.load8ZeroExt32(baseIndexWithProvenValue(m_heaps.characters8, m_out.loadPtr(stringImpl, m_heaps.StringImpl_data), index,
-                m_graph.child(m_node, 1))));
+        LValue char8BitValue = m_out.load8ZeroExt32(m_out.baseIndex(
+            m_heaps.characters8,
+            m_out.loadPtr(stringImpl, m_heaps.StringImpl_data),
+            m_out.zeroExtPtr(index)));
+        ValueFromBlock char8Bit = m_out.anchor(char8BitValue);
         m_out.jump(bitsContinuation);
 
         m_out.appendTo(is16Bit, bigCharacter);
 
-        LValue char16BitValue = m_out.load16ZeroExt32(baseIndexWithProvenValue(
+        LValue char16BitValue = m_out.load16ZeroExt32(m_out.baseIndex(
             m_heaps.characters16,
             m_out.loadPtr(stringImpl, m_heaps.StringImpl_data),
-            index,
-            m_graph.child(m_node, 1)));
+            m_out.zeroExtPtr(index)));
         ValueFromBlock char16Bit = m_out.anchor(char16BitValue);
         m_out.branch(
             m_out.above(char16BitValue, m_out.constInt32(maxSingleCharacterString)),
@@ -10044,6 +10051,9 @@ IGNORE_CLANG_WARNINGS_END
         if (m_node->op() == StringCharAt) {
             // String#charAt can accept out of range index and it always returns an empty string.
             results.append(m_out.anchor(weakPointer(jsEmptyString(vm()))));
+        } else if (m_node->op() == StringAt && m_node->arrayMode().isOutOfBounds()) {
+            // String#at can accept out of range index and it always returns undefined.
+            results.append(m_out.anchor(m_out.constInt64(JSValue::encode(jsUndefined()))));
         } else {
             if (m_node->arrayMode().isInBounds()) {
                 speculate(OutOfBounds, noValue(), nullptr, m_out.booleanTrue);
@@ -10079,6 +10089,11 @@ IGNORE_CLANG_WARNINGS_END
     }
 
     void compileStringCharAt()
+    {
+        setJSValue(compileStringCharAtImpl());
+    }
+
+    void compileStringAt()
     {
         setJSValue(compileStringCharAtImpl());
     }

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -110,6 +110,7 @@ namespace JSC {
     macro(ReflectGetPrototypeOfIntrinsic) \
     macro(ReflectOwnKeysIntrinsic) \
     macro(StringConstructorIntrinsic) \
+    macro(StringPrototypeAtIntrinsic) \
     macro(StringPrototypeCodePointAtIntrinsic) \
     macro(StringPrototypeIndexOfIntrinsic) \
     macro(StringPrototypeLocaleCompareIntrinsic) \


### PR DESCRIPTION
#### 95e9295e5ff3bb36eb40c8a1e4053bce85e00f03
<pre>
[JSC] Optimize `String.prototype.at` like `String.prototype.charAt`
<a href="https://bugs.webkit.org/show_bug.cgi?id=217139">https://bugs.webkit.org/show_bug.cgi?id=217139</a>

Reviewed by NOBODY (OOPS!).

This patch optimizes `String.prototype.at`. It reuses most of the optimizations made for `String.prototype.charAt`, although there are some differences according to the specifications[1][2]:

- Returns undefined instead of an empty string when out of bounds
- Treats the `index` as `length + index` when the `index` is negative

                                            TipOfTree                  Patched

string-prototype-at-negative-index        2.3190+-0.0785     ^      1.6215+-0.1655        ^ definitely 1.4302x faster
string-prototype-at-out-of-bounds         1.7695+-0.1920            1.6320+-0.0462          might be 1.0843x faster
string-prototype-at-positive-index        1.9503+-0.1246     ^      1.6083+-0.1145        ^ definitely 1.2126x faster

[1]: <a href="https://tc39.es/ecma262/#sec-string.prototype.charat">https://tc39.es/ecma262/#sec-string.prototype.charat</a>
[2]: <a href="https://tc39.es/ecma262/#sec-string.prototype.at">https://tc39.es/ecma262/#sec-string.prototype.at</a>

* JSTests/microbenchmarks/string-prototype-at-negative-index.js: Added.
(test):
* JSTests/microbenchmarks/string-prototype-at-out-of-bounds.js: Added.
(test):
* JSTests/microbenchmarks/string-prototype-at-positive-index.js: Added.
(test):
* JSTests/stress/string-prototype-at.js: Added.
(shouldBe):
(testZeroIndex):
(testPositiveIndex):
(testOutOfBounds):
(testNegativeIndex):
* Source/JavaScriptCore/builtins/StringPrototype.js:
(at): Deleted.
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGArrayMode.h:
* Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp:
(JSC::DFG::BackwardsPropagationPhase::propagate):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::hasArrayMode):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compileGetByValOnString):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileStringCharAtImpl):
(JSC::FTL::DFG::LowerDFGToB3::compileStringAt):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::StringPrototype::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95e9295e5ff3bb36eb40c8a1e4053bce85e00f03

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50650 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44022 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33051 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24662 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39025 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24851 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41507 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20326 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22319 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42684 "Found 1 new test failure: fast/css/viewport-height-border.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6016 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/41262 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44330 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43117 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52544 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/47461 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23012 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19360 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46334 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24281 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45387 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25075 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54958 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24003 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11302 "Passed tests") | 
<!--EWS-Status-Bubble-End-->