### PR TITLE
WebKit process termination with xpc_connection_kill does not always work

### DIFF
--- a/Source/WebKit/Platform/cocoa/XPCUtilities.h
+++ b/Source/WebKit/Platform/cocoa/XPCUtilities.h
@@ -36,5 +36,6 @@ enum class ReasonCode : uint64_t {
 };
 
 void terminateWithReason(xpc_connection_t, ReasonCode, const char* reason);
+void handleXPCExitMessage(xpc_object_t);
 
 }

--- a/Source/WebKit/Shared/Authentication/cocoa/AuthenticationManagerCocoa.mm
+++ b/Source/WebKit/Shared/Authentication/cocoa/AuthenticationManagerCocoa.mm
@@ -31,6 +31,7 @@
 #import "AuthenticationChallengeDisposition.h"
 #import "ClientCertificateAuthenticationXPCConstants.h"
 #import "Connection.h"
+#import "XPCUtilities.h"
 #import <pal/spi/cocoa/NSXPCConnectionSPI.h>
 #import <pal/spi/cocoa/SecKeyProxySPI.h>
 #import <wtf/MainThread.h>
@@ -50,6 +51,9 @@ void AuthenticationManager::initializeConnection(IPC::Connection* connection)
     // The following xpc event handler overwrites the boostrap event handler and is only used
     // to capture client certificate credential.
     xpc_connection_set_event_handler(connection->xpcConnection(), ^(xpc_object_t event) {
+
+        handleXPCExitMessage(event);
+
         callOnMainRunLoop([event = OSObjectPtr(event), weakThis = weakThis] {
             RELEASE_ASSERT(isMainRunLoop());
 

--- a/Source/WebKit/Shared/Cocoa/XPCEndpoint.mm
+++ b/Source/WebKit/Shared/Cocoa/XPCEndpoint.mm
@@ -25,6 +25,7 @@
 
 #import "config.h"
 #import "XPCEndpoint.h"
+#import "XPCUtilities.h"
 
 #import <wtf/cocoa/Entitlements.h>
 #import <wtf/text/ASCIILiteral.h>
@@ -45,6 +46,8 @@ XPCEndpoint::XPCEndpoint()
     xpc_connection_set_target_queue(m_connection.get(), dispatch_get_main_queue());
     xpc_connection_set_event_handler(m_connection.get(), ^(xpc_object_t message) {
         xpc_type_t type = xpc_get_type(message);
+
+        handleXPCExitMessage(message);
 
         if (type == XPC_TYPE_CONNECTION) {
             OSObjectPtr<xpc_connection_t> connection = message;

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -29,6 +29,7 @@
 #import "WKCrashReporter.h"
 #import "XPCEndpointMessages.h"
 #import "XPCServiceEntryPoint.h"
+#import "XPCUtilities.h"
 #import <CoreFoundation/CoreFoundation.h>
 #import <mach/mach.h>
 #import <pal/spi/cf/CFUtilitiesSPI.h>
@@ -177,6 +178,8 @@ void XPCServiceEventHandler(xpc_connection_t peer)
             }
             return;
         }
+
+        handleXPCExitMessage(event);
 
         auto* messageName = xpc_dictionary_get_string(event, "message-name");
         if (!messageName) {


### PR DESCRIPTION
#### 3c2c899f692d5278142b9c476868672da9ae8e04
<pre>
WebKit process termination with xpc_connection_kill does not always work
<a href="https://bugs.webkit.org/show_bug.cgi?id=272669">https://bugs.webkit.org/show_bug.cgi?id=272669</a>
<a href="https://rdar.apple.com/126479653">rdar://126479653</a>

Reviewed by Chris Dumez.

WebKit process termination with xpc_connection_kill does not always work. We are currently seeing flaky
termination behavior on macOS, where the child processes are not always terminated successfully.
Additionally, on iOS, the XPC connection has become anonymous due to migration to extensions for WebKit
processes, and xpc_connection_kill does not support anonymous connections. This patch addresses this
issue by creating and sending a XPC message to the child process to request termination. This has a
high chance of success, since we know that the XPC connection termination watchdog is holding a
background assertion on the process, so it is not suspended. Additionally, the XPC message is being
handled on the XPC event handler thread, which is handling very few messages, so it is very unlikely
that it is blocked and cannot handle the message. This gives the process a chance to exit cleanly and
send a reply back. If the UI process does not receive the expected reply, it will try calling
xpc_connection_kill.

* Source/WebKit/Platform/cocoa/XPCUtilities.h:
* Source/WebKit/Platform/cocoa/XPCUtilities.mm:
(WebKit::terminateWithReason):
(WebKit::handleXPCExitMessage):
* Source/WebKit/Shared/Authentication/cocoa/AuthenticationManagerCocoa.mm:
(WebKit::AuthenticationManager::initializeConnection):
* Source/WebKit/Shared/Cocoa/XPCEndpoint.mm:
(WebKit::XPCEndpoint::XPCEndpoint):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::XPCServiceEventHandler):

Canonical link: <a href="https://commits.webkit.org/277509@main">https://commits.webkit.org/277509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36c2bd5de25d21415f3488b7b167266c2470f72d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26989 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50597 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50478 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43850 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24474 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38897 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; 40 flakes 76 failures; Uploaded test results; 15 flakes 58 failures; Running compile-webkit-without-change") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48377 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24669 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41310 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20194 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22148 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5844 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44159 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42923 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52372 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22832 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46215 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24104 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45249 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24894 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6765 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23825 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->