### PR TITLE
[GTK][WPE] Unreviewed build fix for Ubuntu 20.04 after 277428@main

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -200,6 +200,9 @@ static String dmabufRendererWithSupportedBuffers()
 #if USE(LIBDRM)
 static String renderBufferFormat(WebKitURISchemeRequest* request)
 {
+#if !HAVE(DRM_GET_FORMAT_NAME)
+    return "Unknown"_s;
+#else
     StringBuilder bufferFormat;
     auto format = webkitWebViewGetRendererBufferFormat(webkit_uri_scheme_request_get_web_view(request));
     if (format.fourcc) {
@@ -233,6 +236,7 @@ static String renderBufferFormat(WebKitURISchemeRequest* request)
         bufferFormat.append("Unknown"_s);
 
     return bufferFormat.toString();
+#endif
 }
 #endif
 #endif

--- a/Source/cmake/OptionsGTK.cmake
+++ b/Source/cmake/OptionsGTK.cmake
@@ -323,6 +323,10 @@ if (USE_LIBDRM)
     if (NOT LibDRM_FOUND)
         message(FATAL_ERROR "libdrm is required for USE_LIBDRM")
     endif ()
+
+    set(CMAKE_REQUIRED_LIBRARIES LibDRM::LibDRM)
+    WEBKIT_CHECK_HAVE_FUNCTION(HAVE_DRM_GET_FORMAT_NAME drmGetFormatName xf86drm.h)
+    unset(CMAKE_REQUIRED_LIBRARIES)
 endif ()
 
 SET_AND_EXPOSE_TO_BUILD(USE_TEXTURE_MAPPER ON)

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -378,6 +378,10 @@ if (USE_LIBDRM)
     if (NOT LibDRM_FOUND)
         message(FATAL_ERROR "libdrm is required for USE_LIBDRM")
     endif ()
+
+    set(CMAKE_REQUIRED_LIBRARIES LibDRM::LibDRM)
+    WEBKIT_CHECK_HAVE_FUNCTION(HAVE_DRM_GET_FORMAT_NAME drmGetFormatName xf86drm.h)
+    unset(CMAKE_REQUIRED_LIBRARIES)
 endif ()
 
 if (USE_GBM)


### PR DESCRIPTION
#### cfa9adfee2d5bbbc00179f3e783b08668e129846
<pre>
[GTK][WPE] Unreviewed build fix for Ubuntu 20.04 after 277428@main

`drmGetFormatName()` was added to `libdrm` in version 2.4.113.
The latest version available in Ubuntu 20.04 repos is 2.4.107.

* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::renderBufferFormat):
* Source/cmake/OptionsGTK.cmake:
* Source/cmake/OptionsWPE.cmake:

Canonical link: <a href="https://commits.webkit.org/277506@main">https://commits.webkit.org/277506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49346fa0f949756bb6ce8f38465328e38fd17509

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47788 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50471 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43843 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24467 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38906 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41306 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20192 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22131 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5837 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/41076 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44155 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42919 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52365 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/47281 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22825 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19172 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46201 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24097 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45242 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10548 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24887 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54779 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23818 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11248 "Passed tests") | 
<!--EWS-Status-Bubble-End-->