### PR TITLE
[JSC] `Set#symmetricDifference` should call `this.has` in each iteration

### DIFF
--- a/JSTests/stress/set-prototype-symmetricDifference-mutate-this.js
+++ b/JSTests/stress/set-prototype-symmetricDifference-mutate-this.js
@@ -1,0 +1,28 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ', expected: ' + expected);
+}
+
+const setA = new Set(["a", "b", "c", "d", "e"]);
+
+const values = ["f", "g", "h", "i", "j"];
+const setB = {
+    size: values.length,
+    has() { return true },
+    keys() {
+        let index = 0;
+        return {
+            next() {
+                const done = index >= values.length;
+                if (!setA.has("f")) setA.add("f");
+                return {
+                    done,
+                    value: values[index++]
+                };
+            }
+        };
+    }
+};
+
+const result = setA.symmetricDifference(setB);
+shouldBe(JSON.stringify(Array.from(result)), JSON.stringify(["a", "b", "c", "d", "e", "g", "h", "i", "j"]));

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -135,9 +135,6 @@ test/built-ins/RegExp/unicodeSets/generated/rgi-emoji-15.1.js:
 test/built-ins/RegExp/unicode_full_case_folding.js:
   default: 'Test262Error: \u0390 does not match \u1fd3'
   strict mode: 'Test262Error: \u0390 does not match \u1fd3'
-test/built-ins/Set/prototype/symmetricDifference/set-like-class-mutation.js:
-  default: 'Test262Error: Expected [a, d, e, q, x, c] and [a, c, d, e, q, x] to have the same contents. '
-  strict mode: 'Test262Error: Expected [a, d, e, q, x, c] and [a, c, d, e, q, x] to have the same contents. '
 test/built-ins/SharedArrayBuffer/options-maxbytelength-compared-before-object-creation.js:
   default: 'Test262Error: Expected a RangeError but got a Test262Error'
   strict mode: 'Test262Error: Expected a RangeError but got a Test262Error'

--- a/Source/JavaScriptCore/builtins/SetPrototype.js
+++ b/Source/JavaScriptCore/builtins/SetPrototype.js
@@ -209,7 +209,7 @@ function symmetricDifference(other)
 
     var result = @setClone(this);
     for (var key of wrapper) {
-        if (result.@has(key))
+        if (this.@has(key))
             result.@delete(key);
         else
             result.@add(key);


### PR DESCRIPTION
#### 4b16138ae6dd3449c3b7b5a7c17f67a69b40d340
<pre>
[JSC] `Set#symmetricDifference` should call `this.has` in each iteration
<a href="https://bugs.webkit.org/show_bug.cgi?id=272679">https://bugs.webkit.org/show_bug.cgi?id=272679</a>

Reviewed by Yusuke Suzuki.

According to the spec[1](7.b.iv), `SetDataHas` in each iteration of `Set#symmetricDifference` should be called on `O`, not on `resultSetData`.

[1]: <a href="https://tc39.es/proposal-set-methods/#sec-set.prototype.symmetricdifference">https://tc39.es/proposal-set-methods/#sec-set.prototype.symmetricdifference</a>

* JSTests/stress/set-prototype-symmetricDifference-mutate-this.js: Added.
(shouldBe):
(const.setB.has):
(const.setB.keys):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/builtins/SetPrototype.js:
(symmetricDifference):

Canonical link: <a href="https://commits.webkit.org/277526@main">https://commits.webkit.org/277526@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce42d48affbb38080ea1cc75b8e677a4107f5957

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47796 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50600 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50479 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43851 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24475 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38907 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48378 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24671 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41313 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20197 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22149 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42505 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5845 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/41084 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC; Running jscore-test") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44162 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42926 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52373 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/47289 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22833 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19191 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46206 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 107 flakes 43 failures; Uploaded test results; 6 flakes 31 failures; Running compile-webkit-without-change") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24105 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45247 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24895 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54787 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6781 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23826 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11251 "Passed tests") | 
<!--EWS-Status-Bubble-End-->