### PR TITLE
[Unified PDF] Data Detectors are offset from detected items on embedded PDFs

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -192,8 +192,6 @@ public:
     WebCore::IntRect convertFromPluginToRootView(const WebCore::IntRect&) const;
     WebCore::IntRect boundsOnScreen() const;
 
-    WebCore::IntPoint mousePositionInView(const WebMouseEvent&) const;
-
     bool showContextMenuAtPoint(const WebCore::IntPoint&);
     WebCore::AXObjectCache* axObjectCache() const;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -1132,13 +1132,8 @@ WebCore::AXObjectCache* PDFPluginBase::axObjectCache() const
 WebCore::IntPoint PDFPluginBase::lastKnownMousePositionInView() const
 {
     if (m_lastMouseEvent)
-        return mousePositionInView(*m_lastMouseEvent);
+        return convertFromRootViewToPlugin(m_lastMouseEvent->position());
     return { };
-}
-
-WebCore::IntPoint PDFPluginBase::mousePositionInView(const WebMouseEvent& event) const
-{
-    return convertFromRootViewToPlugin(event.position());
 }
 
 void PDFPluginBase::navigateToURL(const URL& url)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
@@ -34,6 +34,7 @@
 #include "WebMouseEvent.h"
 #include <WebCore/DataDetectorElementInfo.h>
 #include <WebCore/FloatRect.h>
+#include <WebCore/FrameView.h>
 #include <WebCore/GraphicsLayer.h>
 #include <WebCore/GraphicsLayerClient.h>
 #include <WebCore/IntPoint.h>
@@ -116,10 +117,13 @@ RetainPtr<DDHighlightRef> PDFDataDetectorOverlayController::createPlatformDataDe
     if (!plugin)
         return { };
 
-    auto selectionBoundsInPluginSpace = plugin->rectForSelectionInPluginSpace(dataDetectorItem.selection().get());
-    auto visibleContentRectInPluginSpace = plugin->visibleContentRect();
+    RefPtr mainFrameView = plugin->mainFrameView();
+    if (!mainFrameView)
+        return { };
 
-    return ::WebKit::createPlatformDataDetectorHighlight(Vector<FloatRect>::from(WTFMove(selectionBoundsInPluginSpace)), WTFMove(visibleContentRectInPluginSpace));
+    auto rectForSelectionInMainFrameContentsSpace = plugin->rectForSelectionInMainFrameContentsSpace(dataDetectorItem.selection().get());
+
+    return ::WebKit::createPlatformDataDetectorHighlight(Vector<FloatRect>::from(WTFMove(rectForSelectionInMainFrameContentsSpace)), mainFrameView->visibleContentRect());
 }
 
 bool PDFDataDetectorOverlayController::handleMouseEvent(const WebMouseEvent& event, PDFDocumentLayout::PageIndex pageIndex)
@@ -128,12 +132,17 @@ bool PDFDataDetectorOverlayController::handleMouseEvent(const WebMouseEvent& eve
     if (!plugin)
         return false;
 
+    RefPtr mainFrameView = plugin->mainFrameView();
+    if (!mainFrameView)
+        return false;
+
     if (!PAL::isDataDetectorsFrameworkAvailable())
         return false;
 
     updateDataDetectorHighlightsIfNeeded(pageIndex);
 
-    auto mousePositionInPluginSpace = plugin->mousePositionInView(event);
+    auto mousePositionInWindowSpace = event.position();
+    auto mousePositionInMainFrameContentsSpace = mainFrameView->windowToContents(mousePositionInWindowSpace);
     bool mouseIsOverActiveHighlightButton = false;
     m_staleDataDetectorItemWithHighlight = std::exchange(m_activeDataDetectorItemWithHighlight, { { }, { } });
     RefPtr<PDFDataDetectorItem> dataDetectorItemForActiveHighlight;
@@ -141,7 +150,7 @@ bool PDFDataDetectorOverlayController::handleMouseEvent(const WebMouseEvent& eve
     if (auto iterator = m_pdfDataDetectorItemsWithHighlightsMap.find(pageIndex); iterator != m_pdfDataDetectorItemsWithHighlightsMap.end()) {
         for (auto& [dataDetectorItem, coreHighlight] : iterator->value) {
             Boolean isOverButton = NO;
-            if (!PAL::softLink_DataDetectors_DDHighlightPointIsOnHighlight(coreHighlight->highlight(), mousePositionInPluginSpace, &isOverButton))
+            if (!PAL::softLink_DataDetectors_DDHighlightPointIsOnHighlight(coreHighlight->highlight(), mousePositionInMainFrameContentsSpace, &isOverButton))
                 continue;
 
             mouseIsOverActiveHighlightButton = isOverButton;
@@ -167,24 +176,26 @@ bool PDFDataDetectorOverlayController::handleMouseEvent(const WebMouseEvent& eve
     }
 
     if (event.type() == WebEventType::MouseDown && mouseIsOverActiveHighlightButton)
-        return handleDataDetectorAction(mousePositionInPluginSpace, *m_activeDataDetectorItemWithHighlight.first);
+        return handleDataDetectorAction(mousePositionInWindowSpace, *m_activeDataDetectorItemWithHighlight.first);
 
     return false;
 }
 
-bool PDFDataDetectorOverlayController::handleDataDetectorAction(const IntPoint& mousePositionInPluginSpace, PDFDataDetectorItem& dataDetectorItem)
+bool PDFDataDetectorOverlayController::handleDataDetectorAction(const IntPoint& mousePositionInWindowSpace, PDFDataDetectorItem& dataDetectorItem)
 {
     RefPtr plugin = protectedPlugin();
-
     if (!plugin)
         return false;
 
-    auto rectForSelectionInPluginSpace = roundedIntRect(plugin->rectForSelectionInPluginSpace(dataDetectorItem.selection().get()));
+    RefPtr mainFrameView = plugin->mainFrameView();
+    if (!mainFrameView)
+        return false;
 
-    plugin->handleClickForDataDetectionResult({ dataDetectorItem.scannerResult(), rectForSelectionInPluginSpace }, mousePositionInPluginSpace);
+    auto rectForSelectionInMainFrameContentsSpace = roundedIntRect(plugin->rectForSelectionInMainFrameContentsSpace(dataDetectorItem.selection().get()));
+
+    plugin->handleClickForDataDetectionResult({ dataDetectorItem.scannerResult(), mainFrameView->contentsToWindow(rectForSelectionInMainFrameContentsSpace) }, mousePositionInWindowSpace);
     return true;
 }
-
 
 void PDFDataDetectorOverlayController::updateDataDetectorHighlightsIfNeeded(PDFDocumentLayout::PageIndex pageIndex)
 {
@@ -268,16 +279,16 @@ void PDFDataDetectorOverlayController::didInvalidateHighlightOverlayRects(std::o
     if (!plugin)
         return;
 
-    Vector<IntRect> dirtyRectsInContentSpace;
+    Vector<IntRect> dirtyRectsInMainFrameContentsSpace;
 
     if (activeHighlight)
-        dirtyRectsInContentSpace.appendVector(plugin->boundsForSelection(activeDataDetectorItem->selection().get(), UnifiedPDFPlugin::CoordinateSpace::Contents));
+        dirtyRectsInMainFrameContentsSpace.append(plugin->rectForSelectionInMainFrameContentsSpace(activeDataDetectorItem->selection().get()));
 
     if (previousActiveHighlight)
-        dirtyRectsInContentSpace.appendVector(plugin->boundsForSelection(previousDataDetectorItem->selection().get(), UnifiedPDFPlugin::CoordinateSpace::Contents));
+        dirtyRectsInMainFrameContentsSpace.append(plugin->rectForSelectionInMainFrameContentsSpace(previousDataDetectorItem->selection().get()));
 
-    WTF::forEach(dirtyRectsInContentSpace, [&](const auto& dirtyRectInContentSpace) {
-        installOverlayIfNeeded().setNeedsDisplay(dirtyRectInContentSpace);
+    WTF::forEach(dirtyRectsInMainFrameContentsSpace, [&](const auto& dirtyRectInMainFrameContentsSpace) {
+        installOverlayIfNeeded().setNeedsDisplay(dirtyRectInMainFrameContentsSpace);
     });
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -41,6 +41,7 @@ OBJC_CLASS PDFPage;
 OBJC_CLASS WKPDFFormMutationObserver;
 
 namespace WebCore {
+class FrameView;
 class PageOverlay;
 
 enum class DelegatedScrollingMode : uint8_t;
@@ -52,7 +53,6 @@ namespace WebKit {
 
 class AsyncPDFRenderer;
 #if ENABLE(UNIFIED_PDF_DATA_DETECTION)
-class PDFDataDetectorItem;
 class PDFDataDetectorOverlayController;
 #endif
 class PDFPluginPasswordField;
@@ -111,6 +111,8 @@ public:
     };
     using PDFElementTypes = OptionSet<PDFElementType>;
 
+    WebCore::FrameView* mainFrameView() const;
+
     CGRect pluginBoundsForAnnotation(RetainPtr<PDFAnnotation>&) const final;
     void setActiveAnnotation(RetainPtr<PDFAnnotation>&&) final;
     void focusNextAnnotation() final;
@@ -148,7 +150,7 @@ public:
     RefPtr<WebCore::GraphicsLayer> createGraphicsLayer(WebCore::GraphicsLayerClient&);
     float deviceScaleFactor() const override;
 
-    WebCore::FloatRect rectForSelectionInPluginSpace(PDFSelection *) const;
+    WebCore::FloatRect rectForSelectionInMainFrameContentsSpace(PDFSelection *) const;
 
     /*
         Unified PDF Plugin coordinate spaces, in depth order:


### PR DESCRIPTION
#### bbd3a8dd40bdb2cbbe6d8f20cf98bf18ee430619
<pre>
[Unified PDF] Data Detectors are offset from detected items on embedded PDFs
<a href="https://bugs.webkit.org/show_bug.cgi?id=272684">https://bugs.webkit.org/show_bug.cgi?id=272684</a>
<a href="https://rdar.apple.com/126232906">rdar://126232906</a>

Reviewed by Abrar Rahman Protyasha.

276131@main added support for Data Detectors for Unified PDF. However, the
geometry used for highlights was using the plugin&apos;s coordinate space. This is
incorrect for embedded PDFs, as the `PageOverlay` uses `OverlayType::Document`.

Fix by ensuring all highlight geometry uses the main frame&apos;s contents
coordinate space.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::lastKnownMousePositionInView const):
(WebKit::PDFPluginBase::mousePositionInView const): Deleted.

Revert the change made in 276131@main, as this method now has a single use,
inside the same class.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm:
(WebKit::PDFDataDetectorOverlayController::createPlatformDataDetectorHighlight const):
(WebKit::PDFDataDetectorOverlayController::handleMouseEvent):
(WebKit::PDFDataDetectorOverlayController::handleDataDetectorAction):

Click information should be in the window&apos;s coordinate space.

(WebKit::PDFDataDetectorOverlayController::didInvalidateHighlightOverlayRects):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::mainFrameView const):

Expose the main frame&apos;s `FrameView`, so that the overlay controller can get
the `visibleContentRect`, and convert between coordinate spaces.

(WebKit::UnifiedPDFPlugin::rectForSelectionInMainFrameContentsSpace const):

Similar to `ServicesOverlayController`, the only way to convert to document
coordinates is to call `contentsToWindow` and then `windowToContents`.

(WebKit::UnifiedPDFPlugin::rectForSelectionInPluginSpace const): Deleted.

Canonical link: <a href="https://commits.webkit.org/277510@main">https://commits.webkit.org/277510@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f26473250baf6b76e623059efcb5a1ea818a6d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47798 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50481 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43853 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32860 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24477 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38908 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24672 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41307 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20200 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22150 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5847 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44163 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42920 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52375 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22835 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19193 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46209 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 41 flakes 121 failures; Uploaded test results; 9 flakes 72 failures; Running compile-webkit-without-change") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24107 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45250 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10549 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24897 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23828 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->