### PR TITLE
Allow some access to localhost as mixed content

### DIFF
--- a/LayoutTests/http/tests/security/mixedContent/insecure-localhost-image-in-main-frame-UpgradeMixedContent-expected.txt
+++ b/LayoutTests/http/tests/security/mixedContent/insecure-localhost-image-in-main-frame-UpgradeMixedContent-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: The page at https://127.0.0.1:8443/security/mixedContent/resources/frame-with-insecure-localhost-image.html requested insecure content from http://localhost:8080/security/resources/compass.jpg. This content was not upgraded and must be served from the local host.
+
+This test opens a window that loads an insecure image from localhost. We should trigger a mixed content callback because the main frame in the window is HTTPS but is displaying insecure content.

--- a/LayoutTests/http/tests/security/mixedContent/insecure-localhost-image-in-main-frame-UpgradeMixedContent.html
+++ b/LayoutTests/http/tests/security/mixedContent/insecure-localhost-image-in-main-frame-UpgradeMixedContent.html
@@ -1,0 +1,24 @@
+<html><!-- webkit-test-runner [ UpgradeMixedContentEnabled=true IPAddressAndLocalhostMixedContentUpgradeTestingEnabled=false ] -->
+<body>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.addEventListener("message", function (e) {
+    if (window.testRunner)
+        testRunner.notifyDone();
+}, false);
+
+</script>
+<p>This test opens a window that loads an insecure image from localhost.  We should trigger a
+mixed content callback because the main frame in the window is HTTPS but is
+displaying insecure content.</p>
+<script>
+onload = function() {
+    window.open("https://127.0.0.1:8443/security/mixedContent/resources/frame-with-insecure-localhost-image.html");
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/mixedContent/resources/frame-with-insecure-localhost-image.html
+++ b/LayoutTests/http/tests/security/mixedContent/resources/frame-with-insecure-localhost-image.html
@@ -1,0 +1,7 @@
+<img src="http://localhost:8080/security/resources/compass.jpg">
+<script>
+window.onload = function() {
+    if (window.opener)
+        window.opener.postMessage('done', '*');
+};
+</script>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2911,12 +2911,12 @@ ICECandidateFilteringEnabled:
     WebCore:
       default: true
 
-IPAddressMixedContentUpgradeTestingEnabled:
+IPAddressAndLocalhostMixedContentUpgradeTestingEnabled:
   type: bool
   status: testable
   category: security
-  humanReadableName: "Upgrade IP address in mixed content"
-  humanReadableDescription: "Enable Upgrade IP address in mixed content"
+  humanReadableName: "Upgrade IP addresses and localhost in mixed content"
+  humanReadableDescription: "Enable Upgrading IP addresses and localhost in mixed content"
   defaultValue:
     WebKitLegacy:
       default: false

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -120,6 +120,7 @@ enum class SDKAlignedBehavior {
     ScrollViewSubclassImplementsAddGestureRecognizer,
     ThrowIfCanDeclareGlobalFunctionFails,
     ThrowOnKVCInstanceVariableAccess,
+    BlockOptionallyBlockableMixedContent,
 
     NumberOfBehaviors
 };

--- a/Source/WebCore/page/SecurityOrigin.cpp
+++ b/Source/WebCore/page/SecurityOrigin.cpp
@@ -619,13 +619,18 @@ bool SecurityOrigin::isSameSchemeHostPort(const SecurityOrigin& other) const
     return true;
 }
 
+bool SecurityOrigin::isLocalhostAddress(StringView host)
+{
+    // FIXME: Ensure that localhost resolves to the loopback address.
+    return equalLettersIgnoringASCIICase(host, "localhost"_s) || host.endsWithIgnoringASCIICase(".localhost"_s);
+}
+
 bool SecurityOrigin::isLocalHostOrLoopbackIPAddress(StringView host)
 {
     if (isLoopbackIPAddress(host))
         return true;
 
-    // FIXME: Ensure that localhost resolves to the loopback address.
-    if (equalLettersIgnoringASCIICase(host, "localhost"_s) || host.endsWithIgnoringASCIICase(".localhost"_s))
+    if (isLocalhostAddress(host))
         return true;
 
     return false;

--- a/Source/WebCore/page/SecurityOrigin.h
+++ b/Source/WebCore/page/SecurityOrigin.h
@@ -201,6 +201,7 @@ public:
     void setIsPotentiallyTrustworthy(bool value) { m_isPotentiallyTrustworthy = value; }
 
     WEBCORE_EXPORT static bool isLocalHostOrLoopbackIPAddress(StringView);
+    WEBCORE_EXPORT static bool isLocalhostAddress(StringView);
 
     const SecurityOriginData& data() const { return m_data; }
 


### PR DESCRIPTION
#### 464e3e51f7c8b5a6d8ce6f077d0455307cf5721d
<pre>
Allow some access to localhost as mixed content
<a href="https://bugs.webkit.org/show_bug.cgi?id=272461">https://bugs.webkit.org/show_bug.cgi?id=272461</a>
<a href="https://rdar.apple.com/125851000">rdar://125851000</a>

Reviewed by Alex Christensen.

Historically, WebKit has viewed localhost as insecure, but it allowed
unrestricted access to localhost. In 274409@main, I added support for Mixed
Content Level 2 where subresources are either upgraded from http: to https:, or
they are blocked.  But, we don&apos;t upgrade all subresources, we only upgrade a
subset of passive (image/video/audio) resources. If the resource fetch requires
CORS, then we block.

This change contains two fixes:

1) On iOS, continuing using the previous mixed content behavior via a Linked-On-Or-After check
2) Don&apos;t upgrade connections to localhost, but continue enforcing all other requirements

I also renamed the testing preference that controls whether we upgrade IP
addresses so that it now covers upgrading localhost, as well. The console log
message is adjusted to reflect this change, too.

This change includes one additional test that loads mixed content from
localhost, and I manually verified that the LOOA check.

* LayoutTests/http/tests/security/mixedContent/insecure-localhost-image-in-main-frame-UpgradeMixedContent-expected.txt: Added.
* LayoutTests/http/tests/security/mixedContent/insecure-localhost-image-in-main-frame-UpgradeMixedContent.html: Added.
* LayoutTests/http/tests/security/mixedContent/resources/frame-with-insecure-localhost-image.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebCore/loader/MixedContentChecker.cpp:
(WebCore::logConsoleWarningForUpgrade):
(WebCore::isUpgradeMixedContentEnabled):
(WebCore::frameAndAncestorsCanDisplayInsecureContent):
(WebCore::MixedContentChecker::frameAndAncestorsCanRunInsecureContent):
(WebCore::MixedContentChecker::shouldUpgradeInsecureContent):
(WebCore::shouldBlockInsecureContent):
* Source/WebCore/page/SecurityOrigin.cpp:
(WebCore::SecurityOrigin::isLocalhostAddress):
(WebCore::SecurityOrigin::isLocalHostOrLoopbackIPAddress):
* Source/WebCore/page/SecurityOrigin.h:
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::upgradeInsecureRequestIfNeeded const):

Canonical link: <a href="https://commits.webkit.org/277709@main">https://commits.webkit.org/277709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/128dfb35f6407f423f4d2767522324a837e69152

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48352 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27564 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/51306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51040 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44417 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50657 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25085 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48934 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/25255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/51306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/20645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/22735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/51306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6408 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/41649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/44688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/51306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52944 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/47843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/23399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/19738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/24664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/51306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/45749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/25469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55338 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6879 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24387 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/11386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->