### PR TITLE
Make CachedImage calculate allowsOrientationOverride when loading the image is complete

### DIFF
--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -854,12 +854,9 @@ String HTMLImageElement::crossOrigin() const
 
 bool HTMLImageElement::allowsOrientationOverride() const
 {
-    auto* cachedImage = this->cachedImage();
-    if (!cachedImage)
-        return true;
-
-    auto image = cachedImage->image();
-    return !image || image->sourceURL().protocolIsData() || cachedImage->isCORSSameOrigin();
+    if (auto* cachedImage = this->cachedImage())
+        return cachedImage->allowsOrientationOverride();
+    return true;
 }
 
 Image* HTMLImageElement::image() const

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -67,6 +67,9 @@ public:
 
     bool canRender(const RenderElement* renderer, float multiplier) { return !errorOccurred() && !imageSizeForRenderer(renderer, multiplier).isEmpty(); }
 
+    void setAllowsOrientationOverride(bool b) { m_allowsOrientationOverride = b; }
+    bool allowsOrientationOverride() const { return m_allowsOrientationOverride; }
+
     void setContainerContextForClient(const CachedImageClient&, const LayoutSize&, float, const URL&);
     bool usesImageContainerSize() const { return m_image && m_image->usesContainerSize(); }
     bool imageHasRelativeWidth() const { return m_image && m_image->hasRelativeWidth(); }
@@ -208,6 +211,7 @@ private:
     bool m_shouldPaintBrokenImage : 1;
     bool m_forceUpdateImageDataEnabledForTesting : 1;
     bool m_layerBasedSVGEngineEnabled : 1 { false };
+    bool m_allowsOrientationOverride : 1;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### da92319fd54b5cf9dcbe546135204314df8ea4f8
<pre>
Make CachedImage calculate allowsOrientationOverride when loading the image is complete
<a href="https://bugs.webkit.org/show_bug.cgi?id=272690">https://bugs.webkit.org/show_bug.cgi?id=272690</a>
<a href="https://rdar.apple.com/126495895">rdar://126495895</a>

Reviewed by Cameron McCormack.

Cache the value of allowsOrientationOverride when the image is loaded and reuse
the cached value instead of recalculating it every time it is needed.

* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::allowsOrientationOverride const):
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::CachedImage):
(WebCore::CachedImage::clearImage):
(WebCore::CachedImage::finishLoading):
* Source/WebCore/loader/cache/CachedImage.h:

Canonical link: <a href="https://commits.webkit.org/277830@main">https://commits.webkit.org/277830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46489a3fa14e1b2e9ee7fc9c00079d8619ede3b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50508 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43880 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50132 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24505 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38924 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24688 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41330 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20217 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22168 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42610 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5874 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44185 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52402 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22863 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19213 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46231 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24134 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45269 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10724 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24926 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23856 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->