### PR TITLE
Start including remote frames when building inspector objects

### DIFF
--- a/LayoutTests/http/tests/inspector/dom/site-isolated-node-expected.txt
+++ b/LayoutTests/http/tests/inspector/dom/site-isolated-node-expected.txt
@@ -1,0 +1,8 @@
+
+ERROR: Missing frame for given frameId
+PASS: Page should have a subframe.
+
+== Running test suite: CommandLineAPI.$0.cross-frame
+-- Running test case: AttemptCrossFrame$0AccessFromMainFrame
+Setting $0 to node within subframe.
+

--- a/LayoutTests/http/tests/inspector/dom/site-isolated-node.html
+++ b/LayoutTests/http/tests/inspector/dom/site-isolated-node.html
@@ -1,0 +1,43 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!doctype html>
+<html>
+<head>
+<script type="text/javascript" src="../resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("CommandLineAPI.$0.cross-frame");
+
+    let mainFrame = WI.networkManager.mainFrame;
+    let childFrames = Array.from(mainFrame.childFrameCollection);
+    InspectorTest.expectEqual(childFrames.length, 1, "Page should have a subframe.");
+
+    let iframeNodeId;
+
+    suite.addTestCase({
+        name: "AttemptCrossFrame$0AccessFromMainFrame",
+        description: "Should not be able to access $0 node in different domain subframe from the main frame.",
+        test(resolve, reject) {
+            InspectorTest.log("Setting $0 to node within subframe.");
+            DOMAgent.setInspectedNode(iframeNodeId);
+            RuntimeAgent.evaluate.invoke({expression: "$0", includeCommandLineAPI: true}, (error, _, wasThrown) => {    
+                InspectorTest.assert(!error, "Should not be a protocol error.");
+                InspectorTest.assert(!wasThrown, "Should not be an exception.");
+                resolve();
+            });
+        }
+    });
+
+    WI.domManager.requestDocument((documentNode) => {
+        documentNode.querySelector("iframe#myframe", (nodeId) => {
+            iframeNodeId = nodeId;
+            suite.runTestCasesAndFinish();
+        });
+    });
+}
+</script>
+</head>
+<body>
+<iframe id="myframe" src="http://localhost:8000/inspector/page/resources/test-page.html" onload="runTest()"></iframe>
+</body>
+</html>

--- a/Source/JavaScriptCore/inspector/protocol/Page.json
+++ b/Source/JavaScriptCore/inspector/protocol/Page.json
@@ -69,11 +69,11 @@
             "properties": [
                 { "name": "id", "type": "string", "description": "Frame unique identifier." },
                 { "name": "parentId", "type": "string", "optional": true, "description": "Parent frame identifier." },
-                { "name": "loaderId", "$ref": "Network.LoaderId", "description": "Identifier of the loader associated with this frame." },
+                { "name": "loaderId", "$ref": "Network.LoaderId", "optional": true, "description": "Identifier of the loader associated with this frame." },
                 { "name": "name", "type": "string", "optional": true, "description": "Frame's name as specified in the tag." },
-                { "name": "url", "type": "string", "description": "Frame document's URL." },
-                { "name": "securityOrigin", "type": "string", "description": "Frame document's security origin." },
-                { "name": "mimeType", "type": "string", "description": "Frame document's mimeType as determined by the browser." }
+                { "name": "url", "type": "string", "optional": true, "description": "Frame document's URL." },
+                { "name": "securityOrigin", "type": "string", "optional": true, "description": "Frame document's security origin." },
+                { "name": "mimeType", "type": "string", "optional": true, "description": "Frame document's mimeType as determined by the browser." }
             ]
         },
         {

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
@@ -162,8 +162,8 @@ private:
     void overridePrefersContrast(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&&);
     void overridePrefersColorScheme(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&&);
 
-    Ref<Inspector::Protocol::Page::Frame> buildObjectForFrame(LocalFrame*);
-    Ref<Inspector::Protocol::Page::FrameResourceTree> buildObjectForFrameTree(LocalFrame*);
+    Ref<Inspector::Protocol::Page::Frame> buildObjectForFrame(Frame*);
+    Ref<Inspector::Protocol::Page::FrameResourceTree> buildObjectForFrameTree(Frame*);
 
     std::unique_ptr<Inspector::PageFrontendDispatcher> m_frontendDispatcher;
     RefPtr<Inspector::PageBackendDispatcher> m_backendDispatcher;


### PR DESCRIPTION
#### 5a69f2f9dd82c655eecece54732c69f7386ccb86
<pre>
Start including remote frames when building inspector objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=272691">https://bugs.webkit.org/show_bug.cgi?id=272691</a>
<a href="https://rdar.apple.com/126495980">rdar://126495980</a>

Reviewed by NOBODY (OOPS!).

Start including remote frames when building object trees for web inspector.
Later we will need to fill these in by requesting nodes from the appropriate
backend hosting the LocalFrame.

The layout test only verifies that inspector gets a frame that it cannot query
(because it is remote.) This will be expanded in future changes.

* LayoutTests/http/tests/inspector/dom/site-isolated-node-expected.txt: Added.
* LayoutTests/http/tests/inspector/dom/site-isolated-node.html: Added.
* Source/JavaScriptCore/inspector/protocol/Page.json:
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::buildObjectForFrame):
(WebCore::InspectorPageAgent::buildObjectForFrameTree):
* Source/WebCore/inspector/agents/InspectorPageAgent.h:
</pre>