### PR TITLE
REGRESSION [ iOS ] 5X TestWebKitAPI.CopyRTF.Strips are crashing and failing

### DIFF
--- a/Tools/Scripts/webkitpy/port/darwin.py
+++ b/Tools/Scripts/webkitpy/port/darwin.py
@@ -265,7 +265,8 @@ class DarwinPort(ApplePort):
     def environment_for_api_tests(self):
         environment = super(DarwinPort, self).environment_for_api_tests()
         build_root_path = str(self._build_path())
-        for name in ['DYLD_LIBRARY_PATH', '__XPC_DYLD_LIBRARY_PATH', 'DYLD_FRAMEWORK_PATH', '__XPC_DYLD_FRAMEWORK_PATH']:
+        # nsattributedstringagent which gets launched by test runner must set __XPC_DYLD_LIBRARY_PATH and __XPC_DYLD_FRAMEWORK_PATH.
+        for name in ['DYLD_LIBRARY_PATH', '__XPC_DYLD_LIBRARY_PATH', '__XPC___XPC_DYLD_LIBRARY_PATH', 'DYLD_FRAMEWORK_PATH', '__XPC_DYLD_FRAMEWORK_PATH', '__XPC___XPC_DYLD_FRAMEWORK_PATH']:
             self._append_value_colon_separated(environment, name, build_root_path)
         return environment
 


### PR DESCRIPTION
#### 8df4906592e14d06bf448b40c426081479e8f931
<pre>
REGRESSION [ iOS ] 5X TestWebKitAPI.CopyRTF.Strips are crashing and failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=272239">https://bugs.webkit.org/show_bug.cgi?id=272239</a>
<a href="https://rdar.apple.com/125982015">rdar://125982015</a>

Reviewed by Wenson Hsieh, Tim Horton and Chris Dumez.

Set __XPC___XPC_DYLD_LIBRARY_PATH and __XPC___XPC_DYLD_FRAMEWORK_PATH so that nsattributedstringagent
will launch WebKit processes with _XPC_DYLD_LIBRARY_PATH and _XPC_DYLD_FRAMEWORK_PATH set.

* Tools/Scripts/webkitpy/port/darwin.py:
(DarwinPort.environment_for_api_tests):

Canonical link: <a href="https://commits.webkit.org/277530@main">https://commits.webkit.org/277530@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c099b982965e59ee12c824e15a868ce71526303c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47841 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50523 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43895 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50147 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24521 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38932 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24711 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41356 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20224 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/47702 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22186 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42537 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5889 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44212 "Found 17 new API test failures: TestWebKitAPI.PasteHTML.PreservesMSOList, TestWebKitAPI.PasteHTML.StripsMSOListWhenMissingMSOHTMLElement, TestWebKitAPI.PasteHTML.TransformColorsOfDarkContentButNotSemanticColor, TestWebKitAPI.DragAndDropTests.ExternalSourceHTMLToContentEditable, TestWebKitAPI.PasteHTML.TransformColorsOfDarkContent, TestWebKitAPI.UIPasteboardTests.DataTransferGetDataWhenPastingPlatformRepresentations, TestWebKitAPI.PasteHTML.ExposesHTMLTypeInDataTransfer, TestWebKitAPI.DragAndDropTests.DataTransferGetDataWhenDroppingImageAndMarkup, TestWebKitAPI.WKAttachmentTestsIOS.PasteRichTextCopiedFromNotes, TestWebKitAPI.PasteHTML.PreservesMSOListInCompatibilityMode ... (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42965 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52417 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22880 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19231 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46240 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24151 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45279 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24942 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6785 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23871 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->