### PR TITLE
[JSC] Do not take concurrent JS lock on CodeBlock when repatching DirectCall on the main thread

### DIFF
--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.h
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.h
@@ -482,7 +482,8 @@ private:
     void initialize();
     void repatchSpeculatively();
 
-    std::tuple<CodeBlock*, CodePtr<JSEntryPtrTag>> retrieveCallInfo(FunctionExecutable*);
+    CodeBlock* retrieveCodeBlock(FunctionExecutable*);
+    CodePtr<JSEntryPtrTag> retrieveCodePtr(const ConcurrentJSLocker&, CodeBlock*);
 
     CallType m_callType : 4;
     UseDataIC m_useDataIC : 1;

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -3474,9 +3474,8 @@ bool CodeBlock::useDataIC() const
     return true;
 }
 
-CodePtr<JSEntryPtrTag> CodeBlock::addressForCallConcurrently(ArityCheckMode arityCheck) const
+CodePtr<JSEntryPtrTag> CodeBlock::addressForCallConcurrently(const ConcurrentJSLocker&, ArityCheckMode arityCheck) const
 {
-    ConcurrentJSLocker locker(m_lock);
     if (!m_jitCode)
         return nullptr;
     return m_jitCode->addressForCall(arityCheck);

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -346,7 +346,7 @@ public:
 
     bool useDataIC() const;
 
-    CodePtr<JSEntryPtrTag> addressForCallConcurrently(ArityCheckMode) const;
+    CodePtr<JSEntryPtrTag> addressForCallConcurrently(const ConcurrentJSLocker&, ArityCheckMode) const;
 
 #if ENABLE(JIT)
     CodeBlock* replacement();


### PR DESCRIPTION
#### 5cdeb9ec81887f1cdaae3780fb7d4bbbfc2ac8b8
<pre>
[JSC] Do not take concurrent JS lock on CodeBlock when repatching DirectCall on the main thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=272699">https://bugs.webkit.org/show_bug.cgi?id=272699</a>
<a href="https://rdar.apple.com/problem/126505237">rdar://problem/126505237</a>

Reviewed by Justin Michaud.

Stop taking a ConcurrentJSLock for DirectCall repatching since this is happening on the main thread.

* Source/JavaScriptCore/bytecode/CallLinkInfo.cpp:
(JSC::DirectCallLinkInfo::retrieveCodeBlock):
(JSC::DirectCallLinkInfo::retrieveCodePtr):
(JSC::DirectCallLinkInfo::repatchSpeculatively):
(JSC::DirectCallLinkInfo::validateSpeculativeRepatchOnMainThread):
(JSC::DirectCallLinkInfo::retrieveCallInfo): Deleted.
* Source/JavaScriptCore/bytecode/CallLinkInfo.h:
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::addressForCallConcurrently const):
* Source/JavaScriptCore/bytecode/CodeBlock.h:

Canonical link: <a href="https://commits.webkit.org/277516@main">https://commits.webkit.org/277516@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dca7d034e0a01fc3524f9259eb471736244b4814

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47848 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50530 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43902 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24531 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38941 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48430 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24725 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20236 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22193 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5896 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/41137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/44206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/42988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52424 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/47340 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22891 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/19236 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46248 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/24159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45288 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/24950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54838 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6771 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23879 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11265 "Passed tests") | 
<!--EWS-Status-Bubble-End-->