### PR TITLE
Expand use of WKBundlePagePostMessageWithAsyncReply in WebKitTestRunner

### DIFF
--- a/Source/WTF/wtf/CompletionHandler.h
+++ b/Source/WTF/wtf/CompletionHandler.h
@@ -47,6 +47,7 @@ class CompletionHandler<Out(In...)> {
 public:
     using OutType = Out;
     using InTypes = std::tuple<In...>;
+    using Impl = typename Function<Out(In...)>::Impl;
 
     CompletionHandler() = default;
 
@@ -67,6 +68,8 @@ public:
     }
 
     explicit operator bool() const { return !!m_function; }
+
+    Impl* leak() { return m_function.leak(); }
 
     Out operator()(In... in)
     {
@@ -165,6 +168,11 @@ public:
 private:
     CompletionHandler<void()> m_completionHandler;
 };
+
+template<typename Out, typename... In> CompletionHandler<Out(In...)> adopt(typename CompletionHandler<Out(In...)>::Impl* impl)
+{
+    return Function<Out(In...)>(impl, Function<Out(In...)>::Adopt);
+}
 
 } // namespace WTF
 

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
@@ -277,8 +277,6 @@ template<typename T> void postSynchronousPageMessage(const char* name, const WKR
     }
 }
 
-void asyncReplyHandler(WKTypeRef reply, void* context);
 void postMessageWithAsyncReply(const char* messageName, JSValueRef callback);
-JSValueRef stringArrayToJS(JSContextRef, WKArrayRef);
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -294,7 +294,6 @@ public:
     void setAlwaysAcceptCookies(bool);
     void setOnlyAcceptFirstPartyCookies(bool);
     void removeAllCookies(JSValueRef callback);
-    void callRemoveAllCookiesCallback();
 
     // Custom full screen behavior.
     void setHasCustomFullScreenBehavior(bool value) { m_customFullScreenBehavior = value; }
@@ -580,7 +579,6 @@ public:
     void setIsMediaKeySystemPermissionGranted(bool);
 
     void takeViewPortSnapshot(JSValueRef callback);
-    void viewPortSnapshotTaken(WKStringRef);
 
     void flushConsoleLogs(JSValueRef callback);
 
@@ -588,7 +586,6 @@ public:
     void generateTestReport(JSStringRef message, JSStringRef group);
 
     void getAndClearReportedWindowProxyAccessDomains(JSValueRef);
-    void didGetAndClearReportedWindowProxyAccessDomains(WKArrayRef);
 
 private:
     TestRunner();
@@ -653,7 +650,6 @@ private:
     bool m_hasSetDowngradeReferrerCallback { false };
     bool m_hasSetBlockThirdPartyCookiesCallback { false };
     bool m_hasSetFirstPartyWebsiteDataRemovalModeCallback { false };
-    bool m_takeViewPortSnapshot { false };
 };
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -276,7 +276,7 @@ public:
     void setManagedDomains(WKArrayRef originURLs);
     void statisticsResetToConsistentState();
 
-    void removeAllCookies();
+    void removeAllCookies(CompletionHandler<void(WKTypeRef)>&&);
 
     void getAllStorageAccessEntries(CompletionHandler<void(WKTypeRef)>&&);
     void setRequestStorageAccessThrowsExceptionUntilReload(bool enabled);

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -778,11 +778,6 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         return;
     }
 
-    if (WKStringIsEqualToUTF8CString(messageName, "RemoveAllCookies")) {
-        TestController::singleton().removeAllCookies();
-        return;
-    }
-
     if (WKStringIsEqualToUTF8CString(messageName, "StatisticsClearInMemoryAndPersistentStore")) {
         TestController::singleton().statisticsClearInMemoryAndPersistentStore();
         return;
@@ -805,12 +800,6 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
 
     if (WKStringIsEqualToUTF8CString(messageName, "SetStatisticsFirstPartyWebsiteDataRemovalMode")) {
         TestController::singleton().setStatisticsFirstPartyWebsiteDataRemovalMode(booleanValue(messageBody));
-        return;
-    }
-    
-    if (WKStringIsEqualToUTF8CString(messageName, "TakeViewPortSnapshot")) {
-        auto value = TestController::singleton().takeViewPortSnapshot();
-        postPageMessage("ViewPortSnapshotTaken", value.get());
         return;
     }
 
@@ -883,12 +872,6 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
 
     if (WKStringIsEqualToUTF8CString(messageName, "SkipPolicyDelegateNotifyDone")) {
         TestController::singleton().skipPolicyDelegateNotifyDone();
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "GetAndClearReportedWindowProxyAccessDomains")) {
-        auto value = TestController::singleton().getAndClearReportedWindowProxyAccessDomains();
-        postPageMessage("DidGetAndClearReportedWindowProxyAccessDomains", value.get());
         return;
     }
 
@@ -1762,11 +1745,6 @@ void TestInvocation::didSetVeryPrevalentResource()
 void TestInvocation::didSetHasHadUserInteraction()
 {
     postPageMessage("CallDidSetHasHadUserInteraction");
-}
-
-void TestInvocation::didRemoveAllCookies()
-{
-    postPageMessage("CallDidRemoveAllCookies");
 }
 
 void TestInvocation::didReceiveLoadedSubresourceDomains(Vector<String>&& domains)

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -91,7 +91,6 @@ public:
     void didSetVeryPrevalentResource();
     void didSetHasHadUserInteraction();
     void didReceiveLoadedSubresourceDomains(Vector<String>&& domains);
-    void didRemoveAllCookies();
 
     void didRemoveAllSessionCredentials();
 


### PR DESCRIPTION
#### 0e046a9f289e4ab46fcbf70f18a785b630903060
<pre>
Expand use of WKBundlePagePostMessageWithAsyncReply in WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=272700">https://bugs.webkit.org/show_bug.cgi?id=272700</a>
<a href="https://rdar.apple.com/126506518">rdar://126506518</a>

Reviewed by Sihui Liu.

This makes the tests work better with site isolation by sending the reply to the
requesting process instead of the main frame&apos;s process.

I added the ability to leak and adopt a CompletionHandler like we can a Function
to use it as the void* context for C API calls.

* Source/WTF/wtf/CompletionHandler.h:
(WTF::CompletionHandler&lt;Out):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::didReceiveMessageToPage):
(WTR::stringArrayToJS):
(WTR::postMessageWithAsyncReply):
(WTR::asyncReplyHandler): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::removeAllCookies):
(WTR::TestRunner::takeViewPortSnapshot):
(WTR::TestRunner::getAndClearReportedWindowProxyAccessDomains):
(WTR::stringArrayToJS): Deleted.
(WTR::TestRunner::callRemoveAllCookiesCallback): Deleted.
(WTR::TestRunner::viewPortSnapshotTaken): Deleted.
(WTR::TestRunner::didGetAndClearReportedWindowProxyAccessDomains): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::didReceiveAsyncMessageFromInjectedBundle):
(WTR::TestController::getAllStorageAccessEntries):
(WTR::TestController::removeAllCookies):
(WTR::getAllStorageAccessEntriesCallback): Deleted.
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):
(WTR::TestInvocation::didRemoveAllCookies): Deleted.
* Tools/WebKitTestRunner/TestInvocation.h:

Canonical link: <a href="https://commits.webkit.org/277544@main">https://commits.webkit.org/277544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d698d4700a800cf873cadf0a672cb9457c1ee549

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27069 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50699 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50550 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43922 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50175 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24551 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38950 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24741 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41388 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20245 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22219 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42570 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5916 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/41158 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44226 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52444 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/47360 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22911 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19262 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46264 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24179 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45305 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24970 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54858 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6794 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23900 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11273 "Passed tests") | 
<!--EWS-Status-Bubble-End-->