### PR TITLE
Remove legacy serialization infrastructure starting with Cocoa platform

### DIFF
--- a/Source/WTF/wtf/ArgumentCoder.h
+++ b/Source/WTF/wtf/ArgumentCoder.h
@@ -34,6 +34,10 @@ namespace IPC {
 class Decoder;
 class Encoder;
 
+#if HAVE(ONLY_MODERN_SERIALIZATION)
+template<typename T, typename = void> struct ArgumentCoder;
+#else
+
 template<typename T, typename I = T, typename = void> struct HasLegacyDecoder : std::false_type { };
 template<typename T, typename I> struct HasLegacyDecoder<T, I, std::void_t<decltype(I::decode(std::declval<Decoder&>(), std::declval<T&>()))>> : std::true_type { };
 template<typename T, typename I = T, typename = void> struct HasModernDecoder : std::false_type { };
@@ -79,6 +83,7 @@ template<typename T, typename = void> struct ArgumentCoder {
         }
     }
 };
+#endif // HAVE(ONLY_MODERN_SERIALIZATION)
 
 template<>
 struct ArgumentCoder<bool> {

--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -1791,3 +1791,8 @@
 #if !defined(HAVE_AUDIO_CONVERTER_SERVICE) && PLATFORM(MAC) && __MAC_OS_X_VERSION_MAX_ALLOWED > 140400
 #define HAVE_AUDIO_CONVERTER_SERVICE 1
 #endif
+
+// FIXME: Other platforms should finish migration to *.serialization.in.
+#if PLATFORM(COCOA)
+#define ONLY_MODERN_SERIALIZATION 1
+#endif

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -52,8 +52,10 @@ enum class MessageFlags : uint8_t;
 enum class ShouldDispatchWhenWaitingForSyncReply : uint8_t;
 
 template<typename, typename> struct ArgumentCoder;
+#if !HAVE(ONLY_MODERN_SERIALIZATION)
 template<typename, typename, typename> struct HasLegacyDecoder;
 template<typename, typename, typename> struct HasModernDecoder;
+#endif
 
 #ifdef __OBJC__
 template<typename T> using IsObjCObject = std::enable_if_t<std::is_convertible<T *, id>::value, T *>;
@@ -121,6 +123,7 @@ public:
     template<typename T>
     WARN_UNUSED_RETURN std::optional<T> decodeObject();
 
+#if !HAVE(ONLY_MODERN_SERIALIZATION)
     template<typename T>
     WARN_UNUSED_RETURN bool decode(T& t)
     {
@@ -140,6 +143,7 @@ public:
         }
         return true;
     }
+#endif
 
     template<typename T>
     Decoder& operator>>(std::optional<T>& t)
@@ -154,11 +158,14 @@ public:
     std::optional<T> decode()
     {
         using Impl = ArgumentCoder<std::remove_cvref_t<T>, void>;
+#if !HAVE(ONLY_MODERN_SERIALIZATION)
         if constexpr(HasModernDecoder<T, Impl>::value) {
+#endif
             std::optional<T> t { Impl::decode(*this) };
             if (UNLIKELY(!t))
                 markInvalid();
             return t;
+#if !HAVE(ONLY_MODERN_SERIALIZATION)
         } else {
             std::optional<T> t { T { } };
             if (LIKELY(Impl::decode(*this, *t)))
@@ -166,6 +173,7 @@ public:
             markInvalid();
             return std::nullopt;
         }
+#endif
     }
 
 #ifdef __OBJC__


### PR DESCRIPTION
#### 908ce185ca46f4abbf99e821bd312442abe80bfb
<pre>
Remove legacy serialization infrastructure starting with Cocoa platform
<a href="https://bugs.webkit.org/show_bug.cgi?id=272703">https://bugs.webkit.org/show_bug.cgi?id=272703</a>
<a href="https://rdar.apple.com/126508648">rdar://126508648</a>

Reviewed by Brady Eidson.

This is the first step towards removing legacy encoding.
Cocoa&apos;s data structures have migrated to *.serialization.in with a few exceptions that
have been handled manually.  Other platforms still have a small amount of work to do,
but this will help clarify what is needed.

* Source/WTF/wtf/ArgumentCoder.h:
* Source/WTF/wtf/PlatformHave.h:
* Source/WebKit/Platform/IPC/Decoder.h:
(IPC::Decoder::decode):

Canonical link: <a href="https://commits.webkit.org/277527@main">https://commits.webkit.org/277527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/283ef6fab78963ceafb05d3ff103edcb17e11a89

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50546 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43918 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32933 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24547 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38948 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41385 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20243 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22217 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5912 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/41154 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44225 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52440 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/47356 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22908 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19260 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46252 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24175 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45292 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24966 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54854 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6782 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23895 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11271 "Passed tests") | 
<!--EWS-Status-Bubble-End-->