### PR TITLE
Remove InterpolationQualityMaintainer

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -315,13 +315,11 @@ ImageDrawResult GraphicsContext::drawImage(Image& image, const FloatRect& destin
 
 ImageDrawResult GraphicsContext::drawImage(Image& image, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions options)
 {
-    InterpolationQualityMaintainer interpolationQualityForThisScope(*this, options.interpolationQuality());
     return image.draw(*this, destination, source, options);
 }
 
 ImageDrawResult GraphicsContext::drawTiledImage(Image& image, const FloatRect& destination, const FloatPoint& source, const FloatSize& tileSize, const FloatSize& spacing, ImagePaintingOptions options)
 {
-    InterpolationQualityMaintainer interpolationQualityForThisScope(*this, options.interpolationQuality());
     return image.drawTiled(*this, destination, source, tileSize, spacing, options);
 }
 
@@ -333,8 +331,7 @@ ImageDrawResult GraphicsContext::drawTiledImage(Image& image, const FloatRect& d
         return drawImage(image, destination, source, options);
     }
 
-    InterpolationQualityMaintainer interpolationQualityForThisScope(*this, options.interpolationQuality());
-    return image.drawTiled(*this, destination, source, tileScaleFactor, hRule, vRule, { options.compositeOperator() });
+    return image.drawTiled(*this, destination, source, tileScaleFactor, hRule, vRule, { options.compositeOperator(), options.interpolationQuality() });
 }
 
 RefPtr<NativeImage> GraphicsContext::nativeImageForDrawing(ImageBuffer& imageBuffer)
@@ -356,7 +353,6 @@ void GraphicsContext::drawImageBuffer(ImageBuffer& image, const FloatRect& desti
 
 void GraphicsContext::drawImageBuffer(ImageBuffer& image, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions options)
 {
-    InterpolationQualityMaintainer interpolationQualityForThisScope(*this, options.interpolationQuality());
     FloatRect sourceScaled = source;
     sourceScaled.scale(image.resolutionScale());
     if (auto nativeImage = nativeImageForDrawing(image))
@@ -384,7 +380,6 @@ void GraphicsContext::drawConsumingImageBuffer(RefPtr<ImageBuffer> image, const 
     if (!image)
         return;
     ASSERT(this != &image->context());
-    InterpolationQualityMaintainer interpolationQualityForThisScope(*this, options.interpolationQuality());
     FloatRect scaledSource = source;
     scaledSource.scale(image->resolutionScale());
     if (auto nativeImage = ImageBuffer::sinkIntoNativeImage(WTFMove(image)))

--- a/Source/WebCore/platform/graphics/GraphicsContextStateSaver.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextStateSaver.h
@@ -115,32 +115,4 @@ private:
     unsigned m_stackSize;
 };
 
-class InterpolationQualityMaintainer {
-public:
-    explicit InterpolationQualityMaintainer(GraphicsContext& graphicsContext, InterpolationQuality interpolationQualityToUse)
-        : m_graphicsContext(graphicsContext)
-        , m_currentInterpolationQuality(graphicsContext.imageInterpolationQuality())
-        , m_interpolationQualityChanged(interpolationQualityToUse != InterpolationQuality::Default && m_currentInterpolationQuality != interpolationQualityToUse)
-    {
-        if (m_interpolationQualityChanged)
-            m_graphicsContext.setImageInterpolationQuality(interpolationQualityToUse);
-    }
-
-    explicit InterpolationQualityMaintainer(GraphicsContext& graphicsContext, std::optional<InterpolationQuality> interpolationQuality)
-        : InterpolationQualityMaintainer(graphicsContext, interpolationQuality ? interpolationQuality.value() : graphicsContext.imageInterpolationQuality())
-    {
-    }
-
-    ~InterpolationQualityMaintainer()
-    {
-        if (m_interpolationQualityChanged)
-            m_graphicsContext.setImageInterpolationQuality(m_currentInterpolationQuality);
-    }
-
-private:
-    GraphicsContext& m_graphicsContext;
-    InterpolationQuality m_currentInterpolationQuality;
-    bool m_interpolationQualityChanged;
-};
-
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -369,7 +369,9 @@ void GraphicsContextCG::drawNativeImageInternal(NativeImage& nativeImage, const 
 
     auto oldCompositeOperator = compositeOperation();
     auto oldBlendMode = blendMode();
+    auto oldImageInterpolationQuality = imageInterpolationQuality();
     setCGBlendMode(context, options.compositeOperator(), options.blendMode());
+    CGContextSetInterpolationQuality(context, toCGInterpolationQuality(options.interpolationQuality()));
 
     // Make the origin be at adjustedDestRect.location()
     CGContextTranslateCTM(context, adjustedDestRect.x(), adjustedDestRect.y());
@@ -397,6 +399,7 @@ void GraphicsContextCG::drawNativeImageInternal(NativeImage& nativeImage, const 
         CGContextSetShouldAntialias(context, wasAntialiased);
 #endif
         setCGBlendMode(context, oldCompositeOperator, oldBlendMode);
+        CGContextSetInterpolationQuality(context, toCGInterpolationQuality(oldImageInterpolationQuality));
     }
 
     LOG_WITH_STREAM(Images, stream << "GraphicsContextCG::drawNativeImageInternal " << image.get() << " size " << imageSize << " into " << destRect << " took " << (MonotonicTime::now() - startTime).milliseconds() << "ms");
@@ -427,6 +430,7 @@ void GraphicsContextCG::drawPattern(NativeImage& nativeImage, const FloatRect& d
     CGContextClipToRect(context, destRect);
 
     setCGBlendMode(context, options.compositeOperator(), options.blendMode());
+    CGContextSetInterpolationQuality(context, toCGInterpolationQuality(options.interpolationQuality()));
 
     CGContextTranslateCTM(context, destRect.x(), destRect.y() + destRect.height());
     CGContextScaleCTM(context, 1, -1);

--- a/Source/WebCore/rendering/RenderHTMLCanvas.cpp
+++ b/Source/WebCore/rendering/RenderHTMLCanvas.cpp
@@ -31,7 +31,6 @@
 #include "GraphicsContext.h"
 #include "HTMLCanvasElement.h"
 #include "HTMLNames.h"
-#include "ImageQualityController.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
 #include "Page.h"
@@ -95,8 +94,6 @@ void RenderHTMLCanvas::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& pa
 
     if (paintInfo.phase == PaintPhase::Foreground)
         page().addRelevantRepaintedObject(*this, intersection(replacedContentRect, contentBoxRect));
-
-    InterpolationQualityMaintainer interpolationMaintainer(context, ImageQualityController::interpolationQualityFromStyle(style()));
 
     canvasElement().setIsSnapshotting(paintInfo.paintBehavior.contains(PaintBehavior::Snapshotting));
     canvasElement().paint(context, replacedContentRect);

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
@@ -63,10 +63,10 @@ void RenderViewTransitionCapture::paintReplaced(PaintInfo& paintInfo, const Layo
     IntPoint position = snappedIntRect(replacedContentRect).location();
     position.moveBy(roundedIntPoint(m_overflowRect.location()));
 
-    InterpolationQualityMaintainer interpolationMaintainer(context, ImageQualityController::interpolationQualityFromStyle(style()));
-    if (m_oldImage)
-        context.drawImageBuffer(*m_oldImage, position, { context.compositeOperation() });
-
+    if (m_oldImage) {
+        auto imageInterpolationQuality = ImageQualityController::interpolationQualityFromStyle(style());
+        context.drawImageBuffer(*m_oldImage, position, { context.compositeOperation(), imageInterpolationQuality.value_or(context.imageInterpolationQuality()) });
+    }
 }
 
 void RenderViewTransitionCapture::layout()

--- a/Source/WebCore/rendering/style/NinePieceImage.cpp
+++ b/Source/WebCore/rendering/style/NinePieceImage.cpp
@@ -218,19 +218,21 @@ void NinePieceImage::paint(GraphicsContext& graphicsContext, const RenderElement
     if (!image)
         return;
 
-    InterpolationQualityMaintainer interpolationMaintainer(graphicsContext, ImageQualityController::interpolationQualityFromStyle(style));
+    auto imageInterpolationQuality = ImageQualityController::interpolationQualityFromStyle(style);
+    auto options = ImagePaintingOptions { op, ImageOrientation::Orientation::FromImage, imageInterpolationQuality.value_or(graphicsContext.imageInterpolationQuality()) };
+
     for (ImagePiece piece = MinPiece; piece < MaxPiece; ++piece) {
         if ((piece == MiddlePiece && !fill()) || isEmptyPieceRect(piece, destinationRects, sourceRects))
             continue;
 
         if (isCornerPiece(piece)) {
-            graphicsContext.drawImage(*image, destinationRects[piece], sourceRects[piece], { op, ImageOrientation::Orientation::FromImage });
+            graphicsContext.drawImage(*image, destinationRects[piece], sourceRects[piece], options);
             continue;
         }
 
         Image::TileRule hRule = isHorizontalPiece(piece) ? static_cast<Image::TileRule>(horizontalRule()) : Image::StretchTile;
         Image::TileRule vRule = isVerticalPiece(piece) ? static_cast<Image::TileRule>(verticalRule()) : Image::StretchTile;
-        graphicsContext.drawTiledImage(*image, destinationRects[piece], sourceRects[piece], tileScales[piece], hRule, vRule, { op, ImageOrientation::Orientation::FromImage });
+        graphicsContext.drawTiledImage(*image, destinationRects[piece], sourceRects[piece], tileScales[piece], hRule, vRule, options);
     }
 }
 


### PR DESCRIPTION
#### 3b4a30f9088c82d69276ffa9d01bc470a5798936
<pre>
Remove InterpolationQualityMaintainer
<a href="https://bugs.webkit.org/show_bug.cgi?id=272705">https://bugs.webkit.org/show_bug.cgi?id=272705</a>
<a href="https://rdar.apple.com/126509822">rdar://126509822</a>

Reviewed by NOBODY (OOPS!).

Applying InterpolationQuality through InterpolationQualityMaintainer requires a
separate call to GraphicsContext::didUpdateState() which may require an IPC call
in the case of GPUProcess DOM rendering.

Save the call to GraphicsContext::setImageInterpolationQuality() and make
GraphicsContext::drawNativeImageInternal() set the platform InterpolationQuality.

* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::paint):
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::drawImage):
(WebCore::GraphicsContext::drawTiledImage):
(WebCore::GraphicsContext::drawImageBuffer):
(WebCore::GraphicsContext::drawConsumingImageBuffer):
* Source/WebCore/platform/graphics/GraphicsContextStateSaver.h:
(WebCore::InterpolationQualityMaintainer::InterpolationQualityMaintainer): Deleted.
(WebCore::InterpolationQualityMaintainer::~InterpolationQualityMaintainer): Deleted.
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::drawNativeImageInternal):
(WebCore::GraphicsContextCG::drawPattern):
* Source/WebCore/rendering/RenderHTMLCanvas.cpp:
(WebCore::RenderHTMLCanvas::paintReplaced):
* Source/WebCore/rendering/RenderViewTransitionCapture.cpp:
(WebCore::RenderViewTransitionCapture::paintReplaced):
* Source/WebCore/rendering/style/NinePieceImage.cpp:
(WebCore::NinePieceImage::paint const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b4a30f9088c82d69276ffa9d01bc470a5798936

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27084 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50568 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43940 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50193 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24571 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38972 "Found 3 new test failures: fast/borders/border-image-pixelated.html, fast/images/image-rendering-interpolation.html, http/wpt/2dcontext/imagebitmap/createImageBitmap-sizing.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48469 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24764 "Found 3 new test failures: fast/canvas/canvas-imageSmoothingEnabled-repaint.html, fast/canvas/canvas-imageSmoothingEnabled.html, fast/canvas/canvas-imageSmoothingQuality.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41404 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20263 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22231 "Found 6 new test failures: imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-images-to-the-canvas/drawimage_canvas.html, imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-images-to-the-canvas/drawimage_html_image.html, imported/w3c/web-platform-tests/html/canvas/element/manual/image-smoothing/imagesmoothing.html, imported/w3c/web-platform-tests/html/canvas/offscreen/manual/image-smoothing/image.smoothing.html, imported/w3c/web-platform-tests/html/canvas/offscreen/manual/image-smoothing/image.smoothing.worker.html, imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/inferred-mrow-stretchy.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42584 "Found 8 new test failures: fast/canvas/canvas-imageSmoothingEnabled.html, fast/canvas/canvas-imageSmoothingQuality.html, fast/css/viewport-height-border.html, imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-images-to-the-canvas/drawimage_canvas.html, imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-images-to-the-canvas/drawimage_html_image.html, imported/w3c/web-platform-tests/html/canvas/element/manual/image-smoothing/imagesmoothing.html, imported/w3c/web-platform-tests/html/canvas/offscreen/manual/image-smoothing/image.smoothing.html, imported/w3c/web-platform-tests/html/canvas/offscreen/manual/image-smoothing/image.smoothing.worker.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5934 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44239 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43021 "Found 7 new test failures: fast/canvas/canvas-imageSmoothingEnabled.html, fast/canvas/canvas-imageSmoothingQuality.html, imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-images-to-the-canvas/drawimage_canvas.html, imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-images-to-the-canvas/drawimage_html_image.html, imported/w3c/web-platform-tests/html/canvas/element/manual/image-smoothing/imagesmoothing.html, imported/w3c/web-platform-tests/html/canvas/offscreen/manual/image-smoothing/image.smoothing.html, imported/w3c/web-platform-tests/html/canvas/offscreen/manual/image-smoothing/image.smoothing.worker.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52462 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22929 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19284 "Found 8 new test failures: fast/canvas/canvas-imageSmoothingEnabled.html, fast/canvas/canvas-imageSmoothingQuality.html, fast/mediastream/getUserMedia-to-canvas-1.html, imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-images-to-the-canvas/drawimage_canvas.html, imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-images-to-the-canvas/drawimage_html_image.html, imported/w3c/web-platform-tests/html/canvas/element/manual/image-smoothing/imagesmoothing.html, imported/w3c/web-platform-tests/html/canvas/offscreen/manual/image-smoothing/image.smoothing.html, imported/w3c/web-platform-tests/html/canvas/offscreen/manual/image-smoothing/image.smoothing.worker.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46266 "Found 3 new test failures: fast/borders/border-image-pixelated.html, fast/images/image-rendering-interpolation.html, http/wpt/2dcontext/imagebitmap/createImageBitmap-sizing.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24199 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45307 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24989 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23920 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->