### PR TITLE
heap-use-after-free | Style::Resolver::setViewTransitionStyles; WebCore::ViewTransition::updatePseudoElementStyles; WebCore::ViewTransition::activateViewTransition

### DIFF
--- a/LayoutTests/fast/css/view-transitions-update-pseudo-element-crash-expected.txt
+++ b/LayoutTests/fast/css/view-transitions-update-pseudo-element-crash-expected.txt
@@ -1,0 +1,2 @@
+
+Test passes if it doesn't crash

--- a/LayoutTests/fast/css/view-transitions-update-pseudo-element-crash.html
+++ b/LayoutTests/fast/css/view-transitions-update-pseudo-element-crash.html
@@ -1,0 +1,13 @@
+<script>
+    function crash() {
+        document.startViewTransition();
+        style = document.activeElement.style;
+        style.setProperty("overflow-y", "-webkit-paged-x");
+        if (window.testRunner)
+            testRunner.dumpAsText();
+    }
+</script>
+<body onload=crash()>
+    <video controls></video>
+    <p>Test passes if it doesn't crash</p>
+</body>

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -414,7 +414,7 @@ ExceptionOr<void> ViewTransition::captureNewState()
 
 void ViewTransition::setupDynamicStyleSheet(const AtomString& name, const CapturedElement& capturedElement)
 {
-    auto& resolver = protectedDocument()->styleScope().resolver();
+    Ref resolver = protectedDocument()->styleScope().resolver();
 
     // image animation name rule
     {
@@ -426,7 +426,7 @@ void ViewTransition::setupDynamicStyleSheet(const AtomString& name, const Captur
         Ref props = MutableStyleProperties::create();
         props->setProperty(CSSPropertyAnimationName, WTFMove(valueList));
 
-        resolver.setViewTransitionStyles(CSSSelector::PseudoElement::ViewTransitionOld, name, props);
+        resolver->setViewTransitionStyles(CSSSelector::PseudoElement::ViewTransitionOld, name, props);
     }
 
     {
@@ -438,7 +438,7 @@ void ViewTransition::setupDynamicStyleSheet(const AtomString& name, const Captur
         Ref props = MutableStyleProperties::create();
         props->setProperty(CSSPropertyAnimationName, WTFMove(valueList));
 
-        resolver.setViewTransitionStyles(CSSSelector::PseudoElement::ViewTransitionNew, name, props);
+        resolver->setViewTransitionStyles(CSSSelector::PseudoElement::ViewTransitionNew, name, props);
     }
 
     if (!capturedElement.oldImage || !capturedElement.newElement)
@@ -450,7 +450,7 @@ void ViewTransition::setupDynamicStyleSheet(const AtomString& name, const Captur
         Ref props = MutableStyleProperties::create();
         props->setProperty(CSSPropertyAnimationName, WTFMove(list));
 
-        resolver.setViewTransitionStyles(CSSSelector::PseudoElement::ViewTransitionGroup, name, props);
+        resolver->setViewTransitionStyles(CSSSelector::PseudoElement::ViewTransitionGroup, name, props);
     }
 
     // image pair isolation rule
@@ -458,7 +458,7 @@ void ViewTransition::setupDynamicStyleSheet(const AtomString& name, const Captur
         Ref props = MutableStyleProperties::create();
         props->setProperty(CSSPropertyIsolation, CSSPrimitiveValue::create(CSSValueID::CSSValueIsolate));
 
-        resolver.setViewTransitionStyles(CSSSelector::PseudoElement::ViewTransitionImagePair, name, props);
+        resolver->setViewTransitionStyles(CSSSelector::PseudoElement::ViewTransitionImagePair, name, props);
     }
 
     if (!capturedElement.oldProperties)
@@ -478,7 +478,7 @@ void ViewTransition::setupDynamicStyleSheet(const AtomString& name, const Captur
     keyframes->wrapperAppendKeyframe(WTFMove(keyframe));
 
     // We can add this to the normal namespace, since we recreate the resolver when the view-transition ends.
-    resolver.addKeyframeStyle(WTFMove(keyframes));
+    resolver->addKeyframeStyle(WTFMove(keyframes));
 }
 
 // https://drafts.csswg.org/css-view-transitions/#setup-transition-pseudo-elements
@@ -672,7 +672,7 @@ Ref<MutableStyleProperties> ViewTransition::copyElementBaseProperties(Element& e
 // https://drafts.csswg.org/css-view-transitions-1/#update-pseudo-element-styles
 ExceptionOr<void> ViewTransition::updatePseudoElementStyles()
 {
-    auto& resolver = protectedDocument()->styleScope().resolver();
+    Ref resolver = protectedDocument()->styleScope().resolver();
 
     for (auto& [name, capturedElement] : m_namedElements.map()) {
         RefPtr<MutableStyleProperties> properties;
@@ -705,7 +705,7 @@ ExceptionOr<void> ViewTransition::updatePseudoElementStyles()
             // group styles rule
             if (!capturedElement->groupStyleProperties) {
                 capturedElement->groupStyleProperties = properties;
-                resolver.setViewTransitionStyles(CSSSelector::PseudoElement::ViewTransitionGroup, name, *properties);
+                resolver->setViewTransitionStyles(CSSSelector::PseudoElement::ViewTransitionGroup, name, *properties);
             } else
                 capturedElement->groupStyleProperties->mergeAndOverrideOnConflict(*properties);
         }


### PR DESCRIPTION
#### 84ebf5141996487b18210ca5c38429477fc7eb23
<pre>
heap-use-after-free | Style::Resolver::setViewTransitionStyles; WebCore::ViewTransition::updatePseudoElementStyles; WebCore::ViewTransition::activateViewTransition
<a href="https://bugs.webkit.org/show_bug.cgi?id=272709">https://bugs.webkit.org/show_bug.cgi?id=272709</a>
<a href="https://rdar.apple.com/125944789">rdar://125944789</a>

Reviewed by Chris Dumez.

Adopt `Ref` smart pointer to fix the UAF.

* LayoutTests/fast/css/view-transitions-update-pseudo-element-crash-expected.txt: Added.
* LayoutTests/fast/css/view-transitions-update-pseudo-element-crash.html: Added.
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::setupDynamicStyleSheet):
(WebCore::ViewTransition::updatePseudoElementStyles):

Canonical link: <a href="https://commits.webkit.org/277521@main">https://commits.webkit.org/277521@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c539a156ee0695c14101209e5cc12594372c311e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27077 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/50717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50561 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43933 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50186 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32948 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24563 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38953 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48462 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/24748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/50717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20249 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/22226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/50717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5927 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/44234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/50717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52455 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/22922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/19267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46259 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/24192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/50717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/45299 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10559 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/24981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23911 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->