### PR TITLE
[view-transitions] https://simple-set-demos.glitch.me/gross-cube-transition doesn't render 3d effects.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-preserve-3d-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-preserve-3d-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: transform-style: preserve-3d is respected on pseudo elements</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+
+<style>
+body {
+  background: pink;
+}
+div {
+  width: 200px;
+  height: 200px;
+  background: green;
+}
+
+</style>
+
+<div id="target"></div>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-preserve-3d-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-preserve-3d-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: transform-style: preserve-3d is respected on pseudo elements</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+
+<style>
+body {
+  background: pink;
+}
+div {
+  width: 200px;
+  height: 200px;
+  background: green;
+}
+
+</style>
+
+<div id="target"></div>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-preserve-3d.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-preserve-3d.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>View transitions: transform-style: preserve-3d is respected on pseudo elements</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<link rel="author" href="mailto:mattwoodrow@apple.com">
+<link rel="match" href="pseudo-element-preserve-3d-ref.html">
+<script src="/common/reftest-wait.js"></script>
+<style>
+div {
+  width: 200px;
+  height: 200px;
+  background: green;
+  view-transition-name: target;
+}
+
+/* We're verifying what we capture, so just display the old contents for 5 minutes.  */
+html::view-transition-group(*) { animation-duration: 300s; }
+html::view-transition-group(target) { background: green; }
+html::view-transition-new(*) { animation: unset; opacity: 0; }
+html::view-transition-old(*) { animation: unset; opacity: 1; }
+/* hide the root so we show transition background to ensure we're in a transition */
+html::view-transition-group(root) { animation: unset; opacity: 0; }
+html::view-transition { background: pink; }
+html::view-transition-image-pair(target) {
+  transform: rotateX(90deg);
+  transform-style: preserve-3d;
+}
+html::view-transition-old(target) {
+  transform: rotateX(90deg);
+}
+</style>
+
+<div id="target"></div>
+<script>
+failIfNot(document.startViewTransition, "Missing document.startViewTransition");
+
+async function runTest() {
+  let t = document.startViewTransition();
+  t.ready.then(takeScreenshot);
+}
+onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>
+
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -4084,18 +4084,20 @@ Ref<HitTestingTransformState> RenderLayer::createLocalTransformState(RenderLayer
     return transformState.releaseNonNull();
 }
 
-static bool parentLayerIsDOMParent(const RenderLayer& layer)
+bool RenderLayer::ancestorLayerIsDOMParent(const RenderLayer* ancestor) const
 {
-    if (!layer.parent())
+    if (!ancestor)
         return false;
-    if (!layer.renderer().element() || !layer.renderer().element()->parentElementInComposedTree())
-        return false;
-    return layer.parent()->renderer().element() == layer.renderer().element()->parentElementInComposedTree();
+    if (renderer().element() && ancestor->renderer().element() == renderer().element()->parentElementInComposedTree())
+        return true;
+
+    std::optional<PseudoId> parentPseudoId = parentPseudoElement(renderer().style().pseudoElementType());
+    return parentPseudoId && *parentPseudoId == ancestor->renderer().style().pseudoElementType();
 }
 
 bool RenderLayer::participatesInPreserve3D() const
 {
-    return parentLayerIsDOMParent(*this) && parent()->preserves3D() && (transform() || renderer().style().backfaceVisibility() == BackfaceVisibility::Hidden || preserves3D());
+    return ancestorLayerIsDOMParent(parent()) && parent()->preserves3D() && (transform() || renderer().style().backfaceVisibility() == BackfaceVisibility::Hidden || preserves3D());
 }
 
 // hitTestLocation and hitTestRect are relative to rootLayer.

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -884,6 +884,8 @@ public:
 
     void paintSVGResourceLayer(GraphicsContext&, const AffineTransform& contentTransform);
 
+    bool ancestorLayerIsDOMParent(const RenderLayer* ancestor) const;
+
 private:
 
     void setNextSibling(RenderLayer* next) { m_next = next; }

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -2381,15 +2381,6 @@ void RenderLayerBacking::positionOverflowControlsLayers()
     }
 }
 
-static bool ancestorLayerIsDOMParent(RenderLayer& layer, const RenderLayer* compositingAncestor)
-{
-    if (!compositingAncestor)
-        return false;
-    if (!layer.renderer().element() || !layer.renderer().element()->parentElementInComposedTree())
-        return false;
-    return compositingAncestor->renderer().element() == layer.renderer().element()->parentElementInComposedTree();
-}
-
 static bool ancestorLayerWillCombineTransform(const RenderLayer* compositingAncestor)
 {
     if (!compositingAncestor)
@@ -2401,7 +2392,7 @@ bool RenderLayerBacking::updateTransformFlatteningLayer(const RenderLayer* compo
 {
     bool needsFlatteningLayer = false;
     // If our parent layer has preserve-3d or perspective, and it's not our DOM parent, then we need a flattening layer to block that from being applied in 3d.
-    if (ancestorLayerWillCombineTransform(compositingAncestor) && !ancestorLayerIsDOMParent(m_owningLayer, compositingAncestor))
+    if (ancestorLayerWillCombineTransform(compositingAncestor) && !m_owningLayer.ancestorLayerIsDOMParent(compositingAncestor))
         needsFlatteningLayer = true;
 
     bool layerChanged = false;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -118,6 +118,18 @@ enum class PseudoId : uint32_t {
     PublicPseudoIdMask = ((1 << FirstInternalPseudoId) - 1) & ~((1 << FirstPublicPseudoId) - 1)
 };
 
+inline std::optional<PseudoId> parentPseudoElement(PseudoId pseudoId)
+{
+    switch (pseudoId) {
+    case PseudoId::FirstLetter: return PseudoId::FirstLine;
+    case PseudoId::ViewTransitionGroup: return PseudoId::ViewTransition;
+    case PseudoId::ViewTransitionImagePair: return PseudoId::ViewTransitionGroup;
+    case PseudoId::ViewTransitionNew: return PseudoId::ViewTransitionImagePair;
+    case PseudoId::ViewTransitionOld: return PseudoId::ViewTransitionImagePair;
+    default: return std::nullopt;
+    }
+}
+
 class PseudoIdSet {
 public:
     PseudoIdSet()

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -563,26 +563,9 @@ ResolutionContext TreeResolver::makeResolutionContext()
 ResolutionContext TreeResolver::makeResolutionContextForPseudoElement(const ElementUpdate& elementUpdate, const PseudoElementIdentifier& pseudoElementIdentifier)
 {
     auto parentStyle = [&]() -> const RenderStyle* {
-        switch (pseudoElementIdentifier.pseudoId) {
-        case PseudoId::FirstLetter:
-            if (auto* firstLineStyle = elementUpdate.style->getCachedPseudoStyle({ PseudoId::FirstLine }))
-                return firstLineStyle;
-            break;
-        case PseudoId::ViewTransitionGroup:
-            if (auto* viewTransitionStyle = elementUpdate.style->getCachedPseudoStyle({ PseudoId::ViewTransition }))
-                return viewTransitionStyle;
-            break;
-        case PseudoId::ViewTransitionImagePair:
-            if (auto* groupStyle = elementUpdate.style->getCachedPseudoStyle({ PseudoId::ViewTransitionGroup, pseudoElementIdentifier.nameArgument }))
-                return groupStyle;
-            break;
-        case PseudoId::ViewTransitionOld:
-        case PseudoId::ViewTransitionNew:
-            if (auto* imagePairStyle = elementUpdate.style->getCachedPseudoStyle({ PseudoId::ViewTransitionImagePair, pseudoElementIdentifier.nameArgument }))
-                return imagePairStyle;
-            break;
-        default:
-            break;
+        if (auto parentPseudoId = parentPseudoElement(pseudoElementIdentifier.pseudoId)) {
+            if (auto* parentPseudoStyle = elementUpdate.style->getCachedPseudoStyle({ *parentPseudoId, (*parentPseudoId == PseudoId::ViewTransitionGroup || *parentPseudoId == PseudoId::ViewTransitionImagePair) ? pseudoElementIdentifier.nameArgument : nullAtom() }))
+                return parentPseudoStyle;
         }
         return elementUpdate.style.get();
     };


### PR DESCRIPTION
#### 84c369e893d8167a747e771777a93565c0d7e9df
<pre>
[view-transitions] <a href="https://simple-set-demos.glitch.me/gross-cube-transition">https://simple-set-demos.glitch.me/gross-cube-transition</a> doesn&apos;t render 3d effects.
<a href="https://bugs.webkit.org/show_bug.cgi?id=272713">https://bugs.webkit.org/show_bug.cgi?id=272713</a>
&lt;<a href="https://rdar.apple.com/126513916">rdar://126513916</a>&gt;

Reviewed by Tim Nguyen.

ancestorLayerIsDOMParent (used for determing if &apos;transform-style: preserve-3d&apos;
from the parent should be applied) was only taking into account &apos;Element&apos; ancestors.
Add support for also checking for pseudo-element parents in the view-transition
tree.

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-preserve-3d-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-preserve-3d-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-preserve-3d.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::ancestorLayerIsDOMParent const):
(WebCore::RenderLayer::participatesInPreserve3D const):
(WebCore::parentLayerIsDOMParent): Deleted.
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateTransformFlatteningLayer):
(WebCore::ancestorLayerIsDOMParent): Deleted.
* Source/WebCore/rendering/style/RenderStyleConstants.h:
(WebCore::parentPseudoElement):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::makeResolutionContextForPseudoElement):

Canonical link: <a href="https://commits.webkit.org/277639@main">https://commits.webkit.org/277639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ce8098638416987776c8c082f2aedbc43e25bc5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27228 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50941 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50710 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44081 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50330 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24720 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39270 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Passed layout tests; 27 flakes 77 failures; Uploaded test results") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48606 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24901 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41545 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20365 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22382 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42721 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6074 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44368 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43156 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52603 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23071 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19426 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46610 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; layout-tests (exception)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41695 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45432 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10630 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25136 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24057 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->