### PR TITLE
[Site Isolation] Properly create scrolling tree for web process with multiple root frames

### DIFF
--- a/LayoutTests/http/tests/site-isolation/scrolling/multiple-root-frames-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/scrolling/multiple-root-frames-expected.txt
@@ -1,0 +1,51 @@
+Verifies scrolling tree for page with multiple iframes in the same process.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+(scrolling tree
+  (frame scrolling node
+    (scrollable area size width=800 height=600)
+    (total content size width=800 height=600)
+    (last committed scroll position (0,0))
+    (scrollable area parameters
+      (horizontal scroll elasticity 2)
+      (vertical scroll elasticity 2)
+      (horizontal scrollbar mode 0)
+      (vertical scrollbar mode 0))
+    (layout viewport (0,0) width=800 height=600)
+    (min layoutViewport origin (0,0))
+    (max layoutViewport origin (0,0))
+    (behavior for fixed 1)
+    (frame hosting node
+      (has hosting context identifier )
+      (frame scrolling node
+        (scrollable area size width=300 height=400)
+        (total content size width=300 height=400)
+        (last committed scroll position (0,0))
+        (scrollable area parameters
+          (horizontal scroll elasticity 0)
+          (vertical scroll elasticity 0)
+          (horizontal scrollbar mode 0)
+          (vertical scrollbar mode 0))
+        (layout viewport (0,0) width=300 height=400)
+        (min layoutViewport origin (0,0))
+        (max layoutViewport origin (0,0))
+        (behavior for fixed 1)))
+    (frame hosting node
+      (has hosting context identifier )
+      (frame scrolling node
+        (scrollable area size width=200 height=100)
+        (total content size width=200 height=100)
+        (last committed scroll position (0,0))
+        (scrollable area parameters
+          (horizontal scroll elasticity 0)
+          (vertical scroll elasticity 0)
+          (horizontal scrollbar mode 0)
+          (vertical scrollbar mode 0))
+        (layout viewport (0,0) width=200 height=100)
+        (min layoutViewport origin (0,0))
+        (max layoutViewport origin (0,0))
+        (behavior for fixed 1)))))
+

--- a/LayoutTests/http/tests/site-isolation/scrolling/multiple-root-frames.html
+++ b/LayoutTests/http/tests/site-isolation/scrolling/multiple-root-frames.html
@@ -5,7 +5,7 @@
     <pre id="scrollingTree"></pre>
 </body>
 <script>
-description("Verifies scrolling tree for simple page.");
+description("Verifies scrolling tree for page with multiple iframes in the same process.");
 jsTestIsAsync = true;
 
 if (window.testRunner) {
@@ -17,9 +17,11 @@ window.addEventListener('load', async () => {
     if (!window.internals)
         return
 
+    await UIHelper.ensurePresentationUpdate();
     document.getElementById('scrollingTree').innerText = await UIHelper.getScrollingTree();
     if (window.testRunner)
         testRunner.notifyDone();
 }, false);
 </script>
-<iframe width="300" height="300" src="http://localhost:8000/site-isolation/scrolling/resources/empty-iframe.html"></iframe>
+<iframe width="300" height="400" src="http://localhost:8000/site-isolation/scrolling/resources/empty-iframe.html"></iframe>
+<iframe width="200" height="100" src="http://localhost:8000/site-isolation/scrolling/resources/empty-iframe.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/scrolling/remove-root-frame-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/scrolling/remove-root-frame-expected.txt
@@ -1,0 +1,36 @@
+Verifies that root frames are successfully removed from scrolling trees when removed from the DOM.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+(scrolling tree
+  (frame scrolling node
+    (scrollable area size width=800 height=600)
+    (total content size width=800 height=600)
+    (last committed scroll position (0,0))
+    (scrollable area parameters
+      (horizontal scroll elasticity 2)
+      (vertical scroll elasticity 2)
+      (horizontal scrollbar mode 0)
+      (vertical scrollbar mode 0))
+    (layout viewport (0,0) width=800 height=600)
+    (min layoutViewport origin (0,0))
+    (max layoutViewport origin (0,0))
+    (behavior for fixed 1)
+    (frame hosting node
+      (has hosting context identifier )
+      (frame scrolling node
+        (scrollable area size width=300 height=400)
+        (total content size width=300 height=400)
+        (last committed scroll position (0,0))
+        (scrollable area parameters
+          (horizontal scroll elasticity 0)
+          (vertical scroll elasticity 0)
+          (horizontal scrollbar mode 0)
+          (vertical scrollbar mode 0))
+        (layout viewport (0,0) width=300 height=400)
+        (min layoutViewport origin (0,0))
+        (max layoutViewport origin (0,0))
+        (behavior for fixed 1)))))
+

--- a/LayoutTests/http/tests/site-isolation/scrolling/remove-root-frame.html
+++ b/LayoutTests/http/tests/site-isolation/scrolling/remove-root-frame.html
@@ -1,0 +1,30 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<body>
+    <pre id="scrollingTree"></pre>
+</body>
+<script>
+description("Verifies that root frames are successfully removed from scrolling trees when removed from the DOM.");
+jsTestIsAsync = true;
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();            
+}
+
+window.addEventListener('load', async () => {
+    if (!window.internals)
+        return
+    frameToRemove.parentElement.removeChild(frameToRemove);
+    if (window.GCController)
+        GCController.collect();
+    document.getElementById('scrollingTree').innerText = await UIHelper.getScrollingTree();
+    setTimeout(function() {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 500);
+}, false);
+</script>
+<iframe width="300" height="400" src="http://localhost:8000/site-isolation/scrolling/resources/empty-iframe.html"></iframe>
+<iframe width="200" height="100" id=frameToRemove src="http://localhost:8000/site-isolation/scrolling/resources/empty-iframe.html"></iframe>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4646,7 +4646,7 @@ webkit.org/b/257904 http/tests/site-isolation/page-zoom.html [ Skip ]
 webkit.org/b/257904 http/tests/site-isolation/selection-focus.html [ Skip ]
 webkit.org/b/257904 http/tests/site-isolation/basic-iframe-render-output.html [ Failure Timeout Pass ]
 
-webkit.org/b/269550 http/tests/site-isolation/scrolling/basic-scrolling-tree.html [ Skip ]
+webkit.org/b/269550 http/tests/site-isolation/scrolling/ [ Skip ]
 
 # This test can't be enabled on iOS until EventSenderProxyIOS::keyDown() is implemented.
 http/tests/site-isolation/key-events.html [ Skip ]

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -853,6 +853,7 @@
 		E4A0AD3D1A96253C00536DF6 /* WorkQueueCocoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4A0AD3C1A96253C00536DF6 /* WorkQueueCocoa.cpp */; };
 		EB2C86D9267B275D0052CB9A /* CPUTimePOSIX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB2C86D8267B275C0052CB9A /* CPUTimePOSIX.cpp */; };
 		EB61EDC72409CCC1001EFE36 /* SystemTracingCocoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB61EDC62409CCC0001EFE36 /* SystemTracingCocoa.cpp */; };
+		FA0C387B2BEAD56B00583842 /* SmallMap.h in Headers */ = {isa = PBXBuildFile; fileRef = FA0C387A2BEAD56B00583842 /* SmallMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE032AD22463E43B0012D7C7 /* WTFConfig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE032AD02463E43B0012D7C7 /* WTFConfig.cpp */; };
 		FE03831C2ABC04F700A576A2 /* TZoneMallocInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FE03831A2ABC04F700A576A2 /* TZoneMallocInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE03831D2ABC04F700A576A2 /* TZoneMalloc.h in Headers */ = {isa = PBXBuildFile; fileRef = FE03831B2ABC04F700A576A2 /* TZoneMalloc.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1818,6 +1819,7 @@
 		EF7D6CD59D8642A8A0DA86AD /* StackTrace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StackTrace.h; sourceTree = "<group>"; };
 		F6D67D3226F90142006E0349 /* Int128.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Int128.h; sourceTree = "<group>"; };
 		F72BBDB107FA424886178B9E /* SymbolImpl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SymbolImpl.cpp; sourceTree = "<group>"; };
+		FA0C387A2BEAD56B00583842 /* SmallMap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SmallMap.h; sourceTree = "<group>"; };
 		FE032AD02463E43B0012D7C7 /* WTFConfig.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WTFConfig.cpp; sourceTree = "<group>"; };
 		FE032AD12463E43B0012D7C7 /* WTFConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WTFConfig.h; sourceTree = "<group>"; };
 		FE03831A2ABC04F700A576A2 /* TZoneMallocInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TZoneMallocInlines.h; sourceTree = "<group>"; };
@@ -2382,6 +2384,7 @@
 				A748744F17A0BDAE00FA04CB /* SixCharacterHash.cpp */,
 				A748745017A0BDAE00FA04CB /* SixCharacterHash.h */,
 				A8A4730C151A825B004123FF /* SizeLimits.cpp */,
+				FA0C387A2BEAD56B00583842 /* SmallMap.h */,
 				0FA6F39220CC73A200A03DCD /* SmallSet.cpp */,
 				7936D6A91C99F8AE000D1AED /* SmallSet.h */,
 				A30D412D1F0DE13F00B71954 /* SoftLinking.h */,
@@ -3427,6 +3430,7 @@
 				DD3DC89627A4BF8E007E5B61 /* SinglyLinkedList.h in Headers */,
 				DD3DC99427A4BF8E007E5B61 /* SinglyLinkedListWithTail.h in Headers */,
 				DD3DC92F27A4BF8E007E5B61 /* SixCharacterHash.h in Headers */,
+				FA0C387B2BEAD56B00583842 /* SmallMap.h in Headers */,
 				DD3DC8DE27A4BF8E007E5B61 /* SmallSet.h in Headers */,
 				DDF3076727C086CD006A526F /* SoftLinking.h in Headers */,
 				DD3DC8D727A4BF8E007E5B61 /* SoftLinking.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -265,6 +265,7 @@ set(WTF_PUBLIC_HEADERS
     SinglyLinkedList.h
     SinglyLinkedListWithTail.h
     SixCharacterHash.h
+    SmallMap.h
     SmallSet.h
     SoftLinking.h
     SortedArrayMap.h

--- a/Source/WTF/wtf/SmallMap.h
+++ b/Source/WTF/wtf/SmallMap.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <variant>
+#include <wtf/HashMap.h>
+#include <wtf/ScopedLambda.h>
+#include <wtf/StdLibExtras.h>
+
+namespace WTF {
+
+// This is a map optimized for holding 0 or 1 items with no hashing or allocations in those cases.
+template<typename Key, typename Value>
+class SmallMap {
+public:
+    using Pair = KeyValuePair<Key, Value>;
+    using Map = HashMap<Key, Value>;
+    using Storage = std::variant<std::monostate, Pair, Map>;
+
+    static_assert(sizeof(Pair) <= 4 * sizeof(uint64_t), "Don't use SmallMap with large types. It probably wastes memory.");
+
+    Value& ensure(const Key& key, const auto& functor)
+    {
+        ASSERT(Map::isValidKey(key));
+        if (std::holds_alternative<std::monostate>(m_storage)) {
+            m_storage = Pair { key, functor() };
+            return std::get<Pair>(m_storage).value;
+        }
+        if (auto* pair = std::get_if<Pair>(&m_storage)) {
+            if (pair->key == key)
+                return pair->value;
+            Map map;
+            map.add(WTFMove(pair->key), WTFMove(pair->value));
+            m_storage = WTFMove(map);
+            return std::get<Map>(m_storage).add(key, functor()).iterator->value;
+        }
+        return std::get<Map>(m_storage).ensure(key, functor).iterator->value;
+    }
+
+    void remove(const Key& key)
+    {
+        ASSERT(Map::isValidKey(key));
+        if (auto* pair = std::get_if<Pair>(&m_storage)) {
+            if (pair->key == key)
+                m_storage = std::monostate { };
+        } else if (auto* map = std::get_if<Map>(&m_storage))
+            map->remove(key);
+    }
+
+    const Value* get(const Key& key) const
+    {
+        ASSERT(Map::isValidKey(key));
+        if (auto* pair = std::get_if<Pair>(&m_storage)) {
+            if (pair->key == key)
+                return std::addressof(pair->value);
+        } else if (auto* map = std::get_if<Map>(&m_storage)) {
+            if (auto it = map->find(key); it != map->end())
+                return std::addressof(it->value);
+        }
+        return nullptr;
+    }
+
+    void forEach(const auto& callback) const
+    {
+        switchOn(m_storage, [&] (const std::monostate&) {
+        }, [&] (const Pair& pair) {
+            callback(pair.key, pair.value);
+        }, [&] (const Map& map) {
+            for (auto& [key, value] : map)
+                callback(key, value);
+        });
+    }
+
+    size_t size() const
+    {
+        return switchOn(m_storage, [&] (const std::monostate&) {
+            return 0u;
+        }, [&] (const Pair&) {
+            return 1u;
+        }, [&] (const Map& map) {
+            return map.size();
+        });
+    }
+
+    const Storage& rawStorage() const { return m_storage; }
+
+private:
+    Storage m_storage;
+};
+
+} // namespace WTF
+
+using WTF::SmallMap;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6716,7 +6716,7 @@ void Document::setBackForwardCacheState(BackForwardCacheState state)
             if (page && m_frame->isMainFrame()) {
                 frameView->resetScrollbarsAndClearContentsSize();
                 if (RefPtr scrollingCoordinator = page->scrollingCoordinator())
-                    scrollingCoordinator->clearAllNodes();
+                    scrollingCoordinator->clearAllNodes(m_frame->rootFrame().frameID());
             }
         }
 

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -233,8 +233,11 @@ LocalFrame::~LocalFrame()
         localMainFrame->selfOnlyDeref();
 
     if (isRootFrame()) {
-        if (RefPtr page = this->page())
+        if (RefPtr page = this->page()) {
             page->removeRootFrame(*this);
+            if (auto* scrollingCoordinator = page->scrollingCoordinator())
+                scrollingCoordinator->rootFrameWasRemoved(frameID());
+        }
     }
 }
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -6194,6 +6194,11 @@ void LocalFrameView::scrollbarStyleDidChange()
     scrollbarsController().updateScrollbarStyle();
 }
 
+FrameIdentifier LocalFrameView::rootFrameID() const
+{
+    return m_frame->rootFrame().frameID();
+}
+
 } // namespace WebCore
 
 #undef PAGE_ID

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -724,6 +724,8 @@ public:
 
     WEBCORE_EXPORT void scrollbarStyleDidChange();
 
+    FrameIdentifier rootFrameID() const final;
+
 private:
     explicit LocalFrameView(LocalFrame&);
 

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -62,7 +62,6 @@ namespace WebCore {
 
 AsyncScrollingCoordinator::AsyncScrollingCoordinator(Page* page)
     : ScrollingCoordinator(page)
-    , m_scrollingStateTree(makeUnique<ScrollingStateTree>(this))
     , m_hysterisisActivity([this](auto state) { hysterisisTimerFired(state); }, 200_ms)
 {
 }
@@ -109,7 +108,17 @@ void AsyncScrollingCoordinator::handleWheelEventPhase(ScrollingNodeID nodeID, Pl
 
 RefPtr<ScrollingStateNode> AsyncScrollingCoordinator::stateNodeForNodeID(ScrollingNodeID nodeID) const
 {
-    return m_scrollingStateTree->stateNodeForID(nodeID);
+    return WTF::switchOn(m_scrollingStateTrees.rawStorage(), [] (const std::monostate&) -> RefPtr<ScrollingStateNode> {
+        return nullptr;
+    }, [&] (const KeyValuePair<FrameIdentifier, UniqueRef<ScrollingStateTree>>& pair) {
+        return pair.value->stateNodeForID(nodeID);
+    }, [&] (const HashMap<FrameIdentifier, UniqueRef<ScrollingStateTree>>& map) -> RefPtr<ScrollingStateNode> {
+        for (auto& tree : map.values()) {
+            if (RefPtr scrollingNode = tree->stateNodeForID(nodeID))
+                return scrollingNode;
+        }
+        return nullptr;
+    });
 }
 
 RefPtr<ScrollingStateNode> AsyncScrollingCoordinator::stateNodeForScrollableArea(const ScrollableArea& scrollableArea) const
@@ -117,7 +126,47 @@ RefPtr<ScrollingStateNode> AsyncScrollingCoordinator::stateNodeForScrollableArea
     auto scrollingNodeID = scrollableArea.scrollingNodeID();
     if (!scrollingNodeID)
         return nullptr;
-    return m_scrollingStateTree->stateNodeForID(scrollingNodeID);
+    if (auto* scrollingStateTree = existingScrollingStateTreeForRootFrameID(scrollableArea.rootFrameID()))
+        return scrollingStateTree->stateNodeForID(scrollingNodeID);
+    return nullptr;
+}
+
+ScrollingStateTree& AsyncScrollingCoordinator::ensureScrollingStateTreeForRootFrameID(FrameIdentifier rootFrameID)
+{
+    ASSERT(Frame::isRootFrameIdentifier(rootFrameID));
+    return m_scrollingStateTrees.ensure(rootFrameID, [&] {
+        return makeUniqueRef<ScrollingStateTree>(this);
+    });
+}
+
+const ScrollingStateTree* AsyncScrollingCoordinator::existingScrollingStateTreeForRootFrameID(FrameIdentifier rootFrameID) const
+{
+    auto* result = m_scrollingStateTrees.get(rootFrameID);
+    if (!result)
+        return nullptr;
+    return &result->get();
+}
+
+void AsyncScrollingCoordinator::rootFrameWasRemoved(FrameIdentifier rootFrameID)
+{
+    m_scrollingStateTrees.remove(rootFrameID);
+}
+
+ScrollingStateTree* AsyncScrollingCoordinator::stateTreeForNodeID(ScrollingNodeID nodeID) const
+{
+    return WTF::switchOn(m_scrollingStateTrees.rawStorage(), [] (const std::monostate&) -> ScrollingStateTree* {
+        return nullptr;
+    }, [&] (const KeyValuePair<FrameIdentifier, UniqueRef<ScrollingStateTree>>& pair) -> ScrollingStateTree* {
+        if (RefPtr scrollingNode = pair.value->stateNodeForID(nodeID))
+            return pair.value.ptr();
+        return nullptr;
+    }, [&] (const HashMap<FrameIdentifier, UniqueRef<ScrollingStateTree>>& map) -> ScrollingStateTree* {
+        for (auto& tree : map.values()) {
+            if (RefPtr scrollingNode = tree->stateNodeForID(nodeID))
+                return tree.ptr();
+        }
+        return nullptr;
+    });
 }
 
 static inline void setStateScrollingNodeSnapOffsetsAsFloat(ScrollingStateScrollingNode& node, const LayoutScrollSnapOffsetsInfo* offsetInfo, float deviceScaleFactor)
@@ -131,20 +180,21 @@ static inline void setStateScrollingNodeSnapOffsetsAsFloat(ScrollingStateScrolli
     node.setSnapOffsetsInfo(offsetInfo->convertUnits<FloatScrollSnapOffsetsInfo>(deviceScaleFactor));
 }
 
-void AsyncScrollingCoordinator::willCommitTree()
+void AsyncScrollingCoordinator::willCommitTree(FrameIdentifier rootFrameID)
 {
-    updateEventTrackingRegions();
+    updateEventTrackingRegions(rootFrameID);
 }
 
-void AsyncScrollingCoordinator::updateEventTrackingRegions()
+void AsyncScrollingCoordinator::updateEventTrackingRegions(FrameIdentifier rootFrameID)
 {
     if (!m_eventTrackingRegionsDirty)
         return;
 
-    if (!m_scrollingStateTree->rootStateNode())
+    auto* scrollingStateTree = existingScrollingStateTreeForRootFrameID(rootFrameID);
+    if (!scrollingStateTree || !scrollingStateTree->rootStateNode())
         return;
 
-    m_scrollingStateTree->rootStateNode()->setEventTrackingRegions(absoluteEventTrackingRegions());
+    scrollingStateTree->rootStateNode()->setEventTrackingRegions(absoluteEventTrackingRegions());
     m_eventTrackingRegionsDirty = false;
 }
 
@@ -155,8 +205,10 @@ void AsyncScrollingCoordinator::frameViewLayoutUpdated(LocalFrameView& frameView
 
     m_eventTrackingRegionsDirty = true;
 
+    auto scrollingStateNode = stateNodeForNodeID(frameView.scrollingNodeID());
+
     // If there isn't a root node yet, don't do anything. We'll be called again after creating one.
-    if (!m_scrollingStateTree->rootStateNode())
+    if (!scrollingStateNode)
         return;
 
     // We have to schedule a commit, but the computed non-fast region may not have actually changed.
@@ -234,7 +286,7 @@ void AsyncScrollingCoordinator::updateIsMonitoringWheelEventsForFrameView(const 
 void AsyncScrollingCoordinator::frameViewEventTrackingRegionsChanged(LocalFrameView& frameView)
 {
     m_eventTrackingRegionsDirty = true;
-    if (!m_scrollingStateTree->rootStateNode())
+    if (!ensureScrollingStateTreeForRootFrameID(frameView.frame().rootFrame().frameID()).rootStateNode())
         return;
 
     // We have to schedule a commit, but the computed non-fast region may not have actually changed.
@@ -487,7 +539,10 @@ void AsyncScrollingCoordinator::scheduleRenderingUpdate()
 LocalFrameView* AsyncScrollingCoordinator::frameViewForScrollingNode(LocalFrame& rootFrame, ScrollingNodeID scrollingNodeID) const
 {
     ASSERT(rootFrame.isRootFrame());
-    if (scrollingNodeID == m_scrollingStateTree->rootStateNode()->scrollingNodeID()) {
+    auto* scrollingStateTree = existingScrollingStateTreeForRootFrameID(rootFrame.frameID());
+    if (!scrollingStateTree || !scrollingStateTree->rootStateNode())
+        return nullptr;
+    if (scrollingNodeID == scrollingStateTree->rootStateNode()->scrollingNodeID()) {
         if (rootFrame.view() && rootFrame.view()->scrollingNodeID() == scrollingNodeID)
             return rootFrame.view();
     }
@@ -521,7 +576,7 @@ LocalFrameView* AsyncScrollingCoordinator::frameViewForScrollingNode(LocalFrame&
 
 LocalFrameView* AsyncScrollingCoordinator::frameViewForScrollingNode(ScrollingNodeID scrollingNodeID) const
 {
-    if (!m_scrollingStateTree->rootStateNode() || !page())
+    if (!page())
         return nullptr;
     for (const auto& rootFrame : page()->rootFrames()) {
         if (RefPtr frameView = frameViewForScrollingNode(rootFrame.get(), scrollingNodeID))
@@ -809,39 +864,43 @@ void AsyncScrollingCoordinator::scrollableAreaScrollbarLayerDidChange(Scrollable
         scrollableArea.horizontalScrollbarLayerDidChange();
 }
 
-ScrollingNodeID AsyncScrollingCoordinator::createNode(ScrollingNodeType nodeType, ScrollingNodeID newNodeID)
+ScrollingNodeID AsyncScrollingCoordinator::createNode(FrameIdentifier rootFrameID, ScrollingNodeType nodeType, ScrollingNodeID newNodeID)
 {
     LOG_WITH_STREAM(ScrollingTree, stream << "AsyncScrollingCoordinator::createNode " << nodeType << " node " << newNodeID);
+    auto& scrollingStateTree = ensureScrollingStateTreeForRootFrameID(rootFrameID);
     // TODO: rdar://123052250 Need a better way to fix scrolling tree in iframe process
-    if ((!m_scrollingStateTree->rootStateNode() && nodeType == ScrollingNodeType::Subframe) || (m_scrollingStateTree->rootStateNode() && m_scrollingStateTree->rootStateNode()->scrollingNodeID() == newNodeID))
-        return m_scrollingStateTree->insertNode(nodeType, newNodeID, { }, 0);
-    return m_scrollingStateTree->createUnparentedNode(nodeType, newNodeID);
+    if ((!scrollingStateTree.rootStateNode() && nodeType == ScrollingNodeType::Subframe) || (scrollingStateTree.rootStateNode() && scrollingStateTree.rootStateNode()->scrollingNodeID() == newNodeID))
+        return scrollingStateTree.insertNode(nodeType, newNodeID, { }, 0);
+    return scrollingStateTree.createUnparentedNode(nodeType, newNodeID);
 }
 
-ScrollingNodeID AsyncScrollingCoordinator::insertNode(ScrollingNodeType nodeType, ScrollingNodeID newNodeID, ScrollingNodeID parentID, size_t childIndex)
+ScrollingNodeID AsyncScrollingCoordinator::insertNode(FrameIdentifier rootFrameID, ScrollingNodeType nodeType, ScrollingNodeID newNodeID, ScrollingNodeID parentID, size_t childIndex)
 {
     LOG_WITH_STREAM(ScrollingTree, stream << "AsyncScrollingCoordinator::insertNode " << nodeType << " node " << newNodeID << " parent " << parentID << " index " << childIndex);
-    return m_scrollingStateTree->insertNode(nodeType, newNodeID, parentID, childIndex);
+    return ensureScrollingStateTreeForRootFrameID(rootFrameID).insertNode(nodeType, newNodeID, parentID, childIndex);
 }
 
 void AsyncScrollingCoordinator::unparentNode(ScrollingNodeID nodeID)
 {
-    m_scrollingStateTree->unparentNode(nodeID);
+    if (auto* stateTree = stateTreeForNodeID(nodeID))
+        stateTree->unparentNode(nodeID);
 }
 
 void AsyncScrollingCoordinator::unparentChildrenAndDestroyNode(ScrollingNodeID nodeID)
 {
-    m_scrollingStateTree->unparentChildrenAndDestroyNode(nodeID);
+    if (auto* stateTree = stateTreeForNodeID(nodeID))
+        stateTree->unparentChildrenAndDestroyNode(nodeID);
 }
 
 void AsyncScrollingCoordinator::detachAndDestroySubtree(ScrollingNodeID nodeID)
 {
-    m_scrollingStateTree->detachAndDestroySubtree(nodeID);
+    if (auto* stateTree = stateTreeForNodeID(nodeID))
+        stateTree->detachAndDestroySubtree(nodeID);
 }
 
-void AsyncScrollingCoordinator::clearAllNodes()
+void AsyncScrollingCoordinator::clearAllNodes(FrameIdentifier rootFrameID)
 {
-    m_scrollingStateTree->clear();
+    ensureScrollingStateTreeForRootFrameID(rootFrameID).clear();
 }
 
 ScrollingNodeID AsyncScrollingCoordinator::parentOfNode(ScrollingNodeID nodeID) const
@@ -867,8 +926,8 @@ Vector<ScrollingNodeID> AsyncScrollingCoordinator::childrenOfNode(ScrollingNodeI
 void AsyncScrollingCoordinator::reconcileViewportConstrainedLayerPositions(ScrollingNodeID scrollingNodeID, const LayoutRect& viewportRect, ScrollingLayerPositionAction action)
 {
     LOG_WITH_STREAM(Scrolling, stream << getCurrentProcessID() << " AsyncScrollingCoordinator::reconcileViewportConstrainedLayerPositions for viewport rect " << viewportRect << " and node " << scrollingNodeID);
-
-    m_scrollingStateTree->reconcileViewportConstrainedLayerPositions(scrollingNodeID, viewportRect, action);
+    if (auto* stateTree = stateTreeForNodeID(scrollingNodeID))
+        stateTree->reconcileViewportConstrainedLayerPositions(scrollingNodeID, viewportRect, action);
 }
 
 void AsyncScrollingCoordinator::ensureRootStateNodeForFrameView(LocalFrameView& frameView)
@@ -880,7 +939,7 @@ void AsyncScrollingCoordinator::ensureRootStateNodeForFrameView(LocalFrameView& 
     // For non-main frames, it is only possible to arrive in this function from
     // RenderLayerCompositor::updateBacking where the node has already been created.
     ASSERT(frameView.frame().isMainFrame());
-    insertNode(ScrollingNodeType::MainFrame, frameView.scrollingNodeID(), { }, 0);
+    insertNode(frameView.frame().rootFrame().frameID(), ScrollingNodeType::MainFrame, frameView.scrollingNodeID(), { }, 0);
 }
 
 void AsyncScrollingCoordinator::setNodeLayers(ScrollingNodeID nodeID, const NodeLayers& nodeLayers)
@@ -1079,9 +1138,10 @@ void AsyncScrollingCoordinator::windowScreenDidChange(PlatformDisplayID displayI
         m_scrollingTree->windowScreenDidChange(displayID, nominalFramesPerSecond);
 }
 
-bool AsyncScrollingCoordinator::hasSubscrollers() const
+bool AsyncScrollingCoordinator::hasSubscrollers(FrameIdentifier rootFrameID) const
 {
-    return m_scrollingStateTree && m_scrollingStateTree->scrollingNodeCount() > 1;
+    auto* scrollingStateTree = existingScrollingStateTreeForRootFrameID(rootFrameID);
+    return scrollingStateTree && scrollingStateTree->scrollingNodeCount() > 1;
 }
 
 bool AsyncScrollingCoordinator::isUserScrollInProgress(ScrollingNodeID nodeID) const
@@ -1129,13 +1189,18 @@ ScrollingNodeID AsyncScrollingCoordinator::scrollableContainerNodeID(const Rende
 
 String AsyncScrollingCoordinator::scrollingStateTreeAsText(OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const
 {
-    if (m_scrollingStateTree->rootStateNode()) {
-        if (m_eventTrackingRegionsDirty)
-            m_scrollingStateTree->rootStateNode()->setEventTrackingRegions(absoluteEventTrackingRegions());
-        return m_scrollingStateTree->scrollingStateTreeAsText(behavior);
-    }
+    StringBuilder stateTree;
+    m_scrollingStateTrees.forEach([&] (auto& key, auto& tree) {
+        if (tree->rootStateNode()) {
+            if (m_eventTrackingRegionsDirty)
+                tree->rootStateNode()->setEventTrackingRegions(absoluteEventTrackingRegions());
+            if (m_scrollingStateTrees.size() > 1)
+                stateTree.append("Tree-for-root-frameID: " + key.toString());
+            stateTree.append(tree->scrollingStateTreeAsText(behavior));
+        }
+    });
 
-    return emptyString();
+    return stateTree.toString();
 }
 
 String AsyncScrollingCoordinator::scrollingTreeAsText(OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const
@@ -1205,6 +1270,12 @@ bool AsyncScrollingCoordinator::scrollAnimatorEnabled() const
         return false;
     auto& settings = localMainFrame->settings();
     return settings.scrollAnimatorEnabled();
+}
+
+std::unique_ptr<ScrollingStateTree> AsyncScrollingCoordinator::commitTreeStateForRootFrameID(FrameIdentifier rootFrameID, LayerRepresentation::Type type)
+{
+    auto& scrollingStateTree = ensureScrollingStateTreeForRootFrameID(rootFrameID);
+    return scrollingStateTree.commit(type);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.h
@@ -104,6 +104,7 @@ public:
     virtual void frameViewRootLayerDidChange(LocalFrameView&);
 
     virtual void frameViewWillBeDetached(LocalFrameView&) { }
+    virtual void rootFrameWasRemoved(FrameIdentifier) { }
 
     // Traverses the scrolling tree, setting layer positions to represent the current scrolled state.
     virtual void applyScrollingTreeLayerPositions() { }
@@ -136,9 +137,9 @@ public:
     virtual void wheelEventWasProcessedByMainThread(const PlatformWheelEvent&, std::optional<WheelScrollGestureState>) { }
 
     // Create an unparented node.
-    virtual ScrollingNodeID createNode(ScrollingNodeType, ScrollingNodeID newNodeID) { return newNodeID; }
+    virtual ScrollingNodeID createNode(FrameIdentifier, ScrollingNodeType, ScrollingNodeID newNodeID) { return newNodeID; }
     // Parent a node in the scrolling tree. This may return a new nodeID if the node type changed. parentID = 0 sets the root node.
-    virtual ScrollingNodeID insertNode(ScrollingNodeType, ScrollingNodeID newNodeID, ScrollingNodeID /*parentID*/, size_t /*childIndex*/ = notFound) { return newNodeID; }
+    virtual ScrollingNodeID insertNode(FrameIdentifier, ScrollingNodeType, ScrollingNodeID newNodeID, ScrollingNodeID /*parentID*/, size_t /*childIndex*/ = notFound) { return newNodeID; }
     // Node will be unparented, but not destroyed. It's the client's responsibility to either re-parent or destroy this node.
     virtual void unparentNode(ScrollingNodeID) { }
     // Node will be destroyed, and its children left unparented.
@@ -146,7 +147,7 @@ public:
     // Node will be unparented, and it and its children destroyed.
     virtual void detachAndDestroySubtree(ScrollingNodeID) { }
     // Destroy the tree, including both parented and unparented nodes.
-    virtual void clearAllNodes() { }
+    virtual void clearAllNodes(FrameIdentifier) { }
 
     virtual ScrollingNodeID parentOfNode(ScrollingNodeID) const { return { }; }
     virtual Vector<ScrollingNodeID> childrenOfNode(ScrollingNodeID) const { return { }; }
@@ -183,7 +184,7 @@ public:
     virtual bool isScrollSnapInProgress(ScrollingNodeID) const { return false; }
     virtual void updateScrollSnapPropertiesWithFrameView(const LocalFrameView&) { }
     virtual void setScrollPinningBehavior(ScrollPinningBehavior) { }
-    virtual bool hasSubscrollers() const { return false; }
+    virtual bool hasSubscrollers(FrameIdentifier) const { return false; }
 
     // Generated a unique id for scrolling nodes.
     WEBCORE_EXPORT ScrollingNodeID uniqueScrollingNodeID();
@@ -229,7 +230,7 @@ protected:
     GraphicsLayer* headerLayerForFrameView(LocalFrameView&);
     GraphicsLayer* footerLayerForFrameView(LocalFrameView&);
 
-    virtual void willCommitTree() { }
+    virtual void willCommitTree(FrameIdentifier) { }
 
     WEBCORE_EXPORT Page* page() const;
     RefPtr<Page> protectedPage() const;

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.h
@@ -70,7 +70,6 @@ public:
     bool hasChangedProperties() const { return m_hasChangedProperties; }
 
     bool hasNewRootStateNode() const { return m_hasNewRootStateNode; }
-    void setHasNewRootStateNode(bool hasNewRoot) { m_hasNewRootStateNode = hasNewRoot; }
 
     unsigned nodeCount() const { return m_stateNodeMap.size(); }
     unsigned scrollingNodeCount() const { return m_scrollingNodeCount; }
@@ -93,7 +92,7 @@ public:
         --m_scrollingNodeCount;
     }
 
-    String scrollingStateTreeAsText(OptionSet<ScrollingStateTreeAsTextBehavior>) const;
+    WEBCORE_EXPORT String scrollingStateTreeAsText(OptionSet<ScrollingStateTreeAsTextBehavior>) const;
     FrameIdentifier rootFrameIdentifier() const { return m_rootFrameIdentifier; }
     void setRootFrameIdentifier(FrameIdentifier frameID) { m_rootFrameIdentifier = frameID; }
 

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -255,7 +255,7 @@ public:
     WEBCORE_EXPORT virtual void scrollingTreeNodeScrollbarMinimumThumbLengthDidChange(WebCore::ScrollingNodeID, ScrollbarOrientation, int) { };
 
     void addScrollingNodeToHostedSubtreeMap(WebCore::LayerHostingContextIdentifier, Ref<ScrollingTreeFrameHostingNode>);
-    void removeNode(ScrollingNodeID);
+    void removeNode(ScrollingNodeID, ScrollingTreeFrameHostingNode* = nullptr);
     void removeFrameHostingNode(LayerHostingContextIdentifier);
 
     WEBCORE_EXPORT std::optional<FrameIdentifier> frameIDForScrollingNodeID(ScrollingNodeID);

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.cpp
@@ -83,6 +83,14 @@ void ScrollingTreeFrameHostingNode::willBeDestroyed()
     removeHostedChildren();
 }
 
+void ScrollingTreeFrameHostingNode::removeHostedChild(RefPtr<ScrollingTreeNode> node)
+{
+    if (node) {
+        m_hostedChildren.remove(node);
+        m_children.removeFirst(node.releaseNonNull());
+    }
+}
+
 void ScrollingTreeFrameHostingNode::applyLayerPositions()
 {
 }

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.h
@@ -45,6 +45,7 @@ public:
     void willBeDestroyed() override;
     void addHostedChild(RefPtr<ScrollingTreeNode> node) { m_hostedChildren.add(node); }
     void removeHostedChildren();
+    void removeHostedChild(RefPtr<ScrollingTreeNode>);
 
 private:
     ScrollingTreeFrameHostingNode(ScrollingTree&, ScrollingNodeID);

--- a/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp
@@ -55,18 +55,20 @@ void ThreadedScrollingCoordinator::pageDestroyed()
 
 void ThreadedScrollingCoordinator::commitTreeStateIfNeeded()
 {
-    willCommitTree();
+    scrollingStateTrees().forEach([&] (auto& key, auto& value) {
+        willCommitTree(key);
 
-    LOG_WITH_STREAM(Scrolling, stream << "ThreadedScrollingCoordinator::commitTreeState, has changes " << scrollingStateTree()->hasChangedProperties());
+        LOG_WITH_STREAM(Scrolling, stream << "ThreadedScrollingCoordinator::commitTreeState, has changes " << value->hasChangedProperties());
 
-    if (!scrollingStateTree()->hasChangedProperties())
-        return;
+        if (!value->hasChangedProperties())
+            return;
 
-    LOG_WITH_STREAM(ScrollingTree, stream << "ThreadedScrollingCoordinator::commitTreeState: state tree " << scrollingStateTreeAsText(debugScrollingStateTreeAsTextBehaviors));
+        LOG_WITH_STREAM(ScrollingTree, stream << "ThreadedScrollingCoordinator::commitTreeState: state tree " << scrollingStateTreeAsText(debugScrollingStateTreeAsTextBehaviors));
 
-    auto stateTree = scrollingStateTree()->commit(LayerRepresentation::PlatformLayerRepresentation);
-    stateTree->setRootFrameIdentifier(page()->mainFrame().frameID());
-    scrollingTree()->commitTreeState(WTFMove(stateTree));
+        auto stateTree = commitTreeStateForRootFrameID(key, LayerRepresentation::PlatformLayerRepresentation);
+        stateTree->setRootFrameIdentifier(key);
+        scrollingTree()->commitTreeState(WTFMove(stateTree));
+    });
 }
 
 WheelEventHandlingResult ThreadedScrollingCoordinator::handleWheelEventForScrolling(const PlatformWheelEvent& wheelEvent, ScrollingNodeID targetNodeID, std::optional<WheelScrollGestureState> gestureState)

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -435,6 +435,7 @@ public:
     virtual void updateScrollAnchoringElement() { }
     virtual void updateScrollPositionForScrollAnchoringController() { }
     virtual void invalidateScrollAnchoringElement() { }
+    virtual FrameIdentifier rootFrameID() const { return { }; }
 
     WEBCORE_EXPORT void setScrollbarsController(std::unique_ptr<ScrollbarsController>&&);
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1937,7 +1937,7 @@ bool RenderLayerBacking::maintainsEventRegion() const
     if (!settings.asyncFrameScrollingEnabled() && !settings.asyncOverflowScrollingEnabled())
         return false;
 
-    if (!m_owningLayer.page().scrollingCoordinator()->hasSubscrollers())
+    if (!m_owningLayer.page().scrollingCoordinator()->hasSubscrollers(renderer().view().frame().rootFrame().frameID()))
         return false;
 
     return true;

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -2042,5 +2042,10 @@ void RenderLayerScrollableArea::invalidateScrollAnchoringElement()
         m_scrollAnchoringController->invalidateAnchorElement();
 }
 
+FrameIdentifier RenderLayerScrollableArea::rootFrameID() const
+{
+    return m_layer.renderer().frame().rootFrame().frameID();
+}
+
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -267,6 +267,8 @@ public:
 
     void createScrollbarsController() final;
 
+    FrameIdentifier rootFrameID() const final;
+
 private:
     bool hasHorizontalOverflow() const;
     bool hasVerticalOverflow() const;

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -1214,4 +1214,9 @@ bool RenderListBox::isVisibleToHitTesting() const
     return visibleToHitTesting();
 }
 
+FrameIdentifier RenderListBox::rootFrameID() const
+{
+    return view().frameView().frame().rootFrame().frameID();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderListBox.h
+++ b/Source/WebCore/rendering/RenderListBox.h
@@ -73,7 +73,8 @@ public:
     unsigned size() const;
 
     bool scroll(ScrollDirection, ScrollGranularity, unsigned stepCount = 1, Element** stopElement = nullptr, RenderBox* startBox = nullptr, const IntPoint& wheelEventAbsolutePoint = IntPoint()) override;
-    
+    FrameIdentifier rootFrameID() const final;
+
 private:
     bool isVisibleToHitTesting() const final;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -191,8 +191,6 @@ private:
 
     unsigned m_countOfTransactionsWithNonEmptyLayerChanges { 0 };
 
-    HashMap<WebCore::ProcessIdentifier, WebCore::FrameIdentifier> m_commitsForFrameID;
-
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     Seconds m_acceleratedTimelineTimeOrigin;
     MonotonicTime m_animationCurrentTime;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -288,19 +288,6 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
                 m_remoteLayerTreeHost->detachRootLayer();
         }
 
-        // TODO: rdar://126001790 properly handle commits from a web process with multiple root frames.
-        // Currently we get commits for each frame if a web process has multiple root frames. This
-        // currently results in sending across the same scrolling tree multiple times, which can result
-        // in a cycle when a web process has a granparent and grandchild frame, with another process having
-        // the intermediate frame. For now only do scrolling tree commits for the first root frame we see
-        // from a process.
-        auto it = m_commitsForFrameID.find(layerTreeTransaction.processIdentifier());
-        if (it != m_commitsForFrameID.end()) {
-            if (it->value != scrollingTreeTransaction.rootFrameIdentifier())
-                return;
-        } else
-            m_commitsForFrameID.set(layerTreeTransaction.processIdentifier(), scrollingTreeTransaction.rootFrameIdentifier());
-
 #if ENABLE(ASYNC_SCROLLING)
 #if PLATFORM(IOS_FAMILY)
         if (!layerTreeTransaction.isMainFrameProcessTransaction()) {

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -261,6 +261,7 @@ public:
 #endif
 
     uint64_t streamedBytes() const;
+    WebCore::FrameIdentifier rootFrameID() const final;
 
 protected:
     virtual double contentScaleFactor() const = 0;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -1228,6 +1228,11 @@ void PDFPluginBase::registerPDFTest(RefPtr<WebCore::VoidCallback>&& callback)
         m_pdfTestCallback = WTFMove(callback);
 }
 
+FrameIdentifier PDFPluginBase::rootFrameID() const
+{
+    return m_view->frame()->rootFrame().frameID();
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(PDF_PLUGIN)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -649,7 +649,7 @@ void UnifiedPDFPlugin::createScrollingNodeIfNecessary()
         return;
 
     m_scrollingNodeID = scrollingCoordinator->uniqueScrollingNodeID();
-    scrollingCoordinator->createNode(ScrollingNodeType::PluginScrolling, m_scrollingNodeID);
+    scrollingCoordinator->createNode(m_frame->coreLocalFrame()->rootFrame().frameID(), ScrollingNodeType::PluginScrolling, m_scrollingNodeID);
 
 #if ENABLE(SCROLLING_THREAD)
     m_scrollContainerLayer->setScrollingNodeID(m_scrollingNodeID);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -389,7 +389,7 @@ void RemoteLayerTreeDrawingArea::updateRendering()
         RemoteScrollingCoordinatorTransaction scrollingTransaction;
 #if ENABLE(ASYNC_SCROLLING)
         if (webPage->scrollingCoordinator())
-            scrollingTransaction = downcast<RemoteScrollingCoordinator>(*webPage->scrollingCoordinator()).buildTransaction();
+            scrollingTransaction = downcast<RemoteScrollingCoordinator>(*webPage->scrollingCoordinator()).buildTransaction(rootLayer.frameID);
         scrollingTransaction.setFrameIdentifier(rootLayer.frameID);
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
@@ -48,7 +48,7 @@ public:
         return adoptRef(*new RemoteScrollingCoordinator(page));
     }
 
-    RemoteScrollingCoordinatorTransaction buildTransaction();
+    RemoteScrollingCoordinatorTransaction buildTransaction(WebCore::FrameIdentifier);
 
     void scrollingStateInUIProcessChanged(const RemoteScrollingUIState&);
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
@@ -103,12 +103,12 @@ void RemoteScrollingCoordinator::setScrollPinningBehavior(ScrollPinningBehavior)
     // FIXME: send to the UI process.
 }
 
-RemoteScrollingCoordinatorTransaction RemoteScrollingCoordinator::buildTransaction()
+RemoteScrollingCoordinatorTransaction RemoteScrollingCoordinator::buildTransaction(FrameIdentifier rootFrameID)
 {
-    willCommitTree();
+    willCommitTree(rootFrameID);
 
     return {
-        scrollingStateTree()->commit(LayerRepresentation::PlatformLayerIDRepresentation),
+        ensureScrollingStateTreeForRootFrameID(rootFrameID).commit(LayerRepresentation::PlatformLayerIDRepresentation),
         std::exchange(m_clearScrollLatchingInNextTransaction, false),
         { },
         RemoteScrollingCoordinatorTransaction::FromDeserialization::No


### PR DESCRIPTION
#### 48aa61d62068efcceb7aebce99d86384e5d2f0f0
<pre>
[Site Isolation] Properly create scrolling tree for web process with multiple root frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=272721">https://bugs.webkit.org/show_bug.cgi?id=272721</a>
<a href="https://rdar.apple.com/126001790">rdar://126001790</a>

Reviewed by Simon Fraser.

Adjust AsyncScrollingCoordinator to hold a scrolling state tree per root frame.
Also thanks to Alex who helped take this pr over the finishing line.

* LayoutTests/http/tests/site-isolation/scrolling/basic-scrolling-tree.html:
* LayoutTests/http/tests/site-isolation/scrolling/multiple-root-frames-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/scrolling/multiple-root-frames.html: Copied from LayoutTests/http/tests/site-isolation/scrolling/basic-scrolling-tree.html.
* LayoutTests/http/tests/site-isolation/scrolling/remove-root-frame-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/scrolling/remove-root-frame.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/SmallMap.h: Added.
(WTF::SmallMap::ensure):
(WTF::SmallMap::remove):
(WTF::SmallMap::get const):
(WTF::SmallMap::forEach const):
(WTF::SmallMap::size const):
(WTF::SmallMap::rawStorage const):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setBackForwardCacheState):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::~LocalFrame):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::rootFrameID const):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::AsyncScrollingCoordinator):
(WebCore::AsyncScrollingCoordinator::stateNodeForNodeID const):
(WebCore::AsyncScrollingCoordinator::stateNodeForScrollableArea const):
(WebCore::AsyncScrollingCoordinator::ensureScrollingStateTreeForRootFrameID):
(WebCore::AsyncScrollingCoordinator::existingScrollingStateTreeForRootFrameID const):
(WebCore::AsyncScrollingCoordinator::rootFrameWasRemoved):
(WebCore::AsyncScrollingCoordinator::stateTreeForNodeID const):
(WebCore::AsyncScrollingCoordinator::willCommitTree):
(WebCore::AsyncScrollingCoordinator::updateEventTrackingRegions):
(WebCore::AsyncScrollingCoordinator::frameViewLayoutUpdated):
(WebCore::AsyncScrollingCoordinator::frameViewEventTrackingRegionsChanged):
(WebCore::AsyncScrollingCoordinator::frameViewForScrollingNode const):
(WebCore::AsyncScrollingCoordinator::createNode):
(WebCore::AsyncScrollingCoordinator::insertNode):
(WebCore::AsyncScrollingCoordinator::unparentNode):
(WebCore::AsyncScrollingCoordinator::unparentChildrenAndDestroyNode):
(WebCore::AsyncScrollingCoordinator::detachAndDestroySubtree):
(WebCore::AsyncScrollingCoordinator::clearAllNodes):
(WebCore::AsyncScrollingCoordinator::reconcileViewportConstrainedLayerPositions):
(WebCore::AsyncScrollingCoordinator::ensureRootStateNodeForFrameView):
(WebCore::AsyncScrollingCoordinator::hasSubscrollers const):
(WebCore::AsyncScrollingCoordinator::scrollingStateTreeAsText const):
(WebCore::AsyncScrollingCoordinator::commitTreeStateForRootFrameID):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h:
(WebCore::AsyncScrollingCoordinator::scrollingStateTrees const):
(WebCore::AsyncScrollingCoordinator::scrollingStateTree): Deleted.
* Source/WebCore/page/scrolling/ScrollingCoordinator.h:
(WebCore::ScrollingCoordinator::rootFrameWasRemoved):
(WebCore::ScrollingCoordinator::createNode):
(WebCore::ScrollingCoordinator::insertNode):
(WebCore::ScrollingCoordinator::clearAllNodes):
(WebCore::ScrollingCoordinator::hasSubscrollers const):
(WebCore::ScrollingCoordinator::willCommitTree):
* Source/WebCore/page/scrolling/ScrollingStateTree.h:
* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::removeNode):
(WebCore::ScrollingTree::commitTreeStateInternal):
* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.cpp:
(WebCore::ScrollingTreeFrameHostingNode::removeHostedChild):
* Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.h:
* Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp:
(WebCore::ThreadedScrollingCoordinator::commitTreeStateIfNeeded):
* Source/WebCore/platform/ScrollableArea.h:
(WebCore::ScrollableArea::rootFrameID const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::maintainsEventRegion const):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateCompositingLayers):
(WebCore::RenderLayerCompositor::attachWidgetContentLayersIfNecessary):
(WebCore::RenderLayerCompositor::registerScrollingNodeID):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::rootFrameID const):
* Source/WebCore/rendering/RenderLayerScrollableArea.h:
* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::rootFrameID const):
* Source/WebCore/rendering/RenderListBox.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::rootFrameID const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::createScrollingNodeIfNecessary):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm:
(WebKit::RemoteScrollingCoordinator::buildTransaction):
* Tools/TestWebKitAPI/Tests/WTF/SmallSet.cpp:
(TestWebKitAPI::TEST(WTF_SmallMap, Basic)):

Canonical link: <a href="https://commits.webkit.org/278591@main">https://commits.webkit.org/278591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/269b787fa85a094c32b5ff0b827f376488c5c64c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51000 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30299 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3326 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54257 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1689 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53301 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36585 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1355 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41552 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53098 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27941 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43941 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22670 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25276 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1196 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9440 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/44338 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47256 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1270 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55851 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/50501 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26107 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1167 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48953 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27358 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44012 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48079 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28236 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57976 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7409 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27089 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11935 "Passed tests") | 
<!--EWS-Status-Bubble-End-->