### PR TITLE
[JSC] Make DFG finalization less locking

### DIFF
--- a/Source/JavaScriptCore/bytecode/RecordedStatuses.cpp
+++ b/Source/JavaScriptCore/bytecode/RecordedStatuses.cpp
@@ -28,24 +28,6 @@
 
 namespace JSC {
 
-RecordedStatuses& RecordedStatuses::operator=(RecordedStatuses&& other)
-{
-    calls = WTFMove(other.calls);
-    gets = WTFMove(other.gets);
-    puts = WTFMove(other.puts);
-    ins = WTFMove(other.ins);
-    deletes = WTFMove(other.deletes);
-    checkPrivateBrands = WTFMove(other.checkPrivateBrands);
-    setPrivateBrands = WTFMove(other.setPrivateBrands);
-    shrinkToFit();
-    return *this;
-}
-
-RecordedStatuses::RecordedStatuses(RecordedStatuses&& other)
-{
-    *this = WTFMove(other);
-}
-
 CallLinkStatus* RecordedStatuses::addCallLinkStatus(const CodeOrigin& codeOrigin, const CallLinkStatus& status)
 {
     auto statusPtr = makeUnique<CallLinkStatus>(status);

--- a/Source/JavaScriptCore/bytecode/RecordedStatuses.h
+++ b/Source/JavaScriptCore/bytecode/RecordedStatuses.h
@@ -36,16 +36,10 @@
 namespace JSC {
 
 struct RecordedStatuses {
-    RecordedStatuses() { }
-    
-    RecordedStatuses& operator=(const RecordedStatuses& other) = delete;
-    
-    RecordedStatuses& operator=(RecordedStatuses&& other);
-    
-    RecordedStatuses(const RecordedStatuses& other) = delete;
-    
-    RecordedStatuses(RecordedStatuses&& other);
-    
+    WTF_MAKE_STRUCT_FAST_ALLOCATED(RecordedStatuses);
+
+    RecordedStatuses() = default;
+
     CallLinkStatus* addCallLinkStatus(const CodeOrigin&, const CallLinkStatus&);
     GetByStatus* addGetByStatus(const CodeOrigin&, const GetByStatus&);
     PutByStatus* addPutByStatus(const CodeOrigin&, const PutByStatus&);

--- a/Source/JavaScriptCore/dfg/DFGCommonData.h
+++ b/Source/JavaScriptCore/dfg/DFGCommonData.h
@@ -127,7 +127,7 @@ public:
     FixedVector<AdaptiveStructureWatchpoint> m_adaptiveStructureWatchpoints;
     FixedVector<AdaptiveInferredPropertyValueWatchpoint> m_adaptiveInferredPropertyValueWatchpoints;
     std::unique_ptr<PCToCodeOriginMap> m_pcToCodeOriginMap;
-    RecordedStatuses recordedStatuses;
+    std::unique_ptr<RecordedStatuses> recordedStatuses;
     FixedVector<JumpReplacement> m_jumpReplacements;
     FixedVector<std::unique_ptr<BoyerMooreHorspoolTable<uint8_t>>> m_stringSearchTable8;
     Bag<StructureStubInfo> m_stubInfos;

--- a/Source/JavaScriptCore/dfg/DFGPlan.h
+++ b/Source/JavaScriptCore/dfg/DFGPlan.h
@@ -92,7 +92,7 @@ public:
     DesiredIdentifiers& identifiers() { return m_identifiers; }
     DesiredWeakReferences& weakReferences() { return m_weakReferences; }
     DesiredTransitions& transitions() { return m_transitions; }
-    RecordedStatuses& recordedStatuses() { return m_recordedStatuses; }
+    RecordedStatuses& recordedStatuses() { return *m_recordedStatuses.get(); }
 
     bool willTryToTierUp() const { return m_willTryToTierUp; }
     void setWillTryToTierUp(bool willTryToTierUp) { m_willTryToTierUp = willTryToTierUp; }
@@ -132,7 +132,7 @@ private:
     DesiredIdentifiers m_identifiers;
     DesiredWeakReferences m_weakReferences;
     DesiredTransitions m_transitions;
-    RecordedStatuses m_recordedStatuses;
+    std::unique_ptr<RecordedStatuses> m_recordedStatuses;
 
     HashMap<BytecodeIndex, FixedVector<BytecodeIndex>> m_tierUpInLoopHierarchy;
     Vector<BytecodeIndex> m_tierUpAndOSREnterBytecodes;


### PR DESCRIPTION
#### a98619eaf5aab9fffb6856b8254038a10a67092a
<pre>
[JSC] Make DFG finalization less locking
<a href="https://bugs.webkit.org/show_bug.cgi?id=272722">https://bugs.webkit.org/show_bug.cgi?id=272722</a>
<a href="https://rdar.apple.com/126521673">rdar://126521673</a>

Reviewed by Justin Michaud.

Make DFG finalization less locking, which makes operationOptimize less
frequently taking a lock &amp; stopping accidentally with heap threads.

In this patch,

1. Weak reference FixedVector moving does not need to take a lock. They are pointer size move. And old field was always nullptr.
   (Keep in mind that we always emit write-barrier onto CodeBlock when finishing finalization, and GC is deferred during finalization.
    So any kind of added references etc. does not matter even without write-barrier etc.).
2. Make RecordedStatuses std::unique_ptr and move it to CodeBlock without a lock. Due to (1)&apos;s reason, this is also fine.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::propagateTransitions):
(JSC::CodeBlock::finalizeUnconditionally):
(JSC::CodeBlock::getICStatusMap):
(JSC::CodeBlock::stronglyVisitStrongReferences):
* Source/JavaScriptCore/bytecode/RecordedStatuses.cpp:
(JSC::RecordedStatuses::operator=): Deleted.
(JSC::RecordedStatuses::RecordedStatuses): Deleted.
* Source/JavaScriptCore/bytecode/RecordedStatuses.h:
(JSC::RecordedStatuses::RecordedStatuses): Deleted.
* Source/JavaScriptCore/dfg/DFGCommonData.h:
* Source/JavaScriptCore/dfg/DFGDesiredWeakReferences.cpp:
(JSC::DFG::DesiredWeakReferences::reallyAdd):
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::finalizeInGC):
(JSC::DFG::Plan::compileInThreadImpl):
(JSC::DFG::Plan::finalizeInThread):
(JSC::DFG::Plan::reallyAdd):
(JSC::DFG::Plan::finalize):
(JSC::DFG::Plan::checkLivenessAndVisitChildren):
* Source/JavaScriptCore/dfg/DFGPlan.h:

Canonical link: <a href="https://commits.webkit.org/277568@main">https://commits.webkit.org/277568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6523cbc17bb2ec579ae08f5287cc8f5c1313abb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47909 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50590 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43962 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32981 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24595 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38976 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48491 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41417 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20274 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22262 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42598 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5956 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/41206 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44256 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43032 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52484 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/47400 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22951 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19310 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46281 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24221 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45325 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25012 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54898 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6810 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23942 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11283 "Passed tests") | 
<!--EWS-Status-Bubble-End-->