### PR TITLE
Use non-nullable type for PerformanceEntry::startTimeCompareLessThan

### DIFF
--- a/Source/WebCore/page/Performance.h
+++ b/Source/WebCore/page/Performance.h
@@ -81,10 +81,10 @@ public:
     PerformanceNavigation* navigation();
     PerformanceTiming* timing();
 
-    Vector<RefPtr<PerformanceEntry>> getEntries() const;
-    Vector<RefPtr<PerformanceEntry>> getEntriesByType(const String& entryType) const;
-    Vector<RefPtr<PerformanceEntry>> getEntriesByName(const String& name, const String& entryType) const;
-    void appendBufferedEntriesByType(const String& entryType, Vector<RefPtr<PerformanceEntry>>&, PerformanceObserver&) const;
+    Vector<Ref<PerformanceEntry>> getEntries() const;
+    Vector<Ref<PerformanceEntry>> getEntriesByType(const String& entryType) const;
+    Vector<Ref<PerformanceEntry>> getEntriesByName(const String& name, const String& entryType) const;
+    void appendBufferedEntriesByType(const String& entryType, Vector<Ref<PerformanceEntry>>&, PerformanceObserver&) const;
 
     void clearResourceTimings();
     void setResourceTimingBufferSize(unsigned);
@@ -142,11 +142,11 @@ private:
     mutable RefPtr<PerformanceTiming> m_timing;
 
     // https://w3c.github.io/resource-timing/#sec-extensions-performance-interface recommends initial buffer size of 250.
-    Vector<RefPtr<PerformanceEntry>> m_resourceTimingBuffer;
+    Vector<Ref<PerformanceEntry>> m_resourceTimingBuffer;
     unsigned m_resourceTimingBufferSize { 250 };
 
     Timer m_resourceTimingBufferFullTimer;
-    Vector<RefPtr<PerformanceEntry>> m_backupResourceTimingBuffer;
+    Vector<Ref<PerformanceEntry>> m_backupResourceTimingBuffer;
 
     // https://w3c.github.io/resource-timing/#dfn-resource-timing-buffer-full-flag
     bool m_resourceTimingBufferFullFlag { false };

--- a/Source/WebCore/page/PerformanceEntry.h
+++ b/Source/WebCore/page/PerformanceEntry.h
@@ -60,7 +60,7 @@ public:
 
     static std::optional<Type> parseEntryTypeString(const String& entryType);
 
-    static bool startTimeCompareLessThan(const RefPtr<PerformanceEntry>& a, const RefPtr<PerformanceEntry>& b)
+    static bool startTimeCompareLessThan(const Ref<PerformanceEntry>& a, const Ref<PerformanceEntry>& b)
     {
         return a->startTime() < b->startTime();
     }

--- a/Source/WebCore/page/PerformanceObserver.cpp
+++ b/Source/WebCore/page/PerformanceObserver.cpp
@@ -110,7 +110,7 @@ ExceptionOr<void> PerformanceObserver::observe(Init&& init)
     return { };
 }
 
-Vector<RefPtr<PerformanceEntry>> PerformanceObserver::takeRecords()
+Vector<Ref<PerformanceEntry>> PerformanceObserver::takeRecords()
 {
     return std::exchange(m_entriesToDeliver, { });
 }
@@ -127,7 +127,7 @@ void PerformanceObserver::disconnect()
 
 void PerformanceObserver::queueEntry(PerformanceEntry& entry)
 {
-    m_entriesToDeliver.append(&entry);
+    m_entriesToDeliver.append(entry);
 }
 
 void PerformanceObserver::deliver()
@@ -139,7 +139,7 @@ void PerformanceObserver::deliver()
     if (!context)
         return;
 
-    Vector<RefPtr<PerformanceEntry>> entries = std::exchange(m_entriesToDeliver, { });
+    Vector<Ref<PerformanceEntry>> entries = std::exchange(m_entriesToDeliver, { });
     auto list = PerformanceObserverEntryList::create(WTFMove(entries));
 
     InspectorInstrumentation::willFireObserverCallback(*context, "PerformanceObserver"_s);

--- a/Source/WebCore/page/PerformanceObserver.h
+++ b/Source/WebCore/page/PerformanceObserver.h
@@ -57,7 +57,7 @@ public:
 
     ExceptionOr<void> observe(Init&&);
     void disconnect();
-    Vector<RefPtr<PerformanceEntry>> takeRecords();
+    Vector<Ref<PerformanceEntry>> takeRecords();
 
     OptionSet<PerformanceEntry::Type> typeFilter() const { return m_typeFilter; }
 
@@ -76,7 +76,7 @@ private:
     RefPtr<Performance> protectedPerformance() const;
 
     RefPtr<Performance> m_performance;
-    Vector<RefPtr<PerformanceEntry>> m_entriesToDeliver;
+    Vector<Ref<PerformanceEntry>> m_entriesToDeliver;
     Ref<PerformanceObserverCallback> m_callback;
     OptionSet<PerformanceEntry::Type> m_typeFilter;
     bool m_registered { false };

--- a/Source/WebCore/page/PerformanceObserverEntryList.cpp
+++ b/Source/WebCore/page/PerformanceObserverEntryList.cpp
@@ -30,12 +30,12 @@
 
 namespace WebCore {
 
-Ref<PerformanceObserverEntryList> PerformanceObserverEntryList::create(Vector<RefPtr<PerformanceEntry>>&& entries)
+Ref<PerformanceObserverEntryList> PerformanceObserverEntryList::create(Vector<Ref<PerformanceEntry>>&& entries)
 {
     return adoptRef(*new PerformanceObserverEntryList(WTFMove(entries)));
 }
 
-PerformanceObserverEntryList::PerformanceObserverEntryList(Vector<RefPtr<PerformanceEntry>>&& entries)
+PerformanceObserverEntryList::PerformanceObserverEntryList(Vector<Ref<PerformanceEntry>>&& entries)
     : m_entries(WTFMove(entries))
 {
     ASSERT(!m_entries.isEmpty());
@@ -43,14 +43,14 @@ PerformanceObserverEntryList::PerformanceObserverEntryList(Vector<RefPtr<Perform
     std::stable_sort(m_entries.begin(), m_entries.end(), PerformanceEntry::startTimeCompareLessThan);
 }
 
-Vector<RefPtr<PerformanceEntry>> PerformanceObserverEntryList::getEntriesByType(const String& entryType) const
+Vector<Ref<PerformanceEntry>> PerformanceObserverEntryList::getEntriesByType(const String& entryType) const
 {
     return getEntriesByName(String(), entryType);
 }
 
-Vector<RefPtr<PerformanceEntry>> PerformanceObserverEntryList::getEntriesByName(const String& name, const String& entryType) const
+Vector<Ref<PerformanceEntry>> PerformanceObserverEntryList::getEntriesByName(const String& name, const String& entryType) const
 {
-    Vector<RefPtr<PerformanceEntry>> entries;
+    Vector<Ref<PerformanceEntry>> entries;
 
     // PerformanceObservers can only be registered for valid types.
     // So if the incoming entryType is an unknown type, there will be no matches.

--- a/Source/WebCore/page/PerformanceObserverEntryList.h
+++ b/Source/WebCore/page/PerformanceObserverEntryList.h
@@ -36,16 +36,16 @@ class PerformanceEntry;
 class PerformanceObserverEntryList : public RefCounted<PerformanceObserverEntryList> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<PerformanceObserverEntryList> create(Vector<RefPtr<PerformanceEntry>>&& entries);
+    static Ref<PerformanceObserverEntryList> create(Vector<Ref<PerformanceEntry>>&& entries);
 
-    const Vector<RefPtr<PerformanceEntry>>& getEntries() const { return m_entries; }
-    Vector<RefPtr<PerformanceEntry>> getEntriesByType(const String& entryType) const;
-    Vector<RefPtr<PerformanceEntry>> getEntriesByName(const String& name, const String& entryType) const;
+    const Vector<Ref<PerformanceEntry>>& getEntries() const { return m_entries; }
+    Vector<Ref<PerformanceEntry>> getEntriesByType(const String& entryType) const;
+    Vector<Ref<PerformanceEntry>> getEntriesByName(const String& name, const String& entryType) const;
 
 private:
-    PerformanceObserverEntryList(Vector<RefPtr<PerformanceEntry>>&& entries);
+    PerformanceObserverEntryList(Vector<Ref<PerformanceEntry>>&& entries);
 
-    Vector<RefPtr<PerformanceEntry>> m_entries;
+    Vector<Ref<PerformanceEntry>> m_entries;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/PerformanceUserTiming.cpp
+++ b/Source/WebCore/page/PerformanceUserTiming.cpp
@@ -88,17 +88,17 @@ static void clearPerformanceEntries(PerformanceEntryMap& map, const String& name
 
 static void addPerformanceEntry(PerformanceEntryMap& map, const String& name, PerformanceEntry& entry)
 {
-    auto& performanceEntryList = map.ensure(name, [] { return Vector<RefPtr<PerformanceEntry>>(); }).iterator->value;
-    performanceEntryList.append(&entry);
+    auto& performanceEntryList = map.ensure(name, [] { return Vector<Ref<PerformanceEntry>>(); }).iterator->value;
+    performanceEntryList.append(entry);
 }
 
 ExceptionOr<Ref<PerformanceMark>> PerformanceUserTiming::mark(JSC::JSGlobalObject& globalObject, const String& markName, std::optional<PerformanceMarkOptions>&& markOptions)
 {
-    Ref context = *m_performance.scriptExecutionContext();
+    Ref context = *m_performance->scriptExecutionContext();
 
     std::optional<MonotonicTime> timestamp;
     if (markOptions && markOptions->startTime)
-        timestamp = m_performance.monotonicTimeFromRelativeTime(*markOptions->startTime);
+        timestamp = m_performance->monotonicTimeFromRelativeTime(*markOptions->startTime);
 
     RefPtr document = dynamicDowncast<Document>(context);
     InspectorInstrumentation::performanceMark(context.get(), markName, timestamp, document ? document->protectedFrame().get() : nullptr);
@@ -134,8 +134,8 @@ ExceptionOr<double> PerformanceUserTiming::convertMarkToTimestamp(const String& 
                 return 0.0;
 
             // PerformanceTiming should always be non-null for the Document ScriptExecutionContext.
-            ASSERT(m_performance.timing());
-            auto timing = m_performance.timing();
+            ASSERT(m_performance->timing());
+            auto timing = m_performance->timing();
             auto startTime = timing->navigationStart();
             auto endTime = ((*timing).*(*function))();
             if (!endTime)
@@ -167,7 +167,7 @@ ExceptionOr<Ref<PerformanceMeasure>> PerformanceUserTiming::measure(const String
             return end.releaseException();
         endTime = end.returnValue();
     } else
-        endTime = m_performance.now();
+        endTime = m_performance->now();
 
     double startTime;
     if (!startMark.isNull()) {
@@ -203,7 +203,7 @@ ExceptionOr<Ref<PerformanceMeasure>> PerformanceUserTiming::measure(JSC::JSGloba
             return duration.releaseException();
         endTime = start.returnValue() + duration.returnValue();
     } else
-        endTime = m_performance.now();
+        endTime = m_performance->now();
 
     double startTime;
     if (measureOptions.start) {
@@ -275,30 +275,30 @@ void PerformanceUserTiming::clearMeasures(const String& measureName)
     clearPerformanceEntries(m_measuresMap, measureName);
 }
 
-static Vector<RefPtr<PerformanceEntry>> convertToEntrySequence(const PerformanceEntryMap& map)
+static Vector<Ref<PerformanceEntry>> convertToEntrySequence(const PerformanceEntryMap& map)
 {
-    Vector<RefPtr<PerformanceEntry>> entries;
+    Vector<Ref<PerformanceEntry>> entries;
     for (auto& entry : map.values())
         entries.appendVector(entry);
     return entries;
 }
 
-Vector<RefPtr<PerformanceEntry>> PerformanceUserTiming::getMarks() const
+Vector<Ref<PerformanceEntry>> PerformanceUserTiming::getMarks() const
 {
     return convertToEntrySequence(m_marksMap);
 }
 
-Vector<RefPtr<PerformanceEntry>> PerformanceUserTiming::getMarks(const String& name) const
+Vector<Ref<PerformanceEntry>> PerformanceUserTiming::getMarks(const String& name) const
 {
     return m_marksMap.get(name);
 }
 
-Vector<RefPtr<PerformanceEntry>> PerformanceUserTiming::getMeasures() const
+Vector<Ref<PerformanceEntry>> PerformanceUserTiming::getMeasures() const
 {
     return convertToEntrySequence(m_measuresMap);
 }
 
-Vector<RefPtr<PerformanceEntry>> PerformanceUserTiming::getMeasures(const String& name) const
+Vector<Ref<PerformanceEntry>> PerformanceUserTiming::getMeasures(const String& name) const
 {
     return m_measuresMap.get(name);
 }

--- a/Source/WebCore/page/PerformanceUserTiming.h
+++ b/Source/WebCore/page/PerformanceUserTiming.h
@@ -39,7 +39,7 @@ namespace WebCore {
 
 class Performance;
 
-using PerformanceEntryMap = HashMap<String, Vector<RefPtr<PerformanceEntry>>>;
+using PerformanceEntryMap = HashMap<String, Vector<Ref<PerformanceEntry>>>;
 
 class PerformanceUserTiming {
     WTF_MAKE_FAST_ALLOCATED;
@@ -53,11 +53,11 @@ public:
     ExceptionOr<Ref<PerformanceMeasure>> measure(JSC::JSGlobalObject&, const String& measureName, std::optional<StartOrMeasureOptions>&&, const String& endMark);
     void clearMeasures(const String& measureName);
 
-    Vector<RefPtr<PerformanceEntry>> getMarks() const;
-    Vector<RefPtr<PerformanceEntry>> getMeasures() const;
+    Vector<Ref<PerformanceEntry>> getMarks() const;
+    Vector<Ref<PerformanceEntry>> getMeasures() const;
 
-    Vector<RefPtr<PerformanceEntry>> getMarks(const String& name) const;
-    Vector<RefPtr<PerformanceEntry>> getMeasures(const String& name) const;
+    Vector<Ref<PerformanceEntry>> getMarks(const String& name) const;
+    Vector<Ref<PerformanceEntry>> getMeasures(const String& name) const;
 
     static bool isRestrictedMarkName(const String& markName);
 
@@ -69,7 +69,7 @@ private:
     ExceptionOr<Ref<PerformanceMeasure>> measure(const String& measureName, const String& startMark, const String& endMark);
     ExceptionOr<Ref<PerformanceMeasure>> measure(JSC::JSGlobalObject&, const String& measureName, const PerformanceMeasureOptions&);
 
-    Performance& m_performance;
+    WeakRef<Performance, WeakPtrImplWithEventTargetData> m_performance;
     PerformanceEntryMap m_marksMap;
     PerformanceEntryMap m_measuresMap;
 };


### PR DESCRIPTION
#### 9a4557b59bf5a2186b95aea0fef7fbb65417d1f1
<pre>
Use non-nullable type for PerformanceEntry::startTimeCompareLessThan
<a href="https://bugs.webkit.org/show_bug.cgi?id=272723">https://bugs.webkit.org/show_bug.cgi?id=272723</a>
<a href="https://rdar.apple.com/126260830">rdar://126260830</a>

Reviewed by Chris Dumez.

And use a WeakRef for PerformanceUserTiming.m_performance.

* Source/WebCore/page/Performance.cpp:
(WebCore::Performance::getEntries const):
(WebCore::Performance::getEntriesByType const):
(WebCore::Performance::getEntriesByName const):
(WebCore::Performance::appendBufferedEntriesByType const):
(WebCore::Performance::resourceTimingBufferFullTimerFired):
* Source/WebCore/page/Performance.h:
* Source/WebCore/page/PerformanceEntry.h:
(WebCore::PerformanceEntry::startTimeCompareLessThan):
* Source/WebCore/page/PerformanceObserver.cpp:
(WebCore::PerformanceObserver::takeRecords):
(WebCore::PerformanceObserver::queueEntry):
(WebCore::PerformanceObserver::deliver):
* Source/WebCore/page/PerformanceObserver.h:
* Source/WebCore/page/PerformanceObserverEntryList.cpp:
(WebCore::PerformanceObserverEntryList::create):
(WebCore::PerformanceObserverEntryList::PerformanceObserverEntryList):
(WebCore::PerformanceObserverEntryList::getEntriesByType const):
(WebCore::PerformanceObserverEntryList::getEntriesByName const):
* Source/WebCore/page/PerformanceObserverEntryList.h:
(WebCore::PerformanceObserverEntryList::getEntries const):
* Source/WebCore/page/PerformanceUserTiming.cpp:
(WebCore::addPerformanceEntry):
(WebCore::PerformanceUserTiming::mark):
(WebCore::PerformanceUserTiming::convertMarkToTimestamp const):
(WebCore::PerformanceUserTiming::measure):
(WebCore::convertToEntrySequence):
(WebCore::PerformanceUserTiming::getMarks const):
(WebCore::PerformanceUserTiming::getMeasures const):
* Source/WebCore/page/PerformanceUserTiming.h:

Canonical link: <a href="https://commits.webkit.org/279020@main">https://commits.webkit.org/279020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/442eeb6a5d760019bb57a6076d16352c84a15ccf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50772 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50595 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43967 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50220 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32987 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24602 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38980 "Passed tests") | [⏳ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48496 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41429 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20278 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22260 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42612 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44262 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43044 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 11 flakes 1 failures; Uploaded test results; Running re-run-layout-tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52489 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22956 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19305 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46289 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24226 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45333 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11419 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25017 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23947 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->