### PR TITLE
Change LocalFrameView* to a reference in `PopupMenu::show()`

### DIFF
--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -448,7 +448,7 @@ class EmptyPopupMenu : public PopupMenu {
 public:
     EmptyPopupMenu() = default;
 private:
-    void show(const IntRect&, LocalFrameView*, int) final { }
+    void show(const IntRect&, LocalFrameView&, int) final { }
     void hide() final { }
     void updateFromElement() final { }
     void disconnectClient() final { }

--- a/Source/WebCore/platform/PopupMenu.h
+++ b/Source/WebCore/platform/PopupMenu.h
@@ -31,7 +31,7 @@ class LocalFrameView;
 class PopupMenu : public RefCounted<PopupMenu> {
 public:
     virtual ~PopupMenu() = default;
-    virtual void show(const IntRect&, LocalFrameView*, int selectedIndex) = 0;
+    virtual void show(const IntRect&, LocalFrameView&, int selectedIndex) = 0;
     virtual void hide() = 0;
     virtual void updateFromElement() = 0;
     virtual void disconnectClient() = 0;

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -384,7 +384,7 @@ void RenderMenuList::showPopup()
     FloatPoint absTopLeft = localToAbsolute(FloatPoint(), UseTransforms);
     IntRect absBounds = absoluteBoundingBoxRectIgnoringTransforms();
     absBounds.setLocation(roundedIntPoint(absTopLeft));
-    m_popup->show(absBounds, &view().frameView(), selectElement().optionToListIndex(selectElement().selectedIndex())); // May destroy `this`.
+    m_popup->show(absBounds, view().frameView(), selectElement().optionToListIndex(selectElement().selectedIndex())); // May destroy `this`.
 }
 #endif
 

--- a/Source/WebCore/rendering/RenderSearchField.cpp
+++ b/Source/WebCore/rendering/RenderSearchField.cpp
@@ -145,7 +145,7 @@ void RenderSearchField::showPopup()
     FloatPoint absTopLeft = localToAbsolute(FloatPoint(), UseTransforms);
     IntRect absBounds = absoluteBoundingBoxRectIgnoringTransforms();
     absBounds.setLocation(roundedIntPoint(absTopLeft));
-    protectedSearchPopup()->protectedPopupMenu()->show(absBounds, &view().frameView(), -1);
+    protectedSearchPopup()->protectedPopupMenu()->show(absBounds, view().frameView(), -1);
 }
 
 void RenderSearchField::hidePopup()

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.cpp
@@ -90,7 +90,7 @@ Vector<WebPopupItem> WebPopupMenu::populateItems()
     });
 }
 
-void WebPopupMenu::show(const IntRect& rect, LocalFrameView* view, int selectedIndex)
+void WebPopupMenu::show(const IntRect& rect, LocalFrameView& view, int selectedIndex)
 {
     // FIXME: We should probably inform the client to also close the menu.
     Vector<WebPopupItem> items = populateItems();
@@ -105,12 +105,12 @@ void WebPopupMenu::show(const IntRect& rect, LocalFrameView* view, int selectedI
     m_page->setActivePopupMenu(this);
 
     // Move to page coordinates
-    IntRect pageCoordinates(view->contentsToWindow(rect.location()), rect.size());
+    IntRect pageCoordinates(view.contentsToWindow(rect.location()), rect.size());
 
     PlatformPopupMenuData platformData;
     setUpPlatformData(pageCoordinates, platformData);
 
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebPageProxy::ShowPopupMenuFromFrame(view->frame().frameID(), pageCoordinates, static_cast<uint64_t>(m_popupClient->menuStyle().textDirection()), items, selectedIndex, platformData), m_page->identifier());
+    WebProcess::singleton().parentProcessConnection()->send(Messages::WebPageProxy::ShowPopupMenuFromFrame(view.frame().frameID(), pageCoordinates, static_cast<uint64_t>(m_popupClient->menuStyle().textDirection()), items, selectedIndex, platformData), m_page->identifier());
 }
 
 void WebPopupMenu::hide()

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.h
@@ -51,7 +51,7 @@ public:
     WebCore::PopupMenuClient* client() const { return m_popupClient; }
 #endif
 
-    void show(const WebCore::IntRect&, WebCore::LocalFrameView*, int selectedIndex) override;
+    void show(const WebCore::IntRect&, WebCore::LocalFrameView&, int selectedIndex) override;
     void hide() override;
     void updateFromElement() override;
     void disconnectClient() override;

--- a/Source/WebKitLegacy/ios/WebCoreSupport/PopupMenuIOS.h
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/PopupMenuIOS.h
@@ -37,7 +37,7 @@ class PopupMenuIOS : public WebCore::PopupMenu {
 public:
     PopupMenuIOS(WebCore::PopupMenuClient*);
 
-    void show(const WebCore::IntRect&, WebCore::LocalFrameView*, int selectedIndex) override;
+    void show(const WebCore::IntRect&, WebCore::LocalFrameView&, int selectedIndex) override;
     void hide() override;
     void updateFromElement() override;
     void disconnectClient() override;

--- a/Source/WebKitLegacy/ios/WebCoreSupport/PopupMenuIOS.mm
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/PopupMenuIOS.mm
@@ -34,7 +34,7 @@ PopupMenuIOS::PopupMenuIOS(PopupMenuClient* client)
 {
 }
 
-void PopupMenuIOS::show(const IntRect&, LocalFrameView*, int /*selectedIndex*/)
+void PopupMenuIOS::show(const IntRect&, LocalFrameView&, int /*selectedIndex*/)
 {
 }
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.h
@@ -34,7 +34,7 @@ public:
     PopupMenuMac(WebCore::PopupMenuClient*);
     ~PopupMenuMac();
 
-    void show(const WebCore::IntRect&, WebCore::LocalFrameView*, int selectedIndex) override;
+    void show(const WebCore::IntRect&, WebCore::LocalFrameView&, int selectedIndex) override;
     void hide() override;
     void updateFromElement() override;
     void disconnectClient() override;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm
@@ -127,7 +127,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
 }
 
-void PopupMenuMac::show(const IntRect& r, LocalFrameView* v, int selectedIndex)
+void PopupMenuMac::show(const IntRect& r, LocalFrameView& frameView, int selectedIndex)
 {
     populate();
     int numItems = [m_popup numberOfItems];
@@ -142,7 +142,7 @@ void PopupMenuMac::show(const IntRect& r, LocalFrameView* v, int selectedIndex)
     if (selectedIndex == -1 && numItems == 2 && !m_client->shouldPopOver() && ![[m_popup itemAtIndex:1] isEnabled])
         selectedIndex = 0;
 
-    NSView* view = v->documentView();
+    NSView* view = frameView.documentView();
 
     TextDirection textDirection = m_client->menuStyle().textDirection();
 
@@ -181,7 +181,7 @@ void PopupMenuMac::show(const IntRect& r, LocalFrameView* v, int selectedIndex)
     }
     // Save the current event that triggered the popup, so we can clean up our event
     // state after the NSMenu goes away.
-    Ref frame { v->frame() };
+    Ref frame { frameView.frame() };
     RetainPtr<NSEvent> event = frame->eventHandler().currentNSEvent();
     
     Ref<PopupMenuMac> protector(*this);


### PR DESCRIPTION
#### c2fb38fa01e93ab76eab178d4c93b78eed0b6d43
<pre>
Change LocalFrameView* to a reference in `PopupMenu::show()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=272725">https://bugs.webkit.org/show_bug.cgi?id=272725</a>
<a href="https://rdar.apple.com/126529496">rdar://126529496</a>

Reviewed by Alex Christensen.

The LocalFrameView passed to this function cannot be null.

* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/platform/PopupMenu.h:
* Source/WebCore/rendering/RenderMenuList.cpp:
(RenderMenuList::showPopup):
* Source/WebCore/rendering/RenderSearchField.cpp:
(WebCore::RenderSearchField::showPopup):
* Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.cpp:
(WebKit::WebPopupMenu::show):
* Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.h:
* Source/WebKitLegacy/ios/WebCoreSupport/PopupMenuIOS.h:
* Source/WebKitLegacy/ios/WebCoreSupport/PopupMenuIOS.mm:
(PopupMenuIOS::show):
* Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.h:
* Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm:
(PopupMenuMac::show):

Canonical link: <a href="https://commits.webkit.org/277557@main">https://commits.webkit.org/277557@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cd52847090047da9fc1c0e3666bd7ed54e24588

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50602 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43974 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50227 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24609 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38985 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48503 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24785 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41436 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20283 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22270 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5968 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44266 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52496 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22963 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19313 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46293 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24233 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45337 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25024 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6802 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23954 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->