### PR TITLE
Sometimes the contents of a visibility:hidden iframe become visible

### DIFF
--- a/LayoutTests/compositing/visibility/iframe-visibility-hidden-expected.html
+++ b/LayoutTests/compositing/visibility/iframe-visibility-hidden-expected.html
@@ -5,7 +5,6 @@
 <style>
 div {
     margin: 8px;
-    margin-right: 26px;
     width: 50px;
     height: 50px;
     background-color: green;
@@ -14,12 +13,12 @@ div {
 
 .positioned {
     position: absolute;
-    left: 80px;
     top: 8px;
 }
 </style>
 </head>
 <body>
-<div></div><div class=positioned></div>
+<div></div>
+<div class="positioned" style="left: 100px"></div>
 </body>
 </html>

--- a/LayoutTests/compositing/visibility/iframe-visibility-hidden.html
+++ b/LayoutTests/compositing/visibility/iframe-visibility-hidden.html
@@ -33,26 +33,38 @@ function elementIsVisibleNow()
 }
 </script>
 <style>
-#iframe2 {
-    position: absolute;
-    left: 80px;
-    top: 8px;
-}
-</style>
+    iframe {
+        border: none;
+        width: 80px;
+        height: 80px;
+    }
+    .positioned {
+        position: absolute;
+        top: 8px;
+    }
+    .composited {
+        transform: translateZ(0);
+    }
+    </style>
 </head>
 <body>
-<iframe frameborder=no id=iframe1 onload="makeiframe1Visible()" width="80" height="80" style="visibility: hidden"
+<iframe id=iframe1 onload="makeiframe1Visible()" style="visibility: hidden"
     srcdoc="<div style='will-change: transform; width: 50px; height: 50px; background-color: green;'>
           <div style='visibility: visible;'></div>
         </div>">
 </iframe>
-<iframe frameborder=no id=iframe2 onload="makeiframe2Visible()" width="80" height="80" style="visibility: hidden"
+<iframe id=iframe2 class="positioned" onload="makeiframe2Visible()" style="left: 100px; visibility: hidden"
     srcdoc="
         <video style='width: 50px; height: 50px; background-color: green;'>
             <source src='movie.mp4' type='video/mp4'>
         </video>">
 </iframe>
-<iframe frameborder=no width="80" height="80" style="visibility: hidden"
+<iframe class="positioned" style="left: 200px; visibility: hidden"
+    srcdoc="<div style='will-change: transform; width: 50px; height: 50px; background-color: red;'>
+          <div style='visibility: visible;'></div>
+        </div>">
+</iframe>
+<iframe class="positioned composited" style="left: 300px; visibility: hidden"
     srcdoc="<div style='will-change: transform; width: 50px; height: 50px; background-color: red;'>
           <div style='visibility: visible;'></div>
         </div>">

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1211,9 +1211,11 @@ bool RenderLayerBacking::updateConfiguration(const RenderLayer* compositingAnces
     }
 #endif // ENABLE(MODEL_ELEMENT)
     // FIXME: Why do we do this twice?
-    if (CheckedPtr widget = dynamicDowncast<RenderWidget>(renderer()); widget && compositor.attachWidgetContentLayers(*widget)) {
-        m_owningLayer.setNeedsCompositingGeometryUpdate();
-        layerConfigChanged = true;
+    if (CheckedPtr widget = dynamicDowncast<RenderWidget>(renderer())) {
+        if (compositor.attachWidgetContentLayersIfNecessary(*widget).layerHierarchyChanged) {
+            m_owningLayer.setNeedsCompositingGeometryUpdate();
+            layerConfigChanged = true;
+        }
     }
 
     if (RenderLayerCompositor::hasCompositedWidgetContents(renderer())) {

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -302,8 +302,13 @@ public:
     static bool isCompositedPlugin(const RenderObject&);
 
     static RenderLayerCompositor* frameContentsCompositor(RenderWidget&);
-    // Returns true the widget contents layer was parented.
-    bool attachWidgetContentLayers(RenderWidget&);
+
+    struct WidgetLayerAttachment {
+        bool widgetLayersAttachedAsChildren { false };
+        bool layerHierarchyChanged { false };
+    };
+    WidgetLayerAttachment attachWidgetContentLayersIfNecessary(RenderWidget&);
+
     void collectViewTransitionNewContentLayers(RenderLayer&, Vector<Ref<GraphicsLayer>>&);
 
     // Update the geometry of the layers used for clipping and scrolling in frames.


### PR DESCRIPTION
#### d927d70696167cf17a12a6d444674b1a8bed5381
<pre>
Sometimes the contents of a visibility:hidden iframe become visible
<a href="https://bugs.webkit.org/show_bug.cgi?id=272727">https://bugs.webkit.org/show_bug.cgi?id=272727</a>
<a href="https://rdar.apple.com/126178201">rdar://126178201</a>

Reviewed by Matt Woodrow.

A normal composited but `visibility:hidden` layer uses `setContentsVisible(false)`
to hide its contents (by clearing the layer&apos;s `contents` property), and this works
within a document because `visibility` is inherited, and allows a visible child
inside a hidden ancestor.

For plugin or iframe layers we try to avoid making them composited when they
are `visibility:hidden`. However, if they are composited for other reasons (e.g.
`position:fixed`) then we hide their layer contents, but we fail to hide their
descendant layers, which GraphicsLayer parented via `attachWidgetContentLayers()`.

Fix this by not parenting the widget&apos;s content layers in `RenderLayerCompositor::attachWidgetContentLayersIfNecessary()`,
and enhancing the return value to distinguish between &quot;widget has contents via child layers&quot;, and &quot;mutated the layer hierarchy&quot;
since the two callers were using the return value in two different ways.

Enhance an existing test to exercise this case.
* LayoutTests/compositing/visibility/iframe-visibility-hidden-expected.html:
* LayoutTests/compositing/visibility/iframe-visibility-hidden.html:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateConfiguration):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateBackingAndHierarchy):
(WebCore::RenderLayerCompositor::attachWidgetContentLayersIfNecessary):
(WebCore::RenderLayerCompositor::attachWidgetContentLayers): Deleted.
* Source/WebCore/rendering/RenderLayerCompositor.h:

Canonical link: <a href="https://commits.webkit.org/277643@main">https://commits.webkit.org/277643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea4bda8cef4c8243bffb9ec841129ea4fdfd0495

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50731 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44105 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50351 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33137 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24743 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39300 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; layout-tests (exception)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48627 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24917 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41554 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20383 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22398 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42730 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6098 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44387 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43165 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52627 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23092 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19448 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46619 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; layout-tests (exception)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24357 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41706 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45453 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10634 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25157 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24079 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->