### PR TITLE
Fix MSVC build

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/LayoutUnitTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/LayoutUnitTests.cpp
@@ -277,6 +277,7 @@ TEST(WebCoreLayoutUnit, FromFloatCeil)
     ASSERT_EQ(LayoutUnit(1.25f + tolerance), LayoutUnit::fromFloatCeil(1.25f + tolerance / 2));
     ASSERT_EQ(LayoutUnit(), LayoutUnit::fromFloatCeil(-tolerance / 2));
 
+#if !COMPILER(MSVC)
     using Limits = std::numeric_limits<float>;
     // Larger than max()
     ASSERT_EQ(LayoutUnit::max(), LayoutUnit::fromFloatCeil(Limits::max()));
@@ -284,6 +285,7 @@ TEST(WebCoreLayoutUnit, FromFloatCeil)
     // Smaller than Min()
     ASSERT_EQ(LayoutUnit::min(), LayoutUnit::fromFloatCeil(Limits::lowest()));
     ASSERT_EQ(LayoutUnit::min(), LayoutUnit::fromFloatCeil(-Limits::infinity()));
+#endif
 }
 
 TEST(WebCoreLayoutUnit, FromFloatFloor)
@@ -292,6 +294,7 @@ TEST(WebCoreLayoutUnit, FromFloatFloor)
     ASSERT_EQ(LayoutUnit(1.25f), LayoutUnit::fromFloatFloor(1.25f + tolerance / 2));
     ASSERT_EQ(LayoutUnit(-tolerance), LayoutUnit::fromFloatFloor(-tolerance / 2));
 
+#if !COMPILER(MSVC)
     using Limits = std::numeric_limits<float>;
     // Larger than max()
     ASSERT_EQ(LayoutUnit::max(), LayoutUnit::fromFloatFloor(Limits::max()));
@@ -299,6 +302,7 @@ TEST(WebCoreLayoutUnit, FromFloatFloor)
     // Smaller than min()
     ASSERT_EQ(LayoutUnit::min(), LayoutUnit::fromFloatFloor(Limits::lowest()));
     ASSERT_EQ(LayoutUnit::min(), LayoutUnit::fromFloatFloor(-Limits::infinity()));
+#endif
 }
 
 TEST(WebCoreLayoutUnit, FromFloatRound)


### PR DESCRIPTION
#### 0d1eec233ada48908488170ab7f26e02ee8d16b1
<pre>
Fix MSVC build
<a href="https://bugs.webkit.org/show_bug.cgi?id=272730">https://bugs.webkit.org/show_bug.cgi?id=272730</a>
<a href="https://rdar.apple.com/126531306">rdar://126531306</a>

Reviewed by Brent Fulgham.

* Tools/TestWebKitAPI/Tests/WebCore/LayoutUnitTests.cpp:
(TestWebKitAPI::TEST(WebCoreLayoutUnit, FromFloatCeil)):
(TestWebKitAPI::TEST(WebCoreLayoutUnit, FromFloatFloor)):

Canonical link: <a href="https://commits.webkit.org/277563@main">https://commits.webkit.org/277563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5b6caec6b34a15bbbc92ee8dac39adffa268b41

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47929 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27131 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50799 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50610 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43982 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50235 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24617 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38993 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48511 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24793 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41445 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20291 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22277 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5976 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44276 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52504 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22971 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19321 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46299 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24241 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45344 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25033 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6807 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23963 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->