### PR TITLE
[WPE] Generate damage region information

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5245,6 +5245,21 @@ ProcessSwapOnCrossSiteNavigationEnabled:
       "PLATFORM(PLAYSTATION)": false
       default: true
 
+PropagateDamagingInformation:
+   type: bool
+   status: testable
+   category: dom
+   humanReadableName: "Propagate Damaging Information"
+   humanReadableDescription: "Propagate Damaging Information"
+   condition: USE(COORDINATED_GRAPHICS)
+   defaultValue:
+     WebCore:
+       default: false
+     WebKitLegacy:
+       default: false
+     WebKit:
+       default: false
+
 PunchOutWhiteBackgroundsInDarkMode:
   type: bool
   status: embedder
@@ -6809,6 +6824,21 @@ UnifiedPDFEnabled:
       default: false
     WebCore:
       default: false
+
+UnifyDamagedRegions:
+   type: bool
+   status: testable
+   category: dom
+   humanReadableName: "Unify Damaged Regions"
+   humanReadableDescription: "Unify Damaged Regions"
+   condition: USE(COORDINATED_GRAPHICS)
+   defaultValue:
+     WebCore:
+       default: false
+     WebKitLegacy:
+       default: false
+     WebKit:
+       default: false
 
 UpgradeKnownHostsToHTTPSEnabled:
   type: bool

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1903,6 +1903,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/ColorUtilities.h
     platform/graphics/ComplexTextController.h
     platform/graphics/ContentTypeUtilities.h
+    platform/graphics/Damage.h
     platform/graphics/DashArray.h
     platform/graphics/DecodingOptions.h
     platform/graphics/DecomposedGlyphs.h

--- a/Source/WebCore/platform/graphics/Damage.h
+++ b/Source/WebCore/platform/graphics/Damage.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "FloatRect.h"
+#include "Region.h"
+#include <wtf/ForbidHeapAllocation.h>
+
+namespace WebCore {
+
+class Damage {
+    WTF_FORBID_HEAP_ALLOCATION;
+
+public:
+    using Rects = Vector<IntRect, 1>;
+
+    enum class ShouldPropagate : bool {
+        No,
+        Yes,
+    };
+
+    Damage() = default;
+    Damage(Damage&&) = default;
+    Damage(const Damage&) = default;
+    Damage& operator=(const Damage&) = default;
+
+    static const Damage& invalid()
+    {
+        static const Damage invalidDamage(true);
+        return invalidDamage;
+    }
+
+    ALWAYS_INLINE const Region& region() const { return m_region; }
+    ALWAYS_INLINE IntRect bounds() const { return m_region.bounds(); }
+    ALWAYS_INLINE Rects rects() const { return m_region.rects(); }
+    ALWAYS_INLINE bool isEmpty() const  { return !m_invalid && m_region.isEmpty(); }
+    ALWAYS_INLINE bool isInvalid() const { return m_invalid; }
+
+    void invalidate()
+    {
+        m_invalid = true;
+    }
+
+    ALWAYS_INLINE void add(const Region& region)
+    {
+        if (isInvalid())
+            return;
+        m_region.unite(region);
+        mergeIfNeeded();
+    }
+
+    ALWAYS_INLINE void add(const IntRect& rect)
+    {
+        if (isInvalid())
+            return;
+        m_region.unite(rect);
+        mergeIfNeeded();
+    }
+
+    ALWAYS_INLINE void add(const FloatRect& rect)
+    {
+        add(enclosingIntRect(rect));
+    }
+
+    ALWAYS_INLINE void add(const Damage& other)
+    {
+        m_invalid = other.isInvalid();
+        add(other.m_region);
+    }
+
+private:
+    bool m_invalid;
+    Region m_region;
+
+    // From RenderView.cpp::repaintViewRectangle():
+    // Region will get slow if it gets too complex.
+    // Merge all rects so far to bounds if this happens.
+    static constexpr auto maximumGridSize = 16 * 16;
+
+    ALWAYS_INLINE void mergeIfNeeded()
+    {
+        if (UNLIKELY(m_region.gridSize() > maximumGridSize))
+            m_region = Region(m_region.bounds());
+    }
+
+    explicit Damage(bool invalid, Region&& region = { })
+        : m_invalid(invalid)
+        , m_region(WTFMove(region))
+    {
+    }
+
+    friend struct IPC::ArgumentCoder<Damage, void>;
+};
+
+static inline WTF::TextStream& operator<<(WTF::TextStream& ts, const Damage& damage)
+{
+    if (damage.isInvalid())
+        return ts << "Damage[invalid]";
+    return ts << "Damage" << damage.rects();
+}
+
+};

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -476,6 +476,8 @@ public:
 
     virtual void setContentsNeedsDisplay() { };
 
+    virtual void markDamageRectsUnreliable() { };
+
     // The tile phase is relative to the GraphicsLayer bounds.
     virtual void setContentsTilePhase(const FloatSize& p) { m_contentsTilePhase = p; }
     FloatSize contentsTilePhase() const { return m_contentsTilePhase; }

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaCompositionLayer.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaCompositionLayer.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "Color.h"
+#include "Damage.h"
 #include "FilterOperations.h"
 #include "FloatPoint.h"
 #include "FloatPoint3D.h"
@@ -87,6 +88,7 @@ public:
                     bool debugBorderChanged : 1;
                     bool scrollingNodeChanged : 1;
                     bool eventRegionChanged : 1;
+                    bool damageChanged : 1;
                 };
                 uint32_t value { 0 };
             };
@@ -124,6 +126,7 @@ public:
         WebCore::FloatSize contentsTilePhase;
         WebCore::FloatSize contentsTileSize;
         WebCore::FloatRoundedRect contentsClippingRect;
+        WebCore::Damage damage;
 
         float opacity { 0 };
         WebCore::Color solidColor;
@@ -233,6 +236,8 @@ public:
             staging.imageBacking = pending.imageBacking;
         if (pending.delta.animatedBackingStoreClientChanged)
             staging.animatedBackingStoreClient = pending.animatedBackingStoreClient;
+        if (pending.delta.damageChanged)
+            staging.damage = pending.damage;
 
         pending.delta = { };
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -59,7 +59,10 @@ struct TextureMapperLayer::ComputeTransformData {
     }
 };
 
-TextureMapperLayer::TextureMapperLayer() = default;
+TextureMapperLayer::TextureMapperLayer(Damage::ShouldPropagate propagateDamage)
+    : m_propagateDamage(propagateDamage)
+{
+}
 
 TextureMapperLayer::~TextureMapperLayer()
 {
@@ -218,8 +221,31 @@ void TextureMapperLayer::paintSelf(TextureMapperPaintOptions& options)
         solidColorLayer.setColor(m_state.solidColor);
         contentsLayer = &solidColorLayer;
     }
-    if (!contentsLayer)
+
+    if (!contentsLayer) {
+        // Use the damage information we received from the CoordinatedGraphicsLayer
+        // Here we ignore the targetRect parameter as it should already have
+        // been covered by the damage tracking in setNeedsDisplay/setNeedsDisplayInRect
+        // calls from CoordinatedGraphicsLayer.
+        if (m_propagateDamage == Damage::ShouldPropagate::Yes) {
+            if (m_damage.isInvalid())
+                recordDamage(layerRect(), transform, options);
+            else {
+                for (const auto& rect : m_damage.rects()) {
+                    ASSERT(!rect.isEmpty());
+                    recordDamage(rect, transform, options);
+                }
+            }
+            clearDamage();
+        }
         return;
+    }
+
+    if (m_propagateDamage == Damage::ShouldPropagate::Yes) {
+        // Layers with content layer are always fully damaged for now...
+        recordDamage(layerRect(), transform, options);
+        clearDamage();
+    }
 
     if (!m_state.contentsTileSize.isEmpty()) {
         options.textureMapper.setWrapMode(TextureMapper::WrapMode::Repeat);
@@ -827,10 +853,15 @@ void TextureMapperLayer::addChild(TextureMapperLayer* childLayer)
 
     childLayer->m_parent = this;
     m_children.append(childLayer);
+
+    if (m_visitor)
+        childLayer->acceptDamageVisitor(*m_visitor);
 }
 
 void TextureMapperLayer::removeFromParent()
 {
+    dismissDamageVisitor();
+
     if (m_parent) {
         size_t index = m_parent->m_children.find(this);
         ASSERT(index != notFound);
@@ -843,8 +874,10 @@ void TextureMapperLayer::removeFromParent()
 void TextureMapperLayer::removeAllChildren()
 {
     auto oldChildren = WTFMove(m_children);
-    for (auto* child : oldChildren)
+    for (auto* child : oldChildren) {
+        child->dismissDamageVisitor();
         child->m_parent = nullptr;
+    }
 }
 
 void TextureMapperLayer::setMaskLayer(TextureMapperLayer* maskLayer)
@@ -1022,6 +1055,8 @@ bool TextureMapperLayer::descendantsOrSelfHaveRunningAnimations() const
 bool TextureMapperLayer::applyAnimationsRecursively(MonotonicTime time)
 {
     bool hasRunningAnimations = syncAnimations(time);
+    if (hasRunningAnimations) // FIXME Too broad?
+        addDamage(layerRect());
     if (m_state.replicaLayer)
         hasRunningAnimations |= m_state.replicaLayer->applyAnimationsRecursively(time);
     if (m_state.backdropLayer)
@@ -1048,6 +1083,40 @@ bool TextureMapperLayer::syncAnimations(MonotonicTime time)
 #endif
 
     return applicationResults.hasRunningAnimations;
+}
+
+void TextureMapperLayer::acceptDamageVisitor(TextureMapperLayerDamageVisitor& visitor)
+{
+    if (&visitor == m_visitor)
+        return;
+
+    m_visitor = &visitor;
+
+    for (auto* child : m_children)
+        child->acceptDamageVisitor(visitor);
+}
+
+void TextureMapperLayer::dismissDamageVisitor()
+{
+    for (auto* child : m_children)
+        child->dismissDamageVisitor();
+    m_visitor = nullptr;
+}
+
+void TextureMapperLayer::recordDamage(const FloatRect& rect, const TransformationMatrix& transform, const TextureMapperPaintOptions& options)
+{
+    if (!m_visitor)
+        return;
+
+    FloatQuad quad(rect);
+    quad = transform.mapQuad(quad);
+    FloatRect transformedRect = quad.boundingBox();
+    // Some layers are drawn on an intermediate surface and have this offset applied to convert to the
+    // intermediate surface coordinates. In order to translate back to actual coordinates,
+    // we have to undo it.
+    if (!options.offset.isZero())
+        transformedRect.move(-options.offset);
+    m_visitor->recordDamage(transformedRect);
 }
 
 }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
@@ -123,6 +123,7 @@ public:
     void setNeedsDisplay() override;
     void setNeedsDisplayInRect(const FloatRect&, ShouldClipToLayer = ClipToLayer) override;
     void setContentsNeedsDisplay() override;
+    void markDamageRectsUnreliable() override;
     void deviceOrPageScaleFactorChanged() override;
     void flushCompositingState(const FloatRect&) override;
     void flushCompositingStateForThisLayerOnly() override;
@@ -233,6 +234,7 @@ private:
     Nicosia::PlatformLayer::LayerID m_id;
     GraphicsLayerTransform m_layerTransform;
     TransformationMatrix m_cachedInverseTransform;
+    TransformationMatrix m_cachedCombinedTransform;
     FloatSize m_pixelAlignmentOffset;
     FloatSize m_adjustedSize;
     FloatPoint m_adjustedPosition;
@@ -255,6 +257,7 @@ private:
         bool completeLayer { false };
         Vector<FloatRect> rects;
     } m_needsDisplay;
+    bool m_damagedRectsAreUnreliable { false };
 
     RefPtr<Image> m_compositedImage;
     RefPtr<NativeImage> m_compositedNativeImage;

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1687,6 +1687,18 @@ void RenderLayerBacking::updateScrollOffset(ScrollOffset scrollOffset)
     ASSERT(m_scrolledContentsLayer->position().isZero());
 }
 
+static bool layerRendererStyleHas3DTransformOperation(RenderLayer& layer)
+{
+    auto* renderer = &layer.renderer();
+    if (layer.isReflection())
+        renderer = downcast<RenderLayerModelObject>(renderer->parent());
+    const RenderStyle& style = renderer->style();
+    return style.transform().has3DOperation()
+        || (style.translate() && style.translate()->is3DOperation())
+        || (style.scale() && style.scale()->is3DOperation())
+        || (style.rotate() && style.rotate()->is3DOperation());
+}
+
 void RenderLayerBacking::updateAfterDescendants()
 {
     // FIXME: this potentially duplicates work we did in updateConfiguration().
@@ -1706,6 +1718,10 @@ void RenderLayerBacking::updateAfterDescendants()
         ASSERT(!m_backgroundLayer);
         m_graphicsLayer->setContentsOpaque(!m_hasSubpixelRounding && m_owningLayer.backgroundIsKnownToBeOpaqueInRect(compositedBounds()));
     }
+
+    if (layerRendererStyleHas3DTransformOperation(m_owningLayer)
+        || m_owningLayer.hasCompositedScrollableOverflow())
+        m_graphicsLayer->markDamageRectsUnreliable();
 
     m_graphicsLayer->setContentsVisible(m_owningLayer.hasVisibleContent() || hasVisibleNonCompositedDescendants());
     if (m_scrollContainerLayer) {

--- a/Source/WebKit/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
@@ -37,8 +37,9 @@
 namespace WebKit {
 using namespace WebCore;
 
-CoordinatedGraphicsScene::CoordinatedGraphicsScene(CoordinatedGraphicsSceneClient* client)
+CoordinatedGraphicsScene::CoordinatedGraphicsScene(CoordinatedGraphicsSceneClient* client, Damage::ShouldPropagate propagateDamage)
     : m_client(client)
+    , m_propagateDamage(propagateDamage)
 {
 }
 
@@ -58,6 +59,8 @@ void CoordinatedGraphicsScene::applyStateChanges(const Vector<RefPtr<Nicosia::Sc
 void CoordinatedGraphicsScene::paintToCurrentGLContext(const TransformationMatrix& matrix, const FloatRect& clipRect, bool flipY)
 {
     updateSceneState();
+
+    m_damage = WebCore::Damage();
 
     TextureMapperLayer* currentRootLayer = rootLayer();
     if (!currentRootLayer)
@@ -90,11 +93,11 @@ void CoordinatedGraphicsScene::onNewBufferAvailable()
     updateViewport();
 }
 
-TextureMapperLayer& texmapLayer(Nicosia::CompositionLayer& compositionLayer)
+static TextureMapperLayer& texmapLayer(Nicosia::CompositionLayer& compositionLayer, Damage::ShouldPropagate propagateDamage)
 {
     auto& compositionState = compositionLayer.compositionState();
     if (!compositionState.layer) {
-        compositionState.layer = makeUnique<TextureMapperLayer>();
+        compositionState.layer = makeUnique<TextureMapperLayer>(propagateDamage);
         compositionState.layer->setID(compositionLayer.id());
     }
     return *compositionState.layer;
@@ -219,7 +222,7 @@ void CoordinatedGraphicsScene::updateSceneState()
             // Handle the root layer, adding it to the TextureMapperLayer tree
             // on the first update. No such change is expected later.
             {
-                auto& rootLayer = texmapLayer(*state.rootLayer);
+                auto& rootLayer = texmapLayer(*state.rootLayer, m_propagateDamage);
                 if (rootLayer.id() != m_rootLayerID) {
                     m_rootLayerID = rootLayer.id();
                     RELEASE_ASSERT(m_rootLayer->children().isEmpty());
@@ -257,9 +260,9 @@ void CoordinatedGraphicsScene::updateSceneState()
             // the incoming state changes. Layer backings are stored so that the updates
             // (possibly time-consuming) can be done outside of this scene update.
             for (auto& compositionLayer : m_nicosia.state.layers) {
-                auto& layer = texmapLayer(*compositionLayer);
+                auto& layer = texmapLayer(*compositionLayer, m_propagateDamage);
                 compositionLayer->commitState(
-                    [&layer, &layersByBacking, &replacedProxiesToInvalidate]
+                    [this, &layer, &layersByBacking, &replacedProxiesToInvalidate]
                     (const Nicosia::CompositionLayer::LayerState& layerState)
                     {
                         if (layerState.delta.positionChanged)
@@ -293,7 +296,7 @@ void CoordinatedGraphicsScene::updateSceneState()
                         if (layerState.delta.filtersChanged)
                             layer.setFilters(layerState.filters);
                         if (layerState.delta.backdropFiltersChanged)
-                            layer.setBackdropLayer(layerState.backdropLayer ? &texmapLayer(*layerState.backdropLayer) : nullptr);
+                            layer.setBackdropLayer(layerState.backdropLayer ? &texmapLayer(*layerState.backdropLayer, m_propagateDamage) : nullptr);
                         if (layerState.delta.backdropFiltersRectChanged)
                             layer.setBackdropFiltersRect(layerState.backdropFiltersRect);
                         if (layerState.delta.animationsChanged)
@@ -301,13 +304,15 @@ void CoordinatedGraphicsScene::updateSceneState()
 
                         if (layerState.delta.childrenChanged) {
                             layer.setChildren(WTF::map(layerState.children,
-                                [](auto& child) { return &texmapLayer(*child); }));
+                                [this](auto& child) {
+                                    return &texmapLayer(*child, m_propagateDamage);
+                                }));
                         }
 
                         if (layerState.delta.maskChanged)
-                            layer.setMaskLayer(layerState.mask ? &texmapLayer(*layerState.mask) : nullptr);
+                            layer.setMaskLayer(layerState.mask ? &texmapLayer(*layerState.mask, m_propagateDamage) : nullptr);
                         if (layerState.delta.replicaChanged)
-                            layer.setReplicaLayer(layerState.replica ? &texmapLayer(*layerState.replica) : nullptr);
+                            layer.setReplicaLayer(layerState.replica ? &texmapLayer(*layerState.replica, m_propagateDamage) : nullptr);
 
                         if (layerState.delta.flagsChanged) {
                             layer.setContentsOpaque(layerState.flags.contentsOpaque);
@@ -331,6 +336,7 @@ void CoordinatedGraphicsScene::updateSceneState()
                         }
 
                         if (layerState.backingStore) {
+                            layer.acceptDamageVisitor(*this);
                             layersByBacking.backingStore.append(
                                 { std::ref(layer), std::ref(*layerState.backingStore), layerState.backingStore->takeUpdate() });
                         } else
@@ -350,6 +356,12 @@ void CoordinatedGraphicsScene::updateSceneState()
                             layer.setAnimatedBackingStoreClient(layerState.animatedBackingStoreClient.get());
                         else
                             layer.setAnimatedBackingStoreClient(nullptr);
+
+                        if (layerState.delta.damageChanged) {
+                            layer.addDamage(layerState.damage);
+                            if (layerState.damage.isInvalid())
+                                layer.invalidateDamage();
+                        }
                     });
             }
         });
@@ -427,7 +439,8 @@ void CoordinatedGraphicsScene::ensureRootLayer()
     if (m_rootLayer)
         return;
 
-    m_rootLayer = makeUnique<TextureMapperLayer>();
+    m_rootLayer = makeUnique<TextureMapperLayer>(m_propagateDamage);
+    m_rootLayer->acceptDamageVisitor(*this);
     m_rootLayer->setMasksToBounds(false);
     m_rootLayer->setDrawsContent(false);
     m_rootLayer->setAnchorPoint(FloatPoint3D(0, 0, 0));
@@ -454,6 +467,7 @@ void CoordinatedGraphicsScene::purgeGLResources()
 
     m_imageBackingStoreContainers = { };
 
+    m_rootLayer->dismissDamageVisitor();
     m_rootLayer = nullptr;
     m_rootLayerID = 0;
     m_textureMapper = nullptr;
@@ -464,6 +478,11 @@ void CoordinatedGraphicsScene::detach()
     ASSERT(RunLoop::isMain());
     m_isActive = false;
     m_client = nullptr;
+}
+
+void CoordinatedGraphicsScene::recordDamage(const FloatRect& damagedRect)
+{
+    m_damage.add(damagedRect);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/dmabuf/AcceleratedBackingStoreDMABuf.messages.in
+++ b/Source/WebKit/UIProcess/dmabuf/AcceleratedBackingStoreDMABuf.messages.in
@@ -24,5 +24,5 @@ messages -> AcceleratedBackingStoreDMABuf NotRefCounted {
     DidCreateBuffer(uint64_t id, WebCore::IntSize size, uint32_t format, Vector<UnixFileDescriptor> fds, Vector<uint32_t> offsets, Vector<uint32_t> strides, uint64_t modifier, WebKit::DMABufRendererBufferFormat::Usage usage)
     DidCreateBufferSHM(uint64_t id, WebCore::ShareableBitmapHandle handle)
     DidDestroyBuffer(uint64_t id)
-    Frame(uint64_t id)
+    Frame(uint64_t id, std::optional<WebCore::Region> damage)
 }

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
@@ -535,7 +535,7 @@ void AcceleratedBackingStoreDMABuf::didDestroyBuffer(uint64_t id)
     m_buffers.remove(id);
 }
 
-void AcceleratedBackingStoreDMABuf::frame(uint64_t bufferID)
+void AcceleratedBackingStoreDMABuf::frame(uint64_t bufferID, const std::optional<WebCore::Region>&)
 {
     ASSERT(!m_pendingBuffer);
     auto* buffer = m_buffers.get(bufferID);

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
@@ -45,6 +45,7 @@ struct gbm_bo;
 
 namespace WebCore {
 class IntRect;
+class Region;
 class ShareableBitmap;
 class ShareableBitmapHandle;
 }
@@ -78,7 +79,7 @@ private:
     void didCreateBuffer(uint64_t id, const WebCore::IntSize&, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, DMABufRendererBufferFormat::Usage);
     void didCreateBufferSHM(uint64_t id, WebCore::ShareableBitmapHandle&&);
     void didDestroyBuffer(uint64_t id);
-    void frame(uint64_t id);
+    void frame(uint64_t id, const std::optional<WebCore::Region>&);
     void frameDone();
     void ensureGLContext();
     bool prepareForRendering();

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp
@@ -31,7 +31,7 @@
 #include "AcceleratedSurfaceDMABufMessages.h"
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
-#include <WebCore/IntRect.h>
+#include <WebCore/Region.h>
 #include <WebCore/ShareableBitmap.h>
 #include <wpe/wpe-platform.h>
 #include <wtf/glib/GUniquePtr.h>
@@ -124,7 +124,7 @@ void AcceleratedBackingStoreDMABuf::didDestroyBuffer(uint64_t id)
         m_bufferIDs.remove(buffer.get());
 }
 
-void AcceleratedBackingStoreDMABuf::frame(uint64_t bufferID)
+void AcceleratedBackingStoreDMABuf::frame(uint64_t bufferID, const std::optional<WebCore::Region>& damage)
 {
     ASSERT(!m_pendingBuffer);
     auto* buffer = m_buffers.get(bufferID);
@@ -133,9 +133,24 @@ void AcceleratedBackingStoreDMABuf::frame(uint64_t bufferID)
         return;
     }
 
+    // Rely on the layout of IntRect matching that of WPERectangle
+    // to pass directly a pointer below instead of using copies.
+    static_assert(sizeof(WebCore::IntRect) == sizeof(WPERectangle));
+
+    Vector<WebCore::IntRect, 1> damageRects;
+    if (damage) {
+        if (damage->isEmpty())
+            damageRects.append({ 0, 0, 0, 0 });
+        else
+            damageRects = damage->rects();
+    }
+
+    ASSERT(damageRects.size() <= std::numeric_limits<guint>::max());
+    const auto* rects = damageRects.size() ? reinterpret_cast<const WPERectangle*>(damageRects.data()) : nullptr;
+
     m_pendingBuffer = buffer;
     GUniqueOutPtr<GError> error;
-    if (!wpe_view_render_buffer(m_wpeView.get(), m_pendingBuffer.get(), &error.outPtr())) {
+    if (!wpe_view_render_buffer(m_wpeView.get(), m_pendingBuffer.get(), rects, damageRects.size(), &error.outPtr())) {
         g_warning("Failed to render frame: %s", error->message);
         frameDone();
     }

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h
@@ -37,7 +37,7 @@ typedef struct _WPEBuffer WPEBuffer;
 typedef struct _WPEView WPEView;
 
 namespace WebCore {
-class IntRect;
+class Region;
 class ShareableBitmapHandle;
 }
 
@@ -68,7 +68,7 @@ private:
     void didCreateBuffer(uint64_t id, const WebCore::IntSize&, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, DMABufRendererBufferFormat::Usage);
     void didCreateBufferSHM(uint64_t id, WebCore::ShareableBitmapHandle&&);
     void didDestroyBuffer(uint64_t id);
-    void frame(uint64_t bufferID);
+    void frame(uint64_t bufferID, const std::optional<WebCore::Region>&);
     void frameDone();
     void bufferRendered();
     void bufferReleased(WPEBuffer*);

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -880,6 +880,8 @@ gboolean wpe_view_unmaximize(WPEView* view)
  * wpe_view_render_buffer:
  * @view: a #WPEView
  * @buffer: a #WPEBuffer to render
+ * @damage_rects: (nullable) (array length=n_damage_rects): damage rectangles
+ * @n_damage_rects: number of rectangles in @damage_rects
  * @error: return location for error or %NULL to ignore
  *
  * Render the given @buffer into @view.
@@ -888,13 +890,13 @@ gboolean wpe_view_unmaximize(WPEView* view)
  *
  * Returns: %TRUE if buffer will be rendered, or %FALSE otherwise
  */
-gboolean wpe_view_render_buffer(WPEView* view, WPEBuffer* buffer, GError** error)
+gboolean wpe_view_render_buffer(WPEView* view, WPEBuffer* buffer, const WPERectangle* damageRects, guint nDamageRects, GError** error)
 {
     g_return_val_if_fail(WPE_IS_VIEW(view), FALSE);
     g_return_val_if_fail(WPE_IS_BUFFER(buffer), FALSE);
 
     auto* viewClass = WPE_VIEW_GET_CLASS(view);
-    return viewClass->render_buffer(view, buffer, error);
+    return viewClass->render_buffer(view, buffer, damageRects, nDamageRects, error);
 }
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.h
@@ -49,31 +49,33 @@ struct _WPEViewClass
 {
     GObjectClass parent_class;
 
-    gboolean                (* render_buffer)                 (WPEView      *view,
-                                                               WPEBuffer    *buffer,
-                                                               GError      **error);
-    WPEMonitor             *(* get_monitor)                   (WPEView      *view);
-    gboolean                (* resize)                        (WPEView      *view,
-                                                               int           width,
-                                                               int           height);
-    gboolean                (* set_fullscreen)                (WPEView      *view,
-                                                               gboolean      fullscreen);
-    gboolean                (* set_maximized)                 (WPEView      *view,
-                                                               gboolean      maximized);
-    WPEBufferDMABufFormats *(* get_preferred_dma_buf_formats) (WPEView      *view);
-    void                    (* set_cursor_from_name)          (WPEView      *view,
-                                                               const char   *name);
-    void                    (* set_cursor_from_bytes)         (WPEView      *view,
-                                                               GBytes       *bytes,
-                                                               guint         width,
-                                                               guint         height,
-                                                               guint         stride,
-                                                               guint         hotspot_x,
-                                                               guint         hotspot_y);
-    void                    (* set_opaque_rectangles)         (WPEView      *view,
-                                                               WPERectangle *rects,
-                                                               guint         n_rects);
-    gboolean                (* can_be_mapped)                 (WPEView      *view);
+    gboolean                (* render_buffer)                 (WPEView            *view,
+                                                               WPEBuffer          *buffer,
+                                                               const WPERectangle *damage_rects,
+                                                               guint               n_damage_rects,
+                                                               GError            **error);
+    WPEMonitor             *(* get_monitor)                   (WPEView            *view);
+    gboolean                (* resize)                        (WPEView            *view,
+                                                               int                 width,
+                                                               int                 height);
+    gboolean                (* set_fullscreen)                (WPEView            *view,
+                                                               gboolean            fullscreen);
+    gboolean                (* set_maximized)                 (WPEView            *view,
+                                                               gboolean            maximized);
+    WPEBufferDMABufFormats *(* get_preferred_dma_buf_formats) (WPEView            *view);
+    void                    (* set_cursor_from_name)          (WPEView            *view,
+                                                               const char         *name);
+    void                    (* set_cursor_from_bytes)         (WPEView            *view,
+                                                               GBytes             *bytes,
+                                                               guint               width,
+                                                               guint               height,
+                                                               guint               stride,
+                                                               guint               hotspot_x,
+                                                               guint               hotspot_y);
+    void                    (* set_opaque_rectangles)         (WPEView            *view,
+                                                               WPERectangle       *rects,
+                                                               guint               n_rects);
+    gboolean                (* can_be_mapped)                 (WPEView            *view);
 
     gpointer padding[32];
 };
@@ -106,63 +108,65 @@ typedef enum {
 
 WPE_API GQuark                  wpe_view_error_quark                   (void);
 
-WPE_API WPEView                *wpe_view_new                           (WPEDisplay   *display);
-WPE_API WPEDisplay             *wpe_view_get_display                   (WPEView      *view);
-WPE_API int                     wpe_view_get_width                     (WPEView      *view);
-WPE_API int                     wpe_view_get_height                    (WPEView      *view);
-WPE_API void                    wpe_view_closed                        (WPEView      *view);
-WPE_API gboolean                wpe_view_resize                        (WPEView      *view,
-                                                                        int           width,
-                                                                        int           height);
-WPE_API void                    wpe_view_resized                       (WPEView      *view,
-                                                                        int           width,
-                                                                        int           height);
-WPE_API gdouble                 wpe_view_get_scale                     (WPEView      *view);
-WPE_API void                    wpe_view_scale_changed                 (WPEView      *view,
-                                                                        gdouble       scale);
-WPE_API gboolean                wpe_view_get_visible                   (WPEView      *view);
-WPE_API void                    wpe_view_set_visible                   (WPEView      *view,
-                                                                        gboolean      visible);
-WPE_API gboolean                wpe_view_get_mapped                    (WPEView      *view);
-WPE_API void                    wpe_view_map                           (WPEView      *view);
-WPE_API void                    wpe_view_unmap                         (WPEView      *view);
-WPE_API void                    wpe_view_set_cursor_from_name          (WPEView      *view,
-                                                                        const char   *name);
-WPE_API void                    wpe_view_set_cursor_from_bytes         (WPEView      *view,
-                                                                        GBytes       *bytes,
-                                                                        guint         width,
-                                                                        guint         height,
-                                                                        guint         stride,
-                                                                        guint         hotspot_x,
-                                                                        guint         hotspot_y);
-WPE_API WPEViewState            wpe_view_get_state                     (WPEView      *view);
-WPE_API void                    wpe_view_state_changed                 (WPEView      *view,
-                                                                        WPEViewState  state);
-WPE_API WPEMonitor             *wpe_view_get_monitor                   (WPEView      *view);
-WPE_API gboolean                wpe_view_fullscreen                    (WPEView      *view);
-WPE_API gboolean                wpe_view_unfullscreen                  (WPEView      *view);
-WPE_API gboolean                wpe_view_maximize                      (WPEView      *view);
-WPE_API gboolean                wpe_view_unmaximize                    (WPEView      *view);
-WPE_API gboolean                wpe_view_render_buffer                 (WPEView      *view,
-                                                                        WPEBuffer    *buffer,
-                                                                        GError      **error);
-WPE_API void                    wpe_view_buffer_rendered               (WPEView      *view,
-                                                                        WPEBuffer    *buffer);
-WPE_API void                    wpe_view_buffer_released               (WPEView      *view,
-                                                                        WPEBuffer    *buffer);
-WPE_API void                    wpe_view_event                         (WPEView      *view,
-                                                                        WPEEvent     *event);
-WPE_API guint                   wpe_view_compute_press_count           (WPEView      *view,
-                                                                        gdouble       x,
-                                                                        gdouble       y,
-                                                                        guint         button,
-                                                                        guint32       time);
-WPE_API void                    wpe_view_focus_in                      (WPEView      *view);
-WPE_API void                    wpe_view_focus_out                     (WPEView      *view);
-WPE_API WPEBufferDMABufFormats *wpe_view_get_preferred_dma_buf_formats (WPEView      *view);
-WPE_API void                    wpe_view_set_opaque_rectangles         (WPEView      *view,
-                                                                        WPERectangle *rects,
-                                                                        guint         n_rects);
+WPE_API WPEView                *wpe_view_new                           (WPEDisplay         *display);
+WPE_API WPEDisplay             *wpe_view_get_display                   (WPEView            *view);
+WPE_API int                     wpe_view_get_width                     (WPEView            *view);
+WPE_API int                     wpe_view_get_height                    (WPEView            *view);
+WPE_API void                    wpe_view_closed                        (WPEView            *view);
+WPE_API gboolean                wpe_view_resize                        (WPEView            *view,
+                                                                        int                 width,
+                                                                        int                 height);
+WPE_API void                    wpe_view_resized                       (WPEView            *view,
+                                                                        int                 width,
+                                                                        int                 height);
+WPE_API gdouble                 wpe_view_get_scale                     (WPEView            *view);
+WPE_API void                    wpe_view_scale_changed                 (WPEView            *view,
+                                                                        gdouble             scale);
+WPE_API gboolean                wpe_view_get_visible                   (WPEView            *view);
+WPE_API void                    wpe_view_set_visible                   (WPEView            *view,
+                                                                        gboolean            visible);
+WPE_API gboolean                wpe_view_get_mapped                    (WPEView            *view);
+WPE_API void                    wpe_view_map                           (WPEView            *view);
+WPE_API void                    wpe_view_unmap                         (WPEView            *view);
+WPE_API void                    wpe_view_set_cursor_from_name          (WPEView            *view,
+                                                                        const char         *name);
+WPE_API void                    wpe_view_set_cursor_from_bytes         (WPEView            *view,
+                                                                        GBytes             *bytes,
+                                                                        guint               width,
+                                                                        guint               height,
+                                                                        guint               stride,
+                                                                        guint               hotspot_x,
+                                                                        guint               hotspot_y);
+WPE_API WPEViewState            wpe_view_get_state                     (WPEView            *view);
+WPE_API void                    wpe_view_state_changed                 (WPEView            *view,
+                                                                        WPEViewState        state);
+WPE_API WPEMonitor             *wpe_view_get_monitor                   (WPEView            *view);
+WPE_API gboolean                wpe_view_fullscreen                    (WPEView            *view);
+WPE_API gboolean                wpe_view_unfullscreen                  (WPEView            *view);
+WPE_API gboolean                wpe_view_maximize                      (WPEView            *view);
+WPE_API gboolean                wpe_view_unmaximize                    (WPEView            *view);
+WPE_API gboolean                wpe_view_render_buffer                 (WPEView            *view,
+                                                                        WPEBuffer          *buffer,
+                                                                        const WPERectangle *damage_rects,
+                                                                        guint               n_damage_rects,
+                                                                        GError            **error);
+WPE_API void                    wpe_view_buffer_rendered               (WPEView            *view,
+                                                                        WPEBuffer          *buffer);
+WPE_API void                    wpe_view_buffer_released               (WPEView            *view,
+                                                                        WPEBuffer          *buffer);
+WPE_API void                    wpe_view_event                         (WPEView            *view,
+                                                                        WPEEvent           *event);
+WPE_API guint                   wpe_view_compute_press_count           (WPEView            *view,
+                                                                        gdouble             x,
+                                                                        gdouble             y,
+                                                                        guint               button,
+                                                                        guint32             time);
+WPE_API void                    wpe_view_focus_in                      (WPEView            *view);
+WPE_API void                    wpe_view_focus_out                     (WPEView            *view);
+WPE_API WPEBufferDMABufFormats *wpe_view_get_preferred_dma_buf_formats (WPEView            *view);
+WPE_API void                    wpe_view_set_opaque_rectangles         (WPEView            *view,
+                                                                        WPERectangle       *rects,
+                                                                        guint               n_rects);
 
 G_END_DECLS
 

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp
@@ -387,7 +387,7 @@ static gboolean wpeViewDRMRequestUpdate(WPEViewDRM* view, GError** error)
     return wpeViewDRMCommitLegacy(WPE_VIEW_DRM(view), *drmBuffer, error);
 }
 
-static gboolean wpeViewDRMRenderBuffer(WPEView* view, WPEBuffer* buffer, GError** error)
+static gboolean wpeViewDRMRenderBuffer(WPEView* view, WPEBuffer* buffer, const WPERectangle*, guint, GError** error)
 {
     auto* drmBuffer = static_cast<WPE::DRM::Buffer*>(wpe_buffer_get_user_data(buffer));
     if (!drmBuffer) {

--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.cpp
@@ -96,7 +96,7 @@ static void wpeViewHeadlessDispose(GObject* object)
     G_OBJECT_CLASS(wpe_view_headless_parent_class)->dispose(object);
 }
 
-static gboolean wpeViewHeadlessRenderBuffer(WPEView* view, WPEBuffer* buffer, GError**)
+static gboolean wpeViewHeadlessRenderBuffer(WPEView* view, WPEBuffer* buffer, const WPERectangle*, guint, GError**)
 {
     auto* priv = WPE_VIEW_HEADLESS(view)->priv;
     priv->pendingBuffer = buffer;

--- a/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h
@@ -32,6 +32,10 @@ namespace WTF {
 class RunLoop;
 }
 
+namespace WebCore {
+class Region;
+}
+
 namespace WebKit {
 
 class WebPage;
@@ -58,7 +62,7 @@ public:
     virtual void willDestroyGLContext() { }
     virtual void finalize() { }
     virtual void willRenderFrame() { }
-    virtual void didRenderFrame() { }
+    virtual void didRenderFrame(const std::optional<WebCore::Region>&) { }
 
     virtual void didCreateCompositingRunLoop(WTF::RunLoop&) { }
     virtual void willDestroyCompositingRunLoop() { }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -37,6 +37,7 @@
 #include "WebProcess.h"
 #include <WebCore/AsyncScrollingCoordinator.h>
 #include <WebCore/Chrome.h>
+#include <WebCore/Damage.h>
 #include <WebCore/LocalFrame.h>
 #include <WebCore/LocalFrameView.h>
 #include <WebCore/PageOverlayController.h>
@@ -84,12 +85,20 @@ LayerTreeHost::LayerTreeHost(WebPage& webPage, WebCore::PlatformDisplayID displa
     scaledSize.scale(m_webPage.deviceScaleFactor());
     float scaleFactor = m_webPage.deviceScaleFactor() * m_viewportController.pageScaleFactor();
 
+    const auto damagePropagation = ([](const WebCore::Settings& settings) {
+        if (!settings.propagateDamagingInformation())
+            return ThreadedCompositor::DamagePropagation::None;
+        if (settings.unifyDamagedRegions())
+            return ThreadedCompositor::DamagePropagation::Unified;
+        return ThreadedCompositor::DamagePropagation::Region;
+    })(m_webPage.corePage()->settings());
+
 #if HAVE(DISPLAY_LINK)
     // FIXME: remove the displayID from ThreadedCompositor too.
     auto displayID = m_webPage.corePage()->displayID();
-    m_compositor = ThreadedCompositor::create(*this, displayID, scaledSize, scaleFactor, m_surface->shouldPaintMirrored());
+    m_compositor = ThreadedCompositor::create(*this, displayID, scaledSize, scaleFactor, m_surface->shouldPaintMirrored(), damagePropagation);
 #else
-    m_compositor = ThreadedCompositor::create(*this, *this, displayID, scaledSize, scaleFactor, m_surface->shouldPaintMirrored());
+    m_compositor = ThreadedCompositor::create(*this, *this, displayID, scaledSize, scaleFactor, m_surface->shouldPaintMirrored(), damagePropagation);
 #endif
     m_layerTreeContext.contextID = m_surface->surfaceID();
     m_surface->didCreateCompositingRunLoop(m_compositor->compositingRunLoop());
@@ -192,6 +201,8 @@ void LayerTreeHost::setViewOverlayRootLayer(GraphicsLayer* viewOverlayRootLayer)
 
 void LayerTreeHost::scrollNonCompositedContents(const IntRect& rect)
 {
+    m_scrolledSinceLastFrame = true;
+
     auto* frameView = m_webPage.localMainFrameView();
     if (!frameView || !frameView->delegatesScrolling())
         return;
@@ -308,6 +319,7 @@ void LayerTreeHost::didChangeViewport()
     float pageScale = m_viewportController.pageScaleFactor();
     IntPoint scrollPosition = roundedIntPoint(visibleRect.location());
     if (m_lastScrollPosition != scrollPosition) {
+        m_scrolledSinceLastFrame = true;
         m_lastScrollPosition = scrollPosition;
         m_compositor->setScrollPosition(m_lastScrollPosition, m_webPage.deviceScaleFactor() * pageScale);
 
@@ -409,9 +421,16 @@ void LayerTreeHost::clearIfNeeded()
     m_surface->clearIfNeeded();
 }
 
-void LayerTreeHost::didRenderFrame(uint32_t compositionResponseID)
+void LayerTreeHost::didRenderFrame(uint32_t compositionResponseID, const WebCore::Damage& damage)
 {
-    m_surface->didRenderFrame();
+    std::optional<WebCore::Region> damageRegion;
+    if (!m_scrolledSinceLastFrame && !damage.isInvalid())
+        damageRegion = damage.region();
+
+    m_surface->didRenderFrame(damageRegion);
+
+    m_scrolledSinceLastFrame = false;
+
 #if HAVE(DISPLAY_LINK)
     m_compositionResponseID = compositionResponseID;
     if (!m_didRenderFrameTimer.isActive())

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -50,6 +50,7 @@
 
 namespace WebCore {
 class CoordinatedGraphicsLayer;
+class Damage;
 class IntRect;
 class IntSize;
 class GraphicsLayer;
@@ -140,7 +141,7 @@ private:
     void resize(const WebCore::IntSize&) override;
     void willRenderFrame() override;
     void clearIfNeeded() override;
-    void didRenderFrame(uint32_t) override;
+    void didRenderFrame(uint32_t, const WebCore::Damage&) override;
     void displayDidRefresh(WebCore::PlatformDisplayID) override;
 
 #if !HAVE(DISPLAY_LINK)
@@ -166,6 +167,7 @@ private:
     bool m_scheduledWhileWaitingForRenderer { false };
     float m_lastPageScaleFactor { 1 };
     WebCore::IntPoint m_lastScrollPosition;
+    bool m_scrolledSinceLastFrame { false };
     WebCore::GraphicsLayer* m_viewOverlayRootLayer { nullptr };
     std::unique_ptr<AcceleratedSurface> m_surface;
     RefPtr<ThreadedCompositor> m_compositor;

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
@@ -34,6 +34,7 @@
 #include "WebProcess.h"
 #include <WebCore/GLFence.h>
 #include <WebCore/PlatformDisplay.h>
+#include <WebCore/Region.h>
 #include <WebCore/ShareableBitmap.h>
 #include <array>
 #include <epoxy/egl.h>
@@ -602,7 +603,7 @@ void AcceleratedSurfaceDMABuf::willRenderFrame()
         WTFLogAlways("AcceleratedSurfaceDMABuf was unable to construct a complete framebuffer");
 }
 
-void AcceleratedSurfaceDMABuf::didRenderFrame()
+void AcceleratedSurfaceDMABuf::didRenderFrame(const std::optional<WebCore::Region>& damage)
 {
     if (!m_target)
         return;
@@ -613,7 +614,7 @@ void AcceleratedSurfaceDMABuf::didRenderFrame()
         glFlush();
 
     m_target->didRenderFrame();
-    WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStoreDMABuf::Frame(m_target->id()), m_id);
+    WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStoreDMABuf::Frame(m_target->id(), damage), m_id);
 }
 
 void AcceleratedSurfaceDMABuf::releaseBuffer(uint64_t targetID)

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
@@ -44,6 +44,7 @@ struct gbm_bo;
 #endif
 
 namespace WebCore {
+class Region;
 class ShareableBitmap;
 class ShareableBitmapHandle;
 }
@@ -72,7 +73,7 @@ private:
     void didCreateGLContext() override;
     void willDestroyGLContext() override;
     void willRenderFrame() override;
-    void didRenderFrame() override;
+    void didRenderFrame(const std::optional<WebCore::Region>&) override;
 
     void didCreateCompositingRunLoop(WTF::RunLoop&) override;
     void willDestroyCompositingRunLoop() override;
@@ -101,7 +102,7 @@ private:
         uint64_t id() const { return m_id; }
 
         virtual void willRenderFrame() const;
-        virtual void didRenderFrame() { };
+        virtual void didRenderFrame() { }
 
     protected:
         RenderTarget(uint64_t, const WebCore::IntSize&);

--- a/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp
+++ b/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp
@@ -106,7 +106,7 @@ void AcceleratedSurfaceLibWPE::willRenderFrame()
     wpe_renderer_backend_egl_target_frame_will_render(m_backend);
 }
 
-void AcceleratedSurfaceLibWPE::didRenderFrame()
+void AcceleratedSurfaceLibWPE::didRenderFrame(const std::optional<WebCore::Region>&)
 {
     ASSERT(m_backend);
     wpe_renderer_backend_egl_target_frame_rendered(m_backend);

--- a/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h
+++ b/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h
@@ -56,7 +56,7 @@ public:
     void initialize() override;
     void finalize() override;
     void willRenderFrame() override;
-    void didRenderFrame() override;
+    void didRenderFrame(const std::optional<WebCore::Region>&) override;
 
 private:
     AcceleratedSurfaceLibWPE(WebPage&, Client&);


### PR DESCRIPTION
#### a6a10cdfb8baf3512b99b36741595efa8c6feb06
<pre>
[WPE] Generate damage region information
<a href="https://bugs.webkit.org/show_bug.cgi?id=265777">https://bugs.webkit.org/show_bug.cgi?id=265777</a>

Reviewed by Carlos Garcia Campos.

Includes code and ideas from Lauro Moura, Pawel Lampe, Carlos Garcia
Campos, and Miguel Gomez.

Implement tracking which part of a frame change since the previous one.
This may be used to let display systems optimize presentation of the
rendered frames by updating only the parts that have been &quot;damaged&quot;.
While usually negligible on desktops, this can result in significant
savings on embedded devices, particularly in memory bandwith and GPU
usage.

Information about damaged frames is collected mainly from repainted
rectangles (from CoordinatedGraphicsLayer) and animated layers (from
TextureMapperLayer), and recorded in a new helper Damage class.

This is a first pass that only propagates the recorded Damage along with
DMA-BUF buffers, and forwards the information to the Wayland compositor
support in WPEPlatform. It should be possible to propagate the
information through EGL where the EGL_{KHR,EXT}_swap_buffers_with_damage
extension is present, which would work when the WPEPlatform API is not
being used; gdk_dmabuf_texture_builder_set_update_region() could be
used for the GTK port; and the optional FB_DAMAGE_CLIPS property for
the DRM platform. These are left to be implemented later on.

The intention for now is to lay out the foundations, and hence the
feature is gated behind a runtime flag. Being an initial implementation,
there are number of shortcomings that may be addressed as follow-ups.

There is an attempt at detecting whether 3D transforms are used, with
the intention of invalidating the whole frame; this mostly works but it
would be better to properly handle these instead of causing full-frame
damage.

There is a pre-existing issue which manifests itself more obviously with
damage tracking enabled: while animating, the renderer content may not
be as crisp as static; typically WebKit would repaint the crisper
version of the content after animations have completed, but if some
parts have not changed since the last frame, they will show up fuzzy
because they are not considered as damaged. This is independent from
damage tracking.

Enabling damage tracking seems add negligible CPU usage: enabling it is
neutral on Speedometer and MotionMark, which for the WPE port are CPU
bound due to rasterization through Cairo being CPU bound.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml: Add feature
  flags to enable damage tracking, and to produce a single rectangle
  with the bounds of the damaged region instead of multiple rectangles.
* Source/WebCore/Headers.cmake:
* Source/WebCore/platform/graphics/Damage.h: Added.
(WebCore::Damage::invalid):
(WebCore::Damage::region const):
(WebCore::Damage::bounds const):
(WebCore::Damage::rects const):
(WebCore::Damage::isEmpty const):
(WebCore::Damage::isInvalid const):
(WebCore::Damage::invalidate):
(WebCore::Damage::add):
(WebCore::Damage::mergeIfNeeded):
(WebCore::Damage::Damage):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::markDamageRectsUnreliable):
* Source/WebCore/platform/graphics/nicosia/NicosiaCompositionLayer.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::TextureMapperLayer):
(WebCore::TextureMapperLayer::paintSelf):
(WebCore::TextureMapperLayer::addChild):
(WebCore::TextureMapperLayer::removeFromParent):
(WebCore::TextureMapperLayer::removeAllChildren):
(WebCore::TextureMapperLayer::applyAnimationsRecursively):
(WebCore::TextureMapperLayer::acceptDamageVisitor):
(WebCore::TextureMapperLayer::dismissDamageVisitor):
(WebCore::TextureMapperLayer::recordDamage):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h:
(WebCore::TextureMapperLayer::clearDamage):
(WebCore::TextureMapperLayer::invalidateDamage):
(WebCore::TextureMapperLayer::addDamage):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp:
(WebCore::CoordinatedGraphicsLayer::setContentsOpaque):
(WebCore::CoordinatedGraphicsLayer::markDamageRectsUnreliable):
(WebCore::CoordinatedGraphicsLayer::setNeedsDisplay):
(WebCore::CoordinatedGraphicsLayer::setNeedsDisplayInRect):
(WebCore::CoordinatedGraphicsLayer::flushCompositingStateForThisLayerOnly):
(WebCore::CoordinatedGraphicsLayer::computeTransformedVisibleRect):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::layerRendererStyleHas3DTransformOperation):
(WebCore::RenderLayerBacking::updateAfterDescendants):
* Source/WebKit/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.cpp:
(WebKit::CoordinatedGraphicsScene::CoordinatedGraphicsScene):
(WebKit::CoordinatedGraphicsScene::paintToCurrentGLContext):
(WebKit::texmapLayer):
(WebKit::CoordinatedGraphicsScene::updateSceneState):
(WebKit::CoordinatedGraphicsScene::ensureRootLayer):
(WebKit::CoordinatedGraphicsScene::purgeGLResources):
(WebKit::CoordinatedGraphicsScene::recordDamage):
* Source/WebKit/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.h:
(WebKit::CoordinatedGraphicsScene::lastDamage const):
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::create):
(WebKit::ThreadedCompositor::ThreadedCompositor):
(WebKit::ThreadedCompositor::renderLayerTree):
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h:
* Source/WebKit/UIProcess/dmabuf/AcceleratedBackingStoreDMABuf.messages.in:
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::frame):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h:
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::frame):
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h:
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpe_view_render_buffer):
* Source/WebKit/WPEPlatform/wpe/WPEView.h:
* Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp:
(wpeViewDRMRenderBuffer):
* Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.cpp:
(wpeViewHeadlessRenderBuffer):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:
* Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h:
(WebKit::AcceleratedSurface::didRenderFrame):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::LayerTreeHost):
(WebKit::LayerTreeHost::scrollNonCompositedContents):
(WebKit::LayerTreeHost::didChangeViewport):
(WebKit::LayerTreeHost::didRenderFrame):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::didRenderFrame):
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h:
* Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp:
(WebKit::AcceleratedSurfaceLibWPE::didRenderFrame):
* Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h:

Canonical link: <a href="https://commits.webkit.org/280193@main">https://commits.webkit.org/280193@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9469c9579ca5dfc1472b3293248ac1707e6e73e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35290 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58965 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6398 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58092 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6594 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/45071 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4423 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57995 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33184 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48258 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26209 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29967 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5586 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4541 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/49042 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60552 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/55202 "Built successfully and passed tests") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/5977 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52499 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48327 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/52026 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/76963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8275 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31119 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/76963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32203 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33285 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31951 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->