### PR TITLE
REGRESSION (277239@main): 4 tests in TestWebKitAPI.IPCTestingAPI are consistent failure/timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
@@ -256,9 +256,10 @@ TEST(IPCTestingAPI, CanSendAsyncMessageToGPUProcess)
     [webView setUIDelegate:delegate.get()];
 
     done = false;
-    [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><script>(async function test() {"
-        "window.result = await IPC.sendMessage('GPU', 0, IPC.messages.RemoteAudioDestinationManager_StartAudioDestination.name, [{type: 'uint64_t', value: 12345}]);"
-        "alert(!!result)"
+    [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><script>(function test() {"
+        "let c = IPC.connectionForProcessTarget('GPU');"
+        "let cb = (result) => { window.result = result; alert(!!result); };"
+        "c.sendWithAsyncReply(0, IPC.messages.RemoteAudioDestinationManager_StartAudioDestination.name, [{type: 'uint64_t', value: 12345}], cb);"
         "})();</script>"];
     TestWebKitAPI::Util::run(&done);
 
@@ -275,10 +276,11 @@ TEST(IPCTestingAPI, CanSendInvalidAsyncMessageToGPUProcessWithoutTermination)
     [webView setUIDelegate:delegate.get()];
 
     done = false;
-    [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><script>(async function test() {"
-        "IPC.sendMessage('GPU', 0, IPC.messages.GPUConnectionToWebProcess_CreateRenderingBackend.name, []);"
-        "window.result = await IPC.sendMessage('GPU', 0, IPC.messages.RemoteAudioDestinationManager_StartAudioDestination.name, [{type: 'uint64_t', value: 12345}]);"
-        "alert(!!result)"
+    [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><script>(function test() {"
+        "let c = IPC.connectionForProcessTarget('GPU');"
+        "c.sendMessage(0, IPC.messages.GPUConnectionToWebProcess_CreateRenderingBackend.name, []);"
+        "let cb = (result) => { window.result = result; alert(!!result); };"
+        "c.sendWithAsyncReply(0, IPC.messages.RemoteAudioDestinationManager_StartAudioDestination.name, [{type: 'uint64_t', value: 12345}], cb);"
         "})();</script>"];
     TestWebKitAPI::Util::run(&done);
 
@@ -363,10 +365,12 @@ TEST(IPCTestingAPI, DecodesReplyArgumentsForAsyncMessage)
     [webView setUIDelegate:delegate.get()];
 
     done = false;
-    promptResult = @"foo";
-    [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><script>IPC.sendMessage(\"Networking\", 0, IPC.messages.NetworkConnectionToWebProcess_HasStorageAccess.name,"
+    [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><script>"
+        "let c = IPC.connectionForProcessTarget('Networking');"
+        "let cb = (result) => alert(JSON.stringify(result.arguments));"
+        "c.sendWithAsyncReply(0, IPC.messages.NetworkConnectionToWebProcess_HasStorageAccess.name,"
         "[{type: 'RegistrableDomain', value: 'https://ipctestingapi.com'}, {type: 'RegistrableDomain', value: 'https://webkit.org'}, {type: 'FrameID', value: IPC.frameID},"
-        "{type: 'uint64_t', value: IPC.pageID}]).then((result) => alert(JSON.stringify(result.arguments)));</script>"];
+        "{type: 'uint64_t', value: IPC.pageID}], cb);</script>"];
     TestWebKitAPI::Util::run(&done);
 
     EXPECT_STREQ([alertMessage UTF8String], "[{\"type\":\"bool\",\"value\":false}]");
@@ -426,8 +430,10 @@ TEST(IPCTestingAPI, CanInterceptHasStorageAccess)
     promptResult = @"foo";
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><script>let targetMessage = {}; const messageName = IPC.messages.NetworkConnectionToWebProcess_HasStorageAccess.name;"
         "IPC.addOutgoingMessageListener('Networking', (currentMessage) => { if (currentMessage.name == messageName) targetMessage = currentMessage; });"
-        "IPC.sendMessage('Networking', 0, messageName, [{type: 'RegistrableDomain', value: 'https://ipctestingapi.com'}, {type: 'RegistrableDomain', value: 'https://webkit.org'},"
-        "{type: 'FrameID', value: IPC.frameID}, {type: 'uint64_t', value: IPC.pageID}]).then((result) => alert(JSON.stringify(result.arguments)));</script>"];
+        "let c = IPC.connectionForProcessTarget('Networking');"
+        "let cb = (result) => alert(JSON.stringify(result.arguments));"
+        "c.sendWithAsyncReply(0, messageName, [{type: 'RegistrableDomain', value: 'https://ipctestingapi.com'}, {type: 'RegistrableDomain', value: 'https://webkit.org'},"
+        "{type: 'FrameID', value: IPC.frameID}, {type: 'uint64_t', value: IPC.pageID}], cb);</script>"];
     TestWebKitAPI::Util::run(&done);
 
     EXPECT_STREQ([alertMessage UTF8String], "[{\"type\":\"bool\",\"value\":false}]");


### PR DESCRIPTION
#### 38921d39818c38b77b070e4c5ff7993d3ea9a1bf
<pre>
REGRESSION (277239@main): 4 tests in TestWebKitAPI.IPCTestingAPI are consistent failure/timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=272735">https://bugs.webkit.org/show_bug.cgi?id=272735</a>
<a href="https://rdar.apple.com/126516172">rdar://126516172</a>

Reviewed by Ryosuke Niwa.

The 277239@main made sending async messages possible only with the
dedicated sendWithAsyncReply. The patch did not change the API tests
in IPCTestingAPI.mm.

Fix by making the change in IPCTestingAPI.mm, too.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm:
(TEST(IPCTestingAPI, CanSendAsyncMessageToGPUProcess)):
(TEST(IPCTestingAPI, CanSendInvalidAsyncMessageToGPUProcessWithoutTermination)):
(DecodesReplyArgumentsForAsyncMessage)):
(CanInterceptHasStorageAccess)):

Canonical link: <a href="https://commits.webkit.org/277567@main">https://commits.webkit.org/277567@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f192497e521d30706b5c6d64d5ba68778660e42

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27145 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50623 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43995 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50248 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33017 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24632 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39002 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48524 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24811 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41461 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20302 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22288 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5989 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/44287 "Build was cancelled. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52517 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22985 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19334 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46311 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24254 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45357 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10582 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25046 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23976 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->