### PR TITLE
The contents layer of placeholder canvas of OffscreenCanvas is lost when switching off the tab

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1327,7 +1327,6 @@ http/tests/websocket/tests/hybi/imported/blink/permessage-deflate-window-bits.ht
 http/wpt/offscreen-canvas/transferToImageBitmap-webgl.html [ ImageOnlyFailure Failure ]
 imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.resize.html [ Failure Pass ]
 imported/w3c/web-platform-tests/html/canvas/offscreen/the-offscreen-canvas/size.large.html [ Skip ]
-webkit.org/b/272327 fast/canvas/offscreen-nested-worker-serialization.html [ Failure Pass ]
 
 # MSE in worker is only supported on platform with the GPU process active and where MSE is enabled by default
 # (this excludes iPhone (no MediaSource) and Linux/Windows (no GPUP))

--- a/LayoutTests/fast/canvas/offscreen-nested-worker-serialization.html
+++ b/LayoutTests/fast/canvas/offscreen-nested-worker-serialization.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><!-- webkit-test-runner [ OffscreenCanvasEnabled=true ] -->
 <body style="margin:0">
-<canvas id="c" style="background: red;"></canvas>
+<canvas id="c" style="background: red; image-rendering: crisp-edges"></canvas>
 <script>
 if (window.testRunner)
     testRunner.waitUntilDone();

--- a/LayoutTests/fast/canvas/offscreen-visibility-change-expected.html
+++ b/LayoutTests/fast/canvas/offscreen-visibility-change-expected.html
@@ -1,0 +1,5 @@
+<body style="margin:0">
+<div style="width: 300px; height: 150px; background-color: red"></div>
+<div style="position: absolute; top: 75px; left: 0px; width: 150px; height: 75px; background-color: lime"></div>
+<div style="position: absolute; top: 0px; left: 150px; width: 150px; height: 75px; background-color: yellow"></div>
+</body>

--- a/LayoutTests/fast/canvas/offscreen-visibility-change.html
+++ b/LayoutTests/fast/canvas/offscreen-visibility-change.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html><!-- webkit-test-runner [ OffscreenCanvasEnabled=true ] -->
+<head>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body style="margin:0">
+<canvas id="c" style="background-color: red; image-rendering: crisp-edges;"></canvas>
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+async function runTest() {
+    const offscreen = c.transferControlToOffscreen();
+    let ctx = offscreen.getContext('2d');
+    ctx.fillStyle = "lime";
+    ctx.fillRect(0, 75, 150, 150);
+    ctx.fillStyle = "yellow";
+    ctx.fillRect(150, 0, 300, 75);
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    c.style.visibilty = "hidden";
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    c.style.visibility = "";
+    await UIHelper.renderingUpdate();
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+runTest();
+</script>
+</body>

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -220,8 +220,14 @@ bool RemoteLayerTreeHost::updateLayerTree(const RemoteLayerTreeTransaction& tran
 
     // Drop the contents of any layers which were unparented; the Web process will re-send
     // the backing store in the commit that reparents them.
-    for (auto& newlyUnreachableLayerID : transaction.layerIDsWithNewlyUnreachableBackingStore())
-        layerForID(newlyUnreachableLayerID).contents = nullptr;
+    for (auto& newlyUnreachableLayerID : transaction.layerIDsWithNewlyUnreachableBackingStore()) {
+        auto* node = nodeForID(newlyUnreachableLayerID);
+        ASSERT(node);
+        if (node) {
+            node->layer().contents = nullptr;
+            node->setAsyncContentsIdentifier(std::nullopt);
+        }
+    }
 
 #if PLATFORM(MAC)
     if (updateBannerLayers(transaction))

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -130,7 +130,7 @@ public:
         return m_asyncContentsIdentifier;
     }
 
-    void setAsyncContentsIdentifier(const WebCore::RenderingResourceIdentifier& identifier)
+    void setAsyncContentsIdentifier(std::optional<WebCore::RenderingResourceIdentifier> identifier)
     {
         m_asyncContentsIdentifier = identifier;
     }


### PR DESCRIPTION
#### 106c6c814493351a5bf25497d24eebb60ad61478
<pre>
The contents layer of placeholder canvas of OffscreenCanvas is lost when switching off the tab
<a href="https://bugs.webkit.org/show_bug.cgi?id=272322">https://bugs.webkit.org/show_bug.cgi?id=272322</a>
<a href="https://rdar.apple.com/126070648">rdar://126070648</a>

Reviewed by Matt Woodrow.

When layer becomes unreachable, its contents is cleared. Clear also
the async contents id. When the layer becomes reachable, the content
can be reassigned.

* LayoutTests/TestExpectations:
* LayoutTests/fast/canvas/offscreen-visibility-change-expected.html: Added.
* LayoutTests/fast/canvas/offscreen-visibility-change.html: Added.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::updateLayerTree):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h:
(WebKit::RemoteLayerTreeNode::setAsyncContentsIdentifier):

Canonical link: <a href="https://commits.webkit.org/277654@main">https://commits.webkit.org/277654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fc34e2210eec0540373322ab4f9aecefb91213d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50802 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44178 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24826 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39317 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48698 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25014 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41608 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20446 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22496 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42782 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6170 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44471 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43215 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52701 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23164 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19521 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46659 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24428 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41771 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45534 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10639 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25230 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24151 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->