### PR TITLE
REGRESSION (277328@main): [ MacOS WK1 ] fast/canvas/offscreen-nested-worker-serialization.html is a constant timeout

### DIFF
--- a/LayoutTests/fast/canvas/offscreen-nested-worker-serialization-expected.html
+++ b/LayoutTests/fast/canvas/offscreen-nested-worker-serialization-expected.html
@@ -1,16 +1,5 @@
-<!DOCTYPE html>
 <body style="margin:0">
-<canvas id="c" style="background: red;"></canvas>
-<script src="resources/offscreen-nested-worker.js"></script>
-<script>
-onmessage({data: {canvas: c}});
-if (window.testRunner) {
-    testRunner.waitUntilDone();
-    requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-            testRunner.notifyDone();
-        });
-    });
-}
-</script>
+<div style="width: 300px; height: 150px; background-color: red"></div>
+<div style="position: absolute; top: 75px; left: 0px; width: 150px; height: 75px; background-color: lime"></div>
+<div style="position: absolute; top: 0px; left: 150px; width: 150px; height: 75px; background-color: yellow"></div>
 </body>

--- a/LayoutTests/fast/canvas/offscreen-nested-worker-serialization.html
+++ b/LayoutTests/fast/canvas/offscreen-nested-worker-serialization.html
@@ -1,19 +1,21 @@
-<!DOCTYPE html><!-- webkit-test-runner [ UseGPUProcessForWebGLEnabled=true OffscreenCanvasEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ OffscreenCanvasEnabled=true ] -->
 <body style="margin:0">
 <canvas id="c" style="background: red;"></canvas>
 <script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
 let worker = new Worker('resources/offscreen-worker.js');
 const offscreen = c.transferControlToOffscreen();
 worker.postMessage({canvas: offscreen},[offscreen]);
-if (window.testRunner) {
-    testRunner.waitUntilDone();
-    worker.onmessage = () => {
+worker.onmessage = () => {
+    requestAnimationFrame(() => {
         requestAnimationFrame(() => {
-            requestAnimationFrame(() => {
+            if (window.testRunner)
                 testRunner.notifyDone();
-            });
+            else
+                console.log("done");
         });
-    };
-}
+    });
+};
 </script>
 </body>

--- a/LayoutTests/fast/canvas/resources/offscreen-nested-worker.js
+++ b/LayoutTests/fast/canvas/resources/offscreen-nested-worker.js
@@ -1,15 +1,14 @@
 onmessage = function(event) {
-    console.log(event)
-    console.log(event.data)
-    console.log(event.data.canvas)
-    let gl = event.data.canvas.getContext('webgl');
-    gl.enable(gl.SCISSOR_TEST);
-    gl.scissor(0, 0, 150, 75);
-    gl.clearColor(0, 1, 0, 1);
-    gl.clear(gl.COLOR_BUFFER_BIT);
-    gl.scissor(150, 75, 150, 75);
-    gl.clearColor(1, 1, 0, 1);
-    gl.clear(gl.COLOR_BUFFER_BIT);
-    if (typeof window == "undefined")
-        self.postMessage("done");
+    let ctx = event.data.canvas.getContext('2d');
+    ctx.fillStyle = "lime";
+    ctx.fillRect(0, 75, 150, 150);
+    ctx.fillStyle = "yellow";
+    ctx.fillRect(150, 0, 300, 75);
+    // Ensure that offscreen canvas has submitted the frame to the placeholder by ensuring
+    // "update rendering" phase of Worker lifecycle has executed few times.
+    requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+            self.postMessage("done");
+        });
+    });
 };

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2834,8 +2834,6 @@ imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties
 [ Sonoma ] imported/w3c/web-platform-tests/css/filter-effects/css-filters-animation-drop-shadow.html [ ImageOnlyFailure ]
 [ Sonoma ] imported/w3c/web-platform-tests/web-animations/timing-model/animations/infinite-duration-animation.html [ ImageOnlyFailure ]
 
-webkit.org/b/272657 fast/canvas/offscreen-nested-worker-serialization.html [ Skip ]
-
 # webkit.org/b/272718 NEW TEST (277048@main): [ Sonoma WK1 ]2X imported/w3c/web-platform-tests/web-animations/animation-model/side-effects-of-animations are consistent failures
 [ Sonoma+ ] imported/w3c/web-platform-tests/web-animations/animation-model/side-effects-of-animations-current.html [ ImageOnlyFailure ]
 [ Sonoma+ ] imported/w3c/web-platform-tests/web-animations/animation-model/side-effects-of-animations-in-effect.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### 25be8d6371093c7bc40042867d31fcb62659346c
<pre>
REGRESSION (277328@main): [ MacOS WK1 ] fast/canvas/offscreen-nested-worker-serialization.html is a constant timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=272657">https://bugs.webkit.org/show_bug.cgi?id=272657</a>
<a href="https://rdar.apple.com/126461671">rdar://126461671</a>

Reviewed by Matt Woodrow.

Make the worker use 2D Context instead of WebGL, so it works with WK1
offscreen canvas.
Make the worker wait a bit before notifying done, so that placeholder
canvas has the time to receive the frame.
Make the expectation not use the test code, to make the test code
simpler.

* LayoutTests/fast/canvas/offscreen-nested-worker-serialization-expected.html:
* LayoutTests/fast/canvas/offscreen-nested-worker-serialization.html:
* LayoutTests/fast/canvas/resources/offscreen-nested-worker.js:
(onmessage):
* LayoutTests/platform/mac-wk1/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/277605@main">https://commits.webkit.org/277605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/658e5b24873dc6fe1a742a15d91335454f130d0e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50631 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44003 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24640 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39007 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48532 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41474 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20308 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22300 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42659 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5997 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44294 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43092 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52525 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22993 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19339 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46319 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-visibility-hidden-child.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24262 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41615 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45365 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10611 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25056 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23984 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->