### PR TITLE
Follow-up fix to 277527@main

### DIFF
--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -1793,7 +1793,7 @@
 #endif
 
 // FIXME: Other platforms should finish migration to *.serialization.in.
-#if PLATFORM(WIN)
+#if PLATFORM(WIN) || PLATFORM(COCOA)
 #define HAVE_ONLY_MODERN_SERIALIZATION 1
 #endif
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -423,6 +423,14 @@ void ArgumentCoder<WebKit::ChangedLayers>::encode(Encoder& encoder, const WebKit
     }
 }
 
+template<> struct ArgumentCoder<WebKit::RemoteLayerBackingStore> {
+    static void encode(Encoder& encoder, const WebKit::RemoteLayerBackingStore& store)
+    {
+        store.encode(encoder);
+    }
+    // This intentionally has no decode because it is only decoded as a RemoteLayerBackingStoreProperties.
+};
+
 void ArgumentCoder<WebKit::RemoteLayerBackingStoreOrProperties>::encode(Encoder& encoder, const WebKit::RemoteLayerBackingStoreOrProperties& instance)
 {
     // The web content process has a std::unique_ptr<RemoteLayerBackingStore> but we want it to decode

--- a/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
@@ -154,6 +154,25 @@ struct EncodingCounter {
     CounterValues& m_counterValues;
 };
 
+} // namespace TestWebKitAPI
+
+namespace IPC {
+
+template<> struct ArgumentCoder<TestWebKitAPI::EncodingCounter> {
+    static void encode(Encoder& encoder, const TestWebKitAPI::EncodingCounter& counter)
+    {
+        counter.encode(encoder);
+    }
+    static void encode(Encoder& encoder, TestWebKitAPI::EncodingCounter&& counter)
+    {
+        WTFMove(counter).encode(encoder);
+    }
+};
+
+} // namespace IPC
+
+namespace TestWebKitAPI {
+
 enum class EncodingCounterTestType {
     LValue,
     RValue,
@@ -349,6 +368,26 @@ struct DecodingMoveCounter {
 
     unsigned moveCounter { 0 };
 };
+
+} // namespace TestWebKitAPI
+
+namespace IPC {
+
+template<> struct ArgumentCoder<TestWebKitAPI::DecodingMoveCounter> {
+    template<typename Encoder>
+    static void encode(Encoder& encoder, TestWebKitAPI::DecodingMoveCounter&& counter)
+    {
+        WTFMove(counter).encode(encoder);
+    }
+    static std::optional<TestWebKitAPI::DecodingMoveCounter> decode(Decoder& decoder)
+    {
+        return TestWebKitAPI::DecodingMoveCounter::decode(decoder);
+    }
+};
+
+} // namespace IPC
+
+namespace TestWebKitAPI {
 
 TYPED_TEST_P(ArgumentCoderDecodingMoveCounterTest, DecodeDirectly)
 {

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -147,6 +147,22 @@ std::optional<CFHolderForTesting> CFHolderForTesting::decode(IPC::Decoder& decod
     } };
 }
 
+namespace IPC {
+
+template<> struct ArgumentCoder<CFHolderForTesting> {
+    template<typename Encoder>
+    static void encode(Encoder& encoder, const CFHolderForTesting& holder)
+    {
+        holder.encode(encoder);
+    }
+    static std::optional<CFHolderForTesting> decode(Decoder& decoder)
+    {
+        return CFHolderForTesting::decode(decoder);
+    }
+};
+
+}
+
 static bool cvPixelBufferRefsEqual(CVPixelBufferRef pixelBuffer1, CVPixelBufferRef pixelBuffer2)
 {
     CVPixelBufferLockBaseAddress(pixelBuffer1, 0);
@@ -453,6 +469,22 @@ std::optional<ObjCHolderForTesting> ObjCHolderForTesting::decode(IPC::Decoder& d
     return { {
         WTFMove(*value)
     } };
+}
+
+namespace IPC {
+
+template<> struct ArgumentCoder<ObjCHolderForTesting> {
+    template<typename Encoder>
+    static void encode(Encoder& encoder, const ObjCHolderForTesting& holder)
+    {
+        holder.encode(encoder);
+    }
+    static std::optional<ObjCHolderForTesting> decode(Decoder& decoder)
+    {
+        return ObjCHolderForTesting::decode(decoder);
+    }
+};
+
 }
 
 @interface NSDateComponents ()


### PR DESCRIPTION
#### 93c46cf87c69e32f3e0c38bdfbada8adc0fd8ab6
<pre>
Follow-up fix to 277527@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=272742">https://bugs.webkit.org/show_bug.cgi?id=272742</a>

Reviewed by Alex Christensen and Don Olmstead.

* Source/WTF/wtf/PlatformHave.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(IPC::ArgumentCoder&lt;WebKit::RemoteLayerBackingStore&gt;::encode):
* Source/WebKit/Shared/mac/ObjCObjectGraph.mm:
(WebKit::ObjCObjectGraph::decode):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSIPCSemaphore::JSIPCSemaphore):
(WebKit::IPCTestingAPI::JSIPCConnectionHandle::JSIPCConnectionHandle):
(WebKit::IPCTestingAPI::JSIPCConnection::JSIPCConnection):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::JSIPCStreamClientConnection):
(WebKit::IPCTestingAPI::JSIPCStreamServerConnectionHandle::JSIPCStreamServerConnectionHandle):
(WebKit::IPCTestingAPI::JSIPCStreamConnectionBuffer::JSIPCStreamConnectionBuffer):
(WebKit::IPCTestingAPI::JSSharedMemory::JSSharedMemory):
(WebKit::IPCTestingAPI::JSIPC::JSIPC):
(WebKit::IPCTestingAPI::extractSyncIPCMessageInfo):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::streamBuffer):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::setSemaphores):
(WebKit::IPCTestingAPI::extractIPCStreamMessageInfo):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendWithAsyncReply):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendSyncMessage):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendIPCStreamTesterSyncCrashOnZero):
(WebKit::IPCTestingAPI::JSIPCSemaphore::signal):
(WebKit::IPCTestingAPI::JSIPCSemaphore::waitFor):
(WebKit::IPCTestingAPI::JSSharedMemory::readBytes):
(WebKit::IPCTestingAPI::arrayBufferSpanFromValueRef):
(WebKit::IPCTestingAPI::JSSharedMemory::writeBytes):
(WebKit::IPCTestingAPI::JSIPCStreamConnectionBuffer::readHeaderBytes):
(WebKit::IPCTestingAPI::JSIPCStreamConnectionBuffer::readDataBytes):
(WebKit::IPCTestingAPI::JSIPCStreamConnectionBuffer::readBytes):
(WebKit::IPCTestingAPI::JSIPCStreamConnectionBuffer::writeHeaderBytes):
(WebKit::IPCTestingAPI::JSIPCStreamConnectionBuffer::writeDataBytes):
(WebKit::IPCTestingAPI::JSIPCStreamConnectionBuffer::writeBytes):
(WebKit::IPCTestingAPI::JSIPC::processTargetFromArgument):
(WebKit::IPCTestingAPI::JSIPC::addMessageListener):
(WebKit::IPCTestingAPI::messageNameFromArgument):
(WebKit::IPCTestingAPI::encodeTypedArray):
(WebKit::IPCTestingAPI::encodeRemoteRenderingBackendCreationParameters):
(WebKit::IPCTestingAPI::encodeSharedMemory):
(WebKit::IPCTestingAPI::encodeStreamConnectionBuffer):
(WebKit::IPCTestingAPI::encodeStreamServerConnectionHandle):
(WebKit::IPCTestingAPI::encodeSemaphore):
(WebKit::IPCTestingAPI::encodeConnectionHandle):
(IPC::ArgumentCoder&lt;WebKit::IPCTestingAPI::VectorEncodeHelper&gt;::encode):
(WebKit::IPCTestingAPI::JSMessageListener::jsDescriptionFromDecoder):
* Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp:
(TestWebKitAPI::ArgumentCoderEncoderDecoderTest&lt;IPC::StreamConnectionEncoder&gt;::Impl::Impl):
(TestWebKitAPI::EncodingCounter::CounterValues::CounterValues):
(TestWebKitAPI::EncodingCounter::EncodingCounter):
(IPC::ArgumentCoder&lt;TestWebKitAPI::EncodingCounter&gt;::encode):
(IPC::ArgumentCoder&lt;TestWebKitAPI::DecodingMoveCounter&gt;::encode):
(IPC::ArgumentCoder&lt;TestWebKitAPI::DecodingMoveCounter&gt;::decode):
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(IPC::ArgumentCoder&lt;CFHolderForTesting&gt;::encode):
(IPC::ArgumentCoder&lt;CFHolderForTesting&gt;::decode):
(IPC::ArgumentCoder&lt;ObjCHolderForTesting&gt;::encode):
(IPC::ArgumentCoder&lt;ObjCHolderForTesting&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/277916@main">https://commits.webkit.org/277916@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14daeeacd8dcaa7b6c225568e5ba9636643b1819

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51593 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44976 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51211 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34071 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25647 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39977 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25768 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42171 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21082 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23228 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43343 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6961 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/42205 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45159 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43844 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53504 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/48397 "Found 1 new JSC stress test failure: stress/scoped-arguments-table-should-be-tolerant-for-oom.js.bytecode-cache (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23957 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20221 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47287 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25220 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42380 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46241 "Found 4 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/listbox, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/menulist, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/value/basic (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26029 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55892 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6997 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24940 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11505 "Passed tests") | 
<!--EWS-Status-Bubble-End-->