### PR TITLE
Reduce usage of legacy IPC decoders

### DIFF
--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -529,12 +529,12 @@ template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTrai
     template<typename Decoder>
     static std::optional<HashMapType> decode(Decoder& decoder)
     {
-        unsigned hashMapSize;
-        if (!decoder.decode(hashMapSize))
+        auto hashMapSize = decoder.template decode<unsigned>();
+        if (!hashMapSize)
             return std::nullopt;
 
         HashMapType hashMap;
-        for (unsigned i = 0; i < hashMapSize; ++i) {
+        for (unsigned i = 0; i < *hashMapSize; ++i) {
             auto key = decoder.template decode<KeyArg>();
             if (UNLIKELY(!key))
                 return std::nullopt;
@@ -570,12 +570,12 @@ template<typename KeyArg, typename HashArg, typename KeyTraitsArg, typename Hash
     template<typename Decoder>
     static std::optional<HashSetType> decode(Decoder& decoder)
     {
-        unsigned hashSetSize;
-        if (!decoder.decode(hashSetSize))
+        auto hashSetSize = decoder.template decode<unsigned>();
+        if (!hashSetSize)
             return std::nullopt;
 
         HashSetType hashSet;
-        for (unsigned i = 0; i < hashSetSize; ++i) {
+        for (unsigned i = 0; i < *hashSetSize; ++i) {
             auto key = decoder.template decode<KeyArg>();
             if (!key)
                 return std::nullopt;
@@ -609,24 +609,24 @@ template<typename KeyArg, typename HashArg, typename KeyTraitsArg> struct Argume
     template<typename Decoder>
     static std::optional<HashCountedSetType> decode(Decoder& decoder)
     {
-        unsigned hashCountedSetSize;
-        if (!decoder.decode(hashCountedSetSize))
+        auto hashCountedSetSize = decoder.template decode<unsigned>();
+        if (!hashCountedSetSize)
             return std::nullopt;
 
         HashCountedSetType tempHashCountedSet;
-        for (unsigned i = 0; i < hashCountedSetSize; ++i) {
-            KeyArg key;
-            if (!decoder.decode(key))
+        for (unsigned i = 0; i < *hashCountedSetSize; ++i) {
+            auto key = decoder.template decode<KeyArg>();
+            if (!key)
                 return std::nullopt;
 
-            unsigned count;
-            if (!decoder.decode(count))
+            auto count = decoder.template decode<unsigned>();
+            if (!count)
                 return std::nullopt;
 
-            if (UNLIKELY(!HashCountedSetType::isValidValue(key)))
+            if (UNLIKELY(!HashCountedSetType::isValidValue(*key)))
                 return std::nullopt;
 
-            if (UNLIKELY(!tempHashCountedSet.add(key, count).isNewEntry)) {
+            if (UNLIKELY(!tempHashCountedSet.add(*key, *count).isNewEntry)) {
                 // The hash counted set already has the specified key, bail.
                 return std::nullopt;
             }

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -423,14 +423,14 @@ void Connection::dispatchMessageReceiverMessage(MessageReceiver& messageReceiver
         return;
     }
 
-    SyncRequestID syncRequestID;
-    if (UNLIKELY(!decoder->decode(syncRequestID))) {
+    auto syncRequestID = decoder->decode<SyncRequestID>();
+    if (UNLIKELY(!syncRequestID)) {
         // We received an invalid sync message.
         // FIXME: Handle this.
         return;
     }
 
-    auto replyEncoder = makeUniqueRef<Encoder>(MessageName::SyncMessageReply, syncRequestID.toUInt64());
+    auto replyEncoder = makeUniqueRef<Encoder>(MessageName::SyncMessageReply, syncRequestID->toUInt64());
 
     // Hand off both the decoder and encoder to the work queue message receiver.
     bool wasHandled = messageReceiver.didReceiveSyncMessage(*this, *decoder, replyEncoder);
@@ -1169,8 +1169,8 @@ void Connection::dispatchSyncMessage(Decoder& decoder)
     assertIsCurrent(dispatcher());
     ASSERT(decoder.isSyncMessage());
 
-    SyncRequestID syncRequestID;
-    if (UNLIKELY(!decoder.decode(syncRequestID))) {
+    auto syncRequestID = decoder.decode<SyncRequestID>();
+    if (UNLIKELY(!syncRequestID)) {
         // We received an invalid sync message.
         return;
     }
@@ -1181,7 +1181,7 @@ void Connection::dispatchSyncMessage(Decoder& decoder)
         --m_inDispatchSyncMessageCount;
     });
 
-    auto replyEncoder = makeUniqueRef<Encoder>(MessageName::SyncMessageReply, syncRequestID.toUInt64());
+    auto replyEncoder = makeUniqueRef<Encoder>(MessageName::SyncMessageReply, syncRequestID->toUInt64());
 
     bool wasHandled = false;
     if (decoder.messageName() == MessageName::WrappedAsyncMessageForTesting) {

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
@@ -190,13 +190,13 @@ StreamServerConnection::DispatchResult StreamServerConnection::dispatchStreamMes
 
 bool StreamServerConnection::processSetStreamDestinationID(Decoder&& decoder, RefPtr<StreamMessageReceiver>& currentReceiver)
 {
-    uint64_t destinationID = 0;
-    if (!decoder.decode(destinationID)) {
+    auto destinationID = decoder.decode<uint64_t>();
+    if (!destinationID) {
         protectedConnection()->dispatchDidReceiveInvalidMessage(decoder.messageName());
         return false;
     }
-    if (m_currentDestinationID != destinationID) {
-        m_currentDestinationID = destinationID;
+    if (m_currentDestinationID != *destinationID) {
+        m_currentDestinationID = *destinationID;
         currentReceiver = nullptr;
     }
     auto result = m_buffer.release(decoder.currentBufferOffset());

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -574,11 +574,11 @@ template<> std::optional<RetainPtr<id>> decodeObjectDirectlyRequiringAllowedClas
     auto& allowedClasses = decoder.allowedClasses();
     RELEASE_ASSERT(allowedClasses.size());
 
-    RetainPtr<CFDataRef> data;
-    if (!decoder.decode(data))
+    auto data = decoder.decode<RetainPtr<CFDataRef>>();
+    if (!data)
         return std::nullopt;
 
-    auto unarchiver = adoptNS([[NSKeyedUnarchiver alloc] initForReadingFromData:bridge_cast(data.get()) error:nullptr]);
+    auto unarchiver = adoptNS([[NSKeyedUnarchiver alloc] initForReadingFromData:bridge_cast(data->get()) error:nullptr]);
     unarchiver.get().decodingFailurePolicy = NSDecodingFailurePolicyRaiseException;
 
     auto delegate = adoptNS([[WKSecureCodingArchivingDelegate alloc] init]);


### PR DESCRIPTION
#### a44e98636cf4f89adfc903e8e9f822e7bcdf8084
<pre>
Reduce usage of legacy IPC decoders
<a href="https://bugs.webkit.org/show_bug.cgi?id=272751">https://bugs.webkit.org/show_bug.cgi?id=272751</a>

Reviewed by Alex Christensen.

There are many places where legacy decoders are still used, port
those to use the modern decoders.

* Source/WebKit/Platform/IPC/ArgumentCoders.h:
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::dispatchMessageReceiverMessage):
(IPC::Connection::dispatchSyncMessage):
* Source/WebKit/Platform/IPC/Decoder.cpp:
(IPC::Decoder::unwrapForTesting):
* Source/WebKit/Platform/IPC/HandleMessage.h:
(IPC::handleMessageSynchronous):
* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::processSetStreamDestinationID):
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::decodeObjectDirectlyRequiringAllowedClasses&lt;NSObject&lt;NSSecureCoding&gt;&gt;):

Canonical link: <a href="https://commits.webkit.org/277598@main">https://commits.webkit.org/277598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ec0c1f75fae0c408687b9e9c025ab6fd1b66abd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50858 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50646 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44018 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24657 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39024 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48547 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24839 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41504 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20325 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22315 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6012 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44312 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43114 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52540 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23008 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19354 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46332 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24277 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45379 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25071 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6822 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23999 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->