### PR TITLE
[ews-build.webkit.org] Set default EMAIL when apply patch

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -1067,7 +1067,10 @@ class ApplyPatch(steps.ShellSequence, CompositeStepMixin, ShellMixin):
     description = ['apply-patch']
     descriptionDone = ['Applied patch']
     haltOnFailure = True
-    env = dict(FILTER_BRANCH_SQUELCH_WARNING='1')
+    env = dict(
+        FILTER_BRANCH_SQUELCH_WARNING='1',
+        EMAIL=FROM_EMAIL,
+    )
     FILTER_BRANCH_PROGRAM = '''import re
 import sys
 

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -3774,7 +3774,10 @@ class TestUpdateWorkingDirectory(BuildStepMixinAdditions, unittest.TestCase):
 
 class TestApplyPatch(BuildStepMixinAdditions, unittest.TestCase):
     READ_LIMIT = 1000
-    ENV = dict(FILTER_BRANCH_SQUELCH_WARNING='1')
+    ENV = dict(
+        FILTER_BRANCH_SQUELCH_WARNING='1',
+        EMAIL='ews@webkit.org',
+    )
 
     @staticmethod
     def downloadFileRecordingContents(limit, recorder):


### PR DESCRIPTION
#### e37311e7535186c330f8c4210dcb07a8e912f0af
<pre>
[ews-build.webkit.org] Set default EMAIL when apply patch
<a href="https://bugs.webkit.org/show_bug.cgi?id=272757">https://bugs.webkit.org/show_bug.cgi?id=272757</a>
<a href="https://rdar.apple.com/126553445">rdar://126553445</a>

Reviewed by Ryan Haddad.

* Tools/CISupport/ews-build/steps.py:
(ApplyPatch): Set EMAIL environment variable.
* Tools/CISupport/ews-build/steps_unittest.py:
(TestApplyPatch):

Canonical link: <a href="https://commits.webkit.org/277547@main">https://commits.webkit.org/277547@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df7f8e1cf851ad81136ac4f25c34bbfefcf58099

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47975 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27178 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/50870 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50656 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44028 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50281 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33058 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24668 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39030 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 20 flakes 80 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48557 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/24850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/50870 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20331 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/22333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/50870 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6022 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/44320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/50870 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52550 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/23018 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/19365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/48008 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/24287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/50870 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45386 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/25082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6796 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24009 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->