### PR TITLE
Unreviewed, revert 277264@main,277181@main due to breaking JSC debug ability

### DIFF
--- a/Source/WTF/wtf/HashTraits.h
+++ b/Source/WTF/wtf/HashTraits.h
@@ -212,8 +212,8 @@ template<typename T> struct HashTraits<UniqueRef<T>> : SimpleClassHashTraits<Uni
 template<> struct HashTraits<ASCIILiteral> : SimpleClassHashTraits<ASCIILiteral> {
     static ASCIILiteral emptyValue() { return { }; }
 
-    static void constructDeletedValue(ASCIILiteral& slot) { slot = ASCIILiteral::deletedValue(); }
-    static bool isDeletedValue(const ASCIILiteral& value) { return value.isDeletedValue(); }
+    static void constructDeletedValue(ASCIILiteral& slot) { slot = ASCIILiteral::fromLiteralUnsafe(reinterpret_cast<const char*>(-1)); }
+    static bool isDeletedValue(const ASCIILiteral& value) { return value.characters() == reinterpret_cast<const char*>(-1); }
 };
 
 template<typename P, typename Q, typename R> struct HashTraits<RefPtr<P, Q, R>> : SimpleClassHashTraits<RefPtr<P, Q, R>> {

--- a/Source/WTF/wtf/text/ASCIILiteral.cpp
+++ b/Source/WTF/wtf/text/ASCIILiteral.cpp
@@ -1,6 +1,5 @@
 /*
  * Copyright (C) 2018 Yusuke Suzuki <utatane.tea@gmail.com>
- * Copyright (C) 2024 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,13 +27,12 @@
 #include <wtf/text/ASCIILiteral.h>
 
 #include <wtf/PrintStream.h>
-#include <wtf/text/StringView.h>
 
 namespace WTF {
 
 void ASCIILiteral::dump(PrintStream& out) const
 {
-    out.print(StringView(span8()));
+    out.print(m_characters);
 }
 
 } // namespace WTF


### PR DESCRIPTION
#### 70624666054bc35e4d04a2e15ec8654dc4ddabda
<pre>
Unreviewed, revert 277264@main,277181@main due to breaking JSC debug ability
<a href="https://bugs.webkit.org/show_bug.cgi?id=272759">https://bugs.webkit.org/show_bug.cgi?id=272759</a>
<a href="https://rdar.apple.com/126559753">rdar://126559753</a>

* Source/WTF/wtf/HashTraits.h:
(WTF::HashTraits&lt;ASCIILiteral&gt;::constructDeletedValue):
(WTF::HashTraits&lt;ASCIILiteral&gt;::isDeletedValue):
* Source/WTF/wtf/text/ASCIILiteral.cpp:
(WTF::ASCIILiteral::dump const):
* Source/WTF/wtf/text/ASCIILiteral.h:
(WTF::ASCIILiteral::length const):
(WTF::StringLiterals::operator _s):
(WTF::ASCIILiteral::deletedValue): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70624666054bc35e4d04a2e15ec8654dc4ddabda

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27188 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50884 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50666 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44038 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33068 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24680 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39043 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48567 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24866 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20340 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22346 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6032 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/41278 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44336 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52560 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/47477 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23028 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19382 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46349 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24297 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41660 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45394 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25092 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54974 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24019 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11307 "Passed tests") | 
<!--EWS-Status-Bubble-End-->