### PR TITLE
declarativeNetRequest redirect and modifyHeaders rules don't work.

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -553,6 +553,9 @@ void NavigationState::NavigationClient::decidePolicyForNavigationAction(WebPageP
                 listener->ignore();
                 return;
             }
+
+            if (RefPtr extensionController = webPage->webExtensionController())
+                extensionController->updateWebsitePoliciesForNavigation(*defaultWebsitePolicies, navigationAction);
 #endif
 
             if (!navigationAction->targetFrame()) {
@@ -623,6 +626,9 @@ void NavigationState::NavigationClient::decidePolicyForNavigationAction(WebPageP
                 localListener->ignore();
                 return;
             }
+
+            if (RefPtr extensionController = webPageProxy->webExtensionController())
+                extensionController->updateWebsitePoliciesForNavigation(*apiWebsitePolicies, navigationAction);
 #endif
 
             switch (actionPolicy) {

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -57,6 +57,11 @@ OBJC_PROTOCOL(_WKWebExtensionControllerDelegatePrivate);
 #import "_WKWebExtensionController.h"
 #endif
 
+namespace API {
+class NavigationAction;
+class WebsitePolicies;
+}
+
 namespace WebKit {
 
 class ContextMenuContextData;
@@ -159,6 +164,8 @@ public:
     void inspectorWillOpen(WebInspectorUIProxy&, WebPageProxy&);
     void inspectorWillClose(WebInspectorUIProxy&, WebPageProxy&);
 #endif
+
+    void updateWebsitePoliciesForNavigation(API::WebsitePolicies&, API::NavigationAction&);
 
     void resourceLoadDidSendRequest(WebPageProxyIdentifier, const ResourceLoadInfo&, const WebCore::ResourceRequest&);
     void resourceLoadDidPerformHTTPRedirection(WebPageProxyIdentifier, const ResourceLoadInfo&, const WebCore::ResourceResponse&, const WebCore::ResourceRequest&);


### PR DESCRIPTION
#### 63355e0745267f9891ebe07dc1f3aa96e59eb707
<pre>
declarativeNetRequest redirect and modifyHeaders rules don&apos;t work.
<a href="https://webkit.org/b/272763">https://webkit.org/b/272763</a>
<a href="https://rdar.apple.com/problem/126562335">rdar://problem/126562335</a>

Reviewed by Brian Weinstein.

We were not setting activeContentRuleListActionPatterns() for the network process to check if the extension
had permissions to modify the requests, since the rules require declarativeNetRequestWithHostAccess and
granted host permission patterns.

* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::NavigationClient::decidePolicyForNavigationAction): Added call to extension controller.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::resourceDataForPath): Add support for any JSON.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::updateWebsitePoliciesForNavigation): Added. Set activeContentRuleListActionPatterns
for each extension context that has declarativeNetRequestWithHostAccess permissions.
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, DISABLED_RedirectRule)): Added. Blocked on fixing
<a href="https://rdar.apple.com/116459903">rdar://116459903</a> (Web Process is crashing when using declarativeNetRequest to redirect a page).
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostAccessPermission)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostPermission)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRule)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithoutHostAccessPermission)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithoutHostPermission)): Added.

Canonical link: <a href="https://commits.webkit.org/277681@main">https://commits.webkit.org/277681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5c1a944cc3f3fc18e9094d0ed446451c20a4b57

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48282 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50970 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44347 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50587 "Failed to checkout and rebase branch from PR 27335") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25015 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48864 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/25191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/20590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/22671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6338 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/44629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52874 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23329 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/19681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24594 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/41896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/45700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25399 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6860 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24317 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->