### PR TITLE
[Remote Inspection] Make it easier to inspect only iframes with nearby navigational elements

### DIFF
--- a/LayoutTests/fast/element-targeting/target-iframe-above-nav-bar-expected.txt
+++ b/LayoutTests/fast/element-targeting/target-iframe-above-nav-bar-expected.txt
@@ -1,0 +1,9 @@
+
+Navigation Bar
+This test requires WebKitTestRunner.
+
+PASS targetSelector is ".frame-wrapper"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/element-targeting/target-iframe-above-nav-bar.html
+++ b/LayoutTests/fast/element-targeting/target-iframe-above-nav-bar.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+body, html {
+    margin: 0;
+    font-family: system-ui;
+}
+
+.nav {
+    position: sticky;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 50px;
+    background: gray;
+    color: white;
+    text-align: center;
+    font-size: 20px;
+    line-height: 50px;
+}
+
+.content {
+    margin-top: 100px;
+}
+
+.frame-wrapper {
+    width: 100%;
+    height: 150px;
+}
+
+iframe {
+    width: 100%;
+    height: 100%;
+}
+</style>
+</head>
+<body>
+<header>
+    <div class="frame-wrapper">
+        <iframe frameborder="0" srcdoc="<head><style>body, html { background: tomato; width: 100%; height: 100%; margin: 0; }</style></head><body></body>"></iframe>
+    </div>
+    <div class="nav" role="navigation">Navigation Bar</div>
+</header>
+<p class="content">This test requires WebKitTestRunner.</p>
+<pre id="console"></pre>
+<script>
+jsTestIsAsync = true;
+addEventListener("load", async () => {
+    targetSelector = await UIHelper.adjustVisibilityForFrontmostTarget(50, 100);
+    shouldBeEqualToString("targetSelector", ".frame-wrapper");
+    finishJSTest();
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### a65c65a9ee61610307216fd8dda89d6ff89b441e
<pre>
[Remote Inspection] Make it easier to inspect only iframes with nearby navigational elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=272765">https://bugs.webkit.org/show_bug.cgi?id=272765</a>
<a href="https://rdar.apple.com/123279263">rdar://123279263</a>

Reviewed by Megan Gardner.

Adjust the targeting heuristic to make it easier to inspect `iframe`s without targeting enclosing
container elements that contain navigational elements (e.g. nav bars). If needed, we can expand this
&quot;narrowing heuristic&quot; to care about more than just navigational elements.

* LayoutTests/fast/element-targeting/target-iframe-above-nav-bar-expected.txt: Added.
* LayoutTests/fast/element-targeting/target-iframe-above-nav-bar.html: Added.
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::isNavigationalElement):
(WebCore::containsNavigationalElement):
(WebCore::isTargetCandidate):
(WebCore::ElementTargetingController::findTargets):

Canonical link: <a href="https://commits.webkit.org/277578@main">https://commits.webkit.org/277578@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55492173978e597adf3a164c9c98d7730e1eb478

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50898 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50677 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44049 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50303 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24692 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39048 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48579 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24872 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20345 "Found 1 new API test failure: /WPE/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22352 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6043 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/44342 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52571 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23039 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19392 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46370 "Found 1 new test failure: imported/w3c/web-platform-tests/scroll-animations/css/animation-inactive-outside-range-test.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24308 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41670 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45408 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/10598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25104 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24030 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->