### PR TITLE
[Quirk] Investigate adding MediaSession support to Netflix as a Quirk

### DIFF
--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -347,8 +347,8 @@ $(PROJECT_DIR)/Modules/applepay/ApplePayCouponCodeUpdate.idl
 $(PROJECT_DIR)/Modules/applepay/ApplePayDateComponents.idl
 $(PROJECT_DIR)/Modules/applepay/ApplePayDateComponentsRange.idl
 $(PROJECT_DIR)/Modules/applepay/ApplePayDeferredPaymentRequest.idl
-$(PROJECT_DIR)/Modules/applepay/ApplePayDisbursementPaymentRequest.idl
 $(PROJECT_DIR)/Modules/applepay/ApplePayDetailsUpdateBase.idl
+$(PROJECT_DIR)/Modules/applepay/ApplePayDisbursementPaymentRequest.idl
 $(PROJECT_DIR)/Modules/applepay/ApplePayError.idl
 $(PROJECT_DIR)/Modules/applepay/ApplePayErrorCode.idl
 $(PROJECT_DIR)/Modules/applepay/ApplePayErrorContactField.idl
@@ -1811,6 +1811,8 @@ $(PROJECT_DIR)/page/PerformanceResourceTiming.idl
 $(PROJECT_DIR)/page/PerformanceServerTiming.idl
 $(PROJECT_DIR)/page/PerformanceTiming.idl
 $(PROJECT_DIR)/page/PostMessageOptions.idl
+$(PROJECT_DIR)/page/Quirks.js
+$(PROJECT_DIR)/page/QuirksInternals.js
 $(PROJECT_DIR)/page/ResizeObserver.idl
 $(PROJECT_DIR)/page/ResizeObserverBoxOptions.idl
 $(PROJECT_DIR)/page/ResizeObserverCallback.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -3435,6 +3435,10 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/NodeName.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/PaintWorkletGlobalScopeConstructors.idl
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/PlugInsResources.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/PlugInsResourcesData.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/QuirksBuiltins.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/QuirksBuiltins.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/QuirksInternalsBuiltins.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/QuirksInternalsBuiltins.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/ReadableByteStreamControllerBuiltins.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/ReadableByteStreamControllerBuiltins.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/ReadableByteStreamInternalsBuiltins.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -2546,6 +2546,7 @@ WebCore_BUILTINS_SOURCES = \
     $(WebCore)/dom/TextEncoderStream.js \
     $(WebCore)/bindings/js/JSDOMBindingInternals.js \
     $(WebCore)/inspector/CommandLineAPIModuleSource.js \
+    $(WebCore)/page/QuirksInternals.js \
 #
 
 BUILTINS_GENERATOR_SCRIPTS = \

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -267,6 +267,12 @@ void MediaSession::setActionHandler(MediaSessionAction action, RefPtr<MediaSessi
     notifyActionHandlerObservers();
 }
 
+bool MediaSession::hasActionHandler(const MediaSessionAction action) const
+{
+    Locker lock { m_actionHandlersLock };
+    return m_actionHandlers.contains(action);
+}
+
 void MediaSession::callActionHandler(const MediaSessionActionDetails& actionDetails, DOMPromiseDeferred<void>&& promise)
 {
     ALWAYS_LOG(LOGIDENTIFIER);

--- a/Source/WebCore/Modules/mediasession/MediaSession.h
+++ b/Source/WebCore/Modules/mediasession/MediaSession.h
@@ -65,7 +65,7 @@ public:
     void setPlaybackState(MediaSessionPlaybackState);
 
     void setActionHandler(MediaSessionAction, RefPtr<MediaSessionActionHandler>&&);
-
+    bool hasActionHandler(MediaSessionAction) const;
     void callActionHandler(const MediaSessionActionDetails&, DOMPromiseDeferred<void>&&);
 
     template <typename Visitor> void visitActionHandlers(Visitor&) const;

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1078,6 +1078,8 @@ private:
 
     bool videoUsesElementFullscreen() const;
 
+    void ensureNetflixMediaSessionQuirkIfNecessary();
+
 #if !RELEASE_LOG_DISABLED
     const void* mediaPlayerLogIdentifier() final { return logIdentifier(); }
     const Logger& mediaPlayerLogger() final { return logger(); }

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -171,10 +171,7 @@ bool Quirks::needsAutoplayPlayPauseEvents() const
 // - iOS PiP
 bool Quirks::needsSeekingSupportDisabled() const
 {
-    if (!needsQuirks())
-        return false;
-
-    return isDomain("netflix.com"_s);
+    return false;
 }
 
 // netflix.com https://bugs.webkit.org/show_bug.cgi?id=193301
@@ -1857,6 +1854,17 @@ bool Quirks::needsGetElementsByNameQuirk() const
 #else
     return false;
 #endif
+}
+
+bool Quirks::needsNetflixMediaSessionQuirk() const
+{
+    if (!needsQuirks())
+        return false;
+
+    if (!m_shouldIgnorePlaysInlineRequirementQuirk)
+        m_shouldIgnorePlaysInlineRequirementQuirk = m_document->isTopDocument() && isDomain("netflix.com"_s);
+
+    return *m_shouldIgnorePlaysInlineRequirementQuirk;
 }
 
 }

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -192,6 +192,8 @@ public:
 
     bool needsGetElementsByNameQuirk() const;
 
+    bool needsNetflixMediaSessionQuirk() const;
+
 private:
     bool needsQuirks() const;
     bool isDomain(const String&) const;
@@ -263,6 +265,7 @@ private:
     mutable std::optional<bool> m_needsDisableDOMPasteAccessQuirk;
     mutable std::optional<bool> m_shouldDisableElementFullscreen;
     mutable std::optional<bool> m_shouldIgnorePlaysInlineRequirementQuirk;
+    mutable std::optional<bool> m_needsNetflixMediaSessionQuirk;
 
     Vector<RegistrableDomain> m_subFrameDomainsForStorageAccessQuirk;
 };

--- a/Source/WebCore/page/QuirksInternals.js
+++ b/Source/WebCore/page/QuirksInternals.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// @internal
+
+async function installNetflixMediaSessionQuirk() {
+    function sleepFor(duration) {
+        return new Promise(resolve => { setTimeout(resolve, duration); });
+    }
+    function getNetflixAPI() {
+        return window?.netflix?.appContext?.state?.playerApp?.getAPI();
+    }
+    function getWatchSessionId() {
+        return getNetflixAPI()?.videoPlayer?.getAllPlayerSessionIds()?.find((val => val?.includes("watch")));
+    }
+    function getVideoId() {
+        return getNetflixAPI()?.getVideoIdBySessionId(getWatchSessionId());
+    }
+    function getVideoPlayer() {
+        return getNetflixAPI()?.videoPlayer?.getVideoPlayerBySessionId(getWatchSessionId());
+    };
+
+    while (!getVideoPlayer())
+        await sleepFor(100);
+
+    navigator.mediaSession.setActionHandler('play', event => {
+        getVideoPlayer()?.play();
+    });
+    navigator.mediaSession.setActionHandler('pause', event => {
+        getVideoPlayer()?.pause();
+    });
+    navigator.mediaSession.setActionHandler('seekto', event => {
+        getVideoPlayer()?.seek(event.seekTime * 1000)
+    });
+    navigator.mediaSession.setActionHandler('seekforward', event => {
+        let player = getVideoPlayer();
+        if (!player)
+            return;
+        let targetTime = player.getCurrentTime() / 1000 + (event.seekOffset | 10);
+        let duration = player.getDuration() / 1000;
+        if (targetTime >= duration)
+            targetTime = duration;
+        player.seek(targetTime * 1000);
+    });
+    navigator.mediaSession.setActionHandler('seekbackward', event => {
+        let player = getVideoPlayer();
+        if (!player)
+            return;
+        let targetTime = player.getCurrentTime() / 1000 - (event.seekOffset | 10);
+        if (targetTime <= 0)
+            targetTime = 0;
+        player.seek(targetTime * 1000);
+    });
+
+    function updatePlaybackState(event) {
+        let player = getVideoPlayer();
+        if (!player)
+            return;
+        navigator.mediaSession.setPositionState({
+            duration: player.getDuration() / 1000,
+            position: player.getCurrentTime() / 1000, playbackState: 1
+        })
+    };
+
+    function updatePlayingState(event) {
+        let player = getVideoPlayer();
+        if (!player)
+            return;
+        navigator.mediaSession.playbackState = player.getPaused() ? 'paused' : 'playing';
+    }
+
+    let player = getVideoPlayer();
+    player.addEventListener('durationchanged', updatePlaybackState);
+    player.addEventListener('currenttimechanged', updatePlaybackState);
+    player.addEventListener('pausedchanged', updatePlayingState);
+    player.addEventListener('playingchanged', updatePlayingState);
+}


### PR DESCRIPTION
#### 7f442b04bc86a206bc7ceac5e836ef2292a52ca5
<pre>
[Quirk] Investigate adding MediaSession support to Netflix as a Quirk
<a href="https://bugs.webkit.org/show_bug.cgi?id=272772">https://bugs.webkit.org/show_bug.cgi?id=272772</a>
<a href="https://rdar.apple.com/126569331">rdar://126569331</a>

Reviewed by NOBODY (OOPS!).

Add a mechanism to inject MediaSession action handlers using Netflix&apos;s internal controls API.

* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::MediaSession::hasActionHandler const):
* Source/WebCore/Modules/mediasession/MediaSession.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::m_remote):
(WebCore::HTMLMediaElement::ensureNetflixMediaSessionQuirkIfNecessary):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsSeekingSupportDisabled const):
(WebCore::Quirks::needsNetflixMediaSessionQuirk const):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksInternals.js: Added.
(async installNetflixMediaSessionQuirk.sleepFor):
(async installNetflixMediaSessionQuirk):
(async installNetflixMediaSessionQuirk.getWatchSessionId):
(async installNetflixMediaSessionQuirk.getVideoPlayer):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f442b04bc86a206bc7ceac5e836ef2292a52ca5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49062 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52037 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51787 "Hash 7f442b04 for PR 27346 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45135 "Hash 7f442b04 for PR 27346 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51366 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25820 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/51787 "Hash 7f442b04 for PR 27346 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50411 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25912 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42295 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/51787 "Hash 7f442b04 for PR 27346 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23365 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43468 "Passed tests") | [❌ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7215 "Hash 7f442b04 for PR 27346 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45295 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43973 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53700 "Hash 7f442b04 for PR 27346 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24129 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20354 "Found 60 new test failures: accessibility/ARIA-reflection.html, accessibility/accessibility-crash-focused-element-change.html, accessibility/accessibility-crash-setattribute.html, accessibility/combobox/aria-combobox-control-owns-elements.html, accessibility/combobox/aria-combobox-hierarchy.html, accessibility/combobox/aria-combobox-no-owns.html, accessibility/combobox/mac/aria-combobox-activedescendant.html, accessibility/combobox/mac/combobox-activedescendant-notifications.html, accessibility/combobox/mac/combobox-value.html, accessibility/custom-elements/autocomplete.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/53700 "Hash 7f442b04 for PR 27346 does not build (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25407 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42501 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/53700 "Hash 7f442b04 for PR 27346 does not build (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26196 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25131 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->