### PR TITLE
Incorrect Sec-Fetch-Site values on iframes

### DIFF
--- a/LayoutTests/http/tests/navigation/sec-fetch-site-header-expected.txt
+++ b/LayoutTests/http/tests/navigation/sec-fetch-site-header-expected.txt
@@ -1,0 +1,10 @@
+Tests the behavior of sec-fetch-site header.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS secFetchSite is expected
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/navigation/sec-fetch-site-header-on-crossorigin-redirection-expected.txt
+++ b/LayoutTests/http/tests/navigation/sec-fetch-site-header-on-crossorigin-redirection-expected.txt
@@ -1,0 +1,10 @@
+Tests the behavior of sec-fetch-site header.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS secFetchSite is expected
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/navigation/sec-fetch-site-header-on-crossorigin-redirection.html
+++ b/LayoutTests/http/tests/navigation/sec-fetch-site-header-on-crossorigin-redirection.html
@@ -1,0 +1,8 @@
+<script>
+if (window.testRunner) {
+    testRunner.clearBackForwardList();
+    testRunner.dumpBackForwardList();
+    testRunner.dumpAsText();
+    testRunner.queueLoad("http://localhost:8000/resources/redirect.py?url=http://127.0.0.1:8000/referrer-policy/resources/check-sec-fetch-site.py%3Fexpected%3Dnone");
+}
+</script>

--- a/LayoutTests/http/tests/navigation/sec-fetch-site-header-on-redirection-expected.txt
+++ b/LayoutTests/http/tests/navigation/sec-fetch-site-header-on-redirection-expected.txt
@@ -1,0 +1,15 @@
+Tests the behavior of sec-fetch-site header.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS secFetchSite is expected
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+
+============== Back Forward List ==============
+        http://127.0.0.1:8000/navigation/sec-fetch-site-header-on-redirection.html  **nav target**
+curr->  http://127.0.0.1:8000/referrer-policy/resources/check-sec-fetch-site.py?expected=none  **nav target**
+===============================================

--- a/LayoutTests/http/tests/navigation/sec-fetch-site-header-on-redirection.html
+++ b/LayoutTests/http/tests/navigation/sec-fetch-site-header-on-redirection.html
@@ -1,0 +1,8 @@
+<script>
+if (window.testRunner) {
+    testRunner.clearBackForwardList();
+    testRunner.dumpBackForwardList();
+    testRunner.dumpAsText();
+    testRunner.queueLoad("/resources/redirect.py?url=http://127.0.0.1:8000/referrer-policy/resources/check-sec-fetch-site.py%3Fexpected%3Dnone");
+}
+</script>

--- a/LayoutTests/http/tests/navigation/sec-fetch-site-header.html
+++ b/LayoutTests/http/tests/navigation/sec-fetch-site-header.html
@@ -1,0 +1,8 @@
+<script>
+if (window.testRunner) {
+    testRunner.clearBackForwardList();
+    testRunner.dumpBackForwardList();
+    testRunner.dumpAsText();
+    testRunner.queueLoad("https://localhost:8443/referrer-policy/resources/check-sec-fetch-site.py?expected=none");
+}
+</script>

--- a/LayoutTests/http/tests/referrer-policy-anchor/no-referrer/sec-fetch-site-cross-origin-http-expected.txt
+++ b/LayoutTests/http/tests/referrer-policy-anchor/no-referrer/sec-fetch-site-cross-origin-http-expected.txt
@@ -1,0 +1,10 @@
+Tests the behavior of sec-fetch-site header.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS secFetchSite is expected
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/referrer-policy-anchor/no-referrer/sec-fetch-site-cross-origin-http.html
+++ b/LayoutTests/http/tests/referrer-policy-anchor/no-referrer/sec-fetch-site-cross-origin-http.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<body onload="clickLink()">
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+function clickLink() {
+    let expected = "cross-site";
+    let a = document.createElement("a");
+    let policy = "no-referrer";
+    a.referrerPolicy = policy;
+    a.href = "http://localhost:8080/referrer-policy/resources/check-sec-fetch-site.py?test&sfs-co&expected=" + expected;
+    a.click();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/referrer-policy/resources/check-sec-fetch-site.py
+++ b/LayoutTests/http/tests/referrer-policy/resources/check-sec-fetch-site.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+from urllib.parse import parse_qs
+
+secFetchSite = os.environ.get('HTTP_SEC_FETCH_SITE', 'missing')
+
+query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)
+expected = query.get('expected', [''])[0]
+
+sys.stdout.write('Content-Type: text/html\r\n\r\n')
+
+print('''<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests the behavior of sec-fetch-site header.");
+
+let secFetchSite = "{}";
+let expected = "{}";
+shouldBe("secFetchSite", "expected");
+if (window.testRunner)
+    testRunner.notifyDone();
+</script>'''.format(secFetchSite, expected))

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/generated/element-iframe.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/generated/element-iframe.sub-expected.txt
@@ -18,4 +18,6 @@ PASS sec-fetch-user - Not sent to non-trustworthy cross-site destination
 FAIL sec-fetch-site - HTTPS downgrade (header not sent) assert_not_own_property: unexpected property "sec-fetch-site" is found on object
 PASS sec-fetch-site - HTTPS upgrade
 PASS sec-fetch-site - HTTPS downgrade-upgrade
+PASS sec-fetch-site - no referrer
+PASS sec-fetch-site - no referrer - redirection
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/generated/element-iframe.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/generated/element-iframe.sub.html
@@ -34,6 +34,19 @@ Sources:
       });
   }
 
+  function induceNoReferrerRequest(url, test) {
+    const iframe = document.createElement('iframe');
+    iframe.referrerPolicy = 'no-referrer';
+    iframe.setAttribute('src', url);
+
+    document.body.appendChild(iframe);
+    test.add_cleanup(() => iframe.remove());
+
+    return new Promise((resolve) => {
+      iframe.onload = iframe.onerror = resolve;
+    });
+  }
+
   promise_test((t) => {
     const key = '{{uuid()}}';
 
@@ -245,6 +258,34 @@ Sources:
           assert_array_equals(headers['sec-fetch-site'], ['cross-site']);
         });
   }, 'sec-fetch-site - HTTPS downgrade-upgrade');
+
+  promise_test((t) => {
+    const key = '{{uuid()}}';
+
+    return induceNoReferrerRequest(
+        makeRequestURL(key, ['httpsOrigin'], {mime: 'text/html'}),
+        t
+      )
+      .then(() => retrieve(key))
+      .then((headers) => {
+          assert_own_property(headers, 'sec-fetch-site');
+          assert_array_equals(headers['sec-fetch-site'], ['cross-site']);
+        });
+  }, 'sec-fetch-site - no referrer');
+
+  promise_test((t) => {
+    const key = '{{uuid()}}';
+
+    return induceNoReferrerRequest(
+        makeRequestURL(key, ['httpsOrigin', 'httpOrigin'], {mime: 'text/html'}),
+        t
+      )
+      .then(() => retrieve(key))
+      .then((headers) => {
+          assert_own_property(headers, 'sec-fetch-site');
+          assert_array_equals(headers['sec-fetch-site'], ['cross-site']);
+        });
+  }, 'sec-fetch-site - no referrer - redirection');
   </script>
   </body>
 </html>

--- a/LayoutTests/platform/mac-wk1/http/tests/navigation/sec-fetch-site-header-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/navigation/sec-fetch-site-header-expected.txt
@@ -1,0 +1,16 @@
+Tests the behavior of sec-fetch-site header.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+FAIL secFetchSite should be none. Was cross-site.
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+
+
+============== Back Forward List ==============
+        http://127.0.0.1:8000/navigation/sec-fetch-site-header.html  **nav target**
+curr->  https://localhost:8443/referrer-policy/resources/check-sec-fetch-site.py?expected=none  **nav target**
+===============================================

--- a/LayoutTests/platform/mac-wk1/http/tests/navigation/sec-fetch-site-header-on-crossorigin-redirection-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/navigation/sec-fetch-site-header-on-crossorigin-redirection-expected.txt
@@ -1,0 +1,16 @@
+Tests the behavior of sec-fetch-site header.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+FAIL secFetchSite should be none. Was cross-site.
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+
+
+============== Back Forward List ==============
+        http://127.0.0.1:8000/navigation/sec-fetch-site-header-on-crossorigin-redirection.html  **nav target**
+curr->  http://127.0.0.1:8000/referrer-policy/resources/check-sec-fetch-site.py?expected=none  **nav target**
+===============================================

--- a/LayoutTests/platform/mac-wk1/http/tests/navigation/sec-fetch-site-header-on-redirection-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/navigation/sec-fetch-site-header-on-redirection-expected.txt
@@ -1,0 +1,16 @@
+Tests the behavior of sec-fetch-site header.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+FAIL secFetchSite should be none. Was same-origin.
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+
+
+============== Back Forward List ==============
+        http://127.0.0.1:8000/navigation/sec-fetch-site-header-on-redirection.html  **nav target**
+curr->  http://127.0.0.1:8000/referrer-policy/resources/check-sec-fetch-site.py?expected=none  **nav target**
+===============================================

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -127,7 +127,7 @@ SubresourceLoader::SubresourceLoader(LocalFrame& frame, CachedResource& resource
     m_resourceType = ContentExtensions::toResourceType(resource.type(), resource.resourceRequest().requester());
 #endif
     m_canCrossOriginRequestsAskUserForCredentials = resource.type() == CachedResource::Type::MainResource;
-    m_site = CachedResourceLoader::computeFetchMetadataSite(resource.resourceRequest(), resource.type(), options.mode, frame.document()->securityOrigin());
+    m_site = CachedResourceLoader::computeFetchMetadataSite(resource.resourceRequest(), resource.type(), options.mode, frame.document()->securityOrigin(), FetchMetadataSite::SameOrigin, frame.isMainFrame() && m_documentLoader && m_documentLoader->isRequestFromClientOrUserInput());
 }
 
 SubresourceLoader::~SubresourceLoader()
@@ -300,7 +300,7 @@ void SubresourceLoader::willSendRequestInternal(ResourceRequest&& newRequest, co
         RefPtr documentLoader = this->documentLoader();
         Ref originalOrigin = SecurityOrigin::create(redirectResponse.url());
         Ref cachedResourceLoader = documentLoader->cachedResourceLoader();
-        m_site = cachedResourceLoader->computeFetchMetadataSite(newRequest, m_resource->type(), options().mode, originalOrigin, m_site);
+        m_site = CachedResourceLoader::computeFetchMetadataSite(newRequest, m_resource->type(), options().mode, originalOrigin, m_site, m_frame && m_frame->isMainFrame() && documentLoader->isRequestFromClientOrUserInput());
 
         if (!cachedResourceLoader->updateRequestAfterRedirection(resource->type(), newRequest, options(), m_site, originalRequest().url())) {
             SUBRESOURCELOADER_RELEASE_LOG("willSendRequestInternal: resource load canceled because CachedResourceLoader::updateRequestAfterRedirection (really CachedResourceLoader::canRequestAfterRedirection) said no");

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -721,10 +721,10 @@ static void updateRequestFetchMetadataHeaders(ResourceRequest& request, const Re
     request.setHTTPHeaderField(HTTPHeaderName::SecFetchSite, convertEnumerationToString(site));
 }
 
-FetchMetadataSite CachedResourceLoader::computeFetchMetadataSite(const ResourceRequest& request, CachedResource::Type type, FetchOptions::Mode mode, const SecurityOrigin& originalOrigin, FetchMetadataSite originalSite)
+FetchMetadataSite CachedResourceLoader::computeFetchMetadataSite(const ResourceRequest& request, CachedResource::Type type, FetchOptions::Mode mode, const SecurityOrigin& originalOrigin, FetchMetadataSite originalSite, bool isDirectlyUserInitiatedRequest)
 {
     // This is true when a user causes a request, such as entering a URL.
-    if (mode == FetchOptions::Mode::Navigate && type == CachedResource::Type::MainResource && !request.hasHTTPReferrer())
+    if (mode == FetchOptions::Mode::Navigate && type == CachedResource::Type::MainResource && isDirectlyUserInitiatedRequest)
         return FetchMetadataSite::None;
 
     // If this is a redirect we start with the old value.
@@ -921,7 +921,7 @@ void CachedResourceLoader::updateHTTPRequestHeaders(FrameLoader& frameLoader, Ca
     // ability it is best to not set any FetchMetadata headers as sites generally expect
     // all of them or none.
     if (!frameLoader.frame().document() || !frameLoader.frame().document()->quirks().shouldDisableFetchMetadata()) {
-        auto site = computeFetchMetadataSite(request.resourceRequest(), type, request.options().mode, frameLoader.frame().document()->protectedSecurityOrigin());
+        auto site = computeFetchMetadataSite(request.resourceRequest(), type, request.options().mode, frameLoader.frame().document()->protectedSecurityOrigin(), FetchMetadataSite::SameOrigin, frameLoader.frame().isMainFrame() && m_documentLoader && m_documentLoader->isRequestFromClientOrUserInput());
         updateRequestFetchMetadataHeaders(request.resourceRequest(), request.options(), site);
     }
     request.updateUserAgentHeader(frameLoader);

--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -173,7 +173,7 @@ public:
 
     Vector<CachedResourceHandle<CachedResource>> visibleResourcesToPrioritize();
 
-    static FetchMetadataSite computeFetchMetadataSite(const ResourceRequest&, CachedResource::Type, FetchOptions::Mode, const SecurityOrigin& originalOrigin, FetchMetadataSite originalSite = FetchMetadataSite::SameOrigin);
+    static FetchMetadataSite computeFetchMetadataSite(const ResourceRequest&, CachedResource::Type, FetchOptions::Mode, const SecurityOrigin& originalOrigin, FetchMetadataSite originalSite, bool isDirectlyUserInitiatedRequest);
 
 private:
     explicit CachedResourceLoader(DocumentLoader*);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1776,6 +1776,10 @@ RefPtr<API::Navigation> WebPageProxy::loadRequest(ResourceRequest&& request, Sho
 
     Ref navigation = m_navigationState->createLoadRequestNavigation(process().coreProcessIdentifier(), ResourceRequest(request), m_backForwardList->protectedCurrentItem());
 
+    auto navigationData = navigation->lastNavigationAction();
+    navigationData.isRequestFromClientOrUserInput = true;
+    navigation->setLastNavigationAction(WTFMove(navigationData));
+
     if (shouldForceForegroundPriorityForClientNavigation())
         navigation->setClientNavigationActivity(process().throttler().foregroundActivity("Client navigation"_s));
 
@@ -1819,7 +1823,7 @@ void WebPageProxy::loadRequestWithNavigationShared(Ref<WebProcessProxy>&& proces
     loadParameters.isNavigatingToAppBoundDomain = isNavigatingToAppBoundDomain;
     loadParameters.existingNetworkResourceLoadIdentifierToResume = existingNetworkResourceLoadIdentifierToResume;
     loadParameters.advancedPrivacyProtections = navigation.originatorAdvancedPrivacyProtections();
-    loadParameters.isRequestFromClientOrUserInput = navigation.isRequestFromClientOrUserInput() || shouldTreatAsContinuingLoad == ShouldTreatAsContinuingLoad::No;
+    loadParameters.isRequestFromClientOrUserInput = navigation.isRequestFromClientOrUserInput();
     maybeInitializeSandboxExtensionHandle(process, url, internals().pageLoadState.resourceDirectoryURL(), loadParameters.sandboxExtensionHandle);
 
     prepareToLoadWebPage(process, loadParameters);
@@ -1874,6 +1878,10 @@ RefPtr<API::Navigation> WebPageProxy::loadFile(const String& fileURLString, cons
     }
 
     Ref navigation = m_navigationState->createLoadRequestNavigation(process().coreProcessIdentifier(), ResourceRequest(fileURL), m_backForwardList->protectedCurrentItem());
+
+    auto navigationData = navigation->lastNavigationAction();
+    navigationData.isRequestFromClientOrUserInput = true;
+    navigation->setLastNavigationAction(WTFMove(navigationData));
 
     if (shouldForceForegroundPriorityForClientNavigation())
         navigation->setClientNavigationActivity(process().throttler().foregroundActivity("Client navigation"_s));


### PR DESCRIPTION
#### ab5d20c0ff1557bf6de443c88ffea5b0eb88b30f
<pre>
Incorrect Sec-Fetch-Site values on iframes
<a href="https://rdar.apple.com/109358563">rdar://109358563</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=256472">https://bugs.webkit.org/show_bug.cgi?id=256472</a>

Reviewed by Chris Dumez.

We use DocumentLoader::isRequestFromClientOrUserInput as a heuristic for directly user-initiated requests used in
the computation of Sec-Fetch-Site as per <a href="https://w3c.github.io/webappsec-fetch-metadata/#sec-fetch-site-header.">https://w3c.github.io/webappsec-fetch-metadata/#sec-fetch-site-header.</a>
We remove the use of referrer since this is broken when referrer policy is no-referrer.
And we restrict to main frame navigation only.

In case of process swap, we could miscompute isRequestFromClientOrUserInput. We update WebPageProxy code to correctly compute LoadParameters.isRequestFromClientOrUserInput correctly.

Covered by tests.

* LayoutTests/http/tests/navigation/sec-fetch-site-header-expected.txt: Added.
* LayoutTests/http/tests/navigation/sec-fetch-site-header-on-crossorigin-redirection-expected.txt: Added.
* LayoutTests/http/tests/navigation/sec-fetch-site-header-on-crossorigin-redirection.html: Added.
* LayoutTests/http/tests/navigation/sec-fetch-site-header-on-redirection-expected.txt: Added.
* LayoutTests/http/tests/navigation/sec-fetch-site-header-on-redirection.html: Added.
* LayoutTests/http/tests/navigation/sec-fetch-site-header.html: Added.
* LayoutTests/http/tests/referrer-policy-anchor/no-referrer/sec-fetch-site-cross-origin-http-expected.txt: Added.
* LayoutTests/http/tests/referrer-policy-anchor/no-referrer/sec-fetch-site-cross-origin-http.html: Added.
* LayoutTests/http/tests/referrer-policy/resources/check-sec-fetch-site.py: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/generated/element-iframe.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/generated/element-iframe.sub.html:
* LayoutTests/platform/mac-wk1/http/tests/navigation/sec-fetch-site-header-expected.txt: Added.
* LayoutTests/platform/mac-wk1/http/tests/navigation/sec-fetch-site-header-on-crossorigin-redirection-expected.txt: Added.
* LayoutTests/platform/mac-wk1/http/tests/navigation/sec-fetch-site-header-on-redirection-expected.txt: Added.
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::SubresourceLoader):
(WebCore::SubresourceLoader::willSendRequestInternal):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::computeFetchMetadataSite):
(WebCore::CachedResourceLoader::updateHTTPRequestHeaders):
* Source/WebCore/loader/cache/CachedResourceLoader.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::loadRequest):
(WebKit::WebPageProxy::loadRequestWithNavigationShared):
(WebKit::WebPageProxy::loadFile):

Canonical link: <a href="https://commits.webkit.org/277662@main">https://commits.webkit.org/277662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af8e4fd6bf65ed2b9595f3a15f499d91efc83e2d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50792 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44168 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50412 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33219 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24814 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39309 "Found 5 new test failures: imported/w3c/web-platform-tests/fetch/metadata/generated/element-a.sub.html, imported/w3c/web-platform-tests/fetch/metadata/generated/element-area.sub.html, imported/w3c/web-platform-tests/fetch/metadata/generated/element-iframe.sub.html, imported/w3c/web-platform-tests/fetch/metadata/generated/element-meta-refresh.optional.sub.html, imported/w3c/web-platform-tests/fetch/metadata/generated/window-location.sub.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48688 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41598 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20437 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22481 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42780 "Found 1 new test failure: fast/css/viewport-height-outline.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6160 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44497 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52691 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23154 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19511 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46653 "Found 3 new test failures: imported/w3c/web-platform-tests/fetch/metadata/generated/element-a.sub.html, imported/w3c/web-platform-tests/fetch/metadata/generated/element-area.sub.html, imported/w3c/web-platform-tests/fetch/metadata/generated/window-location.sub.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24418 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41766 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45523 "Found 3 new API test failures: /WebKitGTK/TestDownloads:/webkit/Downloads/destination-uri, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestSSL:/webkit/WebKitWebView/tls-errors-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10647 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25220 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24141 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->