### PR TITLE
[GCC] Unreviewed, build fix for Debian 11 after 277566@main

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -252,88 +252,83 @@ enum class MetadataReadMode {
 
 constexpr inline JSEntrypointInterpreterCalleeMetadata jsEntrypointMetadataForGPR(GPRReg g, MetadataReadMode mode)
 {
-    using enum JSEntrypointInterpreterCalleeMetadata;
-    using enum MetadataReadMode;
-    if (mode == Write) {
+    if (mode == MetadataReadMode::Write) {
         for (unsigned i = 0; i < GPRInfo::numberOfArgumentRegisters; ++i) {
             if (g == GPRInfo::toArgumentRegister(i)) {
                 return static_cast<JSEntrypointInterpreterCalleeMetadata>(
-                    static_cast<int8_t>(WA0) + i);
+                    static_cast<int8_t>(JSEntrypointInterpreterCalleeMetadata::WA0) + i);
             }
         }
 
         if (g == GPRInfo::returnValueGPR)
-            return WR0;
+            return JSEntrypointInterpreterCalleeMetadata::WR0;
         if (g == GPRInfo::returnValueGPR2)
-            return WR1;
+            return JSEntrypointInterpreterCalleeMetadata::WR1;
 
         RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(false);
-        return InvalidRegister;
+        return JSEntrypointInterpreterCalleeMetadata::InvalidRegister;
     }
 
     if (g == GPRInfo::argumentGPR0)
-        return WA0_READ;
+        return JSEntrypointInterpreterCalleeMetadata::WA0_READ;
 
     RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(false);
-    return InvalidRegister;
+    return JSEntrypointInterpreterCalleeMetadata::InvalidRegister;
 }
 
 constexpr inline JSEntrypointInterpreterCalleeMetadata jsEntrypointMetadataForFPR(FPRReg f, MetadataReadMode mode)
 {
-    using enum JSEntrypointInterpreterCalleeMetadata;
-    using enum MetadataReadMode;
-    RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(mode == Write);
+    RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(mode == MetadataReadMode::Write);
 
     for (unsigned i = 0; i < GPRInfo::numberOfArgumentRegisters; ++i) {
         if (f == FPRInfo::toArgumentRegister(i)) {
             return static_cast<JSEntrypointInterpreterCalleeMetadata>(
-                static_cast<int8_t>(WAF0) + i);
+                static_cast<int8_t>(JSEntrypointInterpreterCalleeMetadata::WAF0) + i);
         }
     }
     RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(false);
-    return InvalidRegister;
+    return JSEntrypointInterpreterCalleeMetadata::InvalidRegister;
 }
 
 inline void dumpJSEntrypointInterpreterCalleeMetadata(const Vector<JSEntrypointInterpreterCalleeMetadata>& data)
 {
-    using enum JSEntrypointInterpreterCalleeMetadata;
     constexpr auto printOp = [](JSEntrypointInterpreterCalleeMetadata o) {
         switch (o) {
-        case Memory: dataLog("Memory"); break;
-        case Done: dataLog("Done"); break;
-        case FrameSize: dataLog("FrameSize"); break;
-        case LoadI32: dataLog("LoadI32"); break;
-        case LoadF32: dataLog("LoadF32"); break;
-        case LoadF64: dataLog("LoadF64"); break;
-        case StoreI32: dataLog("StoreI32"); break;
-        case StoreF32: dataLog("StoreF32"); break;
-        case StoreF64: dataLog("StoreF64"); break;
-        case LoadI64: dataLog("LoadI64"); break;
-        case StoreI64: dataLog("StoreI64"); break;
-        case BoxInt32: dataLog("BoxInt32"); break;
-        case BoxFloat32: dataLog("BoxFloat32"); break;
-        case BoxFloat64: dataLog("BoxFloat64"); break;
-        case UnBoxInt32: dataLog("UnBoxInt32"); break;
-        case UnBoxFloat32: dataLog("UnBoxFloat32"); break;
-        case UnBoxFloat64: dataLog("UnBoxFloat64"); break;
-        case Zero: dataLog("Zero"); break;
-        case Undefined: dataLog("Undefined"); break;
-        case BoxInt64: dataLog("BoxInt64"); break;
-        case UnBoxInt64: dataLog("UnBoxInt64"); break;
-        case Call: dataLog("Call"); break;
-        case WA0_READ: dataLog("WA0_READ"); break;
+        case JSEntrypointInterpreterCalleeMetadata::Memory: dataLog("Memory"); break;
+        case JSEntrypointInterpreterCalleeMetadata::Done: dataLog("Done"); break;
+        case JSEntrypointInterpreterCalleeMetadata::FrameSize: dataLog("FrameSize"); break;
+        case JSEntrypointInterpreterCalleeMetadata::LoadI32: dataLog("LoadI32"); break;
+        case JSEntrypointInterpreterCalleeMetadata::LoadF32: dataLog("LoadF32"); break;
+        case JSEntrypointInterpreterCalleeMetadata::LoadF64: dataLog("LoadF64"); break;
+        case JSEntrypointInterpreterCalleeMetadata::StoreI32: dataLog("StoreI32"); break;
+        case JSEntrypointInterpreterCalleeMetadata::StoreF32: dataLog("StoreF32"); break;
+        case JSEntrypointInterpreterCalleeMetadata::StoreF64: dataLog("StoreF64"); break;
+        case JSEntrypointInterpreterCalleeMetadata::LoadI64: dataLog("LoadI64"); break;
+        case JSEntrypointInterpreterCalleeMetadata::StoreI64: dataLog("StoreI64"); break;
+        case JSEntrypointInterpreterCalleeMetadata::BoxInt32: dataLog("BoxInt32"); break;
+        case JSEntrypointInterpreterCalleeMetadata::BoxFloat32: dataLog("BoxFloat32"); break;
+        case JSEntrypointInterpreterCalleeMetadata::BoxFloat64: dataLog("BoxFloat64"); break;
+        case JSEntrypointInterpreterCalleeMetadata::UnBoxInt32: dataLog("UnBoxInt32"); break;
+        case JSEntrypointInterpreterCalleeMetadata::UnBoxFloat32: dataLog("UnBoxFloat32"); break;
+        case JSEntrypointInterpreterCalleeMetadata::UnBoxFloat64: dataLog("UnBoxFloat64"); break;
+        case JSEntrypointInterpreterCalleeMetadata::Zero: dataLog("Zero"); break;
+        case JSEntrypointInterpreterCalleeMetadata::Undefined: dataLog("Undefined"); break;
+        case JSEntrypointInterpreterCalleeMetadata::BoxInt64: dataLog("BoxInt64"); break;
+        case JSEntrypointInterpreterCalleeMetadata::UnBoxInt64: dataLog("UnBoxInt64"); break;
+        case JSEntrypointInterpreterCalleeMetadata::Call: dataLog("Call"); break;
+        case JSEntrypointInterpreterCalleeMetadata::WA0_READ: dataLog("WA0_READ"); break;
         default: {
-            RELEASE_ASSERT(o >= WA0);
-            RELEASE_ASSERT(o < InvalidRegister);
-            if (o < WR0) {
+            RELEASE_ASSERT(o >= JSEntrypointInterpreterCalleeMetadata::WA0);
+            RELEASE_ASSERT(o < JSEntrypointInterpreterCalleeMetadata::InvalidRegister);
+            if (o < JSEntrypointInterpreterCalleeMetadata::WR0) {
                 dataLog("WA");
-                dataLog(static_cast<int8_t>(o) - static_cast<int8_t>(WA0));
-            } else if (o < WAF0) {
+                dataLog(static_cast<int8_t>(o) - static_cast<int8_t>(JSEntrypointInterpreterCalleeMetadata::WA0));
+            } else if (o < JSEntrypointInterpreterCalleeMetadata::WAF0) {
                 dataLog("R");
-                dataLog(static_cast<int8_t>(o) - static_cast<int8_t>(WR0));
+                dataLog(static_cast<int8_t>(o) - static_cast<int8_t>(JSEntrypointInterpreterCalleeMetadata::WR0));
             } else {
                 dataLog("FA");
-                dataLog(static_cast<int8_t>(o) - static_cast<int8_t>(WAF0));
+                dataLog(static_cast<int8_t>(o) - static_cast<int8_t>(JSEntrypointInterpreterCalleeMetadata::WAF0));
             }
         }
         }
@@ -345,18 +340,18 @@ inline void dumpJSEntrypointInterpreterCalleeMetadata(const Vector<JSEntrypointI
     };
     for (unsigned pc = 0; pc < data.size();) {
         switch (data[pc]) {
-        case FrameSize:
+        case JSEntrypointInterpreterCalleeMetadata::FrameSize:
             printOp(data[pc++]);
             dataLog(static_cast<int>(data[pc++]));
             break;
-        case LoadI32:
-        case LoadF32:
-        case LoadF64:
-        case StoreI32:
-        case StoreF32:
-        case StoreF64:
-        case LoadI64:
-        case StoreI64:
+        case JSEntrypointInterpreterCalleeMetadata::LoadI32:
+        case JSEntrypointInterpreterCalleeMetadata::LoadF32:
+        case JSEntrypointInterpreterCalleeMetadata::LoadF64:
+        case JSEntrypointInterpreterCalleeMetadata::StoreI32:
+        case JSEntrypointInterpreterCalleeMetadata::StoreF32:
+        case JSEntrypointInterpreterCalleeMetadata::StoreF64:
+        case JSEntrypointInterpreterCalleeMetadata::LoadI64:
+        case JSEntrypointInterpreterCalleeMetadata::StoreI64:
             printOp(data[pc++]);
             printOffset(data[pc++]);
             break;


### PR DESCRIPTION
#### fb54302c60a6994a7228aec170a75b609b3e1320
<pre>
[GCC] Unreviewed, build fix for Debian 11 after 277566@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=267481">https://bugs.webkit.org/show_bug.cgi?id=267481</a>

GCC10.2 doesn&apos;t support &quot;using enum&quot;.

* Source/JavaScriptCore/wasm/WasmCallee.h:
(JSC::Wasm::jsEntrypointMetadataForGPR):
(JSC::Wasm::jsEntrypointMetadataForFPR):
(JSC::Wasm::dumpJSEntrypointInterpreterCalleeMetadata):
* Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp:
(JSC::Wasm::LLIntPlan::makeInterpretedJSToWasmCallee):

Canonical link: <a href="https://commits.webkit.org/277600@main">https://commits.webkit.org/277600@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51b7b250c36a106b58c0b7ffed336d832ed8a791

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50766 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44142 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33176 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24782 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48662 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24957 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20415 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22438 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6134 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/41376 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44414 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52665 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/47573 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23128 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19480 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24392 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41740 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45502 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25194 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55068 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6823 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24115 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11325 "Passed tests") | 
<!--EWS-Status-Bubble-End-->