### PR TITLE
Timing-Allow-Origin works with 302

### DIFF
--- a/LayoutTests/http/wpt/resource-timing/resources/rt-utilities.sub.js
+++ b/LayoutTests/http/wpt/resource-timing/resources/rt-utilities.sub.js
@@ -37,12 +37,22 @@ function crossOriginURL(key, path) {
     return `http://localhost:{{ports[http][1]}}/${path}?${key}`;
 }
 
+function simpleCrossOriginURLBase() {
+    return `http://localhost:{{ports[http][1]}}`;
+}
+
 function urlWithRedirectTo(url) {
     return `/common/redirect.py?location=${encodeURIComponent(url)}`;
 }
 
 function addPipeHeaders(url, headers) {
     return `${url}&pipe=${headers.join("|")}`;
+}
+
+function addACAOHeader(url) {
+    return addPipeHeaders(url, [
+        `header(Access-Control-Allow-Origin,*)`,
+    ]);
 }
 
 function addTimingAllowOriginHeader(url, origin) {

--- a/LayoutTests/http/wpt/resource-timing/rt-cors-2-expected.txt
+++ b/LayoutTests/http/wpt/resource-timing/rt-cors-2-expected.txt
@@ -1,0 +1,5 @@
+Resource Timing: CORS requests
+
+
+PASS Cross-origin redirection with TAO to same origin loads without TAO must have filtered timing data
+

--- a/LayoutTests/http/wpt/resource-timing/rt-cors-2.html
+++ b/LayoutTests/http/wpt/resource-timing/rt-cors-2.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Resource Timing - CORS requests</title>
+<link rel="help" href="https://w3c.github.io/resource-timing/#cross-origin-resources">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/rt-utilities.sub.js"></script>
+</head>
+<body>
+<h1>Resource Timing: CORS requests</h1>
+<div id="log"></div>
+<script src="rt-cors-2.js"></script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/resource-timing/rt-cors-2.js
+++ b/LayoutTests/http/wpt/resource-timing/rt-cors-2.js
@@ -1,0 +1,52 @@
+function assertAlways(entry) {
+    assert_equals(entry.workerStart, 0, "entry should not have a workerStart time");
+    assert_equals(entry.secureConnectionStart, 0, "entry should not have a secureConnectionStart time");
+
+    assert_not_equals(entry.startTime, 0, "entry should have a non-0 fetchStart time");
+    assert_not_equals(entry.fetchStart, 0, "entry should have a non-0 startTime time");
+    assert_not_equals(entry.responseEnd, 0, "entry should have a non-0 responseEnd time");
+
+    assert_greater_than_equal(entry.fetchStart, entry.startTime, "fetchStart after startTime");
+    assert_greater_than_equal(entry.responseEnd, entry.fetchStart, "responseEnd after fetchStart");
+}
+
+function assertRedirectWithDisallowedTimingData(entry) {
+    assertAlways(entry);
+    assert_equals(entry.redirectStart, 0, "entry should not have a redirectStart time");
+    assert_equals(entry.redirectEnd, 0, "entry should not have a redirectEnd time");
+    assert_equals(entry.startTime, entry.fetchStart, "entry startTime should have matched redirectStart but it was disallowed so it should match fetchStart");
+}
+
+function assertDisallowedTimingData(entry) {
+    // These attributes must be zero:
+    // https://w3c.github.io/resource-timing/#cross-origin-resources
+    const keys = [
+        "redirectStart",
+        "redirectEnd",
+        "domainLookupStart",
+        "domainLookupEnd",
+        "connectStart",
+        "connectEnd",
+        "requestStart",
+        "responseStart",
+        "secureConnectionStart",
+    ];
+    for (let key of keys)
+        assert_equals(entry[key], 0, `entry ${key} must be zero for Cross Origin resource without passing Timing-Allow-Origin check`);
+}
+
+promise_test(function(t) {
+    let promise = observeResources(1).then(([entry]) => {
+        assertRedirectWithDisallowedTimingData(entry);
+        assertDisallowedTimingData(entry);
+    });
+
+    let sameOriginURL = uniqueDataURL("redirect-cross-origin-to-same-origin");
+    sameOriginURL = addACAOHeader(sameOriginURL);
+    const urlRedirect = urlWithRedirectTo(sameOriginURL);
+    const urlWithoutTAO = simpleCrossOriginURLBase() + urlRedirect;
+    const url = addTimingAllowOriginHeader(urlWithoutTAO, location.origin);
+
+    fetch(url);
+    return promise;
+}, "Cross-origin redirection with TAO to same origin loads without TAO must have filtered timing data");

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.h
@@ -157,6 +157,8 @@ public:
     const NetworkSession* networkSession() const;
     NetworkSession* networkSession();
 
+    virtual void setTimingAllowFailedFlag() { }
+
 protected:
     NetworkDataTask(NetworkSession&, NetworkDataTaskClient&, const WebCore::ResourceRequest&, WebCore::StoredCredentialsPolicy, bool shouldClearReferrerOnHTTPSToHTTPRedirect, bool dataTaskIsForMainFrameNavigation);
 

--- a/Source/WebKit/NetworkProcess/NetworkLoad.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.cpp
@@ -323,6 +323,12 @@ void NetworkLoad::setH2PingCallback(const URL& url, CompletionHandler<void(Expec
         completionHandler(makeUnexpected(internalError(url)));
 }
 
+void NetworkLoad::setTimingAllowFailedFlag()
+{
+    if (m_task)
+        m_task->setTimingAllowFailedFlag();
+}
+
 String NetworkLoad::attributedBundleIdentifier(WebPageProxyIdentifier pageID)
 {
     if (m_task)

--- a/Source/WebKit/NetworkProcess/NetworkLoad.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.h
@@ -81,6 +81,8 @@ public:
     String description() const;
     void setH2PingCallback(const URL&, CompletionHandler<void(Expected<WTF::Seconds, WebCore::ResourceError>&&)>&&);
 
+    void setTimingAllowFailedFlag();
+
 private:
     // NetworkDataTaskClient
     void willPerformHTTPRedirection(WebCore::ResourceResponse&&, WebCore::ResourceRequest&&, RedirectCompletionHandler&&) final;

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -70,6 +70,9 @@ NetworkLoadChecker::NetworkLoadChecker(NetworkProcess& networkProcess, NetworkRe
     , m_schemeRegistry(schemeRegistry)
     , m_networkResourceLoader(networkResourceLoader)
 {
+    if (m_requestLoadType == LoadType::MainFrame)
+        m_origin = m_topOrigin;
+
     m_isSameOriginRequest = isSameOrigin(m_url, m_origin.get());
     switch (options.credentials) {
     case FetchOptions::Credentials::Include:
@@ -207,6 +210,15 @@ ResourceError NetworkLoadChecker::validateResponse(const ResourceRequest& reques
     if (response.containsInvalidHTTPHeaders())
         return badResponseHeadersError(request.url());
 
+    auto scope = makeScopeExit([&] {
+        if (!checkTAO(response)) {
+            if (auto metrics = response.takeNetworkLoadMetrics()) {
+                metrics->failsTAOCheck = true;
+                response.setDeprecatedNetworkLoadMetrics(WTFMove(metrics));
+            }
+        }
+    });
+
     if (m_redirectCount)
         response.setRedirected(true);
 
@@ -238,8 +250,10 @@ ResourceError NetworkLoadChecker::validateResponse(const ResourceRequest& reques
     ASSERT(m_options.mode == FetchOptions::Mode::Cors);
 
     // If we have a 304, the cached response is in WebProcess so we let WebProcess do the CORS check on the cached response.
-    if (response.httpStatusCode() == httpStatus304NotModified)
+    if (response.httpStatusCode() == httpStatus304NotModified) {
+        response.setTainting(ResourceResponse::Tainting::Cors);
         return { };
+    }
 
     auto result = passesAccessControlCheck(response, m_storedCredentialsPolicy, *origin(), m_networkResourceLoader.get());
     if (!result)
@@ -247,6 +261,30 @@ ResourceError NetworkLoadChecker::validateResponse(const ResourceRequest& reques
 
     response.setTainting(ResourceResponse::Tainting::Cors);
     return { };
+}
+
+// https://fetch.spec.whatwg.org/#concept-tao-check
+bool NetworkLoadChecker::checkTAO(const ResourceResponse& response)
+{
+    if (m_timingAllowFailedFlag)
+        return false;
+
+    if (m_origin) {
+        const auto& timingAllowOriginString = response.httpHeaderField(HTTPHeaderName::TimingAllowOrigin);
+        for (auto originWithSpace : StringView(timingAllowOriginString).split(',')) {
+            auto origin = originWithSpace.trim(isASCIIWhitespaceWithoutFF<UChar>);
+            if (origin == "*"_s || origin == m_origin->toString())
+                return true;
+        }
+    }
+
+    if (m_options.mode == FetchOptions::Mode::Navigate && !m_isSameOriginRequest) {
+        m_timingAllowFailedFlag = true;
+        return false;
+    }
+
+    m_timingAllowFailedFlag = response.tainting() != ResourceResponse::Tainting::Basic;
+    return !m_timingAllowFailedFlag;
 }
 
 auto NetworkLoadChecker::accessControlErrorForValidationHandler(String&& message) -> RequestOrRedirectionTripletOrError

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
@@ -116,6 +116,8 @@ public:
 
     const WebCore::FetchOptions& options() const { return m_options; }
 
+    bool timingAllowFailedFlag() const { return m_timingAllowFailedFlag; }
+
 private:
     WebCore::ContentSecurityPolicy* contentSecurityPolicy();
     const WebCore::OriginAccessPatterns& originAccessPatterns() const;
@@ -148,6 +150,8 @@ private:
 #endif
 
     RefPtr<WebCore::SecurityOrigin> parentOrigin() const { return m_parentOrigin; }
+
+    bool checkTAO(const WebCore::ResourceResponse&);
 
     WebCore::FetchOptions m_options;
     WebCore::StoredCredentialsPolicy m_storedCredentialsPolicy;
@@ -188,6 +192,8 @@ private:
     LoadType m_requestLoadType;
     RefPtr<NetworkSchemeRegistry> m_schemeRegistry;
     WeakPtr<NetworkResourceLoader> m_networkResourceLoader;
+
+    bool m_timingAllowFailedFlag { false };
 };
 
 }

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -926,6 +926,8 @@ void NetworkResourceLoader::didReceiveResponse(ResourceResponse&& receivedRespon
             });
             return completionHandler(PolicyAction::Ignore);
         }
+        if (m_networkLoad && m_networkLoadChecker->timingAllowFailedFlag())
+            m_networkLoad->setTimingAllowFailedFlag();
     }
 
     initializeReportingEndpoints(m_response);
@@ -1056,6 +1058,8 @@ void NetworkResourceLoader::didReceiveBuffer(const WebCore::FragmentedSharedBuff
 
 void NetworkResourceLoader::didFinishLoading(const NetworkLoadMetrics& networkLoadMetrics)
 {
+    ASSERT(!m_networkLoadChecker || networkLoadMetrics.failsTAOCheck == m_networkLoadChecker->timingAllowFailedFlag());
+
     LOADER_RELEASE_LOG("didFinishLoading: (numBytesReceived=%zd, hasCacheEntryForValidation=%d)", m_numBytesReceived, !!m_cacheEntryForValidation);
 
     if (shouldCaptureExtraNetworkLoadMetrics())
@@ -1247,6 +1251,9 @@ void NetworkResourceLoader::willSendRedirectedRequestInternal(ResourceRequest&& 
                 this->didFailLoading(result.error());
                 return completionHandler({ });
             }
+
+            if (m_networkLoad && m_networkLoadChecker && m_networkLoadChecker->timingAllowFailedFlag())
+                m_networkLoad->setTimingAllowFailedFlag();
 
             LOADER_RELEASE_LOG("willSendRedirectedRequest: NetworkLoadChecker::checkRedirection is done");
             if (m_parameters.options.redirect == FetchOptions::Redirect::Manual) {

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
@@ -104,6 +104,8 @@ private:
     NSURLSessionTask* task() const final;
     WebCore::StoredCredentialsPolicy storedCredentialsPolicy() const final { return m_storedCredentialsPolicy; }
 
+    void setTimingAllowFailedFlag() final;
+
     WeakPtr<SessionWrapper> m_sessionWrapper;
     RefPtr<SandboxExtension> m_sandboxExtension;
     RetainPtr<NSURLSessionDataTask> m_task;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -680,19 +680,9 @@ void NetworkDataTaskCocoa::setEmulatedConditions(const std::optional<int64_t>& b
 
 #endif // ENABLE(INSPECTOR_NETWORK_THROTTLING)
 
-void NetworkDataTaskCocoa::checkTAO(const WebCore::ResourceResponse& response)
+void NetworkDataTaskCocoa::setTimingAllowFailedFlag()
 {
-    if (networkLoadMetrics().failsTAOCheck)
-        return;
-
-    RefPtr<WebCore::SecurityOrigin> origin;
-    if (isTopLevelNavigation())
-        origin = WebCore::SecurityOrigin::create(firstRequest().url());
-    else
-        origin = m_sourceOrigin;
-
-    if (origin)
-        networkLoadMetrics().failsTAOCheck = !passesTimingAllowOriginCheck(response, *origin);
+    networkLoadMetrics().failsTAOCheck = true;
 }
 
 NSURLSessionTask* NetworkDataTaskCocoa::task() const

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -630,7 +630,6 @@ static void updateIgnoreStrictTransportSecuritySetting(RetainPtr<NSURLRequest>& 
             ASSERT_NOT_REACHED();
 
         WebCore::ResourceResponse resourceResponse(response);
-        networkDataTask->checkTAO(resourceResponse);
 
         networkDataTask->willPerformHTTPRedirection(WTFMove(resourceResponse), request, [session = networkDataTask->networkSession(), completionHandler = makeBlockPtr(completionHandler), taskIdentifier, shouldIgnoreHSTS](auto&& request) {
 #if !LOG_DISABLED
@@ -1095,8 +1094,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         // Lazy initialization is not helpful in the WebKit2 case because we always end up initializing
         // all the fields when sending the response to the WebContent process over IPC.
         resourceResponse.disableLazyInitialization();
-
-        networkDataTask->checkTAO(resourceResponse);
 
         resourceResponse.setDeprecatedNetworkLoadMetrics(WebCore::copyTimingData(taskMetrics, networkDataTask->networkLoadMetrics()));
 

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -593,16 +593,15 @@ void NetworkDataTaskCurl::updateNetworkLoadMetrics(WebCore::NetworkLoadMetrics& 
     if (!m_startTime)
         m_startTime = networkLoadMetrics.fetchStart;
 
-    if (!m_failsTAOCheck) {
-        RefPtr<SecurityOrigin> origin = isTopLevelNavigation() ? SecurityOrigin::create(firstRequest().url()) : m_sourceOrigin;
-        if (origin)
-            m_failsTAOCheck = !passesTimingAllowOriginCheck(m_response, *origin);
-    }
-
     networkLoadMetrics.redirectStart = m_startTime;
     networkLoadMetrics.redirectCount = m_redirectCount;
     networkLoadMetrics.failsTAOCheck = m_failsTAOCheck;
     networkLoadMetrics.hasCrossOriginRedirect = m_hasCrossOriginRedirect;
+}
+
+void NetworkDataTaskCurl::setTimingAllowFailedFlag()
+{
+    m_failsTAOCheck = true;
 }
 
 void NetworkDataTaskCurl::setPendingDownloadLocation(const String& filename, SandboxExtension::Handle&& sandboxExtensionHandle, bool allowOverwrite)

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h
@@ -67,6 +67,7 @@ private:
     void resume() override;
     void invalidateAndCancel() override;
     NetworkDataTask::State state() const override;
+    void setTimingAllowFailedFlag() final;
 
     Ref<WebCore::CurlRequest> createCurlRequest(WebCore::ResourceRequest&&, RequestStatus = RequestStatus::NewRequest);
     void curlDidSendData(WebCore::CurlRequest&, unsigned long long, unsigned long long) override;

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -460,13 +460,12 @@ void NetworkDataTaskSoup::didSendRequest(GRefPtr<GInputStream>&& inputStream)
     m_networkLoadMetrics.responseStart = MonotonicTime::now();
 #endif
 
-    if (!m_networkLoadMetrics.failsTAOCheck) {
-        RefPtr<SecurityOrigin> origin = isTopLevelNavigation() ? SecurityOrigin::create(firstRequest().url()) : m_sourceOrigin;
-        if (origin)
-            m_networkLoadMetrics.failsTAOCheck = !passesTimingAllowOriginCheck(m_response, *origin);
-    }
-
     dispatchDidReceiveResponse();
+}
+
+void NetworkDataTaskSoup::setTimingAllowFailedFlag()
+{
+    m_networkLoadMetrics.failsTAOCheck = true;
 }
 
 void NetworkDataTaskSoup::dispatchDidReceiveResponse()

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.h
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.h
@@ -54,6 +54,7 @@ private:
     void resume() override;
     void invalidateAndCancel() override;
     NetworkDataTask::State state() const override;
+    void setTimingAllowFailedFlag() final;
 
     void setPendingDownloadLocation(const String&, SandboxExtension::Handle&&, bool /*allowOverwrite*/) override;
     String suggestedFilename() const override;


### PR DESCRIPTION
#### 6a2c5a3042534caf2df6952d1d7d151d3e3c76bc
<pre>
Timing-Allow-Origin works with 302
<a href="https://bugs.webkit.org/show_bug.cgi?id=272682">https://bugs.webkit.org/show_bug.cgi?id=272682</a>
<a href="https://rdar.apple.com/126531139">rdar://126531139</a>

Reviewed by Alex Christensen.

We move the TAO check from platform specific NetworkDataTask implementations to NetworkLoadChecker.
This allows us to implement the algorithm as defined in fetch, including checking the response tainting.
This aligns behavior with Chrome and Firefox.
For top level navigation, we were using the source origin, but we should use the top origin for top level navigations,
as top level navigations are same origin.

* LayoutTests/http/wpt/resource-timing/resources/rt-utilities.sub.js:
(addACAOHeader):
* LayoutTests/http/wpt/resource-timing/rt-cors-2-expected.txt: Added.
* LayoutTests/http/wpt/resource-timing/rt-cors-2.html: Added.
* LayoutTests/http/wpt/resource-timing/rt-cors-2.js: Added.
(assertAlways):
(assertRedirectWithDisallowedTimingData):
(assertDisallowedTimingData):
(promise_test):
* Source/WebKit/NetworkProcess/NetworkDataTask.h:
(WebKit::NetworkDataTask::setTimingAllowFailedFlag):
* Source/WebKit/NetworkProcess/NetworkLoad.cpp:
(WebKit::NetworkLoad::setTimingAllowFailedFlag):
* Source/WebKit/NetworkProcess/NetworkLoad.h:
* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::validateResponse):
(WebKit::NetworkLoadChecker::checkTAO):
* Source/WebKit/NetworkProcess/NetworkLoadChecker.h:
(WebKit::NetworkLoadChecker::timingAllowFailedFlag const):
(WebKit::NetworkLoadChecker::isSameOriginRequest const):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::didReceiveResponse):
(WebKit::NetworkResourceLoader::didFinishLoading):
(WebKit::NetworkResourceLoader::willSendRedirectedRequestInternal):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::setTimingAllowFailedFlag):
(WebKit::NetworkDataTaskCocoa::checkTAO): Deleted.
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(-[WKNetworkSessionDelegate URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler:]):
(-[WKNetworkSessionDelegate URLSession:dataTask:didReceiveResponse:completionHandler:]):
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp:
(WebKit::NetworkDataTaskCurl::updateNetworkLoadMetrics):
(WebKit::NetworkDataTaskCurl::setTimingAllowFailedFlag):
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h:
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
(WebKit::NetworkDataTaskSoup::didSendRequest):
(WebKit::NetworkDataTaskSoup::setTimingAllowFailedFlag):
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.h:

Canonical link: <a href="https://commits.webkit.org/278448@main">https://commits.webkit.org/278448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3fbc746a7bbf25460472e3ff53f9f80a68c911e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50589 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53848 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1279 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/930 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41241 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52688 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27538 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43568 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22351 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24929 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/826 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9028 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46916 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/889 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55437 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25690 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/794 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48649 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43715 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47703 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11077 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27814 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26680 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->