### PR TITLE
[GStreamer][WebRTC] Improvements in variable framerate outgoing sources

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1901,6 +1901,7 @@ webkit.org/b/264803 fast/mediastream/mediastreamtrack-video-resize-event.html [ 
 webkit.org/b/265865 imported/w3c/web-platform-tests/webrtc-stats/rtp-stats-creation.html [ Skip ]
 
 # Requires video scaling adaptation.
+webrtc/captureCanvas-webrtc-with-video-scaling-adaptation.html [ Failure ]
 webrtc/video-maxBitrate.html [ Failure ]
 webrtc/video-maxBitrate-vp8.html [ Failure ]
 

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
@@ -33,6 +33,10 @@
 #include "WebGLRenderingContextBase.h"
 #include <wtf/IsoMallocInlines.h>
 
+#if USE(GSTREAMER)
+#include "VideoFrameGStreamer.h"
+#endif
+
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(CanvasCaptureMediaStreamTrack);
@@ -201,6 +205,18 @@ void CanvasCaptureMediaStreamTrack::Source::captureCanvas()
     }();
     if (!videoFrame)
         return;
+
+#if USE(GSTREAMER)
+    auto gstVideoFrame = downcast<VideoFrameGStreamer>(videoFrame);
+    if (m_frameRequestRate)
+        gstVideoFrame->setFrameRate(*m_frameRequestRate);
+    else {
+        static const double s_frameRate = 60;
+        gstVideoFrame->setMaxFrameRate(s_frameRate);
+        gstVideoFrame->setPresentationTime(m_presentationTimeStamp);
+        m_presentationTimeStamp = m_presentationTimeStamp + MediaTime::createWithDouble(1.0 / s_frameRate);
+    }
+#endif
 
     VideoFrameTimeMetadata metadata;
     metadata.captureTime = MonotonicTime::now().secondsSinceEpoch();

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h
@@ -91,6 +91,9 @@ private:
         std::optional<RealtimeMediaSourceSettings> m_currentSettings;
         HTMLCanvasElement* m_canvas;
         RefPtr<Image> m_currentImage;
+#if USE(GSTREAMER)
+        MediaTime m_presentationTimeStamp { MediaTime::zeroTime() };
+#endif
     };
 
     CanvasCaptureMediaStreamTrack(Document&, Ref<HTMLCanvasElement>&&, Ref<Source>&&);

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -833,8 +833,7 @@ RefPtr<VideoFrame> HTMLCanvasElement::toVideoFrame()
 #if PLATFORM(COCOA)
     return VideoFrame::createFromPixelBuffer(pixelBuffer.releaseNonNull());
 #elif USE(GSTREAMER)
-    // FIXME: Hardcoding 30fps here is not great. Ideally we should get this from the compositor refresh rate, somehow.
-    return VideoFrameGStreamer::createFromPixelBuffer(pixelBuffer.releaseNonNull(), VideoFrameGStreamer::CanvasContentType::Canvas2D, VideoFrameGStreamer::Rotation::None, MediaTime::invalidTime(), { }, 30, false, { });
+    return VideoFrameGStreamer::createFromPixelBuffer(pixelBuffer.releaseNonNull(), VideoFrameGStreamer::CanvasContentType::Canvas2D);
 #endif
 #else
     return nullptr;

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
@@ -48,6 +48,11 @@ public:
 
     static RefPtr<VideoFrameGStreamer> createFromPixelBuffer(Ref<PixelBuffer>&&, CanvasContentType canvasContentType, Rotation videoRotation = VideoFrame::Rotation::None, const MediaTime& presentationTime = MediaTime::invalidTime(), const IntSize& destinationSize = { }, double frameRate = 1, bool videoMirrored = false, std::optional<VideoFrameTimeMetadata>&& metadata = std::nullopt, PlatformVideoColorSpace&& = { });
 
+    void setFrameRate(double);
+    void setMaxFrameRate(double);
+
+    void setPresentationTime(const MediaTime&);
+
     RefPtr<VideoFrameGStreamer> resizeTo(const IntSize&);
 
     GRefPtr<GstSample> resizedSample(const IntSize&);

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
@@ -60,16 +60,14 @@ RealtimeOutgoingVideoSourceGStreamer::RealtimeOutgoingVideoSourceGStreamer(const
     m_videoFlip = makeGStreamerElement("videoflip", nullptr);
     gst_util_set_object_arg(G_OBJECT(m_videoFlip.get()), "method", "automatic");
 
-    // Variable framerate for canvas capture tracks requires further investigation, so disable it for now.
-    if (!track.isCanvas()) {
-        m_videoRate = makeGStreamerElement("videorate", nullptr);
-        g_object_set(m_videoRate.get(), "skip-to-first", TRUE, nullptr);
-        m_frameRateCapsFilter = makeGStreamerElement("capsfilter", nullptr);
-        gst_bin_add_many(GST_BIN_CAST(m_bin.get()), m_videoRate.get(), m_frameRateCapsFilter.get(), nullptr);
-    }
+    m_videoRate = makeGStreamerElement("videorate", nullptr);
+    m_frameRateCapsFilter = makeGStreamerElement("capsfilter", nullptr);
+
+    // https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/issues/97#note_56575
+    g_object_set(m_videoRate.get(), "skip-to-first", TRUE, "drop-only", TRUE, "average-period", UINT64_C(1), nullptr);
 
     m_encoder = gst_element_factory_make("webkitvideoencoder", nullptr);
-    gst_bin_add_many(GST_BIN_CAST(m_bin.get()), m_videoFlip.get(), m_videoConvert.get(), m_encoder.get(), nullptr);
+    gst_bin_add_many(GST_BIN_CAST(m_bin.get()), m_videoRate.get(), m_frameRateCapsFilter.get(), m_videoFlip.get(), m_videoConvert.get(), m_encoder.get(), nullptr);
 }
 
 RTCRtpCapabilities RealtimeOutgoingVideoSourceGStreamer::rtpCapabilities() const
@@ -138,9 +136,8 @@ bool RealtimeOutgoingVideoSourceGStreamer::setPayloadType(const GRefPtr<GstCaps>
             gst_caps_set_simple(encoderCaps.get(), "profile", G_TYPE_STRING, vp9Profile, nullptr);
     } else if (encoding == "h264"_s) {
         encoderCaps = adoptGRef(gst_caps_new_empty_simple("video/x-h264"));
-        // FIXME: https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/issues/893
-        // gst_util_set_object_arg(G_OBJECT(m_payloader.get()), "aggregate-mode", "zero-latency");
-        // g_object_set(m_payloader.get(), "config-interval", -1, nullptr);
+        gst_util_set_object_arg(G_OBJECT(m_payloader.get()), "aggregate-mode", "zero-latency");
+        g_object_set(m_payloader.get(), "config-interval", -1, nullptr);
 
         const char* profile = gst_structure_get_string(structure.get(), "profile");
         if (!profile)
@@ -148,6 +145,8 @@ bool RealtimeOutgoingVideoSourceGStreamer::setPayloadType(const GRefPtr<GstCaps>
         gst_caps_set_simple(encoderCaps.get(), "profile", G_TYPE_STRING, profile, nullptr);
     } else if (encoding == "h265"_s) {
         encoderCaps = adoptGRef(gst_caps_new_empty_simple("video/x-h265"));
+        gst_util_set_object_arg(G_OBJECT(m_payloader.get()), "aggregate-mode", "zero-latency");
+        g_object_set(m_payloader.get(), "config-interval", -1, nullptr);
         // FIXME: profile tier level?
     } else if (encoding == "av1"_s) {
         encoderCaps = adoptGRef(gst_caps_new_empty_simple("video/x-av1"));


### PR DESCRIPTION
#### 0dd2540f475d5c11b3e0ebc6537052a3803a85b0
<pre>
[GStreamer][WebRTC] Improvements in variable framerate outgoing sources
<a href="https://bugs.webkit.org/show_bug.cgi?id=272811">https://bugs.webkit.org/show_bug.cgi?id=272811</a>

Reviewed by Xabier Rodriguez-Calvar.

Set the max-framerate field on the caps of variable framerate sources, such as canvas. Then on
outgoing video sources the videorate element can be made mandatory. This patch also re-enables
aggregate-mode and config-interval on h264/h265 payloaders.

* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp:
(WebCore::CanvasCaptureMediaStreamTrack::Source::captureCanvas):
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::toVideoFrame):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::setBufferFields):
(WebCore::VideoFrameGStreamer::createFromPixelBuffer):
(WebCore::VideoFrameGStreamer::setMaxFrameRate):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingVideoSourceGStreamer::RealtimeOutgoingVideoSourceGStreamer):
(WebCore::RealtimeOutgoingVideoSourceGStreamer::setPayloadType):

Canonical link: <a href="https://commits.webkit.org/277730@main">https://commits.webkit.org/277730@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c06428858c090526bdb6cf92aa800e0c519cad4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51113 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44490 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50731 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25159 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39574 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49007 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25317 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41800 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20703 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22801 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6482 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/44741 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43450 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53018 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23472 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/19801 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46898 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24737 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41996 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45812 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10681 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25542 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24460 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->