### PR TITLE
PerformanceResourceTiming redirectStarts may be wrongly exposed as 0 for cross origin loads

### DIFF
--- a/LayoutTests/http/wpt/resource-timing/rt-cors-redirection-expected.txt
+++ b/LayoutTests/http/wpt/resource-timing/rt-cors-redirection-expected.txt
@@ -1,0 +1,17 @@
+Resource Timing: CORS requests
+
+
+PASS Redirect to Same Origin request must have timing data
+PASS Redirect to Cross Origin resource without Timing-Allow-Origin must have filtered timing data
+PASS Redirect to Cross Origin resource with Timing-Allow-Origin null value must have filtered timing data
+PASS Redirect to Cross Origin resource with Timing-Allow-Origin wildcard must have timing data
+PASS Redirect to Cross Origin resource with origin in Timing-Allow-Origin list must have timing data (only entry)
+PASS Redirect to Cross Origin resource with origin in Timing-Allow-Origin list must have timing data (middle entry, comma separated)
+PASS Redirect to Cross Origin resource with origin in Timing-Allow-Origin list must have timing data (middle entry, multiple headers)
+PASS Redirect to Cross Origin resource with origin not in Timing-Allow-Origin list must have filtered timing data (other origins, comma separated)
+PASS Redirect to Cross Origin resource with origin not in Timing-Allow-Origin list must have filtered timing data (other origins, multiple headers)
+PASS Redirect to Cross Origin resource with origin not in Timing-Allow-Origin list must have filtered timing data (case-sensitive)
+PASS Multiple level redirect to Same Origin resource must have timing data
+PASS Multiple level redirect to Cross Origin resource without Timing-Allow-Origin must have must have filtered timing data
+PASS Multiple level redirect to Cross Origin resource with Timing-Allow-Origin must have must have timing data
+

--- a/LayoutTests/http/wpt/resource-timing/rt-cors-redirection.html
+++ b/LayoutTests/http/wpt/resource-timing/rt-cors-redirection.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Resource Timing - CORS requests</title>
+<link rel="help" href="https://w3c.github.io/resource-timing/#cross-origin-resources">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/rt-utilities.sub.js"></script>
+</head>
+<body>
+<h1>Resource Timing: CORS requests</h1>
+<div id="log"></div>
+<script src="rt-cors-redirection.js"></script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/resource-timing/rt-cors-redirection.js
+++ b/LayoutTests/http/wpt/resource-timing/rt-cors-redirection.js
@@ -1,0 +1,147 @@
+function assertRedirectTimingData(entry) {
+    assert_not_equals(entry.redirectStart, 0, "entry should have a redirectStart time");
+}
+
+function assertRedirectWithDisallowedTimingData(entry) {
+    assert_equals(entry.redirectStart, 0, "entry should not have a redirectStart time");
+}
+
+promise_test(function(t) {
+    let promise = observeResources(1).then(([entry]) => {
+        assertRedirectTimingData(entry);
+    });
+    let url = uniqueDataURL("redirect-same-origin-1", "same-origin");
+    fetch(urlWithRedirectTo(url));
+    return promise;
+}, "Redirect to Same Origin request must have timing data");
+
+promise_test(function(t) {
+    let promise = observeResources(1).then(([entry]) => {
+        assertRedirectWithDisallowedTimingData(entry);
+    });
+    let url = uniqueDataURL("redirect-cross-origin-1", "cross-origin");
+    url = url + "&pipe=header(Access-Control-Allow-Origin,*)";
+    fetch(urlWithRedirectTo(url));
+    return promise;
+}, "Redirect to Cross Origin resource without Timing-Allow-Origin must have filtered timing data");
+
+promise_test(function(t) {
+    let promise = observeResources(1).then(([entry]) => {
+        assertRedirectWithDisallowedTimingData(entry);
+    });
+    let url = uniqueDataURL("redirect-null", "cross-origin");
+    url = addTimingAllowOriginHeader(url, "null");
+    fetch(urlWithRedirectTo(url));
+    return promise;
+}, "Redirect to Cross Origin resource with Timing-Allow-Origin null value must have filtered timing data");
+
+promise_test(function(t) {
+    let promise = observeResources(1).then(([entry]) => {
+        assertRedirectTimingData(entry);
+    });
+    let url = uniqueDataURL("redirect-wildcard", "cross-origin");
+    url = addTimingAllowOriginHeader(url, "*");
+    fetch(urlWithRedirectTo(url));
+    return promise;
+}, "Redirect to Cross Origin resource with Timing-Allow-Origin wildcard must have timing data");
+
+promise_test(function(t) {
+    let promise = observeResources(1).then(([entry]) => {
+        assertRedirectTimingData(entry);
+    });
+    let url = uniqueDataURL("redirect-only-entry", "cross-origin");
+    url = addTimingAllowOriginHeader(url, location.origin);
+    fetch(urlWithRedirectTo(url));
+    return promise;
+}, "Redirect to Cross Origin resource with origin in Timing-Allow-Origin list must have timing data (only entry)");
+
+promise_test(function(t) {
+    let promise = observeResources(1).then(([entry]) => {
+        assertRedirectTimingData(entry);
+    });
+    let url = uniqueDataURL("redirect-middle-entry", "cross-origin");
+    url = addCommaSeparatedTimingAllowOriginHeaders(url, ["example.com", location.origin, "example.com"]);
+    fetch(urlWithRedirectTo(url));
+    return promise;
+}, "Redirect to Cross Origin resource with origin in Timing-Allow-Origin list must have timing data (middle entry, comma separated)");
+
+promise_test(function(t) {
+    let promise = observeResources(1).then(([entry]) => {
+        assertRedirectTimingData(entry);
+    });
+    let url = uniqueDataURL("redirect-middle-entry", "cross-origin");
+    url = addMultipleTimingAllowOriginHeaders(url, ["example.com", location.origin, "example.com"]);
+    fetch(urlWithRedirectTo(url));
+    return promise;
+}, "Redirect to Cross Origin resource with origin in Timing-Allow-Origin list must have timing data (middle entry, multiple headers)");
+
+promise_test(function(t) {
+    let promise = observeResources(1).then(([entry]) => {
+        assertRedirectWithDisallowedTimingData(entry);
+    });
+    let url = uniqueDataURL("redirect-other-origins", "cross-origin");
+    url = addCommaSeparatedTimingAllowOriginHeaders(url, [location.origin + ".test", "x" + location.origin]);
+    fetch(urlWithRedirectTo(url));
+    return promise;
+}, "Redirect to Cross Origin resource with origin not in Timing-Allow-Origin list must have filtered timing data (other origins, comma separated)");
+
+promise_test(function(t) {
+    let promise = observeResources(1).then(([entry]) => {
+        assertRedirectWithDisallowedTimingData(entry);
+    });
+    let url = uniqueDataURL("redirect-other-origins", "cross-origin");
+    url = addMultipleTimingAllowOriginHeaders(url, [location.origin + ".test", "x" + location.origin]);
+    fetch(urlWithRedirectTo(url));
+    return promise;
+}, "Redirect to Cross Origin resource with origin not in Timing-Allow-Origin list must have filtered timing data (other origins, multiple headers)");
+
+promise_test(function(t) {
+    let promise = observeResources(1).then(([entry]) => {
+        assertRedirectWithDisallowedTimingData(entry);
+    });
+    let url = uniqueDataURL("redirect-case-sensitive", "cross-origin");
+    url = addTimingAllowOriginHeader(url, location.origin.toUpperCase());
+    fetch(urlWithRedirectTo(url));
+    return promise;
+}, "Redirect to Cross Origin resource with origin not in Timing-Allow-Origin list must have filtered timing data (case-sensitive)");
+
+
+// Multiple redirects
+
+promise_test(function(t) {
+    let promise = observeResources(1).then(([entry]) => {
+        assertRedirectTimingData(entry);
+    });
+    let url = uniqueDataURL("multiple-redirect-same-origin", "same-origin");
+    let urlRedirect1 = urlWithRedirectTo(url);
+    let urlRedirect2 = urlWithRedirectTo(urlRedirect1);
+    let urlRedirect3 = urlWithRedirectTo(urlRedirect2);
+    fetch(urlRedirect3);
+    return promise;
+}, "Multiple level redirect to Same Origin resource must have timing data");
+
+promise_test(function(t) {
+    let promise = observeResources(1).then(([entry]) => {
+        assertRedirectWithDisallowedTimingData(entry);
+    });
+    let url = uniqueDataURL("multiple-redirect-cross-origin", "cross-origin");
+    url += "&pipe=header(Access-Control-Allow-Origin,*)";
+    let urlRedirect1 = urlWithRedirectTo(url);
+    let urlRedirect2 = urlWithRedirectTo(urlRedirect1);
+    let urlRedirect3 = urlWithRedirectTo(urlRedirect2);
+    fetch(urlRedirect3);
+    return promise;
+}, "Multiple level redirect to Cross Origin resource without Timing-Allow-Origin must have must have filtered timing data");
+
+promise_test(function(t) {
+    let promise = observeResources(1).then(([entry]) => {
+        assertRedirectTimingData(entry);
+    });
+    let url = uniqueDataURL("multiple-redirect-cross-origin-timing-allowed", "cross-origin");
+    url = addTimingAllowOriginHeader(url, location.origin);
+    let urlRedirect1 = urlWithRedirectTo(url);
+    let urlRedirect2 = urlWithRedirectTo(urlRedirect1);
+    let urlRedirect3 = urlWithRedirectTo(urlRedirect2);
+    fetch(urlRedirect3);
+    return promise;
+}, "Multiple level redirect to Cross Origin resource with Timing-Allow-Origin must have must have timing data");

--- a/LayoutTests/platform/mac-wk1/http/wpt/resource-timing/rt-cors-redirection-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/wpt/resource-timing/rt-cors-redirection-expected.txt
@@ -1,0 +1,17 @@
+Resource Timing: CORS requests
+
+
+PASS Redirect to Same Origin request must have timing data
+PASS Redirect to Cross Origin resource without Timing-Allow-Origin must have filtered timing data
+PASS Redirect to Cross Origin resource with Timing-Allow-Origin null value must have filtered timing data
+FAIL Redirect to Cross Origin resource with Timing-Allow-Origin wildcard must have timing data assert_not_equals: entry should have a redirectStart time got disallowed value 0
+FAIL Redirect to Cross Origin resource with origin in Timing-Allow-Origin list must have timing data (only entry) assert_not_equals: entry should have a redirectStart time got disallowed value 0
+FAIL Redirect to Cross Origin resource with origin in Timing-Allow-Origin list must have timing data (middle entry, comma separated) assert_not_equals: entry should have a redirectStart time got disallowed value 0
+FAIL Redirect to Cross Origin resource with origin in Timing-Allow-Origin list must have timing data (middle entry, multiple headers) assert_not_equals: entry should have a redirectStart time got disallowed value 0
+PASS Redirect to Cross Origin resource with origin not in Timing-Allow-Origin list must have filtered timing data (other origins, comma separated)
+PASS Redirect to Cross Origin resource with origin not in Timing-Allow-Origin list must have filtered timing data (other origins, multiple headers)
+PASS Redirect to Cross Origin resource with origin not in Timing-Allow-Origin list must have filtered timing data (case-sensitive)
+PASS Multiple level redirect to Same Origin resource must have timing data
+PASS Multiple level redirect to Cross Origin resource without Timing-Allow-Origin must have must have filtered timing data
+FAIL Multiple level redirect to Cross Origin resource with Timing-Allow-Origin must have must have timing data assert_not_equals: entry should have a redirectStart time got disallowed value 0
+

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
@@ -102,6 +102,8 @@ public:
 
     void enableContentExtensionsCheck() { m_checkContentExtensions = true; }
 
+    bool isSameOriginRequest() const { return m_isSameOriginRequest; }
+
     RefPtr<WebCore::SecurityOrigin> origin() const { return m_origin; }
     RefPtr<WebCore::SecurityOrigin> topOrigin() const { return m_topOrigin; }
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1087,7 +1087,7 @@ void NetworkResourceLoader::didFinishLoading(const NetworkLoadMetrics& networkLo
             m_contentFilter->stopFilteringMainResource();
         }
 #endif
-        send(Messages::WebResourceLoader::DidFinishResourceLoad(networkLoadMetrics));
+        sendDidFinishResourceLoad(networkLoadMetrics);
     }
 
     tryStoreAsCacheEntry();
@@ -1096,6 +1096,19 @@ void NetworkResourceLoader::didFinishLoading(const NetworkLoadMetrics& networkLo
         m_connection->networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::ResourceLoadDidCompleteWithError(m_parameters.webPageProxyID, resourceLoadInfo(), m_response, { }), 0);
 
     cleanup(LoadResult::Success);
+}
+
+void NetworkResourceLoader::sendDidFinishResourceLoad(const NetworkLoadMetrics& networkLoadMetrics)
+{
+    if (m_didChangeOfNetworkLoad && m_parameters.options.mode != FetchOptions::Mode::Navigate && !networkLoadMetrics.failsTAOCheck) {
+        auto updatedNetworkLoadMetrics = networkLoadMetrics;
+        updatedNetworkLoadMetrics.redirectCount = m_redirectCount;
+        if (m_networkLoadChecker && !m_networkLoadChecker->isSameOriginRequest())
+            updatedNetworkLoadMetrics.hasCrossOriginRedirect = true;
+        send(Messages::WebResourceLoader::DidFinishResourceLoad(updatedNetworkLoadMetrics));
+        return;
+    }
+    send(Messages::WebResourceLoader::DidFinishResourceLoad(networkLoadMetrics));
 }
 
 void NetworkResourceLoader::didFailLoading(const ResourceError& error)
@@ -1351,6 +1364,7 @@ void NetworkResourceLoader::restartNetworkLoad(WebCore::ResourceRequest&& newReq
         LOADER_RELEASE_LOG("restartNetworkLoad: Cancelling existing network load so we can restart the load.");
         m_networkLoad->cancel();
         m_networkLoad = nullptr;
+        m_didChangeOfNetworkLoad = true;
     }
 
     completionHandler({ });

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -138,6 +138,8 @@ public:
     void didReceiveChallenge(const WebCore::AuthenticationChallenge&) final;
     bool shouldCaptureExtraNetworkLoadMetrics() const final;
 
+    void sendDidFinishResourceLoad(const WebCore::NetworkLoadMetrics&);
+
     // CrossOriginAccessControlCheckDisabler
     bool crossOriginAccessControlCheckEnabled() const override;
         
@@ -307,6 +309,7 @@ private:
     std::unique_ptr<NetworkCache::Entry> m_cacheEntryWaitingForContinueDidReceiveResponse;
     std::unique_ptr<NetworkLoadChecker> m_networkLoadChecker;
     bool m_shouldRestartLoad { false };
+    bool m_didChangeOfNetworkLoad { false };
     ResponseCompletionHandler m_responseCompletionHandler;
     bool m_shouldCaptureExtraNetworkLoadMetrics { false };
     bool m_isKeptAlive { false };


### PR DESCRIPTION
#### f5e082831b1034c69ea0074409f572cc39c3e688
<pre>
PerformanceResourceTiming redirectStarts may be wrongly exposed as 0 for cross origin loads
<a href="https://bugs.webkit.org/show_bug.cgi?id=272810">https://bugs.webkit.org/show_bug.cgi?id=272810</a>
<a href="https://rdar.apple.com/problem/126609893">rdar://problem/126609893</a>

Reviewed by NOBODY (OOPS!).

When restarting a NetworkLoad, we change of NetworkDataTask.
The redirectCount metric is thus potentially wrong.
Given we store this information in NetworkResourceLoader, we fix it at that level.

As can be seen from <a href="https://results.webkit.org/?suite=layout-tests&amp">https://results.webkit.org/?suite=layout-tests&amp</a>;test=http%2Fwpt%2Fresource-timing%2Frt-cors.html,
for instance in <a href="https://build.webkit.org/results/Apple-Monterey-Release-AppleSilicon-WK2-Tests/277600@main%20(14798)/http/wpt/resource-timing/rt-cors-pretty-diff.html">https://build.webkit.org/results/Apple-Monterey-Release-AppleSilicon-WK2-Tests/277600@main%20(14798)/http/wpt/resource-timing/rt-cors-pretty-diff.html</a>,i
WK2 bots fail LayoutTests/http/wpt/resource-timing/rt-cors.html consistently due to redirectStart being set to 0 for some of the tests.
We split LayoutTests/http/wpt/resource-timing/rt-cors.html redirection tests in its own file named LayoutTests/http/wpt/resource-timing/rt-cors-redirection.html,
as one non redirection test in LayoutTests/http/wpt/resource-timing/rt-cors.html is flaky.

* LayoutTests/http/wpt/resource-timing/rt-cors-expected.txt:
* LayoutTests/http/wpt/resource-timing/rt-cors-redirection-expected.txt: Copied from LayoutTests/http/wpt/resource-timing/rt-cors-expected.txt.
* LayoutTests/http/wpt/resource-timing/rt-cors-redirection.html: Added.
* LayoutTests/http/wpt/resource-timing/rt-cors-redirection.js: Copied from LayoutTests/http/wpt/resource-timing/rt-cors.js.
(assertAlways):
(assertRedirectTimingData):
(assertRedirectWithDisallowedTimingData):
(assertNonRedirectTimingData):
(assertAllowedTimingData):
(assertDisallowedTimingData):
(promise_test):
* LayoutTests/http/wpt/resource-timing/rt-cors-redirection.worker-expected.txt: Copied from LayoutTests/http/wpt/resource-timing/rt-cors.worker-expected.txt.
* LayoutTests/http/wpt/resource-timing/rt-cors-redirection.worker.html: Added.
* LayoutTests/http/wpt/resource-timing/rt-cors-redirection.worker.js: Added.
(testNecessaryPerformanceFeatures):
* LayoutTests/http/wpt/resource-timing/rt-cors.js:
(promise_test):
* LayoutTests/http/wpt/resource-timing/rt-cors.worker-expected.txt:
* LayoutTests/platform/mac-wk1/http/wpt/resource-timing/rt-cors-redirection-expected.txt: Renamed from LayoutTests/platform/mac-wk1/http/wpt/resource-timing/rt-cors-expected.txt.
* LayoutTests/platform/mac-wk1/http/wpt/resource-timing/rt-cors-redirection.worker-expected.txt: Renamed from LayoutTests/platform/mac-wk1/http/wpt/resource-timing/rt-cors.worker-expected.txt.
* Source/WebKit/NetworkProcess/NetworkLoadChecker.h:
(WebKit::NetworkLoadChecker::isSameOriginRequest const):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::didFinishLoading):
(WebKit::NetworkResourceLoader::sendDidFinishResourceLoad):
(WebKit::NetworkResourceLoader::restartNetworkLoad):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d53bea5cb0a7580e0f94ed55297d7d7b66cb8b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27341 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50821 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44197 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39334 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48714 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41618 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20460 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22534 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42793 "Found 1 new test failure: fast/css/viewport-height-outline.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6188 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44509 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43233 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52721 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23180 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19552 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46672 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-visibility-hidden-child.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24445 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41784 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45551 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25248 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24168 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->