### PR TITLE
Move WTF::Markable to the modern serializer API

### DIFF
--- a/Source/WTF/wtf/Markable.h
+++ b/Source/WTF/wtf/Markable.h
@@ -167,9 +167,6 @@ public:
         return std::optional<T>(*this);
     }
 
-    template<typename Encoder> void encode(Encoder&) const;
-    template<typename Decoder> static std::optional<Markable> decode(Decoder&);
-
 private:
     T m_value;
 };
@@ -190,35 +187,6 @@ template <typename T, typename Traits> constexpr bool operator==(const Markable<
 template <typename T, typename Traits> constexpr bool operator==(const Markable<T, Traits>& x, const T& v) { return bool(x) && x.value() == v; }
 template <typename T, typename Traits> constexpr bool operator==(const T& v, const Markable<T, Traits>& x) { return bool(x) && v == x.value(); }
 
-template <typename T, typename Traits>
-template<typename Encoder>
-void Markable<T, Traits>::encode(Encoder& encoder) const
-{
-    bool isEmpty = Traits::isEmptyValue(m_value);
-    encoder << isEmpty;
-    if (!isEmpty)
-        encoder << m_value;
-}
-
-template <typename T, typename Traits>
-template<typename Decoder>
-std::optional<Markable<T, Traits>> Markable<T, Traits>::decode(Decoder& decoder)
-{
-    std::optional<bool> isEmpty;
-    decoder >> isEmpty;
-    if (!isEmpty)
-        return std::nullopt;
-
-    if (*isEmpty)
-        return Markable { };
-
-    std::optional<T> value;
-    decoder >> value;
-    if (!value)
-        return std::nullopt;
-
-    return Markable { WTFMove(*value) };
-}
 
 } // namespace WTF
 


### PR DESCRIPTION
#### d32f1f651c127cdd9ebc047062e3643d504ea37a
<pre>
Move WTF::Markable to the modern serializer API
<a href="https://bugs.webkit.org/show_bug.cgi?id=272818">https://bugs.webkit.org/show_bug.cgi?id=272818</a>

Reviewed by Kimmo Kinnunen.

The WTF::Markable serializers are using the legacy API, so make it use instead
its own specialiation of ArgumentCoders. Move the implementation also to
ArgumentCoders.h, where other WTF types have theirs.

* Source/WTF/wtf/Markable.h:
(WTF::Traits&gt;::encode const): Deleted.
(WTF::Traits&gt;::decode): Deleted.
* Source/WebKit/Platform/IPC/ArgumentCoders.h:

Canonical link: <a href="https://commits.webkit.org/277668@main">https://commits.webkit.org/277668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c35cc1cdfaa033fbf22f3cfbf78b5e045d297b1e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27467 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51209 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50943 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44320 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24987 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39416 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48837 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25162 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20565 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22642 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6311 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/41552 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44600 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43323 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52847 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/47746 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23302 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19654 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46754 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24567 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41871 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45670 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25372 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55241 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6855 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24290 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11370 "Passed tests") | 
<!--EWS-Status-Bubble-End-->