### PR TITLE
Use more smart pointers for dynamicDowncast<>in SVG code

### DIFF
--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -108,8 +108,8 @@ static inline bool findPreviousAndNextAttributes(RenderElement& start, RenderSVG
 {
     ASSERT(locateElement);
     // FIXME: Make this iterative.
-    for (auto& child : childrenOfType<RenderObject>(start)) {
-        if (auto* text = dynamicDowncast<RenderSVGInlineText>(child)) {
+    for (CheckedRef child : childrenOfType<RenderObject>(start)) {
+        if (auto* text = dynamicDowncast<RenderSVGInlineText>(child.get())) {
             if (locateElement != text) {
                 if (stopAfterNext) {
                     next = text->layoutAttributes();
@@ -124,7 +124,7 @@ static inline bool findPreviousAndNextAttributes(RenderElement& start, RenderSVG
             continue;
         }
 
-        auto* childSVGInline = dynamicDowncast<RenderSVGInline>(child);
+        auto* childSVGInline = dynamicDowncast<RenderSVGInline>(child.get());
         if (!childSVGInline)
             continue;
 

--- a/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp
@@ -72,7 +72,7 @@ inline SVGUseElement* associatedUseElement(SVGGraphicsElement& element)
 FloatSize RenderSVGTransformableContainer::additionalContainerTranslation() const
 {
     Ref graphicsElement = this->graphicsElement();
-    if (auto* useElement = associatedUseElement(graphicsElement)) {
+    if (RefPtr useElement = associatedUseElement(graphicsElement)) {
         SVGLengthContext lengthContext(graphicsElement.ptr());
         return { useElement->x().value(lengthContext), useElement->y().value(lengthContext) };
     }

--- a/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
+++ b/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
@@ -169,10 +169,10 @@ FloatRect SVGBoundingBoxComputation::handleRootOrContainer(const SVGBoundingBoxC
     //    - If child is not rendered then continue to the next descendant graphics element.
     //    - Otherwise, set box to be the union of box and the result of invoking the algorithm to compute a bounding box with child
     //      as the element and the same values for space, fill, stroke, markers and clipped as the corresponding algorithm input values.
-    for (auto& child : childrenOfType<RenderLayerModelObject>(m_renderer)) {
+    for (CheckedRef child : childrenOfType<RenderLayerModelObject>(m_renderer)) {
         if (is<RenderSVGHiddenContainer>(child))
             continue;
-        if (auto* shape = dynamicDowncast<RenderSVGShape>(child); shape && shape->isRenderingDisabled())
+        if (auto* shape = dynamicDowncast<RenderSVGShape>(child.get()); shape && shape->isRenderingDisabled())
             continue;
 
         SVGBoundingBoxComputation childBoundingBoxComputation(child);

--- a/Source/WebCore/rendering/svg/SVGContainerLayout.cpp
+++ b/Source/WebCore/rendering/svg/SVGContainerLayout.cpp
@@ -72,20 +72,22 @@ void SVGContainerLayout::layoutChildren(bool containerNeedsLayout)
             if (child.isAnonymous()) {
                 ASSERT(is<RenderSVGViewportContainer>(child));
                 needsLayout = true;
-            } else if (auto* element = dynamicDowncast<SVGElement>(*child.node()); element && element->hasRelativeLengths()) {
-                // When containerNeedsLayout is false and the layout size changed, we have to check whether this child uses relative lengths
+            } else if (RefPtr element = dynamicDowncast<SVGElement>(child.node())) {
+                if (element->hasRelativeLengths()) {
+                    // When containerNeedsLayout is false and the layout size changed, we have to check whether this child uses relative lengths
 
-                // When the layout size changed and when using relative values tell the RenderSVGShape to update its shape object
-                if (CheckedPtr shape = dynamicDowncast<RenderSVGShape>(child)) {
-                    shape->setNeedsShapeUpdate();
-                    needsLayout = true;
-                } else if (CheckedPtr svgText = dynamicDowncast<RenderSVGText>(child)) {
-                    svgText->setNeedsTextMetricsUpdate();
-                    svgText->setNeedsPositioningValuesUpdate();
-                    needsLayout = true;
-                } else if (CheckedPtr resource = dynamicDowncast<RenderSVGResourceGradient>(child))
-                    resource->invalidateGradient();
-                // FIXME: [LBSE] Add pattern support.
+                    // When the layout size changed and when using relative values tell the RenderSVGShape to update its shape object
+                    if (CheckedPtr shape = dynamicDowncast<RenderSVGShape>(child)) {
+                        shape->setNeedsShapeUpdate();
+                        needsLayout = true;
+                    } else if (CheckedPtr svgText = dynamicDowncast<RenderSVGText>(child)) {
+                        svgText->setNeedsTextMetricsUpdate();
+                        svgText->setNeedsPositioningValuesUpdate();
+                        needsLayout = true;
+                    } else if (CheckedPtr resource = dynamicDowncast<RenderSVGResourceGradient>(child))
+                        resource->invalidateGradient();
+                    // FIXME: [LBSE] Add pattern support.
+                }
             }
         }
 
@@ -131,7 +133,7 @@ void SVGContainerLayout::positionChildrenRelativeToContainer()
         // only meaningful for the children of the RenderSVGRoot. RenderSVGRoot itself is positioned according to
         // the CSS box model object, where we need to respect border & padding, encoded in the contentBoxLocation().
         // -> Position all RenderSVGRoot children relative to the contentBoxLocation() to avoid intruding border/padding area.
-        if (auto* svgRoot = dynamicDowncast<RenderSVGRoot>(m_container))
+        if (CheckedPtr svgRoot = dynamicDowncast<RenderSVGRoot>(m_container))
             return -svgRoot->contentBoxLocation();
 
         // For (inner) RenderSVGViewportContainer nominalSVGLayoutLocation() returns the viewport boundaries,

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -129,14 +129,14 @@ bool SVGRenderSupport::checkForSVGRepaintDuringLayout(const RenderElement& rende
         return false;
     // When a parent container is transformed in SVG, all children will be painted automatically
     // so we are able to skip redundant repaint checks.
-    auto* parent = dynamicDowncast<LegacyRenderSVGContainer>(renderer.parent());
+    CheckedPtr parent = dynamicDowncast<LegacyRenderSVGContainer>(renderer.parent());
     return !parent || !parent->didTransformToRootUpdate();
 }
 
 // Update a bounding box taking into account the validity of the other bounding box.
 static inline void updateObjectBoundingBox(FloatRect& objectBoundingBox, bool& objectBoundingBoxValid, const RenderObject* other, FloatRect otherBoundingBox)
 {
-    auto* otherContainer = dynamicDowncast<LegacyRenderSVGContainer>(*other);
+    CheckedPtr otherContainer = dynamicDowncast<LegacyRenderSVGContainer>(*other);
     bool otherValid = !otherContainer || otherContainer->isObjectBoundingBoxValid();
     if (!otherValid)
         return;
@@ -155,21 +155,21 @@ void SVGRenderSupport::computeContainerBoundingBoxes(const RenderElement& contai
     objectBoundingBox = FloatRect();
     objectBoundingBoxValid = false;
     repaintBoundingBox = FloatRect();
-    for (auto& current : childrenOfType<RenderObject>(container)) {
-        if (current.isLegacyRenderSVGHiddenContainer())
+    for (CheckedRef current : childrenOfType<RenderObject>(container)) {
+        if (current->isLegacyRenderSVGHiddenContainer())
             continue;
 
         // Don't include elements in the union that do not render.
-        if (auto* shape = dynamicDowncast<LegacyRenderSVGShape>(current); shape && shape->isRenderingDisabled())
+        if (auto* shape = dynamicDowncast<LegacyRenderSVGShape>(current.ptr()); shape && shape->isRenderingDisabled())
             continue;
 
-        const AffineTransform& transform = current.localToParentTransform();
+        const AffineTransform& transform = current->localToParentTransform();
         if (transform.isIdentity()) {
-            updateObjectBoundingBox(objectBoundingBox, objectBoundingBoxValid, &current, current.objectBoundingBox());
-            repaintBoundingBox.unite(current.repaintRectInLocalCoordinates(repaintRectCalculation));
+            updateObjectBoundingBox(objectBoundingBox, objectBoundingBoxValid, current.ptr(), current->objectBoundingBox());
+            repaintBoundingBox.unite(current->repaintRectInLocalCoordinates(repaintRectCalculation));
         } else {
-            updateObjectBoundingBox(objectBoundingBox, objectBoundingBoxValid, &current, transform.mapRect(current.objectBoundingBox()));
-            repaintBoundingBox.unite(transform.mapRect(current.repaintRectInLocalCoordinates(repaintRectCalculation)));
+            updateObjectBoundingBox(objectBoundingBox, objectBoundingBoxValid, current.ptr(), transform.mapRect(current->objectBoundingBox()));
+            repaintBoundingBox.unite(transform.mapRect(current->repaintRectInLocalCoordinates(repaintRectCalculation)));
         }
     }
 }
@@ -178,18 +178,18 @@ FloatRect SVGRenderSupport::computeContainerStrokeBoundingBox(const RenderElemen
 {
     ASSERT(container.isLegacyRenderSVGRoot() || container.isLegacyRenderSVGContainer());
     FloatRect strokeBoundingBox = FloatRect();
-    for (auto& current : childrenOfType<RenderObject>(container)) {
-        if (current.isLegacyRenderSVGHiddenContainer())
+    for (CheckedRef current : childrenOfType<RenderObject>(container)) {
+        if (current->isLegacyRenderSVGHiddenContainer())
             continue;
 
         // Don't include elements in the union that do not render.
-        if (auto* shape = dynamicDowncast<LegacyRenderSVGShape>(current); shape && shape->isRenderingDisabled())
+        if (auto* shape = dynamicDowncast<LegacyRenderSVGShape>(current.ptr()); shape && shape->isRenderingDisabled())
             continue;
 
-        FloatRect childStrokeBoundingBox = current.strokeBoundingBox();
-        if (auto* currentElement = dynamicDowncast<RenderElement>(current))
+        FloatRect childStrokeBoundingBox = current->strokeBoundingBox();
+        if (auto* currentElement = dynamicDowncast<RenderElement>(current.get()))
             SVGRenderSupport::intersectRepaintRectWithResources(*currentElement, childStrokeBoundingBox, RepaintRectCalculation::Accurate);
-        const AffineTransform& transform = current.localToParentTransform();
+        const AffineTransform& transform = current->localToParentTransform();
         if (transform.isIdentity())
             strokeBoundingBox.unite(childStrokeBoundingBox);
         else
@@ -228,7 +228,7 @@ static inline void invalidateResourcesOfChildren(RenderElement& renderer)
 
 static inline bool layoutSizeOfNearestViewportChanged(const RenderElement& renderer)
 {
-    for (auto* start = &renderer; start; start = start->parent()) {
+    for (CheckedPtr start = &renderer; start; start = start->parent()) {
         if (auto* svgRoot = dynamicDowncast<LegacyRenderSVGRoot>(*start))
             return svgRoot->isLayoutSizeChanged();
         if (auto* container = dynamicDowncast<LegacyRenderSVGViewportContainer>(*start))
@@ -303,7 +303,7 @@ void SVGRenderSupport::layoutChildren(RenderElement& start, bool selfNeedsLayout
             if (!childEverHadLayout)
                 child.repaint();
         } else if (layoutSizeChanged) {
-            if (auto* childElement = dynamicDowncast<RenderElement>(child))
+            if (CheckedPtr childElement = dynamicDowncast<RenderElement>(child))
                 elementsThatDidNotReceiveLayout.add(*childElement);
         }
 
@@ -389,13 +389,13 @@ inline FloatRect clipPathReferenceBox(const RenderElement& renderer, CSSBoxType 
 inline bool isPointInCSSClippingArea(const RenderElement& renderer, const FloatPoint& point)
 {
     RefPtr clipPathOperation = renderer.style().clipPath();
-    if (RefPtr clipPath = dynamicDowncast<ShapePathOperation>(clipPathOperation.get())) {
+    if (auto* clipPath = dynamicDowncast<ShapePathOperation>(clipPathOperation.get())) {
         FloatRect referenceBox = clipPathReferenceBox(renderer, clipPath->referenceBox());
         if (!referenceBox.contains(point))
             return false;
         return clipPath->pathForReferenceRect(referenceBox).contains(point, clipPath->windRule());
     }
-    if (RefPtr clipPath = dynamicDowncast<BoxPathOperation>(clipPathOperation.get())) {
+    if (auto* clipPath = dynamicDowncast<BoxPathOperation>(clipPathOperation.get())) {
         FloatRect referenceBox = clipPathReferenceBox(renderer, clipPath->referenceBox());
         if (!referenceBox.contains(point))
             return false;
@@ -408,7 +408,7 @@ inline bool isPointInCSSClippingArea(const RenderElement& renderer, const FloatP
 void SVGRenderSupport::clipContextToCSSClippingArea(GraphicsContext& context, const RenderElement& renderer)
 {
     RefPtr clipPathOperation = renderer.style().clipPath();
-    if (RefPtr clipPath = dynamicDowncast<ShapePathOperation>(clipPathOperation.get())) {
+    if (auto* clipPath = dynamicDowncast<ShapePathOperation>(clipPathOperation.get())) {
         auto localToParentTransform = renderer.localToParentTransform();
 
         auto referenceBox = clipPathReferenceBox(renderer, clipPath->referenceBox());
@@ -419,7 +419,7 @@ void SVGRenderSupport::clipContextToCSSClippingArea(GraphicsContext& context, co
 
         context.clipPath(path, clipPath->windRule());
     }
-    if (RefPtr clipPath = dynamicDowncast<BoxPathOperation>(clipPathOperation.get())) {
+    if (auto* clipPath = dynamicDowncast<BoxPathOperation>(clipPathOperation.get())) {
         FloatRect referenceBox = clipPathReferenceBox(renderer, clipPath->referenceBox());
         context.clipPath(clipPath->pathForReferenceRect(FloatRoundedRect { referenceBox }));
     }
@@ -597,7 +597,7 @@ FloatRect SVGRenderSupport::calculateApproximateStrokeBoundingBox(const RenderEl
         return calculateApproximateScalingStrokeBoundingBox(renderer, renderer.objectBoundingBox());
     };
 
-    if (auto* shape = dynamicDowncast<LegacyRenderSVGShape>(renderer))
+    if (CheckedPtr shape = dynamicDowncast<LegacyRenderSVGShape>(renderer))
         return shape->adjustStrokeBoundingBoxForMarkersAndZeroLengthLinecaps(RepaintRectCalculation::Fast, calculate(*shape));
 
     const auto& shape = downcast<RenderSVGShape>(renderer);

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -240,8 +240,7 @@ void writeSVGPaintingFeatures(TextStream& ts, const RenderElement& renderer, Opt
             writeSVGFillPaintingResource(ts, renderer, *fillPaintingResource);
 
         writeIfNotDefault(ts, "clip rule", svgStyle->clipRule(), WindRule::NonZero);
-    }
-    else if (auto* shape = dynamicDowncast<RenderSVGShape>(renderer)) {
+    } else if (auto* shape = dynamicDowncast<RenderSVGShape>(renderer)) {
         Color fallbackColor;
         if (auto* strokePaintingResource = LegacyRenderSVGResource::strokePaintingResource(const_cast<RenderSVGShape&>(*shape), shape->style(), fallbackColor))
             writeSVGStrokePaintingResource(ts, renderer, *strokePaintingResource, shape->protectedGraphicsElement());
@@ -605,7 +604,7 @@ void writeResources(TextStream& ts, const RenderObject& renderer, OptionSet<Rend
         AtomString id = resourceClipPath->fragment();
         if (LegacyRenderSVGResourceClipper* clipper = getRenderSVGResourceById<LegacyRenderSVGResourceClipper>(renderer.treeScopeForSVGReferences(), id)) {
             ts << indent << " ";
-            writeNameAndQuotedValue(ts, "clipPath", resourceClipPath->fragment());
+            writeNameAndQuotedValue(ts, "clipPath", id);
             ts << " ";
             writeStandardPrefix(ts, *clipper, behavior, WriteIndentOrNot::No);
             ts << " " << clipper->resourceBoundingBox(renderer, RepaintRectCalculation::Accurate) << "\n";

--- a/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
@@ -221,7 +221,7 @@ void SVGTextMetricsBuilder::walkTree(RenderElement& start, RenderSVGInlineText* 
 {
     unsigned valueListPosition = 0;
     UChar lastCharacter = 0;
-    auto* child = start.firstChild();
+    CheckedPtr child = start.firstChild();
     while (child) {
         if (auto* text = dynamicDowncast<RenderSVGInlineText>(*child)) {
             data.processRenderer = !stopAtLeaf || stopAtLeaf == text;

--- a/Source/WebCore/rendering/svg/SVGTextQuery.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextQuery.cpp
@@ -56,7 +56,7 @@ static inline LegacyInlineFlowBox* flowBoxForRenderer(RenderObject* renderer)
     if (!renderer)
         return nullptr;
 
-    if (auto* renderBlock = dynamicDowncast<RenderBlockFlow>(*renderer)) {
+    if (CheckedPtr renderBlock = dynamicDowncast<RenderBlockFlow>(*renderer)) {
         // If we're given a block element, it has to be a RenderSVGText.
         ASSERT(is<RenderSVGText>(*renderBlock));
 
@@ -66,7 +66,7 @@ static inline LegacyInlineFlowBox* flowBoxForRenderer(RenderObject* renderer)
         return flowBox;
     }
 
-    if (auto* renderInline = dynamicDowncast<RenderInline>(*renderer)) {
+    if (CheckedPtr renderInline = dynamicDowncast<RenderInline>(*renderer)) {
         // We're given a RenderSVGInline or objects that derive from it (RenderSVGTSpan / RenderSVGTextPath)
         // RenderSVGInline only ever contains a single line box.
         auto* flowBox = renderInline->firstLineBox();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
@@ -155,7 +155,7 @@ static void getElementCTM(SVGElement* element, AffineTransform& transform)
     AffineTransform localTransform;
     Node* current = element;
 
-    while (auto* currentElement = dynamicDowncast<SVGElement>(current)) {
+    while (RefPtr currentElement = dynamicDowncast<SVGElement>(current)) {
         localTransform = currentElement->renderer()->localToParentTransform();
         transform = localTransform.multiply(transform);
         // For getCTM() computation, stop at the nearest viewport element

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
@@ -116,17 +116,17 @@ bool LegacyRenderSVGResourceClipper::pathOnlyClipping(GraphicsContext& context, 
     // as well as NonZero can cause self-clipping of the elements.
     // See also http://www.w3.org/TR/SVG/painting.html#FillRuleProperty
     for (Node* childNode = clipPathElement().firstChild(); childNode; childNode = childNode->nextSibling()) {
-        auto* graphicsElement = dynamicDowncast<SVGGraphicsElement>(*childNode);
+        RefPtr graphicsElement = dynamicDowncast<SVGGraphicsElement>(*childNode);
         if (!graphicsElement)
             continue;
-        auto* renderer = graphicsElement->renderer();
+        CheckedPtr renderer = graphicsElement->renderer();
         if (!renderer)
             continue;
         if (rendererRequiresMaskClipping(*renderer))
             return false;
 
         // For <use> elements, delegate the decision whether to use mask clipping or not to the referenced element.
-        if (auto* useElement = dynamicDowncast<SVGUseElement>(graphicsElement)) {
+        if (auto* useElement = dynamicDowncast<SVGUseElement>(graphicsElement.get())) {
             auto* clipChildRenderer = useElement->rendererClipChild();
             if (clipChildRenderer && rendererRequiresMaskClipping(*clipChildRenderer))
                 return false;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp
@@ -51,7 +51,7 @@ bool LegacyRenderSVGTransformableContainer::calculateLocalTransform()
     // If we're either the renderer for a <use> element, or for any <g> element inside the shadow
     // tree, that was created during the use/symbol/svg expansion in SVGUseElement. These containers
     // need to respect the translations induced by their corresponding use elements x/y attributes.
-    auto* useElement = dynamicDowncast<SVGUseElement>(element.get());
+    RefPtr useElement = dynamicDowncast<SVGUseElement>(element.get());
     if (!useElement && element->isInShadowTree() && is<SVGGElement>(element)) {
         if (auto* correspondingElement = dynamicDowncast<SVGUseElement>(element->correspondingElement()))
             useElement = correspondingElement;

--- a/Source/WebCore/svg/SVGFEComponentTransferElement.cpp
+++ b/Source/WebCore/svg/SVGFEComponentTransferElement.cpp
@@ -98,7 +98,7 @@ bool SVGFEComponentTransferElement::setFilterEffectAttributeFromChild(FilterEffe
 {
     ASSERT(isRelevantTransferFunctionElement(childElement));
 
-    auto* child = dynamicDowncast<SVGComponentTransferFunctionElement>(childElement);
+    RefPtr child = dynamicDowncast<SVGComponentTransferFunctionElement>(childElement);
     ASSERT(child);
     if (!child)
         return false;

--- a/Source/WebCore/svg/SVGFontFaceSrcElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceSrcElement.cpp
@@ -51,10 +51,10 @@ Ref<CSSValueList> SVGFontFaceSrcElement::createSrcValue() const
 {
     CSSValueListBuilder list;
     for (auto& child : childrenOfType<SVGElement>(*this)) {
-        if (auto* element = dynamicDowncast<SVGFontFaceUriElement>(child)) {
+        if (RefPtr element = dynamicDowncast<SVGFontFaceUriElement>(child)) {
             if (auto srcValue = element->createSrcValue(); !srcValue->isEmpty())
                 list.append(WTFMove(srcValue));
-        } else if (auto* element = dynamicDowncast<SVGFontFaceNameElement>(child)) {
+        } else if (RefPtr element = dynamicDowncast<SVGFontFaceNameElement>(child)) {
             if (auto srcValue = element->createSrcValue(); !srcValue->isEmpty())
                 list.append(WTFMove(srcValue));
         }

--- a/Source/WebCore/svg/SVGGraphicsElement.cpp
+++ b/Source/WebCore/svg/SVGGraphicsElement.cpp
@@ -221,12 +221,10 @@ void SVGGraphicsElement::invalidateResourceImageBuffersIfNeeded()
     if (!document().settings().layerBasedSVGEngineEnabled())
         return;
     if (CheckedPtr svgRenderer = dynamicDowncast<RenderLayerModelObject>(renderer())) {
-        if (auto* container = svgRenderer->enclosingLayer()->enclosingSVGHiddenOrResourceContainer()) {
-            if (auto* maskRenderer = dynamicDowncast<RenderSVGResourceMasker>(container))
+        if (CheckedPtr container = svgRenderer->enclosingLayer()->enclosingSVGHiddenOrResourceContainer()) {
+            if (auto* maskRenderer = dynamicDowncast<RenderSVGResourceMasker>(container.get()))
                 maskRenderer->invalidateMask();
-        }
-        if (auto* container = svgRenderer->enclosingLayer()->enclosingSVGHiddenOrResourceContainer()) {
-            if (auto* patternRenderer = dynamicDowncast<RenderSVGResourcePattern>(container))
+            if (auto* patternRenderer = dynamicDowncast<RenderSVGResourcePattern>(container.get()))
                 patternRenderer->invalidatePattern(RenderSVGResourcePattern::SuppressRepaint::Yes);
         }
     }


### PR DESCRIPTION
#### 7196d1f760d62c84bcddef4c342d42398a9048bd
<pre>
Use more smart pointers for dynamicDowncast&lt;&gt;in SVG code
<a href="https://bugs.webkit.org/show_bug.cgi?id=272817">https://bugs.webkit.org/show_bug.cgi?id=272817</a>

Reviewed by Chris Dumez.

Use more smart pointers for dynamicDowncast&lt;&gt;in SVG code.

* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::findPreviousAndNextAttributes):
* Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp:
(WebCore::RenderSVGTransformableContainer::additionalContainerTranslation const):
* Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp:
(WebCore::SVGBoundingBoxComputation::handleRootOrContainer const):
* Source/WebCore/rendering/svg/SVGContainerLayout.cpp:
(WebCore::SVGContainerLayout::layoutChildren):
(WebCore::SVGContainerLayout::positionChildrenRelativeToContainer):
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::checkForSVGRepaintDuringLayout):
(WebCore::updateObjectBoundingBox):
(WebCore::SVGRenderSupport::computeContainerBoundingBoxes):
(WebCore::SVGRenderSupport::computeContainerStrokeBoundingBox):
(WebCore::layoutSizeOfNearestViewportChanged):
(WebCore::SVGRenderSupport::layoutChildren):
(WebCore::isPointInCSSClippingArea):
(WebCore::SVGRenderSupport::clipContextToCSSClippingArea):
(WebCore::SVGRenderSupport::calculateApproximateStrokeBoundingBox):
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(WebCore::writeSVGPaintingFeatures):
(WebCore::writeResources):
* Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp:
(WebCore::SVGTextMetricsBuilder::walkTree):
* Source/WebCore/rendering/svg/SVGTextQuery.cpp:
(WebCore::flowBoxForRenderer):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp:
(WebCore::getElementCTM):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp:
(WebCore::LegacyRenderSVGResourceClipper::pathOnlyClipping):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp:
(WebCore::LegacyRenderSVGTransformableContainer::calculateLocalTransform):
* Source/WebCore/svg/SVGFEComponentTransferElement.cpp:
(WebCore::SVGFEComponentTransferElement::setFilterEffectAttributeFromChild):
* Source/WebCore/svg/SVGFontFaceSrcElement.cpp:
(WebCore::SVGFontFaceSrcElement::createSrcValue const):
* Source/WebCore/svg/SVGGraphicsElement.cpp:
(WebCore::SVGGraphicsElement::invalidateResourceImageBuffersIfNeeded):

Canonical link: <a href="https://commits.webkit.org/277661@main">https://commits.webkit.org/277661@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7cd1ccd1c96e00c340580e2c26a45ad5ce2842fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48260 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50948 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44325 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50565 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24992 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48842 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25166 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20568 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22646 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6316 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44604 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43328 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52852 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23307 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19657 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46757 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24572 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41876 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/45676 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10643 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25377 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24295 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->