### PR TITLE
[visionOS] Refine transition for Image Fullscreen

### DIFF
--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -47,7 +47,7 @@ using namespace WebCore;
 #if ENABLE(QUICKLOOK_FULLSCREEN)
 static WorkQueue& sharedQuickLookFileQueue()
 {
-    static NeverDestroyed<Ref<WorkQueue>> queue(WorkQueue::create("com.apple.WebKit.QuickLookFileQueue"_s));
+    static NeverDestroyed<Ref<WorkQueue>> queue(WorkQueue::create("com.apple.WebKit.QuickLookFileQueue"_s, WorkQueue::QOS::UserInteractive));
     return queue.get();
 }
 #endif

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -757,6 +757,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
     RetainPtr<WKFullScreenParentWindowState> _parentWindowState;
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     RetainPtr<WKSPreviewWindowController> _previewWindowController;
+    bool _isImageElement;
 #endif // QUICKLOOK_FULLSCREEN
 #endif
 
@@ -865,6 +866,9 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 #if PLATFORM(VISION)
     _lastKnownParentWindow = [webView window];
     _parentWindowState = adoptNS([[WKFullScreenParentWindowState alloc] initWithWindow:_lastKnownParentWindow.get()]);
+#if ENABLE(QUICKLOOK_FULLSCREEN)
+    _isImageElement = manager->isImageElement();
+#endif // QUICKLOOK_FULLSCREEN
 #endif
     _fullScreenState = WebKit::WaitingToEnterFullScreen;
     _blocksReturnToFullscreenFromPictureInPicture = manager->blocksReturnToFullscreenFromPictureInPicture();
@@ -1713,6 +1717,11 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 
 - (void)_configureSpatialFullScreenTransition
 {
+#if ENABLE(QUICKLOOK_FULLSCREEN)
+    if (_isImageElement)
+        return;
+#endif // QUICKLOOK_FULLSCREEN
+
     CGRect originalWindowBounds = [_lastKnownParentWindow bounds];
     CGRect fullscreenWindowBounds = [_window bounds];
 
@@ -1789,9 +1798,25 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
     WKFullScreenParentWindowState *originalState = _parentWindowState.get();
 
 #if ENABLE(QUICKLOOK_FULLSCREEN)
-    bool isImageElement = self._manager && self._manager->isImageElement();
-#else
-    bool isImageElement = false;
+    auto* manager = self._manager;
+    if (manager && _isImageElement) {
+        if (enter) {
+            // The fullscreen window won't be displayed.
+            [inWindow setHidden:YES];
+
+            manager->prepareQuickLookImageURL([strongSelf = retainPtr(self), self, outWindow = retainPtr(outWindow), completionHandler = WTFMove(completionHandler)] (URL&& url) mutable {
+                UIWindowScene *scene = [outWindow windowScene];
+                _previewWindowController = adoptNS([WebKit::allocWKSPreviewWindowControllerInstance() initWithURL:url sceneID:scene._sceneIdentifier]);
+                [_previewWindowController setDelegate:self];
+                [_previewWindowController presentWindow];
+                completionHandler();
+            });
+        } else {
+            [_fullscreenViewController dismissViewControllerAnimated:NO completion:nil];
+            completionHandler();
+        }
+        return;
+    }
 #endif
 
     inWindow.transform3D = CATransform3DTranslate(originalState.transform3D, 0, 0, kIncomingWindowZOffset);
@@ -1832,8 +1857,8 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
         } completion:nil];
     }
 
-    auto completion = makeBlockPtr([controller = retainPtr(controller), inWindow = retainPtr(inWindow), originalState = retainPtr(originalState), enter, isImageElement, completionHandler = WTFMove(completionHandler)] (BOOL finished) mutable {
-        WebKit::resizeScene([inWindow windowScene], [inWindow bounds].size, [controller, inWindow, originalState, enter, isImageElement, completionHandler = WTFMove(completionHandler)]() mutable {
+    auto completion = makeBlockPtr([controller = retainPtr(controller), inWindow = retainPtr(inWindow), originalState = retainPtr(originalState), enter, completionHandler = WTFMove(completionHandler)] (BOOL finished) mutable {
+        WebKit::resizeScene([inWindow windowScene], [inWindow bounds].size, [controller, inWindow, originalState, enter, completionHandler = WTFMove(completionHandler)]() mutable {
             Class inWindowClass = enter ? [UIWindow class] : [originalState windowClass];
             object_setClass(inWindow.get(), inWindowClass);
 
@@ -1858,36 +1883,17 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
                 [controller->_fullscreenViewController dismissViewControllerAnimated:NO completion:nil];
             }
 
-            if (enter && isImageElement)
-                scene.mrui_placement.preferredChromeOptions = RSSSceneChromeOptionsNone;
-            else
-                scene.mrui_placement.preferredChromeOptions = [originalState sceneChromeOptions];
+            scene.mrui_placement.preferredChromeOptions = [originalState sceneChromeOptions];
 
             completionHandler();
         });
     });
 
-    CGFloat inWindowAlpha = 1;
-#if ENABLE(QUICKLOOK_FULLSCREEN)
-    auto* manager = self._manager;
-    if (manager && manager->isImageElement()) {
-        if (enter) {
-            inWindowAlpha = 0;
-            manager->prepareQuickLookImageURL([strongSelf = retainPtr(self), self, inWindow = retainPtr(inWindow)] (URL&& url) mutable {
-                UIWindowScene *scene = [inWindow windowScene];
-                _previewWindowController = adoptNS([WebKit::allocWKSPreviewWindowControllerInstance() initWithURL:url sceneID:scene._sceneIdentifier]);
-                [_previewWindowController setDelegate:self];
-                [_previewWindowController presentWindow];
-            });
-        }
-    }
-#endif
-
     [UIView animateWithDuration:kIncomingWindowFadeDuration delay:kIncomingWindowFadeDelay options:UIViewAnimationOptionCurveEaseInOut animations:^{
         if (!enter)
             [self _setOrnamentsHidden:NO];
 
-        inWindow.alpha = inWindowAlpha;
+        inWindow.alpha = 1;
     } completion:completion.get()];
 }
 
@@ -1908,19 +1914,26 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 - (void)showUI
 {
 #if PLATFORM(VISION)
-    UIWindowScene *scene = [_window windowScene];
+
 #if ENABLE(QUICKLOOK_FULLSCREEN)
-    if (self._manager && self._manager->isImageElement())
-        scene.mrui_placement.preferredChromeOptions = RSSSceneChromeOptionsNone;
-    else
+    if (_isImageElement)
+        return;
 #endif // QUICKLOOK_FULLSCREEN
-        scene.mrui_placement.preferredChromeOptions = [_parentWindowState sceneChromeOptions];
+
+    UIWindowScene *scene = [_window windowScene];
+    scene.mrui_placement.preferredChromeOptions = [_parentWindowState sceneChromeOptions];
 #endif
 }
 
 - (void)hideUI
 {
 #if PLATFORM(VISION)
+
+#if ENABLE(QUICKLOOK_FULLSCREEN)
+    if (_isImageElement)
+        return;
+#endif // QUICKLOOK_FULLSCREEN
+
     UIWindowScene *scene = [_window windowScene];
     scene.mrui_placement.preferredChromeOptions = RSSSceneChromeOptionsNone;
 #endif


### PR DESCRIPTION
#### 078b086740b309270f57e55054d1da8298ffce4f
<pre>
[visionOS] Refine transition for Image Fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=272829">https://bugs.webkit.org/show_bug.cgi?id=272829</a>
&lt;<a href="https://rdar.apple.com/126218680">rdar://126218680</a>&gt;

Reviewed by Aditya Keerthi.

Special case the transition to fullscreen when using Quick Look, since
scene swapping will take care of the animation, and we don&apos;t display the
fullscreen window.
Bump the QOS of the WorkQueue. It&apos;s only used as part of the fullscreen
transition, in reaction to user action.

* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::sharedQuickLookFileQueue):
QOS bump.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController enterFullScreen:]):
Keep track of whether or not we&apos;re using Image Fullscreen. It impacts
the exit transition, and we don&apos;t want to depend on the exact moment the
image buffer is released in WebFullScreenManagerProxy.
(-[WKFullScreenWindowController _configureSpatialFullScreenTransition]):
Skip the spatial fullscreen transition window manipulation when using
Image Fullscreen.
(-[WKFullScreenWindowController _performSpatialFullScreenTransition:completionHandler:]):
Add a new Image Fullscreen code path for the transition in and out of
fullscreen. Hide the fullscreen window since we&apos;re not using it.
Remove the old branches at different points during the transition.
(-[WKFullScreenWindowController showUI]):
Remove the Image Fullscreen specific chrome management, the WebKit
window will be hidden.

Canonical link: <a href="https://commits.webkit.org/278327@main">https://commits.webkit.org/278327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b88bcdd6f3808c73584daa34fcbbc85aef61b07f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29462 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53429 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/861 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/471 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40938 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52270 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27137 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43177 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22035 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24560 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8549 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46548 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/489 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55012 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25267 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/433 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48335 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26528 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47349 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11012 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27391 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26260 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->