### PR TITLE
WebKit's CNPostalAddress serialization confuses empty-vs-nil for formattedAddress

### DIFF
--- a/Source/WebKit/Shared/Cocoa/CoreIPCContacts.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCContacts.mm
@@ -62,15 +62,15 @@ RetainPtr<id> CoreIPCCNPostalAddress::toID() const
 {
     RetainPtr<CNMutablePostalAddress> address = adoptNS([[PAL::getCNMutablePostalAddressClass() alloc] init]);
 
-    address.get().street = (NSString *)m_street;
-    address.get().subLocality = (NSString *)m_subLocality;
-    address.get().city = (NSString *)m_city;
-    address.get().subAdministrativeArea = (NSString *)m_subAdministrativeArea;
-    address.get().state = (NSString *)m_state;
-    address.get().postalCode = (NSString *)m_postalCode;
-    address.get().country = (NSString *)m_country;
-    address.get().ISOCountryCode = (NSString *)m_isoCountryCode;
-    address.get().formattedAddress = (NSString *)m_formattedAddress;
+    address.get().street = nsStringNilIfNull(m_street);
+    address.get().subLocality = nsStringNilIfNull(m_subLocality);
+    address.get().city = nsStringNilIfNull(m_city);
+    address.get().subAdministrativeArea = nsStringNilIfNull(m_subAdministrativeArea);
+    address.get().state = nsStringNilIfNull(m_state);
+    address.get().postalCode = nsStringNilIfNull(m_postalCode);
+    address.get().country = nsStringNilIfNull(m_country);
+    address.get().ISOCountryCode = nsStringNilIfNull(m_isoCountryCode);
+    address.get().formattedAddress = nsStringNilIfNull(m_formattedAddress);
 
     return address;
 }


### PR DESCRIPTION
#### 2b1e91d086f9cc43aa9115c91b28d4baa77faeda
<pre>
WebKit&apos;s CNPostalAddress serialization confuses empty-vs-nil for formattedAddress
<a href="https://rdar.apple.com/126270905">rdar://126270905</a>

Reviewed by Ben Nham.

The default (NSString *) operator converts null strings to an empty @&quot;&quot;

For CNPostalAddress, that means we were losing important fidelity in the deserialized object
that was breaking other frameworks in subtle ways.

This was further confused by the fact that CNPostalAddresses `isEqual:` method treats nil
and empty string as equivalent on these properties.

`nsStringNilIfNull` to the rescue - along with a regression test that manually makes sure we
got the nil-vs-empty part correct.

* Source/WebKit/Shared/Cocoa/CoreIPCContacts.mm:
(WebKit::CoreIPCCNPostalAddress::toID const):

* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(CNPostalAddressTesting_isEqual):
(operator==):
(TEST(IPCSerialization, Basic)):

Canonical link: <a href="https://commits.webkit.org/277627@main">https://commits.webkit.org/277627@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73f01357ceeb9e1a0a1c35a88057ead339585f4f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48142 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27351 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50831 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44208 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50448 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24858 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48724 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/25064 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20469 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22542 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6198 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44517 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43246 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52732 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23189 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19559 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24455 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45566 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10621 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25259 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24177 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->