### PR TITLE
[WGSL] Attribute validator asserts on non-overrides

### DIFF
--- a/Source/WebGPU/WGSL/AttributeValidator.cpp
+++ b/Source/WebGPU/WGSL/AttributeValidator.cpp
@@ -236,8 +236,9 @@ void AttributeValidator::visit(AST::Variable& variable)
         if (auto* idAttribute = dynamicDowncast<AST::IdAttribute>(attribute)) {
             auto& idExpression = idAttribute->value();
             if (variable.flavor() != AST::VariableFlavor::Override)
-                error(attribute.span(), "@id attribute must only be applied to override variables of scalar type");
-            RELEASE_ASSERT(satisfies(variable.storeType(), Constraints::Scalar));
+                error(attribute.span(), "@id attribute must only be applied to override variables");
+            else
+                RELEASE_ASSERT(satisfies(variable.storeType(), Constraints::Scalar));
 
             // https://gpuweb.github.io/cts/standalone/?q=webgpu:shader,validation,parse,attribute:expressions:value=%22override%22;attribute=%22binding%22
             auto& constantValue = idExpression.constantValue();

--- a/Source/WebGPU/WGSL/tests/invalid/attribute-validation.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/attribute-validation.wgsl
@@ -20,9 +20,11 @@ struct S {
 // CHECK-L: @binding value must be non-negative
 @group(-1) @binding(-1) var<private> x: i32;
 
-// CHECK-L: @id attribute must only be applied to override variables of scalar type
-// CHECK-L: @id value must be non-negative
+// CHECK-L: @id attribute must only be applied to override variables
 @id(-1) var<private> y: i32;
+
+// CHECK-L: @id value must be non-negative
+@id(-1) override z: i32;
 
 // CHECK-L: @must_use can only be applied to functions that return a value
 @must_use

--- a/Source/WebGPU/WGSL/tests/invalid/division.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/division.wgsl
@@ -198,7 +198,7 @@ fn testF32Compound()
 
 fn testDivisorOverflow()
 {
-    // CHECK-L: value 8144182087775404032 cannot be represented as 'i32'
+    // CHECK-L: value 8144182087775404419 cannot be represented as 'i32'
     let x = 1;
     _ = x / 8144182087775404419;
 }


### PR DESCRIPTION
#### 990e1a76ed379729e2bf9eb827e029dcdf00a1d2
<pre>
[WGSL] Attribute validator asserts on non-overrides
<a href="https://bugs.webkit.org/show_bug.cgi?id=272837">https://bugs.webkit.org/show_bug.cgi?id=272837</a>
<a href="https://rdar.apple.com/126621130">rdar://126621130</a>

Reviewed by Mike Wyrzykowski.

In 277194@main I added an assertion that the store type of a variable with an @id
attribute must scalar, but that only holds if the variable is an override.

* Source/WebGPU/WGSL/AttributeValidator.cpp:
(WGSL::AttributeValidator::visit):
* Source/WebGPU/WGSL/tests/invalid/attribute-validation.wgsl:
* Source/WebGPU/WGSL/tests/invalid/division.wgsl:

Canonical link: <a href="https://commits.webkit.org/277666@main">https://commits.webkit.org/277666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7ff1e858550afb2727fc67cbe97d386265f4ede

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27361 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50841 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44218 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24868 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39349 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48734 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25074 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41634 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20477 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22552 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6209 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44525 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43253 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52743 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23199 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19568 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46687 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24465 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41803 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45578 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10645 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25269 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24187 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->