### PR TITLE
[WGSL] Field access should support pointers

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -474,6 +474,8 @@ Packing RewriteGlobalVariables::getPacking(AST::CallExpression& call)
                     auto* type = base.inferredType();
                     if (auto* reference = std::get_if<Types::Reference>(type))
                         type = reference->element;
+                    if (auto* pointer = std::get_if<Types::Pointer>(type))
+                        type = pointer->element;
                     auto& structure = std::get<Types::Struct>(*type).structure;
                     auto& lastMember = structure.members().last();
                     RELEASE_ASSERT(lastMember.name().id() == fieldAccess->fieldName().id());

--- a/Source/WebGPU/WGSL/MangleNames.cpp
+++ b/Source/WebGPU/WGSL/MangleNames.cpp
@@ -163,6 +163,8 @@ void NameManglerVisitor::visit(AST::FieldAccessExpression& access)
     auto* baseType = access.base().inferredType();
     if (auto* reference = std::get_if<Types::Reference>(baseType))
         baseType = reference->element;
+    if (auto* pointer = std::get_if<Types::Pointer>(baseType))
+        baseType = pointer->element;
     auto* structType = std::get_if<Types::Struct>(baseType);
     if (!structType)
         return;

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -2080,7 +2080,12 @@ void FunctionDefinitionWriter::visit(AST::IdentifierExpression& identifier)
 void FunctionDefinitionWriter::visit(AST::FieldAccessExpression& access)
 {
     visit(access.base());
-    m_stringBuilder.append(".", access.fieldName());
+    auto* baseType = access.base().inferredType();
+    if (baseType && std::holds_alternative<Types::Pointer>(*baseType))
+        m_stringBuilder.append("->");
+    else
+        m_stringBuilder.append(".");
+    m_stringBuilder.append(access.fieldName());
 }
 
 void FunctionDefinitionWriter::visit(AST::BoolLiteral& literal)

--- a/Source/WebGPU/WGSL/tests/valid/access-expression.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/access-expression.wgsl
@@ -227,4 +227,9 @@ fn testStructAccessExpression()
     var s: S;
     let x: i32 = s.x;
     s.x = 0;
+
+    {
+      let s = &s;
+      s.x = 0;
+    }
 }


### PR DESCRIPTION
#### 2459e1442e9d4021cbbacdc9114a51136d7a7d57
<pre>
[WGSL] Field access should support pointers
<a href="https://bugs.webkit.org/show_bug.cgi?id=272838">https://bugs.webkit.org/show_bug.cgi?id=272838</a>
<a href="https://rdar.apple.com/126621076">rdar://126621076</a>

Reviewed by Mike Wyrzykowski.

The WGSL spec was updated to support struct field access on pointers (e.g. (&amp;x).y),
and while the type checker was updated to support it, there were a couple other
changes necessary:
- the renamer/mangler did not correctly rename the field when accessing a pointer
- the global rewriter asserted that the base should be either a reference or a struct
- the code generator was not emitting the correct code (i.e. x-&gt;y instead of x.y)

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::getPacking):
* Source/WebGPU/WGSL/MangleNames.cpp:
(WGSL::NameManglerVisitor::visit):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/tests/valid/access-expression.wgsl:

Canonical link: <a href="https://commits.webkit.org/277665@main">https://commits.webkit.org/277665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fef0295f4493c18aa5c7ac4c9113b8b80f5b433d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50842 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44219 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33297 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24869 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39350 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48735 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25073 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41636 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20479 "Found 1 new API test failure: /WPE/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22551 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6210 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44524 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43255 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52744 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23200 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19569 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46688 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24466 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45576 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10646 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25270 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24188 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->