### PR TITLE
[WPE] Variable length array build warning

### DIFF
--- a/Source/WebCore/platform/xr/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebCore/platform/xr/openxr/PlatformXROpenXR.cpp
@@ -366,14 +366,14 @@ void OpenXRDevice::collectSupportedSessionModes()
     auto result = xrEnumerateViewConfigurations(m_instance, m_systemId, 0, &viewConfigurationCount, nullptr);
     RETURN_IF_FAILED(result, "xrEnumerateViewConfigurations", m_instance);
 
-    XrViewConfigurationType viewConfigurations[viewConfigurationCount];
-    result = xrEnumerateViewConfigurations(m_instance, m_systemId, viewConfigurationCount, &viewConfigurationCount, viewConfigurations);
+    Vector<XrViewConfigurationType> viewConfigurations(viewConfigurationCount);
+    result = xrEnumerateViewConfigurations(m_instance, m_systemId, viewConfigurationCount, &viewConfigurationCount, viewConfigurations.data());
     RETURN_IF_FAILED(result, "xrEnumerateViewConfigurations", m_instance);
 
     FeatureList features = collectSupportedFeatures();
-    for (uint32_t i = 0; i < viewConfigurationCount; ++i) {
+    for (auto& viewConfiguration : viewConfigurations) {
         auto viewConfigurationProperties = createStructure<XrViewConfigurationProperties, XR_TYPE_VIEW_CONFIGURATION_PROPERTIES>();
-        result = xrGetViewConfigurationProperties(m_instance, m_systemId, viewConfigurations[i], &viewConfigurationProperties);
+        result = xrGetViewConfigurationProperties(m_instance, m_systemId, viewConfiguration, &viewConfigurationProperties);
         if (result != XR_SUCCESS) {
             LOG(XR, "xrGetViewConfigurationProperties(): error %s\n", resultToString(result, m_instance).utf8().data());
             continue;

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursor.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursor.cpp
@@ -69,11 +69,10 @@ void Cursor::updateBuffer(const uint8_t* pixels, uint32_t width, uint32_t height
     RELEASE_ASSERT(width <= m_deviceWidth);
     RELEASE_ASSERT(height <= m_deviceHeight);
 
-    uint32_t deviceBuffer[m_deviceWidth * m_deviceHeight];
-    memset(deviceBuffer, 0, sizeof(deviceBuffer));
+    Vector<uint32_t> deviceBuffer(m_deviceWidth * m_deviceHeight);
     for (uint32_t i = 0; i < height; ++i)
-        memcpy(deviceBuffer + i * m_deviceWidth, pixels + i * stride, stride);
-    gbm_bo_write(m_buffer->bufferObject(), deviceBuffer, sizeof(deviceBuffer));
+        memcpy(&deviceBuffer[i * m_deviceWidth], pixels + i * stride, stride);
+    gbm_bo_write(m_buffer->bufferObject(), deviceBuffer.data(), deviceBuffer.sizeInBytes());
 }
 
 void Cursor::setFromName(const char* name, double scale)


### PR DESCRIPTION
#### 72ef47e183a417a7e337b9b5b7d5ae448079f744
<pre>
[WPE] Variable length array build warning
<a href="https://bugs.webkit.org/show_bug.cgi?id=272830">https://bugs.webkit.org/show_bug.cgi?id=272830</a>

Reviewed by Michael Catanzaro.

Variable-length arrays (VLAs) are supported in C (since the C99 standard). But not in the C++
standard. This is an extension of some compilers.

* Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursor.cpp:
(WPE::DRM::Cursor::updateBuffer): Store the cursor pixels data in a Vector.
* Source/WebCore/platform/xr/openxr/PlatformXROpenXR.cpp: Store the viewConfigurations in a Vector.

Canonical link: <a href="https://commits.webkit.org/277675@main">https://commits.webkit.org/277675@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/268799560eabfabb27f3fbeb3709a77b4783d2b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51112 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50860 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44237 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50477 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24891 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39361 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48753 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25088 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41645 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20494 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22566 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42821 "Found 1 new test failure: fast/css/viewport-height-outline.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6228 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44538 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43265 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52763 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23218 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19581 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46696 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-visibility-hidden-child.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24484 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45591 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10649 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25288 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24206 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->