### PR TITLE
Run AppSSO extensions as embedded view controller

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -251,7 +251,7 @@ void SOAuthorizationSession::continueStartAfterDecidePolicy(const SOAuthorizatio
 #endif
     [m_soAuthorization setAuthorizationOptions:authorizationOptions];
 
-#if PLATFORM(IOS) || PLATFORM(VISION)
+#if PLATFORM(VISION)
     if (![[m_page->cocoaView() UIDelegate] respondsToSelector:@selector(_presentingViewControllerForWebView:)])
         [m_soAuthorization setEnableEmbeddedAuthorizationViewController:NO];
 #endif
@@ -396,6 +396,10 @@ void SOAuthorizationSession::presentViewController(SOAuthorizationViewController
     // WKFullScreenViewController even though that is the presenting view controller of the WKWebView.
     // We should call PageClientImpl::presentingViewController() instead.
     UIViewController *presentingViewController = m_page->uiClient().presentingViewController();
+#if !PLATFORM(VISION)
+    if (!presentingViewController)
+        presentingViewController = [m_page->cocoaView() window].rootViewController;
+#endif
     if (!presentingViewController) {
         uiCallback(NO, adoptNS([[NSError alloc] initWithDomain:SOErrorDomain code:kSOErrorAuthorizationPresentationFailed userInfo:nil]).get());
         return;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
@@ -621,12 +621,11 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed1)
     Util::run(&authorizationPerformed);
     checkAuthorizationOptions(false, emptyString(), 0);
     EXPECT_FALSE(policyForAppSSOPerformed); // The delegate isn't registered, so this won't be set.
-#if PLATFORM(MAC)
+#if PLATFORM(MAC) || PLATFORM(IOS)
     EXPECT_TRUE(gAuthorization.enableEmbeddedAuthorizationViewController);
-#elif PLATFORM(IOS) || PLATFORM(VISION)
+#elif PLATFORM(VISION)
     EXPECT_FALSE(gAuthorization.enableEmbeddedAuthorizationViewController);
 #endif
-
     RetainPtr<NSURL> redirectURL = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];


### PR DESCRIPTION
#### 0e4a1f7efbb2f619ccb39dd616a6f72e473b3455
<pre>
Run AppSSO extensions as embedded view controller
<a href="https://bugs.webkit.org/show_bug.cgi?id=272841">https://bugs.webkit.org/show_bug.cgi?id=272841</a>
<a href="https://rdar.apple.com/110662540">rdar://110662540</a>

Reviewed by Brent Fulgham.

Running as an embedded view controller prevents sessions from being cancelled whenn
switching apps. This is nessesary for SSO extensions that use MFA for example, as
they must switch apps to get the code.

Tested with multiple SSO extensions.

* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::SOAuthorizationSession::continueStartAfterDecidePolicy):
(WebKit::SOAuthorizationSession::presentViewController):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm:
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceed1)):

Canonical link: <a href="https://commits.webkit.org/277981@main">https://commits.webkit.org/277981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e72d9beb4868553a9e97b88e7b99447e7d7585e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51770 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45122 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51354 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34246 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25803 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40087 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25895 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42282 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21196 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23351 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43458 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7172 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45286 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43961 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53680 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24116 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20351 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47403 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-offscreen-child.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25393 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42489 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46373 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10809 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26182 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25114 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->