### PR TITLE
Fix PlayStation build break after 277590@main.

### DIFF
--- a/Source/WebCore/platform/network/curl/CurlRequest.h
+++ b/Source/WebCore/platform/network/curl/CurlRequest.h
@@ -42,7 +42,7 @@ class NetworkLoadMetrics;
 class ResourceError;
 class FragmentedSharedBuffer;
 
-class CurlRequest final : public ThreadSafeRefCounted<CurlRequest>, public CurlRequestSchedulerClient, public CurlMultipartHandleClient, public CanMakeThreadSafeCheckedPtr<CurlRequest> {
+class CurlRequest : public ThreadSafeRefCounted<CurlRequest>, public CurlRequestSchedulerClient, public CurlMultipartHandleClient, public CanMakeThreadSafeCheckedPtr<CurlRequest> {
     WTF_MAKE_NONCOPYABLE(CurlRequest);
     WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CurlRequest);


### PR DESCRIPTION
#### c81b16f6914beabab5d4257ea1dbc60abf684fdf
<pre>
Fix PlayStation build break after 277590@main.
<a href="https://bugs.webkit.org/show_bug.cgi?id=272842">https://bugs.webkit.org/show_bug.cgi?id=272842</a>

Reviewed by NOBODY (OOPS!).

277590@main made class WebCore::CurlRequest final, however for Playstation build,
a derived class CurlTMServiceRequest is needed.

* Source/WebCore/platform/network/curl/CurlRequest.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c81b16f6914beabab5d4257ea1dbc60abf684fdf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48169 "Failed to checkout and rebase branch from PR 27404") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27378 "Failed to checkout and rebase branch from PR 27404") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51110 "Failed to checkout and rebase branch from PR 27404") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50858 "Failed to checkout and rebase branch from PR 27404") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44235 "Failed to checkout and rebase branch from PR 27404") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50475 "Failed to checkout and rebase branch from PR 27404") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33313 "Failed to checkout and rebase branch from PR 27404") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24889 "Failed to checkout and rebase branch from PR 27404") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/50858 "Failed to checkout and rebase branch from PR 27404") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48751 "Failed to checkout and rebase branch from PR 27404") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/33313 "Failed to checkout and rebase branch from PR 27404") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/51110 "Failed to checkout and rebase branch from PR 27404") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/50858 "Failed to checkout and rebase branch from PR 27404") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/33313 "Failed to checkout and rebase branch from PR 27404") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/51110 "Failed to checkout and rebase branch from PR 27404") | [❌ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6226 "Failed to checkout and rebase branch from PR 27404") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/33313 "Failed to checkout and rebase branch from PR 27404") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/51110 "Failed to checkout and rebase branch from PR 27404") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52761 "Failed to checkout and rebase branch from PR 27404") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23216 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/24889 "Failed to checkout and rebase branch from PR 27404") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/52761 "Failed to checkout and rebase branch from PR 27404") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24482 "Failed to checkout and rebase branch from PR 27404") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/51110 "Failed to checkout and rebase branch from PR 27404") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/52761 "Failed to checkout and rebase branch from PR 27404") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25286 "Built successfully") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24204 "Failed to checkout and rebase branch from PR 27404") | | | 
<!--EWS-Status-Bubble-End-->