### PR TITLE
http/tests/site-isolation/draw-after-navigation.html is a flaky failure

### DIFF
--- a/LayoutTests/http/tests/site-isolation/draw-after-navigation.html
+++ b/LayoutTests/http/tests/site-isolation/draw-after-navigation.html
@@ -1,5 +1,16 @@
 <!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
-<head><meta name="fuzzy" content="maxDifference=112; totalPixels=900"/></head>
+<head>
+<meta name="fuzzy" content="maxDifference=112; totalPixels=900"/>
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+onmessage = (event) => {
+    if (window.testRunner && event.data == "onload")
+        testRunner.notifyDone();
+}
+</script>
+</head>
 <body bgcolor=blue>
 <iframe src="http://localhost:8000/site-isolation/resources/navigate-to-green-background.html" frameborder=0></iframe>
 </body>

--- a/LayoutTests/http/tests/site-isolation/iframe-and-window-open.html
+++ b/LayoutTests/http/tests/site-isolation/iframe-and-window-open.html
@@ -16,8 +16,10 @@ addEventListener("message", (event) => {
         openedWindow.postMessage('initial reply', '*');
         return;
     }
-    testPassed("received message from opened window: " + event.data);
-    finishJSTest();
+    if (event.data.startsWith("opened window received: ")) {
+        testPassed("received message from opened window: " + event.data);
+        finishJSTest();
+    }
 });
 
 </script>

--- a/LayoutTests/http/tests/site-isolation/resources/green-background.html
+++ b/LayoutTests/http/tests/site-isolation/resources/green-background.html
@@ -1,1 +1,4 @@
 <body style='background-color:green'/>
+<script>
+onload = () => { window.parent.postMessage("onload", "*"); }
+</script>


### PR DESCRIPTION
#### 0e9d2d4b26842fc2c41aae84c8a1154724ebbd76
<pre>
http/tests/site-isolation/draw-after-navigation.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=272853">https://bugs.webkit.org/show_bug.cgi?id=272853</a>
<a href="https://rdar.apple.com/126644250">rdar://126644250</a>

Reviewed by Sihui Liu.

The test should not complete until the iframe navigation has completed.

* LayoutTests/http/tests/site-isolation/draw-after-navigation.html:
* LayoutTests/http/tests/site-isolation/iframe-and-window-open.html:
* LayoutTests/http/tests/site-isolation/resources/green-background.html:

Canonical link: <a href="https://commits.webkit.org/277685@main">https://commits.webkit.org/277685@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9dd3332e4435d254008316ab91fc8fc962d7f648

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27506 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/51248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50982 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44359 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25027 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48876 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/25198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/51248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/20600 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/22678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/51248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6350 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/44636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/51248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52886 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/23341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/19692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/24606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/51248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/45705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/25411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6862 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/24329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->