### PR TITLE
Optimize the computation of layout overflow

### DIFF
--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -745,10 +745,11 @@ void RenderBlock::addOverflowFromPositionedObjects()
     if (!positionedDescendants)
         return;
 
+    auto clientBoxRect = this->flippedClientBoxRect();
     for (auto& positionedObject : *positionedDescendants) {
         // Fixed positioned elements don't contribute to layout overflow, since they don't scroll with the content.
         if (positionedObject.style().position() != PositionType::Fixed)
-            addOverflowFromChild(positionedObject, { positionedObject.x(), positionedObject.y() });
+            addOverflowFromChild(positionedObject, { positionedObject.x(), positionedObject.y() }, clientBoxRect);
     }
 }
 
@@ -3376,6 +3377,19 @@ void RenderBlock::setIntrinsicBorderForFieldset(LayoutUnit padding)
         rareData = &ensureBlockRareData(*this);
     }
     rareData->m_intrinsicBorderForFieldset = padding;
+}
+
+RectEdges<LayoutUnit> RenderBlock::borderWidths() const
+{
+    if (!intrinsicBorderForFieldset())
+        return RenderBox::borderWidths();
+
+    return {
+        borderTop(),
+        borderRight(),
+        borderBottom(),
+        borderLeft()
+    };
 }
 
 LayoutUnit RenderBlock::borderTop() const

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -203,10 +203,13 @@ public:
     // (flexbox, block, etc.)
     LayoutUnit intrinsicBorderForFieldset() const;
     void setIntrinsicBorderForFieldset(LayoutUnit);
+
+    RectEdges<LayoutUnit> borderWidths() const override;
     LayoutUnit borderTop() const override;
     LayoutUnit borderBottom() const override;
     LayoutUnit borderLeft() const override;
     LayoutUnit borderRight() const override;
+
     LayoutUnit borderBefore() const override;
     LayoutUnit adjustBorderBoxLogicalHeightForBoxSizing(LayoutUnit height) const override;
     LayoutUnit adjustContentBoxLogicalHeightForBoxSizing(std::optional<LayoutUnit> height) const override;

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -169,8 +169,10 @@ public:
 
     void addVisualEffectOverflow();
     LayoutRect applyVisualEffectOverflow(const LayoutRect&) const;
+
     void addOverflowFromChild(const RenderBox& child) { addOverflowFromChild(child, child.locationOffset()); }
     void addOverflowFromChild(const RenderBox& child, const LayoutSize& delta);
+    void addOverflowFromChild(const RenderBox&, const LayoutSize& delta, const LayoutRect& flippedClientRect);
 
     void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption>) const override;
 
@@ -772,6 +774,8 @@ private:
     LayoutPoint topLeftLocationWithFlipping() const;
 
     void clipContentForBorderRadius(GraphicsContext&, const LayoutPoint&, float);
+
+    void addLayoutOverflow(const LayoutRect&, const LayoutRect& flippedClientRect);
 
 private:
     // The width/height of the contents + borders + padding.  The x/y location is relative to our container (which is not always our parent).

--- a/Source/WebCore/rendering/RenderBoxModelObject.h
+++ b/Source/WebCore/rendering/RenderBoxModelObject.h
@@ -127,12 +127,15 @@ public:
     virtual inline LayoutUnit paddingStart() const;
     virtual inline LayoutUnit paddingEnd() const;
 
+    virtual inline RectEdges<LayoutUnit> borderWidths() const;
     virtual inline LayoutUnit borderTop() const;
     virtual inline LayoutUnit borderBottom() const;
     virtual inline LayoutUnit borderLeft() const;
     virtual inline LayoutUnit borderRight() const;
+
     virtual inline LayoutUnit horizontalBorderExtent() const;
     virtual inline LayoutUnit verticalBorderExtent() const;
+
     virtual inline LayoutUnit borderBefore() const;
     virtual inline LayoutUnit borderAfter() const;
     virtual inline LayoutUnit borderStart() const;

--- a/Source/WebCore/rendering/RenderBoxModelObjectInlines.h
+++ b/Source/WebCore/rendering/RenderBoxModelObjectInlines.h
@@ -78,6 +78,16 @@ inline LayoutSize RenderBoxModelObject::stickyPositionLogicalOffset() const { re
 inline LayoutUnit RenderBoxModelObject::verticalBorderAndPaddingExtent() const { return borderTop() + borderBottom() + paddingTop() + paddingBottom(); }
 inline LayoutUnit RenderBoxModelObject::verticalBorderExtent() const { return borderTop() + borderBottom(); }
 
+inline RectEdges<LayoutUnit> RenderBoxModelObject::borderWidths() const
+{
+    return {
+        LayoutUnit(style().borderTopWidth()),
+        LayoutUnit(style().borderRightWidth()),
+        LayoutUnit(style().borderBottomWidth()),
+        LayoutUnit(style().borderLeftWidth())
+    };
+}
+
 inline LayoutUnit RenderBoxModelObject::computedCSSPadding(const Length& padding) const
 {
     LayoutUnit containerWidth;

--- a/Source/WebCore/rendering/RenderTable.h
+++ b/Source/WebCore/rendering/RenderTable.h
@@ -57,15 +57,16 @@ public:
     
     bool collapseBorders() const { return style().borderCollapse() == BorderCollapse::Collapse; }
 
-    LayoutUnit borderStart() const override { return m_borderStart; }
-    LayoutUnit borderEnd() const override { return m_borderEnd; }
-    LayoutUnit borderBefore() const override;
-    LayoutUnit borderAfter() const override;
+    LayoutUnit borderStart() const final { return m_borderStart; }
+    LayoutUnit borderEnd() const final { return m_borderEnd; }
+    LayoutUnit borderBefore() const final;
+    LayoutUnit borderAfter() const final;
 
-    inline LayoutUnit borderLeft() const override;
-    inline LayoutUnit borderRight() const override;
-    inline LayoutUnit borderTop() const override;
-    inline LayoutUnit borderBottom() const override;
+    RectEdges<LayoutUnit> borderWidths() const final;
+    inline LayoutUnit borderLeft() const final;
+    inline LayoutUnit borderRight() const final;
+    inline LayoutUnit borderTop() const final;
+    inline LayoutUnit borderBottom() const final;
 
     Color bgColor() const { return style().visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor); }
 

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -1019,6 +1019,23 @@ inline CollapsedBorderValue RenderTableCell::cachedCollapsedBottomBorder(const R
     return styleForCellFlow.isLeftToRightDirection() ? section()->cachedCollapsedBorder(*this, CBSEnd) : section()->cachedCollapsedBorder(*this, CBSStart);
 }
 
+RectEdges<LayoutUnit> RenderTableCell::borderWidths() const
+{
+    RenderTable* table = this->table();
+    if (!table)
+        return RenderBlockFlow::borderWidths();
+
+    if (!table->collapseBorders())
+        return RenderBlockFlow::borderWidths();
+
+    return {
+        borderHalfTop(false),
+        borderHalfRight(false),
+        borderHalfBottom(false),
+        borderHalfLeft(false)
+    };
+}
+
 LayoutUnit RenderTableCell::borderLeft() const
 {
     RenderTable* table = this->table();

--- a/Source/WebCore/rendering/RenderTableCell.h
+++ b/Source/WebCore/rendering/RenderTableCell.h
@@ -65,6 +65,7 @@ public:
 
     void setCellLogicalWidth(LayoutUnit constrainedLogicalWidth);
 
+    RectEdges<LayoutUnit> borderWidths() const override;
     LayoutUnit borderLeft() const override;
     LayoutUnit borderRight() const override;
     LayoutUnit borderTop() const override;

--- a/Source/WebCore/rendering/RenderTableInlines.h
+++ b/Source/WebCore/rendering/RenderTableInlines.h
@@ -52,6 +52,16 @@ inline LayoutUnit RenderTable::borderTop() const
     return style().isLeftToRightDirection() ? borderStart() : borderEnd();
 }
 
+inline RectEdges<LayoutUnit> RenderTable::borderWidths() const
+{
+    return {
+        borderTop(),
+        borderRight(),
+        borderBottom(),
+        borderLeft()
+    };
+}
+
 inline LayoutUnit RenderTable::bordersPaddingAndSpacingInRowDirection() const
 {
     // 'border-spacing' only applies to separate borders (see 17.6.1 The separated borders model).


### PR DESCRIPTION
#### f3cac57896a33a50aae815d1c1947c6a45c9d3db
<pre>
Optimize the computation of layout overflow
<a href="https://bugs.webkit.org/show_bug.cgi?id=272859">https://bugs.webkit.org/show_bug.cgi?id=272859</a>
&lt;<a href="https://rdar.apple.com/problem/126651525">rdar://problem/126651525</a>&gt;

Reviewed by Alan Baradlay.

Computing layout overflow would call the 4 virtual border width functions
many times, so add a single virtual border widths getter to reduce that overhead.

Also `flippedClientBoxRect()` has non-trivial cost and would be computed each time
for the container, so compute that once and pass it into `addOverflowFromChild()`.

Finally check the `hasNonVisibleOverflow()` bit in a couple of places before
doing tests for various kinds of overflow.

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::addOverflowFromPositionedObjects):
(WebCore::RenderBlock::borderWidths const):
* Source/WebCore/rendering/RenderBlock.h:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::addOverflowFromChild):
(WebCore::RenderBox::addLayoutOverflow):
(WebCore::RenderBox::layoutOverflowRectForPropagation const):
(WebCore::RenderBox::flippedClientBoxRect const):
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderBoxModelObject.h:
* Source/WebCore/rendering/RenderBoxModelObjectInlines.h:
(WebCore::RenderBoxModelObject::borderWidths const):
* Source/WebCore/rendering/RenderTable.h:
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::borderWidths const):
* Source/WebCore/rendering/RenderTableCell.h:
* Source/WebCore/rendering/RenderTableInlines.h:
(WebCore::RenderTable::borderWidths const):

Canonical link: <a href="https://commits.webkit.org/277679@main">https://commits.webkit.org/277679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90a5dfd21fa16907768dd5005f209a5127605429

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50894 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44271 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50511 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33349 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24936 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39375 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48787 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25118 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41664 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20517 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22597 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42842 "Found 1 new test failure: fast/css/viewport-height-outline.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6262 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44563 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43290 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52797 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23253 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19609 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46713 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24518 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45617 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10651 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25323 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24241 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->