### PR TITLE
[YARR JIT] Intermittent crash when calling through areCanonicallyEquivalentThunk

### DIFF
--- a/Source/JavaScriptCore/jit/JITThunks.cpp
+++ b/Source/JavaScriptCore/jit/JITThunks.cpp
@@ -35,6 +35,7 @@
 #include "SlowPathCall.h"
 #include "ThunkGenerators.h"
 #include "VM.h"
+#include "YarrJIT.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
@@ -55,6 +56,7 @@ void JITThunks::initialize(VM& vm)
 #define JSC_DEFINE_COMMON_JIT_THUNK(name, func) \
     m_commonThunks[static_cast<unsigned>(CommonJITThunkID::name)] = func(vm);
 JSC_FOR_EACH_COMMON_THUNK(JSC_DEFINE_COMMON_JIT_THUNK)
+JSC_FOR_EACH_YARR_JIT_BACKREFERENCES_THUNK(JSC_DEFINE_COMMON_JIT_THUNK)
 #undef JSC_DEFINE_COMMON_JIT_THUNK
 }
 

--- a/Source/JavaScriptCore/jit/JITThunks.h
+++ b/Source/JavaScriptCore/jit/JITThunks.h
@@ -75,14 +75,23 @@ class NativeExecutable;
     macro(ReturnFromBaseline, returnFromBaselineGenerator) \
     macro(ArityFixup, arityFixupGenerator) \
 
+
+#if ENABLE(YARR_JIT_BACKREFERENCES_FOR_16BIT_EXPRS)
+#define JSC_FOR_EACH_YARR_JIT_BACKREFERENCES_THUNK(macro) \
+    macro(AreCanonicallyEquivalent, Yarr::areCanonicallyEquivalentThunkGenerator)
+#else
+#define JSC_FOR_EACH_YARR_JIT_BACKREFERENCES_THUNK(macro)
+#endif
+
 enum class CommonJITThunkID : uint8_t {
 #define JSC_DEFINE_COMMON_JIT_THUNK_ID(name, func) name,
 JSC_FOR_EACH_COMMON_THUNK(JSC_DEFINE_COMMON_JIT_THUNK_ID)
+JSC_FOR_EACH_YARR_JIT_BACKREFERENCES_THUNK(JSC_DEFINE_COMMON_JIT_THUNK_ID)
 #undef JSC_DEFINE_COMMON_JIT_THUNK_ID
 };
 
 #define JSC_COUNT_COMMON_JIT_THUNK_ID(name, func) + 1
-static constexpr unsigned numberOfCommonThunkIDs = 0 JSC_FOR_EACH_COMMON_THUNK(JSC_COUNT_COMMON_JIT_THUNK_ID);
+static constexpr unsigned numberOfCommonThunkIDs = 0 JSC_FOR_EACH_COMMON_THUNK(JSC_COUNT_COMMON_JIT_THUNK_ID) JSC_FOR_EACH_YARR_JIT_BACKREFERENCES_THUNK(JSC_COUNT_COMMON_JIT_THUNK_ID);
 #undef JSC_COUNT_COMMON_JIT_THUNK_ID
 
 class JITThunks final : private WeakHandleOwner {

--- a/Source/JavaScriptCore/yarr/YarrJIT.h
+++ b/Source/JavaScriptCore/yarr/YarrJIT.h
@@ -446,6 +446,10 @@ class YarrJITRegisters;
 void jitCompileInlinedTest(StackCheck*, StringView, OptionSet<Yarr::Flags>, CharSize, VM*, YarrBoyerMooreData&, CCallHelpers&, YarrJITRegisters&);
 #endif
 
+#if ENABLE(YARR_JIT_BACKREFERENCES_FOR_16BIT_EXPRS)
+MacroAssemblerCodeRef<JITThunkPtrTag> areCanonicallyEquivalentThunkGenerator(VM&);
+#endif
+
 } } // namespace JSC::Yarr
 
 #endif


### PR DESCRIPTION
#### bd4bbbbc4c513f941a99773e53798cedb694b9c4
<pre>
[YARR JIT] Intermittent crash when calling through areCanonicallyEquivalentThunk
<a href="https://bugs.webkit.org/show_bug.cgi?id=272862">https://bugs.webkit.org/show_bug.cgi?id=272862</a>
<a href="https://rdar.apple.com/126253524">rdar://126253524</a>

Reviewed by Yusuke Suzuki.

THe speculation for the crash we are seeing is that there is a race condition where the thunk&apos;s code is not
properly synced across all thread.
Moved the generation of the recently added areCanonicallyEquivalent thunk to be a common thunk that is created
at VM initialization time.

* Source/JavaScriptCore/jit/JITThunks.cpp:
(JSC::JITThunks::initialize):
* Source/JavaScriptCore/jit/JITThunks.h:
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::areCanonicallyEquivalentThunkGenerator):
* Source/JavaScriptCore/yarr/YarrJIT.h:

Canonical link: <a href="https://commits.webkit.org/277722@main">https://commits.webkit.org/277722@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f5a4548cc116bc8621b6a3254ca114bd395d22d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48210 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50897 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44274 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33424 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24940 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39381 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48792 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25184 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41665 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20525 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22664 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42843 "Found 1 new test failure: fast/css/viewport-height-outline.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6265 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/41506 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44622 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43292 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52800 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/47700 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23256 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19613 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46716 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24521 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41841 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45622 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10675 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25326 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55195 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24244 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11345 "Passed tests") | 
<!--EWS-Status-Bubble-End-->