### PR TITLE
REGRESSION [ iOS ] 5X TestWebKitAPI.CopyRTF.Strips are crashing and failing

### DIFF
--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -87,7 +87,6 @@ Tests/WebKitCocoa/ContextMenus.mm
 Tests/WebKitCocoa/CookieAcceptPolicy.mm
 Tests/WebKitCocoa/CookiePrivateBrowsing.mm
 Tests/WebKitCocoa/CopyHTML.mm
-Tests/WebKitCocoa/CopyRTF.mm
 Tests/WebKitCocoa/CopyURL.mm
 Tests/WebKitCocoa/Copying.mm
 Tests/WebKitCocoa/CreateWebArchive.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -885,6 +885,7 @@
 		9B1F6F791F90559E00B55744 /* copy-html.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9B1056421F9047CC00D5583F /* copy-html.html */; };
 		9B26FCCA159D16DE00CC3765 /* HTMLFormCollectionNamedItem.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9B26FCB4159D15E700CC3765 /* HTMLFormCollectionNamedItem.html */; };
 		9B270FEE1DDC2C0B002D53F3 /* closed-shadow-tree-test.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9B270FED1DDC25FD002D53F3 /* closed-shadow-tree-test.html */; };
+		9B2DC5532BD0963D0066D149 /* CopyRTF.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9B2DC5522BD0963D0066D149 /* CopyRTF.mm */; };
 		9B4B5EA522DEBE19001E3D5A /* SelectionModifyByParagraphBoundary.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9B4B5EA422DEBE19001E3D5A /* SelectionModifyByParagraphBoundary.mm */; };
 		9B4F8FA7159D52DD002D9F94 /* HTMLCollectionNamedItem.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9B4F8FA6159D52CA002D9F94 /* HTMLCollectionNamedItem.html */; };
 		9B59F12A2034086F009E63D5 /* mso-list-compat-mode.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 9B59F12920340854009E63D5 /* mso-list-compat-mode.html */; };
@@ -2143,7 +2144,6 @@
 		1C66BDEB2A8E81CB009D4452 /* WKWebExtensionTab.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionTab.mm; sourceTree = "<group>"; };
 		1C6B84BB2B0C3F4B00E885DD /* WKWebExtensionAPIMenus.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPIMenus.mm; sourceTree = "<group>"; };
 		1C734B5220788C4800F430EA /* SystemColors.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SystemColors.mm; sourceTree = "<group>"; };
-		1C79201B234BDD9B001EAF23 /* CopyRTF.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CopyRTF.mm; sourceTree = "<group>"; };
 		1C7FEB1F207C0F2D00D23278 /* BackgroundColor.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BackgroundColor.mm; sourceTree = "<group>"; };
 		1C81802625FB09E200608B3E /* FontRegistrySandboxCheck.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FontRegistrySandboxCheck.mm; sourceTree = "<group>"; };
 		1C8ECFF12AFD6F49007BAA62 /* WKWebExtensionAPICommands.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPICommands.mm; sourceTree = "<group>"; };
@@ -3082,6 +3082,7 @@
 		9B26FC6B159D061000CC3765 /* HTMLFormCollectionNamedItem.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = HTMLFormCollectionNamedItem.mm; sourceTree = "<group>"; };
 		9B26FCB4159D15E700CC3765 /* HTMLFormCollectionNamedItem.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = HTMLFormCollectionNamedItem.html; sourceTree = "<group>"; };
 		9B270FED1DDC25FD002D53F3 /* closed-shadow-tree-test.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "closed-shadow-tree-test.html"; sourceTree = "<group>"; };
+		9B2DC5522BD0963D0066D149 /* CopyRTF.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CopyRTF.mm; sourceTree = "<group>"; };
 		9B4B5EA422DEBE19001E3D5A /* SelectionModifyByParagraphBoundary.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SelectionModifyByParagraphBoundary.mm; sourceTree = "<group>"; };
 		9B4F8FA3159D52B1002D9F94 /* HTMLCollectionNamedItem.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = HTMLCollectionNamedItem.mm; sourceTree = "<group>"; };
 		9B4F8FA6159D52CA002D9F94 /* HTMLCollectionNamedItem.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = HTMLCollectionNamedItem.html; sourceTree = "<group>"; };
@@ -4075,7 +4076,6 @@
 				5C19A5231FD0F32600EEA323 /* CookiePrivateBrowsing.mm */,
 				9B1056411F9045C700D5583F /* CopyHTML.mm */,
 				9999108A1F393C8B008AD455 /* Copying.mm */,
-				1C79201B234BDD9B001EAF23 /* CopyRTF.mm */,
 				9B7A37C21F8AEBA5004AA228 /* CopyURL.mm */,
 				510A921D24DB38ED00BFD89C /* CreateWebArchive.mm */,
 				952F7164270BD97E00D00DCC /* CSSViewportUnits.mm */,
@@ -5654,6 +5654,7 @@
 				5142B2701517C88B00C32B19 /* ContextMenuCanCopyURL.mm */,
 				37FB72951DB2E82F00E41BE4 /* ContextMenuDefaultItemsHaveTags.mm */,
 				F4613F1C27DC2EDD007CCDE6 /* ContextMenuTests.mm */,
+				9B2DC5522BD0963D0066D149 /* CopyRTF.mm */,
 				7AEAD47C1E20113800416EFE /* CrossPartitionFileSchemeAccess.mm */,
 				E5AA8D1C25151CC60051CC45 /* DateInputTests.mm */,
 				939BA91614103412001A01BD /* DeviceScaleFactorOnBack.mm */,
@@ -6531,6 +6532,7 @@
 				A1C142C224AA7B2E00444207 /* ContextMenuMouseEvents.mm in Sources */,
 				F4613F1D27DC2EDD007CCDE6 /* ContextMenuTests.mm in Sources */,
 				F4034FA1275D5402003A81F8 /* CookieConsent.mm in Sources */,
+				9B2DC5532BD0963D0066D149 /* CopyRTF.mm in Sources */,
 				510A667B27D301AC00D22629 /* CoreMediaUtilities.mm in Sources */,
 				7CCE7EAC1A411A3400447C4C /* Counters.cpp in Sources */,
 				7AEAD47F1E20116C00416EFE /* CrossPartitionFileSchemeAccess.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
@@ -31,6 +31,7 @@
 #import "TestWKWebView.h"
 #import <WebKit/WKFrameInfoPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WKWebpagePreferencesPrivate.h>
 #import <WebKit/_WKFrameTreeNode.h>
 #import <WebKit/_WKTargetedElementInfo.h>
 #import <WebKit/_WKTargetedElementRequest.h>

--- a/Tools/TestWebKitAPI/Tests/mac/CopyRTF.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/CopyRTF.mm
@@ -26,36 +26,19 @@
 
 #import "config.h"
 
-#if PLATFORM(COCOA)
+#if PLATFORM(MAC)
 
 #import "PlatformUtilities.h"
 #import "Test.h"
 #import "TestWKWebView.h"
 #import <wtf/RetainPtr.h>
 
-#if PLATFORM(IOS_FAMILY)
-#import <MobileCoreServices/MobileCoreServices.h>
-#endif
-
-#if USE(APPKIT)
 using PlatformColor = NSColor;
-#else
-using PlatformColor = UIColor;
-#endif
 
-#if USE(APPKIT)
 static NSData *readRTFDataFromPasteboard()
 {
     return [[NSPasteboard generalPasteboard] dataForType:NSPasteboardTypeRTF];
 }
-#else
-static NSData *readRTFDataFromPasteboard()
-{
-    id value = [[UIPasteboard generalPasteboard] valueForPasteboardType:(__bridge NSString *)kUTTypeRTF];
-    ASSERT([value isKindOfClass:[NSData class]]);
-    return value;
-}
-#endif
 
 static RetainPtr<NSAttributedString> copyAttributedStringFromHTML(NSString *htmlString, bool forceDarkMode)
 {
@@ -182,4 +165,4 @@ TEST(CopyRTF, StripsUserSelectNoneQuirks)
     EXPECT_WK_STREQ([attributedString string].UTF8String, "hello world WebKit\nsome\nuser-select-none\ncontent\nfoo bar");
 }
 
-#endif // PLATFORM(COCOA)
+#endif // PLATFORM(MAC)


### PR DESCRIPTION
#### afd796ea8b79b39a957b3137a859567f819ffb75
<pre>
REGRESSION [ iOS ] 5X TestWebKitAPI.CopyRTF.Strips are crashing and failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=272239">https://bugs.webkit.org/show_bug.cgi?id=272239</a>

Reviewed by NOBODY (OOPS!).

Skip these tests on iOS family since there doesn&apos;t seem to be a solution for the underlying problem.

The test failures are caused because nsattributedstringagent which gets launched by TestWebKitAPI
loads locally built WebKit but then launched WebContent process, networking process, etc... without
setting `__XPC_DYLD_FRAMEWORK_PATH` and `__XPC_DYLD_LIBRARY_PATH`.

One solution is to set `__XPC___XPC_DYLD_FRAMEWORK_PATH` and `__XPC___XPC_DYLD_LIBRARY_PATH` which
is a solution implemented in 277530@main. But setting these environmental variables causes two drag
&amp; drop tests to fail (webkit.org/b/272778).

An alternative approach is to launch nsattributedstringagent with system WebKit instead of locally
built WebKit but this is not possible without also making TestWebKitAPI launch WebContent, networking,
etc... processes with system WebKit (i.e. launch WebContent with locally built WebKit but launch
nsattributedstringagent with system WebKit).

Calling `setenv` to set `__XPC___XPC_DYLD_FRAMEWORK_PATH` and `__XPC___XPC_DYLD_LIBRARY_PATH` in
`CopyRTF` tests themselves doesn&apos;t work either.

* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm:
* Tools/TestWebKitAPI/Tests/mac/CopyRTF.mm: Renamed from Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyRTF.mm.
(readRTFDataFromPasteboard):
(copyAttributedStringFromHTML):
(checkColor):
(TEST(CopyRTF, StripsDefaultTextColorOfDarkContent)):
(TEST(CopyRTF, StripsDefaultTextColorOfLightContent)):
(TEST(CopyRTF, StripsDataDetectorsLinks)):
(TEST(CopyRTF, StripsUserSelectNone)):
(TEST(CopyRTF, StripsUserSelectNoneQuirks)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afd796ea8b79b39a957b3137a859567f819ffb75

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48216 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27427 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/51166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50904 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/44281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50521 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24947 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48798 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/25126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/51166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20524 "Failed to checkout and rebase branch from PR 27419") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/22605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/51166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6272 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/44568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/51166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52807 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/23263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/19618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/24528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/51166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45624 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/25333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24251 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->