### PR TITLE
Add CryptoKit implementation for X25519/Ed25519

### DIFF
--- a/Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift
+++ b/Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift
@@ -224,4 +224,50 @@ extension P521.Signing.PrivateKey {
     }
 }
 
+extension Curve25519.Signing.PrivateKey {
+    init(span: SpanConstUInt8) throws {
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        try self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
+    }
+    public func signature(span: SpanConstUInt8) throws -> VectorUInt8 {
+        if span.empty() {
+            return try self.signature(for: Data.empty()).copyToVectorUInt8()
+        }
+        return try self.signature(for: Data.temporaryDataFromSpan(spanNoCopy: span)).copyToVectorUInt8()
+    }
+}
+
+extension Curve25519.Signing.PublicKey {
+    init(span: SpanConstUInt8) throws {
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        try self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
+    }
+    public func isValidSignature(signature: SpanConstUInt8, data: SpanConstUInt8) -> Bool {
+        if signature.empty() || data.empty() {
+            return false
+        }
+        return self.isValidSignature(Data.temporaryDataFromSpan(spanNoCopy: signature), for: Data.temporaryDataFromSpan(spanNoCopy: data))
+    }
+}
+
+extension Curve25519.KeyAgreement.PrivateKey {
+    init(span: SpanConstUInt8) throws {
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        try self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
+    }
+    public func sharedSecretFromKeyAgreement(pubSpan: SpanConstUInt8) throws -> VectorUInt8 {
+        if pubSpan.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        let pub =  try Curve25519.KeyAgreement.PublicKey(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: pubSpan))
+        return try self.sharedSecretFromKeyAgreement(with: pub).copyToVectorUInt8()
+    }
+}
+
 #endif

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.cpp
@@ -34,14 +34,14 @@
 namespace WebCore {
 
 #if !PLATFORM(COCOA) && !USE(GCRYPT)
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmEd25519::platformSign(const CryptoKeyOKP&, const Vector<uint8_t>&)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmEd25519::platformSign(const CryptoKeyOKP&, const Vector<uint8_t>&, UseCryptoKit)
 {
     ASSERT_NOT_REACHED();
     notImplemented();
     return Exception { ExceptionCode::NotSupportedError };
 }
 
-ExceptionOr<bool> CryptoAlgorithmEd25519::platformVerify(const CryptoKeyOKP&, const Vector<uint8_t>&, const Vector<uint8_t>&)
+ExceptionOr<bool> CryptoAlgorithmEd25519::platformVerify(const CryptoKeyOKP&, const Vector<uint8_t>&, const Vector<uint8_t>&, UseCryptoKit)
 {
     ASSERT_NOT_REACHED();
     notImplemented();
@@ -79,9 +79,10 @@ void CryptoAlgorithmEd25519::sign(const CryptoAlgorithmParameters&, Ref<CryptoKe
         exceptionCallback(ExceptionCode::InvalidAccessError);
         return;
     }
+    UseCryptoKit useCryptoKit = context.settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
     dispatchOperationInWorkQueue(workQueue, context, WTFMove(callback), WTFMove(exceptionCallback),
-        [key = WTFMove(key), data = WTFMove(data)] {
-            return platformSign(downcast<CryptoKeyOKP>(key.get()), data);
+        [key = WTFMove(key), data = WTFMove(data), useCryptoKit] {
+            return platformSign(downcast<CryptoKeyOKP>(key.get()), data, useCryptoKit);
     });
 }
 
@@ -91,9 +92,10 @@ void CryptoAlgorithmEd25519::verify(const CryptoAlgorithmParameters&, Ref<Crypto
         exceptionCallback(ExceptionCode::InvalidAccessError);
         return;
     }
+    UseCryptoKit useCryptoKit = context.settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
     dispatchOperationInWorkQueue(workQueue, context, WTFMove(callback), WTFMove(exceptionCallback),
-        [key = WTFMove(key), signature = WTFMove(signature), data = WTFMove(data)] {
-            return platformVerify(downcast<CryptoKeyOKP>(key.get()), signature, data);
+        [key = WTFMove(key), signature = WTFMove(signature), data = WTFMove(data), useCryptoKit] {
+            return platformVerify(downcast<CryptoKeyOKP>(key.get()), signature, data, useCryptoKit);
         });
 }
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.h
@@ -28,6 +28,9 @@
 
 namespace WebCore {
 
+constexpr auto ed25519KeySize = 32;
+constexpr auto ed25519SignatureSize = ed25519KeySize * 2;
+
 class CryptoKeyOKP;
 
 class CryptoAlgorithmEd25519 final : public CryptoAlgorithm {
@@ -46,8 +49,8 @@ private:
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit) final;
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit) final;
 
-    static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoKeyOKP&, const Vector<uint8_t>&);
-    static ExceptionOr<bool> platformVerify(const CryptoKeyOKP&, const Vector<uint8_t>&, const Vector<uint8_t>&);
+    static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoKeyOKP&, const Vector<uint8_t>&, UseCryptoKit);
+    static ExceptionOr<bool> platformVerify(const CryptoKeyOKP&, const Vector<uint8_t>&, const Vector<uint8_t>&, UseCryptoKit);
 };
 
 inline CryptoAlgorithmIdentifier CryptoAlgorithmEd25519::identifier() const

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.h
@@ -40,7 +40,7 @@ private:
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit) final;
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit) final;
 
-    static std::optional<Vector<uint8_t>> platformDeriveBits(const CryptoKeyOKP&, const CryptoKeyOKP&);
+    static std::optional<Vector<uint8_t>> platformDeriveBits(const CryptoKeyOKP&, const CryptoKeyOKP&, UseCryptoKit);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp
@@ -143,12 +143,12 @@ static ExceptionOr<bool> verifyEd25519(const Vector<uint8_t>& key, size_t keyLen
     return { error == GPG_ERR_NO_ERROR };
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmEd25519::platformSign(const CryptoKeyOKP& key, const Vector<uint8_t>& data)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmEd25519::platformSign(const CryptoKeyOKP& key, const Vector<uint8_t>& data, UseCryptoKit)
 {
     return signEd25519(key.platformKey(), key.keySizeInBytes(), data);
 }
 
-ExceptionOr<bool> CryptoAlgorithmEd25519::platformVerify(const CryptoKeyOKP& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
+ExceptionOr<bool> CryptoAlgorithmEd25519::platformVerify(const CryptoKeyOKP& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data, UseCryptoKit)
 {
     return verifyEd25519(key.platformKey(), key.keySizeInBytes(), signature, data);
 }

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmX25519GCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmX25519GCrypt.cpp
@@ -32,7 +32,7 @@ static std::optional<Vector<uint8_t>> gcryptDerive(const Vector<uint8_t>& baseKe
     return GCrypt::RFC7748::X25519(baseKey, publicKey);
 }
 
-std::optional<Vector<uint8_t>> CryptoAlgorithmX25519::platformDeriveBits(const CryptoKeyOKP& baseKey, const CryptoKeyOKP& publicKey)
+std::optional<Vector<uint8_t>> CryptoAlgorithmX25519::platformDeriveBits(const CryptoKeyOKP& baseKey, const CryptoKeyOKP& publicKey, UseCryptoKit)
 {
     return gcryptDerive(baseKey.platformKey(), publicKey.platformKey());
 }


### PR DESCRIPTION
#### a16a1e8ea319fea611553fd4d6354559dfd49054
<pre>
Add CryptoKit implementation for X25519/Ed25519
<a href="https://rdar.apple.com/126582690">rdar://126582690</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=272786">https://bugs.webkit.org/show_bug.cgi?id=272786</a>

Reviewed by Alex Christensen.

ed25519/x25519 cryptokit implementation.
wpt tests run fine with cryptokit enabled.

Also adding sha1 as an option for ecdsa. That was missed in the last
attempt. Some refactoring in the swift shim to group extensions.

* Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift:
(EdRv.errCode):
(EdRv.signature):
(EdRv.keyBytes):
(EdKey.sign(_:key:data:)):
(EdKey.verify(_:key:signature:data:)):
(EdKey.deriveBits(_:priv:pub:)):
* Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift:
(Curve25519.signature(_:)):
(Curve25519.isValidSignature(_:data:)):
(Curve25519.sharedSecretFromKeyAgreement(_:)):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.cpp:
(WebCore::CryptoAlgorithmEd25519::sign):
(WebCore::CryptoAlgorithmEd25519::verify):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp:
(WebCore::CryptoAlgorithmX25519::deriveBits):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.h:
* Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp:
(WebCore::toCKHashFunction):
(WebCore::verifyHashParameter):
(WebCore::signECDSACryptoKit):
(WebCore::verifyECDSACryptoKit):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp:
(WebCore::signEd25519):
(WebCore::verifyEd25519):
(WebCore::signEd25519CryptoKit):
(WebCore::verifyEd25519CryptoKit):
(WebCore::CryptoAlgorithmEd25519::platformSign):
(WebCore::CryptoAlgorithmEd25519::platformVerify):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmX25519Cocoa.cpp:
(WebCore::deriveBitsCryptoKit):
(WebCore::deriveBitsCoreCrypto):
(WebCore::CryptoAlgorithmX25519::platformDeriveBits):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp:
(WebCore::CryptoAlgorithmEd25519::platformSign):
(WebCore::CryptoAlgorithmEd25519::platformVerify):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmX25519GCrypt.cpp:
(WebCore::CryptoAlgorithmX25519::platformDeriveBits):

Canonical link: <a href="https://commits.webkit.org/277746@main">https://commits.webkit.org/277746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79fdea02d8ea8d755d6dda93684664fe74ca6a5a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51414 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51143 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44520 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50761 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25189 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39615 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25346 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20734 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22829 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6512 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44771 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53048 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23502 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/19827 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46925 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24767 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42028 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/45844 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25572 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6899 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24490 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->