### PR TITLE
REGRESSION [ iOS ] 5X TestWebKitAPI.CopyRTF.Strips are crashing and failing

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
@@ -1398,6 +1398,16 @@ bool WKPreferencesGetCustomPasteboardDataEnabled(WKPreferencesRef preferencesRef
     return toImpl(preferencesRef)->customPasteboardDataEnabled();
 }
 
+void WKPreferencesSetWriteRichTextDataWhenCopyingOrDragging(WKPreferencesRef preferencesRef, bool flag)
+{
+    toImpl(preferencesRef)->setWriteRichTextDataWhenCopyingOrDragging(flag);
+}
+
+bool WKPreferencesGetWriteRichTextDataWhenCopyingOrDragging(WKPreferencesRef preferencesRef)
+{
+    return toImpl(preferencesRef)->writeRichTextDataWhenCopyingOrDragging();
+}
+
 void WKPreferencesSetWebShareEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
     toImpl(preferencesRef)->setWebShareEnabled(flag);

--- a/Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h
@@ -388,6 +388,9 @@ WK_EXPORT bool WKPreferencesGetDataTransferItemsEnabled(WKPreferencesRef);
 WK_EXPORT void WKPreferencesSetCustomPasteboardDataEnabled(WKPreferencesRef, bool flag);
 WK_EXPORT bool WKPreferencesGetCustomPasteboardDataEnabled(WKPreferencesRef);
 
+WK_EXPORT void WKPreferencesSetWriteRichTextDataWhenCopyingOrDragging(WKPreferencesRef, bool flag);
+WK_EXPORT bool WKPreferencesGetWriteRichTextDataWhenCopyingOrDragging(WKPreferencesRef);
+
 // Defaults to false, true for iOS
 WK_EXPORT void WKPreferencesSetWebShareEnabled(WKPreferencesRef, bool flag);
 WK_EXPORT bool WKPreferencesGetWebShareEnabled(WKPreferencesRef);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyRTF.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyRTF.mm
@@ -31,6 +31,8 @@
 #import "PlatformUtilities.h"
 #import "Test.h"
 #import "TestWKWebView.h"
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKPreferencesRefPrivate.h>
 #import <wtf/RetainPtr.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -60,6 +62,9 @@ static NSData *readRTFDataFromPasteboard()
 static RetainPtr<NSAttributedString> copyAttributedStringFromHTML(NSString *htmlString, bool forceDarkMode)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+
+    auto preferences = (__bridge WKPreferencesRef)[[webView configuration] preferences];
+    WKPreferencesSetWriteRichTextDataWhenCopyingOrDragging(preferences, true);
 
     if (forceDarkMode)
         [webView forceDarkMode];


### PR DESCRIPTION
#### 57b120b52e9486103826c045c2538ab4d1067d63
<pre>
REGRESSION [ iOS ] 5X TestWebKitAPI.CopyRTF.Strips are crashing and failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=272239">https://bugs.webkit.org/show_bug.cgi?id=272239</a>

Reviewed by Wenson Hsieh.

The test failures are caused because nsattributedstringagent which gets launched by TestWebKitAPI
loads locally built WebKit but then launched WebContent process, networking process, etc... without
setting `__XPC_DYLD_FRAMEWORK_PATH` and `__XPC_DYLD_LIBRARY_PATH`.

Fix the tests by enabling WriteRichTextDataWhenCopyingOrDragging to trigger the legacy behavior.

* Source/WebKit/UIProcess/API/C/WKPreferences.cpp:
(WKPreferencesSetWriteRichTextDataWhenCopyingOrDragging):
(WKPreferencesGetWriteRichTextDataWhenCopyingOrDragging):
* Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyRTF.mm:
(copyAttributedStringFromHTML):

Canonical link: <a href="https://commits.webkit.org/277655@main">https://commits.webkit.org/277655@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f8aebb94cc4bc63890798544059c02137975ac4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50909 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44286 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50526 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24952 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48803 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25131 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20531 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22610 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6277 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44573 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43298 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52812 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23268 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19622 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46722 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24533 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41847 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45628 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25338 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6849 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24256 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->