### PR TITLE
heap-use-after-free | WebCore::RenderLayer::updateLayerListsIfNeeded; WebCore::forEachElementInPaintOrder; WebCore::forEachElementInPaintOrder

### DIFF
--- a/LayoutTests/fast/css/view-transitions-update-layer-lists-crash-expected.txt
+++ b/LayoutTests/fast/css/view-transitions-update-layer-lists-crash-expected.txt
@@ -1,0 +1,3 @@
+Test passes if there is no crash.
+
+

--- a/LayoutTests/fast/css/view-transitions-update-layer-lists-crash.html
+++ b/LayoutTests/fast/css/view-transitions-update-layer-lists-crash.html
@@ -1,0 +1,32 @@
+Test passes if there is no crash.
+<script>
+function onload() {
+    var canvas = document.createElement("canvas");
+    canvas.toBlob(callback, "foo");
+    if (window.testRunner)
+        testRunner.dumpAsText();
+}
+function callback() {
+    var obj = {};
+    var rootStyle = document.querySelector("html").style;
+    rootStyle.setProperty("hyphenate-limit-lines", "1");
+    rootStyle.setProperty("-webkit-text-combine", "horizontal");
+}
+</script>
+<body onload=onload()>
+    <iframe id="htmlvar00017" srcdoc="Ga ?o]Y" onload="document.startViewTransition();"></iframe>
+    <a id="htmlvar00018">
+        <audio id="htmlvar00019"></audio>
+    </a>
+    <shadow>
+        <dl id="htmlvar00021">
+            <dt>
+                <dir id="htmlvar00028">
+                    <li id="htmlvar00029" contenteditable="plaintext-only">
+                        <iframe id="htmlvar00030"></iframe>
+                    </li>
+                </dir>
+            </dt>
+        </dl>
+    </shadow>
+</body>

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -357,8 +357,12 @@ ExceptionOr<void> ViewTransition::captureOldState()
     ListHashSet<AtomString> usedTransitionNames;
     Vector<Ref<Element>> captureElements;
     Ref document = *m_document;
+    // Ensure style & render tree are up-to-date.
+    document->updateStyleIfNeeded();
+
     if (CheckedPtr view = document->renderView()) {
         m_initialLargeViewportSize = view->sizeForCSSLargeViewportUnits();
+
         auto result = forEachElementInPaintOrder([&](Element& element) -> ExceptionOr<void> {
             if (auto name = effectiveViewTransitionName(element); !name.isNull()) {
                 if (auto check = checkDuplicateViewTransitionName(name, usedTransitionNames); check.hasException())
@@ -508,6 +512,9 @@ void ViewTransition::activateViewTransition()
 {
     if (m_phase == ViewTransitionPhase::Done)
         return;
+
+    // Ensure style & render tree are up-to-date.
+    protectedDocument()->updateStyleIfNeeded();
 
     // FIXME: Set rendering suppression for view transitions to false.
     if (!protectedDocument()->renderView() || protectedDocument()->renderView()->sizeForCSSLargeViewportUnits() != m_initialLargeViewportSize) {


### PR DESCRIPTION
#### cd5d1b32f5a4b4348623a5171df6bfba1f92b4f2
<pre>
heap-use-after-free | WebCore::RenderLayer::updateLayerListsIfNeeded; WebCore::forEachElementInPaintOrder; WebCore::forEachElementInPaintOrder
<a href="https://bugs.webkit.org/show_bug.cgi?id=272868">https://bugs.webkit.org/show_bug.cgi?id=272868</a>
<a href="https://rdar.apple.com/126636219">rdar://126636219</a>

Reviewed by Ryosuke Niwa.

The code inside the `forEachElementInPaintOrder` callback can end up destroying RenderLayers indirectly through `updateStyleIfNeeded` which is invoked through `Element::checkVisibility`.

Call `document-&gt;updateStyleIfNeeded()` before the callback is invoked to avoid destroying RenderLayers while iterating through layers.

* LayoutTests/fast/css/view-transitions-update-layer-lists-crash-expected.txt: Added.
* LayoutTests/fast/css/view-transitions-update-layer-lists-crash.html: Added.
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::captureOldState):
(WebCore::ViewTransition::activateViewTransition):

Canonical link: <a href="https://commits.webkit.org/277779@main">https://commits.webkit.org/277779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28fd13cdbba63ef9fc362600c46463eb542ce9ab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48539 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27750 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51226 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44604 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50844 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25273 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39683 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25424 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41880 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20793 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22902 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43054 "Exiting early after 10 failures. 18 tests run. 1 flakes") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6595 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44841 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43540 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53133 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23585 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19893 "9 flakes 1 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46990 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24850 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42086 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45913 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10705 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25655 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24573 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->