### PR TITLE
REGRESSION (277474@main): [ MacOS iOS ] TestWebKitAPI.IPCTestingAPI.CanInterceptFindString is a consistent failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
@@ -469,33 +469,19 @@ TEST(IPCTestingAPI, CanInterceptFindString)
     }];
     TestWebKitAPI::Util::run(&done);
 
-    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"messages = messages.filter((message) => message.name == IPC.messages.WebPage_FindString.name); messages.length"].UTF8String, "2");
+    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"messages = messages.filter((message) => message.name == IPC.messages.WebPage_FindString.name); messages.length"].UTF8String, "1");
     EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"messages[0].description"].UTF8String, "WebPage_FindString");
-    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"messages[1].description"].UTF8String, "WebPage_FindString");
-
-    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"firstMessageArgs = messages[0].arguments; firstMessageArgs.length"].intValue, 3);
-    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"firstMessageArgs[0].type"].UTF8String, "String");
-    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"firstMessageArgs[0].value"].UTF8String, "hello");
-    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"firstMessageArgs[1].type"].UTF8String, "uint16_t");
-    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"firstMessageArgs[1].value"].intValue, 0x811);
-    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"firstMessageArgs[1].isOptionSet"].boolValue, YES);
-    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"firstMessageArgs[2].type"].UTF8String, "uint32_t");
-    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"firstMessageArgs[2].value"].intValue, 1);
-
-    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"secondMessageArgs = messages[1].arguments; secondMessageArgs.length"].intValue, 3);
-    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"secondMessageArgs[0].type"].UTF8String, "String");
-    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"secondMessageArgs[0].value"].UTF8String, "hello");
-    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"secondMessageArgs[1].type"].UTF8String, "uint16_t");
-    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"secondMessageArgs[1].value"].intValue, 0x11);
-    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"secondMessageArgs[1].isOptionSet"].boolValue, YES);
-    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"secondMessageArgs[2].type"].UTF8String, "uint32_t");
-    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"secondMessageArgs[2].value"].intValue, 1);
+    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"args = messages[0].arguments; args.length"].intValue, 3);
+    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"args[0].type"].UTF8String, "String");
+    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"args[0].value"].UTF8String, "hello");
+    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"args[1].type"].UTF8String, "uint16_t");
+    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"args[1].value"].intValue, 0x11);
+    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"args[1].isOptionSet"].boolValue, YES);
+    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"args[2].type"].UTF8String, "uint32_t");
+    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"args[2].value"].intValue, 1);
 
     EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"typeof(messages[0].syncRequestID)"].UTF8String, "undefined");
-    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"typeof(messages[1].syncRequestID)"].UTF8String, "undefined");
     EXPECT_EQ([webView stringByEvaluatingJavaScript:@"messages[0].destinationID"].intValue,
-        [webView stringByEvaluatingJavaScript:@"IPC.webPageProxyID.toString()"].intValue);
-    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"messages[1].destinationID"].intValue,
         [webView stringByEvaluatingJavaScript:@"IPC.webPageProxyID.toString()"].intValue);
 }
 


### PR DESCRIPTION
#### 21d883e4fcced712e505439cbd3beaae9b85fbe4
<pre>
REGRESSION (277474@main): [ MacOS iOS ] TestWebKitAPI.IPCTestingAPI.CanInterceptFindString is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=272870">https://bugs.webkit.org/show_bug.cgi?id=272870</a>
<a href="https://rdar.apple.com/126656958">rdar://126656958</a>

Reviewed by Aditya Keerthi.

FindString is no longer unconditionally sent twice after 277474@main, so remove the expectations for
the second message.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm:
(CanInterceptFindString)):

Canonical link: <a href="https://commits.webkit.org/277645@main">https://commits.webkit.org/277645@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48e1d94f2d0a925707a3bba7d47cfeb109d93f58

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27440 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/51182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50917 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/44294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24960 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48811 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/25135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/51182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20537 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/22615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/51182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6285 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/44576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/51182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52820 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/23276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/19629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/24541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/51182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/45635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/25346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6845 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/24264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->