### PR TITLE
Remove shouldAlwaysUsePluginDocument

### DIFF
--- a/Source/WebCore/dom/DOMImplementation.cpp
+++ b/Source/WebCore/dom/DOMImplementation.cpp
@@ -196,9 +196,6 @@ Ref<Document> DOMImplementation::createDocument(const String& contentType, Local
         return FTPDirectoryDocument::create(frame, settings, url);
 #endif
 
-    if (frame && frame->loader().client().shouldAlwaysUsePluginDocument(contentType))
-        return PluginDocument::create(*frame, url);
-
     // The following is the relatively costly lookup that requires initializing the plug-in database.
     if (frame && frame->page()) {
         if (frame->page()->pluginData().supportsWebVisibleMimeType(contentType, PluginData::OnlyApplicationPlugins))

--- a/Source/WebCore/loader/DocumentWriter.cpp
+++ b/Source/WebCore/loader/DocumentWriter.cpp
@@ -118,8 +118,6 @@ Ref<Document> DocumentWriter::createDocument(const URL& url, ScriptExecutionCont
 {
     Ref frame = *m_frame;
     CheckedRef frameLoader = frame->loader();
-    if (!frameLoader->stateMachine().isDisplayingInitialEmptyDocument() && frameLoader->client().shouldAlwaysUsePluginDocument(m_mimeType))
-        return PluginDocument::create(frame, url);
 
     auto useSinkDocument = [&]() {
 #if ENABLE(PDF_PLUGIN)

--- a/Source/WebCore/loader/LocalFrameLoaderClient.h
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.h
@@ -298,7 +298,6 @@ public:
     virtual std::optional<double> dataDetectionReferenceDate() { return std::nullopt; }
 #endif
 
-    virtual bool shouldAlwaysUsePluginDocument(const String& /*mimeType*/) const { return false; }
     virtual bool shouldLoadMediaElementURL(const URL&) const { return true; }
 
     virtual void didChangeScrollOffset() { }

--- a/Source/WebCore/loader/SubframeLoader.cpp
+++ b/Source/WebCore/loader/SubframeLoader.cpp
@@ -373,10 +373,6 @@ RefPtr<LocalFrame> FrameLoader::SubframeLoader::loadSubframe(HTMLFrameOwnerEleme
 bool FrameLoader::SubframeLoader::shouldUsePlugin(const URL& url, const String& mimeType, bool hasFallback, bool& useFallback)
 {
     Ref frame = m_frame.get();
-    if (frame->checkedLoader()->client().shouldAlwaysUsePluginDocument(mimeType)) {
-        useFallback = false;
-        return true;
-    }
 
     ObjectContentType objectType = frame->checkedLoader()->client().objectContentType(url, mimeType);
     // If an object's content can't be handled and it has no fallback, let


### PR DESCRIPTION
#### 7766d8c67414d29385d2c60a7c2befa620e8feb0
<pre>
Remove shouldAlwaysUsePluginDocument
<a href="https://bugs.webkit.org/show_bug.cgi?id=272854">https://bugs.webkit.org/show_bug.cgi?id=272854</a>

Reviewed by Alex Christensen.

This function always returns false now, and does not use the parameter input given at all.

* Source/WebCore/dom/DOMImplementation.cpp:
(WebCore::DOMImplementation::createDocument):
* Source/WebCore/loader/DocumentWriter.cpp:
(WebCore::DocumentWriter::createDocument):
* Source/WebCore/loader/LocalFrameLoaderClient.h:
* Source/WebCore/loader/SubframeLoader.cpp:
(WebCore::FrameLoader::SubframeLoader::shouldUsePlugin):

Canonical link: <a href="https://commits.webkit.org/277692@main">https://commits.webkit.org/277692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/163d092caadcf1beaafaf430e48a39f5d4a468ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48230 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51183 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50918 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44295 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50535 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24961 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39393 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25140 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41673 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20540 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22620 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42851 "Found 1 new test failure: fast/css/viewport-height-outline.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6286 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44581 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52821 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19630 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46734 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24542 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41850 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45642 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10661 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25347 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24265 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->