### PR TITLE
HTMLMediaElement.played TimeRanges missing the last range on ended

### DIFF
--- a/LayoutTests/media/video-played-ranges-1-expected.txt
+++ b/LayoutTests/media/video-played-ranges-1-expected.txt
@@ -59,5 +59,13 @@ Test 27 OK
 Test 28 OK
 Test 29 OK
 Test 30 OK
+
+Test playing to end, should extend range end
+RUN(handlePromise(video.play()))
+EVENT(pause)
+EVENT(ended)
+Test 31 OK
+Test 32 OK
+Test 33 OK
 END OF TEST
 

--- a/LayoutTests/media/video-played-ranges-1.html
+++ b/LayoutTests/media/video-played-ranges-1.html
@@ -13,6 +13,7 @@
                 JumpBackAndPlayToNewRange,
                 JumpAndExtendRangeStart,
                 JumpAndExtendRangeEnd,
+                PlayToEnd,
             ];
     
             // NOTE: Detailed results are not printed for this test because time values are different from machine
@@ -85,6 +86,16 @@
                 willPauseInExistingRange = false;
                 willExtendAnExistingRange = true;
                 playForMillisecs(30);
+            }
+
+            function PlayToEnd()
+            {
+                consoleWrite("<br><b><em>Test playing to end, should extend range end</em></b>");
+        
+                var newTime = (video.duration - 0.05).toFixed(2);
+                runSilently("video.currentTime = " + newTime);
+    
+                playUntilEnded();
             }
 
         </script>

--- a/LayoutTests/media/video-played.js
+++ b/LayoutTests/media/video-played.js
@@ -52,6 +52,8 @@ function nextTest()
 
 function pause(evt)
 {
+    if (video.ended)
+        return;
     currentTime = video.currentTime.toFixed(2);
     
     if (!willExtendAnExistingRange)
@@ -66,6 +68,15 @@ function pause(evt)
 function canplay(event) 
 {
     testRanges();
+    nextTest();
+}
+
+function ended(evt)
+{
+    testExpected('video.currentTime == video.duration', true);
+    testExpected('video.played.length >= 1', true);
+    testExpected('video.played.end(video.played.length -1) == video.duration', true);
+
     nextTest();
 }
 
@@ -143,6 +154,13 @@ function playForMillisecs(milliseconds)
     setTimeout(callPauseIfTimeIsReached, milliseconds + 100);
 }
 
+async function playUntilEnded()
+{
+    run("handlePromise(video.play())");
+
+    await waitFor(video, 'ended');
+}
+
 function videoPlayedMain()
 {
     findMediaElement();
@@ -155,6 +173,7 @@ function videoPlayedMain()
     waitForEvent("loadedmetadata");
     waitForEvent("canplay", canplay); // Will trigger nextTest() which launches the tests.
     waitForEvent("pause", pause);
+    waitForEvent("ended", ended);
     
     video.load();
 }

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3706,8 +3706,6 @@ webkit.org/b/236930 accessibility/ios-simulator/aria-details.html [ Crash Pass ]
 
 webkit.org/b/238284 editing/spelling/spellcheck-async-remove-frame.html [ Pass Crash ]
 
-webkit.org/b/238771 media/video-played-ranges-1.html [ Pass Failure ]
-
 webkit.org/b/237108 http/tests/websocket/tests/hybi/extensions.html [ Pass ]
 
 webkit.org/b/238824 http/tests/workers/service/openwindow-from-notification-click.html [ Pass Failure ]

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -5672,6 +5672,8 @@ void HTMLMediaElement::mediaPlayerTimeChanged()
                 if (!wasSeeking)
                     addBehaviorRestrictionsOnEndIfNecessary();
                 setAutoplayEventPlaybackState(AutoplayEventPlaybackState::None);
+                if (now > m_lastSeekTime)
+                    addPlayedRange(m_lastSeekTime, now);
             }
             setPlaying(false);
             // If the media element has a current media controller, then report the controller state


### PR DESCRIPTION
#### 8338d4d31d30908f186423844c9940b3356fd897
<pre>
HTMLMediaElement.played TimeRanges missing the last range on ended
<a href="https://bugs.webkit.org/show_bug.cgi?id=271679">https://bugs.webkit.org/show_bug.cgi?id=271679</a>
<a href="https://rdar.apple.com/125741797">rdar://125741797</a>

Reviewed by Eric Carlson.

Added TimeRange to `played` TimeRanges once we reach the end of the media.

* LayoutTests/media/video-played-ranges-1-expected.txt:
* LayoutTests/media/video-played-ranges-1.html:
* LayoutTests/media/video-played.js:
(pause):
(ended):
(async playUntilEnded):
(videoPlayedMain):
* LayoutTests/platform/ios/TestExpectations: Remove expectation as test was flacky due to the use
of the GPU process and incorrect time estimation, which was fixed in 276761@main
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::mediaPlayerTimeChanged):

Canonical link: <a href="https://commits.webkit.org/277706@main">https://commits.webkit.org/277706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bd905d5c45c4e2d25530962fd9db07fdef40b9e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48237 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27448 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50925 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44302 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50542 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24968 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39409 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48819 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25144 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41677 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20545 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22624 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42855 "Found 1 new test failure: fast/css/viewport-height-outline.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6293 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44584 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43310 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52829 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23284 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19636 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46740 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24549 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41854 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45648 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/10669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25354 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24272 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->