### PR TITLE
Do some more std::span adoption

### DIFF
--- a/Source/JavaScriptCore/API/JSStringRef.cpp
+++ b/Source/JavaScriptCore/API/JSStringRef.cpp
@@ -44,13 +44,13 @@ JSStringRef JSStringCreateWithUTF8CString(const char* string)
 {
     JSC::initialize();
     if (string) {
-        size_t length = strlen(string);
-        Vector<UChar, 1024> buffer(length);
+        auto stringSpan = span8(string);
+        Vector<UChar, 1024> buffer(stringSpan.size());
         UChar* p = buffer.data();
         bool sourceContainsOnlyASCII;
-        if (convertUTF8ToUTF16(std::span { reinterpret_cast<const char8_t*>(string), length }, &p, p + length, &sourceContainsOnlyASCII)) {
+        if (convertUTF8ToUTF16(spanReinterpretCast<const char8_t>(stringSpan), &p, p + buffer.size(), &sourceContainsOnlyASCII)) {
             if (sourceContainsOnlyASCII)
-                return &OpaqueJSString::create({ reinterpret_cast<const LChar*>(string), length }).leakRef();
+                return &OpaqueJSString::create(stringSpan).leakRef();
             return &OpaqueJSString::create({ buffer.data(), p }).leakRef();
         }
     }

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -247,10 +247,10 @@ public:
 
     class InputStream {
     public:
-        InputStream(const CharType* input, unsigned start, unsigned length, bool decodeSurrogatePairs)
-            : input(input)
+        InputStream(std::span<const CharType> input, unsigned start, bool decodeSurrogatePairs)
+            : input(input.data())
             , pos(start)
-            , length(length)
+            , length(input.size())
             , decodeSurrogatePairs(decodeSurrogatePairs)
         {
         }
@@ -2166,11 +2166,11 @@ public:
         return output[0];
     }
 
-    Interpreter(BytecodePattern* pattern, unsigned* output, const CharType* input, unsigned length, unsigned start)
+    Interpreter(BytecodePattern* pattern, unsigned* output, std::span<const CharType> input, unsigned start)
         : pattern(pattern)
         , compileMode(pattern->compileMode())
         , output(output)
-        , input(input, start, length, pattern->eitherUnicode())
+        , input(input, start, pattern->eitherUnicode())
         , startOffset(start)
         , remainingMatchCount(matchLimit)
     {
@@ -3107,20 +3107,20 @@ unsigned interpret(BytecodePattern* bytecode, StringView input, unsigned start, 
 {
     SuperSamplerScope superSamplerScope(false);
     if (input.is8Bit())
-        return Interpreter<LChar>(bytecode, output, input.characters8(), input.length(), start).interpret();
-    return Interpreter<UChar>(bytecode, output, input.characters16(), input.length(), start).interpret();
+        return Interpreter<LChar>(bytecode, output, input.span8(), start).interpret();
+    return Interpreter<UChar>(bytecode, output, input.span16(), start).interpret();
 }
 
-unsigned interpret(BytecodePattern* bytecode, const LChar* input, unsigned length, unsigned start, unsigned* output)
+unsigned interpret(BytecodePattern* bytecode, std::span<const LChar> input, unsigned start, unsigned* output)
 {
     SuperSamplerScope superSamplerScope(false);
-    return Interpreter<LChar>(bytecode, output, input, length, start).interpret();
+    return Interpreter<LChar>(bytecode, output, input, start).interpret();
 }
 
-unsigned interpret(BytecodePattern* bytecode, const UChar* input, unsigned length, unsigned start, unsigned* output)
+unsigned interpret(BytecodePattern* bytecode, std::span<const UChar> input, unsigned start, unsigned* output)
 {
     SuperSamplerScope superSamplerScope(false);
-    return Interpreter<UChar>(bytecode, output, input, length, start).interpret();
+    return Interpreter<UChar>(bytecode, output, input, start).interpret();
 }
 
 // These should be the same for both UChar & LChar.

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.h
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.h
@@ -536,7 +536,7 @@ private:
 
 JS_EXPORT_PRIVATE std::unique_ptr<BytecodePattern> byteCompile(YarrPattern&, BumpPointerAllocator*, ErrorCode&, ConcurrentJSLock* = nullptr);
 JS_EXPORT_PRIVATE unsigned interpret(BytecodePattern*, StringView input, unsigned start, unsigned* output);
-unsigned interpret(BytecodePattern*, const LChar* input, unsigned length, unsigned start, unsigned* output);
-unsigned interpret(BytecodePattern*, const UChar* input, unsigned length, unsigned start, unsigned* output);
+unsigned interpret(BytecodePattern*, std::span<const LChar> input, unsigned start, unsigned* output);
+unsigned interpret(BytecodePattern*, std::span<const UChar> input, unsigned start, unsigned* output);
 
 } } // namespace JSC::Yarr

--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -104,8 +104,7 @@ ALLOW_NONLITERAL_FORMAT_BEGIN
     }
 
     Vector<char, 256> buffer;
-    unsigned length = result;
-    buffer.grow(length + 1);
+    buffer.grow(result + 1);
 
     // Now do the formatting again, guaranteed to fit.
     vsnprintf(buffer.data(), buffer.size(), format, argsCopy);
@@ -113,7 +112,7 @@ ALLOW_NONLITERAL_FORMAT_BEGIN
 
 ALLOW_NONLITERAL_FORMAT_END
 
-    return StringImpl::create(std::span { reinterpret_cast<const LChar*>(buffer.data()), length });
+    return StringImpl::create(buffer.subspan(0, buffer.size() - 1));
 }
 
 #if PLATFORM(COCOA)

--- a/Source/WTF/wtf/unicode/icu/CollatorICU.cpp
+++ b/Source/WTF/wtf/unicode/icu/CollatorICU.cpp
@@ -211,14 +211,14 @@ static void setStateLatin1(UCharIterator* iterator, uint32_t state, UErrorCode*)
     iterator->index = state;
 }
 
-static UCharIterator createLatin1Iterator(const LChar* characters, int length)
+static UCharIterator createLatin1Iterator(std::span<const LChar> characters)
 {
     UCharIterator iterator;
-    iterator.context = characters;
-    iterator.length = length;
+    iterator.context = characters.data();
+    iterator.length = characters.size();
     iterator.start = 0;
     iterator.index = 0;
-    iterator.limit = length;
+    iterator.limit = characters.size();
     iterator.reservedField = 0;
     iterator.getIndex = getIndexLatin1;
     iterator.move = moveLatin1;
@@ -236,7 +236,7 @@ static UCharIterator createLatin1Iterator(const LChar* characters, int length)
 UCharIterator createIterator(StringView string)
 {
     if (string.is8Bit())
-        return createLatin1Iterator(string.characters8(), string.length());
+        return createLatin1Iterator(string.span8());
     UCharIterator iterator;
     uiter_setString(&iterator, string.characters16(), string.length());
     return iterator;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6481,13 +6481,13 @@ static inline bool isValidNameASCII(std::span<const CharType> characters)
     return true;
 }
 
-static bool isValidNameASCIIWithoutColon(const LChar* characters, unsigned length)
+static bool isValidNameASCIIWithoutColon(std::span<const LChar> characters)
 {
-    auto c = characters[0];
+    auto c = characters.front();
     if (!(isASCIIAlpha(c) || c == '_'))
         return false;
 
-    for (unsigned i = 1; i < length; ++i) {
+    for (size_t i = 1; i < characters.size(); ++i) {
         c = characters[i];
         if (!(isASCIIAlphanumeric(c) || c == '_' || c == '-' || c == '.'))
             return false;
@@ -6530,7 +6530,7 @@ ExceptionOr<std::pair<AtomString, AtomString>> Document::parseQualifiedName(cons
     bool sawColon = false;
     unsigned colonPosition = 0;
 
-    bool isValidLocalName = qualifiedName.is8Bit() && isValidNameASCIIWithoutColon(qualifiedName.characters8(), qualifiedName.length());
+    bool isValidLocalName = qualifiedName.is8Bit() && isValidNameASCIIWithoutColon(qualifiedName.span8());
     if (LIKELY(isValidLocalName))
         return std::pair<AtomString, AtomString> { { }, { qualifiedName } };
 

--- a/Source/WebCore/html/MediaFragmentURIParser.cpp
+++ b/Source/WebCore/html/MediaFragmentURIParser.cpp
@@ -44,18 +44,18 @@ constexpr int secondsPerHour = 3600;
 constexpr int secondsPerMinute = 60;
 constexpr unsigned nptIdentifierLength = 4; // "npt:"
 
-static String collectDigits(const LChar* input, unsigned length, unsigned& position)
+static String collectDigits(std::span<const LChar> input, unsigned& position)
 {
     StringBuilder digits;
 
     // http://www.ietf.org/rfc/rfc2326.txt
     // DIGIT ; any positive number
-    while (position < length && isASCIIDigit(input[position]))
+    while (position < input.size() && isASCIIDigit(input[position]))
         digits.append(input[position++]);
     return digits.toString();
 }
 
-static StringView collectFraction(const LChar* input, unsigned length, unsigned& position)
+static StringView collectFraction(std::span<const LChar> input, unsigned& position)
 {
     // http://www.ietf.org/rfc/rfc2326.txt
     // [ "." *DIGIT ]
@@ -63,9 +63,9 @@ static StringView collectFraction(const LChar* input, unsigned length, unsigned&
         return { };
 
     unsigned start = position++;
-    while (position < length && isASCIIDigit(input[position]))
+    while (position < input.size() && isASCIIDigit(input[position]))
         ++position;
-    return std::span(input + start, position - start);
+    return input.subspan(start, position - start);
 }
 
 MediaFragmentURIParser::MediaFragmentURIParser(const URL& url)
@@ -175,7 +175,7 @@ void MediaFragmentURIParser::parseTimeFragment()
         
         MediaTime start = MediaTime::invalidTime();
         MediaTime end = MediaTime::invalidTime();
-        if (parseNPTFragment(fragment.second.characters8(), fragment.second.length(), start, end)) {
+        if (parseNPTFragment(fragment.second.span8(), start, end)) {
             m_startTime = start;
             m_endTime = end;
             m_timeFormat = NormalPlayTime;
@@ -191,13 +191,13 @@ void MediaFragmentURIParser::parseTimeFragment()
     m_fragments.clear();
 }
 
-bool MediaFragmentURIParser::parseNPTFragment(const LChar* timeString, unsigned length, MediaTime& startTime, MediaTime& endTime)
+bool MediaFragmentURIParser::parseNPTFragment(std::span<const LChar> timeString, MediaTime& startTime, MediaTime& endTime)
 {
     unsigned offset = 0;
-    if (length >= nptIdentifierLength && timeString[0] == 'n' && timeString[1] == 'p' && timeString[2] == 't' && timeString[3] == ':')
+    if (timeString.size() >= nptIdentifierLength && timeString[0] == 'n' && timeString[1] == 'p' && timeString[2] == 't' && timeString[3] == ':')
         offset += nptIdentifierLength;
 
-    if (offset == length)
+    if (offset == timeString.size())
         return false;
     
     // http://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/#naming-time
@@ -206,22 +206,22 @@ bool MediaFragmentURIParser::parseNPTFragment(const LChar* timeString, unsigned 
     if (timeString[offset] == ',')
         startTime = MediaTime::zeroTime();
     else {
-        if (!parseNPTTime(timeString, length, offset, startTime))
+        if (!parseNPTTime(timeString, offset, startTime))
             return false;
     }
 
-    if (offset == length)
+    if (offset == timeString.size())
         return true;
 
     if (timeString[offset] != ',')
         return false;
-    if (++offset == length)
+    if (++offset == timeString.size())
         return false;
 
-    if (!parseNPTTime(timeString, length, offset, endTime))
+    if (!parseNPTTime(timeString, offset, endTime))
         return false;
 
-    if (offset != length)
+    if (offset != timeString.size())
         return false;
     
     if (startTime >= endTime)
@@ -230,12 +230,12 @@ bool MediaFragmentURIParser::parseNPTFragment(const LChar* timeString, unsigned 
     return true;
 }
 
-bool MediaFragmentURIParser::parseNPTTime(const LChar* timeString, unsigned length, unsigned& offset, MediaTime& time)
+bool MediaFragmentURIParser::parseNPTTime(std::span<const LChar> timeString, unsigned& offset, MediaTime& time)
 {
     enum Mode { minutes, hours };
     Mode mode = minutes;
 
-    if (offset >= length || !isASCIIDigit(timeString[offset]))
+    if (offset >= timeString.size() || !isASCIIDigit(timeString[offset]))
         return false;
 
     // http://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/#npttimedef
@@ -257,18 +257,18 @@ bool MediaFragmentURIParser::parseNPTTime(const LChar* timeString, unsigned leng
     // npt-mm        =   2DIGIT      ; 0-59
     // npt-ss        =   2DIGIT      ; 0-59
 
-    String digits1 = collectDigits(timeString, length, offset);
+    String digits1 = collectDigits(timeString, offset);
     int value1 = parseInteger<int>(digits1).value_or(0);
-    if (offset >= length || timeString[offset] == ',') {
+    if (offset >= timeString.size() || timeString[offset] == ',') {
         time = MediaTime::createWithDouble(value1);
         return true;
     }
 
     MediaTime fraction;
     if (timeString[offset] == '.') {
-        if (offset == length)
+        if (offset == timeString.size())
             return true;
-        auto digits = collectFraction(timeString, length, offset);
+        auto digits = collectFraction(timeString, offset);
         bool isValid;
         fraction = MediaTime::createWithDouble(digits.toDouble(isValid));
         time = MediaTime::createWithDouble(value1) + fraction;
@@ -281,23 +281,23 @@ bool MediaFragmentURIParser::parseNPTTime(const LChar* timeString, unsigned leng
         mode = hours;
 
     // Collect the next sequence of 0-9 after ':'
-    if (offset >= length || timeString[offset++] != ':')
+    if (offset >= timeString.size() || timeString[offset++] != ':')
         return false;
-    if (offset >= length || !isASCIIDigit(timeString[(offset)]))
+    if (offset >= timeString.size() || !isASCIIDigit(timeString[(offset)]))
         return false;
-    String digits2 = collectDigits(timeString, length, offset);
+    String digits2 = collectDigits(timeString, offset);
     if (digits2.length() != 2)
         return false;
     int value2 = parseInteger<int>(digits2).value();
 
     // Detect whether this timestamp includes hours.
     int value3;
-    if (mode == hours || (offset < length && timeString[offset] == ':')) {
-        if (offset >= length || timeString[offset++] != ':')
+    if (mode == hours || (offset < timeString.size() && timeString[offset] == ':')) {
+        if (offset >= timeString.size() || timeString[offset++] != ':')
             return false;
-        if (offset >= length || !isASCIIDigit(timeString[offset]))
+        if (offset >= timeString.size() || !isASCIIDigit(timeString[offset]))
             return false;
-        String digits3 = collectDigits(timeString, length, offset);
+        String digits3 = collectDigits(timeString, offset);
         if (digits3.length() != 2)
             return false;
         value3 = parseInteger<int>(digits3).value();
@@ -307,9 +307,9 @@ bool MediaFragmentURIParser::parseNPTTime(const LChar* timeString, unsigned leng
         value1 = 0;
     }
 
-    if (offset < length && timeString[offset] == '.') {
+    if (offset < timeString.size() && timeString[offset] == '.') {
         bool isValid;
-        fraction = MediaTime::createWithDouble(collectFraction(timeString, length, offset).toDouble(isValid));
+        fraction = MediaTime::createWithDouble(collectFraction(timeString, offset).toDouble(isValid));
     }
     
     time = MediaTime::createWithDouble((value1 * secondsPerHour) + (value2 * secondsPerMinute) + value3) + fraction;

--- a/Source/WebCore/html/MediaFragmentURIParser.h
+++ b/Source/WebCore/html/MediaFragmentURIParser.h
@@ -47,8 +47,8 @@ private:
     
     enum TimeFormat { None, Invalid, NormalPlayTime, SMPTETimeCode, WallClockTimeCode };
     void parseTimeFragment();
-    bool parseNPTFragment(const LChar*, unsigned length, MediaTime& startTime, MediaTime& endTime);
-    bool parseNPTTime(const LChar*, unsigned length, unsigned& offset, MediaTime&);
+    bool parseNPTFragment(std::span<const LChar>, MediaTime& startTime, MediaTime& endTime);
+    bool parseNPTTime(std::span<const LChar>, unsigned& offset, MediaTime&);
 
     URL m_url;
     TimeFormat m_timeFormat;


### PR DESCRIPTION
#### 80048c7a5d58bf64d74980b482916878ae7610bc
<pre>
Do some more std::span adoption
<a href="https://bugs.webkit.org/show_bug.cgi?id=272881">https://bugs.webkit.org/show_bug.cgi?id=272881</a>

Reviewed by Geoffrey Garen.

* Source/JavaScriptCore/API/JSStringRef.cpp:
(JSStringCreateWithUTF8CString):
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::InputStream::InputStream):
(JSC::Yarr::Interpreter::Interpreter):
(JSC::Yarr::interpret):
* Source/JavaScriptCore/yarr/YarrInterpreter.h:
* Source/WTF/wtf/Assertions.cpp:
(WTF::createWithFormatAndArguments):
* Source/WTF/wtf/text/StringView.cpp:
(WTF::convertASCIICase):
(WTF::StringView::convertToASCIILowercase const):
(WTF::StringView::convertToASCIIUppercase const):
(WTF::convertASCIILowercaseAtom):
(WTF::StringView::convertToASCIILowercaseAtom const):
* Source/WTF/wtf/unicode/icu/CollatorICU.cpp:
(WTF::createLatin1Iterator):
(WTF::createIterator):
* Source/WebCore/dom/Document.cpp:
(WebCore::isValidNameASCIIWithoutColon):
(WebCore::Document::parseQualifiedName):
* Source/WebCore/html/MediaFragmentURIParser.cpp:
(WebCore::collectDigits):
(WebCore::collectFraction):
(WebCore::MediaFragmentURIParser::parseTimeFragment):
(WebCore::MediaFragmentURIParser::parseNPTFragment):
(WebCore::MediaFragmentURIParser::parseNPTTime):
* Source/WebCore/html/MediaFragmentURIParser.h:

Canonical link: <a href="https://commits.webkit.org/277678@main">https://commits.webkit.org/277678@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66f802902ebab38301998ca0f71098b20973def4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48249 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51203 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50937 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44314 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50554 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33395 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24981 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39407 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48831 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41686 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20556 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22637 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42864 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6305 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/41546 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44596 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52841 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/47740 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23296 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19649 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46747 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24561 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41865 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45658 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25366 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55235 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6859 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24284 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11356 "Passed tests") | 
<!--EWS-Status-Bubble-End-->