### PR TITLE
[WebGPU] ComputePassEncoder::setBindGroup crashes under some invalid arguments

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2089,6 +2089,8 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Debug ] fast/workers/worker-cloneport.html [ Slow ]
 [ Debug ] fast/webgpu/present-without-compute-pipeline.html [ Slow ]
 [ Debug ] fast/webgpu/multidimensional-texture-bounds.html [ Slow ]
+[ Debug ] fast/webgpu/fuzz-272863.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-272863.html [ Pass Failure ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/fuzz-272863-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-272863-expected.txt
@@ -1,0 +1,675 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 982x5202
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x5202
+  RenderBlock {HTML} at (0,0) size 785x5202 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x5186
+      RenderText {#text} at (32,137) size 26x17
+        text run at (32,137) width 26: "\x{C1AA}\x{C94}"
+      RenderText {#text} at (57,137) size 87x17
+        text run at (57,137) width 87: "\x{4F78}\x{D83F}\x{DE8B}\x{D83F}\x{DDDC}\x{9E7}\x{C52}\x{63A9}\x{77E1}"
+      RenderText {#text} at (443,137) size 62x17
+        text run at (443,137) width 62: "\x{910F}\x{742A}\x{B92}\x{D83D}\x{DE81}"
+      RenderText {#text} at (504,137) size 65x17
+        text run at (504,137) width 65: "\x{D75}\x{BE26}\x{D83E}\x{DED9}\x{2ABB}"
+      RenderText {#text} at (568,137) size 98x17
+        text run at (568,137) width 98: "\x{A76}\x{44CD}\x{DF6}\x{4F0}\x{1C62}\x{FD8}\x{235A}\x{173E}\x{D83F}\x{DED7}"
+      RenderText {#text} at (665,137) size 72x17
+        text run at (665,137) width 72: "\x{D83E}\x{DD5B}\x{200B}\x{D83D}\x{DFEA}\x{1A46}\x{AB6F}\x{D83F}\x{DF12}"
+      RenderText {#text} at (300,296) size 63x17
+        text run at (300,296) width 15: "\x{34E5}"
+        text run at (315,296) width 11 RTL: "\x{85D}"
+        text run at (325,296) width 38: "\x{F632}\x{B956}\x{FFC}"
+      RenderText {#text} at (362,296) size 123x17
+        text run at (362,296) width 123: "\x{4E06}\x{CECA}\x{D83F}\x{DED1}\x{E430}\x{96AB}\x{85DD}\x{575E}\x{1D9}\x{879E}"
+      RenderText {#text} at (484,296) size 79x17
+        text run at (484,296) width 79: "\x{D83E}\x{DCE2}\x{AD5}\x{8870}\x{20C7}\x{B348}\x{AD31}"
+      RenderText {#text} at (562,296) size 45x17
+        text run at (562,296) width 35: "\x{C6E8}\x{D83E}\x{DC2A}\x{A026}"
+        text run at (596,296) width 11 RTL: "\x{7DA}"
+      RenderText {#text} at (606,296) size 82x17
+        text run at (606,296) width 16: "\x{3FBE}"
+        text run at (621,296) width 10 RTL: "\x{72F}\x{82B}"
+        text run at (630,296) width 58: "\x{91B1}\x{1F7}\x{D83F}\x{DC56}\x{ED0}\x{77B4}"
+      RenderText {#text} at (600,454) size 70x17
+        text run at (600,454) width 70: "\x{9AA}\x{4946}\x{4B32}\x{D83E}\x{DCA5}\x{908}\x{D83F}\x{DF1A}"
+      RenderImage {IMG} at (284,592) size 21x165
+      RenderText {#text} at (305,744) size 80x17
+        text run at (305,744) width 80: "\x{3091}\x{9AD}\x{ABA2}\x{CFD}\x{D83D}\x{DF95}\x{B13}\x{4B0E}"
+      RenderText {#text} at (384,744) size 154x17
+        text run at (384,744) width 63: "\x{C22}\x{4C66}\x{A99C}\x{D83E}\x{DEB0}"
+        text run at (446,744) width 15 RTL: "\x{6FA}"
+        text run at (460,744) width 78: "\x{F675}\x{5712}\x{E343}\x{A88A}\x{4B4}\x{608C}"
+      RenderText {#text} at (553,744) size 36x17
+        text run at (553,744) width 36: "\x{55A7}\x{D83F}\x{DF2E}\x{2DD8}"
+      RenderText {#text} at (588,744) size 107x17
+        text run at (588,744) width 60: "\x{D83E}\x{DC95}\x{16CF}\x{C63A}\x{82D}\x{A2F8}\x{D83D}\x{DFD8}"
+        text run at (647,744) width 12 RTL: "\x{86B}"
+        text run at (658,744) width 37: "\x{A737}\x{D83F}\x{DF22}\x{D83F}\x{DFBF}"
+      RenderText {#text} at (0,744) size 762x181
+        text run at (694,744) width 68: "\x{1401}\x{CD2}\x{B6E4}\x{8940}\x{AF27}"
+        text run at (0,908) width 57: "\x{CAE4}\x{90}\x{8DB9}\x{1EC8}\x{FF00}"
+      RenderText {#text} at (72,908) size 37x17
+        text run at (72,908) width 27: "\x{B66D}\x{592}\x{D83F}\x{DEDD}"
+        text run at (98,908) width 11 RTL: "\x{64A}"
+      RenderText {#text} at (457,908) size 94x17
+        text run at (457,908) width 94: "\x{5D93}\x{D7F}\x{5957}\x{D83E}\x{DE78}\x{51B}\x{E8D}\x{D7C}"
+      RenderText {#text} at (550,908) size 120x17
+        text run at (550,908) width 120: "\x{7195}\x{556F}\x{D83E}\x{DCAE}\x{ED7}\x{D83F}\x{DC74}\x{D83F}\x{DC9A}\x{D83F}\x{DF3F}\x{D83E}\x{DE67}\x{C08D}\x{2E51}"
+      RenderText {#text} at (0,908) size 755x175
+        text run at (669,908) width 86: "\x{D83E}\x{DF48}\x{25CA}\x{5554}\x{4281}\x{D83F}\x{DF60}\x{E4EE}\x{434E}"
+        text run at (0,1066) width 20 RTL: "\x{FD79}"
+        text run at (19,1066) width 26: "\x{CAA}\x{C890}"
+      RenderText {#text} at (44,1066) size 42x17
+        text run at (44,1066) width 42: "\x{C93}\x{D83D}\x{DE93}\x{995}"
+      RenderText {#text} at (385,1066) size 99x17
+        text run at (385,1066) width 99: "\x{140}\x{30B}\x{D83F}\x{DD8B}\x{E03E}\x{D83E}\x{DF2B}\x{75AD}\x{D83E}\x{DCE1}\x{E7C2}\x{CF21}\x{420}"
+      RenderText {#text} at (483,1066) size 22x17
+        text run at (483,1066) width 22: "\x{D83E}\x{DF49}\x{6}"
+      RenderText {#text} at (504,1066) size 108x17
+        text run at (504,1066) width 108: "\x{C24}\x{4EF}\x{D83F}\x{DED8}\x{30C9}\x{6D71}\x{40B1}\x{D83E}\x{DEF4}\x{F888}"
+      RenderText {#text} at (611,1066) size 115x17
+        text run at (611,1066) width 115: "\x{6EDD}\x{D83E}\x{DD93}\x{929}\x{6982}\x{C1A}\x{E97}\x{4E1}\x{2813}\x{3ED}\x{585}"
+      RenderText {#text} at (0,1066) size 751x42
+        text run at (725,1066) width 26: "\x{EFCC}\x{4DA1}"
+        text run at (0,1091) width 44: "\x{13B}\x{D83E}\x{DC1C}\x{55D6}\x{A35}"
+      RenderText {#text} at (0,1501) size 86x17
+        text run at (0,1501) width 8: "\x{663}"
+        text run at (7,1501) width 79: "\x{73A6}\x{D83D}\x{DF18}\x{F3F}\x{B3C}\x{38BB}\x{B45}\x{823}\x{D83F}\x{DC95}"
+      RenderText {#text} at (85,1501) size 63x17
+        text run at (85,1501) width 63: "\x{4592}\x{21E7}\x{8DB}\x{B90B}\x{499}"
+      RenderText {#text} at (147,1501) size 107x17
+        text run at (147,1501) width 22: "\x{D83F}\x{DD08}\x{D840}"
+        text run at (168,1501) width 15 RTL: "\x{8BE}"
+        text run at (182,1501) width 72: "\x{6A31}\x{407}\x{975}\x{D83F}\x{DFC9}\x{8716}\x{D83F}\x{DE6D}"
+      RenderText {#text} at (253,1501) size 32x17
+        text run at (253,1501) width 32: "\x{2D8F}\x{F772}"
+      RenderText {#text} at (284,1501) size 11x17
+        text run at (284,1501) width 11: "\x{517}\x{343}"
+      RenderText {#text} at (294,1501) size 42x17
+        text run at (294,1501) width 42: "\x{DDBE}\x{5A81}\x{8744}"
+      RenderText {#text} at (335,1501) size 29x17
+        text run at (335,1501) width 29: "\x{A2C5}\x{B79D}\x{B9}"
+      RenderText {#text} at (363,1501) size 72x17
+        text run at (363,1501) width 72: "\x{B3A7}\x{E810}\x{AFF5}\x{B583}\x{46FD}"
+      RenderText {#text} at (434,1501) size 81x17
+        text run at (434,1501) width 81: "\x{1A23}\x{991C}\x{FD7}\x{D83F}\x{DEE9}\x{D83E}\x{DC87}\x{BEF1}\x{D83E}\x{DF30}"
+      RenderText {#text} at (514,1501) size 72x17
+        text run at (514,1501) width 72: "\x{BC91}\x{AD3}\x{D4C}\x{95A}\x{C81E}\x{90A}"
+      RenderText {#text} at (585,1501) size 108x17
+        text run at (585,1501) width 37: "\x{648D}\x{D83E}\x{DCFE}\x{EED5}"
+        text run at (621,1501) width 9 RTL: "\x{7D6}"
+        text run at (629,1501) width 64: "\x{FE45}\x{1A75}\x{EBF6}\x{5997}\x{1B95}\x{C3C}"
+      RenderText {#text} at (213,2180) size 110x17
+        text run at (213,2180) width 15: "\x{730E}"
+        text run at (228,2180) width 22 RTL: "\x{893}\x{63B}"
+        text run at (249,2180) width 74: "\x{37B0}\x{D83D}\x{DF13}\x{7144}\x{A748}\x{D83D}\x{DEA3}\x{654}"
+      RenderHTMLCanvas {CANVAS} at (322,1523) size 301x670
+      RenderText {#text} at (622,2180) size 53x17
+        text run at (622,2180) width 23: "\x{EAD5}\x{D5A}"
+        text run at (644,2180) width 24 RTL: "\x{8B8}\x{FBA}"
+        text run at (667,2180) width 8: "\x{FF}"
+      RenderText {#text} at (674,2180) size 46x17
+        text run at (674,2180) width 46: "\x{4E04}\x{4715}\x{2ED7}"
+      RenderText {#text} at (0,2180) size 739x45
+        text run at (719,2180) width 20: "\x{EDB}\x{A016}"
+        text run at (0,2208) width 51: "\x{4EE}\x{D83D}\x{DF66}\x{E14F}\x{25B}\x{F27C}"
+      RenderText {#text} at (50,2208) size 123x17
+        text run at (50,2208) width 12 RTL: "\x{88F}"
+        text run at (61,2208) width 66: "\x{56DE}\x{75E3}\x{8FF1}\x{D83E}\x{DDF9}"
+        text run at (126,2208) width 11 RTL: "\x{803}"
+        text run at (136,2208) width 37: "\x{185E}\x{4350}\x{295}\x{D83D}\x{DF2A}"
+      RenderText {#text} at (172,2208) size 70x17
+        text run at (172,2208) width 51: "\x{2AF}\x{34CD}\x{725A}\x{D83D}\x{DE76}"
+        text run at (222,2208) width 20 RTL: "\x{FD02}"
+      RenderText {#text} at (241,2208) size 126x17
+        text run at (241,2208) width 38: "\x{D665}\x{9AD8}\x{296}"
+        text run at (278,2208) width 12 RTL: "\x{FB37}"
+        text run at (289,2208) width 67: "\x{BEE8}\x{D83F}\x{DE77}\x{D359}\x{9A67}\x{D83F}\x{DE37}"
+        text run at (355,2208) width 12 RTL: "\x{5FC}"
+      RenderText {#text} at (366,2208) size 57x17
+        text run at (366,2208) width 57: "\x{A5ED}\x{C406}\x{162E}\x{9661}"
+      RenderText {#text} at (422,2208) size 64x17
+        text run at (422,2208) width 64: "\x{FFE}\x{3ACD}\x{4A37}\x{EEAE}\x{D83E}\x{DC79}"
+      RenderText {#text} at (485,2208) size 124x17
+        text run at (485,2208) width 124: "\x{A1}\x{55C}\x{F41D}\x{AA95}\x{3A64}\x{F68F}\x{D83D}\x{DF3B}\x{DA00}\x{855B}\x{C24D}\x{447D}"
+      RenderText {#text} at (608,2208) size 122x17
+        text run at (608,2208) width 122: "\x{F315}\x{41E}\x{DD54}\x{D83E}\x{DDE2}\x{D83D}\x{DEE9}\x{5B24}\x{BBB7}\x{A8A2}\x{24F}"
+      RenderText {#text} at (0,2208) size 760x224
+        text run at (729,2208) width 31: "\x{9C9D}\x{BB35}"
+        text run at (0,2415) width 52: "\x{431F}\x{D83E}\x{DFBF}\x{9FE}\x{4545}"
+      RenderText {#text} at (51,2415) size 138x17
+        text run at (51,2415) width 71: "\x{B606}\x{C420}\x{C27D}\x{308}\x{886E}\x{563}"
+        text run at (121,2415) width 14 RTL: "\x{77D}"
+        text run at (134,2415) width 55: "\x{3948}\x{5EF4}\x{A28E}\x{BAB6}"
+      RenderText {#text} at (204,2415) size 114x17
+        text run at (204,2415) width 114: "\x{CFC9}\x{AB02}\x{BFB0}\x{D83F}\x{DE32}\x{3CC0}\x{8AD8}\x{2711}\x{4D25}"
+      RenderText {#text} at (317,2415) size 104x17
+        text run at (317,2415) width 104: "\x{19EE}\x{9E44}\x{E64A}\x{D83E}\x{DC17}\x{D83E}\x{DE59}\x{62A1}\x{1F7}\x{7F8F}"
+      RenderText {#text} at (420,2415) size 46x17
+        text run at (420,2415) width 46: "\x{2458}\x{D83E}\x{DDEF}\x{27C8}"
+      RenderText {#text} at (465,2415) size 28x17
+        text run at (465,2415) width 28: "\x{C985}\x{1645}"
+      RenderImage {IMG} at (492,2227) size 182x201
+      RenderText {#text} at (673,2415) size 61x17
+        text run at (673,2415) width 61: "\x{D83F}\x{DE63}\x{D83D}\x{DEC6}\x{3355}\x{D83E}\x{DF0E}\x{17A6}"
+      RenderText {#text} at (290,2554) size 67x17
+        text run at (290,2554) width 67: "\x{89}\x{4AC3}\x{9A87}\x{E4F1}\x{8154}"
+      RenderText {#text} at (356,2554) size 120x17
+        text run at (356,2554) width 72: "\x{D83E}\x{DE82}\x{1D98}\x{629D}\x{AE61}\x{7BCB}"
+        text run at (427,2554) width 14 RTL: "\x{852}"
+        text run at (440,2554) width 36: "\x{B2BB}\x{28EC}\x{29B1}"
+      RenderText {#text} at (475,2554) size 51x17
+        text run at (475,2554) width 51: "\x{D83D}\x{DF4E}\x{D83F}\x{DC12}\x{634B}\x{6008}"
+      RenderText {#text} at (525,2554) size 118x17
+        text run at (525,2554) width 118: "\x{278}\x{4C70}\x{905}\x{D83E}\x{DD64}\x{D83E}\x{DED5}\x{A441}\x{D83F}\x{DE86}\x{D83E}\x{DFDA}\x{D83F}\x{DFAB}"
+      RenderText {#text} at (0,2554) size 767x175
+        text run at (642,2554) width 71: "\x{2F6C}\x{9192}\x{586B}\x{291}\x{4D45}"
+        text run at (712,2554) width 25 RTL: "\x{FD21}"
+        text run at (736,2554) width 31: "\x{CF1C}\x{8A0B}"
+        text run at (0,2712) width 11: "\x{E4C8}"
+      RenderImage {IMG} at (10,2573) size 295x152
+      RenderText {#text} at (304,2712) size 88x17
+        text run at (304,2712) width 40: "\x{A78E}\x{63A3}\x{C4AF}"
+        text run at (343,2712) width 10 RTL: "\x{843}"
+        text run at (352,2712) width 40: "\x{30B2}\x{AE1B}\x{A810}"
+      RenderText {#text} at (391,2712) size 26x17
+        text run at (391,2712) width 26: "\x{D83D}\x{DEED}\x{98D1}"
+      RenderText {#text} at (416,2712) size 103x17
+        text run at (416,2712) width 103: "\x{C934}\x{C655}\x{1CA}\x{ACA}\x{D83E}\x{DC1C}'\x{D83E}\x{DD9D}\x{D83F}\x{DC62}"
+      RenderText {#text} at (518,2712) size 81x17
+        text run at (518,2712) width 27: "\x{BCE}\x{3CEB}"
+        text run at (544,2712) width 9 RTL: "\x{5E8}"
+        text run at (552,2712) width 47: "\x{397B}\x{F98}\x{A58}\x{2104}"
+      RenderImage {IMG} at (300,2765) size 26x233
+      RenderText {#text} at (626,2985) size 70x17
+        text run at (626,2985) width 55: "\x{D83D}\x{DEF7}\x{83C5}\x{D83E}\x{DDE1}"
+        text run at (681,2985) width 15 RTL: "\x{5D4}\x{846}"
+      RenderText {#text} at (0,2985) size 756x252
+        text run at (695,2985) width 61: "\x{D8E}\x{9EB9}\x{9FD5}\x{D83F}\x{DE5F}"
+        text run at (0,3220) width 53: "\x{88DA}\x{655}\x{D83F}\x{DF38}\x{B757}\x{3D8}\x{FE2A}"
+      RenderText {#text} at (52,3220) size 48x17
+        text run at (52,3220) width 48: "\x{2602}\x{5A15}\x{1797}\x{A38}"
+      RenderText {#text} at (99,3220) size 52x17
+        text run at (99,3220) width 52: "\x{DA07}\x{547E}\x{D83D}\x{DF3C}\x{8CAF}"
+      RenderImage {IMG} at (150,3004) size 247x229
+      RenderText {#text} at (396,3220) size 47x17
+        text run at (396,3220) width 47: "\x{D83F}\x{DC3E}\x{262}\x{3E0D}\x{E7E9}"
+      RenderText {#text} at (442,3220) size 103x17
+        text run at (442,3220) width 27: "\x{D851}\x{5F41}"
+        text run at (468,3220) width 20 RTL: "\x{837}"
+        text run at (487,3220) width 58: "\x{B48}\x{D83E}\x{DCB0}\x{BDCB}\x{B8EC}"
+      RenderText {#text} at (544,3220) size 46x17
+        text run at (544,3220) width 46: "\x{7A6}\x{90EE}\x{548D}\x{B538}"
+      RenderText {#text} at (589,3220) size 60x17
+        text run at (589,3220) width 8: "\x{31F}"
+        text run at (596,3220) width 8 RTL: "\x{676}"
+        text run at (603,3220) width 46: "\x{7053}\x{2F9B}\x{305}\x{657A}"
+      RenderText {#text} at (648,3220) size 105x17
+        text run at (648,3220) width 63: "\x{A6B}\x{AA0}\x{4013}\x{8F6E}\x{A9D1}\x{6DB}"
+        text run at (710,3220) width 6 RTL: "\x{FE97}"
+        text run at (715,3220) width 38: "\x{7754}\x{2FAF}\x{D83D}\x{DF4C}"
+      RenderText {#text} at (0,3220) size 764x47
+        text run at (752,3220) width 12: "\x{2EF8}"
+        text run at (0,3250) width 15: "\x{37A9}"
+      RenderText {#text} at (0,3421) size 56x17
+        text run at (0,3421) width 56: "\x{D83F}\x{DC0D}\x{67DC}\x{6EA3}\x{3A79}"
+      RenderText {#text} at (55,3421) size 67x17
+        text run at (55,3421) width 67: "\x{1}\x{CA89}\x{7852}\x{BDBC}\x{BED}"
+      RenderText {#text} at (0,3834) size 55x17
+        text run at (0,3834) width 55: "\x{3EA}\x{5659}\x{B224}\x{5A3A}"
+      RenderImage {IMG} at (54,3788) size 47x59
+      RenderText {#text} at (100,3834) size 93x17
+        text run at (100,3834) width 93: "\x{7D65}\x{4D20}\x{898}\x{D83F}\x{DE70}\x{B767}\x{90C}\x{4CCF}"
+      RenderText {#text} at (527,3834) size 122x17
+        text run at (527,3834) width 122: "\x{8AA4}\x{A3E}\x{B9F}\x{1F10}\x{E49}\x{D83F}\x{DF44}\x{B78}\x{CE88}\x{19F5}\x{D83D}\x{DEC0}"
+      RenderText {#text} at (648,3834) size 93x17
+        text run at (648,3834) width 67: "\x{DAB}\x{B758}\x{E82}\x{339}\x{D754}\x{98B}"
+        text run at (714,3834) width 12 RTL: "\x{895}"
+        text run at (725,3834) width 16: "\x{B544}"
+      RenderText {#text} at (0,3973) size 117x17
+        text run at (0,3973) width 117: "\x{5DE9}\x{BAC7}\x{615A}\x{443}\x{D83E}\x{DC0B}\x{5AE9}\x{FB8}\x{3E2D}\x{45A8}"
+      RenderImage {IMG} at (116,3920) size 156x66
+      RenderText {#text} at (271,3973) size 111x17
+        text run at (271,3973) width 111: "\x{4456}\x{763D}\x{6858}\x{3197}\x{7B4A}\x{A6C5}\x{13D1}\x{AE2C}"
+      RenderText {#text} at (381,3973) size 82x17
+        text run at (381,3973) width 82: "\x{4907}\x{B652}\x{D83E}\x{DE43}\x{CBD5}\x{C520}\x{459}"
+      RenderImage {IMG} at (462,3859) size 288x127
+      RenderText {#text} at (0,4001) size 120x17
+        text run at (0,4001) width 120: "\x{D83F}\x{DDA7}\x{363}\x{D83E}\x{DC47}\x{5E75}\x{D83F}\x{DE23}\x{1AE}\x{A8E5}\x{D83F}\x{DEF3}\x{48DF}\x{5107}"
+      RenderText {#text} at (119,4001) size 27x17
+        text run at (119,4001) width 27: "\x{E95D}\x{BA46}"
+      RenderText {#text} at (145,4001) size 110x17
+        text run at (145,4001) width 99: "\x{6D9B}\x{D83D}\x{DE24}\x{8BA2}\x{6CE6}\x{E9B}\x{D83E}\x{DFA8}\x{1361}\x{22DE}"
+        text run at (243,4001) width 12 RTL: "\x{621}\x{709}"
+      RenderText {#text} at (254,4001) size 35x17
+        text run at (254,4001) width 35: "\x{D83F}\x{DD69}\x{5660}\x{A0E6}"
+      RenderText {#text} at (288,4001) size 84x17
+        text run at (288,4001) width 84: "\x{6B8D}\x{CD3F}{\x{BA63}\x{D83F}\x{DC58}\x{D83E}\x{DE79}"
+      RenderText {#text} at (371,4001) size 79x17
+        text run at (371,4001) width 79: "\x{6BB9}\x{D83F}\x{DEA4}\x{2C97}\x{2972}\x{1BF}\x{DE85}\x{CFE7}"
+      RenderText {#text} at (449,4001) size 67x17
+        text run at (449,4001) width 67: "\x{EF1}\x{B007}\x{3F51}\x{261D}\x{D83F}\x{DC63}"
+      RenderText {#text} at (515,4001) size 76x17
+        text run at (515,4001) width 44: "\x{98B8}\x{29B}\x{9DD}\x{D83E}\x{DF77}"
+        text run at (558,4001) width 12 RTL: "\x{812}"
+        text run at (569,4001) width 22: "\x{970}\x{4E6C}"
+      RenderText {#text} at (590,4001) size 140x17
+        text run at (590,4001) width 140: "\x{D83D}\x{DFE5}\x{D83E}\x{DC26}\x{61CA}\x{D83E}\x{DE1C}\x{D83E}\x{DC4B}\x{8674}\x{3056}\x{1992}\x{37B8}\x{8F24}"
+      RenderImage {IMG} at (0,4272) size 76x41
+      RenderText {#text} at (76,4300) size 26x17
+        text run at (76,4300) width 26: "\x{E444}\x{8A50}"
+      RenderText {#text} at (101,4300) size 123x17
+        text run at (101,4300) width 123: "\x{6E4}\x{312}\x{D83E}\x{DDBF}\x{D3EF}\x{2A01}\x{8F1B}\x{24D5}\x{D83F}\x{DD89}\x{CE5}\x{4551}"
+      RenderImage {IMG} at (223,4251) size 56x62
+      RenderText {#text} at (278,4300) size 31x17
+        text run at (278,4300) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (308,4300) size 81x17
+        text run at (308,4300) width 81: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (388,4300) size 69x17
+        text run at (388,4300) width 7 RTL: "\x{692}"
+        text run at (394,4300) width 63: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (0,4363) size 298x170
+      RenderText {#text} at (298,4520) size 103x17
+        text run at (298,4520) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (438,4520) size 100x17
+        text run at (438,4520) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (537,4520) size 117x17
+        text run at (537,4520) width 32: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (568,4520) width 10 RTL: "\x{79B}"
+        text run at (577,4520) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (0,4540) size 292x253
+      RenderText {#text} at (292,4780) size 103x17
+        text run at (292,4780) width 103: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (394,4780) size 105x17
+        text run at (394,4780) width 105: "\x{10D}\x{BA96}\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (498,4780) size 102x17
+        text run at (498,4780) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (599,4780) size 116x17
+        text run at (599,4780) width 116: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (0,4811) size 34x17
+        text run at (0,4811) width 34: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (33,4811) size 120x17
+        text run at (33,4811) width 26: "\x{24BF}\x{B00}"
+        text run at (58,4811) width 12 RTL: "\x{5FF}"
+        text run at (69,4811) width 14: "\x{2FA}\x{B13}"
+        text run at (82,4811) width 11 RTL: "\x{8BC}"
+        text run at (92,4811) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (152,4811) size 88x17
+        text run at (152,4811) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (239,4811) size 88x17
+        text run at (239,4811) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (326,4811) size 22x17
+        text run at (326,4811) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (347,4811) size 111x17
+        text run at (347,4811) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (457,4811) size 79x17
+        text run at (457,4811) width 79: "\x{ECB8}\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (535,4811) size 85x17
+        text run at (535,4811) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+      RenderText {#text} at (619,4811) size 100x17
+        text run at (619,4811) width 80: "\x{D83F}\x{DD83}\x{D83F}\x{DD58}\x{6EE2}\x{47A3}\x{10B}\x{2CC7}\x{BC62}"
+        text run at (698,4811) width 10 RTL: "\x{67F}"
+        text run at (707,4811) width 12: "\x{D83F}\x{DC12}"
+      RenderText {#text} at (0,4811) size 752x45
+        text run at (718,4811) width 34: "\x{F24}\x{A756}\x{4864}"
+        text run at (0,4839) width 116: "\x{D83D}\x{DF2C}\x{D83E}\x{DD04}\x{D83D}\x{DFF9}\x{D83E}\x{DD6D}\x{D83D}\x{DF33}\x{9AA9}\x{FF4C}\x{D83E}\x{DEAD}"
+      RenderText {#text} at (115,4839) size 52x17
+        text run at (115,4839) width 27: "\x{84E2}\x{D83E}\x{DCB2}"
+        text run at (141,4839) width 11 RTL: "\x{793}"
+        text run at (151,4839) width 16: "\x{812B}"
+      RenderText {#text} at (166,4839) size 119x17
+        text run at (166,4839) width 119: "\x{CD98}\x{D83E}\x{DEF8}\x{D83E}\x{DDA7}\x{AF08}\x{4EB8}\x{1243}\x{B2E}\x{FF7}"
+      RenderText {#text} at (284,4839) size 96x17
+        text run at (284,4839) width 96: "\x{1E56}\x{DB7F}\x{3BE0}\x{9F86}\x{4C4D}\x{D83F}\x{DCB1}\x{D83E}\x{DD9F}"
+      RenderText {#text} at (379,4839) size 60x17
+        text run at (379,4839) width 16: "\x{AC6C}"
+        text run at (394,4839) width 15 RTL: "\x{84C}"
+        text run at (408,4839) width 31: "\x{3CFB}\x{C01}"
+      RenderText {#text} at (438,4839) size 84x17
+        text run at (438,4839) width 84: "\x{C96F}\x{CFE}\x{D83E}\x{DD4C}\x{2EB1}\x{BFB}\x{D83F}\x{DFDA}"
+      RenderText {#text} at (521,4839) size 74x17
+        text run at (521,4839) width 74: "\x{966}\x{D83D}\x{DE44}\x{F51D}\x{D83E}\x{DF45}\x{F91}\x{2772}\x{D83F}\x{DF3B}"
+      RenderText {#text} at (594,4839) size 89x17
+        text run at (594,4839) width 67: "\x{94A5}\x{8A96}\x{6D75}\x{D83F}\x{DC81}\x{180}"
+        text run at (660,4839) width 12 RTL: "\x{6A6}"
+        text run at (671,4839) width 12: "\x{D83F}\x{DC37}"
+      RenderText {#text} at (682,4839) size 78x17
+        text run at (682,4839) width 58: "\x{EA1}\x{FB1}\x{A34}\x{5543}\x{D83F}\x{DF64}"
+        text run at (739,4839) width 13 RTL: "\x{801}"
+        text run at (751,4839) width 9: "\x{2EE1}"
+      RenderText {#text} at (0,4865) size 34x17
+        text run at (0,4865) width 34: "\x{1498}\x{D83F}\x{DE40}\x{D83E}\x{DC29}"
+      RenderText {#text} at (33,4865) size 23x17
+        text run at (33,4865) width 23: "\x{3040}\x{D83E}\x{DE44}"
+      RenderText {#text} at (55,4865) size 74x17
+        text run at (55,4865) width 74: "\x{D83F}\x{DF07}\x{DE60}\x{958}\x{D83F}\x{DD30}\x{4AC5}\x{3F37}"
+      RenderText {#text} at (128,4865) size 133x17
+        text run at (128,4865) width 133: "\x{7F0}\x{9CF}\x{C47A}\x{D74}\x{161C}\x{1F13}\x{97BB}\x{4FF7}\x{3AEF}\x{D83E}\x{DC98}\x{DDA}"
+      RenderText {#text} at (260,4865) size 111x17
+        text run at (260,4865) width 111: "\x{E60A}\x{5E72}\x{FAFC}\x{A318}\x{960}\x{9825}\x{265E}\x{6633}\x{6C91}"
+      RenderText {#text} at (370,4865) size 109x17
+        text run at (370,4865) width 61: "\x{739A}\x{2679}\x{24C2}\x{4019}"
+        text run at (430,4865) width 12 RTL: "\x{5C9}"
+        text run at (441,4865) width 38: "\x{CEE6}\x{D83E}\x{DF11}\x{A44}"
+      RenderText {#text} at (478,4865) size 32x17
+        text run at (478,4865) width 32: "\x{A89}\x{D83E}\x{DE59}\x{D83E}\x{DE6F}"
+      RenderText {#text} at (509,4865) size 83x17
+        text run at (509,4865) width 68: "\x{C1D6}\x{DC6A}\x{6930}\x{9921}\x{432}\x{ED}"
+        text run at (576,4865) width 5 RTL: "\x{701}"
+        text run at (580,4865) width 12: "\x{C84}"
+      RenderText {#text} at (591,4865) size 98x17
+        text run at (591,4865) width 98: "\x{D83D}\x{DE53}\x{D83F}\x{DC79}\x{C460}\x{BEF2}\x{4C04}\x{156}\x{372}\x{47A}"
+      RenderText {#text} at (688,4865) size 23x17
+        text run at (688,4865) width 23: "\x{D83E}\x{DC7C}\x{D83F}\x{DC5B}"
+      RenderText {#text} at (0,4865) size 756x43
+        text run at (710,4865) width 46: "\x{37FE}\x{9416}\x{9668}"
+        text run at (0,4891) width 54: "\x{E6B0}\x{F1F}\x{E27B}\x{B1B}\x{6F8B}"
+      RenderText {#text} at (53,4891) size 89x17
+        text run at (53,4891) width 89: "\x{533}\x{D83F}\x{DDD9}\x{C481}\x{C5EC}\x{A889}\x{49D9}\x{D83F}\x{DEBB}"
+      RenderText {#text} at (141,4891) size 120x17
+        text run at (141,4891) width 16: "\x{589C}"
+        text run at (156,4891) width 12 RTL: "\x{5CC}"
+        text run at (167,4891) width 49: "\x{1FF}\x{8296}\x{D83F}\x{DD87}\x{C9CD}"
+        text run at (215,4891) width 11 RTL: "\x{5E1}"
+        text run at (225,4891) width 12: "\x{EB97}"
+        text run at (236,4891) width 14 RTL: "\x{8B6}"
+        text run at (249,4891) width 12: "\x{D83E}\x{DE33}"
+      RenderText {#text} at (260,4891) size 70x17
+        text run at (260,4891) width 70: "\x{29E}\x{3AD8}\x{911F}\x{4170}\x{89AC}"
+      RenderText {#text} at (329,4891) size 127x17
+        text run at (329,4891) width 127: "\x{DAE}\x{D83E}\x{DFD0}\x{D676}\x{7A82}\x{D83F}\x{DC92}\x{D33}\x{99C8}\x{D83E}\x{DD52}\x{8FDE}\x{140}"
+      RenderText {#text} at (455,4891) size 145x17
+        text run at (455,4891) width 128: "\x{D83E}\x{DCB1}\x{D83E}\x{DCB7}\x{D83F}\x{DDE3}\x{B97C}\x{C855}\x{CD5B}\x{CF1}\x{C54C}\x{4043}\x{1535}"
+        text run at (587,4891) width 13 RTL: "\x{83D}"
+      RenderText {#text} at (582,4891) size 84x17
+        text run at (582,4891) width 6 RTL: "\x{5D5}"
+        text run at (599,4891) width 67: "\x{5E92}\x{1E8A}\x{9A39}\x{D29}\x{D83F}\x{DEBA}"
+      RenderText {#text} at (665,4891) size 31x17
+        text run at (665,4891) width 31: "\x{47B5}\x{8C8D}"
+      RenderText {#text} at (0,4891) size 764x45
+        text run at (695,4891) width 69: "\x{275C}\x{145}\x{C5C7}\x{F654}\x{DAD7}\x{BDD7}"
+        text run at (0,4919) width 19: "n\x{F047}"
+      RenderText {#text} at (18,4919) size 120x17
+        text run at (18,4919) width 28: "\x{ABB4}\x{AACB}\x{A19}"
+        text run at (45,4919) width 15 RTL: "\x{717}"
+        text run at (59,4919) width 79: "\x{E620}\x{D83E}\x{DC2C}\x{D83D}\x{DE54}\x{2C3}\x{BD07}\x{536}\x{4AFF}"
+      RenderText {#text} at (137,4919) size 63x17
+        text run at (137,4919) width 32: "\x{D83E}\x{DDCC}\x{D83E}\x{DC21}"
+        text run at (168,4919) width 17 RTL: "\x{6BE}\x{769}"
+        text run at (184,4919) width 16: "\x{41BE}"
+      RenderText {#text} at (199,4919) size 41x17
+        text run at (199,4919) width 15 RTL: "\x{808}"
+        text run at (213,4919) width 27: "\x{D83E}\x{DE4B}\x{4961}"
+      RenderText {#text} at (239,4919) size 48x17
+        text run at (239,4919) width 48: "\x{2CE9}\x{E5A6}\x{7C86}\x{10}"
+      RenderText {#text} at (286,4919) size 140x17
+        text run at (286,4919) width 140: "\x{D83F}\x{DE92}\x{E10B}\x{E644}\x{346D}\x{DD9}\x{EC1}\x{1D39}\x{BAE0}\x{CCC}\x{D0A}\x{272D}"
+      RenderText {#text} at (425,4919) size 144x17
+        text run at (425,4919) width 144: "\x{8E33}\x{F5F6}\x{D83E}\x{DD52}\x{542C}\x{AE0C}\x{33F}\x{B49F}\x{D83E}\x{DCA8}\x{DA4}\x{D83F}\x{DC82}\x{6138}"
+      RenderText {#text} at (568,4919) size 102x17
+        text run at (568,4919) width 33: "\x{D83F}\x{DF2D}\x{F4A7}\x{E7C6}"
+        text run at (600,4919) width 10 RTL: "\x{639}"
+        text run at (609,4919) width 27: "\x{FDD}\x{8C02}"
+        text run at (635,4919) width 5 RTL: "\x{627}"
+        text run at (639,4919) width 31: "\x{64C5}\x{3878}"
+      RenderText {#text} at (0,4919) size 768x44
+        text run at (669,4919) width 99: "\x{911D}\x{B0A}\x{D83E}\x{DF5D}\x{530D}\x{D6F0}\x{302}\x{9DF7}\x{D18}"
+        text run at (0,4946) width 15: "\x{B088}\x{EC9}"
+      RenderText {#text} at (14,4946) size 27x17
+        text run at (14,4946) width 12: "\x{D83F}\x{DDBE}"
+        text run at (35,4946) width 6 RTL: "\x{6C0}"
+      RenderText {#text} at (25,4946) size 76x17
+        text run at (25,4946) width 11 RTL: "\x{6D1}"
+        text run at (40,4946) width 61: "\x{B7EC}\x{DC39}\x{73EF}\x{1F90}\x{D83E}\x{DFE6}"
+      RenderText {#text} at (100,4946) size 132x17
+        text run at (100,4946) width 111: "\x{326D}\x{F53}\x{D83E}\x{DCAB}\x{482}\x{D83E}\x{DFFE}\x{B32F}\x{D83F}\x{DD03}\x{5C3E}\x{3D9C}"
+        text run at (210,4946) width 22 RTL: "\x{FCFC}"
+      RenderText {#text} at (231,4946) size 102x17
+        text run at (231,4946) width 77: "\x{8950}\x{4E2A}\x{EDC}\x{D83E}\x{DCD7}\x{D83F}\x{DD84}\x{44E}"
+        text run at (307,4946) width 11 RTL: "\x{848}"
+        text run at (317,4946) width 16: "\x{AF80}"
+      RenderText {#text} at (332,4946) size 129x17
+        text run at (332,4946) width 129: "\x{54D7}\x{E79C}\x{8C16}\x{63C6}\x{F54D}\x{8CEB}\x{8E6}\x{D83E}\x{DD1E}\x{F5BB}\x{AD09}"
+      RenderText {#text} at (460,4946) size 95x17
+        text run at (460,4946) width 95: "\x{D07B}\x{D83D}\x{DEBF}\x{C5}\x{D83E}\x{DCF7}\x{F8}\x{4AC9}\x{6E8E}"
+      RenderText {#text} at (554,4946) size 112x17
+        text run at (554,4946) width 112: "\x{C7FE}\x{AE4D}\x{4827}\x{BA55}\x{62AD}\x{FBA}\x{6065}\x{4EFC}"
+      RenderText {#text} at (0,4946) size 755x45
+        text run at (665,4946) width 90: "\x{10C6}\x{4BF}\x{BBE4}\x{D3B}\x{A0A}\x{B8E}\x{1487}\x{D83F}\x{DC7C}"
+        text run at (0,4974) width 32: "\x{23D}\x{1AA}\x{8F3F}"
+      RenderText {#text} at (31,4974) size 36x17
+        text run at (31,4974) width 36: "\x{328}\x{E96}\x{D83F}\x{DF71}\x{F10F}"
+      RenderText {#text} at (66,4974) size 88x17
+        text run at (66,4974) width 88: "\x{614A}\x{C870}\x{E997}\x{D83F}\x{DE46}\x{2D8B}\x{B80}\x{EFC4}"
+      RenderText {#text} at (153,4974) size 140x17
+        text run at (153,4974) width 140: "\x{496B}\x{D83F}\x{DE84}\x{D3D8}\x{D83D}\x{DF44}\x{1244}\x{D83E}\x{DD7C}\x{3C8A}\x{D73F}\x{E6DF}\x{D83F}\x{DD5E}"
+      RenderText {#text} at (292,4974) size 11x17
+        text run at (292,4974) width 11: "\x{2995}\x{F7D}"
+      RenderText {#text} at (302,4974) size 60x17
+        text run at (302,4974) width 60: "\x{515D}\x{DEA}k\x{D83F}\x{DDE9}\x{D099}"
+      RenderText {#text} at (361,4974) size 83x17
+        text run at (361,4974) width 83: "\x{4936}\x{A04}\x{D83D}\x{DE68}\x{7F8E}\x{5145}\x{3B80}"
+      RenderText {#text} at (443,4974) size 42x17
+        text run at (443,4974) width 42: "\x{B92B}\x{B663}\x{D83F}\x{DF52}"
+      RenderText {#text} at (484,4974) size 32x17
+        text run at (484,4974) width 32: "\x{D83F}\x{DD45}\x{4C8}\x{1500}"
+      RenderText {#text} at (515,4974) size 103x17
+        text run at (515,4974) width 11 RTL: "\x{649}"
+        text run at (525,4974) width 93: "Y\x{E2}\x{D83D}\x{DFCF}\x{BE7}\x{E856}\x{D83D}\x{DF5D}\x{96CF}\x{76BA}"
+      RenderText {#text} at (617,4974) size 71x17
+        text run at (617,4974) width 71: "\x{3190}\x{B978}\x{898}\x{AD2C}\x{CF05}"
+      RenderText {#text} at (687,4974) size 49x17
+        text run at (687,4974) width 49: "\x{D83F}\x{DC2C}\x{DDE0}\x{2E3F}\x{3B9A}"
+      RenderText {#text} at (0,5002) size 78x17
+        text run at (0,5002) width 31: "\x{D83E}\x{DE42}\x{A6E}\x{D9FC}"
+        text run at (30,5002) width 18 RTL: "\x{FC17}"
+        text run at (47,5002) width 31: "\x{24A9}\x{5434}"
+      RenderText {#text} at (77,5002) size 138x17
+        text run at (77,5002) width 138: "\x{8EB0}\x{D83F}\x{DCBB}\x{8B92}\x{4961}\x{D83F}\x{DE5F}\x{815F}\x{1496}\x{75DF}\x{F135}\x{D83E}\x{DCAE}\x{AB94}"
+      RenderText {#text} at (214,5002) size 119x17
+        text run at (214,5002) width 119: "\x{7}\x{F4E}\x{E9C5}\x{D83E}\x{DD16}\x{FF4}\x{C8B2}\x{8885}\x{1181}\x{D83F}\x{DDD6}"
+      RenderText {#text} at (332,5002) size 138x17
+        text run at (332,5002) width 138: "\x{F40D}\x{D83E}\x{DE7B}\x{D83F}\x{DE68}\x{481}\x{1242}\x{BA41}\x{8A50}\x{D83F}\x{DD54}\x{2F2A}\x{D83D}\x{DE49}"
+      RenderText {#text} at (469,5002) size 137x17
+        text run at (469,5002) width 137: "\x{884F}\x{146B}\x{D9C5}\x{D83E}\x{DF3C}\x{40EA}\x{BCD5}\x{5E1B}\x{A59}\x{D83E}\x{DCDD}\x{D83F}\x{DDF0}\x{7C60}"
+      RenderText {#text} at (605,5002) size 119x17
+        text run at (605,5002) width 119: "\x{5BB}\x{D83D}\x{DF58}\x{994}\x{D6F}\x{D83F}\x{DCBF}\x{1E35}\x{DD08}\x{90FE}\x{16AD}\x{B0D1}\x{5E87}"
+      RenderText {#text} at (0,5002) size 758x45
+        text run at (723,5002) width 35: "\x{78F9}\x{D83F}\x{DC10}\x{A0E3}"
+        text run at (0,5030) width 15: "\x{5AFC}"
+      RenderText {#text} at (15,5030) size 130x17
+        text run at (15,5030) width 130: "\x{5084}\x{BECB}\x{6B64}\x{D83E}\x{DC65}\x{D72B}\x{7CD8}\x{D83F}\x{DC17}\x{9C6}\x{D83F}\x{DEF6}\x{7A6}"
+      RenderText {#text} at (144,5030) size 67x17
+        text run at (144,5030) width 67: "\x{21AA}\x{C3A9}\x{32C1}\x{1E22}\x{D00}"
+      RenderText {#text} at (210,5030) size 111x17
+        text run at (210,5030) width 10 RTL: "\x{682}"
+        text run at (219,5030) width 102: "\x{78A3}\x{E49}\x{B61}\x{C2}\x{E55}\x{555}\x{3F5}\x{A4E9}\x{34EC}\x{D83E}\x{DE4D}"
+      RenderText {#text} at (320,5030) size 96x17
+        text run at (320,5030) width 42: "\x{5699}\x{8FFA}\x{F786}"
+        text run at (361,5030) width 9 RTL: "\x{685}"
+        text run at (369,5030) width 47: "\x{1D3F}\x{DB6B}\x{BF05}\x{4083}"
+      RenderText {#text} at (415,5030) size 35x17
+        text run at (415,5030) width 31: "\x{7F14}\x{9D87}"
+        text run at (445,5030) width 5 RTL: "\x{627}"
+      RenderText {#text} at (449,5030) size 53x17
+        text run at (449,5030) width 53: "\x{D83F}\x{DD01}\x{4ED3}\x{60F4}\x{2C4D}"
+      RenderText {#text} at (501,5030) size 52x17
+        text run at (501,5030) width 52: "\x{D404}\x{ADEF}\x{558}\x{D83F}\x{DC9A}"
+      RenderText {#text} at (552,5030) size 73x17
+        text run at (552,5030) width 12: "\x{D83E}\x{DF0D}"
+        text run at (563,5030) width 12 RTL: "\x{5EA}"
+        text run at (574,5030) width 51: "\x{1211}\x{EE55}\x{1C8A}\x{D83F}\x{DEAD}"
+      RenderText {#text} at (0,5030) size 744x42
+        text run at (624,5030) width 120: "\x{D83E}\x{DE97}\x{AFC9}\x{D83F}\x{DC32}\x{D83F}\x{DD2F}\x{20A}\x{F3F1}\x{D83E}\x{DD8F}\x{2E70}\x{3838}"
+        text run at (0,5055) width 11: "\x{D83E}\x{DF9C}"
+      RenderText {#text} at (10,5055) size 121x17
+        text run at (10,5055) width 121: "\x{D83E}\x{DC74}\x{D83D}\x{DF80}\x{FAE}\x{EA64}\x{525}\x{D83F}\x{DF92}\x{D83E}\x{DE4A}\x{4F6}\x{D83F}\x{DE5D}\x{D83E}\x{DF5C}\x{88DC}"
+      RenderText {#text} at (130,5055) size 38x17
+        text run at (130,5055) width 38: "\x{6B58}\x{CF96}\x{168B}"
+      RenderText {#text} at (167,5055) size 108x17
+        text run at (167,5055) width 50: "\x{B850}\x{D83D}\x{DF15}\x{850E}\x{C90}"
+        text run at (216,5055) width 8 RTL: "\x{6C1}"
+        text run at (223,5055) width 52: "\x{D83F}\x{DF5B}\x{6949}\x{4E7E}\x{9BA}"
+      RenderText {#text} at (274,5055) size 110x17
+        text run at (274,5055) width 12: "\x{D83E}\x{DC0E}"
+        text run at (285,5055) width 10 RTL: "\x{7D5}"
+        text run at (294,5055) width 90: "\x{3ADE}\x{D83D}\x{DFBF}\x{55B}\x{D83E}\x{DFD0}\x{F3C9}\x{AFC}\x{D83F}\x{DEA7}\x{FD5}\x{B6C}"
+      RenderText {#text} at (383,5055) size 57x17
+        text run at (383,5055) width 57: "\x{945}\x{5DA4}\x{D83E}\x{DDEE}\x{53A}"
+      RenderText {#text} at (439,5055) size 107x17
+        text run at (439,5055) width 107: "\x{81F7}\x{48AB}\x{2610}\x{6F92}\x{D83E}\x{DC73}\x{8881}\x{45F}\x{F920}"
+      RenderText {#text} at (545,5055) size 128x17
+        text run at (545,5055) width 128: "\x{E4B}\x{DD7}\x{736}\x{F5A}\x{7373}\x{532}\x{D83E}\x{DC9E}\x{D83E}\x{DE64}\x{274A}\x{CBF1}\x{6AA5}"
+      RenderText {#text} at (0,5055) size 751x45
+        text run at (672,5055) width 79: "\x{DEDD}\x{DC4D}\x{D83F}\x{DEBA}\x{D83F}\x{DE46}\x{F56F}\x{141D}\x{BA38}"
+        text run at (0,5083) width 48: "\x{E100}\x{E5A4}\x{E4D8}\x{6679}"
+      RenderText {#text} at (47,5083) size 51x17
+        text run at (47,5083) width 51: "\x{8AC3}\x{5294}\x{E15}\x{F006}"
+      RenderText {#text} at (97,5083) size 123x17
+        text run at (97,5083) width 123: "\x{F769}\x{D83E}\x{DCA1}\x{D83E}\x{DDF9}\x{25AE}\x{72E5}\x{D83E}\x{DCCF}\x{4A8C}\x{D1F0}\x{D83E}\x{DC81}\x{1C7A}"
+      RenderText {#text} at (219,5083) size 118x17
+        text run at (219,5083) width 22: "\x{D83F}\x{DEF5}\x{F8EC}"
+        text run at (240,5083) width 11 RTL: "\x{6D0}"
+        text run at (250,5083) width 16: "\x{487A}"
+        text run at (265,5083) width 7 RTL: "\x{693}"
+        text run at (271,5083) width 66: "\x{F3C}\x{9485}\x{673D}\x{D83E}\x{DCAB}\x{81DF}"
+      RenderText {#text} at (336,5083) size 130x17
+        text run at (336,5083) width 109: "\x{4A16}\x{82C6}\x{643C}\x{D83D}\x{DEB5}\x{135B}\x{DB59}\x{D83F}\x{DF91}\x{EA82}"
+        text run at (444,5083) width 11 RTL: "\x{752}"
+        text run at (454,5083) width 12: "\x{D83E}\x{DC78}"
+      RenderText {#text} at (465,5083) size 22x17
+        text run at (465,5083) width 22: "\x{94EA}\x{227}"
+      RenderText {#text} at (486,5083) size 124x17
+        text run at (486,5083) width 66: "\x{BA4}\x{1557}\x{E7B2}\x{E3DF}\x{D83D}\x{DE1A}"
+        text run at (551,5083) width 18 RTL: "\x{FCFA}"
+        text run at (568,5083) width 42: "\x{82F5}\x{A7BB}\x{C572}"
+      RenderText {#text} at (609,5083) size 105x17
+        text run at (609,5083) width 105: "\x{EDFC}\x{EFEA}\x{99D}\x{BD3D}\x{A907}\x{CBD}\x{D83F}\x{DF12}\x{918}\x{53F}\x{F1}"
+      RenderText {#text} at (713,5083) size 30x17
+        text run at (713,5083) width 23: "\x{AF5}\x{DCE}"
+        text run at (735,5083) width 8 RTL: "\x{84B}"
+      RenderText {#text} at (0,5083) size 758x45
+        text run at (742,5083) width 16: "\x{D83D}\x{DF05}"
+        text run at (0,5111) width 102: "\x{6B6B}\x{A57}\x{D83F}\x{DE71}\x{A8A}\x{FAB9}\x{2E87}\x{E26D}\x{9DC0}"
+      RenderText {#text} at (101,5111) size 127x17
+        text run at (101,5111) width 127: "\x{C1F9}\x{D83F}\x{DE33}\x{F143}\x{815B}\x{D83E}\x{DCFB}\x{AE3E}\x{4D6}\x{246}\x{D83D}\x{DF03}\x{B53D}"
+      RenderText {#text} at (227,5111) size 128x17
+        text run at (227,5111) width 128: "\x{D83E}\x{DCCB}\x{A4F7}\x{3F2}\x{4A5}\x{F49}\x{6D02}\x{2BE1}\x{1DAF}\x{D83E}\x{DE79}\x{3F1D}\x{B2D}"
+      RenderText {#text} at (354,5111) size 44x17
+        text run at (354,5111) width 44: "\x{E6FD}\x{D83E}\x{DCEA}\x{C86}\x{D83D}\x{DFB6}"
+      RenderText {#text} at (397,5111) size 94x17
+        text run at (397,5111) width 94: "\x{8550}\x{315}\x{D83F}\x{DEBE}\x{9D59}\x{A8E0}\x{D29}\x{DD57}\x{3736}"
+      RenderText {#text} at (490,5111) size 40x17
+        text run at (490,5111) width 40: "\x{978}\x{16F}\x{A1C}\x{9FCF}"
+      RenderText {#text} at (529,5111) size 121x17
+        text run at (529,5111) width 121: "\x{445}\x{C7E}\x{49B4}\x{F256}\x{9EB}\x{E2B3}\x{7D5D}\x{D83D}\x{DF3A}\x{D83F}\x{DDB5}\x{F993}"
+      RenderText {#text} at (649,5111) size 90x17
+        text run at (649,5111) width 90: "\x{203}\x{799B}\x{D83F}\x{DF95}\x{6834}\x{4A6E}\x{D83F}\x{DEEA}\x{634E}"
+      RenderText {#text} at (0,5111) size 754x45
+        text run at (738,5111) width 16: "\x{B821}"
+        text run at (0,5139) width 48: "\x{A615}\x{1D6}\x{4E7}\x{E06C}q"
+      RenderText {#text} at (47,5139) size 57x17
+        text run at (47,5139) width 57: "\x{D83E}\x{DEC0}\x{FAA}\x{D83D}\x{DED3}\x{474A}"
+      RenderText {#text} at (103,5139) size 117x17
+        text run at (103,5139) width 117: "\x{F198}\x{27BB}\x{5D7A}\x{AA7}\x{AF9C}\x{1EE4}\x{23C2}\x{35DA}\x{E551}"
+      RenderText {#text} at (219,5139) size 27x17
+        text run at (219,5139) width 27: "\x{5A8F}\x{D67}"
+      RenderText {#text} at (245,5139) size 25x17
+        text run at (245,5139) width 25: "\x{422F}\x{F34}"
+      RenderText {#text} at (269,5139) size 113x17
+        text run at (269,5139) width 113: "\x{4E0B}\x{AD32}\x{9EF}\x{92F2}\x{6147}\x{A0D8}\x{D83E}\x{DDCE}\x{D63F}"
+      RenderText {#text} at (381,5139) size 97x17
+        text run at (381,5139) width 16: "\x{D83E}\x{DF77}\x{2D42}"
+        text run at (396,5139) width 15 RTL: "\x{FC9D}"
+        text run at (410,5139) width 68: "\x{56AB}\x{38D3}\x{32E0}\x{1EF}\x{D6B}"
+      RenderText {#text} at (477,5139) size 20x17
+        text run at (477,5139) width 20: "\x{10}\x{E8A}"
+      RenderText {#text} at (496,5139) size 122x17
+        text run at (496,5139) width 23: "\x{D83E}\x{DC7F}\x{E324}"
+        text run at (518,5139) width 12 RTL: "\x{88A}"
+        text run at (529,5139) width 89: "\x{F2E}\x{9192}\x{B089}\x{E52B}\x{D83E}\x{DE89}\x{D83D}\x{DFBF}\x{8FA8}"
+      RenderText {#text} at (617,5139) size 77x17
+        text run at (617,5139) width 77: "\x{BAB5}\x{D028}\x{E7E}\x{D83F}\x{DC2F}\x{E14}\x{38B9}"
+      RenderText {#text} at (693,5139) size 50x17
+        text run at (693,5139) width 50: "\x{34E}\x{A22F}\x{24F}\x{D83E}\x{DC0E}\x{7F63}"
+      RenderText {#text} at (0,5139) size 758x42
+        text run at (742,5139) width 16: "\x{725E}"
+        text run at (0,5164) width 52: "\x{3512}\x{89F2}\x{E971}\x{F91}"
+        text run at (51,5164) width 10 RTL: "\x{5E4}"
+      RenderText {#text} at (60,5164) size 46x17
+        text run at (60,5164) width 46: "\x{F2C1}\x{570}\x{178}\x{91C7}"
+layer at (8,142) size 16x16
+  RenderVideo {VIDEO} at (0,134) size 16x16
+layer at (24,142) size 16x16
+  RenderVideo {VIDEO} at (16,134) size 16x16
+layer at (151,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (143,0) size 300x150
+layer at (8,167) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,159) size 300x150
+layer at (8,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,317) size 300x150
+layer at (308,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,317) size 300x150
+layer at (8,481) size 284x284
+  RenderVideo {VIDEO} at (0,473) size 284x284
+layer at (546,749) size 16x16
+  RenderVideo {VIDEO} at (537,741) size 17x16
+layer at (65,913) size 16x16
+  RenderVideo {VIDEO} at (56,905) size 17x16
+layer at (116,779) size 349x150
+  RenderHTMLCanvas {CANVAS} at (108,771) size 350x150
+layer at (93,937) size 300x150
+  RenderHTMLCanvas {CANVAS} at (85,929) size 301x150
+layer at (8,1120) size 885x385
+  RenderHTMLCanvas {CANVAS} at (0,1112) size 885x385
+layer at (8,1988) size 213x213
+  RenderVideo {VIDEO} at (0,1980) size 213x213
+layer at (196,2420) size 16x16
+  RenderVideo {VIDEO} at (188,2412) size 17x16
+layer at (8,2448) size 290x127
+  RenderHTMLCanvas {CANVAS} at (0,2440) size 290x127
+layer at (8,2856) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,2848) size 300x150
+layer at (334,2739) size 300x267
+  RenderHTMLCanvas {CANVAS} at (326,2731) size 300x267
+layer at (8,3276) size 974x150
+  RenderHTMLCanvas {CANVAS} at (0,3268) size 974x150
+layer at (8,3447) size 905x349
+  RenderHTMLCanvas {CANVAS} at (0,3439) size 905x349
+layer at (200,3832) size 335x23
+  RenderHTMLCanvas {CANVAS} at (192,3824) size 336x23
+layer at (748,3839) size 16x16
+  RenderVideo {VIDEO} at (740,3831) size 17x16
+layer at (465,4030) size 291x291
+  RenderVideo {VIDEO} at (456,4022) size 292x291
+layer at (408,4328) size 38x213
+  RenderVideo {VIDEO} at (400,4320) size 39x213

--- a/LayoutTests/fast/webgpu/fuzz-272863.html
+++ b/LayoutTests/fast/webgpu/fuzz-272863.html
@@ -1,0 +1,30274 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUCommandEncoder} commandEncoder
+ */
+function pseudoSubmit(device, commandEncoder) {
+  device.pushErrorScope('validation');
+  commandEncoder.clearBuffer(device.createBuffer({size: 0, usage: 0}), 0, 0);
+  device.popErrorScope().then(() => {});
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let device0 = await adapter0.requestDevice(
+{
+label: '\uaebe\u004d\u{1fe52}\u0bfd\u9c0a\u1063\u0ecf\u1822\uc2ce\uc8a0\u{1f625}',
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 7,
+maxColorAttachmentBytesPerSample: 50,
+maxVertexAttributes: 22,
+maxVertexBufferArrayStride: 7902,
+maxStorageTexturesPerShaderStage: 15,
+maxStorageBuffersPerShaderStage: 11,
+maxDynamicStorageBuffersPerPipelineLayout: 47330,
+maxBindingsPerBindGroup: 7639,
+maxTextureDimension1D: 13557,
+maxTextureDimension2D: 15850,
+maxVertexBuffers: 9,
+minUniformBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 186636031,
+maxInterStageShaderVariables: 89,
+maxInterStageShaderComponents: 62,
+},
+}
+);
+let img0 = await imageWithData(292, 253, '#b3339566', '#89e16eed');
+let querySet0 = device0.createQuerySet(
+{
+label: '\u0fa2\u0df9\ue38f\uedae\u0d8b\uae1f\u7fb3\u0125\ud247\u08d4\u9c5e',
+type: 'occlusion',
+count: 2483,
+}
+);
+document.body.prepend('\u24dd\u1788\u{1fa55}\u06eb\u0103\u{1fa5c}\u{1f9eb}\u0db9');
+let querySet1 = device0.createQuerySet(
+{
+label: '\u9296\u7b77\uc07e',
+type: 'occlusion',
+count: 3761,
+}
+);
+let commandEncoder0 = device0.createCommandEncoder(
+{
+label: '\u5797\u0899\u09c2\u0a89\u03db\u0860\u0717\u6d43\u{1face}',
+}
+);
+let computePassEncoder0 = commandEncoder0.beginComputePass(
+{
+label: '\u{1fbaa}\u0b9b\u08d7\u6066\uce88\u05d4'
+}
+);
+let commandEncoder1 = device0.createCommandEncoder(
+{
+label: '\u0f6d\u0046\uea74\u80ce\u116e',
+}
+);
+let texture0 = device0.createTexture(
+{
+label: '\u05a7\u{1fd8d}\u0d55\u3097\ua6b2\u{1f64a}',
+size: [14742, 5, 1],
+mipLevelCount: 7,
+format: 'astc-6x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-6x5-unorm',
+'astc-6x5-unorm',
+'astc-6x5-unorm'
+],
+}
+);
+let bindGroupLayout0 = device0.createBindGroupLayout(
+{
+label: '\u0312\u0ccb\u742b\u75b9\u{1fe1d}\u28fe\uabba',
+entries: [
+
+],
+}
+);
+let bindGroup0 = device0.createBindGroup({
+label: '\u4d7c\u6f96',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let textureView0 = texture0.createView(
+{
+dimension: '2d-array',
+format: 'astc-6x5-unorm',
+baseMipLevel: 1,
+mipLevelCount: 4,
+}
+);
+let bindGroup1 = device0.createBindGroup({
+label: '\u3be0\u479e\u0d07\u720a\u2ae0\u{1f730}\u0738\u5688\ufb37',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let querySet2 = device0.createQuerySet(
+{
+label: '\u281e\u0864\u{1fc05}\u88b5\ua24b\u831d',
+type: 'occlusion',
+count: 2283,
+}
+);
+pseudoSubmit(device0, commandEncoder1);
+let textureView1 = texture0.createView(
+{
+label: '\u4cdb\u48f6\u{1f777}\u9140\ucc0e\ud73c\u{1f98a}\u1073',
+aspect: 'all',
+format: 'astc-6x5-unorm',
+baseMipLevel: 1,
+mipLevelCount: 1,
+}
+);
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundleEncoder0 = device0.createRenderBundleEncoder(
+{
+label: '\u{1feae}\u9b35\u5e52\u{1f925}\u9550\ua8d7\ua98c',
+colorFormats: [
+'rg8sint',
+undefined,
+'rg32uint',
+'rg16uint',
+'r32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 154,
+}
+);
+let renderBundle0 = renderBundleEncoder0.finish(
+{
+label: '\ua9e7\u016e\u03e2\u019f\ud70b\u{1f686}\ubcee'
+}
+);
+let videoFrame0 = new VideoFrame(img0, {timestamp: 0});
+let pipelineLayout0 = device0.createPipelineLayout(
+{
+label: '\uf302\ubec5\u{1fe1a}\u{1f966}\ubf14\u{1fa8e}\ue075\ufe52',
+bindGroupLayouts: [
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0
+],
+}
+);
+let sampler0 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 62.154,
+lodMaxClamp: 69.791,
+}
+);
+let externalTexture0 = device0.importExternalTexture(
+{
+label: '\u3e25\uf38f\u4333\u714a\u4dae',
+source: videoFrame0,
+colorSpace: 'display-p3',
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 4,
+  origin: { x: 78, y: 5, z: 0 },
+  aspect: 'all',
+},
+new Int16Array(new ArrayBuffer(56)),
+/* required buffer size: 436 */{
+offset: 436,
+},
+{width: 840, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let texture1 = device0.createTexture(
+{
+size: {width: 172, height: 16, depthOrArrayLayers: 97},
+mipLevelCount: 5,
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 2,
+  origin: { x: 864, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(8),
+/* required buffer size: 235 */{
+offset: 235,
+},
+{width: 576, height: 5, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder2 = device0.createCommandEncoder(
+{
+label: '\u0ff5\u{1f6f6}\u{1f73c}',
+}
+);
+let querySet3 = device0.createQuerySet(
+{
+label: '\u{1f92c}\u4bbd\u521f\u0f16\u5691\u64e9\ub1fc\u{1f8bf}\u0531\u04bd\u0cf6',
+type: 'occlusion',
+count: 1664,
+}
+);
+pseudoSubmit(device0, commandEncoder0);
+let texture2 = device0.createTexture(
+{
+label: '\u{1f9ee}\u{1f7c8}\ue63a\u8cf5\u434f\u0ed6\u893d\ub8f8\u2731\u231e',
+size: {width: 8536},
+dimension: '1d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 5628, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(643),
+/* required buffer size: 643 */{
+offset: 643,
+},
+{width: 8970, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let texture3 = device0.createTexture(
+{
+size: {width: 6440, height: 215, depthOrArrayLayers: 234},
+mipLevelCount: 9,
+sampleCount: 1,
+format: 'astc-5x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+}
+);
+let textureView2 = texture0.createView(
+{
+label: '\u0aa0\ub71f\u0379\u0dbc\u1c2f\u{1fb2f}\ubbe0\u0f84',
+dimension: '2d',
+format: 'astc-6x5-unorm',
+baseMipLevel: 4,
+mipLevelCount: 2,
+}
+);
+document.body.append('\u010d\uba96\u12fd\u{1fa2d}\u0965\u9671\u01c5\u4e8f');
+let videoFrame1 = new VideoFrame(img0, {timestamp: 0});
+let bindGroup2 = device0.createBindGroup({
+label: '\u1990\u08c0\u0a07\u0156\u9391\u0281\u0f71\u009a\u12fd\u5233\ub579',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let texture4 = device0.createTexture(
+{
+label: '\ubaaf\u{1f6f2}\ua504\u1fd9',
+size: [8102, 1, 247],
+mipLevelCount: 3,
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let textureView3 = texture3.createView(
+{
+label: '\u0038\u0537\u0689\u9a71\u32c8',
+baseMipLevel: 7,
+baseArrayLayer: 79,
+arrayLayerCount: 2,
+}
+);
+let renderBundle1 = renderBundleEncoder0.finish();
+let promise0 = device0.queue.onSubmittedWorkDone();
+try {
+await promise0;
+} catch {}
+let texture5 = device0.createTexture(
+{
+label: '\u68fa\u{1f9fb}\u0bc6\u68fc',
+size: {width: 7129},
+dimension: '1d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundle2 = renderBundleEncoder0.finish(
+{
+label: '\u{1fe3d}\u8a96\u9d80\u764a\u{1fead}\u7ee7\u05de'
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture4,
+  mipLevel: 2,
+  origin: { x: 792, y: 1, z: 169 },
+  aspect: 'all',
+},
+new Uint32Array(new ArrayBuffer(64)),
+/* required buffer size: 20673802 */{
+offset: 193,
+bytesPerRow: 4507,
+rowsPerImage: 139,
+},
+{width: 1071, height: 0, depthOrArrayLayers: 34}
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img0);
+let bindGroup3 = device0.createBindGroup({
+label: '\u697d\u{1fa5a}\u0f18\u0972',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let commandEncoder3 = device0.createCommandEncoder();
+let video0 = await videoWithData();
+let buffer0 = device0.createBuffer(
+{
+label: '\u20e9\u{1fc8b}\u{1fd0f}\u048e\u0528\u1ccc\u{1f88d}\u{1f983}\ub5cc',
+size: 16466,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let texture6 = device0.createTexture(
+{
+label: '\uc2d1\u174b',
+size: [102, 102, 1],
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'r16float'
+],
+}
+);
+let computePassEncoder1 = commandEncoder3.beginComputePass();
+let texture7 = device0.createTexture(
+{
+size: {width: 49, height: 1, depthOrArrayLayers: 1923},
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundleEncoder1 = device0.createRenderBundleEncoder(
+{
+label: '\u0fb7\u{1fea9}\u0fba\u{1f682}\u0e17\u021e\u0fcf\u05fb\u97e5',
+colorFormats: [
+'rgba32float',
+'rgba8unorm',
+'rgba16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 634,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder1.insertDebugMarker(
+'\u091f'
+);
+} catch {}
+document.body.append('\u052b\u{1fab4}\u6b33\u6575\u02db\uf261\u09f9\u7167');
+let bindGroup4 = device0.createBindGroup({
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let bindGroup5 = device0.createBindGroup({
+label: '\ufcf8\u713c\u{1ff26}\u{1f660}\u{1fc25}\u8488\u088d\u0ec0',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let pipelineLayout1 = device0.createPipelineLayout(
+{
+label: '\u03ab\u088a\u{1f8ec}\u{1f937}\u057b\u29b0',
+bindGroupLayouts: [
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0
+],
+}
+);
+let computePassEncoder2 = commandEncoder2.beginComputePass(
+{
+
+}
+);
+try {
+renderBundleEncoder1.setBindGroup(
+3,
+bindGroup3
+);
+} catch {}
+let canvas0 = document.createElement('canvas');
+let renderBundleEncoder2 = device0.createRenderBundleEncoder(
+{
+label: '\u{1f98e}\u0d6a\u{1fc65}\u3ed5\u1532\u9790\u0886\u44b0\u{1fbd3}\u0d05',
+colorFormats: [
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 550,
+stencilReadOnly: false,
+}
+);
+let offscreenCanvas0 = new OffscreenCanvas(724, 316);
+let bindGroup6 = device0.createBindGroup({
+label: '\u7c79\u{1fa88}\u{1f692}\u{1fa93}\u04fc\u0045',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let commandEncoder4 = device0.createCommandEncoder();
+let querySet4 = device0.createQuerySet(
+{
+label: '\ue828\u{1fdce}\u3090',
+type: 'occlusion',
+count: 1369,
+}
+);
+try {
+computePassEncoder1.setBindGroup(
+4,
+bindGroup1
+);
+} catch {}
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+querySet0.destroy();
+} catch {}
+let bindGroup7 = device0.createBindGroup({
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let textureView4 = texture4.createView(
+{
+label: '\u0f5f\u5b8a\u56f4\u{1f7c1}',
+baseMipLevel: 2,
+baseArrayLayer: 136,
+arrayLayerCount: 4,
+}
+);
+let sampler1 = device0.createSampler(
+{
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 13.968,
+lodMaxClamp: 85.249,
+maxAnisotropy: 5,
+}
+);
+try {
+computePassEncoder1.setBindGroup(
+5,
+bindGroup6
+);
+} catch {}
+let img1 = await imageWithData(298, 170, '#3c66022d', '#3e9dff0c');
+let pipelineLayout2 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+
+],
+}
+);
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup8 = device0.createBindGroup({
+label: '\u{1fd68}\u{1f621}\u9607\u624d\u8974',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let commandEncoder5 = device0.createCommandEncoder(
+{
+}
+);
+let texture8 = device0.createTexture(
+{
+label: '\ufafd\u0dcd\u0fd1\u{1ff62}\u04db\u0090\uf6df\u8848\ub5c2\u0115\u{1f7cd}',
+size: [6, 1, 225],
+mipLevelCount: 2,
+dimension: '3d',
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'bgra8unorm-srgb'
+],
+}
+);
+let textureView5 = texture5.createView(
+{
+label: '\ub92a\u{1fff1}\u317e\u{1fa6b}\u0897\u0ee8\u{1fe6a}',
+}
+);
+document.body.prepend('\u0b25\u{1fc03}\u{1fd50}\u079b\u{1f9c3}\u0576\ue20f\u0280\u4dee\u013a\uf0f9');
+let commandEncoder6 = device0.createCommandEncoder(
+{
+}
+);
+let texture9 = device0.createTexture(
+{
+label: '\u6b11\u064e\u3e7f\u{1f798}\ud959\u75c5',
+size: {width: 56, height: 47, depthOrArrayLayers: 188},
+mipLevelCount: 5,
+format: 'rgba32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let textureView6 = texture9.createView(
+{
+mipLevelCount: 3,
+baseArrayLayer: 139,
+arrayLayerCount: 1,
+}
+);
+let renderBundleEncoder3 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'r16uint',
+undefined,
+'r16sint',
+'rg32sint',
+'rgba16sint',
+'rgba32uint',
+'rg16sint',
+'rg32uint'
+],
+sampleCount: 78,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder1.setBindGroup(
+3,
+bindGroup8,
+new Uint32Array(7741),
+3820,
+0
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 1, depthOrArrayLayers: 225}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 136, y: 252 },
+  flipY: true,
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 145 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 6, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\u1fa5\ud272\u923b\u0658\u65f1\ube17\u2cd9\u0c06\ue310\u{1fced}');
+let offscreenCanvas1 = new OffscreenCanvas(11, 972);
+let bindGroup9 = device0.createBindGroup({
+label: '\u419b\u{1fc68}\u0970\u662a\u7298\udfdc\u{1fca5}\u1e8a\u{1fb90}',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let buffer1 = device0.createBuffer(
+{
+size: 35904,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+try {
+renderBundleEncoder3.setVertexBuffer(
+22,
+undefined,
+150379975,
+3913381217
+);
+} catch {}
+try {
+querySet3.destroy();
+} catch {}
+try {
+commandEncoder6.copyTextureToTexture(
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: { x: 1667, y: 0, z: 98 },
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 2,
+  origin: { x: 639, y: 0, z: 72 },
+  aspect: 'all',
+},
+{width: 987, height: 1, depthOrArrayLayers: 97}
+);
+} catch {}
+try {
+commandEncoder5.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 1, depthOrArrayLayers: 225}
+*/
+{
+  source: video0,
+  origin: { x: 5, y: 16 },
+  flipY: false,
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 3, y: 0, z: 30 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 2, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let imageBitmap0 = await createImageBitmap(video0);
+let commandEncoder7 = device0.createCommandEncoder(
+{
+label: '\uedb1\u0438\u350c\u0662\u9c72\u0969',
+}
+);
+let renderBundleEncoder4 = device0.createRenderBundleEncoder(
+{
+label: '\u0ec0\u{1fe16}\u3c05\u4a97\u0930\uebc1',
+colorFormats: [
+'rgba16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 407,
+depthReadOnly: true,
+stencilReadOnly: false,
+}
+);
+let sampler2 = device0.createSampler(
+{
+label: '\u{1f758}\u{1f6dd}\u0b08\ue2ca\uc2d4\u0be8\u2e1b\u{1fbc3}\u08a2\u6c40\u{1f79b}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMinClamp: 97.783,
+lodMaxClamp: 98.699,
+}
+);
+try {
+renderBundleEncoder2.setVertexBuffer(
+66,
+undefined,
+3896452630,
+12072366
+);
+} catch {}
+try {
+querySet3.destroy();
+} catch {}
+try {
+commandEncoder4.copyTextureToTexture(
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 3, y: 0, z: 106 },
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 0, y: 1, z: 10 },
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 100}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 2, y: 16, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(64),
+/* required buffer size: 25275 */{
+offset: 479,
+bytesPerRow: 328,
+rowsPerImage: 301,
+},
+{width: 98, height: 76, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 1, depthOrArrayLayers: 225}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 7, y: 7 },
+  flipY: false,
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 5, y: 1, z: 188 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+document.body.append('\u123e\u{1f8aa}\u{1fb0c}');
+try {
+computePassEncoder1.setBindGroup(
+6,
+bindGroup6,
+new Uint32Array(922),
+912,
+0
+);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(
+6,
+bindGroup5
+);
+} catch {}
+try {
+buffer0.destroy();
+} catch {}
+try {
+commandEncoder7.copyBufferToBuffer(
+buffer0,
+4560,
+buffer1,
+34068,
+1272
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 3, height: 1, depthOrArrayLayers: 112}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 16, y: 171 },
+  flipY: false,
+},
+{
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 45 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 3, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let img2 = await imageWithData(287, 127, '#4c4a6dd3', '#1d05c5b8');
+try {
+offscreenCanvas1.getContext('webgpu');
+} catch {}
+let texture10 = device0.createTexture(
+{
+label: '\u{1fb0d}\u{1f8c1}\u{1feec}\ube22\u4c95\u0d91',
+size: {width: 13584, height: 36, depthOrArrayLayers: 155},
+mipLevelCount: 5,
+format: 'astc-12x12-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-12x12-unorm',
+'astc-12x12-unorm-srgb'
+],
+}
+);
+let computePassEncoder3 = commandEncoder7.beginComputePass(
+{
+label: '\u0208\u517b\ua921'
+}
+);
+let renderBundle3 = renderBundleEncoder0.finish(
+{
+label: '\u{1fe22}\u{1fb95}\u{1f8c2}\u2f36\uebd9\ucafb'
+}
+);
+let sampler3 = device0.createSampler(
+{
+label: '\u0175\u0c4d\u{1f617}\u19de\u83bd',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 57.625,
+lodMaxClamp: 64.743,
+maxAnisotropy: 14,
+}
+);
+try {
+computePassEncoder1.setBindGroup(
+3,
+bindGroup1
+);
+} catch {}
+try {
+commandEncoder5.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+document.body.prepend('\u{1fec6}\ud55e\u0402\u{1ff7b}\u8a4e\ucade\ub7b1\u1e61');
+try {
+computePassEncoder3.setBindGroup(
+2,
+bindGroup9,
+new Uint32Array(5616),
+219,
+0
+);
+} catch {}
+let canvas1 = document.createElement('canvas');
+let offscreenCanvas2 = new OffscreenCanvas(11, 236);
+let commandEncoder8 = device0.createCommandEncoder(
+{
+label: '\u0d38\u580a\uafb8\u{1f955}\u3d17',
+}
+);
+let renderBundle4 = renderBundleEncoder2.finish(
+{
+label: '\u0f0a\u0804\u3800\u{1f942}\u855e\udb8f\u078d\uc6bd\u570b'
+}
+);
+let sampler4 = device0.createSampler(
+{
+label: '\ue97f\u{1fe26}\ua28b',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 22.276,
+}
+);
+try {
+renderBundleEncoder4.setBindGroup(
+6,
+bindGroup5
+);
+} catch {}
+try {
+commandEncoder5.copyBufferToBuffer(
+buffer0,
+1760,
+buffer1,
+10192,
+1796
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let texture11 = device0.createTexture(
+{
+label: '\u03f2\u{1f6b6}\u{1fcdc}',
+size: [14820, 40, 45],
+mipLevelCount: 2,
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x10-unorm-srgb',
+'astc-10x10-unorm'
+],
+}
+);
+try {
+commandEncoder5.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 3, height: 1, depthOrArrayLayers: 112}
+*/
+{
+  source: video0,
+  origin: { x: 15, y: 8 },
+  flipY: false,
+},
+{
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 2, y: 0, z: 44 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend(video0);
+let renderBundleEncoder5 = device0.createRenderBundleEncoder(
+{
+label: '\u0fb7\ub2c8\u0242\u05ac\u0203',
+colorFormats: [
+'r8uint',
+'r8unorm',
+'r16float',
+'rg16float',
+'rgba16uint',
+'rgba8unorm',
+'rg8uint',
+'rg16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 109,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle5 = renderBundleEncoder5.finish(
+{
+label: '\u2f80\u09c6\u5d72\u{1f907}\u6fdf\u8a23\u{1fecd}\u{1feb9}'
+}
+);
+let sampler5 = device0.createSampler(
+{
+label: '\uc563\u{1fbc3}\ue6a0\ue38b\ud088\u0cb6\ud14c',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 84.059,
+lodMaxClamp: 99.437,
+compare: 'greater',
+}
+);
+try {
+computePassEncoder1.setBindGroup(
+2,
+bindGroup7
+);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(
+5,
+bindGroup8
+);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(
+94,
+undefined
+);
+} catch {}
+try {
+commandEncoder6.copyTextureToTexture(
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 4, y: 0, z: 16 },
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 7 },
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 104}
+);
+} catch {}
+try {
+commandEncoder2.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let bindGroup10 = device0.createBindGroup({
+label: '\u{1fd36}\u005c\u0732\udd46\u{1f8a6}\udf8b\u{1feee}\u13ec\ucc76\u0f79',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let texture12 = device0.createTexture(
+{
+label: '\u0ed7\ub5dd\uc583\u{1fae2}\uf958\u3135\uf325\u03a9\uc20a\ue48e',
+size: [30, 8, 80],
+mipLevelCount: 1,
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+renderBundleEncoder4.setBindGroup(
+3,
+bindGroup5,
+new Uint32Array(1448),
+958,
+0
+);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(
+80,
+undefined,
+369062073,
+1572875653
+);
+} catch {}
+try {
+commandEncoder2.copyTextureToTexture(
+{
+  texture: texture4,
+  mipLevel: 2,
+  origin: { x: 42, y: 1, z: 29 },
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: { x: 206, y: 0, z: 34 },
+  aspect: 'all',
+},
+{width: 327, height: 0, depthOrArrayLayers: 182}
+);
+} catch {}
+try {
+commandEncoder4.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let commandEncoder9 = device0.createCommandEncoder(
+{
+label: '\u2080\u{1fe09}\u0952\ubb98\u71a9\u8db6\u{1fec9}\uc1d7',
+}
+);
+let computePassEncoder4 = commandEncoder4.beginComputePass();
+try {
+commandEncoder8.copyTextureToTexture(
+{
+  texture: texture10,
+  mipLevel: 3,
+  origin: { x: 828, y: 0, z: 3 },
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 4,
+  origin: { x: 24, y: 0, z: 13 },
+  aspect: 'all',
+},
+{width: 480, height: 0, depthOrArrayLayers: 117}
+);
+} catch {}
+document.body.append('\u24bf\u0b00\u05ff\u02fa\u0b13\u08bc\u0b7b\u0fd1\u{1ff3c}\ucef8\u9508');
+let offscreenCanvas3 = new OffscreenCanvas(890, 365);
+let sampler6 = device0.createSampler(
+{
+label: '\u{1fb1e}\u0976\u0876\uce54',
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 73.381,
+compare: 'less-equal',
+maxAnisotropy: 17,
+}
+);
+try {
+renderBundleEncoder3.setBindGroup(
+4,
+bindGroup3,
+new Uint32Array(8928),
+5587,
+0
+);
+} catch {}
+try {
+computePassEncoder0.pushDebugGroup(
+'\uf613'
+);
+} catch {}
+document.body.prepend(img1);
+try {
+texture11.label = '\u0c64\u0cbf\ue7f4\u0563\u4e6c\uf37b';
+} catch {}
+let computePassEncoder5 = commandEncoder9.beginComputePass(
+{
+label: '\u10bb\u{1f75d}\u7dd1\ufa15\u0355\u0481\u{1f97b}\u0f95\u00ad'
+}
+);
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(
+54,
+undefined,
+916316992,
+949569877
+);
+} catch {}
+try {
+commandEncoder2.copyBufferToBuffer(
+buffer0,
+9100,
+buffer1,
+27212,
+5932
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 3, height: 1, depthOrArrayLayers: 112}
+*/
+{
+  source: img0,
+  origin: { x: 160, y: 171 },
+  flipY: false,
+},
+{
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 1, y: 0, z: 6 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+video0.height = 213;
+let commandEncoder10 = device0.createCommandEncoder();
+let textureView7 = texture6.createView(
+{
+}
+);
+let computePassEncoder6 = commandEncoder10.beginComputePass(
+{
+label: '\ubc3c\u22b9\u5e35\u0c0f\u0e75\u{1f96c}\u0b98\ue537\ufd2c'
+}
+);
+let renderBundle6 = renderBundleEncoder0.finish();
+let sampler7 = device0.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+compare: 'less-equal',
+}
+);
+try {
+computePassEncoder5.setBindGroup(
+5,
+bindGroup6,
+[]
+);
+} catch {}
+try {
+commandEncoder2.copyTextureToTexture(
+{
+  texture: texture10,
+  mipLevel: 3,
+  origin: { x: 240, y: 0, z: 98 },
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 3,
+  origin: { x: 264, y: 12, z: 47 },
+  aspect: 'all',
+},
+{width: 996, height: 0, depthOrArrayLayers: 36}
+);
+} catch {}
+document.body.prepend('\u0cad\u0d94\u4b88\u0816\u394d\uf0ed\u36a2\u0a98\u3a3e');
+let bindGroup11 = device0.createBindGroup({
+label: '\u7b03\u0aed\u0118\u0071\u0f22\u0715',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let commandEncoder11 = device0.createCommandEncoder();
+let texture13 = device0.createTexture(
+{
+size: {width: 1218, height: 1, depthOrArrayLayers: 1522},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rg8uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8uint'
+],
+}
+);
+let renderBundleEncoder6 = device0.createRenderBundleEncoder(
+{
+label: '\u{1f67d}\uc7e8\u{1fd6a}',
+colorFormats: [
+'rg32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 116,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+commandEncoder5.copyBufferToBuffer(
+buffer0,
+15896,
+buffer1,
+23012,
+476
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder6.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+renderBundleEncoder6.insertDebugMarker(
+'\u05ee'
+);
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder12 = device0.createCommandEncoder(
+{
+}
+);
+let texture14 = device0.createTexture(
+{
+label: '\u044c\u0baf\ued09\uef8b\u{1fb58}',
+size: {width: 118, height: 1, depthOrArrayLayers: 124},
+mipLevelCount: 6,
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundle7 = renderBundleEncoder4.finish(
+{
+label: '\ub456\u0615\u6094'
+}
+);
+let sampler8 = device0.createSampler(
+{
+label: '\u03df\u174b\ua950',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 89.636,
+lodMaxClamp: 92.741,
+maxAnisotropy: 5,
+}
+);
+try {
+renderBundleEncoder1.setBindGroup(
+3,
+bindGroup8,
+new Uint32Array(9430),
+287,
+0
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture14,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 41 },
+  aspect: 'all',
+},
+new Uint8Array(new ArrayBuffer(32)),
+/* required buffer size: 1059163 */{
+offset: 643,
+bytesPerRow: 297,
+rowsPerImage: 108,
+},
+{width: 3, height: 1, depthOrArrayLayers: 34}
+);
+} catch {}
+let video1 = await videoWithData();
+let commandEncoder13 = device0.createCommandEncoder(
+{
+label: '\u0316\ub51b\u636a\u5ec0\u0f54\u29b4\u02a2\u265c\u{1f6a1}',
+}
+);
+let commandBuffer0 = commandEncoder12.finish(
+{
+label: '\u5231\uee0e\u0c7b\u50e3\u522f\u08c1\u7879',
+}
+);
+pseudoSubmit(device0, commandEncoder11);
+let renderBundleEncoder7 = device0.createRenderBundleEncoder(
+{
+label: '\u0911\u8d93\u{1f899}\ud783\u{1f7bd}\u{1f772}',
+colorFormats: [
+'rg16float',
+'rg16sint',
+'r16uint',
+'rgba8unorm-srgb',
+'rg32uint',
+'r32uint',
+'rgba16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 800,
+stencilReadOnly: true,
+}
+);
+let renderBundle8 = renderBundleEncoder5.finish(
+{
+
+}
+);
+let sampler9 = device0.createSampler(
+{
+label: '\ud3f7\ude1a\u0872\u{1f6d1}\u{1fec8}\u5a3c',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 5.654,
+compare: 'always',
+maxAnisotropy: 15,
+}
+);
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder2.copyBufferToBuffer(
+buffer0,
+7556,
+buffer1,
+28104,
+5144
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+await promise1;
+} catch {}
+let renderBundleEncoder8 = device0.createRenderBundleEncoder(
+{
+label: '\uaaa7\u094e\u7c86',
+colorFormats: [
+'r32float',
+'rgba8sint',
+'rgba32uint',
+'rgba16uint',
+'r8sint'
+],
+sampleCount: 523,
+stencilReadOnly: false,
+}
+);
+try {
+computePassEncoder0.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 3, height: 1, depthOrArrayLayers: 112}
+*/
+{
+  source: video1,
+  origin: { x: 3, y: 4 },
+  flipY: false,
+},
+{
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 3, y: 0, z: 52 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise2 = adapter0.requestAdapterInfo();
+let buffer2 = device0.createBuffer(
+{
+label: '\u0900\uc4a0\u0793',
+size: 60696,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+}
+);
+let commandEncoder14 = device0.createCommandEncoder(
+{
+label: '\u8036\u0c8c\ubfa1\u0854\uc4d4\u0d74\u4cc0\u{1fa96}\u0600\u55ae\u0d48',
+}
+);
+let textureView8 = texture14.createView(
+{
+label: '\uc3d2\u0f64\u420f\u0103\u{1ff60}',
+dimension: '2d',
+aspect: 'all',
+baseMipLevel: 2,
+mipLevelCount: 3,
+baseArrayLayer: 97,
+}
+);
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let gpuCanvasContext1 = offscreenCanvas2.getContext('webgpu');
+let imageData0 = new ImageData(64, 208);
+try {
+offscreenCanvas3.getContext('webgpu');
+} catch {}
+let bindGroupLayout1 = device0.createBindGroupLayout(
+{
+label: '\u062b\uef76\u239b\u4f04\ue180\u0475\u6a6a\u{1ffd0}\u91f8\u0609',
+entries: [
+{
+binding: 2766,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+},
+{
+binding: 2712,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'non-filtering' },
+}
+],
+}
+);
+let texture15 = device0.createTexture(
+{
+label: '\u{1fef5}\u8fa8\u{1f81f}\u062f\u0222\u08be',
+size: {width: 10478},
+dimension: '1d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder15 = device0.createCommandEncoder();
+let texture16 = device0.createTexture(
+{
+label: '\u021e\uc82c\u{1f61c}\u3fbc\u050b',
+size: {width: 215, height: 1, depthOrArrayLayers: 1790},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8uint'
+],
+}
+);
+try {
+computePassEncoder5.setBindGroup(
+4,
+bindGroup5,
+new Uint32Array(1738),
+441,
+0
+);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer0,
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+54548,
+new DataView(new ArrayBuffer(46089)),
+13044,
+6028
+);
+} catch {}
+document.body.prepend(img1);
+let bindGroup12 = device0.createBindGroup({
+label: '\u2a04\u04c0\u{1fd28}\u6565\uae83\u0df0',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let buffer3 = device0.createBuffer(
+{
+label: '\u0a2c\u1416\u087e\u7aec\u9bd0\u{1fcef}\u{1f951}',
+size: 28909,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let commandEncoder16 = device0.createCommandEncoder();
+try {
+renderBundleEncoder1.setVertexBuffer(
+89,
+undefined,
+818954555,
+371767234
+);
+} catch {}
+try {
+commandEncoder14.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture10,
+  mipLevel: 4,
+  origin: { x: 120, y: 0, z: 121 },
+  aspect: 'all',
+},
+new ArrayBuffer(64),
+/* required buffer size: 1456486 */{
+offset: 801,
+bytesPerRow: 995,
+rowsPerImage: 77,
+},
+{width: 540, height: 0, depthOrArrayLayers: 20}
+);
+} catch {}
+try {
+computePassEncoder4.setBindGroup(
+3,
+bindGroup7
+);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(
+1,
+bindGroup1
+);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+2,
+bindGroup6,
+new Uint32Array(6802),
+1304,
+0
+);
+} catch {}
+try {
+commandEncoder14.copyTextureToTexture(
+{
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 2, y: 0, z: 28 },
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 4, y: 0, z: 143 },
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 82}
+);
+} catch {}
+document.body.prepend(video1);
+let videoFrame2 = new VideoFrame(video0, {timestamp: 0});
+let buffer4 = device0.createBuffer(
+{
+label: '\u0194\u0483\u823a\u3de6',
+size: 45042,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+try {
+renderBundleEncoder6.setBindGroup(
+4,
+bindGroup12,
+new Uint32Array(7357),
+5257,
+0
+);
+} catch {}
+try {
+commandEncoder13.copyBufferToTexture(
+{
+/* bytesInLastRow: 10672 widthInBlocks: 5336 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 60514 */
+offset: 49842,
+buffer: buffer2,
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: { x: 968, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 5336, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+42540,
+new Float32Array(45588),
+36156,
+1516
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture14,
+  mipLevel: 0,
+  origin: { x: 6, y: 1, z: 55 },
+  aspect: 'all',
+},
+new DataView(new ArrayBuffer(64)),
+/* required buffer size: 1403508 */{
+offset: 981,
+bytesPerRow: 343,
+rowsPerImage: 87,
+},
+{width: 11, height: 0, depthOrArrayLayers: 48}
+);
+} catch {}
+gc();
+let canvas2 = document.createElement('canvas');
+let bindGroup13 = device0.createBindGroup({
+layout: bindGroupLayout1,
+entries: [
+{
+binding: 2766,
+resource: externalTexture0
+},
+{
+binding: 2712,
+resource: sampler4
+}
+],
+});
+let buffer5 = device0.createBuffer(
+{
+size: 10590,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+try {
+renderBundleEncoder3.setBindGroup(
+4,
+bindGroup11
+);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(
+3,
+buffer5,
+7420
+);
+} catch {}
+try {
+commandEncoder5.copyBufferToBuffer(
+buffer4,
+32596,
+buffer1,
+4096,
+6804
+);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let bindGroup14 = device0.createBindGroup({
+label: '\u01c0\u2d6c\u{1fa24}\u443e\u{1feb4}\u0141\u{1fb4c}\u{1fd24}\u436e',
+layout: bindGroupLayout1,
+entries: [
+{
+binding: 2766,
+resource: externalTexture0
+},
+{
+binding: 2712,
+resource: sampler2
+}
+],
+});
+try {
+computePassEncoder1.setBindGroup(
+4,
+bindGroup14,
+new Uint32Array(6915),
+1034,
+0
+);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+4,
+bindGroup10,
+new Uint32Array(21),
+8,
+0
+);
+} catch {}
+try {
+commandEncoder16.resolveQuerySet(
+querySet1,
+400,
+624,
+buffer5,
+1024
+);
+} catch {}
+let textureView9 = texture11.createView(
+{
+label: '\u3138\u0d65\u96d1\ube6a\uda64\u0e02\u{1f8ba}\u01e8\u126e',
+dimension: '2d',
+aspect: 'all',
+format: 'astc-10x10-unorm-srgb',
+baseMipLevel: 1,
+baseArrayLayer: 14,
+}
+);
+let computePassEncoder7 = commandEncoder13.beginComputePass(
+{
+label: '\ud961\u0a4d\u97d2'
+}
+);
+try {
+renderBundleEncoder6.setVertexBuffer(
+7,
+buffer5,
+5960
+);
+} catch {}
+try {
+commandEncoder14.resolveQuerySet(
+querySet2,
+899,
+883,
+buffer5,
+1792
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append('\u7a2a\uf372\u8321\uec39\u9a92\u0f10\ubd6d');
+let textureView10 = texture8.createView(
+{
+arrayLayerCount: 1,
+}
+);
+let renderBundleEncoder9 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgb10a2unorm',
+'rgba8uint',
+'r32float',
+'rg16float',
+'rgba32sint',
+'rgba8sint',
+undefined,
+'rgb10a2unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 358,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder7.setBindGroup(
+4,
+bindGroup1,
+new Uint32Array(5424),
+4606,
+0
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8sint',
+'r16uint',
+'rgba16float',
+'rgba16float'
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 90, y: 38, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(32),
+/* required buffer size: 11022 */{
+offset: 388,
+bytesPerRow: 295,
+},
+{width: 7, height: 37, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandBuffer1 = commandEncoder16.finish(
+{
+}
+);
+let textureView11 = texture4.createView(
+{
+label: '\u7812\u296f\u{1feb8}\u0bf5\u{1fe1c}\u05c9\u7c70\uc08c\u942b\uea36\u4b46',
+dimension: '2d',
+baseMipLevel: 2,
+baseArrayLayer: 228,
+}
+);
+try {
+renderBundleEncoder9.setVertexBuffer(
+7,
+buffer5
+);
+} catch {}
+try {
+commandEncoder14.copyBufferToBuffer(
+buffer5,
+6940,
+buffer2,
+58176,
+1480
+);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb',
+'rgb9e5ufloat',
+'rgba8unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let texture17 = gpuCanvasContext0.getCurrentTexture();
+let textureView12 = texture17.createView(
+{
+label: '\u956d\u17ce\u00c6\u{1f902}\u2047\u3611\u7cd0\u0ebb\u34c9\uead5\u056b',
+dimension: '2d-array',
+format: 'rgba8sint',
+mipLevelCount: 1,
+}
+);
+let computePassEncoder8 = commandEncoder7.beginComputePass(
+{
+
+}
+);
+let sampler10 = device0.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 11.391,
+lodMaxClamp: 42.503,
+}
+);
+try {
+renderBundleEncoder1.setBindGroup(
+6,
+bindGroup8
+);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(
+7,
+buffer5,
+8320,
+2052
+);
+} catch {}
+try {
+commandEncoder6.resolveQuerySet(
+querySet0,
+227,
+1009,
+buffer5,
+768
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 28 },
+  aspect: 'all',
+},
+new ArrayBuffer(24),
+/* required buffer size: 6476795 */{
+offset: 884,
+bytesPerRow: 159,
+rowsPerImage: 241,
+},
+{width: 0, height: 1, depthOrArrayLayers: 170}
+);
+} catch {}
+try {
+await promise2;
+} catch {}
+let commandBuffer2 = commandEncoder15.finish(
+{
+label: '\u0d49\u4b78\u0009\uafa4',
+}
+);
+try {
+computePassEncoder6.setBindGroup(
+5,
+bindGroup14
+);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(
+6,
+bindGroup12
+);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(
+2,
+buffer5,
+5544,
+4088
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+28092,
+new Int16Array(13833),
+10179
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 1, depthOrArrayLayers: 225}
+*/
+{
+  source: img2,
+  origin: { x: 180, y: 43 },
+  flipY: false,
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 12 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 6, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\u0115\u6749\u{1f6aa}\ubb6a\uc0f2\u52ef');
+let texture18 = device0.createTexture(
+{
+label: '\u9a4d\u9de4\u0ce5\ub018\u0db2\u08ca\u8f77\u{1f679}\uae94\u0484\u8c1e',
+size: {width: 90, height: 5, depthOrArrayLayers: 31},
+mipLevelCount: 3,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+let sampler11 = device0.createSampler(
+{
+label: '\u4242\u3ab7\u0b09\uaf45\uaa0a\u1cf9',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 2.474,
+lodMaxClamp: 39.676,
+}
+);
+try {
+renderBundleEncoder8.setBindGroup(
+5,
+bindGroup2,
+new Uint32Array(5150),
+758,
+0
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+7,
+buffer5,
+3376,
+718
+);
+} catch {}
+try {
+commandEncoder2.copyBufferToBuffer(
+buffer5,
+3724,
+buffer1,
+20340,
+4240
+);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+renderBundleEncoder3.insertDebugMarker(
+'\u{1fcb1}'
+);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer1,
+commandBuffer2,
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+12484,
+new DataView(new ArrayBuffer(44010)),
+22095,
+2544
+);
+} catch {}
+let gpuCanvasContext2 = offscreenCanvas0.getContext('webgpu');
+let bindGroup15 = device0.createBindGroup({
+label: '\u{1fbc1}\u4b46',
+layout: bindGroupLayout1,
+entries: [
+{
+binding: 2766,
+resource: externalTexture0
+},
+{
+binding: 2712,
+resource: sampler2
+}
+],
+});
+let buffer6 = device0.createBuffer(
+{
+label: '\ufe20\u{1f799}\u{1fd82}\u0485\u5475\ue856\ud200\u{1f784}',
+size: 41156,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let commandEncoder17 = device0.createCommandEncoder(
+{
+label: '\u{1fb3a}\u{1f753}\u{1f7b9}\u{1fe95}',
+}
+);
+let computePassEncoder9 = commandEncoder2.beginComputePass(
+{
+label: '\u{1fe46}\u{1f7e8}\u{1f81d}\ueec5\u620c'
+}
+);
+try {
+texture14.destroy();
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: { x: 3846, y: 1, z: 0 },
+  aspect: 'all',
+},
+new Uint8Array(new ArrayBuffer(64)),
+/* required buffer size: 929 */{
+offset: 929,
+},
+{width: 1397, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let imageData1 = new ImageData(12, 60);
+let videoFrame3 = new VideoFrame(offscreenCanvas3, {timestamp: 0});
+let computePassEncoder10 = commandEncoder8.beginComputePass();
+let renderBundleEncoder10 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg32sint',
+'r32sint',
+'rg11b10ufloat',
+'rg32uint',
+undefined,
+undefined
+],
+sampleCount: 744,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+commandEncoder17.copyBufferToBuffer(
+buffer5,
+8876,
+buffer6,
+38716,
+1256
+);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder6.copyTextureToTexture(
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 169 },
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 55 },
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 42}
+);
+} catch {}
+try {
+commandEncoder17.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let imageBitmap1 = await createImageBitmap(imageData0);
+let commandBuffer3 = commandEncoder14.finish(
+{
+label: '\ua7c1\uc9df\ue5b6\u11b3\ufb9f\ud1d2\u{1f9a8}\u4e4b\u{1ffb6}',
+}
+);
+let renderBundleEncoder11 = device0.createRenderBundleEncoder(
+{
+label: '\uce3c\uac71\u80c2\u0101\udcc4',
+colorFormats: [
+'rgba32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 58,
+}
+);
+let sampler12 = device0.createSampler(
+{
+label: '\ue5ec\ue8f1\u02d4\u6c2b\u0b19',
+addressModeU: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 38.263,
+lodMaxClamp: 71.761,
+maxAnisotropy: 8,
+}
+);
+try {
+computePassEncoder4.setBindGroup(
+3,
+bindGroup4,
+new Uint32Array(6729),
+5067,
+0
+);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(
+1,
+bindGroup1
+);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(
+4,
+bindGroup2,
+new Uint32Array(8642),
+3980,
+0
+);
+} catch {}
+let promise3 = buffer1.mapAsync(
+GPUMapMode.READ,
+1840
+);
+try {
+commandEncoder5.resolveQuerySet(
+querySet4,
+616,
+224,
+buffer6,
+1024
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+29936,
+new DataView(new ArrayBuffer(32702)),
+20168,
+3280
+);
+} catch {}
+document.body.prepend(canvas0);
+let commandEncoder18 = device0.createCommandEncoder(
+{
+label: '\ufc81\u8aa3\u{1f99d}',
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+2,
+bindGroup0
+);
+} catch {}
+try {
+commandEncoder5.copyBufferToBuffer(
+buffer0,
+6444,
+buffer2,
+33684,
+340
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder5.resolveQuerySet(
+querySet3,
+140,
+1256,
+buffer5,
+256
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture9,
+  mipLevel: 0,
+  origin: { x: 8, y: 10, z: 50 },
+  aspect: 'all',
+},
+new ArrayBuffer(40),
+/* required buffer size: 20275695 */{
+offset: 605,
+bytesPerRow: 722,
+rowsPerImage: 211,
+},
+{width: 38, height: 19, depthOrArrayLayers: 134}
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend('\u0692\u{1fb0b}\u0996\u04a8\u00d7\ueabe\uaab0');
+let offscreenCanvas4 = new OffscreenCanvas(248, 273);
+try {
+renderBundleEncoder11.setIndexBuffer(
+buffer6,
+'uint32'
+);
+} catch {}
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+25188,
+new Int16Array(34085),
+5116,
+4972
+);
+} catch {}
+let bindGroup16 = device0.createBindGroup({
+label: '\u030f\u6f4c\u{1f82a}\u7bc9\u0eb4\ueb8b\u{1ff46}\u6a93\ud5f8\u2d5e',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let computePassEncoder11 = commandEncoder17.beginComputePass(
+{
+
+}
+);
+try {
+computePassEncoder6.setBindGroup(
+3,
+bindGroup11,
+new Uint32Array(582),
+212,
+0
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder18.clearBuffer(
+buffer1,
+24240
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let commandEncoder19 = device0.createCommandEncoder(
+{
+}
+);
+try {
+commandEncoder18.clearBuffer(
+buffer6
+);
+dissociateBuffer(device0, buffer6);
+} catch {}
+video0.width = 130;
+let querySet5 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 1174,
+}
+);
+let computePassEncoder12 = commandEncoder18.beginComputePass();
+try {
+commandEncoder5.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+4716,
+new BigUint64Array(25545),
+20008,
+2764
+);
+} catch {}
+let bindGroupLayout2 = device0.createBindGroupLayout(
+{
+label: '\u0bf1\u0235\u{1fbc3}\ufa29\u5acd',
+entries: [
+
+],
+}
+);
+let bindGroup17 = device0.createBindGroup({
+layout: bindGroupLayout2,
+entries: [
+
+],
+});
+let texture19 = device0.createTexture(
+{
+label: '\u4a23\u{1f6fe}\u7089\u06f2\ub61d\uc3f5\ub100\u0b09',
+size: {width: 4772, height: 12, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'eac-rg11unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'eac-rg11unorm'
+],
+}
+);
+let sampler13 = device0.createSampler(
+{
+label: '\u669e\u04ff\u{1ff2f}\u614e\ud8e5\u0baa\u280b\u6eb3\u{1f979}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 51.907,
+lodMaxClamp: 91.120,
+maxAnisotropy: 8,
+}
+);
+try {
+renderBundleEncoder7.setBindGroup(
+4,
+bindGroup17,
+new Uint32Array(8653),
+3496,
+0
+);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder6.resolveQuerySet(
+querySet1,
+2971,
+721,
+buffer5,
+1280
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: { x: 121, y: 1, z: 4 },
+  aspect: 'all',
+},
+new ArrayBuffer(32),
+/* required buffer size: 12132470 */{
+offset: 470,
+bytesPerRow: 13480,
+rowsPerImage: 180,
+},
+{width: 3335, height: 0, depthOrArrayLayers: 6}
+);
+} catch {}
+document.body.prepend('\u9aa4\u116f\u{1fcb4}\u2376\ud945\uf70c\u0907');
+let imageData2 = new ImageData(152, 216);
+let commandEncoder20 = device0.createCommandEncoder(
+{
+label: '\uf28b\ue9e2\u0744\ucfc1',
+}
+);
+let texture20 = device0.createTexture(
+{
+label: '\u{1fe44}\u00c6\ubeeb\u9a91\uf4d5\u4a93',
+size: [200, 216, 1],
+dimension: '2d',
+format: 'astc-10x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x8-unorm-srgb',
+'astc-10x8-unorm',
+'astc-10x8-unorm-srgb'
+],
+}
+);
+let textureView13 = texture12.createView(
+{
+label: '\ue374\ub443\u{1fe62}\u6cd6\u3d8c\u{1f65e}\u1df3\u{1fee5}',
+baseMipLevel: 0,
+baseArrayLayer: 75,
+arrayLayerCount: 1,
+}
+);
+let computePassEncoder13 = commandEncoder5.beginComputePass();
+try {
+await buffer3.mapAsync(
+GPUMapMode.WRITE,
+0,
+4860
+);
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 3, height: 1, depthOrArrayLayers: 112}
+*/
+{
+  source: imageData1,
+  origin: { x: 9, y: 28 },
+  flipY: false,
+},
+{
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 0, y: 1, z: 57 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 3, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let texture21 = device0.createTexture(
+{
+label: '\u{1f663}\u2603',
+size: [12460, 5, 180],
+mipLevelCount: 11,
+format: 'astc-10x5-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundle9 = renderBundleEncoder0.finish(
+{
+label: '\u{1f8f7}\u{1f8ea}\u{1f706}\u{1fb23}\u{1ff34}'
+}
+);
+try {
+renderBundleEncoder6.setVertexBuffer(
+8,
+buffer6,
+4104,
+32401
+);
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 1, depthOrArrayLayers: 225}
+*/
+{
+  source: video0,
+  origin: { x: 3, y: 5 },
+  flipY: true,
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 9 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 5, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let textureView14 = texture4.createView(
+{
+label: '\u033c\u4fed\u12b2\ua64e',
+baseArrayLayer: 57,
+arrayLayerCount: 7,
+}
+);
+let computePassEncoder14 = commandEncoder20.beginComputePass(
+{
+label: '\uae81\u{1fa35}\u1dc6\ue802'
+}
+);
+let renderBundleEncoder12 = device0.createRenderBundleEncoder(
+{
+label: '\u1ccd\u7652\ube68\u801d',
+colorFormats: [
+'rgb10a2uint',
+'rg32sint',
+'bgra8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 253,
+depthReadOnly: true,
+}
+);
+let renderBundle10 = renderBundleEncoder10.finish(
+{
+label: '\u0627\u{1fda1}\u83c5\u3f18\u929e\ufe9d\u0ca3\u08d0'
+}
+);
+try {
+commandEncoder19.copyBufferToBuffer(
+buffer4,
+8460,
+buffer6,
+4108,
+27444
+);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder19.copyTextureToBuffer(
+{
+  texture: texture17,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 5088 */
+offset: 5088,
+buffer: buffer2,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let canvas3 = document.createElement('canvas');
+let textureView15 = texture21.createView(
+{
+label: '\u2504\u81b3\u02ae\u{1f8d9}\u0a6d\u08db\u0db9\uf098\u0311\u00f4\u8258',
+dimension: '2d',
+baseMipLevel: 9,
+mipLevelCount: 1,
+baseArrayLayer: 172,
+}
+);
+try {
+computePassEncoder1.end();
+} catch {}
+let arrayBuffer0 = buffer3.getMappedRange(
+0,
+724
+);
+try {
+commandEncoder6.clearBuffer(
+buffer1,
+29484
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer3,
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+24976,
+new BigUint64Array(38778),
+18050,
+1924
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 10, y: 1, z: 98 },
+  aspect: 'all',
+},
+new Float32Array(new ArrayBuffer(16)),
+/* required buffer size: 67338944 */{
+offset: 509,
+bytesPerRow: 283,
+rowsPerImage: 145,
+},
+{width: 31, height: 0, depthOrArrayLayers: 1642}
+);
+} catch {}
+document.body.append('\u{1fb52}\u{1fa24}');
+let video2 = await videoWithData();
+let querySet6 = device0.createQuerySet(
+{
+label: '\u06b1\u057f\u1858\u3f15\u89df\u03c7\ue3ba\u{1f64e}\u8bf1\u6778',
+type: 'occlusion',
+count: 994,
+}
+);
+let sampler14 = device0.createSampler(
+{
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 33.455,
+lodMaxClamp: 79.802,
+}
+);
+try {
+commandEncoder3.copyBufferToBuffer(
+buffer2,
+24012,
+buffer6,
+38284,
+944
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder6.resolveQuerySet(
+querySet3,
+43,
+642,
+buffer5,
+4352
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+55004,
+new Float32Array(6158),
+681,
+1004
+);
+} catch {}
+let bindGroup18 = device0.createBindGroup({
+label: '\u1ce8\u4d08',
+layout: bindGroupLayout2,
+entries: [
+
+],
+});
+let computePassEncoder15 = commandEncoder19.beginComputePass(
+{
+label: '\u{1fd47}\u79ce\u0df5\ub748\u0eff\u0bf4\u0802\u0632\uecd8\uf4f7\u500d'
+}
+);
+let renderBundleEncoder13 = device0.createRenderBundleEncoder(
+{
+label: '\u0aa9\u{1ff7d}\uf45b\u7d94\u4006\u{1fd13}',
+colorFormats: [
+'rg32uint',
+'rgba32sint',
+'rg32sint',
+'r8sint',
+'rg32float'
+],
+sampleCount: 726,
+stencilReadOnly: true,
+}
+);
+let renderBundle11 = renderBundleEncoder0.finish(
+{
+label: '\ud0cf\u7295\u1927\u{1f9e3}\u6d22\u486c\u008e'
+}
+);
+try {
+renderBundleEncoder6.setBindGroup(
+0,
+bindGroup13
+);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(
+7,
+buffer6,
+30044,
+7809
+);
+} catch {}
+try {
+commandEncoder3.copyTextureToTexture(
+{
+  texture: texture10,
+  mipLevel: 2,
+  origin: { x: 1740, y: 12, z: 58 },
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 3,
+  origin: { x: 48, y: 0, z: 120 },
+  aspect: 'all',
+},
+{width: 1284, height: 0, depthOrArrayLayers: 16}
+);
+} catch {}
+let commandEncoder21 = device0.createCommandEncoder();
+let querySet7 = device0.createQuerySet(
+{
+label: '\u1aa4\uc91b\u6209\u0586\u{1f728}\u{1faae}\u{1fcf0}',
+type: 'occlusion',
+count: 3142,
+}
+);
+pseudoSubmit(device0, commandEncoder4);
+try {
+computePassEncoder6.setBindGroup(
+2,
+bindGroup18,
+new Uint32Array(8410),
+3109,
+0
+);
+} catch {}
+try {
+commandEncoder3.copyBufferToBuffer(
+buffer6,
+27044,
+buffer2,
+51760,
+4356
+);
+dissociateBuffer(device0, buffer6);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+16808,
+new BigUint64Array(32833),
+32776,
+44
+);
+} catch {}
+let bindGroup19 = device0.createBindGroup({
+label: '\u{1f88e}\ud64d\u0b6b\u0e78\uebf2\u{1fbc6}\u35ab\u{1f6e0}',
+layout: bindGroupLayout1,
+entries: [
+{
+binding: 2766,
+resource: externalTexture0
+},
+{
+binding: 2712,
+resource: sampler0
+}
+],
+});
+let querySet8 = device0.createQuerySet(
+{
+label: '\u{1f647}\u{1fcce}',
+type: 'occlusion',
+count: 3355,
+}
+);
+let textureView16 = texture19.createView(
+{
+label: '\u5ae4\ud62c\u4bdb\ue463\u7971\u0de4\u0e68',
+dimension: '2d-array',
+baseMipLevel: 3,
+}
+);
+let sampler15 = device0.createSampler(
+{
+label: '\uaf1f\uf09e\u9936\u{1f780}\u98ed\u7479\u{1f629}\u02b5\u02b2\u20f6\u74f4',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 17.099,
+lodMaxClamp: 69.118,
+}
+);
+try {
+computePassEncoder12.setBindGroup(
+4,
+bindGroup15,
+new Uint32Array(6166),
+3437,
+0
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+5656,
+new BigUint64Array(43334),
+18528,
+2224
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 1, depthOrArrayLayers: 225}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 5, y: 147 },
+  flipY: true,
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 3, y: 0, z: 170 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipelineLayout3 = device0.createPipelineLayout(
+{
+label: '\u0dd2\u0cf9\u99e5\u670a\u861b',
+bindGroupLayouts: [
+bindGroupLayout1
+],
+}
+);
+let commandEncoder22 = device0.createCommandEncoder(
+{
+label: '\u{1f956}\u6c4c\ued4b\u6740\u685e\u5393\u1e07',
+}
+);
+let texture22 = device0.createTexture(
+{
+label: '\u{1fd09}\u{1f84c}\u0ed9\u3506\u68dc\u4965\u0ded\u1d35\u07ee\uf16e',
+size: {width: 32, height: 10, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+dimension: '2d',
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-8x5-unorm-srgb',
+'astc-8x5-unorm',
+'astc-8x5-unorm-srgb'
+],
+}
+);
+try {
+commandEncoder21.copyBufferToBuffer(
+buffer0,
+776,
+buffer1,
+14348,
+11368
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder21.resolveQuerySet(
+querySet4,
+1138,
+157,
+buffer5,
+768
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+35764,
+new BigUint64Array(23360),
+15996,
+2864
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let bindGroup20 = device0.createBindGroup({
+layout: bindGroupLayout2,
+entries: [
+
+],
+});
+pseudoSubmit(device0, commandEncoder22);
+let texture23 = device0.createTexture(
+{
+label: '\u1b7d\u{1f7d2}\u03d8\u4eb0\u02d6\u{1f6f9}\u0485\u726d\u0897',
+size: [32, 408, 1],
+mipLevelCount: 3,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-8x8-unorm-srgb',
+'astc-8x8-unorm-srgb'
+],
+}
+);
+let renderBundle12 = renderBundleEncoder1.finish(
+{
+label: '\ue96d\ucf73\u{1fc7a}\uf514\u{1fd5a}\u0d89\u88e2\u528e\ud9b2'
+}
+);
+try {
+computePassEncoder14.setBindGroup(
+5,
+bindGroup14,
+new Uint32Array(7474),
+3500,
+0
+);
+} catch {}
+let arrayBuffer1 = buffer3.getMappedRange(
+4720,
+64
+);
+try {
+commandEncoder6.copyBufferToBuffer(
+buffer2,
+532,
+buffer1,
+740,
+6052
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder3.clearBuffer(
+buffer6
+);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder3.resolveQuerySet(
+querySet0,
+1212,
+1257,
+buffer5,
+0
+);
+} catch {}
+try {
+await promise3;
+} catch {}
+let canvas4 = document.createElement('canvas');
+try {
+window.someLabel = querySet3.label;
+} catch {}
+let sampler16 = device0.createSampler(
+{
+label: '\u0e6d\u2d76\u{1fa94}\u0fcf',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 94.094,
+lodMaxClamp: 97.793,
+compare: 'less-equal',
+maxAnisotropy: 1,
+}
+);
+let externalTexture1 = device0.importExternalTexture(
+{
+label: '\u0d8e\u06d6\u05f0\u074d\u0fc5',
+source: video0,
+colorSpace: 'display-p3',
+}
+);
+try {
+commandEncoder21.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 1, depthOrArrayLayers: 225}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 5, y: 50 },
+  flipY: false,
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 213 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 5, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let bindGroup21 = device0.createBindGroup({
+label: '\u15c3\u{1ff29}\u9ee8\u6e99\uf9cd\u3c45',
+layout: bindGroupLayout2,
+entries: [
+
+],
+});
+let commandEncoder23 = device0.createCommandEncoder();
+let textureView17 = texture1.createView(
+{
+label: '\ud013\ucb12\u2007\u26a2\u0a21\u6669\u{1f691}\u6e01\u87cb\ua424\u8c0a',
+format: 'eac-rg11snorm',
+baseMipLevel: 2,
+mipLevelCount: 1,
+baseArrayLayer: 78,
+arrayLayerCount: 4,
+}
+);
+let computePassEncoder16 = commandEncoder6.beginComputePass(
+{
+label: '\u0904\u045b\u{1ff2c}\u{1f75a}\uda51\u04c7\u2c67\u{1ffb2}\u0df7\u{1fcda}\u{1f8bd}'
+}
+);
+let renderBundleEncoder14 = device0.createRenderBundleEncoder(
+{
+label: '\ufd83\u0e18\u75bb\u4c70\u7e4b\u5ae5\u0d30\u723b\uf114',
+colorFormats: [
+'rg8uint',
+undefined,
+'rg16uint',
+'rgba16uint',
+'rg32float',
+'r8uint'
+],
+sampleCount: 489,
+depthReadOnly: true,
+}
+);
+let renderBundle13 = renderBundleEncoder14.finish(
+{
+label: '\u{1fc06}\u{1febe}\u0fcb'
+}
+);
+try {
+renderBundleEncoder6.setBindGroup(
+6,
+bindGroup8
+);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(
+1,
+buffer5
+);
+} catch {}
+try {
+commandEncoder23.copyTextureToBuffer(
+{
+  texture: texture15,
+  mipLevel: 0,
+  origin: { x: 1874, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 46928 widthInBlocks: 5866 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 46672 */
+offset: 46672,
+buffer: buffer2,
+},
+{width: 5866, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder23.resolveQuerySet(
+querySet3,
+1405,
+152,
+buffer6,
+1536
+);
+} catch {}
+try {
+commandEncoder21.clearBuffer(
+buffer6,
+22272
+);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+9180,
+new Float32Array(47850),
+22434,
+996
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 2,
+  origin: { x: 120, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer1),
+/* required buffer size: 126 */{
+offset: 126,
+},
+{width: 3306, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let gpuCanvasContext3 = canvas3.getContext('webgpu');
+let commandEncoder24 = device0.createCommandEncoder(
+{
+}
+);
+let querySet9 = device0.createQuerySet(
+{
+label: '\u8d28\u071e\u8a89\u03ab\u814d\u{1faf9}\u06ce\u50ca',
+type: 'occlusion',
+count: 1279,
+}
+);
+let texture24 = device0.createTexture(
+{
+label: '\ua465\u9017\u0024\ue981',
+size: {width: 42, height: 63, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'depth24plus',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth24plus'
+],
+}
+);
+let texture25 = gpuCanvasContext1.getCurrentTexture();
+let sampler17 = device0.createSampler(
+{
+label: '\u620a\u{1fbaa}\u0df6\u090f\u{1ffae}\ua92c\u34ea',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 97.695,
+lodMaxClamp: 99.538,
+compare: 'less-equal',
+}
+);
+try {
+commandEncoder23.resolveQuerySet(
+querySet1,
+2148,
+245,
+buffer6,
+37376
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let img3 = await imageWithData(155, 66, '#001998b3', '#2b661c42');
+let textureView18 = texture18.createView(
+{
+label: '\u01f4\uf8da\u3210\ue5e2\u{1fc5b}\u04e3\u{1fe17}\u0a67\u{1fece}\u00e4',
+baseMipLevel: 2,
+baseArrayLayer: 22,
+arrayLayerCount: 6,
+}
+);
+try {
+renderBundleEncoder8.setBindGroup(
+3,
+bindGroup10
+);
+} catch {}
+try {
+commandEncoder3.copyBufferToBuffer(
+buffer0,
+11272,
+buffer6,
+33660,
+4632
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 3, height: 1, depthOrArrayLayers: 112}
+*/
+{
+  source: video2,
+  origin: { x: 11, y: 2 },
+  flipY: true,
+},
+{
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 1, y: 1, z: 66 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 2, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\u0d70\u3846');
+try {
+offscreenCanvas4.getContext('bitmaprenderer');
+} catch {}
+let texture26 = device0.createTexture(
+{
+label: '\u{1f6a2}\u{1fa4f}\u12b6\u5eae',
+size: {width: 3348, height: 180, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'astc-12x12-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-12x12-unorm-srgb',
+'astc-12x12-unorm-srgb'
+],
+}
+);
+try {
+computePassEncoder12.setBindGroup(
+3,
+bindGroup16,
+new Uint32Array(8238),
+6854,
+0
+);
+} catch {}
+try {
+computePassEncoder5.end();
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(
+buffer6,
+'uint16',
+15230,
+15853
+);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(
+3,
+buffer6,
+33876,
+3315
+);
+} catch {}
+try {
+commandEncoder21.copyTextureToTexture(
+{
+  texture: texture26,
+  mipLevel: 3,
+  origin: { x: 12, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: { x: 540, y: 12, z: 27 },
+  aspect: 'all',
+},
+{width: 204, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(
+querySet1,
+186,
+426,
+buffer6,
+35840
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 1, depthOrArrayLayers: 225}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 107, y: 112 },
+  flipY: false,
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 212 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 6, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend(canvas2);
+let textureView19 = texture7.createView(
+{
+label: '\u{1f779}\u0464\u{1fc72}\u79b4\u{1fba2}\uef0f\u0856\ub31a\u5289\u0b89',
+dimension: '3d',
+aspect: 'all',
+}
+);
+let renderBundle14 = renderBundleEncoder11.finish(
+{
+label: '\u0a6c\u0009\uc96c\ua7af\u61b2\u0f02\u5696\u6a86'
+}
+);
+try {
+commandEncoder9.clearBuffer(
+buffer6
+);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+renderBundleEncoder13.insertDebugMarker(
+'\u0752'
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let renderBundle15 = renderBundleEncoder2.finish(
+{
+label: '\u{1f782}\u{1fbc1}\u0017\u08c9\u08cc\ud588\u33ca'
+}
+);
+let sampler18 = device0.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMaxClamp: 62.079,
+compare: 'equal',
+}
+);
+try {
+renderBundleEncoder7.setVertexBuffer(
+7,
+buffer6,
+3532,
+10753
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+748,
+new Int16Array(45732),
+8559,
+12460
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: { x: 2008, y: 1, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(56),
+/* required buffer size: 793 */{
+offset: 793,
+},
+{width: 4564, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 1, depthOrArrayLayers: 225}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 31, y: 47 },
+  flipY: false,
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 2, y: 0, z: 130 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\uc403\ued76\uf09d\u{1f8c4}\ude85\u0356\u96c6\ue0be\u0bf7');
+let imageData3 = new ImageData(188, 208);
+let videoFrame4 = new VideoFrame(canvas1, {timestamp: 0});
+let computePassEncoder17 = commandEncoder3.beginComputePass(
+{
+label: '\u41bf\u2431\u99e2'
+}
+);
+try {
+renderBundleEncoder8.setBindGroup(
+1,
+bindGroup8
+);
+} catch {}
+try {
+commandEncoder21.copyBufferToBuffer(
+buffer5,
+2956,
+buffer2,
+23644,
+5736
+);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+renderBundleEncoder3.insertDebugMarker(
+'\u8f2c'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+29420,
+new DataView(new ArrayBuffer(12602)),
+10352,
+284
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture25,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer1),
+/* required buffer size: 584 */{
+offset: 576,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let texture27 = device0.createTexture(
+{
+size: {width: 8032, height: 4, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.COPY_DST,
+}
+);
+let textureView20 = texture17.createView(
+{
+dimension: '2d-array',
+format: 'rgba8sint',
+}
+);
+let computePassEncoder18 = commandEncoder23.beginComputePass(
+{
+label: '\u02e8\u0b31\u0e62\u9da7\u{1f6bd}\u9914\u0067'
+}
+);
+let sampler19 = device0.createSampler(
+{
+label: '\u0206\u{1ff2c}\u03e9\u{1ffd1}\ua2c7\u08d3\udd02\u{1fcea}\u3ce0\ue101\uc458',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 99.683,
+lodMaxClamp: 99.981,
+}
+);
+try {
+renderBundleEncoder8.setBindGroup(
+6,
+bindGroup10,
+new Uint32Array(773),
+700,
+0
+);
+} catch {}
+try {
+commandEncoder21.copyBufferToBuffer(
+buffer2,
+57308,
+buffer1,
+14272,
+64
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+40916,
+new BigUint64Array(58387),
+49767,
+8
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 3, height: 1, depthOrArrayLayers: 112}
+*/
+{
+  source: img2,
+  origin: { x: 116, y: 44 },
+  flipY: false,
+},
+{
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 93 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\uecb8\u68fb\u7337\u0c07\u0fe0\u8a1c');
+let promise4 = navigator.gpu.requestAdapter(
+{
+}
+);
+let renderBundle16 = renderBundleEncoder0.finish(
+{
+label: '\u557a\u12ea\u9121\u3d80\uf8db'
+}
+);
+let sampler20 = device0.createSampler(
+{
+label: '\ubaa1\u0f7b\u7652\u{1fb08}\u0805\u0776\u046a\u0296',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 79.242,
+lodMaxClamp: 94.840,
+}
+);
+try {
+renderBundleEncoder6.setBindGroup(
+0,
+bindGroup17
+);
+} catch {}
+try {
+commandEncoder24.resolveQuerySet(
+querySet1,
+639,
+435,
+buffer5,
+768
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+16292,
+new BigUint64Array(40001),
+27763,
+168
+);
+} catch {}
+document.body.prepend(img3);
+document.body.append('\ub050\u7756\u0372\u{1f7f3}\u0d22\u012c\u29b8');
+let img4 = await imageWithData(76, 41, '#92795987', '#5f8de778');
+let pipelineLayout4 = device0.createPipelineLayout(
+{
+label: '\u399e\ua95c\u{1f9a4}\u67f5\u3349\u{1fbe3}\u07be',
+bindGroupLayouts: [
+bindGroupLayout2,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0
+],
+}
+);
+let buffer7 = device0.createBuffer(
+{
+label: '\u057b\u25db\u040d\u068a\u{1fa9a}\u{1ff88}\u{1f73f}\u2346\ue188\u34dd',
+size: 24322,
+usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let textureView21 = texture14.createView(
+{
+label: '\u39e9\ua1b8\u{1f98c}\u0670\u03bd\u0244',
+mipLevelCount: 5,
+baseArrayLayer: 16,
+arrayLayerCount: 14,
+}
+);
+try {
+device0.queue.writeBuffer(
+buffer2,
+28716,
+new DataView(new ArrayBuffer(42767)),
+22608,
+4868
+);
+} catch {}
+gc();
+let img5 = await imageWithData(55, 62, '#5f343aff', '#12a49bed');
+let texture28 = device0.createTexture(
+{
+label: '\u0916\u0759\u5f47\u0a09\u0fc5\u0e65\u{1fe1a}\u0908',
+size: [255, 1, 462],
+mipLevelCount: 2,
+dimension: '3d',
+format: 'r32sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+renderBundleEncoder12.setBindGroup(
+1,
+bindGroup20
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+4,
+buffer5,
+4456
+);
+} catch {}
+try {
+computePassEncoder13.insertDebugMarker(
+'\u5e04'
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 3, height: 1, depthOrArrayLayers: 112}
+*/
+{
+  source: img3,
+  origin: { x: 8, y: 61 },
+  flipY: true,
+},
+{
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 1, y: 0, z: 12 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 2, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let canvas5 = document.createElement('canvas');
+let img6 = await imageWithData(79, 79, '#a1129feb', '#c90dc279');
+let buffer8 = device0.createBuffer(
+{
+label: '\u0055\u401a',
+size: 1308,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+try {
+commandEncoder21.clearBuffer(
+buffer6,
+17604,
+12948
+);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(
+querySet3,
+927,
+55,
+buffer6,
+37376
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+32220,
+new Float32Array(33855),
+7425,
+2156
+);
+} catch {}
+let gpuCanvasContext4 = canvas4.getContext('webgpu');
+let shaderModule0 = device0.createShaderModule(
+{
+label: '\ufb26\u{1fa74}\u54c6\u0adb\u00ea\u{1fd98}\u0bac\ua69a',
+code: `
+
+@compute @workgroup_size(5, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@builtin(sample_mask) f0: u32,
+@location(6) f1: vec2<f32>,
+@location(1) f2: vec4<f32>,
+@location(2) f3: vec2<f32>,
+@location(7) f4: vec4<u32>,
+@location(0) f5: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(7) a0: vec2<f16>, @location(50) a1: vec2<f16>, @location(47) a2: vec4<f16>, @location(73) a3: f16, @location(62) a4: i32, @location(51) a5: i32, @location(14) a6: vec4<u32>, @location(49) a7: vec2<u32>, @location(54) a8: vec4<f32>, @location(69) a9: vec2<u32>, @location(48) a10: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S0 {
+@location(16) f0: f16,
+@location(17) f1: vec3<f16>,
+@location(20) f2: vec2<u32>,
+@location(21) f3: vec3<i32>,
+@location(10) f4: f32,
+@location(8) f5: i32,
+@location(1) f6: vec2<f32>,
+@location(18) f7: f32,
+@location(14) f8: vec4<i32>,
+@location(15) f9: vec4<f16>,
+@location(13) f10: vec3<f32>,
+@location(0) f11: vec4<u32>
+}
+struct VertexOutput0 {
+@location(17) f0: vec3<f32>,
+@location(62) f1: i32,
+@location(60) f2: f16,
+@location(15) f3: vec4<u32>,
+@location(57) f4: vec4<f16>,
+@location(19) f5: f32,
+@location(11) f6: f32,
+@location(66) f7: vec3<u32>,
+@location(54) f8: vec4<f32>,
+@location(79) f9: vec2<i32>,
+@location(49) f10: vec2<u32>,
+@location(7) f11: vec2<f16>,
+@location(69) f12: vec2<u32>,
+@location(51) f13: i32,
+@location(55) f14: f16,
+@location(50) f15: vec2<f16>,
+@location(73) f16: f16,
+@location(6) f17: vec4<f16>,
+@location(78) f18: vec3<f32>,
+@location(59) f19: vec2<i32>,
+@location(70) f20: vec2<i32>,
+@location(14) f21: vec4<u32>,
+@builtin(position) f22: vec4<f32>,
+@location(47) f23: vec4<f16>,
+@location(48) f24: vec4<f32>,
+@location(45) f25: vec3<f16>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(3) a1: vec2<f32>, @location(2) a2: vec2<u32>, @location(5) a3: vec2<f16>, @location(6) a4: u32, @location(19) a5: vec2<u32>, @builtin(instance_index) a6: u32, @location(4) a7: vec2<f32>, a8: S0, @location(11) a9: vec3<u32>, @location(9) a10: vec3<i32>, @location(7) a11: vec4<f32>, @location(12) a12: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+}
+);
+let commandEncoder25 = device0.createCommandEncoder(
+{
+}
+);
+let textureView22 = texture26.createView(
+{
+label: '\u{1f81f}\uae72\u{1fa27}\u2869\u0585\udcd1',
+format: 'astc-12x12-unorm-srgb',
+mipLevelCount: 2,
+}
+);
+let computePassEncoder19 = commandEncoder21.beginComputePass(
+{
+label: '\ufa81\u7d5f\u7bc0\u{1ff57}\u5698\u061b'
+}
+);
+try {
+renderBundleEncoder8.setVertexBuffer(
+8,
+buffer6,
+31608,
+4223
+);
+} catch {}
+try {
+commandEncoder9.clearBuffer(
+buffer6
+);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(
+querySet3,
+759,
+219,
+buffer6,
+20224
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+9040,
+new BigUint64Array(29610),
+14770,
+3424
+);
+} catch {}
+let pipeline0 = device0.createRenderPipeline(
+{
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1536,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 1472,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x4',
+offset: 808,
+shaderLocation: 15,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 1500,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'snorm8x2',
+offset: 5014,
+shaderLocation: 13,
+},
+{
+format: 'sint32',
+offset: 4192,
+shaderLocation: 9,
+},
+{
+format: 'float32',
+offset: 2924,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x2',
+offset: 4464,
+shaderLocation: 4,
+},
+{
+format: 'snorm16x4',
+offset: 3904,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 5716,
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 48,
+shaderLocation: 1,
+},
+{
+format: 'sint32x3',
+offset: 648,
+shaderLocation: 21,
+},
+{
+format: 'sint32x2',
+offset: 3368,
+shaderLocation: 8,
+},
+{
+format: 'uint8x2',
+offset: 1486,
+shaderLocation: 2,
+},
+{
+format: 'float32',
+offset: 4160,
+shaderLocation: 10,
+},
+{
+format: 'uint8x2',
+offset: 1386,
+shaderLocation: 20,
+},
+{
+format: 'uint32x3',
+offset: 1140,
+shaderLocation: 19,
+},
+{
+format: 'uint32x3',
+offset: 1264,
+shaderLocation: 0,
+},
+{
+format: 'uint16x4',
+offset: 5096,
+shaderLocation: 6,
+},
+{
+format: 'uint32x3',
+offset: 1876,
+shaderLocation: 11,
+},
+{
+format: 'float32x4',
+offset: 1912,
+shaderLocation: 16,
+},
+{
+format: 'snorm8x4',
+offset: 68,
+shaderLocation: 5,
+},
+{
+format: 'sint16x2',
+offset: 2280,
+shaderLocation: 14,
+},
+{
+format: 'float32x2',
+offset: 948,
+shaderLocation: 3,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x6ffc5a7,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg8sint',
+},
+{
+format: 'r16float',
+writeMask: GPUColorWrite.ALL,
+},
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 1744,
+depthBias: 57,
+depthBiasSlopeScale: 46,
+depthBiasClamp: 95,
+},
+}
+);
+document.body.prepend(img5);
+let computePassEncoder20 = commandEncoder25.beginComputePass(
+{
+
+}
+);
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture19,
+  mipLevel: 1,
+  origin: { x: 712, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 265 */{
+offset: 265,
+},
+{width: 1168, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise5 = device0.createComputePipelineAsync(
+{
+label: '\uef85\u{1f635}\u{1fff5}\u5e40\u65de\u8575\ub635\u0ee8\u0ec9\u0a18',
+layout: 'auto',
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageData4 = new ImageData(28, 140);
+let renderBundle17 = renderBundleEncoder9.finish(
+{
+label: '\ufc03\u8838\u33b0'
+}
+);
+try {
+renderBundleEncoder6.setVertexBuffer(
+2,
+buffer5,
+5404,
+2519
+);
+} catch {}
+try {
+texture24.destroy();
+} catch {}
+try {
+commandEncoder9.copyTextureToTexture(
+{
+  texture: texture18,
+  mipLevel: 0,
+  origin: { x: 15, y: 0, z: 6 },
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 3,
+  origin: { x: 525, y: 5, z: 54 },
+  aspect: 'all',
+},
+{width: 35, height: 0, depthOrArrayLayers: 13}
+);
+} catch {}
+let pipeline1 = await device0.createRenderPipelineAsync(
+{
+label: '\u0837\u0bda\u0fdb\u01ab\u{1fc10}\u{1fd86}\u013d\u{1fb6f}\u80b2\u{1f6e2}',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 996,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x2',
+offset: 100,
+shaderLocation: 13,
+},
+{
+format: 'sint32x4',
+offset: 320,
+shaderLocation: 14,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 764,
+shaderLocation: 10,
+},
+{
+format: 'uint8x2',
+offset: 20,
+shaderLocation: 20,
+},
+{
+format: 'float32x4',
+offset: 420,
+shaderLocation: 4,
+},
+{
+format: 'unorm16x4',
+offset: 788,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 1156,
+attributes: [
+{
+format: 'uint16x2',
+offset: 528,
+shaderLocation: 6,
+},
+{
+format: 'uint8x4',
+offset: 876,
+shaderLocation: 2,
+},
+{
+format: 'sint32x4',
+offset: 760,
+shaderLocation: 8,
+},
+{
+format: 'float32x2',
+offset: 1120,
+shaderLocation: 17,
+},
+{
+format: 'float32x2',
+offset: 812,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x4',
+offset: 960,
+shaderLocation: 15,
+},
+{
+format: 'uint16x4',
+offset: 648,
+shaderLocation: 19,
+},
+{
+format: 'unorm16x4',
+offset: 636,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x3',
+offset: 4720,
+shaderLocation: 9,
+},
+{
+format: 'float32',
+offset: 1220,
+shaderLocation: 5,
+},
+{
+format: 'snorm16x2',
+offset: 2396,
+shaderLocation: 12,
+},
+{
+format: 'sint32x4',
+offset: 4308,
+shaderLocation: 21,
+},
+{
+format: 'float32x4',
+offset: 3560,
+shaderLocation: 18,
+},
+{
+format: 'uint16x2',
+offset: 2888,
+shaderLocation: 11,
+},
+{
+format: 'float16x4',
+offset: 1732,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 5616,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 5024,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x1df7f6b6,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+{
+format: 'rgba32float',
+}
+],
+},
+}
+);
+document.body.append('\u{1fd83}\u{1fd58}\u6ee2\u47a3\u010b\u2cc7\ubc62\u067f\u{1fc12}');
+let video3 = await videoWithData();
+let textureView23 = texture3.createView(
+{
+label: '\uedff\u{1f841}\u089e\u{1f93d}',
+dimension: '2d',
+baseMipLevel: 5,
+mipLevelCount: 2,
+baseArrayLayer: 220,
+}
+);
+try {
+commandEncoder24.copyBufferToBuffer(
+buffer8,
+888,
+buffer1,
+11556,
+384
+);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder24.resolveQuerySet(
+querySet1,
+3237,
+212,
+buffer6,
+26112
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 1, depthOrArrayLayers: 225}
+*/
+{
+  source: imageData0,
+  origin: { x: 37, y: 167 },
+  flipY: false,
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 177 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 6, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline2 = await device0.createRenderPipelineAsync(
+{
+layout: 'auto',
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 4940,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x4',
+offset: 752,
+shaderLocation: 17,
+},
+{
+format: 'uint32',
+offset: 3888,
+shaderLocation: 20,
+},
+{
+format: 'snorm8x2',
+offset: 1896,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 3508,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x4',
+offset: 1204,
+shaderLocation: 8,
+},
+{
+format: 'sint32',
+offset: 1856,
+shaderLocation: 14,
+},
+{
+format: 'snorm16x2',
+offset: 532,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x2',
+offset: 2744,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x4',
+offset: 2616,
+shaderLocation: 15,
+},
+{
+format: 'uint32x4',
+offset: 2756,
+shaderLocation: 0,
+},
+{
+format: 'float32',
+offset: 2428,
+shaderLocation: 4,
+},
+{
+format: 'snorm16x4',
+offset: 24,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x2',
+offset: 936,
+shaderLocation: 5,
+},
+{
+format: 'float32x2',
+offset: 2380,
+shaderLocation: 1,
+},
+{
+format: 'uint32',
+offset: 2664,
+shaderLocation: 2,
+},
+{
+format: 'uint32x3',
+offset: 176,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 6344,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 1964,
+shaderLocation: 9,
+},
+{
+format: 'float16x4',
+offset: 964,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 4388,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x2',
+offset: 4008,
+shaderLocation: 21,
+},
+{
+format: 'uint8x4',
+offset: 3100,
+shaderLocation: 19,
+},
+{
+format: 'unorm16x4',
+offset: 2360,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x2',
+offset: 2716,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 5588,
+attributes: [
+{
+format: 'uint16x4',
+offset: 5168,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+cullMode: 'back',
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32sint',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 1569,
+stencilWriteMask: 2326,
+depthBias: 40,
+depthBiasClamp: 68,
+},
+}
+);
+let imageData5 = new ImageData(24, 196);
+let videoFrame5 = videoFrame1.clone();
+let buffer9 = device0.createBuffer(
+{
+label: '\ueb3c\ub0c1\u0707\u9517\u7405\u0355\u0c51\u0ae1\u38a1',
+size: 32203,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let commandEncoder26 = device0.createCommandEncoder();
+let texture29 = device0.createTexture(
+{
+size: [143, 1, 152],
+dimension: '3d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+let computePassEncoder21 = commandEncoder13.beginComputePass(
+{
+label: '\u7460\u{1f6d7}\u9e9a\u{1fe98}'
+}
+);
+let renderBundle18 = renderBundleEncoder14.finish(
+{
+label: '\uf1f0\u0465\u324b'
+}
+);
+try {
+renderBundleEncoder12.setBindGroup(
+2,
+bindGroup9,
+new Uint32Array(1372),
+447,
+0
+);
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(
+querySet6,
+59,
+789,
+buffer5,
+1280
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise6 = adapter0.requestAdapterInfo();
+let textureView24 = texture1.createView(
+{
+label: '\u1d28\u{1fa23}\u057d\u7834\ud7a5\u32d9\u8802\u4650\ucf67\u{1fc27}',
+dimension: '2d',
+baseMipLevel: 2,
+mipLevelCount: 1,
+baseArrayLayer: 30,
+}
+);
+try {
+computePassEncoder16.setBindGroup(
+3,
+bindGroup21
+);
+} catch {}
+try {
+commandEncoder24.resolveQuerySet(
+querySet0,
+1573,
+480,
+buffer5,
+768
+);
+} catch {}
+try {
+await promise6;
+} catch {}
+document.body.prepend('\u06e4\u0312\u{1f9bf}\ud3ef\u2a01\u8f1b\u24d5\u{1fd89}\u0ce5\u4551');
+try {
+renderBundleEncoder7.setBindGroup(
+5,
+bindGroup3,
+new Uint32Array(2445),
+1291,
+0
+);
+} catch {}
+try {
+commandEncoder26.resolveQuerySet(
+querySet0,
+1100,
+1049,
+buffer5,
+768
+);
+} catch {}
+let pipeline3 = device0.createComputePipeline(
+{
+layout: 'auto',
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let textureView25 = texture1.createView(
+{
+label: '\ue09c\u0676',
+dimension: '2d',
+baseMipLevel: 4,
+baseArrayLayer: 13,
+}
+);
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+commandEncoder24.clearBuffer(
+buffer6
+);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder26.resolveQuerySet(
+querySet3,
+86,
+514,
+buffer5,
+512
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 1, depthOrArrayLayers: 225}
+*/
+{
+  source: video1,
+  origin: { x: 2, y: 15 },
+  flipY: false,
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 3, y: 0, z: 61 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 3, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+canvas2.width = 432;
+let texture30 = device0.createTexture(
+{
+label: '\u47e8\u833f\u{1fc2a}\u3c86\ufa82\u1548\ucdba\u{1f98b}\ufcac',
+size: {width: 80, height: 6, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'astc-10x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x6-unorm',
+'astc-10x6-unorm',
+'astc-10x6-unorm-srgb'
+],
+}
+);
+let textureView26 = texture30.createView(
+{
+format: 'astc-10x6-unorm',
+baseMipLevel: 1,
+}
+);
+pseudoSubmit(device0, commandEncoder23);
+let texture31 = device0.createTexture(
+{
+label: '\u9b2e\u0ee1\u7959\uc2df\ue1b4',
+size: {width: 1904, height: 72, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'eac-rg11unorm',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+let textureView27 = texture13.createView(
+{
+label: '\u{1f61b}\u02d9\u0e47\u690c',
+}
+);
+try {
+computePassEncoder16.setBindGroup(
+0,
+bindGroup13,
+new Uint32Array(4501),
+3296,
+0
+);
+} catch {}
+try {
+commandEncoder9.insertDebugMarker(
+'\u078f'
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 1, depthOrArrayLayers: 225}
+*/
+{
+  source: img5,
+  origin: { x: 1, y: 36 },
+  flipY: false,
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 128 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 6, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let gpuCanvasContext5 = canvas1.getContext('webgpu');
+let video4 = await videoWithData();
+let commandEncoder27 = device0.createCommandEncoder(
+{
+label: '\u{1f94f}\u6565\uf32c',
+}
+);
+let textureView28 = texture27.createView(
+{
+dimension: '2d-array',
+mipLevelCount: 3,
+}
+);
+let renderBundleEncoder15 = device0.createRenderBundleEncoder(
+{
+label: '\ud0a2\u{1fd01}\uc5c7',
+colorFormats: [
+'r8unorm',
+'rg8uint',
+'rgba16sint',
+'r16sint',
+'r32uint',
+'rgba32uint',
+'rgba16uint'
+],
+sampleCount: 576,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder7.setVertexBuffer(
+5,
+buffer6,
+37964,
+1660
+);
+} catch {}
+let arrayBuffer2 = buffer3.getMappedRange(
+728,
+2876
+);
+try {
+commandEncoder9.copyBufferToBuffer(
+buffer5,
+1440,
+buffer2,
+5592,
+236
+);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 1, depthOrArrayLayers: 225}
+*/
+{
+  source: imageData2,
+  origin: { x: 134, y: 110 },
+  flipY: false,
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 181 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 2, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline4 = device0.createRenderPipeline(
+{
+label: '\u{1fffd}\u{1fb22}\uf209\u05f0\u2d49\ufc3e\uf16a\u6412\uc015\u4d4e\u257c',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 2124,
+attributes: [
+{
+format: 'unorm8x2',
+offset: 620,
+shaderLocation: 13,
+},
+{
+format: 'uint32x2',
+offset: 1196,
+shaderLocation: 19,
+},
+{
+format: 'snorm8x2',
+offset: 1500,
+shaderLocation: 10,
+},
+{
+format: 'sint8x2',
+offset: 796,
+shaderLocation: 9,
+},
+{
+format: 'unorm8x2',
+offset: 492,
+shaderLocation: 12,
+},
+{
+format: 'sint16x4',
+offset: 1120,
+shaderLocation: 8,
+},
+{
+format: 'uint8x4',
+offset: 992,
+shaderLocation: 6,
+},
+{
+format: 'float16x2',
+offset: 880,
+shaderLocation: 7,
+},
+{
+format: 'float32x2',
+offset: 900,
+shaderLocation: 16,
+},
+{
+format: 'float16x2',
+offset: 1028,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x2',
+offset: 1414,
+shaderLocation: 1,
+},
+{
+format: 'uint8x4',
+offset: 524,
+shaderLocation: 2,
+},
+{
+format: 'sint32x4',
+offset: 780,
+shaderLocation: 21,
+},
+{
+format: 'snorm8x4',
+offset: 1236,
+shaderLocation: 17,
+},
+{
+format: 'snorm16x2',
+offset: 576,
+shaderLocation: 5,
+},
+{
+format: 'float16x4',
+offset: 1600,
+shaderLocation: 3,
+},
+{
+format: 'uint16x4',
+offset: 112,
+shaderLocation: 11,
+},
+{
+format: 'uint8x4',
+offset: 1228,
+shaderLocation: 0,
+},
+{
+format: 'float32x3',
+offset: 2092,
+shaderLocation: 4,
+},
+{
+format: 'sint16x2',
+offset: 1900,
+shaderLocation: 14,
+},
+{
+format: 'float16x4',
+offset: 1016,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x3',
+offset: 5656,
+shaderLocation: 20,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rgb10a2unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+}
+],
+},
+}
+);
+let canvas6 = document.createElement('canvas');
+let imageBitmap2 = await createImageBitmap(img0);
+try {
+canvas5.getContext('webgl');
+} catch {}
+let buffer10 = device0.createBuffer(
+{
+label: '\u{1f753}\u8460\u{1fd31}\u{1ffb8}\u9fbd\u0078',
+size: 7248,
+usage: GPUBufferUsage.INDEX,
+mappedAtCreation: true,
+}
+);
+let computePassEncoder22 = commandEncoder5.beginComputePass();
+try {
+renderBundleEncoder8.setIndexBuffer(
+buffer6,
+'uint16',
+23240,
+15308
+);
+} catch {}
+try {
+querySet8.destroy();
+} catch {}
+try {
+commandEncoder24.copyBufferToBuffer(
+buffer5,
+8288,
+buffer6,
+4188,
+16
+);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder27.clearBuffer(
+buffer2
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+document.body.prepend('\ue444\u8a50');
+let computePassEncoder23 = commandEncoder9.beginComputePass(
+{
+
+}
+);
+let sampler21 = device0.createSampler(
+{
+label: '\ua63f\u074f\u0a39',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 23.863,
+}
+);
+try {
+computePassEncoder11.setBindGroup(
+2,
+bindGroup16
+);
+} catch {}
+try {
+computePassEncoder8.setPipeline(
+pipeline3
+);
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(
+buffer6,
+8432,
+buffer1,
+13224,
+8648
+);
+dissociateBuffer(device0, buffer6);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder26.resolveQuerySet(
+querySet5,
+554,
+317,
+buffer6,
+17920
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture19,
+  mipLevel: 3,
+  origin: { x: 68, y: 4, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 652 */{
+offset: 652,
+bytesPerRow: 1833,
+},
+{width: 444, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+let pipeline5 = await device0.createRenderPipelineAsync(
+{
+label: '\ue5ae\u0e55\ue83b\u91d7\u68e5\u05a7',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 2644,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 348,
+shaderLocation: 5,
+},
+{
+format: 'uint32x3',
+offset: 1600,
+shaderLocation: 6,
+},
+{
+format: 'float32x2',
+offset: 2328,
+shaderLocation: 13,
+},
+{
+format: 'uint32x4',
+offset: 1744,
+shaderLocation: 19,
+},
+{
+format: 'uint32x4',
+offset: 2164,
+shaderLocation: 2,
+},
+{
+format: 'sint16x2',
+offset: 180,
+shaderLocation: 14,
+},
+{
+format: 'float32x2',
+offset: 1372,
+shaderLocation: 4,
+},
+{
+format: 'uint32x2',
+offset: 1728,
+shaderLocation: 11,
+},
+{
+format: 'uint32',
+offset: 1528,
+shaderLocation: 20,
+},
+{
+format: 'unorm16x4',
+offset: 2360,
+shaderLocation: 1,
+},
+{
+format: 'sint32x2',
+offset: 1020,
+shaderLocation: 8,
+},
+{
+format: 'snorm16x2',
+offset: 396,
+shaderLocation: 7,
+},
+{
+format: 'sint32x3',
+offset: 228,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x4',
+offset: 848,
+shaderLocation: 12,
+},
+{
+format: 'uint16x2',
+offset: 224,
+shaderLocation: 0,
+},
+{
+format: 'float16x4',
+offset: 1060,
+shaderLocation: 16,
+},
+{
+format: 'float32x2',
+offset: 1852,
+shaderLocation: 18,
+},
+{
+format: 'float32',
+offset: 1564,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 5400,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32',
+offset: 4664,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 2228,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 896,
+shaderLocation: 10,
+},
+{
+format: 'sint32x2',
+offset: 1060,
+shaderLocation: 21,
+},
+{
+format: 'float32',
+offset: 1804,
+shaderLocation: 15,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+frontFace: 'ccw',
+cullMode: 'back',
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg32sint',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-clamp',
+passOp: 'zero',
+},
+stencilReadMask: 3657,
+depthBias: 72,
+depthBiasSlopeScale: 47,
+depthBiasClamp: 14,
+},
+}
+);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.prepend(img4);
+try {
+computePassEncoder12.setBindGroup(
+3,
+bindGroup5,
+new Uint32Array(7720),
+6590,
+0
+);
+} catch {}
+try {
+commandEncoder26.copyBufferToTexture(
+{
+/* bytesInLastRow: 46 widthInBlocks: 23 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 51204 */
+offset: 51204,
+bytesPerRow: 256,
+buffer: buffer2,
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 42, y: 57, z: 1 },
+  aspect: 'all',
+},
+{width: 23, height: 22, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let pipeline6 = device0.createRenderPipeline(
+{
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 3864,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x3',
+offset: 3536,
+shaderLocation: 14,
+},
+{
+format: 'snorm8x2',
+offset: 3094,
+shaderLocation: 16,
+},
+{
+format: 'float32x4',
+offset: 24,
+shaderLocation: 15,
+},
+{
+format: 'uint16x2',
+offset: 2624,
+shaderLocation: 2,
+},
+{
+format: 'uint8x4',
+offset: 3716,
+shaderLocation: 11,
+},
+{
+format: 'unorm16x2',
+offset: 3644,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 244,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 44,
+shaderLocation: 8,
+},
+{
+format: 'snorm16x2',
+offset: 64,
+shaderLocation: 13,
+},
+{
+format: 'unorm16x4',
+offset: 20,
+shaderLocation: 18,
+},
+{
+format: 'sint16x2',
+offset: 8,
+shaderLocation: 9,
+},
+{
+format: 'uint32x2',
+offset: 160,
+shaderLocation: 6,
+},
+{
+format: 'uint8x2',
+offset: 60,
+shaderLocation: 0,
+},
+{
+format: 'float32x2',
+offset: 184,
+shaderLocation: 12,
+},
+{
+format: 'float32x2',
+offset: 132,
+shaderLocation: 10,
+},
+{
+format: 'uint32x2',
+offset: 108,
+shaderLocation: 19,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 180,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 4264,
+shaderLocation: 5,
+},
+{
+format: 'sint8x4',
+offset: 7124,
+shaderLocation: 21,
+},
+{
+format: 'uint8x2',
+offset: 4352,
+shaderLocation: 20,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 1816,
+shaderLocation: 4,
+},
+{
+format: 'unorm16x2',
+offset: 6124,
+shaderLocation: 7,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 2284,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8sint',
+writeMask: 0,
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'dst-alpha',
+dstFactor: 'dst'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'dst',
+dstFactor: 'one-minus-dst-alpha'
+},
+},
+format: 'rg16float',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+undefined,
+{
+format: 'r16float',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rgba16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+try {
+canvas6.getContext('webgl');
+} catch {}
+try {
+window.someLabel = texture31.label;
+} catch {}
+let renderBundle19 = renderBundleEncoder4.finish(
+{
+label: '\u{1f859}\u7de1\u074f\u02f1\uf5c6\u340a\u325f'
+}
+);
+try {
+computePassEncoder9.setPipeline(
+pipeline3
+);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(
+3,
+bindGroup2,
+new Uint32Array(8787),
+4091,
+0
+);
+} catch {}
+try {
+commandEncoder24.copyTextureToBuffer(
+{
+  texture: texture17,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 1600 */
+offset: 1592,
+buffer: buffer6,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+computePassEncoder22.pushDebugGroup(
+'\uea31'
+);
+} catch {}
+let gpuCanvasContext6 = canvas2.getContext('webgpu');
+canvas3.height = 524;
+let imageBitmap3 = await createImageBitmap(imageData0);
+let querySet10 = device0.createQuerySet(
+{
+label: '\u07ac\u4fa5\uf58b\ub950\u061d\ue533\u005d\u00fa',
+type: 'occlusion',
+count: 3455,
+}
+);
+let renderBundle20 = renderBundleEncoder14.finish(
+{
+
+}
+);
+let sampler22 = device0.createSampler(
+{
+label: '\uce80\u{1f781}\u0c80\u01a9\ueb9e\u4194\uc61d',
+addressModeU: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 49.487,
+lodMaxClamp: 94.448,
+maxAnisotropy: 1,
+}
+);
+try {
+computePassEncoder6.setPipeline(
+pipeline3
+);
+} catch {}
+try {
+commandEncoder27.resolveQuerySet(
+querySet4,
+693,
+68,
+buffer6,
+21248
+);
+} catch {}
+try {
+gpuCanvasContext3.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'bgra8unorm',
+'rg16float',
+'bgra8unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+6940,
+new DataView(new ArrayBuffer(21941)),
+8082,
+9056
+);
+} catch {}
+let pipeline7 = device0.createRenderPipeline(
+{
+label: '\u6cbb\u87f2\u01dc\ub9e7\u9132\udbd1\u1e80\uf9bf\u0ee7\u{1ffcd}\u8f3f',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 7352,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x4',
+offset: 4912,
+shaderLocation: 16,
+},
+{
+format: 'uint32x3',
+offset: 1088,
+shaderLocation: 6,
+},
+{
+format: 'uint32x3',
+offset: 2552,
+shaderLocation: 20,
+},
+{
+format: 'uint32',
+offset: 5820,
+shaderLocation: 0,
+},
+{
+format: 'sint8x4',
+offset: 4452,
+shaderLocation: 9,
+},
+{
+format: 'uint16x4',
+offset: 1848,
+shaderLocation: 2,
+},
+{
+format: 'uint8x4',
+offset: 7076,
+shaderLocation: 11,
+},
+{
+format: 'uint8x2',
+offset: 2934,
+shaderLocation: 19,
+},
+{
+format: 'snorm16x2',
+offset: 648,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x2',
+offset: 4044,
+shaderLocation: 15,
+},
+{
+format: 'unorm8x4',
+offset: 5080,
+shaderLocation: 1,
+},
+{
+format: 'sint32x4',
+offset: 7260,
+shaderLocation: 21,
+},
+{
+format: 'float32x3',
+offset: 2404,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 2384,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 2172,
+shaderLocation: 7,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 1736,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x2',
+offset: 1450,
+shaderLocation: 3,
+},
+{
+format: 'float32',
+offset: 1872,
+shaderLocation: 5,
+},
+{
+format: 'unorm8x4',
+offset: 1984,
+shaderLocation: 13,
+},
+{
+format: 'snorm8x4',
+offset: 2128,
+shaderLocation: 12,
+},
+{
+format: 'sint8x2',
+offset: 482,
+shaderLocation: 8,
+},
+{
+format: 'unorm8x2',
+offset: 1568,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 848,
+attributes: [
+{
+format: 'sint32',
+offset: 516,
+shaderLocation: 14,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 1,
+mask: 0xef5079d8,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rg8unorm',
+writeMask: GPUColorWrite.RED,
+},
+{
+format: 'rg16float',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+undefined
+],
+},
+}
+);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let bindGroup22 = device0.createBindGroup({
+label: '\u094b\u{1fa30}',
+layout: bindGroupLayout1,
+entries: [
+{
+binding: 2712,
+resource: sampler2
+},
+{
+binding: 2766,
+resource: externalTexture1
+}
+],
+});
+let computePassEncoder24 = commandEncoder27.beginComputePass(
+{
+label: '\u08e3\u{1fb01}\u1ca6\u0766\u13dd\u{1f696}\u0f68\u2864\ufb84\u{1f96d}'
+}
+);
+let sampler23 = device0.createSampler(
+{
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 85.750,
+lodMaxClamp: 86.355,
+}
+);
+try {
+renderBundleEncoder12.setVertexBuffer(
+2,
+buffer7,
+1896,
+6137
+);
+} catch {}
+try {
+commandEncoder26.resolveQuerySet(
+querySet6,
+777,
+60,
+buffer6,
+15360
+);
+} catch {}
+let querySet11 = device0.createQuerySet(
+{
+label: '\ue35e\u9b7c\u57aa\uf352\u0c07\uca0b\u95b1',
+type: 'occlusion',
+count: 3767,
+}
+);
+let texture32 = device0.createTexture(
+{
+size: [11160, 5, 99],
+mipLevelCount: 12,
+format: 'rg32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32uint',
+'rg32uint',
+'rg32uint'
+],
+}
+);
+let externalTexture2 = device0.importExternalTexture(
+{
+source: video2,
+colorSpace: 'display-p3',
+}
+);
+try {
+computePassEncoder9.setPipeline(
+pipeline3
+);
+} catch {}
+try {
+commandEncoder24.clearBuffer(
+buffer2
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device0,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'stencil8',
+'stencil8'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let pipeline8 = device0.createComputePipeline(
+{
+label: '\u0892\u7e86\u0812\u073d\ue777',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.append('\u0f24\ua756\u4864\u{1f72c}\u{1f904}\u{1f7f9}\u{1f96d}\u{1f733}\u9aa9\uff4c\u{1faad}');
+let videoFrame6 = new VideoFrame(canvas3, {timestamp: 0});
+let buffer11 = device0.createBuffer(
+{
+size: 32904,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+mappedAtCreation: true,
+}
+);
+let commandEncoder28 = device0.createCommandEncoder(
+{
+}
+);
+let renderBundleEncoder16 = device0.createRenderBundleEncoder(
+{
+label: '\u3320\u0b70\u86ad\u06a0\ud9ae\u018d\u285a\u247b\uccc8\u5297',
+colorFormats: [
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 866,
+depthReadOnly: true,
+}
+);
+let renderBundle21 = renderBundleEncoder1.finish(
+{
+
+}
+);
+try {
+renderBundleEncoder13.setBindGroup(
+6,
+bindGroup1
+);
+} catch {}
+try {
+commandEncoder24.copyBufferToBuffer(
+buffer8,
+852,
+buffer2,
+4960,
+252
+);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder24.copyTextureToTexture(
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: { x: 2796, y: 24, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 4,
+  origin: { x: 348, y: 0, z: 4 },
+  aspect: 'all',
+},
+{width: 420, height: 0, depthOrArrayLayers: 129}
+);
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'bgra8unorm-srgb',
+'astc-8x5-unorm',
+'astc-10x5-unorm',
+'bgra8unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let pipeline9 = await promise5;
+let textureView29 = texture4.createView(
+{
+label: '\u22a9\ua912',
+dimension: '2d',
+mipLevelCount: 2,
+baseArrayLayer: 115,
+}
+);
+let renderBundle22 = renderBundleEncoder7.finish(
+{
+label: '\u08f4\ufe10\u0f13\uc254\u{1fa1d}\u03bc\u{1ff61}\u4c74'
+}
+);
+try {
+renderBundleEncoder3.setVertexBuffer(
+7,
+buffer11,
+4376
+);
+} catch {}
+try {
+commandEncoder26.copyBufferToTexture(
+{
+/* bytesInLastRow: 2560 widthInBlocks: 160 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 7232 */
+offset: 7232,
+rowsPerImage: 52,
+buffer: buffer5,
+},
+{
+  texture: texture0,
+  mipLevel: 2,
+  origin: { x: 2052, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 960, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder24.resolveQuerySet(
+querySet4,
+712,
+459,
+buffer6,
+25600
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 3, height: 1, depthOrArrayLayers: 112}
+*/
+{
+  source: imageData2,
+  origin: { x: 52, y: 156 },
+  flipY: false,
+},
+{
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 63 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 3, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\u84e2\u{1f8b2}\u0793\u812b');
+let bindGroup23 = device0.createBindGroup({
+label: '\u0b13\u{1f809}\ud8d9\u{1faf1}\u0868\u{1f958}\u1271',
+layout: bindGroupLayout2,
+entries: [
+
+],
+});
+let commandEncoder29 = device0.createCommandEncoder(
+{
+label: '\uae68\u0aa8\uc596',
+}
+);
+let querySet12 = device0.createQuerySet(
+{
+label: '\u0481\uacfc\u5e6f\u{1ff5e}\u{1f691}\uc5ca',
+type: 'occlusion',
+count: 50,
+}
+);
+try {
+renderBundleEncoder13.setVertexBuffer(
+8,
+buffer6,
+14980,
+25888
+);
+} catch {}
+try {
+commandEncoder28.resolveQuerySet(
+querySet4,
+653,
+510,
+buffer5,
+0
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.append('\ucd98\u{1faf8}\u{1f9a7}\uaf08\u4eb8\u1243\u0b2e\u0ff7');
+try {
+window.someLabel = renderBundle10.label;
+} catch {}
+let querySet13 = device0.createQuerySet(
+{
+label: '\uabb4\u0533\u0074\u{1feb0}\ud1ad\u4675',
+type: 'occlusion',
+count: 1544,
+}
+);
+let renderBundle23 = renderBundleEncoder8.finish();
+try {
+renderBundleEncoder12.setBindGroup(
+5,
+bindGroup15
+);
+} catch {}
+try {
+commandEncoder24.copyBufferToBuffer(
+buffer0,
+2148,
+buffer11,
+1188,
+1264
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+renderBundleEncoder15.insertDebugMarker(
+'\u{1fad3}'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+49924,
+new Int16Array(24554),
+20474
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout(
+{
+label: '\uc168\u0fff\u{1fc4b}\u{1fd09}\u{1f7a6}\u0299\u22e9\uc9c5\u4ff3',
+entries: [
+{
+binding: 150,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let texture33 = device0.createTexture(
+{
+label: '\u{1fb5b}\u{1fa52}',
+size: [201, 1, 232],
+mipLevelCount: 5,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+let computePassEncoder25 = commandEncoder29.beginComputePass(
+{
+label: '\u0f18\u78ff\u3d49\uf0b3\u8a22\u{1fd8c}\u2da6\u07a3'
+}
+);
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+commandEncoder24.copyTextureToBuffer(
+{
+  texture: texture23,
+  mipLevel: 2,
+  origin: { x: 0, y: 16, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 41424 */
+offset: 41424,
+buffer: buffer2,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+externalTexture1.label = '\u8f69\ub1a2\u{1fb67}\u3bda';
+} catch {}
+let bindGroup24 = device0.createBindGroup({
+label: '\u734d\u0693\u3b7a\u0d2d\u{1fdc7}\ueec6\u0dfb\u{1f64f}\u{1ffe9}\u0416\u0259',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let texture34 = device0.createTexture(
+{
+label: '\u52df\uac98',
+size: [7896],
+dimension: '1d',
+format: 'rg16uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg16uint'
+],
+}
+);
+let renderBundle24 = renderBundleEncoder8.finish();
+let sampler24 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 81.253,
+lodMaxClamp: 94.719,
+maxAnisotropy: 17,
+}
+);
+try {
+commandEncoder26.copyBufferToBuffer(
+buffer9,
+10912,
+buffer1,
+5928,
+12996
+);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'astc-6x6-unorm-srgb',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba32uint',
+'astc-6x6-unorm'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 45, y: 0, z: 52 },
+  aspect: 'all',
+},
+new Int32Array(arrayBuffer1),
+/* required buffer size: 34448537 */{
+offset: 357,
+bytesPerRow: 30086,
+rowsPerImage: 104,
+},
+{width: 7449, height: 1, depthOrArrayLayers: 12}
+);
+} catch {}
+let commandEncoder30 = device0.createCommandEncoder(
+{
+label: '\ue0a4\u0ec9\u778e\u4413\u097b\u1422\ud5ba\u2a7f',
+}
+);
+let computePassEncoder26 = commandEncoder24.beginComputePass(
+{
+label: '\u{1fcb6}\u{1fe00}\u0bc6\u01fe\u0824\u0a7a'
+}
+);
+let sampler25 = device0.createSampler(
+{
+label: '\u84ec\u9874',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 86.446,
+lodMaxClamp: 93.741,
+maxAnisotropy: 12,
+}
+);
+try {
+renderBundleEncoder12.setBindGroup(
+3,
+bindGroup18
+);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(
+5,
+bindGroup20,
+new Uint32Array(2060),
+1465,
+0
+);
+} catch {}
+let arrayBuffer3 = buffer3.getMappedRange(
+4784,
+76
+);
+try {
+commandEncoder30.resolveQuerySet(
+querySet0,
+1618,
+846,
+buffer6,
+19200
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+1852,
+new DataView(new ArrayBuffer(49895)),
+39623
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 12, height: 1, depthOrArrayLayers: 232}
+*/
+{
+  source: imageData5,
+  origin: { x: 12, y: 154 },
+  flipY: true,
+},
+{
+  texture: texture33,
+  mipLevel: 4,
+  origin: { x: 3, y: 0, z: 119 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 9, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline10 = await device0.createComputePipelineAsync(
+{
+label: '\uea25\u5b8c\ua605\u038e\u89fc\u2ea6\ud7b1\u{1f6cf}\u0ce0\udd1c',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let video5 = await videoWithData();
+let buffer12 = device0.createBuffer(
+{
+label: '\udba8\u0eea\ufe4b\u{1fd24}\u{1f693}',
+size: 24562,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+}
+);
+let querySet14 = device0.createQuerySet(
+{
+label: '\u051f\u7fc9\u3bac\u0e71\u{1ffa2}',
+type: 'occlusion',
+count: 262,
+}
+);
+let commandBuffer4 = commandEncoder30.finish(
+{
+label: '\ue525\u9e2d\u9f5b\u159c\u08d6',
+}
+);
+let renderBundle25 = renderBundleEncoder7.finish(
+{
+label: '\uf470\uf0c0'
+}
+);
+try {
+computePassEncoder26.setPipeline(
+pipeline8
+);
+} catch {}
+try {
+commandEncoder18.copyBufferToBuffer(
+buffer9,
+28524,
+buffer1,
+20400,
+812
+);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+26272,
+new DataView(new ArrayBuffer(50430)),
+49392,
+716
+);
+} catch {}
+let canvas7 = document.createElement('canvas');
+let commandBuffer5 = commandEncoder28.finish(
+{
+}
+);
+let computePassEncoder27 = commandEncoder26.beginComputePass(
+{
+label: '\ufbc3\u0e32\u6e85\u4d43\uc8a6'
+}
+);
+try {
+buffer11.unmap();
+} catch {}
+try {
+gpuCanvasContext5.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 324, y: 36, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(11503),
+/* required buffer size: 11503 */{
+offset: 447,
+bytesPerRow: 2260,
+rowsPerImage: 22,
+},
+{width: 1512, height: 60, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await promise7;
+} catch {}
+let bindGroup25 = device0.createBindGroup({
+label: '\u0532\u0da9\u0214\u{1ffd5}\u52cb\u{1f85d}\u9726\ub89c\udf4d\u0eae\u0e3a',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let querySet15 = device0.createQuerySet(
+{
+label: '\u0750\u64d6\u{1fdfb}\u{1fc0c}\u0e82',
+type: 'occlusion',
+count: 414,
+}
+);
+let sampler26 = device0.createSampler(
+{
+label: '\u09cf\u25cc\u1bbf\uc037',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 97.266,
+lodMaxClamp: 97.360,
+}
+);
+try {
+commandEncoder18.resolveQuerySet(
+querySet2,
+485,
+1463,
+buffer6,
+6144
+);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+document.body.append('\u1e56\udb7f\u3be0\u9f86\u4c4d\u{1fcb1}\u{1f99f}');
+let videoFrame7 = new VideoFrame(offscreenCanvas3, {timestamp: 0});
+try {
+commandEncoder18.copyBufferToBuffer(
+buffer5,
+1584,
+buffer11,
+25556,
+5248
+);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let bindGroup26 = device0.createBindGroup({
+label: '\uf697\u{1fe01}\u{1fa37}\u0dcd\u{1fa38}\u0bea\ueff3\u{1ffc1}\ued02\u{1f63a}',
+layout: bindGroupLayout2,
+entries: [
+
+],
+});
+let computePassEncoder28 = commandEncoder18.beginComputePass(
+{
+label: '\uf1a6\u{1f9d7}\u{1f919}\u00b3\ub4b0\u{1f793}\u0afa'
+}
+);
+let renderBundleEncoder17 = device0.createRenderBundleEncoder(
+{
+label: '\u0184\u6532\ud566\u3d49\u0ca0',
+colorFormats: [
+'rgba8unorm',
+'rgba16float',
+'rg16uint',
+'r32uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 759,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder3.setIndexBuffer(
+buffer11,
+'uint32',
+6172,
+10863
+);
+} catch {}
+let arrayBuffer4 = buffer1.getMappedRange(
+1840,
+256
+);
+try {
+device0.queue.submit([
+]);
+} catch {}
+let pipeline11 = device0.createRenderPipeline(
+{
+label: '\ub3cf\u0ba0\u3db2\u1fbd',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 520,
+shaderLocation: 8,
+},
+{
+format: 'sint16x4',
+offset: 5032,
+shaderLocation: 21,
+}
+],
+},
+{
+arrayStride: 488,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x2',
+offset: 388,
+shaderLocation: 14,
+},
+{
+format: 'unorm8x4',
+offset: 280,
+shaderLocation: 12,
+},
+{
+format: 'uint32x2',
+offset: 388,
+shaderLocation: 2,
+},
+{
+format: 'float32x2',
+offset: 88,
+shaderLocation: 13,
+},
+{
+format: 'uint32x3',
+offset: 236,
+shaderLocation: 20,
+},
+{
+format: 'uint32',
+offset: 276,
+shaderLocation: 19,
+},
+{
+format: 'sint8x2',
+offset: 64,
+shaderLocation: 9,
+},
+{
+format: 'float16x2',
+offset: 60,
+shaderLocation: 1,
+},
+{
+format: 'uint32',
+offset: 364,
+shaderLocation: 6,
+},
+{
+format: 'float32x2',
+offset: 276,
+shaderLocation: 16,
+},
+{
+format: 'uint32',
+offset: 56,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 5644,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 2484,
+shaderLocation: 5,
+},
+{
+format: 'unorm8x4',
+offset: 752,
+shaderLocation: 18,
+},
+{
+format: 'unorm16x4',
+offset: 2352,
+shaderLocation: 7,
+},
+{
+format: 'float16x4',
+offset: 468,
+shaderLocation: 4,
+},
+{
+format: 'snorm16x4',
+offset: 972,
+shaderLocation: 10,
+},
+{
+format: 'unorm8x4',
+offset: 972,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 4096,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 3356,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 2044,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 6664,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x3',
+offset: 4068,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 3876,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 3780,
+shaderLocation: 15,
+}
+],
+}
+]
+},
+primitive: {
+unclippedDepth: true,
+},
+}
+);
+let videoFrame8 = new VideoFrame(img4, {timestamp: 0});
+let commandEncoder31 = device0.createCommandEncoder(
+{
+label: '\u29f0\uf189\u7080\uc967',
+}
+);
+let computePassEncoder29 = commandEncoder31.beginComputePass(
+{
+
+}
+);
+let externalTexture3 = device0.importExternalTexture(
+{
+label: '\u0ccc\u{1fcf8}',
+source: video1,
+colorSpace: 'display-p3',
+}
+);
+try {
+computePassEncoder28.setPipeline(
+pipeline8
+);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(
+5,
+buffer6,
+30240,
+3301
+);
+} catch {}
+try {
+buffer12.destroy();
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 1006 */{
+offset: 974,
+},
+{width: 16, height: 5, depthOrArrayLayers: 1}
+);
+} catch {}
+let renderBundleEncoder18 = device0.createRenderBundleEncoder(
+{
+label: '\u0c5c\u333e\u8847\u{1f83a}\u0860\u0995\u{1f9f0}\u392f\u{1f976}\u0684',
+colorFormats: [
+undefined
+],
+sampleCount: 231,
+stencilReadOnly: true,
+}
+);
+let renderBundle26 = renderBundleEncoder8.finish(
+{
+label: '\u0c90\uf5d5\u05bf\u09c8\u01eb\ua6b8\u{1fff7}\ub1c0'
+}
+);
+let sampler27 = device0.createSampler(
+{
+label: '\u{1f6b9}\u0f4c\u032f\ufbb1\u4295\uff59\u0610\u{1f89e}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 92.065,
+lodMaxClamp: 96.997,
+}
+);
+try {
+computePassEncoder8.dispatchWorkgroups(
+2,
+1,
+5
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture33,
+  mipLevel: 4,
+  origin: { x: 8, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 1494776 */{
+offset: 93,
+bytesPerRow: 73,
+rowsPerImage: 91,
+},
+{width: 2, height: 1, depthOrArrayLayers: 226}
+);
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+let pipeline12 = await device0.createComputePipelineAsync(
+{
+label: '\u060f\u4267',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let bindGroup27 = device0.createBindGroup({
+label: '\u0ef2\uefe0\u547b\u16a9\u600f\u{1fc66}',
+layout: bindGroupLayout3,
+entries: [
+{
+binding: 150,
+resource: externalTexture2
+}
+],
+});
+let texture35 = device0.createTexture(
+{
+label: '\u462d\u9bcd\u0f81\u1d12\u{1fbcb}\u9229\ub16a\ub1db\u08da',
+size: {width: 220, height: 4, depthOrArrayLayers: 180},
+mipLevelCount: 4,
+format: 'etc2-rgb8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'etc2-rgb8unorm',
+'etc2-rgb8unorm',
+'etc2-rgb8unorm'
+],
+}
+);
+try {
+renderBundleEncoder6.setBindGroup(
+0,
+bindGroup14
+);
+} catch {}
+try {
+computePassEncoder22.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+10832,
+new Float32Array(10743),
+6581
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture32,
+  mipLevel: 6,
+  origin: { x: 152, y: 0, z: 11 },
+  aspect: 'all',
+},
+new Int16Array(arrayBuffer1),
+/* required buffer size: 768 */{
+offset: 768,
+},
+{width: 14, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let commandEncoder32 = device0.createCommandEncoder(
+{
+}
+);
+try {
+computePassEncoder29.setBindGroup(
+0,
+bindGroup16,
+new Uint32Array(8559),
+1147,
+0
+);
+} catch {}
+let arrayBuffer5 = buffer3.getMappedRange(
+4040,
+536
+);
+try {
+commandEncoder32.copyBufferToBuffer(
+buffer4,
+30120,
+buffer11,
+7264,
+824
+);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+adapter0.label = '\u83fb\ueefc\u0ae4\ue3f4\u9277';
+} catch {}
+let buffer13 = device0.createBuffer(
+{
+size: 45008,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+pseudoSubmit(device0, commandEncoder2);
+let sampler28 = device0.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 89.899,
+lodMaxClamp: 93.271,
+}
+);
+try {
+commandEncoder32.clearBuffer(
+buffer6
+);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer4,
+]);
+} catch {}
+let pipeline13 = device0.createRenderPipeline(
+{
+label: '\u0ec4\u{1ff2c}\u011e\u5c85\u71c7',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 2052,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 976,
+shaderLocation: 4,
+},
+{
+format: 'sint8x2',
+offset: 1188,
+shaderLocation: 14,
+},
+{
+format: 'unorm8x4',
+offset: 824,
+shaderLocation: 10,
+},
+{
+format: 'float32x2',
+offset: 1056,
+shaderLocation: 17,
+},
+{
+format: 'uint16x4',
+offset: 24,
+shaderLocation: 6,
+},
+{
+format: 'snorm16x4',
+offset: 1548,
+shaderLocation: 1,
+},
+{
+format: 'float32',
+offset: 808,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 6092,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 2004,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 212,
+shaderLocation: 5,
+},
+{
+format: 'sint8x4',
+offset: 648,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x2',
+offset: 308,
+shaderLocation: 18,
+},
+{
+format: 'unorm16x2',
+offset: 1424,
+shaderLocation: 3,
+},
+{
+format: 'uint32x4',
+offset: 308,
+shaderLocation: 2,
+},
+{
+format: 'uint32x2',
+offset: 896,
+shaderLocation: 0,
+},
+{
+format: 'uint32x3',
+offset: 1924,
+shaderLocation: 20,
+}
+],
+},
+{
+arrayStride: 6124,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 1540,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 7488,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 1144,
+shaderLocation: 16,
+},
+{
+format: 'float32x4',
+offset: 6236,
+shaderLocation: 15,
+},
+{
+format: 'unorm8x4',
+offset: 2176,
+shaderLocation: 13,
+},
+{
+format: 'uint32x3',
+offset: 3796,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 7016,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x2',
+offset: 6834,
+shaderLocation: 21,
+},
+{
+format: 'uint16x2',
+offset: 288,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 3776,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 6916,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 168,
+shaderLocation: 12,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0xf8b50ae2,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'rg8sint',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'zero',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'decrement-clamp',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 2681,
+stencilWriteMask: 3376,
+depthBias: 14,
+},
+}
+);
+try {
+await promise8;
+} catch {}
+document.body.prepend('\u{1f7e5}\u{1f826}\u61ca\u{1fa1c}\u{1f84b}\u8674\u3056\u1992\u37b8\u8f24');
+let offscreenCanvas5 = new OffscreenCanvas(369, 765);
+let imageBitmap4 = await createImageBitmap(offscreenCanvas0);
+let querySet16 = device0.createQuerySet(
+{
+label: '\u034a\u92f5\u5411\u0f39\u01c6\ue2e5',
+type: 'occlusion',
+count: 1236,
+}
+);
+let computePassEncoder30 = commandEncoder32.beginComputePass(
+{
+label: '\u{1fd88}\uf086\u8093\u74bc\u7960\ubc90\ua39d'
+}
+);
+try {
+renderBundleEncoder13.setBindGroup(
+2,
+bindGroup2,
+new Uint32Array(4830),
+373,
+0
+);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(
+buffer6,
+'uint16',
+12926,
+8223
+);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(
+5,
+buffer13,
+37228,
+6518
+);
+} catch {}
+try {
+canvas7.getContext('webgl');
+} catch {}
+let querySet17 = device0.createQuerySet(
+{
+label: '\u{1f86b}\u6f8d\u{1fa76}\ub0e9\u{1f862}\ud2c0\u0a89\u4039\ud02a\u0205',
+type: 'occlusion',
+count: 3925,
+}
+);
+try {
+computePassEncoder24.setPipeline(
+pipeline3
+);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(
+4,
+buffer6,
+25264,
+8969
+);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 3, height: 1, depthOrArrayLayers: 112}
+*/
+{
+  source: canvas1,
+  origin: { x: 170, y: 88 },
+  flipY: false,
+},
+{
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 88 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 3, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let videoFrame9 = new VideoFrame(canvas0, {timestamp: 0});
+try {
+renderBundleEncoder6.setBindGroup(
+6,
+bindGroup8
+);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 50, height: 1, depthOrArrayLayers: 232}
+*/
+{
+  source: video2,
+  origin: { x: 0, y: 14 },
+  flipY: true,
+},
+{
+  texture: texture33,
+  mipLevel: 2,
+  origin: { x: 16, y: 0, z: 141 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+document.body.prepend('\u98b8\u029b\u09dd\u{1fb77}\u0812\u0970\u4e6c');
+let bindGroup28 = device0.createBindGroup({
+label: '\u1910\u3206\u0eee\udf7a\u77bf\u0e6e',
+layout: bindGroupLayout1,
+entries: [
+{
+binding: 2712,
+resource: sampler28
+},
+{
+binding: 2766,
+resource: externalTexture3
+}
+],
+});
+let texture36 = device0.createTexture(
+{
+label: '\u{1fa7c}\u1d1b\u91ce\u328f\u1b7f\uf2e7',
+size: [8687],
+dimension: '1d',
+format: 'r8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView30 = texture0.createView(
+{
+label: '\u55e3\uedd5\u98c4\ud824',
+format: 'astc-6x5-unorm',
+baseMipLevel: 5,
+mipLevelCount: 2,
+}
+);
+try {
+computePassEncoder30.setPipeline(
+pipeline8
+);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(
+7,
+buffer11,
+21236,
+1270
+);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture9,
+  mipLevel: 2,
+  origin: { x: 4, y: 0, z: 8 },
+  aspect: 'all',
+},
+new ArrayBuffer(8),
+/* required buffer size: 8369963 */{
+offset: 60,
+bytesPerRow: 225,
+rowsPerImage: 215,
+},
+{width: 8, height: 5, depthOrArrayLayers: 174}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 1, depthOrArrayLayers: 225}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 38, y: 206 },
+  flipY: true,
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 220 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 3, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let canvas8 = document.createElement('canvas');
+let bindGroup29 = device0.createBindGroup({
+layout: bindGroupLayout1,
+entries: [
+{
+binding: 2766,
+resource: externalTexture1
+},
+{
+binding: 2712,
+resource: sampler14
+}
+],
+});
+let commandEncoder33 = device0.createCommandEncoder(
+{
+label: '\u0cc1\ue88f\u7cbc\u19e1\u097f\u{1f871}',
+}
+);
+let renderBundleEncoder19 = device0.createRenderBundleEncoder(
+{
+label: '\uc744\u017d\u4d29\u4cc4\u4148\u8cb1',
+colorFormats: [
+'rgb10a2unorm',
+'rgba16float',
+'r32float'
+],
+sampleCount: 155,
+}
+);
+let sampler29 = device0.createSampler(
+{
+label: '\u{1fa05}\u06d5\u5f3a\u9526',
+addressModeU: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 55.038,
+lodMaxClamp: 85.808,
+}
+);
+try {
+renderBundleEncoder6.setVertexBuffer(
+8,
+buffer7,
+18472,
+823
+);
+} catch {}
+try {
+commandEncoder33.copyBufferToTexture(
+{
+/* bytesInLastRow: 128 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 28656 */
+offset: 22896,
+bytesPerRow: 512,
+buffer: buffer13,
+},
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 100, y: 120, z: 0 },
+  aspect: 'all',
+},
+{width: 80, height: 96, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder33.copyTextureToBuffer(
+{
+  texture: texture26,
+  mipLevel: 1,
+  origin: { x: 864, y: 12, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 576 widthInBlocks: 36 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 51424 */
+offset: 51424,
+bytesPerRow: 768,
+buffer: buffer2,
+},
+{width: 432, height: 48, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let pipeline14 = device0.createRenderPipeline(
+{
+label: '\ud15f\u4dfa\ufaf8\u{1fd84}\u{1fb03}\ue74b\u7dfb\u9353\ue612\u0fd3\uf528',
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x4',
+offset: 4980,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x2',
+offset: 5452,
+shaderLocation: 17,
+},
+{
+format: 'float32x3',
+offset: 5276,
+shaderLocation: 18,
+},
+{
+format: 'float32',
+offset: 836,
+shaderLocation: 1,
+},
+{
+format: 'sint8x2',
+offset: 1836,
+shaderLocation: 9,
+},
+{
+format: 'unorm8x4',
+offset: 5716,
+shaderLocation: 16,
+},
+{
+format: 'snorm16x4',
+offset: 6180,
+shaderLocation: 5,
+},
+{
+format: 'float32x3',
+offset: 68,
+shaderLocation: 15,
+},
+{
+format: 'uint16x4',
+offset: 2072,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x2',
+offset: 7492,
+shaderLocation: 3,
+},
+{
+format: 'sint32',
+offset: 6788,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 5256,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 2564,
+attributes: [
+{
+format: 'unorm8x2',
+offset: 2186,
+shaderLocation: 4,
+},
+{
+format: 'sint8x2',
+offset: 906,
+shaderLocation: 8,
+},
+{
+format: 'uint32x4',
+offset: 1648,
+shaderLocation: 2,
+},
+{
+format: 'snorm8x2',
+offset: 344,
+shaderLocation: 13,
+},
+{
+format: 'uint16x4',
+offset: 2296,
+shaderLocation: 19,
+},
+{
+format: 'sint32x2',
+offset: 940,
+shaderLocation: 21,
+},
+{
+format: 'float32x4',
+offset: 1676,
+shaderLocation: 12,
+},
+{
+format: 'unorm8x2',
+offset: 1138,
+shaderLocation: 7,
+},
+{
+format: 'uint16x2',
+offset: 1964,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 5680,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x2',
+offset: 4800,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 7120,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 5460,
+shaderLocation: 20,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rg32float',
+writeMask: 0,
+},
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'zero',
+dstFactor: 'constant'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'dst-alpha',
+dstFactor: 'one-minus-src'
+},
+},
+format: 'r16float',
+},
+undefined
+],
+},
+depthStencil: {
+format: 'stencil8',
+stencilFront: {
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 502,
+stencilWriteMask: 3371,
+depthBias: 54,
+depthBiasSlopeScale: 45,
+depthBiasClamp: 67,
+},
+}
+);
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+document.body.append('\uac6c\u084c\u3cfb\u0c01');
+let querySet18 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 1134,
+}
+);
+let texture37 = device0.createTexture(
+{
+label: '\ueb97\ud18b\u0472\u074c\ubf12\u0e6f\u5547\u0cf9\u6876',
+size: {width: 209, height: 91, depthOrArrayLayers: 99},
+mipLevelCount: 8,
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg8snorm',
+'rg8snorm',
+'rg8snorm'
+],
+}
+);
+let textureView31 = texture17.createView(
+{
+}
+);
+try {
+renderBundleEncoder13.setBindGroup(
+2,
+bindGroup15,
+[]
+);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(
+0,
+buffer7,
+7792,
+5489
+);
+} catch {}
+try {
+commandEncoder33.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder33.resolveQuerySet(
+querySet2,
+955,
+1245,
+buffer13,
+16384
+);
+} catch {}
+try {
+renderBundleEncoder3.insertDebugMarker(
+'\u0a57'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer11,
+30588,
+new DataView(new ArrayBuffer(18601)),
+10980,
+188
+);
+} catch {}
+document.body.append('\uc96f\u0cfe\u{1f94c}\u2eb1\u0bfb\u{1ffda}');
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+try {
+offscreenCanvas5.getContext('webgpu');
+} catch {}
+let commandEncoder34 = device0.createCommandEncoder(
+{
+label: '\u0359\u{1faa0}\u{1f7ea}',
+}
+);
+let querySet19 = device0.createQuerySet(
+{
+label: '\ud93e\u054d\u7f4f\uea0f\u0ca1',
+type: 'occlusion',
+count: 2468,
+}
+);
+let texture38 = device0.createTexture(
+{
+label: '\u50eb\u{1ff4d}\ue4c9',
+size: {width: 38, height: 9, depthOrArrayLayers: 71},
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundleEncoder20 = device0.createRenderBundleEncoder(
+{
+label: '\uaf89\ud10a\u{1f992}\u3b4c\ucc07\u{1f7d1}\u{1f6b3}\u5f25',
+colorFormats: [
+'rg16float',
+undefined,
+undefined
+],
+sampleCount: 112,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder26.setBindGroup(
+0,
+bindGroup16,
+new Uint32Array(3929),
+3548,
+0
+);
+} catch {}
+try {
+computePassEncoder26.dispatchWorkgroups(
+2
+);
+} catch {}
+try {
+computePassEncoder6.dispatchWorkgroupsIndirect(
+buffer12,
+19848
+);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(
+4,
+bindGroup27
+);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(
+buffer11,
+'uint32',
+24244,
+8300
+);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(
+5,
+buffer13
+);
+} catch {}
+let arrayBuffer6 = buffer1.getMappedRange(
+2136,
+60
+);
+try {
+commandEncoder34.copyBufferToBuffer(
+buffer8,
+1300,
+buffer6,
+12156,
+0
+);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder33.copyBufferToTexture(
+{
+/* bytesInLastRow: 70 widthInBlocks: 35 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 41844 */
+offset: 20782,
+bytesPerRow: 256,
+buffer: buffer2,
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 25, y: 3, z: 0 },
+  aspect: 'all',
+},
+{width: 35, height: 83, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder34.copyTextureToBuffer(
+{
+  texture: texture30,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 13696 */
+offset: 13696,
+bytesPerRow: 0,
+rowsPerImage: 156,
+buffer: buffer6,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder33.clearBuffer(
+buffer6
+);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let gpuCanvasContext7 = canvas8.getContext('webgpu');
+let buffer14 = device0.createBuffer(
+{
+label: '\u75de\u0999\u{1f7b5}\u{1f673}\u{1f74c}\u7e86\u7c76\u8557',
+size: 41527,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+try {
+computePassEncoder24.setPipeline(
+pipeline10
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer5,
+]);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 733, y: 0, z: 48 },
+  aspect: 'all',
+},
+new Uint32Array(arrayBuffer5),
+/* required buffer size: 34584227 */{
+offset: 265,
+bytesPerRow: 14965,
+rowsPerImage: 154,
+},
+{width: 3703, height: 1, depthOrArrayLayers: 16}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 1, depthOrArrayLayers: 225}
+*/
+{
+  source: imageData4,
+  origin: { x: 11, y: 19 },
+  flipY: true,
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 105 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(
+1,
+buffer11,
+4768
+);
+} catch {}
+let arrayBuffer7 = buffer10.getMappedRange(
+0,
+1824
+);
+try {
+commandEncoder33.copyBufferToBuffer(
+buffer8,
+1184,
+buffer2,
+19984,
+120
+);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+gpuCanvasContext4.configure(
+{
+device: device0,
+format: 'etc2-rgb8a1unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+canvas5.height = 944;
+document.body.prepend('\u0ef1\ub007\u3f51\u261d\u{1fc63}');
+let promise9 = navigator.gpu.requestAdapter(
+{
+}
+);
+let canvas9 = document.createElement('canvas');
+let buffer15 = device0.createBuffer(
+{
+label: '\u0b5c\u0515\u890a',
+size: 53099,
+usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+}
+);
+let commandEncoder35 = device0.createCommandEncoder(
+{
+}
+);
+let texture39 = device0.createTexture(
+{
+label: '\u0bcb\u1d82\u4d30\u0f4e\uf680',
+size: {width: 4030},
+dimension: '1d',
+format: 'rg8uint',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+let textureView32 = texture14.createView(
+{
+dimension: '2d',
+baseMipLevel: 2,
+mipLevelCount: 2,
+baseArrayLayer: 36,
+}
+);
+let externalTexture4 = device0.importExternalTexture(
+{
+label: '\u08b2\u957e\u1e3a\u4970\u088b\u{1faf1}\u04ed\u2e77\u{1ff25}',
+source: videoFrame7,
+colorSpace: 'display-p3',
+}
+);
+try {
+commandEncoder33.clearBuffer(
+buffer11
+);
+dissociateBuffer(device0, buffer11);
+} catch {}
+let gpuCanvasContext8 = canvas9.getContext('webgpu');
+let pipelineLayout5 = device0.createPipelineLayout(
+{
+label: '\udda8\u79e6\udb67\u01fe\u316c',
+bindGroupLayouts: [
+bindGroupLayout1,
+bindGroupLayout2,
+bindGroupLayout3,
+bindGroupLayout3,
+bindGroupLayout1
+],
+}
+);
+let computePassEncoder31 = commandEncoder34.beginComputePass();
+let renderBundle27 = renderBundleEncoder13.finish(
+{
+label: '\u{1fad6}\u4621\ucfe2\u{1fe95}\u{1f7e8}\u{1f7aa}'
+}
+);
+try {
+computePassEncoder19.end();
+} catch {}
+try {
+commandEncoder33.resolveQuerySet(
+querySet8,
+690,
+2439,
+buffer12,
+768
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer14,
+5884,
+new DataView(new ArrayBuffer(15339)),
+9231,
+4128
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 2,
+  origin: { x: 402, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 822 */{
+offset: 822,
+},
+{width: 2958, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline15 = device0.createComputePipeline(
+{
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let canvas10 = document.createElement('canvas');
+let buffer16 = device0.createBuffer(
+{
+label: '\u5af5\u{1ffbc}\u020d\ueada\u8f82\u{1fc10}\u0ca1',
+size: 29593,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let texture40 = device0.createTexture(
+{
+label: '\u0511\u790a\u0c7f\u0bd3\u0445\u8264\u0382\u8760\u0b0b',
+size: [80, 5, 55],
+mipLevelCount: 5,
+format: 'astc-5x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder32 = commandEncoder21.beginComputePass(
+{
+label: '\uf3c0\ub7b2\u9ab8\ub054\u0304\u0e68'
+}
+);
+let renderBundleEncoder21 = device0.createRenderBundleEncoder(
+{
+label: '\u0cd7\ud36d\u97ba\uaa21\u0743\uae22\u0e57',
+colorFormats: [
+'rgba8unorm',
+'rgba16uint',
+'r16float',
+'rgba8sint'
+],
+sampleCount: 743,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle28 = renderBundleEncoder0.finish();
+let sampler30 = device0.createSampler(
+{
+label: '\u{1f6eb}\u43d3\u00d6\u02fc\uca30',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 4.956,
+lodMaxClamp: 50.774,
+}
+);
+try {
+computePassEncoder32.setBindGroup(
+1,
+bindGroup12,
+new Uint32Array(214),
+156,
+0
+);
+} catch {}
+try {
+computePassEncoder6.dispatchWorkgroups(
+3,
+3
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+11240,
+new Int16Array(15539),
+373
+);
+} catch {}
+let gpuCanvasContext9 = canvas10.getContext('webgpu');
+let commandEncoder36 = device0.createCommandEncoder();
+try {
+buffer13.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 201, height: 1, depthOrArrayLayers: 232}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 1, y: 6 },
+  flipY: false,
+},
+{
+  texture: texture33,
+  mipLevel: 0,
+  origin: { x: 92, y: 0, z: 61 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 11, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\u0966\u{1f644}\uf51d\u{1fb45}\u0f91\u2772\u{1ff3b}');
+let texture41 = device0.createTexture(
+{
+label: '\u30d3\u01f1\u{1fab6}',
+size: {width: 820, height: 20, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'eac-rg11unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'eac-rg11unorm',
+'eac-rg11unorm',
+'eac-rg11unorm'
+],
+}
+);
+let texture42 = gpuCanvasContext1.getCurrentTexture();
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder36.resolveQuerySet(
+querySet8,
+2250,
+384,
+buffer12,
+6400
+);
+} catch {}
+try {
+gpuCanvasContext4.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'bgra8unorm-srgb'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 1, depthOrArrayLayers: 225}
+*/
+{
+  source: img3,
+  origin: { x: 25, y: 23 },
+  flipY: true,
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 4 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+canvas10.height = 333;
+let video6 = await videoWithData();
+let commandEncoder37 = device0.createCommandEncoder(
+{
+label: '\ueeba\u0087\u0209\ub3f5\u{1ff2b}',
+}
+);
+try {
+renderBundleEncoder21.setVertexBuffer(
+2,
+buffer11
+);
+} catch {}
+try {
+commandEncoder37.copyBufferToBuffer(
+buffer6,
+14528,
+buffer11,
+26000,
+2420
+);
+dissociateBuffer(device0, buffer6);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder37.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer14,
+7904,
+new BigUint64Array(60853),
+54743,
+684
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 1, depthOrArrayLayers: 225}
+*/
+{
+  source: canvas9,
+  origin: { x: 25, y: 54 },
+  flipY: true,
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 74 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 3, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline16 = device0.createComputePipeline(
+{
+label: '\u3ac6\u0ee2',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageData6 = new ImageData(96, 256);
+let bindGroupLayout4 = device0.createBindGroupLayout(
+{
+label: '\u{1f8ab}\u1e5b\u43ec\uda34\u6fa5',
+entries: [
+
+],
+}
+);
+try {
+computePassEncoder20.setBindGroup(
+3,
+bindGroup18
+);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(
+5,
+bindGroup16,
+new Uint32Array(7223),
+298,
+0
+);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(
+0,
+bindGroup6
+);
+} catch {}
+try {
+buffer4.destroy();
+} catch {}
+try {
+commandEncoder35.copyBufferToTexture(
+{
+/* bytesInLastRow: 192 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 23872 */
+offset: 23872,
+bytesPerRow: 256,
+buffer: buffer6,
+},
+{
+  texture: texture41,
+  mipLevel: 2,
+  origin: { x: 96, y: 4, z: 0 },
+  aspect: 'all',
+},
+{width: 48, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 0, y: 72, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 562 */{
+offset: 562,
+bytesPerRow: 396,
+},
+{width: 170, height: 72, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\u6bb9\u{1fea4}\u2c97\u2972\u01bf\ude85\ucfe7');
+try {
+texture17.label = '\u02d0\ua632\u0018\uf883\ub240\u{1f87e}';
+} catch {}
+let sampler31 = device0.createSampler(
+{
+label: '\u{1f778}\u5655\u003b\u{1fb0c}\u4ee7\u0aa4',
+addressModeU: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 0.274,
+lodMaxClamp: 62.064,
+maxAnisotropy: 19,
+}
+);
+try {
+buffer6.destroy();
+} catch {}
+try {
+await buffer9.mapAsync(
+GPUMapMode.WRITE,
+26480,
+5568
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture41,
+  mipLevel: 1,
+  origin: { x: 60, y: 4, z: 0 },
+  aspect: 'all',
+},
+new Float32Array(new ArrayBuffer(24)),
+/* required buffer size: 794 */{
+offset: 794,
+},
+{width: 276, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend('\u6b8d\ucd3f\u007b\uba63\u{1fc58}\u{1fa79}');
+let textureView33 = texture42.createView(
+{
+label: '\u{1f88a}\u080d\u0cc3\u13b4\ufa32\u{1f803}\u{1fc51}',
+}
+);
+let renderBundleEncoder22 = device0.createRenderBundleEncoder(
+{
+label: '\u4887\u{1f61f}\u026f\u{1ffa9}\ucb9e\u13ed',
+colorFormats: [
+'rgba16uint',
+'rgba32float'
+],
+sampleCount: 319,
+}
+);
+try {
+computePassEncoder27.setPipeline(
+pipeline8
+);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(
+0,
+bindGroup5
+);
+} catch {}
+try {
+commandEncoder33.copyTextureToBuffer(
+{
+  texture: texture31,
+  mipLevel: 1,
+  origin: { x: 72, y: 20, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 1952 widthInBlocks: 122 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 47712 */
+offset: 47712,
+buffer: buffer2,
+},
+{width: 488, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder33.clearBuffer(
+buffer1,
+22912
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder35.resolveQuerySet(
+querySet5,
+75,
+812,
+buffer13,
+8192
+);
+} catch {}
+let pipeline17 = device0.createComputePipeline(
+{
+label: '\u{1f724}\u0cdc\u4798\ue221\u0548\u{1f6a2}',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let bindGroup30 = device0.createBindGroup({
+layout: bindGroupLayout1,
+entries: [
+{
+binding: 2766,
+resource: externalTexture0
+},
+{
+binding: 2712,
+resource: sampler15
+}
+],
+});
+try {
+commandEncoder35.copyBufferToBuffer(
+buffer2,
+41188,
+buffer14,
+20676,
+9240
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder37.copyTextureToTexture(
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 5 },
+  aspect: 'all',
+},
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 60, y: 168, z: 0 },
+  aspect: 'all',
+},
+{width: 20, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+offscreenCanvas1.height = 827;
+pseudoSubmit(device0, commandEncoder9);
+let texture43 = device0.createTexture(
+{
+label: '\u0163\u{1f9e3}\ub503\u620c\u{1f7ef}\ub875\ucd4f\ude58\u79e4',
+size: {width: 570, height: 1, depthOrArrayLayers: 1452},
+mipLevelCount: 9,
+dimension: '3d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+let renderBundle29 = renderBundleEncoder22.finish(
+{
+
+}
+);
+try {
+computePassEncoder21.setPipeline(
+pipeline12
+);
+} catch {}
+try {
+await buffer3.mapAsync(
+GPUMapMode.WRITE,
+0,
+25564
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+27284,
+new BigUint64Array(47094),
+16357,
+920
+);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let commandEncoder38 = device0.createCommandEncoder(
+{
+label: '\u00eb\u8b4f\ud1c0\u9969\u{1fd89}',
+}
+);
+let querySet20 = device0.createQuerySet(
+{
+label: '\u4fc4\u4d3e\u5973\u06ae\u3429',
+type: 'occlusion',
+count: 3970,
+}
+);
+try {
+renderBundleEncoder19.setBindGroup(
+2,
+bindGroup22
+);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(
+buffer6,
+'uint16'
+);
+} catch {}
+try {
+commandEncoder38.clearBuffer(
+buffer11
+);
+dissociateBuffer(device0, buffer11);
+} catch {}
+let videoFrame10 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder(
+{
+label: '\u020f\uaa98\u490c\u5f4e\u{1fa1f}\u63b3\u{1fb13}',
+colorFormats: [
+'rgba16float',
+'rgba8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 303,
+depthReadOnly: true,
+}
+);
+try {
+computePassEncoder8.setBindGroup(
+2,
+bindGroup29
+);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(
+3,
+bindGroup23,
+[]
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let arrayBuffer8 = buffer9.getMappedRange(
+26480,
+1832
+);
+try {
+commandEncoder33.copyTextureToTexture(
+{
+  texture: texture37,
+  mipLevel: 6,
+  origin: { x: 1, y: 1, z: 14 },
+  aspect: 'all',
+},
+{
+  texture: texture37,
+  mipLevel: 2,
+  origin: { x: 37, y: 19, z: 33 },
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 54}
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 1, depthOrArrayLayers: 225}
+*/
+{
+  source: video4,
+  origin: { x: 6, y: 8 },
+  flipY: false,
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 2, y: 0, z: 114 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 3, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let commandEncoder39 = device0.createCommandEncoder(
+{
+label: '\u{1fc17}\ucd74\uc6e1\uf113\u{1f875}\u420a\u0969\u6316\u{1fb7f}',
+}
+);
+let renderBundleEncoder24 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'r32float',
+'bgra8unorm',
+'rg11b10ufloat'
+],
+sampleCount: 117,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder15.setVertexBuffer(
+2,
+buffer7,
+820,
+21983
+);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder38.clearBuffer(
+buffer11
+);
+dissociateBuffer(device0, buffer11);
+} catch {}
+let pipeline18 = device0.createComputePipeline(
+{
+label: '\u25d5\u588d\u9fda\u0a23\u0fb1',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend('\u{1fd69}\u5660\ua0e6');
+let bindGroupLayout5 = device0.createBindGroupLayout(
+{
+entries: [
+{
+binding: 1598,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '3d' },
+},
+{
+binding: 2439,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+},
+{
+binding: 3826,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let buffer17 = device0.createBuffer(
+{
+label: '\u{1f7e2}\u0c77\u07cb',
+size: 22438,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let commandEncoder40 = device0.createCommandEncoder(
+{
+label: '\u0d92\u{1f8f3}\u0a41\u0a27\u3cfa\u30ec\uecbd',
+}
+);
+let renderBundleEncoder25 = device0.createRenderBundleEncoder(
+{
+label: '\u70c0\u{1f9e2}\u02b6\u0f63\u7e3b\ub9e5\u74c6\ud26b',
+colorFormats: [
+undefined,
+'rgba16sint',
+'rgba8sint',
+'rgba32sint',
+'rgb10a2unorm'
+],
+sampleCount: 179,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder30.dispatchWorkgroupsIndirect(
+buffer12,
+11492
+);
+} catch {}
+try {
+commandEncoder33.resolveQuerySet(
+querySet0,
+1887,
+172,
+buffer16,
+23808
+);
+} catch {}
+try {
+computePassEncoder16.insertDebugMarker(
+'\u86f9'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+45228,
+new Int16Array(15411),
+2517,
+5252
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture19,
+  mipLevel: 0,
+  origin: { x: 1464, y: 8, z: 0 },
+  aspect: 'all',
+},
+new Int32Array(arrayBuffer2),
+/* required buffer size: 131 */{
+offset: 131,
+bytesPerRow: 5671,
+},
+{width: 1388, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 12, height: 1, depthOrArrayLayers: 232}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 138, y: 151 },
+  flipY: false,
+},
+{
+  texture: texture33,
+  mipLevel: 4,
+  origin: { x: 5, y: 1, z: 129 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let imageBitmap5 = await createImageBitmap(video0);
+let commandEncoder41 = device0.createCommandEncoder(
+{
+label: '\u520b\u{1f893}\u0a67\u{1f670}\ud099\u{1f7b9}\uce5b',
+}
+);
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder36.copyBufferToBuffer(
+buffer6,
+31572,
+buffer2,
+9040,
+5244
+);
+dissociateBuffer(device0, buffer6);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder41.copyBufferToTexture(
+{
+/* bytesInLastRow: 816 widthInBlocks: 51 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 9888 */
+offset: 9888,
+buffer: buffer16,
+},
+{
+  texture: texture19,
+  mipLevel: 3,
+  origin: { x: 100, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 204, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder35.clearBuffer(
+buffer17,
+13932,
+8432
+);
+dissociateBuffer(device0, buffer17);
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+let pipeline19 = device0.createComputePipeline(
+{
+label: '\uea34\u{1fd4e}\ue22d\u4c3e\u0842\u3465\u{1fd86}\u{1fdf7}',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline20 = device0.createRenderPipeline(
+{
+label: '\uaca7\u166b\u8f65\udb83\uf32d\u7ef2\u2902\u3db1\u{1f858}',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 5256,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32',
+offset: 2756,
+shaderLocation: 5,
+},
+{
+format: 'unorm8x2',
+offset: 1586,
+shaderLocation: 17,
+},
+{
+format: 'unorm16x4',
+offset: 2508,
+shaderLocation: 12,
+},
+{
+format: 'uint32x4',
+offset: 528,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x2',
+offset: 4164,
+shaderLocation: 7,
+},
+{
+format: 'sint8x2',
+offset: 4016,
+shaderLocation: 14,
+},
+{
+format: 'float32x3',
+offset: 1200,
+shaderLocation: 18,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 640,
+shaderLocation: 15,
+},
+{
+format: 'float16x4',
+offset: 5020,
+shaderLocation: 13,
+},
+{
+format: 'snorm16x2',
+offset: 4120,
+shaderLocation: 1,
+},
+{
+format: 'uint16x2',
+offset: 3316,
+shaderLocation: 19,
+},
+{
+format: 'uint16x2',
+offset: 2284,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x2',
+offset: 744,
+shaderLocation: 4,
+},
+{
+format: 'uint32',
+offset: 5088,
+shaderLocation: 6,
+},
+{
+format: 'float32x3',
+offset: 4988,
+shaderLocation: 10,
+},
+{
+format: 'sint32x3',
+offset: 1800,
+shaderLocation: 8,
+},
+{
+format: 'float16x4',
+offset: 4920,
+shaderLocation: 3,
+},
+{
+format: 'sint32x2',
+offset: 572,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 7208,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32',
+offset: 6628,
+shaderLocation: 21,
+}
+],
+},
+{
+arrayStride: 1656,
+attributes: [
+{
+format: 'uint32x4',
+offset: 464,
+shaderLocation: 20,
+},
+{
+format: 'uint32x4',
+offset: 960,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x4',
+offset: 1644,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'one-minus-src-alpha',
+dstFactor: 'dst'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'one-minus-src',
+dstFactor: 'dst'
+},
+},
+format: 'rg11b10ufloat',
+writeMask: 0,
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'src-alpha-saturated',
+dstFactor: 'src-alpha-saturated'
+},
+},
+format: 'rg8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+undefined,
+undefined,
+undefined,
+{
+format: 'rg8unorm',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rg16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}
+],
+},
+}
+);
+let bindGroup31 = device0.createBindGroup({
+label: '\u{1fc80}\u0cf5\uedf3\u486c\u6600\u0917\u697e\u84eb\u{1fd0c}',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let renderBundle30 = renderBundleEncoder15.finish();
+try {
+computePassEncoder26.setPipeline(
+pipeline8
+);
+} catch {}
+try {
+commandEncoder37.copyBufferToBuffer(
+buffer0,
+11920,
+buffer6,
+416,
+4172
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder33.copyTextureToBuffer(
+{
+  texture: texture13,
+  mipLevel: 5,
+  origin: { x: 3, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 30 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 7642 */
+offset: 4058,
+bytesPerRow: 256,
+rowsPerImage: 1,
+buffer: buffer17,
+},
+{width: 15, height: 0, depthOrArrayLayers: 15}
+);
+dissociateBuffer(device0, buffer17);
+} catch {}
+let bindGroup32 = device0.createBindGroup({
+label: '\u0212\uc555\ub23c\ua2e1\uc879\u{1f614}\u0512',
+layout: bindGroupLayout2,
+entries: [
+
+],
+});
+let sampler32 = device0.createSampler(
+{
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 39.067,
+lodMaxClamp: 55.802,
+}
+);
+try {
+computePassEncoder27.setPipeline(
+pipeline15
+);
+} catch {}
+let bindGroupLayout6 = device0.createBindGroupLayout(
+{
+label: '\u070a\u03b1\uf53f\u{1fc2e}\u42a2\u6460\u9e10\u9fcd\u8c02',
+entries: [
+{
+binding: 547,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 92,
+visibility: 0,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let bindGroup33 = device0.createBindGroup({
+label: '\u012d\u04c1\u7993\ubf4b',
+layout: bindGroupLayout2,
+entries: [
+
+],
+});
+let pipelineLayout6 = device0.createPipelineLayout(
+{
+label: '\u0fa5\u0d6c\u{1fcdd}\ufcbd\u089c\u{1ff94}\u8599',
+bindGroupLayouts: [
+bindGroupLayout1,
+bindGroupLayout5,
+bindGroupLayout5,
+bindGroupLayout2,
+bindGroupLayout0
+],
+}
+);
+let querySet21 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 3857,
+}
+);
+let texture44 = device0.createTexture(
+{
+size: [20, 208, 35],
+mipLevelCount: 4,
+format: 'eac-r11unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+texture24.destroy();
+} catch {}
+try {
+await buffer3.mapAsync(
+GPUMapMode.WRITE,
+12448,
+16036
+);
+} catch {}
+try {
+commandEncoder35.copyBufferToBuffer(
+buffer13,
+3444,
+buffer1,
+19008,
+3676
+);
+dissociateBuffer(device0, buffer13);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+await promise10;
+} catch {}
+document.body.append('\u94a5\u8a96\u6d75\u{1fc81}\u0180\u06a6\u{1fc37}');
+let texture45 = device0.createTexture(
+{
+label: '\uf9bf\u{1f78d}\u0576\u0447\u18a7',
+size: [6611, 76, 1],
+mipLevelCount: 5,
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'r16sint'
+],
+}
+);
+let textureView34 = texture33.createView(
+{
+baseMipLevel: 1,
+mipLevelCount: 2,
+baseArrayLayer: 225,
+arrayLayerCount: 2,
+}
+);
+let renderBundleEncoder26 = device0.createRenderBundleEncoder(
+{
+label: '\u01f6\u{1ff95}\uaf08\u38f1\u{1f85e}\u442e\u4d5c\u48d2',
+colorFormats: [
+'rg32float',
+'rg16float',
+'rgba8sint',
+'rgba8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 587,
+stencilReadOnly: true,
+}
+);
+try {
+commandEncoder40.copyTextureToBuffer(
+{
+  texture: texture26,
+  mipLevel: 1,
+  origin: { x: 24, y: 48, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 1920 widthInBlocks: 120 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 40560 */
+offset: 40560,
+bytesPerRow: 2048,
+rowsPerImage: 287,
+buffer: buffer2,
+},
+{width: 1440, height: 24, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder39.clearBuffer(
+buffer14,
+216,
+35900
+);
+dissociateBuffer(device0, buffer14);
+} catch {}
+let pipeline21 = await device0.createRenderPipelineAsync(
+{
+label: '\u6a81\uf4be\u0bca\u50b4\u{1fdda}\u0582\u1c39\u{1f626}\uc569\ua8e0',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1492,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 700,
+shaderLocation: 13,
+},
+{
+format: 'snorm16x2',
+offset: 1304,
+shaderLocation: 5,
+},
+{
+format: 'sint32x4',
+offset: 708,
+shaderLocation: 14,
+},
+{
+format: 'snorm8x4',
+offset: 404,
+shaderLocation: 4,
+},
+{
+format: 'sint16x4',
+offset: 1092,
+shaderLocation: 8,
+},
+{
+format: 'float32x4',
+offset: 1132,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 4904,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x2',
+offset: 2072,
+shaderLocation: 16,
+},
+{
+format: 'snorm8x4',
+offset: 4304,
+shaderLocation: 17,
+},
+{
+format: 'unorm16x4',
+offset: 924,
+shaderLocation: 12,
+},
+{
+format: 'uint32x3',
+offset: 3200,
+shaderLocation: 11,
+},
+{
+format: 'sint16x4',
+offset: 1404,
+shaderLocation: 21,
+},
+{
+format: 'uint8x4',
+offset: 4084,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 1624,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 1556,
+shaderLocation: 10,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 1568,
+shaderLocation: 3,
+},
+{
+format: 'float32x2',
+offset: 124,
+shaderLocation: 18,
+},
+{
+format: 'uint16x2',
+offset: 1568,
+shaderLocation: 2,
+},
+{
+format: 'uint32x4',
+offset: 852,
+shaderLocation: 6,
+},
+{
+format: 'unorm8x2',
+offset: 1616,
+shaderLocation: 15,
+},
+{
+format: 'uint32x2',
+offset: 1076,
+shaderLocation: 20,
+},
+{
+format: 'sint16x4',
+offset: 848,
+shaderLocation: 9,
+},
+{
+format: 'float32x2',
+offset: 840,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 2484,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 1112,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0xb90cb809,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'bgra8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'src',
+dstFactor: 'dst-alpha'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'dst',
+dstFactor: 'src'
+},
+},
+format: 'r16float',
+},
+undefined
+],
+},
+}
+);
+let commandEncoder42 = device0.createCommandEncoder(
+{
+label: '\u0f67\u0401',
+}
+);
+try {
+renderBundleEncoder24.setVertexBuffer(
+8,
+buffer6,
+5092,
+2213
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder37.clearBuffer(
+buffer2
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture40,
+  mipLevel: 1,
+  origin: { x: 10, y: 0, z: 7 },
+  aspect: 'all',
+},
+new ArrayBuffer(646410),
+/* required buffer size: 646410 */{
+offset: 310,
+bytesPerRow: 194,
+rowsPerImage: 74,
+},
+{width: 25, height: 5, depthOrArrayLayers: 46}
+);
+} catch {}
+offscreenCanvas3.width = 991;
+gc();
+let querySet22 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 2841,
+}
+);
+let texture46 = device0.createTexture(
+{
+label: '\u64b7\u0616\u{1f8b8}\u{1f935}',
+size: {width: 15234, height: 5, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+dimension: '2d',
+format: 'astc-6x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-6x5-unorm',
+'astc-6x5-unorm-srgb',
+'astc-6x5-unorm-srgb'
+],
+}
+);
+try {
+computePassEncoder6.setBindGroup(
+6,
+bindGroup21,
+new Uint32Array(5096),
+3815,
+0
+);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(
+7,
+buffer5
+);
+} catch {}
+let pipeline22 = device0.createComputePipeline(
+{
+label: '\u77db\u27ad\u0ac3\u449d\uffde\u92cd\u4d31\u87b1\u0cae',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+gc();
+let img7 = await imageWithData(118, 40, '#c5b55ca6', '#2b7ad91f');
+let commandEncoder43 = device0.createCommandEncoder();
+try {
+renderBundleEncoder3.setVertexBuffer(
+4,
+buffer16
+);
+} catch {}
+try {
+commandEncoder33.clearBuffer(
+buffer14,
+17596,
+10452
+);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 50, height: 1, depthOrArrayLayers: 232}
+*/
+{
+  source: imageData5,
+  origin: { x: 14, y: 71 },
+  flipY: false,
+},
+{
+  texture: texture33,
+  mipLevel: 2,
+  origin: { x: 47, y: 1, z: 82 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 2, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline23 = device0.createRenderPipeline(
+{
+label: '\ub480\u0d3f\u1640\u0ac9\u347c\u{1fcb2}\u6dcf\u253d\u{1fa26}\u2738',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1304,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 508,
+shaderLocation: 0,
+},
+{
+format: 'uint32',
+offset: 740,
+shaderLocation: 2,
+},
+{
+format: 'float16x4',
+offset: 816,
+shaderLocation: 17,
+},
+{
+format: 'float32x4',
+offset: 840,
+shaderLocation: 3,
+},
+{
+format: 'unorm16x4',
+offset: 704,
+shaderLocation: 12,
+},
+{
+format: 'unorm16x4',
+offset: 684,
+shaderLocation: 15,
+},
+{
+format: 'uint16x2',
+offset: 760,
+shaderLocation: 19,
+},
+{
+format: 'sint8x2',
+offset: 956,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x4',
+offset: 788,
+shaderLocation: 5,
+},
+{
+format: 'unorm16x2',
+offset: 728,
+shaderLocation: 10,
+},
+{
+format: 'unorm8x4',
+offset: 388,
+shaderLocation: 1,
+},
+{
+format: 'sint16x2',
+offset: 364,
+shaderLocation: 14,
+},
+{
+format: 'float16x4',
+offset: 316,
+shaderLocation: 18,
+},
+{
+format: 'uint16x2',
+offset: 1132,
+shaderLocation: 11,
+},
+{
+format: 'float16x4',
+offset: 800,
+shaderLocation: 13,
+},
+{
+format: 'unorm16x2',
+offset: 836,
+shaderLocation: 16,
+},
+{
+format: 'float16x4',
+offset: 168,
+shaderLocation: 4,
+},
+{
+format: 'float32x2',
+offset: 348,
+shaderLocation: 7,
+},
+{
+format: 'uint8x4',
+offset: 1216,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 6248,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 5180,
+shaderLocation: 20,
+}
+],
+},
+{
+arrayStride: 7396,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 7664,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 4144,
+attributes: [
+{
+format: 'sint16x2',
+offset: 3148,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 1368,
+attributes: [
+
+],
+},
+{
+arrayStride: 7328,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 576,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 360,
+shaderLocation: 21,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16sint',
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rg16float',
+},
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'dst-alpha',
+dstFactor: 'one-minus-dst'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'one-minus-constant',
+dstFactor: 'src'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+pseudoSubmit(device0, commandEncoder33);
+let renderBundle31 = renderBundleEncoder2.finish();
+try {
+computePassEncoder8.setBindGroup(
+5,
+bindGroup18
+);
+} catch {}
+try {
+computePassEncoder32.setPipeline(
+pipeline15
+);
+} catch {}
+try {
+commandEncoder35.copyBufferToBuffer(
+buffer5,
+3176,
+buffer6,
+32104,
+2364
+);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder35.clearBuffer(
+buffer14,
+41056,
+352
+);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture32,
+  mipLevel: 4,
+  origin: { x: 186, y: 0, z: 3 },
+  aspect: 'all',
+},
+new Int8Array(arrayBuffer3),
+/* required buffer size: 10605474 */{
+offset: 954,
+bytesPerRow: 3273,
+rowsPerImage: 40,
+},
+{width: 404, height: 0, depthOrArrayLayers: 82}
+);
+} catch {}
+let bindGroupLayout7 = device0.createBindGroupLayout(
+{
+label: '\u0eca\ua4e8\u0266\u6614\ud125\udf4b\u{1f951}\u06ec',
+entries: [
+
+],
+}
+);
+try {
+computePassEncoder20.setPipeline(
+pipeline3
+);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(
+4,
+buffer7
+);
+} catch {}
+try {
+commandEncoder37.resolveQuerySet(
+querySet7,
+2902,
+155,
+buffer12,
+11008
+);
+} catch {}
+offscreenCanvas3.width = 610;
+document.body.append('\u0ea1\u0fb1\u0a34\u5543\u{1ff64}\u0801\u2ee1');
+try {
+computePassEncoder20.dispatchWorkgroups(
+2,
+5
+);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(
+buffer13,
+'uint32',
+30632,
+5279
+);
+} catch {}
+try {
+commandEncoder35.clearBuffer(
+buffer6
+);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+gpuCanvasContext8.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let video7 = await videoWithData();
+let querySet23 = device0.createQuerySet(
+{
+label: '\u0033\u3c5c\ue3f3\ua008\ue65b\u0e10\uec43\u093b\u99d2',
+type: 'occlusion',
+count: 3242,
+}
+);
+let commandBuffer6 = commandEncoder39.finish(
+{
+label: '\udb3e\u{1ff76}\uf29a\uc0c1\u8171\ua385',
+}
+);
+let texture47 = device0.createTexture(
+{
+label: '\u8975\u12ca\ud973\u{1fc2a}',
+size: [4820, 10, 220],
+mipLevelCount: 3,
+format: 'astc-10x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-10x10-unorm'
+],
+}
+);
+let textureView35 = texture33.createView(
+{
+label: '\ubed4\u{1f80d}\u{1f756}\ue03b\u580c',
+dimension: '2d',
+baseMipLevel: 1,
+mipLevelCount: 3,
+baseArrayLayer: 169,
+}
+);
+let sampler33 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 78.303,
+compare: 'less',
+maxAnisotropy: 2,
+}
+);
+try {
+renderBundleEncoder23.setBindGroup(
+1,
+bindGroup7
+);
+} catch {}
+try {
+gpuCanvasContext4.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+56776,
+new Float32Array(37908),
+7751,
+452
+);
+} catch {}
+let pipeline24 = await device0.createRenderPipelineAsync(
+{
+label: '\u6aac\uffa5',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 2204,
+attributes: [
+{
+format: 'float32',
+offset: 776,
+shaderLocation: 10,
+},
+{
+format: 'float32x2',
+offset: 908,
+shaderLocation: 12,
+},
+{
+format: 'float16x4',
+offset: 1380,
+shaderLocation: 4,
+},
+{
+format: 'uint8x2',
+offset: 26,
+shaderLocation: 2,
+},
+{
+format: 'uint32x3',
+offset: 1456,
+shaderLocation: 6,
+},
+{
+format: 'snorm8x4',
+offset: 396,
+shaderLocation: 18,
+},
+{
+format: 'uint32',
+offset: 1084,
+shaderLocation: 19,
+},
+{
+format: 'sint32',
+offset: 532,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x4',
+offset: 1428,
+shaderLocation: 5,
+},
+{
+format: 'unorm16x2',
+offset: 1116,
+shaderLocation: 17,
+},
+{
+format: 'sint32',
+offset: 2100,
+shaderLocation: 14,
+},
+{
+format: 'uint32x2',
+offset: 720,
+shaderLocation: 20,
+}
+],
+},
+{
+arrayStride: 4356,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x2',
+offset: 920,
+shaderLocation: 13,
+},
+{
+format: 'float16x2',
+offset: 2908,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x4',
+offset: 8,
+shaderLocation: 7,
+},
+{
+format: 'float32x3',
+offset: 3572,
+shaderLocation: 1,
+},
+{
+format: 'uint16x2',
+offset: 2408,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x2',
+offset: 4320,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 5456,
+attributes: [
+{
+format: 'float32x4',
+offset: 1540,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 2644,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 1684,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 2008,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32',
+offset: 428,
+shaderLocation: 21,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 2528,
+attributes: [
+
+],
+},
+{
+arrayStride: 1252,
+attributes: [
+
+],
+},
+{
+arrayStride: 4380,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x3',
+offset: 32,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+format: 'r32float',
+writeMask: 0,
+},
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+undefined,
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'one-minus-src',
+dstFactor: 'dst-alpha'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'src-alpha-saturated',
+dstFactor: 'constant'
+},
+},
+format: 'rg8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'rg32uint',
+}
+],
+},
+depthStencil: {
+format: 'stencil8',
+stencilFront: {
+compare: 'never',
+failOp: 'invert',
+depthFailOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 1707,
+stencilWriteMask: 3385,
+depthBias: 52,
+depthBiasSlopeScale: 24,
+depthBiasClamp: 15,
+},
+}
+);
+document.body.prepend('\u6d9b\u{1f624}\u8ba2\u6ce6\u0e9b\u{1fba8}\u1361\u22de\u0621\u0709');
+let bindGroup34 = device0.createBindGroup({
+layout: bindGroupLayout6,
+entries: [
+{
+binding: 547,
+resource: externalTexture3
+},
+{
+binding: 92,
+resource: sampler28
+}
+],
+});
+let commandBuffer7 = commandEncoder35.finish(
+{
+label: '\u{1fc93}\u011c\u4b82\u27a0\u0d69\uc231\udf3e\ua0dd\uafdb',
+}
+);
+let textureView36 = texture13.createView(
+{
+label: '\uc23b\uef37\u66ad\u0291\u{1fcdb}\u{1fa1d}\u0d96\u043b',
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+let renderBundle32 = renderBundleEncoder2.finish(
+{
+label: '\u{1f66a}\u0341\u88d5\u4d82\u0c60'
+}
+);
+try {
+computePassEncoder8.setPipeline(
+pipeline10
+);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(
+buffer6,
+'uint32',
+28144,
+3757
+);
+} catch {}
+try {
+commandEncoder36.resolveQuerySet(
+querySet10,
+1450,
+315,
+buffer5,
+4352
+);
+} catch {}
+let pipeline25 = await device0.createComputePipelineAsync(
+{
+label: '\u9a8b\u{1fcff}\u1a98\u691a\u00b7\u{1fc38}\ucd25\u0f2c',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline26 = device0.createRenderPipeline(
+{
+label: '\u48f6\u061f\u0de5\u68a4\u0789\u5b97\uf22e\u09a6\u4252\u5618\ub3e6',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 7748,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 2636,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x2',
+offset: 2192,
+shaderLocation: 12,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 6204,
+shaderLocation: 15,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 5192,
+shaderLocation: 3,
+},
+{
+format: 'snorm8x4',
+offset: 2936,
+shaderLocation: 1,
+},
+{
+format: 'uint16x4',
+offset: 696,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x2',
+offset: 5564,
+shaderLocation: 13,
+},
+{
+format: 'uint32',
+offset: 4692,
+shaderLocation: 19,
+},
+{
+format: 'sint32x3',
+offset: 1716,
+shaderLocation: 21,
+},
+{
+format: 'float16x2',
+offset: 7288,
+shaderLocation: 18,
+},
+{
+format: 'float32x4',
+offset: 2780,
+shaderLocation: 5,
+},
+{
+format: 'uint8x2',
+offset: 5790,
+shaderLocation: 11,
+},
+{
+format: 'unorm8x2',
+offset: 2042,
+shaderLocation: 7,
+},
+{
+format: 'uint32x4',
+offset: 1896,
+shaderLocation: 0,
+},
+{
+format: 'snorm8x4',
+offset: 4616,
+shaderLocation: 16,
+},
+{
+format: 'sint32x4',
+offset: 5620,
+shaderLocation: 14,
+},
+{
+format: 'uint32',
+offset: 5672,
+shaderLocation: 20,
+}
+],
+},
+{
+arrayStride: 6312,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 5872,
+shaderLocation: 10,
+},
+{
+format: 'uint32',
+offset: 5344,
+shaderLocation: 6,
+},
+{
+format: 'float32x4',
+offset: 3592,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x4',
+offset: 2712,
+shaderLocation: 17,
+},
+{
+format: 'sint32x3',
+offset: 5696,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x95971e64,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.BLUE,
+},
+{
+format: 'r16float',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'dst',
+dstFactor: 'one-minus-src'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rg16float',
+},
+undefined,
+undefined,
+undefined,
+{
+format: 'rg8unorm',
+writeMask: 0,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+canvas5.width = 905;
+gc();
+document.body.append('\u1498\u{1fe40}\u{1f829}');
+let img8 = await imageWithData(83, 200, '#b1085f36', '#04bdb855');
+let computePassEncoder33 = commandEncoder38.beginComputePass(
+{
+label: '\u004c\u0a2c\u838e\u7dfd\u04b0\u3293\u0c9a\u0742\u{1f7ab}\u0653'
+}
+);
+let renderBundleEncoder27 = device0.createRenderBundleEncoder(
+{
+label: '\u4485\u5e86\ua65e\u7ab4\u{1fe1d}\u2da8\u9595\u{1ffc4}\ue216',
+colorFormats: [
+'rgb10a2uint',
+'rg16float',
+'r16uint',
+undefined,
+'rg16float',
+'r16sint',
+'r32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 687,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+let sampler34 = device0.createSampler(
+{
+label: '\u0efe\u0efd\u9d98\ua2ae\u9960\u0d2e\u0055',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 17.435,
+lodMaxClamp: 28.221,
+maxAnisotropy: 13,
+}
+);
+try {
+commandEncoder36.copyTextureToTexture(
+{
+  texture: texture4,
+  mipLevel: 2,
+  origin: { x: 1475, y: 0, z: 191 },
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: { x: 1898, y: 1, z: 79 },
+  aspect: 'all',
+},
+{width: 527, height: 0, depthOrArrayLayers: 28}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer11,
+4924,
+new Float32Array(56473),
+28110,
+2832
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 100, height: 1, depthOrArrayLayers: 232}
+*/
+{
+  source: video3,
+  origin: { x: 5, y: 4 },
+  flipY: true,
+},
+{
+  texture: texture33,
+  mipLevel: 1,
+  origin: { x: 82, y: 0, z: 9 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 10, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let bindGroupLayout8 = device0.createBindGroupLayout(
+{
+label: '\ua0f9\u07e1\u{1fd2d}\u{1f7f6}\u{1fd39}',
+entries: [
+{
+binding: 7549,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '2d-array' },
+},
+{
+binding: 3897,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'non-filtering' },
+},
+{
+binding: 6426,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let bindGroup35 = device0.createBindGroup({
+label: '\u09d9\uefee\u00bb\u{1fb51}\u9582\u{1f842}\u9e7e\ucf20\u{1fe25}',
+layout: bindGroupLayout1,
+entries: [
+{
+binding: 2712,
+resource: sampler23
+},
+{
+binding: 2766,
+resource: externalTexture3
+}
+],
+});
+let buffer18 = device0.createBuffer(
+{
+label: '\u7ceb\u{1fee2}\u9e9a\u2605\u80f5\u0b33\u{1f909}\ue739',
+size: 8676,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let querySet24 = device0.createQuerySet(
+{
+label: '\u6e71\u31a8',
+type: 'occlusion',
+count: 1305,
+}
+);
+let texture48 = device0.createTexture(
+{
+label: '\u0cbd\u034b\u0528\u06bb\udf34\u{1f9c2}\u0414\u8707\ue729\u{1f8f2}\u0a6b',
+size: [168, 6, 130],
+mipLevelCount: 8,
+format: 'astc-6x6-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-6x6-unorm-srgb',
+'astc-6x6-unorm',
+'astc-6x6-unorm'
+],
+}
+);
+let renderBundle33 = renderBundleEncoder16.finish();
+let sampler35 = device0.createSampler(
+{
+label: '\u0940\u06cc\u2d03\u5585\u0317\u{1fd56}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 40.943,
+lodMaxClamp: 77.707,
+}
+);
+try {
+renderBundleEncoder27.setIndexBuffer(
+buffer10,
+'uint32',
+4380,
+669
+);
+} catch {}
+try {
+commandEncoder42.copyBufferToBuffer(
+buffer5,
+7280,
+buffer11,
+19756,
+1968
+);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder41.clearBuffer(
+buffer2
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer17,
+18288,
+new BigUint64Array(9392),
+7482,
+80
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 50, height: 1, depthOrArrayLayers: 232}
+*/
+{
+  source: img7,
+  origin: { x: 59, y: 19 },
+  flipY: false,
+},
+{
+  texture: texture33,
+  mipLevel: 2,
+  origin: { x: 4, y: 0, z: 155 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 4, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let commandEncoder44 = device0.createCommandEncoder(
+{
+label: '\u0ab8\u08c0\u0d81\ueb16\u2dbb\u76b4',
+}
+);
+try {
+renderBundleEncoder24.setBindGroup(
+3,
+bindGroup9
+);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(
+7,
+buffer5,
+4364,
+1466
+);
+} catch {}
+try {
+commandEncoder37.copyBufferToBuffer(
+buffer2,
+35004,
+buffer1,
+6580,
+25152
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline27 = await device0.createComputePipelineAsync(
+{
+label: '\uc8a3\uc803',
+layout: pipelineLayout6,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+}
+);
+gc();
+document.body.append('\u3040\u{1fa44}');
+let querySet25 = device0.createQuerySet(
+{
+label: '\u03de\u0cc7',
+type: 'occlusion',
+count: 1436,
+}
+);
+let texture49 = device0.createTexture(
+{
+size: [162, 1, 113],
+mipLevelCount: 8,
+dimension: '3d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let renderBundle34 = renderBundleEncoder19.finish(
+{
+label: '\u05fd\ue06f\u015f\u{1f8ac}\u045b'
+}
+);
+try {
+computePassEncoder21.setBindGroup(
+2,
+bindGroup21
+);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(
+3,
+buffer13,
+3096,
+29010
+);
+} catch {}
+let promise11 = buffer14.mapAsync(
+GPUMapMode.READ,
+0,
+5316
+);
+try {
+commandEncoder44.copyTextureToTexture(
+{
+  texture: texture40,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 11 },
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 675, y: 30, z: 70 },
+  aspect: 'all',
+},
+{width: 25, height: 0, depthOrArrayLayers: 17}
+);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 5, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: img3,
+  origin: { x: 79, y: 43 },
+  flipY: false,
+},
+{
+  texture: texture49,
+  mipLevel: 5,
+  origin: { x: 2, y: 1, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let imageData7 = new ImageData(32, 256);
+let promise12 = adapter0.requestAdapterInfo();
+let commandEncoder45 = device0.createCommandEncoder();
+let texture50 = device0.createTexture(
+{
+label: '\u05a9\ub827',
+size: [11024, 4, 1],
+mipLevelCount: 12,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'etc2-rgb8unorm-srgb',
+'etc2-rgb8unorm-srgb'
+],
+}
+);
+let renderBundleEncoder28 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 970,
+depthReadOnly: true,
+stencilReadOnly: false,
+}
+);
+try {
+commandEncoder43.copyBufferToBuffer(
+buffer4,
+26716,
+buffer14,
+27056,
+8716
+);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder36.clearBuffer(
+buffer2
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+gpuCanvasContext3.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'etc2-rgb8a1unorm',
+'rgb9e5ufloat',
+'bgra8unorm-srgb'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+let buffer19 = device0.createBuffer(
+{
+label: '\u{1ff8b}\u371c\u{1fefe}',
+size: 12202,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let commandEncoder46 = device0.createCommandEncoder();
+let computePassEncoder34 = commandEncoder40.beginComputePass(
+{
+label: '\u1fdb\u4541'
+}
+);
+let sampler36 = device0.createSampler(
+{
+label: '\u{1fc62}\u064d\u7a50',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 51.456,
+lodMaxClamp: 62.696,
+compare: 'less-equal',
+maxAnisotropy: 9,
+}
+);
+try {
+renderBundleEncoder3.setVertexBuffer(
+90,
+undefined,
+993102838,
+1785281944
+);
+} catch {}
+try {
+commandEncoder42.clearBuffer(
+buffer11
+);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder43.resolveQuerySet(
+querySet3,
+1412,
+109,
+buffer6,
+8192
+);
+} catch {}
+try {
+gpuCanvasContext7.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture51 = gpuCanvasContext7.getCurrentTexture();
+let renderBundle35 = renderBundleEncoder15.finish(
+{
+label: '\udf39\u20b9\u22fb\u{1fb2e}\u0734\u7b8a\uace7\u{1fbbb}\u12c8\ubca0\u{1fd88}'
+}
+);
+try {
+computePassEncoder15.setPipeline(
+pipeline19
+);
+} catch {}
+let promise14 = device0.popErrorScope();
+let shaderModule1 = device0.createShaderModule(
+{
+label: '\u{1ff1a}\ua3b4\u{1ff95}\u06df\u0981\u3e05\ud1d1\u03f0\uad9f\u00fb\u02ae',
+code: `
+
+@compute @workgroup_size(3, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: vec2<i32>,
+@builtin(sample_mask) f1: u32,
+@location(6) f2: i32,
+@location(0) f3: vec4<f32>,
+@location(1) f4: u32,
+@location(3) f5: f32,
+@location(5) f6: vec2<u32>,
+@location(2) f7: vec2<u32>,
+@location(7) f8: f32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(sample_mask) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(11) a0: vec3<i32>, @location(9) a1: vec2<f32>, @location(8) a2: vec2<f32>, @location(16) a3: vec2<u32>, @builtin(vertex_index) a4: u32, @location(19) a5: vec4<u32>, @location(3) a6: vec2<f16>, @location(1) a7: vec3<f16>, @location(12) a8: vec2<f32>, @location(17) a9: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+}
+);
+let bindGroup36 = device0.createBindGroup({
+label: '\u0c56\ucb58\u{1f8c0}\u6bff\u046f\ue792\ue02f\u0770\u3ac2',
+layout: bindGroupLayout7,
+entries: [
+
+],
+});
+let pipelineLayout7 = device0.createPipelineLayout(
+{
+label: '\u0e5c\ub0e9\u0550\ubc7d',
+bindGroupLayouts: [
+bindGroupLayout4,
+bindGroupLayout7,
+bindGroupLayout0
+],
+}
+);
+let buffer20 = device0.createBuffer(
+{
+label: '\u71da\ue22f\ud36e',
+size: 6883,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+mappedAtCreation: false,
+}
+);
+try {
+computePassEncoder6.dispatchWorkgroups(
+3,
+3,
+2
+);
+} catch {}
+try {
+computePassEncoder32.setPipeline(
+pipeline18
+);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(
+3,
+bindGroup5
+);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(
+2,
+buffer7,
+13932,
+7382
+);
+} catch {}
+try {
+commandEncoder43.resolveQuerySet(
+querySet2,
+73,
+418,
+buffer16,
+19712
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16float'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture25,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new BigUint64Array(arrayBuffer8),
+/* required buffer size: 2 */{
+offset: 2,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\u{1ff07}\ude60\u0958\u{1fd30}\u4ac5\u3f37');
+try {
+window.someLabel = commandEncoder29.label;
+} catch {}
+let pipelineLayout8 = device0.createPipelineLayout(
+{
+label: '\uaf69\u313b\u0c62\ub944\u07ec\u2a10\ub766',
+bindGroupLayouts: [
+bindGroupLayout3,
+bindGroupLayout3,
+bindGroupLayout3,
+bindGroupLayout4,
+bindGroupLayout8
+],
+}
+);
+let textureView37 = texture17.createView(
+{
+label: '\u34b8\u5bcc\u8c5d\u5f85\u3276\u0438\u2b17\u{1ffd0}\uc578',
+}
+);
+try {
+computePassEncoder6.dispatchWorkgroupsIndirect(
+buffer15,
+41624
+);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(
+buffer6,
+'uint32',
+24740,
+14911
+);
+} catch {}
+let bindGroup37 = device0.createBindGroup({
+label: '\u{1f9b9}\u30f1\ub383',
+layout: bindGroupLayout1,
+entries: [
+{
+binding: 2766,
+resource: externalTexture2
+},
+{
+binding: 2712,
+resource: sampler11
+}
+],
+});
+let commandBuffer8 = commandEncoder44.finish(
+{
+label: '\u9b57\u8270\u07d1\ua9f4\u0ae0\ua80a\u0d43\u{1f718}\ub0f2\u825c',
+}
+);
+let computePassEncoder35 = commandEncoder45.beginComputePass(
+{
+label: '\u9113\ua7d4\uf1f2\ucf11\uccdd\u2363\u06de'
+}
+);
+try {
+commandEncoder41.copyBufferToBuffer(
+buffer18,
+472,
+buffer14,
+35420,
+1764
+);
+dissociateBuffer(device0, buffer18);
+dissociateBuffer(device0, buffer14);
+} catch {}
+let videoFrame11 = new VideoFrame(canvas0, {timestamp: 0});
+let buffer21 = device0.createBuffer(
+{
+label: '\u8ee3\u0e5e\ue283',
+size: 2170,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let commandEncoder47 = device0.createCommandEncoder(
+{
+label: '\uc91f\u0ca3\uae89\ue700',
+}
+);
+try {
+commandEncoder46.clearBuffer(
+buffer14,
+30316,
+1484
+);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture49,
+  mipLevel: 3,
+  origin: { x: 18, y: 0, z: 4 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 10465 */{
+offset: 161,
+bytesPerRow: 206,
+rowsPerImage: 10,
+},
+{width: 2, height: 1, depthOrArrayLayers: 6}
+);
+} catch {}
+let pipeline28 = device0.createRenderPipeline(
+{
+label: '\u01e8\u7082\u6cf6\ub27a\u0f95',
+layout: pipelineLayout5,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 6564,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x2',
+offset: 1752,
+shaderLocation: 3,
+},
+{
+format: 'float32x2',
+offset: 5668,
+shaderLocation: 1,
+},
+{
+format: 'sint32x2',
+offset: 3444,
+shaderLocation: 11,
+},
+{
+format: 'snorm8x4',
+offset: 5404,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'float32x3',
+offset: 1132,
+shaderLocation: 12,
+},
+{
+format: 'uint32x2',
+offset: 2604,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 2900,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 2700,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 5156,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 88,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x2',
+offset: 400,
+shaderLocation: 17,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32float',
+}
+],
+},
+}
+);
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+document.body.append('\u07f0\u09cf\uc47a\u0d74\u161c\u1f13\u97bb\u4ff7\u3aef\u{1f898}\u0dda');
+try {
+window.someLabel = computePassEncoder26.label;
+} catch {}
+let commandEncoder48 = device0.createCommandEncoder(
+{
+label: '\u165b\u8fcc\u0d0b\u{1ffdb}\u0628\u29ca',
+}
+);
+let querySet26 = device0.createQuerySet(
+{
+label: '\u78b6\uf857\ubc95\u031d\uba69\ub498\u{1fad7}\u7d19',
+type: 'occlusion',
+count: 552,
+}
+);
+let texture52 = device0.createTexture(
+{
+label: '\u02dd\u65e4\u44ca',
+size: [12170, 6, 1],
+mipLevelCount: 10,
+format: 'astc-10x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundle36 = renderBundleEncoder16.finish();
+try {
+computePassEncoder6.setBindGroup(
+1,
+bindGroup25
+);
+} catch {}
+try {
+computePassEncoder34.setBindGroup(
+3,
+bindGroup9,
+new Uint32Array(288),
+126,
+0
+);
+} catch {}
+try {
+commandEncoder42.copyBufferToBuffer(
+buffer2,
+5028,
+buffer17,
+288,
+15952
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer17);
+} catch {}
+try {
+commandEncoder46.copyTextureToTexture(
+{
+  texture: texture32,
+  mipLevel: 8,
+  origin: { x: 5, y: 0, z: 2 },
+  aspect: 'all',
+},
+{
+  texture: texture32,
+  mipLevel: 3,
+  origin: { x: 1074, y: 0, z: 2 },
+  aspect: 'all',
+},
+{width: 33, height: 0, depthOrArrayLayers: 95}
+);
+} catch {}
+gc();
+let bindGroup38 = device0.createBindGroup({
+label: '\ue6f9\u0c36\u9b39\u366f\ubd0a\u867c\u0695',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let querySet27 = device0.createQuerySet(
+{
+label: '\u003c\u0968',
+type: 'occlusion',
+count: 901,
+}
+);
+let texture53 = device0.createTexture(
+{
+label: '\u1248\u2160\ua56d\u{1f7ed}',
+size: [224, 60, 1],
+mipLevelCount: 4,
+format: 'astc-4x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-4x4-unorm',
+'astc-4x4-unorm',
+'astc-4x4-unorm'
+],
+}
+);
+try {
+computePassEncoder21.setBindGroup(
+1,
+bindGroup0,
+new Uint32Array(5613),
+2684,
+0
+);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(
+7,
+buffer7,
+19328,
+2256
+);
+} catch {}
+try {
+commandEncoder36.copyTextureToTexture(
+{
+  texture: texture49,
+  mipLevel: 7,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture49,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder48.clearBuffer(
+buffer14,
+8840,
+28796
+);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+renderBundleEncoder6.insertDebugMarker(
+'\u5a6a'
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'astc-6x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32sint',
+'astc-6x5-unorm-srgb',
+'astc-6x5-unorm-srgb',
+'r8snorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let canvas11 = document.createElement('canvas');
+try {
+adapter0.label = '\u7156\uab28\u8e50\u{1f920}\uaee1\u496c';
+} catch {}
+let bindGroup39 = device0.createBindGroup({
+label: '\u0174\uad35\u{1fc14}\uf41f\u0c2f\u5a1c\u1611',
+layout: bindGroupLayout7,
+entries: [
+
+],
+});
+let buffer22 = device0.createBuffer(
+{
+size: 50326,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+}
+);
+let commandEncoder49 = device0.createCommandEncoder(
+{
+label: '\u{1ff79}\u{1f8d8}\ufe7a\u4933\u38a8\u955f\u0a88',
+}
+);
+let textureView38 = texture53.createView(
+{
+label: '\u{1fdfd}\ue84e\ue5c8',
+dimension: '2d',
+format: 'astc-4x4-unorm',
+baseMipLevel: 3,
+}
+);
+document.body.append('\ue60a\u5e72\ufafc\ua318\u0960\u9825\u265e\u6633\u6c91');
+try {
+canvas11.getContext('webgl');
+} catch {}
+try {
+externalTexture4.label = '\u8770\ube76\u0f29\u077f';
+} catch {}
+let texture54 = device0.createTexture(
+{
+label: '\u{1f859}\u9e87\u{1fb83}\u43c6\uca55\u05e5\uc1e4\u08fc\ufec4\u{1fa74}',
+size: {width: 3917, height: 13, depthOrArrayLayers: 57},
+mipLevelCount: 6,
+format: 'rg32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder29 = device0.createRenderBundleEncoder(
+{
+label: '\ue003\u{1fa4d}\u{1fcec}\u3dd4\ubdb2\u{1fdf6}',
+colorFormats: [
+'bgra8unorm-srgb',
+'rgba32sint',
+'r8uint',
+'rgba8unorm-srgb'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 612,
+depthReadOnly: true,
+}
+);
+try {
+computePassEncoder30.dispatchWorkgroups(
+1,
+5,
+2
+);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(
+8,
+buffer11,
+7524
+);
+} catch {}
+try {
+commandEncoder49.resolveQuerySet(
+querySet0,
+1516,
+544,
+buffer20,
+512
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer17,
+4596,
+new BigUint64Array(52846),
+13278,
+1364
+);
+} catch {}
+let promise15 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(img2);
+let bindGroup40 = device0.createBindGroup({
+label: '\u0f48\ufec6\u{1f7fc}\u6576',
+layout: bindGroupLayout1,
+entries: [
+{
+binding: 2766,
+resource: externalTexture0
+},
+{
+binding: 2712,
+resource: sampler23
+}
+],
+});
+try {
+computePassEncoder14.end();
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(
+7,
+buffer5,
+8464
+);
+} catch {}
+try {
+commandEncoder43.copyBufferToBuffer(
+buffer6,
+14744,
+buffer1,
+21064,
+4740
+);
+dissociateBuffer(device0, buffer6);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 10, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: img5,
+  origin: { x: 41, y: 42 },
+  flipY: false,
+},
+{
+  texture: texture49,
+  mipLevel: 4,
+  origin: { x: 1, y: 0, z: 4 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 3, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\ue95d\uba46');
+let texture55 = device0.createTexture(
+{
+label: '\ucfe6\u1657\u000e\u0b59\ue147\ue085\u0b0b\u{1fbb5}\ud18f\uc267\u026d',
+size: {width: 13552, height: 4, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'astc-4x4-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-4x4-unorm',
+'astc-4x4-unorm',
+'astc-4x4-unorm'
+],
+}
+);
+try {
+computePassEncoder28.dispatchWorkgroups(
+1,
+5,
+3
+);
+} catch {}
+try {
+commandEncoder42.copyBufferToBuffer(
+buffer0,
+9700,
+buffer19,
+1156,
+3248
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer19);
+} catch {}
+try {
+commandEncoder48.clearBuffer(
+buffer2
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder42.resolveQuerySet(
+querySet22,
+1174,
+260,
+buffer20,
+512
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 45, y: 24, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer5,
+/* required buffer size: 788 */{
+offset: 788,
+bytesPerRow: 291,
+rowsPerImage: 156,
+},
+{width: 53, height: 4, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+document.body.prepend('\u{1fda7}\u0363\u{1f847}\u5e75\u{1fe23}\u01ae\ua8e5\u{1fef3}\u48df\u5107');
+let imageData8 = new ImageData(12, 164);
+let bindGroupLayout9 = device0.createBindGroupLayout(
+{
+entries: [
+{
+binding: 4111,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 6093,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+try {
+renderBundleEncoder21.setIndexBuffer(
+buffer6,
+'uint16',
+40660,
+345
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer20,
+4920,
+new BigUint64Array(58941),
+35686,
+108
+);
+} catch {}
+let commandEncoder50 = device0.createCommandEncoder();
+try {
+computePassEncoder20.dispatchWorkgroupsIndirect(
+buffer12,
+2024
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 1, depthOrArrayLayers: 225}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 291, y: 107 },
+  flipY: false,
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 137 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 5, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+canvas5.height = 909;
+let imageBitmap6 = await createImageBitmap(img7);
+try {
+gpuCanvasContext4.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer20,
+5704,
+new Int16Array(28478),
+26089,
+344
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 81, height: 1, depthOrArrayLayers: 56}
+*/
+{
+  source: img5,
+  origin: { x: 4, y: 11 },
+  flipY: true,
+},
+{
+  texture: texture49,
+  mipLevel: 1,
+  origin: { x: 25, y: 0, z: 6 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 45, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\u739a\u2679\u24c2\u4019\u05c9\ucee6\u{1fb11}\u0a44');
+let bindGroup41 = device0.createBindGroup({
+label: '\u029f\u{1fc48}\u{1ff8f}\u06f3\ub85e\u0230',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let commandEncoder51 = device0.createCommandEncoder(
+{
+label: '\ub749\ud7dc\ucec7\u0875\u68fe\u{1fc34}\u{1f756}',
+}
+);
+let renderBundle37 = renderBundleEncoder10.finish(
+{
+label: '\u0fc9\u8509\u6895\u0b28\u29cc\u0ede\u0a65\u07b1\u7b36\ua465'
+}
+);
+let sampler37 = device0.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+minFilter: 'linear',
+lodMinClamp: 88.374,
+lodMaxClamp: 94.190,
+}
+);
+try {
+computePassEncoder30.dispatchWorkgroups(
+1,
+1
+);
+} catch {}
+try {
+computePassEncoder26.dispatchWorkgroupsIndirect(
+buffer15,
+3316
+);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(
+1,
+bindGroup25,
+new Uint32Array(3097),
+2108,
+0
+);
+} catch {}
+try {
+commandEncoder37.copyTextureToBuffer(
+{
+  texture: texture22,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 45120 */
+offset: 45120,
+bytesPerRow: 0,
+buffer: buffer22,
+},
+{width: 0, height: 5, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer22);
+} catch {}
+let bindGroup42 = device0.createBindGroup({
+label: '\u7376\u0d8d\u5860\u72fa\u894a\u{1f859}\u7f77\ueb38',
+layout: bindGroupLayout4,
+entries: [
+
+],
+});
+let commandEncoder52 = device0.createCommandEncoder(
+{
+label: '\u04d1\udec3\u49b7\u06b6\u{1ffbc}\uea66\ufb15',
+}
+);
+let renderBundle38 = renderBundleEncoder24.finish();
+let sampler38 = device0.createSampler(
+{
+label: '\u963e\u{1fb3b}\u{1fa26}\u3b48\u{1fc35}\uf3cf\u62cb',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 84.997,
+maxAnisotropy: 19,
+}
+);
+try {
+computePassEncoder26.dispatchWorkgroups(
+3,
+5,
+1
+);
+} catch {}
+try {
+device0.pushErrorScope(
+'validation'
+);
+} catch {}
+let commandEncoder53 = device0.createCommandEncoder();
+let commandBuffer9 = commandEncoder53.finish(
+{
+label: '\ub3dd\u{1fec2}\u17cd\u00e4\ubd03\u0316\u2e2f\u155a',
+}
+);
+let textureView39 = texture17.createView(
+{
+label: '\uda10\uf5f8\ub459\u3710\u764c\u0cde',
+dimension: '2d-array',
+format: 'r16uint',
+}
+);
+try {
+computePassEncoder26.dispatchWorkgroups(
+4,
+3,
+3
+);
+} catch {}
+try {
+computePassEncoder10.setPipeline(
+pipeline22
+);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(
+3,
+bindGroup42
+);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(
+8,
+buffer16,
+19784
+);
+} catch {}
+try {
+commandEncoder46.clearBuffer(
+buffer6,
+11904
+);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let promise16 = device0.createRenderPipelineAsync(
+{
+label: '\u448d\uc538\ua668\u{1fd8c}\ua2ed\u0441\u2c10\u0912\u7145\u5a7e',
+layout: pipelineLayout6,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 460,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x2',
+offset: 90,
+shaderLocation: 19,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 196,
+shaderLocation: 3,
+},
+{
+format: 'sint16x2',
+offset: 96,
+shaderLocation: 11,
+},
+{
+format: 'snorm8x2',
+offset: 216,
+shaderLocation: 9,
+},
+{
+format: 'uint32',
+offset: 228,
+shaderLocation: 16,
+},
+{
+format: 'float32',
+offset: 24,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 4160,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 3128,
+shaderLocation: 12,
+},
+{
+format: 'unorm16x2',
+offset: 476,
+shaderLocation: 1,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 664,
+shaderLocation: 8,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x3be137c1,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'src',
+dstFactor: 'one-minus-src'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'bgra8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'invert',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'zero',
+},
+stencilReadMask: 579,
+depthBias: 90,
+depthBiasSlopeScale: 87,
+depthBiasClamp: 90,
+},
+}
+);
+document.body.prepend(img2);
+let shaderModule2 = device0.createShaderModule(
+{
+label: '\u4468\u3384\u{1f918}\u86eb\u167c',
+code: `
+
+@compute @workgroup_size(2, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(1) f0: u32,
+@location(6) f1: vec3<i32>,
+@location(5) f2: vec2<f32>,
+@location(2) f3: vec4<f32>,
+@builtin(frag_depth) f4: f32,
+@location(7) f5: i32,
+@location(0) f6: vec2<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(19) a0: vec4<u32>, @builtin(vertex_index) a1: u32, @location(18) a2: vec2<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let pipelineLayout9 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout6,
+bindGroupLayout8
+],
+}
+);
+let commandEncoder54 = device0.createCommandEncoder(
+{
+label: '\u06ac\uef82',
+}
+);
+try {
+renderBundleEncoder26.setBindGroup(
+6,
+bindGroup33
+);
+} catch {}
+let bindGroup43 = device0.createBindGroup({
+label: '\u058e\uec8a\u5310\u8daa\u98fd',
+layout: bindGroupLayout9,
+entries: [
+{
+binding: 4111,
+resource: {
+buffer: buffer20,
+offset: 0,
+size: 2152,
+}
+},
+{
+binding: 6093,
+resource: sampler18
+}
+],
+});
+let renderBundle39 = renderBundleEncoder7.finish(
+{
+label: '\u2740\u{1f6fd}\u07d7\u0e20\u1522\u{1f8da}\ud078\u{1ff8f}\ufb4a\u01fc\u{1fab1}'
+}
+);
+let promise17 = device0.queue.onSubmittedWorkDone();
+document.body.append('\u0a89\u{1fa59}\u{1fa6f}');
+let renderBundleEncoder30 = device0.createRenderBundleEncoder(
+{
+label: '\u{1ff9a}\u9be2\u0768\u{1fa3f}\uc691\ub26c\u818b\u0891\ua7fb',
+colorFormats: [
+'rgba32sint',
+'r32sint'
+],
+sampleCount: 699,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+commandEncoder42.copyBufferToBuffer(
+buffer16,
+12532,
+buffer2,
+28372,
+14844
+);
+dissociateBuffer(device0, buffer16);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder50.resolveQuerySet(
+querySet8,
+2479,
+215,
+buffer12,
+9984
+);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+document.body.append('\uc1d6\udc6a\u6930\u9921\u0432\u00ed\u0701\u0c84');
+let img9 = await imageWithData(46, 59, '#4fbc415d', '#f1dcc807');
+let promise18 = adapter0.requestAdapterInfo();
+let bindGroupLayout10 = device0.createBindGroupLayout(
+{
+label: '\u2aae\ud262\u917b\u4597\ue628\u8656\ucc80\u{1f667}',
+entries: [
+{
+binding: 4187,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+},
+{
+binding: 2600,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let renderBundle40 = renderBundleEncoder0.finish();
+try {
+computePassEncoder30.dispatchWorkgroups(
+1,
+2,
+1
+);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(
+6,
+buffer11,
+17652,
+5825
+);
+} catch {}
+let arrayBuffer9 = buffer3.getMappedRange(
+12448,
+2960
+);
+try {
+commandEncoder46.resolveQuerySet(
+querySet12,
+4,
+10,
+buffer5,
+4608
+);
+} catch {}
+let commandEncoder55 = device0.createCommandEncoder(
+{
+label: '\u{1f846}\ud7c1\u020c\u9cfe\u{1faf7}\ub067\u{1ff4b}',
+}
+);
+try {
+computePassEncoder6.setPipeline(
+pipeline25
+);
+} catch {}
+try {
+commandEncoder41.copyTextureToBuffer(
+{
+  texture: texture13,
+  mipLevel: 1,
+  origin: { x: 29, y: 0, z: 373 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 1094 widthInBlocks: 547 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 11976 */
+offset: 11976,
+buffer: buffer11,
+},
+{width: 547, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder37.resolveQuerySet(
+querySet22,
+157,
+72,
+buffer5,
+9472
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 50, height: 1, depthOrArrayLayers: 232}
+*/
+{
+  source: imageBitmap6,
+  origin: { x: 73, y: 22 },
+  flipY: true,
+},
+{
+  texture: texture33,
+  mipLevel: 2,
+  origin: { x: 13, y: 0, z: 126 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 29, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\u{1f653}\u{1fc79}\uc460\ubef2\u4c04\u0156\u0372\u047a');
+let promise19 = navigator.gpu.requestAdapter(
+{
+}
+);
+let img10 = await imageWithData(21, 165, '#1aa48ee7', '#f4126511');
+let commandEncoder56 = device0.createCommandEncoder(
+{
+label: '\uf45e\u{1faa4}\u0514\u{1fb29}',
+}
+);
+let querySet28 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 3256,
+}
+);
+let texture56 = device0.createTexture(
+{
+label: '\u25c7\u0b9c\u04f7\u0334\u0434\u3ea5',
+size: {width: 224, height: 48, depthOrArrayLayers: 88},
+mipLevelCount: 6,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'etc2-rgb8unorm',
+'etc2-rgb8unorm-srgb'
+],
+}
+);
+let computePassEncoder36 = commandEncoder36.beginComputePass(
+{
+label: '\u03e1\u{1f707}\u00a5\ubd54\u{1fbe2}\u{1f6b4}\u0725\ua395\u{1fc97}\u{1f860}'
+}
+);
+let renderBundleEncoder31 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8uint',
+'r32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 642,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+buffer2.destroy();
+} catch {}
+try {
+commandEncoder51.copyTextureToBuffer(
+{
+  texture: texture18,
+  mipLevel: 2,
+  origin: { x: 5, y: 0, z: 10 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 35248 */
+offset: 9904,
+bytesPerRow: 256,
+rowsPerImage: 99,
+buffer: buffer22,
+},
+{width: 0, height: 0, depthOrArrayLayers: 2}
+);
+dissociateBuffer(device0, buffer22);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer9,
+commandBuffer8,
+commandBuffer7,
+]);
+} catch {}
+let img11 = await imageWithData(1, 200, '#cff1fa2e', '#3a7d52e4');
+let imageBitmap7 = await createImageBitmap(img11);
+let textureView40 = texture12.createView(
+{
+dimension: '2d',
+baseArrayLayer: 10,
+arrayLayerCount: 1,
+}
+);
+try {
+renderBundleEncoder20.setIndexBuffer(
+buffer10,
+'uint16'
+);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(
+8,
+buffer11,
+23420,
+6363
+);
+} catch {}
+try {
+commandEncoder48.copyBufferToTexture(
+{
+/* bytesInLastRow: 1632 widthInBlocks: 102 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 49072 */
+offset: 49072,
+buffer: buffer2,
+},
+{
+  texture: texture0,
+  mipLevel: 4,
+  origin: { x: 18, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 612, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+gpuCanvasContext8.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'bgra8unorm',
+'bgra8unorm',
+'bgra8unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+pseudoSubmit(device0, commandEncoder51);
+let sampler39 = device0.createSampler(
+{
+label: '\u0a45\u{1f968}\u027d\u0efb\u033e',
+addressModeU: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 13.010,
+lodMaxClamp: 32.690,
+}
+);
+let externalTexture5 = device0.importExternalTexture(
+{
+label: '\u{1fbaf}\uf550',
+source: videoFrame0,
+colorSpace: 'srgb',
+}
+);
+try {
+computePassEncoder8.setBindGroup(
+4,
+bindGroup1,
+new Uint32Array(4903),
+4354,
+0
+);
+} catch {}
+try {
+texture14.destroy();
+} catch {}
+let promise20 = buffer17.mapAsync(
+GPUMapMode.READ,
+0,
+3084
+);
+try {
+device0.queue.writeBuffer(
+buffer22,
+15636,
+new BigUint64Array(6503),
+3871,
+896
+);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let pipelineLayout10 = device0.createPipelineLayout(
+{
+label: '\u4e95\ubf8f\uc4c3\u{1fdb7}',
+bindGroupLayouts: [
+
+],
+}
+);
+let textureView41 = texture16.createView(
+{
+label: '\u491a\u4e42',
+mipLevelCount: 1,
+}
+);
+let computePassEncoder37 = commandEncoder49.beginComputePass();
+try {
+await buffer8.mapAsync(
+GPUMapMode.WRITE,
+376,
+508
+);
+} catch {}
+try {
+commandEncoder55.copyBufferToTexture(
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 54160 */
+offset: 54160,
+buffer: buffer2,
+},
+{
+  texture: texture22,
+  mipLevel: 1,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+computePassEncoder26.insertDebugMarker(
+'\u0451'
+);
+} catch {}
+let promise21 = device0.createRenderPipelineAsync(
+{
+label: '\u{1f74d}\ufcaf\u3279\u{1f984}\u0f81\u9573',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 3752,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 1468,
+shaderLocation: 8,
+},
+{
+format: 'uint16x2',
+offset: 1848,
+shaderLocation: 19,
+},
+{
+format: 'uint16x4',
+offset: 3040,
+shaderLocation: 16,
+},
+{
+format: 'sint8x4',
+offset: 1120,
+shaderLocation: 11,
+},
+{
+format: 'unorm16x2',
+offset: 420,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 1980,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 1880,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 6380,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x4',
+offset: 5904,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 6904,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 5940,
+shaderLocation: 3,
+},
+{
+format: 'float32x3',
+offset: 6608,
+shaderLocation: 17,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'src-alpha',
+dstFactor: 'zero'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'one',
+dstFactor: 'dst'
+},
+},
+format: 'bgra8unorm-srgb',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+try {
+await promise12;
+} catch {}
+document.body.append('\u{1f87c}\u{1fc5b}');
+let canvas12 = document.createElement('canvas');
+let img12 = await imageWithData(165, 30, '#0295c6b7', '#b203e029');
+try {
+window.someLabel = commandEncoder14.label;
+} catch {}
+let commandEncoder57 = device0.createCommandEncoder(
+{
+label: '\u481a\u0eeb\u0796\u02b4\u0f19',
+}
+);
+let textureView42 = texture20.createView(
+{
+label: '\uf8c3\u56eb\u630d\u8288\udae8\uebbb\u6f9c',
+baseArrayLayer: 0,
+}
+);
+let renderBundleEncoder32 = device0.createRenderBundleEncoder(
+{
+label: '\uc695\u{1ffe9}\u{1fe49}\u{1f823}\ufcae',
+colorFormats: [
+'rg16float',
+'rgba16float',
+'r32sint',
+'rg32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 447,
+}
+);
+try {
+computePassEncoder30.setBindGroup(
+2,
+bindGroup15
+);
+} catch {}
+document.body.prepend('\u4907\ub652\u{1fa43}\ucbd5\uc520\u0459');
+let shaderModule3 = device0.createShaderModule(
+{
+label: '\u{1f755}\u458b\u{1f9f2}\u0d25\u{1f813}\u3b3b\u{1fe1d}\u5380',
+code: `
+
+@compute @workgroup_size(4, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S2 {
+@builtin(front_facing) f0: bool,
+@location(63) f1: vec2<f16>,
+@location(48) f2: vec3<f16>
+}
+
+@fragment
+fn fragment0(@location(72) a0: vec4<f16>, @location(36) a1: f32, @location(82) a2: vec4<u32>, @location(64) a3: vec3<u32>, a4: S2, @location(18) a5: vec4<f32>, @builtin(position) a6: vec4<f32>, @location(2) a7: i32, @location(20) a8: i32) {
+
+}
+
+struct S1 {
+@location(5) f0: i32,
+@location(2) f1: vec3<f16>,
+@location(11) f2: vec4<i32>,
+@location(1) f3: vec4<f32>,
+@location(6) f4: vec4<i32>,
+@location(4) f5: vec3<u32>,
+@location(14) f6: vec3<u32>,
+@location(8) f7: f32,
+@location(12) f8: vec2<u32>,
+@location(17) f9: vec2<u32>,
+@location(19) f10: vec3<u32>,
+@location(9) f11: vec2<f32>,
+@location(21) f12: vec2<f16>,
+@location(7) f13: vec3<f16>,
+@location(0) f14: vec3<f32>,
+@builtin(instance_index) f15: u32,
+@builtin(vertex_index) f16: u32,
+@location(10) f17: vec4<f16>,
+@location(15) f18: vec3<f16>,
+@location(18) f19: f16,
+@location(3) f20: vec2<f16>
+}
+struct VertexOutput0 {
+@location(63) f26: vec2<f16>,
+@location(2) f27: i32,
+@location(56) f28: vec2<f32>,
+@location(18) f29: vec4<f32>,
+@location(78) f30: vec4<f32>,
+@location(19) f31: vec4<f32>,
+@location(44) f32: vec2<f32>,
+@location(62) f33: vec2<i32>,
+@location(52) f34: vec4<f32>,
+@location(82) f35: vec4<u32>,
+@location(72) f36: vec4<f16>,
+@location(26) f37: vec3<f16>,
+@location(46) f38: i32,
+@location(32) f39: f32,
+@location(66) f40: vec2<u32>,
+@location(65) f41: vec2<f16>,
+@location(42) f42: vec3<f32>,
+@location(64) f43: vec3<u32>,
+@location(27) f44: vec2<u32>,
+@location(48) f45: vec3<f16>,
+@location(74) f46: vec3<u32>,
+@location(36) f47: f32,
+@location(0) f48: vec3<f32>,
+@builtin(position) f49: vec4<f32>,
+@location(20) f50: i32
+}
+
+@vertex
+fn vertex0(a0: S1, @location(20) a1: vec2<i32>, @location(13) a2: vec2<u32>, @location(16) a3: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroup44 = device0.createBindGroup({
+label: '\u092c\u21e8\u3378\uf24f\u3608\u07f7\uaabf\u0862\ua52f\u0c1a',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let texture57 = device0.createTexture(
+{
+label: '\u{1fec6}\u357f\u{1fac3}\u06f0\udfc6\u073a\u0d6e\u{1fb47}\uee03\u{1fdf0}',
+size: {width: 225, height: 106, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'rgba8uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8uint'
+],
+}
+);
+let textureView43 = texture27.createView(
+{
+label: '\u0823\u3a55\ue713\u0bcb',
+dimension: '2d-array',
+baseMipLevel: 1,
+}
+);
+let renderBundleEncoder33 = device0.createRenderBundleEncoder(
+{
+label: '\ucbc7\u{1fce4}\u0890',
+colorFormats: [
+'bgra8unorm-srgb',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 222,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder18.setVertexBuffer(
+0,
+buffer6,
+28108,
+11881
+);
+} catch {}
+try {
+commandEncoder52.copyBufferToBuffer(
+buffer9,
+9340,
+buffer21,
+752,
+260
+);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer21);
+} catch {}
+try {
+commandEncoder20.copyTextureToTexture(
+{
+  texture: texture18,
+  mipLevel: 1,
+  origin: { x: 5, y: 0, z: 19 },
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 2,
+  origin: { x: 505, y: 20, z: 28 },
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder48.resolveQuerySet(
+querySet1,
+3684,
+40,
+buffer5,
+6400
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer22,
+8440,
+new Int16Array(34870),
+6716,
+16300
+);
+} catch {}
+gc();
+let querySet29 = device0.createQuerySet(
+{
+label: '\ue3d7\uab55\u{1f9e4}\u3aa4\u{1ff78}',
+type: 'occlusion',
+count: 886,
+}
+);
+let renderBundleEncoder34 = device0.createRenderBundleEncoder(
+{
+label: '\u0d6c\u{1f6a4}\u{1fb69}\u9f70\u619e\u{1f735}\u04d7\u0f6c\u058f\u7ce7',
+colorFormats: [
+'r8unorm',
+'r16uint',
+'rg16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 246,
+}
+);
+try {
+device0.queue.writeBuffer(
+buffer11,
+11116,
+new Int16Array(15983),
+12633
+);
+} catch {}
+try {
+canvas12.getContext('webgl2');
+} catch {}
+let bindGroup45 = device0.createBindGroup({
+label: '\u{1fb00}\u72b4\u0bd1\u05c4\ue9c7',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let commandEncoder58 = device0.createCommandEncoder();
+let querySet30 = device0.createQuerySet(
+{
+label: '\u467f\ud202\u{1f6fa}\u73ce\u49b0\ub126',
+type: 'occlusion',
+count: 1103,
+}
+);
+try {
+renderBundleEncoder29.setVertexBuffer(
+6,
+buffer15,
+20064,
+16632
+);
+} catch {}
+try {
+commandEncoder58.copyTextureToBuffer(
+{
+  texture: texture26,
+  mipLevel: 3,
+  origin: { x: 144, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 48 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 11760 */
+offset: 11712,
+buffer: buffer6,
+},
+{width: 36, height: 12, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer6,
+]);
+} catch {}
+let promise22 = device0.queue.onSubmittedWorkDone();
+let bindGroup46 = device0.createBindGroup({
+label: '\u903f\u{1fbc3}\ueb04\u{1f76c}\u0d06\u81ee\u5675\u0f70\u{1f7e7}',
+layout: bindGroupLayout1,
+entries: [
+{
+binding: 2766,
+resource: externalTexture2
+},
+{
+binding: 2712,
+resource: sampler28
+}
+],
+});
+let textureView44 = texture2.createView(
+{
+}
+);
+try {
+computePassEncoder24.setBindGroup(
+4,
+bindGroup18
+);
+} catch {}
+try {
+commandEncoder43.copyTextureToTexture(
+{
+  texture: texture47,
+  mipLevel: 2,
+  origin: { x: 20, y: 0, z: 71 },
+  aspect: 'all',
+},
+{
+  texture: texture47,
+  mipLevel: 1,
+  origin: { x: 580, y: 0, z: 14 },
+  aspect: 'all',
+},
+{width: 1170, height: 0, depthOrArrayLayers: 59}
+);
+} catch {}
+try {
+commandEncoder56.clearBuffer(
+buffer22,
+35828,
+10092
+);
+dissociateBuffer(device0, buffer22);
+} catch {}
+try {
+commandEncoder50.resolveQuerySet(
+querySet5,
+1089,
+32,
+buffer12,
+22784
+);
+} catch {}
+let commandEncoder59 = device0.createCommandEncoder(
+{
+label: '\u04c3\u098f\u{1fb6e}\u7926\u7453\uf492\u045e\u3531',
+}
+);
+let texture58 = device0.createTexture(
+{
+label: '\u765d\ubefa\ua047\u9a22\u0701\u{1f89d}',
+size: {width: 10316, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'r32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+let externalTexture6 = device0.importExternalTexture(
+{
+label: '\ubbdd\udfac\u8cf7\u0167\ua50d',
+source: video3,
+colorSpace: 'display-p3',
+}
+);
+try {
+renderBundleEncoder26.setVertexBuffer(
+3,
+buffer7,
+6272,
+7713
+);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 12, height: 1, depthOrArrayLayers: 232}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 12, y: 64 },
+  flipY: true,
+},
+{
+  texture: texture33,
+  mipLevel: 4,
+  origin: { x: 3, y: 0, z: 111 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 4, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline29 = await device0.createComputePipelineAsync(
+{
+label: '\ucee7\u0299\u06c1\ued4a\u04da\u0056\ub9c7',
+layout: pipelineLayout10,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let texture59 = device0.createTexture(
+{
+label: '\u{1fced}\ubf80\u432c\u0260\u{1f66f}\u516b\u67f8\uab8d\u0dd7',
+size: [4895, 5, 72],
+mipLevelCount: 8,
+format: 'astc-5x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+let textureView45 = texture39.createView(
+{
+label: '\u02d3\u8c0d\u2278',
+baseMipLevel: 0,
+arrayLayerCount: 1,
+}
+);
+try {
+computePassEncoder31.end();
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+5,
+bindGroup32
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder41.resolveQuerySet(
+querySet7,
+1397,
+176,
+buffer12,
+19200
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture33,
+  mipLevel: 2,
+  origin: { x: 15, y: 0, z: 21 },
+  aspect: 'all',
+},
+arrayBuffer8,
+/* required buffer size: 940928 */{
+offset: 815,
+bytesPerRow: 211,
+rowsPerImage: 27,
+},
+{width: 27, height: 1, depthOrArrayLayers: 166}
+);
+} catch {}
+try {
+computePassEncoder29.end();
+} catch {}
+try {
+commandEncoder50.copyTextureToTexture(
+{
+  texture: texture14,
+  mipLevel: 5,
+  origin: { x: 0, y: 1, z: 61 },
+  aspect: 'all',
+},
+{
+  texture: texture14,
+  mipLevel: 2,
+  origin: { x: 9, y: 0, z: 14 },
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 9}
+);
+} catch {}
+try {
+commandEncoder58.resolveQuerySet(
+querySet26,
+373,
+134,
+buffer12,
+2816
+);
+} catch {}
+let promise23 = device0.queue.onSubmittedWorkDone();
+try {
+await promise11;
+} catch {}
+let textureView46 = texture32.createView(
+{
+label: '\u024f\u{1fcc0}\ub6fa\u{1fae9}\uba42\u{1fade}\u0400\u{1f62a}\u0fcd\u5530\u0bab',
+aspect: 'all',
+baseMipLevel: 2,
+mipLevelCount: 4,
+baseArrayLayer: 74,
+arrayLayerCount: 5,
+}
+);
+let renderBundleEncoder35 = device0.createRenderBundleEncoder(
+{
+label: '\u0744\u9a68\u8063\ud94a',
+colorFormats: [
+'rgb10a2unorm',
+'r32float',
+'rgba8uint',
+'rg16float',
+'rgba16float',
+'rgba8unorm-srgb'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 235,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler40 = device0.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 29.698,
+lodMaxClamp: 79.774,
+maxAnisotropy: 2,
+}
+);
+let pipeline30 = await promise21;
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let offscreenCanvas6 = new OffscreenCanvas(960, 500);
+let bindGroupLayout11 = device0.createBindGroupLayout(
+{
+label: '\u3629\ueff9\ubaf1\u{1fb23}\u9428\u15fb\u327c',
+entries: [
+
+],
+}
+);
+let arrayBuffer10 = buffer3.getMappedRange(
+26288,
+764
+);
+try {
+commandEncoder56.copyBufferToBuffer(
+buffer9,
+3520,
+buffer2,
+43952,
+944
+);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder59.copyTextureToTexture(
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 2, y: 0, z: 58 },
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder41.resolveQuerySet(
+querySet17,
+2176,
+388,
+buffer13,
+24832
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer19,
+10828,
+new Int16Array(43938),
+638,
+500
+);
+} catch {}
+let pipeline31 = device0.createComputePipeline(
+{
+label: '\u{1fb2a}\u0b76\u38db\u6e9c\u0474\u4265\ua54e\u8164\u23d9\u0225\u{1ff73}',
+layout: pipelineLayout8,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let gpuCanvasContext10 = offscreenCanvas6.getContext('webgpu');
+gc();
+document.body.prepend('\u4456\u763d\u6858\u3197\u7b4a\ua6c5\u13d1\uae2c');
+let bindGroupLayout12 = device0.createBindGroupLayout(
+{
+label: '\u05aa\u0d8d\u24c3\u5249\u{1f8a9}\uc835\u4b89\ube5b\u66ef\u672c\u5aef',
+entries: [
+
+],
+}
+);
+let textureView47 = texture34.createView(
+{
+label: '\u04c1\u07fb\u{1f99d}\u{1f914}\u{1ffed}\ub0e0\udca7\ubd74\u{1fb58}\u982d',
+dimension: '1d',
+}
+);
+let sampler41 = device0.createSampler(
+{
+label: '\u{1ffed}\uc419\u{1f663}',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 56.195,
+lodMaxClamp: 82.904,
+}
+);
+try {
+computePassEncoder27.setBindGroup(
+0,
+bindGroup22
+);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(
+3,
+buffer6,
+3648,
+32461
+);
+} catch {}
+try {
+commandEncoder48.copyTextureToTexture(
+{
+  texture: texture47,
+  mipLevel: 0,
+  origin: { x: 3080, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture47,
+  mipLevel: 2,
+  origin: { x: 60, y: 0, z: 87 },
+  aspect: 'all',
+},
+{width: 690, height: 0, depthOrArrayLayers: 104}
+);
+} catch {}
+try {
+commandEncoder48.resolveQuerySet(
+querySet7,
+2462,
+604,
+buffer16,
+1280
+);
+} catch {}
+let videoFrame12 = videoFrame3.clone();
+let computePassEncoder38 = commandEncoder47.beginComputePass(
+{
+label: '\u{1fec3}\u914d\ue72e\u15be\u{1fae4}\u7784\u4cc5'
+}
+);
+let renderBundleEncoder36 = device0.createRenderBundleEncoder(
+{
+label: '\u0741\u{1fcf1}\u02b0\u04b8\u{1fe5f}\u315e\u20b1',
+colorFormats: [
+'rg32float',
+'rg11b10ufloat',
+'r32sint',
+'bgra8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 242,
+}
+);
+try {
+computePassEncoder17.setBindGroup(
+6,
+bindGroup16,
+new Uint32Array(9827),
+17,
+0
+);
+} catch {}
+try {
+device0.pushErrorScope(
+'out-of-memory'
+);
+} catch {}
+try {
+commandEncoder31.resolveQuerySet(
+querySet4,
+931,
+30,
+buffer22,
+256
+);
+} catch {}
+let pipeline32 = device0.createComputePipeline(
+{
+label: '\ub481\u08fc\u051e\u540a\u{1fbe6}\uf60c\u8584\u00c5\u{1fe38}',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageBitmap8 = await createImageBitmap(video0);
+let imageData9 = new ImageData(52, 92);
+let texture60 = device0.createTexture(
+{
+label: '\u363e\u{1f794}\u6cc0\ucfb6\u{1ff3c}\u0888',
+size: {width: 1802, height: 1, depthOrArrayLayers: 244},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rg16sint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg16sint'
+],
+}
+);
+let computePassEncoder39 = commandEncoder42.beginComputePass();
+let arrayBuffer11 = buffer9.getMappedRange(
+28312,
+3208
+);
+try {
+await promise18;
+} catch {}
+document.body.append('\u37fe\u9416\u9668\ue6b0\u0f1f\ue27b\u0b1b\u6f8b');
+let commandEncoder60 = device0.createCommandEncoder(
+{
+label: '\u{1f7cf}\u35ab\u8460\u{1fcb3}\ueb09\u1f4a\u9542\ufd11\ud806\u{1fd1e}',
+}
+);
+let renderBundle41 = renderBundleEncoder27.finish(
+{
+label: '\u01d3\u5005\u{1ffd3}\u0e7b\u98ea\u026e'
+}
+);
+try {
+computePassEncoder16.end();
+} catch {}
+try {
+computePassEncoder25.setPipeline(
+pipeline3
+);
+} catch {}
+try {
+commandEncoder60.copyBufferToBuffer(
+buffer5,
+5288,
+buffer1,
+10856,
+1104
+);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder43.resolveQuerySet(
+querySet26,
+533,
+0,
+buffer13,
+11264
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 50, height: 1, depthOrArrayLayers: 232}
+*/
+{
+  source: video6,
+  origin: { x: 3, y: 4 },
+  flipY: false,
+},
+{
+  texture: texture33,
+  mipLevel: 2,
+  origin: { x: 0, y: 1, z: 128 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 10, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline33 = await promise16;
+let bindGroup47 = device0.createBindGroup({
+label: '\u6791\ue7a5\u07f1\u{1fd3e}\uc169\uf98c\u0284\u4c0c\u79d2\ue9d2\u00bd',
+layout: bindGroupLayout4,
+entries: [
+
+],
+});
+let renderBundleEncoder37 = device0.createRenderBundleEncoder(
+{
+label: '\ua653\u5d6b\ub39d\u{1fb12}\u007b\u739c\u0eea\u85ec\u4d3c',
+colorFormats: [
+'rg32float',
+undefined,
+'rgba32float',
+'r32uint',
+undefined,
+'rgba16float',
+'rgb10a2uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 973,
+}
+);
+try {
+computePassEncoder26.setPipeline(
+pipeline15
+);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(
+buffer11,
+'uint32',
+28588
+);
+} catch {}
+try {
+commandEncoder43.copyTextureToTexture(
+{
+  texture: texture40,
+  mipLevel: 3,
+  origin: { x: 5, y: 0, z: 33 },
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 6,
+  origin: { x: 45, y: 0, z: 189 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 4}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 10, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: imageBitmap6,
+  origin: { x: 13, y: 24 },
+  flipY: true,
+},
+{
+  texture: texture49,
+  mipLevel: 4,
+  origin: { x: 3, y: 0, z: 2 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 7, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline34 = device0.createRenderPipeline(
+{
+label: '\u01fe\u1a65\u7ca8\u{1fa59}',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 4800,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 6084,
+attributes: [
+{
+format: 'snorm16x2',
+offset: 276,
+shaderLocation: 16,
+},
+{
+format: 'uint8x2',
+offset: 4650,
+shaderLocation: 20,
+},
+{
+format: 'float32',
+offset: 1948,
+shaderLocation: 17,
+},
+{
+format: 'sint8x2',
+offset: 2210,
+shaderLocation: 9,
+},
+{
+format: 'sint16x4',
+offset: 1184,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x4',
+offset: 488,
+shaderLocation: 10,
+},
+{
+format: 'uint16x2',
+offset: 5804,
+shaderLocation: 2,
+},
+{
+format: 'uint8x4',
+offset: 4572,
+shaderLocation: 6,
+},
+{
+format: 'float16x2',
+offset: 3992,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x4',
+offset: 4608,
+shaderLocation: 4,
+},
+{
+format: 'uint32x2',
+offset: 1588,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x2',
+offset: 3484,
+shaderLocation: 3,
+},
+{
+format: 'uint32',
+offset: 1064,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 728,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 532,
+shaderLocation: 18,
+},
+{
+format: 'float32x2',
+offset: 76,
+shaderLocation: 15,
+},
+{
+format: 'float32',
+offset: 504,
+shaderLocation: 13,
+},
+{
+format: 'uint8x4',
+offset: 368,
+shaderLocation: 19,
+},
+{
+format: 'unorm16x2',
+offset: 184,
+shaderLocation: 12,
+},
+{
+format: 'unorm8x4',
+offset: 292,
+shaderLocation: 5,
+},
+{
+format: 'float32',
+offset: 356,
+shaderLocation: 1,
+},
+{
+format: 'sint8x4',
+offset: 700,
+shaderLocation: 21,
+},
+{
+format: 'sint32x2',
+offset: 608,
+shaderLocation: 14,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0xb716c6d3,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'rg11b10ufloat',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'rg8unorm',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+undefined
+],
+},
+}
+);
+let querySet31 = device0.createQuerySet(
+{
+label: '\u0d66\u{1fa85}\u0c2a\u{1f6f4}\u9939\u{1fa16}\u09b7\u{1f607}\u{1fc22}\u8c57\uacbe',
+type: 'occlusion',
+count: 807,
+}
+);
+let renderBundleEncoder38 = device0.createRenderBundleEncoder(
+{
+label: '\u90db\u{1ff4a}\u05b3',
+colorFormats: [
+'rgba16uint',
+'rgb10a2unorm',
+'rgba8sint',
+undefined,
+'rg32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 688,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder33.setPipeline(
+pipeline3
+);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(
+buffer20,
+'uint32',
+2248,
+3829
+);
+} catch {}
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 3, height: 1, depthOrArrayLayers: 112}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 223, y: 40 },
+  flipY: true,
+},
+{
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 81 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 3, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await promise17;
+} catch {}
+document.body.prepend(img3);
+try {
+adapter0.label = '\u0c09\u{1f733}\ucbf9\u0a80\u{1fec2}\u{1ffe4}\u6a17\u{1f81f}';
+} catch {}
+let commandEncoder61 = device0.createCommandEncoder(
+{
+label: '\u005e\u9aaf\u254c\u{1ffb7}',
+}
+);
+let querySet32 = device0.createQuerySet(
+{
+label: '\u0b48\u8fc1',
+type: 'occlusion',
+count: 1375,
+}
+);
+let sampler42 = device0.createSampler(
+{
+label: '\u029e\ua871',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 64.051,
+compare: 'greater-equal',
+}
+);
+try {
+renderBundleEncoder17.setIndexBuffer(
+buffer11,
+'uint16'
+);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(
+3,
+undefined
+);
+} catch {}
+try {
+commandEncoder60.copyBufferToBuffer(
+buffer2,
+41356,
+buffer22,
+21784,
+7328
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer22);
+} catch {}
+try {
+await promise20;
+} catch {}
+let querySet33 = device0.createQuerySet(
+{
+label: '\ue303\u8d78\uca45\u{1fe52}\ubbca\ufb7d',
+type: 'occlusion',
+count: 449,
+}
+);
+try {
+computePassEncoder38.setPipeline(
+pipeline3
+);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(
+4,
+bindGroup19
+);
+} catch {}
+try {
+commandEncoder6.copyTextureToBuffer(
+{
+  texture: texture17,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 33264 */
+offset: 33264,
+buffer: buffer2,
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder34.resolveQuerySet(
+querySet29,
+310,
+83,
+buffer13,
+8960
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer21,
+2144,
+new DataView(new ArrayBuffer(40965)),
+23575,
+12
+);
+} catch {}
+let promise24 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 5, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 260, y: 88 },
+  flipY: false,
+},
+{
+  texture: texture49,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline35 = device0.createComputePipeline(
+{
+label: '\u8f3a\u05db\uc162\u0119\u{1fa13}\u{1f795}\u0c73\ua0e1\u0c88',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline36 = await device0.createRenderPipelineAsync(
+{
+label: '\u0c18\uca1f\ue334\u{1f932}\u046a\uc91d\u{1f967}\uc8c6\uae7b\uc1de\u090f',
+layout: 'auto',
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 764,
+attributes: [
+{
+format: 'snorm16x2',
+offset: 100,
+shaderLocation: 8,
+},
+{
+format: 'uint32x2',
+offset: 288,
+shaderLocation: 16,
+},
+{
+format: 'float32x3',
+offset: 708,
+shaderLocation: 3,
+},
+{
+format: 'snorm8x4',
+offset: 580,
+shaderLocation: 1,
+},
+{
+format: 'uint32x4',
+offset: 664,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 6440,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 3232,
+shaderLocation: 17,
+},
+{
+format: 'sint32x2',
+offset: 5792,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 4564,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 4504,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 6548,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 1996,
+attributes: [
+{
+format: 'float16x2',
+offset: 952,
+shaderLocation: 12,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'src-alpha-saturated',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'src',
+dstFactor: 'one'
+},
+},
+format: 'bgra8unorm-srgb',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rg16sint',
+writeMask: 0,
+},
+{
+format: 'rg8uint',
+}
+],
+},
+}
+);
+let videoFrame13 = new VideoFrame(videoFrame3, {timestamp: 0});
+let commandEncoder62 = device0.createCommandEncoder(
+{
+label: '\u86ff\u3977',
+}
+);
+let externalTexture7 = device0.importExternalTexture(
+{
+label: '\u{1f894}\u06c7\u0141',
+source: video2,
+colorSpace: 'srgb',
+}
+);
+try {
+renderBundleEncoder21.setVertexBuffer(
+8,
+buffer16,
+22644
+);
+} catch {}
+try {
+commandEncoder59.clearBuffer(
+buffer11
+);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder20.resolveQuerySet(
+querySet20,
+3497,
+177,
+buffer22,
+48640
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer21,
+1080,
+new Int16Array(13865),
+10444,
+4
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture53,
+  mipLevel: 2,
+  origin: { x: 16, y: 0, z: 0 },
+  aspect: 'all',
+},
+new BigUint64Array(arrayBuffer8),
+/* required buffer size: 1100 */{
+offset: 324,
+bytesPerRow: 324,
+},
+{width: 32, height: 12, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise25 = device0.createRenderPipelineAsync(
+{
+label: '\ub8e4\ucd0f',
+layout: pipelineLayout7,
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 3152,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32',
+offset: 544,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x4',
+offset: 596,
+shaderLocation: 15,
+},
+{
+format: 'snorm8x2',
+offset: 256,
+shaderLocation: 16,
+},
+{
+format: 'uint16x4',
+offset: 1928,
+shaderLocation: 13,
+},
+{
+format: 'float16x4',
+offset: 2036,
+shaderLocation: 2,
+},
+{
+format: 'uint8x4',
+offset: 12,
+shaderLocation: 19,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 444,
+shaderLocation: 7,
+},
+{
+format: 'unorm16x2',
+offset: 2756,
+shaderLocation: 10,
+},
+{
+format: 'unorm8x4',
+offset: 1136,
+shaderLocation: 21,
+},
+{
+format: 'sint32x4',
+offset: 1428,
+shaderLocation: 20,
+},
+{
+format: 'sint32x2',
+offset: 1532,
+shaderLocation: 11,
+},
+{
+format: 'uint8x2',
+offset: 2976,
+shaderLocation: 14,
+},
+{
+format: 'float32x4',
+offset: 184,
+shaderLocation: 3,
+},
+{
+format: 'sint32x4',
+offset: 412,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 6200,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x3',
+offset: 1596,
+shaderLocation: 5,
+},
+{
+format: 'uint32',
+offset: 320,
+shaderLocation: 12,
+},
+{
+format: 'float32x3',
+offset: 5048,
+shaderLocation: 0,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 1436,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 6512,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 6028,
+shaderLocation: 17,
+},
+{
+format: 'float32x3',
+offset: 628,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 5376,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 1804,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 5536,
+attributes: [
+{
+format: 'snorm8x2',
+offset: 1354,
+shaderLocation: 8,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0x192482d,
+},
+fragment: {
+module: shaderModule3,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'zero',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 725,
+stencilWriteMask: 2667,
+depthBias: 99,
+depthBiasSlopeScale: 40,
+depthBiasClamp: 14,
+},
+}
+);
+let commandEncoder63 = device0.createCommandEncoder(
+{
+label: '\u2883\u16bb\uf8d1\u19fd\u087a\u0bc0',
+}
+);
+let querySet34 = device0.createQuerySet(
+{
+label: '\u72d1\u{1f7ce}\uc306\u00eb\u8d4b',
+type: 'occlusion',
+count: 1976,
+}
+);
+let computePassEncoder40 = commandEncoder46.beginComputePass(
+{
+label: '\u607d\u9c97\u12be\ua3fc\u{1fbe4}'
+}
+);
+let renderBundleEncoder39 = device0.createRenderBundleEncoder(
+{
+label: '\u{1f6f4}\u7739\ue124\u3230\u60aa\u08bc\u{1ff33}',
+colorFormats: [
+'rg16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 890,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let externalTexture8 = device0.importExternalTexture(
+{
+label: '\u95a0\u{1fa39}\u9649\u3c8d\u7c9a',
+source: videoFrame9,
+colorSpace: 'display-p3',
+}
+);
+let arrayBuffer12 = buffer3.getMappedRange(
+27056,
+1188
+);
+try {
+commandEncoder55.resolveQuerySet(
+querySet9,
+3,
+558,
+buffer12,
+8448
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 100, height: 1, depthOrArrayLayers: 232}
+*/
+{
+  source: img1,
+  origin: { x: 209, y: 28 },
+  flipY: false,
+},
+{
+  texture: texture33,
+  mipLevel: 1,
+  origin: { x: 12, y: 0, z: 184 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 24, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise26 = device0.createRenderPipelineAsync(
+{
+label: '\u289c\u928f\u674a\uf8e8\u{1f9be}',
+layout: pipelineLayout7,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 2988,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 1636,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x4',
+offset: 2496,
+shaderLocation: 9,
+},
+{
+format: 'uint32x2',
+offset: 1180,
+shaderLocation: 19,
+},
+{
+format: 'unorm8x4',
+offset: 696,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x2',
+offset: 1700,
+shaderLocation: 1,
+},
+{
+format: 'unorm8x4',
+offset: 668,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 436,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 400,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 352,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 236,
+shaderLocation: 3,
+},
+{
+format: 'uint32x3',
+offset: 144,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x2268bc86,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'constant',
+dstFactor: 'dst-alpha'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'dst-alpha',
+dstFactor: 'dst-alpha'
+},
+},
+format: 'bgra8unorm-srgb',
+writeMask: 0,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}
+],
+},
+}
+);
+document.body.prepend('\u5de9\ubac7\u615a\u0443\u{1f80b}\u5ae9\u0fb8\u3e2d\u45a8');
+let commandEncoder64 = device0.createCommandEncoder(
+{
+label: '\u{1f9c2}\u0506\u0466\u0060\u3a99',
+}
+);
+try {
+computePassEncoder33.setBindGroup(
+5,
+bindGroup24
+);
+} catch {}
+try {
+computePassEncoder28.dispatchWorkgroups(
+2,
+4,
+2
+);
+} catch {}
+try {
+commandEncoder55.copyBufferToBuffer(
+buffer5,
+1500,
+buffer20,
+2912,
+1332
+);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer20);
+} catch {}
+let commandBuffer10 = commandEncoder60.finish();
+let textureView48 = texture47.createView(
+{
+label: '\u03a0\u80c5\u0e8f\ub15d\u{1f834}\u82b3\u15e3\u608c\u0f19\u{1fbac}\u9570',
+dimension: '2d',
+baseMipLevel: 1,
+baseArrayLayer: 11,
+}
+);
+try {
+computePassEncoder28.dispatchWorkgroups(
+3,
+2,
+4
+);
+} catch {}
+try {
+computePassEncoder30.setPipeline(
+pipeline35
+);
+} catch {}
+try {
+commandEncoder62.copyBufferToTexture(
+{
+/* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 45372 */
+offset: 45372,
+bytesPerRow: 256,
+buffer: buffer2,
+},
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder58.resolveQuerySet(
+querySet25,
+652,
+650,
+buffer5,
+2304
+);
+} catch {}
+try {
+commandEncoder63.pushDebugGroup(
+'\u{1f811}'
+);
+} catch {}
+try {
+renderBundleEncoder26.insertDebugMarker(
+'\u22de'
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 1, depthOrArrayLayers: 225}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 156, y: 28 },
+  flipY: false,
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 155 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 6, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let bindGroupLayout13 = device0.createBindGroupLayout(
+{
+label: '\u4a64\u03ee\uf579\ud5e3',
+entries: [
+{
+binding: 5823,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+},
+{
+binding: 2703,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let texture61 = device0.createTexture(
+{
+label: '\u0049\ueb60\u0f44\u{1fe98}\u0dd9\u1be8\u0690\u571c\u2985',
+size: {width: 56, height: 4, depthOrArrayLayers: 102},
+mipLevelCount: 2,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder41 = commandEncoder63.beginComputePass(
+{
+label: '\u{1fc4f}\u{1fd2e}\u6dd1\ub8fa\ud45f\u0b11\u0c4b\ub0a2'
+}
+);
+try {
+texture39.destroy();
+} catch {}
+try {
+commandEncoder57.clearBuffer(
+buffer20,
+3688,
+1776
+);
+dissociateBuffer(device0, buffer20);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer10,
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer11,
+11680,
+new DataView(new ArrayBuffer(22375)),
+6527
+);
+} catch {}
+let pipeline37 = await promise26;
+let video8 = await videoWithData();
+let commandEncoder65 = device0.createCommandEncoder(
+{
+label: '\u{1fb7f}\u{1f8df}\u{1f9fd}\u2c7e\u{1ff28}',
+}
+);
+let computePassEncoder42 = commandEncoder37.beginComputePass(
+{
+label: '\u029c\udb8e'
+}
+);
+let renderBundle42 = renderBundleEncoder38.finish(
+{
+
+}
+);
+let bindGroup48 = device0.createBindGroup({
+label: '\u7cf4\u034d\u{1f8a1}\u0578',
+layout: bindGroupLayout7,
+entries: [
+
+],
+});
+let buffer23 = device0.createBuffer(
+{
+label: '\u{1f998}\u0087\u1d49\u{1fa21}\u0159\u120b\ud13d\ua17b',
+size: 57590,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+}
+);
+let commandEncoder66 = device0.createCommandEncoder(
+{
+label: '\u{1f9f8}\u45f7\u{1f6d2}\u0362\uc341\u1a26\u{1f73a}\u0f90\u9daf',
+}
+);
+let textureView49 = texture61.createView(
+{
+label: '\u4bb1\u0ab3',
+baseMipLevel: 1,
+baseArrayLayer: 91,
+arrayLayerCount: 10,
+}
+);
+try {
+renderBundleEncoder28.setVertexBuffer(
+8,
+buffer11,
+3992,
+14796
+);
+} catch {}
+try {
+commandEncoder41.copyTextureToTexture(
+{
+  texture: texture47,
+  mipLevel: 0,
+  origin: { x: 110, y: 0, z: 79 },
+  aspect: 'all',
+},
+{
+  texture: texture47,
+  mipLevel: 2,
+  origin: { x: 160, y: 0, z: 114 },
+  aspect: 'all',
+},
+{width: 430, height: 0, depthOrArrayLayers: 94}
+);
+} catch {}
+try {
+commandEncoder57.resolveQuerySet(
+querySet7,
+1690,
+22,
+buffer12,
+8704
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer24 = device0.createBuffer(
+{
+label: '\ubefb\u0715\uc6fe\u{1fffd}\u{1ff5b}\u{1fe25}\u{1f873}',
+size: 18720,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let sampler43 = device0.createSampler(
+{
+label: '\u66a9\ucd5b\ud7c0\uc456\uc90b\u89e5\u0aa4\ubdbe\ubc98\uc017\u{1fffe}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+lodMinClamp: 87.308,
+lodMaxClamp: 88.246,
+compare: 'never',
+}
+);
+try {
+buffer7.unmap();
+} catch {}
+try {
+commandEncoder61.copyBufferToBuffer(
+buffer16,
+11488,
+buffer6,
+33868,
+4732
+);
+dissociateBuffer(device0, buffer16);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder66.copyTextureToTexture(
+{
+  texture: texture17,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture42,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer19,
+11616,
+new BigUint64Array(64245),
+61241,
+64
+);
+} catch {}
+let promise27 = device0.createRenderPipelineAsync(
+{
+label: '\u07eb\uedd6\ue36d\u8696\u0013',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 3660,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 160,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 3740,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 3020,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 652,
+shaderLocation: 19,
+}
+],
+}
+]
+},
+multisample: {
+mask: 0x10ae18cd,
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+format: 'r32uint',
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'bgra8unorm-srgb',
+},
+undefined,
+undefined,
+{
+format: 'rg32float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+},
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 3273,
+stencilWriteMask: 3443,
+depthBias: 66,
+depthBiasClamp: 58,
+},
+}
+);
+let videoFrame14 = new VideoFrame(canvas6, {timestamp: 0});
+let shaderModule4 = device0.createShaderModule(
+{
+code: `
+
+@compute @workgroup_size(7, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S3 {
+@location(59) f0: vec3<u32>,
+@location(73) f1: f32,
+@location(58) f2: vec2<i32>,
+@location(20) f3: f32,
+@location(21) f4: vec3<i32>,
+@builtin(sample_mask) f5: u32,
+@location(13) f6: vec3<f32>,
+@location(85) f7: vec2<f16>,
+@location(82) f8: vec2<i32>,
+@location(53) f9: f32,
+@location(67) f10: vec2<f32>,
+@location(70) f11: i32,
+@location(57) f12: vec4<u32>,
+@location(5) f13: f16,
+@location(27) f14: vec3<i32>,
+@location(64) f15: u32,
+@builtin(position) f16: vec4<f32>,
+@location(22) f17: vec3<f32>,
+@location(62) f18: vec2<f32>,
+@builtin(front_facing) f19: bool
+}
+
+@fragment
+fn fragment0(@location(83) a0: vec2<i32>, @location(19) a1: vec4<f32>, @location(2) a2: i32, @location(43) a3: vec3<u32>, @location(48) a4: vec4<u32>, @location(54) a5: vec3<i32>, @location(55) a6: u32, @location(10) a7: vec2<i32>, @location(1) a8: vec2<u32>, @location(0) a9: vec4<f16>, a10: S3, @builtin(sample_index) a11: u32) {
+
+}
+
+struct VertexOutput0 {
+@location(55) f51: u32,
+@location(58) f52: vec2<i32>,
+@location(67) f53: vec2<f32>,
+@location(13) f54: vec3<f32>,
+@builtin(position) f55: vec4<f32>,
+@location(48) f56: vec4<u32>,
+@location(83) f57: vec2<i32>,
+@location(53) f58: f32,
+@location(73) f59: f32,
+@location(64) f60: u32,
+@location(82) f61: vec2<i32>,
+@location(54) f62: vec3<i32>,
+@location(59) f63: vec3<u32>,
+@location(5) f64: f16,
+@location(19) f65: vec4<f32>,
+@location(21) f66: vec3<i32>,
+@location(0) f67: vec4<f16>,
+@location(85) f68: vec2<f16>,
+@location(27) f69: vec3<i32>,
+@location(22) f70: vec3<f32>,
+@location(70) f71: i32,
+@location(2) f72: i32,
+@location(1) f73: vec2<u32>,
+@location(10) f74: vec2<i32>,
+@location(57) f75: vec4<u32>,
+@location(20) f76: f32,
+@location(62) f77: vec2<f32>,
+@location(43) f78: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(13) a0: u32, @location(19) a1: vec4<f32>, @location(4) a2: vec3<u32>, @location(11) a3: f32, @location(7) a4: vec3<f16>, @location(8) a5: vec3<f16>, @builtin(vertex_index) a6: u32, @location(2) a7: vec4<f16>, @location(20) a8: vec2<u32>, @location(18) a9: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroup49 = device0.createBindGroup({
+label: '\u0c29\u4e94\u6d4d\u04c1\u6cb3\u0b13',
+layout: bindGroupLayout3,
+entries: [
+{
+binding: 150,
+resource: externalTexture5
+}
+],
+});
+let texture62 = device0.createTexture(
+{
+label: '\ufde0\u{1f923}\uc9f3\u7fb0\u7ec8\u0080\u0f12\u9d02\u61b2\u{1f6b2}\u{1f6c5}',
+size: [7312, 4, 66],
+mipLevelCount: 8,
+format: 'etc2-rgb8a1unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'etc2-rgb8a1unorm'
+],
+}
+);
+try {
+renderBundleEncoder39.setVertexBuffer(
+1,
+buffer5,
+20
+);
+} catch {}
+try {
+window.someLabel = textureView41.label;
+} catch {}
+let bindGroup50 = device0.createBindGroup({
+label: '\uf58d\u529d\uba1f\u8dd5\u86b6\u0c8a\u09c0\uc194',
+layout: bindGroupLayout6,
+entries: [
+{
+binding: 547,
+resource: externalTexture1
+},
+{
+binding: 92,
+resource: sampler34
+}
+],
+});
+let commandEncoder67 = device0.createCommandEncoder(
+{
+label: '\u6837\u2d7b\u4a50\u{1fd43}\u0970\u2b27\ua002\u3c01',
+}
+);
+let commandBuffer11 = commandEncoder20.finish(
+{
+label: '\u08c2\u09d0\u083a',
+}
+);
+try {
+computePassEncoder17.setPipeline(
+pipeline15
+);
+} catch {}
+try {
+commandEncoder48.copyBufferToTexture(
+{
+/* bytesInLastRow: 176 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 57600 */
+offset: 57600,
+bytesPerRow: 256,
+buffer: buffer2,
+},
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 30, y: 120, z: 0 },
+  aspect: 'all',
+},
+{width: 110, height: 48, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder62.copyTextureToTexture(
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 10, y: 0, z: 45 },
+  aspect: 'all',
+},
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 40, y: 88, z: 0 },
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder52.insertDebugMarker(
+'\u{1fb7d}'
+);
+} catch {}
+let pipeline38 = device0.createComputePipeline(
+{
+label: '\uc164\u52d9\uf9fd\u3fa9',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageBitmap9 = await createImageBitmap(canvas11);
+let texture63 = device0.createTexture(
+{
+label: '\u078b\u{1ffce}\u148a\u0438\u09c9\uc5d4\u1a34\u1d1a\u{1fb2c}',
+size: [640],
+dimension: '1d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg32sint'
+],
+}
+);
+let textureView50 = texture36.createView(
+{
+label: '\u332d\u{1ff52}\u8d45\u21f4',
+baseMipLevel: 0,
+mipLevelCount: 1,
+}
+);
+let computePassEncoder43 = commandEncoder55.beginComputePass(
+{
+
+}
+);
+try {
+computePassEncoder36.setBindGroup(
+0,
+bindGroup24,
+new Uint32Array(6534),
+3809,
+0
+);
+} catch {}
+try {
+computePassEncoder38.dispatchWorkgroups(
+1,
+3,
+5
+);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(
+0,
+bindGroup40
+);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(
+8,
+buffer5
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer20,
+4036,
+new BigUint64Array(56132),
+41012,
+328
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture62,
+  mipLevel: 6,
+  origin: { x: 36, y: 0, z: 3 },
+  aspect: 'all',
+},
+new Uint32Array(arrayBuffer12),
+/* required buffer size: 687945 */{
+offset: 225,
+bytesPerRow: 116,
+rowsPerImage: 104,
+},
+{width: 36, height: 4, depthOrArrayLayers: 58}
+);
+} catch {}
+let promise28 = device0.queue.onSubmittedWorkDone();
+let texture64 = device0.createTexture(
+{
+label: '\ueb65\u0a22\u1ac4',
+size: {width: 15850, height: 5, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-10x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let sampler44 = device0.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 80.348,
+lodMaxClamp: 81.745,
+}
+);
+try {
+computePassEncoder43.setPipeline(
+pipeline22
+);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(
+4,
+bindGroup33,
+[]
+);
+} catch {}
+try {
+commandEncoder56.resolveQuerySet(
+querySet0,
+1657,
+61,
+buffer24,
+13568
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture40,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 33 },
+  aspect: 'all',
+},
+new ArrayBuffer(42616),
+/* required buffer size: 42616 */{
+offset: 928,
+bytesPerRow: 216,
+rowsPerImage: 193,
+},
+{width: 5, height: 0, depthOrArrayLayers: 2}
+);
+} catch {}
+let pipeline39 = await device0.createComputePipelineAsync(
+{
+label: '\u996b\ue6d3\u{1f84e}\ua142\u{1fe30}\u3478\u5780',
+layout: pipelineLayout10,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+},
+}
+);
+let pipeline40 = await promise25;
+let buffer25 = device0.createBuffer(
+{
+label: '\u03bc\u051d\u83b8',
+size: 64124,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+mappedAtCreation: true,
+}
+);
+let querySet35 = device0.createQuerySet(
+{
+label: '\ua44f\u52c6\u0d55\u0b54\ud7b9\u99e0\u11e4',
+type: 'occlusion',
+count: 3802,
+}
+);
+try {
+computePassEncoder11.setBindGroup(
+6,
+bindGroup39,
+new Uint32Array(4800),
+47,
+0
+);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(
+buffer11,
+'uint32'
+);
+} catch {}
+try {
+buffer11.destroy();
+} catch {}
+try {
+device0.destroy();
+} catch {}
+offscreenCanvas3.width = 280;
+try {
+await promise23;
+} catch {}
+let canvas13 = document.createElement('canvas');
+try {
+sampler28.label = '\u4826\u0564\u8511\u238d\ua4b9\u0076\u28c8';
+} catch {}
+let img13 = await imageWithData(244, 36, '#12a3a594', '#cf02b35d');
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let canvas14 = document.createElement('canvas');
+let imageBitmap10 = await createImageBitmap(videoFrame1);
+let imageBitmap11 = await createImageBitmap(canvas6);
+let renderBundle43 = renderBundleEncoder12.finish();
+try {
+computePassEncoder28.setPipeline(
+pipeline3
+);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(
+6,
+bindGroup20
+);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(
+2,
+buffer5,
+5052,
+5460
+);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer11,
+]);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let gpuCanvasContext11 = canvas14.getContext('webgpu');
+document.body.append('\u0533\u{1fdd9}\uc481\uc5ec\ua889\u49d9\u{1febb}');
+let imageBitmap12 = await createImageBitmap(videoFrame12);
+let sampler45 = device0.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+}
+);
+try {
+computePassEncoder26.setPipeline(
+pipeline3
+);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(
+1,
+bindGroup48,
+new Uint32Array(1258),
+529,
+0
+);
+} catch {}
+try {
+commandEncoder59.copyTextureToTexture(
+{
+  texture: texture10,
+  mipLevel: 3,
+  origin: { x: 468, y: 0, z: 85 },
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 3,
+  origin: { x: 216, y: 12, z: 1 },
+  aspect: 'all',
+},
+{width: 108, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder48.clearBuffer(
+buffer2,
+43692
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 0, y: 3, z: 1 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer4),
+/* required buffer size: 762 */{
+offset: 762,
+bytesPerRow: 317,
+},
+{width: 92, height: 99, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+video7.height = 288;
+let img14 = await imageWithData(267, 39, '#08d018a0', '#080aad28');
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+document.body.prepend(video4);
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+document.body.append('\u589c\u05cc\u01ff\u8296\u{1fd87}\uc9cd\u05e1\ueb97\u08b6\u{1fa33}');
+let gpuCanvasContext12 = canvas13.getContext('webgpu');
+try {
+window.someLabel = externalTexture1.label;
+} catch {}
+let imageData10 = new ImageData(8, 156);
+let imageData11 = new ImageData(140, 32);
+let imageBitmap13 = await createImageBitmap(img2);
+document.body.append('\u029e\u3ad8\u911f\u4170\u89ac');
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+canvas12.height = 23;
+document.body.prepend('\u0dab\ub758\u0e82\u0339\ud754\u098b\u0895\ub544');
+gc();
+let imageData12 = new ImageData(144, 204);
+document.body.prepend('\u8aa4\u0a3e\u0b9f\u1f10\u0e49\u{1ff44}\u0b78\uce88\u19f5\u{1f6c0}');
+let promise29 = adapter0.requestAdapterInfo();
+let img15 = await imageWithData(296, 206, '#a0cca532', '#f860dc5d');
+try {
+adapter0.label = '\ue7ef\u5624\uacfa\u03a3\u599f\u3f3a\u13b5\udf7a\u{1fde0}';
+} catch {}
+document.body.prepend(canvas12);
+document.body.prepend('\u7d65\u4d20\u0898\u{1fe70}\ub767\u090c\u4ccf');
+let querySet36 = device0.createQuerySet(
+{
+label: '\u2279\u01e1\uad03\u57fc\u{1f90e}\ub8ef\u9f05\u0e83\u186a',
+type: 'occlusion',
+count: 337,
+}
+);
+let computePassEncoder44 = commandEncoder48.beginComputePass(
+{
+label: '\u112f\uc1f4\u8216\u6a19\uf90f\u2b15\uead3'
+}
+);
+try {
+computePassEncoder15.setPipeline(
+pipeline15
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer19,
+612,
+new Float32Array(3590),
+3128,
+124
+);
+} catch {}
+let pipeline41 = device0.createComputePipeline(
+{
+label: '\u0306\u81a6\u0cb1\u3c5c\ue5c3\u0712\u{1f9a4}\u{1f79a}',
+layout: pipelineLayout7,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+},
+}
+);
+document.body.append('\u0dae\u{1fbd0}\ud676\u7a82\u{1fc92}\u0d33\u99c8\u{1f952}\u8fde\u0140');
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let imageData13 = new ImageData(220, 252);
+document.body.prepend(img9);
+try {
+await promise29;
+} catch {}
+document.body.prepend('\u03ea\u5659\ub224\u5a3a');
+let imageBitmap14 = await createImageBitmap(imageBitmap10);
+let adapter1 = await promise4;
+let imageData14 = new ImageData(200, 56);
+try {
+await promise13;
+} catch {}
+let imageData15 = new ImageData(48, 244);
+let adapter2 = await promise9;
+try {
+await promise24;
+} catch {}
+let videoFrame15 = new VideoFrame(videoFrame9, {timestamp: 0});
+let device1 = await adapter2.requestDevice(
+{
+label: '\u20f7\u035e\u0fee\u8dce\u0088\u83b9\u032a\u0f66',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 45,
+maxVertexBufferArrayStride: 11447,
+maxStorageTexturesPerShaderStage: 7,
+maxStorageBuffersPerShaderStage: 10,
+maxDynamicStorageBuffersPerPipelineLayout: 18805,
+maxBindingsPerBindGroup: 6138,
+maxTextureDimension1D: 13224,
+maxTextureDimension2D: 8574,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 260701165,
+maxInterStageShaderVariables: 55,
+maxInterStageShaderComponents: 87,
+},
+}
+);
+let video9 = await videoWithData();
+gc();
+let offscreenCanvas7 = new OffscreenCanvas(280, 350);
+try {
+await promise22;
+} catch {}
+try {
+offscreenCanvas7.getContext('webgl2');
+} catch {}
+let bindGroupLayout14 = device0.createBindGroupLayout(
+{
+label: '\u0446\u06ee\u2814',
+entries: [
+{
+binding: 6185,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 3181,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 2317,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'non-filtering' },
+}
+],
+}
+);
+let pipelineLayout11 = device0.createPipelineLayout(
+{
+label: '\u{1fddf}\u{1ffd7}',
+bindGroupLayouts: [
+
+],
+}
+);
+let texture65 = device0.createTexture(
+{
+label: '\u017d\u04fa\u0c32\u1172',
+size: [26, 1, 844],
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+let textureView51 = texture65.createView(
+{
+label: '\u2879\u{1fc36}\u0c0f\u0203\uba35\uc5d5\u{1fe03}\ub356\u{1fa66}\u6cdd',
+baseMipLevel: 1,
+}
+);
+try {
+computePassEncoder43.setPipeline(
+pipeline19
+);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(
+3,
+bindGroup11
+);
+} catch {}
+try {
+commandEncoder59.clearBuffer(
+buffer25,
+63392,
+396
+);
+dissociateBuffer(device0, buffer25);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture30,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Int32Array(arrayBuffer9),
+/* required buffer size: 204 */{
+offset: 204,
+},
+{width: 10, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+canvas1.height = 173;
+document.body.append('\u{1f8b1}\u{1f8b7}\u{1fde3}\ub97c\uc855\ucd5b\u0cf1\uc54c\u4043\u1535\u083d');
+try {
+await promise14;
+} catch {}
+let bindGroupLayout15 = device1.createBindGroupLayout(
+{
+entries: [
+{
+binding: 1627,
+visibility: GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 4821,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+let commandEncoder68 = device1.createCommandEncoder(
+{
+}
+);
+let texture66 = gpuCanvasContext8.getCurrentTexture();
+document.body.append('\u05d5\u5e92\u1e8a\u9a39\u0d29\u{1feba}');
+let promise30 = adapter1.requestDevice(
+{
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 52,
+maxVertexAttributes: 25,
+maxVertexBufferArrayStride: 5916,
+maxStorageTexturesPerShaderStage: 43,
+maxStorageBuffersPerShaderStage: 14,
+maxDynamicStorageBuffersPerPipelineLayout: 582,
+maxBindingsPerBindGroup: 6633,
+maxTextureDimension1D: 11990,
+maxTextureDimension2D: 9444,
+maxVertexBuffers: 12,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 32668663,
+maxInterStageShaderVariables: 104,
+maxInterStageShaderComponents: 81,
+},
+}
+);
+let textureView52 = texture66.createView(
+{
+label: '\u6e28\u1e26\u2343\u01a4\ud25a',
+dimension: '2d-array',
+}
+);
+offscreenCanvas0.height = 126;
+let pipelineLayout12 = device1.createPipelineLayout(
+{
+label: '\u0967\ue350\u{1f8cd}\u18da',
+bindGroupLayouts: [
+bindGroupLayout15,
+bindGroupLayout15,
+bindGroupLayout15,
+bindGroupLayout15,
+bindGroupLayout15
+],
+}
+);
+let buffer26 = device1.createBuffer(
+{
+label: '\u3af9\u8747\u372d\u6a3c\u4be5\u0915',
+size: 59123,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+}
+);
+let querySet37 = device1.createQuerySet(
+{
+label: '\ue2db\u205b\u{1fe13}',
+type: 'occlusion',
+count: 2657,
+}
+);
+try {
+commandEncoder68.copyBufferToTexture(
+{
+/* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 28648 */
+offset: 28648,
+buffer: buffer26,
+},
+{
+  texture: texture66,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device1, buffer26);
+} catch {}
+try {
+await promise15;
+} catch {}
+try {
+await adapter1.requestAdapterInfo();
+} catch {}
+let adapter3 = await navigator.gpu.requestAdapter(
+{
+}
+);
+try {
+await adapter3.requestAdapterInfo();
+} catch {}
+try {
+await promise28;
+} catch {}
+document.body.prepend(canvas5);
+let imageBitmap15 = await createImageBitmap(offscreenCanvas7);
+let videoFrame16 = new VideoFrame(offscreenCanvas2, {timestamp: 0});
+let canvas15 = document.createElement('canvas');
+let img16 = await imageWithData(279, 172, '#6a4e4c39', '#84266cb6');
+try {
+canvas15.getContext('webgpu');
+} catch {}
+let bindGroup51 = device1.createBindGroup({
+label: '\u78d7\u09cc\uc087\u71be\u{1ff40}\u6a2a\u264d\ueef7\u0c7a',
+layout: bindGroupLayout15,
+entries: [
+{
+binding: 4821,
+resource: {
+buffer: buffer26,
+offset: 35264,
+size: 2452,
+}
+},
+{
+binding: 1627,
+resource: {
+buffer: buffer26,
+offset: 38080,
+size: 19108,
+}
+}
+],
+});
+let commandEncoder69 = device1.createCommandEncoder(
+{
+label: '\u7383\u{1ff07}\u0612\u071e\ue339\u0e64\u1516\u0368\ub6c3\ubf5b\u{1fc6b}',
+}
+);
+let texture67 = device1.createTexture(
+{
+size: [343, 1, 24],
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+device1.queue.writeTexture(
+{
+  texture: texture67,
+  mipLevel: 0,
+  origin: { x: 275, y: 0, z: 1 },
+  aspect: 'all',
+},
+new DataView(new ArrayBuffer(8)),
+/* required buffer size: 424913 */{
+offset: 49,
+bytesPerRow: 71,
+rowsPerImage: 272,
+},
+{width: 13, height: 0, depthOrArrayLayers: 23}
+);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+gc();
+let bindGroup52 = device1.createBindGroup({
+layout: bindGroupLayout15,
+entries: [
+{
+binding: 4821,
+resource: {
+buffer: buffer26,
+offset: 43136,
+size: 9468,
+}
+},
+{
+binding: 1627,
+resource: {
+buffer: buffer26,
+offset: 53120,
+size: 896,
+}
+}
+],
+});
+let textureView53 = texture66.createView(
+{
+label: '\uf5e7\uc660\u0311\u0489\u01aa\u{1f953}\ua963\u448d\u0bf4\u{1fee0}\u8fd1',
+}
+);
+let computePassEncoder45 = commandEncoder68.beginComputePass(
+{
+label: '\u{1f669}\u{1fba5}\uc4e2\u05b0\u93ae\u7d4f\u{1fca4}\uefb2'
+}
+);
+try {
+device1.pushErrorScope(
+'internal'
+);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let shaderModule5 = device1.createShaderModule(
+{
+label: '\ud23b\uec50\ue982\u85d8\uee09\u9f64\u73ab\u1ee9\u563b',
+code: `@group(3) @binding(1627)
+var<storage, read_write> parameter0: array<u32>;
+
+@compute @workgroup_size(2, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@builtin(frag_depth) f0: f32,
+@location(7) f1: vec4<i32>,
+@location(5) f2: i32,
+@location(0) f3: vec4<i32>,
+@location(1) f4: vec4<f32>,
+@location(4) f5: i32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(sample_mask) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(4) a0: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+}
+);
+let textureView54 = texture67.createView(
+{
+label: '\u0358\u8ae0\u07ee\u0e73\u{1f9d1}\u5c4b\ua305',
+dimension: '2d',
+baseArrayLayer: 10,
+}
+);
+document.body.prepend('\u0001\uca89\u7852\ubdbc\u0bed');
+let imageData16 = new ImageData(128, 196);
+let shaderModule6 = device1.createShaderModule(
+{
+label: '\u{1f9e9}\u{1f6c0}\uda38\u01b5\ufeae\u05fd\ua767\u0e26',
+code: `@group(1) @binding(4821)
+var<storage, read_write> type0: array<u32>;
+
+@compute @workgroup_size(1, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S5 {
+@location(50) f0: vec4<u32>,
+@location(36) f1: vec3<f32>,
+@builtin(front_facing) f2: bool,
+@location(6) f3: vec3<f32>,
+@location(11) f4: vec2<f32>,
+@location(38) f5: vec3<i32>,
+@location(8) f6: f32,
+@location(19) f7: i32,
+@location(44) f8: vec3<f16>,
+@location(20) f9: vec3<f16>,
+@location(9) f10: vec3<f32>,
+@location(41) f11: vec3<i32>
+}
+struct FragmentOutput0 {
+@location(4) f0: vec3<f32>,
+@location(0) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(52) a0: vec2<u32>, @location(32) a1: vec2<u32>, @location(17) a2: vec2<i32>, @location(21) a3: u32, @location(53) a4: vec3<f32>, @location(54) a5: vec4<u32>, @location(30) a6: f32, @location(12) a7: vec4<f16>, @location(7) a8: vec3<f32>, @location(42) a9: vec4<f32>, @location(13) a10: vec3<i32>, @location(10) a11: vec2<u32>, @location(26) a12: f16, @location(18) a13: vec4<f16>, a14: S5, @location(27) a15: vec4<f16>, @location(37) a16: vec4<f32>, @location(23) a17: vec2<f32>, @location(24) a18: vec3<f16>, @location(22) a19: vec4<f32>, @location(1) a20: f16, @location(16) a21: vec3<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S4 {
+@location(8) f0: f32,
+@location(14) f1: i32,
+@location(5) f2: vec4<i32>,
+@location(11) f3: vec4<u32>
+}
+struct VertexOutput0 {
+@location(12) f79: vec4<f16>,
+@location(10) f80: vec2<u32>,
+@location(24) f81: vec3<f16>,
+@location(26) f82: f16,
+@location(16) f83: vec3<f32>,
+@location(22) f84: vec4<f32>,
+@location(17) f85: vec2<i32>,
+@location(52) f86: vec2<u32>,
+@location(7) f87: vec3<f32>,
+@location(20) f88: vec3<f16>,
+@location(50) f89: vec4<u32>,
+@location(53) f90: vec3<f32>,
+@location(27) f91: vec4<f16>,
+@location(36) f92: vec3<f32>,
+@location(54) f93: vec4<u32>,
+@location(18) f94: vec4<f16>,
+@location(9) f95: vec3<f32>,
+@location(6) f96: vec3<f32>,
+@location(42) f97: vec4<f32>,
+@location(13) f98: vec3<i32>,
+@builtin(position) f99: vec4<f32>,
+@location(32) f100: vec2<u32>,
+@location(19) f101: i32,
+@location(30) f102: f32,
+@location(41) f103: vec3<i32>,
+@location(1) f104: f16,
+@location(37) f105: vec4<f32>,
+@location(44) f106: vec3<f16>,
+@location(21) f107: u32,
+@location(38) f108: vec3<i32>,
+@location(11) f109: vec2<f32>,
+@location(8) f110: f32,
+@location(23) f111: vec2<f32>
+}
+
+@vertex
+fn vertex0(@location(12) a0: vec2<u32>, @location(15) a1: vec2<f32>, a2: S4, @builtin(instance_index) a3: u32, @location(10) a4: vec2<u32>, @location(9) a5: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let texture68 = device1.createTexture(
+{
+label: '\u4325\u{1f7c7}\u{1f998}\u0deb',
+size: [4068, 1, 57],
+mipLevelCount: 9,
+format: 'depth16unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let computePassEncoder46 = commandEncoder69.beginComputePass(
+{
+label: '\ud671\u0afc\u0c2a\u03d9'
+}
+);
+try {
+device1.pushErrorScope(
+'validation'
+);
+} catch {}
+let pipeline42 = device1.createRenderPipeline(
+{
+label: '\u6fd2\u7dff\u7de0\uc55d\uf246\u546d',
+layout: pipelineLayout12,
+vertex: {
+module: shaderModule5,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 8164,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x2',
+offset: 4804,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0xc7ffdb65,
+},
+fragment: {
+module: shaderModule5,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'rg32float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'keep',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 3783,
+stencilWriteMask: 2474,
+depthBias: 1,
+depthBiasSlopeScale: 24,
+},
+}
+);
+try {
+adapter1.label = '\u{1f72c}\ue9d2\u{1fde7}\ue756\u92a8';
+} catch {}
+let canvas16 = document.createElement('canvas');
+let gpuCanvasContext13 = canvas16.getContext('webgpu');
+let shaderModule7 = device1.createShaderModule(
+{
+label: '\u0901\ue4bb\u8380\u{1fbf3}\u{1fa9a}\u0704\u{1fcd0}\uf1ab\u0f5b',
+code: `@group(1) @binding(1627)
+var<storage, read_write> function0: array<u32>;
+
+@compute @workgroup_size(7, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S7 {
+@builtin(position) f0: vec4<f32>
+}
+struct FragmentOutput0 {
+@location(2) f0: vec2<f32>,
+@location(1) f1: vec4<f32>,
+@location(5) f2: vec3<i32>,
+@location(6) f3: u32,
+@location(3) f4: vec4<i32>,
+@location(7) f5: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool, @builtin(sample_mask) a2: u32, a3: S7) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S6 {
+@location(0) f0: vec3<f16>,
+@location(8) f1: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(12) a0: vec3<u32>, @location(6) a1: vec4<f32>, @location(13) a2: vec3<i32>, a3: S6, @location(11) a4: vec2<f32>, @location(5) a5: vec2<f16>, @location(10) a6: vec3<u32>, @builtin(vertex_index) a7: u32, @location(9) a8: vec4<i32>, @location(3) a9: u32, @location(1) a10: vec2<f32>, @location(15) a11: f16, @location(2) a12: i32, @location(4) a13: vec2<u32>, @builtin(instance_index) a14: u32, @location(14) a15: vec2<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let textureView55 = texture67.createView(
+{
+label: '\uf7bf\u{1ff30}\u5fbc\uc3fa\u30ee\u{1fe26}\u49eb\ubeed',
+dimension: '2d',
+aspect: 'all',
+baseArrayLayer: 23,
+}
+);
+try {
+computePassEncoder46.setBindGroup(
+0,
+bindGroup52,
+new Uint32Array(2850),
+2550,
+0
+);
+} catch {}
+try {
+gpuCanvasContext12.configure(
+{
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg16uint',
+'rgba8unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture66,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 67 */{
+offset: 67,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device1.destroy();
+} catch {}
+document.body.prepend('\u{1fc0d}\u67dc\u6ea3\u3a79');
+let imageData17 = new ImageData(144, 56);
+canvas1.width = 290;
+offscreenCanvas1.height = 716;
+let videoFrame17 = new VideoFrame(offscreenCanvas3, {timestamp: 0});
+let video10 = await videoWithData();
+canvas0.height = 267;
+gc();
+document.body.append('\u47b5\u8c8d');
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+document.body.prepend(canvas2);
+document.body.prepend('\u2ef8\u37a9');
+let imageData18 = new ImageData(8, 64);
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let texture69 = device0.createTexture(
+{
+label: '\u0db4\ud416\uf45e\u602a\u86a3\ubc87',
+size: {width: 7071, height: 97, depthOrArrayLayers: 153},
+mipLevelCount: 8,
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8uint'
+],
+}
+);
+try {
+computePassEncoder25.setPipeline(
+pipeline29
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer21,
+292,
+new Int16Array(28564),
+26949,
+620
+);
+} catch {}
+let pipeline43 = device0.createRenderPipeline(
+{
+label: '\u05ce\ufb61\u0447\u{1f78a}\u8c4b\u920d',
+layout: pipelineLayout7,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 632,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32',
+offset: 212,
+shaderLocation: 16,
+},
+{
+format: 'sint32x2',
+offset: 592,
+shaderLocation: 11,
+},
+{
+format: 'uint16x4',
+offset: 492,
+shaderLocation: 19,
+},
+{
+format: 'snorm8x4',
+offset: 132,
+shaderLocation: 12,
+},
+{
+format: 'float32x3',
+offset: 164,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x4',
+offset: 32,
+shaderLocation: 8,
+},
+{
+format: 'float32x2',
+offset: 152,
+shaderLocation: 1,
+},
+{
+format: 'float32x3',
+offset: 428,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 1712,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 800,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x53261eab,
+},
+}
+);
+document.body.append('\u275c\u0145\uc5c7\uf654\udad7\ubdd7\u006e\uf047');
+let imageData19 = new ImageData(164, 72);
+let textureView56 = texture68.createView(
+{
+label: '\u{1fe18}\u6add',
+dimension: '2d',
+baseMipLevel: 5,
+baseArrayLayer: 23,
+}
+);
+try {
+computePassEncoder45.setBindGroup(
+0,
+bindGroup51
+);
+} catch {}
+document.body.prepend('\u0a6b\u0aa0\u4013\u8f6e\ua9d1\u06db\ufe97\u7754\u2faf\u{1f74c}');
+let offscreenCanvas8 = new OffscreenCanvas(649, 721);
+document.body.prepend('\u031f\u0676\u7053\u2f9b\u0305\u657a');
+let img17 = await imageWithData(26, 233, '#16a964ca', '#c5f94591');
+let gpuCanvasContext14 = offscreenCanvas8.getContext('webgpu');
+let canvas17 = document.createElement('canvas');
+let gpuCanvasContext15 = canvas17.getContext('webgpu');
+document.body.append('\uabb4\uaacb\u0a19\u0717\ue620\u{1f82c}\u{1f654}\u02c3\ubd07\u0536\u4aff');
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let imageBitmap16 = await createImageBitmap(offscreenCanvas6);
+let img18 = await imageWithData(131, 205, '#da1d3f95', '#c25fd09f');
+let imageData20 = new ImageData(228, 80);
+canvas5.height = 686;
+document.body.prepend('\u07a6\u90ee\u548d\ub538');
+document.body.prepend('\ud851\u5f41\u0837\u0b48\u{1f8b0}\ubdcb\ub8ec');
+let imageBitmap17 = await createImageBitmap(canvas2);
+let videoFrame18 = new VideoFrame(videoFrame12, {timestamp: 0});
+gc();
+let texture70 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder47 = commandEncoder52.beginComputePass(
+{
+label: '\u096c\ufe32\uf0f6\ua151\u0ee7\u{1fafb}\u{1fda9}'
+}
+);
+try {
+computePassEncoder35.setBindGroup(
+0,
+bindGroup14,
+new Uint32Array(8227),
+3331,
+0
+);
+} catch {}
+try {
+commandEncoder62.copyBufferToBuffer(
+buffer2,
+43452,
+buffer1,
+19104,
+16300
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder66.resolveQuerySet(
+querySet11,
+3724,
+17,
+buffer22,
+22016
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 1, depthOrArrayLayers: 225}
+*/
+{
+  source: imageBitmap15,
+  origin: { x: 57, y: 344 },
+  flipY: true,
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 3, y: 1, z: 140 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 3, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+canvas14.height = 960;
+canvas5.height = 349;
+gc();
+try {
+window.someLabel = textureView54.label;
+} catch {}
+document.body.append('\u{1f9cc}\u{1f821}\u06be\u0769\u41be');
+let offscreenCanvas9 = new OffscreenCanvas(950, 664);
+let video11 = await videoWithData();
+document.body.append('\u0808\u{1fa4b}\u4961');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let img19 = await imageWithData(165, 160, '#a9569b1c', '#fe50df2b');
+let videoFrame19 = new VideoFrame(imageBitmap10, {timestamp: 0});
+document.body.append('\u2ce9\ue5a6\u7c86\u0010');
+offscreenCanvas0.height = 571;
+document.body.append('\u{1fe92}\ue10b\ue644\u346d\u0dd9\u0ec1\u1d39\ubae0\u0ccc\u0d0a\u272d');
+let img20 = await imageWithData(220, 151, '#4267e2a6', '#ae608d9b');
+let video12 = await videoWithData();
+let videoFrame20 = new VideoFrame(videoFrame16, {timestamp: 0});
+try {
+offscreenCanvas9.getContext('bitmaprenderer');
+} catch {}
+let canvas18 = document.createElement('canvas');
+let canvas19 = document.createElement('canvas');
+let video13 = await videoWithData();
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let canvas20 = document.createElement('canvas');
+try {
+await adapter2.requestAdapterInfo();
+} catch {}
+document.body.prepend('\u{1fc3e}\u0262\u3e0d\ue7e9');
+let gpuCanvasContext16 = canvas20.getContext('webgpu');
+let bindGroup53 = device1.createBindGroup({
+label: '\ua4c5\u25b8\u4fdb\u0766\uae9e\u085c',
+layout: bindGroupLayout15,
+entries: [
+{
+binding: 1627,
+resource: {
+buffer: buffer26,
+offset: 49344,
+size: 4132,
+}
+},
+{
+binding: 4821,
+resource: {
+buffer: buffer26,
+offset: 47936,
+size: 5268,
+}
+}
+],
+});
+let externalTexture9 = device1.importExternalTexture(
+{
+label: '\u8240\u{1f6b6}\u2623\u{1ff2b}\u9767',
+source: video8,
+colorSpace: 'srgb',
+}
+);
+let pipeline44 = device1.createRenderPipeline(
+{
+label: '\u6228\u9d92\u7d7c\uc9c8\ud25e\uf7f4\u9afa\u0997\u0401',
+layout: 'auto',
+vertex: {
+module: shaderModule7,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 104,
+attributes: [
+{
+format: 'sint16x2',
+offset: 92,
+shaderLocation: 13,
+},
+{
+format: 'uint32x3',
+offset: 28,
+shaderLocation: 10,
+},
+{
+format: 'uint32x2',
+offset: 12,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 9600,
+attributes: [
+{
+format: 'uint32x2',
+offset: 3792,
+shaderLocation: 4,
+},
+{
+format: 'unorm16x2',
+offset: 8220,
+shaderLocation: 11,
+},
+{
+format: 'sint32x3',
+offset: 7528,
+shaderLocation: 2,
+},
+{
+format: 'float32',
+offset: 576,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 9760,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 7948,
+shaderLocation: 15,
+},
+{
+format: 'snorm8x4',
+offset: 4436,
+shaderLocation: 6,
+},
+{
+format: 'uint32x4',
+offset: 3440,
+shaderLocation: 14,
+},
+{
+format: 'float16x2',
+offset: 1092,
+shaderLocation: 8,
+},
+{
+format: 'float16x4',
+offset: 1896,
+shaderLocation: 1,
+},
+{
+format: 'unorm8x4',
+offset: 2364,
+shaderLocation: 0,
+},
+{
+format: 'uint32x2',
+offset: 4916,
+shaderLocation: 3,
+},
+{
+format: 'sint8x4',
+offset: 1740,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule7,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+{
+format: 'rgba8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+format: 'rg32float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}
+],
+},
+}
+);
+document.body.append('\u8e33\uf5f6\u{1f952}\u542c\uae0c\u033f\ub49f\u{1f8a8}\u0da4\u{1fc82}\u6138');
+document.body.append('\u{1ff2d}\uf4a7\ue7c6\u0639\u0fdd\u8c02\u0627\u64c5\u3878');
+gc();
+video1.width = 291;
+offscreenCanvas3.height = 483;
+try {
+window.someLabel = externalTexture1.label;
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let imageData21 = new ImageData(56, 244);
+let videoFrame21 = new VideoFrame(imageBitmap11, {timestamp: 0});
+try {
+canvas19.getContext('webgl');
+} catch {}
+let texture71 = device0.createTexture(
+{
+label: '\u6abd\u{1f739}\u5fd6\u043c\u0bd8\ud139\u{1fd17}\u9c29\u5946\uf64c\u0ce5',
+size: [75, 230, 1],
+mipLevelCount: 6,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-5x5-unorm',
+'astc-5x5-unorm-srgb'
+],
+}
+);
+let textureView57 = texture9.createView(
+{
+label: '\u072c\u{1fe3b}\u0f56\u6e2f\u0d76',
+dimension: '2d-array',
+baseMipLevel: 4,
+baseArrayLayer: 111,
+arrayLayerCount: 35,
+}
+);
+try {
+await buffer21.mapAsync(
+GPUMapMode.READ,
+0,
+2060
+);
+} catch {}
+try {
+commandEncoder62.copyBufferToBuffer(
+buffer13,
+11252,
+buffer6,
+10776,
+25476
+);
+dissociateBuffer(device0, buffer13);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder43.resolveQuerySet(
+querySet13,
+1117,
+403,
+buffer20,
+1792
+);
+} catch {}
+let pipeline45 = device0.createComputePipeline(
+{
+label: '\u0cf6\u083f\uc63e',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+}
+);
+let img21 = await imageWithData(246, 229, '#b77cbbbc', '#e49b5266');
+offscreenCanvas8.width = 268;
+try {
+canvas18.getContext('2d');
+} catch {}
+document.body.prepend(img21);
+document.body.append('\u911d\u0b0a\u{1fb5d}\u530d\ud6f0\u0302\u9df7\u0d18\ub088\u0ec9');
+document.body.append('\u{1fdbe}\u06c0');
+let imageData22 = new ImageData(28, 144);
+let renderBundle44 = renderBundleEncoder6.finish(
+{
+label: '\u0eb6\u{1fab6}'
+}
+);
+try {
+computePassEncoder6.setBindGroup(
+3,
+bindGroup36
+);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(
+0,
+bindGroup43
+);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(
+3,
+buffer16,
+14344,
+4970
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer22,
+14936,
+new Int16Array(33654),
+11866,
+8856
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 24, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(arrayBuffer12),
+/* required buffer size: 844 */{
+offset: 844,
+bytesPerRow: 186,
+rowsPerImage: 249,
+},
+{width: 0, height: 5, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+document.body.prepend('\uda07\u547e\u{1f73c}\u8caf');
+let offscreenCanvas10 = new OffscreenCanvas(331, 243);
+video0.width = 38;
+document.body.prepend('\u2602\u5a15\u1797\u0a38');
+try {
+offscreenCanvas10.getContext('webgl');
+} catch {}
+document.body.append('\u06d1\ub7ec\udc39\u73ef\u1f90\u{1fbe6}');
+let offscreenCanvas11 = new OffscreenCanvas(615, 1003);
+document.body.append('\u326d\u0f53\u{1f8ab}\u0482\u{1fbfe}\ub32f\u{1fd03}\u5c3e\u3d9c\ufcfc');
+try {
+adapter1.label = '\u{1f902}\u0d81';
+} catch {}
+let offscreenCanvas12 = new OffscreenCanvas(118, 323);
+video11.width = 76;
+document.body.prepend('\u0d8e\u9eb9\u9fd5\u{1fe5f}\u88da\u0655\u{1ff38}\ub757\u03d8\ufe2a');
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+document.body.prepend('\u{1f6f7}\u83c5\u{1f9e1}\u05d4\u0846');
+let video14 = await videoWithData();
+try {
+offscreenCanvas11.getContext('webgl2');
+} catch {}
+document.body.prepend(canvas0);
+canvas15.width = 885;
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+document.body.prepend(video9);
+let imageBitmap18 = await createImageBitmap(imageData13);
+let videoFrame22 = videoFrame11.clone();
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+let imageData23 = new ImageData(8, 216);
+let videoFrame23 = new VideoFrame(canvas6, {timestamp: 0});
+let bindGroupLayout16 = device0.createBindGroupLayout(
+{
+entries: [
+
+],
+}
+);
+pseudoSubmit(device0, commandEncoder49);
+let texture72 = device0.createTexture(
+{
+label: '\u0503\u{1fad9}\ub8d3\u0edc\ua4ea\u{1fa7a}\u{1fec7}\u9cab\u0951\u0702\u08b9',
+size: {width: 176, height: 104, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth16unorm'
+],
+}
+);
+let computePassEncoder48 = commandEncoder59.beginComputePass();
+try {
+computePassEncoder28.dispatchWorkgroups(
+4
+);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(
+7,
+buffer16,
+1500,
+21138
+);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+await buffer19.mapAsync(
+GPUMapMode.READ,
+0,
+11528
+);
+} catch {}
+try {
+commandEncoder57.resolveQuerySet(
+querySet29,
+728,
+140,
+buffer13,
+30976
+);
+} catch {}
+let canvas21 = document.createElement('canvas');
+let img22 = await imageWithData(128, 202, '#bb9fa7d6', '#99bb056b');
+let imageBitmap19 = await createImageBitmap(videoFrame6);
+let adapter4 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let canvas22 = document.createElement('canvas');
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+try {
+canvas22.getContext('webgpu');
+} catch {}
+let gpuCanvasContext17 = canvas21.getContext('webgpu');
+let imageData24 = new ImageData(68, 156);
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let img23 = await imageWithData(78, 31, '#22d43291', '#df4bf242');
+let gpuCanvasContext18 = offscreenCanvas12.getContext('webgpu');
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+document.body.prepend(img17);
+gc();
+let imageData25 = new ImageData(56, 100);
+let promise31 = adapter4.requestDevice(
+{
+label: '\ue9e1\u0270\u{1f6f5}\u0f2d\u0174\u{1fc3d}',
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 52,
+maxVertexAttributes: 21,
+maxVertexBufferArrayStride: 42243,
+maxStorageTexturesPerShaderStage: 26,
+maxStorageBuffersPerShaderStage: 29,
+maxDynamicStorageBuffersPerPipelineLayout: 61797,
+maxBindingsPerBindGroup: 3334,
+maxTextureDimension1D: 8596,
+maxTextureDimension2D: 8446,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 162995559,
+maxInterStageShaderVariables: 43,
+maxInterStageShaderComponents: 97,
+},
+}
+);
+let img24 = await imageWithData(128, 129, '#525cd5ab', '#715476a0');
+document.body.append('\u8950\u4e2a\u0edc\u{1f8d7}\u{1fd84}\u044e\u0848\uaf80');
+document.body.prepend(canvas13);
+let promise32 = navigator.gpu.requestAdapter(
+{
+}
+);
+video10.width = 239;
+let adapter5 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let bindGroupLayout17 = device1.createBindGroupLayout(
+{
+entries: [
+{
+binding: 3061,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '1d' },
+}
+],
+}
+);
+let commandEncoder70 = device1.createCommandEncoder(
+{
+}
+);
+let texture73 = device1.createTexture(
+{
+label: '\u6066\ubb99\u{1f9ec}\u{1f685}\u33ed\u{1f8b4}\u10d4',
+size: [174, 5, 155],
+mipLevelCount: 8,
+format: 'astc-6x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-6x5-unorm'
+],
+}
+);
+let textureView58 = texture68.createView(
+{
+label: '\ua820\ufaee\u{1fa27}\ud521\u169c\uf9ed\u0dce\u{1fba3}',
+dimension: '2d',
+baseMipLevel: 1,
+mipLevelCount: 5,
+}
+);
+let sampler46 = device1.createSampler(
+{
+label: '\u{1fc69}\u{1fac2}\u02d9\u7210',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 16.180,
+lodMaxClamp: 63.366,
+}
+);
+try {
+device1.queue.writeTexture(
+{
+  texture: texture73,
+  mipLevel: 0,
+  origin: { x: 36, y: 5, z: 64 },
+  aspect: 'all',
+},
+new BigInt64Array(new ArrayBuffer(32)),
+/* required buffer size: 197148 */{
+offset: 972,
+bytesPerRow: 122,
+rowsPerImage: 24,
+},
+{width: 12, height: 0, depthOrArrayLayers: 68}
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline46 = await device1.createRenderPipelineAsync(
+{
+label: '\u9e83\ud6b4',
+layout: pipelineLayout12,
+vertex: {
+module: shaderModule5,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 3020,
+attributes: [
+{
+format: 'uint32x2',
+offset: 1464,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+},
+fragment: {
+module: shaderModule5,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rgba8sint',
+},
+{
+format: 'rgba8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+{
+format: 'r8sint',
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL,
+},
+undefined,
+{
+format: 'r16sint',
+writeMask: 0,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'greater',
+depthFailOp: 'replace',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'keep',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 63,
+stencilWriteMask: 1973,
+depthBias: 78,
+depthBiasClamp: 95,
+},
+}
+);
+let img25 = await imageWithData(70, 221, '#5a7c6a1c', '#79413100');
+let imageData26 = new ImageData(32, 248);
+try {
+adapter2.label = '\u7733\u013c\u11b4\ud587';
+} catch {}
+document.body.prepend(video2);
+document.body.append('\u54d7\ue79c\u8c16\u63c6\uf54d\u8ceb\u08e6\u{1f91e}\uf5bb\uad09');
+let imageBitmap20 = await createImageBitmap(canvas14);
+gc();
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+let imageData27 = new ImageData(68, 204);
+let video15 = await videoWithData();
+try {
+videoFrame1.close();
+} catch {}
+gc();
+let device2 = await adapter5.requestDevice(
+{
+label: '\u{1fe9b}\uc53c\u{1fafe}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 35,
+maxVertexAttributes: 25,
+maxVertexBufferArrayStride: 10600,
+maxStorageTexturesPerShaderStage: 35,
+maxStorageBuffersPerShaderStage: 36,
+maxDynamicStorageBuffersPerPipelineLayout: 41432,
+maxBindingsPerBindGroup: 1172,
+maxTextureDimension1D: 9063,
+maxTextureDimension2D: 14654,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 11292172,
+maxInterStageShaderVariables: 112,
+maxInterStageShaderComponents: 81,
+},
+}
+);
+let imageBitmap21 = await createImageBitmap(imageBitmap6);
+let commandEncoder71 = device2.createCommandEncoder();
+let renderBundleEncoder40 = device2.createRenderBundleEncoder(
+{
+label: '\u2ea7\u4184\u0c3e\u0e4c\u0f28',
+colorFormats: [
+'rg11b10ufloat',
+'rgba16uint',
+'rg32float',
+undefined,
+'rgb10a2uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 412,
+depthReadOnly: true,
+}
+);
+let renderBundle45 = renderBundleEncoder40.finish(
+{
+label: '\u031d\u4a64\u{1f87f}\u0530\u47f8\u{1fdf2}'
+}
+);
+let sampler47 = device2.createSampler(
+{
+label: '\u2d47\u{1fa1c}\u0c4a\uede8\u817c\u0dc9\u{1febb}\u856c',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 75.632,
+lodMaxClamp: 81.014,
+}
+);
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+document.body.append('\ud07b\u{1f6bf}\u00c5\u{1f8f7}\u00f8\u4ac9\u6e8e');
+video9.height = 213;
+gc();
+let buffer27 = device2.createBuffer(
+{
+label: '\u4d5c\u0342\u8384\u0ea8\u0984\u4373\u{1f829}\u00f5',
+size: 56168,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: false,
+}
+);
+let renderBundle46 = renderBundleEncoder40.finish(
+{
+
+}
+);
+let img26 = await imageWithData(9, 141, '#3e20eefa', '#ba4255d4');
+let video16 = await videoWithData();
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+let device3 = await adapter3.requestDevice(
+{
+label: '\u8cd4\u6648\u{1ffc1}\u949d\u6ae1\u{1fcbd}\u004c',
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 9,
+maxColorAttachmentBytesPerSample: 54,
+maxVertexAttributes: 27,
+maxVertexBufferArrayStride: 8034,
+maxStorageTexturesPerShaderStage: 22,
+maxStorageBuffersPerShaderStage: 22,
+maxDynamicStorageBuffersPerPipelineLayout: 59601,
+maxBindingsPerBindGroup: 5479,
+maxTextureArrayLayers: 256,
+maxTextureDimension1D: 8370,
+maxTextureDimension2D: 10523,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 97875874,
+maxInterStageShaderVariables: 110,
+maxInterStageShaderComponents: 77,
+},
+}
+);
+let img27 = await imageWithData(294, 152, '#eb7cc0dc', '#2847198d');
+let commandBuffer12 = commandEncoder71.finish(
+{
+}
+);
+let promise33 = device2.queue.onSubmittedWorkDone();
+document.body.append('\uc7fe\uae4d\u4827\uba55\u62ad\u0fba\u6065\u4efc');
+let canvas23 = document.createElement('canvas');
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+document.body.append('\u10c6\u04bf\ubbe4\u0d3b\u0a0a\u0b8e\u1487\u{1fc7c}\u023d\u01aa\u8f3f');
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+await promise33;
+} catch {}
+document.body.prepend('\u0bce\u3ceb\u05e8\u397b\u0f98\u0a58\u2104');
+let video17 = await videoWithData();
+let imageBitmap22 = await createImageBitmap(imageBitmap19);
+document.body.prepend('\uc934\uc655\u01ca\u0aca\u{1f81c}\u0027\u{1f99d}\u{1fc62}');
+let canvas24 = document.createElement('canvas');
+let promise34 = adapter0.requestAdapterInfo();
+document.body.append('\u0328\u0e96\u{1ff71}\uf10f');
+let offscreenCanvas13 = new OffscreenCanvas(891, 800);
+try {
+adapter4.label = '\u01d8\uae9a\u90f2';
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+gc();
+let adapter6 = await navigator.gpu.requestAdapter(
+{
+}
+);
+try {
+computePassEncoder46.setBindGroup(
+1,
+bindGroup52
+);
+} catch {}
+try {
+computePassEncoder46.setBindGroup(
+7,
+bindGroup52,
+new Uint32Array(5157),
+5118,
+0
+);
+} catch {}
+let pipeline47 = device1.createComputePipeline(
+{
+label: '\u7d9e\ued7c\u8059\u06c9\u03fb\u63db\u{1f9f9}\u85da\ueae7\u{1fe49}',
+layout: pipelineLayout12,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+canvas8.width = 234;
+document.body.prepend('\u{1f6ed}\u98d1');
+try {
+externalTexture9.label = '\u51aa\ue206\u02a8\u3be5\ub1b9\ue270\uc269\uea83';
+} catch {}
+document.body.prepend('\ua78e\u63a3\uc4af\u0843\u30b2\uae1b\ua810');
+try {
+canvas23.getContext('webgl');
+} catch {}
+let renderBundleEncoder41 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg32sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 341,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle47 = renderBundleEncoder41.finish(
+{
+label: '\ub552\u1ef4\uc539\ubfcd\ubca5\u9e49\u67e4\u0809'
+}
+);
+try {
+device2.queue.submit([
+]);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer27,
+38476,
+new Float32Array(34161),
+28298,
+1444
+);
+} catch {}
+document.body.prepend(img27);
+document.body.append('\u614a\uc870\ue997\u{1fe46}\u2d8b\u0b80\uefc4');
+document.body.prepend('\u2f6c\u9192\u586b\u0291\u4d45\ufd21\ucf1c\u8a0b\ue4c8');
+let canvas25 = document.createElement('canvas');
+let imageData28 = new ImageData(184, 172);
+try {
+canvas24.getContext('webgpu');
+} catch {}
+let texture74 = device2.createTexture(
+{
+label: '\u0d69\u{1f84e}',
+size: [11506, 46, 1],
+mipLevelCount: 7,
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb9e5ufloat',
+'rgb9e5ufloat',
+'rgb9e5ufloat'
+],
+}
+);
+let sampler48 = device2.createSampler(
+{
+label: '\u{1fb20}\u91dd\u{1fc07}\u41c9\u0aa2\u130b\u3fbc',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 43.862,
+lodMaxClamp: 83.326,
+compare: 'greater-equal',
+}
+);
+try {
+device2.queue.writeBuffer(
+buffer27,
+48944,
+new Int16Array(56580),
+5684,
+480
+);
+} catch {}
+let offscreenCanvas14 = new OffscreenCanvas(941, 11);
+let buffer28 = device2.createBuffer(
+{
+label: '\ue33e\u73b9\u{1f640}\u2741\ub4b5',
+size: 55260,
+usage: GPUBufferUsage.MAP_READ,
+}
+);
+let renderBundle48 = renderBundleEncoder40.finish(
+{
+
+}
+);
+let sampler49 = device2.createSampler(
+{
+label: '\u235e\u0e8b\ubfb8\u9140\u6a0d\u0733\uebf5\u534d\ue2ae\u0bb4\u1ce3',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 9.156,
+lodMaxClamp: 34.712,
+maxAnisotropy: 1,
+}
+);
+try {
+device2.queue.writeTexture(
+{
+  texture: texture74,
+  mipLevel: 4,
+  origin: { x: 172, y: 2, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 906 */{
+offset: 906,
+bytesPerRow: 1882,
+},
+{width: 441, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let bindGroupLayout18 = device2.createBindGroupLayout(
+{
+entries: [
+{
+binding: 617,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+},
+{
+binding: 636,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 807,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '2d-array' },
+}
+],
+}
+);
+let sampler50 = device2.createSampler(
+{
+label: '\u8aeb\ub3b1\ubd79\u0481\u0590',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 4.276,
+maxAnisotropy: 13,
+}
+);
+try {
+device2.queue.submit([
+]);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture74,
+  mipLevel: 1,
+  origin: { x: 3335, y: 1, z: 0 },
+  aspect: 'all',
+},
+new Int16Array(arrayBuffer8),
+/* required buffer size: 105120 */{
+offset: 82,
+bytesPerRow: 7506,
+},
+{width: 1865, height: 14, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise35 = device2.queue.onSubmittedWorkDone();
+document.body.append('\u496b\u{1fe84}\ud3d8\u{1f744}\u1244\u{1f97c}\u3c8a\ud73f\ue6df\u{1fd5e}');
+try {
+await promise35;
+} catch {}
+canvas22.height = 3441749726;
+document.body.append('\u2995\u0f7d');
+let videoFrame24 = new VideoFrame(img19, {timestamp: 0});
+let commandEncoder72 = device3.createCommandEncoder(
+{
+}
+);
+gc();
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let gpuCanvasContext19 = canvas25.getContext('webgpu');
+canvas22.width = 349;
+gc();
+try {
+window.someLabel = commandEncoder72.label;
+} catch {}
+let querySet38 = device3.createQuerySet(
+{
+type: 'occlusion',
+count: 3484,
+}
+);
+let texture75 = device3.createTexture(
+{
+label: '\ue4eb\u{1f7e5}\u00c4\u63fd',
+size: [5088],
+dimension: '1d',
+format: 'rg8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let offscreenCanvas15 = new OffscreenCanvas(154, 359);
+let video18 = await videoWithData();
+document.body.append('\u515d\u0dea\u006b\u{1fde9}\ud099');
+let commandEncoder73 = device3.createCommandEncoder(
+{
+label: '\ud1b7\u{1fbdb}\u0219\u{1fd5f}\ubc7f\uaf57\ud4c0\u0afa',
+}
+);
+try {
+offscreenCanvas13.getContext('bitmaprenderer');
+} catch {}
+video7.height = 122;
+gc();
+let canvas26 = document.createElement('canvas');
+let renderBundleEncoder42 = device3.createRenderBundleEncoder(
+{
+label: '\u{1f965}\u2847',
+colorFormats: [
+'rg16uint',
+'rgba32uint',
+'bgra8unorm',
+'rgb10a2uint',
+'r8unorm',
+'r8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 699,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle49 = renderBundleEncoder42.finish(
+{
+label: '\u46b7\u090a\u232b\u8496\u{1f7a2}\u0989\u40e0\ub596'
+}
+);
+let bindGroupLayout19 = device3.createBindGroupLayout(
+{
+label: '\u{1fbc0}\u88e4\u3b9b',
+entries: [
+{
+binding: 2861,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+}
+],
+}
+);
+let renderBundle50 = renderBundleEncoder42.finish(
+{
+label: '\u0df3\u01db'
+}
+);
+try {
+device3.destroy();
+} catch {}
+let img28 = await imageWithData(67, 279, '#c7888eb7', '#4a4ad17a');
+let video19 = await videoWithData();
+let textureView59 = texture74.createView(
+{
+label: '\u79ab\ua7bd\u{1fba4}\u0ff2',
+baseMipLevel: 4,
+arrayLayerCount: 1,
+}
+);
+let renderBundle51 = renderBundleEncoder41.finish(
+{
+label: '\u{1fa77}\u09fc'
+}
+);
+try {
+device2.pushErrorScope(
+'validation'
+);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer27,
+32520,
+new Float32Array(34543),
+8632,
+32
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture74,
+  mipLevel: 1,
+  origin: { x: 111, y: 11, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(199817),
+/* required buffer size: 199817 */{
+offset: 169,
+bytesPerRow: 22205,
+rowsPerImage: 44,
+},
+{width: 5502, height: 9, depthOrArrayLayers: 1}
+);
+} catch {}
+let adapter7 = await navigator.gpu.requestAdapter();
+let pipelineLayout13 = device2.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout18
+],
+}
+);
+let buffer29 = device2.createBuffer(
+{
+size: 63442,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: false,
+}
+);
+try {
+buffer29.unmap();
+} catch {}
+try {
+device2.queue.submit([
+commandBuffer12,
+]);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture74,
+  mipLevel: 0,
+  origin: { x: 2171, y: 22, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer6,
+/* required buffer size: 142144 */{
+offset: 36,
+bytesPerRow: 9492,
+rowsPerImage: 18,
+},
+{width: 2305, height: 15, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await promise34;
+} catch {}
+try {
+offscreenCanvas14.getContext('webgl');
+} catch {}
+let gpuCanvasContext20 = canvas26.getContext('webgpu');
+let buffer30 = device2.createBuffer(
+{
+label: '\u838f\u0bdd\u0225\u2e0c\u39e9\ua01a\u{1fe33}\ub060\u{1f920}\u8702\u0ebb',
+size: 14108,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+mappedAtCreation: true,
+}
+);
+let renderBundleEncoder43 = device2.createRenderBundleEncoder(
+{
+label: '\ua352\u7076\ue58a\u0017\u077c\u4faf\u8180\u1a4b\u{1f7e8}\u{1fd19}\u6690',
+colorFormats: [
+'rgba32uint',
+'r32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 219,
+depthReadOnly: true,
+}
+);
+document.body.prepend('\u0278\u4c70\u0905\u{1f964}\u{1fad5}\ua441\u{1fe86}\u{1fbda}\u{1ffab}');
+let canvas27 = document.createElement('canvas');
+try {
+window.someLabel = sampler50.label;
+} catch {}
+let textureView60 = texture74.createView(
+{
+label: '\u7afb\u1a6f\u{1fceb}\u0f79\u{1f6d5}\u6687',
+baseMipLevel: 3,
+mipLevelCount: 4,
+}
+);
+let sampler51 = device2.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 97.894,
+lodMaxClamp: 98.873,
+maxAnisotropy: 13,
+}
+);
+try {
+renderBundleEncoder43.setVertexBuffer(
+70,
+undefined,
+3925140623,
+277493340
+);
+} catch {}
+try {
+texture74.destroy();
+} catch {}
+canvas4.height = 709;
+gc();
+let imageData29 = new ImageData(236, 152);
+let textureView61 = texture74.createView(
+{
+label: '\u48ba\u03e3\u6db0',
+dimension: '2d-array',
+baseMipLevel: 4,
+mipLevelCount: 1,
+}
+);
+let sampler52 = device2.createSampler(
+{
+mipmapFilter: 'nearest',
+lodMinClamp: 58.427,
+lodMaxClamp: 89.639,
+}
+);
+document.body.prepend('\u{1f74e}\u{1fc12}\u634b\u6008');
+let videoFrame25 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+let querySet39 = device2.createQuerySet(
+{
+label: '\u{1faee}\u0c62\u{1f930}\u{1f62c}\u8fb3\u8854\uc390\u249b\u{1fd59}\u{1f882}\u22c1',
+type: 'occlusion',
+count: 1229,
+}
+);
+let texture76 = device2.createTexture(
+{
+label: '\u0f0f\u{1f805}\ubad4\ue25b\u05aa\udc5d\u0dfc',
+size: [124, 4, 59],
+mipLevelCount: 6,
+format: 'etc2-rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder44 = device2.createRenderBundleEncoder(
+{
+label: '\u{1f6d3}\uf6e6\u8a26\u3df8\u6e97\uc324',
+colorFormats: [
+undefined,
+undefined,
+'rg8uint',
+'rg16uint',
+undefined,
+'rgb10a2uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 410,
+}
+);
+try {
+renderBundleEncoder43.setVertexBuffer(
+47,
+undefined,
+3550131733,
+244810470
+);
+} catch {}
+let imageBitmap23 = await createImageBitmap(img8);
+let device4 = await adapter6.requestDevice(
+{
+label: '\u21ed\u{1fb51}\ufd88\ueed6\u{1f9c4}\u2b75\u0b30',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 6,
+maxColorAttachmentBytesPerSample: 64,
+maxVertexAttributes: 18,
+maxVertexBufferArrayStride: 51828,
+maxStorageTexturesPerShaderStage: 25,
+maxStorageBuffersPerShaderStage: 15,
+maxDynamicStorageBuffersPerPipelineLayout: 9574,
+maxBindingsPerBindGroup: 6180,
+maxTextureDimension1D: 8885,
+maxTextureDimension2D: 10548,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 9367609,
+maxInterStageShaderVariables: 72,
+maxInterStageShaderComponents: 118,
+},
+}
+);
+let offscreenCanvas16 = new OffscreenCanvas(454, 1000);
+let imageBitmap24 = await createImageBitmap(imageBitmap12);
+document.body.prepend('\u{1fa82}\u1d98\u629d\uae61\u7bcb\u0852\ub2bb\u28ec\u29b1');
+let videoFrame26 = new VideoFrame(video11, {timestamp: 0});
+let device5 = await adapter7.requestDevice(
+{
+label: '\ud30e\uc548\uf6e5\u95ab\u558f\u{1fb4e}\u0cf6\u047a\u0d5e',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxColorAttachmentBytesPerSample: 56,
+maxVertexAttributes: 22,
+maxVertexBufferArrayStride: 9315,
+maxStorageTexturesPerShaderStage: 7,
+maxStorageBuffersPerShaderStage: 12,
+maxDynamicStorageBuffersPerPipelineLayout: 60877,
+maxBindingsPerBindGroup: 8549,
+maxTextureDimension1D: 8393,
+maxTextureDimension2D: 10651,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 162268208,
+maxInterStageShaderVariables: 83,
+maxInterStageShaderComponents: 86,
+},
+}
+);
+let imageData30 = new ImageData(136, 192);
+let img29 = await imageWithData(254, 86, '#6b0aa90a', '#95670159');
+let buffer31 = device4.createBuffer(
+{
+label: '\u77bd\u1d22\u53c3',
+size: 59064,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let promise36 = device4.queue.onSubmittedWorkDone();
+canvas2.width = 974;
+document.body.prepend('\u0089\u4ac3\u9a87\ue4f1\u8154');
+let querySet40 = device2.createQuerySet(
+{
+type: 'occlusion',
+count: 4060,
+}
+);
+try {
+renderBundleEncoder44.setVertexBuffer(
+2,
+undefined,
+3077235278,
+306342681
+);
+} catch {}
+try {
+buffer29.destroy();
+} catch {}
+let promise37 = device2.queue.onSubmittedWorkDone();
+let img30 = await imageWithData(198, 296, '#e678b818', '#7df0bd35');
+let shaderModule8 = device2.createShaderModule(
+{
+label: '\uc77f\u01ac\u097d\u661b\u026a\uec1a\u9142\u{1ffaa}\u{1f9b7}',
+code: `@group(0) @binding(636)
+var<storage, read_write> type1: array<u32>;
+
+@compute @workgroup_size(3, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@location(91) a0: vec4<u32>, @location(67) a1: u32, @location(96) a2: vec2<i32>, @builtin(sample_mask) a3: u32, @location(71) a4: vec2<u32>, @location(28) a5: vec2<i32>, @location(3) a6: f32, @builtin(sample_index) a7: u32) {
+
+}
+
+struct VertexOutput0 {
+@location(105) f112: vec3<f32>,
+@location(40) f113: vec4<f16>,
+@location(79) f114: vec3<u32>,
+@location(12) f115: vec3<i32>,
+@location(35) f116: vec3<f32>,
+@location(65) f117: vec2<f16>,
+@location(66) f118: i32,
+@location(63) f119: vec2<i32>,
+@location(88) f120: u32,
+@location(71) f121: vec2<u32>,
+@location(32) f122: vec3<u32>,
+@location(86) f123: vec4<f32>,
+@location(72) f124: vec2<f16>,
+@location(27) f125: vec4<u32>,
+@location(108) f126: vec3<f16>,
+@location(56) f127: vec2<f32>,
+@builtin(position) f128: vec4<f32>,
+@location(74) f129: vec2<f16>,
+@location(67) f130: u32,
+@location(2) f131: vec2<u32>,
+@location(26) f132: vec3<i32>,
+@location(38) f133: vec2<u32>,
+@location(8) f134: f16,
+@location(13) f135: f16,
+@location(103) f136: vec3<i32>,
+@location(28) f137: vec2<i32>,
+@location(96) f138: vec2<i32>,
+@location(18) f139: vec2<i32>,
+@location(46) f140: vec3<u32>,
+@location(93) f141: i32,
+@location(62) f142: f32,
+@location(3) f143: f32,
+@location(97) f144: vec4<i32>,
+@location(6) f145: vec2<f32>,
+@location(91) f146: vec4<u32>,
+@location(5) f147: f32
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(24) a1: f16, @location(23) a2: vec4<u32>, @location(6) a3: vec2<u32>, @location(4) a4: vec4<f32>, @location(15) a5: vec4<i32>, @location(22) a6: vec4<f32>, @location(7) a7: vec4<i32>, @location(16) a8: i32, @location(20) a9: vec4<f32>, @location(17) a10: vec3<i32>, @location(2) a11: vec3<f16>, @location(19) a12: vec2<f16>, @location(18) a13: vec3<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let textureView62 = texture76.createView(
+{
+label: '\u{1f9b0}\u2ddc\ub50c\uf6d4\u16f0\u0ef0',
+baseMipLevel: 2,
+mipLevelCount: 1,
+baseArrayLayer: 15,
+arrayLayerCount: 21,
+}
+);
+let renderBundle52 = renderBundleEncoder41.finish(
+{
+
+}
+);
+let sampler53 = device2.createSampler(
+{
+label: '\u{1fc0b}\u0575\u{1fbdd}\u3570\u04b2\u223b\u5d50\u0a12\u06f8\u39b1',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMaxClamp: 79.163,
+}
+);
+let pipelineLayout14 = device2.createPipelineLayout(
+{
+bindGroupLayouts: [
+
+],
+}
+);
+let commandEncoder74 = device2.createCommandEncoder(
+{
+label: '\ua5ca\u0b2c\u001b\u79bf\u{1f9dc}',
+}
+);
+let renderBundle53 = renderBundleEncoder44.finish();
+let pipeline48 = await device2.createComputePipelineAsync(
+{
+label: '\u9f87\u9c01\u0aad\u865b\u{1fd1d}\u0745\u09b3\ub9a1\uc5e1',
+layout: pipelineLayout14,
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+},
+}
+);
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let img31 = await imageWithData(92, 277, '#9596abbb', '#3d9a0084');
+let querySet41 = device2.createQuerySet(
+{
+type: 'occlusion',
+count: 2908,
+}
+);
+pseudoSubmit(device2, commandEncoder74);
+let renderBundle54 = renderBundleEncoder41.finish(
+{
+label: '\u2d14\u09af\uef1b\u07c4\u6af5'
+}
+);
+try {
+device2.queue.writeBuffer(
+buffer27,
+14128,
+new BigUint64Array(12553),
+8533
+);
+} catch {}
+let renderBundleEncoder45 = device5.createRenderBundleEncoder(
+{
+label: '\u85aa\u0cea\u{1fd8c}\u{1fa8b}',
+colorFormats: [
+'r16sint',
+'rgb10a2uint',
+'rg8uint',
+'rg8uint',
+'rg8unorm',
+'r8unorm',
+'bgra8unorm-srgb'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 236,
+}
+);
+try {
+renderBundleEncoder45.setVertexBuffer(
+42,
+undefined
+);
+} catch {}
+document.body.append('\u4936\u0a04\u{1f668}\u7f8e\u5145\u3b80');
+let sampler54 = device5.createSampler(
+{
+label: '\u00ea\u77ec\uffe1\u{1f678}\u00f0\u3b1f\u0538\u8ff1\u5b34\uded4',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+maxAnisotropy: 7,
+}
+);
+try {
+await promise37;
+} catch {}
+let canvas28 = document.createElement('canvas');
+let commandEncoder75 = device5.createCommandEncoder(
+{
+label: '\uf1b6\u8a9d',
+}
+);
+let texture77 = device5.createTexture(
+{
+label: '\uecf2\u2b7b\uc474\ua21a\u0f7c\u09d4\ued2b\u9f5b\u042a\u{1f859}\u0563',
+size: {width: 51, height: 140, depthOrArrayLayers: 1},
+format: 'stencil8',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'stencil8',
+'stencil8'
+],
+}
+);
+let computePassEncoder49 = commandEncoder75.beginComputePass();
+let renderBundle55 = renderBundleEncoder45.finish(
+{
+label: '\u{1fe9e}\u0cfe\u{1f9af}\u{1ff51}\u{1fc77}\u{1f6ab}\ufa01\u3150\u6958\u{1ff2c}\u{1fddd}'
+}
+);
+let promise38 = device5.queue.onSubmittedWorkDone();
+let texture78 = device4.createTexture(
+{
+label: '\u8a77\u1185\ud43c\u557a\u{1f8fa}\u1251\ud3bf',
+size: {width: 100, height: 168, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let bindGroupLayout20 = device4.createBindGroupLayout(
+{
+label: '\u{1f94e}\u{1f999}\u0e87\ud98a\u{1fac6}\u019a',
+entries: [
+
+],
+}
+);
+let bindGroup54 = device4.createBindGroup({
+label: '\u{1fee8}\u{1f845}\ue8aa\uc132\udf4f\u0f4a\ub592\u0984\u{1fa3e}',
+layout: bindGroupLayout20,
+entries: [
+
+],
+});
+let commandEncoder76 = device4.createCommandEncoder(
+{
+label: '\ucd8d\u0eaa\u{1f6fa}\u5cad\u7dc2\uadee\u5551\u722d',
+}
+);
+let querySet42 = device4.createQuerySet(
+{
+label: '\u23af\u79cd\u{1fd19}\u{1fe02}',
+type: 'occlusion',
+count: 3855,
+}
+);
+let textureView63 = texture78.createView(
+{
+label: '\ue350\u72d7\u5a71\u{1f628}\u195a\u{1f607}\u0468\u03ce\u5d4f\u0d7a\u1e52',
+dimension: '2d-array',
+baseMipLevel: 1,
+}
+);
+let computePassEncoder50 = commandEncoder76.beginComputePass(
+{
+label: '\u0487\u1cd7'
+}
+);
+try {
+computePassEncoder50.end();
+} catch {}
+try {
+commandEncoder76.copyTextureToTexture(
+{
+  texture: texture78,
+  mipLevel: 1,
+  origin: { x: 8, y: 32, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture78,
+  mipLevel: 1,
+  origin: { x: 44, y: 36, z: 0 },
+  aspect: 'all',
+},
+{width: 8, height: 20, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipelineLayout15 = device4.createPipelineLayout(
+{
+bindGroupLayouts: [
+
+],
+}
+);
+let buffer32 = device4.createBuffer(
+{
+size: 45988,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let textureView64 = texture78.createView(
+{
+label: '\u{1f81d}\u00c9\u9641\u0af8\u694e',
+baseMipLevel: 1,
+}
+);
+let renderBundleEncoder46 = device4.createRenderBundleEncoder(
+{
+label: '\u27d2\u{1f9f4}\u0d8e',
+colorFormats: [
+'r32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 692,
+}
+);
+try {
+await buffer31.mapAsync(
+GPUMapMode.WRITE,
+51440,
+784
+);
+} catch {}
+let video20 = await videoWithData();
+let gpuCanvasContext21 = canvas27.getContext('webgpu');
+canvas28.height = 278;
+let imageData31 = new ImageData(184, 108);
+try {
+adapter7.label = '\ub358\u4c38\uc3de\u{1faf3}\u{1fdec}';
+} catch {}
+try {
+offscreenCanvas16.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder77 = device5.createCommandEncoder(
+{
+label: '\u384b\u59a2\u759c\uf491\u0c7f\ubbf0\ufa52',
+}
+);
+let computePassEncoder51 = commandEncoder77.beginComputePass(
+{
+label: '\uc7a2\u{1fc76}\u06e9\u02c5\u3b74\u73ba\u{1fc02}'
+}
+);
+let canvas29 = document.createElement('canvas');
+document.body.prepend(canvas1);
+let renderBundleEncoder47 = device5.createRenderBundleEncoder(
+{
+label: '\u{1f7f4}\u40a4\u0362\u2d11\u9b9e\u9ad6\u6ade\ue33f\u9262\ucab4',
+colorFormats: [
+'r32sint',
+'rgba8unorm-srgb',
+'bgra8unorm-srgb',
+'rg32float',
+'rg11b10ufloat',
+'rg16uint',
+'r32float',
+'rgb10a2unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 653,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+let renderBundle56 = renderBundleEncoder45.finish(
+{
+label: '\u0faa\u{1f7d5}\u{1fe1c}'
+}
+);
+let offscreenCanvas17 = new OffscreenCanvas(770, 394);
+let imageData32 = new ImageData(216, 44);
+let videoFrame27 = videoFrame7.clone();
+let buffer33 = device5.createBuffer(
+{
+label: '\u{1f886}\u0e61\uae2c\u06e8',
+size: 21994,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: false,
+}
+);
+let renderBundleEncoder48 = device5.createRenderBundleEncoder(
+{
+label: '\u{1fe03}\u{1fde0}\u08ed\u62fe\u3aaf\u1adf',
+colorFormats: [
+'r8unorm',
+'r16uint',
+'rg8uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 615,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder48.insertDebugMarker(
+'\u0e5e'
+);
+} catch {}
+try {
+device5.queue.writeBuffer(
+buffer33,
+13300,
+new Float32Array(43096),
+9163,
+1820
+);
+} catch {}
+document.body.prepend('\u{1fe63}\u{1f6c6}\u3355\u{1fb0e}\u17a6');
+let imageData33 = new ImageData(156, 172);
+let buffer34 = device4.createBuffer(
+{
+label: '\u227c\u0145\u3454\u300f\u0996\uf025\u0669\u{1fa18}\u83cf',
+size: 18856,
+usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+}
+);
+let querySet43 = device4.createQuerySet(
+{
+label: '\u04f6\u0097\u0dd8\u84ca\ub78e\u2835\u{1ff52}\u01ec\u0645',
+type: 'occlusion',
+count: 2536,
+}
+);
+let texture79 = device4.createTexture(
+{
+label: '\u0efa\u5e43\uf5b9\ueef4\u9777',
+size: {width: 139, height: 1, depthOrArrayLayers: 176},
+mipLevelCount: 1,
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'r8uint',
+'r8uint',
+'r8uint'
+],
+}
+);
+let sampler55 = device4.createSampler(
+{
+label: '\u31cb\uc362\u770d\u3d6b',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+maxAnisotropy: 18,
+}
+);
+try {
+renderBundleEncoder46.setIndexBuffer(
+buffer34,
+'uint32',
+4136,
+9391
+);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(
+81,
+undefined,
+3412177188,
+82517087
+);
+} catch {}
+try {
+renderBundleEncoder46.insertDebugMarker(
+'\u{1fc6d}'
+);
+} catch {}
+let promise39 = device4.queue.onSubmittedWorkDone();
+let videoFrame28 = new VideoFrame(canvas6, {timestamp: 0});
+let renderBundleEncoder49 = device2.createRenderBundleEncoder(
+{
+label: '\u4c25\u4755\u{1fc73}\u{1fe03}\ua2b7\u094c',
+colorFormats: [
+'rgba16uint',
+'rgba8unorm',
+undefined,
+'rg16uint',
+undefined,
+'rgba16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 27,
+depthReadOnly: true,
+}
+);
+try {
+gpuCanvasContext6.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgb10a2unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+offscreenCanvas4.height = 836;
+let imageData34 = new ImageData(160, 140);
+let querySet44 = device4.createQuerySet(
+{
+label: '\u461d\uc91d\u0d08\u{1f707}\u4934\u5b57\u03a6',
+type: 'occlusion',
+count: 1420,
+}
+);
+let textureView65 = texture79.createView(
+{
+dimension: '2d-array',
+baseArrayLayer: 15,
+arrayLayerCount: 119,
+}
+);
+let computePassEncoder52 = commandEncoder76.beginComputePass(
+{
+label: '\u0f28\u00b1\u097f\u6eb9'
+}
+);
+try {
+buffer31.unmap();
+} catch {}
+video8.width = 165;
+let img32 = await imageWithData(181, 201, '#03b4a6d0', '#572c430b');
+let bindGroupLayout21 = device2.createBindGroupLayout(
+{
+label: '\u{1fc78}\ue8fa',
+entries: [
+{
+binding: 219,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+}
+],
+}
+);
+try {
+renderBundleEncoder49.setVertexBuffer(
+18,
+undefined,
+1233373056,
+160354088
+);
+} catch {}
+let texture80 = device2.createTexture(
+{
+label: '\u{1fb4e}\u9ae5',
+size: {width: 671, height: 1, depthOrArrayLayers: 1696},
+mipLevelCount: 11,
+dimension: '3d',
+format: 'rg32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32uint',
+'rg32uint'
+],
+}
+);
+let textureView66 = texture74.createView(
+{
+label: '\u09f4\u8ed9\uae1d\u4e2f\u03a1\u0a09',
+dimension: '2d-array',
+aspect: 'all',
+baseMipLevel: 4,
+mipLevelCount: 2,
+}
+);
+let renderBundleEncoder50 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8unorm-srgb'
+],
+sampleCount: 464,
+stencilReadOnly: true,
+}
+);
+let sampler56 = device2.createSampler(
+{
+label: '\u7b54\u30b5\u0d04\ud6b9',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 23.834,
+lodMaxClamp: 27.145,
+maxAnisotropy: 2,
+}
+);
+try {
+gpuCanvasContext18.configure(
+{
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture80,
+  mipLevel: 1,
+  origin: { x: 8, y: 0, z: 570 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 70687103 */{
+offset: 383,
+bytesPerRow: 1770,
+rowsPerImage: 192,
+},
+{width: 221, height: 0, depthOrArrayLayers: 209}
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext22 = offscreenCanvas15.getContext('webgpu');
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+document.body.append('\ub92b\ub663\u{1ff52}');
+document.body.prepend(img32);
+gc();
+let bindGroupLayout22 = device5.createBindGroupLayout(
+{
+label: '\u70ef\u7866\u8084\ua313\u05f0\u74c9\u0951\u43f3',
+entries: [
+
+],
+}
+);
+let querySet45 = device5.createQuerySet(
+{
+label: '\u86f0\u8d49\u0cbc\u06a0\ua6de\u4406\u09f7\u0a62\u{1fee9}\u03b3',
+type: 'occlusion',
+count: 2792,
+}
+);
+let textureView67 = texture77.createView(
+{
+label: '\u6173\u63e9\u0f85\uaf11\u{1f7fd}\u71e9\u0e06\u{1f74d}\u{1f63f}\u88eb\udf72',
+}
+);
+let renderBundle57 = renderBundleEncoder45.finish();
+try {
+device5.destroy();
+} catch {}
+document.body.prepend('\uc985\u1645');
+let querySet46 = device2.createQuerySet(
+{
+label: '\u0bc3\u61ab\u0d36\u2394\ue251\ud594\u{1fb09}\u58af\ub8cc',
+type: 'occlusion',
+count: 1086,
+}
+);
+let textureView68 = texture74.createView(
+{
+dimension: '2d-array',
+baseMipLevel: 5,
+mipLevelCount: 1,
+}
+);
+try {
+device2.queue.writeBuffer(
+buffer27,
+21828,
+new BigUint64Array(15950),
+7879,
+4200
+);
+} catch {}
+gc();
+document.body.prepend('\u2458\u{1f9ef}\u27c8');
+let offscreenCanvas18 = new OffscreenCanvas(463, 340);
+let sampler57 = device4.createSampler(
+{
+label: '\u01f1\ub4e4',
+addressModeU: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 4.956,
+lodMaxClamp: 5.193,
+}
+);
+try {
+computePassEncoder52.setBindGroup(
+5,
+bindGroup54
+);
+} catch {}
+try {
+renderBundleEncoder46.setBindGroup(
+0,
+bindGroup54,
+new Uint32Array(2081),
+593,
+0
+);
+} catch {}
+try {
+renderBundleEncoder46.setIndexBuffer(
+buffer34,
+'uint16',
+8706,
+2197
+);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(
+5,
+undefined
+);
+} catch {}
+try {
+await promise36;
+} catch {}
+let offscreenCanvas19 = new OffscreenCanvas(478, 1000);
+let imageBitmap25 = await createImageBitmap(img24);
+try {
+window.someLabel = device2.label;
+} catch {}
+try {
+await buffer28.mapAsync(
+GPUMapMode.READ,
+376
+);
+} catch {}
+try {
+renderBundleEncoder43.pushDebugGroup(
+'\u{1f8c9}'
+);
+} catch {}
+let pipeline49 = await device2.createComputePipelineAsync(
+{
+label: '\u9119\u0601',
+layout: pipelineLayout14,
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline50 = await device2.createRenderPipelineAsync(
+{
+layout: pipelineLayout14,
+vertex: {
+module: shaderModule8,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 3292,
+attributes: [
+{
+format: 'float32x3',
+offset: 396,
+shaderLocation: 20,
+},
+{
+format: 'sint8x4',
+offset: 2864,
+shaderLocation: 16,
+},
+{
+format: 'uint16x4',
+offset: 3260,
+shaderLocation: 23,
+},
+{
+format: 'float16x2',
+offset: 2204,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 6124,
+attributes: [
+{
+format: 'uint16x2',
+offset: 3848,
+shaderLocation: 6,
+},
+{
+format: 'sint32x3',
+offset: 3068,
+shaderLocation: 15,
+},
+{
+format: 'snorm8x4',
+offset: 3428,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x2',
+offset: 2922,
+shaderLocation: 4,
+},
+{
+format: 'sint32',
+offset: 4692,
+shaderLocation: 7,
+},
+{
+format: 'float32',
+offset: 5660,
+shaderLocation: 2,
+},
+{
+format: 'sint32',
+offset: 6080,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 9056,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x4',
+offset: 3412,
+shaderLocation: 24,
+}
+],
+},
+{
+arrayStride: 2152,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 9892,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 5352,
+shaderLocation: 22,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0x10b0545c,
+},
+fragment: {
+module: shaderModule8,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+failOp: 'decrement-wrap',
+depthFailOp: 'replace',
+passOp: 'invert',
+},
+stencilReadMask: 331,
+stencilWriteMask: 818,
+depthBias: 56,
+depthBiasClamp: 45,
+},
+}
+);
+let offscreenCanvas20 = new OffscreenCanvas(777, 698);
+try {
+offscreenCanvas18.getContext('bitmaprenderer');
+} catch {}
+let img33 = await imageWithData(278, 281, '#90812da4', '#95e6972f');
+let video21 = await videoWithData();
+let videoFrame29 = new VideoFrame(videoFrame0, {timestamp: 0});
+let imageBitmap26 = await createImageBitmap(offscreenCanvas20);
+let querySet47 = device2.createQuerySet(
+{
+label: '\u1cfd\ud0d0\u{1fc98}',
+type: 'occlusion',
+count: 1601,
+}
+);
+let sampler58 = device2.createSampler(
+{
+label: '\u786d\u027d\u{1f91c}\u{1fe86}\u06b3\u7559\u{1fa5c}',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 1.322,
+compare: 'greater',
+}
+);
+try {
+device2.pushErrorScope(
+'validation'
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture80,
+  mipLevel: 4,
+  origin: { x: 1, y: 0, z: 8 },
+  aspect: 'all',
+},
+arrayBuffer7,
+/* required buffer size: 5658504 */{
+offset: 760,
+bytesPerRow: 373,
+rowsPerImage: 237,
+},
+{width: 10, height: 1, depthOrArrayLayers: 65}
+);
+} catch {}
+let querySet48 = device2.createQuerySet(
+{
+label: '\u0b4f\u{1fe6e}\u{1fdd8}\u089f\u09d7\u{1fa14}\u{1f795}',
+type: 'occlusion',
+count: 3373,
+}
+);
+let renderBundleEncoder51 = device2.createRenderBundleEncoder(
+{
+label: '\u{1fdbc}\uc1fe\ud4df\u22c5\u{1fb68}\ufcc9\u{1f67c}\u0162\u0d67',
+colorFormats: [
+'r16float',
+'rgba16sint',
+'rgba16uint',
+'rg16float',
+'rgb10a2unorm',
+'rg8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 354,
+}
+);
+let renderBundle58 = renderBundleEncoder51.finish(
+{
+label: '\u9587\u0c46\u{1fd9a}\u01a9\u0e25\u{1fdda}\uf2c5\ue8c1\u2d12\u47da\uf6bf'
+}
+);
+try {
+device2.queue.writeTexture(
+{
+  texture: texture80,
+  mipLevel: 3,
+  origin: { x: 12, y: 0, z: 113 },
+  aspect: 'all',
+},
+new ArrayBuffer(80),
+/* required buffer size: 2563948 */{
+offset: 276,
+bytesPerRow: 340,
+rowsPerImage: 290,
+},
+{width: 9, height: 1, depthOrArrayLayers: 27}
+);
+} catch {}
+try {
+gpuCanvasContext22.unconfigure();
+} catch {}
+let img34 = await imageWithData(205, 269, '#1248f549', '#996e67b7');
+let imageData35 = new ImageData(156, 40);
+let bindGroup55 = device2.createBindGroup({
+label: '\ua246\u{1fc49}\u0f41\u0b4a\u071d\u0987',
+layout: bindGroupLayout21,
+entries: [
+{
+binding: 219,
+resource: textureView68
+}
+],
+});
+let renderBundle59 = renderBundleEncoder41.finish(
+{
+
+}
+);
+try {
+device2.queue.writeBuffer(
+buffer27,
+27948,
+new BigUint64Array(29978),
+21587,
+204
+);
+} catch {}
+let imageData36 = new ImageData(236, 112);
+try {
+computePassEncoder52.setBindGroup(
+4,
+bindGroup54,
+[]
+);
+} catch {}
+document.body.prepend('\u19ee\u9e44\ue64a\u{1f817}\u{1fa59}\u62a1\u01f7\u7f8f');
+let img35 = await imageWithData(132, 156, '#ca8c4bae', '#c33befca');
+try {
+await promise39;
+} catch {}
+offscreenCanvas1.width = 706;
+document.body.append('\u{1fd45}\u04c8\u1500');
+let canvas30 = document.createElement('canvas');
+let gpuCanvasContext23 = offscreenCanvas19.getContext('webgpu');
+try {
+canvas30.getContext('webgl');
+} catch {}
+let videoFrame30 = new VideoFrame(video4, {timestamp: 0});
+let texture81 = device4.createTexture(
+{
+label: '\u{1fc6b}\u0f73\ub0c1\uc2db\u{1f83e}\u0049\u{1fc86}',
+size: [7468, 4, 214],
+mipLevelCount: 12,
+format: 'eac-r11snorm',
+usage: GPUTextureUsage.COPY_DST,
+}
+);
+let sampler59 = device4.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 25.119,
+compare: 'equal',
+maxAnisotropy: 1,
+}
+);
+let imageData37 = new ImageData(216, 176);
+try {
+await promise38;
+} catch {}
+let offscreenCanvas21 = new OffscreenCanvas(428, 393);
+let bindGroup56 = device5.createBindGroup({
+label: '\u{1ff19}\ud4cd\uddc7\uc305\uf4a0\u32ea\u24d4\u040c\u049d',
+layout: bindGroupLayout22,
+entries: [
+
+],
+});
+let pipelineLayout16 = device5.createPipelineLayout(
+{
+label: '\u06c6\u3f85\u1c55\u0a70\u0427\u0bf1\u810d',
+bindGroupLayouts: [
+
+],
+}
+);
+let texture82 = device5.createTexture(
+{
+label: '\u{1fd50}\u7114\u{1f857}\u8025\u954d\u5acd\u4e7d\u{1f6a4}\u0314\ucba4\u052d',
+size: [37, 610, 1],
+mipLevelCount: 7,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST,
+}
+);
+let textureView69 = texture82.createView(
+{
+baseMipLevel: 1,
+mipLevelCount: 6,
+}
+);
+let renderBundleEncoder52 = device5.createRenderBundleEncoder(
+{
+label: '\u{1f9d2}\u0661\u0d40\uca90\u1193\u6fb0',
+colorFormats: [
+'r32sint',
+'r8uint',
+'rgba8uint',
+'r8uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 152,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder51.setBindGroup(
+2,
+bindGroup56
+);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(
+88,
+undefined,
+2204166887,
+2003288755
+);
+} catch {}
+try {
+renderBundleEncoder48.pushDebugGroup(
+'\u04b0'
+);
+} catch {}
+try {
+renderBundleEncoder48.popDebugGroup();
+} catch {}
+gc();
+document.body.append('\u0649\u0059\u00e2\u{1f7cf}\u0be7\ue856\u{1f75d}\u96cf\u76ba');
+let commandEncoder78 = device4.createCommandEncoder(
+{
+label: '\u8034\u0d82\ub13d\u52ff\u1b63\uf6ed\u0b3b',
+}
+);
+try {
+commandEncoder78.copyBufferToTexture(
+{
+/* bytesInLastRow: 64 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 47888 */
+offset: 47888,
+bytesPerRow: 256,
+buffer: buffer31,
+},
+{
+  texture: texture78,
+  mipLevel: 1,
+  origin: { x: 16, y: 4, z: 0 },
+  aspect: 'all',
+},
+{width: 32, height: 36, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device4, buffer31);
+} catch {}
+try {
+commandEncoder78.copyTextureToTexture(
+{
+  texture: texture78,
+  mipLevel: 0,
+  origin: { x: 12, y: 16, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture78,
+  mipLevel: 1,
+  origin: { x: 32, y: 4, z: 0 },
+  aspect: 'all',
+},
+{width: 4, height: 56, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend('\ucfc9\uab02\ubfb0\u{1fe32}\u3cc0\u8ad8\u2711\u4d25');
+let offscreenCanvas22 = new OffscreenCanvas(658, 757);
+let gpuCanvasContext24 = offscreenCanvas21.getContext('webgpu');
+let imageBitmap27 = await createImageBitmap(videoFrame10);
+let offscreenCanvas23 = new OffscreenCanvas(863, 445);
+let video22 = await videoWithData();
+let imageBitmap28 = await createImageBitmap(imageData22);
+let buffer35 = device4.createBuffer(
+{
+label: '\ue4c1\u05b8\u0af0\u01b4\u04c0\u{1f75d}\u052b\u0fdd\u09dc\u09b6\u{1ff35}',
+size: 59542,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let textureView70 = texture79.createView(
+{
+label: '\u{1ffef}\ud648\uae0c\u0675\u2276\u096a\u37ff',
+dimension: '2d',
+baseArrayLayer: 111,
+}
+);
+let computePassEncoder53 = commandEncoder78.beginComputePass();
+try {
+renderBundleEncoder46.setVertexBuffer(
+35,
+undefined,
+1644827884,
+1986218987
+);
+} catch {}
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let canvas31 = document.createElement('canvas');
+try {
+canvas31.getContext('webgl2');
+} catch {}
+let pipelineLayout17 = device2.createPipelineLayout(
+{
+label: '\u39eb\uefb8\u4edf\u15ae\u6726\u8b5a\ua4a2\u08f8\u6948',
+bindGroupLayouts: [
+bindGroupLayout18,
+bindGroupLayout18,
+bindGroupLayout21,
+bindGroupLayout21,
+bindGroupLayout21,
+bindGroupLayout18,
+bindGroupLayout21,
+bindGroupLayout21
+],
+}
+);
+try {
+renderBundleEncoder49.setBindGroup(
+9,
+bindGroup55
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer27,
+36156,
+new BigUint64Array(26461),
+8769,
+16
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture80,
+  mipLevel: 9,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new BigUint64Array(arrayBuffer11),
+/* required buffer size: 1118 */{
+offset: 680,
+bytesPerRow: 10,
+rowsPerImage: 43,
+},
+{width: 1, height: 1, depthOrArrayLayers: 2}
+);
+} catch {}
+let promise40 = device2.queue.onSubmittedWorkDone();
+let pipeline51 = await device2.createRenderPipelineAsync(
+{
+label: '\u{1ff37}\u15ab\uc6f6\u8db8\u7ee2\u7874',
+layout: 'auto',
+vertex: {
+module: shaderModule8,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 3656,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 1424,
+shaderLocation: 4,
+},
+{
+format: 'sint32x2',
+offset: 2436,
+shaderLocation: 17,
+},
+{
+format: 'sint32x2',
+offset: 1972,
+shaderLocation: 15,
+},
+{
+format: 'sint32',
+offset: 256,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x2',
+offset: 1340,
+shaderLocation: 19,
+},
+{
+format: 'uint8x2',
+offset: 2712,
+shaderLocation: 23,
+},
+{
+format: 'sint32',
+offset: 2136,
+shaderLocation: 7,
+},
+{
+format: 'float32',
+offset: 1032,
+shaderLocation: 18,
+},
+{
+format: 'uint16x4',
+offset: 2288,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 3708,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 3392,
+shaderLocation: 20,
+},
+{
+format: 'unorm8x2',
+offset: 782,
+shaderLocation: 22,
+},
+{
+format: 'snorm8x4',
+offset: 2528,
+shaderLocation: 24,
+},
+{
+format: 'snorm16x2',
+offset: 2796,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0x2d739692,
+},
+fragment: {
+module: shaderModule8,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+failOp: 'replace',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 945,
+depthBias: 43,
+depthBiasClamp: 1,
+},
+}
+);
+document.body.prepend(video14);
+offscreenCanvas21.width = 2;
+let renderBundleEncoder53 = device2.createRenderBundleEncoder(
+{
+label: '\ufd35\u{1fc78}\u2f47\ubbeb\u04eb\ud61d\u0cdf\u0646\u{1f63a}\uf043\u0ab7',
+colorFormats: [
+'rg16uint',
+'rg32uint'
+],
+sampleCount: 621,
+}
+);
+let renderBundle60 = renderBundleEncoder51.finish(
+{
+label: '\u6d14\u{1f6f0}\ue828\u023f\u8a63\u97fc\u6cde\u067f\ub259'
+}
+);
+let pipeline52 = device2.createRenderPipeline(
+{
+label: '\u929a\uc100\ua9a2',
+layout: pipelineLayout17,
+vertex: {
+module: shaderModule8,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 3464,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 2208,
+shaderLocation: 20,
+},
+{
+format: 'snorm8x2',
+offset: 1716,
+shaderLocation: 22,
+},
+{
+format: 'snorm16x4',
+offset: 408,
+shaderLocation: 24,
+},
+{
+format: 'sint32x4',
+offset: 2672,
+shaderLocation: 7,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 84,
+shaderLocation: 18,
+},
+{
+format: 'snorm16x2',
+offset: 2820,
+shaderLocation: 2,
+},
+{
+format: 'sint32x4',
+offset: 2952,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x4',
+offset: 756,
+shaderLocation: 19,
+},
+{
+format: 'sint32',
+offset: 2536,
+shaderLocation: 15,
+},
+{
+format: 'float32x3',
+offset: 528,
+shaderLocation: 4,
+},
+{
+format: 'uint32x4',
+offset: 1568,
+shaderLocation: 6,
+},
+{
+format: 'uint8x4',
+offset: 1900,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 2832,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x2',
+offset: 1020,
+shaderLocation: 17,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule8,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'replace',
+depthFailOp: 'increment-wrap',
+passOp: 'invert',
+},
+stencilWriteMask: 2371,
+depthBias: 3,
+depthBiasSlopeScale: 30,
+},
+}
+);
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let gpuCanvasContext25 = offscreenCanvas20.getContext('webgpu');
+document.body.prepend('\ub606\uc420\uc27d\u0308\u886e\u0563\u077d\u3948\u5ef4\ua28e\ubab6');
+try {
+adapter3.label = '\u08cb\u95cf\ue4b0\ub8c9\u{1ff33}\ue43c';
+} catch {}
+let gpuCanvasContext26 = offscreenCanvas23.getContext('webgpu');
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+document.body.prepend('\u9c9d\ubb35\u431f\u{1fbbf}\u09fe\u4545');
+let videoFrame31 = videoFrame6.clone();
+try {
+canvas28.getContext('2d');
+} catch {}
+document.body.append('\u3190\ub978\u0898\uad2c\ucf05');
+let texture83 = device2.createTexture(
+{
+label: '\u{1fc6d}\u09cf\u0d23',
+size: [11, 11, 134],
+mipLevelCount: 8,
+dimension: '3d',
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView71 = texture74.createView(
+{
+label: '\ub8f6\ua4ec\ufaa8\u02ce\u9e7b\u6e54',
+baseMipLevel: 3,
+mipLevelCount: 3,
+}
+);
+let renderBundle61 = renderBundleEncoder41.finish(
+{
+label: '\u0433\ue6e7\udaca\ub431'
+}
+);
+try {
+renderBundleEncoder43.popDebugGroup();
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer27,
+19640,
+new Float32Array(15923),
+11792,
+3556
+);
+} catch {}
+try {
+await promise40;
+} catch {}
+try {
+gpuCanvasContext26.unconfigure();
+} catch {}
+document.body.append('\u{1fc2c}\udde0\u2e3f\u3b9a');
+document.body.append('\u{1fa42}\u0a6e\ud9fc\ufc17\u24a9\u5434');
+document.body.prepend('\uf315\u041e\udd54\u{1f9e2}\u{1f6e9}\u5b24\ubbb7\ua8a2\u024f');
+let video23 = await videoWithData();
+let texture84 = device2.createTexture(
+{
+label: '\u092f\u0de7\u9fa3\u5d3c\u{1f8d3}\ufa3e\u8a69\u04b6',
+size: {width: 240, height: 96, depthOrArrayLayers: 16},
+mipLevelCount: 2,
+format: 'eac-r11snorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'eac-r11snorm',
+'eac-r11snorm'
+],
+}
+);
+let sampler60 = device2.createSampler(
+{
+label: '\u{1f737}\u{1fdbb}\u{1ffb7}\u03b7\ue087\u051e\udee0\u0fbb\u0b3c',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 42.478,
+lodMaxClamp: 75.266,
+}
+);
+let img36 = await imageWithData(102, 60, '#69c3f92c', '#6e48d305');
+let canvas32 = document.createElement('canvas');
+document.body.prepend('\u00a1\u055c\uf41d\uaa95\u3a64\uf68f\u{1f73b}\uda00\u855b\uc24d\u447d');
+let offscreenCanvas24 = new OffscreenCanvas(757, 80);
+let imageBitmap29 = await createImageBitmap(imageBitmap20);
+try {
+offscreenCanvas22.getContext('webgl2');
+} catch {}
+document.body.append('\u8eb0\u{1fcbb}\u8b92\u4961\u{1fe5f}\u815f\u1496\u75df\uf135\u{1f8ae}\uab94');
+try {
+offscreenCanvas24.getContext('webgl2');
+} catch {}
+let bindGroup57 = device4.createBindGroup({
+label: '\u61ce\u{1f829}\u5679\u0350',
+layout: bindGroupLayout20,
+entries: [
+
+],
+});
+let querySet49 = device4.createQuerySet(
+{
+label: '\u07aa\u020b\u8231',
+type: 'occlusion',
+count: 2733,
+}
+);
+let textureView72 = texture78.createView(
+{
+label: '\u6ec3\ue929',
+}
+);
+let renderBundleEncoder54 = device4.createRenderBundleEncoder(
+{
+label: '\u0e02\u{1fb2e}\u0ca9\u8fc4\u935e\u14cb\u0e48\u3643\u{1f620}\ubec1\u{1ff37}',
+colorFormats: [
+'r8sint',
+'r32uint',
+'r8sint',
+'rgba16float',
+'r8unorm',
+'rg32sint',
+'rg8unorm',
+'r16uint'
+],
+sampleCount: 772,
+}
+);
+try {
+computePassEncoder53.setBindGroup(
+0,
+bindGroup54,
+new Uint32Array(7144),
+1054,
+0
+);
+} catch {}
+try {
+renderBundleEncoder54.setVertexBuffer(
+37,
+undefined,
+3513058745,
+740244263
+);
+} catch {}
+try {
+gpuCanvasContext15.configure(
+{
+device: device4,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+document.body.prepend('\u0ffe\u3acd\u4a37\ueeae\u{1f879}');
+let bindGroupLayout23 = device2.createBindGroupLayout(
+{
+label: '\u0dd8\u{1f9d2}\ued7b',
+entries: [
+{
+binding: 430,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+},
+{
+binding: 939,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+}
+],
+}
+);
+try {
+buffer27.unmap();
+} catch {}
+document.body.prepend('\ua5ed\uc406\u162e\u9661');
+let img37 = await imageWithData(145, 134, '#431caf37', '#2e0a61a8');
+document.body.prepend('\ud665\u9ad8\u0296\ufb37\ubee8\u{1fe77}\ud359\u9a67\u{1fe37}\u05fc');
+let video24 = await videoWithData();
+let imageData38 = new ImageData(208, 232);
+let gpuCanvasContext27 = canvas32.getContext('webgpu');
+let promise41 = adapter2.requestAdapterInfo();
+let renderBundleEncoder55 = device4.createRenderBundleEncoder(
+{
+label: '\u059f\ue523\u{1f894}\ucf6d\u{1f6ca}\u8f86\ua285\ud89d\u7a41',
+colorFormats: [
+undefined,
+undefined,
+'r16sint',
+undefined,
+undefined,
+'rg16float',
+'r8unorm'
+],
+sampleCount: 403,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle62 = renderBundleEncoder54.finish(
+{
+label: '\u0560\u8658\u0f4d\u{1fa4a}\u96ef\u2db5\u9151\u09e8\u{1f800}\u836e\ubd6b'
+}
+);
+try {
+renderBundleEncoder46.setBindGroup(
+5,
+bindGroup54
+);
+} catch {}
+try {
+computePassEncoder53.end();
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+document.body.append('\u0007\u0f4e\ue9c5\u{1f916}\u0ff4\uc8b2\u8885\u1181\u{1fdd6}');
+try {
+renderBundleEncoder53.setBindGroup(
+2,
+bindGroup55
+);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(
+3,
+undefined
+);
+} catch {}
+let arrayBuffer13 = buffer30.getMappedRange(
+0,
+11560
+);
+try {
+await promise41;
+} catch {}
+document.body.append('\uf40d\u{1fa7b}\u{1fe68}\u0481\u1242\uba41\u8a50\u{1fd54}\u2f2a\u{1f649}');
+let imageBitmap30 = await createImageBitmap(canvas16);
+let bindGroupLayout24 = device2.createBindGroupLayout(
+{
+label: '\u0086\u87b6\u{1faf3}\u{1fd06}\u06e9\u26bb\u5099\u0760\u08d2\uf5d7\ud575',
+entries: [
+
+],
+}
+);
+let renderBundle63 = renderBundleEncoder51.finish(
+{
+label: '\u3fbf\u0476\u6c84\u8153\u9b4e\u{1f768}'
+}
+);
+try {
+renderBundleEncoder43.setBindGroup(
+6,
+bindGroup55
+);
+} catch {}
+try {
+device2.pushErrorScope(
+'validation'
+);
+} catch {}
+let promise42 = device2.queue.onSubmittedWorkDone();
+let commandEncoder79 = device2.createCommandEncoder(
+{
+label: '\u99f5\u037b\uda81\u01eb\ud983\u99f4\udfe9\u05df\u05f6\u5262\u3039',
+}
+);
+let textureView73 = texture80.createView(
+{
+label: '\u{1f86f}\u{1fe0d}\ua737',
+baseMipLevel: 9,
+mipLevelCount: 1,
+baseArrayLayer: 0,
+arrayLayerCount: 1,
+}
+);
+let renderBundle64 = renderBundleEncoder49.finish(
+{
+label: '\u36f4\u058d\u{1f9c5}'
+}
+);
+let sampler61 = device2.createSampler(
+{
+label: '\u09c5\ufc6e\u{1ffb3}\u0295\u30b3\u04b2\u1d92\ubd08',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 14.549,
+lodMaxClamp: 95.124,
+}
+);
+try {
+commandEncoder79.copyBufferToBuffer(
+buffer30,
+24,
+buffer29,
+16816,
+10444
+);
+dissociateBuffer(device2, buffer30);
+dissociateBuffer(device2, buffer29);
+} catch {}
+try {
+commandEncoder79.clearBuffer(
+buffer27,
+11560
+);
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+commandEncoder79.resolveQuerySet(
+querySet47,
+1086,
+344,
+buffer30,
+6912
+);
+} catch {}
+let pipeline53 = device2.createComputePipeline(
+{
+label: '\uf9ac\ue205\u0294\u{1f672}\u0911\u05d8',
+layout: pipelineLayout17,
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+try {
+offscreenCanvas17.getContext('webgpu');
+} catch {}
+let gpuCanvasContext28 = canvas29.getContext('webgpu');
+let bindGroup58 = device5.createBindGroup({
+label: '\u7ca2\u0096\u{1f70b}\u0aaf\u0b26',
+layout: bindGroupLayout22,
+entries: [
+
+],
+});
+let video25 = await videoWithData();
+let imageBitmap31 = await createImageBitmap(imageBitmap3);
+let videoFrame32 = new VideoFrame(img11, {timestamp: 0});
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let adapter8 = await promise19;
+let bindGroup59 = device4.createBindGroup({
+layout: bindGroupLayout20,
+entries: [
+
+],
+});
+let buffer36 = device4.createBuffer(
+{
+size: 58083,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: false,
+}
+);
+let texture85 = device4.createTexture(
+{
+label: '\u33a0\u7d93',
+size: {width: 169, height: 1, depthOrArrayLayers: 219},
+mipLevelCount: 6,
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder54 = commandEncoder78.beginComputePass(
+{
+label: '\u{1f86e}\u31a5\u0440\u{1f716}\ueaea\u{1fecc}\u06b1\uaadb\u6c0d\ufb66\uc167'
+}
+);
+try {
+computePassEncoder52.setBindGroup(
+5,
+bindGroup57,
+new Uint32Array(6785),
+1939,
+0
+);
+} catch {}
+try {
+gpuCanvasContext26.configure(
+{
+device: device4,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rgb10a2uint',
+'rgba16float',
+'rgba16float'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer35,
+22416,
+new Float32Array(62062),
+22044,
+6600
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture78,
+  mipLevel: 1,
+  origin: { x: 4, y: 24, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 830 */{
+offset: 830,
+bytesPerRow: 89,
+},
+{width: 44, height: 20, depthOrArrayLayers: 0}
+);
+} catch {}
+let bindGroup60 = device2.createBindGroup({
+layout: bindGroupLayout24,
+entries: [
+
+],
+});
+try {
+commandEncoder79.copyTextureToBuffer(
+{
+  texture: texture76,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 26 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 7056 */
+offset: 7056,
+bytesPerRow: 0,
+rowsPerImage: 295,
+buffer: buffer27,
+},
+{width: 0, height: 0, depthOrArrayLayers: 31}
+);
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+commandEncoder79.resolveQuerySet(
+querySet48,
+3339,
+8,
+buffer30,
+1536
+);
+} catch {}
+let offscreenCanvas25 = new OffscreenCanvas(875, 610);
+let imageBitmap32 = await createImageBitmap(imageData3);
+document.body.prepend('\u02af\u34cd\u725a\u{1f676}\ufd02');
+let shaderModule9 = device2.createShaderModule(
+{
+label: '\u{1fd91}\uc36f\ubebb',
+code: `@group(3) @binding(219)
+var<storage, read_write> i0: array<u32>;
+
+@compute @workgroup_size(1, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@builtin(sample_mask) f0: u32,
+@location(1) f1: vec3<i32>,
+@location(2) f2: vec4<f32>,
+@location(7) f3: i32,
+@location(4) f4: vec4<u32>,
+@location(3) f5: vec4<i32>,
+@location(0) f6: i32,
+@location(6) f7: i32,
+@location(5) f8: f32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(sample_mask) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(2) a0: i32, @location(20) a1: vec4<f16>, @location(13) a2: vec4<f32>, @location(12) a3: f32, @location(10) a4: vec4<i32>, @location(4) a5: vec3<u32>, @location(5) a6: vec3<f16>, @location(22) a7: vec2<f16>, @location(9) a8: vec2<f16>, @location(23) a9: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroup61 = device2.createBindGroup({
+label: '\u0bb4\u0feb\ua213\u77f4',
+layout: bindGroupLayout21,
+entries: [
+{
+binding: 219,
+resource: textureView66
+}
+],
+});
+let commandEncoder80 = device2.createCommandEncoder(
+{
+label: '\uf445\u0425\ucca8\u0c4a\u{1fc33}\u0c27\u7691\u0015\u1fad\u{1ff15}\u0343',
+}
+);
+let querySet50 = device2.createQuerySet(
+{
+label: '\ueeb9\u3313\uef55\u8009\u{1f7a8}\u{1f87e}\u{1f656}',
+type: 'occlusion',
+count: 1548,
+}
+);
+try {
+commandEncoder80.copyTextureToTexture(
+{
+  texture: texture80,
+  mipLevel: 9,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture80,
+  mipLevel: 1,
+  origin: { x: 269, y: 0, z: 773 },
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 3}
+);
+} catch {}
+try {
+commandEncoder79.clearBuffer(
+buffer29,
+46904,
+2324
+);
+dissociateBuffer(device2, buffer29);
+} catch {}
+try {
+gpuCanvasContext24.configure(
+{
+device: device2,
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+document.body.prepend(canvas18);
+document.body.append('\u884f\u146b\ud9c5\u{1fb3c}\u40ea\ubcd5\u5e1b\u0a59\u{1f8dd}\u{1fdf0}\u7c60');
+let offscreenCanvas26 = new OffscreenCanvas(8, 70);
+document.body.prepend('\u088f\u56de\u75e3\u8ff1\u{1f9f9}\u0803\u185e\u4350\u0295\u{1f72a}');
+let bindGroup62 = device2.createBindGroup({
+label: '\u{1fe31}\u68a9\u19e3\ueb7b\u0c25\u09e0\u0bf8\u0db4\u0ab1',
+layout: bindGroupLayout21,
+entries: [
+{
+binding: 219,
+resource: textureView61
+}
+],
+});
+let textureView74 = texture83.createView(
+{
+baseMipLevel: 3,
+mipLevelCount: 2,
+}
+);
+let renderBundle65 = renderBundleEncoder44.finish(
+{
+
+}
+);
+try {
+commandEncoder79.resolveQuerySet(
+querySet41,
+2739,
+73,
+buffer30,
+7936
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.prepend('\u0edb\ua016\u04ee\u{1f766}\ue14f\u025b\uf27c');
+let device6 = await adapter8.requestDevice(
+{
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 8,
+maxColorAttachmentBytesPerSample: 44,
+maxVertexAttributes: 26,
+maxVertexBufferArrayStride: 64041,
+maxStorageTexturesPerShaderStage: 40,
+maxStorageBuffersPerShaderStage: 17,
+maxDynamicStorageBuffersPerPipelineLayout: 12316,
+maxBindingsPerBindGroup: 3580,
+maxTextureDimension1D: 9533,
+maxTextureDimension2D: 12387,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 260229320,
+maxInterStageShaderVariables: 107,
+maxInterStageShaderComponents: 119,
+},
+}
+);
+gc();
+document.body.prepend('\u4e04\u4715\u2ed7');
+let img38 = await imageWithData(194, 118, '#0de6da09', '#d8c76da4');
+try {
+offscreenCanvas26.getContext('webgl2');
+} catch {}
+let gpuCanvasContext29 = offscreenCanvas25.getContext('webgpu');
+document.body.prepend('\uead5\u0d5a\u08b8\u0fba\u00ff');
+let commandEncoder81 = device4.createCommandEncoder();
+let sampler62 = device4.createSampler(
+{
+label: '\uf3bb\u71f4\u8815\u7bbe\u05f4\u507f\u554c\u0840\u{1f651}\ud3e4\ue2aa',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 90.089,
+lodMaxClamp: 96.531,
+compare: 'never',
+}
+);
+try {
+computePassEncoder54.setBindGroup(
+4,
+bindGroup57
+);
+} catch {}
+try {
+renderBundleEncoder55.setBindGroup(
+5,
+bindGroup57,
+new Uint32Array(9483),
+5942,
+0
+);
+} catch {}
+try {
+await promise42;
+} catch {}
+let imageData39 = new ImageData(84, 16);
+gc();
+document.body.append('\u05bb\u{1f758}\u0994\u0d6f\u{1fcbf}\u1e35\udd08\u90fe\u16ad\ub0d1\u5e87');
+let buffer37 = device4.createBuffer(
+{
+label: '\u010c\u{1fd4c}\u2247\u5d79',
+size: 44924,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let computePassEncoder55 = commandEncoder81.beginComputePass(
+{
+label: '\u{1fd4f}\uf497\uf524\u0db5\u415f\u{1f8fb}'
+}
+);
+let renderBundle66 = renderBundleEncoder54.finish(
+{
+label: '\u0fbf\u0827\u00d6'
+}
+);
+let sampler63 = device4.createSampler(
+{
+label: '\ub624\u{1f7e8}\u0e2e\u3769',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 71.735,
+lodMaxClamp: 79.166,
+}
+);
+try {
+computePassEncoder52.setBindGroup(
+2,
+bindGroup59
+);
+} catch {}
+try {
+renderBundleEncoder46.setBindGroup(
+0,
+bindGroup54
+);
+} catch {}
+try {
+renderBundleEncoder55.setBindGroup(
+2,
+bindGroup57,
+new Uint32Array(1756),
+28,
+0
+);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(
+92,
+undefined,
+4152035506,
+108909683
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture81,
+  mipLevel: 8,
+  origin: { x: 16, y: 0, z: 110 },
+  aspect: 'all',
+},
+new Int16Array(arrayBuffer4),
+/* required buffer size: 1665973 */{
+offset: 143,
+bytesPerRow: 239,
+rowsPerImage: 170,
+},
+{width: 4, height: 0, depthOrArrayLayers: 42}
+);
+} catch {}
+let commandEncoder82 = device2.createCommandEncoder(
+{
+label: '\ue3eb\u{1f723}\u9dfa\u1b78\u5c88\u2535\u{1fd66}\ud6f3\uf7a5',
+}
+);
+let computePassEncoder56 = commandEncoder82.beginComputePass(
+{
+label: '\u{1fe7d}\u{1f645}\u7be1'
+}
+);
+let sampler64 = device2.createSampler(
+{
+label: '\uecab\u6a76\u2ebb\ub7f9\u509d',
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 25.129,
+lodMaxClamp: 80.323,
+}
+);
+try {
+buffer30.unmap();
+} catch {}
+try {
+commandEncoder80.copyTextureToTexture(
+{
+  texture: texture80,
+  mipLevel: 4,
+  origin: { x: 4, y: 1, z: 76 },
+  aspect: 'all',
+},
+{
+  texture: texture80,
+  mipLevel: 5,
+  origin: { x: 0, y: 1, z: 29 },
+  aspect: 'all',
+},
+{width: 17, height: 0, depthOrArrayLayers: 16}
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture80,
+  mipLevel: 2,
+  origin: { x: 123, y: 0, z: 146 },
+  aspect: 'all',
+},
+arrayBuffer10,
+/* required buffer size: 405534 */{
+offset: 818,
+bytesPerRow: 181,
+rowsPerImage: 52,
+},
+{width: 0, height: 1, depthOrArrayLayers: 44}
+);
+} catch {}
+let pipeline54 = device2.createRenderPipeline(
+{
+label: '\u074b\u08e3\u5742\u{1ffa3}\u7c4c\u74a2',
+layout: pipelineLayout14,
+vertex: {
+module: shaderModule8,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 2372,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 1058,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x4',
+offset: 1952,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x4',
+offset: 2264,
+shaderLocation: 20,
+},
+{
+format: 'float16x2',
+offset: 156,
+shaderLocation: 2,
+},
+{
+format: 'sint32x2',
+offset: 2280,
+shaderLocation: 7,
+},
+{
+format: 'uint16x4',
+offset: 1416,
+shaderLocation: 23,
+},
+{
+format: 'sint32',
+offset: 572,
+shaderLocation: 17,
+},
+{
+format: 'sint16x4',
+offset: 1184,
+shaderLocation: 16,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 456,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 9016,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 8832,
+shaderLocation: 22,
+},
+{
+format: 'uint32x3',
+offset: 7364,
+shaderLocation: 6,
+},
+{
+format: 'float32x3',
+offset: 6748,
+shaderLocation: 24,
+},
+{
+format: 'sint32',
+offset: 4680,
+shaderLocation: 15,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x8b9df79d,
+},
+fragment: {
+module: shaderModule8,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 2743,
+stencilWriteMask: 3501,
+depthBias: 45,
+depthBiasSlopeScale: 16,
+depthBiasClamp: 59,
+},
+}
+);
+let imageBitmap33 = await createImageBitmap(img35);
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+gc();
+try {
+adapter3.label = '\u7354\u6b57\u04ca\ue4b0\u{1f73e}';
+} catch {}
+let textureView75 = texture78.createView(
+{
+aspect: 'all',
+baseMipLevel: 1,
+arrayLayerCount: 1,
+}
+);
+try {
+device6.addEventListener('uncapturederror', e => { log('device6.uncapturederror'); log(e); e.label = device6.label; });
+} catch {}
+try {
+commandEncoder79.clearBuffer(
+buffer29,
+55360,
+5992
+);
+dissociateBuffer(device2, buffer29);
+} catch {}
+try {
+commandEncoder80.resolveQuerySet(
+querySet47,
+842,
+630,
+buffer30,
+4864
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer27,
+1032,
+new Int16Array(5407),
+1067
+);
+} catch {}
+document.body.append('\u78f9\u{1fc10}\ua0e3\u5afc');
+let imageBitmap34 = await createImageBitmap(imageData25);
+let commandEncoder83 = device2.createCommandEncoder(
+{
+label: '\u043a\u{1fa98}',
+}
+);
+let texture86 = device2.createTexture(
+{
+label: '\uf743\u4e07\u7d38\u0f77\u6083\ub56a\u0149\u02b8',
+size: {width: 248, height: 80, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let sampler65 = device2.createSampler(
+{
+label: '\u36e0\u054f\u2536\u04e3\u{1fb5c}\u088b\u0b0f\uca19\u1210\u0b83',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 35.796,
+lodMaxClamp: 75.601,
+}
+);
+try {
+commandEncoder79.resolveQuerySet(
+querySet41,
+582,
+585,
+buffer30,
+7424
+);
+} catch {}
+let pipeline55 = device2.createRenderPipeline(
+{
+label: '\u3ec9\u05c9\ude2e\uccfc\u1da7\u0fd2\u96d2\u698e\ud323\u6e48\u5f7f',
+layout: pipelineLayout13,
+vertex: {
+module: shaderModule9,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 2220,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 708,
+shaderLocation: 5,
+},
+{
+format: 'unorm16x4',
+offset: 1252,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 2760,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x4',
+offset: 756,
+shaderLocation: 2,
+},
+{
+format: 'float32x2',
+offset: 1532,
+shaderLocation: 9,
+},
+{
+format: 'snorm8x2',
+offset: 416,
+shaderLocation: 12,
+},
+{
+format: 'float32x2',
+offset: 220,
+shaderLocation: 20,
+},
+{
+format: 'unorm8x4',
+offset: 1816,
+shaderLocation: 13,
+},
+{
+format: 'uint8x2',
+offset: 1464,
+shaderLocation: 4,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 1208,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 1100,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 948,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0xa726201e,
+},
+fragment: {
+module: shaderModule9,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8sint',
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'dst',
+dstFactor: 'one-minus-src-alpha'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'bgra8unorm-srgb',
+},
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'replace',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'invert',
+},
+stencilReadMask: 3647,
+stencilWriteMask: 3508,
+depthBias: 76,
+depthBiasSlopeScale: 65,
+depthBiasClamp: 52,
+},
+}
+);
+canvas1.height = 127;
+try {
+gpuCanvasContext21.unconfigure();
+} catch {}
+document.body.append('\u5084\ubecb\u6b64\u{1f865}\ud72b\u7cd8\u{1fc17}\u09c6\u{1fef6}\u07a6');
+document.body.prepend(canvas18);
+document.body.append('\u21aa\uc3a9\u32c1\u1e22\u0d00');
+let adapter9 = await navigator.gpu.requestAdapter(
+{
+powerPreference: 'low-power',
+}
+);
+try {
+gpuCanvasContext23.unconfigure();
+} catch {}
+gc();
+document.body.prepend('\u730e\u0893\u063b\u37b0\u{1f713}\u7144\ua748\u{1f6a3}\u0654');
+let bindGroupLayout25 = device6.createBindGroupLayout(
+{
+label: '\u048b\uf374\u8002\u{1ffcc}\ub7b5\u8e39\u04e2\u0a69',
+entries: [
+
+],
+}
+);
+let pipelineLayout18 = device6.createPipelineLayout(
+{
+label: '\u0092\u9528\u3187',
+bindGroupLayouts: [
+bindGroupLayout25
+],
+}
+);
+let commandEncoder84 = device6.createCommandEncoder(
+{
+label: '\u0822\u43d2\u1671\uc0c7',
+}
+);
+let querySet51 = device6.createQuerySet(
+{
+label: '\udae1\u0a3f\u1c02\u06b7\u0ec9\u{1fb10}',
+type: 'occlusion',
+count: 1883,
+}
+);
+let device7 = await promise30;
+let imageBitmap35 = await createImageBitmap(imageBitmap24);
+let querySet52 = device4.createQuerySet(
+{
+label: '\u0c5f\uc239\u48a5\u0848\u606d\ud409\u8caa\u4700',
+type: 'occlusion',
+count: 471,
+}
+);
+document.body.prepend(video9);
+let renderBundleEncoder56 = device6.createRenderBundleEncoder(
+{
+label: '\u0b31\u0e55\uaab3\u5709\ub8d5\u{1ffe4}\uf8b7\u0ab4\ub767',
+colorFormats: [
+'rgba32sint',
+'rg32sint',
+'rgba8unorm'
+],
+sampleCount: 82,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+let renderBundle67 = renderBundleEncoder56.finish(
+{
+
+}
+);
+let promise43 = device6.queue.onSubmittedWorkDone();
+document.body.prepend('\u648d\u{1f8fe}\ueed5\u07d6\ufe45\u1a75\uebf6\u5997\u1b95\u0c3c');
+document.body.append('\u0682\u78a3\u0e49\u0b61\u00c2\u0e55\u0555\u03f5\ua4e9\u34ec\u{1fa4d}');
+let imageData40 = new ImageData(60, 32);
+let imageBitmap36 = await createImageBitmap(video25);
+try {
+externalTexture1.label = '\u7636\u{1f8c8}\ua50a\u{1fe88}\u0e81\u0ff3\u8fa6\u0640\u{1fe3c}\ubdc3\ude87';
+} catch {}
+let imageBitmap37 = await createImageBitmap(videoFrame19);
+document.body.append('\u5699\u8ffa\uf786\u0685\u1d3f\udb6b\ubf05\u4083');
+let promise44 = adapter0.requestAdapterInfo();
+try {
+await promise43;
+} catch {}
+let img39 = await imageWithData(157, 66, '#3511ee31', '#586adf48');
+let bindGroup63 = device4.createBindGroup({
+label: '\u155a\u0972\u{1fc38}\uc479\u{1fc0b}',
+layout: bindGroupLayout20,
+entries: [
+
+],
+});
+let sampler66 = device4.createSampler(
+{
+label: '\ua19d\u3a9c\ud4f8\u{1fd8c}\u41a6\u{1fdb3}\u0fb6\ua749',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 9.988,
+lodMaxClamp: 50.411,
+}
+);
+try {
+gpuCanvasContext5.configure(
+{
+device: device4,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'etc2-rgb8unorm',
+'rgba8unorm'
+],
+}
+);
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer37,
+3892,
+new DataView(new ArrayBuffer(47152)),
+20326,
+12636
+);
+} catch {}
+let imageBitmap38 = await createImageBitmap(imageBitmap0);
+let promise45 = device7.queue.onSubmittedWorkDone();
+offscreenCanvas0.width = 835;
+let texture87 = device4.createTexture(
+{
+label: '\u087b\u0e59\u0df5',
+size: {width: 192, height: 12, depthOrArrayLayers: 9},
+mipLevelCount: 4,
+format: 'etc2-rgb8a1unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'etc2-rgb8a1unorm',
+'etc2-rgb8a1unorm-srgb'
+],
+}
+);
+let imageData41 = new ImageData(248, 24);
+let promise46 = adapter5.requestAdapterInfo();
+let bindGroup64 = device4.createBindGroup({
+label: '\u{1f78f}\u{1f6d8}\u{1f86f}\u0d3f\u3ffb\u353b\u13ac\u{1fb45}',
+layout: bindGroupLayout20,
+entries: [
+
+],
+});
+let texture88 = device4.createTexture(
+{
+label: '\u0e2b\u0709\u3e6a\u451a\u99b4\ub976\u0b59\u{1fdc9}',
+size: {width: 52, height: 52, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'astc-4x4-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder57 = device4.createRenderBundleEncoder(
+{
+colorFormats: [
+'bgra8unorm',
+'rgba8uint',
+undefined,
+'rgba16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 312,
+depthReadOnly: false,
+}
+);
+try {
+device4.queue.writeBuffer(
+buffer35,
+55044,
+new DataView(new ArrayBuffer(10811)),
+9601,
+1104
+);
+} catch {}
+try {
+gpuCanvasContext26.unconfigure();
+} catch {}
+document.body.prepend('\ubc91\u0ad3\u0d4c\u095a\uc81e\u090a');
+let texture89 = device7.createTexture(
+{
+label: '\u6726\u852f\u6777\uc091\u84ca\u{1feb4}\ud082\ufaf4',
+size: {width: 235, height: 180, depthOrArrayLayers: 30},
+mipLevelCount: 5,
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rg8sint',
+'rg8sint',
+'rg8sint'
+],
+}
+);
+try {
+device7.queue.writeTexture(
+{
+  texture: texture89,
+  mipLevel: 4,
+  origin: { x: 13, y: 0, z: 21 },
+  aspect: 'all',
+},
+arrayBuffer3,
+/* required buffer size: 31240 */{
+offset: 690,
+bytesPerRow: 94,
+rowsPerImage: 105,
+},
+{width: 0, height: 11, depthOrArrayLayers: 4}
+);
+} catch {}
+let querySet53 = device4.createQuerySet(
+{
+label: '\u{1f6e4}\ucf25',
+type: 'occlusion',
+count: 1177,
+}
+);
+let sampler67 = device4.createSampler(
+{
+label: '\u4e62\u09bc\ud499\uc73a\ub2b7\u0d88\u38c2\u2371',
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMaxClamp: 59.486,
+}
+);
+try {
+renderBundleEncoder57.setBindGroup(
+1,
+bindGroup59,
+new Uint32Array(7433),
+3651,
+0
+);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(
+16,
+undefined,
+3047010420,
+935033041
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture78,
+  mipLevel: 0,
+  origin: { x: 36, y: 72, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 970 */{
+offset: 970,
+bytesPerRow: 344,
+},
+{width: 60, height: 80, depthOrArrayLayers: 0}
+);
+} catch {}
+let bindGroup65 = device4.createBindGroup({
+label: '\u{1fb4b}\u0914\u011a\u0094\udd36\u026f\u{1fe3a}\udcaf\u9cd5\u063a\u29e5',
+layout: bindGroupLayout20,
+entries: [
+
+],
+});
+let textureView76 = texture79.createView(
+{
+label: '\u08cc\ub248\u006e\ue19c\u0d90\u0f02\u0479',
+dimension: '2d',
+baseArrayLayer: 17,
+}
+);
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55) };
+} catch {}
+let videoFrame33 = new VideoFrame(videoFrame28, {timestamp: 0});
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+try {
+await promise45;
+} catch {}
+document.body.append('\u7f14\u9d87\u0627');
+let img40 = await imageWithData(165, 178, '#ca6927df', '#faae12df');
+let bindGroup66 = device4.createBindGroup({
+label: '\u{1ffd8}\u{1f658}\ua307\u{1f990}\u{1feaf}\ud311\udffa\u76f0',
+layout: bindGroupLayout20,
+entries: [
+
+],
+});
+let texture90 = device4.createTexture(
+{
+label: '\u70da\u1256\u{1f97f}\u934e',
+size: {width: 6416, height: 4, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+
+],
+}
+);
+let textureView77 = texture90.createView(
+{
+label: '\u6b89\u0967\u2671\u6e94\u836c\u0db5\ud54f',
+dimension: '2d',
+baseMipLevel: 2,
+}
+);
+let renderBundleEncoder58 = device4.createRenderBundleEncoder(
+{
+label: '\u{1fa91}\u{1fe23}\u0146\u3d63',
+colorFormats: [
+'r32sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 483,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler68 = device4.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 30.410,
+lodMaxClamp: 57.759,
+compare: 'equal',
+}
+);
+try {
+renderBundleEncoder55.setVertexBuffer(
+24,
+undefined,
+1520298772,
+2370601811
+);
+} catch {}
+gc();
+let texture91 = device4.createTexture(
+{
+label: '\u6e5b\u6b91\u922c\u{1ffe4}\u090d\u74ba',
+size: {width: 6704},
+dimension: '1d',
+format: 'rg32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32float',
+'rg32float',
+'rg32float'
+],
+}
+);
+let renderBundleEncoder59 = device4.createRenderBundleEncoder(
+{
+label: '\u2ec0\u0ca6\u083d\u0317\u0100',
+colorFormats: [
+'rgba8unorm-srgb',
+'r16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 689,
+depthReadOnly: true,
+}
+);
+let renderBundle68 = renderBundleEncoder46.finish();
+try {
+renderBundleEncoder58.setVertexBuffer(
+96,
+undefined,
+3517071652,
+313799648
+);
+} catch {}
+let video26 = await videoWithData();
+let shaderModule10 = device1.createShaderModule(
+{
+label: '\ufa63\u{1fdca}\ud4f5\u{1f783}',
+code: `@group(3) @binding(4821)
+var<storage, read_write> type2: array<u32>;
+
+@compute @workgroup_size(8, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(7) f0: f32,
+@builtin(sample_mask) f1: u32,
+@location(3) f2: i32,
+@location(1) f3: vec3<u32>,
+@location(4) f4: vec4<i32>,
+@location(2) f5: vec4<i32>,
+@location(0) f6: f32,
+@location(5) f7: f32,
+@location(6) f8: f32,
+@builtin(frag_depth) f9: f32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S8 {
+@location(7) f0: vec2<i32>,
+@location(6) f1: vec4<f16>,
+@location(4) f2: i32,
+@location(11) f3: vec2<i32>,
+@location(9) f4: vec4<f16>,
+@location(10) f5: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec2<u32>, @location(14) a1: vec4<u32>, a2: S8, @location(13) a3: f32, @location(0) a4: vec2<f32>, @location(3) a5: i32, @location(5) a6: vec3<f16>, @location(2) a7: vec4<f32>, @location(8) a8: vec4<u32>, @location(1) a9: i32, @location(12) a10: f32, @builtin(instance_index) a11: u32, @builtin(vertex_index) a12: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture92 = device1.createTexture(
+{
+label: '\ubde1\u096a\u794d\u{1f692}\u0f9c\u{1fd58}',
+size: [70, 198, 207],
+mipLevelCount: 7,
+format: 'astc-10x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-10x6-unorm-srgb',
+'astc-10x6-unorm-srgb',
+'astc-10x6-unorm-srgb'
+],
+}
+);
+let renderBundleEncoder60 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba32sint',
+'rg8sint',
+'rgba8uint',
+'rg32uint',
+'rgba8sint',
+'rg16sint',
+'rg8unorm'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 743,
+stencilReadOnly: true,
+}
+);
+try {
+commandEncoder70.copyTextureToTexture(
+{
+  texture: texture73,
+  mipLevel: 0,
+  origin: { x: 150, y: 0, z: 87 },
+  aspect: 'all',
+},
+{
+  texture: texture73,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 114 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 2}
+);
+} catch {}
+try {
+computePassEncoder46.insertDebugMarker(
+'\u0b4b'
+);
+} catch {}
+let offscreenCanvas27 = new OffscreenCanvas(154, 592);
+let sampler69 = device4.createSampler(
+{
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 25.496,
+}
+);
+let externalTexture10 = device4.importExternalTexture(
+{
+label: '\u0576\u09ac\u0799\u0a06\u32e8\u{1fb7f}\u0d1d\udab5\u3d23\u64c0\uc4c4',
+source: videoFrame21,
+colorSpace: 'srgb',
+}
+);
+try {
+renderBundleEncoder59.setBindGroup(
+0,
+bindGroup64,
+new Uint32Array(5341),
+4585,
+0
+);
+} catch {}
+try {
+await buffer31.mapAsync(
+GPUMapMode.WRITE
+);
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer35,
+37136,
+new Int16Array(23988),
+11545,
+9788
+);
+} catch {}
+let gpuCanvasContext30 = offscreenCanvas27.getContext('webgpu');
+let canvas33 = document.createElement('canvas');
+let bindGroupLayout26 = device7.createBindGroupLayout(
+{
+label: '\ufada\u18b1\u9ef3\uecd0\u{1fb3c}\u0f24\u81f4\u71d8\u0ae3\u53c0\uec58',
+entries: [
+
+],
+}
+);
+let bindGroup67 = device4.createBindGroup({
+label: '\u67d9\u7549\u92dd\u0e97\ubf06\u8aa7\u011b\ua8c9\u{1f92a}',
+layout: bindGroupLayout20,
+entries: [
+
+],
+});
+let renderBundle69 = renderBundleEncoder58.finish(
+{
+label: '\u076f\u{1f6ae}'
+}
+);
+try {
+renderBundleEncoder57.setBindGroup(
+5,
+bindGroup65
+);
+} catch {}
+try {
+gpuCanvasContext13.configure(
+{
+device: device4,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+document.body.append('\u{1fd01}\u4ed3\u60f4\u2c4d');
+let videoFrame34 = new VideoFrame(canvas17, {timestamp: 0});
+let bindGroup68 = device4.createBindGroup({
+label: '\u8b05\ua3cc\uda48\ubb9b\ubeef\u9677\u5613\u82fe\u06c3\uc935\ub8e1',
+layout: bindGroupLayout20,
+entries: [
+
+],
+});
+let renderBundle70 = renderBundleEncoder57.finish(
+{
+label: '\u3084\u{1fbb2}\u{1fd1a}\u05e5\u5d79\ud4e6\u456c\uc753\u{1f63c}\ubd83\u4201'
+}
+);
+let sampler70 = device4.createSampler(
+{
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+lodMinClamp: 1.986,
+lodMaxClamp: 85.780,
+}
+);
+try {
+computePassEncoder52.setBindGroup(
+1,
+bindGroup65
+);
+} catch {}
+try {
+computePassEncoder55.setBindGroup(
+5,
+bindGroup66,
+new Uint32Array(6282),
+1389,
+0
+);
+} catch {}
+try {
+computePassEncoder55.end();
+} catch {}
+try {
+commandEncoder81.copyBufferToBuffer(
+buffer36,
+22180,
+buffer37,
+6048,
+18068
+);
+dissociateBuffer(device4, buffer36);
+dissociateBuffer(device4, buffer37);
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer35,
+52080,
+new DataView(new ArrayBuffer(30232)),
+15865,
+2548
+);
+} catch {}
+let gpuCanvasContext31 = canvas33.getContext('webgpu');
+document.body.append('\ud404\uadef\u0558\u{1fc9a}');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+document.body.prepend('\u1a23\u991c\u0fd7\u{1fee9}\u{1f887}\ubef1\u{1fb30}');
+let adapter10 = await promise32;
+let bindGroup69 = device6.createBindGroup({
+label: '\u{1f737}\u{1f98f}\u{1fc5d}',
+layout: bindGroupLayout25,
+entries: [
+
+],
+});
+document.body.prepend('\ub3a7\ue810\uaff5\ub583\u46fd');
+let bindGroup70 = device4.createBindGroup({
+label: '\uefea\ubdd9',
+layout: bindGroupLayout20,
+entries: [
+
+],
+});
+let commandBuffer13 = commandEncoder81.finish(
+{
+}
+);
+let texture93 = device4.createTexture(
+{
+size: [2100, 5, 32],
+mipLevelCount: 2,
+dimension: '2d',
+format: 'astc-6x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-6x5-unorm'
+],
+}
+);
+try {
+computePassEncoder52.setBindGroup(
+0,
+bindGroup63,
+new Uint32Array(5034),
+3395,
+0
+);
+} catch {}
+try {
+renderBundleEncoder55.setBindGroup(
+1,
+bindGroup54,
+[]
+);
+} catch {}
+try {
+renderBundleEncoder55.setBindGroup(
+4,
+bindGroup59,
+new Uint32Array(8047),
+3317,
+0
+);
+} catch {}
+try {
+adapter9.label = '\u0a23\u1537\u028f\u0073\u{1fcd4}\u860d\ue678\u2c0e\ub31e\u{1fb0f}';
+} catch {}
+let commandEncoder85 = device2.createCommandEncoder(
+{
+label: '\u2a12\u{1f986}\u38ee\u0e8d\u0d9b',
+}
+);
+let textureView78 = texture86.createView(
+{
+label: '\u0870\u074a\u{1fa62}\u02fa\u0b9b\u0f20\u{1fbdb}\u0ecb\u930c\u6890\ue891',
+dimension: '2d-array',
+}
+);
+let sampler71 = device2.createSampler(
+{
+label: '\u4bd5\u{1fa28}\ud4ce',
+addressModeU: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 32.343,
+lodMaxClamp: 78.574,
+}
+);
+try {
+renderBundleEncoder50.setBindGroup(
+7,
+bindGroup60,
+new Uint32Array(8270),
+4983,
+0
+);
+} catch {}
+try {
+gpuCanvasContext23.configure(
+{
+device: device2,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'etc2-rgb8a1unorm-srgb'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let pipeline56 = device2.createRenderPipeline(
+{
+label: '\u18b7\u{1fccc}\uc0d1\u0d0c\ufc2f\u30e9\u1d4a\uc23a\u886c\uf33e\ueacc',
+layout: pipelineLayout13,
+vertex: {
+module: shaderModule9,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 8784,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x4',
+offset: 7240,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x4',
+offset: 1972,
+shaderLocation: 9,
+},
+{
+format: 'snorm8x4',
+offset: 1232,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 9580,
+attributes: [
+{
+format: 'snorm16x4',
+offset: 1416,
+shaderLocation: 5,
+},
+{
+format: 'unorm8x2',
+offset: 3346,
+shaderLocation: 23,
+},
+{
+format: 'float32',
+offset: 7656,
+shaderLocation: 20,
+},
+{
+format: 'uint16x4',
+offset: 324,
+shaderLocation: 4,
+},
+{
+format: 'float32x2',
+offset: 7448,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 6132,
+attributes: [
+{
+format: 'float32x2',
+offset: 2084,
+shaderLocation: 12,
+},
+{
+format: 'sint8x2',
+offset: 2724,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x1ea1b45e,
+},
+fragment: {
+module: shaderModule9,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}
+],
+},
+}
+);
+let sampler72 = device2.createSampler(
+{
+label: '\u8046\u{1f9eb}\ub514\u{1f765}\u308b\u66bd\u494a',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 89.413,
+lodMaxClamp: 92.532,
+maxAnisotropy: 7,
+}
+);
+try {
+renderBundleEncoder50.setBindGroup(
+9,
+bindGroup55,
+new Uint32Array(8376),
+4038,
+0
+);
+} catch {}
+try {
+commandEncoder80.resolveQuerySet(
+querySet46,
+273,
+662,
+buffer30,
+2048
+);
+} catch {}
+let img41 = await imageWithData(260, 81, '#793b6585', '#591ccbdb');
+let bindGroup71 = device7.createBindGroup({
+label: '\u45f7\uad9c\u01a6',
+layout: bindGroupLayout26,
+entries: [
+
+],
+});
+let pipelineLayout19 = device7.createPipelineLayout(
+{
+label: '\u76d6\u09d5\u27f3\u0163\u{1fdd8}',
+bindGroupLayouts: [
+bindGroupLayout26,
+bindGroupLayout26
+],
+}
+);
+let texture94 = device7.createTexture(
+{
+label: '\u1fba\u0f87\u5185',
+size: [112, 75, 69],
+mipLevelCount: 5,
+dimension: '2d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rg8sint'
+],
+}
+);
+let renderBundleEncoder61 = device7.createRenderBundleEncoder(
+{
+label: '\uc7b6\u0754\u{1f695}\ue179\uf1fc\uef64\u{1fd7f}\ucfa2\uee4b\uf94a',
+colorFormats: [
+'rg16uint'
+],
+sampleCount: 115,
+stencilReadOnly: true,
+}
+);
+let sampler73 = device7.createSampler(
+{
+label: '\u{1fe1b}\u{1f668}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 43.774,
+maxAnisotropy: 19,
+}
+);
+try {
+renderBundleEncoder61.setBindGroup(
+6,
+bindGroup71,
+new Uint32Array(3894),
+1745,
+0
+);
+} catch {}
+let video27 = await videoWithData();
+let shaderModule11 = device2.createShaderModule(
+{
+code: `@group(5) @binding(617)
+var<storage, read_write> local0: array<u32>;
+
+@compute @workgroup_size(4, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(1) f0: i32
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S9 {
+@location(15) f0: vec3<u32>,
+@location(7) f1: vec4<f32>,
+@location(2) f2: vec3<f32>,
+@location(6) f3: u32,
+@location(24) f4: u32,
+@location(9) f5: vec3<f16>,
+@location(17) f6: vec4<u32>,
+@location(13) f7: u32,
+@location(12) f8: f16,
+@location(23) f9: vec3<f16>,
+@location(3) f10: vec2<u32>,
+@location(8) f11: vec2<f32>,
+@location(21) f12: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec4<i32>, @location(11) a1: vec4<i32>, @builtin(instance_index) a2: u32, @location(14) a3: vec3<u32>, @builtin(vertex_index) a4: u32, @location(0) a5: vec2<u32>, a6: S9, @location(16) a7: vec4<f16>, @location(22) a8: vec3<i32>, @location(1) a9: vec3<u32>, @location(20) a10: vec3<u32>, @location(10) a11: vec2<i32>, @location(19) a12: vec2<f16>, @location(4) a13: vec4<i32>, @location(18) a14: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroup72 = device2.createBindGroup({
+label: '\u1133\u7e0b\u0661\u1608\u020d\u2a2b\ud09a\ubc61',
+layout: bindGroupLayout21,
+entries: [
+{
+binding: 219,
+resource: textureView78
+}
+],
+});
+try {
+computePassEncoder56.setBindGroup(
+9,
+bindGroup62,
+new Uint32Array(7648),
+5523,
+0
+);
+} catch {}
+try {
+renderBundleEncoder50.setBindGroup(
+10,
+bindGroup60
+);
+} catch {}
+try {
+commandEncoder80.copyBufferToBuffer(
+buffer30,
+6088,
+buffer29,
+2164,
+604
+);
+dissociateBuffer(device2, buffer30);
+dissociateBuffer(device2, buffer29);
+} catch {}
+try {
+commandEncoder83.copyTextureToTexture(
+{
+  texture: texture80,
+  mipLevel: 3,
+  origin: { x: 10, y: 0, z: 10 },
+  aspect: 'all',
+},
+{
+  texture: texture80,
+  mipLevel: 9,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext11.configure(
+{
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer27,
+12340,
+new DataView(new ArrayBuffer(41407)),
+17509,
+2772
+);
+} catch {}
+document.body.prepend('\ua2c5\ub79d\u00b9');
+let computePassEncoder57 = commandEncoder79.beginComputePass(
+{
+label: '\u24e6\u2d86\u{1fd1a}\u033d\u{1f9ff}\ubeb4\ud1f4\u1d85\u0ff4'
+}
+);
+try {
+computePassEncoder56.setBindGroup(
+8,
+bindGroup72,
+new Uint32Array(6893),
+4309,
+0
+);
+} catch {}
+canvas11.height = 836;
+let querySet54 = device4.createQuerySet(
+{
+label: '\u0b8b\u419c\u4579\u0a8f\u{1f7e6}\u91ca\u8bc2',
+type: 'occlusion',
+count: 723,
+}
+);
+try {
+computePassEncoder52.setBindGroup(
+4,
+bindGroup63,
+new Uint32Array(9244),
+2449,
+0
+);
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer37,
+9796,
+new BigUint64Array(62327),
+22419,
+2996
+);
+} catch {}
+let imageBitmap39 = await createImageBitmap(img24);
+document.body.append('\u{1fb0d}\u05ea\u1211\uee55\u1c8a\u{1fead}');
+let bindGroupLayout27 = device0.createBindGroupLayout(
+{
+label: '\u193c\u3d77\u51a4\u691a\u32f2\u{1fe40}\u{1f9e7}\u{1f74e}\u{1f87f}\ueaf7',
+entries: [
+{
+binding: 7501,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+}
+],
+}
+);
+let bindGroup73 = device0.createBindGroup({
+label: '\u051a\u{1f651}',
+layout: bindGroupLayout1,
+entries: [
+{
+binding: 2712,
+resource: sampler15
+},
+{
+binding: 2766,
+resource: externalTexture6
+}
+],
+});
+let renderBundleEncoder62 = device0.createRenderBundleEncoder(
+{
+label: '\u{1fc9e}\ue300\ucc42\u0d6b\ubeae\ued0b\u{1f9d5}\uaee8',
+colorFormats: [
+'r8unorm',
+'rgba8unorm-srgb',
+'rgba16float',
+'rgba32sint'
+],
+sampleCount: 111,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler74 = device0.createSampler(
+{
+label: '\u{1f90d}\u0e05\u1bc9\u{1f7c6}\u{1ff9a}\u0400',
+addressModeU: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 98.734,
+maxAnisotropy: 13,
+}
+);
+try {
+computePassEncoder28.dispatchWorkgroups(
+5,
+5,
+5
+);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(
+5,
+buffer6,
+26324,
+4157
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 40, height: 1, depthOrArrayLayers: 28}
+*/
+{
+  source: imageData24,
+  origin: { x: 11, y: 146 },
+  flipY: false,
+},
+{
+  texture: texture49,
+  mipLevel: 2,
+  origin: { x: 32, y: 0, z: 22 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 2, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\uddbe\u5a81\u8744');
+let querySet55 = device6.createQuerySet(
+{
+label: '\u08cb\ud3dc\ub26f\u{1f7ea}\ueecc\uf19c\u0b4c\u25e6\u{1ffd1}\u0684',
+type: 'occlusion',
+count: 2879,
+}
+);
+let renderBundleEncoder63 = device6.createRenderBundleEncoder(
+{
+label: '\ua847\u06b4\u0b3f',
+colorFormats: [
+'rg11b10ufloat',
+'rg11b10ufloat',
+'rgba16float'
+],
+sampleCount: 625,
+depthReadOnly: true,
+}
+);
+document.body.prepend('\u0517\u0343');
+document.body.prepend('\u2d8f\uf772');
+let imageData42 = new ImageData(188, 72);
+let bindGroup74 = device2.createBindGroup({
+layout: bindGroupLayout24,
+entries: [
+
+],
+});
+let commandBuffer14 = commandEncoder80.finish();
+let renderBundle71 = renderBundleEncoder40.finish(
+{
+label: '\ub1fd\u{1fd8c}\u{1faac}\u{1f947}'
+}
+);
+try {
+renderBundleEncoder43.setVertexBuffer(
+22,
+undefined,
+2265903520,
+631028922
+);
+} catch {}
+try {
+commandEncoder83.copyBufferToBuffer(
+buffer30,
+13444,
+buffer29,
+14392,
+392
+);
+dissociateBuffer(device2, buffer30);
+dissociateBuffer(device2, buffer29);
+} catch {}
+try {
+commandEncoder85.clearBuffer(
+buffer29,
+39312,
+8876
+);
+dissociateBuffer(device2, buffer29);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture86,
+  mipLevel: 1,
+  origin: { x: 12, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Int32Array(arrayBuffer8),
+/* required buffer size: 834 */{
+offset: 834,
+bytesPerRow: 195,
+},
+{width: 80, height: 32, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+offscreenCanvas8.width = 234;
+try {
+window.someLabel = textureView69.label;
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+await promise44;
+} catch {}
+canvas6.width = 86;
+gc();
+let video28 = await videoWithData();
+document.body.prepend('\u{1fd08}\ud840\u08be\u6a31\u0407\u0975\u{1ffc9}\u8716\u{1fe6d}');
+let bindGroupLayout28 = device7.createBindGroupLayout(
+{
+label: '\u9210\u1c5f\ue1f9\ub93d',
+entries: [
+{
+binding: 5659,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 5899,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let buffer38 = device7.createBuffer(
+{
+label: '\uac87\u{1f824}',
+size: 28134,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+mappedAtCreation: false,
+}
+);
+let querySet56 = device7.createQuerySet(
+{
+type: 'occlusion',
+count: 3131,
+}
+);
+let textureView79 = texture89.createView(
+{
+label: '\u0db3\uf288\u0909\u{1f96b}\ub710\u5bde\udf97\uaa71\u{1fe0e}\u{1fad3}',
+dimension: '2d',
+mipLevelCount: 2,
+baseArrayLayer: 9,
+}
+);
+let sampler75 = device7.createSampler(
+{
+label: '\u746a\u358c\u042a\uad69\u{1f63d}\ue23f\u7194\u43ec\u0094\ua616',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 39.766,
+lodMaxClamp: 40.218,
+maxAnisotropy: 1,
+}
+);
+try {
+renderBundleEncoder61.setVertexBuffer(
+11,
+buffer38,
+26572,
+633
+);
+} catch {}
+try {
+device7.queue.writeBuffer(
+buffer38,
+1192,
+new Int16Array(32211),
+15074,
+5328
+);
+} catch {}
+gc();
+try {
+adapter7.label = '\ua114\ude7a\u{1fd2e}\u2eef\u28c6\u{1fa3d}\u17bc\u0573\u0419';
+} catch {}
+try {
+device7.label = '\uc5c7\uc180\udb92\u94ca\u8c88\u{1fe01}\u44b7\u{1f6d3}\u{1f841}\u7454\u0072';
+} catch {}
+let querySet57 = device7.createQuerySet(
+{
+label: '\u725a\u9fd0\u75c5\u289d\u7e58',
+type: 'occlusion',
+count: 2107,
+}
+);
+let renderBundleEncoder64 = device7.createRenderBundleEncoder(
+{
+label: '\u20f9\u0353\u6376\u5a44',
+colorFormats: [
+undefined,
+'bgra8unorm',
+'rgba32sint',
+undefined,
+'rg8uint',
+'r32float',
+'rg11b10ufloat',
+'r32sint'
+],
+sampleCount: 637,
+stencilReadOnly: true,
+}
+);
+let renderBundle72 = renderBundleEncoder64.finish();
+let sampler76 = device7.createSampler(
+{
+label: '\u{1feb4}\u828f\uf9cc',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 16.649,
+maxAnisotropy: 10,
+}
+);
+gc();
+gc();
+let texture95 = device2.createTexture(
+{
+label: '\ue299\u0cef\u011d\u08de\u{1f993}\uff27\u0b18\u4f4a\udc19\u9a7b\u0a77',
+size: [556, 1, 290],
+mipLevelCount: 4,
+sampleCount: 1,
+dimension: '3d',
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'r8unorm'
+],
+}
+);
+try {
+commandEncoder85.copyBufferToBuffer(
+buffer30,
+9408,
+buffer27,
+2484,
+4196
+);
+dissociateBuffer(device2, buffer30);
+dissociateBuffer(device2, buffer27);
+} catch {}
+let img42 = await imageWithData(117, 249, '#6cbe63c6', '#edbb155f');
+try {
+gpuCanvasContext24.unconfigure();
+} catch {}
+let textureView80 = texture89.createView(
+{
+label: '\u6c03\u656c\u{1f98a}\u{1f97e}\u0ebe\u5bce\udbec\u{1fcd4}',
+dimension: '2d',
+baseMipLevel: 2,
+mipLevelCount: 2,
+baseArrayLayer: 14,
+}
+);
+let renderBundle73 = renderBundleEncoder64.finish(
+{
+
+}
+);
+try {
+device7.queue.writeTexture(
+{
+  texture: texture89,
+  mipLevel: 1,
+  origin: { x: 10, y: 45, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(48),
+/* required buffer size: 1888185 */{
+offset: 265,
+bytesPerRow: 375,
+rowsPerImage: 173,
+},
+{width: 85, height: 18, depthOrArrayLayers: 30}
+);
+} catch {}
+offscreenCanvas7.width = 362;
+gc();
+let texture96 = device7.createTexture(
+{
+label: '\u{1fd7e}\uf216\ua142\u{1fb4f}\u{1fe19}\ubdd7',
+size: [204, 1, 1617],
+dimension: '3d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8sint',
+'rg8sint'
+],
+}
+);
+let renderBundle74 = renderBundleEncoder64.finish(
+{
+label: '\udff0\u8283\u0d9f\u5431\u7276\u5489\u0f43\u0332\u1b13\uc653'
+}
+);
+let sampler77 = device7.createSampler(
+{
+label: '\u{1ff76}\ubbe8\uf7d1\u0688',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 5.011,
+lodMaxClamp: 95.430,
+maxAnisotropy: 9,
+}
+);
+try {
+renderBundleEncoder61.setVertexBuffer(
+2,
+buffer38,
+8816,
+652
+);
+} catch {}
+try {
+gpuCanvasContext15.configure(
+{
+device: device7,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rgb10a2unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device7.queue.writeBuffer(
+buffer38,
+27120,
+new BigUint64Array(52215),
+17042,
+28
+);
+} catch {}
+let videoFrame35 = new VideoFrame(canvas2, {timestamp: 0});
+let renderBundleEncoder65 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+'r16sint'
+],
+sampleCount: 32,
+depthReadOnly: false,
+}
+);
+try {
+renderBundleEncoder43.setBindGroup(
+9,
+bindGroup55
+);
+} catch {}
+try {
+device2.queue.submit([
+commandBuffer14,
+]);
+} catch {}
+let pipeline57 = device2.createComputePipeline(
+{
+label: '\u7b18\u2be1\u31d8',
+layout: pipelineLayout17,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let bindGroupLayout29 = device2.createBindGroupLayout(
+{
+label: '\u{1ff13}\u9568\u0165\u01a8\ud679\u7c59\u30f9\u{1fb56}\u{1fa4d}\u007f',
+entries: [
+{
+binding: 384,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+},
+{
+binding: 53,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+}
+],
+}
+);
+let bindGroup75 = device2.createBindGroup({
+label: '\u77ae\ua864\u0725',
+layout: bindGroupLayout24,
+entries: [
+
+],
+});
+let textureView81 = texture95.createView(
+{
+baseMipLevel: 2,
+}
+);
+let computePassEncoder58 = commandEncoder85.beginComputePass(
+{
+label: '\ud967\u093d'
+}
+);
+let renderBundleEncoder66 = device2.createRenderBundleEncoder(
+{
+label: '\u{1f808}\u{1faa4}\u9f5a\u0004\u5783\u7b12\u0ea4\ud6c9',
+colorFormats: [
+undefined,
+'bgra8unorm',
+'rg32uint',
+'r8sint',
+'rg32uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 685,
+depthReadOnly: true,
+}
+);
+document.body.append('\u{1fa97}\uafc9\u{1fc32}\u{1fd2f}\u020a\uf3f1\u{1f98f}\u2e70\u3838\u{1fb9c}');
+let img43 = await imageWithData(289, 93, '#1e419c2f', '#97f8f2c4');
+offscreenCanvas21.height = 76;
+try {
+await promise46;
+} catch {}
+try {
+renderBundleEncoder56.label = '\ubea8\u2bce\u{1f844}';
+} catch {}
+let commandEncoder86 = device6.createCommandEncoder(
+{
+label: '\ub558\uf139\u0daf\u0d9f\u09ca\u50bc\u{1fb55}\u{1feac}\u5ec3',
+}
+);
+document.body.append('\u{1f874}\u{1f780}\u0fae\uea64\u0525\u{1ff92}\u{1fa4a}\u04f6\u{1fe5d}\u{1fb5c}\u88dc');
+try {
+renderBundleEncoder61.setBindGroup(
+3,
+bindGroup71
+);
+} catch {}
+try {
+renderBundleEncoder61.setIndexBuffer(
+buffer38,
+'uint32',
+928,
+1881
+);
+} catch {}
+try {
+renderBundleEncoder61.setVertexBuffer(
+8,
+buffer38,
+3372,
+24130
+);
+} catch {}
+try {
+gpuCanvasContext25.unconfigure();
+} catch {}
+let imageBitmap40 = await createImageBitmap(offscreenCanvas4);
+let videoFrame36 = new VideoFrame(img10, {timestamp: 0});
+let querySet58 = device6.createQuerySet(
+{
+type: 'occlusion',
+count: 3536,
+}
+);
+let texture97 = device6.createTexture(
+{
+label: '\u{1f81b}\u{1fdd0}\u053c\u{1fabf}\u9f27',
+size: [1521, 54, 5],
+mipLevelCount: 3,
+format: 'r16sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'r16sint'
+],
+}
+);
+let textureView82 = texture97.createView(
+{
+label: '\u{1fb1b}\u72cf\u{1fabb}',
+dimension: '2d',
+baseMipLevel: 2,
+baseArrayLayer: 1,
+}
+);
+let renderBundle75 = renderBundleEncoder63.finish();
+canvas18.height = 670;
+try {
+computePassEncoder52.setBindGroup(
+1,
+bindGroup63,
+new Uint32Array(3779),
+1814,
+0
+);
+} catch {}
+try {
+renderBundleEncoder55.setIndexBuffer(
+buffer34,
+'uint16',
+5044,
+10203
+);
+} catch {}
+let device8 = await adapter10.requestDevice(
+{
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'indirect-first-instance',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 5,
+maxColorAttachmentBytesPerSample: 42,
+maxVertexAttributes: 18,
+maxVertexBufferArrayStride: 39934,
+maxStorageTexturesPerShaderStage: 21,
+maxStorageBuffersPerShaderStage: 37,
+maxDynamicStorageBuffersPerPipelineLayout: 54761,
+maxBindingsPerBindGroup: 1721,
+maxTextureDimension1D: 15500,
+maxTextureDimension2D: 12134,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 136032539,
+maxInterStageShaderVariables: 18,
+maxInterStageShaderComponents: 70,
+},
+}
+);
+let querySet59 = device6.createQuerySet(
+{
+type: 'occlusion',
+count: 3359,
+}
+);
+let texture98 = device6.createTexture(
+{
+size: {width: 1348, height: 11, depthOrArrayLayers: 1},
+sampleCount: 4,
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16sint'
+],
+}
+);
+let renderPassEncoder0 = commandEncoder84.beginRenderPass(
+{
+label: '\u7acd\u6c31\u8788\u{1f9e2}\u{1f721}\u0f10\u23e1\u8a1a\u{1fa1e}\u{1faec}\u{1ffcb}',
+colorAttachments: [
+{
+view: textureView82,
+clearValue: {
+r: 834.1,
+g: -412.3,
+b: 4.342,
+a: -332.7,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined,
+undefined,
+undefined,
+undefined
+],
+occlusionQuerySet: querySet58,
+maxDrawCount: 13328,
+}
+);
+try {
+renderPassEncoder0.setBindGroup(
+7,
+bindGroup69
+);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant(
+{
+r: -886.3,
+g: 450.2,
+b: 869.7,
+a: 471.3,
+}
+);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(
+317,
+9,
+50,
+1
+);
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+262.4,
+7.159,
+0.2372,
+1.275,
+0.3059,
+0.8350
+);
+} catch {}
+let bindGroupLayout30 = device2.createBindGroupLayout(
+{
+label: '\u4587\u0181\u7393\u040e\u05e7',
+entries: [
+{
+binding: 944,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let commandEncoder87 = device2.createCommandEncoder();
+let querySet60 = device2.createQuerySet(
+{
+label: '\u0b06\uf7bb\u0730\ue984\uce6c\u0a55\u{1f6f0}\u140c\u039c',
+type: 'occlusion',
+count: 1802,
+}
+);
+let textureView83 = texture80.createView(
+{
+baseMipLevel: 5,
+mipLevelCount: 4,
+}
+);
+try {
+computePassEncoder57.setPipeline(
+pipeline49
+);
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(
+7,
+bindGroup72,
+new Uint32Array(7789),
+6062,
+0
+);
+} catch {}
+try {
+device2.pushErrorScope(
+'internal'
+);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+commandEncoder87.copyBufferToBuffer(
+buffer30,
+11992,
+buffer29,
+49708,
+1828
+);
+dissociateBuffer(device2, buffer30);
+dissociateBuffer(device2, buffer29);
+} catch {}
+let pipeline58 = await device2.createComputePipelineAsync(
+{
+layout: pipelineLayout17,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline59 = device2.createRenderPipeline(
+{
+label: '\u0946\u0e05\uda53',
+layout: pipelineLayout13,
+vertex: {
+module: shaderModule9,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 7940,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 860,
+shaderLocation: 5,
+},
+{
+format: 'sint32x2',
+offset: 2504,
+shaderLocation: 10,
+},
+{
+format: 'float32',
+offset: 1408,
+shaderLocation: 20,
+},
+{
+format: 'float32',
+offset: 6676,
+shaderLocation: 12,
+},
+{
+format: 'sint8x2',
+offset: 366,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x2',
+offset: 1512,
+shaderLocation: 9,
+},
+{
+format: 'float32x4',
+offset: 3148,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 2824,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 2200,
+shaderLocation: 22,
+},
+{
+format: 'float32x4',
+offset: 244,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 10328,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x4',
+offset: 9532,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x2215b144,
+},
+fragment: {
+module: shaderModule9,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16sint',
+writeMask: 0,
+},
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'one-minus-src-alpha',
+dstFactor: 'one-minus-dst-alpha'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rg16uint',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'zero',
+dstFactor: 'one-minus-dst-alpha'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'dst',
+dstFactor: 'one-minus-constant'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.GREEN,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+let querySet61 = device3.createQuerySet(
+{
+label: '\ua135\ub62a\u2b21\u{1fe56}\u{1f9fd}\u{1fa2c}\uc26b\ubb22',
+type: 'occlusion',
+count: 155,
+}
+);
+let textureView84 = texture75.createView(
+{
+label: '\u872c\u3c38\u0c63',
+mipLevelCount: 1,
+baseArrayLayer: 0,
+}
+);
+let renderBundle76 = renderBundleEncoder42.finish();
+let offscreenCanvas28 = new OffscreenCanvas(902, 419);
+try {
+window.someLabel = renderBundle69.label;
+} catch {}
+let commandEncoder88 = device4.createCommandEncoder(
+{
+}
+);
+let querySet62 = device4.createQuerySet(
+{
+type: 'occlusion',
+count: 1178,
+}
+);
+let renderBundle77 = renderBundleEncoder54.finish(
+{
+label: '\u{1fd13}\ua18d\u97c2\u1412'
+}
+);
+try {
+renderBundleEncoder55.setIndexBuffer(
+buffer34,
+'uint16',
+1668,
+6286
+);
+} catch {}
+try {
+commandEncoder88.copyBufferToBuffer(
+buffer31,
+58288,
+buffer35,
+4720,
+684
+);
+dissociateBuffer(device4, buffer31);
+dissociateBuffer(device4, buffer35);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture85,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 107 },
+  aspect: 'all',
+},
+arrayBuffer11,
+/* required buffer size: 5401724 */{
+offset: 454,
+bytesPerRow: 302,
+rowsPerImage: 245,
+},
+{width: 5, height: 0, depthOrArrayLayers: 74}
+);
+} catch {}
+document.body.prepend('\u4592\u21e7\u08db\ub90b\u0499');
+let imageData43 = new ImageData(60, 208);
+let bindGroup76 = device7.createBindGroup({
+layout: bindGroupLayout28,
+entries: [
+{
+binding: 5899,
+resource: sampler73
+},
+{
+binding: 5659,
+resource: {
+buffer: buffer38,
+offset: 2400,
+size: 13748,
+}
+}
+],
+});
+try {
+renderBundleEncoder61.setVertexBuffer(
+5,
+buffer38,
+3588
+);
+} catch {}
+try {
+gpuCanvasContext22.configure(
+{
+device: device7,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let adapter11 = await navigator.gpu.requestAdapter(
+{
+}
+);
+offscreenCanvas9.width = 830;
+let textureView85 = texture83.createView(
+{
+label: '\u0ac8\u2897\u5384\ue639\u{1ff39}\u0a06\u5ebb',
+format: 'rgba16float',
+baseMipLevel: 5,
+mipLevelCount: 2,
+}
+);
+try {
+commandEncoder87.copyBufferToBuffer(
+buffer30,
+12888,
+buffer27,
+19536,
+268
+);
+dissociateBuffer(device2, buffer30);
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+commandEncoder83.copyTextureToTexture(
+{
+  texture: texture80,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 8 },
+  aspect: 'all',
+},
+{
+  texture: texture80,
+  mipLevel: 3,
+  origin: { x: 53, y: 0, z: 104 },
+  aspect: 'all',
+},
+{width: 7, height: 1, depthOrArrayLayers: 15}
+);
+} catch {}
+let pipeline60 = await device2.createComputePipelineAsync(
+{
+label: '\u{1fece}\u3973\u54cc\ud186\uca1a\u0b78\u4abd\u09f8',
+layout: pipelineLayout13,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend('\u0663\u73a6\u{1f718}\u0f3f\u0b3c\u38bb\u0b45\u0823\u{1fc95}');
+let buffer39 = device6.createBuffer(
+{
+label: '\ucd3d\u01e5\u0f5f\u23a9\ua8a9\udcaa\u0b9a',
+size: 60428,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: false,
+}
+);
+let renderPassEncoder1 = commandEncoder86.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined,
+{
+view: textureView82,
+clearValue: {
+r: -870.0,
+g: -210.6,
+b: 982.1,
+a: -820.4,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined,
+undefined
+],
+occlusionQuerySet: querySet51,
+maxDrawCount: 27232,
+}
+);
+let renderBundle78 = renderBundleEncoder56.finish(
+{
+label: '\u{1fb39}\u0af5\uc5dc\u0906\u3072'
+}
+);
+try {
+renderPassEncoder0.setBindGroup(
+4,
+bindGroup69,
+new Uint32Array(2024),
+1605,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(
+8
+);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(
+257
+);
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.append('\u6b58\ucf96\u168b');
+let adapter12 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let imageBitmap41 = await createImageBitmap(videoFrame29);
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+document.body.prepend(canvas15);
+let renderBundleEncoder67 = device2.createRenderBundleEncoder(
+{
+label: '\u471d\u7e59\u08c4\u6bf5\u62ae\u{1fdde}',
+colorFormats: [
+'r8unorm',
+'rgba16sint',
+'rgb10a2uint',
+'rgb10a2unorm'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 456,
+depthReadOnly: false,
+}
+);
+try {
+commandEncoder83.copyTextureToTexture(
+{
+  texture: texture80,
+  mipLevel: 3,
+  origin: { x: 33, y: 0, z: 8 },
+  aspect: 'all',
+},
+{
+  texture: texture80,
+  mipLevel: 4,
+  origin: { x: 9, y: 0, z: 3 },
+  aspect: 'all',
+},
+{width: 25, height: 0, depthOrArrayLayers: 103}
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer27,
+25900,
+new BigUint64Array(59075),
+32831,
+1568
+);
+} catch {}
+let pipeline61 = device2.createComputePipeline(
+{
+label: '\u767e\u0500\u24d9\u8e81\u021e\u1a27',
+layout: pipelineLayout13,
+compute: {
+module: shaderModule9,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend('\uefcc\u4da1\u013b\u{1f81c}\u55d6\u0a35');
+let renderBundle79 = renderBundleEncoder42.finish(
+{
+label: '\u84a0\ub108\uf668\u3a40\u{1fa5e}\u6a6d\u034f\ub069'
+}
+);
+let sampler78 = device3.createSampler(
+{
+label: '\u2a3e\u06de\u{1ffce}\u{1fd3f}\u7a60\u2f30\u06d3\u003d\u0759\u39b5',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 0.867,
+maxAnisotropy: 1,
+}
+);
+let canvas34 = document.createElement('canvas');
+let renderBundleEncoder68 = device6.createRenderBundleEncoder(
+{
+label: '\u0eea\ub1ba\u0e26\u4a6c\uc22a\u4fa4\u0b11\u1246',
+colorFormats: [
+undefined,
+'rgba32float',
+'bgra8unorm',
+'r16float',
+'rg16float',
+'bgra8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 801,
+}
+);
+let sampler79 = device6.createSampler(
+{
+label: '\u{1f96e}\u{1fc9f}\u32b2',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 61.615,
+lodMaxClamp: 86.305,
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder0.beginOcclusionQuery(
+80
+);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant(
+{
+r: 161.6,
+g: -221.6,
+b: 712.8,
+a: 188.3,
+}
+);
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+47.51,
+8.886,
+319.1,
+3.403,
+0.6559,
+0.7681
+);
+} catch {}
+try {
+renderBundleEncoder68.setBindGroup(
+2,
+bindGroup69
+);
+} catch {}
+try {
+renderPassEncoder1.pushDebugGroup(
+'\u{1f6eb}'
+);
+} catch {}
+try {
+renderPassEncoder1.popDebugGroup();
+} catch {}
+let imageBitmap42 = await createImageBitmap(canvas23);
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer37,
+12700,
+new DataView(new ArrayBuffer(9091)),
+6074,
+688
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture81,
+  mipLevel: 7,
+  origin: { x: 12, y: 4, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(12171305),
+/* required buffer size: 12171305 */{
+offset: 911,
+bytesPerRow: 214,
+rowsPerImage: 267,
+},
+{width: 48, height: 0, depthOrArrayLayers: 214}
+);
+} catch {}
+try {
+adapter0.label = '\u0cc2\u01ed';
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let videoFrame37 = new VideoFrame(imageBitmap40, {timestamp: 0});
+document.body.append('\ub850\u{1f715}\u850e\u0c90\u06c1\u{1ff5b}\u6949\u4e7e\u09ba');
+try {
+renderPassEncoder1.setBindGroup(
+1,
+bindGroup69
+);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(
+404
+);
+} catch {}
+try {
+renderPassEncoder1.setViewport(
+117.5,
+2.638,
+0.1373,
+8.058,
+0.5354,
+0.9605
+);
+} catch {}
+try {
+renderBundleEncoder68.insertDebugMarker(
+'\u7863'
+);
+} catch {}
+let gpuCanvasContext32 = canvas34.getContext('webgpu');
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+try {
+renderBundleEncoder67.setBindGroup(
+9,
+bindGroup75,
+new Uint32Array(7540),
+7187,
+0
+);
+} catch {}
+try {
+commandEncoder87.copyBufferToBuffer(
+buffer30,
+13128,
+buffer29,
+33032,
+160
+);
+dissociateBuffer(device2, buffer30);
+dissociateBuffer(device2, buffer29);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer27,
+28516,
+new Int16Array(33058),
+25667,
+4264
+);
+} catch {}
+let promise47 = device2.queue.onSubmittedWorkDone();
+document.body.append('\u{1f80e}\u07d5\u3ade\u{1f7bf}\u055b\u{1fbd0}\uf3c9\u0afc\u{1fea7}\u0fd5\u0b6c');
+let sampler80 = device2.createSampler(
+{
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+lodMinClamp: 71.506,
+lodMaxClamp: 84.807,
+}
+);
+try {
+computePassEncoder57.dispatchWorkgroups(
+1
+);
+} catch {}
+try {
+computePassEncoder56.setPipeline(
+pipeline57
+);
+} catch {}
+try {
+commandEncoder87.resolveQuerySet(
+querySet39,
+21,
+851,
+buffer30,
+1536
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer27,
+21144,
+new DataView(new ArrayBuffer(45535)),
+14215
+);
+} catch {}
+try {
+await promise47;
+} catch {}
+gc();
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55) };
+} catch {}
+let offscreenCanvas29 = new OffscreenCanvas(890, 128);
+try {
+offscreenCanvas28.getContext('webgl2');
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+0,
+undefined
+);
+} catch {}
+try {
+gpuCanvasContext15.configure(
+{
+device: device6,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb',
+'bgra8unorm'
+],
+}
+);
+} catch {}
+gc();
+document.body.append('\u0945\u5da4\u{1f9ee}\u053a');
+let offscreenCanvas30 = new OffscreenCanvas(386, 187);
+try {
+await adapter1.requestAdapterInfo();
+} catch {}
+try {
+adapter7.label = '\u19c9\uddec\u5696\u526f';
+} catch {}
+let shaderModule12 = device2.createShaderModule(
+{
+code: `
+
+@compute @workgroup_size(2, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S11 {
+@location(69) f0: vec4<f32>,
+@location(16) f1: u32,
+@builtin(sample_mask) f2: u32,
+@location(4) f3: vec2<f32>,
+@location(47) f4: vec3<u32>,
+@location(64) f5: vec2<f32>,
+@location(74) f6: u32,
+@location(99) f7: vec2<i32>,
+@location(41) f8: vec4<f32>,
+@location(9) f9: vec3<f32>,
+@location(102) f10: vec2<f16>,
+@location(29) f11: vec2<u32>,
+@location(52) f12: vec4<f32>,
+@builtin(sample_index) f13: u32,
+@location(0) f14: vec2<u32>,
+@location(111) f15: vec4<f16>,
+@builtin(front_facing) f16: bool,
+@location(37) f17: vec2<u32>,
+@location(88) f18: vec4<i32>,
+@location(24) f19: vec3<u32>,
+@location(61) f20: vec2<u32>,
+@location(7) f21: vec3<u32>,
+@location(53) f22: f16,
+@location(75) f23: vec4<f16>,
+@location(25) f24: vec3<f32>,
+@location(92) f25: vec4<f32>,
+@location(31) f26: f16
+}
+struct FragmentOutput0 {
+@location(6) f0: u32,
+@location(7) f1: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(11) a0: vec3<f16>, @location(35) a1: vec4<u32>, @builtin(position) a2: vec4<f32>, @location(26) a3: vec3<u32>, @location(109) a4: vec4<u32>, @location(28) a5: vec3<f32>, a6: S11) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S10 {
+@location(16) f0: vec4<f16>,
+@location(17) f1: vec3<i32>,
+@location(12) f2: vec4<u32>,
+@location(19) f3: vec3<i32>,
+@location(10) f4: vec2<u32>,
+@location(0) f5: vec2<f16>,
+@location(5) f6: i32,
+@location(7) f7: f32,
+@location(9) f8: vec4<f32>,
+@location(22) f9: vec3<u32>,
+@location(23) f10: vec3<i32>,
+@location(8) f11: vec4<i32>,
+@location(21) f12: vec4<f32>,
+@location(4) f13: vec4<f16>,
+@location(15) f14: vec4<f32>,
+@location(24) f15: vec3<u32>,
+@location(11) f16: vec2<i32>,
+@location(18) f17: i32
+}
+struct VertexOutput0 {
+@location(69) f148: vec4<f32>,
+@location(0) f149: vec2<u32>,
+@location(11) f150: vec3<f16>,
+@location(53) f151: f16,
+@location(47) f152: vec3<u32>,
+@location(4) f153: vec2<f32>,
+@location(41) f154: vec4<f32>,
+@location(61) f155: vec2<u32>,
+@location(99) f156: vec2<i32>,
+@location(109) f157: vec4<u32>,
+@location(92) f158: vec4<f32>,
+@location(64) f159: vec2<f32>,
+@location(26) f160: vec3<u32>,
+@location(9) f161: vec3<f32>,
+@location(16) f162: u32,
+@location(7) f163: vec3<u32>,
+@location(28) f164: vec3<f32>,
+@location(29) f165: vec2<u32>,
+@location(25) f166: vec3<f32>,
+@location(35) f167: vec4<u32>,
+@location(24) f168: vec3<u32>,
+@location(102) f169: vec2<f16>,
+@location(75) f170: vec4<f16>,
+@location(37) f171: vec2<u32>,
+@location(74) f172: u32,
+@location(88) f173: vec4<i32>,
+@location(31) f174: f16,
+@builtin(position) f175: vec4<f32>,
+@location(111) f176: vec4<f16>,
+@location(52) f177: vec4<f32>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(2) a1: vec2<u32>, @location(1) a2: f32, @builtin(vertex_index) a3: u32, @location(3) a4: f16, @location(20) a5: vec4<f32>, @location(13) a6: vec2<f16>, @location(14) a7: vec2<i32>, @location(6) a8: vec2<f16>, a9: S10) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+try {
+computePassEncoder56.end();
+} catch {}
+try {
+renderBundleEncoder53.setBindGroup(
+7,
+bindGroup60,
+[]
+);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+commandEncoder87.copyTextureToTexture(
+{
+  texture: texture95,
+  mipLevel: 2,
+  origin: { x: 19, y: 1, z: 37 },
+  aspect: 'all',
+},
+{
+  texture: texture95,
+  mipLevel: 3,
+  origin: { x: 36, y: 0, z: 21 },
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 13}
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 139, height: 1, depthOrArrayLayers: 72}
+*/
+{
+  source: canvas34,
+  origin: { x: 26, y: 144 },
+  flipY: true,
+},
+{
+  texture: texture95,
+  mipLevel: 2,
+  origin: { x: 13, y: 1, z: 10 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 125, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline62 = device2.createRenderPipeline(
+{
+layout: pipelineLayout17,
+vertex: {
+module: shaderModule11,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 6612,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 824,
+shaderLocation: 2,
+},
+{
+format: 'float32x4',
+offset: 1424,
+shaderLocation: 21,
+},
+{
+format: 'uint8x4',
+offset: 1360,
+shaderLocation: 6,
+},
+{
+format: 'unorm16x4',
+offset: 3860,
+shaderLocation: 9,
+},
+{
+format: 'uint8x2',
+offset: 5470,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x4',
+offset: 4972,
+shaderLocation: 19,
+},
+{
+format: 'uint32x3',
+offset: 4656,
+shaderLocation: 1,
+},
+{
+format: 'uint32x4',
+offset: 448,
+shaderLocation: 14,
+},
+{
+format: 'float32x4',
+offset: 2076,
+shaderLocation: 23,
+},
+{
+format: 'sint32x3',
+offset: 5548,
+shaderLocation: 5,
+},
+{
+format: 'sint32',
+offset: 6188,
+shaderLocation: 4,
+},
+{
+format: 'float32x4',
+offset: 4516,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x2',
+offset: 572,
+shaderLocation: 12,
+},
+{
+format: 'uint8x4',
+offset: 2536,
+shaderLocation: 3,
+},
+{
+format: 'float16x2',
+offset: 4452,
+shaderLocation: 18,
+},
+{
+format: 'sint16x4',
+offset: 3224,
+shaderLocation: 10,
+},
+{
+format: 'uint32x3',
+offset: 3944,
+shaderLocation: 17,
+},
+{
+format: 'uint16x4',
+offset: 4928,
+shaderLocation: 20,
+},
+{
+format: 'sint8x2',
+offset: 5976,
+shaderLocation: 22,
+},
+{
+format: 'uint32x3',
+offset: 1988,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 4832,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x4',
+offset: 228,
+shaderLocation: 24,
+},
+{
+format: 'uint16x2',
+offset: 772,
+shaderLocation: 0,
+},
+{
+format: 'sint32x2',
+offset: 4092,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 8524,
+attributes: [
+{
+format: 'snorm8x2',
+offset: 3488,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 3464,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 2564,
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 1196,
+shaderLocation: 8,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+}
+);
+try {
+offscreenCanvas30.getContext('webgpu');
+} catch {}
+let texture99 = device7.createTexture(
+{
+label: '\u{1fcab}\u171e\u{1fb7f}\ucd22\u062b',
+size: [72, 192, 108],
+mipLevelCount: 6,
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-12x12-unorm',
+'astc-12x12-unorm'
+],
+}
+);
+let sampler81 = device7.createSampler(
+{
+label: '\u{1fdb8}\u6565\u07e3\u6425\u01b8\ua35b\u{1fb2b}',
+addressModeU: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMinClamp: 98.209,
+lodMaxClamp: 98.402,
+maxAnisotropy: 1,
+}
+);
+try {
+renderBundleEncoder61.setBindGroup(
+6,
+bindGroup76
+);
+} catch {}
+try {
+renderBundleEncoder61.setVertexBuffer(
+3,
+buffer38,
+16060,
+1729
+);
+} catch {}
+let querySet63 = device7.createQuerySet(
+{
+label: '\u4812\uedfa',
+type: 'occlusion',
+count: 3369,
+}
+);
+let renderBundle80 = renderBundleEncoder61.finish(
+{
+label: '\u6695\uf472\ua514\u07aa\u6eff\u73ed\u00e1\u9b2a'
+}
+);
+let sampler82 = device7.createSampler(
+{
+label: '\uc367\u{1ffb6}\ua91b',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 77.792,
+lodMaxClamp: 97.977,
+compare: 'never',
+}
+);
+try {
+buffer38.unmap();
+} catch {}
+try {
+device7.queue.writeTexture(
+{
+  texture: texture89,
+  mipLevel: 3,
+  origin: { x: 5, y: 6, z: 7 },
+  aspect: 'all',
+},
+new ArrayBuffer(298909),
+/* required buffer size: 298909 */{
+offset: 211,
+bytesPerRow: 152,
+rowsPerImage: 151,
+},
+{width: 9, height: 3, depthOrArrayLayers: 14}
+);
+} catch {}
+document.body.append('\u81f7\u48ab\u2610\u6f92\u{1f873}\u8881\u045f\uf920');
+try {
+await device2.popErrorScope();
+} catch {}
+try {
+commandEncoder87.clearBuffer(
+buffer27
+);
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture80,
+  mipLevel: 1,
+  origin: { x: 22, y: 1, z: 273 },
+  aspect: 'all',
+},
+arrayBuffer6,
+/* required buffer size: 13729086 */{
+offset: 451,
+bytesPerRow: 1915,
+rowsPerImage: 67,
+},
+{width: 208, height: 0, depthOrArrayLayers: 108}
+);
+} catch {}
+let pipeline63 = device2.createRenderPipeline(
+{
+label: '\u1581\u0c9b',
+layout: pipelineLayout14,
+vertex: {
+module: shaderModule8,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 3572,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x4',
+offset: 1412,
+shaderLocation: 19,
+},
+{
+format: 'sint16x4',
+offset: 3000,
+shaderLocation: 7,
+},
+{
+format: 'uint32x3',
+offset: 2604,
+shaderLocation: 6,
+},
+{
+format: 'snorm16x2',
+offset: 452,
+shaderLocation: 24,
+},
+{
+format: 'float32x4',
+offset: 500,
+shaderLocation: 4,
+},
+{
+format: 'sint8x2',
+offset: 834,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 10104,
+attributes: [
+{
+format: 'unorm8x4',
+offset: 7428,
+shaderLocation: 22,
+},
+{
+format: 'snorm8x4',
+offset: 7380,
+shaderLocation: 18,
+},
+{
+format: 'sint16x2',
+offset: 7976,
+shaderLocation: 15,
+},
+{
+format: 'sint32',
+offset: 9036,
+shaderLocation: 17,
+},
+{
+format: 'unorm8x4',
+offset: 10064,
+shaderLocation: 20,
+},
+{
+format: 'unorm16x2',
+offset: 8888,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 4028,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32',
+offset: 3500,
+shaderLocation: 23,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0xd2a89a7c,
+},
+fragment: {
+module: shaderModule8,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilWriteMask: 2648,
+depthBias: 65,
+depthBiasSlopeScale: 31,
+depthBiasClamp: 11,
+},
+}
+);
+document.body.prepend('\u6edd\u{1f993}\u0929\u6982\u0c1a\u0e97\u04e1\u2813\u03ed\u0585');
+let texture100 = device6.createTexture(
+{
+label: '\u2a4b\u0fd9\u{1f6fb}\uca59\u89bf\ua3b3\ue3ff\u0f3e',
+size: {width: 190, height: 24, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'astc-5x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+renderBundleEncoder68.setBindGroup(
+6,
+bindGroup69
+);
+} catch {}
+try {
+gpuCanvasContext25.configure(
+{
+device: device6,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+document.body.prepend('\u0c24\u04ef\u{1fed8}\u30c9\u6d71\u40b1\u{1faf4}\uf888');
+let promise48 = navigator.gpu.requestAdapter(
+{
+}
+);
+canvas28.width = 353;
+let adapter13 = await promise48;
+try {
+offscreenCanvas29.getContext('webgpu');
+} catch {}
+let texture101 = device2.createTexture(
+{
+label: '\uc9c1\udda1\u5f95',
+size: {width: 140, height: 140, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'depth32float'
+],
+}
+);
+let textureView86 = texture76.createView(
+{
+label: '\u{1f738}\u98c3\u5ea0\u{1faba}\u1c32\u0f43\u0e2b',
+baseMipLevel: 5,
+baseArrayLayer: 47,
+arrayLayerCount: 12,
+}
+);
+let computePassEncoder59 = commandEncoder82.beginComputePass(
+{
+
+}
+);
+let renderBundleEncoder69 = device2.createRenderBundleEncoder(
+{
+label: '\u4254\u427f\u1db7\u0d3e\ue2a2\u324d\u2b1a\u0069\u3113',
+colorFormats: [
+'rg32sint',
+'rgb10a2uint',
+'rg8uint',
+'rg8uint'
+],
+sampleCount: 449,
+depthReadOnly: true,
+}
+);
+try {
+computePassEncoder57.setPipeline(
+pipeline60
+);
+} catch {}
+try {
+commandEncoder83.clearBuffer(
+buffer27
+);
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture80,
+  mipLevel: 3,
+  origin: { x: 7, y: 0, z: 45 },
+  aspect: 'all',
+},
+new Uint8Array(new ArrayBuffer(72)),
+/* required buffer size: 7878803 */{
+offset: 807,
+bytesPerRow: 587,
+rowsPerImage: 220,
+},
+{width: 57, height: 1, depthOrArrayLayers: 62}
+);
+} catch {}
+document.body.prepend('\u{1fb49}\u0006');
+video21.width = 263;
+let texture102 = device8.createTexture(
+{
+label: '\u28c4\u{1fe92}\uee9d\u0e6e',
+size: [167, 1, 1579],
+mipLevelCount: 9,
+dimension: '3d',
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16float',
+'rgba16float'
+],
+}
+);
+let renderBundleEncoder70 = device8.createRenderBundleEncoder(
+{
+label: '\u7229\uca1e\u6a13\u2da8\u0299\u0a81\u16db\u063c\u097a\u016f',
+colorFormats: [
+'r16sint',
+'rg8uint',
+undefined,
+'rgba32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 748,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler83 = device8.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 61.338,
+lodMaxClamp: 62.178,
+maxAnisotropy: 10,
+}
+);
+try {
+await device8.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend('\u0140\u030b\u{1fd8b}\ue03e\u{1fb2b}\u75ad\u{1f8e1}\ue7c2\ucf21\u0420');
+let buffer40 = device6.createBuffer(
+{
+size: 8536,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+}
+);
+try {
+renderPassEncoder1.setStencilReference(
+4069
+);
+} catch {}
+try {
+device6.queue.writeBuffer(
+buffer40,
+140,
+new Int16Array(35817),
+3132,
+628
+);
+} catch {}
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+document.body.prepend(img10);
+document.body.append('\u0e4b\u0dd7\u0736\u0f5a\u7373\u0532\u{1f89e}\u{1fa64}\u274a\ucbf1\u6aa5');
+let promise49 = adapter10.requestAdapterInfo();
+let texture103 = device7.createTexture(
+{
+label: '\u5a5e\u{1f893}\u028d\u33f1\u3617\ub3c7',
+size: [60, 204, 1],
+mipLevelCount: 6,
+format: 'astc-12x12-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-12x12-unorm-srgb',
+'astc-12x12-unorm',
+'astc-12x12-unorm'
+],
+}
+);
+try {
+device7.addEventListener('uncapturederror', e => { log('device7.uncapturederror'); log(e); e.label = device7.label; });
+} catch {}
+try {
+gpuCanvasContext27.configure(
+{
+device: device7,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let renderBundle81 = renderBundleEncoder46.finish();
+let sampler84 = device4.createSampler(
+{
+label: '\u4b98\u0920\u0d90',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+lodMaxClamp: 78.018,
+}
+);
+document.body.append('\udedd\udc4d\u{1feba}\u{1fe46}\uf56f\u141d\uba38\ue100\ue5a4\ue4d8\u6679');
+let device9 = await promise31;
+try {
+adapter13.label = '\u0b8a\ubc66\u3dc1\u{1f616}\u9af1\ua7af\ucd84\u5340\u8729\u8ed5\uc863';
+} catch {}
+let renderBundleEncoder71 = device8.createRenderBundleEncoder(
+{
+label: '\u6c05\u{1ffa6}\uc243\u2a30\u8918\u{1fea6}',
+colorFormats: [
+'rgba32float',
+'r32uint',
+'rg16sint',
+'rg32sint',
+undefined,
+'rgba16float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 232,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder71.setVertexBuffer(
+6,
+undefined,
+2939380740,
+869176666
+);
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+document.body.append('\u8ac3\u5294\u0e15\uf006');
+let imageBitmap43 = await createImageBitmap(offscreenCanvas1);
+let querySet64 = device4.createQuerySet(
+{
+type: 'occlusion',
+count: 3168,
+}
+);
+let computePassEncoder60 = commandEncoder88.beginComputePass(
+{
+label: '\u1de6\u9a72\udd51'
+}
+);
+let externalTexture11 = device4.importExternalTexture(
+{
+source: video27,
+colorSpace: 'srgb',
+}
+);
+try {
+renderBundleEncoder55.setBindGroup(
+1,
+bindGroup57
+);
+} catch {}
+let adapter14 = await navigator.gpu.requestAdapter(
+{
+}
+);
+try {
+querySet56.label = '\u01a0\u{1fcde}\u2893\ufef6\u4959\u0f25\u0b70';
+} catch {}
+let pipelineLayout20 = device7.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout28,
+bindGroupLayout28,
+bindGroupLayout26,
+bindGroupLayout28,
+bindGroupLayout26,
+bindGroupLayout26
+],
+}
+);
+let querySet65 = device7.createQuerySet(
+{
+type: 'occlusion',
+count: 2062,
+}
+);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+canvas21.height = 358;
+let querySet66 = device4.createQuerySet(
+{
+label: '\u548c\u93cd\uf0ad\u{1fe29}\u1328',
+type: 'occlusion',
+count: 42,
+}
+);
+let renderBundle82 = renderBundleEncoder57.finish();
+let imageBitmap44 = await createImageBitmap(imageData31);
+let imageData44 = new ImageData(252, 244);
+let sampler85 = device9.createSampler(
+{
+label: '\u{1fec6}\u{1f8ac}\u{1f860}\ua425\uf596\u{1fdd5}\u03ce',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 35.477,
+lodMaxClamp: 67.932,
+maxAnisotropy: 3,
+}
+);
+let bindGroup77 = device7.createBindGroup({
+label: '\ub28d\u799a\u{1fd0e}\uf847\u55ff\u0c83\u{1f744}',
+layout: bindGroupLayout26,
+entries: [
+
+],
+});
+let buffer41 = device7.createBuffer(
+{
+label: '\ua914\u{1f827}\u09fa\u0804',
+size: 13790,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+}
+);
+let textureView87 = texture89.createView(
+{
+label: '\ue322\u{1f93a}\ufb25\uf7a2\u6949\u3b26\u0e21',
+dimension: '2d',
+baseMipLevel: 2,
+mipLevelCount: 1,
+baseArrayLayer: 18,
+arrayLayerCount: 1,
+}
+);
+let renderBundleEncoder72 = device7.createRenderBundleEncoder(
+{
+label: '\u{1f9fa}\u0ad4\u01d7\u483f\u1e61',
+colorFormats: [
+undefined,
+undefined
+],
+sampleCount: 783,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder72.setBindGroup(
+7,
+bindGroup76,
+new Uint32Array(2163),
+2150,
+0
+);
+} catch {}
+try {
+renderBundleEncoder72.setVertexBuffer(
+2,
+buffer41
+);
+} catch {}
+document.body.append('\uf769\u{1f8a1}\u{1f9f9}\u25ae\u72e5\u{1f8cf}\u4a8c\ud1f0\u{1f881}\u1c7a');
+let commandEncoder89 = device2.createCommandEncoder();
+let texture104 = device2.createTexture(
+{
+label: '\u691b\udd04\u0190\u0e04\u4169\u8773\u1a54\u0f33',
+size: [427, 51, 1],
+mipLevelCount: 2,
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+try {
+computePassEncoder59.setBindGroup(
+5,
+bindGroup61
+);
+} catch {}
+try {
+computePassEncoder57.setPipeline(
+pipeline49
+);
+} catch {}
+try {
+renderBundleEncoder69.setBindGroup(
+4,
+bindGroup55,
+new Uint32Array(8633),
+2956,
+0
+);
+} catch {}
+try {
+commandEncoder83.copyBufferToBuffer(
+buffer30,
+6576,
+buffer29,
+11064,
+2196
+);
+dissociateBuffer(device2, buffer30);
+dissociateBuffer(device2, buffer29);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+canvas12.width = 335;
+let device10 = await adapter12.requestDevice(
+{
+label: '\ue2c6\u{1f98b}\u02d9\u02f2\u02e1\u{1ffa2}\ud918\u0238\u0371\u6698',
+requiredFeatures: [
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+}
+);
+try {
+await promise49;
+} catch {}
+let videoFrame38 = new VideoFrame(canvas26, {timestamp: 0});
+let shaderModule13 = device7.createShaderModule(
+{
+label: '\u0b6a\u4209\u91b4\u3121\u09c4\u0a92\u0a94\u{1f863}\u0d13',
+code: `@group(1) @binding(5659)
+var<storage, read_write> local1: array<u32>;
+@group(3) @binding(5899)
+var<storage, read_write> field0: array<u32>;
+
+@compute @workgroup_size(7, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(7) f0: i32,
+@location(3) f1: vec4<u32>,
+@location(1) f2: vec3<i32>,
+@location(6) f3: vec3<i32>,
+@location(5) f4: f32,
+@location(4) f5: vec4<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S12 {
+@location(21) f0: vec2<f32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec4<i32>, @location(9) a1: vec3<u32>, @location(20) a2: i32, @location(15) a3: vec4<u32>, @location(2) a4: vec3<u32>, @location(14) a5: u32, @location(19) a6: vec4<f16>, @location(22) a7: vec4<f32>, @location(1) a8: vec2<i32>, @location(23) a9: vec3<f16>, @location(6) a10: u32, a11: S12, @location(3) a12: vec3<f16>, @location(5) a13: vec3<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+}
+);
+let bindGroupLayout31 = device7.createBindGroupLayout(
+{
+label: '\u0cba\u{1fac7}\u04bd\u0e8c\u0d1b',
+entries: [
+
+],
+}
+);
+let commandEncoder90 = device7.createCommandEncoder(
+{
+label: '\uee35\u4fae\u080c',
+}
+);
+let querySet67 = device7.createQuerySet(
+{
+label: '\u01c5\u52f1\ucf91\u6abe\u59df\u{1fba7}\u65bc\u2dc3\uf788\uf46e',
+type: 'occlusion',
+count: 875,
+}
+);
+let renderBundle83 = renderBundleEncoder72.finish(
+{
+label: '\u0c05\u7831\u9a26'
+}
+);
+let sampler86 = device7.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 85.704,
+lodMaxClamp: 94.840,
+}
+);
+try {
+commandEncoder90.copyTextureToBuffer(
+{
+  texture: texture103,
+  mipLevel: 1,
+  origin: { x: 24, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 12624 */
+offset: 12624,
+bytesPerRow: 0,
+buffer: buffer38,
+},
+{width: 0, height: 96, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device7, buffer38);
+} catch {}
+try {
+commandEncoder90.copyTextureToTexture(
+{
+  texture: texture103,
+  mipLevel: 1,
+  origin: { x: 12, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture103,
+  mipLevel: 0,
+  origin: { x: 36, y: 132, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 60, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device7.queue.writeTexture(
+{
+  texture: texture94,
+  mipLevel: 3,
+  origin: { x: 10, y: 0, z: 2 },
+  aspect: 'all',
+},
+new ArrayBuffer(1627421),
+/* required buffer size: 1627421 */{
+offset: 723,
+bytesPerRow: 153,
+rowsPerImage: 161,
+},
+{width: 1, height: 7, depthOrArrayLayers: 67}
+);
+} catch {}
+let textureView88 = texture93.createView(
+{
+dimension: '2d',
+baseMipLevel: 0,
+mipLevelCount: 2,
+baseArrayLayer: 8,
+}
+);
+try {
+computePassEncoder54.setBindGroup(
+3,
+bindGroup63
+);
+} catch {}
+try {
+renderBundleEncoder59.setBindGroup(
+4,
+bindGroup66
+);
+} catch {}
+gc();
+document.body.append('\u{1fef5}\uf8ec\u06d0\u487a\u0693\u0f3c\u9485\u673d\u{1f8ab}\u81df');
+let shaderModule14 = device7.createShaderModule(
+{
+label: '\uec62\uc6a0\u78a2\uc1be\u{1f714}\ud6fc\ub805\u2b6a\u1a66\udc04\u{1fc07}',
+code: `
+
+@compute @workgroup_size(5, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S13 {
+@location(18) f0: vec2<i32>,
+@location(75) f1: vec3<u32>,
+@location(69) f2: vec3<u32>,
+@location(79) f3: vec4<f32>,
+@location(62) f4: vec4<u32>,
+@location(95) f5: i32,
+@builtin(position) f6: vec4<f32>,
+@location(43) f7: vec3<f16>,
+@location(47) f8: vec3<u32>,
+@location(64) f9: vec4<i32>,
+@location(17) f10: vec2<i32>
+}
+struct FragmentOutput0 {
+@location(4) f0: i32,
+@location(6) f1: vec3<i32>,
+@location(1) f2: vec4<i32>,
+@location(3) f3: u32,
+@location(5) f4: f32,
+@location(2) f5: vec2<f32>,
+@builtin(sample_mask) f6: u32
+}
+
+@fragment
+fn fragment0(@location(91) a0: vec3<i32>, @location(35) a1: vec4<u32>, @location(45) a2: vec4<f32>, @builtin(sample_index) a3: u32, @location(67) a4: vec3<i32>, @location(77) a5: vec2<f32>, @location(4) a6: vec3<f32>, @builtin(sample_mask) a7: u32, @location(83) a8: u32, a9: S13, @location(10) a10: vec3<f16>, @location(93) a11: i32, @location(37) a12: vec4<i32>, @builtin(front_facing) a13: bool, @location(15) a14: u32, @location(38) a15: vec2<i32>, @location(98) a16: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(0) f178: vec4<f32>,
+@location(18) f179: vec2<i32>,
+@location(63) f180: u32,
+@location(95) f181: i32,
+@location(38) f182: vec2<i32>,
+@location(91) f183: vec3<i32>,
+@location(17) f184: vec2<i32>,
+@location(45) f185: vec4<f32>,
+@location(94) f186: vec2<f32>,
+@location(37) f187: vec4<i32>,
+@location(47) f188: vec3<u32>,
+@location(70) f189: vec2<u32>,
+@location(35) f190: vec4<u32>,
+@location(93) f191: i32,
+@location(83) f192: u32,
+@location(75) f193: vec3<u32>,
+@location(67) f194: vec3<i32>,
+@location(51) f195: vec4<f16>,
+@location(4) f196: vec3<f32>,
+@location(77) f197: vec2<f32>,
+@location(7) f198: u32,
+@location(31) f199: f16,
+@location(79) f200: vec4<f32>,
+@location(62) f201: vec4<u32>,
+@location(10) f202: vec3<f16>,
+@builtin(position) f203: vec4<f32>,
+@location(69) f204: vec3<u32>,
+@location(80) f205: vec2<f16>,
+@location(43) f206: vec3<f16>,
+@location(65) f207: u32,
+@location(78) f208: f16,
+@location(98) f209: u32,
+@location(15) f210: u32,
+@location(64) f211: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec2<f32>, @location(4) a1: vec3<f32>, @location(8) a2: vec4<f32>, @location(20) a3: u32, @location(10) a4: vec3<i32>, @location(21) a5: vec2<u32>, @location(19) a6: vec2<f32>, @location(14) a7: f16, @location(12) a8: vec3<f32>, @location(22) a9: vec3<u32>, @location(9) a10: vec2<f16>, @location(18) a11: vec2<f32>, @location(17) a12: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let textureView89 = texture99.createView(
+{
+label: '\u0358\u{1fd94}\u{1f923}\u89a4\u8ca5\u{1ff97}\u2b8e\u{1f722}',
+baseMipLevel: 2,
+mipLevelCount: 1,
+baseArrayLayer: 19,
+}
+);
+let renderBundle84 = renderBundleEncoder72.finish(
+{
+label: '\u89c2\u046e\u{1fb89}\ud117\u07a0'
+}
+);
+let sampler87 = device7.createSampler(
+{
+label: '\u{1fd41}\ubef3\u920e\u93ee\u7a2c\u428b\u0d19',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMaxClamp: 72.242,
+compare: 'equal',
+}
+);
+let pipeline64 = device7.createComputePipeline(
+{
+label: '\u009e\u0764\u032e\u6901\u{1fc43}\u0888\u{1fa9f}\u08e7\ub155\ufb7b\ue8d3',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+let offscreenCanvas31 = new OffscreenCanvas(279, 581);
+try {
+offscreenCanvas31.getContext('webgl');
+} catch {}
+let bindGroupLayout32 = device7.createBindGroupLayout(
+{
+entries: [
+{
+binding: 5632,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 351745, hasDynamicOffset: true },
+},
+{
+binding: 6517,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+},
+{
+binding: 1798,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+let pipelineLayout21 = device7.createPipelineLayout(
+{
+label: '\uc1df\u{1fcc1}',
+bindGroupLayouts: [
+bindGroupLayout32,
+bindGroupLayout32,
+bindGroupLayout26,
+bindGroupLayout26,
+bindGroupLayout28,
+bindGroupLayout26,
+bindGroupLayout31,
+bindGroupLayout28,
+bindGroupLayout28,
+bindGroupLayout31,
+bindGroupLayout32
+],
+}
+);
+let texture105 = gpuCanvasContext6.getCurrentTexture();
+let renderPassEncoder2 = commandEncoder90.beginRenderPass(
+{
+label: '\u8aaf\u8c52\u9bca\ucbda\u{1f822}\ud256\u{1f74a}\u06c7\uea2b',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+{
+view: textureView87,
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet63,
+maxDrawCount: 2936,
+}
+);
+let renderBundleEncoder73 = device7.createRenderBundleEncoder(
+{
+label: '\u8340\u0e4e\u{1fad7}\u0873\u9017\uee04\u{1f8e1}\uf5f3\u{1fe6b}\u095c',
+colorFormats: [
+'rgba8unorm-srgb',
+'r16float',
+undefined,
+'rg16float',
+'r16uint',
+'r16float',
+'r8uint',
+'rgba8unorm'
+],
+sampleCount: 208,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder2.setScissorRect(
+52,
+14,
+4,
+1
+);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+42.16,
+22.61,
+11.31,
+17.96,
+0.9491,
+0.9594
+);
+} catch {}
+try {
+renderBundleEncoder73.setBindGroup(
+6,
+bindGroup71
+);
+} catch {}
+try {
+renderBundleEncoder73.setBindGroup(
+6,
+bindGroup71,
+new Uint32Array(1388),
+977,
+0
+);
+} catch {}
+try {
+renderBundleEncoder73.setVertexBuffer(
+4,
+buffer41
+);
+} catch {}
+let promise50 = device7.createComputePipelineAsync(
+{
+label: '\u0f3d\u0f28\u03fd\ue281\u{1f617}\u1760\uff05\ub1c3',
+layout: pipelineLayout20,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.append('\u4a16\u82c6\u643c\u{1f6b5}\u135b\udb59\u{1ff91}\uea82\u0752\u{1f878}');
+let bindGroup78 = device4.createBindGroup({
+label: '\u2c67\u0a07\u7457\u{1fac1}\u0dee\u4d27\ufebe\ubcc8\u0397',
+layout: bindGroupLayout20,
+entries: [
+
+],
+});
+let renderBundle85 = renderBundleEncoder54.finish(
+{
+label: '\u7401\uf050\u0fed'
+}
+);
+document.body.prepend(canvas25);
+let bindGroupLayout33 = device2.createBindGroupLayout(
+{
+label: '\ucdb2\udbbd',
+entries: [
+{
+binding: 1012,
+visibility: 0,
+sampler: { type: 'comparison' },
+},
+{
+binding: 957,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+},
+{
+binding: 395,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+}
+],
+}
+);
+try {
+computePassEncoder57.setPipeline(
+pipeline48
+);
+} catch {}
+try {
+renderBundleEncoder69.setBindGroup(
+9,
+bindGroup72,
+new Uint32Array(4385),
+1435,
+0
+);
+} catch {}
+try {
+renderBundleEncoder65.pushDebugGroup(
+'\ub4a5'
+);
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+document.body.prepend('\u0c93\u{1f693}\u0995');
+let imageBitmap45 = await createImageBitmap(video28);
+video21.width = 210;
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let video29 = await videoWithData();
+let video30 = await videoWithData();
+let sampler88 = device9.createSampler(
+{
+label: '\u{1fef1}\u41d6\ue06d\ufe64',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 37.299,
+lodMaxClamp: 71.735,
+}
+);
+document.body.prepend('\u{1fb48}\u25ca\u5554\u4281\u{1ff60}\ue4ee\u434e\ufd79\u0caa\uc890');
+try {
+renderPassEncoder2.setBindGroup(
+9,
+bindGroup76
+);
+} catch {}
+try {
+renderBundleEncoder73.setBindGroup(
+10,
+bindGroup77
+);
+} catch {}
+try {
+device7.queue.writeBuffer(
+buffer38,
+16856,
+new BigUint64Array(34736),
+6552,
+488
+);
+} catch {}
+try {
+device7.queue.writeTexture(
+{
+  texture: texture89,
+  mipLevel: 0,
+  origin: { x: 62, y: 31, z: 25 },
+  aspect: 'all',
+},
+new ArrayBuffer(198337),
+/* required buffer size: 198337 */{
+offset: 569,
+bytesPerRow: 221,
+rowsPerImage: 255,
+},
+{width: 97, height: 130, depthOrArrayLayers: 4}
+);
+} catch {}
+let bindGroupLayout34 = device4.createBindGroupLayout(
+{
+entries: [
+{
+binding: 1092,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '2d-array' },
+},
+{
+binding: 1031,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 7,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+let bindGroup79 = device4.createBindGroup({
+layout: bindGroupLayout20,
+entries: [
+
+],
+});
+let textureView90 = texture79.createView(
+{
+label: '\u0216\u042d\u{1f80a}\ubb34\uc643\uf72e\u{1f822}\ue8c8',
+dimension: '2d',
+baseArrayLayer: 25,
+arrayLayerCount: 1,
+}
+);
+let promise51 = device4.queue.onSubmittedWorkDone();
+document.body.prepend('\u7195\u556f\u{1f8ae}\u0ed7\u{1fc74}\u{1fc9a}\u{1ff3f}\u{1fa67}\uc08d\u2e51');
+let videoFrame39 = new VideoFrame(img13, {timestamp: 0});
+let renderBundle86 = renderBundleEncoder71.finish(
+{
+label: '\u0b03\u098a\u0067\uedc8'
+}
+);
+try {
+await promise51;
+} catch {}
+gc();
+let textureView91 = texture79.createView(
+{
+label: '\ue0b4\u{1fbdf}\u8e49\ucc24\uccc5\ue012\u{1fc56}\u0208',
+dimension: '2d',
+baseArrayLayer: 142,
+}
+);
+try {
+device4.queue.writeTexture(
+{
+  texture: texture91,
+  mipLevel: 0,
+  origin: { x: 702, y: 1, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(56),
+/* required buffer size: 406 */{
+offset: 406,
+rowsPerImage: 227,
+},
+{width: 3006, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let renderBundle87 = renderBundleEncoder71.finish(
+{
+
+}
+);
+let sampler89 = device8.createSampler(
+{
+addressModeU: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+}
+);
+try {
+renderBundleEncoder70.setVertexBuffer(
+61,
+undefined,
+1436530241,
+2127149129
+);
+} catch {}
+video27.height = 161;
+gc();
+let commandEncoder91 = device6.createCommandEncoder(
+{
+}
+);
+let renderBundle88 = renderBundleEncoder56.finish(
+{
+label: '\u0ddb\ud3d8'
+}
+);
+let sampler90 = device6.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 15.548,
+lodMaxClamp: 32.215,
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant(
+{
+r: -960.1,
+g: 4.132,
+b: -35.83,
+a: -188.2,
+}
+);
+} catch {}
+try {
+device6.destroy();
+} catch {}
+video29.height = 284;
+let canvas35 = document.createElement('canvas');
+let canvas36 = document.createElement('canvas');
+try {
+renderPassEncoder2.beginOcclusionQuery(
+40
+);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: 506.4,
+g: 592.2,
+b: -902.1,
+a: 544.2,
+}
+);
+} catch {}
+try {
+renderBundleEncoder73.setBindGroup(
+4,
+bindGroup77
+);
+} catch {}
+try {
+renderBundleEncoder73.setIndexBuffer(
+buffer38,
+'uint32',
+17040
+);
+} catch {}
+try {
+await device7.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(video17);
+document.body.prepend('\u5d93\u0d7f\u5957\u{1fa78}\u051b\u0e8d\u0d7c');
+try {
+canvas36.getContext('webgpu');
+} catch {}
+try {
+texture19.label = '\u1107\uf4c9\u22ce';
+} catch {}
+gc();
+let shaderModule15 = device2.createShaderModule(
+{
+label: '\uf7e7\ucdda\ub827\u5956\u2c27\u0203\u0ae5',
+code: `
+
+@compute @workgroup_size(4, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(2) f0: i32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(17) a1: vec4<f32>, @location(9) a2: vec3<i32>, @location(21) a3: vec3<f32>, @location(10) a4: i32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+}
+);
+let sampler91 = device2.createSampler(
+{
+label: '\u07c8\u{1fc4a}\u994c\u{1fa92}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+maxAnisotropy: 1,
+}
+);
+let externalTexture12 = device2.importExternalTexture(
+{
+label: '\u7857\u24d2\uf5f3',
+source: video12,
+colorSpace: 'display-p3',
+}
+);
+try {
+renderBundleEncoder53.pushDebugGroup(
+'\uef7a'
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device2.destroy();
+} catch {}
+document.body.prepend(canvas22);
+document.body.append('\u94ea\u0227');
+try {
+gpuCanvasContext31.configure(
+{
+device: device9,
+format: 'rgba16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth24plus',
+'rgba16float',
+'rgba8snorm',
+'rgba16float'
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let imageBitmap46 = await createImageBitmap(img4);
+try {
+computePassEncoder60.end();
+} catch {}
+try {
+renderBundleEncoder59.setBindGroup(
+4,
+bindGroup65,
+new Uint32Array(346),
+227,
+0
+);
+} catch {}
+try {
+renderBundleEncoder55.setIndexBuffer(
+buffer34,
+'uint32',
+16172
+);
+} catch {}
+try {
+commandEncoder88.copyBufferToTexture(
+{
+/* bytesInLastRow: 480 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 46000 */
+offset: 46000,
+buffer: buffer36,
+},
+{
+  texture: texture90,
+  mipLevel: 3,
+  origin: { x: 300, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 120, height: 4, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device4, buffer36);
+} catch {}
+document.body.append('\u0ba4\u1557\ue7b2\ue3df\u{1f61a}\ufcfa\u82f5\ua7bb\uc572');
+let bindGroup80 = device7.createBindGroup({
+label: '\ue41c\u2391',
+layout: bindGroupLayout28,
+entries: [
+{
+binding: 5659,
+resource: {
+buffer: buffer38,
+offset: 21152,
+size: 2184,
+}
+},
+{
+binding: 5899,
+resource: sampler73
+}
+],
+});
+try {
+renderPassEncoder2.setBindGroup(
+7,
+bindGroup77
+);
+} catch {}
+try {
+renderBundleEncoder73.insertDebugMarker(
+'\uc522'
+);
+} catch {}
+let querySet68 = device8.createQuerySet(
+{
+label: '\u0d10\ub2fb\u{1f92b}\u7e8b\u3251\uc2e0\u5e9e',
+type: 'occlusion',
+count: 4079,
+}
+);
+let renderBundleEncoder74 = device8.createRenderBundleEncoder(
+{
+label: '\u7063\uf627\u608e\u0028\u{1ff0d}\u2db1\uce75\ub192\u{1fe77}\u7325',
+colorFormats: [
+'rgba16sint',
+'rgba8sint',
+'rg32uint',
+'rgb10a2unorm',
+'rgba8unorm'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 402,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder70.setVertexBuffer(
+75,
+undefined
+);
+} catch {}
+let device11 = await adapter14.requestDevice(
+{
+label: '\u{1f66d}\u5fc2\ub468\uc96a\u0ce8\u3093',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 53,
+maxVertexAttributes: 17,
+maxVertexBufferArrayStride: 33949,
+maxStorageTexturesPerShaderStage: 16,
+maxStorageBuffersPerShaderStage: 20,
+maxDynamicStorageBuffersPerPipelineLayout: 32314,
+maxBindingsPerBindGroup: 1926,
+maxTextureDimension1D: 15108,
+maxTextureDimension2D: 12013,
+minStorageBufferOffsetAlignment: 256,
+maxUniformBufferBindingSize: 171434810,
+maxInterStageShaderVariables: 120,
+maxInterStageShaderComponents: 107,
+},
+}
+);
+let offscreenCanvas32 = new OffscreenCanvas(45, 37);
+try {
+device1.label = '\u{1fad0}\u0d6a\u0531\u{1f640}\ue116';
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let img44 = await imageWithData(30, 66, '#ebaf1be2', '#73e87490');
+let canvas37 = document.createElement('canvas');
+let bindGroupLayout35 = device5.createBindGroupLayout(
+{
+label: '\ubb2a\u67c3',
+entries: [
+{
+binding: 639,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'filtering' },
+},
+{
+binding: 7555,
+visibility: 0,
+storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '1d' },
+}
+],
+}
+);
+let pipelineLayout22 = device5.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout35,
+bindGroupLayout35,
+bindGroupLayout22,
+bindGroupLayout22
+],
+}
+);
+let commandEncoder92 = device5.createCommandEncoder(
+{
+label: '\u{1fe93}\u0caf\u{1fb26}\u1fd5\u474e',
+}
+);
+let computePassEncoder61 = commandEncoder92.beginComputePass(
+{
+label: '\u25d4\u{1f9b5}\uf279'
+}
+);
+let renderBundleEncoder75 = device5.createRenderBundleEncoder(
+{
+label: '\u0995\u{1f77a}\u{1ffa2}',
+colorFormats: [
+'rg16float',
+'r8sint',
+'r8sint',
+'rg32sint',
+'r16uint'
+],
+sampleCount: 847,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder52.setVertexBuffer(
+62,
+undefined
+);
+} catch {}
+try {
+device5.queue.writeBuffer(
+buffer33,
+6000,
+new Int16Array(23905),
+20082,
+2544
+);
+} catch {}
+document.body.prepend('\ub66d\u0592\u{1fedd}\u064a');
+try {
+canvas37.getContext('webgpu');
+} catch {}
+let querySet69 = device4.createQuerySet(
+{
+type: 'occlusion',
+count: 3851,
+}
+);
+let computePassEncoder62 = commandEncoder88.beginComputePass(
+{
+label: '\u{1f9e5}\u0b2f\u0579'
+}
+);
+let renderBundle89 = renderBundleEncoder55.finish(
+{
+label: '\u{1fb3c}\u{1f9db}\u63d5\uf4b6'
+}
+);
+try {
+computePassEncoder62.setBindGroup(
+4,
+bindGroup54
+);
+} catch {}
+try {
+renderBundleEncoder59.setBindGroup(
+5,
+bindGroup57
+);
+} catch {}
+try {
+buffer32.destroy();
+} catch {}
+document.body.prepend(video25);
+offscreenCanvas13.height = 551;
+try {
+adapter0.label = '\ue31c\u7eaa';
+} catch {}
+let commandEncoder93 = device7.createCommandEncoder();
+try {
+renderPassEncoder2.setBindGroup(
+0,
+bindGroup71
+);
+} catch {}
+try {
+commandEncoder93.copyTextureToTexture(
+{
+  texture: texture96,
+  mipLevel: 0,
+  origin: { x: 42, y: 0, z: 740 },
+  aspect: 'all',
+},
+{
+  texture: texture89,
+  mipLevel: 2,
+  origin: { x: 28, y: 2, z: 3 },
+  aspect: 'all',
+},
+{width: 23, height: 1, depthOrArrayLayers: 20}
+);
+} catch {}
+try {
+commandEncoder93.resolveQuerySet(
+querySet63,
+2154,
+467,
+buffer38,
+16128
+);
+} catch {}
+try {
+gpuCanvasContext15.configure(
+{
+device: device7,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let texture106 = device10.createTexture(
+{
+label: '\u422f\ua2be\u0094\u014a\ubfae\u00e8\ue46b',
+size: [220, 12, 1],
+mipLevelCount: 2,
+format: 'astc-5x4-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-5x4-unorm-srgb',
+'astc-5x4-unorm-srgb'
+],
+}
+);
+let sampler92 = device10.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMaxClamp: 98.090,
+compare: 'greater',
+}
+);
+try {
+await device8.popErrorScope();
+} catch {}
+let device12 = await adapter11.requestDevice(
+{
+label: '\ufaa3\ueac2\u{1fd9c}\u7d81\u{1fca1}\u0760\uddfd\u074b\u{1f664}\u97ea',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxColorAttachmentBytesPerSample: 35,
+maxVertexAttributes: 21,
+maxVertexBufferArrayStride: 29585,
+maxStorageTexturesPerShaderStage: 28,
+maxStorageBuffersPerShaderStage: 44,
+maxDynamicStorageBuffersPerPipelineLayout: 37495,
+maxBindingsPerBindGroup: 9905,
+maxTextureDimension1D: 13223,
+maxTextureDimension2D: 11892,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 96478108,
+maxInterStageShaderVariables: 44,
+maxInterStageShaderComponents: 109,
+},
+}
+);
+let texture107 = device4.createTexture(
+{
+label: '\u2fc8\u{1f70a}\u2a44\uf98a\u0865',
+size: {width: 20, height: 120, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'astc-5x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-5x5-unorm',
+'astc-5x5-unorm-srgb',
+'astc-5x5-unorm'
+],
+}
+);
+let textureView92 = texture78.createView(
+{
+label: '\ua4e9\u0363\uc9a3',
+baseMipLevel: 1,
+mipLevelCount: 1,
+}
+);
+let renderBundle90 = renderBundleEncoder55.finish();
+try {
+renderBundleEncoder59.setBindGroup(
+3,
+bindGroup64
+);
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+let querySet70 = device4.createQuerySet(
+{
+label: '\u211e\u72d0\u3854\u64e4\u0430\u0bd6\u0aed\u0f8c\ue9b4\u{1f83d}',
+type: 'occlusion',
+count: 27,
+}
+);
+let sampler93 = device4.createSampler(
+{
+label: '\u8295\u{1fd8c}\u1c52\u1e68\u0a8b\ufa45\ub00b\u0f40',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMaxClamp: 57.155,
+maxAnisotropy: 1,
+}
+);
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append('\uedfc\uefea\u099d\ubd3d\ua907\u0cbd\u{1ff12}\u0918\u053f\u00f1');
+document.body.prepend('\u1401\u0cd2\ub6e4\u8940\uaf27\ucae4\u0090\u8db9\u1ec8\uff00');
+let img45 = await imageWithData(207, 50, '#abab471b', '#731e5f89');
+try {
+adapter0.label = '\uc923\ua57d\u0e1b\u827b\u1b16';
+} catch {}
+offscreenCanvas29.height = 161;
+gc();
+document.body.prepend('\u{1f895}\u16cf\uc63a\u082d\ua2f8\u{1f7d8}\u086b\ua737\u{1ff22}\u{1ffbf}');
+let querySet71 = device9.createQuerySet(
+{
+type: 'occlusion',
+count: 2313,
+}
+);
+let texture108 = gpuCanvasContext5.getCurrentTexture();
+let textureView93 = texture108.createView(
+{
+label: '\ua459\ue6e0\u0e12\u5b96\u{1fd9f}\u{1f874}\u07f1\ua368\u{1fe4d}',
+}
+);
+let sampler94 = device9.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 65.194,
+lodMaxClamp: 93.377,
+}
+);
+document.body.prepend('\u55a7\u{1ff2e}\u2dd8');
+let buffer42 = device9.createBuffer(
+{
+label: '\u21ab\u4701\u0aa3\u6399\ub61a',
+size: 60856,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let texture109 = device9.createTexture(
+{
+size: {width: 126, height: 1, depthOrArrayLayers: 147},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let externalTexture13 = device9.importExternalTexture(
+{
+label: '\u025e\ubece\u0943\u9115\u{1f889}\u7bec',
+source: videoFrame17,
+}
+);
+let offscreenCanvas33 = new OffscreenCanvas(549, 236);
+let video31 = await videoWithData();
+let gpuCanvasContext33 = offscreenCanvas33.getContext('webgpu');
+document.body.prepend(video17);
+let imageBitmap47 = await createImageBitmap(canvas10);
+let offscreenCanvas34 = new OffscreenCanvas(139, 485);
+try {
+renderBundleEncoder70.setVertexBuffer(
+22,
+undefined
+);
+} catch {}
+let gpuCanvasContext34 = offscreenCanvas34.getContext('webgpu');
+let offscreenCanvas35 = new OffscreenCanvas(898, 168);
+let texture110 = device7.createTexture(
+{
+label: '\ub1c6\uc56a\ud216\uca2c\u0378\u0564\ud1cf\u{1fa2b}',
+size: [156, 1, 133],
+format: 'rg8uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rg8uint',
+'rg8uint',
+'rg8uint'
+],
+}
+);
+let sampler95 = device7.createSampler(
+{
+label: '\u{1f822}\u{1fc33}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 0.482,
+lodMaxClamp: 20.382,
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder2.setStencilReference(
+2203
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+1,
+buffer41,
+9480,
+2818
+);
+} catch {}
+try {
+buffer38.unmap();
+} catch {}
+try {
+commandEncoder93.copyTextureToTexture(
+{
+  texture: texture103,
+  mipLevel: 3,
+  origin: { x: 0, y: 12, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture103,
+  mipLevel: 0,
+  origin: { x: 12, y: 12, z: 1 },
+  aspect: 'all',
+},
+{width: 0, height: 12, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device7.queue.writeBuffer(
+buffer38,
+2896,
+new DataView(new ArrayBuffer(13684)),
+4853,
+1356
+);
+} catch {}
+document.body.append('\u0af5\u0dce\u084b');
+let texture111 = device9.createTexture(
+{
+label: '\u272d\u719f\u0ea5\u14a7\u{1ff6c}\ub200\u{1faea}',
+size: {width: 1891},
+dimension: '1d',
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'r16uint'
+],
+}
+);
+let textureView94 = texture108.createView(
+{
+label: '\uf420\u0e55\u5b1e\u7955\uf095\u{1f72f}',
+}
+);
+let renderBundleEncoder76 = device9.createRenderBundleEncoder(
+{
+label: '\ub4d4\u502f\u056c\u5682\u75d8\u0924\u0f14\u0c52\u0ee4\u{1f8f8}\ua627',
+colorFormats: [
+'rgba16uint',
+'bgra8unorm',
+'rgba8unorm',
+'rg32float'
+],
+sampleCount: 419,
+stencilReadOnly: true,
+}
+);
+try {
+gpuCanvasContext22.configure(
+{
+device: device9,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgba8unorm-srgb',
+'rgba8unorm-srgb',
+'rgba8unorm-srgb'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+await device9.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout36 = device10.createBindGroupLayout(
+{
+label: '\u02ab\u7708\u0756',
+entries: [
+{
+binding: 582,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+}
+],
+}
+);
+let texture112 = device10.createTexture(
+{
+label: '\ucd37\u4279\ue55c\u1023\u0642\u0b19',
+size: {width: 6185, height: 92, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+dimension: '2d',
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32sint',
+'r32sint'
+],
+}
+);
+let sampler96 = device10.createSampler(
+{
+label: '\u0921\u{1ffb4}\u{1ff44}\u81b3\u3db5',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 56.131,
+lodMaxClamp: 94.848,
+maxAnisotropy: 2,
+}
+);
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let querySet72 = device8.createQuerySet(
+{
+label: '\u7e45\u00d9\u{1fa05}\u6c1e',
+type: 'occlusion',
+count: 3470,
+}
+);
+let texture113 = device8.createTexture(
+{
+size: [6897, 41, 1],
+mipLevelCount: 7,
+format: 'rgba32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView95 = texture102.createView(
+{
+label: '\ua139\u1532\ua3ea\u{1fb6d}',
+baseMipLevel: 8,
+baseArrayLayer: 0,
+}
+);
+let gpuCanvasContext35 = offscreenCanvas35.getContext('webgpu');
+try {
+window.someLabel = sampler88.label;
+} catch {}
+let buffer43 = device9.createBuffer(
+{
+label: '\u{1ffac}\u010d\u0728\ua3e4\u6e7c\u5b3b\u46c6\u{1ff70}\uae75',
+size: 44124,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+mappedAtCreation: false,
+}
+);
+let querySet73 = device9.createQuerySet(
+{
+label: '\u2ae0\u1155\u{1feff}\uf547\u{1fa30}\u240c\u{1fe35}\ub621\u410a\u0618',
+type: 'occlusion',
+count: 2195,
+}
+);
+offscreenCanvas20.height = 334;
+document.body.append('\u{1f705}\u6b6b\u0a57\u{1fe71}\u0a8a\ufab9\u2e87\ue26d\u9dc0');
+let gpuCanvasContext36 = offscreenCanvas32.getContext('webgpu');
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+canvas16.width = 431;
+let texture114 = device4.createTexture(
+{
+label: '\u4074\u06d7\u391a\udde9\ude06\u0201\u{1f992}\u0bb7\u3eb0\ued22',
+size: [9885, 1, 135],
+mipLevelCount: 14,
+format: 'stencil8',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+let sampler97 = device4.createSampler(
+{
+label: '\ufcc0\u271d\u483f\u9939\u0a09\u0117\u04d7\ueacd\u{1fb5c}\u{1f805}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 98.533,
+lodMaxClamp: 99.439,
+}
+);
+try {
+renderBundleEncoder59.setBindGroup(
+1,
+bindGroup63
+);
+} catch {}
+let gpuCanvasContext37 = canvas35.getContext('webgpu');
+canvas3.height = 937;
+let offscreenCanvas36 = new OffscreenCanvas(84, 710);
+let buffer44 = device7.createBuffer(
+{
+label: '\u053d\u1afd\uaa33\u84e7\u3308\u3f46\u{1f8fa}',
+size: 6319,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+}
+);
+let renderPassEncoder3 = commandEncoder93.beginRenderPass(
+{
+label: '\u{1ffaf}\u0373\u07a4\u6649\u08a9\uc88d\u29a8\u{1fca4}',
+colorAttachments: [
+undefined,
+undefined,
+{
+view: textureView87,
+clearValue: {
+r: -772.6,
+g: -124.4,
+b: 230.4,
+a: -34.84,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined
+],
+occlusionQuerySet: querySet63,
+maxDrawCount: 332720,
+}
+);
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: 488.2,
+g: 577.1,
+b: -294.1,
+a: 211.2,
+}
+);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(
+2011
+);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(
+11,
+buffer38,
+18532,
+1239
+);
+} catch {}
+try {
+renderBundleEncoder73.setVertexBuffer(
+5,
+buffer41
+);
+} catch {}
+try {
+device7.queue.writeBuffer(
+buffer38,
+15368,
+new Int16Array(36583),
+943,
+5472
+);
+} catch {}
+try {
+device7.queue.writeTexture(
+{
+  texture: texture89,
+  mipLevel: 1,
+  origin: { x: 29, y: 19, z: 8 },
+  aspect: 'all',
+},
+new BigInt64Array(new ArrayBuffer(0)),
+/* required buffer size: 589491 */{
+offset: 10,
+bytesPerRow: 207,
+rowsPerImage: 255,
+},
+{width: 76, height: 43, depthOrArrayLayers: 12}
+);
+} catch {}
+let pipeline65 = device7.createRenderPipeline(
+{
+label: '\u47c5\ua7cf\u848a\ucdd7\udac3\u{1fbd4}\u0d46\ue751\u7e23\u04c8',
+layout: pipelineLayout19,
+vertex: {
+module: shaderModule14,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 436,
+shaderLocation: 19,
+},
+{
+format: 'float32x2',
+offset: 448,
+shaderLocation: 14,
+},
+{
+format: 'snorm8x2',
+offset: 5656,
+shaderLocation: 17,
+},
+{
+format: 'unorm8x4',
+offset: 1052,
+shaderLocation: 9,
+},
+{
+format: 'sint32',
+offset: 4840,
+shaderLocation: 10,
+},
+{
+format: 'uint32x2',
+offset: 1880,
+shaderLocation: 20,
+},
+{
+format: 'snorm8x4',
+offset: 5408,
+shaderLocation: 18,
+},
+{
+format: 'snorm8x2',
+offset: 1170,
+shaderLocation: 8,
+},
+{
+format: 'unorm16x4',
+offset: 128,
+shaderLocation: 11,
+},
+{
+format: 'uint16x2',
+offset: 320,
+shaderLocation: 22,
+},
+{
+format: 'uint32x2',
+offset: 1068,
+shaderLocation: 21,
+}
+],
+},
+{
+arrayStride: 496,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 1804,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 92,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 676,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 5416,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 400,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x2',
+offset: 240,
+shaderLocation: 12,
+},
+{
+format: 'float16x4',
+offset: 204,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule14,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'r16float',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r8uint',
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'keep',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 1980,
+depthBias: 7,
+depthBiasSlopeScale: 87,
+},
+}
+);
+let gpuCanvasContext38 = offscreenCanvas36.getContext('webgpu');
+let buffer45 = device8.createBuffer(
+{
+label: '\u2f67\u4c5f\u04ad\u022b\ubdd1\ua98d\u08fa\u5d8c\u0a12\u09df',
+size: 7270,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+}
+);
+let commandEncoder94 = device8.createCommandEncoder();
+let textureView96 = texture102.createView(
+{
+baseMipLevel: 7,
+mipLevelCount: 1,
+}
+);
+try {
+commandEncoder94.clearBuffer(
+buffer45,
+700,
+1404
+);
+dissociateBuffer(device8, buffer45);
+} catch {}
+try {
+gpuCanvasContext6.configure(
+{
+device: device8,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+await device8.queue.onSubmittedWorkDone();
+} catch {}
+let video32 = await videoWithData();
+try {
+renderPassEncoder3.setStencilReference(
+3729
+);
+} catch {}
+try {
+renderPassEncoder3.setViewport(
+40.53,
+22.64,
+0.3640,
+14.02,
+0.2939,
+0.3988
+);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer38,
+'uint16'
+);
+} catch {}
+try {
+renderBundleEncoder73.setVertexBuffer(
+5,
+buffer38,
+15680,
+3906
+);
+} catch {}
+try {
+device7.queue.writeBuffer(
+buffer38,
+18732,
+new Int16Array(43685),
+28617,
+3676
+);
+} catch {}
+let imageBitmap48 = await createImageBitmap(imageBitmap45);
+let texture115 = device12.createTexture(
+{
+label: '\u{1f60c}\u08ba\u06ea\u41fc\u0442\u{1fbd6}\u{1fbde}\u{1fdb6}\ueebf\udf01\ubdfd',
+size: [12809],
+dimension: '1d',
+format: 'rgba32uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+gpuCanvasContext5.configure(
+{
+device: device12,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+adapter11.label = '\u0647\u{1f8e4}\u{1fb7d}\ue456\u0eef\u0648\ue85c\uf7d2';
+} catch {}
+try {
+window.someLabel = externalTexture8.label;
+} catch {}
+document.body.prepend('\u0c22\u4c66\ua99c\u{1fab0}\u06fa\uf675\u5712\ue343\ua88a\u04b4\u608c');
+let texture116 = device4.createTexture(
+{
+size: {width: 3965, height: 8, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+dimension: '2d',
+format: 'astc-5x4-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-5x4-unorm-srgb'
+],
+}
+);
+try {
+renderBundleEncoder59.setIndexBuffer(
+buffer34,
+'uint16',
+1082,
+3887
+);
+} catch {}
+try {
+gpuCanvasContext9.configure(
+{
+device: device4,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'bgra8unorm',
+'rgba8uint',
+'astc-5x4-unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device4.queue.submit([
+commandBuffer13,
+]);
+} catch {}
+gc();
+let pipelineLayout23 = device10.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout36,
+bindGroupLayout36
+],
+}
+);
+let commandEncoder95 = device10.createCommandEncoder(
+{
+}
+);
+let querySet74 = device10.createQuerySet(
+{
+type: 'occlusion',
+count: 3953,
+}
+);
+let texture117 = device10.createTexture(
+{
+size: {width: 96, height: 4, depthOrArrayLayers: 163},
+mipLevelCount: 2,
+format: 'astc-4x4-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-4x4-unorm',
+'astc-4x4-unorm-srgb'
+],
+}
+);
+gc();
+document.body.append('\uc1f9\u{1fe33}\uf143\u815b\u{1f8fb}\uae3e\u04d6\u0246\u{1f703}\ub53d');
+let imageData45 = new ImageData(96, 116);
+gc();
+let img46 = await imageWithData(299, 226, '#794c6e20', '#1a2b674c');
+let video33 = await videoWithData();
+try {
+window.someLabel = device7.label;
+} catch {}
+let pipelineLayout24 = device7.createPipelineLayout(
+{
+label: '\u7561\u0331\u{1fb95}\u075e\ufebc',
+bindGroupLayouts: [
+bindGroupLayout28,
+bindGroupLayout26,
+bindGroupLayout28,
+bindGroupLayout32,
+bindGroupLayout32,
+bindGroupLayout31,
+bindGroupLayout32,
+bindGroupLayout32,
+bindGroupLayout32,
+bindGroupLayout32,
+bindGroupLayout26
+],
+}
+);
+let querySet75 = device7.createQuerySet(
+{
+label: '\ue677\u34cb\ua696\u{1fda0}\u83a8\u0a12\u{1f6d9}\u0bc4\ud9ae\u7d02\u{1fcf4}',
+type: 'occlusion',
+count: 2593,
+}
+);
+let renderBundle91 = renderBundleEncoder64.finish(
+{
+label: '\u{1f7e7}\u4351\ua8df\ud3c6\u02ed\u{1fa0d}\u698b'
+}
+);
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: 528.9,
+g: -829.7,
+b: -832.2,
+a: 23.09,
+}
+);
+} catch {}
+try {
+renderBundleEncoder73.setBindGroup(
+6,
+bindGroup77,
+new Uint32Array(2383),
+1979,
+0
+);
+} catch {}
+try {
+renderBundleEncoder73.setVertexBuffer(
+6,
+buffer41
+);
+} catch {}
+let canvas38 = document.createElement('canvas');
+let commandEncoder96 = device8.createCommandEncoder(
+{
+label: '\u0059\u1542\ufd0a',
+}
+);
+let texture118 = device8.createTexture(
+{
+label: '\uaa90\u0b5a\u0dd9\u1dfa\u842e',
+size: {width: 1872, height: 1, depthOrArrayLayers: 1602},
+mipLevelCount: 10,
+dimension: '3d',
+format: 'r8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+try {
+renderBundleEncoder74.setIndexBuffer(
+buffer45,
+'uint32',
+3252,
+687
+);
+} catch {}
+try {
+commandEncoder96.copyTextureToTexture(
+{
+  texture: texture113,
+  mipLevel: 6,
+  origin: { x: 55, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture113,
+  mipLevel: 4,
+  origin: { x: 17, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 28, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+canvas38.getContext('webgpu');
+} catch {}
+let img47 = await imageWithData(101, 45, '#7bc99aaa', '#92a59112');
+let commandEncoder97 = device9.createCommandEncoder(
+{
+}
+);
+try {
+device9.queue.writeBuffer(
+buffer43,
+10660,
+new Int16Array(15269),
+9854,
+392
+);
+} catch {}
+document.body.prepend('\u3091\u09ad\uaba2\u0cfd\u{1f795}\u0b13\u4b0e');
+let querySet76 = device9.createQuerySet(
+{
+label: '\u{1f8f5}\ub2ad\u6adc\u07f4\udd12',
+type: 'occlusion',
+count: 4058,
+}
+);
+let textureView97 = texture111.createView(
+{
+label: '\ud2ab\u07aa\u4708\u{1fa2c}\u60f2\u04d8\uec6a\u028b\u0123\u677a\u3d2b',
+mipLevelCount: 1,
+}
+);
+let renderBundleEncoder77 = device9.createRenderBundleEncoder(
+{
+colorFormats: [
+'r8sint',
+'rgb10a2uint',
+'rgba8unorm-srgb',
+'bgra8unorm',
+undefined,
+'rg16sint',
+'r8unorm'
+],
+sampleCount: 442,
+}
+);
+let renderBundle92 = renderBundleEncoder76.finish(
+{
+label: '\u{1f647}\u8eaa\u{1f995}\ucecd\u6197\u0fa1\u2e75\u035e\u1a91\u{1ff9c}'
+}
+);
+try {
+renderBundleEncoder77.setVertexBuffer(
+13,
+undefined,
+524037263,
+430100631
+);
+} catch {}
+try {
+commandEncoder97.copyTextureToBuffer(
+{
+  texture: texture111,
+  mipLevel: 0,
+  origin: { x: 129, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 2124 widthInBlocks: 1062 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 40820 */
+offset: 40820,
+bytesPerRow: 2304,
+buffer: buffer43,
+},
+{width: 1062, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device9, buffer43);
+} catch {}
+let imageBitmap49 = await createImageBitmap(imageData9);
+let bindGroupLayout37 = device10.createBindGroupLayout(
+{
+entries: [
+{
+binding: 895,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '2d' },
+}
+],
+}
+);
+let commandEncoder98 = device10.createCommandEncoder();
+let textureView98 = texture106.createView(
+{
+label: '\u08d4\u0f0b\u3fb0\ue3b8\ub1b9',
+dimension: '2d-array',
+baseMipLevel: 0,
+mipLevelCount: 1,
+}
+);
+let renderBundleEncoder78 = device10.createRenderBundleEncoder(
+{
+label: '\u{1f6b9}\u{1fead}\ud807\uaee1\u89dc\u0a33\u0a3b\u{1f9a7}',
+colorFormats: [
+'rgba8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 25,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+offscreenCanvas5.height = 142;
+let renderPassEncoder4 = commandEncoder96.beginRenderPass(
+{
+label: '\udd5d\uf500\u9278\u5bda\uc34e\ucf94\u{1f89d}\u6bbf',
+colorAttachments: [
+{
+view: textureView95,
+depthSlice: 2,
+clearValue: {
+r: 481.7,
+g: -591.3,
+b: 569.8,
+a: 569.6,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView95,
+depthSlice: 3,
+clearValue: {
+r: -909.7,
+g: -258.8,
+b: -922.3,
+a: -689.8,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView95,
+depthSlice: 0,
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView96,
+depthSlice: 7,
+clearValue: {
+r: -956.9,
+g: 312.9,
+b: -732.1,
+a: -997.2,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView95,
+depthSlice: 1,
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+maxDrawCount: 101688,
+}
+);
+try {
+device8.queue.writeBuffer(
+buffer45,
+968,
+new BigUint64Array(11047),
+8423,
+588
+);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let imageBitmap50 = await createImageBitmap(img29);
+pseudoSubmit(device7, commandEncoder90);
+let textureView99 = texture103.createView(
+{
+dimension: '2d-array',
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+let renderBundle93 = renderBundleEncoder61.finish(
+{
+label: '\u{1f6d8}\uc737\u{1fcfc}\u00a1\u{1fc52}\u0496\u00b9'
+}
+);
+try {
+renderPassEncoder3.setBindGroup(
+7,
+bindGroup80
+);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(
+1,
+bindGroup76,
+new Uint32Array(5240),
+2519,
+0
+);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(
+48
+);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(
+1465
+);
+} catch {}
+try {
+renderBundleEncoder73.setVertexBuffer(
+0,
+buffer41,
+4828
+);
+} catch {}
+try {
+device7.queue.writeTexture(
+{
+  texture: texture89,
+  mipLevel: 2,
+  origin: { x: 28, y: 10, z: 3 },
+  aspect: 'all',
+},
+new ArrayBuffer(16),
+/* required buffer size: 236119 */{
+offset: 248,
+bytesPerRow: 231,
+rowsPerImage: 60,
+},
+{width: 10, height: 2, depthOrArrayLayers: 18}
+);
+} catch {}
+let videoFrame40 = new VideoFrame(video18, {timestamp: 0});
+let querySet77 = device11.createQuerySet(
+{
+type: 'occlusion',
+count: 3162,
+}
+);
+let texture119 = device11.createTexture(
+{
+label: '\u7dfe\u06a9\udb9a',
+size: {width: 82, height: 82, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth24plus-stencil8'
+],
+}
+);
+let renderBundleEncoder79 = device11.createRenderBundleEncoder(
+{
+colorFormats: [
+'r32float',
+'rgba16sint',
+'bgra8unorm-srgb',
+'rg11b10ufloat',
+undefined,
+'rgb10a2unorm'
+],
+sampleCount: 814,
+depthReadOnly: true,
+}
+);
+let promise52 = device11.queue.onSubmittedWorkDone();
+let renderBundle94 = renderBundleEncoder76.finish(
+{
+
+}
+);
+try {
+renderBundleEncoder77.setVertexBuffer(
+2,
+undefined,
+1207226297,
+2693292016
+);
+} catch {}
+gc();
+let renderBundleEncoder80 = device9.createRenderBundleEncoder(
+{
+colorFormats: [
+'r16float',
+'rgba8uint',
+undefined,
+'rg16uint',
+'bgra8unorm',
+'r8unorm',
+'rgb10a2uint'
+],
+sampleCount: 63,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let pipelineLayout25 = device4.createPipelineLayout(
+{
+label: '\u09c8\u8c83\u0a2e',
+bindGroupLayouts: [
+
+],
+}
+);
+let renderBundleEncoder81 = device4.createRenderBundleEncoder(
+{
+label: '\uef7f\u0ba4',
+colorFormats: [
+'rg11b10ufloat',
+undefined,
+'rgb10a2unorm',
+'rgba8unorm'
+],
+sampleCount: 134,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+await device4.popErrorScope();
+} catch {}
+document.body.prepend(img10);
+let shaderModule16 = device2.createShaderModule(
+{
+code: `@group(0) @binding(617)
+var<storage, read_write> i1: array<u32>;
+
+@compute @workgroup_size(7, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(1) f0: f32,
+@location(6) f1: i32,
+@location(7) f2: vec3<f32>,
+@location(2) f3: vec2<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(10) a0: vec3<f16>, @location(7) a1: vec3<u32>, @location(23) a2: vec3<u32>, @location(14) a3: f32, @location(9) a4: vec3<f16>, @location(20) a5: vec3<i32>, @location(17) a6: vec2<u32>, @builtin(instance_index) a7: u32, @location(11) a8: vec3<i32>, @location(6) a9: vec4<f32>, @location(0) a10: f16, @location(3) a11: f16, @location(19) a12: vec3<u32>, @location(22) a13: vec2<f16>, @location(2) a14: f32, @location(5) a15: vec3<u32>, @location(8) a16: vec3<f16>, @builtin(vertex_index) a17: u32, @location(24) a18: vec2<i32>, @location(13) a19: vec2<f16>, @location(21) a20: vec2<f16>, @location(4) a21: u32, @location(1) a22: vec2<f16>, @location(18) a23: vec3<u32>, @location(12) a24: vec4<f16>, @location(15) a25: vec2<f32>, @location(16) a26: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture120 = device2.createTexture(
+{
+label: '\u6c92\u{1f7b7}\u621b\u0cfd\u08e8',
+size: {width: 6566, height: 1, depthOrArrayLayers: 5},
+mipLevelCount: 2,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'stencil8'
+],
+}
+);
+try {
+computePassEncoder57.setBindGroup(
+6,
+bindGroup75,
+new Uint32Array(3108),
+994,
+0
+);
+} catch {}
+try {
+renderBundleEncoder67.setBindGroup(
+10,
+bindGroup74
+);
+} catch {}
+try {
+commandEncoder89.copyTextureToBuffer(
+{
+  texture: texture104,
+  mipLevel: 0,
+  origin: { x: 196, y: 8, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 108 widthInBlocks: 54 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 51132 */
+offset: 51132,
+bytesPerRow: 256,
+buffer: buffer29,
+},
+{width: 54, height: 13, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device2, buffer29);
+} catch {}
+try {
+commandEncoder83.clearBuffer(
+buffer29,
+14104,
+30916
+);
+dissociateBuffer(device2, buffer29);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture95,
+  mipLevel: 3,
+  origin: { x: 6, y: 1, z: 30 },
+  aspect: 'all',
+},
+new Int16Array(arrayBuffer13),
+/* required buffer size: 2648 */{
+offset: 254,
+bytesPerRow: 63,
+rowsPerImage: 38,
+},
+{width: 61, height: 0, depthOrArrayLayers: 2}
+);
+} catch {}
+canvas15.height = 385;
+let texture121 = device10.createTexture(
+{
+size: {width: 1607},
+dimension: '1d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgba8snorm'
+],
+}
+);
+let computePassEncoder63 = commandEncoder98.beginComputePass(
+{
+
+}
+);
+try {
+await promise52;
+} catch {}
+document.body.append('\u{1f8cb}\ua4f7\u03f2\u04a5\u0f49\u6d02\u2be1\u1daf\u{1fa79}\u3f1d\u0b2d');
+let pipelineLayout26 = device7.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout28,
+bindGroupLayout28,
+bindGroupLayout28,
+bindGroupLayout28,
+bindGroupLayout28,
+bindGroupLayout26,
+bindGroupLayout31,
+bindGroupLayout32,
+bindGroupLayout31,
+bindGroupLayout28
+],
+}
+);
+let commandEncoder99 = device7.createCommandEncoder(
+{
+label: '\udc1f\u6b5c\u076a\u0a5f\u{1fcc8}\u018f\uf1e2\u2f5e\udd3a\uaed7',
+}
+);
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: -531.2,
+g: 609.7,
+b: -753.3,
+a: -810.4,
+}
+);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(
+3749
+);
+} catch {}
+try {
+renderPassEncoder3.setViewport(
+45.69,
+11.00,
+5.281,
+11.12,
+0.9069,
+0.9962
+);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer38,
+'uint16',
+9708,
+5385
+);
+} catch {}
+try {
+renderBundleEncoder73.setVertexBuffer(
+8,
+buffer41,
+12768,
+226
+);
+} catch {}
+try {
+commandEncoder99.resolveQuerySet(
+querySet65,
+1720,
+67,
+buffer38,
+4608
+);
+} catch {}
+try {
+device7.queue.writeBuffer(
+buffer38,
+23412,
+new BigUint64Array(32805),
+12375,
+88
+);
+} catch {}
+let pipeline66 = await device7.createRenderPipelineAsync(
+{
+label: '\u0eb1\uebb4\u03c2\uac96\uf3d6\u{1f836}\u0f51\u1809\ub966',
+layout: pipelineLayout19,
+vertex: {
+module: shaderModule13,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 64,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x4',
+offset: 44,
+shaderLocation: 15,
+},
+{
+format: 'uint32x3',
+offset: 8,
+shaderLocation: 9,
+},
+{
+format: 'uint8x2',
+offset: 30,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 2800,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x2',
+offset: 2252,
+shaderLocation: 5,
+},
+{
+format: 'float32x4',
+offset: 1672,
+shaderLocation: 22,
+},
+{
+format: 'snorm16x2',
+offset: 112,
+shaderLocation: 19,
+},
+{
+format: 'sint32x2',
+offset: 1720,
+shaderLocation: 1,
+},
+{
+format: 'snorm16x4',
+offset: 2232,
+shaderLocation: 3,
+},
+{
+format: 'sint8x4',
+offset: 120,
+shaderLocation: 8,
+},
+{
+format: 'sint32x3',
+offset: 128,
+shaderLocation: 20,
+}
+],
+},
+{
+arrayStride: 2736,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x4',
+offset: 2100,
+shaderLocation: 23,
+},
+{
+format: 'uint16x2',
+offset: 2232,
+shaderLocation: 2,
+},
+{
+format: 'float32x2',
+offset: 2216,
+shaderLocation: 21,
+},
+{
+format: 'uint16x4',
+offset: 200,
+shaderLocation: 14,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule13,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+undefined,
+{
+format: 'rgba16uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(
+buffer45,
+'uint32',
+804,
+2712
+);
+} catch {}
+try {
+device8.queue.writeBuffer(
+buffer45,
+7260,
+new Float32Array(20831),
+1375,
+0
+);
+} catch {}
+let offscreenCanvas37 = new OffscreenCanvas(611, 1015);
+let imageBitmap51 = await createImageBitmap(videoFrame11);
+let sampler98 = device12.createSampler(
+{
+addressModeU: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 99.400,
+lodMaxClamp: 99.575,
+compare: 'always',
+}
+);
+document.body.prepend(video29);
+let adapter15 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let videoFrame41 = new VideoFrame(img36, {timestamp: 0});
+try {
+await adapter5.requestAdapterInfo();
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant(
+{
+r: 831.2,
+g: 183.6,
+b: 505.9,
+a: -527.0,
+}
+);
+} catch {}
+try {
+commandEncoder94.copyTextureToTexture(
+{
+  texture: texture113,
+  mipLevel: 6,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture113,
+  mipLevel: 0,
+  origin: { x: 416, y: 35, z: 0 },
+  aspect: 'all',
+},
+{width: 43, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder94.clearBuffer(
+buffer45,
+788,
+788
+);
+dissociateBuffer(device8, buffer45);
+} catch {}
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+document.body.prepend('\u09aa\u4946\u4b32\u{1f8a5}\u0908\u{1ff1a}');
+try {
+offscreenCanvas37.getContext('webgl2');
+} catch {}
+document.body.prepend(canvas24);
+let video34 = await videoWithData();
+let img48 = await imageWithData(231, 136, '#33777eeb', '#d4f89455');
+let renderPassEncoder5 = commandEncoder94.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView96,
+depthSlice: 2,
+clearValue: {
+r: 64.92,
+g: 492.3,
+b: -531.8,
+a: 358.9,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+undefined,
+{
+view: textureView96,
+depthSlice: 8,
+clearValue: {
+r: -689.2,
+g: -55.21,
+b: -643.7,
+a: -581.8,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView95,
+depthSlice: 3,
+clearValue: {
+r: 476.0,
+g: 712.1,
+b: 50.86,
+a: -617.7,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+undefined,
+undefined
+],
+occlusionQuerySet: querySet72,
+}
+);
+let renderBundleEncoder82 = device8.createRenderBundleEncoder(
+{
+label: '\u5590\udd3d\u03f5\uddb3',
+colorFormats: [
+'r16float'
+],
+sampleCount: 984,
+}
+);
+let renderBundle95 = renderBundleEncoder70.finish(
+{
+label: '\u0aab\u093f\ub37a\uabb2'
+}
+);
+let canvas39 = document.createElement('canvas');
+let querySet78 = device4.createQuerySet(
+{
+label: '\u1229\u24b1\u45c6\u5ae0\uee3a',
+type: 'occlusion',
+count: 2354,
+}
+);
+let textureView100 = texture78.createView(
+{
+label: '\u7449\ud96f\u0442\u{1ff2b}\u{1f7a7}\u09f7\u{1f6b3}\u01f7\u{1fd36}\udd9e',
+baseMipLevel: 1,
+mipLevelCount: 1,
+arrayLayerCount: 1,
+}
+);
+let sampler99 = device4.createSampler(
+{
+label: '\ue3ea\u030b\u{1fd2b}\uf192',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 82.900,
+lodMaxClamp: 94.045,
+maxAnisotropy: 8,
+}
+);
+try {
+renderBundleEncoder59.setVertexBuffer(
+94,
+undefined
+);
+} catch {}
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+document.body.prepend(canvas31);
+document.body.append('\ue6fd\u{1f8ea}\u0c86\u{1f7b6}');
+let gpuCanvasContext39 = canvas39.getContext('webgpu');
+document.body.append('\u8550\u0315\u{1febe}\u9d59\ua8e0\u0d29\udd57\u3736');
+let adapter16 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let promise53 = adapter16.requestAdapterInfo();
+let commandEncoder100 = device8.createCommandEncoder();
+let querySet79 = device8.createQuerySet(
+{
+label: '\u{1fbc7}\u169e\u0af1\u{1f62f}\u01e4\u25db\uc471\ueccb\u26a4\u{1f91d}\u01aa',
+type: 'occlusion',
+count: 655,
+}
+);
+pseudoSubmit(device8, commandEncoder100);
+let renderBundleEncoder83 = device8.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg16float',
+'rg8sint',
+'r8uint',
+'rgba16uint'
+],
+sampleCount: 608,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant(
+{
+r: -664.0,
+g: 690.3,
+b: 823.4,
+a: 641.0,
+}
+);
+} catch {}
+document.body.prepend('\u3fbe\u072f\u082b\u91b1\u01f7\u{1fc56}\u0ed0\u77b4');
+let buffer46 = device4.createBuffer(
+{
+label: '\ud5a7\u44e7\u05ac\u0521\u72af\u{1fb65}\ud338',
+size: 19929,
+usage: GPUBufferUsage.INDEX,
+mappedAtCreation: false,
+}
+);
+let textureView101 = texture116.createView(
+{
+label: '\u95a0\u8027\u0841\u0fb6\u{1fb04}\ua409',
+dimension: '2d-array',
+format: 'astc-5x4-unorm-srgb',
+baseMipLevel: 1,
+mipLevelCount: 4,
+arrayLayerCount: 1,
+}
+);
+let sampler100 = device4.createSampler(
+{
+label: '\ue566\u{1f9f1}\uf596\u{1fba4}\u71b2\u271f\u068f\ua43b',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+lodMinClamp: 38.678,
+lodMaxClamp: 51.455,
+}
+);
+try {
+computePassEncoder54.pushDebugGroup(
+'\u0528'
+);
+} catch {}
+try {
+computePassEncoder54.popDebugGroup();
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let canvas40 = document.createElement('canvas');
+try {
+commandEncoder97.clearBuffer(
+buffer43,
+23080,
+9192
+);
+dissociateBuffer(device9, buffer43);
+} catch {}
+let texture122 = device7.createTexture(
+{
+label: '\ub447\ud24c\uf81b\u777a\u2c6a\u10f3\u123e\u3cbd\u0018',
+size: [8735],
+dimension: '1d',
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING,
+}
+);
+try {
+renderPassEncoder3.setBlendConstant(
+{
+r: -901.2,
+g: -606.8,
+b: 162.2,
+a: 815.4,
+}
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+1,
+buffer41,
+8968,
+71
+);
+} catch {}
+try {
+renderBundleEncoder73.setBindGroup(
+0,
+bindGroup80
+);
+} catch {}
+try {
+renderBundleEncoder73.setVertexBuffer(
+2,
+buffer38,
+18012
+);
+} catch {}
+try {
+commandEncoder99.copyTextureToTexture(
+{
+  texture: texture96,
+  mipLevel: 0,
+  origin: { x: 152, y: 0, z: 1033 },
+  aspect: 'all',
+},
+{
+  texture: texture94,
+  mipLevel: 2,
+  origin: { x: 4, y: 17, z: 20 },
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 45}
+);
+} catch {}
+try {
+device7.queue.writeTexture(
+{
+  texture: texture103,
+  mipLevel: 1,
+  origin: { x: 24, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer13,
+/* required buffer size: 513 */{
+offset: 513,
+bytesPerRow: 205,
+},
+{width: 0, height: 96, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline67 = device7.createComputePipeline(
+{
+label: '\u{1fffe}\u3fb3\u{1fc84}\u09f7\u99c1',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule13,
+entryPoint: 'compute0',
+},
+}
+);
+let pipeline68 = await device7.createRenderPipelineAsync(
+{
+layout: pipelineLayout26,
+vertex: {
+module: shaderModule14,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 608,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 160,
+shaderLocation: 18,
+},
+{
+format: 'unorm16x4',
+offset: 88,
+shaderLocation: 12,
+},
+{
+format: 'sint16x2',
+offset: 544,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 2032,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 1468,
+shaderLocation: 20,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 1548,
+shaderLocation: 17,
+},
+{
+format: 'uint16x2',
+offset: 136,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 1128,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 148,
+shaderLocation: 11,
+},
+{
+format: 'unorm16x2',
+offset: 20,
+shaderLocation: 4,
+},
+{
+format: 'float32x4',
+offset: 632,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'snorm16x2',
+offset: 3820,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 1200,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 476,
+shaderLocation: 21,
+}
+],
+},
+{
+arrayStride: 3428,
+attributes: [
+{
+format: 'unorm16x2',
+offset: 2868,
+shaderLocation: 14,
+},
+{
+format: 'unorm8x2',
+offset: 2414,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+primitive: {
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule14,
+entryPoint: 'fragment0',
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+failOp: 'replace',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2065,
+depthBiasSlopeScale: 69,
+},
+}
+);
+try {
+gpuCanvasContext37.unconfigure();
+} catch {}
+document.body.append('\u0978\u016f\u0a1c\u9fcf');
+let imageData46 = new ImageData(192, 148);
+try {
+canvas40.getContext('2d');
+} catch {}
+let texture123 = device12.createTexture(
+{
+label: '\u00a3\u847c\udd81\u{1fccb}\u0fb2\u{1ffbd}\ue107\u0565\u0dc8\u0d55',
+size: {width: 6510},
+dimension: '1d',
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rgba16float',
+'rgba16float'
+],
+}
+);
+try {
+device12.queue.writeTexture(
+{
+  texture: texture123,
+  mipLevel: 0,
+  origin: { x: 367, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer7,
+/* required buffer size: 196 */{
+offset: 196,
+bytesPerRow: 43185,
+rowsPerImage: 283,
+},
+{width: 5386, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let sampler101 = device11.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeW: 'repeat',
+lodMinClamp: 20.528,
+lodMaxClamp: 78.009,
+}
+);
+gc();
+document.body.prepend('\uc6e8\u{1f82a}\ua026\u07da');
+let texture124 = device4.createTexture(
+{
+label: '\u5088\u09f5\u96c9\uc49c\u0629\u06f5\ud9ef',
+size: [156, 104, 222],
+mipLevelCount: 7,
+dimension: '2d',
+format: 'eac-rg11unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'eac-rg11unorm',
+'eac-rg11unorm',
+'eac-rg11unorm'
+],
+}
+);
+let textureView102 = texture90.createView(
+{
+label: '\u1bb2\u39c3\u{1fb85}',
+dimension: '2d-array',
+baseMipLevel: 2,
+mipLevelCount: 1,
+baseArrayLayer: 0,
+}
+);
+try {
+computePassEncoder62.setBindGroup(
+2,
+bindGroup68
+);
+} catch {}
+try {
+computePassEncoder52.setBindGroup(
+0,
+bindGroup79,
+new Uint32Array(7018),
+1786,
+0
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture78,
+  mipLevel: 1,
+  origin: { x: 16, y: 8, z: 0 },
+  aspect: 'all',
+},
+new Float32Array(new ArrayBuffer(64)),
+/* required buffer size: 1250 */{
+offset: 350,
+bytesPerRow: 68,
+rowsPerImage: 243,
+},
+{width: 8, height: 56, depthOrArrayLayers: 1}
+);
+} catch {}
+let commandEncoder101 = device9.createCommandEncoder(
+{
+label: '\u42f6\u{1fe91}\u7c45\uc234\u{1fdfc}\u{1f63e}\ua509\ud448\u{1fc23}\uefaf',
+}
+);
+let querySet80 = device9.createQuerySet(
+{
+label: '\u{1fea6}\u99a9',
+type: 'occlusion',
+count: 1764,
+}
+);
+let renderBundleEncoder84 = device9.createRenderBundleEncoder(
+{
+label: '\u70a5\ue80e\u{1f8f8}\u0f04\u92d6\u9be8\ua7bf',
+colorFormats: [
+'rg32uint',
+undefined,
+'r8uint',
+'rgb10a2uint',
+'r8sint',
+'r16sint',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 734,
+depthReadOnly: true,
+}
+);
+let renderBundle96 = renderBundleEncoder80.finish(
+{
+label: '\u00c1\u01df\u0d65\u31e0\u67d5\u0fe1'
+}
+);
+try {
+renderBundleEncoder77.setIndexBuffer(
+buffer43,
+'uint32',
+36836,
+1970
+);
+} catch {}
+try {
+gpuCanvasContext25.configure(
+{
+device: device9,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let renderBundle97 = renderBundleEncoder55.finish(
+{
+label: '\udfed\u0ea4'
+}
+);
+let externalTexture14 = device4.importExternalTexture(
+{
+label: '\u{1f92d}\ud4ec\uda94\ub96b\u2c62',
+source: video31,
+colorSpace: 'srgb',
+}
+);
+try {
+renderBundleEncoder81.setVertexBuffer(
+87,
+undefined,
+1015116224,
+2566439872
+);
+} catch {}
+let promise54 = device4.queue.onSubmittedWorkDone();
+document.body.append('\u0445\u0c7e\u49b4\uf256\u09eb\ue2b3\u7d5d\u{1f73a}\u{1fdb5}\uf993');
+document.body.append('\u0203\u799b\u{1ff95}\u6834\u4a6e\u{1feea}\u634e');
+offscreenCanvas7.height = 420;
+let imageData47 = new ImageData(60, 192);
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+try {
+adapter8.label = '\u035a\u126c\u609f\u6409\u{1f7df}\uc234\u73fd\u06f4';
+} catch {}
+let textureView103 = texture79.createView(
+{
+label: '\u{1f813}\u{1fdda}\u06b6\u60ff\u08da\u{1fab3}',
+baseArrayLayer: 119,
+arrayLayerCount: 31,
+}
+);
+let renderBundle98 = renderBundleEncoder59.finish(
+{
+label: '\u{1fba3}\u0610\u{1f7b9}'
+}
+);
+try {
+renderBundleEncoder81.setBindGroup(
+5,
+bindGroup63
+);
+} catch {}
+try {
+computePassEncoder54.pushDebugGroup(
+'\u0982'
+);
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer35,
+58632,
+new Int16Array(56095),
+53617,
+256
+);
+} catch {}
+document.body.append('\ub821\ua615\u01d6\u04e7\ue06c\u0071');
+let adapter17 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let offscreenCanvas38 = new OffscreenCanvas(330, 287);
+let bindGroup81 = device7.createBindGroup({
+layout: bindGroupLayout31,
+entries: [
+
+],
+});
+let pipelineLayout27 = device7.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout31,
+bindGroupLayout32,
+bindGroupLayout32,
+bindGroupLayout28,
+bindGroupLayout31,
+bindGroupLayout26,
+bindGroupLayout26,
+bindGroupLayout28,
+bindGroupLayout31,
+bindGroupLayout26
+],
+}
+);
+let commandEncoder102 = device7.createCommandEncoder(
+{
+label: '\u{1fd13}\u2df9\u{1f69d}\u6c8d\u04f9\u5da2\u03b3\u04f1\u3e74\u036a\u{1fa25}',
+}
+);
+let querySet81 = device7.createQuerySet(
+{
+label: '\u{1f7c5}\u059c\u0b2b\u974d\u0c50\u{1fd96}',
+type: 'occlusion',
+count: 41,
+}
+);
+let texture125 = device7.createTexture(
+{
+size: {width: 4728, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+sampleCount: 1,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'stencil8',
+'stencil8',
+'stencil8'
+],
+}
+);
+let renderBundle99 = renderBundleEncoder72.finish(
+{
+label: '\u{1f9db}\uf321\ue302\u2954\u061c\u{1feda}\u{1f8ea}\u0ab0\u8106'
+}
+);
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: -539.1,
+g: 429.1,
+b: 408.4,
+a: 316.3,
+}
+);
+} catch {}
+let gpuCanvasContext40 = offscreenCanvas38.getContext('webgpu');
+document.body.prepend('\u{1f8e2}\u0ad5\u8870\u20c7\ub348\uad31');
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+document.body.prepend('\u4e06\uceca\u{1fed1}\ue430\u96ab\u85dd\u575e\u01d9\u879e');
+let img49 = await imageWithData(164, 33, '#3e0f2ce8', '#5cd4c8bf');
+let commandEncoder103 = device11.createCommandEncoder();
+let texture126 = device11.createTexture(
+{
+label: '\u{1fe69}\u000d\u{1ff40}\u412c\ue78d\u02e0\ubf51\u0db6',
+size: {width: 718, height: 1, depthOrArrayLayers: 766},
+mipLevelCount: 8,
+dimension: '3d',
+format: 'rgba8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let img50 = await imageWithData(224, 24, '#85350e66', '#95ee9304');
+let promise55 = adapter15.requestAdapterInfo();
+let texture127 = device7.createTexture(
+{
+label: '\uac9d\u1920\u00ae\u0a99\u0bf4\u01a3\u71ec',
+size: [16, 16, 1],
+format: 'etc2-rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'etc2-rgba8unorm-srgb',
+'etc2-rgba8unorm',
+'etc2-rgba8unorm-srgb'
+],
+}
+);
+let sampler102 = device7.createSampler(
+{
+label: '\u{1fab4}\u{1fd35}\uad31\u8713\u2b53',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMaxClamp: 43.783,
+}
+);
+try {
+renderBundleEncoder73.setBindGroup(
+1,
+bindGroup81,
+new Uint32Array(7345),
+6106,
+0
+);
+} catch {}
+try {
+commandEncoder99.copyBufferToBuffer(
+buffer41,
+5932,
+buffer38,
+7980,
+6956
+);
+dissociateBuffer(device7, buffer41);
+dissociateBuffer(device7, buffer38);
+} catch {}
+try {
+commandEncoder99.resolveQuerySet(
+querySet63,
+1208,
+138,
+buffer38,
+24064
+);
+} catch {}
+try {
+await device7.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline69 = device7.createComputePipeline(
+{
+label: '\u{1f814}\u5e77\u{1fd8e}\u{1fed3}\u9367\u1344',
+layout: pipelineLayout21,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline70 = device7.createRenderPipeline(
+{
+label: '\u65e0\u74a8\u6cbf\u{1fa15}\ufefa\u{1f927}\u5665',
+layout: 'auto',
+vertex: {
+module: shaderModule14,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 4476,
+attributes: [
+{
+format: 'float32x3',
+offset: 1196,
+shaderLocation: 19,
+},
+{
+format: 'uint16x2',
+offset: 4028,
+shaderLocation: 21,
+},
+{
+format: 'unorm16x4',
+offset: 936,
+shaderLocation: 17,
+},
+{
+format: 'uint32x3',
+offset: 864,
+shaderLocation: 22,
+},
+{
+format: 'snorm16x2',
+offset: 1520,
+shaderLocation: 14,
+},
+{
+format: 'unorm8x4',
+offset: 2048,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x4',
+offset: 948,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x4',
+offset: 4092,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 896,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 1396,
+attributes: [
+{
+format: 'sint32x3',
+offset: 732,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 1192,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x2',
+offset: 560,
+shaderLocation: 18,
+},
+{
+format: 'snorm8x2',
+offset: 468,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x4',
+offset: 860,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 2524,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 4908,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 3288,
+shaderLocation: 20,
+}
+],
+}
+]
+},
+primitive: {
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule14,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'dst-alpha',
+dstFactor: 'one-minus-src'
+},
+},
+format: 'rg8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+format: 'r8uint',
+}
+],
+},
+}
+);
+document.body.append('\u{1fac0}\u0faa\u{1f6d3}\u474a');
+let canvas41 = document.createElement('canvas');
+let buffer47 = device3.createBuffer(
+{
+label: '\u3756\u0121\u0048\u1c59\uc5a5',
+size: 56610,
+usage: GPUBufferUsage.MAP_WRITE,
+}
+);
+let commandEncoder104 = device3.createCommandEncoder(
+{
+}
+);
+let texture128 = device3.createTexture(
+{
+label: '\u0f5a\ub782\u0854\u0c16\udae3',
+size: {width: 204, height: 1, depthOrArrayLayers: 99},
+dimension: '3d',
+format: 'rg8uint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let textureView104 = texture128.createView(
+{
+label: '\u183c\u006b\uea85\u{1f917}\u0c7e\u1071\u27a0\ub5b7\u0c95',
+}
+);
+let renderBundle100 = renderBundleEncoder42.finish(
+{
+
+}
+);
+try {
+buffer47.unmap();
+} catch {}
+try {
+commandEncoder72.copyTextureToTexture(
+{
+  texture: texture128,
+  mipLevel: 0,
+  origin: { x: 18, y: 0, z: 75 },
+  aspect: 'all',
+},
+{
+  texture: texture75,
+  mipLevel: 0,
+  origin: { x: 3016, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 151, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+gpuCanvasContext32.configure(
+{
+device: device3,
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32uint',
+'astc-8x5-unorm',
+'astc-12x12-unorm',
+'astc-12x12-unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let texture129 = device8.createTexture(
+{
+label: '\u0434\ucbc7\u0ee0\u{1fb8a}\ued0f\u0ecb\u{1f865}\u0a91',
+size: [160, 240, 1],
+mipLevelCount: 3,
+format: 'eac-r11snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'eac-r11snorm'
+],
+}
+);
+let sampler103 = device8.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 97.923,
+maxAnisotropy: 18,
+}
+);
+let externalTexture15 = device8.importExternalTexture(
+{
+label: '\u04d1\u{1f838}\u0454\ufa64\u{1fe57}',
+source: videoFrame5,
+colorSpace: 'srgb',
+}
+);
+try {
+device8.queue.writeTexture(
+{
+  texture: texture113,
+  mipLevel: 4,
+  origin: { x: 56, y: 1, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 39 */{
+offset: 39,
+},
+{width: 351, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\u34e5\u085d\uf632\ub956\u0ffc');
+let querySet82 = device7.createQuerySet(
+{
+label: '\u367a\u8f91\u7338\u2ca8\u09a2\u6a10\u9f0d\u3060\u38cc\ub28e\u0930',
+type: 'occlusion',
+count: 3197,
+}
+);
+let texture130 = device7.createTexture(
+{
+size: {width: 11266},
+dimension: '1d',
+format: 'rg16uint',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+try {
+renderPassEncoder3.setBindGroup(
+8,
+bindGroup77,
+new Uint32Array(6714),
+5221,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder3.setViewport(
+39.60,
+5.065,
+11.99,
+3.609,
+0.5310,
+0.6478
+);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(
+buffer38,
+'uint16',
+1850
+);
+} catch {}
+try {
+renderBundleEncoder73.setBindGroup(
+5,
+bindGroup80
+);
+} catch {}
+try {
+renderBundleEncoder73.setBindGroup(
+6,
+bindGroup77,
+new Uint32Array(4019),
+51,
+0
+);
+} catch {}
+try {
+canvas41.getContext('webgl');
+} catch {}
+let commandEncoder105 = device9.createCommandEncoder(
+{
+label: '\ud7dc\u{1f74f}\u09ff\u{1f724}\u0d3d\ud3d1',
+}
+);
+let commandBuffer15 = commandEncoder105.finish(
+{
+label: '\u{1ffb4}\u6082\u070f',
+}
+);
+let texture131 = device9.createTexture(
+{
+label: '\ueb8b\u{1fe5b}',
+size: {width: 752, height: 1, depthOrArrayLayers: 745},
+mipLevelCount: 3,
+dimension: '3d',
+format: 'r8uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'r8uint',
+'r8uint'
+],
+}
+);
+let renderBundleEncoder85 = device9.createRenderBundleEncoder(
+{
+label: '\u8b76\uee9e\u6df8\u{1fdd8}\u9186\u053d\ucd2c\u2271\u0ca4\u071a',
+colorFormats: [
+'bgra8unorm-srgb',
+'rg32float',
+'rg32uint',
+undefined,
+'rgba16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 391,
+depthReadOnly: true,
+}
+);
+let sampler104 = device9.createSampler(
+{
+label: '\ua70e\ued58\u017d\uf9c5\uf4c0',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMaxClamp: 26.699,
+}
+);
+try {
+commandEncoder97.clearBuffer(
+buffer43
+);
+dissociateBuffer(device9, buffer43);
+} catch {}
+try {
+device9.queue.writeBuffer(
+buffer43,
+4804,
+new BigUint64Array(51903),
+32794,
+4160
+);
+} catch {}
+try {
+device9.queue.writeTexture(
+{
+  texture: texture109,
+  mipLevel: 1,
+  origin: { x: 3, y: 0, z: 12 },
+  aspect: 'all',
+},
+new ArrayBuffer(414285),
+/* required buffer size: 414285 */{
+offset: 417,
+bytesPerRow: 379,
+rowsPerImage: 26,
+},
+{width: 25, height: 0, depthOrArrayLayers: 43}
+);
+} catch {}
+try {
+await promise54;
+} catch {}
+gc();
+document.body.append('\uf198\u27bb\u5d7a\u0aa7\uaf9c\u1ee4\u23c2\u35da\ue551');
+let texture132 = device8.createTexture(
+{
+label: '\u0d0f\u042c',
+size: {width: 168, height: 68, depthOrArrayLayers: 207},
+mipLevelCount: 7,
+format: 'etc2-rgb8a1unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'etc2-rgb8a1unorm-srgb',
+'etc2-rgb8a1unorm',
+'etc2-rgb8a1unorm'
+],
+}
+);
+let textureView105 = texture102.createView(
+{
+baseMipLevel: 7,
+mipLevelCount: 1,
+}
+);
+let renderBundleEncoder86 = device8.createRenderBundleEncoder(
+{
+label: '\u069a\u786a\u{1f699}',
+colorFormats: [
+'rgba32sint',
+'r32uint',
+'rgba16float',
+undefined,
+'r32float',
+'r8unorm'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 899,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler105 = device8.createSampler(
+{
+label: '\u15d6\u{1f875}\u0a31',
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 53.726,
+lodMaxClamp: 90.640,
+}
+);
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(
+buffer45,
+'uint16',
+330
+);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(
+82,
+undefined,
+3146321058,
+889059106
+);
+} catch {}
+let img51 = await imageWithData(126, 49, '#a8742e24', '#8fcc16c3');
+let bindGroupLayout38 = device8.createBindGroupLayout(
+{
+label: '\u04c0\u3762\u1884\u071e\u4029\uc2a7\u{1fca5}\uc5f9',
+entries: [
+
+],
+}
+);
+let bindGroup82 = device8.createBindGroup({
+layout: bindGroupLayout38,
+entries: [
+
+],
+});
+try {
+renderPassEncoder4.setVertexBuffer(
+27,
+undefined,
+3699852859,
+83187928
+);
+} catch {}
+try {
+renderBundleEncoder74.setBindGroup(
+0,
+bindGroup82,
+new Uint32Array(1353),
+1322,
+0
+);
+} catch {}
+document.body.append('\u5a8f\u0d67');
+gc();
+let video35 = await videoWithData();
+let querySet83 = device11.createQuerySet(
+{
+label: '\u0779\udaa8\u0108\ud554\u{1f8db}\uc99c\u{1fd42}',
+type: 'occlusion',
+count: 694,
+}
+);
+let commandBuffer16 = commandEncoder103.finish(
+{
+label: '\u4a7f\u{1f6b4}\u08f8\u6d68\u{1fdc5}',
+}
+);
+let renderBundleEncoder87 = device11.createRenderBundleEncoder(
+{
+label: '\ubffb\u01fc\u{1fb07}\udb7c\u0dfb\u0f7a',
+colorFormats: [
+'r16float',
+'r32float',
+'rg8uint'
+],
+sampleCount: 644,
+stencilReadOnly: true,
+}
+);
+let renderBundle101 = renderBundleEncoder79.finish(
+{
+label: '\u51c5\u0961\u03e5\u0357\u0853'
+}
+);
+document.body.append('\u422f\u0f34');
+let imageBitmap52 = await createImageBitmap(imageBitmap23);
+let textureView106 = texture115.createView(
+{
+label: '\u0994\u521d\u0868\u{1ff72}\u{1fc9e}\u9901',
+dimension: '1d',
+format: 'rgba32uint',
+}
+);
+let externalTexture16 = device12.importExternalTexture(
+{
+source: video22,
+}
+);
+document.body.prepend(canvas38);
+let bindGroupLayout39 = device8.createBindGroupLayout(
+{
+entries: [
+{
+binding: 404,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+},
+{
+binding: 1717,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let bindGroup83 = device8.createBindGroup({
+layout: bindGroupLayout38,
+entries: [
+
+],
+});
+let textureView107 = texture113.createView(
+{
+label: '\uf2f7\ub180',
+aspect: 'all',
+baseMipLevel: 5,
+mipLevelCount: 1,
+baseArrayLayer: 0,
+}
+);
+try {
+renderPassEncoder4.setScissorRect(
+0,
+1,
+1,
+0
+);
+} catch {}
+try {
+renderBundleEncoder82.setVertexBuffer(
+23,
+undefined,
+132009161
+);
+} catch {}
+document.body.prepend('\u{1f95b}\u200b\u{1f7ea}\u1a46\uab6f\u{1ff12}');
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+try {
+await promise53;
+} catch {}
+let imageData48 = new ImageData(120, 60);
+let commandEncoder106 = device4.createCommandEncoder();
+let renderBundleEncoder88 = device4.createRenderBundleEncoder(
+{
+label: '\u{1f946}\u4cbc\ua7ae\u12b6\u0753\u{1fe3c}\u81d9\ue971\u03ba\u{1ff2f}\u2b0e',
+colorFormats: [
+'rg16float',
+'r16uint',
+'rg32uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 428,
+}
+);
+let sampler106 = device4.createSampler(
+{
+label: '\u{1fdec}\u{1fa7e}\u{1fa1a}\u0a1b\u1216\u098d',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 99.336,
+maxAnisotropy: 16,
+}
+);
+try {
+computePassEncoder52.setBindGroup(
+0,
+bindGroup66,
+new Uint32Array(2942),
+1178,
+0
+);
+} catch {}
+try {
+renderBundleEncoder88.setBindGroup(
+3,
+bindGroup63,
+[]
+);
+} catch {}
+try {
+renderBundleEncoder88.setVertexBuffer(
+35,
+undefined,
+969304114,
+796133520
+);
+} catch {}
+try {
+commandEncoder106.copyBufferToBuffer(
+buffer36,
+30348,
+buffer35,
+1536,
+23184
+);
+dissociateBuffer(device4, buffer36);
+dissociateBuffer(device4, buffer35);
+} catch {}
+try {
+commandEncoder106.copyBufferToTexture(
+{
+/* bytesInLastRow: 25600 widthInBlocks: 3200 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 43576 */
+offset: 43576,
+buffer: buffer32,
+},
+{
+  texture: texture91,
+  mipLevel: 0,
+  origin: { x: 2156, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 3200, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device4, buffer32);
+} catch {}
+try {
+commandEncoder106.copyTextureToBuffer(
+{
+  texture: texture116,
+  mipLevel: 6,
+  origin: { x: 40, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 6240 */
+offset: 6240,
+buffer: buffer35,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device4, buffer35);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture124,
+  mipLevel: 1,
+  origin: { x: 8, y: 8, z: 12 },
+  aspect: 'all',
+},
+arrayBuffer12,
+/* required buffer size: 6183195 */{
+offset: 571,
+bytesPerRow: 192,
+rowsPerImage: 235,
+},
+{width: 8, height: 28, depthOrArrayLayers: 138}
+);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+video23.width = 101;
+let img52 = await imageWithData(127, 91, '#295ed75b', '#51ccb11f');
+try {
+await promise55;
+} catch {}
+offscreenCanvas20.width = 339;
+try {
+await device4.popErrorScope();
+} catch {}
+try {
+commandEncoder106.copyTextureToBuffer(
+{
+  texture: texture91,
+  mipLevel: 0,
+  origin: { x: 146, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 23360 widthInBlocks: 2920 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 43544 */
+offset: 20184,
+buffer: buffer37,
+},
+{width: 2920, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device4, buffer37);
+} catch {}
+offscreenCanvas24.width = 282;
+document.body.append('\u4e0b\uad32\u09ef\u92f2\u6147\ua0d8\u{1f9ce}\ud63f');
+let img53 = await imageWithData(100, 56, '#b762d2b6', '#4c5f194d');
+let renderPassEncoder6 = commandEncoder99.beginRenderPass(
+{
+label: '\ucd86\u{1fcb0}\u{1fbd2}\uf740\u{1f965}\u2fff\u0f69',
+colorAttachments: [
+{
+view: textureView87,
+clearValue: {
+r: 949.6,
+g: -135.6,
+b: 414.6,
+a: 80.04,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined
+],
+occlusionQuerySet: querySet56,
+}
+);
+try {
+renderPassEncoder6.setBindGroup(
+10,
+bindGroup71
+);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+30,
+23,
+13,
+0
+);
+} catch {}
+try {
+commandEncoder102.clearBuffer(
+buffer38,
+3304,
+8180
+);
+dissociateBuffer(device7, buffer38);
+} catch {}
+let commandEncoder107 = device4.createCommandEncoder(
+{
+label: '\u43a4\ue0ae\uddb3\u6568\u{1f60b}\u40cb\ue61e\ue20d\u0f93\u5c66\u{1fb9a}',
+}
+);
+let sampler107 = device4.createSampler(
+{
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 35.652,
+lodMaxClamp: 42.966,
+}
+);
+try {
+computePassEncoder52.end();
+} catch {}
+try {
+commandEncoder106.copyBufferToBuffer(
+buffer36,
+29420,
+buffer35,
+8176,
+12924
+);
+dissociateBuffer(device4, buffer36);
+dissociateBuffer(device4, buffer35);
+} catch {}
+try {
+commandEncoder106.copyTextureToTexture(
+{
+  texture: texture78,
+  mipLevel: 0,
+  origin: { x: 0, y: 112, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture78,
+  mipLevel: 1,
+  origin: { x: 16, y: 24, z: 0 },
+  aspect: 'all',
+},
+{width: 24, height: 40, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+renderBundleEncoder88.insertDebugMarker(
+'\u9918'
+);
+} catch {}
+gc();
+try {
+commandEncoder101.copyTextureToBuffer(
+{
+  texture: texture111,
+  mipLevel: 0,
+  origin: { x: 154, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 2304 widthInBlocks: 1152 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 40216 */
+offset: 40216,
+buffer: buffer43,
+},
+{width: 1152, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device9, buffer43);
+} catch {}
+try {
+commandEncoder101.insertDebugMarker(
+'\ua619'
+);
+} catch {}
+try {
+await device9.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append('\u{1fb77}\u2d42\ufc9d\u56ab\u38d3\u32e0\u01ef\u0d6b');
+let video36 = await videoWithData();
+let imageBitmap53 = await createImageBitmap(videoFrame31);
+let texture133 = device12.createTexture(
+{
+size: {width: 2, height: 330, depthOrArrayLayers: 22},
+mipLevelCount: 9,
+dimension: '3d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16uint'
+],
+}
+);
+try {
+device12.destroy();
+} catch {}
+let offscreenCanvas39 = new OffscreenCanvas(443, 596);
+pseudoSubmit(device7, commandEncoder102);
+let textureView108 = texture125.createView(
+{
+label: '\u{1f8a4}\u75a9',
+dimension: '2d-array',
+aspect: 'all',
+baseMipLevel: 1,
+mipLevelCount: 1,
+arrayLayerCount: 1,
+}
+);
+try {
+renderBundleEncoder73.setBindGroup(
+5,
+bindGroup80
+);
+} catch {}
+try {
+renderBundleEncoder73.setVertexBuffer(
+1,
+buffer38,
+28124,
+5
+);
+} catch {}
+document.body.prepend('\u0a76\u44cd\u0df6\u04f0\u1c62\u0fd8\u235a\u173e\u{1fed7}');
+let texture134 = device7.createTexture(
+{
+label: '\u1053\u{1fd00}\u{1ff77}\u0017\u36fa\u96e1\u0f5c',
+size: [2340, 132, 1],
+mipLevelCount: 6,
+dimension: '2d',
+format: 'astc-12x12-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-12x12-unorm'
+],
+}
+);
+let externalTexture17 = device7.importExternalTexture(
+{
+label: '\u0b9e\u41dd\u9de1\u4412\u03d2\u8c88\u{1fbef}\u555b\u02ad\ud2aa\u488f',
+source: video15,
+colorSpace: 'display-p3',
+}
+);
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder73.setVertexBuffer(
+0,
+buffer41,
+1464,
+8116
+);
+} catch {}
+let promise56 = device7.createComputePipelineAsync(
+{
+label: '\u9964\u0921\u{1fdc0}\u0882\u{1f8fc}\udbf0\uaeb1',
+layout: pipelineLayout21,
+compute: {
+module: shaderModule13,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext38.unconfigure();
+} catch {}
+let commandEncoder108 = device10.createCommandEncoder(
+{
+}
+);
+let texture135 = device10.createTexture(
+{
+label: '\u{1faef}\u0ab7\ud9ba\u54dc\u{1fe71}\ufd3c\u150b\u{1fec2}\udb56\u05e3',
+size: {width: 6468},
+dimension: '1d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg8unorm',
+'rg8unorm',
+'rg8unorm'
+],
+}
+);
+let imageData49 = new ImageData(228, 4);
+let gpuCanvasContext41 = offscreenCanvas39.getContext('webgpu');
+let renderBundleEncoder89 = device11.createRenderBundleEncoder(
+{
+label: '\u25be\u{1f97e}\ue071\ud224\u{1feca}\u215d\u{1fa28}\u3f56\u{1fedd}\u{1fdf8}',
+colorFormats: [
+'rgba32float',
+'r32sint',
+'rg8sint',
+'rgba16float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 931,
+depthReadOnly: true,
+}
+);
+let sampler108 = device11.createSampler(
+{
+label: '\ud37d\u{1fece}\u0bba\u6c23',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 89.516,
+}
+);
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.prepend('\u0d75\ube26\u{1fad9}\u2abb');
+let promise57 = adapter15.requestAdapterInfo();
+pseudoSubmit(device9, commandEncoder101);
+let buffer48 = device11.createBuffer(
+{
+label: '\u09ee\u45ab\ub95c\u991e\u{1fb2f}\ue043\u289f\u{1ff1b}\u{1fc43}\u0854\u98f1',
+size: 32832,
+usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+}
+);
+let commandEncoder109 = device11.createCommandEncoder(
+{
+label: '\u4436\u{1fce2}',
+}
+);
+try {
+await promise57;
+} catch {}
+let bindGroup84 = device4.createBindGroup({
+label: '\u0a04\u0767\uc913\u0ee1\u0e28\u7592\u561e',
+layout: bindGroupLayout20,
+entries: [
+
+],
+});
+let texture136 = device4.createTexture(
+{
+label: '\u{1fece}\u{1fd89}\u4197\uacc2\u8fc2',
+size: [2968, 48, 1],
+format: 'astc-8x6-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-8x6-unorm-srgb',
+'astc-8x6-unorm-srgb',
+'astc-8x6-unorm-srgb'
+],
+}
+);
+try {
+commandEncoder76.copyBufferToTexture(
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 34688 */
+offset: 34688,
+bytesPerRow: 0,
+rowsPerImage: 188,
+buffer: buffer31,
+},
+{
+  texture: texture107,
+  mipLevel: 2,
+  origin: { x: 5, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 0, height: 25, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device4, buffer31);
+} catch {}
+try {
+commandEncoder76.copyTextureToBuffer(
+{
+  texture: texture91,
+  mipLevel: 0,
+  origin: { x: 285, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 28216 widthInBlocks: 3527 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 38832 */
+offset: 10616,
+buffer: buffer37,
+},
+{width: 3527, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device4, buffer37);
+} catch {}
+try {
+commandEncoder76.copyTextureToTexture(
+{
+  texture: texture78,
+  mipLevel: 1,
+  origin: { x: 8, y: 28, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture78,
+  mipLevel: 0,
+  origin: { x: 40, y: 112, z: 0 },
+  aspect: 'all',
+},
+{width: 32, height: 36, depthOrArrayLayers: 1}
+);
+} catch {}
+let videoFrame42 = new VideoFrame(imageBitmap40, {timestamp: 0});
+document.body.prepend('\u910f\u742a\u0b92\u{1f681}');
+let offscreenCanvas40 = new OffscreenCanvas(489, 777);
+let bindGroup85 = device7.createBindGroup({
+label: '\u{1fb19}\u0786\u5e23\u57d4\u01f5',
+layout: bindGroupLayout28,
+entries: [
+{
+binding: 5659,
+resource: {
+buffer: buffer38,
+offset: 13568,
+size: 4892,
+}
+},
+{
+binding: 5899,
+resource: sampler73
+}
+],
+});
+let renderBundleEncoder90 = device7.createRenderBundleEncoder(
+{
+label: '\ubb10\u0271\u{1fdd0}\u43bd\u1721\u07cb\u5c48\ub934',
+colorFormats: [
+'r16uint',
+'rg16sint',
+undefined,
+'r32float',
+'rg11b10ufloat'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 798,
+}
+);
+try {
+renderPassEncoder6.beginOcclusionQuery(
+16
+);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant(
+{
+r: 167.7,
+g: 779.4,
+b: -423.9,
+a: 126.4,
+}
+);
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(
+3915
+);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(
+6,
+buffer38
+);
+} catch {}
+try {
+device7.pushErrorScope(
+'internal'
+);
+} catch {}
+let promise58 = device7.queue.onSubmittedWorkDone();
+let querySet84 = device8.createQuerySet(
+{
+label: '\u09fa\ua5a4\u{1f837}\udf90\u2ec1\ua16a\uc215\u0bb9\ub191',
+type: 'occlusion',
+count: 1044,
+}
+);
+let texture137 = device8.createTexture(
+{
+label: '\u00b8\u{1f6a8}\u{1f893}\u098c\u0d39',
+size: {width: 12977},
+dimension: '1d',
+format: 'rg32sint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundle102 = renderBundleEncoder70.finish(
+{
+label: '\u{1fcb1}\u2b6f\ucfa1\u0526\u003d\u9bad'
+}
+);
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant(
+{
+r: 16.44,
+g: -178.2,
+b: -551.2,
+a: 514.2,
+}
+);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(
+1714
+);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(
+79,
+undefined,
+856674146
+);
+} catch {}
+try {
+device8.queue.writeTexture(
+{
+  texture: texture129,
+  mipLevel: 1,
+  origin: { x: 44, y: 40, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(80),
+/* required buffer size: 317 */{
+offset: 317,
+bytesPerRow: 204,
+rowsPerImage: 306,
+},
+{width: 28, height: 76, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\u0010\u0e8a');
+let querySet85 = device8.createQuerySet(
+{
+label: '\u{1ffe4}\u7d59\u0eff\u6c75\ue425\u8b44\u75c6\u0b3c\u00e5',
+type: 'occlusion',
+count: 1188,
+}
+);
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder82.setVertexBuffer(
+38,
+undefined,
+3188110307,
+378270554
+);
+} catch {}
+let promise59 = device8.queue.onSubmittedWorkDone();
+let commandEncoder110 = device8.createCommandEncoder(
+{
+label: '\uab13\uf00c\u{1ffa8}\u8f01\u{1f733}\u{1fe1c}\u7635',
+}
+);
+let renderBundle103 = renderBundleEncoder82.finish(
+{
+label: '\u001b\u{1f6cf}\u12bf\u{1f98d}\u8083\u{1f725}\u8c20'
+}
+);
+let sampler109 = device8.createSampler(
+{
+label: '\u0687\u{1fd3a}\u0bc7\u7f4d',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 0.291,
+lodMaxClamp: 78.891,
+}
+);
+try {
+renderPassEncoder4.setBindGroup(
+3,
+bindGroup83
+);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(
+72,
+undefined,
+3097024499,
+69836555
+);
+} catch {}
+try {
+renderBundleEncoder74.setBindGroup(
+4,
+bindGroup83,
+new Uint32Array(1535),
+463,
+0
+);
+} catch {}
+try {
+commandEncoder110.copyTextureToTexture(
+{
+  texture: texture113,
+  mipLevel: 3,
+  origin: { x: 104, y: 4, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture113,
+  mipLevel: 5,
+  origin: { x: 61, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 37, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder110.clearBuffer(
+buffer45,
+3704,
+2016
+);
+dissociateBuffer(device8, buffer45);
+} catch {}
+let querySet86 = device8.createQuerySet(
+{
+label: '\u961c\u{1fb87}\u2388',
+type: 'occlusion',
+count: 2830,
+}
+);
+let renderBundle104 = renderBundleEncoder71.finish(
+{
+label: '\ud373\u{1fe0d}\u9578\uf70b\ue157\u{1fb50}\ue602\u6d1a\u685d'
+}
+);
+try {
+renderPassEncoder4.setScissorRect(
+0,
+0,
+0,
+0
+);
+} catch {}
+try {
+renderBundleEncoder83.setVertexBuffer(
+23,
+undefined
+);
+} catch {}
+try {
+commandEncoder110.clearBuffer(
+buffer45,
+4432,
+2696
+);
+dissociateBuffer(device8, buffer45);
+} catch {}
+try {
+device8.queue.writeTexture(
+{
+  texture: texture113,
+  mipLevel: 1,
+  origin: { x: 315, y: 6, z: 0 },
+  aspect: 'all',
+},
+new Int8Array(arrayBuffer1),
+/* required buffer size: 285564 */{
+offset: 893,
+bytesPerRow: 28471,
+},
+{width: 1777, height: 10, depthOrArrayLayers: 1}
+);
+} catch {}
+let offscreenCanvas41 = new OffscreenCanvas(62, 631);
+try {
+offscreenCanvas41.getContext('webgl2');
+} catch {}
+let commandEncoder111 = device8.createCommandEncoder(
+{
+label: '\ucf0c\u0f32\u9ed1\ud971\u{1fb66}',
+}
+);
+try {
+renderPassEncoder4.setStencilReference(
+2378
+);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(
+buffer45,
+'uint16',
+2356,
+4264
+);
+} catch {}
+let offscreenCanvas42 = new OffscreenCanvas(66, 863);
+let textureView109 = texture126.createView(
+{
+label: '\u{1f86f}\u0763\u{1f80c}',
+baseMipLevel: 4,
+}
+);
+let sampler110 = device11.createSampler(
+{
+label: '\u5dd0\u08bc\u0800\u{1f9b4}\uf83b',
+addressModeU: 'repeat',
+minFilter: 'nearest',
+compare: 'greater',
+}
+);
+try {
+renderBundleEncoder87.setVertexBuffer(
+6,
+buffer48,
+7152,
+22920
+);
+} catch {}
+try {
+await promise59;
+} catch {}
+let texture138 = device8.createTexture(
+{
+label: '\u{1fd03}\u{1fcdb}\u09b0\u345f\u{1ff3a}\ucfac\u0c55\u5e50\u{1f930}\u07fe\ue9fa',
+size: [148, 116, 1],
+mipLevelCount: 7,
+format: 'r16uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16uint',
+'r16uint'
+],
+}
+);
+try {
+renderPassEncoder4.setStencilReference(
+2072
+);
+} catch {}
+try {
+renderPassEncoder4.setViewport(
+0.5578,
+0.4494,
+0.2249,
+0.05397,
+0.3936,
+0.6531
+);
+} catch {}
+try {
+commandEncoder110.copyTextureToTexture(
+{
+  texture: texture129,
+  mipLevel: 1,
+  origin: { x: 16, y: 40, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture129,
+  mipLevel: 1,
+  origin: { x: 12, y: 12, z: 1 },
+  aspect: 'all',
+},
+{width: 24, height: 72, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext22.configure(
+{
+device: device8,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+document.body.prepend(canvas9);
+document.body.prepend('\u4f78\u{1fe8b}\u{1fddc}\u09e7\u0c52\u63a9\u77e1');
+let offscreenCanvas43 = new OffscreenCanvas(802, 757);
+let bindGroup86 = device7.createBindGroup({
+label: '\u{1f717}\uaaa2\u1688',
+layout: bindGroupLayout26,
+entries: [
+
+],
+});
+let textureView110 = texture122.createView(
+{
+label: '\u{1fcc5}\u{1f630}\u9899\u7020\u{1ff73}\uf295',
+}
+);
+try {
+renderPassEncoder6.setBlendConstant(
+{
+r: -538.3,
+g: 671.7,
+b: -933.0,
+a: 135.8,
+}
+);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(
+buffer38,
+'uint16',
+16864
+);
+} catch {}
+let pipeline71 = await device7.createRenderPipelineAsync(
+{
+label: '\u{1f75d}\u0813\u82d8\ubac0\u114a\u357d\udb9c\u0791\u83e4\u0c5e',
+layout: pipelineLayout19,
+vertex: {
+module: shaderModule13,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1684,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 4,
+shaderLocation: 6,
+},
+{
+format: 'unorm16x2',
+offset: 1312,
+shaderLocation: 23,
+},
+{
+format: 'unorm8x2',
+offset: 1448,
+shaderLocation: 3,
+},
+{
+format: 'sint32x4',
+offset: 448,
+shaderLocation: 8,
+},
+{
+format: 'unorm16x4',
+offset: 1212,
+shaderLocation: 19,
+},
+{
+format: 'uint8x2',
+offset: 1564,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 3736,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 896,
+shaderLocation: 21,
+},
+{
+format: 'sint8x2',
+offset: 1270,
+shaderLocation: 20,
+},
+{
+format: 'float32',
+offset: 1096,
+shaderLocation: 5,
+},
+{
+format: 'uint16x2',
+offset: 2392,
+shaderLocation: 2,
+},
+{
+format: 'uint32',
+offset: 1444,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 5328,
+attributes: [
+
+],
+},
+{
+arrayStride: 5904,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 1488,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 2260,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x2',
+offset: 1848,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 4108,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 3048,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 1152,
+shaderLocation: 15,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'back',
+},
+fragment: {
+module: shaderModule13,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'rg16sint',
+writeMask: 0,
+},
+undefined,
+{
+format: 'rgba32uint',
+},
+{
+format: 'rgba8uint',
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'one',
+dstFactor: 'one-minus-src'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}
+],
+},
+}
+);
+let gpuCanvasContext42 = offscreenCanvas40.getContext('webgpu');
+let img54 = await imageWithData(38, 298, '#c5529a55', '#6c436508');
+let commandEncoder112 = device10.createCommandEncoder(
+{
+label: '\u9395\u08ec\u4efa\u3924',
+}
+);
+let textureView111 = texture106.createView(
+{
+label: '\ua338\u5d6d\u{1fa03}\uaa8e\u038c\u{1f89e}\u9c6f\u0562\u04ba',
+dimension: '2d-array',
+}
+);
+let renderBundle105 = renderBundleEncoder78.finish();
+try {
+computePassEncoder63.insertDebugMarker(
+'\uab14'
+);
+} catch {}
+let gpuCanvasContext43 = offscreenCanvas43.getContext('webgpu');
+try {
+await promise58;
+} catch {}
+offscreenCanvas3.width = 352;
+document.body.append('\u{1f87f}\ue324\u088a\u0f2e\u9192\ub089\ue52b\u{1fa89}\u{1f7bf}\u8fa8');
+video16.height = 20;
+document.body.append('\ubab5\ud028\u0e7e\u{1fc2f}\u0e14\u38b9');
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+document.body.append('\u034e\ua22f\u024f\u{1f80e}\u7f63');
+document.body.prepend('\uc1aa\u0c94');
+document.body.append('\u725e\u3512\u89f2\ue971\u0f91\u05e4');
+let canvas42 = document.createElement('canvas');
+try {
+gpuCanvasContext25.unconfigure();
+} catch {}
+let device13 = await adapter17.requestDevice(
+{
+requiredFeatures: [
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+}
+);
+let querySet87 = device9.createQuerySet(
+{
+type: 'occlusion',
+count: 352,
+}
+);
+let texture139 = device9.createTexture(
+{
+label: '\u072e\u{1f827}\u{1f83c}',
+size: {width: 5168, height: 234, depthOrArrayLayers: 6},
+mipLevelCount: 12,
+sampleCount: 1,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'depth24plus-stencil8'
+],
+}
+);
+try {
+commandEncoder97.clearBuffer(
+buffer43
+);
+dissociateBuffer(device9, buffer43);
+} catch {}
+try {
+device9.queue.writeBuffer(
+buffer43,
+436,
+new Float32Array(47299),
+26097,
+8660
+);
+} catch {}
+let gpuCanvasContext44 = offscreenCanvas42.getContext('webgpu');
+document.body.prepend(video2);
+let canvas43 = document.createElement('canvas');
+let renderBundle106 = renderBundleEncoder78.finish(
+{
+label: '\uc7d1\u8d12\u4888\u122e\u8f1f\ua75b\ud0b1\u0502'
+}
+);
+try {
+adapter3.label = '\u90f6\ud2f4\uf747\u5914\u714b\u23e0\u{1f90b}\u0f67\u8df9';
+} catch {}
+let texture140 = device11.createTexture(
+{
+label: '\u008d\u{1fcb9}\u78e0\u9720\u2f67\u{1f6db}\u{1fa9f}\ub9ff\u0843\uf3a9',
+size: {width: 125, height: 151, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView112 = texture126.createView(
+{
+aspect: 'all',
+baseMipLevel: 7,
+}
+);
+try {
+device11.queue.writeTexture(
+{
+  texture: texture126,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Uint8Array(arrayBuffer13),
+/* required buffer size: 31481 */{
+offset: 333,
+bytesPerRow: 56,
+rowsPerImage: 278,
+},
+{width: 3, height: 1, depthOrArrayLayers: 3}
+);
+} catch {}
+let videoFrame43 = new VideoFrame(img17, {timestamp: 0});
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let adapter18 = await navigator.gpu.requestAdapter(
+{
+}
+);
+pseudoSubmit(device11, commandEncoder109);
+let textureView113 = texture140.createView(
+{
+label: '\u4ca4\u048c\u{1f669}\u{1f830}\u{1fbd1}\u0cb4\u{1ffdc}',
+dimension: '2d-array',
+baseMipLevel: 4,
+mipLevelCount: 3,
+}
+);
+let gpuCanvasContext45 = canvas43.getContext('webgpu');
+offscreenCanvas11.width = 359;
+try {
+canvas42.getContext('2d');
+} catch {}
+let renderBundleEncoder91 = device9.createRenderBundleEncoder(
+{
+label: '\u3c3f\u0b58\u{1f847}',
+colorFormats: [
+'rgba32sint',
+'rgb10a2uint',
+'bgra8unorm',
+undefined
+],
+sampleCount: 985,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+buffer43.destroy();
+} catch {}
+try {
+commandEncoder97.copyTextureToBuffer(
+{
+  texture: texture111,
+  mipLevel: 0,
+  origin: { x: 710, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 1728 widthInBlocks: 864 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 17108 */
+offset: 17108,
+bytesPerRow: 1792,
+buffer: buffer43,
+},
+{width: 864, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device9, buffer43);
+} catch {}
+try {
+await device9.queue.onSubmittedWorkDone();
+} catch {}
+canvas43.height = 510;
+let imageBitmap54 = await createImageBitmap(offscreenCanvas27);
+let textureView114 = texture119.createView(
+{
+label: '\u06e3\u09a4\u8789\u0819\u4887\ua542\u7399\u0f82',
+aspect: 'stencil-only',
+mipLevelCount: 2,
+}
+);
+let renderBundleEncoder92 = device11.createRenderBundleEncoder(
+{
+label: '\uef81\u{1f84b}\u{1fe7d}\u{1f62f}\u13ca\u5b1d\uc1b8\u1ea8\ue7e0',
+colorFormats: [
+'r16uint',
+'r32float',
+undefined,
+'rg11b10ufloat'
+],
+sampleCount: 198,
+}
+);
+let renderBundle107 = renderBundleEncoder92.finish();
+try {
+gpuCanvasContext4.configure(
+{
+device: device11,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'bgra8unorm',
+'eac-r11snorm',
+'bgra8unorm',
+'astc-8x8-unorm-srgb'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let video37 = await videoWithData();
+let device14 = await adapter15.requestDevice(
+{
+label: '\u{1f8e7}\u55fe',
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-etc2',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 6,
+maxColorAttachmentBytesPerSample: 39,
+maxVertexAttributes: 20,
+maxVertexBufferArrayStride: 50474,
+maxStorageTexturesPerShaderStage: 15,
+maxStorageBuffersPerShaderStage: 41,
+maxDynamicStorageBuffersPerPipelineLayout: 35139,
+maxBindingsPerBindGroup: 3161,
+maxTextureDimension1D: 12832,
+maxTextureDimension2D: 10571,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 8745252,
+maxInterStageShaderVariables: 55,
+maxInterStageShaderComponents: 77,
+},
+}
+);
+let bindGroupLayout40 = device4.createBindGroupLayout(
+{
+label: '\u0f9f\u{1fcac}\u096b\u551f\u0a93\u3321\ue402',
+entries: [
+{
+binding: 3021,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 944480, hasDynamicOffset: true },
+},
+{
+binding: 3409,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '2d' },
+}
+],
+}
+);
+let bindGroup87 = device4.createBindGroup({
+label: '\u067f\u02d2',
+layout: bindGroupLayout20,
+entries: [
+
+],
+});
+try {
+renderBundleEncoder81.setBindGroup(
+1,
+bindGroup64,
+new Uint32Array(9190),
+3019,
+0
+);
+} catch {}
+try {
+renderBundleEncoder88.setIndexBuffer(
+buffer34,
+'uint16',
+4028,
+2817
+);
+} catch {}
+try {
+commandEncoder106.copyBufferToBuffer(
+buffer32,
+41744,
+buffer37,
+3172,
+1664
+);
+dissociateBuffer(device4, buffer32);
+dissociateBuffer(device4, buffer37);
+} catch {}
+try {
+commandEncoder106.clearBuffer(
+buffer35,
+49840,
+2256
+);
+dissociateBuffer(device4, buffer35);
+} catch {}
+try {
+gpuCanvasContext26.configure(
+{
+device: device4,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rgba16sint',
+'rgba16float',
+'rgba16float'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+document.body.prepend(video31);
+let videoFrame44 = new VideoFrame(canvas42, {timestamp: 0});
+let commandEncoder113 = device14.createCommandEncoder(
+{
+label: '\ub93f\u0f36\u{1fc06}\u026d\ufd41\u{1fc81}\u59aa\u4043\u007a\u0922',
+}
+);
+let computePassEncoder64 = commandEncoder113.beginComputePass(
+{
+label: '\udad4\u{1ffbd}\u{1f6b1}\u{1fa57}\u41c7\u{1fdef}\u578e'
+}
+);
+let renderBundleEncoder93 = device14.createRenderBundleEncoder(
+{
+label: '\u{1f653}\u01ab\u{1fffe}\u1a7f\u1326',
+colorFormats: [
+'rgba8uint',
+'rgba16sint'
+],
+sampleCount: 205,
+depthReadOnly: true,
+stencilReadOnly: false,
+}
+);
+let renderBundle108 = renderBundleEncoder93.finish();
+video34.height = 180;
+let bindGroup88 = device7.createBindGroup({
+label: '\u0cb7\u{1feec}\u25f9\u3180\u0914',
+layout: bindGroupLayout31,
+entries: [
+
+],
+});
+let texture141 = device7.createTexture(
+{
+label: '\u7b78\u4dc0\u18d9\u9eff\u0141',
+size: {width: 174, height: 242, depthOrArrayLayers: 231},
+dimension: '2d',
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'r32uint'
+],
+}
+);
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant(
+{
+r: 676.1,
+g: 659.3,
+b: 510.6,
+a: 842.2,
+}
+);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(
+37,
+32,
+11,
+3
+);
+} catch {}
+try {
+renderBundleEncoder90.setVertexBuffer(
+2,
+buffer41,
+10160,
+2362
+);
+} catch {}
+try {
+device7.queue.writeTexture(
+{
+  texture: texture94,
+  mipLevel: 1,
+  origin: { x: 6, y: 7, z: 55 },
+  aspect: 'all',
+},
+new Int16Array(arrayBuffer8),
+/* required buffer size: 74183 */{
+offset: 851,
+bytesPerRow: 204,
+rowsPerImage: 86,
+},
+{width: 48, height: 16, depthOrArrayLayers: 5}
+);
+} catch {}
+let pipeline72 = await device7.createRenderPipelineAsync(
+{
+label: '\ua8d2\u{1ff7f}\u4e91',
+layout: pipelineLayout19,
+vertex: {
+module: shaderModule13,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 2832,
+attributes: [
+{
+format: 'float16x2',
+offset: 2332,
+shaderLocation: 3,
+},
+{
+format: 'sint8x4',
+offset: 100,
+shaderLocation: 1,
+},
+{
+format: 'uint32x3',
+offset: 2384,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 352,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32',
+offset: 76,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x2',
+offset: 1188,
+shaderLocation: 21,
+},
+{
+format: 'float32',
+offset: 860,
+shaderLocation: 22,
+},
+{
+format: 'uint32x3',
+offset: 4848,
+shaderLocation: 2,
+},
+{
+format: 'uint8x4',
+offset: 3544,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 1652,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 740,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 280,
+shaderLocation: 23,
+},
+{
+format: 'uint8x2',
+offset: 4176,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 1140,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 980,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 296,
+shaderLocation: 6,
+},
+{
+format: 'float16x4',
+offset: 376,
+shaderLocation: 19,
+},
+{
+format: 'sint32x4',
+offset: 760,
+shaderLocation: 20,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0xa3c023ed,
+},
+fragment: {
+module: shaderModule13,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'always',
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 3287,
+depthBias: 36,
+depthBiasSlopeScale: 84,
+},
+}
+);
+let imageBitmap55 = await createImageBitmap(videoFrame7);
+try {
+renderBundleEncoder86.setBindGroup(
+4,
+bindGroup83
+);
+} catch {}
+document.body.append('\uf2c1\u0570\u0178\u91c7');
+let texture142 = device7.createTexture(
+{
+label: '\uba90\uff09\u{1fb2d}\u019e\u4aa0\uf135\u{1fda1}\u{1f630}\u3ae4\u{1fdcb}\ub7b1',
+size: {width: 225, height: 247, depthOrArrayLayers: 90},
+mipLevelCount: 4,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth24plus-stencil8',
+'depth24plus-stencil8',
+'depth24plus-stencil8'
+],
+}
+);
+let sampler111 = device7.createSampler(
+{
+label: '\u492a\u0f38\u{1f653}\u1f1e\u5805\uc8f5',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMaxClamp: 89.513,
+compare: 'less-equal',
+}
+);
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder73.setVertexBuffer(
+3,
+buffer38,
+18896,
+7949
+);
+} catch {}
+try {
+device7.queue.writeBuffer(
+buffer38,
+18932,
+new Int16Array(41857),
+23236,
+1648
+);
+} catch {}
+document.body.prepend(video31);
+let videoFrame45 = new VideoFrame(img4, {timestamp: 0});
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+  log('the end')
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -984,7 +984,8 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
                     if (bufferSizeArgumentBufferIndex)
                         *(uint32_t*)[argumentEncoder[stage] constantDataAtIndex:*bufferSizeArgumentBufferIndex] = entrySize;
                 }
-                stageResources[metalRenderStage(stage)][resourceUsage - 1].append(buffer);
+                if (buffer)
+                    stageResources[metalRenderStage(stage)][resourceUsage - 1].append(buffer);
                 stageResourceUsages[metalRenderStage(stage)][resourceUsage - 1].append(makeBindGroupEntryUsageData(usageForBuffer(layoutBinding->type), entry.binding, apiBuffer));
             } else if (samplerIsPresent) {
                 auto* layoutBinding = hasBinding<WGPUSamplerBindingLayout>(bindGroupLayoutEntries, bindingIndex);
@@ -1063,7 +1064,8 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
 
                 if (stage != ShaderStage::Undefined)
                     [argumentEncoder[stage] setTexture:texture atIndex:index];
-                stageResources[metalRenderStage(stage)][resourceUsage - 1].append(texture);
+                if (texture)
+                    stageResources[metalRenderStage(stage)][resourceUsage - 1].append(texture);
                 ASSERT(texture.parentRelativeLevel == apiTextureView.baseMipLevel());
                 ASSERT(texture.parentRelativeSlice == apiTextureView.baseArrayLayer());
                 stageResourceUsages[metalRenderStage(stage)][resourceUsage - 1].append(makeBindGroupEntryUsageData(textureEntry ? usageForTexture(*textureEntry) : (storageTextureEntry ? usageForStorageTexture(*storageTextureEntry) : BindGroupEntryUsage::ConstantTexture), entry.binding, apiTextureView));

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -102,6 +102,7 @@ public:
     void endEncoding(id<MTLCommandEncoder>);
     void setLastError(NSString*);
     void waitForCommandBufferCompletion();
+    bool encoderIsCurrent(id<MTLCommandEncoder>) const;
 
 private:
     CommandEncoder(id<MTLCommandBuffer>, Device&);

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -42,8 +42,10 @@ if (!m_parentEncoder->isLocked() || m_parentEncoder->isFinished()) { \
     m_device->generateAValidationError([NSString stringWithFormat:@"%s: failed as encoding has finished", __PRETTY_FUNCTION__]); \
     return; \
 } \
-if (!m_computeCommandEncoder || !m_parentEncoder->isValid()) \
-    return;
+if (!m_computeCommandEncoder || !m_parentEncoder->isValid() || !m_parentEncoder->encoderIsCurrent(m_computeCommandEncoder)) { \
+    m_computeCommandEncoder = nil; \
+    return; \
+}
 
 ComputePassEncoder::ComputePassEncoder(id<MTLComputeCommandEncoder> computeCommandEncoder, const WGPUComputePassDescriptor& descriptor, CommandEncoder& parentEncoder, Device& device)
     : m_computeCommandEncoder(computeCommandEncoder)

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -195,10 +195,10 @@ Device::Device(id<MTLDevice> device, id<MTLCommandQueue> defaultQueue, HardwareC
     desc.width = 1;
     desc.height = 1;
     desc.mipmapLevelCount = 1;
-    desc.pixelFormat = MTLPixelFormatR8Unorm;
+    desc.pixelFormat = MTLPixelFormatBGRA8Unorm;
     desc.textureType = MTLTextureType2D;
     desc.storageMode = MTLStorageModeShared;
-    desc.usage = MTLTextureUsageShaderRead;
+    desc.usage = MTLTextureUsageShaderRead | MTLTextureUsageRenderTarget;
     m_placeholderTexture = [m_device newTextureWithDescriptor:desc];
 }
 

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -224,6 +224,7 @@ void PresentationContextIOSurface::configure(Device& device, const WGPUSwapChain
         return;
     }
 
+    textureDescriptor.usage |= MTLTextureUsageRenderTarget;
     for (IOSurface *iosurface in m_ioSurfaces) {
         RefPtr<Texture> parentLuminanceClampTexture;
         if (textureDescriptor.pixelFormat == MTLPixelFormatRGBA16Float) {

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -93,6 +93,9 @@ static RenderBundleICBWithResources* makeRenderBundleICBWithResources(id<MTLIndi
     Vector<BindGroupEntryUsageData> stageResourceUsages[maxStageValue][maxResourceUsageValue];
 
     for (id<MTLResource> r : resources) {
+        if (!r)
+            continue;
+
         ResourceUsageAndRenderStage *usageAndStage = [resources objectForKey:r];
         stageResources[usageAndStage.renderStages - 1][usageAndStage.usage - 1].append(r);
         stageResourceUsages[usageAndStage.renderStages - 1][usageAndStage.usage - 1].append(BindGroupEntryUsageData { .usage = usageAndStage.entryUsage, .binding = usageAndStage.binding, .resource = usageAndStage.resource });

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -46,8 +46,10 @@ if (!m_parentEncoder->isLocked() || m_parentEncoder->isFinished()) { \
     m_device->generateAValidationError([NSString stringWithFormat:@"%s: failed as encoding has finished", __PRETTY_FUNCTION__]); \
     return; \
 } \
-if (!m_renderCommandEncoder || !m_parentEncoder->isValid()) \
-    return;
+if (!m_renderCommandEncoder || !m_parentEncoder->isValid() || !m_parentEncoder->encoderIsCurrent(m_renderCommandEncoder)) { \
+    m_renderCommandEncoder = nil; \
+    return; \
+}
 
 
 RenderPassEncoder::RenderPassEncoder(id<MTLRenderCommandEncoder> renderCommandEncoder, const WGPURenderPassDescriptor& descriptor, NSUInteger visibilityResultBufferSize, bool depthReadOnly, bool stencilReadOnly, CommandEncoder& parentEncoder, id<MTLBuffer> visibilityResultBuffer, uint64_t maxDrawCount, Device& device)


### PR DESCRIPTION
#### 5f97395cfff8d3cd7effe4a5a3c31638cc50eccd
<pre>
[WebGPU] ComputePassEncoder::setBindGroup crashes under some invalid arguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=272863">https://bugs.webkit.org/show_bug.cgi?id=272863</a>
&lt;radar://126621325&gt;

Reviewed by Tadeu Zagallo.

Fix validation errors which were largely caught at the Metal framework layer
but would result in release crashes if run with the validation layer enabled.

* LayoutTests/TestExpectations:
* LayoutTests/fast/webgpu/fuzz-272863-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-272863.html: Added.
Add regression tests, the test passes if it reaches the end.

* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createBindGroup):
* Source/WebGPU/WebGPU/CommandEncoder.h:
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::ensureBlitCommandEncoder):
(WebGPU::CommandEncoder::beginComputePass):
(WebGPU::CommandEncoder::beginRenderPass):
(WebGPU::CommandEncoder::encoderIsCurrent const):
(WebGPU::CommandEncoder::copyTextureToTexture):
(WebGPU::CommandEncoder::validateFinishError const):
(WebGPU::CommandEncoder::resolveQuerySet):
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::Device):
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::configure):
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::makeRenderBundleICBWithResources):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:

Canonical link: <a href="https://commits.webkit.org/277718@main">https://commits.webkit.org/277718@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca2fe1e494faf05db950eef5974ff778ec5ec269

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48278 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27490 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50966 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44343 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25010 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39440 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48860 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25185 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41710 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20587 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22665 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6334 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44623 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43345 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52870 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23325 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19677 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46777 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24590 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41893 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45692 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10672 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25395 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24313 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->