### PR TITLE
[CSS Container Queries][Style queries] Incorrect difference between implicit and explicit initial values for custom properties

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-queries-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-queries-expected.txt
@@ -59,6 +59,10 @@ PASS Style query 'initial' matching
 PASS Style query matching negated value-less query against initial value
 PASS Style query 'initial' not matching
 PASS Style query matching value-less query against non-initial value
+PASS Style query 'initial' matching (with explicit 'initial' value)
+PASS Style query matching negated value-less query against initial value (with explicit 'initial' value)
+PASS Style query 'space' matching
+PASS Style query 'space' not matching
 PASS Style query 'inherit' matching
 PASS Style query 'inherit' not matching
 PASS Style query 'unset' matching

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-queries.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-queries.html
@@ -206,6 +206,9 @@
     --inherit-no: bar;
     --unset-no: baz;
     --initial-no: baz;
+    --space-no: baz;
+    --explicit-initial: initial;
+    --space: ;
   }
   @container style(--initial: initial) {
     #initial { color: green; }
@@ -225,6 +228,18 @@
   @container not style(--inherit-no: inherit) {
     #inherit-no { color: green; }
   }
+  @container style(--explicit-initial: initial) {
+    #explicit-initial { color: green; }
+  }
+  @container not style(--explicit-initial) {
+    #explicit-initial-implicit { color: green; }
+  }
+  @container style(--space: ) {
+    #space { color: green; }
+  }
+  @container not style(--space-no: ) {
+    #space-no { color: green; }
+  }
   @container style(--unset: unset) {
     #unset { color: green; }
   }
@@ -238,6 +253,10 @@
     <div id="initial-implicit"></div>
     <div id="initial-no"></div>
     <div id="initial-no-implicit"></div>
+    <div id="explicit-initial"></div>
+    <div id="explicit-initial-implicit"></div>
+    <div id="space"></div>
+    <div id="space-no"></div>
     <div id="inherit"></div>
     <div id="inherit-no"></div>
     <div id="unset"></div>
@@ -260,6 +279,22 @@
   test(() => {
     assert_equals(getComputedStyle(document.querySelector("#initial-no-implicit")).color, green);
   }, "Style query matching value-less query against non-initial value");
+
+  test(() => {
+    assert_equals(getComputedStyle(document.querySelector("#explicit-initial")).color, green);
+  }, "Style query 'initial' matching (with explicit 'initial' value)");
+
+  test(() => {
+    assert_equals(getComputedStyle(document.querySelector("#explicit-initial-implicit")).color, green);
+  }, "Style query matching negated value-less query against initial value (with explicit 'initial' value)");
+
+  test(() => {
+    assert_equals(getComputedStyle(document.querySelector("#space")).color, green);
+  }, "Style query 'space' matching");
+
+  test(() => {
+    assert_equals(getComputedStyle(document.querySelector("#space-no")).color, green);
+  }, "Style query 'space' not matching");
 
   test(() => {
     assert_equals(getComputedStyle(document.querySelector("#inherit")).color, green);


### PR DESCRIPTION
#### b5ce791faf9e1635a2418f53d054dea2ddc8d442
<pre>
[CSS Container Queries][Style queries] Incorrect difference between implicit and explicit initial values for custom properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=270739">https://bugs.webkit.org/show_bug.cgi?id=270739</a>
<a href="https://rdar.apple.com/124573975">rdar://124573975</a>

Reviewed by Alan Baradlay.

Make sure guaranteed-invalid values match other guaranteed-invalid values whether explicitly (with `initial`) or implicitly specified.

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-queries-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-queries.html:
* Source/WebCore/css/query/ContainerQueryFeatures.cpp:

Test consistently for guaranteed-invalid values.

* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::resolveCustomPropertyForContainerQueries):

Return a nullptr only in failure cases (revert/revert-layer) and an invalid value otherwise.

Canonical link: <a href="https://commits.webkit.org/277670@main">https://commits.webkit.org/277670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39590209c4e3c896635bf948e6e87040bcf48b8f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48261 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50949 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44326 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50566 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33407 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24993 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39418 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48843 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25168 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20567 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22648 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6317 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44606 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52853 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23308 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19660 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46760 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24573 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41875 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45673 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10648 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25378 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24296 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->