### PR TITLE
[GTK][WPE] Add DRMDeviceManager to replace GBMDevice

### DIFF
--- a/Source/WebCore/SourcesGTK.txt
+++ b/Source/WebCore/SourcesGTK.txt
@@ -64,8 +64,9 @@ platform/graphics/egl/GLContextWrapper.cpp @no-unify
 platform/graphics/egl/GLFence.cpp @no-unify
 platform/graphics/egl/PlatformDisplaySurfaceless.cpp @no-unify
 
+platform/graphics/gbm/DRMDeviceManager.cpp
+platform/graphics/gbm/DRMDeviceNode.cpp
 platform/graphics/gbm/GBMBufferSwapchain.cpp
-platform/graphics/gbm/GBMDevice.cpp
 platform/graphics/gbm/GraphicsContextGLGBM.cpp @no-unify
 platform/graphics/gbm/PlatformDisplayGBM.cpp @no-unify
 

--- a/Source/WebCore/SourcesWPE.txt
+++ b/Source/WebCore/SourcesWPE.txt
@@ -65,8 +65,9 @@ platform/graphics/egl/GLContextWrapper.cpp @no-unify
 platform/graphics/egl/GLFence.cpp @no-unify
 platform/graphics/egl/PlatformDisplaySurfaceless.cpp @no-unify
 
+platform/graphics/gbm/DRMDeviceManager.cpp
+platform/graphics/gbm/DRMDeviceNode.cpp
 platform/graphics/gbm/GBMBufferSwapchain.cpp
-platform/graphics/gbm/GBMDevice.cpp
 platform/graphics/gbm/GraphicsContextGLGBM.cpp @no-unify
 platform/graphics/gbm/GraphicsContextGLGBMTextureMapper.cpp @no-unify
 platform/graphics/gbm/PlatformDisplayGBM.cpp @no-unify

--- a/Source/WebCore/platform/TextureMapper.cmake
+++ b/Source/WebCore/platform/TextureMapper.cmake
@@ -165,8 +165,9 @@ if (USE_GBM)
         platform/graphics/gbm/DMABufFormat.h
         platform/graphics/gbm/DMABufObject.h
         platform/graphics/gbm/DMABufReleaseFlag.h
+        platform/graphics/gbm/DRMDeviceManager.h
+        platform/graphics/gbm/DRMDeviceNode.h
         platform/graphics/gbm/GBMBufferSwapchain.h
-        platform/graphics/gbm/GBMDevice.h
         platform/graphics/gbm/GraphicsContextGLGBM.h
     )
 endif ()

--- a/Source/WebCore/platform/graphics/PlatformDisplay.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
@@ -91,7 +91,7 @@
 #endif
 
 #if USE(GBM)
-#include "GBMDevice.h"
+#include "DRMDeviceManager.h"
 #include <drm_fourcc.h>
 #endif
 
@@ -157,8 +157,8 @@ std::unique_ptr<PlatformDisplay> PlatformDisplay::createPlatformDisplay()
 #if PLATFORM(WPE)
     if (s_useDMABufForRendering) {
 #if USE(GBM)
-        if (GBMDevice::singleton().isInitialized()) {
-            if (auto* device = GBMDevice::singleton().device(GBMDevice::Type::Render))
+        if (DRMDeviceManager::singleton().isInitialized()) {
+            if (auto* device = DRMDeviceManager::singleton().mainGBMDeviceNode(DRMDeviceManager::NodeType::Render))
                 return PlatformDisplayGBM::create(device);
         }
 #endif
@@ -527,11 +527,11 @@ const String& PlatformDisplay::drmRenderNodeFile()
 #if USE(GBM)
 struct gbm_device* PlatformDisplay::gbmDevice()
 {
-    auto& device = GBMDevice::singleton();
-    if (!device.isInitialized())
-        device.initialize(drmRenderNodeFile());
+    auto& manager = DRMDeviceManager::singleton();
+    if (!manager.isInitialized())
+        manager.initializeMainDevice(drmRenderNodeFile());
 
-    return device.device(GBMDevice::Type::Render);
+    return manager.mainGBMDeviceNode(DRMDeviceManager::NodeType::Render);
 }
 
 const Vector<PlatformDisplay::DMABufFormat>& PlatformDisplay::dmabufFormats()

--- a/Source/WebCore/platform/graphics/gbm/DRMDeviceNode.cpp
+++ b/Source/WebCore/platform/graphics/gbm/DRMDeviceNode.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DRMDeviceNode.h"
+
+#if USE(LIBDRM)
+#include <fcntl.h>
+#include <unistd.h>
+#include <wtf/SafeStrerror.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/text/WTFString.h>
+
+#if USE(GBM)
+#include <gbm.h>
+#endif
+
+namespace WebCore {
+
+RefPtr<DRMDeviceNode> DRMDeviceNode::create(CString&& filename)
+{
+    return adoptRef(*new DRMDeviceNode(WTFMove(filename)));
+}
+
+DRMDeviceNode::DRMDeviceNode(CString&& filename)
+    : m_filename(WTFMove(filename))
+{
+}
+
+DRMDeviceNode::~DRMDeviceNode()
+{
+#if USE(GBM)
+    if (m_gbmDevice.has_value() && m_gbmDevice.value())
+        gbm_device_destroy(m_gbmDevice.value());
+#endif
+}
+
+#if USE(GBM)
+struct gbm_device* DRMDeviceNode::gbmDevice() const
+{
+    if (m_gbmDevice)
+        return m_gbmDevice.value();
+
+    m_fd = UnixFileDescriptor { open(m_filename.data(), O_RDWR | O_CLOEXEC), UnixFileDescriptor::Adopt };
+    if (m_fd) {
+        m_gbmDevice = gbm_create_device(m_fd.value());
+        if (m_gbmDevice.value())
+            return m_gbmDevice.value();
+
+        WTFLogAlways("Failed to create GBM device for DRM node: %s: %s", m_filename.data(), safeStrerror(errno).data());
+        m_fd = { };
+    } else {
+        WTFLogAlways("Failed to open DRM node %s: %s", m_filename.data(), safeStrerror(errno).data());
+        m_gbmDevice = nullptr;
+    }
+
+    return m_gbmDevice.value();
+}
+#endif
+
+} // namespace WebCore
+
+#endif // USE(LIBDRM)

--- a/Source/WebCore/platform/graphics/gbm/DRMDeviceNode.h
+++ b/Source/WebCore/platform/graphics/gbm/DRMDeviceNode.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(LIBDRM)
+
+#include <wtf/RefCounted.h>
+#include <wtf/text/CString.h>
+#include <wtf/unix/UnixFileDescriptor.h>
+
+#if USE(GBM)
+struct gbm_device;
+#endif
+
+namespace WTF {
+class String;
+}
+
+namespace WebCore {
+
+class DRMDeviceNode : public RefCounted<DRMDeviceNode> {
+public:
+    static RefPtr<DRMDeviceNode> create(CString&&);
+    ~DRMDeviceNode();
+
+    const CString& filename() const { return m_filename; }
+
+#if USE(GBM)
+    struct gbm_device* gbmDevice() const;
+#endif
+
+private:
+    explicit DRMDeviceNode(CString&&);
+
+    CString m_filename;
+#if USE(GBM)
+    mutable WTF::UnixFileDescriptor m_fd;
+    mutable std::optional<struct gbm_device*> m_gbmDevice;
+#endif
+};
+
+} // namespace WebCore
+
+#endif // USE(LIBDRM)

--- a/Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp
@@ -30,7 +30,7 @@
 #if USE(GBM)
 
 #include "DMABufColorSpace.h"
-#include "GBMDevice.h"
+#include "DRMDeviceManager.h"
 #include <gbm.h>
 #include <wtf/SafeStrerror.h>
 
@@ -79,7 +79,7 @@ static inline bool isBufferFormatSupported(const DMABufFormat& format)
 
 RefPtr<GBMBufferSwapchain::Buffer> GBMBufferSwapchain::getBuffer(const BufferDescription& description)
 {
-    auto* device = GBMDevice::singleton().device(GBMDevice::Type::Render);
+    auto* device = DRMDeviceManager::singleton().mainGBMDeviceNode(DRMDeviceManager::NodeType::Render);
     if (!device) {
         WTFLogAlways("Failed to get GBM buffer from swap chain: no GBM device found");
         return nullptr;

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
@@ -31,7 +31,7 @@
 
 #include "ANGLEHeaders.h"
 #include "DMABufEGLUtilities.h"
-#include "GBMDevice.h"
+#include "DRMDeviceManager.h"
 #include "GLFence.h"
 #include "Logging.h"
 #include "PixelBuffer.h"
@@ -113,7 +113,7 @@ void GraphicsContextGLGBM::prepareForDisplay()
 
 bool GraphicsContextGLGBM::platformInitializeContext()
 {
-    auto* device = GBMDevice::singleton().device(GBMDevice::Type::Render);
+    auto* device = DRMDeviceManager::singleton().mainGBMDeviceNode(DRMDeviceManager::NodeType::Render);
     if (!device) {
         LOG(WebGL, "Warning: Unable to access the GBM device, we fallback to common GL images, they require a copy, that causes a performance penalty.");
         return false;

--- a/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
@@ -28,7 +28,7 @@
 #include <wtf/glib/WTFGType.h>
 
 #if USE(GBM)
-#include "GBMDevice.h"
+#include "DRMDeviceManager.h"
 #endif
 
 using namespace WebCore;
@@ -181,7 +181,7 @@ bool webKitDMABufVideoSinkIsEnabled()
     std::call_once(s_flag, [&] {
         const char* value = g_getenv("WEBKIT_GST_DMABUF_SINK_DISABLED");
         s_disabled = value && (equalLettersIgnoringASCIICase(value, "true"_s) || equalLettersIgnoringASCIICase(value, "1"_s));
-        if (!s_disabled && !GBMDevice::singleton().device(GBMDevice::Type::Render)) {
+        if (!s_disabled && !DRMDeviceManager::singleton().mainGBMDeviceNode(DRMDeviceManager::NodeType::Render)) {
             WTFLogAlways("Unable to access the GBM device, disabling DMABuf video sink.");
             s_disabled = true;
         }

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -82,7 +82,7 @@
 #endif
 
 #if USE(GBM)
-#include <WebCore/GBMDevice.h>
+#include <WebCore/DRMDeviceManager.h>
 #endif
 
 namespace WebKit {
@@ -274,7 +274,7 @@ void GPUProcess::initializeGPUProcess(GPUProcessCreationParameters&& parameters)
 #endif
 
 #if USE(GBM)
-    WebCore::GBMDevice::singleton().initialize(parameters.renderDeviceFile);
+    WebCore::DRMDeviceManager::singleton().initializeMainDevice(parameters.renderDeviceFile);
 #endif
 
     m_applicationVisibleName = WTFMove(parameters.applicationVisibleName);

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
@@ -41,7 +41,7 @@
 #include <wtf/SafeStrerror.h>
 
 #if USE(GBM)
-#include <WebCore/GBMDevice.h>
+#include <WebCore/DRMDeviceManager.h>
 #include <WebCore/GBMVersioning.h>
 #include <drm_fourcc.h>
 #endif
@@ -134,7 +134,7 @@ std::unique_ptr<AcceleratedSurfaceDMABuf::RenderTarget> AcceleratedSurfaceDMABuf
         return nullptr;
     }
 
-    auto* device = WebCore::GBMDevice::singleton().device(dmabufFormat.usage == DMABufRendererBufferFormat::Usage::Scanout ? WebCore::GBMDevice::Type::Scanout : WebCore::GBMDevice::Type::Render);
+    auto* device = WebCore::DRMDeviceManager::singleton().mainGBMDeviceNode(dmabufFormat.usage == DMABufRendererBufferFormat::Usage::Scanout ? WebCore::DRMDeviceManager::NodeType::Primary : WebCore::DRMDeviceManager::NodeType::Render);
     if (!device) {
         WTFLogAlways("Failed to create GBM buffer of size %dx%d: no GBM device found", size.width(), size.height());
         return nullptr;

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -54,7 +54,7 @@
 #endif
 
 #if USE(GBM)
-#include <WebCore/GBMDevice.h>
+#include <WebCore/DRMDeviceManager.h>
 #endif
 
 #if PLATFORM(GTK)
@@ -145,7 +145,7 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
 #endif
 
 #if USE(GBM)
-    WebCore::GBMDevice::singleton().initialize(parameters.renderDeviceFile);
+    DRMDeviceManager::singleton().initializeMainDevice(parameters.renderDeviceFile);
 #endif
 
 #if PLATFORM(WPE)
@@ -160,8 +160,8 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
         if (m_dmaBufRendererBufferMode.contains(DMABufRendererBufferMode::Hardware)) {
             const char* disableGBM = getenv("WEBKIT_DMABUF_RENDERER_DISABLE_GBM");
             if (!disableGBM || !strcmp(disableGBM, "0")) {
-                if (auto* device = WebCore::GBMDevice::singleton().device(GBMDevice::Type::Render))
-                    m_displayForCompositing = WebCore::PlatformDisplayGBM::create(device);
+                if (auto* device = DRMDeviceManager::singleton().mainGBMDeviceNode(DRMDeviceManager::NodeType::Render))
+                    m_displayForCompositing = PlatformDisplayGBM::create(device);
             }
         }
 #endif


### PR DESCRIPTION
#### 9b709d7e78e85b3f1f8f4ccc21e4716fa9502925
<pre>
[GTK][WPE] Add DRMDeviceManager to replace GBMDevice
<a href="https://bugs.webkit.org/show_bug.cgi?id=272886">https://bugs.webkit.org/show_bug.cgi?id=272886</a>

Reviewed by Alejandro G. Castro.

GBMDevice assumes there&apos;s always a single GPU device, but linux dmabuf
feedback wayland protocol can give a different target device, so we need
a way to handle multiple devices.

* Source/WebCore/SourcesGTK.txt:
* Source/WebCore/SourcesWPE.txt:
* Source/WebCore/platform/TextureMapper.cmake:
* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
(WebCore::PlatformDisplay::createPlatformDisplay):
(WebCore::PlatformDisplay::gbmDevice):
* Source/WebCore/platform/graphics/gbm/DRMDeviceManager.cpp: Added.
(WebCore::DRMDeviceManager::singleton):
(WebCore::DRMDeviceManager::initializeMainDevice):
(WebCore::DRMDeviceManager::mainDeviceNode const):
(WebCore::DRMDeviceManager::mainGBMDeviceNode const):
(WebCore::DRMDeviceManager::deviceNode):
* Source/WebCore/platform/graphics/gbm/DRMDeviceManager.h: Added.
(WebCore::DRMDeviceManager::isInitialized const):
* Source/WebCore/platform/graphics/gbm/DRMDeviceNode.cpp: Added.
(WebCore::DRMDeviceNode::create):
(WebCore::DRMDeviceNode::DRMDeviceNode):
(WebCore::DRMDeviceNode::~DRMDeviceNode):
(WebCore::DRMDeviceNode::gbmDevice const):
* Source/WebCore/platform/graphics/gbm/DRMDeviceNode.h: Added.
(WebCore::DRMDeviceNode::filename const):
* Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp:
(WebCore::GBMBufferSwapchain::getBuffer):
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp:
(WebCore::GraphicsContextGLGBM::platformInitializeContext):
* Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp:
(webKitDMABufVideoSinkIsEnabled):
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::initializeGPUProcess):
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::create):
* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::WebProcess::platformInitializeWebProcess):

Canonical link: <a href="https://commits.webkit.org/277664@main">https://commits.webkit.org/277664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36d408a76cc5c394733e0bc20e1ed6590abbc50b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48263 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50951 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44328 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50568 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33409 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24995 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48845 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/25171 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20571 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22651 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6319 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44609 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43332 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52855 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23310 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19661 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46761 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24575 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45674 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25380 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6853 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24298 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->