### PR TITLE
Unify XPC error event handling

### DIFF
--- a/Source/WebKit/Platform/cocoa/XPCUtilities.h
+++ b/Source/WebKit/Platform/cocoa/XPCUtilities.h
@@ -36,6 +36,6 @@ enum class ReasonCode : uint64_t {
 };
 
 void terminateWithReason(xpc_connection_t, ReasonCode, const char* reason);
-void handleXPCExitMessage(xpc_object_t);
+void handleXPCExitAndErrorMessage(xpc_object_t);
 
 }

--- a/Source/WebKit/Shared/Authentication/cocoa/AuthenticationManagerCocoa.mm
+++ b/Source/WebKit/Shared/Authentication/cocoa/AuthenticationManagerCocoa.mm
@@ -52,7 +52,7 @@ void AuthenticationManager::initializeConnection(IPC::Connection* connection)
     // to capture client certificate credential.
     xpc_connection_set_event_handler(connection->xpcConnection(), ^(xpc_object_t event) {
 
-        handleXPCExitMessage(event);
+        handleXPCExitAndErrorMessage(event);
 
         callOnMainRunLoop([event = OSObjectPtr(event), weakThis = weakThis] {
             RELEASE_ASSERT(isMainRunLoop());

--- a/Source/WebKit/Shared/Cocoa/XPCEndpoint.mm
+++ b/Source/WebKit/Shared/Cocoa/XPCEndpoint.mm
@@ -47,7 +47,7 @@ XPCEndpoint::XPCEndpoint()
     xpc_connection_set_event_handler(m_connection.get(), ^(xpc_object_t message) {
         xpc_type_t type = xpc_get_type(message);
 
-        handleXPCExitMessage(message);
+        handleXPCExitAndErrorMessage(message);
 
         if (type == XPC_TYPE_CONNECTION) {
             OSObjectPtr<xpc_connection_t> connection = message;

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -163,22 +163,11 @@ void XPCServiceEventHandler(xpc_connection_t peer)
 
     xpc_connection_set_target_queue(peer, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0));
     xpc_connection_set_event_handler(peer, ^(xpc_object_t event) {
-        xpc_type_t type = xpc_get_type(event);
-        if (type != XPC_TYPE_DICTIONARY) {
-            RELEASE_LOG_ERROR(IPC, "XPCServiceEventHandler: Received unexpected XPC event type: %{public}s", xpc_type_get_name(type));
-            if (type == XPC_TYPE_ERROR) {
-                if (event == XPC_ERROR_CONNECTION_INVALID || event == XPC_ERROR_TERMINATION_IMMINENT) {
-                    RELEASE_LOG_FAULT(IPC, "Exiting: Received XPC event type: %{public}s", event == XPC_ERROR_CONNECTION_INVALID ? "XPC_ERROR_CONNECTION_INVALID" : "XPC_ERROR_TERMINATION_IMMINENT");
-                    // FIXME: Handle this case more gracefully.
-                    [[NSRunLoop mainRunLoop] performBlock:^{
-                        exitProcess(EXIT_FAILURE);
-                    }];
-                }
-            }
-            return;
-        }
 
-        handleXPCExitMessage(event);
+        handleXPCExitAndErrorMessage(event);
+
+        if (xpc_get_type(event) != XPC_TYPE_DICTIONARY)
+            return;
 
         auto* messageName = xpc_dictionary_get_string(event, "message-name");
         if (!messageName) {


### PR DESCRIPTION
#### e269f52bb1acd719e0e7ace0e23c3c3773368060
<pre>
Unify XPC error event handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=272891">https://bugs.webkit.org/show_bug.cgi?id=272891</a>
<a href="https://rdar.apple.com/126682733">rdar://126682733</a>

Reviewed by NOBODY (OOPS!).

This patch ensures all WebKit process types have the same behavior when it comes to
handling XPC error messages on the XPC connection to the UI process.

* Source/WebKit/Platform/cocoa/XPCUtilities.h:
* Source/WebKit/Platform/cocoa/XPCUtilities.mm:
(WebKit::handleXPCExitAndErrorMessage):
(WebKit::handleXPCExitMessage): Deleted.
* Source/WebKit/Shared/Authentication/cocoa/AuthenticationManagerCocoa.mm:
(WebKit::AuthenticationManager::initializeConnection):
* Source/WebKit/Shared/Cocoa/XPCEndpoint.mm:
(WebKit::XPCEndpoint::XPCEndpoint):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::XPCServiceEventHandler):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e269f52bb1acd719e0e7ace0e23c3c3773368060

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29151 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2131 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53107 "Hash e269f52b for PR 27442 does not build (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/541 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35191 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/108 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/53107 "Hash e269f52b for PR 27442 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26711 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42902 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/53107 "Hash e269f52b for PR 27442 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24144 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8234 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46178 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/150 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54688 "Hash e269f52b for PR 27442 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24958 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/107 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/54688 "Hash e269f52b for PR 27442 does not build (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26215 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43078 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/54688 "Hash e269f52b for PR 27442 does not build (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27079 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25943 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->