### PR TITLE
Use "event handler content attribute" while getting Trusted Type data for attribute.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getPropertyType-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getPropertyType-expected.txt
@@ -1,9 +1,9 @@
 
 PASS sanity check trustedTypes.getPropertyType for the HTML script element.
-PASS sanity check trustedTypes.getAttributeType.
+FAIL sanity check trustedTypes.getAttributeType. assert_equals: expected (string) "TrustedScript" but got (object) null
 FAIL sanity check trustedTypes.getTypeMapping trustedTypes.getTypeMapping is not a function. (In 'trustedTypes.getTypeMapping()', 'trustedTypes.getTypeMapping' is undefined)
 PASS getPropertyType tests adapted from w3c/trusted-types polyfill
-PASS getAttributeType tests adapted from w3c/trusted-types polyfill
+FAIL getAttributeType tests adapted from w3c/trusted-types polyfill assert_equals: expected (string) "TrustedScript" but got (object) null
 FAIL getTypeMapping tests adapted from w3c/trusted-types polyfill trustedTypes.getTypeMapping is not a function. (In 'trustedTypes.getTypeMapping()', 'trustedTypes.getTypeMapping' is undefined)
 PASS iframe[srcDoc] is defined
 PASS iframe.srcDoc is maybe defined
@@ -23,5 +23,5 @@ PASS IFRAME[srcdoc] is defined
 PASS IFRAME.srcdoc is maybe defined
 PASS iFrAmE[srcdoc] is defined
 PASS iFrAmE.srcdoc is maybe defined
-PASS getPropertyType vs getAttributeType for event handler.
+FAIL getPropertyType vs getAttributeType for event handler. assert_equals: expected (string) "TrustedScript" but got (object) null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-metadata-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-metadata-expected.txt
@@ -17,21 +17,21 @@ PASS Test assignment of TrustedScript on madeup.setAttribute(id,..)
 PASS Test assignment of TrustedScriptURL on madeup.id
 PASS Test assignment of TrustedScriptURL on madeup.setAttribute(id,..)
 PASS Test assignment of string on madeup.onerror
-FAIL Test assignment of string on madeup.setAttribute(onerror,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
+PASS Test assignment of string on madeup.setAttribute(onerror,..)
 PASS Test assignment of TrustedHTML on madeup.onerror
-FAIL Test assignment of TrustedHTML on madeup.setAttribute(onerror,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
+PASS Test assignment of TrustedHTML on madeup.setAttribute(onerror,..)
 PASS Test assignment of TrustedScript on madeup.onerror
 PASS Test assignment of TrustedScript on madeup.setAttribute(onerror,..)
 PASS Test assignment of TrustedScriptURL on madeup.onerror
-FAIL Test assignment of TrustedScriptURL on madeup.setAttribute(onerror,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
+PASS Test assignment of TrustedScriptURL on madeup.setAttribute(onerror,..)
 PASS Test assignment of string on madeup.onclick
-FAIL Test assignment of string on madeup.setAttribute(onclick,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
+PASS Test assignment of string on madeup.setAttribute(onclick,..)
 PASS Test assignment of TrustedHTML on madeup.onclick
-FAIL Test assignment of TrustedHTML on madeup.setAttribute(onclick,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
+PASS Test assignment of TrustedHTML on madeup.setAttribute(onclick,..)
 PASS Test assignment of TrustedScript on madeup.onclick
 PASS Test assignment of TrustedScript on madeup.setAttribute(onclick,..)
 PASS Test assignment of TrustedScriptURL on madeup.onclick
-FAIL Test assignment of TrustedScriptURL on madeup.setAttribute(onclick,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
+PASS Test assignment of TrustedScriptURL on madeup.setAttribute(onclick,..)
 PASS Test assignment of string on b.madeup
 PASS Test assignment of string on b.setAttribute(madeup,..)
 PASS Test assignment of TrustedHTML on b.madeup
@@ -49,19 +49,19 @@ PASS Test assignment of TrustedScript on b.setAttribute(id,..)
 PASS Test assignment of TrustedScriptURL on b.id
 PASS Test assignment of TrustedScriptURL on b.setAttribute(id,..)
 PASS Test assignment of string on b.onerror
-FAIL Test assignment of string on b.setAttribute(onerror,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
+PASS Test assignment of string on b.setAttribute(onerror,..)
 PASS Test assignment of TrustedHTML on b.onerror
-FAIL Test assignment of TrustedHTML on b.setAttribute(onerror,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
+PASS Test assignment of TrustedHTML on b.setAttribute(onerror,..)
 PASS Test assignment of TrustedScript on b.onerror
 PASS Test assignment of TrustedScript on b.setAttribute(onerror,..)
 PASS Test assignment of TrustedScriptURL on b.onerror
-FAIL Test assignment of TrustedScriptURL on b.setAttribute(onerror,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
+PASS Test assignment of TrustedScriptURL on b.setAttribute(onerror,..)
 PASS Test assignment of string on b.onclick
-FAIL Test assignment of string on b.setAttribute(onclick,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
+PASS Test assignment of string on b.setAttribute(onclick,..)
 PASS Test assignment of TrustedHTML on b.onclick
-FAIL Test assignment of TrustedHTML on b.setAttribute(onclick,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
+PASS Test assignment of TrustedHTML on b.setAttribute(onclick,..)
 PASS Test assignment of TrustedScript on b.onclick
 PASS Test assignment of TrustedScript on b.setAttribute(onclick,..)
 PASS Test assignment of TrustedScriptURL on b.onclick
-FAIL Test assignment of TrustedScriptURL on b.setAttribute(onclick,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
+PASS Test assignment of TrustedScriptURL on b.setAttribute(onclick,..)
 

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -2337,14 +2337,6 @@ fast/mediastream/mediastreamtrack-video-frameRate-clone-decreasing.html [ Crash 
 # Trusted Types aren't implemented yet
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-check-report.html [ Failure Pass ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-attribute-via-attribute-node.html [ Failure Pass ]
-webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/Element-setAttribute.html [ Failure ]
-webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-eval.html [ Failure ]
-webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-importScripts.html [ Failure ]
-webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-setAttribute.html [ Failure ]
-webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-HTMLElement-generic.html [ Failure ]
-webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/default-policy-report-only.html [ Failure ]
-webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/default-policy.html [ Failure ]
-webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/worker-constructor.https.html [ Failure ]
 
 # Flaky tests on Aug-2023
 webkit.org/b/261024 animations/change-completed-animation-transform.html [ ImageOnlyFailure Pass ]

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -35,6 +35,9 @@
 #include "ScrollTypes.h"
 #include "ShadowRootMode.h"
 #include "SimulatedClickOptions.h"
+#include "TrustedHTML.h"
+#include "TrustedScript.h"
+#include "TrustedScriptURL.h"
 #include "WebAnimationTypes.h"
 #include <JavaScriptCore/Forward.h>
 
@@ -119,6 +122,7 @@ struct ShadowRootInit;
 
 using ElementName = NodeName;
 using ExplicitlySetAttrElementsMap = HashMap<QualifiedName, Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>>>;
+using TrustedTypeOrString = std::variant<RefPtr<TrustedHTML>, RefPtr<TrustedScript>, RefPtr<TrustedScriptURL>, AtomString>;
 
 // https://drafts.csswg.org/css-contain/#relevant-to-the-user
 enum class ContentRelevancy : uint8_t {
@@ -190,9 +194,9 @@ public:
     AtomString getAttributeForBindings(const AtomString& qualifiedName, ResolveURLs = ResolveURLs::NoExcludingURLsForPrivacy) const;
     inline AtomString getAttributeNSForBindings(const AtomString& namespaceURI, const AtomString& localName, ResolveURLs = ResolveURLs::NoExcludingURLsForPrivacy) const;
 
-    WEBCORE_EXPORT ExceptionOr<void> setAttribute(const AtomString& qualifiedName, const AtomString& value);
+    WEBCORE_EXPORT ExceptionOr<void> setAttribute(const AtomString& qualifiedName, const TrustedTypeOrString& value);
     static ExceptionOr<QualifiedName> parseAttributeName(const AtomString& namespaceURI, const AtomString& qualifiedName);
-    WEBCORE_EXPORT ExceptionOr<void> setAttributeNS(const AtomString& namespaceURI, const AtomString& qualifiedName, const AtomString& value);
+    WEBCORE_EXPORT ExceptionOr<void> setAttributeNS(const AtomString& namespaceURI, const AtomString& qualifiedName, const TrustedTypeOrString& value);
 
     ExceptionOr<bool> toggleAttribute(const AtomString& qualifiedName, std::optional<bool> force);
 

--- a/Source/WebCore/dom/Element.idl
+++ b/Source/WebCore/dom/Element.idl
@@ -42,8 +42,8 @@
     sequence<DOMString> getAttributeNames();
     [DOMJIT=ReadDOM, ImplementedAs=getAttributeForBindings] DOMString? getAttribute([AtomString] DOMString qualifiedName);
     [ImplementedAs=getAttributeNSForBindings] DOMString? getAttributeNS([AtomString] DOMString? namespaceURI, [AtomString] DOMString localName);
-    [CEReactions=Needed] undefined setAttribute([AtomString] DOMString qualifiedName, [AtomString] DOMString value);
-    [CEReactions=Needed] undefined setAttributeNS([AtomString] DOMString? namespaceURI, [AtomString] DOMString qualifiedName, [AtomString] DOMString value);
+    [CEReactions=Needed] undefined setAttribute([AtomString] DOMString qualifiedName, (TrustedType or [AtomString] DOMString) value);
+    [CEReactions=Needed] undefined setAttributeNS([AtomString] DOMString? namespaceURI, [AtomString] DOMString qualifiedName, (TrustedType or [AtomString] DOMString) value);
     [CEReactions=Needed, ImplementedAs=removeAttributeForBindings] undefined removeAttribute([AtomString] DOMString qualifiedName);
     [CEReactions=Needed, ImplementedAs=removeAttributeNSForBindings] undefined removeAttributeNS([AtomString] DOMString? namespaceURI, [AtomString] DOMString localName);
     [CEReactions=Needed] boolean toggleAttribute([AtomString] DOMString qualifiedName, optional boolean force);
@@ -106,3 +106,5 @@ Element includes NonDocumentTypeChildNode;
 Element includes ParentNode;
 Element includes Slotable;
 Element includes InnerHTML;
+
+typedef (TrustedHTML or TrustedScript or TrustedScriptURL) TrustedType;

--- a/Source/WebCore/dom/TrustedScript.h
+++ b/Source/WebCore/dom/TrustedScript.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-class TrustedScript final : public ScriptWrappable, public RefCounted<TrustedScript> {
+class WEBCORE_EXPORT TrustedScript final : public ScriptWrappable, public RefCounted<TrustedScript> {
     WTF_MAKE_ISO_ALLOCATED(TrustedScript);
 public:
     static Ref<TrustedScript> create(const String& data);

--- a/Source/WebCore/dom/TrustedScriptURL.h
+++ b/Source/WebCore/dom/TrustedScriptURL.h
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-class TrustedScriptURL : public ScriptWrappable, public RefCounted<TrustedScriptURL> {
+class WEBCORE_EXPORT TrustedScriptURL : public ScriptWrappable, public RefCounted<TrustedScriptURL> {
     WTF_MAKE_ISO_ALLOCATED(TrustedScriptURL);
 public:
     static Ref<TrustedScriptURL> create(const String& data);

--- a/Source/WebCore/dom/TrustedType.cpp
+++ b/Source/WebCore/dom/TrustedType.cpp
@@ -192,14 +192,17 @@ String getTrustedTypeForAttribute(const String& tagName, const String& attribute
     auto localName = tagName.convertToASCIILowercase();
     auto attributeName = attributeParameter.convertToASCIILowercase();
 
-    if (attributeName.startsWith("on"_s))
-        return trustedTypeToString(TrustedType::TrustedScript);
-
     AtomString elementNS = elementNamespace.isEmpty() ? HTMLNames::xhtmlNamespaceURI : AtomString(elementNamespace);
     AtomString attributeNS = attributeNamespace.isEmpty() ? nullAtom() : AtomString(attributeNamespace);
 
     QualifiedName element(nullAtom(), AtomString(localName), elementNS);
     QualifiedName attribute(nullAtom(), AtomString(attributeName), attributeNS);
+
+    if (attributeNamespace.isNull() && !attributeName.isNull()) {
+        auto& eventName = HTMLElement::eventNameForEventHandlerAttribute(attribute);
+        if (!eventName.isNull())
+            return trustedTypeToString(TrustedType::TrustedScript);
+    }
 
     if (element.matches(HTMLNames::iframeTag) && attribute.matches(HTMLNames::srcdocAttr))
         return trustedTypeToString(TrustedType::TrustedHTML);

--- a/Source/WebCore/dom/TrustedType.h
+++ b/Source/WebCore/dom/TrustedType.h
@@ -45,6 +45,7 @@ enum class TrustedType : int8_t {
 };
 
 ASCIILiteral trustedTypeToString(TrustedType);
+TrustedType stringToTrustedType(String);
 ASCIILiteral trustedTypeToCallbackName(TrustedType);
 
 WEBCORE_EXPORT std::variant<std::monostate, Exception, Ref<TrustedHTML>, Ref<TrustedScript>, Ref<TrustedScriptURL>> processValueWithDefaultPolicy(ScriptExecutionContext&, TrustedType, const String& input, const String& sink);
@@ -55,4 +56,5 @@ WEBCORE_EXPORT ExceptionOr<String> requireTrustedTypesForPreNavigationCheckPasse
 
 ExceptionOr<RefPtr<Text>> processNodeOrStringAsTrustedType(Ref<Document>, RefPtr<Node> parent, std::variant<RefPtr<Node>, String, RefPtr<TrustedScript>>);
 
+WEBCORE_EXPORT String getTrustedTypeForAttribute(const String& tagName, const String& attributeParameter, const String& elementNamespace, const String& attributeNamespace);
 } // namespace WebCore

--- a/Source/WebCore/dom/TrustedTypePolicyFactory.cpp
+++ b/Source/WebCore/dom/TrustedTypePolicyFactory.cpp
@@ -108,26 +108,7 @@ Ref<TrustedScript> TrustedTypePolicyFactory::emptyScript() const
 
 String TrustedTypePolicyFactory::getAttributeType(const String& tagName, const String& attributeParameter, const String& elementNamespace, const String& attributeNamespace) const
 {
-    auto localName = tagName.convertToASCIILowercase();
-    auto attributeName = attributeParameter.convertToASCIILowercase();
-
-    if (attributeName.startsWith("on"_s))
-        return trustedTypeToString(TrustedType::TrustedScript);
-
-    AtomString elementNS = elementNamespace.isEmpty() ? HTMLNames::xhtmlNamespaceURI : AtomString(elementNamespace);
-    AtomString attributeNS = attributeNamespace.isEmpty() ? nullAtom() : AtomString(attributeNamespace);
-
-    QualifiedName element(nullAtom(), AtomString(localName), elementNS);
-    QualifiedName attribute(nullAtom(), AtomString(attributeName), attributeNS);
-
-    if (element.matches(HTMLNames::iframeTag) && attribute.matches(HTMLNames::srcdocAttr))
-        return trustedTypeToString(TrustedType::TrustedHTML);
-    if (element.matches(HTMLNames::scriptTag) && attribute.matches(HTMLNames::srcAttr))
-        return trustedTypeToString(TrustedType::TrustedScriptURL);
-    if (element.matches(SVGNames::scriptTag) && (attribute.matches(SVGNames::hrefAttr) || attribute.matches(XLinkNames::hrefAttr)))
-        return trustedTypeToString(TrustedType::TrustedScriptURL);
-
-    return nullString();
+    return getTrustedTypeForAttribute(tagName, attributeParameter, elementNamespace, attributeNamespace);
 }
 
 String TrustedTypePolicyFactory::getPropertyType(const String& tagName, const String& property, const String& elementNamespace) const


### PR DESCRIPTION
#### 5a58c5b87ddc26daa9cb77bfee4d104ef36217b6
<pre>
Use &quot;event handler content attribute&quot; while getting Trusted Type data for attribute.
<a href="https://bugs.webkit.org/show_bug.cgi?id=272675.">https://bugs.webkit.org/show_bug.cgi?id=272675.</a>

Reviewed by NOBODY (OOPS!).

<a href="https://pr-preview.s3.amazonaws.com/lukewarlow/trusted-types/pull/457.html#get-trusted-type-data-for-attribute">https://pr-preview.s3.amazonaws.com/lukewarlow/trusted-types/pull/457.html#get-trusted-type-data-for-attribute</a>

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getPropertyType-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-metadata-expected.txt:
* Source/WebCore/dom/TrustedType.cpp:
(WebCore::getTrustedTypeForAttribute):
</pre>
----------------------------------------------------------------------
#### 54ca5d314805dadc80f9b8144e9afbab549cea80
<pre>
Implement trusted types integrations with DOM setAttribute APIs.
<a href="https://bugs.webkit.org/show_bug.cgi?id=270436.">https://bugs.webkit.org/show_bug.cgi?id=270436.</a>

Reviewed by NOBODY (OOPS!).

Implement the spec updates at <a href="https://github.com/whatwg/dom/pull/1247.">https://github.com/whatwg/dom/pull/1247.</a>
It also remove the some expectations in GTK as the results should be
in line with the general expectation file.

* LayoutTests/platform/gtk/TestExpectations:
* Source/WebCore/dom/Element.cpp:
(WebCore::getTrustedTypesCompliantAttributeValue):
(WebCore::Element::setAttribute):
(WebCore::Element::setElementsArrayAttribute):
(WebCore::appendAttributes):
(WebCore::Element::setAttributeNS):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/Element.idl:
* Source/WebCore/dom/TrustedType.cpp:
(WebCore::stringToTrustedType):
(WebCore::getAttributeTrustedType):
* Source/WebCore/dom/TrustedType.h:
* Source/WebCore/dom/TrustedTypePolicyFactory.cpp:
(WebCore::TrustedTypePolicyFactory::getAttributeType const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a58c5b87ddc26daa9cb77bfee4d104ef36217b6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51224 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50958 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44335 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50575 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25002 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39431 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48852 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25178 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41704 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20581 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22658 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43827 "Found 1 new test failure: fast/css/viewport-height-outline.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6326 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44616 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43339 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52862 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23317 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19670 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46768 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24582 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41887 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45682 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25387 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24305 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->