### PR TITLE
NEW TEST(277656@main): [ MacOS ] TestWebKitAPI.UnifiedPDF.KeyboardScrollingInSinglePageMode is a consistent timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
@@ -25,7 +25,7 @@
 
 #import "config.h"
 
-#if ENABLE(UNIFIED_PDF)
+#if ENABLE(UNIFIED_PDF_BY_DEFAULT)
 
 #import "CGImagePixelReader.h"
 #import "PlatformUtilities.h"
@@ -95,4 +95,4 @@ TEST(UnifiedPDF, KeyboardScrollingInSinglePageMode)
 
 } // namespace TestWebKitAPI
 
-#endif // ENABLE(UNIFIED_PDF)
+#endif // ENABLE(UNIFIED_PDF_BY_DEFAULT)


### PR DESCRIPTION
#### dfe10e0b9b0dc81eb4edb73f7da8992e767bbc43
<pre>
NEW TEST(277656@main): [ MacOS ] TestWebKitAPI.UnifiedPDF.KeyboardScrollingInSinglePageMode is a consistent timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=272900">https://bugs.webkit.org/show_bug.cgi?id=272900</a>
<a href="https://rdar.apple.com/126695619">rdar://126695619</a>

Reviewed by Abrar Rahman Protyasha.

Limit this test to run only when the unified PDF plugin is used by default.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:

Canonical link: <a href="https://commits.webkit.org/277684@main">https://commits.webkit.org/277684@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd8f908cc923536ca7fe3f0fee1bf405abb467bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50975 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44352 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50592 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33435 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25020 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39446 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48869 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25192 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20591 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22672 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6343 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/44630 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52879 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23334 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/19688 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46783 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24599 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/41901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/45697 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25404 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6861 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24322 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->