### PR TITLE
[Masonry] Update masonry-intrinsic-sizing-001.html

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1636,7 +1636,6 @@ imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/fragmentation/mas
 
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/grid-placement/masonry-grid-placement-named-lines-002.html [ ImageOnlyFailure ]
 
-imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-001.html
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-004.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-001-expected.html
@@ -22,12 +22,6 @@ grid {
   padding: 0 1px 0 2px;
   vertical-align: top;
 }
-.fr {
-  grid-template-columns: 1fr 2fr 1fr 1fr;
-}
-.mixed {
-  grid-template-columns: 1fr 2fr min-content max-content;
-}
 
 item {
   background-color: #444;
@@ -37,57 +31,64 @@ item {
 </head>
 <body>
 
+<!--1-->
 <grid>
   <item style="width:2ch">1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
-  <item>5</item>
-</grid>
-
-<grid style="grid-template-columns: 1ch repeat(3,auto)">
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
+  <item style="width:2ch">2</item>
+  <item style="width:2ch">3</item>
+  <item style="width:2ch">4</item>
   <item style="width:2ch">5</item>
 </grid>
 
+<!--2-->
+<grid>
+  <item style="width:2ch">1</item>
+  <item style="width:2ch">2</item>
+  <item style="width:2ch">3</item>
+  <item style="width:2ch">4</item>
+  <item style="width:2ch">5</item>
+</grid>
+
+<!--3-->
 <grid>
   <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
   <item style="width:2ch; grid-column:2">5</item>
-</grid>
-
-<grid>
-  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
+</grid>
+
+<!--4-->
+<grid>
+  <item>1</item>
   <item style="width:4ch; grid-column:2/span 2">5</item>
-</grid>
-
-<grid>
-  <item>1</item>
   <item>2</item>
   <item>3</item>
-  <item>4</item>
+  <item style="width:calc(2ch - 1px);">4</item>
+</grid>
+
+<!--5-->
+<grid style="grid-template-columns: calc(5ch / 3) calc(5ch / 3) calc(5ch / 3) 1ch; gap: 0px 0px;">
   <item style="grid-column:2/span 2">5</item>
-  <item style="width:5ch; grid-column:1/span 3">6</item>
-</grid>
-
-
-<grid>
   <item>1</item>
+  <item style="grid-column:1/span 3">6</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="width:3ch; grid-column:2/span 2">5</item>
-  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
+<!----- Bug ----->
+<!--6-->
+<grid style="grid-template-columns: calc(5ch / 3) calc(3ch / 2) calc(3ch / 2) 1ch; gap: 0px 0px;">
+  <item style="width:5ch; grid-column:1/span 3">6</item>
+  <item>1</item>
+  <item style="width:3ch; grid-column:2/span 2">5</item>
+  <item>2</item>
+  <item>3</item>
+  <item>4</item>
+</grid>
+
+<!--7-->
 <grid>
   <item>1</item>
   <item>2</item>
@@ -96,6 +97,7 @@ item {
   <item style="grid-column:span 4">5</item>
 </grid>
 
+<!--8-->
 <grid>
   <item>1</item>
   <item>2</item>
@@ -104,166 +106,12 @@ item {
   <item style="width:6ch; grid-column:span 4">5</item>
 </grid>
 
-<grid style="grid-template-columns: repeat(4,1ch)">
+<!--9-->
+<grid>
   <item>1</item>
   <item>2</item>
   <item>3</item>
-  <item>4</item>
-  <item style="width:6ch; grid-column:span 3">5</item>
-</grid>
-
-<!-- ditto with 'fr' sizing -->
-
-<grid class="fr">
-  <item style="width:2ch">1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
-  <item>5</item>
-</grid>
-
-<grid class="fr" style="grid-template-columns: 1ch 2fr 1fr 1fr">
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
-  <item style="width:2ch">5</item>
-</grid>
-
-<grid class="fr">
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
-  <item style="width:2ch; grid-column:2">5</item>
-</grid>
-
-<grid class="fr">
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
-  <item style="width:4ch; grid-column:2/span 2">5</item>
-</grid>
-
-<grid class="fr">
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
-  <item style="grid-column:2/span 2">5</item>
-  <item style="width:5ch; grid-column:1/span 3">6</item>
-</grid>
-
-
-<grid class="fr">
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
-  <item style="width:3ch; grid-column:2/span 2">5</item>
-  <item style="width:5ch; grid-column:1/span 3">6</item>
-</grid>
-
-<grid class="fr">
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
-  <item style="grid-column:span 4">5</item>
-</grid>
-
-<grid class="fr">
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
-  <item style="width:6ch; grid-column:span 4">5</item>
-</grid>
-
-<grid class="fr" style="grid-template-columns: 1ch 2ch 1ch 1ch">
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
-  <item style="width:6ch; grid-column:span 3">5</item>
-</grid>
-
-
-<!-- ditto with mixed sizing -->
-
-<grid class="mixed" style="grid-template-columns: 2ch 4ch 1ch 1ch">
-  <item style="width:2ch">1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
-  <item>5</item>
-</grid>
-
-<grid class="mixed" style="grid-template-columns: 1ch 2ch 1ch 1ch">
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
-  <item style="width:2ch">5</item>
-</grid>
-
-<grid class="mixed">
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
-  <item style="width:2ch; grid-column:2">5</item>
-</grid>
-
-<grid class="mixed">
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
-  <item style="width:4ch; grid-column:2/span 2">5</item>
-</grid>
-
-<grid class="mixed">
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
-  <item style="grid-column:2/span 2">5</item>
-  <item style="width:5ch; grid-column:1/span 3">6</item>
-</grid>
-
-
-<grid class="mixed">
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
-  <item style="width:3ch; grid-column:2/span 2">5</item>
-  <item style="width:5ch; grid-column:1/span 3">6</item>
-</grid>
-
-<grid class="mixed">
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
-  <item style="grid-column:span 4">5</item>
-</grid>
-
-<grid class="mixed">
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
-  <item style="width:6ch; grid-column:span 4">5</item>
-</grid>
-
-<grid class="mixed" style="grid-template-columns: 1ch 2ch 1ch 1ch">
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
+  <item style="width:calc((6ch - 4px) / 3)">4</item>
   <item style="width:6ch; grid-column:span 3">5</item>
 </grid>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-001-fr-sizing-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-001-fr-sizing-expected.html
@@ -5,10 +5,8 @@
 -->
 <html><head>
   <meta charset="utf-8">
-  <title>CSS Grid Test: Masonry layout intrinsic sizing</title>
+  <title>Reference: Masonry layout intrinsic sizing</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
-  <link rel="help" href="https://drafts.csswg.org/css-grid-2">
-  <link rel="match" href="masonry-intrinsic-sizing-001-ref.html">
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
 html,body {
@@ -18,8 +16,8 @@ html,body {
 grid {
   display: inline-grid;
   gap: 1px 2px;
-  grid-template-columns: repeat(4,auto);
-  grid-template-rows: masonry;
+  grid-template-columns: 1fr 2fr 1fr 1fr;
+  grid-auto-rows: 1em;
   border: 1px solid;
   padding: 0 1px 0 2px;
   vertical-align: top;
@@ -33,7 +31,7 @@ item {
 </head>
 <body>
 
-<!--1-->
+<!--10-->
 <grid>
   <item style="width:2ch">1</item>
   <item>2</item>
@@ -42,55 +40,54 @@ item {
   <item>5</item>
 </grid>
 
-<!--2-->
-<grid>
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
+<!--11-->
+<grid style="grid-template-columns: 1fr 2fr 1fr 1fr">
+  <item style="width:2ch">1</item>
+  <item style="width:4ch">2</item>
+  <item style="width:2ch">3</item>
+  <item style="width:2ch">4</item>
   <item style="width:2ch">5</item>
 </grid>
 
-<!--3-->
+<!--12-->
 <grid>
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
+  <item style="width: 1ch">1</item>
   <item style="width:2ch; grid-column:2">5</item>
+  <item style="width: 1ch">2</item>
+  <item style="width: 1ch">3</item>
+  <item style="width: 1ch">4</item>
 </grid>
 
-<!--4-->
+<!--13-->
 <grid>
   <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
   <item style="width:4ch; grid-column:2/span 2">5</item>
-</grid>
-
-<!--5-->
-<grid style="gap: 0px 0px">
-  <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="grid-column:2/span 2">5</item>
-  <item style="width:5ch; grid-column:1/span 3">6</item>
 </grid>
 
-<!----- Bug ----->
-<!--6-->
-<grid style="gap: 0px 0px">
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <item>4</item>
-  <item style="width:3ch; grid-column:2/span 2">5</item>
-  <item style="width:5ch; grid-column:1/span 3">6</item>
-</grid>
+<!--14-->
+<!--<grid>-->
+<!--  <item>1</item>-->
+<!--  <item>2</item>-->
+<!--  <item>3</item>-->
+<!--  <item>4</item>-->
+<!--  <item style="grid-column:2/span 2">5</item>-->
+<!--  <item style="width:5ch; grid-column:1/span 3">6</item>-->
+<!--</grid>-->
 
-<!--7-->
+<!--15-->
+<!--<grid>-->
+<!--  <item>1</item>-->
+<!--  <item>2</item>-->
+<!--  <item>3</item>-->
+<!--  <item>4</item>-->
+<!--  <item style="width:3ch; grid-column:2/span 2">5</item>-->
+<!--  <item style="width:5ch; grid-column:1/span 3">6</item>-->
+<!--</grid>-->
+
+<!--16-->
 <grid>
   <item>1</item>
   <item>2</item>
@@ -99,7 +96,7 @@ item {
   <item style="grid-column:span 4">5</item>
 </grid>
 
-<!--8-->
+<!--17-->
 <grid>
   <item>1</item>
   <item>2</item>
@@ -108,7 +105,7 @@ item {
   <item style="width:6ch; grid-column:span 4">5</item>
 </grid>
 
-<!--9-->
+<!--18-->
 <grid>
   <item>1</item>
   <item>2</item>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-001-fr-sizing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-001-fr-sizing.html
@@ -1,0 +1,120 @@
+<!DOCTYPE HTML>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html><head>
+    <meta charset="utf-8">
+    <title>CSS Grid Test: Masonry layout intrinsic sizing</title>
+    <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
+    <link rel="help" href="https://drafts.csswg.org/css-grid-2">
+    <link rel="match" href="masonry-intrinsic-sizing-001-ref.html">
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+    <style>
+        html,body {
+            color:black; background-color:white; font:15px/1 Ahem; padding:0; margin:0;
+        }
+
+        grid {
+            display: inline-grid;
+            gap: 1px 2px;
+            grid-template-columns: 1fr 2fr 1fr 1fr;
+            grid-template-rows: masonry;
+            border: 1px solid;
+            padding: 0 1px 0 2px;
+            vertical-align: top;
+        }
+
+        item {
+            background-color: #444;
+            color: blue;
+        }
+    </style>
+</head>
+<body>
+
+<!--10-->
+<grid>
+    <item style="width:2ch">1</item>
+    <item>2</item>
+    <item>3</item>
+    <item>4</item>
+    <item>5</item>
+</grid>
+
+<!--11-->
+<grid>
+    <item>1</item>
+    <item>2</item>
+    <item>3</item>
+    <item>4</item>
+    <item style="width:2ch">5</item>
+</grid>
+
+<!--12-->
+<grid>
+    <item>1</item>
+    <item>2</item>
+    <item>3</item>
+    <item>4</item>
+    <item style="width:2ch; grid-column:2">5</item>
+</grid>
+
+<!--13-->
+<grid>
+    <item>1</item>
+    <item>2</item>
+    <item>3</item>
+    <item>4</item>
+    <item style="width:4ch; grid-column:2/span 2">5</item>
+</grid>
+
+<!--14-->
+<!--<grid>-->
+<!--  <item>1</item>-->
+<!--  <item>2</item>-->
+<!--  <item>3</item>-->
+<!--  <item>4</item>-->
+<!--  <item style="grid-column:2/span 2">5</item>-->
+<!--  <item style="width:5ch; grid-column:1/span 3">6</item>-->
+<!--</grid>-->
+
+<!--15-->
+<!--<grid>-->
+<!--  <item>1</item>-->
+<!--  <item>2</item>-->
+<!--  <item>3</item>-->
+<!--  <item>4</item>-->
+<!--  <item style="width:3ch; grid-column:2/span 2">5</item>-->
+<!--  <item style="width:5ch; grid-column:1/span 3">6</item>-->
+<!--</grid>-->
+
+<!--16-->
+<grid>
+  <item>1</item>
+  <item>2</item>
+  <item>3</item>
+  <item>4</item>
+  <item style="grid-column:span 4">5</item>
+</grid>
+
+<!--17-->
+<grid>
+  <item>1</item>
+  <item>2</item>
+  <item>3</item>
+  <item>4</item>
+  <item style="width:6ch; grid-column:span 4">5</item>
+</grid>
+
+<!--18-->
+<grid>
+  <item>1</item>
+  <item>2</item>
+  <item>3</item>
+  <item>4</item>
+  <item style="width:6ch; grid-column:span 3">5</item>
+</grid>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-001-mixed-sizing-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-001-mixed-sizing-expected.html
@@ -1,0 +1,119 @@
+<!DOCTYPE HTML>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html><head>
+  <meta charset="utf-8">
+  <title>Reference: Masonry layout intrinsic sizing</title>
+  <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+  <style>
+html,body {
+  color:black; background-color:white; font:15px/1 Ahem; padding:0; margin:0;
+}
+
+grid {
+  display: inline-grid;
+  gap: 1px 2px;
+  grid-template-columns: 1fr 2fr min-content max-content;
+  grid-auto-rows: 1em;
+  border: 1px solid;
+  padding: 0 1px 0 2px;
+  vertical-align: top;
+}
+
+item {
+  background-color: #444;
+  color: blue;
+}
+</style>
+</head>
+<body>
+
+<!--19-->
+<grid style="grid-template-columns: 2ch 4ch 2ch 2ch">
+  <item style="width:2ch">1</item>
+  <item style="width:4ch">2</item>
+  <item style="width:2ch">3</item>
+  <item style="width:2ch">4</item>
+  <item style="width:2ch" >5</item>
+</grid>
+
+<!--20-->
+<grid style="grid-template-columns: 2ch 4ch 2ch 2ch">
+  <item style="width:2ch">1</item>
+  <item style="width:4ch">2</item>
+  <item style="width:2ch">3</item>
+  <item style="width:2ch">4</item>
+  <item style="width:2ch">5</item>
+</grid>
+
+<!--21-->
+<grid>
+  <item>1</item>
+  <item style="width:2ch; grid-column:2">5</item>
+  <item>2</item>
+  <item>3</item>
+  <item>4</item>
+</grid>
+
+<!--22-->
+<!--<grid>-->
+<!--  <item>1</item>-->
+<!--  <item>2</item>-->
+<!--  <item>3</item>-->
+<!--  <item>4</item>-->
+<!--  <item style="width:4ch; grid-column:2/span 2">5</item>-->
+<!--</grid>-->
+
+<!--23-->
+<!--<grid>-->
+<!--  <item>1</item>-->
+<!--  <item>2</item>-->
+<!--  <item>3</item>-->
+<!--  <item>4</item>-->
+<!--  <item style="grid-column:2/span 2">5</item>-->
+<!--  <item style="width:5ch; grid-column:1/span 3">6</item>-->
+<!--</grid>-->
+
+<!-- Bug -->
+<!--24-->
+<!--<grid>-->
+<!--  <item>1</item>-->
+<!--  <item>2</item>-->
+<!--  <item>3</item>-->
+<!--  <item>4</item>-->
+<!--  <item style="width:3ch; grid-column:2/span 2">5</item>-->
+<!--  <item style="width:5ch; grid-column:1/span 3">6</item>-->
+<!--</grid>-->
+
+<!--25-->
+<!--<grid>-->
+<!--  <item>1</item>-->
+<!--  <item>2</item>-->
+<!--  <item>3</item>-->
+<!--  <item>4</item>-->
+<!--  <item style="grid-column:span 4">5</item>-->
+<!--</grid>-->
+
+<!--26-->
+<!--<grid>-->
+<!--  <item>1</item>-->
+<!--  <item>2</item>-->
+<!--  <item>3</item>-->
+<!--  <item>4</item>-->
+<!--  <item style="width:6ch; grid-column:span 4">5</item>-->
+<!--</grid>-->
+
+<!--27-->
+<!--<grid style="grid-template-columns: 1ch 2ch 1ch 1ch">-->
+<!--  <item>1</item>-->
+<!--  <item>2</item>-->
+<!--  <item>3</item>-->
+<!--  <item>4</item>-->
+<!--  <item style="width:6ch; grid-column:span 3">5</item>-->
+<!--</grid>-->
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-001-mixed-sizing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-001-mixed-sizing.html
@@ -1,0 +1,122 @@
+<!DOCTYPE HTML>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Grid Test: Masonry layout intrinsic sizing</title>
+  <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-2">
+  <link rel="match" href="masonry-intrinsic-sizing-001-ref.html">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+  <style>
+  html,body {
+    color:black; background-color:white; font:15px/1 Ahem; padding:0; margin:0;
+  }
+
+  grid {
+    display: inline-grid;
+    gap: 1px 2px;
+    grid-template-columns: 1fr 2fr min-content max-content;
+    grid-template-rows: masonry;
+    border: 1px solid;
+    padding: 0 1px 0 2px;
+    vertical-align: top;
+  }
+
+  item {
+    background-color: #444;
+    color: blue;
+  }
+  </style>
+</head>
+<body>
+
+<!--19-->
+<grid>
+  <item style="width:2ch">1</item>
+  <item>2</item>
+  <item>3</item>
+  <item>4</item>
+  <item>5</item>
+</grid>
+
+<!--20-->
+<grid>
+  <item>1</item>
+  <item>2</item>
+  <item>3</item>
+  <item>4</item>
+  <item style="width:2ch">5</item>
+</grid>
+
+<!--21-->
+<grid>
+  <item>1</item>
+  <item>2</item>
+  <item>3</item>
+  <item>4</item>
+  <item style="width:2ch; grid-column:2">5</item>
+</grid>
+
+<!--22-->
+<!--<grid>-->
+<!--  <item>1</item>-->
+<!--  <item>2</item>-->
+<!--  <item>3</item>-->
+<!--  <item>4</item>-->
+<!--  <item style="width:4ch; grid-column:2/span 2">5</item>-->
+<!--</grid>-->
+
+<!--23-->
+<!--<grid>-->
+<!--  <item>1</item>-->
+<!--  <item>2</item>-->
+<!--  <item>3</item>-->
+<!--  <item>4</item>-->
+<!--  <item style="grid-column:2/span 2">5</item>-->
+<!--  <item style="width:5ch; grid-column:1/span 3">6</item>-->
+<!--</grid>-->
+
+<!-- Bug -->
+<!--24-->
+<!--<grid>-->
+<!--  <item>1</item>-->
+<!--  <item>2</item>-->
+<!--  <item>3</item>-->
+<!--  <item>4</item>-->
+<!--  <item style="width:3ch; grid-column:2/span 2">5</item>-->
+<!--  <item style="width:5ch; grid-column:1/span 3">6</item>-->
+<!--</grid>-->
+
+<!--25-->
+<!--<grid>-->
+<!--  <item>1</item>-->
+<!--  <item>2</item>-->
+<!--  <item>3</item>-->
+<!--  <item>4</item>-->
+<!--  <item style="grid-column:span 4">5</item>-->
+<!--</grid>-->
+
+<!--26-->
+<!--<grid>-->
+<!--  <item>1</item>-->
+<!--  <item>2</item>-->
+<!--  <item>3</item>-->
+<!--  <item>4</item>-->
+<!--  <item style="width:6ch; grid-column:span 4">5</item>-->
+<!--</grid>-->
+
+<!--27-->
+<!--<grid>-->
+<!--  <item>1</item>-->
+<!--  <item>2</item>-->
+<!--  <item>3</item>-->
+<!--  <item>4</item>-->
+<!--  <item style="width:6ch; grid-column:span 3">5</item>-->
+<!--</grid>-->
+
+</body>
+</html>


### PR DESCRIPTION
#### 977e1cc1c9a4f7dcd0e03d3bd153878d6904dce2
<pre>
[Masonry] Update masonry-intrinsic-sizing-001.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=272904">https://bugs.webkit.org/show_bug.cgi?id=272904</a>

Reviewed by NOBODY (OOPS!).

Let&apos;s get this test passing...

Grid Changes

Sub Test 1
Added style=&quot;width:2ch&quot; across all items. Variable width track sizing would cause all the columns to now be 2ch due to item 5’s width.

Sub Test 2
Same as grid 1.

Added style=&quot;width:2ch&quot; across all items. Variable width track sizing would cause all the columns to now be 2ch due to item 5’s width.

Sub Test 3
Definite items are placed first in masonry.
Moved the &lt;item style=&quot;width:2ch; grid-column:2&quot;&gt;5&lt;/item&gt; further up to match.

Sub Test 4
I adjusted the width of element 4 as it will be affected by number 5, which sets a different width.

Sub Test 5
Need to look into further.

Sub Test 6
Need to look into further.

Sub Test 7
No changes

Sub Test 8
No changes

Sub Test 9
Update column 4 to be the same the same track size as the others.

To get the calculations of the others you need to spread the 6ch over the gap plus 3 other tracks.
This results in 41px (6ch - 4px) left when you exclude the gap. Then divide by the 3 columns to get ~13.67.

Sub Test 10
No changes

Sub Test 11
Updated the first grid template columns to using 1fr instead of 1ch. It was not clear why this was done before.

Next, updated the 1fr column items to a 2ch width, and the 2fr column items to 4ch.

Sub Test 12
Updated the width of 1fr to 1ch and moved item 5 up to align with how masonry lays out definite items.

Sub Test 13
Moved up item 5 to align with how masonry lays out definite items.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-001-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-001-fr-sizing-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-001-fr-sizing.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-001-mixed-sizing-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-001-mixed-sizing.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-001.html:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/382a71b0f89322b1ac572c557f00b471605cc2dc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51219 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44597 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33679 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25266 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39676 "Failure limit exceed. At least found 1 new test failure: imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-001.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49114 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25417 "Exiting early after 10 failures. 50 tests run. 1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41874 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20789 "Found 1 new API test failure: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22895 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-001.html (failure)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6588 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44834 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43541 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-001.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53125 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23578 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19887 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-001.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46981 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-001.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24843 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42080 "Exiting early after 10 failures. 30 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45909 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25648 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24566 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->