### PR TITLE
Create debug overlay for Site Isolation

### DIFF
--- a/Source/WebCore/page/DebugOverlayRegions.h
+++ b/Source/WebCore/page/DebugOverlayRegions.h
@@ -33,6 +33,7 @@ enum class DebugOverlayRegions : uint8_t {
     TouchActionRegion = 1 << 2,
     EditableElementRegion = 1 << 3,
     InteractionRegion = 1 << 4,
+    SiteIsolationRegion = 1 << 5,
 };
 
 }

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -618,6 +618,64 @@ bool InteractionRegionOverlay::mouseEvent(PageOverlay& overlay, const PlatformMo
 }
 
 #if COMPILER(CLANG)
+#pragma mark - SiteIsolationOverlay
+#endif
+
+class SiteIsolationOverlay final : public RegionOverlay {
+public:
+    static Ref<SiteIsolationOverlay> create(Page& page)
+    {
+        return adoptRef(*new SiteIsolationOverlay(page));
+    }
+
+private:
+    explicit SiteIsolationOverlay(Page& page)
+        : RegionOverlay(page, Color::green.colorWithAlphaByte(102))
+    {
+    }
+
+    bool updateRegion() final;
+    void drawRect(PageOverlay&, GraphicsContext&, const IntRect& dirtyRect) final;
+
+    bool mouseEvent(PageOverlay&, const PlatformMouseEvent&) final;
+};
+
+bool SiteIsolationOverlay::updateRegion()
+{
+    m_overlay->setNeedsDisplay();
+    return true;
+}
+
+void SiteIsolationOverlay::drawRect(PageOverlay&, GraphicsContext& context, const IntRect&)
+{
+    GraphicsContextStateSaver stateSaver(context);
+
+    FontCascadeDescription fontDescription;
+    fontDescription.setOneFamily("Helvetica"_s);
+    fontDescription.setSpecifiedSize(12);
+    fontDescription.setComputedSize(12);
+    fontDescription.setWeight(FontSelectionValue(500));
+    FontCascade font(WTFMove(fontDescription));
+    font.update(nullptr);
+
+    for (auto* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        if (!frame->virtualView())
+            continue;
+        auto frameView = frame->virtualView();
+        auto debugStr = (is<RemoteFrame>(frame) ? "remote(" : "local(") + frame->frameID().toString() + ")";
+        TextRun textRun = TextRun(debugStr);
+        context.setFillColor(Color::black);
+
+        context.drawText(font, textRun, FloatPoint { static_cast<float>(frameView->x()), static_cast<float>(frameView->y() + 12) });
+    }
+}
+
+bool SiteIsolationOverlay::mouseEvent(PageOverlay& , const PlatformMouseEvent&)
+{
+    return false;
+}
+
+#if COMPILER(CLANG)
 #pragma mark - RegionOverlay
 #endif
 
@@ -630,6 +688,8 @@ Ref<RegionOverlay> RegionOverlay::create(Page& page, DebugPageOverlays::RegionTy
         return NonFastScrollableRegionOverlay::create(page);
     case DebugPageOverlays::RegionType::InteractionRegion:
         return InteractionRegionOverlay::create(page);
+    case DebugPageOverlays::RegionType::SiteIsolationRegion:
+        return SiteIsolationOverlay::create(page);
     }
     ASSERT_NOT_REACHED();
     return MouseWheelRegionOverlay::create(page);
@@ -797,6 +857,11 @@ void DebugPageOverlays::updateOverlayRegionVisibility(Page& page, OptionSet<Debu
         showRegionOverlay(page, RegionType::InteractionRegion);
     else
         hideRegionOverlay(page, RegionType::InteractionRegion);
+
+    if (visibleRegions.contains(DebugOverlayRegions::SiteIsolationRegion))
+        showRegionOverlay(page, RegionType::SiteIsolationRegion);
+    else
+        hideRegionOverlay(page, RegionType::SiteIsolationRegion);
 }
 
 void DebugPageOverlays::settingsChanged(Page& page)

--- a/Source/WebCore/page/DebugPageOverlays.h
+++ b/Source/WebCore/page/DebugPageOverlays.h
@@ -45,8 +45,9 @@ public:
         WheelEventHandlers,
         NonFastScrollableRegion,
         InteractionRegion,
+        SiteIsolationRegion
     };
-    static constexpr unsigned NumberOfRegionTypes = static_cast<unsigned>(RegionType::InteractionRegion) + 1;
+    static constexpr unsigned NumberOfRegionTypes = static_cast<unsigned>(RegionType::SiteIsolationRegion) + 1;
 
     static void didLayout(LocalFrame&);
     static void didChangeEventHandlers(LocalFrame&);
@@ -97,6 +98,7 @@ inline void DebugPageOverlays::didLayout(LocalFrame& frame)
     sharedDebugOverlays->regionChanged(frame, RegionType::WheelEventHandlers);
     sharedDebugOverlays->regionChanged(frame, RegionType::NonFastScrollableRegion);
     sharedDebugOverlays->regionChanged(frame, RegionType::InteractionRegion);
+    sharedDebugOverlays->regionChanged(frame, RegionType::SiteIsolationRegion);
 }
 
 inline void DebugPageOverlays::didChangeEventHandlers(LocalFrame& frame)
@@ -106,6 +108,7 @@ inline void DebugPageOverlays::didChangeEventHandlers(LocalFrame& frame)
     sharedDebugOverlays->regionChanged(frame, RegionType::WheelEventHandlers);
     sharedDebugOverlays->regionChanged(frame, RegionType::NonFastScrollableRegion);
     sharedDebugOverlays->regionChanged(frame, RegionType::InteractionRegion);
+    sharedDebugOverlays->regionChanged(frame, RegionType::SiteIsolationRegion);
 }
 
 inline void DebugPageOverlays::doAfterUpdateRendering(Page& page)
@@ -116,6 +119,7 @@ inline void DebugPageOverlays::doAfterUpdateRendering(Page& page)
     sharedDebugOverlays->updateRegionIfNecessary(page, RegionType::WheelEventHandlers);
     sharedDebugOverlays->updateRegionIfNecessary(page, RegionType::NonFastScrollableRegion);
     sharedDebugOverlays->updateRegionIfNecessary(page, RegionType::InteractionRegion);
+    sharedDebugOverlays->updateRegionIfNecessary(page, RegionType::SiteIsolationRegion);
 }
 
 inline bool DebugPageOverlays::shouldPaintOverlayIntoLayerForRegionType(Page& page, RegionType regionType)

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3806,7 +3806,7 @@ void RenderLayerBacking::paintContents(const GraphicsLayer* graphicsLayer, Graph
         paintIntoLayer(graphicsLayer, context, dirtyRect, behavior);
 
         auto visibleDebugOverlayRegions = OptionSet<DebugOverlayRegions>::fromRaw(renderer().settings().visibleDebugOverlayRegions());
-        if (visibleDebugOverlayRegions.containsAny({ DebugOverlayRegions::TouchActionRegion, DebugOverlayRegions::EditableElementRegion, DebugOverlayRegions::WheelEventHandlerRegion, DebugOverlayRegions::InteractionRegion }))
+        if (visibleDebugOverlayRegions.containsAny({ DebugOverlayRegions::TouchActionRegion, DebugOverlayRegions::EditableElementRegion, DebugOverlayRegions::WheelEventHandlerRegion, DebugOverlayRegions::InteractionRegion, DebugOverlayRegions::SiteIsolationRegion }))
             paintDebugOverlays(graphicsLayer, context);
 
     } else if (graphicsLayer == layerForHorizontalScrollbar()) {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
@@ -38,6 +38,7 @@ typedef NS_OPTIONS(NSUInteger, _WKDebugOverlayRegions) {
     _WKTouchActionRegion = 1 << 2,
     _WKEditableElementRegion = 1 << 3,
     _WKInteractionRegion WK_API_AVAILABLE(macos(13.0), ios(16.0)) = 1 << 4,
+    _WKSiteIsolationRegion WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA)) = 1 << 5,
 } WK_API_AVAILABLE(macos(10.11), ios(9.0));
 
 typedef NS_OPTIONS(NSUInteger, _WKJavaScriptRuntimeFlags) {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1092,7 +1092,8 @@ void WebChromeClient::attachViewOverlayGraphicsLayer(GraphicsLayer* graphicsLaye
         return;
 
     // FIXME: Support view overlays in iframe processes if needed. <rdar://116202544>
-    drawingArea->attachViewOverlayGraphicsLayer(page->mainWebFrame().frameID(), graphicsLayer);
+    if (page->mainWebFrame().coreLocalFrame())
+        drawingArea->attachViewOverlayGraphicsLayer(page->mainWebFrame().frameID(), graphicsLayer);
 }
 
 void WebChromeClient::setNeedsOneShotDrawingSynchronization()

--- a/Tools/MiniBrowser/mac/SettingsController.h
+++ b/Tools/MiniBrowser/mac/SettingsController.h
@@ -66,6 +66,7 @@ typedef NS_ENUM(NSInteger, AttachmentElementEnabledState) {
 @property (nonatomic, readonly) BOOL usesGameControllerFramework;
 @property (nonatomic, readonly) BOOL networkCacheSpeculativeRevalidationDisabled;
 @property (nonatomic, readonly) BOOL advancedPrivacyProtectionsEnabled;
+@property (nonatomic, readonly) BOOL siteIsolationOverlayEnabled;
 
 @property (nonatomic, readonly) NSString *defaultURL;
 @property (nonatomic, readonly) NSString *customUserAgent;

--- a/Tools/MiniBrowser/mac/SettingsController.m
+++ b/Tools/MiniBrowser/mac/SettingsController.m
@@ -70,6 +70,8 @@ static NSString * const UseMockCaptureDevicesPreferenceKey = @"UseMockCaptureDev
 static NSString * const AttachmentElementEnabledPreferenceKey = @"AttachmentElementEnabled";
 static NSString * const AdvancedPrivacyProtectionsPreferenceKey = @"AdvancedPrivacyProtectionsEnabled";
 
+static NSString * const SiteIsolationOverlayPreferenceKey = @"SiteIsolationOverlayEnabled";
+
 // This default name intentionally overlaps with the key that WebKit2 checks when creating a view.
 static NSString * const UseRemoteLayerTreeDrawingAreaPreferenceKey = @"WebKit2UseRemoteLayerTreeDrawingArea";
 
@@ -82,6 +84,7 @@ typedef NS_ENUM(NSInteger, DebugOverylayMenuItemTag) {
     InteractionRegionOverlayTag,
     ExperimentalFeatureTag,
     InternalDebugFeatureTag,
+    SiteIsolationRegionOverlayTag,
 };
 
 typedef NS_ENUM(NSInteger, AttachmentElementEnabledMenuItemTag) {
@@ -214,6 +217,7 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
     addItemToMenu(debugOverlaysMenu, @"Wheel Event Handler Region", @selector(toggleDebugOverlay:), NO, WheelEventHandlerRegionOverlayTag);
     addItemToMenu(debugOverlaysMenu, @"Interaction Region", @selector(toggleDebugOverlay:), NO, InteractionRegionOverlayTag);
     addItemToMenu(debugOverlaysMenu, @"Resource Usage", @selector(toggleShowResourceUsageOverlay:), NO, 0);
+    addItemToMenu(debugOverlaysMenu, @"Site Isolation", @selector(toggleSiteIsolationOverlay:), NO, SiteIsolationRegionOverlayTag);
 
     NSMenu *experimentalFeaturesMenu = addSubmenu(@"Experimental Features");
     for (_WKExperimentalFeature *feature in WKPreferences._experimentalFeatures) {
@@ -399,6 +403,8 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
         [menuItem setState:[self perWindowWebProcessesDisabled] ? NSControlStateValueOn : NSControlStateValueOff];
     else if (action == @selector(toggleDebugOverlay:))
         [menuItem setState:[self debugOverlayVisible:menuItem] ? NSControlStateValueOn : NSControlStateValueOff];
+    else if (action == @selector(toggleSiteIsolationOverlay:))
+        [menuItem setState:[self siteIsolationOverlayVisible:menuItem] ? NSControlStateValueOn : NSControlStateValueOff];
     else if (action == @selector(changeCustomUserAgent:)) {
 
         NSString *savedUAIdentifier = [[NSUserDefaults standardUserDefaults] stringForKey:CustomUserAgentPreferenceKey];
@@ -737,6 +743,9 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
 
     case InteractionRegionOverlayTag:
         return InteractionRegionOverlayVisiblePreferenceKey;
+
+    case SiteIsolationRegionOverlayTag:
+        return SiteIsolationOverlayPreferenceKey;
     }
     return nil;
 }
@@ -799,6 +808,21 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
         return [[NSUserDefaults standardUserDefaults] boolForKey:preferenceKey];
 
     return NO;
+}
+
+- (void)toggleSiteIsolationOverlay:(id)sender
+{
+    [self _toggleBooleanDefault:SiteIsolationOverlayPreferenceKey];
+}
+
+- (BOOL)siteIsolationOverlayEnabled
+{
+    return [[NSUserDefaults standardUserDefaults] boolForKey:SiteIsolationOverlayPreferenceKey];
+}
+
+- (BOOL)siteIsolationOverlayVisible:(NSMenuItem *)menuItem
+{
+    return [self siteIsolationOverlayEnabled];
 }
 
 - (NSString *)customUserAgent

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -581,6 +581,8 @@ static BOOL areEssentiallyEqual(double a, double b)
         visibleOverlayRegions |= _WKWheelEventHandlerRegion;
     if (settings.interactionRegionOverlayVisible)
         visibleOverlayRegions |= _WKInteractionRegion;
+    if (settings.siteIsolationOverlayEnabled)
+        visibleOverlayRegions |= _WKSiteIsolationRegion;
     
     preferences._visibleDebugOverlayRegions = visibleOverlayRegions;
 


### PR DESCRIPTION
#### b920c9fb0198dbe67b0aaff251dd078c3cfbaa17
<pre>
Create debug overlay for Site Isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=272908">https://bugs.webkit.org/show_bug.cgi?id=272908</a>
<a href="https://rdar.apple.com/problem/126701278">rdar://problem/126701278</a>

Reviewed by Alex Christensen.

This change creates a debug overlay for identifying frames and if
they are either local or remote. This is useful for matching what frames
are what when debugging sites with i-frames with site isolation on.

Currently this only draws for the local main frame and that process&apos;s view
of the other frames. Once we can support view overlays in i-frame processes
this can be expanded to show the current hosting process of each remote i-frame.

* Source/WebCore/page/DebugOverlayRegions.h:
* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::SiteIsolationOverlay::updateRegion):
(WebCore::SiteIsolationOverlay::drawRect):
(WebCore::SiteIsolationOverlay::mouseEvent):
(WebCore::RegionOverlay::create):
(WebCore::DebugPageOverlays::updateOverlayRegionVisibility):
* Source/WebCore/page/DebugPageOverlays.h:
(WebCore::DebugPageOverlays::didLayout):
(WebCore::DebugPageOverlays::didChangeEventHandlers):
(WebCore::DebugPageOverlays::doAfterUpdateRendering):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::paintContents):
* Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::attachViewOverlayGraphicsLayer):
* Tools/MiniBrowser/mac/SettingsController.h:
* Tools/MiniBrowser/mac/SettingsController.m:
(-[SettingsController _populateMenu:]):
(-[SettingsController validateMenuItem:]):
(-[SettingsController preferenceKeyForRegionOverlayTag:]):
(-[SettingsController toggleSiteIsolationOverlay:]):
(-[SettingsController siteIsolationOverlayEnabled]):
(-[SettingsController siteIsolationOverlayVisible:]):
* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController didChangeSettings]):

Canonical link: <a href="https://commits.webkit.org/277703@main">https://commits.webkit.org/277703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdfe610e3ab86a131c89874cafac54a9d956abc9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48306 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27518 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50994 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44371 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50611 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25039 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39462 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25217 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41723 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20607 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22697 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42903 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6362 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/44655 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43361 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52898 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19701 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46799 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24618 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45712 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10664 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25423 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24341 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->