### PR TITLE
Merge Old Monterey and New Ventura EWS Queues Together

### DIFF
--- a/Tools/CISupport/ews-app/ews/common/github.py
+++ b/Tools/CISupport/ews-app/ews/common/github.py
@@ -213,13 +213,7 @@ class GitHubEWS(GitHub):
                           ['jsc-arm64', 'tv', 'mac-AS-debug-wk2', 'gtk-wk2', ''],
                           ['services', 'tv-sim', 'mac-wk2-stress', 'api-gtk', ''],
                           ['merge', 'watch', '', 'jsc-armv7', ''],
-                          ['unsafe-merge', 'watch-sim', '', 'jsc-armv7-tests', ''],
-                          ['', '', 'mac-ventura', '', ''],
-                          ['', '', 'api-mac-ventura', '', ''],
-                          ['', '', 'mac-ventura-wk1', '', ''],
-                          ['', '', 'mac-ventura-wk2', '', ''],
-                          ['jsc-ventura-arm64', '', '', '', ''],
-                          ['', '', 'mac-ventura-wk2-stress', '', '']]
+                          ['unsafe-merge', 'watch-sim', '', 'jsc-armv7-tests', '']]
 
     @classmethod
     def generate_updated_pr_description(self, description, ews_comment):

--- a/Tools/CISupport/ews-app/ews/views/statusbubble.py
+++ b/Tools/CISupport/ews-app/ews/views/statusbubble.py
@@ -43,9 +43,9 @@ class StatusBubble(View):
     # These queue names are from shortname in https://trac.webkit.org/browser/webkit/trunk/Tools/CISupport/ews-build/config.json
     # FIXME: Auto-generate this list https://bugs.webkit.org/show_bug.cgi?id=195640
     # Note: This list is sorted in the order of which bubbles appear in bugzilla.
-    ALL_QUEUES = ['style', 'ios', 'ios-sim', 'mac', 'mac-ventura', 'mac-AS-debug', 'tv', 'tv-sim', 'watch', 'watch-sim', 'gtk', 'wpe', 'wpe-skia', 'wincairo',
-                  'ios-wk2', 'ios-wk2-wpt', 'mac-wk1', 'mac-wk2', 'mac-wk2-stress', 'mac-ventura-wk1', 'mac-ventura-wk2', 'mac-ventura-wk2-stress', 'mac-AS-debug-wk2', 'gtk-wk2', 'wpe-wk2', 'api-ios', 'api-mac',
-                  'api-gtk', 'api-wpe', 'bindings', 'jsc', 'jsc-ventura-arm64', 'jsc-arm64', 'jsc-armv7', 'jsc-armv7-tests', 'webkitperl', 'webkitpy', 'services']
+    ALL_QUEUES = ['style', 'ios', 'ios-sim', 'mac', 'mac-AS-debug', 'tv', 'tv-sim', 'watch', 'watch-sim', 'gtk', 'wpe', 'wpe-skia', 'wincairo',
+                  'ios-wk2', 'ios-wk2-wpt', 'mac-wk1', 'mac-wk2', 'mac-wk2-stress', 'mac-AS-debug-wk2', 'gtk-wk2', 'wpe-wk2', 'api-ios', 'api-mac',
+                  'api-gtk', 'api-wpe', 'bindings', 'jsc', 'jsc-arm64', 'jsc-armv7', 'jsc-armv7-tests', 'webkitperl', 'webkitpy', 'services']
 
     DAYS_TO_CHECK_QUEUE_POSITION = 0.5
     DAYS_TO_HIDE_BUBBLE = 7

--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -53,29 +53,29 @@
     { "name": "wincairo-ews-002", "platform": "wincairo" },
     { "name": "wincairo-ews-003", "platform": "wincairo" },
     { "name": "wincairo-ews-004", "platform": "wincairo" },
-    { "name": "ews100", "platform": "mac-monterey" },
-    { "name": "ews101", "platform": "mac-monterey" },
-    { "name": "ews102", "platform": "mac-monterey" },
-    { "name": "ews103", "platform": "mac-monterey" },
-    { "name": "ews104", "platform": "mac-monterey" },
-    { "name": "ews105", "platform": "mac-monterey" },
+    { "name": "ews100", "platform": "mac-ventura" },
+    { "name": "ews101", "platform": "mac-ventura" },
+    { "name": "ews102", "platform": "mac-ventura" },
+    { "name": "ews103", "platform": "mac-ventura" },
+    { "name": "ews104", "platform": "mac-ventura" },
+    { "name": "ews105", "platform": "mac-ventura" },
     { "name": "ews106", "platform": "mac-ventura" },
-    { "name": "ews107", "platform": "mac-monterey" },
+    { "name": "ews107", "platform": "mac-ventura" },
     { "name": "ews108", "platform": "*" },
     { "name": "ews109", "platform": "ios-17" },
     { "name": "ews110", "platform": "ios-simulator-17" },
     { "name": "ews111", "platform": "ios-simulator-17" },
-    { "name": "ews112", "platform": "mac-monterey" },
-    { "name": "ews113", "platform": "mac-monterey" },
+    { "name": "ews112", "platform": "mac-ventura" },
+    { "name": "ews113", "platform": "mac-ventura" },
     { "name": "ews114", "platform": "*" },
     { "name": "ews115", "platform": "mac-ventura" },
-    { "name": "ews116", "platform": "mac-monterey" },
-    { "name": "ews117", "platform": "mac-monterey" },
+    { "name": "ews116", "platform": "mac-ventura" },
+    { "name": "ews117", "platform": "mac-ventura" },
     { "name": "ews118", "platform": "mac-ventura" },
-    { "name": "ews119", "platform": "mac-monterey" },
+    { "name": "ews119", "platform": "mac-ventura" },
     { "name": "ews120", "platform": "mac-ventura" },
-    { "name": "ews129", "platform": "mac-monterey" },
-    { "name": "ews169", "platform": "mac-monterey" },
+    { "name": "ews129", "platform": "mac-ventura" },
+    { "name": "ews169", "platform": "mac-ventura" },
     { "name": "ews121", "platform": "ios-simulator-17" },
     { "name": "ews122", "platform": "ios-simulator-17" },
     { "name": "ews123", "platform": "ios-simulator-17" },
@@ -96,14 +96,14 @@
     { "name": "ews139", "platform": "*" },
     { "name": "ews140", "platform": "*" },
     { "name": "ews141", "platform": "mac-ventura" },
-    { "name": "ews142", "platform": "mac-monterey" },
-    { "name": "ews143", "platform": "mac-monterey" },
+    { "name": "ews142", "platform": "mac-ventura" },
+    { "name": "ews143", "platform": "mac-ventura" },
     { "name": "ews144", "platform": "mac-ventura" },
-    { "name": "ews145", "platform": "mac-monterey" },
+    { "name": "ews145", "platform": "mac-ventura" },
     { "name": "ews146", "platform": "mac-ventura" },
-    { "name": "ews147", "platform": "mac-monterey" },
-    { "name": "ews148", "platform": "mac-monterey" },
-    { "name": "ews149", "platform": "mac-monterey" },
+    { "name": "ews147", "platform": "mac-ventura" },
+    { "name": "ews148", "platform": "mac-ventura" },
+    { "name": "ews149", "platform": "mac-ventura" },
     { "name": "ews150", "platform": "*" },
     { "name": "ews151", "platform": "*", "max_builds": 3 },
     { "name": "ews152", "platform": "*" },
@@ -115,8 +115,8 @@
     { "name": "ews158", "platform": "*" },
     { "name": "ews159", "platform": "*" },
     { "name": "ews160", "platform": "*" },
-    { "name": "ews161", "platform": "mac-monterey" },
-    { "name": "ews162", "platform": "mac-monterey" },
+    { "name": "ews161", "platform": "mac-ventura" },
+    { "name": "ews162", "platform": "mac-ventura" },
     { "name": "ews163", "platform": "*" },
     { "name": "ews164", "platform": "*" },
     { "name": "ews165", "platform": "*" },
@@ -135,14 +135,14 @@
     { "name": "ews179", "platform": "mac-sonoma" },
     { "name": "ews180", "platform": "mac-sonoma" },
     { "name": "ews181", "platform": "mac-ventura" },
-    { "name": "ews182", "platform": "mac-monterey" },
+    { "name": "ews182", "platform": "mac-ventura" },
     { "name": "ews183", "platform": "*" },
     { "name": "ews184", "platform": "ios-simulator-17" },
     { "name": "ews185", "platform": "ios-simulator-17" },
-    { "name": "ews186", "platform": "mac-monterey" },
-    { "name": "ews187", "platform": "mac-monterey" },
+    { "name": "ews186", "platform": "mac-ventura" },
+    { "name": "ews187", "platform": "mac-ventura" },
     { "name": "ews188", "platform": "mac-ventura" },
-    { "name": "ews189", "platform": "mac-monterey" },
+    { "name": "ews189", "platform": "mac-ventura" },
     { "name": "ews190", "platform": "ios-simulator-17" },
     { "name": "ews191", "platform": "ios-simulator-17" },
     { "name": "ews192", "platform": "ios-simulator-17" },
@@ -217,74 +217,46 @@
       "workernames": ["ews191", "ews192", "ews193", "ews194", "ews195", "ews196", "ews197", "ews198"]
     },
     {
-      "name": "macOS-AppleSilicon-Sonoma-Debug-Build-EWS", "shortname": "mac-AS-debug", "icon": "buildOnly",
+      "name": "macOS-Sonoma-Debug-Build-EWS", "shortname": "mac-AS-debug", "icon": "buildOnly",
       "factory": "macOSBuildOnlyFactory", "platform": "mac-sonoma",
       "configuration": "debug", "architectures": ["arm64"],
-      "triggers": ["macos-applesilicon-sonoma-debug-wk2-tests-ews"],
+      "triggers": ["macos-sonoma-debug-wk2-tests-ews"],
       "workernames": ["ews171", "ews172", "ews173", "ews174"]
     },
     {
-      "name": "macOS-AppleSilicon-Sonoma-Debug-WK2-Tests-EWS", "shortname": "mac-AS-debug-wk2", "icon": "testOnly",
+      "name": "macOS-Sonoma-Debug-WK2-Tests-EWS", "shortname": "mac-AS-debug-wk2", "icon": "testOnly",
       "factory": "macOSWK2Factory", "platform": "mac-sonoma",
       "configuration": "debug",
-      "triggered_by": ["macos-applesilicon-sonoma-debug-build-ews"],
+      "triggered_by": ["macos-sonoma-debug-build-ews"],
       "workernames": ["ews138", "ews139", "ews140", "ews175", "ews176", "ews177", "ews178", "ews179", "ews180"]
     },
     {
-      "name": "macOS-Monterey-Release-Build-EWS", "shortname": "mac", "icon": "buildOnly",
-      "factory": "macOSBuildFactory", "platform": "mac-monterey",
-      "configuration": "release", "architectures": ["x86_64", "arm64"],
-      "triggers": ["api-tests-mac-ews", "macos-monterey-release-wk1-tests-ews", "macos-monterey-release-wk2-tests-ews", "macos-release-wk2-stress-tests-ews"],
-      "workernames": ["ews101", "ews102", "ews103", "ews105", "ews119", "ews161", "ews162"]
-    },
-    {
-      "name": "macOS-Ventura-Release-Build-EWS", "shortname": "mac-ventura", "icon": "buildOnly",
+      "name": "macOS-Ventura-Release-Build-EWS", "shortname": "mac", "icon": "buildOnly",
       "factory": "macOSBuildFactory", "platform": "mac-ventura",
       "configuration": "release", "architectures": ["x86_64", "arm64"],
-      "triggers": ["api-tests-mac-applesilicon-ventura-ews", "macos-applesilicon-ventura-release-wk1-tests-ews", "macos-applesilicon-ventura-release-wk2-tests-ews", "macos-applesilicon-ventura-release-wk2-stress-tests-ews"],
-      "workernames": ["ews118", "ews141", "ews120"]
+      "triggers": ["api-tests-mac-ews", "macos-ventura-release-wk1-tests-ews", "macos-ventura-release-wk2-tests-ews", "macos-release-wk2-stress-tests-ews"],
+      "workernames": ["ews101", "ews102", "ews103", "ews105","ews118", "ews119", "ews120", "ews141", "ews161", "ews162"]
     },
     {
-      "name": "macOS-Monterey-Release-WK1-Tests-EWS", "shortname": "mac-wk1", "icon": "testOnly",
-      "factory": "macOSWK1Factory", "platform": "mac-monterey",
-      "configuration": "release",
-      "triggered_by": ["macos-monterey-release-build-ews"],
-      "workernames": ["ews116", "ews112", "ews117", "ews145", "ews147", "ews148"]
-    },
-    {
-      "name": "macOS-AppleSilicon-Ventura-Release-WK1-Tests-EWS", "shortname": "mac-ventura-wk1", "icon": "testOnly",
+      "name": "macOS-Ventura-Release-WK1-Tests-EWS", "shortname": "mac-wk1", "icon": "testOnly",
       "factory": "macOSWK1Factory", "platform": "mac-ventura",
       "configuration": "release",
       "triggered_by": ["macos-ventura-release-build-ews"],
-      "workernames": ["ews144", "ews146"]
+      "workernames": ["ews116", "ews112", "ews117", "ews144", "ews145", "ews146", "ews147", "ews148"]
     },
     {
-      "name": "macOS-Monterey-Release-WK2-Tests-EWS", "shortname": "mac-wk2", "icon": "testOnly",
-      "factory": "macOSWK2Factory", "platform": "mac-monterey",
-      "configuration": "release",
-      "triggered_by": ["macos-monterey-release-build-ews"],
-      "workernames": ["ews104", "ews107", "ews113", "ews149", "ews169", "ews186", "ews187", "ews189"]
-    },
-    {
-      "name": "macOS-AppleSilicon-Ventura-Release-WK2-Tests-EWS", "shortname": "mac-ventura-wk2", "icon": "testOnly",
+      "name": "macOS-Ventura-Release-WK2-Tests-EWS", "shortname": "mac-wk2", "icon": "testOnly",
       "factory": "macOSWK2Factory", "platform": "mac-ventura",
       "configuration": "release",
       "triggered_by": ["macos-ventura-release-build-ews"],
-      "workernames": ["ews188", "ews115", "ews106"]
+      "workernames": ["ews104", "ews106", "ews107", "ews113", "ews115", "ews149", "ews169", "ews186", "ews187", "ews188", "ews189"]
     },
     {
       "name": "macOS-Release-WK2-Stress-Tests-EWS", "shortname": "mac-wk2-stress", "icon": "testOnly",
-      "factory": "StressTestFactory", "platform": "mac-monterey",
-      "configuration": "release",
-      "triggered_by": ["macos-monterey-release-build-ews"],
-      "workernames": ["ews182"]
-    },
-    {
-      "name": "macOS-AppleSilicon-Ventura-Release-WK2-Stress-Tests-EWS", "shortname": "mac-ventura-wk2-stress", "icon": "testOnly",
       "factory": "StressTestFactory", "platform": "mac-ventura",
       "configuration": "release",
       "triggered_by": ["macos-ventura-release-build-ews"],
-      "workernames": ["ews181"]
+      "workernames": ["ews181", "ews182"]
     },
     {
       "name": "watchOS-10-Build-EWS", "shortname": "watch", "icon": "buildOnly",
@@ -351,15 +323,9 @@
     },
     {
       "name": "JSC-Tests-arm64-EWS", "shortname": "jsc-arm64", "icon": "buildAndTest",
-      "factory": "JSCBuildAndTestsFactory", "platform": "mac-monterey",
-      "configuration": "release", "runTests": "true",
-      "workernames": ["ews137"]
-    },
-    {
-      "name": "JSC-Tests-Ventura-arm64-EWS", "shortname": "jsc-ventura-arm64", "icon": "buildAndTest",
       "factory": "JSCBuildAndTestsFactory", "platform": "mac-ventura",
       "configuration": "release", "runTests": "true",
-      "workernames": ["ews136"]
+      "workernames": ["ews136", "ews137"]
     },
     {
       "name": "JSC-ARMv7-32bits-Build-EWS", "shortname": "jsc-armv7", "icon": "buildOnly",
@@ -397,15 +363,9 @@
     },
     {
       "name": "API-Tests-macOS-EWS", "shortname": "api-mac", "icon": "testOnly",
-      "factory": "APITestsFactory", "platform": "*",
-      "triggered_by": ["macos-monterey-release-build-ews"],
-      "workernames": ["ews100", "ews129", "ews142", "ews143", "ews150"]
-    },
-    {
-      "name": "API-Tests-macOS-AppleSilicon-Ventura-EWS", "shortname": "api-ventura-mac", "icon": "testOnly",
-      "factory": "APITestsFactory", "platform": "*",
+      "factory": "APITestsFactory", "platform": "mac-ventura",
       "triggered_by": ["macos-ventura-release-build-ews"],
-      "workernames": ["ews153", "ews155"]
+      "workernames": ["ews100", "ews129", "ews142", "ews143", "ews150", "ews153", "ews155"]
     },
     {
       "name": "API-Tests-GTK-EWS", "shortname": "api-gtk", "icon": "testOnly",
@@ -455,8 +415,8 @@
       "type": "Try_Userpass", "name": "try", "port": 5555,
       "builderNames": [
             "Apply-WatchList-EWS", "Bindings-Tests-EWS", "GTK-Build-EWS", "iOS-17-Build-EWS", "iOS-17-Simulator-Build-EWS",
-            "JSC-ARMv7-32bits-Build-EWS", "JSC-Tests-EWS", "JSC-Tests-arm64-EWS", "JSC-Tests-Ventura-arm64-EWS",
-            "macOS-AppleSilicon-Sonoma-Debug-Build-EWS", "macOS-Monterey-Release-Build-EWS", "macOS-Ventura-Release-Build-EWS",
+            "JSC-ARMv7-32bits-Build-EWS", "JSC-Tests-EWS", "JSC-Tests-arm64-EWS",
+            "macOS-Sonoma-Debug-Build-EWS", "macOS-Ventura-Release-Build-EWS",
             "Services-EWS", "Style-EWS", "tvOS-17-Build-EWS", "tvOS-17-Simulator-Build-EWS", "watchOS-10-Build-EWS",
             "watchOS-10-Simulator-Build-EWS", "WPE-Build-EWS", "WebKitPerl-Tests-EWS", "WebKitPy-Tests-EWS", "Win-Build-EWS",
             "WPE-Skia-Build-EWS"
@@ -470,8 +430,8 @@
       "type": "AnyBranchScheduler", "name": "pull_request",
       "builderNames": [
             "Bindings-Tests-EWS", "GTK-Build-EWS", "iOS-17-Build-EWS", "iOS-17-Simulator-Build-EWS",
-            "JSC-ARMv7-32bits-Build-EWS", "JSC-Tests-EWS", "JSC-Tests-arm64-EWS", "JSC-Tests-Ventura-arm64-EWS",
-            "macOS-AppleSilicon-Sonoma-Debug-Build-EWS", "macOS-Monterey-Release-Build-EWS", "macOS-Ventura-Release-Build-EWS",
+            "JSC-ARMv7-32bits-Build-EWS", "JSC-Tests-EWS", "JSC-Tests-arm64-EWS",
+            "macOS-Sonoma-Debug-Build-EWS", "macOS-Ventura-Release-Build-EWS",
             "Services-EWS", "Style-EWS", "Style-EWS", "tvOS-17-Build-EWS", "tvOS-17-Simulator-Build-EWS", "watchOS-10-Build-EWS",
             "watchOS-10-Simulator-Build-EWS", "WPE-Build-EWS", "WebKitPerl-Tests-EWS", "WebKitPy-Tests-EWS", "Win-Build-EWS",
             "WPE-Skia-Build-EWS"
@@ -490,44 +450,28 @@
       "builderNames": ["Safe-Merge-Queue"]
     },
     {
-      "type": "Triggerable", "name": "macos-monterey-release-build-ews",
-      "builderNames": ["macOS-Monterey-Release-Build-EWS"]
-    },
-    {
       "type": "Triggerable", "name": "macos-ventura-release-build-ews",
       "builderNames": ["macOS-Ventura-Release-Build-EWS"]
     },
     {
-      "type": "Triggerable", "name": "macos-monterey-release-wk1-tests-ews",
-      "builderNames": ["macOS-Monterey-Release-WK1-Tests-EWS"]
+      "type": "Triggerable", "name": "macos-ventura-release-wk1-tests-ews",
+      "builderNames": ["macOS-Ventura-Release-WK1-Tests-EWS"]
     },
     {
-      "type": "Triggerable", "name": "macos-applesilicon-ventura-release-wk1-tests-ews",
-      "builderNames": ["macOS-AppleSilicon-Ventura-Release-WK1-Tests-EWS"]
-    },
-    {
-      "type": "Triggerable", "name": "macos-monterey-release-wk2-tests-ews",
-      "builderNames": ["macOS-Monterey-Release-WK2-Tests-EWS"]
-    },
-    {
-      "type": "Triggerable", "name": "macos-applesilicon-ventura-release-wk2-tests-ews",
-      "builderNames": ["macOS-AppleSilicon-Ventura-Release-WK2-Tests-EWS"]
+      "type": "Triggerable", "name": "macos-ventura-release-wk2-tests-ews",
+      "builderNames": ["macOS-Ventura-Release-WK2-Tests-EWS"]
     },
     {
       "type": "Triggerable", "name": "macos-release-wk2-stress-tests-ews",
       "builderNames": ["macOS-Release-WK2-Stress-Tests-EWS"]
     },
     {
-      "type": "Triggerable", "name": "macos-applesilicon-ventura-release-wk2-stress-tests-ews",
-      "builderNames": ["macOS-AppleSilicon-Ventura-Release-WK2-Stress-Tests-EWS"]
+      "type": "Triggerable", "name": "macos-sonoma-debug-build-ews",
+      "builderNames": ["macOS-Sonoma-Debug-Build-EWS"]
     },
     {
-      "type": "Triggerable", "name": "macos-applesilicon-sonoma-debug-build-ews",
-      "builderNames": ["macOS-AppleSilicon-Sonoma-Debug-Build-EWS"]
-    },
-    {
-      "type": "Triggerable", "name": "macos-applesilicon-sonoma-debug-wk2-tests-ews",
-      "builderNames": ["macOS-AppleSilicon-Sonoma-Debug-WK2-Tests-EWS"]
+      "type": "Triggerable", "name": "macos-sonoma-debug-wk2-tests-ews",
+      "builderNames": ["macOS-Sonoma-Debug-WK2-Tests-EWS"]
     },
     {
       "type": "Triggerable", "name": "ios-17-sim-build-ews",
@@ -548,10 +492,6 @@
     {
       "type": "Triggerable", "name": "api-tests-mac-ews",
       "builderNames": ["API-Tests-macOS-EWS"]
-    },
-    {
-      "type": "Triggerable", "name": "api-tests-mac-applesilicon-ventura-ews",
-      "builderNames": ["API-Tests-macOS-AppleSilicon-Ventura-EWS"]
     },
     {
       "type": "Triggerable", "name": "gtk-build-ews",

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -171,7 +171,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'trigger-crash-log-submission',
             'set-build-summary'
         ],
-        'macOS-AppleSilicon-Sonoma-Debug-Build-EWS': [
+        'macOS-Sonoma-Debug-Build-EWS': [
             'configure-build',
             'check-change-relevance',
             'validate-change',
@@ -187,7 +187,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'validate-change',
             'compile-webkit'
         ],
-        'macOS-AppleSilicon-Sonoma-Debug-WK2-Tests-EWS': [
+        'macOS-Sonoma-Debug-WK2-Tests-EWS': [
             'configure-build',
             'validate-change',
             'configuration',
@@ -209,21 +209,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'layout-tests',
             'trigger-crash-log-submission',
             'set-build-summary'
-        ],
-        'macOS-Monterey-Release-Build-EWS': [
-            'configure-build',
-            'validate-change',
-            'configuration',
-            'clean-up-git-repo',
-            'checkout-source',
-            'fetch-branch-references',
-            'checkout-specific-revision',
-            'show-identifier',
-            'apply-patch',
-            'checkout-pull-request',
-            'kill-old-processes',
-            'validate-change',
-            'compile-webkit'
         ],
         'macOS-Ventura-Release-Build-EWS': [
             'configure-build',
@@ -240,7 +225,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'validate-change',
             'compile-webkit'
         ],
-        'macOS-Monterey-Release-WK1-Tests-EWS': [
+        'macOS-Ventura-Release-WK1-Tests-EWS': [
             'configure-build',
             'check-change-relevance',
             'validate-change',
@@ -264,54 +249,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'trigger-crash-log-submission',
             'set-build-summary'
         ],
-        'macOS-AppleSilicon-Ventura-Release-WK1-Tests-EWS': [
-            'configure-build',
-            'check-change-relevance',
-            'validate-change',
-            'configuration',
-            'clean-up-git-repo',
-            'checkout-source',
-            'fetch-branch-references',
-            'checkout-specific-revision',
-            'get-test-expectations-baseline',
-            'show-identifier',
-            'apply-patch',
-            'checkout-pull-request',
-            'get-updated-test-expectations',
-            'find-modified-layout-tests',
-            'download-built-product',
-            'extract-built-product',
-            'wait-for-crash-collection',
-            'kill-old-processes',
-            'run-layout-tests-in-stress-mode',
-            'layout-tests',
-            'trigger-crash-log-submission',
-            'set-build-summary'
-        ],
-        'macOS-Monterey-Release-WK2-Tests-EWS': [
-            'configure-build',
-            'validate-change',
-            'configuration',
-            'clean-up-git-repo',
-            'checkout-source',
-            'fetch-branch-references',
-            'checkout-specific-revision',
-            'get-test-expectations-baseline',
-            'show-identifier',
-            'apply-patch',
-            'checkout-pull-request',
-            'get-updated-test-expectations',
-            'find-modified-layout-tests',
-            'download-built-product',
-            'extract-built-product',
-            'wait-for-crash-collection',
-            'kill-old-processes',
-            'run-layout-tests-in-stress-mode',
-            'layout-tests',
-            'trigger-crash-log-submission',
-            'set-build-summary'
-        ],
-        'macOS-AppleSilicon-Ventura-Release-WK2-Tests-EWS': [
+        'macOS-Ventura-Release-WK2-Tests-EWS': [
             'configure-build',
             'validate-change',
             'configuration',
@@ -335,28 +273,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'set-build-summary'
         ],
         'macOS-Release-WK2-Stress-Tests-EWS': [
-            'configure-build',
-            'validate-change',
-            'configuration',
-            'clean-up-git-repo',
-            'checkout-source',
-            'fetch-branch-references',
-            'checkout-specific-revision',
-            'get-test-expectations-baseline',
-            'show-identifier',
-            'apply-patch',
-            'checkout-pull-request',
-            'get-updated-test-expectations',
-            'find-modified-layout-tests',
-            'download-built-product',
-            'extract-built-product',
-            'wait-for-crash-collection',
-            'kill-old-processes',
-            'run-layout-tests-in-stress-mode',
-            'trigger-crash-log-submission',
-            'set-build-summary'
-        ],
-        'macOS-AppleSilicon-Ventura-Release-WK2-Stress-Tests-EWS': [
             'configure-build',
             'validate-change',
             'configuration',
@@ -545,23 +461,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'compile-jsc',
             'jscore-test'
         ],
-        'JSC-Tests-Ventura-arm64-EWS': [
-            'configure-build',
-            'check-change-relevance',
-            'validate-change',
-            'configuration',
-            'clean-up-git-repo',
-            'checkout-source',
-            'fetch-branch-references',
-            'checkout-specific-revision',
-            'show-identifier',
-            'apply-patch',
-            'checkout-pull-request',
-            'kill-old-processes',
-            'validate-change',
-            'compile-jsc',
-            'jscore-test'
-        ],
         'JSC-Tests-EWS': [
             'configure-build',
             'check-change-relevance',
@@ -675,22 +574,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'run-api-tests'
         ],
         'API-Tests-macOS-EWS': [
-            'configure-build',
-            'validate-change',
-            'configuration',
-            'clean-up-git-repo',
-            'checkout-source',
-            'fetch-branch-references',
-            'checkout-specific-revision',
-            'show-identifier',
-            'apply-patch',
-            'checkout-pull-request',
-            'download-built-product',
-            'extract-built-product',
-            'kill-old-processes',
-            'run-api-tests'
-        ],
-        'API-Tests-macOS-AppleSilicon-Ventura-EWS': [
             'configure-build',
             'validate-change',
             'configuration',


### PR DESCRIPTION
#### 1dfaffd55f3a3b0dc03d74e9c24f0f7ba0fbd58d
<pre>
Merge Old Monterey and New Ventura EWS Queues Together
<a href="https://bugs.webkit.org/show_bug.cgi?id=272909">https://bugs.webkit.org/show_bug.cgi?id=272909</a>
<a href="https://rdar.apple.com/126702258">rdar://126702258</a>

Reviewed by Jonathan Bedard.

Merge old Monterey and new Ventura queues together to get ready for Monterey deprecation.

* Tools/CISupport/ews-app/ews/common/github.py:
(GitHubEWS):
* Tools/CISupport/ews-app/ews/views/statusbubble.py:
(StatusBubble):
* Tools/CISupport/ews-build/config.json:
* Tools/CISupport/ews-build/factories_unittest.py:
(TestExpectedBuildSteps):

Canonical link: <a href="https://commits.webkit.org/278182@main">https://commits.webkit.org/278182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6dc624f994a9ecf41739827b1b11539f4898b7d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49744 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29031 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52794 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/52985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/419 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52048 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26648 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/52985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51843 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26562 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/52985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/24002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/44034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8115 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/44540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/54567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/24831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/54567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/49769 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/26097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/54567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/26945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7160 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/25822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->