### PR TITLE
Propogate NaNs thru constant-folded min/max in BBQ JIT

### DIFF
--- a/JSTests/wasm/stress/fp-nan-minmax.js
+++ b/JSTests/wasm/stress/fp-nan-minmax.js
@@ -1,0 +1,60 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "f32_min") (param f32 f32) (result f32)
+        local.get 0
+        local.get 1
+        f32.min
+    )
+    (func (export "f32_max") (param f32 f32) (result f32)
+        local.get 0
+        local.get 1
+        f32.max
+    )
+    (func (export "f64_min") (param f64 f64) (result f64)
+        local.get 0
+        local.get 1
+        f64.min
+    )
+    (func (export "f64_max") (param f64 f64) (result f64)
+        local.get 0
+        local.get 1
+        f64.max
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, {});
+    const { f32_min, f32_max, f64_min, f64_max } = instance.exports;
+
+    let f32_subnormal = Math.pow(2, -126) * (1 - Math.pow(2, -23)); 
+    for (let comparand of [0.0, 1234.1, f32_subnormal, Infinity]) {
+        assert.eq(f32_min(comparand, NaN), NaN);
+        assert.eq(f32_min(NaN, comparand), NaN);
+        assert.eq(f32_min(-comparand, NaN), NaN);
+        assert.eq(f32_min(NaN, -comparand), NaN);
+
+        assert.eq(f32_max(comparand, NaN), NaN);
+        assert.eq(f32_max(NaN, comparand), NaN);
+        assert.eq(f32_max(-comparand, NaN), NaN);
+        assert.eq(f32_max(NaN, -comparand), NaN);
+    }
+
+    let f64_subnormal = Math.pow(2, -1022) * (1 - Math.pow(2, -52));
+    for (let comparand of [0.0, 1234.1, f64_subnormal, Infinity]) {
+        assert.eq(f64_min(comparand, NaN), NaN);
+        assert.eq(f64_min(NaN, comparand), NaN);
+        assert.eq(f64_min(-comparand, NaN), NaN);
+        assert.eq(f64_min(NaN, -comparand), NaN);
+
+        assert.eq(f64_max(comparand, NaN), NaN);
+        assert.eq(f64_max(NaN, comparand), NaN);
+        assert.eq(f64_max(-comparand, NaN), NaN);
+        assert.eq(f64_max(NaN, -comparand), NaN);
+    }
+}
+
+assert.asyncTest(test());

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -2003,7 +2003,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Div(Value lhs, Value rhs, Value& 
     );
 }
 
-template<typename FloatType, MinOrMax IsMinOrMax>
+template<MinOrMax IsMinOrMax, typename FloatType>
 void BBQJIT::emitFloatingPointMinOrMax(FPRReg left, FPRReg right, FPRReg result)
 {
     constexpr bool is32 = sizeof(FloatType) == 4;
@@ -2075,14 +2075,14 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Min(Value lhs, Value rhs, Value& 
 {
     EMIT_BINARY(
         "F32Min", TypeKind::F32,
-        BLOCK(Value::fromF32(std::min(lhs.asF32(), rhs.asF32()))),
+        BLOCK(Value::fromF32(computeFloatingPointMinOrMax<MinOrMax::Min>(lhs.asF32(), rhs.asF32()))),
         BLOCK(
-            emitFloatingPointMinOrMax<float, MinOrMax::Min>(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
+            emitFloatingPointMinOrMax<MinOrMax::Min, float>(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
         ),
         BLOCK(
             ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(wasmScratchFPR);
             emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(wasmScratchFPR));
-            emitFloatingPointMinOrMax<float, MinOrMax::Min>(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
+            emitFloatingPointMinOrMax<MinOrMax::Min, float>(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
         )
     );
 }
@@ -2091,14 +2091,14 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Min(Value lhs, Value rhs, Value& 
 {
     EMIT_BINARY(
         "F64Min", TypeKind::F64,
-        BLOCK(Value::fromF64(std::min(lhs.asF64(), rhs.asF64()))),
+        BLOCK(Value::fromF64(computeFloatingPointMinOrMax<MinOrMax::Min>(lhs.asF64(), rhs.asF64()))),
         BLOCK(
-            emitFloatingPointMinOrMax<double, MinOrMax::Min>(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
+            emitFloatingPointMinOrMax<MinOrMax::Min, double>(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
         ),
         BLOCK(
             ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(wasmScratchFPR);
             emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(wasmScratchFPR));
-            emitFloatingPointMinOrMax<double, MinOrMax::Min>(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
+            emitFloatingPointMinOrMax<MinOrMax::Min, double>(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
         )
     );
 }
@@ -2107,14 +2107,14 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Max(Value lhs, Value rhs, Value& 
 {
     EMIT_BINARY(
         "F32Max", TypeKind::F32,
-        BLOCK(Value::fromF32(std::max(lhs.asF32(), rhs.asF32()))),
+        BLOCK(Value::fromF32(computeFloatingPointMinOrMax<MinOrMax::Max>(lhs.asF32(), rhs.asF32()))),
         BLOCK(
-            emitFloatingPointMinOrMax<float, MinOrMax::Max>(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
+            emitFloatingPointMinOrMax<MinOrMax::Max, float>(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
         ),
         BLOCK(
             ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(wasmScratchFPR);
             emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(wasmScratchFPR));
-            emitFloatingPointMinOrMax<float, MinOrMax::Max>(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
+            emitFloatingPointMinOrMax<MinOrMax::Max, float>(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
         )
     );
 }
@@ -2123,14 +2123,14 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Max(Value lhs, Value rhs, Value& 
 {
     EMIT_BINARY(
         "F64Max", TypeKind::F64,
-        BLOCK(Value::fromF64(std::max(lhs.asF64(), rhs.asF64()))),
+        BLOCK(Value::fromF64(computeFloatingPointMinOrMax<MinOrMax::Max>(lhs.asF64(), rhs.asF64()))),
         BLOCK(
-            emitFloatingPointMinOrMax<double, MinOrMax::Max>(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
+            emitFloatingPointMinOrMax<MinOrMax::Max, double>(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
         ),
         BLOCK(
             ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(wasmScratchFPR);
             emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(wasmScratchFPR));
-            emitFloatingPointMinOrMax<double, MinOrMax::Max>(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
+            emitFloatingPointMinOrMax<MinOrMax::Max, double>(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
         )
     );
 }

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -1404,8 +1404,22 @@ public:
 
     enum class MinOrMax { Min, Max };
 
-    template<typename FloatType, MinOrMax IsMinOrMax>
+    template<MinOrMax IsMinOrMax, typename FloatType>
     void emitFloatingPointMinOrMax(FPRReg left, FPRReg right, FPRReg result);
+
+    template<MinOrMax IsMinOrMax, typename FloatType>
+    constexpr FloatType computeFloatingPointMinOrMax(FloatType left, FloatType right)
+    {
+        if (std::isnan(left))
+            return left;
+        if (std::isnan(right))
+            return right;
+
+        if constexpr (IsMinOrMax == MinOrMax::Min)
+            return std::min<FloatType>(left, right);
+        else
+            return std::max<FloatType>(left, right);
+    }
 
     PartialResult WARN_UNUSED_RETURN addF32Min(Value lhs, Value rhs, Value& result);
 


### PR DESCRIPTION
#### d449735fb88069ee4760cd99ad3f7cf157976224
<pre>
Propogate NaNs thru constant-folded min/max in BBQ JIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=270262">https://bugs.webkit.org/show_bug.cgi?id=270262</a>
<a href="https://rdar.apple.com/120540053">rdar://120540053</a>

Reviewed by Keith Miller.

During constant-folding we use std::min/std::max, which the C++ standard
defines as treating NaNs as &quot;missing values&quot; and therefore returning the
non-NaN value, while conversely WASM expects us to propogate the NaN
operand in all cases.

* JSTests/wasm/stress/fp-nan-minmax.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.export.string_appeared_here.param.f32.f32.result.f32.local.0.local.1.f32.min.func.export.string_appeared_here.param.f32.f32.result.f32.local.0.local.1.f32.max.func.export.string_appeared_here.param.f64.f64.result.f64.local.0.local.1.f64.min.func.export.string_appeared_here.param.f64.f64.result.f64.local.0.local.1.f64.max.async test):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Min):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Min):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Max):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Max):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
(JSC::Wasm::BBQJITImpl::BBQJIT::computeFloatingPointMinOrMax):

Canonical link: <a href="https://commits.webkit.org/277891@main">https://commits.webkit.org/277891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85057a1ef067b547db6643ceeba648166dbc061f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51544 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44923 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34020 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25598 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39949 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25723 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42134 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21052 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23186 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6912 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/42156 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45119 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43804 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53455 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/48348 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23908 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20176 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47255 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25171 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42343 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10764 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25979 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55843 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24891 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11497 "Passed tests") | 
<!--EWS-Status-Bubble-End-->