### PR TITLE
[WebGPU] Queue::writeTexture can fail for some 1D texture copies

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2088,6 +2088,8 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-272863.html [ Pass Failure ]
 [ Debug ] fast/webgpu/fuzz-272903.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-272903.html [ Pass Failure ]
+[ Debug ] fast/webgpu/fuzz-272911.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-272911.html [ Pass Failure ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/fuzz-272911-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-272911-expected.txt
@@ -1,0 +1,675 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 982x5202
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x5202
+  RenderBlock {HTML} at (0,0) size 785x5202 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x5186
+      RenderText {#text} at (32,137) size 26x17
+        text run at (32,137) width 26: "\x{C1AA}\x{C94}"
+      RenderText {#text} at (57,137) size 87x17
+        text run at (57,137) width 87: "\x{4F78}\x{D83F}\x{DE8B}\x{D83F}\x{DDDC}\x{9E7}\x{C52}\x{63A9}\x{77E1}"
+      RenderText {#text} at (443,137) size 62x17
+        text run at (443,137) width 62: "\x{910F}\x{742A}\x{B92}\x{D83D}\x{DE81}"
+      RenderText {#text} at (504,137) size 65x17
+        text run at (504,137) width 65: "\x{D75}\x{BE26}\x{D83E}\x{DED9}\x{2ABB}"
+      RenderText {#text} at (568,137) size 98x17
+        text run at (568,137) width 98: "\x{A76}\x{44CD}\x{DF6}\x{4F0}\x{1C62}\x{FD8}\x{235A}\x{173E}\x{D83F}\x{DED7}"
+      RenderText {#text} at (665,137) size 72x17
+        text run at (665,137) width 72: "\x{D83E}\x{DD5B}\x{200B}\x{D83D}\x{DFEA}\x{1A46}\x{AB6F}\x{D83F}\x{DF12}"
+      RenderText {#text} at (300,296) size 63x17
+        text run at (300,296) width 15: "\x{34E5}"
+        text run at (315,296) width 11 RTL: "\x{85D}"
+        text run at (325,296) width 38: "\x{F632}\x{B956}\x{FFC}"
+      RenderText {#text} at (362,296) size 123x17
+        text run at (362,296) width 123: "\x{4E06}\x{CECA}\x{D83F}\x{DED1}\x{E430}\x{96AB}\x{85DD}\x{575E}\x{1D9}\x{879E}"
+      RenderText {#text} at (484,296) size 79x17
+        text run at (484,296) width 79: "\x{D83E}\x{DCE2}\x{AD5}\x{8870}\x{20C7}\x{B348}\x{AD31}"
+      RenderText {#text} at (562,296) size 45x17
+        text run at (562,296) width 35: "\x{C6E8}\x{D83E}\x{DC2A}\x{A026}"
+        text run at (596,296) width 11 RTL: "\x{7DA}"
+      RenderText {#text} at (606,296) size 82x17
+        text run at (606,296) width 16: "\x{3FBE}"
+        text run at (621,296) width 10 RTL: "\x{72F}\x{82B}"
+        text run at (630,296) width 58: "\x{91B1}\x{1F7}\x{D83F}\x{DC56}\x{ED0}\x{77B4}"
+      RenderText {#text} at (600,454) size 70x17
+        text run at (600,454) width 70: "\x{9AA}\x{4946}\x{4B32}\x{D83E}\x{DCA5}\x{908}\x{D83F}\x{DF1A}"
+      RenderImage {IMG} at (284,592) size 21x165
+      RenderText {#text} at (305,744) size 80x17
+        text run at (305,744) width 80: "\x{3091}\x{9AD}\x{ABA2}\x{CFD}\x{D83D}\x{DF95}\x{B13}\x{4B0E}"
+      RenderText {#text} at (384,744) size 154x17
+        text run at (384,744) width 63: "\x{C22}\x{4C66}\x{A99C}\x{D83E}\x{DEB0}"
+        text run at (446,744) width 15 RTL: "\x{6FA}"
+        text run at (460,744) width 78: "\x{F675}\x{5712}\x{E343}\x{A88A}\x{4B4}\x{608C}"
+      RenderText {#text} at (553,744) size 36x17
+        text run at (553,744) width 36: "\x{55A7}\x{D83F}\x{DF2E}\x{2DD8}"
+      RenderText {#text} at (588,744) size 107x17
+        text run at (588,744) width 60: "\x{D83E}\x{DC95}\x{16CF}\x{C63A}\x{82D}\x{A2F8}\x{D83D}\x{DFD8}"
+        text run at (647,744) width 12 RTL: "\x{86B}"
+        text run at (658,744) width 37: "\x{A737}\x{D83F}\x{DF22}\x{D83F}\x{DFBF}"
+      RenderText {#text} at (0,744) size 762x181
+        text run at (694,744) width 68: "\x{1401}\x{CD2}\x{B6E4}\x{8940}\x{AF27}"
+        text run at (0,908) width 57: "\x{CAE4}\x{90}\x{8DB9}\x{1EC8}\x{FF00}"
+      RenderText {#text} at (72,908) size 37x17
+        text run at (72,908) width 27: "\x{B66D}\x{592}\x{D83F}\x{DEDD}"
+        text run at (98,908) width 11 RTL: "\x{64A}"
+      RenderText {#text} at (457,908) size 94x17
+        text run at (457,908) width 94: "\x{5D93}\x{D7F}\x{5957}\x{D83E}\x{DE78}\x{51B}\x{E8D}\x{D7C}"
+      RenderText {#text} at (550,908) size 120x17
+        text run at (550,908) width 120: "\x{7195}\x{556F}\x{D83E}\x{DCAE}\x{ED7}\x{D83F}\x{DC74}\x{D83F}\x{DC9A}\x{D83F}\x{DF3F}\x{D83E}\x{DE67}\x{C08D}\x{2E51}"
+      RenderText {#text} at (0,908) size 755x175
+        text run at (669,908) width 86: "\x{D83E}\x{DF48}\x{25CA}\x{5554}\x{4281}\x{D83F}\x{DF60}\x{E4EE}\x{434E}"
+        text run at (0,1066) width 20 RTL: "\x{FD79}"
+        text run at (19,1066) width 26: "\x{CAA}\x{C890}"
+      RenderText {#text} at (44,1066) size 42x17
+        text run at (44,1066) width 42: "\x{C93}\x{D83D}\x{DE93}\x{995}"
+      RenderText {#text} at (385,1066) size 99x17
+        text run at (385,1066) width 99: "\x{140}\x{30B}\x{D83F}\x{DD8B}\x{E03E}\x{D83E}\x{DF2B}\x{75AD}\x{D83E}\x{DCE1}\x{E7C2}\x{CF21}\x{420}"
+      RenderText {#text} at (483,1066) size 22x17
+        text run at (483,1066) width 22: "\x{D83E}\x{DF49}\x{6}"
+      RenderText {#text} at (504,1066) size 108x17
+        text run at (504,1066) width 108: "\x{C24}\x{4EF}\x{D83F}\x{DED8}\x{30C9}\x{6D71}\x{40B1}\x{D83E}\x{DEF4}\x{F888}"
+      RenderText {#text} at (611,1066) size 115x17
+        text run at (611,1066) width 115: "\x{6EDD}\x{D83E}\x{DD93}\x{929}\x{6982}\x{C1A}\x{E97}\x{4E1}\x{2813}\x{3ED}\x{585}"
+      RenderText {#text} at (0,1066) size 751x42
+        text run at (725,1066) width 26: "\x{EFCC}\x{4DA1}"
+        text run at (0,1091) width 44: "\x{13B}\x{D83E}\x{DC1C}\x{55D6}\x{A35}"
+      RenderText {#text} at (0,1501) size 86x17
+        text run at (0,1501) width 8: "\x{663}"
+        text run at (7,1501) width 79: "\x{73A6}\x{D83D}\x{DF18}\x{F3F}\x{B3C}\x{38BB}\x{B45}\x{823}\x{D83F}\x{DC95}"
+      RenderText {#text} at (85,1501) size 63x17
+        text run at (85,1501) width 63: "\x{4592}\x{21E7}\x{8DB}\x{B90B}\x{499}"
+      RenderText {#text} at (147,1501) size 107x17
+        text run at (147,1501) width 22: "\x{D83F}\x{DD08}\x{D840}"
+        text run at (168,1501) width 15 RTL: "\x{8BE}"
+        text run at (182,1501) width 72: "\x{6A31}\x{407}\x{975}\x{D83F}\x{DFC9}\x{8716}\x{D83F}\x{DE6D}"
+      RenderText {#text} at (253,1501) size 32x17
+        text run at (253,1501) width 32: "\x{2D8F}\x{F772}"
+      RenderText {#text} at (284,1501) size 11x17
+        text run at (284,1501) width 11: "\x{517}\x{343}"
+      RenderText {#text} at (294,1501) size 42x17
+        text run at (294,1501) width 42: "\x{DDBE}\x{5A81}\x{8744}"
+      RenderText {#text} at (335,1501) size 29x17
+        text run at (335,1501) width 29: "\x{A2C5}\x{B79D}\x{B9}"
+      RenderText {#text} at (363,1501) size 72x17
+        text run at (363,1501) width 72: "\x{B3A7}\x{E810}\x{AFF5}\x{B583}\x{46FD}"
+      RenderText {#text} at (434,1501) size 81x17
+        text run at (434,1501) width 81: "\x{1A23}\x{991C}\x{FD7}\x{D83F}\x{DEE9}\x{D83E}\x{DC87}\x{BEF1}\x{D83E}\x{DF30}"
+      RenderText {#text} at (514,1501) size 72x17
+        text run at (514,1501) width 72: "\x{BC91}\x{AD3}\x{D4C}\x{95A}\x{C81E}\x{90A}"
+      RenderText {#text} at (585,1501) size 108x17
+        text run at (585,1501) width 37: "\x{648D}\x{D83E}\x{DCFE}\x{EED5}"
+        text run at (621,1501) width 9 RTL: "\x{7D6}"
+        text run at (629,1501) width 64: "\x{FE45}\x{1A75}\x{EBF6}\x{5997}\x{1B95}\x{C3C}"
+      RenderText {#text} at (213,2180) size 110x17
+        text run at (213,2180) width 15: "\x{730E}"
+        text run at (228,2180) width 22 RTL: "\x{893}\x{63B}"
+        text run at (249,2180) width 74: "\x{37B0}\x{D83D}\x{DF13}\x{7144}\x{A748}\x{D83D}\x{DEA3}\x{654}"
+      RenderHTMLCanvas {CANVAS} at (322,1523) size 301x670
+      RenderText {#text} at (622,2180) size 53x17
+        text run at (622,2180) width 23: "\x{EAD5}\x{D5A}"
+        text run at (644,2180) width 24 RTL: "\x{8B8}\x{FBA}"
+        text run at (667,2180) width 8: "\x{FF}"
+      RenderText {#text} at (674,2180) size 46x17
+        text run at (674,2180) width 46: "\x{4E04}\x{4715}\x{2ED7}"
+      RenderText {#text} at (0,2180) size 739x45
+        text run at (719,2180) width 20: "\x{EDB}\x{A016}"
+        text run at (0,2208) width 51: "\x{4EE}\x{D83D}\x{DF66}\x{E14F}\x{25B}\x{F27C}"
+      RenderText {#text} at (50,2208) size 123x17
+        text run at (50,2208) width 12 RTL: "\x{88F}"
+        text run at (61,2208) width 66: "\x{56DE}\x{75E3}\x{8FF1}\x{D83E}\x{DDF9}"
+        text run at (126,2208) width 11 RTL: "\x{803}"
+        text run at (136,2208) width 37: "\x{185E}\x{4350}\x{295}\x{D83D}\x{DF2A}"
+      RenderText {#text} at (172,2208) size 70x17
+        text run at (172,2208) width 51: "\x{2AF}\x{34CD}\x{725A}\x{D83D}\x{DE76}"
+        text run at (222,2208) width 20 RTL: "\x{FD02}"
+      RenderText {#text} at (241,2208) size 126x17
+        text run at (241,2208) width 38: "\x{D665}\x{9AD8}\x{296}"
+        text run at (278,2208) width 12 RTL: "\x{FB37}"
+        text run at (289,2208) width 67: "\x{BEE8}\x{D83F}\x{DE77}\x{D359}\x{9A67}\x{D83F}\x{DE37}"
+        text run at (355,2208) width 12 RTL: "\x{5FC}"
+      RenderText {#text} at (366,2208) size 57x17
+        text run at (366,2208) width 57: "\x{A5ED}\x{C406}\x{162E}\x{9661}"
+      RenderText {#text} at (422,2208) size 64x17
+        text run at (422,2208) width 64: "\x{FFE}\x{3ACD}\x{4A37}\x{EEAE}\x{D83E}\x{DC79}"
+      RenderText {#text} at (485,2208) size 124x17
+        text run at (485,2208) width 124: "\x{A1}\x{55C}\x{F41D}\x{AA95}\x{3A64}\x{F68F}\x{D83D}\x{DF3B}\x{DA00}\x{855B}\x{C24D}\x{447D}"
+      RenderText {#text} at (608,2208) size 122x17
+        text run at (608,2208) width 122: "\x{F315}\x{41E}\x{DD54}\x{D83E}\x{DDE2}\x{D83D}\x{DEE9}\x{5B24}\x{BBB7}\x{A8A2}\x{24F}"
+      RenderText {#text} at (0,2208) size 760x224
+        text run at (729,2208) width 31: "\x{9C9D}\x{BB35}"
+        text run at (0,2415) width 52: "\x{431F}\x{D83E}\x{DFBF}\x{9FE}\x{4545}"
+      RenderText {#text} at (51,2415) size 138x17
+        text run at (51,2415) width 71: "\x{B606}\x{C420}\x{C27D}\x{308}\x{886E}\x{563}"
+        text run at (121,2415) width 14 RTL: "\x{77D}"
+        text run at (134,2415) width 55: "\x{3948}\x{5EF4}\x{A28E}\x{BAB6}"
+      RenderText {#text} at (204,2415) size 114x17
+        text run at (204,2415) width 114: "\x{CFC9}\x{AB02}\x{BFB0}\x{D83F}\x{DE32}\x{3CC0}\x{8AD8}\x{2711}\x{4D25}"
+      RenderText {#text} at (317,2415) size 104x17
+        text run at (317,2415) width 104: "\x{19EE}\x{9E44}\x{E64A}\x{D83E}\x{DC17}\x{D83E}\x{DE59}\x{62A1}\x{1F7}\x{7F8F}"
+      RenderText {#text} at (420,2415) size 46x17
+        text run at (420,2415) width 46: "\x{2458}\x{D83E}\x{DDEF}\x{27C8}"
+      RenderText {#text} at (465,2415) size 28x17
+        text run at (465,2415) width 28: "\x{C985}\x{1645}"
+      RenderImage {IMG} at (492,2227) size 182x201
+      RenderText {#text} at (673,2415) size 61x17
+        text run at (673,2415) width 61: "\x{D83F}\x{DE63}\x{D83D}\x{DEC6}\x{3355}\x{D83E}\x{DF0E}\x{17A6}"
+      RenderText {#text} at (290,2554) size 67x17
+        text run at (290,2554) width 67: "\x{89}\x{4AC3}\x{9A87}\x{E4F1}\x{8154}"
+      RenderText {#text} at (356,2554) size 120x17
+        text run at (356,2554) width 72: "\x{D83E}\x{DE82}\x{1D98}\x{629D}\x{AE61}\x{7BCB}"
+        text run at (427,2554) width 14 RTL: "\x{852}"
+        text run at (440,2554) width 36: "\x{B2BB}\x{28EC}\x{29B1}"
+      RenderText {#text} at (475,2554) size 51x17
+        text run at (475,2554) width 51: "\x{D83D}\x{DF4E}\x{D83F}\x{DC12}\x{634B}\x{6008}"
+      RenderText {#text} at (525,2554) size 118x17
+        text run at (525,2554) width 118: "\x{278}\x{4C70}\x{905}\x{D83E}\x{DD64}\x{D83E}\x{DED5}\x{A441}\x{D83F}\x{DE86}\x{D83E}\x{DFDA}\x{D83F}\x{DFAB}"
+      RenderText {#text} at (0,2554) size 767x175
+        text run at (642,2554) width 71: "\x{2F6C}\x{9192}\x{586B}\x{291}\x{4D45}"
+        text run at (712,2554) width 25 RTL: "\x{FD21}"
+        text run at (736,2554) width 31: "\x{CF1C}\x{8A0B}"
+        text run at (0,2712) width 11: "\x{E4C8}"
+      RenderImage {IMG} at (10,2573) size 295x152
+      RenderText {#text} at (304,2712) size 88x17
+        text run at (304,2712) width 40: "\x{A78E}\x{63A3}\x{C4AF}"
+        text run at (343,2712) width 10 RTL: "\x{843}"
+        text run at (352,2712) width 40: "\x{30B2}\x{AE1B}\x{A810}"
+      RenderText {#text} at (391,2712) size 26x17
+        text run at (391,2712) width 26: "\x{D83D}\x{DEED}\x{98D1}"
+      RenderText {#text} at (416,2712) size 103x17
+        text run at (416,2712) width 103: "\x{C934}\x{C655}\x{1CA}\x{ACA}\x{D83E}\x{DC1C}'\x{D83E}\x{DD9D}\x{D83F}\x{DC62}"
+      RenderText {#text} at (518,2712) size 81x17
+        text run at (518,2712) width 27: "\x{BCE}\x{3CEB}"
+        text run at (544,2712) width 9 RTL: "\x{5E8}"
+        text run at (552,2712) width 47: "\x{397B}\x{F98}\x{A58}\x{2104}"
+      RenderImage {IMG} at (300,2765) size 26x233
+      RenderText {#text} at (626,2985) size 70x17
+        text run at (626,2985) width 55: "\x{D83D}\x{DEF7}\x{83C5}\x{D83E}\x{DDE1}"
+        text run at (681,2985) width 15 RTL: "\x{5D4}\x{846}"
+      RenderText {#text} at (0,2985) size 756x252
+        text run at (695,2985) width 61: "\x{D8E}\x{9EB9}\x{9FD5}\x{D83F}\x{DE5F}"
+        text run at (0,3220) width 53: "\x{88DA}\x{655}\x{D83F}\x{DF38}\x{B757}\x{3D8}\x{FE2A}"
+      RenderText {#text} at (52,3220) size 48x17
+        text run at (52,3220) width 48: "\x{2602}\x{5A15}\x{1797}\x{A38}"
+      RenderText {#text} at (99,3220) size 52x17
+        text run at (99,3220) width 52: "\x{DA07}\x{547E}\x{D83D}\x{DF3C}\x{8CAF}"
+      RenderImage {IMG} at (150,3004) size 247x229
+      RenderText {#text} at (396,3220) size 47x17
+        text run at (396,3220) width 47: "\x{D83F}\x{DC3E}\x{262}\x{3E0D}\x{E7E9}"
+      RenderText {#text} at (442,3220) size 103x17
+        text run at (442,3220) width 27: "\x{D851}\x{5F41}"
+        text run at (468,3220) width 20 RTL: "\x{837}"
+        text run at (487,3220) width 58: "\x{B48}\x{D83E}\x{DCB0}\x{BDCB}\x{B8EC}"
+      RenderText {#text} at (544,3220) size 46x17
+        text run at (544,3220) width 46: "\x{7A6}\x{90EE}\x{548D}\x{B538}"
+      RenderText {#text} at (589,3220) size 60x17
+        text run at (589,3220) width 8: "\x{31F}"
+        text run at (596,3220) width 8 RTL: "\x{676}"
+        text run at (603,3220) width 46: "\x{7053}\x{2F9B}\x{305}\x{657A}"
+      RenderText {#text} at (648,3220) size 105x17
+        text run at (648,3220) width 63: "\x{A6B}\x{AA0}\x{4013}\x{8F6E}\x{A9D1}\x{6DB}"
+        text run at (710,3220) width 6 RTL: "\x{FE97}"
+        text run at (715,3220) width 38: "\x{7754}\x{2FAF}\x{D83D}\x{DF4C}"
+      RenderText {#text} at (0,3220) size 764x47
+        text run at (752,3220) width 12: "\x{2EF8}"
+        text run at (0,3250) width 15: "\x{37A9}"
+      RenderText {#text} at (0,3421) size 56x17
+        text run at (0,3421) width 56: "\x{D83F}\x{DC0D}\x{67DC}\x{6EA3}\x{3A79}"
+      RenderText {#text} at (55,3421) size 67x17
+        text run at (55,3421) width 67: "\x{1}\x{CA89}\x{7852}\x{BDBC}\x{BED}"
+      RenderText {#text} at (0,3834) size 55x17
+        text run at (0,3834) width 55: "\x{3EA}\x{5659}\x{B224}\x{5A3A}"
+      RenderImage {IMG} at (54,3788) size 47x59
+      RenderText {#text} at (100,3834) size 93x17
+        text run at (100,3834) width 93: "\x{7D65}\x{4D20}\x{898}\x{D83F}\x{DE70}\x{B767}\x{90C}\x{4CCF}"
+      RenderText {#text} at (527,3834) size 122x17
+        text run at (527,3834) width 122: "\x{8AA4}\x{A3E}\x{B9F}\x{1F10}\x{E49}\x{D83F}\x{DF44}\x{B78}\x{CE88}\x{19F5}\x{D83D}\x{DEC0}"
+      RenderText {#text} at (648,3834) size 93x17
+        text run at (648,3834) width 67: "\x{DAB}\x{B758}\x{E82}\x{339}\x{D754}\x{98B}"
+        text run at (714,3834) width 12 RTL: "\x{895}"
+        text run at (725,3834) width 16: "\x{B544}"
+      RenderText {#text} at (0,3973) size 117x17
+        text run at (0,3973) width 117: "\x{5DE9}\x{BAC7}\x{615A}\x{443}\x{D83E}\x{DC0B}\x{5AE9}\x{FB8}\x{3E2D}\x{45A8}"
+      RenderImage {IMG} at (116,3920) size 156x66
+      RenderText {#text} at (271,3973) size 111x17
+        text run at (271,3973) width 111: "\x{4456}\x{763D}\x{6858}\x{3197}\x{7B4A}\x{A6C5}\x{13D1}\x{AE2C}"
+      RenderText {#text} at (381,3973) size 82x17
+        text run at (381,3973) width 82: "\x{4907}\x{B652}\x{D83E}\x{DE43}\x{CBD5}\x{C520}\x{459}"
+      RenderImage {IMG} at (462,3859) size 288x127
+      RenderText {#text} at (0,4001) size 120x17
+        text run at (0,4001) width 120: "\x{D83F}\x{DDA7}\x{363}\x{D83E}\x{DC47}\x{5E75}\x{D83F}\x{DE23}\x{1AE}\x{A8E5}\x{D83F}\x{DEF3}\x{48DF}\x{5107}"
+      RenderText {#text} at (119,4001) size 27x17
+        text run at (119,4001) width 27: "\x{E95D}\x{BA46}"
+      RenderText {#text} at (145,4001) size 110x17
+        text run at (145,4001) width 99: "\x{6D9B}\x{D83D}\x{DE24}\x{8BA2}\x{6CE6}\x{E9B}\x{D83E}\x{DFA8}\x{1361}\x{22DE}"
+        text run at (243,4001) width 12 RTL: "\x{621}\x{709}"
+      RenderText {#text} at (254,4001) size 35x17
+        text run at (254,4001) width 35: "\x{D83F}\x{DD69}\x{5660}\x{A0E6}"
+      RenderText {#text} at (288,4001) size 84x17
+        text run at (288,4001) width 84: "\x{6B8D}\x{CD3F}{\x{BA63}\x{D83F}\x{DC58}\x{D83E}\x{DE79}"
+      RenderText {#text} at (371,4001) size 79x17
+        text run at (371,4001) width 79: "\x{6BB9}\x{D83F}\x{DEA4}\x{2C97}\x{2972}\x{1BF}\x{DE85}\x{CFE7}"
+      RenderText {#text} at (449,4001) size 67x17
+        text run at (449,4001) width 67: "\x{EF1}\x{B007}\x{3F51}\x{261D}\x{D83F}\x{DC63}"
+      RenderText {#text} at (515,4001) size 76x17
+        text run at (515,4001) width 44: "\x{98B8}\x{29B}\x{9DD}\x{D83E}\x{DF77}"
+        text run at (558,4001) width 12 RTL: "\x{812}"
+        text run at (569,4001) width 22: "\x{970}\x{4E6C}"
+      RenderText {#text} at (590,4001) size 140x17
+        text run at (590,4001) width 140: "\x{D83D}\x{DFE5}\x{D83E}\x{DC26}\x{61CA}\x{D83E}\x{DE1C}\x{D83E}\x{DC4B}\x{8674}\x{3056}\x{1992}\x{37B8}\x{8F24}"
+      RenderImage {IMG} at (0,4272) size 76x41
+      RenderText {#text} at (76,4300) size 26x17
+        text run at (76,4300) width 26: "\x{E444}\x{8A50}"
+      RenderText {#text} at (101,4300) size 123x17
+        text run at (101,4300) width 123: "\x{6E4}\x{312}\x{D83E}\x{DDBF}\x{D3EF}\x{2A01}\x{8F1B}\x{24D5}\x{D83F}\x{DD89}\x{CE5}\x{4551}"
+      RenderImage {IMG} at (223,4251) size 56x62
+      RenderText {#text} at (278,4300) size 31x17
+        text run at (278,4300) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (308,4300) size 81x17
+        text run at (308,4300) width 81: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (388,4300) size 69x17
+        text run at (388,4300) width 7 RTL: "\x{692}"
+        text run at (394,4300) width 63: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (0,4363) size 298x170
+      RenderText {#text} at (298,4520) size 103x17
+        text run at (298,4520) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (438,4520) size 100x17
+        text run at (438,4520) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (537,4520) size 117x17
+        text run at (537,4520) width 32: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (568,4520) width 10 RTL: "\x{79B}"
+        text run at (577,4520) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (0,4540) size 292x253
+      RenderText {#text} at (292,4780) size 103x17
+        text run at (292,4780) width 103: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (394,4780) size 105x17
+        text run at (394,4780) width 105: "\x{10D}\x{BA96}\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (498,4780) size 102x17
+        text run at (498,4780) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (599,4780) size 116x17
+        text run at (599,4780) width 116: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (0,4811) size 34x17
+        text run at (0,4811) width 34: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (33,4811) size 120x17
+        text run at (33,4811) width 26: "\x{24BF}\x{B00}"
+        text run at (58,4811) width 12 RTL: "\x{5FF}"
+        text run at (69,4811) width 14: "\x{2FA}\x{B13}"
+        text run at (82,4811) width 11 RTL: "\x{8BC}"
+        text run at (92,4811) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (152,4811) size 88x17
+        text run at (152,4811) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (239,4811) size 88x17
+        text run at (239,4811) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (326,4811) size 22x17
+        text run at (326,4811) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (347,4811) size 111x17
+        text run at (347,4811) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (457,4811) size 79x17
+        text run at (457,4811) width 79: "\x{ECB8}\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (535,4811) size 85x17
+        text run at (535,4811) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+      RenderText {#text} at (619,4811) size 100x17
+        text run at (619,4811) width 80: "\x{D83F}\x{DD83}\x{D83F}\x{DD58}\x{6EE2}\x{47A3}\x{10B}\x{2CC7}\x{BC62}"
+        text run at (698,4811) width 10 RTL: "\x{67F}"
+        text run at (707,4811) width 12: "\x{D83F}\x{DC12}"
+      RenderText {#text} at (0,4811) size 752x45
+        text run at (718,4811) width 34: "\x{F24}\x{A756}\x{4864}"
+        text run at (0,4839) width 116: "\x{D83D}\x{DF2C}\x{D83E}\x{DD04}\x{D83D}\x{DFF9}\x{D83E}\x{DD6D}\x{D83D}\x{DF33}\x{9AA9}\x{FF4C}\x{D83E}\x{DEAD}"
+      RenderText {#text} at (115,4839) size 52x17
+        text run at (115,4839) width 27: "\x{84E2}\x{D83E}\x{DCB2}"
+        text run at (141,4839) width 11 RTL: "\x{793}"
+        text run at (151,4839) width 16: "\x{812B}"
+      RenderText {#text} at (166,4839) size 119x17
+        text run at (166,4839) width 119: "\x{CD98}\x{D83E}\x{DEF8}\x{D83E}\x{DDA7}\x{AF08}\x{4EB8}\x{1243}\x{B2E}\x{FF7}"
+      RenderText {#text} at (284,4839) size 96x17
+        text run at (284,4839) width 96: "\x{1E56}\x{DB7F}\x{3BE0}\x{9F86}\x{4C4D}\x{D83F}\x{DCB1}\x{D83E}\x{DD9F}"
+      RenderText {#text} at (379,4839) size 60x17
+        text run at (379,4839) width 16: "\x{AC6C}"
+        text run at (394,4839) width 15 RTL: "\x{84C}"
+        text run at (408,4839) width 31: "\x{3CFB}\x{C01}"
+      RenderText {#text} at (438,4839) size 84x17
+        text run at (438,4839) width 84: "\x{C96F}\x{CFE}\x{D83E}\x{DD4C}\x{2EB1}\x{BFB}\x{D83F}\x{DFDA}"
+      RenderText {#text} at (521,4839) size 74x17
+        text run at (521,4839) width 74: "\x{966}\x{D83D}\x{DE44}\x{F51D}\x{D83E}\x{DF45}\x{F91}\x{2772}\x{D83F}\x{DF3B}"
+      RenderText {#text} at (594,4839) size 89x17
+        text run at (594,4839) width 67: "\x{94A5}\x{8A96}\x{6D75}\x{D83F}\x{DC81}\x{180}"
+        text run at (660,4839) width 12 RTL: "\x{6A6}"
+        text run at (671,4839) width 12: "\x{D83F}\x{DC37}"
+      RenderText {#text} at (682,4839) size 78x17
+        text run at (682,4839) width 58: "\x{EA1}\x{FB1}\x{A34}\x{5543}\x{D83F}\x{DF64}"
+        text run at (739,4839) width 13 RTL: "\x{801}"
+        text run at (751,4839) width 9: "\x{2EE1}"
+      RenderText {#text} at (0,4865) size 34x17
+        text run at (0,4865) width 34: "\x{1498}\x{D83F}\x{DE40}\x{D83E}\x{DC29}"
+      RenderText {#text} at (33,4865) size 23x17
+        text run at (33,4865) width 23: "\x{3040}\x{D83E}\x{DE44}"
+      RenderText {#text} at (55,4865) size 74x17
+        text run at (55,4865) width 74: "\x{D83F}\x{DF07}\x{DE60}\x{958}\x{D83F}\x{DD30}\x{4AC5}\x{3F37}"
+      RenderText {#text} at (128,4865) size 133x17
+        text run at (128,4865) width 133: "\x{7F0}\x{9CF}\x{C47A}\x{D74}\x{161C}\x{1F13}\x{97BB}\x{4FF7}\x{3AEF}\x{D83E}\x{DC98}\x{DDA}"
+      RenderText {#text} at (260,4865) size 111x17
+        text run at (260,4865) width 111: "\x{E60A}\x{5E72}\x{FAFC}\x{A318}\x{960}\x{9825}\x{265E}\x{6633}\x{6C91}"
+      RenderText {#text} at (370,4865) size 109x17
+        text run at (370,4865) width 61: "\x{739A}\x{2679}\x{24C2}\x{4019}"
+        text run at (430,4865) width 12 RTL: "\x{5C9}"
+        text run at (441,4865) width 38: "\x{CEE6}\x{D83E}\x{DF11}\x{A44}"
+      RenderText {#text} at (478,4865) size 32x17
+        text run at (478,4865) width 32: "\x{A89}\x{D83E}\x{DE59}\x{D83E}\x{DE6F}"
+      RenderText {#text} at (509,4865) size 83x17
+        text run at (509,4865) width 68: "\x{C1D6}\x{DC6A}\x{6930}\x{9921}\x{432}\x{ED}"
+        text run at (576,4865) width 5 RTL: "\x{701}"
+        text run at (580,4865) width 12: "\x{C84}"
+      RenderText {#text} at (591,4865) size 98x17
+        text run at (591,4865) width 98: "\x{D83D}\x{DE53}\x{D83F}\x{DC79}\x{C460}\x{BEF2}\x{4C04}\x{156}\x{372}\x{47A}"
+      RenderText {#text} at (688,4865) size 23x17
+        text run at (688,4865) width 23: "\x{D83E}\x{DC7C}\x{D83F}\x{DC5B}"
+      RenderText {#text} at (0,4865) size 756x43
+        text run at (710,4865) width 46: "\x{37FE}\x{9416}\x{9668}"
+        text run at (0,4891) width 54: "\x{E6B0}\x{F1F}\x{E27B}\x{B1B}\x{6F8B}"
+      RenderText {#text} at (53,4891) size 89x17
+        text run at (53,4891) width 89: "\x{533}\x{D83F}\x{DDD9}\x{C481}\x{C5EC}\x{A889}\x{49D9}\x{D83F}\x{DEBB}"
+      RenderText {#text} at (141,4891) size 120x17
+        text run at (141,4891) width 16: "\x{589C}"
+        text run at (156,4891) width 12 RTL: "\x{5CC}"
+        text run at (167,4891) width 49: "\x{1FF}\x{8296}\x{D83F}\x{DD87}\x{C9CD}"
+        text run at (215,4891) width 11 RTL: "\x{5E1}"
+        text run at (225,4891) width 12: "\x{EB97}"
+        text run at (236,4891) width 14 RTL: "\x{8B6}"
+        text run at (249,4891) width 12: "\x{D83E}\x{DE33}"
+      RenderText {#text} at (260,4891) size 70x17
+        text run at (260,4891) width 70: "\x{29E}\x{3AD8}\x{911F}\x{4170}\x{89AC}"
+      RenderText {#text} at (329,4891) size 127x17
+        text run at (329,4891) width 127: "\x{DAE}\x{D83E}\x{DFD0}\x{D676}\x{7A82}\x{D83F}\x{DC92}\x{D33}\x{99C8}\x{D83E}\x{DD52}\x{8FDE}\x{140}"
+      RenderText {#text} at (455,4891) size 145x17
+        text run at (455,4891) width 128: "\x{D83E}\x{DCB1}\x{D83E}\x{DCB7}\x{D83F}\x{DDE3}\x{B97C}\x{C855}\x{CD5B}\x{CF1}\x{C54C}\x{4043}\x{1535}"
+        text run at (587,4891) width 13 RTL: "\x{83D}"
+      RenderText {#text} at (582,4891) size 84x17
+        text run at (582,4891) width 6 RTL: "\x{5D5}"
+        text run at (599,4891) width 67: "\x{5E92}\x{1E8A}\x{9A39}\x{D29}\x{D83F}\x{DEBA}"
+      RenderText {#text} at (665,4891) size 31x17
+        text run at (665,4891) width 31: "\x{47B5}\x{8C8D}"
+      RenderText {#text} at (0,4891) size 764x45
+        text run at (695,4891) width 69: "\x{275C}\x{145}\x{C5C7}\x{F654}\x{DAD7}\x{BDD7}"
+        text run at (0,4919) width 19: "n\x{F047}"
+      RenderText {#text} at (18,4919) size 120x17
+        text run at (18,4919) width 28: "\x{ABB4}\x{AACB}\x{A19}"
+        text run at (45,4919) width 15 RTL: "\x{717}"
+        text run at (59,4919) width 79: "\x{E620}\x{D83E}\x{DC2C}\x{D83D}\x{DE54}\x{2C3}\x{BD07}\x{536}\x{4AFF}"
+      RenderText {#text} at (137,4919) size 63x17
+        text run at (137,4919) width 32: "\x{D83E}\x{DDCC}\x{D83E}\x{DC21}"
+        text run at (168,4919) width 17 RTL: "\x{6BE}\x{769}"
+        text run at (184,4919) width 16: "\x{41BE}"
+      RenderText {#text} at (199,4919) size 41x17
+        text run at (199,4919) width 15 RTL: "\x{808}"
+        text run at (213,4919) width 27: "\x{D83E}\x{DE4B}\x{4961}"
+      RenderText {#text} at (239,4919) size 48x17
+        text run at (239,4919) width 48: "\x{2CE9}\x{E5A6}\x{7C86}\x{10}"
+      RenderText {#text} at (286,4919) size 140x17
+        text run at (286,4919) width 140: "\x{D83F}\x{DE92}\x{E10B}\x{E644}\x{346D}\x{DD9}\x{EC1}\x{1D39}\x{BAE0}\x{CCC}\x{D0A}\x{272D}"
+      RenderText {#text} at (425,4919) size 144x17
+        text run at (425,4919) width 144: "\x{8E33}\x{F5F6}\x{D83E}\x{DD52}\x{542C}\x{AE0C}\x{33F}\x{B49F}\x{D83E}\x{DCA8}\x{DA4}\x{D83F}\x{DC82}\x{6138}"
+      RenderText {#text} at (568,4919) size 102x17
+        text run at (568,4919) width 33: "\x{D83F}\x{DF2D}\x{F4A7}\x{E7C6}"
+        text run at (600,4919) width 10 RTL: "\x{639}"
+        text run at (609,4919) width 27: "\x{FDD}\x{8C02}"
+        text run at (635,4919) width 5 RTL: "\x{627}"
+        text run at (639,4919) width 31: "\x{64C5}\x{3878}"
+      RenderText {#text} at (0,4919) size 768x44
+        text run at (669,4919) width 99: "\x{911D}\x{B0A}\x{D83E}\x{DF5D}\x{530D}\x{D6F0}\x{302}\x{9DF7}\x{D18}"
+        text run at (0,4946) width 15: "\x{B088}\x{EC9}"
+      RenderText {#text} at (14,4946) size 27x17
+        text run at (14,4946) width 12: "\x{D83F}\x{DDBE}"
+        text run at (35,4946) width 6 RTL: "\x{6C0}"
+      RenderText {#text} at (25,4946) size 76x17
+        text run at (25,4946) width 11 RTL: "\x{6D1}"
+        text run at (40,4946) width 61: "\x{B7EC}\x{DC39}\x{73EF}\x{1F90}\x{D83E}\x{DFE6}"
+      RenderText {#text} at (100,4946) size 132x17
+        text run at (100,4946) width 111: "\x{326D}\x{F53}\x{D83E}\x{DCAB}\x{482}\x{D83E}\x{DFFE}\x{B32F}\x{D83F}\x{DD03}\x{5C3E}\x{3D9C}"
+        text run at (210,4946) width 22 RTL: "\x{FCFC}"
+      RenderText {#text} at (231,4946) size 102x17
+        text run at (231,4946) width 77: "\x{8950}\x{4E2A}\x{EDC}\x{D83E}\x{DCD7}\x{D83F}\x{DD84}\x{44E}"
+        text run at (307,4946) width 11 RTL: "\x{848}"
+        text run at (317,4946) width 16: "\x{AF80}"
+      RenderText {#text} at (332,4946) size 129x17
+        text run at (332,4946) width 129: "\x{54D7}\x{E79C}\x{8C16}\x{63C6}\x{F54D}\x{8CEB}\x{8E6}\x{D83E}\x{DD1E}\x{F5BB}\x{AD09}"
+      RenderText {#text} at (460,4946) size 95x17
+        text run at (460,4946) width 95: "\x{D07B}\x{D83D}\x{DEBF}\x{C5}\x{D83E}\x{DCF7}\x{F8}\x{4AC9}\x{6E8E}"
+      RenderText {#text} at (554,4946) size 112x17
+        text run at (554,4946) width 112: "\x{C7FE}\x{AE4D}\x{4827}\x{BA55}\x{62AD}\x{FBA}\x{6065}\x{4EFC}"
+      RenderText {#text} at (0,4946) size 755x45
+        text run at (665,4946) width 90: "\x{10C6}\x{4BF}\x{BBE4}\x{D3B}\x{A0A}\x{B8E}\x{1487}\x{D83F}\x{DC7C}"
+        text run at (0,4974) width 32: "\x{23D}\x{1AA}\x{8F3F}"
+      RenderText {#text} at (31,4974) size 36x17
+        text run at (31,4974) width 36: "\x{328}\x{E96}\x{D83F}\x{DF71}\x{F10F}"
+      RenderText {#text} at (66,4974) size 88x17
+        text run at (66,4974) width 88: "\x{614A}\x{C870}\x{E997}\x{D83F}\x{DE46}\x{2D8B}\x{B80}\x{EFC4}"
+      RenderText {#text} at (153,4974) size 140x17
+        text run at (153,4974) width 140: "\x{496B}\x{D83F}\x{DE84}\x{D3D8}\x{D83D}\x{DF44}\x{1244}\x{D83E}\x{DD7C}\x{3C8A}\x{D73F}\x{E6DF}\x{D83F}\x{DD5E}"
+      RenderText {#text} at (292,4974) size 11x17
+        text run at (292,4974) width 11: "\x{2995}\x{F7D}"
+      RenderText {#text} at (302,4974) size 60x17
+        text run at (302,4974) width 60: "\x{515D}\x{DEA}k\x{D83F}\x{DDE9}\x{D099}"
+      RenderText {#text} at (361,4974) size 83x17
+        text run at (361,4974) width 83: "\x{4936}\x{A04}\x{D83D}\x{DE68}\x{7F8E}\x{5145}\x{3B80}"
+      RenderText {#text} at (443,4974) size 42x17
+        text run at (443,4974) width 42: "\x{B92B}\x{B663}\x{D83F}\x{DF52}"
+      RenderText {#text} at (484,4974) size 32x17
+        text run at (484,4974) width 32: "\x{D83F}\x{DD45}\x{4C8}\x{1500}"
+      RenderText {#text} at (515,4974) size 103x17
+        text run at (515,4974) width 11 RTL: "\x{649}"
+        text run at (525,4974) width 93: "Y\x{E2}\x{D83D}\x{DFCF}\x{BE7}\x{E856}\x{D83D}\x{DF5D}\x{96CF}\x{76BA}"
+      RenderText {#text} at (617,4974) size 71x17
+        text run at (617,4974) width 71: "\x{3190}\x{B978}\x{898}\x{AD2C}\x{CF05}"
+      RenderText {#text} at (687,4974) size 49x17
+        text run at (687,4974) width 49: "\x{D83F}\x{DC2C}\x{DDE0}\x{2E3F}\x{3B9A}"
+      RenderText {#text} at (0,5002) size 78x17
+        text run at (0,5002) width 31: "\x{D83E}\x{DE42}\x{A6E}\x{D9FC}"
+        text run at (30,5002) width 18 RTL: "\x{FC17}"
+        text run at (47,5002) width 31: "\x{24A9}\x{5434}"
+      RenderText {#text} at (77,5002) size 138x17
+        text run at (77,5002) width 138: "\x{8EB0}\x{D83F}\x{DCBB}\x{8B92}\x{4961}\x{D83F}\x{DE5F}\x{815F}\x{1496}\x{75DF}\x{F135}\x{D83E}\x{DCAE}\x{AB94}"
+      RenderText {#text} at (214,5002) size 119x17
+        text run at (214,5002) width 119: "\x{7}\x{F4E}\x{E9C5}\x{D83E}\x{DD16}\x{FF4}\x{C8B2}\x{8885}\x{1181}\x{D83F}\x{DDD6}"
+      RenderText {#text} at (332,5002) size 138x17
+        text run at (332,5002) width 138: "\x{F40D}\x{D83E}\x{DE7B}\x{D83F}\x{DE68}\x{481}\x{1242}\x{BA41}\x{8A50}\x{D83F}\x{DD54}\x{2F2A}\x{D83D}\x{DE49}"
+      RenderText {#text} at (469,5002) size 137x17
+        text run at (469,5002) width 137: "\x{884F}\x{146B}\x{D9C5}\x{D83E}\x{DF3C}\x{40EA}\x{BCD5}\x{5E1B}\x{A59}\x{D83E}\x{DCDD}\x{D83F}\x{DDF0}\x{7C60}"
+      RenderText {#text} at (605,5002) size 119x17
+        text run at (605,5002) width 119: "\x{5BB}\x{D83D}\x{DF58}\x{994}\x{D6F}\x{D83F}\x{DCBF}\x{1E35}\x{DD08}\x{90FE}\x{16AD}\x{B0D1}\x{5E87}"
+      RenderText {#text} at (0,5002) size 758x45
+        text run at (723,5002) width 35: "\x{78F9}\x{D83F}\x{DC10}\x{A0E3}"
+        text run at (0,5030) width 15: "\x{5AFC}"
+      RenderText {#text} at (15,5030) size 130x17
+        text run at (15,5030) width 130: "\x{5084}\x{BECB}\x{6B64}\x{D83E}\x{DC65}\x{D72B}\x{7CD8}\x{D83F}\x{DC17}\x{9C6}\x{D83F}\x{DEF6}\x{7A6}"
+      RenderText {#text} at (144,5030) size 67x17
+        text run at (144,5030) width 67: "\x{21AA}\x{C3A9}\x{32C1}\x{1E22}\x{D00}"
+      RenderText {#text} at (210,5030) size 111x17
+        text run at (210,5030) width 10 RTL: "\x{682}"
+        text run at (219,5030) width 102: "\x{78A3}\x{E49}\x{B61}\x{C2}\x{E55}\x{555}\x{3F5}\x{A4E9}\x{34EC}\x{D83E}\x{DE4D}"
+      RenderText {#text} at (320,5030) size 96x17
+        text run at (320,5030) width 42: "\x{5699}\x{8FFA}\x{F786}"
+        text run at (361,5030) width 9 RTL: "\x{685}"
+        text run at (369,5030) width 47: "\x{1D3F}\x{DB6B}\x{BF05}\x{4083}"
+      RenderText {#text} at (415,5030) size 35x17
+        text run at (415,5030) width 31: "\x{7F14}\x{9D87}"
+        text run at (445,5030) width 5 RTL: "\x{627}"
+      RenderText {#text} at (449,5030) size 53x17
+        text run at (449,5030) width 53: "\x{D83F}\x{DD01}\x{4ED3}\x{60F4}\x{2C4D}"
+      RenderText {#text} at (501,5030) size 52x17
+        text run at (501,5030) width 52: "\x{D404}\x{ADEF}\x{558}\x{D83F}\x{DC9A}"
+      RenderText {#text} at (552,5030) size 73x17
+        text run at (552,5030) width 12: "\x{D83E}\x{DF0D}"
+        text run at (563,5030) width 12 RTL: "\x{5EA}"
+        text run at (574,5030) width 51: "\x{1211}\x{EE55}\x{1C8A}\x{D83F}\x{DEAD}"
+      RenderText {#text} at (0,5030) size 744x42
+        text run at (624,5030) width 120: "\x{D83E}\x{DE97}\x{AFC9}\x{D83F}\x{DC32}\x{D83F}\x{DD2F}\x{20A}\x{F3F1}\x{D83E}\x{DD8F}\x{2E70}\x{3838}"
+        text run at (0,5055) width 11: "\x{D83E}\x{DF9C}"
+      RenderText {#text} at (10,5055) size 121x17
+        text run at (10,5055) width 121: "\x{D83E}\x{DC74}\x{D83D}\x{DF80}\x{FAE}\x{EA64}\x{525}\x{D83F}\x{DF92}\x{D83E}\x{DE4A}\x{4F6}\x{D83F}\x{DE5D}\x{D83E}\x{DF5C}\x{88DC}"
+      RenderText {#text} at (130,5055) size 38x17
+        text run at (130,5055) width 38: "\x{6B58}\x{CF96}\x{168B}"
+      RenderText {#text} at (167,5055) size 108x17
+        text run at (167,5055) width 50: "\x{B850}\x{D83D}\x{DF15}\x{850E}\x{C90}"
+        text run at (216,5055) width 8 RTL: "\x{6C1}"
+        text run at (223,5055) width 52: "\x{D83F}\x{DF5B}\x{6949}\x{4E7E}\x{9BA}"
+      RenderText {#text} at (274,5055) size 110x17
+        text run at (274,5055) width 12: "\x{D83E}\x{DC0E}"
+        text run at (285,5055) width 10 RTL: "\x{7D5}"
+        text run at (294,5055) width 90: "\x{3ADE}\x{D83D}\x{DFBF}\x{55B}\x{D83E}\x{DFD0}\x{F3C9}\x{AFC}\x{D83F}\x{DEA7}\x{FD5}\x{B6C}"
+      RenderText {#text} at (383,5055) size 57x17
+        text run at (383,5055) width 57: "\x{945}\x{5DA4}\x{D83E}\x{DDEE}\x{53A}"
+      RenderText {#text} at (439,5055) size 107x17
+        text run at (439,5055) width 107: "\x{81F7}\x{48AB}\x{2610}\x{6F92}\x{D83E}\x{DC73}\x{8881}\x{45F}\x{F920}"
+      RenderText {#text} at (545,5055) size 128x17
+        text run at (545,5055) width 128: "\x{E4B}\x{DD7}\x{736}\x{F5A}\x{7373}\x{532}\x{D83E}\x{DC9E}\x{D83E}\x{DE64}\x{274A}\x{CBF1}\x{6AA5}"
+      RenderText {#text} at (0,5055) size 751x45
+        text run at (672,5055) width 79: "\x{DEDD}\x{DC4D}\x{D83F}\x{DEBA}\x{D83F}\x{DE46}\x{F56F}\x{141D}\x{BA38}"
+        text run at (0,5083) width 48: "\x{E100}\x{E5A4}\x{E4D8}\x{6679}"
+      RenderText {#text} at (47,5083) size 51x17
+        text run at (47,5083) width 51: "\x{8AC3}\x{5294}\x{E15}\x{F006}"
+      RenderText {#text} at (97,5083) size 123x17
+        text run at (97,5083) width 123: "\x{F769}\x{D83E}\x{DCA1}\x{D83E}\x{DDF9}\x{25AE}\x{72E5}\x{D83E}\x{DCCF}\x{4A8C}\x{D1F0}\x{D83E}\x{DC81}\x{1C7A}"
+      RenderText {#text} at (219,5083) size 118x17
+        text run at (219,5083) width 22: "\x{D83F}\x{DEF5}\x{F8EC}"
+        text run at (240,5083) width 11 RTL: "\x{6D0}"
+        text run at (250,5083) width 16: "\x{487A}"
+        text run at (265,5083) width 7 RTL: "\x{693}"
+        text run at (271,5083) width 66: "\x{F3C}\x{9485}\x{673D}\x{D83E}\x{DCAB}\x{81DF}"
+      RenderText {#text} at (336,5083) size 130x17
+        text run at (336,5083) width 109: "\x{4A16}\x{82C6}\x{643C}\x{D83D}\x{DEB5}\x{135B}\x{DB59}\x{D83F}\x{DF91}\x{EA82}"
+        text run at (444,5083) width 11 RTL: "\x{752}"
+        text run at (454,5083) width 12: "\x{D83E}\x{DC78}"
+      RenderText {#text} at (465,5083) size 22x17
+        text run at (465,5083) width 22: "\x{94EA}\x{227}"
+      RenderText {#text} at (486,5083) size 124x17
+        text run at (486,5083) width 66: "\x{BA4}\x{1557}\x{E7B2}\x{E3DF}\x{D83D}\x{DE1A}"
+        text run at (551,5083) width 18 RTL: "\x{FCFA}"
+        text run at (568,5083) width 42: "\x{82F5}\x{A7BB}\x{C572}"
+      RenderText {#text} at (609,5083) size 105x17
+        text run at (609,5083) width 105: "\x{EDFC}\x{EFEA}\x{99D}\x{BD3D}\x{A907}\x{CBD}\x{D83F}\x{DF12}\x{918}\x{53F}\x{F1}"
+      RenderText {#text} at (713,5083) size 30x17
+        text run at (713,5083) width 23: "\x{AF5}\x{DCE}"
+        text run at (735,5083) width 8 RTL: "\x{84B}"
+      RenderText {#text} at (0,5083) size 758x45
+        text run at (742,5083) width 16: "\x{D83D}\x{DF05}"
+        text run at (0,5111) width 102: "\x{6B6B}\x{A57}\x{D83F}\x{DE71}\x{A8A}\x{FAB9}\x{2E87}\x{E26D}\x{9DC0}"
+      RenderText {#text} at (101,5111) size 127x17
+        text run at (101,5111) width 127: "\x{C1F9}\x{D83F}\x{DE33}\x{F143}\x{815B}\x{D83E}\x{DCFB}\x{AE3E}\x{4D6}\x{246}\x{D83D}\x{DF03}\x{B53D}"
+      RenderText {#text} at (227,5111) size 128x17
+        text run at (227,5111) width 128: "\x{D83E}\x{DCCB}\x{A4F7}\x{3F2}\x{4A5}\x{F49}\x{6D02}\x{2BE1}\x{1DAF}\x{D83E}\x{DE79}\x{3F1D}\x{B2D}"
+      RenderText {#text} at (354,5111) size 44x17
+        text run at (354,5111) width 44: "\x{E6FD}\x{D83E}\x{DCEA}\x{C86}\x{D83D}\x{DFB6}"
+      RenderText {#text} at (397,5111) size 94x17
+        text run at (397,5111) width 94: "\x{8550}\x{315}\x{D83F}\x{DEBE}\x{9D59}\x{A8E0}\x{D29}\x{DD57}\x{3736}"
+      RenderText {#text} at (490,5111) size 40x17
+        text run at (490,5111) width 40: "\x{978}\x{16F}\x{A1C}\x{9FCF}"
+      RenderText {#text} at (529,5111) size 121x17
+        text run at (529,5111) width 121: "\x{445}\x{C7E}\x{49B4}\x{F256}\x{9EB}\x{E2B3}\x{7D5D}\x{D83D}\x{DF3A}\x{D83F}\x{DDB5}\x{F993}"
+      RenderText {#text} at (649,5111) size 90x17
+        text run at (649,5111) width 90: "\x{203}\x{799B}\x{D83F}\x{DF95}\x{6834}\x{4A6E}\x{D83F}\x{DEEA}\x{634E}"
+      RenderText {#text} at (0,5111) size 754x45
+        text run at (738,5111) width 16: "\x{B821}"
+        text run at (0,5139) width 48: "\x{A615}\x{1D6}\x{4E7}\x{E06C}q"
+      RenderText {#text} at (47,5139) size 57x17
+        text run at (47,5139) width 57: "\x{D83E}\x{DEC0}\x{FAA}\x{D83D}\x{DED3}\x{474A}"
+      RenderText {#text} at (103,5139) size 117x17
+        text run at (103,5139) width 117: "\x{F198}\x{27BB}\x{5D7A}\x{AA7}\x{AF9C}\x{1EE4}\x{23C2}\x{35DA}\x{E551}"
+      RenderText {#text} at (219,5139) size 27x17
+        text run at (219,5139) width 27: "\x{5A8F}\x{D67}"
+      RenderText {#text} at (245,5139) size 25x17
+        text run at (245,5139) width 25: "\x{422F}\x{F34}"
+      RenderText {#text} at (269,5139) size 113x17
+        text run at (269,5139) width 113: "\x{4E0B}\x{AD32}\x{9EF}\x{92F2}\x{6147}\x{A0D8}\x{D83E}\x{DDCE}\x{D63F}"
+      RenderText {#text} at (381,5139) size 97x17
+        text run at (381,5139) width 16: "\x{D83E}\x{DF77}\x{2D42}"
+        text run at (396,5139) width 15 RTL: "\x{FC9D}"
+        text run at (410,5139) width 68: "\x{56AB}\x{38D3}\x{32E0}\x{1EF}\x{D6B}"
+      RenderText {#text} at (477,5139) size 20x17
+        text run at (477,5139) width 20: "\x{10}\x{E8A}"
+      RenderText {#text} at (496,5139) size 122x17
+        text run at (496,5139) width 23: "\x{D83E}\x{DC7F}\x{E324}"
+        text run at (518,5139) width 12 RTL: "\x{88A}"
+        text run at (529,5139) width 89: "\x{F2E}\x{9192}\x{B089}\x{E52B}\x{D83E}\x{DE89}\x{D83D}\x{DFBF}\x{8FA8}"
+      RenderText {#text} at (617,5139) size 77x17
+        text run at (617,5139) width 77: "\x{BAB5}\x{D028}\x{E7E}\x{D83F}\x{DC2F}\x{E14}\x{38B9}"
+      RenderText {#text} at (693,5139) size 50x17
+        text run at (693,5139) width 50: "\x{34E}\x{A22F}\x{24F}\x{D83E}\x{DC0E}\x{7F63}"
+      RenderText {#text} at (0,5139) size 758x42
+        text run at (742,5139) width 16: "\x{725E}"
+        text run at (0,5164) width 52: "\x{3512}\x{89F2}\x{E971}\x{F91}"
+        text run at (51,5164) width 10 RTL: "\x{5E4}"
+      RenderText {#text} at (60,5164) size 46x17
+        text run at (60,5164) width 46: "\x{F2C1}\x{570}\x{178}\x{91C7}"
+layer at (8,142) size 16x16
+  RenderVideo {VIDEO} at (0,134) size 16x16
+layer at (24,142) size 16x16
+  RenderVideo {VIDEO} at (16,134) size 16x16
+layer at (151,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (143,0) size 300x150
+layer at (8,167) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,159) size 300x150
+layer at (8,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,317) size 300x150
+layer at (308,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,317) size 300x150
+layer at (8,481) size 284x284
+  RenderVideo {VIDEO} at (0,473) size 284x284
+layer at (546,749) size 16x16
+  RenderVideo {VIDEO} at (537,741) size 17x16
+layer at (65,913) size 16x16
+  RenderVideo {VIDEO} at (56,905) size 17x16
+layer at (116,779) size 349x150
+  RenderHTMLCanvas {CANVAS} at (108,771) size 350x150
+layer at (93,937) size 300x150
+  RenderHTMLCanvas {CANVAS} at (85,929) size 301x150
+layer at (8,1120) size 885x385
+  RenderHTMLCanvas {CANVAS} at (0,1112) size 885x385
+layer at (8,1988) size 213x213
+  RenderVideo {VIDEO} at (0,1980) size 213x213
+layer at (196,2420) size 16x16
+  RenderVideo {VIDEO} at (188,2412) size 17x16
+layer at (8,2448) size 290x127
+  RenderHTMLCanvas {CANVAS} at (0,2440) size 290x127
+layer at (8,2856) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,2848) size 300x150
+layer at (334,2739) size 300x267
+  RenderHTMLCanvas {CANVAS} at (326,2731) size 300x267
+layer at (8,3276) size 974x150
+  RenderHTMLCanvas {CANVAS} at (0,3268) size 974x150
+layer at (8,3447) size 905x349
+  RenderHTMLCanvas {CANVAS} at (0,3439) size 905x349
+layer at (200,3832) size 335x23
+  RenderHTMLCanvas {CANVAS} at (192,3824) size 336x23
+layer at (748,3839) size 16x16
+  RenderVideo {VIDEO} at (740,3831) size 17x16
+layer at (465,4030) size 291x291
+  RenderVideo {VIDEO} at (456,4022) size 292x291
+layer at (408,4328) size 38x213
+  RenderVideo {VIDEO} at (400,4320) size 39x213

--- a/LayoutTests/fast/webgpu/fuzz-272911.html
+++ b/LayoutTests/fast/webgpu/fuzz-272911.html
@@ -1,0 +1,30176 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUCommandEncoder} commandEncoder
+ */
+function pseudoSubmit(device, commandEncoder) {
+  device.pushErrorScope('validation');
+  commandEncoder.clearBuffer(device.createBuffer({size: 0, usage: 0}), 0, 0);
+  device.popErrorScope().then(() => {});
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let promise0 = adapter0.requestDevice(
+{
+label: '\u{1fca8}\u{1f985}',
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxBindGroups: 5,
+maxColorAttachmentBytesPerSample: 52,
+maxVertexAttributes: 30,
+maxVertexBufferArrayStride: 28335,
+maxStorageTexturesPerShaderStage: 34,
+maxStorageBuffersPerShaderStage: 18,
+maxDynamicStorageBuffersPerPipelineLayout: 53402,
+maxBindingsPerBindGroup: 6666,
+maxTextureDimension1D: 13594,
+maxTextureDimension2D: 15023,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 186788046,
+maxInterStageShaderVariables: 17,
+maxInterStageShaderComponents: 82,
+},
+}
+);
+let adapter1 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let device0 = await adapter1.requestDevice(
+{
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 6,
+maxColorAttachmentBytesPerSample: 52,
+maxVertexAttributes: 29,
+maxVertexBufferArrayStride: 62328,
+maxStorageTexturesPerShaderStage: 29,
+maxStorageBuffersPerShaderStage: 42,
+maxDynamicStorageBuffersPerPipelineLayout: 30569,
+maxBindingsPerBindGroup: 9137,
+maxTextureDimension1D: 15045,
+maxTextureDimension2D: 16244,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 181983530,
+maxInterStageShaderVariables: 118,
+maxInterStageShaderComponents: 72,
+},
+}
+);
+let offscreenCanvas0 = new OffscreenCanvas(784, 713);
+let videoFrame0 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+let bindGroupLayout0 = device0.createBindGroupLayout(
+{
+label: '\ue90f\u6834\u0764\u7c84\u0d08\ue964\u8163\ue770\u0f25\u{1fd89}',
+entries: [
+{
+binding: 2280,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+},
+{
+binding: 591,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '3d' },
+}
+],
+}
+);
+let buffer0 = device0.createBuffer(
+{
+label: '\u{1ffed}\u7aaa\u04f4\u{1f995}\uc5ca\udb2f\u91b6\u1b69',
+size: 49323,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let querySet0 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 3043,
+}
+);
+gc();
+let commandEncoder0 = device0.createCommandEncoder(
+{
+}
+);
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+document.body.append('\u0d18\u00ee\u855d\u{1fe12}\u9b7e\u{1fc88}\u0fc1\u0fe8');
+let img0 = await imageWithData(118, 218, '#d29ea16c', '#3baada17');
+let imageData0 = new ImageData(208, 140);
+let querySet1 = device0.createQuerySet(
+{
+label: '\u{1f87e}\u03ef\ufa83\u36fe',
+type: 'occlusion',
+count: 2842,
+}
+);
+let texture0 = device0.createTexture(
+{
+label: '\u{1fc4d}\u{1f780}\u32c3\u{1fb9f}\u951f',
+size: [7934],
+dimension: '1d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+}
+);
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img0);
+let imageData1 = new ImageData(80, 112);
+let querySet2 = device0.createQuerySet(
+{
+label: '\uef97\u051a\u{1f927}\u4301\u0bea\ufd53\u9608\u9adc\u53bf',
+type: 'occlusion',
+count: 3393,
+}
+);
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'r8snorm',
+'eac-r11snorm',
+'rg16float',
+'r32uint'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 997, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(32),
+/* required buffer size: 474 */{
+offset: 474,
+bytesPerRow: 15707,
+rowsPerImage: 78,
+},
+{width: 3905, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+gc();
+document.body.append('\uf899\u6c98\u0aef');
+let canvas0 = document.createElement('canvas');
+let pipelineLayout0 = device0.createPipelineLayout(
+{
+label: '\uca9e\u{1ff28}\u05de\u90c0\u27db',
+bindGroupLayouts: [
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0
+],
+}
+);
+let buffer1 = device0.createBuffer(
+{
+label: '\u0134\uc1a7\uca0f\u0c55\ueee4\ue1dd\u0f42\u{1ffa2}\u{1fbec}\u39f6\ub700',
+size: 39589,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let commandEncoder1 = device0.createCommandEncoder();
+let sampler0 = device0.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 97.912,
+maxAnisotropy: 1,
+}
+);
+try {
+commandEncoder1.resolveQuerySet(
+querySet2,
+3004,
+153,
+buffer1,
+22784
+);
+} catch {}
+document.body.prepend(img0);
+let img1 = await imageWithData(262, 44, '#cf8663fe', '#aa6d6fd3');
+let textureView0 = texture0.createView(
+{
+label: '\u7a34\u{1fd6d}\u0b46\u{1f9ce}\u{1fd3e}\u{1fe68}\ub80e\u0538\u5d3a',
+}
+);
+let computePassEncoder0 = commandEncoder1.beginComputePass(
+{
+label: '\u9652\u{1fed1}\u{1fe74}\u011d\u0061\ue228\u0a07\u6ef0\u{1f630}\uee27'
+}
+);
+let renderBundleEncoder0 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'bgra8unorm',
+'rg32sint',
+'r32sint',
+'r8uint',
+'r8uint',
+'rg32float',
+'rg11b10ufloat'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 14,
+stencilReadOnly: true,
+}
+);
+let renderBundle0 = renderBundleEncoder0.finish(
+{
+label: '\u25aa\u3f2e'
+}
+);
+let sampler1 = device0.createSampler(
+{
+label: '\u{1f970}\u046b\u{1f952}\ude29\u{1fa62}\ue481',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 3.817,
+lodMaxClamp: 45.784,
+}
+);
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(672, 583);
+try {
+canvas0.getContext('webgl');
+} catch {}
+let shaderModule0 = device0.createShaderModule(
+{
+label: '\u98b8\uef3f\u88e1\ub158',
+code: `@group(0) @binding(591)
+var<storage, read_write> function0: array<u32>;
+
+@compute @workgroup_size(5, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(0) f0: f32,
+@location(2) f1: vec4<i32>,
+@builtin(frag_depth) f2: f32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S0 {
+@location(7) f0: i32,
+@location(20) f1: i32,
+@location(22) f2: i32
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec4<f16>, @location(4) a1: vec3<u32>, @location(14) a2: vec4<f16>, @builtin(instance_index) a3: u32, @location(15) a4: u32, @location(8) a5: u32, @builtin(vertex_index) a6: u32, @location(6) a7: vec2<i32>, @location(23) a8: vec4<f32>, @location(16) a9: vec2<u32>, @location(19) a10: vec3<u32>, @location(27) a11: vec2<u32>, @location(26) a12: vec4<u32>, @location(13) a13: i32, @location(28) a14: vec3<u32>, @location(10) a15: vec3<f32>, @location(21) a16: vec2<f32>, @location(17) a17: vec3<f32>, @location(24) a18: vec4<f32>, @location(25) a19: vec2<u32>, @location(12) a20: f16, @location(0) a21: f32, @location(3) a22: vec3<i32>, @location(5) a23: f32, @location(9) a24: vec3<f16>, @location(18) a25: vec2<f16>, @location(11) a26: f16, @location(1) a27: f16, a28: S0) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+}
+);
+let bindGroupLayout1 = device0.createBindGroupLayout(
+{
+label: '\u082c\u{1f60a}\u2ec2\u{1fd6b}\u1976\u{1f739}\u{1fd44}',
+entries: [
+{
+binding: 8536,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 1235,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 3950,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '3d' },
+}
+],
+}
+);
+let textureView1 = texture0.createView(
+{
+label: '\u6c43\u241a\u{1f93e}\u1d0b\u0daf\ub045',
+}
+);
+try {
+await promise1;
+} catch {}
+document.body.prepend('\u{1f852}\ua9e4\u094c\u922e\u0410\u00e4\u92e5\u5768\ua21f\uc781\u5865');
+let video0 = await videoWithData();
+let commandEncoder2 = device0.createCommandEncoder(
+{
+label: '\u20b3\u{1fb81}\ued7e\u2789\u0494',
+}
+);
+let textureView2 = texture0.createView(
+{
+label: '\u{1f661}\u06c9\u72f9\u10df\u0967\u0987\u0d34',
+arrayLayerCount: 1,
+}
+);
+let canvas1 = document.createElement('canvas');
+let bindGroupLayout2 = device0.createBindGroupLayout(
+{
+label: '\u{1f62d}\u43bb\ua579\u5b7e\u57c4\u900b\u0d9f\u3252',
+entries: [
+
+],
+}
+);
+let querySet3 = device0.createQuerySet(
+{
+label: '\u{1f87f}\ub3e0',
+type: 'occlusion',
+count: 3929,
+}
+);
+let renderBundleEncoder1 = device0.createRenderBundleEncoder(
+{
+label: '\u061a\u023f\u2d75\u8dee\ufa33\uf106\ua72b\u0025\u97f2\u0464\u{1fce1}',
+colorFormats: [
+'rg8uint',
+'r8uint',
+undefined,
+'rgba8unorm',
+'rgba8uint',
+'bgra8unorm-srgb'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 936,
+}
+);
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder0.copyBufferToBuffer(
+buffer0,
+28884,
+buffer1,
+8140,
+7840
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder0.resolveQuerySet(
+querySet1,
+198,
+1040,
+buffer1,
+20480
+);
+} catch {}
+let buffer2 = device0.createBuffer(
+{
+label: '\u2fc9\u{1fa5c}\ub0d0\u4939',
+size: 6328,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+document.body.prepend('\u{1fa2f}\u2e75\u4f61\u{1fe33}\u58dd\u6c92\u0df3\u0207\u0aa2');
+let textureView3 = texture0.createView(
+{
+label: '\u933e\u{1faf9}\u0146\u{1f9d2}\u0dc0\u{1f626}\u48a4\u570d\u71bd\ud8a4',
+}
+);
+let renderBundleEncoder2 = device0.createRenderBundleEncoder(
+{
+label: '\u4a68\u{1ff66}\u01d6\u1bcb\uf032\u057a\u79b4\uf60b',
+colorFormats: [
+'rgba16float',
+'rg32float',
+'rgba32uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 177,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let externalTexture0 = device0.importExternalTexture(
+{
+label: '\u9578\ua7c9\u048e\ue657\uad4f\u5737\u{1fa23}\u5638\u4f90',
+source: video0,
+colorSpace: 'display-p3',
+}
+);
+try {
+renderBundleEncoder2.setVertexBuffer(
+0,
+buffer1,
+26156,
+9125
+);
+} catch {}
+try {
+commandEncoder2.copyBufferToBuffer(
+buffer2,
+4756,
+buffer1,
+8872,
+1516
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline0 = await device0.createRenderPipelineAsync(
+{
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 34500,
+attributes: [
+{
+format: 'uint8x2',
+offset: 25646,
+shaderLocation: 26,
+},
+{
+format: 'sint32x3',
+offset: 1172,
+shaderLocation: 20,
+},
+{
+format: 'float16x4',
+offset: 16384,
+shaderLocation: 17,
+},
+{
+format: 'unorm16x4',
+offset: 1916,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 56120,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 23036,
+shaderLocation: 25,
+},
+{
+format: 'snorm16x4',
+offset: 2764,
+shaderLocation: 9,
+},
+{
+format: 'float16x2',
+offset: 7308,
+shaderLocation: 2,
+},
+{
+format: 'unorm8x2',
+offset: 24376,
+shaderLocation: 10,
+},
+{
+format: 'float32x4',
+offset: 52620,
+shaderLocation: 21,
+},
+{
+format: 'sint16x2',
+offset: 51260,
+shaderLocation: 22,
+},
+{
+format: 'sint8x4',
+offset: 54824,
+shaderLocation: 7,
+},
+{
+format: 'uint8x4',
+offset: 47000,
+shaderLocation: 8,
+},
+{
+format: 'sint16x2',
+offset: 45116,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x2',
+offset: 32016,
+shaderLocation: 12,
+},
+{
+format: 'uint32x4',
+offset: 17216,
+shaderLocation: 16,
+},
+{
+format: 'uint32x2',
+offset: 22128,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 34268,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 18484,
+shaderLocation: 18,
+},
+{
+format: 'sint8x4',
+offset: 33972,
+shaderLocation: 13,
+},
+{
+format: 'uint32x4',
+offset: 9136,
+shaderLocation: 27,
+}
+],
+},
+{
+arrayStride: 15968,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 13800,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 14348,
+attributes: [
+{
+format: 'uint32x4',
+offset: 10228,
+shaderLocation: 28,
+},
+{
+format: 'float32x2',
+offset: 1968,
+shaderLocation: 24,
+},
+{
+format: 'float32',
+offset: 10196,
+shaderLocation: 5,
+},
+{
+format: 'uint16x2',
+offset: 13452,
+shaderLocation: 19,
+},
+{
+format: 'float16x4',
+offset: 12624,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'sint8x2',
+offset: 8416,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 59004,
+shaderLocation: 0,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 51684,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 56076,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x4',
+offset: 30492,
+shaderLocation: 15,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16float',
+},
+undefined,
+{
+format: 'rgba8sint',
+writeMask: 0,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'zero',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+failOp: 'increment-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 1370,
+depthBias: 54,
+depthBiasSlopeScale: 0,
+},
+}
+);
+let videoFrame1 = new VideoFrame(video0, {timestamp: 0});
+let commandEncoder3 = device0.createCommandEncoder(
+{
+label: '\u0d8b\ueae6\u03fb\u81e6\u4b7f\u{1fb9f}\ue343',
+}
+);
+let texture1 = device0.createTexture(
+{
+size: [8733],
+sampleCount: 1,
+dimension: '1d',
+format: 'rgba32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32sint',
+'rgba32sint',
+'rgba32sint'
+],
+}
+);
+let textureView4 = texture0.createView(
+{
+label: '\u0e0b\u0c78\u0537\u0e4b\u0735\u{1fb27}\u{1fcf3}',
+}
+);
+let renderBundle1 = renderBundleEncoder1.finish();
+let pipeline1 = device0.createRenderPipeline(
+{
+label: '\uea57\u4368\u{1fa81}',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 57260,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x2',
+offset: 13540,
+shaderLocation: 19,
+},
+{
+format: 'uint16x4',
+offset: 52908,
+shaderLocation: 26,
+},
+{
+format: 'uint8x4',
+offset: 36980,
+shaderLocation: 25,
+},
+{
+format: 'sint16x2',
+offset: 51632,
+shaderLocation: 7,
+},
+{
+format: 'float16x4',
+offset: 744,
+shaderLocation: 10,
+},
+{
+format: 'float32x3',
+offset: 24660,
+shaderLocation: 0,
+},
+{
+format: 'float32x2',
+offset: 9496,
+shaderLocation: 9,
+},
+{
+format: 'uint32x4',
+offset: 20892,
+shaderLocation: 16,
+},
+{
+format: 'float32x2',
+offset: 55148,
+shaderLocation: 23,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 44732,
+shaderLocation: 1,
+},
+{
+format: 'sint32',
+offset: 3868,
+shaderLocation: 13,
+},
+{
+format: 'snorm16x2',
+offset: 26204,
+shaderLocation: 11,
+},
+{
+format: 'uint32',
+offset: 48008,
+shaderLocation: 27,
+},
+{
+format: 'snorm16x2',
+offset: 16232,
+shaderLocation: 18,
+},
+{
+format: 'float32x2',
+offset: 6612,
+shaderLocation: 17,
+},
+{
+format: 'uint32x4',
+offset: 25164,
+shaderLocation: 8,
+},
+{
+format: 'uint16x4',
+offset: 56596,
+shaderLocation: 15,
+},
+{
+format: 'unorm8x2',
+offset: 9290,
+shaderLocation: 5,
+},
+{
+format: 'sint32',
+offset: 47308,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 8168,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32',
+offset: 5392,
+shaderLocation: 6,
+},
+{
+format: 'uint16x2',
+offset: 1872,
+shaderLocation: 4,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 7960,
+shaderLocation: 24,
+},
+{
+format: 'float16x4',
+offset: 5044,
+shaderLocation: 21,
+},
+{
+format: 'sint32x2',
+offset: 7276,
+shaderLocation: 20,
+},
+{
+format: 'sint32x3',
+offset: 2412,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 61336,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 31008,
+shaderLocation: 12,
+},
+{
+format: 'snorm16x4',
+offset: 2372,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 42132,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 35664,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32',
+offset: 1308,
+shaderLocation: 28,
+}
+],
+}
+]
+},
+primitive: {
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0xeaf5ff3e,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 445,
+stencilWriteMask: 2077,
+depthBias: 29,
+depthBiasSlopeScale: 91,
+depthBiasClamp: 7,
+},
+}
+);
+canvas0.height = 413;
+let commandEncoder4 = device0.createCommandEncoder(
+{
+label: '\u82f0\u0e97\u57cc\u276b\ude51\u024c',
+}
+);
+let textureView5 = texture0.createView(
+{
+label: '\u03be\uf69e\u1dad\u9431\u{1fba3}\u7ace\u043e\u104a\u89ba\u384c\u274d',
+}
+);
+let sampler2 = device0.createSampler(
+{
+label: '\uc3d8\u0302\u015d\u049e\u8e4d\u0573\u59ac\uea47',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 59.382,
+lodMaxClamp: 95.611,
+compare: 'equal',
+}
+);
+try {
+commandEncoder4.copyBufferToBuffer(
+buffer0,
+16436,
+buffer1,
+35128,
+1508
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture2 = device0.createTexture(
+{
+label: '\u0222\u7f92\u5962\u250d\u0eb7\u591a\uf42b\u0c48\u1dcb',
+size: [2027, 1, 133],
+mipLevelCount: 9,
+dimension: '3d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+
+],
+}
+);
+let textureView6 = texture0.createView(
+{
+label: '\u04fe\u{1fc53}\u15f7',
+}
+);
+let sampler3 = device0.createSampler(
+{
+label: '\u096d\u0d91\u139a\u0265\u2cac\u1e8c\ufae5\uda9b',
+addressModeU: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 33.026,
+lodMaxClamp: 48.539,
+maxAnisotropy: 3,
+}
+);
+try {
+renderBundleEncoder2.setIndexBuffer(
+buffer1,
+'uint32'
+);
+} catch {}
+try {
+commandEncoder2.clearBuffer(
+buffer1,
+4488,
+1308
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(
+querySet0,
+194,
+2608,
+buffer1,
+6912
+);
+} catch {}
+let pipeline2 = device0.createRenderPipeline(
+{
+label: '\u09ed\u{1fbf3}\u0580\udd64\u22cd\u7ba0\u0495\ucc64\ubaca\u0d83\u3e5c',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 51248,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x3',
+offset: 47988,
+shaderLocation: 7,
+},
+{
+format: 'sint32x3',
+offset: 40392,
+shaderLocation: 6,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 39260,
+shaderLocation: 9,
+},
+{
+format: 'float32x2',
+offset: 2460,
+shaderLocation: 10,
+},
+{
+format: 'sint32x3',
+offset: 47444,
+shaderLocation: 3,
+},
+{
+format: 'uint8x4',
+offset: 45920,
+shaderLocation: 25,
+},
+{
+format: 'snorm16x2',
+offset: 29392,
+shaderLocation: 21,
+},
+{
+format: 'float32',
+offset: 26456,
+shaderLocation: 2,
+},
+{
+format: 'uint16x4',
+offset: 23540,
+shaderLocation: 27,
+},
+{
+format: 'float32x4',
+offset: 27296,
+shaderLocation: 14,
+},
+{
+format: 'snorm8x4',
+offset: 29456,
+shaderLocation: 17,
+},
+{
+format: 'float32x2',
+offset: 32712,
+shaderLocation: 1,
+},
+{
+format: 'snorm8x4',
+offset: 31220,
+shaderLocation: 18,
+},
+{
+format: 'sint32',
+offset: 8176,
+shaderLocation: 22,
+},
+{
+format: 'float32',
+offset: 6160,
+shaderLocation: 24,
+},
+{
+format: 'sint32x4',
+offset: 20948,
+shaderLocation: 20,
+},
+{
+format: 'uint8x2',
+offset: 25596,
+shaderLocation: 16,
+},
+{
+format: 'float16x2',
+offset: 45544,
+shaderLocation: 12,
+},
+{
+format: 'uint8x4',
+offset: 27748,
+shaderLocation: 19,
+},
+{
+format: 'snorm8x4',
+offset: 32736,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x4',
+offset: 19508,
+shaderLocation: 23,
+},
+{
+format: 'snorm8x2',
+offset: 41228,
+shaderLocation: 5,
+},
+{
+format: 'uint8x4',
+offset: 19044,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 4456,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 2716,
+shaderLocation: 28,
+},
+{
+format: 'uint32x2',
+offset: 416,
+shaderLocation: 4,
+},
+{
+format: 'uint32x3',
+offset: 1584,
+shaderLocation: 26,
+},
+{
+format: 'float16x4',
+offset: 1772,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 51604,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 32972,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 19776,
+shaderLocation: 15,
+},
+{
+format: 'sint32x2',
+offset: 12604,
+shaderLocation: 13,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'dst-alpha',
+dstFactor: 'zero'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+undefined,
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'zero',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'zero',
+passOp: 'increment-clamp',
+},
+stencilWriteMask: 2358,
+depthBiasSlopeScale: 3,
+depthBiasClamp: 98,
+},
+}
+);
+let offscreenCanvas2 = new OffscreenCanvas(62, 92);
+let querySet4 = device0.createQuerySet(
+{
+label: '\u9414\u{1fc87}\ubf08\ua883\u7f8a',
+type: 'occlusion',
+count: 3085,
+}
+);
+let computePassEncoder1 = commandEncoder0.beginComputePass(
+{
+
+}
+);
+try {
+renderBundleEncoder2.setVertexBuffer(
+5,
+buffer1,
+29752
+);
+} catch {}
+let pipeline3 = device0.createRenderPipeline(
+{
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 28960,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 26288,
+shaderLocation: 6,
+},
+{
+format: 'float32x4',
+offset: 13868,
+shaderLocation: 21,
+}
+],
+},
+{
+arrayStride: 55596,
+attributes: [
+{
+format: 'snorm16x2',
+offset: 39228,
+shaderLocation: 24,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 40564,
+shaderLocation: 0,
+},
+{
+format: 'unorm16x4',
+offset: 7116,
+shaderLocation: 5,
+},
+{
+format: 'snorm16x4',
+offset: 29956,
+shaderLocation: 12,
+},
+{
+format: 'unorm16x4',
+offset: 53464,
+shaderLocation: 10,
+},
+{
+format: 'uint32x4',
+offset: 41380,
+shaderLocation: 8,
+},
+{
+format: 'uint8x4',
+offset: 49032,
+shaderLocation: 25,
+},
+{
+format: 'sint8x2',
+offset: 45596,
+shaderLocation: 22,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 39216,
+shaderLocation: 23,
+},
+{
+format: 'uint16x4',
+offset: 13180,
+shaderLocation: 28,
+},
+{
+format: 'snorm8x2',
+offset: 42774,
+shaderLocation: 9,
+},
+{
+format: 'uint8x2',
+offset: 30516,
+shaderLocation: 4,
+},
+{
+format: 'unorm16x4',
+offset: 18672,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 41520,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x4',
+offset: 11304,
+shaderLocation: 7,
+},
+{
+format: 'uint16x4',
+offset: 33700,
+shaderLocation: 26,
+},
+{
+format: 'float32',
+offset: 40536,
+shaderLocation: 1,
+},
+{
+format: 'sint32',
+offset: 33448,
+shaderLocation: 20,
+},
+{
+format: 'uint32',
+offset: 41468,
+shaderLocation: 19,
+},
+{
+format: 'uint32',
+offset: 37604,
+shaderLocation: 16,
+},
+{
+format: 'uint32x3',
+offset: 6080,
+shaderLocation: 27,
+},
+{
+format: 'uint32x2',
+offset: 21080,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 37164,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 2404,
+shaderLocation: 17,
+},
+{
+format: 'unorm8x4',
+offset: 17132,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 25844,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x2',
+offset: 9768,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 57956,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 21140,
+shaderLocation: 3,
+},
+{
+format: 'float32x4',
+offset: 8312,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 25744,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 4352,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x4',
+offset: 3960,
+shaderLocation: 13,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'one',
+dstFactor: 'one-minus-src'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+},
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'zero',
+depthFailOp: 'keep',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'invert',
+depthFailOp: 'decrement-wrap',
+},
+stencilReadMask: 3835,
+stencilWriteMask: 260,
+depthBias: 2,
+depthBiasSlopeScale: 99,
+depthBiasClamp: 46,
+},
+}
+);
+let video1 = await videoWithData();
+let shaderModule1 = device0.createShaderModule(
+{
+label: '\u0c19\u0ada\u06e4',
+code: `@group(3) @binding(2280)
+var<storage, read_write> local0: array<u32>;
+
+@compute @workgroup_size(3, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S1 {
+@location(9) f0: u32,
+@location(14) f1: vec4<f32>,
+@location(29) f2: vec4<f32>,
+@location(53) f3: vec2<u32>,
+@location(15) f4: vec3<f32>,
+@location(10) f5: vec2<f32>,
+@location(117) f6: vec2<f16>,
+@location(82) f7: vec2<u32>
+}
+struct FragmentOutput0 {
+@location(0) f0: vec2<u32>
+}
+
+@fragment
+fn fragment0(@location(112) a0: f32, a1: S1, @builtin(sample_mask) a2: u32, @builtin(position) a3: vec4<f32>, @builtin(sample_index) a4: u32, @builtin(front_facing) a5: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(117) f0: vec2<f16>,
+@builtin(position) f1: vec4<f32>,
+@location(15) f2: vec3<f32>,
+@location(14) f3: vec4<f32>,
+@location(112) f4: f32,
+@location(29) f5: vec4<f32>,
+@location(9) f6: u32,
+@location(10) f7: vec2<f32>,
+@location(53) f8: vec2<u32>,
+@location(82) f9: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(17) a0: vec3<u32>, @location(22) a1: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let sampler4 = device0.createSampler(
+{
+label: '\u5acf\u{1fa0d}\u08df\u{1f9a1}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 42.881,
+lodMaxClamp: 61.055,
+maxAnisotropy: 19,
+}
+);
+try {
+renderBundleEncoder2.setVertexBuffer(
+1,
+buffer1
+);
+} catch {}
+try {
+commandEncoder4.resolveQuerySet(
+querySet2,
+1728,
+1052,
+buffer1,
+5632
+);
+} catch {}
+let pipeline4 = await device0.createRenderPipelineAsync(
+{
+label: '\u{1fbef}\u{1ffcf}',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 48284,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 41964,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 22768,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 12868,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 50272,
+attributes: [
+
+],
+},
+{
+arrayStride: 59228,
+attributes: [
+
+],
+},
+{
+arrayStride: 12740,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 11384,
+shaderLocation: 22,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'zero',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilWriteMask: 2043,
+depthBias: 31,
+depthBiasSlopeScale: 60,
+},
+}
+);
+let gpuCanvasContext1 = offscreenCanvas2.getContext('webgpu');
+let computePassEncoder2 = commandEncoder4.beginComputePass(
+{
+label: '\ue532\u0d33\uff3d\u08e6\u01b2\ua93e'
+}
+);
+let renderBundle2 = renderBundleEncoder0.finish();
+try {
+commandEncoder3.copyBufferToBuffer(
+buffer0,
+3172,
+buffer1,
+1352,
+35768
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder3.copyBufferToTexture(
+{
+/* bytesInLastRow: 101232 widthInBlocks: 6327 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 9776 */
+offset: 9776,
+buffer: buffer0,
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 882, y: 1, z: 0 },
+  aspect: 'all',
+},
+{width: 6327, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder2.clearBuffer(
+buffer1,
+4432,
+23000
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(
+querySet2,
+1560,
+405,
+buffer1,
+26368
+);
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+let video2 = await videoWithData();
+let shaderModule2 = device0.createShaderModule(
+{
+label: '\u09c5\u06df\u{1f844}\ud7cf\u9054\u7acb\u13bd\u1803\u577c',
+code: `
+
+@compute @workgroup_size(6, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(3) f0: vec2<u32>,
+@location(0) f1: f32,
+@location(6) f2: vec3<u32>,
+@location(1) f3: vec4<f32>,
+@location(7) f4: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(sample_mask) a1: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S2 {
+@location(3) f0: vec4<i32>,
+@location(0) f1: vec3<f16>,
+@location(15) f2: vec4<i32>,
+@location(26) f3: vec4<f16>,
+@location(19) f4: vec4<u32>,
+@location(10) f5: vec4<f32>,
+@location(28) f6: f16,
+@location(11) f7: vec3<f16>,
+@location(17) f8: vec3<f32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(9) a1: f32, @location(22) a2: vec3<i32>, @location(20) a3: vec3<f16>, @builtin(instance_index) a4: u32, @location(5) a5: vec4<u32>, @location(12) a6: vec3<f16>, @location(25) a7: f16, @location(23) a8: vec3<f32>, @location(4) a9: vec4<u32>, @location(8) a10: vec3<f16>, @location(27) a11: f32, @location(14) a12: f16, @location(1) a13: vec2<u32>, @location(7) a14: vec3<f32>, @location(2) a15: vec4<f32>, @location(21) a16: vec3<f32>, @location(18) a17: u32, @location(6) a18: vec3<u32>, @location(16) a19: vec2<f32>, a20: S2) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture3 = device0.createTexture(
+{
+label: '\u79ac\u{1fc6b}\u{1f69c}\u{1f8dd}\u{1f64d}\u11ae\u{1f8a8}\u{1f64b}\uf98b\u5b68',
+size: [11604, 164, 1],
+mipLevelCount: 6,
+format: 'eac-r11snorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'eac-r11snorm',
+'eac-r11snorm'
+],
+}
+);
+let textureView7 = texture2.createView(
+{
+label: '\uc33a\uc1e0\u0dee\u8b5d\ub5d0',
+baseMipLevel: 6,
+mipLevelCount: 2,
+}
+);
+let renderBundle3 = renderBundleEncoder1.finish(
+{
+label: '\u{1fbf9}\u841e'
+}
+);
+try {
+commandEncoder3.copyBufferToTexture(
+{
+/* bytesInLastRow: 2888 widthInBlocks: 722 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 48396 */
+offset: 48396,
+buffer: buffer0,
+},
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 1520, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 722, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder3.copyTextureToBuffer(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 3134, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 8584 widthInBlocks: 2146 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 30204 */
+offset: 21620,
+buffer: buffer1,
+},
+{width: 2146, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder3.clearBuffer(
+buffer1,
+10748,
+21824
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+adapter1.label = '\u{1fc29}\ud4b1\u4471\u{1ff0a}\u{1fdf6}\u4fc5';
+} catch {}
+try {
+window.someLabel = externalTexture0.label;
+} catch {}
+let renderBundleEncoder3 = device0.createRenderBundleEncoder(
+{
+label: '\uc5d1\u0d62\u0c45\u{1fd4d}\u7e62\u51df\u{1fdb5}\uc4b8\u8dd9',
+colorFormats: [
+'rgba32float',
+'rgba16uint',
+'rg16uint',
+'rgba16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 111,
+}
+);
+try {
+commandEncoder3.copyBufferToTexture(
+{
+/* bytesInLastRow: 21636 widthInBlocks: 5409 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 15668 */
+offset: 15668,
+buffer: buffer0,
+},
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 2512, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 5409, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder2.clearBuffer(
+buffer1,
+18904,
+6008
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout(
+{
+entries: [
+
+],
+}
+);
+let commandEncoder5 = device0.createCommandEncoder(
+{
+label: '\u01fd\u{1f7db}\uc47e\u{1f8cb}\u{1f797}\u01bc\u{1fb62}',
+}
+);
+let computePassEncoder3 = commandEncoder2.beginComputePass(
+{
+label: '\u0819\uf642\u5cb9\u14cc\u8997'
+}
+);
+let sampler5 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 42.339,
+lodMaxClamp: 71.515,
+}
+);
+try {
+renderBundleEncoder3.setVertexBuffer(
+16,
+undefined,
+330870801,
+2949279577
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float',
+'rgba16float',
+'depth24plus'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(16),
+/* required buffer size: 987 */{
+offset: 987,
+bytesPerRow: 262,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let canvas2 = document.createElement('canvas');
+let texture4 = device0.createTexture(
+{
+label: '\u9e57\u{1ff4b}',
+size: {width: 180, height: 120, depthOrArrayLayers: 136},
+mipLevelCount: 5,
+format: 'eac-r11snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundle4 = renderBundleEncoder2.finish(
+{
+label: '\u0c3b\u2d51\u{1fee1}\u08cd\u51af'
+}
+);
+try {
+commandEncoder5.copyBufferToBuffer(
+buffer0,
+39256,
+buffer1,
+28840,
+8248
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder5.clearBuffer(
+buffer1,
+5232,
+10952
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder3.resolveQuerySet(
+querySet4,
+1759,
+7,
+buffer1,
+28672
+);
+} catch {}
+let pipeline5 = await device0.createComputePipelineAsync(
+{
+label: '\ue98e\u0d5a\ua476\u057f\u08c8\u{1fa63}\u0902\u02d1\u{1fd8b}\uf1e5',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let promise3 = navigator.gpu.requestAdapter(
+{
+}
+);
+let imageBitmap0 = await createImageBitmap(offscreenCanvas2);
+let commandEncoder6 = device0.createCommandEncoder();
+let sampler6 = device0.createSampler(
+{
+label: '\uc2fe\u0f48\u04c3\u4d62\u020e\u621a',
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 16.767,
+lodMaxClamp: 53.294,
+}
+);
+document.body.prepend('\ufc67\uf0c4\u{1f98f}\u687e\ue114\u74eb\ub33e\u4e78\ufa29\u01bd');
+let bindGroup0 = device0.createBindGroup({
+label: '\u248d\u8c12\u0585\u079f\u{1fb3e}\u{1f924}',
+layout: bindGroupLayout2,
+entries: [
+
+],
+});
+let buffer3 = device0.createBuffer(
+{
+label: '\u6f84\u05de\u2029\u{1fec3}\uedb7\u0326',
+size: 59809,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let commandEncoder7 = device0.createCommandEncoder(
+{
+label: '\u7c8a\u{1fa45}\u435a\u186f\u4e8d\u4c59\u61ee\ub6d5\u{1f828}\u900a\u{1fcda}',
+}
+);
+try {
+commandEncoder6.copyBufferToBuffer(
+buffer0,
+3812,
+buffer3,
+26812,
+30280
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+let commandEncoder8 = device0.createCommandEncoder(
+{
+label: '\udece\ud8fd\u{1fa5b}',
+}
+);
+let querySet5 = device0.createQuerySet(
+{
+label: '\udd67\u9188\ufac0\u{1fc7f}\u07e7\ufd09\u0c38\u4388\ucc27\u06ff',
+type: 'occlusion',
+count: 1106,
+}
+);
+let renderBundleEncoder4 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgb10a2uint',
+'rgba16sint',
+'rg8sint',
+'rg8unorm',
+'bgra8unorm-srgb',
+'r16sint',
+'rgba32uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 279,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder1.setPipeline(
+pipeline5
+);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(
+7,
+buffer1,
+6588,
+27266
+);
+} catch {}
+try {
+commandEncoder5.copyBufferToTexture(
+{
+/* bytesInLastRow: 10 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 32166 */
+offset: 32166,
+buffer: buffer3,
+},
+{
+  texture: texture2,
+  mipLevel: 7,
+  origin: { x: 5, y: 1, z: 0 },
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder8.resolveQuerySet(
+querySet3,
+590,
+2354,
+buffer1,
+5120
+);
+} catch {}
+let pipeline6 = await device0.createComputePipelineAsync(
+{
+label: '\u1d8d\u0d42\u{1f992}\ubda2\u0b71\u49ed\u08c8',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline7 = device0.createRenderPipeline(
+{
+label: '\uff85\u357e',
+layout: 'auto',
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 48728,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 14332,
+shaderLocation: 22,
+},
+{
+format: 'uint8x2',
+offset: 2112,
+shaderLocation: 17,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg8uint',
+writeMask: 0,
+},
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 3703,
+stencilWriteMask: 2405,
+depthBias: 46,
+depthBiasClamp: 1,
+},
+}
+);
+let img2 = await imageWithData(197, 40, '#7fc8b063', '#aaccc038');
+let imageData2 = new ImageData(36, 44);
+let pipelineLayout1 = device0.createPipelineLayout(
+{
+label: '\u{1fad2}\u{1fb79}\u{1fd56}\u{1fed0}\u{1fc0e}\u059e\u0f4a',
+bindGroupLayouts: [
+bindGroupLayout2,
+bindGroupLayout0
+],
+}
+);
+let commandEncoder9 = device0.createCommandEncoder(
+{
+label: '\u8d21\ua02e\u17bb\u4bf7\u{1f81a}',
+}
+);
+let querySet6 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 1160,
+}
+);
+try {
+renderBundleEncoder3.setIndexBuffer(
+buffer3,
+'uint16',
+45316,
+11862
+);
+} catch {}
+try {
+commandEncoder3.copyTextureToBuffer(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 1839, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 5944 widthInBlocks: 1486 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 7596 */
+offset: 7596,
+buffer: buffer3,
+},
+{width: 1486, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let querySet7 = device0.createQuerySet(
+{
+label: '\u{1fe9d}\u{1ffc2}\u9a0e\ub1a5\u0c03\u{1fa7b}\u{1fe1a}\u0dc5\u0fb1\u{1fe5f}\ud09f',
+type: 'occlusion',
+count: 6,
+}
+);
+let textureView8 = texture0.createView(
+{
+label: '\ue7d5\u09dc\u567d\u77d8\ud1d5\ua81e',
+baseArrayLayer: 0,
+}
+);
+let sampler7 = device0.createSampler(
+{
+label: '\u0485\ub592\u0584\u0642\u0df3\u0194',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 84.501,
+lodMaxClamp: 85.074,
+maxAnisotropy: 2,
+}
+);
+offscreenCanvas0.width = 289;
+let textureView9 = texture3.createView(
+{
+label: '\u{1fb5d}\u{1fee2}',
+baseMipLevel: 3,
+}
+);
+try {
+renderBundleEncoder3.setIndexBuffer(
+buffer1,
+'uint32',
+37700,
+1099
+);
+} catch {}
+try {
+commandEncoder5.resolveQuerySet(
+querySet0,
+1447,
+203,
+buffer3,
+42496
+);
+} catch {}
+let canvas3 = document.createElement('canvas');
+let commandEncoder10 = device0.createCommandEncoder(
+{
+label: '\u{1fca1}\u23b4',
+}
+);
+let textureView10 = texture0.createView(
+{
+baseArrayLayer: 0,
+}
+);
+let sampler8 = device0.createSampler(
+{
+label: '\u0c40\u04c0\u04c5\u36b0\ud650\u050c\u{1f9b6}\u1081\u06c5',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 99.893,
+maxAnisotropy: 4,
+}
+);
+try {
+computePassEncoder2.setBindGroup(
+1,
+bindGroup0,
+new Uint32Array(8127),
+1224,
+0
+);
+} catch {}
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+0,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(
+5,
+bindGroup0,
+new Uint32Array(546),
+349,
+0
+);
+} catch {}
+let pipeline8 = device0.createComputePipeline(
+{
+layout: pipelineLayout1,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let bindGroup1 = device0.createBindGroup({
+layout: bindGroupLayout3,
+entries: [
+
+],
+});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder(
+{
+label: '\u0242\u59c2\u018a\u0935\u{1f73e}',
+colorFormats: [
+undefined,
+'rg11b10ufloat'
+],
+sampleCount: 551,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder3.setPipeline(
+pipeline8
+);
+} catch {}
+let pipeline9 = await device0.createRenderPipelineAsync(
+{
+label: '\u{1fec6}\u0a53\u{1f88e}\ubd5b\ubf6e',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 4596,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x4',
+offset: 1520,
+shaderLocation: 23,
+},
+{
+format: 'snorm8x2',
+offset: 2862,
+shaderLocation: 0,
+},
+{
+format: 'float32x2',
+offset: 2876,
+shaderLocation: 7,
+},
+{
+format: 'unorm16x4',
+offset: 4336,
+shaderLocation: 28,
+},
+{
+format: 'snorm8x2',
+offset: 1158,
+shaderLocation: 20,
+},
+{
+format: 'uint32x3',
+offset: 508,
+shaderLocation: 19,
+},
+{
+format: 'unorm16x4',
+offset: 4016,
+shaderLocation: 11,
+},
+{
+format: 'float16x2',
+offset: 2196,
+shaderLocation: 21,
+},
+{
+format: 'sint16x4',
+offset: 3708,
+shaderLocation: 15,
+},
+{
+format: 'snorm16x2',
+offset: 1752,
+shaderLocation: 9,
+},
+{
+format: 'uint32x3',
+offset: 3780,
+shaderLocation: 5,
+},
+{
+format: 'snorm16x4',
+offset: 3436,
+shaderLocation: 14,
+},
+{
+format: 'float16x4',
+offset: 3508,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x4',
+offset: 200,
+shaderLocation: 17,
+},
+{
+format: 'sint16x4',
+offset: 2392,
+shaderLocation: 3,
+},
+{
+format: 'uint8x2',
+offset: 1480,
+shaderLocation: 4,
+},
+{
+format: 'uint32x2',
+offset: 2764,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 53964,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x4',
+offset: 40136,
+shaderLocation: 1,
+},
+{
+format: 'float16x2',
+offset: 10936,
+shaderLocation: 10,
+},
+{
+format: 'unorm16x4',
+offset: 49260,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x2',
+offset: 48338,
+shaderLocation: 12,
+},
+{
+format: 'snorm16x4',
+offset: 52988,
+shaderLocation: 25,
+},
+{
+format: 'sint8x4',
+offset: 16960,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 11416,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 0,
+shaderLocation: 6,
+},
+{
+format: 'unorm16x2',
+offset: 9580,
+shaderLocation: 26,
+}
+],
+},
+{
+arrayStride: 42436,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 38656,
+shaderLocation: 27,
+}
+],
+},
+{
+arrayStride: 59176,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 14828,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'none',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0xcf3ff46,
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'constant',
+dstFactor: 'dst-alpha'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'rgb10a2unorm',
+},
+undefined,
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.BLUE,
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+document.body.prepend(img2);
+document.body.prepend('\ub2d4\u04c1\u15e2\u9c8e');
+let bindGroup2 = device0.createBindGroup({
+label: '\u0e91\u0f5e\ud626\u4513\u7b20\u0670',
+layout: bindGroupLayout3,
+entries: [
+
+],
+});
+let texture5 = device0.createTexture(
+{
+label: '\u3dbe\ua5b0\u99c7',
+size: [88, 88, 1],
+mipLevelCount: 3,
+format: 'rgba32float',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder4 = commandEncoder7.beginComputePass();
+let renderBundleEncoder6 = device0.createRenderBundleEncoder(
+{
+label: '\u{1f768}\uf963\uff66',
+colorFormats: [
+'r8uint',
+'r8uint',
+'rgb10a2uint',
+'bgra8unorm',
+'rg32float',
+'rg8sint'
+],
+sampleCount: 603,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder6.setIndexBuffer(
+buffer3,
+'uint32'
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+2,
+buffer3,
+44856,
+14503
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 5444, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(64),
+/* required buffer size: 788 */{
+offset: 788,
+},
+{width: 3240, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let imageBitmap1 = await createImageBitmap(imageData2);
+try {
+canvas3.getContext('webgl2');
+} catch {}
+let textureView11 = texture3.createView(
+{
+label: '\u0eb3\ua218\u{1fa3e}',
+dimension: '2d-array',
+baseMipLevel: 1,
+mipLevelCount: 3,
+}
+);
+try {
+renderBundleEncoder3.setBindGroup(
+0,
+bindGroup2,
+[]
+);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(
+4,
+buffer3,
+7172
+);
+} catch {}
+try {
+commandEncoder9.insertDebugMarker(
+'\ue04e'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+7232,
+new BigUint64Array(7692),
+4327,
+1488
+);
+} catch {}
+video0.height = 104;
+canvas3.height = 46;
+document.body.prepend('\uadf3\u017e');
+let img3 = await imageWithData(196, 46, '#9b55680d', '#6df16733');
+let bindGroupLayout4 = device0.createBindGroupLayout(
+{
+label: '\u013b\u03a7\u0b00\u{1fadc}\u{1fa7b}',
+entries: [
+
+],
+}
+);
+let bindGroupLayout5 = pipeline1.getBindGroupLayout(0);
+let bindGroup3 = device0.createBindGroup({
+layout: bindGroupLayout3,
+entries: [
+
+],
+});
+let texture6 = device0.createTexture(
+{
+label: '\uf633\u537f',
+size: [5, 125, 40],
+mipLevelCount: 6,
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView12 = texture6.createView(
+{
+label: '\ub332\u60c3\u03df\u8c9c\u85bb\u2411\u087b',
+baseMipLevel: 1,
+mipLevelCount: 2,
+baseArrayLayer: 39,
+}
+);
+let sampler9 = device0.createSampler(
+{
+label: '\u{1f732}\u83d8\u{1f941}\uc6fa\uac2b\u010d\u0c60\ubb1e',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 8.911,
+lodMaxClamp: 67.033,
+}
+);
+try {
+renderBundleEncoder6.setBindGroup(
+1,
+bindGroup2
+);
+} catch {}
+try {
+commandEncoder5.copyBufferToBuffer(
+buffer0,
+992,
+buffer3,
+29380,
+26552
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder10.clearBuffer(
+buffer1,
+3604,
+17440
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let shaderModule3 = device0.createShaderModule(
+{
+label: '\u2fb3\u9166\u{1fcf1}\u{1f7f0}\u0950\ueb7b\u08b0\u02a7\u{1fc0c}\u{1fe82}',
+code: `@group(1) @binding(2280)
+var<storage, read_write> local1: array<u32>;
+
+@compute @workgroup_size(1, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S4 {
+@location(100) f0: vec2<u32>,
+@location(102) f1: vec4<f32>,
+@location(25) f2: vec4<i32>,
+@location(45) f3: vec2<f16>,
+@location(97) f4: f32
+}
+struct FragmentOutput0 {
+@location(3) f0: i32,
+@builtin(sample_mask) f1: u32,
+@location(4) f2: u32
+}
+
+@fragment
+fn fragment0(@location(94) a0: vec4<u32>, a1: S4, @location(109) a2: u32, @location(71) a3: vec2<i32>, @location(108) a4: vec3<f16>, @location(64) a5: vec4<u32>, @location(114) a6: vec4<i32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S3 {
+@location(22) f0: u32,
+@builtin(vertex_index) f1: u32,
+@location(9) f2: vec3<f16>,
+@location(13) f3: vec3<u32>,
+@location(16) f4: vec4<f16>,
+@location(26) f5: vec4<u32>
+}
+struct VertexOutput0 {
+@location(71) f10: vec2<i32>,
+@location(85) f11: f32,
+@location(100) f12: vec2<u32>,
+@location(93) f13: vec2<i32>,
+@location(76) f14: u32,
+@builtin(position) f15: vec4<f32>,
+@location(114) f16: vec4<i32>,
+@location(113) f17: vec4<f32>,
+@location(45) f18: vec2<f16>,
+@location(104) f19: u32,
+@location(94) f20: vec4<u32>,
+@location(108) f21: vec3<f16>,
+@location(80) f22: vec4<f16>,
+@location(25) f23: vec4<i32>,
+@location(2) f24: vec4<f32>,
+@location(3) f25: i32,
+@location(97) f26: f32,
+@location(43) f27: vec3<i32>,
+@location(115) f28: vec2<i32>,
+@location(51) f29: vec2<f16>,
+@location(5) f30: i32,
+@location(0) f31: vec2<f32>,
+@location(102) f32: vec4<f32>,
+@location(69) f33: vec4<u32>,
+@location(22) f34: vec3<f16>,
+@location(23) f35: vec2<f16>,
+@location(64) f36: vec4<u32>,
+@location(109) f37: u32,
+@location(95) f38: vec2<f16>,
+@location(60) f39: i32
+}
+
+@vertex
+fn vertex0(@location(19) a0: f32, @location(10) a1: vec4<f32>, @location(20) a2: f16, @location(24) a3: vec2<f32>, @location(28) a4: vec3<f32>, @builtin(instance_index) a5: u32, @location(23) a6: vec3<f16>, @location(4) a7: vec3<i32>, @location(8) a8: vec2<u32>, @location(6) a9: u32, @location(27) a10: vec3<f32>, @location(1) a11: vec4<f32>, @location(21) a12: u32, @location(18) a13: vec3<i32>, a14: S3, @location(7) a15: vec3<i32>, @location(5) a16: vec4<i32>, @location(25) a17: vec3<f16>, @location(3) a18: vec4<f32>, @location(0) a19: vec3<f16>, @location(12) a20: f32, @location(2) a21: vec4<i32>, @location(14) a22: vec2<i32>, @location(15) a23: vec3<u32>, @location(11) a24: u32, @location(17) a25: vec3<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture7 = device0.createTexture(
+{
+label: '\u8e5c\u{1f638}\ucb76\u0623\u8a80\u{1fc9e}\uab1b\u343d',
+size: {width: 12889},
+dimension: '1d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'r8uint',
+'r8uint'
+],
+}
+);
+let renderBundle5 = renderBundleEncoder5.finish(
+{
+label: '\u83d2\uc2c1\u05c1\u08f3\u0323\u{1fcc8}'
+}
+);
+try {
+texture5.destroy();
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+await buffer0.mapAsync(
+GPUMapMode.WRITE,
+34496,
+5360
+);
+} catch {}
+try {
+commandEncoder6.copyBufferToBuffer(
+buffer2,
+4844,
+buffer1,
+22268,
+620
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+await adapter1.requestAdapterInfo();
+} catch {}
+try {
+canvas2.getContext('webgpu');
+} catch {}
+let bindGroup4 = device0.createBindGroup({
+label: '\u736e\u0811\u1e2c\uf978\u0177\u62d6\u76c1\u0f30\u{1fd64}\u{1f644}',
+layout: bindGroupLayout2,
+entries: [
+
+],
+});
+let pipelineLayout2 = device0.createPipelineLayout(
+{
+label: '\u1ff6\uba8f\u0fae\u{1f70c}\u8957\u{1f7ba}\u{1fec4}\uc40e',
+bindGroupLayouts: [
+bindGroupLayout1,
+bindGroupLayout3,
+bindGroupLayout1,
+bindGroupLayout4,
+bindGroupLayout3
+],
+}
+);
+let querySet8 = device0.createQuerySet(
+{
+label: '\u35a5\u0cb9\u56bc',
+type: 'occlusion',
+count: 2051,
+}
+);
+let texture8 = device0.createTexture(
+{
+label: '\uabcd\u2379\u{1fcd3}\u{1fb9a}\ud963\u{1f9c1}\u7175\uad86\u{1ff59}',
+size: {width: 207, height: 1, depthOrArrayLayers: 65},
+mipLevelCount: 1,
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg16sint'
+],
+}
+);
+try {
+await buffer2.mapAsync(
+GPUMapMode.WRITE
+);
+} catch {}
+try {
+commandEncoder8.clearBuffer(
+buffer3,
+29484,
+14816
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 120, y: 44, z: 0 },
+  aspect: 'all',
+},
+new Float64Array(new ArrayBuffer(56)),
+/* required buffer size: 805 */{
+offset: 805,
+bytesPerRow: 11544,
+},
+{width: 5668, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline10 = device0.createRenderPipeline(
+{
+label: '\u{1ff6b}\u2568\u037c',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 56180,
+attributes: [
+{
+format: 'sint32x2',
+offset: 44924,
+shaderLocation: 22,
+},
+{
+format: 'unorm16x4',
+offset: 484,
+shaderLocation: 20,
+},
+{
+format: 'unorm8x2',
+offset: 25622,
+shaderLocation: 27,
+},
+{
+format: 'uint32x2',
+offset: 24500,
+shaderLocation: 4,
+},
+{
+format: 'snorm16x2',
+offset: 51688,
+shaderLocation: 0,
+},
+{
+format: 'float16x4',
+offset: 51648,
+shaderLocation: 8,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 37328,
+shaderLocation: 21,
+},
+{
+format: 'unorm16x4',
+offset: 40228,
+shaderLocation: 16,
+},
+{
+format: 'sint32x2',
+offset: 39540,
+shaderLocation: 3,
+},
+{
+format: 'snorm8x4',
+offset: 29724,
+shaderLocation: 17,
+},
+{
+format: 'unorm16x2',
+offset: 49968,
+shaderLocation: 9,
+},
+{
+format: 'uint16x2',
+offset: 9076,
+shaderLocation: 19,
+},
+{
+format: 'uint32x4',
+offset: 49136,
+shaderLocation: 18,
+},
+{
+format: 'float32',
+offset: 43152,
+shaderLocation: 26,
+},
+{
+format: 'unorm16x2',
+offset: 53852,
+shaderLocation: 14,
+},
+{
+format: 'snorm16x4',
+offset: 37688,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x4',
+offset: 45608,
+shaderLocation: 10,
+},
+{
+format: 'float32x3',
+offset: 47552,
+shaderLocation: 2,
+},
+{
+format: 'snorm8x2',
+offset: 12934,
+shaderLocation: 11,
+},
+{
+format: 'float16x2',
+offset: 50184,
+shaderLocation: 7,
+},
+{
+format: 'uint32x2',
+offset: 35124,
+shaderLocation: 6,
+},
+{
+format: 'sint32',
+offset: 23072,
+shaderLocation: 15,
+},
+{
+format: 'unorm8x4',
+offset: 17188,
+shaderLocation: 28,
+},
+{
+format: 'snorm16x4',
+offset: 26088,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 516,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 0,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 60776,
+attributes: [
+
+],
+},
+{
+arrayStride: 50268,
+attributes: [
+{
+format: 'unorm8x4',
+offset: 22048,
+shaderLocation: 25,
+}
+],
+},
+{
+arrayStride: 19236,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 3972,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0xe82149ea,
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilReadMask: 2535,
+stencilWriteMask: 3464,
+depthBias: 39,
+},
+}
+);
+let gpuCanvasContext2 = offscreenCanvas1.getContext('webgpu');
+let imageBitmap2 = await createImageBitmap(canvas3);
+try {
+adapter1.label = '\u{1f783}\u235d\u09d4\u7c02\ud522\u{1fd83}';
+} catch {}
+let renderBundleEncoder7 = device0.createRenderBundleEncoder(
+{
+label: '\ub9a3\u0c84\u0b9c\u{1f8f2}\u{1f817}\u{1fe1b}\u4178',
+colorFormats: [
+'r16uint',
+'rgba8unorm-srgb'
+],
+sampleCount: 569,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+commandEncoder3.copyTextureToTexture(
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 116, y: 56, z: 11 },
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 3,
+  origin: { x: 12, y: 4, z: 10 },
+  aspect: 'all',
+},
+{width: 12, height: 4, depthOrArrayLayers: 119}
+);
+} catch {}
+try {
+commandEncoder10.clearBuffer(
+buffer3,
+7732,
+48100
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture4,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 5 },
+  aspect: 'all',
+},
+new ArrayBuffer(72),
+/* required buffer size: 835023 */{
+offset: 303,
+bytesPerRow: 120,
+rowsPerImage: 148,
+},
+{width: 4, height: 0, depthOrArrayLayers: 48}
+);
+} catch {}
+let renderBundleEncoder8 = device0.createRenderBundleEncoder(
+{
+label: '\u{1fff5}\u3bf1\u{1f8d6}\ucadf\u{1fb61}\u{1fd15}\udb1d',
+colorFormats: [
+'rg32uint',
+'bgra8unorm',
+'r8sint'
+],
+sampleCount: 229,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler10 = device0.createSampler(
+{
+label: '\u087d\u{1f75d}\u0567\u04f7\u{1fda2}\u02bd\ubdb8\u{1f746}\ud988\u00e0',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 42.213,
+lodMaxClamp: 59.300,
+}
+);
+try {
+computePassEncoder0.setPipeline(
+pipeline8
+);
+} catch {}
+try {
+commandEncoder10.resolveQuerySet(
+querySet3,
+1619,
+663,
+buffer1,
+17920
+);
+} catch {}
+try {
+renderBundleEncoder4.insertDebugMarker(
+'\u6123'
+);
+} catch {}
+document.body.append('\u0688\u0b34\u0178\u0858\uf899\ud8ea\uec42\u0cf2\uec76\ud521\u4865');
+try {
+renderBundleEncoder8.setVertexBuffer(
+10,
+buffer1,
+19856,
+17376
+);
+} catch {}
+try {
+commandEncoder3.copyTextureToBuffer(
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 213, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 18672 widthInBlocks: 1167 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 29968 */
+offset: 29968,
+buffer: buffer1,
+},
+{width: 1167, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder9.clearBuffer(
+buffer1,
+35688,
+2116
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture4,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 3 },
+  aspect: 'all',
+},
+new ArrayBuffer(24),
+/* required buffer size: 438848 */{
+offset: 608,
+bytesPerRow: 40,
+rowsPerImage: 83,
+},
+{width: 8, height: 0, depthOrArrayLayers: 133}
+);
+} catch {}
+let pipeline11 = await device0.createRenderPipelineAsync(
+{
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 48308,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x4',
+offset: 7500,
+shaderLocation: 17,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 24372,
+shaderLocation: 20,
+},
+{
+format: 'float32x2',
+offset: 1028,
+shaderLocation: 21,
+},
+{
+format: 'float16x2',
+offset: 26796,
+shaderLocation: 10,
+},
+{
+format: 'uint16x4',
+offset: 6160,
+shaderLocation: 6,
+},
+{
+format: 'float16x2',
+offset: 3080,
+shaderLocation: 16,
+},
+{
+format: 'float32x4',
+offset: 28172,
+shaderLocation: 2,
+},
+{
+format: 'uint8x4',
+offset: 24420,
+shaderLocation: 4,
+},
+{
+format: 'unorm16x4',
+offset: 24720,
+shaderLocation: 9,
+},
+{
+format: 'unorm8x2',
+offset: 31166,
+shaderLocation: 25,
+},
+{
+format: 'float32x2',
+offset: 18116,
+shaderLocation: 7,
+},
+{
+format: 'sint16x2',
+offset: 36772,
+shaderLocation: 15,
+},
+{
+format: 'uint16x2',
+offset: 17320,
+shaderLocation: 18,
+},
+{
+format: 'uint32x2',
+offset: 32308,
+shaderLocation: 5,
+},
+{
+format: 'sint32x4',
+offset: 22004,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x4',
+offset: 21424,
+shaderLocation: 11,
+},
+{
+format: 'float32x3',
+offset: 12456,
+shaderLocation: 28,
+},
+{
+format: 'unorm8x2',
+offset: 7150,
+shaderLocation: 23,
+},
+{
+format: 'unorm8x4',
+offset: 3036,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 52688,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 62060,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32',
+offset: 36640,
+shaderLocation: 27,
+},
+{
+format: 'snorm16x2',
+offset: 61492,
+shaderLocation: 12,
+},
+{
+format: 'uint16x4',
+offset: 29008,
+shaderLocation: 1,
+},
+{
+format: 'uint32x2',
+offset: 26844,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+
+],
+},
+{
+arrayStride: 7472,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 6648,
+shaderLocation: 8,
+},
+{
+format: 'snorm16x2',
+offset: 4260,
+shaderLocation: 14,
+},
+{
+format: 'snorm8x2',
+offset: 3362,
+shaderLocation: 26,
+},
+{
+format: 'sint32x4',
+offset: 488,
+shaderLocation: 22,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'back',
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+targets: [
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'one',
+dstFactor: 'dst-alpha'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r16float',
+},
+undefined,
+{
+format: 'rg8uint',
+writeMask: 0,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater',
+passOp: 'zero',
+},
+stencilBack: {
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilReadMask: 3549,
+depthBias: 88,
+depthBiasClamp: 89,
+},
+}
+);
+try {
+canvas1.getContext('2d');
+} catch {}
+let commandEncoder11 = device0.createCommandEncoder(
+{
+label: '\ua695\uf322\ucd65\u{1f85a}\u0d2a\u051e\u1dac\u4d69\u{1febc}\u02d8\u06ce',
+}
+);
+pseudoSubmit(device0, commandEncoder11);
+let texture9 = device0.createTexture(
+{
+label: '\ucb2b\u{1fb99}',
+size: [114, 1, 163],
+mipLevelCount: 3,
+dimension: '3d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let sampler11 = device0.createSampler(
+{
+label: '\u{1f72a}\u5abf\ua057\u06d6\u7212\ue336\u2a46\u0eac\u{1f8f8}\u04de\u461d',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 3.444,
+compare: 'less',
+}
+);
+try {
+renderBundleEncoder7.setBindGroup(
+3,
+bindGroup4
+);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+0,
+bindGroup4,
+new Uint32Array(6048),
+3660,
+0
+);
+} catch {}
+try {
+commandEncoder9.copyBufferToBuffer(
+buffer3,
+50996,
+buffer1,
+24864,
+2020
+);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder8.clearBuffer(
+buffer3,
+40656,
+9648
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let texture10 = device0.createTexture(
+{
+size: [3438],
+dimension: '1d',
+format: 'rg32float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32float'
+],
+}
+);
+let textureView13 = texture8.createView(
+{
+label: '\u075f\u0979\u0b9b\u7768\u{1f7f3}\u0bc6\u9ae5\u0444\u{1ff81}',
+dimension: '2d',
+baseArrayLayer: 54,
+}
+);
+try {
+computePassEncoder1.setBindGroup(
+0,
+bindGroup4
+);
+} catch {}
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+computePassEncoder1.setPipeline(
+pipeline5
+);
+} catch {}
+video0.height = 186;
+let shaderModule4 = device0.createShaderModule(
+{
+label: '\u1106\u{1f88e}\u7fbe\u0fef',
+code: `@group(1) @binding(2280)
+var<storage, read_write> function1: array<u32>;
+
+@compute @workgroup_size(4, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S6 {
+@location(21) f0: vec4<u32>,
+@location(31) f1: vec4<f32>,
+@location(47) f2: vec4<f32>,
+@location(88) f3: vec4<u32>,
+@location(87) f4: vec4<i32>,
+@location(69) f5: vec3<u32>,
+@location(37) f6: vec3<i32>,
+@location(94) f7: vec2<i32>,
+@location(105) f8: vec2<u32>,
+@location(18) f9: u32,
+@location(20) f10: vec3<i32>,
+@location(32) f11: vec3<u32>,
+@location(40) f12: vec2<u32>,
+@location(1) f13: vec4<i32>,
+@builtin(position) f14: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(103) a0: vec2<f16>, @location(86) a1: vec4<f16>, @builtin(sample_index) a2: u32, @location(62) a3: vec3<f32>, a4: S6, @builtin(front_facing) a5: bool, @builtin(sample_mask) a6: u32) -> @location(3) u32 {
+return u32();
+}
+
+struct S5 {
+@location(0) f0: vec3<u32>,
+@location(1) f1: vec3<u32>,
+@location(23) f2: vec4<f32>,
+@location(19) f3: vec2<f32>,
+@location(9) f4: vec4<f32>,
+@location(3) f5: vec2<i32>,
+@location(26) f6: vec4<f32>,
+@location(15) f7: vec4<f16>,
+@location(17) f8: vec4<u32>
+}
+struct VertexOutput0 {
+@location(86) f40: vec4<f16>,
+@location(32) f41: vec3<u32>,
+@location(103) f42: vec2<f16>,
+@builtin(position) f43: vec4<f32>,
+@location(88) f44: vec4<u32>,
+@location(94) f45: vec2<i32>,
+@location(105) f46: vec2<u32>,
+@location(40) f47: vec2<u32>,
+@location(31) f48: vec4<f32>,
+@location(62) f49: vec3<f32>,
+@location(18) f50: u32,
+@location(37) f51: vec3<i32>,
+@location(21) f52: vec4<u32>,
+@location(1) f53: vec4<i32>,
+@location(47) f54: vec4<f32>,
+@location(20) f55: vec3<i32>,
+@location(69) f56: vec3<u32>,
+@location(87) f57: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec2<u32>, @location(13) a1: vec3<f16>, @location(2) a2: vec3<i32>, @location(28) a3: vec4<f16>, @location(22) a4: f16, @location(8) a5: vec2<u32>, @location(6) a6: vec3<i32>, @location(7) a7: vec4<f16>, @location(20) a8: f32, @location(18) a9: vec3<u32>, a10: S5, @location(24) a11: f16, @location(16) a12: vec2<i32>, @location(5) a13: u32, @location(21) a14: i32, @location(27) a15: u32, @location(12) a16: vec3<i32>, @location(4) a17: f16, @builtin(instance_index) a18: u32, @location(25) a19: f16, @location(10) a20: vec3<i32>, @location(14) a21: f32, @builtin(vertex_index) a22: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroup5 = device0.createBindGroup({
+label: '\u05ae\u{1f9e6}\ue9fc\u95fe\u1a5a\u{1fcec}\u{1fd60}\u7172\u31d9\ue4e2',
+layout: bindGroupLayout2,
+entries: [
+
+],
+});
+let computePassEncoder5 = commandEncoder10.beginComputePass();
+let renderBundleEncoder9 = device0.createRenderBundleEncoder(
+{
+label: '\u0c12\u863a\u05e6',
+colorFormats: [
+'r8sint',
+'rgb10a2unorm',
+'rg8uint',
+'r16float',
+'r16float',
+'r8uint',
+undefined
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 19,
+}
+);
+try {
+renderBundleEncoder4.setBindGroup(
+2,
+bindGroup4
+);
+} catch {}
+let arrayBuffer0 = buffer2.getMappedRange(
+0,
+1312
+);
+try {
+commandEncoder5.copyBufferToBuffer(
+buffer2,
+780,
+buffer3,
+59372,
+152
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 1783, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 872 */{
+offset: 872,
+},
+{width: 2670, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let imageData3 = new ImageData(252, 120);
+let bindGroup6 = device0.createBindGroup({
+layout: bindGroupLayout2,
+entries: [
+
+],
+});
+let querySet9 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 748,
+}
+);
+let renderPassEncoder0 = commandEncoder8.beginRenderPass(
+{
+label: '\u5839\u07e6\u5d3c\u{1f945}\u09b6',
+colorAttachments: [
+undefined,
+{
+view: textureView13,
+clearValue: {
+r: -327.6,
+g: -983.9,
+b: 285.4,
+a: 610.7,
+},
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet8,
+maxDrawCount: 16448,
+}
+);
+try {
+renderPassEncoder0.end();
+} catch {}
+let arrayBuffer1 = buffer2.getMappedRange(
+5656,
+404
+);
+try {
+commandEncoder5.clearBuffer(
+buffer3,
+26024,
+25008
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder3.resolveQuerySet(
+querySet0,
+1380,
+1459,
+buffer3,
+12032
+);
+} catch {}
+let pipeline12 = device0.createRenderPipeline(
+{
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 61684,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 59092,
+shaderLocation: 25,
+},
+{
+format: 'snorm16x2',
+offset: 27352,
+shaderLocation: 21,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x2',
+offset: 23210,
+shaderLocation: 16,
+},
+{
+format: 'snorm16x2',
+offset: 25460,
+shaderLocation: 9,
+},
+{
+format: 'uint16x4',
+offset: 19080,
+shaderLocation: 15,
+},
+{
+format: 'uint8x4',
+offset: 20008,
+shaderLocation: 19,
+},
+{
+format: 'sint16x4',
+offset: 5956,
+shaderLocation: 20,
+},
+{
+format: 'uint32x4',
+offset: 27540,
+shaderLocation: 4,
+},
+{
+format: 'snorm16x2',
+offset: 43776,
+shaderLocation: 5,
+},
+{
+format: 'unorm16x4',
+offset: 33312,
+shaderLocation: 23,
+},
+{
+format: 'sint32x3',
+offset: 23616,
+shaderLocation: 3,
+},
+{
+format: 'float32',
+offset: 54072,
+shaderLocation: 12,
+},
+{
+format: 'unorm8x4',
+offset: 54748,
+shaderLocation: 0,
+},
+{
+format: 'sint8x4',
+offset: 12300,
+shaderLocation: 22,
+},
+{
+format: 'uint16x2',
+offset: 51508,
+shaderLocation: 28,
+},
+{
+format: 'float32x3',
+offset: 27196,
+shaderLocation: 2,
+},
+{
+format: 'unorm8x2',
+offset: 4110,
+shaderLocation: 17,
+},
+{
+format: 'float32',
+offset: 16520,
+shaderLocation: 18,
+},
+{
+format: 'unorm16x4',
+offset: 41448,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 61944,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 28384,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 5632,
+shaderLocation: 10,
+},
+{
+format: 'unorm16x2',
+offset: 1996,
+shaderLocation: 1,
+},
+{
+format: 'uint32',
+offset: 16992,
+shaderLocation: 27,
+},
+{
+format: 'sint8x4',
+offset: 2616,
+shaderLocation: 6,
+},
+{
+format: 'uint16x2',
+offset: 5056,
+shaderLocation: 26,
+},
+{
+format: 'float32x2',
+offset: 3640,
+shaderLocation: 24,
+},
+{
+format: 'uint32x2',
+offset: 12012,
+shaderLocation: 8,
+},
+{
+format: 'sint16x2',
+offset: 25160,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 48616,
+attributes: [
+{
+format: 'sint16x2',
+offset: 13456,
+shaderLocation: 13,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16float',
+writeMask: GPUColorWrite.ALL,
+},
+undefined,
+{
+format: 'rgba32sint',
+},
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'invert',
+depthFailOp: 'increment-wrap',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'zero',
+depthFailOp: 'replace',
+passOp: 'replace',
+},
+depthBias: 89,
+depthBiasSlopeScale: 20,
+depthBiasClamp: 90,
+},
+}
+);
+video0.width = 136;
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule5 = device0.createShaderModule(
+{
+label: '\ubb84\ue025\u49e3\udd22\u74b9\u3d15\ua653\u00f8',
+code: `
+
+@compute @workgroup_size(6, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S8 {
+@location(110) f0: vec3<f32>,
+@location(51) f1: vec4<u32>,
+@location(6) f2: i32,
+@location(70) f3: vec2<i32>,
+@location(71) f4: vec3<i32>,
+@location(20) f5: vec3<f32>,
+@location(9) f6: vec4<i32>,
+@location(33) f7: f16,
+@location(109) f8: vec2<u32>,
+@location(42) f9: vec3<u32>,
+@location(35) f10: vec4<f16>,
+@location(82) f11: f16,
+@location(103) f12: u32,
+@location(80) f13: vec2<f16>,
+@location(3) f14: vec4<f16>,
+@location(107) f15: vec2<u32>,
+@location(72) f16: vec2<u32>,
+@location(104) f17: vec3<f32>,
+@location(73) f18: vec2<f16>,
+@location(39) f19: vec2<u32>,
+@location(62) f20: f32,
+@builtin(sample_index) f21: u32,
+@location(114) f22: vec2<u32>,
+@location(59) f23: u32,
+@builtin(position) f24: vec4<f32>,
+@location(45) f25: vec3<f32>,
+@location(7) f26: vec3<i32>
+}
+struct FragmentOutput0 {
+@location(2) f0: i32,
+@location(4) f1: vec4<u32>,
+@location(3) f2: vec4<i32>,
+@location(7) f3: f32,
+@location(5) f4: vec3<u32>,
+@location(0) f5: vec3<i32>,
+@location(6) f6: vec2<f32>
+}
+
+@fragment
+fn fragment0(@location(24) a0: vec2<f32>, @builtin(sample_mask) a1: u32, @location(66) a2: vec4<f32>, @location(36) a3: vec4<u32>, a4: S8, @location(15) a5: vec2<f32>, @builtin(front_facing) a6: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S7 {
+@builtin(instance_index) f0: u32,
+@location(4) f1: i32,
+@location(14) f2: vec3<f32>,
+@location(17) f3: vec3<f32>,
+@location(8) f4: f16,
+@location(0) f5: f32,
+@location(7) f6: vec4<f16>,
+@location(13) f7: vec2<u32>,
+@location(21) f8: vec4<f32>,
+@location(5) f9: u32,
+@location(12) f10: vec3<u32>,
+@location(19) f11: vec3<u32>,
+@location(23) f12: vec3<u32>
+}
+struct VertexOutput0 {
+@location(109) f58: vec2<u32>,
+@location(24) f59: vec2<f32>,
+@location(6) f60: i32,
+@location(42) f61: vec3<u32>,
+@location(59) f62: u32,
+@location(104) f63: vec3<f32>,
+@location(71) f64: vec3<i32>,
+@location(80) f65: vec2<f16>,
+@location(35) f66: vec4<f16>,
+@location(51) f67: vec4<u32>,
+@location(39) f68: vec2<u32>,
+@location(9) f69: vec4<i32>,
+@location(103) f70: u32,
+@location(110) f71: vec3<f32>,
+@location(82) f72: f16,
+@location(114) f73: vec2<u32>,
+@location(3) f74: vec4<f16>,
+@location(36) f75: vec4<u32>,
+@location(72) f76: vec2<u32>,
+@location(70) f77: vec2<i32>,
+@location(15) f78: vec2<f32>,
+@location(66) f79: vec4<f32>,
+@location(33) f80: f16,
+@location(7) f81: vec3<i32>,
+@location(73) f82: vec2<f16>,
+@location(107) f83: vec2<u32>,
+@builtin(position) f84: vec4<f32>,
+@location(62) f85: f32,
+@location(45) f86: vec3<f32>,
+@location(20) f87: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec2<i32>, @builtin(vertex_index) a1: u32, @location(11) a2: i32, @location(24) a3: vec4<u32>, @location(1) a4: f32, @location(16) a5: vec3<i32>, a6: S7, @location(22) a7: f32, @location(25) a8: vec4<f32>, @location(27) a9: vec2<i32>, @location(6) a10: i32, @location(26) a11: i32, @location(9) a12: f32, @location(2) a13: vec3<i32>, @location(15) a14: vec2<f16>, @location(10) a15: vec3<i32>, @location(28) a16: vec2<f16>, @location(18) a17: vec4<f32>, @location(20) a18: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let pipelineLayout3 = device0.createPipelineLayout(
+{
+label: '\u0e31\u79fa\u023c\uda95\u061c\u0270\u{1fa05}\u11f9\u0b7b\u02a4\u8833',
+bindGroupLayouts: [
+bindGroupLayout1,
+bindGroupLayout2,
+bindGroupLayout4
+],
+}
+);
+let commandEncoder12 = device0.createCommandEncoder(
+{
+}
+);
+let renderBundle6 = renderBundleEncoder7.finish(
+{
+label: '\u02b8\u41cd\ub6d9\u28f8'
+}
+);
+document.body.prepend('\u8fe7\u50e0\u01f7');
+let commandEncoder13 = device0.createCommandEncoder(
+{
+label: '\u3fff\ucdad\u06d9\u1b26\ua748\ubf5f\u8d3d\u{1fb5e}\ue006\u7ffb\ue148',
+}
+);
+try {
+renderBundleEncoder6.setVertexBuffer(
+50,
+undefined,
+1311179124,
+1947389659
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+33312,
+new Float32Array(30072),
+25740,
+16
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 28, y: 56, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 858 */{
+offset: 858,
+rowsPerImage: 124,
+},
+{width: 5528, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline13 = device0.createComputePipeline(
+{
+label: '\u47f2\u{1f972}\uc058\u57aa\u92d9\ue856\u78c0\u{1fe1f}\u{1fb10}\u0554',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let bindGroup7 = device0.createBindGroup({
+label: '\u05bb\u04b5\u{1ff9a}\u09d0',
+layout: bindGroupLayout2,
+entries: [
+
+],
+});
+let querySet10 = device0.createQuerySet(
+{
+label: '\udd67\u{1fe89}\ua5eb\u03d8\u0206\u10d6\u{1f743}\u0bd2',
+type: 'occlusion',
+count: 780,
+}
+);
+let texture11 = device0.createTexture(
+{
+label: '\u9f4d\u0d02\u0abe\u2c07\u3d12\ude99',
+size: {width: 10776, height: 104, depthOrArrayLayers: 7},
+mipLevelCount: 3,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'stencil8'
+],
+}
+);
+try {
+renderBundleEncoder4.setVertexBuffer(
+36,
+undefined,
+1711970704,
+220134143
+);
+} catch {}
+try {
+commandEncoder3.clearBuffer(
+buffer3,
+16092,
+29228
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture4,
+  mipLevel: 2,
+  origin: { x: 36, y: 8, z: 46 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 1439674 */{
+offset: 136,
+bytesPerRow: 158,
+rowsPerImage: 138,
+},
+{width: 0, height: 16, depthOrArrayLayers: 67}
+);
+} catch {}
+document.body.append('\u0a1e\u{1ffbb}\u{1f750}\u0c4b\u{1ff7f}\u{1fa54}\uc469\u533e\u9c29\u{1fd36}\u07c6');
+let querySet11 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 2327,
+}
+);
+let texture12 = device0.createTexture(
+{
+size: [233, 1, 159],
+mipLevelCount: 7,
+format: 'depth24plus',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'depth24plus'
+],
+}
+);
+let sampler12 = device0.createSampler(
+{
+label: '\uaa4a\u0d3b\ucd46\u{1fa7a}\ueee3\u5995\u{1fe84}\ue19c\u5e1f\ufebd',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 14.743,
+lodMaxClamp: 69.874,
+}
+);
+try {
+commandEncoder5.resolveQuerySet(
+querySet3,
+224,
+194,
+buffer3,
+17408
+);
+} catch {}
+let video3 = await videoWithData();
+let buffer4 = device0.createBuffer(
+{
+label: '\ue430\u9ec7\u{1feb0}\u7294\u0fb9',
+size: 27247,
+usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+}
+);
+let querySet12 = device0.createQuerySet(
+{
+label: '\u2d58\u86a0\ueb96\u5ef0\u011b\u394b\uf0ce\u{1fed4}',
+type: 'occlusion',
+count: 536,
+}
+);
+let texture13 = device0.createTexture(
+{
+size: {width: 10786},
+dimension: '1d',
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'r32sint',
+'r32sint'
+],
+}
+);
+try {
+renderBundleEncoder3.setBindGroup(
+0,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(
+10,
+buffer3,
+10788,
+44042
+);
+} catch {}
+try {
+commandEncoder4.copyTextureToBuffer(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 2858, y: 1, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 10400 widthInBlocks: 2600 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 58832 */
+offset: 58832,
+rowsPerImage: 129,
+buffer: buffer3,
+},
+{width: 2600, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture3,
+  mipLevel: 5,
+  origin: { x: 160, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Float64Array(new ArrayBuffer(24)),
+/* required buffer size: 1000 */{
+offset: 1000,
+},
+{width: 200, height: 4, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let shaderModule6 = device0.createShaderModule(
+{
+label: '\u0af6\ue367\u4ca0\u{1f9d0}\ue13b\uad76\u0b23\u2d27',
+code: `@group(1) @binding(591)
+var<storage, read_write> field0: array<u32>;
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S10 {
+@builtin(sample_mask) f0: u32,
+@location(47) f1: vec3<u32>
+}
+
+@fragment
+fn fragment0(@location(109) a0: vec2<i32>, @location(49) a1: vec2<f32>, a2: S10, @location(52) a3: vec3<u32>, @location(85) a4: vec2<f32>, @location(3) a5: vec2<f16>, @location(62) a6: vec3<f32>, @location(82) a7: vec2<f16>, @location(99) a8: f16, @location(104) a9: vec3<i32>, @location(1) a10: vec4<u32>, @location(38) a11: i32, @location(15) a12: i32, @location(26) a13: f16, @location(110) a14: vec4<f32>, @location(108) a15: vec3<f16>, @location(69) a16: u32, @location(81) a17: vec2<f16>, @location(48) a18: vec3<i32>, @location(35) a19: vec4<f32>, @location(67) a20: vec2<i32>, @location(63) a21: vec2<f32>, @location(33) a22: vec2<f32>, @location(92) a23: vec4<i32>, @location(55) a24: vec4<i32>, @location(88) a25: vec4<f32>, @location(102) a26: vec2<i32>, @location(10) a27: vec3<i32>, @builtin(sample_index) a28: u32, @location(7) a29: f32, @builtin(position) a30: vec4<f32>) {
+
+}
+
+struct S9 {
+@location(25) f0: f16,
+@location(11) f1: vec4<i32>,
+@location(21) f2: u32,
+@location(26) f3: vec3<i32>,
+@location(16) f4: vec4<u32>,
+@location(27) f5: vec3<f16>,
+@location(14) f6: vec2<f16>,
+@location(20) f7: vec3<f16>,
+@location(9) f8: vec2<f16>
+}
+struct VertexOutput0 {
+@location(35) f88: vec4<f32>,
+@location(10) f89: vec3<i32>,
+@location(81) f90: vec2<f16>,
+@location(82) f91: vec2<f16>,
+@location(102) f92: vec2<i32>,
+@location(49) f93: vec2<f32>,
+@location(63) f94: vec2<f32>,
+@location(92) f95: vec4<i32>,
+@location(69) f96: u32,
+@location(85) f97: vec2<f32>,
+@location(62) f98: vec3<f32>,
+@location(3) f99: vec2<f16>,
+@location(67) f100: vec2<i32>,
+@location(33) f101: vec2<f32>,
+@location(55) f102: vec4<i32>,
+@location(15) f103: i32,
+@location(88) f104: vec4<f32>,
+@location(99) f105: f16,
+@location(108) f106: vec3<f16>,
+@location(38) f107: i32,
+@location(7) f108: f32,
+@location(109) f109: vec2<i32>,
+@location(52) f110: vec3<u32>,
+@location(104) f111: vec3<i32>,
+@location(26) f112: f16,
+@location(48) f113: vec3<i32>,
+@location(110) f114: vec4<f32>,
+@location(1) f115: vec4<u32>,
+@builtin(position) f116: vec4<f32>,
+@location(47) f117: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec2<u32>, @location(6) a1: vec2<f16>, @location(2) a2: f32, @location(5) a3: vec4<u32>, @location(8) a4: vec4<u32>, @location(23) a5: vec3<f32>, a6: S9, @location(3) a7: vec2<f16>, @location(0) a8: f16, @location(19) a9: vec4<i32>, @location(18) a10: vec4<i32>, @location(1) a11: vec3<u32>, @location(24) a12: vec4<u32>, @location(13) a13: vec4<f32>, @builtin(vertex_index) a14: u32, @location(4) a15: vec3<u32>, @location(10) a16: vec2<u32>, @builtin(instance_index) a17: u32, @location(17) a18: vec2<u32>, @location(7) a19: vec4<u32>, @location(12) a20: vec4<f16>, @location(28) a21: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+}
+);
+let querySet13 = device0.createQuerySet(
+{
+label: '\u0afe\u0bd5',
+type: 'occlusion',
+count: 3774,
+}
+);
+let computePassEncoder6 = commandEncoder5.beginComputePass(
+{
+label: '\ud074\ue827\u2ddc\u228b\u54a5'
+}
+);
+let renderBundleEncoder10 = device0.createRenderBundleEncoder(
+{
+label: '\ua686\u{1f82a}',
+colorFormats: [
+'rg16uint',
+'rg8unorm',
+'rg16sint',
+'rgb10a2unorm'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 411,
+}
+);
+try {
+renderBundleEncoder4.setBindGroup(
+0,
+bindGroup1
+);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(
+4,
+buffer3,
+11756,
+10115
+);
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(
+buffer2,
+4924,
+buffer3,
+54756,
+868
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder4.clearBuffer(
+buffer3,
+45272,
+1888
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline14 = device0.createComputePipeline(
+{
+label: '\u06be\u3251\ud8f8\u27a7\u6e59\u{1ff0b}\u3fa6\uba3b\u051c',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend('\u{1fb9f}\ucd93\u0b20');
+let offscreenCanvas3 = new OffscreenCanvas(748, 21);
+let bindGroupLayout6 = device0.createBindGroupLayout(
+{
+label: '\u{1f6cc}\ufcdc\u8fcf\u0fee\uf060\u70c3\u0a3f\u85ad\u{1f9ba}\u1c20',
+entries: [
+{
+binding: 4867,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+},
+{
+binding: 7741,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+let commandEncoder14 = device0.createCommandEncoder(
+{
+label: '\u61cb\u5feb\uafd9\ua295\u0e3e\u0b1b\uddaa\u821c',
+}
+);
+let texture14 = device0.createTexture(
+{
+label: '\u0766\u0f45\uf2a8',
+size: {width: 2280, height: 4, depthOrArrayLayers: 202},
+mipLevelCount: 7,
+format: 'eac-r11snorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'eac-r11snorm',
+'eac-r11snorm',
+'eac-r11snorm'
+],
+}
+);
+let textureView14 = texture5.createView(
+{
+label: '\ud02b\u0d3e\u{1fc85}\u6930\ub742\u020e',
+dimension: '2d-array',
+baseMipLevel: 1,
+}
+);
+let sampler13 = device0.createSampler(
+{
+label: '\u{1f8bb}\u0971\u4c07\u{1fe36}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 90.982,
+lodMaxClamp: 95.685,
+maxAnisotropy: 20,
+}
+);
+try {
+renderBundleEncoder10.setBindGroup(
+2,
+bindGroup3
+);
+} catch {}
+try {
+device0.pushErrorScope(
+'validation'
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgba16float',
+'r8snorm'
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+14064,
+new DataView(new ArrayBuffer(25191)),
+20930,
+196
+);
+} catch {}
+let pipeline15 = device0.createComputePipeline(
+{
+label: '\u0595\u91da',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend('\u6543\u2ddf\u{1f82d}\u4bcc\u10fc\u2775\ue83f\u{1f861}');
+try {
+offscreenCanvas3.getContext('bitmaprenderer');
+} catch {}
+let bindGroup8 = device0.createBindGroup({
+layout: bindGroupLayout2,
+entries: [
+
+],
+});
+let texture15 = device0.createTexture(
+{
+label: '\u1463\ueb14\u81a6\u0427\u040f\u4934\u{1fc9a}\u70b5\ub273\ub4a5\u{1f7ac}',
+size: [91, 65, 1],
+mipLevelCount: 2,
+sampleCount: 1,
+format: 'r8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'r8sint'
+],
+}
+);
+let renderBundleEncoder11 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba16uint',
+'rg32float',
+'bgra8unorm',
+'rgba8unorm',
+undefined,
+'rg32uint'
+],
+sampleCount: 230,
+}
+);
+try {
+renderBundleEncoder8.setBindGroup(
+1,
+bindGroup2
+);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(
+8,
+buffer3,
+29492,
+11852
+);
+} catch {}
+let pipeline16 = await device0.createComputePipelineAsync(
+{
+label: '\u089c\u09b1\u03e5\u8393\u0392\u3dcc',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let img4 = await imageWithData(57, 102, '#e2669d7e', '#b9e12aa9');
+let pipelineLayout4 = device0.createPipelineLayout(
+{
+label: '\u017c\u{1fd35}\u4faf\u{1f610}\u2e12',
+bindGroupLayouts: [
+bindGroupLayout3,
+bindGroupLayout6
+],
+}
+);
+let renderBundle7 = renderBundleEncoder7.finish();
+try {
+computePassEncoder0.setBindGroup(
+0,
+bindGroup0,
+new Uint32Array(5007),
+3554,
+0
+);
+} catch {}
+try {
+device0.pushErrorScope(
+'internal'
+);
+} catch {}
+try {
+querySet10.destroy();
+} catch {}
+let arrayBuffer2 = buffer0.getMappedRange(
+34496,
+4392
+);
+try {
+commandEncoder6.copyBufferToBuffer(
+buffer2,
+3008,
+buffer3,
+6424,
+1504
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder4.resolveQuerySet(
+querySet13,
+3628,
+41,
+buffer3,
+11008
+);
+} catch {}
+let pipeline17 = await device0.createRenderPipelineAsync(
+{
+label: '\u{1f989}\ua933\uffdf\u{1fd63}\u0fcc\u0459\u{1fa2e}',
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule6,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 14784,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 10480,
+shaderLocation: 6,
+},
+{
+format: 'sint32x2',
+offset: 5648,
+shaderLocation: 19,
+},
+{
+format: 'snorm8x4',
+offset: 12028,
+shaderLocation: 14,
+},
+{
+format: 'unorm16x4',
+offset: 39908,
+shaderLocation: 27,
+},
+{
+format: 'float32x2',
+offset: 60264,
+shaderLocation: 0,
+},
+{
+format: 'float32',
+offset: 26640,
+shaderLocation: 25,
+},
+{
+format: 'uint8x4',
+offset: 10664,
+shaderLocation: 7,
+},
+{
+format: 'float32x4',
+offset: 18944,
+shaderLocation: 23,
+},
+{
+format: 'uint8x4',
+offset: 50204,
+shaderLocation: 17,
+},
+{
+format: 'uint8x2',
+offset: 21684,
+shaderLocation: 4,
+},
+{
+format: 'sint32x3',
+offset: 59548,
+shaderLocation: 11,
+},
+{
+format: 'uint8x4',
+offset: 9832,
+shaderLocation: 21,
+},
+{
+format: 'snorm16x4',
+offset: 12548,
+shaderLocation: 20,
+},
+{
+format: 'sint32x2',
+offset: 14412,
+shaderLocation: 28,
+},
+{
+format: 'uint32',
+offset: 21304,
+shaderLocation: 5,
+},
+{
+format: 'snorm8x2',
+offset: 55222,
+shaderLocation: 13,
+},
+{
+format: 'float32x2',
+offset: 47832,
+shaderLocation: 3,
+},
+{
+format: 'sint8x2',
+offset: 40638,
+shaderLocation: 26,
+},
+{
+format: 'uint16x4',
+offset: 29536,
+shaderLocation: 1,
+},
+{
+format: 'uint8x4',
+offset: 40772,
+shaderLocation: 15,
+},
+{
+format: 'snorm8x2',
+offset: 44654,
+shaderLocation: 2,
+},
+{
+format: 'snorm8x2',
+offset: 27964,
+shaderLocation: 12,
+},
+{
+format: 'uint32',
+offset: 21044,
+shaderLocation: 24,
+}
+],
+},
+{
+arrayStride: 57812,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 5840,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x4',
+offset: 1056,
+shaderLocation: 8,
+},
+{
+format: 'unorm8x4',
+offset: 5016,
+shaderLocation: 9,
+},
+{
+format: 'sint16x2',
+offset: 3200,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 49044,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 796,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 19036,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 5108,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 3600,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0x7b4a10ad,
+},
+fragment: {
+module: shaderModule6,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'stencil8',
+stencilFront: {
+compare: 'never',
+failOp: 'zero',
+passOp: 'keep',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'replace',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 959,
+stencilWriteMask: 797,
+depthBias: 49,
+depthBiasSlopeScale: 24,
+depthBiasClamp: 91,
+},
+}
+);
+gc();
+let offscreenCanvas4 = new OffscreenCanvas(942, 579);
+let shaderModule7 = device0.createShaderModule(
+{
+label: '\u{1f650}\u{1fcb9}\ubc0f\u{1f9f0}\u561f\u5877\ub4e3\u03b7\u1ecc\u3e0d',
+code: `
+
+@compute @workgroup_size(7, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(1) f0: vec3<f32>,
+@location(0) f1: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(sample_mask) a1: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(19) a0: vec2<f32>, @location(27) a1: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let querySet14 = device0.createQuerySet(
+{
+label: '\u0b05\u{1fbd2}\u{1fd58}\u297f\u0a1b\u03fd\u{1f824}',
+type: 'occlusion',
+count: 3453,
+}
+);
+pseudoSubmit(device0, commandEncoder13);
+let renderPassEncoder1 = commandEncoder3.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+{
+view: textureView13,
+clearValue: {
+r: 402.8,
+g: -675.3,
+b: -211.4,
+a: 523.4,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined,
+undefined
+],
+occlusionQuerySet: querySet11,
+maxDrawCount: 15592,
+}
+);
+let renderBundleEncoder12 = device0.createRenderBundleEncoder(
+{
+label: '\u0fd8\u60db',
+colorFormats: [
+'r32sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 922,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder6.setPipeline(
+pipeline8
+);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(
+0,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+commandEncoder7.copyBufferToBuffer(
+buffer0,
+37952,
+buffer3,
+4344,
+1264
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder12.copyTextureToBuffer(
+{
+  texture: texture13,
+  mipLevel: 0,
+  origin: { x: 2679, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 22592 widthInBlocks: 5648 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 43240 */
+offset: 43240,
+rowsPerImage: 280,
+buffer: buffer3,
+},
+{width: 5648, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder4.resolveQuerySet(
+querySet10,
+517,
+173,
+buffer1,
+14848
+);
+} catch {}
+document.body.append('\u309a\u1b2a\u009b\u{1f749}\u012e\u{1fd81}\u621a');
+let imageBitmap3 = await createImageBitmap(img1);
+let commandEncoder15 = device0.createCommandEncoder();
+let renderBundleEncoder13 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba32sint',
+'rgba8unorm',
+undefined,
+'r32uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 274,
+}
+);
+let renderBundle8 = renderBundleEncoder6.finish(
+{
+label: '\u5b73\ua3f0\u{1fb29}\udd2a\u0446'
+}
+);
+let sampler14 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 55.854,
+maxAnisotropy: 8,
+}
+);
+try {
+renderPassEncoder1.setBlendConstant(
+{
+r: -141.0,
+g: 199.4,
+b: 725.0,
+a: -370.5,
+}
+);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+2,
+bindGroup8
+);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(
+3,
+buffer1,
+19780,
+12539
+);
+} catch {}
+try {
+commandEncoder6.copyBufferToTexture(
+{
+/* bytesInLastRow: 19648 widthInBlocks: 1228 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 15344 */
+offset: 15344,
+bytesPerRow: 19968,
+buffer: buffer3,
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 6200, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 1228, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder15.clearBuffer(
+buffer1,
+436,
+19568
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker(
+'\udc4a'
+);
+} catch {}
+let pipeline18 = device0.createRenderPipeline(
+{
+label: '\u0d66\u6c26\u{1ffe6}\ud745\u79d0\u{1f962}\u041d',
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 34776,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 5464,
+shaderLocation: 25,
+},
+{
+format: 'uint8x4',
+offset: 17164,
+shaderLocation: 1,
+},
+{
+format: 'uint8x2',
+offset: 29400,
+shaderLocation: 5,
+},
+{
+format: 'float16x2',
+offset: 16364,
+shaderLocation: 17,
+},
+{
+format: 'float32',
+offset: 16276,
+shaderLocation: 14,
+},
+{
+format: 'snorm16x4',
+offset: 12876,
+shaderLocation: 26,
+},
+{
+format: 'uint32x4',
+offset: 12188,
+shaderLocation: 19,
+},
+{
+format: 'unorm16x4',
+offset: 1620,
+shaderLocation: 7,
+},
+{
+format: 'uint16x2',
+offset: 8372,
+shaderLocation: 18,
+},
+{
+format: 'sint32x3',
+offset: 2564,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x2',
+offset: 906,
+shaderLocation: 12,
+},
+{
+format: 'unorm8x2',
+offset: 1652,
+shaderLocation: 9,
+},
+{
+format: 'float32x4',
+offset: 14768,
+shaderLocation: 11,
+},
+{
+format: 'float16x4',
+offset: 384,
+shaderLocation: 28,
+},
+{
+format: 'sint8x2',
+offset: 24358,
+shaderLocation: 15,
+},
+{
+format: 'float32x3',
+offset: 30860,
+shaderLocation: 10,
+},
+{
+format: 'unorm16x2',
+offset: 19636,
+shaderLocation: 21,
+},
+{
+format: 'float16x2',
+offset: 23188,
+shaderLocation: 8,
+},
+{
+format: 'float16x4',
+offset: 26728,
+shaderLocation: 27,
+},
+{
+format: 'unorm16x4',
+offset: 17592,
+shaderLocation: 20,
+}
+],
+},
+{
+arrayStride: 56540,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 2588,
+shaderLocation: 16,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 54488,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 36668,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 16520,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 22760,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 14012,
+shaderLocation: 6,
+},
+{
+format: 'uint16x2',
+offset: 22332,
+shaderLocation: 4,
+},
+{
+format: 'sint8x2',
+offset: 5346,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 21436,
+attributes: [
+
+],
+},
+{
+arrayStride: 15252,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 41488,
+attributes: [
+
+],
+},
+{
+arrayStride: 22452,
+attributes: [
+{
+format: 'unorm16x2',
+offset: 13004,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'always',
+passOp: 'zero',
+},
+depthBias: 61,
+depthBiasSlopeScale: 98,
+depthBiasClamp: 28,
+},
+}
+);
+try {
+await promise2;
+} catch {}
+document.body.prepend('\uf646\u11ca\u4fb2');
+let texture16 = device0.createTexture(
+{
+size: [8906, 1, 1],
+mipLevelCount: 9,
+dimension: '2d',
+format: 'rgba32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+let computePassEncoder7 = commandEncoder7.beginComputePass();
+let renderPassEncoder2 = commandEncoder9.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+{
+view: textureView13,
+clearValue: {
+r: 469.3,
+g: -362.5,
+b: 830.7,
+a: -961.8,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined,
+undefined
+],
+occlusionQuerySet: querySet14,
+maxDrawCount: 131864,
+}
+);
+let renderBundle9 = renderBundleEncoder2.finish(
+{
+label: '\ua7e9\u14a7\u6fc6\u{1fa1c}\u0fc1\u1b20\u077e\u0836\u6bb2\u{1fce3}'
+}
+);
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+computePassEncoder3.setPipeline(
+pipeline13
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+4,
+bindGroup5
+);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+10,
+buffer1,
+21020
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 108, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 30480 */{
+offset: 620,
+},
+{width: 7465, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+pseudoSubmit(device0, commandEncoder4);
+try {
+renderPassEncoder2.setStencilReference(
+1098
+);
+} catch {}
+try {
+renderPassEncoder1.setViewport(
+24.41,
+0.5001,
+13.44,
+0.4083,
+0.6380,
+0.7494
+);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer1,
+'uint32',
+1120,
+38032
+);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(
+5,
+bindGroup8
+);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(
+6,
+buffer1,
+24288
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(40, 23);
+let commandEncoder16 = device0.createCommandEncoder(
+{
+label: '\u0200\uf353\u7b49\u7f6e\u7518\u00d7\u8d2b\u056f\u0c49\uced7\u0412',
+}
+);
+let texture17 = device0.createTexture(
+{
+label: '\u{1f6e2}\u{1f92f}\u09f9\ud9ca\u{1f60b}\u5168',
+size: {width: 4614},
+sampleCount: 1,
+dimension: '1d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder8 = commandEncoder15.beginComputePass(
+{
+label: '\u1e69\u{1fedb}\u0f10\u0391\u9e14'
+}
+);
+let sampler15 = device0.createSampler(
+{
+label: '\u0601\ucb67\ub441\u5dd6\u2192',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 21.777,
+lodMaxClamp: 25.621,
+maxAnisotropy: 5,
+}
+);
+try {
+renderPassEncoder2.beginOcclusionQuery(
+48
+);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant(
+{
+r: 367.4,
+g: -385.6,
+b: 526.1,
+a: -98.20,
+}
+);
+} catch {}
+try {
+renderPassEncoder1.setViewport(
+183.2,
+0.03387,
+7.023,
+0.6034,
+0.6045,
+0.8134
+);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(
+4,
+bindGroup1,
+new Uint32Array(661),
+578,
+0
+);
+} catch {}
+try {
+commandEncoder7.copyBufferToBuffer(
+buffer0,
+18612,
+buffer3,
+43628,
+11388
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder12.copyTextureToBuffer(
+{
+  texture: texture15,
+  mipLevel: 0,
+  origin: { x: 19, y: 32, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 33 widthInBlocks: 33 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 56048 */
+offset: 51663,
+bytesPerRow: 256,
+buffer: buffer3,
+},
+{width: 33, height: 18, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+document.body.prepend(canvas3);
+document.body.prepend('\ud07f\u13b0\u03d4\u0fff\u77b0\u6fd3');
+let commandEncoder17 = device0.createCommandEncoder(
+{
+label: '\u2b9d\u0d30\u{1f821}\u6cc6\u01af',
+}
+);
+let texture18 = device0.createTexture(
+{
+label: '\u02a5\ub6bc\u{1fb2c}\u18a0\u1507\u{1f7a4}\u4bda\udbf7\u076b',
+size: [224, 244, 51],
+mipLevelCount: 5,
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'eac-rg11snorm',
+'eac-rg11snorm'
+],
+}
+);
+let textureView15 = texture2.createView(
+{
+label: '\u8a01\u3c68',
+baseMipLevel: 3,
+mipLevelCount: 5,
+baseArrayLayer: 0,
+}
+);
+try {
+renderPassEncoder2.setBindGroup(
+4,
+bindGroup0
+);
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32sint'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+await promise5;
+} catch {}
+let bindGroupLayout7 = device0.createBindGroupLayout(
+{
+label: '\u0ac7\u08c7\ua74a\u{1fca5}\u0730\u{1fa83}\u5bbb\u{1fb64}\u095f\uc908',
+entries: [
+{
+binding: 2928,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+},
+{
+binding: 4427,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+let pipelineLayout5 = device0.createPipelineLayout(
+{
+label: '\u1951\u8cdb\u{1f60b}\u0c44',
+bindGroupLayouts: [
+bindGroupLayout2
+],
+}
+);
+let texture19 = device0.createTexture(
+{
+label: '\u9085\u{1f66c}\ua731',
+size: [829, 1, 168],
+mipLevelCount: 9,
+dimension: '3d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rg8unorm'
+],
+}
+);
+let sampler16 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+lodMinClamp: 40.228,
+lodMaxClamp: 99.178,
+}
+);
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+73,
+1,
+22,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+2,
+buffer3,
+41580
+);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(
+0,
+bindGroup0,
+[]
+);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(
+3,
+bindGroup0,
+new Uint32Array(7436),
+6081,
+0
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer3,
+39200,
+new Float32Array(62158),
+7029,
+1484
+);
+} catch {}
+let gpuCanvasContext3 = offscreenCanvas4.getContext('webgpu');
+video1.width = 99;
+let promise6 = adapter1.requestAdapterInfo();
+let renderBundle10 = renderBundleEncoder1.finish(
+{
+
+}
+);
+try {
+renderPassEncoder1.setStencilReference(
+3096
+);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(
+5,
+bindGroup3
+);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(
+2,
+bindGroup2,
+new Uint32Array(1606),
+1083,
+0
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder14.copyTextureToTexture(
+{
+  texture: texture15,
+  mipLevel: 1,
+  origin: { x: 1, y: 6, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 0,
+  origin: { x: 27, y: 52, z: 0 },
+  aspect: 'all',
+},
+{width: 33, height: 9, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder12.pushDebugGroup(
+'\u{1ff3e}'
+);
+} catch {}
+try {
+commandEncoder12.popDebugGroup();
+} catch {}
+try {
+commandEncoder14.insertDebugMarker(
+'\ue805'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+13544,
+new Float32Array(44192),
+8056,
+4176
+);
+} catch {}
+let gpuCanvasContext4 = offscreenCanvas5.getContext('webgpu');
+let pipelineLayout6 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout3,
+bindGroupLayout5,
+bindGroupLayout0
+],
+}
+);
+let commandEncoder18 = device0.createCommandEncoder(
+{
+label: '\u00f7\u{1f613}\u{1f69e}\u5a9c\u{1fa1e}',
+}
+);
+let texture20 = device0.createTexture(
+{
+size: [6408, 196, 77],
+mipLevelCount: 2,
+format: 'etc2-rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'etc2-rgba8unorm',
+'etc2-rgba8unorm-srgb',
+'etc2-rgba8unorm'
+],
+}
+);
+let renderBundleEncoder14 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgb10a2uint',
+undefined,
+'rg8sint'
+],
+sampleCount: 58,
+}
+);
+try {
+renderPassEncoder1.setBindGroup(
+3,
+bindGroup7
+);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: 982.1,
+g: 907.8,
+b: -411.2,
+a: -821.3,
+}
+);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+9,
+buffer3,
+57248,
+1579
+);
+} catch {}
+try {
+commandEncoder17.clearBuffer(
+buffer3,
+55784,
+744
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipelineLayout7 = device0.createPipelineLayout(
+{
+label: '\ufe64\u{1fad2}\u0ec7\u0763\u{1fe70}',
+bindGroupLayouts: [
+bindGroupLayout3,
+bindGroupLayout0,
+bindGroupLayout2,
+bindGroupLayout5,
+bindGroupLayout1
+],
+}
+);
+let querySet15 = device0.createQuerySet(
+{
+label: '\u16e5\u{1f86e}\uf97a\ue8d8',
+type: 'occlusion',
+count: 740,
+}
+);
+let renderPassEncoder3 = commandEncoder16.beginRenderPass(
+{
+label: '\u{1fbb3}\u2097\u39a2\u0ba7\u99a7\u4499\u076a\u{1fa30}',
+colorAttachments: [
+{
+view: textureView13,
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet0,
+maxDrawCount: 56448,
+}
+);
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setViewport(
+25.88,
+0.4860,
+48.95,
+0.4528,
+0.5537,
+0.7967
+);
+} catch {}
+try {
+commandEncoder18.copyBufferToBuffer(
+buffer3,
+21240,
+buffer1,
+24096,
+3876
+);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let promise7 = device0.createComputePipelineAsync(
+{
+label: '\u7905\ue2b6\u{1fb3e}\u51a8\u7d5f\u{1f979}\u793f\u0acb',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline19 = await device0.createRenderPipelineAsync(
+{
+label: '\u{1feb4}\u6070\u0785\ua888\u{1fbb4}\u{1f6ed}\u01ce',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 14388,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 59276,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 29320,
+shaderLocation: 10,
+},
+{
+format: 'unorm8x4',
+offset: 13148,
+shaderLocation: 27,
+},
+{
+format: 'uint8x2',
+offset: 36826,
+shaderLocation: 1,
+},
+{
+format: 'uint32x2',
+offset: 52832,
+shaderLocation: 18,
+},
+{
+format: 'uint8x4',
+offset: 6812,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x2',
+offset: 45480,
+shaderLocation: 20,
+},
+{
+format: 'uint32',
+offset: 39672,
+shaderLocation: 5,
+},
+{
+format: 'sint32',
+offset: 40804,
+shaderLocation: 3,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 23816,
+shaderLocation: 23,
+},
+{
+format: 'sint32x2',
+offset: 36524,
+shaderLocation: 22,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 14424,
+shaderLocation: 28,
+},
+{
+format: 'float32x4',
+offset: 55888,
+shaderLocation: 26,
+},
+{
+format: 'sint16x4',
+offset: 39972,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x2',
+offset: 45040,
+shaderLocation: 16,
+},
+{
+format: 'snorm8x2',
+offset: 56702,
+shaderLocation: 11,
+},
+{
+format: 'float32',
+offset: 23144,
+shaderLocation: 7,
+},
+{
+format: 'float32',
+offset: 36768,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 16688,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 16344,
+shaderLocation: 6,
+},
+{
+format: 'float32',
+offset: 10840,
+shaderLocation: 12,
+},
+{
+format: 'float32x4',
+offset: 3776,
+shaderLocation: 9,
+},
+{
+format: 'snorm8x2',
+offset: 7484,
+shaderLocation: 0,
+},
+{
+format: 'float16x4',
+offset: 7456,
+shaderLocation: 14,
+},
+{
+format: 'float32x2',
+offset: 12384,
+shaderLocation: 2,
+},
+{
+format: 'float16x4',
+offset: 3960,
+shaderLocation: 25,
+}
+],
+},
+{
+arrayStride: 1484,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 14420,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 13484,
+shaderLocation: 21,
+},
+{
+format: 'float32x2',
+offset: 6056,
+shaderLocation: 8,
+},
+{
+format: 'uint32x3',
+offset: 1740,
+shaderLocation: 19,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL,
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}
+],
+},
+}
+);
+let canvas4 = document.createElement('canvas');
+let querySet16 = device0.createQuerySet(
+{
+label: '\u0aed\ua381\u{1ffc3}\u{1f6e5}\u0a36\u{1fc09}\u0325',
+type: 'occlusion',
+count: 844,
+}
+);
+let texture21 = device0.createTexture(
+{
+label: '\u{1f9c8}\u{1f870}\u08dc\u6f91\u{1f73f}',
+size: [148, 148, 1],
+mipLevelCount: 2,
+sampleCount: 1,
+dimension: '2d',
+format: 'rg8uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8uint',
+'rg8uint',
+'rg8uint'
+],
+}
+);
+let textureView16 = texture3.createView(
+{
+dimension: '2d-array',
+baseMipLevel: 3,
+}
+);
+let computePassEncoder9 = commandEncoder7.beginComputePass(
+{
+label: '\u3b6b\u0bcd\ud61e'
+}
+);
+let renderBundle11 = renderBundleEncoder7.finish(
+{
+label: '\u0257\u7b22\u3b33\uf443\ue390\u0bf0\u0dbe\ua714\u0837\u0273\u030f'
+}
+);
+try {
+computePassEncoder9.setPipeline(
+pipeline13
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+4,
+bindGroup5
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+5,
+bindGroup6,
+new Uint32Array(1327),
+1021,
+0
+);
+} catch {}
+try {
+buffer0.destroy();
+} catch {}
+let pipeline20 = device0.createComputePipeline(
+{
+label: '\u0e04\u74f9\u09db\ub735\u21f6\ua1aa\u6d87\u0622',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+video3.width = 100;
+let offscreenCanvas6 = new OffscreenCanvas(968, 955);
+let bindGroup9 = device0.createBindGroup({
+label: '\u{1fb0a}\u{1f62e}\u{1f82b}\u031f',
+layout: bindGroupLayout2,
+entries: [
+
+],
+});
+let buffer5 = device0.createBuffer(
+{
+label: '\u{1fae2}\u166a\u09d9\u6dcc\u0912\u9792\u088a',
+size: 30094,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let renderBundleEncoder15 = device0.createRenderBundleEncoder(
+{
+label: '\u77ea\u5085\u{1f753}\u{1fe0a}\ub1c3\uf944\u{1f71a}',
+colorFormats: [
+undefined,
+'r32float'
+],
+sampleCount: 714,
+depthReadOnly: true,
+}
+);
+let renderBundle12 = renderBundleEncoder5.finish();
+try {
+renderPassEncoder1.beginOcclusionQuery(
+40
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+9,
+buffer1,
+28224,
+10645
+);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(
+0,
+bindGroup4,
+new Uint32Array(7501),
+2246,
+0
+);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(
+9,
+buffer3,
+3676
+);
+} catch {}
+let arrayBuffer3 = buffer2.getMappedRange(
+6192,
+16
+);
+try {
+buffer5.destroy();
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder17.clearBuffer(
+buffer5,
+19696,
+6784
+);
+dissociateBuffer(device0, buffer5);
+} catch {}
+let shaderModule8 = device0.createShaderModule(
+{
+code: `@group(1) @binding(2280)
+var<storage, read_write> local2: array<u32>;
+
+@compute @workgroup_size(7, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: vec3<i32>,
+@builtin(sample_mask) f1: u32,
+@location(5) f2: u32,
+@location(1) f3: f32,
+@location(3) f4: i32,
+@location(4) f5: vec2<u32>,
+@location(7) f6: vec3<f32>,
+@location(2) f7: f32
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_index) a1: u32, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S11 {
+@location(5) f0: vec4<f32>,
+@location(25) f1: vec2<u32>,
+@location(4) f2: f32
+}
+
+@vertex
+fn vertex0(a0: S11, @location(15) a1: vec4<i32>, @location(26) a2: vec4<f16>, @builtin(vertex_index) a3: u32, @builtin(instance_index) a4: u32, @location(2) a5: vec2<f32>, @location(23) a6: f32, @location(10) a7: vec4<f32>, @location(1) a8: i32, @location(19) a9: i32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+}
+);
+let commandEncoder19 = device0.createCommandEncoder(
+{
+}
+);
+try {
+renderPassEncoder1.setBindGroup(
+1,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(
+buffer4,
+'uint16',
+9486,
+13532
+);
+} catch {}
+try {
+commandEncoder12.resolveQuerySet(
+querySet4,
+3081,
+3,
+buffer1,
+39424
+);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.append('\u{1fad3}\u0be2\u{1fe44}\udbe4\uf7f9');
+try {
+renderPassEncoder3.setBlendConstant(
+{
+r: -977.2,
+g: -229.7,
+b: -610.6,
+a: -916.3,
+}
+);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+194,
+1,
+3,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+8,
+buffer1,
+27052,
+5164
+);
+} catch {}
+try {
+commandEncoder14.copyTextureToTexture(
+{
+  texture: texture4,
+  mipLevel: 4,
+  origin: { x: 8, y: 0, z: 58 },
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 5,
+  origin: { x: 28, y: 4, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder6.clearBuffer(
+buffer5,
+7348,
+788
+);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker(
+'\u8867'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer3,
+1836,
+new DataView(new ArrayBuffer(27135)),
+9666,
+3904
+);
+} catch {}
+let querySet17 = device0.createQuerySet(
+{
+label: '\u{1fd25}\u61f3\uf32b\u{1faa4}\u0988\uc295\u1c87\u{1ff24}\u8caa\uce67',
+type: 'occlusion',
+count: 564,
+}
+);
+try {
+renderPassEncoder2.setBindGroup(
+3,
+bindGroup1,
+new Uint32Array(9061),
+5568,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: 765.9,
+g: 62.16,
+b: 366.7,
+a: -260.5,
+}
+);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(
+550
+);
+} catch {}
+try {
+renderBundleEncoder12.insertDebugMarker(
+'\u7355'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer3,
+56464,
+new Int16Array(17789),
+9650,
+768
+);
+} catch {}
+let pipeline21 = device0.createRenderPipeline(
+{
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule5,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 48232,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 47200,
+shaderLocation: 12,
+},
+{
+format: 'sint32x4',
+offset: 7960,
+shaderLocation: 11,
+},
+{
+format: 'sint32x2',
+offset: 6224,
+shaderLocation: 27,
+},
+{
+format: 'sint16x4',
+offset: 36440,
+shaderLocation: 26,
+},
+{
+format: 'sint8x2',
+offset: 3612,
+shaderLocation: 10,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 41896,
+shaderLocation: 7,
+},
+{
+format: 'unorm16x4',
+offset: 22592,
+shaderLocation: 21,
+},
+{
+format: 'float32x2',
+offset: 15428,
+shaderLocation: 22,
+},
+{
+format: 'unorm8x4',
+offset: 15740,
+shaderLocation: 8,
+},
+{
+format: 'uint8x4',
+offset: 38320,
+shaderLocation: 23,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 11480,
+shaderLocation: 28,
+},
+{
+format: 'sint8x2',
+offset: 4770,
+shaderLocation: 6,
+},
+{
+format: 'snorm16x4',
+offset: 30024,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x2',
+offset: 37424,
+shaderLocation: 14,
+},
+{
+format: 'sint32x4',
+offset: 18200,
+shaderLocation: 16,
+},
+{
+format: 'uint32',
+offset: 30512,
+shaderLocation: 19,
+},
+{
+format: 'float16x2',
+offset: 9416,
+shaderLocation: 17,
+},
+{
+format: 'sint32x2',
+offset: 42308,
+shaderLocation: 20,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 14952,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x2',
+offset: 13224,
+shaderLocation: 9,
+},
+{
+format: 'snorm8x4',
+offset: 33812,
+shaderLocation: 0,
+},
+{
+format: 'uint16x4',
+offset: 20136,
+shaderLocation: 24,
+},
+{
+format: 'sint16x2',
+offset: 18128,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 42076,
+attributes: [
+{
+format: 'snorm16x4',
+offset: 16108,
+shaderLocation: 1,
+},
+{
+format: 'uint32x2',
+offset: 888,
+shaderLocation: 5,
+},
+{
+format: 'sint16x2',
+offset: 14220,
+shaderLocation: 4,
+},
+{
+format: 'sint32x2',
+offset: 32156,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x2',
+offset: 10456,
+shaderLocation: 25,
+},
+{
+format: 'uint8x4',
+offset: 37396,
+shaderLocation: 13,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x346f666f,
+},
+fragment: {
+module: shaderModule5,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+undefined,
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'rgba16sint',
+writeMask: GPUColorWrite.ALPHA,
+}
+],
+},
+}
+);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder();
+let querySet18 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 1334,
+}
+);
+let renderPassEncoder4 = commandEncoder14.beginRenderPass(
+{
+label: '\u2c31\u0a97',
+colorAttachments: [
+undefined,
+{
+view: textureView13,
+clearValue: {
+r: 226.6,
+g: -236.2,
+b: -254.3,
+a: -893.0,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet7,
+maxDrawCount: 358128,
+}
+);
+let renderBundle13 = renderBundleEncoder13.finish(
+{
+label: '\ucb04\u7492\u51b2\u1a7b\u8437'
+}
+);
+let sampler17 = device0.createSampler(
+{
+label: '\u6826\u0f7b\u0d35\u{1f81e}\u2851\u0458\u030f',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 47.980,
+}
+);
+try {
+renderPassEncoder1.setBindGroup(
+2,
+bindGroup6,
+new Uint32Array(7229),
+4494,
+0
+);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant(
+{
+r: -120.0,
+g: 702.2,
+b: 216.4,
+a: 116.4,
+}
+);
+} catch {}
+try {
+renderPassEncoder3.setViewport(
+91.21,
+0.9649,
+40.42,
+0.00280,
+0.5150,
+0.9411
+);
+} catch {}
+try {
+buffer3.destroy();
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+23152,
+new DataView(new ArrayBuffer(31763)),
+21650,
+412
+);
+} catch {}
+let shaderModule9 = device0.createShaderModule(
+{
+label: '\u{1f9dc}\u{1f63e}\u{1fb72}\ud808\u{1fee8}',
+code: `
+
+@compute @workgroup_size(2, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S13 {
+@builtin(sample_index) f0: u32
+}
+struct FragmentOutput0 {
+@builtin(frag_depth) f0: f32,
+@location(3) f1: vec3<f32>,
+@location(7) f2: vec3<i32>,
+@builtin(sample_mask) f3: u32,
+@location(1) f4: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_mask) a1: u32, @builtin(position) a2: vec4<f32>, a3: S13) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S12 {
+@location(16) f0: vec4<i32>,
+@builtin(vertex_index) f1: u32,
+@location(17) f2: vec3<i32>,
+@location(1) f3: vec4<f32>,
+@location(18) f4: vec4<f32>,
+@location(23) f5: f16,
+@location(26) f6: vec4<f32>,
+@location(24) f7: vec4<u32>,
+@location(25) f8: vec4<f32>,
+@location(5) f9: vec3<f16>,
+@location(21) f10: vec3<u32>,
+@location(20) f11: f32,
+@location(13) f12: vec2<f16>,
+@location(10) f13: vec2<u32>,
+@location(28) f14: vec2<f32>,
+@location(2) f15: vec2<u32>,
+@location(9) f16: vec3<i32>,
+@location(22) f17: vec4<f32>,
+@location(15) f18: vec3<f32>,
+@location(7) f19: i32,
+@location(14) f20: vec3<i32>,
+@location(27) f21: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec3<f16>, @location(0) a1: vec3<f32>, @location(8) a2: vec2<i32>, a3: S12, @location(3) a4: f32, @location(19) a5: i32, @location(12) a6: vec3<u32>, @location(4) a7: vec4<f32>, @location(11) a8: f16, @builtin(instance_index) a9: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let textureView17 = texture14.createView(
+{
+label: '\u0f1e\u015d',
+dimension: '2d',
+baseMipLevel: 6,
+baseArrayLayer: 30,
+}
+);
+let renderBundleEncoder16 = device0.createRenderBundleEncoder(
+{
+label: '\u90c0\ude60\u0b3e\u{1f729}\u1a71',
+colorFormats: [
+'rgba16uint',
+undefined,
+'rg11b10ufloat',
+'rg32sint',
+'rg16float',
+'r8unorm'
+],
+sampleCount: 79,
+depthReadOnly: true,
+}
+);
+let sampler18 = device0.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 81.375,
+lodMaxClamp: 95.786,
+}
+);
+try {
+computePassEncoder6.setPipeline(
+pipeline14
+);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+3,
+bindGroup1
+);
+} catch {}
+try {
+commandEncoder19.clearBuffer(
+buffer5,
+17172,
+1976
+);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder20.resolveQuerySet(
+querySet2,
+312,
+3072,
+buffer3,
+12800
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture17,
+  mipLevel: 0,
+  origin: { x: 1061, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer3,
+/* required buffer size: 319 */{
+offset: 319,
+rowsPerImage: 203,
+},
+{width: 3034, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await promise4;
+} catch {}
+let texture22 = device0.createTexture(
+{
+size: [118, 9, 20],
+format: 'rgba16uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let textureView18 = texture0.createView(
+{
+label: '\u{1fab4}\u9382\ub5da\u6132\u20d8\u{1fc38}\u48b2\u0184',
+}
+);
+let renderBundleEncoder17 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'r8uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 438,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: -815.0,
+g: -370.4,
+b: 959.1,
+a: 903.6,
+}
+);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(
+1,
+bindGroup7,
+[]
+);
+} catch {}
+try {
+commandEncoder20.copyTextureToBuffer(
+{
+  texture: texture19,
+  mipLevel: 8,
+  origin: { x: 1, y: 1, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 4 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 1222 */
+offset: 1222,
+buffer: buffer5,
+},
+{width: 2, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+36508,
+new DataView(new ArrayBuffer(34291)),
+5339,
+2904
+);
+} catch {}
+let pipeline22 = await device0.createComputePipelineAsync(
+{
+label: '\u{1f7fa}\u0ee8\u0f8b\u0266\u5e62\uc870\u0a1f\u35a2',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+renderPassEncoder1.setVertexBuffer(
+5,
+buffer3
+);
+} catch {}
+try {
+commandEncoder20.copyBufferToTexture(
+{
+/* bytesInLastRow: 3836 widthInBlocks: 3836 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 42957 */
+offset: 42957,
+buffer: buffer0,
+},
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: { x: 8355, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 3836, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+17912,
+new Int16Array(58560),
+9730,
+200
+);
+} catch {}
+let pipeline23 = device0.createComputePipeline(
+{
+layout: pipelineLayout3,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let texture23 = device0.createTexture(
+{
+label: '\ua996\u620d\u7d53\u06a3\u0e0e\u{1fe9e}\u0fa8\u{1fdac}\ucf07',
+size: {width: 9492, height: 148, depthOrArrayLayers: 1},
+mipLevelCount: 11,
+dimension: '2d',
+format: 'eac-r11snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+renderPassEncoder4.setVertexBuffer(
+7,
+buffer1,
+7792,
+2832
+);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(
+5,
+bindGroup2
+);
+} catch {}
+try {
+commandEncoder20.copyBufferToBuffer(
+buffer2,
+2640,
+buffer1,
+15744,
+2120
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder18.resolveQuerySet(
+querySet10,
+348,
+144,
+buffer1,
+16384
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+16216,
+new BigUint64Array(12870),
+9151,
+2740
+);
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext5 = offscreenCanvas6.getContext('webgpu');
+let texture24 = device0.createTexture(
+{
+label: '\u58b2\ua735\u3320\u{1fc33}\u08bb\u{1f96b}\u0b01\ud05c\ub48d\u419c',
+size: {width: 13257, height: 150, depthOrArrayLayers: 206},
+mipLevelCount: 9,
+sampleCount: 1,
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16uint'
+],
+}
+);
+try {
+computePassEncoder6.setBindGroup(
+1,
+bindGroup3
+);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(
+buffer1,
+'uint32'
+);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(
+43,
+undefined,
+1226556463,
+724121421
+);
+} catch {}
+try {
+commandEncoder12.resolveQuerySet(
+querySet16,
+499,
+93,
+buffer3,
+43264
+);
+} catch {}
+document.body.append('\u{1ff90}\ua70b\u{1fc9f}\u5df9\u{1f741}\u0234\u{1fd0e}\u0509\u0f8c\u3046\ub13a');
+let imageData4 = new ImageData(208, 172);
+let videoFrame2 = new VideoFrame(offscreenCanvas1, {timestamp: 0});
+let textureView19 = texture12.createView(
+{
+label: '\u0908\u0ba0\uc123\uf336\u{1fa2d}',
+dimension: '2d',
+format: 'depth24plus',
+baseMipLevel: 4,
+mipLevelCount: 1,
+baseArrayLayer: 131,
+}
+);
+try {
+computePassEncoder9.setPipeline(
+pipeline8
+);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: 209.6,
+g: -922.3,
+b: -759.8,
+a: 498.2,
+}
+);
+} catch {}
+try {
+renderPassEncoder1.setViewport(
+61.56,
+0.4544,
+117.3,
+0.5233,
+0.07297,
+0.5391
+);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(
+0,
+bindGroup8
+);
+} catch {}
+try {
+commandEncoder18.copyBufferToBuffer(
+buffer2,
+5956,
+buffer5,
+1408,
+368
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture9,
+  mipLevel: 2,
+  origin: { x: 2, y: 0, z: 24 },
+  aspect: 'all',
+},
+new BigInt64Array(new ArrayBuffer(64)),
+/* required buffer size: 178020 */{
+offset: 700,
+bytesPerRow: 124,
+rowsPerImage: 286,
+},
+{width: 25, height: 0, depthOrArrayLayers: 6}
+);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+try {
+await promise8;
+} catch {}
+let commandEncoder21 = device0.createCommandEncoder(
+{
+label: '\u{1fbe4}\u8ee4',
+}
+);
+let renderBundleEncoder18 = device0.createRenderBundleEncoder(
+{
+label: '\u3ad4\u0534\u711e\ude04\u0817\ue9ef\u4d5b\u{1f950}',
+colorFormats: [
+'rgba8unorm-srgb',
+undefined,
+'bgra8unorm-srgb',
+'rg16sint',
+'rgba32float'
+],
+sampleCount: 763,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder3.setVertexBuffer(
+7,
+buffer1,
+20952,
+10540
+);
+} catch {}
+let pipeline24 = device0.createRenderPipeline(
+{
+label: '\u34fa\u0877\u{1f668}\u{1fb9f}\u7de1\u0ada\u018c',
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule5,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 13476,
+attributes: [
+{
+format: 'float32',
+offset: 3440,
+shaderLocation: 8,
+},
+{
+format: 'uint32x4',
+offset: 10860,
+shaderLocation: 24,
+},
+{
+format: 'float32x3',
+offset: 9184,
+shaderLocation: 18,
+},
+{
+format: 'float32',
+offset: 572,
+shaderLocation: 0,
+},
+{
+format: 'uint8x2',
+offset: 2140,
+shaderLocation: 23,
+},
+{
+format: 'uint16x4',
+offset: 8220,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 7424,
+attributes: [
+{
+format: 'uint16x4',
+offset: 5104,
+shaderLocation: 19,
+},
+{
+format: 'unorm8x4',
+offset: 6964,
+shaderLocation: 25,
+},
+{
+format: 'sint8x2',
+offset: 222,
+shaderLocation: 27,
+},
+{
+format: 'sint16x2',
+offset: 1904,
+shaderLocation: 6,
+},
+{
+format: 'sint32',
+offset: 5032,
+shaderLocation: 20,
+},
+{
+format: 'unorm16x4',
+offset: 5952,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 50212,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 26484,
+shaderLocation: 17,
+},
+{
+format: 'sint32x2',
+offset: 34880,
+shaderLocation: 11,
+},
+{
+format: 'sint32x3',
+offset: 30884,
+shaderLocation: 2,
+},
+{
+format: 'snorm8x4',
+offset: 18600,
+shaderLocation: 15,
+},
+{
+format: 'uint16x2',
+offset: 47176,
+shaderLocation: 13,
+},
+{
+format: 'sint8x4',
+offset: 47704,
+shaderLocation: 26,
+},
+{
+format: 'uint32x2',
+offset: 1504,
+shaderLocation: 12,
+},
+{
+format: 'float16x4',
+offset: 40188,
+shaderLocation: 28,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'snorm16x2',
+offset: 788,
+shaderLocation: 21,
+},
+{
+format: 'sint32x3',
+offset: 29396,
+shaderLocation: 16,
+},
+{
+format: 'snorm8x2',
+offset: 582,
+shaderLocation: 9,
+},
+{
+format: 'sint32x3',
+offset: 10824,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x2',
+offset: 62284,
+shaderLocation: 14,
+},
+{
+format: 'snorm16x2',
+offset: 61612,
+shaderLocation: 7,
+},
+{
+format: 'float32x3',
+offset: 20036,
+shaderLocation: 1,
+},
+{
+format: 'sint8x4',
+offset: 4496,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 34700,
+attributes: [
+
+],
+},
+{
+arrayStride: 9136,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 6092,
+attributes: [
+{
+format: 'sint32x4',
+offset: 956,
+shaderLocation: 3,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule5,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+},
+undefined,
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALL,
+},
+{
+format: 'rgba8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rgba8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+format: 'rg32float',
+}
+],
+},
+}
+);
+let canvas5 = document.createElement('canvas');
+let imageBitmap4 = await createImageBitmap(canvas5);
+let sampler19 = device0.createSampler(
+{
+label: '\u03e9\u4d81\u8899\u{1fdc2}\u{1ff59}\u0f7d',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 7.663,
+compare: 'less',
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(
+143,
+1,
+44,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+190.8,
+0.7006,
+8.668,
+0.2429,
+0.7480,
+0.7642
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+1,
+buffer1,
+33396,
+3147
+);
+} catch {}
+try {
+commandEncoder18.copyBufferToBuffer(
+buffer2,
+4640,
+buffer5,
+7276,
+1504
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder18.resolveQuerySet(
+querySet12,
+99,
+251,
+buffer1,
+15872
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture16,
+  mipLevel: 3,
+  origin: { x: 137, y: 1, z: 0 },
+  aspect: 'all',
+},
+new Uint32Array(arrayBuffer2),
+/* required buffer size: 743 */{
+offset: 743,
+bytesPerRow: 13982,
+rowsPerImage: 240,
+},
+{width: 857, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline25 = device0.createComputePipeline(
+{
+label: '\u0ca6\u95b9\u4dc7\u0997\u0520\u1372\uc6fb\u0413\u0993\u479a\u005b',
+layout: 'auto',
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let buffer6 = device0.createBuffer(
+{
+label: '\uac2a\u015f',
+size: 11662,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+}
+);
+let textureView20 = texture3.createView(
+{
+dimension: '2d-array',
+baseMipLevel: 3,
+}
+);
+let renderBundle14 = renderBundleEncoder3.finish(
+{
+label: '\u769d\ueba4\u419a\u{1fa00}\uf600'
+}
+);
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+9,
+buffer3,
+33528,
+22058
+);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(
+2,
+bindGroup3,
+new Uint32Array(8708),
+7239,
+0
+);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(
+0,
+buffer3,
+42028
+);
+} catch {}
+try {
+commandEncoder15.copyBufferToTexture(
+{
+/* bytesInLastRow: 40 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 12328 */
+offset: 12328,
+bytesPerRow: 256,
+buffer: buffer3,
+},
+{
+  texture: texture23,
+  mipLevel: 8,
+  origin: { x: 4, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 20, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+document.body.append('\ucbb0\u{1fae7}\ub490\udd76\uadde\u141a');
+let imageBitmap5 = await createImageBitmap(imageBitmap0);
+let bindGroupLayout8 = device0.createBindGroupLayout(
+{
+label: '\u8a52\u8f40',
+entries: [
+
+],
+}
+);
+let sampler20 = device0.createSampler(
+{
+label: '\ub1bd\u0bda\u{1fc02}\u2ced\uebf2\u{1fefd}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 36.207,
+compare: 'less',
+maxAnisotropy: 16,
+}
+);
+try {
+renderPassEncoder1.setVertexBuffer(
+6,
+buffer3,
+15208,
+24834
+);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(
+88,
+undefined,
+3760016274,
+220501290
+);
+} catch {}
+try {
+commandEncoder21.copyTextureToTexture(
+{
+  texture: texture23,
+  mipLevel: 7,
+  origin: { x: 0, y: 4, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 88, y: 60, z: 33 },
+  aspect: 'all',
+},
+{width: 64, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\u{1f946}\ucd1e\ue637\u0824\u0001\u{1f7c6}\ufdba\u6821');
+let texture25 = device0.createTexture(
+{
+label: '\u0ccc\u5200\u2b12\u0499',
+size: {width: 12606},
+dimension: '1d',
+format: 'rgba32sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32sint',
+'rgba32sint'
+],
+}
+);
+try {
+renderPassEncoder3.setBindGroup(
+5,
+bindGroup9
+);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(
+80
+);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant(
+{
+r: -391.7,
+g: 511.2,
+b: 662.8,
+a: 622.4,
+}
+);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer4,
+'uint16',
+5602,
+6644
+);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+5,
+buffer3,
+12864
+);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(
+2,
+bindGroup0,
+new Uint32Array(1971),
+1733,
+0
+);
+} catch {}
+try {
+commandEncoder18.clearBuffer(
+buffer5,
+13812,
+7000
+);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder17.resolveQuerySet(
+querySet10,
+12,
+135,
+buffer3,
+26112
+);
+} catch {}
+let pipeline26 = device0.createComputePipeline(
+{
+label: '\u0f27\u{1fbda}\u{1fde6}\u0f60\uef77\u{1f8b4}\u95eb\u4fe7\uf940',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageBitmap6 = await createImageBitmap(offscreenCanvas3);
+let promise9 = adapter1.requestAdapterInfo();
+try {
+canvas4.getContext('bitmaprenderer');
+} catch {}
+let renderPassEncoder5 = commandEncoder12.beginRenderPass(
+{
+label: '\u0b20\uece3',
+colorAttachments: [
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView19,
+depthClearValue: 0.2337511417965954,
+depthLoadOp: 'clear',
+depthStoreOp: 'discard',
+stencilClearValue: 61331,
+},
+occlusionQuerySet: querySet17,
+}
+);
+try {
+computePassEncoder1.setBindGroup(
+4,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(
+1,
+bindGroup9
+);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(
+buffer3,
+'uint32'
+);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(
+1,
+buffer6,
+6096,
+1914
+);
+} catch {}
+try {
+commandEncoder6.copyBufferToTexture(
+{
+/* bytesInLastRow: 8304 widthInBlocks: 519 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 50656 */
+offset: 42352,
+bytesPerRow: 8448,
+buffer: buffer3,
+},
+{
+  texture: texture16,
+  mipLevel: 2,
+  origin: { x: 1333, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 519, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder6.resolveQuerySet(
+querySet14,
+1869,
+1004,
+buffer1,
+16384
+);
+} catch {}
+let videoFrame3 = new VideoFrame(imageBitmap6, {timestamp: 0});
+let commandEncoder22 = device0.createCommandEncoder(
+{
+label: '\ub71d\u2baa\ud7da\u83b8\u02df\ufc5a',
+}
+);
+let texture26 = device0.createTexture(
+{
+label: '\u{1ffe6}\u691e\u0715\uebb0\u24ac\u14a4\ub697\u0e84\u{1f8f7}\u4f68',
+size: {width: 11959, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 11,
+format: 'r8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'r8unorm',
+'r8unorm',
+'r8unorm'
+],
+}
+);
+let computePassEncoder10 = commandEncoder22.beginComputePass();
+try {
+renderPassEncoder1.setBindGroup(
+4,
+bindGroup5
+);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(
+3,
+bindGroup1,
+new Uint32Array(3379),
+1718,
+0
+);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant(
+{
+r: 303.6,
+g: 560.4,
+b: 882.7,
+a: -448.9,
+}
+);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(
+1,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(
+3,
+buffer3,
+44528,
+13845
+);
+} catch {}
+let arrayBuffer4 = buffer2.getMappedRange(
+6064,
+24
+);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let texture27 = device0.createTexture(
+{
+label: '\u{1ff71}\u0c6d\u9456\u4fc6\uf59f\u0806\u771c',
+size: [44, 36, 69],
+mipLevelCount: 3,
+format: 'etc2-rgb8a1unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'etc2-rgb8a1unorm',
+'etc2-rgb8a1unorm-srgb',
+'etc2-rgb8a1unorm'
+],
+}
+);
+let renderPassEncoder6 = commandEncoder19.beginRenderPass(
+{
+label: '\u0e9c\u{1fa68}\udd63\u0763\u{1fae6}\u0ce6\u{1f7ad}\u0268\u667a\u92b0\u0b21',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView19,
+depthLoadOp: 'load',
+depthStoreOp: 'store',
+depthReadOnly: false,
+},
+occlusionQuerySet: querySet10,
+maxDrawCount: 69608,
+}
+);
+try {
+computePassEncoder9.end();
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(
+3,
+bindGroup3
+);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(
+8,
+buffer1,
+2472,
+14743
+);
+} catch {}
+try {
+commandEncoder7.copyTextureToBuffer(
+{
+  texture: texture13,
+  mipLevel: 0,
+  origin: { x: 144, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 42524 widthInBlocks: 10631 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 58524 */
+offset: 58524,
+buffer: buffer3,
+},
+{width: 10631, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder17.clearBuffer(
+buffer1,
+5968,
+12800
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder6.resolveQuerySet(
+querySet14,
+1298,
+1782,
+buffer1,
+7680
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+let gpuCanvasContext6 = canvas5.getContext('webgpu');
+try {
+await promise9;
+} catch {}
+let commandEncoder23 = device0.createCommandEncoder(
+{
+label: '\uee63\u585e\u0e6d\uc2e6',
+}
+);
+let renderBundle15 = renderBundleEncoder2.finish();
+try {
+renderPassEncoder1.beginOcclusionQuery(
+32
+);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant(
+{
+r: -368.7,
+g: -490.2,
+b: 343.6,
+a: 715.2,
+}
+);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(
+buffer6,
+'uint16',
+7476,
+3037
+);
+} catch {}
+try {
+commandEncoder18.clearBuffer(
+buffer3,
+32060,
+3892
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let offscreenCanvas7 = new OffscreenCanvas(421, 264);
+let imageData5 = new ImageData(244, 116);
+let renderBundleEncoder19 = device0.createRenderBundleEncoder(
+{
+label: '\u3348\u{1f9b4}\u9676\u039d',
+colorFormats: [
+undefined,
+'rg16uint'
+],
+sampleCount: 315,
+}
+);
+try {
+renderPassEncoder1.setBlendConstant(
+{
+r: -205.9,
+g: 112.3,
+b: 357.7,
+a: 771.2,
+}
+);
+} catch {}
+try {
+renderPassEncoder5.setViewport(
+6.064,
+0.1645,
+7.886,
+0.7673,
+0.8909,
+0.9917
+);
+} catch {}
+document.body.append('\u3f21\u{1fc00}\ud9d9\u{1f99b}\u{1f9cc}\ubd11\u{1f633}\u07dd\u5fcd\u3c02\u720f');
+try {
+offscreenCanvas7.getContext('bitmaprenderer');
+} catch {}
+let computePassEncoder11 = commandEncoder21.beginComputePass(
+{
+label: '\u0cae\uf85b\uef1a\u8037\u{1fc47}\u219f\u7030\uba6a\u24dc\u{1ff38}'
+}
+);
+let renderPassEncoder7 = commandEncoder23.beginRenderPass(
+{
+colorAttachments: [
+undefined
+],
+depthStencilAttachment: {
+view: textureView19,
+depthClearValue: -7.957770910120829,
+depthReadOnly: true,
+},
+maxDrawCount: 305000,
+}
+);
+try {
+renderPassEncoder1.setBindGroup(
+0,
+bindGroup3,
+new Uint32Array(2866),
+1067,
+0
+);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(
+394
+);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(
+buffer6,
+'uint16',
+8202,
+1400
+);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(
+5,
+buffer6,
+3100,
+4324
+);
+} catch {}
+try {
+device0.pushErrorScope(
+'validation'
+);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(
+buffer2,
+1848,
+buffer6,
+10040,
+260
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder7.resolveQuerySet(
+querySet9,
+262,
+160,
+buffer1,
+25088
+);
+} catch {}
+let textureView21 = texture6.createView(
+{
+mipLevelCount: 6,
+arrayLayerCount: 15,
+}
+);
+let computePassEncoder12 = commandEncoder17.beginComputePass(
+{
+label: '\u0623\u5f60\u2030\u{1fa72}'
+}
+);
+let sampler21 = device0.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 81.651,
+lodMaxClamp: 94.305,
+}
+);
+try {
+computePassEncoder5.setPipeline(
+pipeline13
+);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(
+8
+);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(
+1,
+0,
+9,
+0
+);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(
+3,
+buffer6,
+9736
+);
+} catch {}
+try {
+commandEncoder6.copyBufferToBuffer(
+buffer0,
+32400,
+buffer6,
+9576,
+1492
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder15.copyTextureToTexture(
+{
+  texture: texture15,
+  mipLevel: 1,
+  origin: { x: 12, y: 7, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 1,
+  origin: { x: 3, y: 1, z: 0 },
+  aspect: 'all',
+},
+{width: 33, height: 15, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+12068,
+new DataView(new ArrayBuffer(9875)),
+4249,
+4704
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture3,
+  mipLevel: 5,
+  origin: { x: 84, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 53 */{
+offset: 53,
+bytesPerRow: 63,
+},
+{width: 12, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let promise10 = device0.createComputePipelineAsync(
+{
+label: '\u2851\u0c2f\u429e\u0f7c\u{1f8d2}\u0b64',
+layout: pipelineLayout6,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let computePassEncoder13 = commandEncoder7.beginComputePass(
+{
+label: '\u552f\u0a2e\ub328\ube65'
+}
+);
+try {
+computePassEncoder0.setPipeline(
+pipeline20
+);
+} catch {}
+try {
+renderPassEncoder1.setViewport(
+171.7,
+0.6229,
+17.28,
+0.3176,
+0.4772,
+0.5073
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+8,
+buffer6
+);
+} catch {}
+try {
+commandEncoder18.clearBuffer(
+buffer5,
+10416,
+16092
+);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture27,
+  mipLevel: 1,
+  origin: { x: 8, y: 4, z: 3 },
+  aspect: 'all',
+},
+new DataView(arrayBuffer1),
+/* required buffer size: 133641 */{
+offset: 71,
+bytesPerRow: 286,
+rowsPerImage: 8,
+},
+{width: 4, height: 16, depthOrArrayLayers: 59}
+);
+} catch {}
+document.body.prepend('\u{1fa7d}\u6085\u7361\u{1fa5a}');
+try {
+device0.label = '\u085a\u{1fca5}\u{1ff41}';
+} catch {}
+let shaderModule10 = device0.createShaderModule(
+{
+label: '\u{1f870}\u00f5\u{1fdb0}\uf5fd\u{1fa33}',
+code: `
+
+@compute @workgroup_size(4, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(7) f0: vec3<f32>,
+@location(1) f1: vec3<f32>,
+@location(3) f2: vec2<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S14 {
+@location(18) f0: vec4<f16>,
+@location(8) f1: vec2<u32>,
+@location(20) f2: vec3<f32>,
+@location(0) f3: i32,
+@location(15) f4: vec3<f16>,
+@location(25) f5: vec4<f32>,
+@location(21) f6: f16,
+@location(19) f7: f16
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(13) a1: vec4<u32>, @location(17) a2: vec2<u32>, @builtin(vertex_index) a3: u32, @location(10) a4: vec3<u32>, @location(2) a5: vec2<u32>, @location(1) a6: vec4<f16>, @location(7) a7: vec2<f32>, a8: S14, @location(16) a9: vec2<i32>, @location(22) a10: vec2<f16>, @location(11) a11: vec2<f32>, @location(26) a12: vec2<f32>, @location(24) a13: f32, @location(14) a14: vec3<i32>, @location(9) a15: f32, @location(28) a16: vec2<f16>, @location(23) a17: f16, @location(5) a18: u32, @location(4) a19: f32, @location(3) a20: vec2<u32>, @location(27) a21: vec2<f32>, @location(6) a22: vec4<f32>, @location(12) a23: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroup10 = device0.createBindGroup({
+label: '\u057a\ua0e3',
+layout: bindGroupLayout2,
+entries: [
+
+],
+});
+let querySet19 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 433,
+}
+);
+let textureView22 = texture25.createView(
+{
+label: '\u003d\u2965\u69c9\u0819\u5936\u09bc\u0a51\u{1f620}\u0a7a',
+}
+);
+let computePassEncoder14 = commandEncoder18.beginComputePass(
+{
+label: '\u{1fd94}\u0a07\u{1fdb4}\u{1f65d}\u790a\u5911\u0ebb\ubf19\u{1f7f5}'
+}
+);
+let renderBundle16 = renderBundleEncoder2.finish(
+{
+label: '\u{1fe83}\u810e\u03ff\u8622\u00ca\u8b4c\u2f5e\u11c6'
+}
+);
+try {
+renderBundleEncoder12.setIndexBuffer(
+buffer3,
+'uint32',
+32164,
+10658
+);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(
+2,
+buffer1
+);
+} catch {}
+try {
+commandEncoder15.copyBufferToTexture(
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 58920 */
+offset: 58920,
+bytesPerRow: 0,
+rowsPerImage: 80,
+buffer: buffer3,
+},
+{
+  texture: texture4,
+  mipLevel: 4,
+  origin: { x: 0, y: 4, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 136}
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder15.copyTextureToTexture(
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 3562, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 481, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 1271, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipelineLayout8 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout2,
+bindGroupLayout2,
+bindGroupLayout4,
+bindGroupLayout7,
+bindGroupLayout2
+],
+}
+);
+let textureView23 = texture4.createView(
+{
+label: '\u0ef6\u416d\u0000\u0aa0',
+dimension: '2d',
+baseMipLevel: 4,
+baseArrayLayer: 55,
+arrayLayerCount: 1,
+}
+);
+try {
+computePassEncoder13.setBindGroup(
+2,
+bindGroup10
+);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant(
+{
+r: 383.2,
+g: 620.7,
+b: -513.1,
+a: 216.6,
+}
+);
+} catch {}
+try {
+renderPassEncoder3.setViewport(
+205.8,
+0.6151,
+0.8408,
+0.1232,
+0.8559,
+0.9646
+);
+} catch {}
+try {
+commandEncoder15.clearBuffer(
+buffer5,
+19084,
+10836
+);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+1136,
+new Float32Array(29925),
+29433,
+336
+);
+} catch {}
+document.body.prepend('\u{1f7a6}\u0be5');
+let shaderModule11 = device0.createShaderModule(
+{
+code: `@group(2) @binding(3950)
+var<storage, read_write> field1: array<u32>;
+
+@compute @workgroup_size(4, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S16 {
+@builtin(position) f0: vec4<f32>,
+@builtin(front_facing) f1: bool
+}
+struct FragmentOutput0 {
+@location(0) f0: vec4<f32>,
+@location(1) f1: vec3<f32>,
+@location(6) f2: vec4<u32>,
+@location(5) f3: vec3<u32>,
+@location(7) f4: vec3<i32>,
+@location(4) f5: vec4<f32>,
+@location(2) f6: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, a1: S16, @builtin(sample_mask) a2: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S15 {
+@location(2) f0: u32,
+@location(12) f1: f16,
+@location(20) f2: vec2<f16>,
+@location(15) f3: vec2<i32>,
+@location(16) f4: u32,
+@location(18) f5: vec3<f16>,
+@location(19) f6: vec2<f16>,
+@location(1) f7: vec3<u32>,
+@location(14) f8: vec2<f16>,
+@location(28) f9: vec2<i32>,
+@location(23) f10: vec2<i32>,
+@location(27) f11: f16,
+@location(9) f12: vec3<u32>,
+@location(10) f13: vec2<f32>,
+@location(8) f14: vec4<f16>,
+@location(22) f15: vec4<u32>,
+@location(26) f16: vec3<f16>,
+@location(7) f17: vec4<f32>,
+@location(11) f18: vec2<u32>,
+@location(24) f19: vec4<u32>,
+@location(25) f20: vec3<f16>,
+@location(21) f21: vec2<i32>,
+@location(4) f22: vec2<u32>,
+@location(5) f23: vec2<i32>,
+@location(0) f24: vec3<f32>,
+@location(13) f25: vec3<i32>,
+@location(3) f26: f16,
+@builtin(vertex_index) f27: u32
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec4<u32>, @builtin(instance_index) a1: u32, @location(17) a2: vec2<f16>, a3: S15) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let querySet20 = device0.createQuerySet(
+{
+label: '\uc71a\u1b94\u1162\u{1f662}',
+type: 'occlusion',
+count: 1476,
+}
+);
+try {
+renderPassEncoder5.beginOcclusionQuery(
+56
+);
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant(
+{
+r: 829.5,
+g: 428.3,
+b: 769.3,
+a: 297.5,
+}
+);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(
+2,
+bindGroup7
+);
+} catch {}
+document.body.prepend('\u{1fdbb}\ua0b3\u0816\ude30\u0f57\u0770\uab3b');
+let bindGroup11 = device0.createBindGroup({
+layout: bindGroupLayout4,
+entries: [
+
+],
+});
+try {
+computePassEncoder14.setPipeline(
+pipeline26
+);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(
+0,
+bindGroup10
+);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant(
+{
+r: 873.5,
+g: -67.09,
+b: -933.1,
+a: -325.4,
+}
+);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(
+102,
+0,
+104,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+6,
+buffer3,
+14872
+);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(
+5,
+buffer3
+);
+} catch {}
+try {
+commandEncoder15.clearBuffer(
+buffer6,
+7228,
+472
+);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let bindGroup12 = device0.createBindGroup({
+label: '\u4026\u6880\uec5a\u005b\u5f98\u{1f6a8}\u4b84',
+layout: bindGroupLayout7,
+entries: [
+{
+binding: 4427,
+resource: sampler2
+},
+{
+binding: 2928,
+resource: textureView23
+}
+],
+});
+let buffer7 = device0.createBuffer(
+{
+label: '\u0e3b\u4c9f',
+size: 57785,
+usage: GPUBufferUsage.MAP_WRITE,
+}
+);
+let textureView24 = texture23.createView(
+{
+label: '\u94f8\u0b82\ua06a\u07aa\u5ce5\u0287\u{1fc43}\u76c3\udd8a\u0945',
+dimension: '2d-array',
+mipLevelCount: 6,
+baseArrayLayer: 0,
+}
+);
+let computePassEncoder15 = commandEncoder6.beginComputePass(
+{
+label: '\u9919\u{1f8ff}\u3aca\u9ff8\u9571\u0792\ue5e7\u{1fbf6}\u0761\uae54'
+}
+);
+try {
+renderPassEncoder3.beginOcclusionQuery(
+40
+);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+9,
+buffer6,
+4764,
+5897
+);
+} catch {}
+try {
+window.someLabel = textureView16.label;
+} catch {}
+let pipelineLayout9 = device0.createPipelineLayout(
+{
+label: '\u3eae\u0160\u716b\ue3e4\u0fe0',
+bindGroupLayouts: [
+bindGroupLayout1,
+bindGroupLayout5,
+bindGroupLayout5,
+bindGroupLayout1,
+bindGroupLayout2,
+bindGroupLayout7
+],
+}
+);
+let querySet21 = device0.createQuerySet(
+{
+label: '\u0cd9\u{1feba}\u0e28\u5572\u52e7',
+type: 'occlusion',
+count: 605,
+}
+);
+try {
+computePassEncoder10.setPipeline(
+pipeline5
+);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+34,
+1,
+12,
+0
+);
+} catch {}
+try {
+gpuCanvasContext4.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg16uint',
+'depth24plus',
+'depth24plus'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let pipeline27 = await promise7;
+let bindGroup13 = device0.createBindGroup({
+layout: bindGroupLayout3,
+entries: [
+
+],
+});
+let commandEncoder24 = device0.createCommandEncoder(
+{
+label: '\u{1fa9e}\u6ba4\u3d0a\u{1f813}\u8c7e\u03d9',
+}
+);
+let renderBundle17 = renderBundleEncoder18.finish(
+{
+
+}
+);
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant(
+{
+r: -849.9,
+g: 843.4,
+b: 947.1,
+a: 158.6,
+}
+);
+} catch {}
+try {
+renderPassEncoder5.setStencilReference(
+2280
+);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+26.41,
+0.08320,
+38.80,
+0.1028,
+0.2488,
+0.3134
+);
+} catch {}
+try {
+commandEncoder15.copyTextureToBuffer(
+{
+  texture: texture23,
+  mipLevel: 4,
+  origin: { x: 16, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 280 widthInBlocks: 35 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 51168 */
+offset: 51168,
+buffer: buffer3,
+},
+{width: 140, height: 4, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let buffer8 = device0.createBuffer(
+{
+label: '\u0b4c\udfd4\u{1f66c}\ubae8\u0939\u087a\u56a8\u0fa5\u0c1e\u{1fdc4}',
+size: 40069,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let sampler22 = device0.createSampler(
+{
+label: '\u{1fbff}\u{1ff01}\u0813\u{1ff99}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 60.056,
+lodMaxClamp: 71.104,
+maxAnisotropy: 2,
+}
+);
+try {
+computePassEncoder10.setBindGroup(
+3,
+bindGroup7
+);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(
+4065
+);
+} catch {}
+try {
+renderPassEncoder5.setViewport(
+0.9986,
+0.9766,
+8.872,
+0.00575,
+0.8939,
+0.8975
+);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(
+10,
+buffer6,
+4032,
+6109
+);
+} catch {}
+try {
+commandEncoder15.copyTextureToBuffer(
+{
+  texture: texture15,
+  mipLevel: 1,
+  origin: { x: 9, y: 1, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 25 widthInBlocks: 25 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 46376 */
+offset: 46376,
+bytesPerRow: 256,
+buffer: buffer3,
+},
+{width: 25, height: 28, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder20.resolveQuerySet(
+querySet8,
+674,
+140,
+buffer3,
+43520
+);
+} catch {}
+try {
+commandEncoder15.insertDebugMarker(
+'\u0d7b'
+);
+} catch {}
+try {
+await promise6;
+} catch {}
+document.body.append('\ucdfb\u3d20\u0e31\u{1fa19}\ua014\u{1fb14}');
+let offscreenCanvas8 = new OffscreenCanvas(778, 654);
+let promise11 = adapter1.requestAdapterInfo();
+pseudoSubmit(device0, commandEncoder23);
+let renderBundle18 = renderBundleEncoder13.finish(
+{
+label: '\u8184\u{1f91c}\u9563\u531f\u{1fd05}\u5026'
+}
+);
+let sampler23 = device0.createSampler(
+{
+label: '\ue975\u4523\u{1fe11}\u8217\ud0b1\u2d3c\uf85a\u0e10\ubba5\u02c0',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 96.081,
+lodMaxClamp: 96.975,
+maxAnisotropy: 5,
+}
+);
+try {
+computePassEncoder0.dispatchWorkgroups(
+3,
+2
+);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(
+7,
+buffer1,
+20848,
+17008
+);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(
+3,
+bindGroup6,
+new Uint32Array(968),
+740,
+0
+);
+} catch {}
+try {
+commandEncoder15.copyTextureToTexture(
+{
+  texture: texture25,
+  mipLevel: 0,
+  origin: { x: 4185, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 8,
+  origin: { x: 4, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline28 = device0.createRenderPipeline(
+{
+label: '\u{1f6c4}\u7781\u28b5\u8dd0\u{1f658}\ubbf9\u21e7\u0598\udb99',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 9832,
+attributes: [
+
+],
+},
+{
+arrayStride: 43092,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 22012,
+shaderLocation: 20,
+},
+{
+format: 'float32x3',
+offset: 10352,
+shaderLocation: 17,
+},
+{
+format: 'float16x4',
+offset: 31148,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x4',
+offset: 35516,
+shaderLocation: 2,
+},
+{
+format: 'uint16x4',
+offset: 25596,
+shaderLocation: 15,
+},
+{
+format: 'float32',
+offset: 41844,
+shaderLocation: 0,
+},
+{
+format: 'float32x3',
+offset: 29168,
+shaderLocation: 9,
+},
+{
+format: 'uint32x3',
+offset: 8900,
+shaderLocation: 26,
+},
+{
+format: 'unorm8x2',
+offset: 28194,
+shaderLocation: 21,
+},
+{
+format: 'uint8x2',
+offset: 40392,
+shaderLocation: 4,
+},
+{
+format: 'sint32x3',
+offset: 3832,
+shaderLocation: 6,
+},
+{
+format: 'uint32x2',
+offset: 30984,
+shaderLocation: 16,
+},
+{
+format: 'unorm8x4',
+offset: 40820,
+shaderLocation: 1,
+},
+{
+format: 'snorm8x2',
+offset: 30974,
+shaderLocation: 18,
+},
+{
+format: 'uint32x2',
+offset: 8772,
+shaderLocation: 25,
+}
+],
+},
+{
+arrayStride: 31408,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x3',
+offset: 2864,
+shaderLocation: 28,
+},
+{
+format: 'sint16x4',
+offset: 1440,
+shaderLocation: 22,
+},
+{
+format: 'snorm8x2',
+offset: 4924,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 46628,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x4',
+offset: 33820,
+shaderLocation: 23,
+},
+{
+format: 'uint16x4',
+offset: 6092,
+shaderLocation: 19,
+},
+{
+format: 'snorm8x4',
+offset: 26192,
+shaderLocation: 24,
+}
+],
+},
+{
+arrayStride: 25568,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x2',
+offset: 2296,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 54272,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 23484,
+shaderLocation: 14,
+},
+{
+format: 'uint8x2',
+offset: 22154,
+shaderLocation: 27,
+}
+],
+},
+{
+arrayStride: 13556,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x2',
+offset: 1702,
+shaderLocation: 7,
+},
+{
+format: 'sint8x2',
+offset: 1654,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 10836,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x2',
+offset: 5516,
+shaderLocation: 3,
+},
+{
+format: 'uint32',
+offset: 4640,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 45052,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 33092,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8unorm',
+writeMask: 0,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 431,
+stencilWriteMask: 2204,
+depthBias: 89,
+depthBiasSlopeScale: 18,
+depthBiasClamp: 48,
+},
+}
+);
+let img5 = await imageWithData(105, 18, '#f5c693f2', '#ad5f8773');
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let bindGroup14 = device0.createBindGroup({
+label: '\u{1fb46}\u0fca',
+layout: bindGroupLayout8,
+entries: [
+
+],
+});
+let buffer9 = device0.createBuffer(
+{
+label: '\u523d\u21d8\u{1fe40}\u6754\u{1fa32}\u7ba0\u08b0\ue0f4\u4281\u0d8d',
+size: 43744,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+let commandEncoder25 = device0.createCommandEncoder(
+{
+label: '\u{1fc80}\u0ea1\u0bad\u03cb\u14cd\u04d2',
+}
+);
+let textureView25 = texture13.createView(
+{
+dimension: '1d',
+}
+);
+let renderPassEncoder8 = commandEncoder24.beginRenderPass(
+{
+label: '\u0c67\u5bcc\u6c94\uc135\u3e85\u04fe\u{1f7f3}\ueb7d',
+colorAttachments: [
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView19,
+depthClearValue: 0.5563078491634917,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+},
+occlusionQuerySet: querySet8,
+maxDrawCount: 307784,
+}
+);
+let renderBundle19 = renderBundleEncoder12.finish(
+{
+label: '\u0051\u571e\ub62a'
+}
+);
+try {
+computePassEncoder11.setPipeline(
+pipeline22
+);
+} catch {}
+try {
+commandEncoder20.copyBufferToTexture(
+{
+/* bytesInLastRow: 37440 widthInBlocks: 2340 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 24016 */
+offset: 24016,
+bytesPerRow: 37632,
+buffer: buffer0,
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 2683, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 2340, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+292,
+new Float32Array(1650),
+724,
+100
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture17,
+  mipLevel: 0,
+  origin: { x: 2139, y: 1, z: 1 },
+  aspect: 'all',
+},
+new Int32Array(new ArrayBuffer(64)),
+/* required buffer size: 390 */{
+offset: 390,
+rowsPerImage: 70,
+},
+{width: 1882, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline29 = device0.createRenderPipeline(
+{
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule4,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 20004,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x2',
+offset: 14684,
+shaderLocation: 3,
+},
+{
+format: 'float32x4',
+offset: 13928,
+shaderLocation: 15,
+},
+{
+format: 'uint8x4',
+offset: 15280,
+shaderLocation: 5,
+},
+{
+format: 'sint16x2',
+offset: 3472,
+shaderLocation: 21,
+},
+{
+format: 'float32',
+offset: 18700,
+shaderLocation: 26,
+},
+{
+format: 'sint16x4',
+offset: 18880,
+shaderLocation: 12,
+},
+{
+format: 'sint8x4',
+offset: 8356,
+shaderLocation: 16,
+},
+{
+format: 'float32x2',
+offset: 14120,
+shaderLocation: 19,
+},
+{
+format: 'uint8x4',
+offset: 4156,
+shaderLocation: 11,
+},
+{
+format: 'unorm16x4',
+offset: 10060,
+shaderLocation: 4,
+},
+{
+format: 'uint8x4',
+offset: 18176,
+shaderLocation: 8,
+},
+{
+format: 'sint32x2',
+offset: 11548,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 16220,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 7740,
+shaderLocation: 14,
+},
+{
+format: 'sint8x2',
+offset: 13972,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x4',
+offset: 1736,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 39320,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 37728,
+shaderLocation: 20,
+},
+{
+format: 'uint32',
+offset: 9144,
+shaderLocation: 1,
+},
+{
+format: 'snorm8x2',
+offset: 15508,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x4',
+offset: 35956,
+shaderLocation: 7,
+},
+{
+format: 'float32x2',
+offset: 31400,
+shaderLocation: 24,
+},
+{
+format: 'float32',
+offset: 31368,
+shaderLocation: 28,
+},
+{
+format: 'snorm16x2',
+offset: 6920,
+shaderLocation: 25,
+}
+],
+},
+{
+arrayStride: 20524,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 13436,
+shaderLocation: 0,
+},
+{
+format: 'uint32x4',
+offset: 4272,
+shaderLocation: 17,
+},
+{
+format: 'uint32x2',
+offset: 13380,
+shaderLocation: 27,
+},
+{
+format: 'uint8x4',
+offset: 5888,
+shaderLocation: 18,
+},
+{
+format: 'sint32x3',
+offset: 12900,
+shaderLocation: 6,
+},
+{
+format: 'unorm16x4',
+offset: 18724,
+shaderLocation: 23,
+},
+{
+format: 'snorm16x2',
+offset: 17580,
+shaderLocation: 22,
+}
+],
+}
+]
+},
+primitive: {
+cullMode: 'front',
+},
+multisample: {
+mask: 0xf6c76471,
+},
+fragment: {
+module: shaderModule4,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 539,
+stencilWriteMask: 3841,
+depthBias: 28,
+depthBiasSlopeScale: 21,
+depthBiasClamp: 87,
+},
+}
+);
+offscreenCanvas6.height = 223;
+let bindGroup15 = device0.createBindGroup({
+label: '\u312a\u{1fe8c}\u{1fc2e}\u4492\ua74b\u621c',
+layout: bindGroupLayout2,
+entries: [
+
+],
+});
+let querySet22 = device0.createQuerySet(
+{
+label: '\u5095\udcd8\u014a\ubcfe\u{1fba3}\u{1fe19}\u56c0\ud191',
+type: 'occlusion',
+count: 3379,
+}
+);
+let renderBundle20 = renderBundleEncoder5.finish();
+try {
+computePassEncoder3.setPipeline(
+pipeline23
+);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant(
+{
+r: -437.1,
+g: -832.4,
+b: 421.4,
+a: -928.9,
+}
+);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+80.32,
+0.2153,
+7.833,
+0.2314,
+0.1336,
+0.7822
+);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(
+4,
+bindGroup14,
+new Uint32Array(3993),
+2227,
+0
+);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(
+9,
+buffer1,
+13256,
+24579
+);
+} catch {}
+try {
+commandEncoder15.copyBufferToTexture(
+{
+/* bytesInLastRow: 2646 widthInBlocks: 1323 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 31510 */
+offset: 31510,
+buffer: buffer8,
+},
+{
+  texture: texture17,
+  mipLevel: 0,
+  origin: { x: 494, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 1323, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder25.clearBuffer(
+buffer3,
+14928,
+11080
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline30 = device0.createComputePipeline(
+{
+label: '\ue86e\u3f4c\u0618\ueed5',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+}
+);
+offscreenCanvas5.height = 618;
+document.body.append('\u342a\u2d2f\u{1fe9b}\u{1f6d1}\u08ae\u{1f8d8}\u04ce\u6cdc');
+let texture28 = device0.createTexture(
+{
+label: '\u01a1\u2dde\u5276\u9e93\uf886\u265b\u0718\u02af\u{1fb33}\u0e19\u0450',
+size: {width: 4080, height: 228, depthOrArrayLayers: 1},
+mipLevelCount: 10,
+dimension: '2d',
+format: 'eac-r11snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let textureView26 = texture15.createView(
+{
+baseMipLevel: 1,
+}
+);
+let renderBundle21 = renderBundleEncoder18.finish(
+{
+label: '\ubcbd\u800c'
+}
+);
+let sampler24 = device0.createSampler(
+{
+label: '\u{1f9ee}\u210e',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 77.588,
+compare: 'equal',
+maxAnisotropy: 20,
+}
+);
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder7.setViewport(
+12.28,
+0.1987,
+0.8072,
+0.7469,
+0.02935,
+0.6603
+);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(
+3,
+bindGroup15,
+new Uint32Array(1031),
+724,
+0
+);
+} catch {}
+try {
+commandEncoder20.copyTextureToTexture(
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: { x: 0, y: 16, z: 69 },
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 52 },
+  aspect: 'all',
+},
+{width: 8, height: 4, depthOrArrayLayers: 30}
+);
+} catch {}
+try {
+commandEncoder15.resolveQuerySet(
+querySet22,
+731,
+2395,
+buffer3,
+18176
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture23,
+  mipLevel: 1,
+  origin: { x: 1132, y: 44, z: 0 },
+  aspect: 'all',
+},
+new Uint32Array(arrayBuffer3),
+/* required buffer size: 325 */{
+offset: 325,
+bytesPerRow: 132,
+rowsPerImage: 288,
+},
+{width: 28, height: 32, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let canvas6 = document.createElement('canvas');
+let bindGroupLayout9 = device0.createBindGroupLayout(
+{
+label: '\u0c3d\u0f1b\u4647\u0bd5',
+entries: [
+{
+binding: 3392,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+},
+{
+binding: 7277,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+}
+],
+}
+);
+let commandBuffer0 = commandEncoder25.finish(
+{
+label: '\u8515\u0455\u730a\u1256\u09ea\u052d\u{1f95b}\u00aa\u{1fbb1}\u0e05',
+}
+);
+let renderBundleEncoder20 = device0.createRenderBundleEncoder(
+{
+label: '\u{1f6ae}\ud9aa\u88ed',
+colorFormats: [
+'rg32sint',
+'rgba16sint',
+'rgba8uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 801,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler25 = device0.createSampler(
+{
+label: '\u0b26\u009f\u0ec0\uf8a5\u0879\uf194\u79ab',
+addressModeU: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 31.424,
+lodMaxClamp: 62.822,
+maxAnisotropy: 19,
+}
+);
+try {
+renderPassEncoder2.setBindGroup(
+3,
+bindGroup9
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+2,
+bindGroup13,
+new Uint32Array(8643),
+4811,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(
+1905
+);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer3,
+'uint16',
+33782,
+23246
+);
+} catch {}
+let arrayBuffer5 = buffer2.getMappedRange(
+6088,
+60
+);
+try {
+commandEncoder15.copyTextureToTexture(
+{
+  texture: texture15,
+  mipLevel: 0,
+  origin: { x: 39, y: 11, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 1,
+  origin: { x: 3, y: 14, z: 0 },
+  aspect: 'all',
+},
+{width: 42, height: 17, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline31 = await promise10;
+document.body.prepend('\u02ff\ubbf6\u078f\u7d00\u{1f6df}\u{1f80c}\ufe4b\u0f32\uc6bf');
+let bindGroup16 = device0.createBindGroup({
+label: '\ue041\u4937\u161c\uec7b\u3c56\ufc20\u335a\u{1f7d0}\u0852\u69b8',
+layout: bindGroupLayout3,
+entries: [
+
+],
+});
+let renderBundle22 = renderBundleEncoder16.finish(
+{
+label: '\u71c7\u0a8a\ub41f'
+}
+);
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(
+13,
+1,
+0,
+0
+);
+} catch {}
+try {
+commandEncoder15.clearBuffer(
+buffer1,
+21404,
+12744
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+renderPassEncoder6.insertDebugMarker(
+'\u620b'
+);
+} catch {}
+let bindGroup17 = device0.createBindGroup({
+label: '\u9913\u9f42\u00c7\u0d45\u0ef1\u67e4\u689e\u{1fc9d}',
+layout: bindGroupLayout6,
+entries: [
+{
+binding: 7741,
+resource: {
+buffer: buffer3,
+offset: 4832,
+size: 4908,
+}
+},
+{
+binding: 4867,
+resource: textureView22
+}
+],
+});
+let querySet23 = device0.createQuerySet(
+{
+label: '\u2e16\u1ea5\u0c88',
+type: 'occlusion',
+count: 2088,
+}
+);
+let textureView27 = texture5.createView(
+{
+label: '\u01ae\ue5aa\u5c6b\u18a9\u{1fd6e}',
+baseMipLevel: 2,
+baseArrayLayer: 0,
+}
+);
+let renderBundle23 = renderBundleEncoder16.finish(
+{
+label: '\u05ae\u06bd\ub905'
+}
+);
+try {
+computePassEncoder0.dispatchWorkgroups(
+4,
+1,
+1
+);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(
+32
+);
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant(
+{
+r: -28.17,
+g: -838.4,
+b: -815.2,
+a: 817.5,
+}
+);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(
+2353
+);
+} catch {}
+try {
+commandEncoder15.resolveQuerySet(
+querySet8,
+1792,
+47,
+buffer1,
+3584
+);
+} catch {}
+let pipeline32 = device0.createComputePipeline(
+{
+label: '\u017d\u{1fd96}\u073f\u{1f7db}\u0c7e\u0e05\u0f30\u{1faba}\u0246\ua75c',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule10,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let pipelineLayout10 = device0.createPipelineLayout(
+{
+label: '\u4937\u51e5\u053a\u{1fdde}\u9215\u{1fd4f}\u{1f6f9}',
+bindGroupLayouts: [
+bindGroupLayout0,
+bindGroupLayout2,
+bindGroupLayout9
+],
+}
+);
+let querySet24 = device0.createQuerySet(
+{
+label: '\u3713\u{1ffa8}',
+type: 'occlusion',
+count: 3962,
+}
+);
+let renderBundle24 = renderBundleEncoder5.finish(
+{
+
+}
+);
+try {
+computePassEncoder0.dispatchWorkgroups(
+1,
+1,
+5
+);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(
+2,
+bindGroup2,
+new Uint32Array(6025),
+5311,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(
+buffer1,
+'uint32',
+26492
+);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(
+2,
+bindGroup9
+);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(
+buffer6,
+'uint32',
+2396,
+7663
+);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(
+buffer8,
+6560,
+buffer3,
+25964,
+27756
+);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+1324,
+new DataView(new ArrayBuffer(165)),
+165,
+0
+);
+} catch {}
+let canvas7 = document.createElement('canvas');
+let shaderModule12 = device0.createShaderModule(
+{
+code: `
+
+@compute @workgroup_size(8, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S18 {
+@location(27) f0: f32,
+@location(44) f1: f16,
+@builtin(sample_mask) f2: u32,
+@location(26) f3: i32,
+@location(110) f4: vec4<u32>,
+@location(7) f5: vec4<i32>,
+@location(76) f6: vec4<f32>,
+@location(111) f7: vec4<i32>,
+@location(104) f8: vec4<f32>,
+@location(28) f9: i32,
+@location(34) f10: f32,
+@location(11) f11: vec4<u32>,
+@location(51) f12: vec2<i32>,
+@location(117) f13: vec3<f32>,
+@location(17) f14: vec2<f16>,
+@location(115) f15: vec3<u32>
+}
+struct FragmentOutput0 {
+@location(3) f0: vec2<i32>,
+@location(1) f1: vec4<u32>,
+@location(6) f2: vec2<i32>,
+@location(4) f3: u32
+}
+
+@fragment
+fn fragment0(@location(102) a0: f32, a1: S18, @location(79) a2: vec3<i32>, @location(61) a3: i32, @location(89) a4: vec3<u32>, @location(25) a5: vec4<u32>, @builtin(sample_index) a6: u32, @location(65) a7: vec3<u32>, @location(53) a8: vec4<f32>, @location(1) a9: vec2<u32>, @location(103) a10: f16, @location(21) a11: vec4<f16>, @location(43) a12: f32, @location(68) a13: i32, @location(19) a14: vec2<u32>, @location(67) a15: vec2<u32>, @builtin(position) a16: vec4<f32>, @builtin(front_facing) a17: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S17 {
+@location(8) f0: vec4<f32>
+}
+struct VertexOutput0 {
+@location(76) f118: vec4<f32>,
+@location(65) f119: vec3<u32>,
+@builtin(position) f120: vec4<f32>,
+@location(61) f121: i32,
+@location(34) f122: f32,
+@location(79) f123: vec3<i32>,
+@location(103) f124: f16,
+@location(7) f125: vec4<i32>,
+@location(115) f126: vec3<u32>,
+@location(51) f127: vec2<i32>,
+@location(89) f128: vec3<u32>,
+@location(102) f129: f32,
+@location(25) f130: vec4<u32>,
+@location(68) f131: i32,
+@location(117) f132: vec3<f32>,
+@location(26) f133: i32,
+@location(21) f134: vec4<f16>,
+@location(67) f135: vec2<u32>,
+@location(1) f136: vec2<u32>,
+@location(19) f137: vec2<u32>,
+@location(17) f138: vec2<f16>,
+@location(27) f139: f32,
+@location(53) f140: vec4<f32>,
+@location(28) f141: i32,
+@location(104) f142: vec4<f32>,
+@location(11) f143: vec4<u32>,
+@location(110) f144: vec4<u32>,
+@location(111) f145: vec4<i32>,
+@location(44) f146: f16,
+@location(43) f147: f32
+}
+
+@vertex
+fn vertex0(@location(21) a0: vec4<f32>, @location(16) a1: u32, @location(15) a2: vec4<f32>, @location(18) a3: vec2<u32>, @location(7) a4: vec4<f16>, @location(14) a5: i32, @location(23) a6: vec2<f32>, @location(28) a7: vec2<u32>, @location(1) a8: vec3<i32>, @builtin(instance_index) a9: u32, @location(2) a10: u32, @builtin(vertex_index) a11: u32, @location(3) a12: vec2<f16>, @location(26) a13: vec4<u32>, @location(5) a14: vec4<f16>, @location(17) a15: f32, @location(12) a16: vec3<u32>, @location(9) a17: vec4<u32>, @location(4) a18: i32, @location(0) a19: vec4<f32>, @location(22) a20: vec4<i32>, @location(27) a21: vec3<f16>, a22: S17, @location(24) a23: i32, @location(10) a24: vec2<i32>, @location(20) a25: f32, @location(11) a26: f16, @location(6) a27: vec2<i32>, @location(13) a28: vec4<f32>, @location(19) a29: vec3<f32>, @location(25) a30: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture29 = device0.createTexture(
+{
+label: '\u2af2\u6562\u0a5c\u4cfe',
+size: {width: 212, height: 1, depthOrArrayLayers: 1133},
+mipLevelCount: 8,
+sampleCount: 1,
+dimension: '3d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder16 = commandEncoder20.beginComputePass(
+{
+label: '\u02a6\u5d7f\u90fc\ud9b3\u967d\u5b0f\u0301'
+}
+);
+let renderBundle25 = renderBundleEncoder7.finish(
+{
+
+}
+);
+try {
+computePassEncoder12.setBindGroup(
+3,
+bindGroup17,
+[]
+);
+} catch {}
+try {
+computePassEncoder3.setBindGroup(
+3,
+bindGroup13,
+new Uint32Array(1913),
+1746,
+0
+);
+} catch {}
+try {
+computePassEncoder5.setPipeline(
+pipeline15
+);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(
+buffer3,
+1156,
+buffer9,
+25776,
+12540
+);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder15.copyTextureToBuffer(
+{
+  texture: texture21,
+  mipLevel: 0,
+  origin: { x: 8, y: 29, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 196 widthInBlocks: 98 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 25590 */
+offset: 13106,
+bytesPerRow: 512,
+buffer: buffer3,
+},
+{width: 98, height: 25, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder15.clearBuffer(
+buffer6,
+6208,
+1212
+);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let pipeline33 = await device0.createComputePipelineAsync(
+{
+label: '\udcfe\u9272\ubf9a\u0b11\u4400\u{1f729}\u{1f7d9}\u{1fa91}\u0cc2\u88e5\u3820',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+},
+}
+);
+let shaderModule13 = device0.createShaderModule(
+{
+label: '\u217f\u0699\u{1f9b6}\u{1f76e}\u03c8\u8d9f\u0d98',
+code: `@group(2) @binding(1235)
+var<storage, read_write> type0: array<u32>;
+
+@compute @workgroup_size(4, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(7) f0: vec2<f32>,
+@location(0) f1: vec4<u32>,
+@location(3) f2: vec4<u32>,
+@location(2) f3: vec3<f32>,
+@location(4) f4: vec2<i32>,
+@location(5) f5: vec3<f32>,
+@location(6) f6: f32,
+@location(1) f7: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S19 {
+@location(5) f0: vec3<i32>,
+@location(14) f1: vec3<f32>,
+@location(16) f2: vec4<i32>,
+@location(25) f3: vec2<f16>,
+@location(11) f4: vec3<f32>,
+@location(6) f5: vec2<i32>,
+@location(28) f6: vec4<i32>,
+@builtin(vertex_index) f7: u32,
+@location(13) f8: i32,
+@location(12) f9: vec3<i32>,
+@location(7) f10: vec2<f32>,
+@location(3) f11: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(23) a0: vec3<f32>, @location(9) a1: vec3<f16>, @location(8) a2: vec2<f32>, @location(18) a3: vec4<u32>, @location(1) a4: vec3<f32>, @location(21) a5: vec4<i32>, @location(2) a6: vec4<u32>, @location(27) a7: vec3<u32>, a8: S19) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+}
+);
+let bindGroup18 = device0.createBindGroup({
+label: '\u4aee\u0cec\uf139\u{1ffa4}\u2182\u9472\u657f\u6c3b\u063f\u11e2',
+layout: bindGroupLayout8,
+entries: [
+
+],
+});
+let querySet25 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 3266,
+}
+);
+try {
+renderPassEncoder7.setBlendConstant(
+{
+r: 623.6,
+g: 996.6,
+b: 748.6,
+a: -933.8,
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+36992,
+new Int16Array(25582),
+19575,
+184
+);
+} catch {}
+let promise12 = device0.createRenderPipelineAsync(
+{
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 26684,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32',
+offset: 5840,
+shaderLocation: 26,
+},
+{
+format: 'sint32',
+offset: 8288,
+shaderLocation: 7,
+},
+{
+format: 'sint8x2',
+offset: 23200,
+shaderLocation: 22,
+},
+{
+format: 'sint32',
+offset: 10832,
+shaderLocation: 3,
+},
+{
+format: 'snorm8x2',
+offset: 4886,
+shaderLocation: 23,
+},
+{
+format: 'uint32',
+offset: 19020,
+shaderLocation: 15,
+},
+{
+format: 'uint32x2',
+offset: 13564,
+shaderLocation: 28,
+},
+{
+format: 'unorm16x4',
+offset: 5228,
+shaderLocation: 17,
+},
+{
+format: 'float16x2',
+offset: 3156,
+shaderLocation: 5,
+},
+{
+format: 'uint8x4',
+offset: 19912,
+shaderLocation: 19,
+},
+{
+format: 'float32x4',
+offset: 7844,
+shaderLocation: 1,
+},
+{
+format: 'snorm8x4',
+offset: 24748,
+shaderLocation: 11,
+},
+{
+format: 'uint32x3',
+offset: 14620,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 37048,
+attributes: [
+{
+format: 'uint8x2',
+offset: 35162,
+shaderLocation: 27,
+},
+{
+format: 'sint32x4',
+offset: 8884,
+shaderLocation: 20,
+},
+{
+format: 'float32x4',
+offset: 3180,
+shaderLocation: 12,
+},
+{
+format: 'unorm16x4',
+offset: 32204,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 7748,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 33904,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 31516,
+shaderLocation: 16,
+},
+{
+format: 'float32x2',
+offset: 22936,
+shaderLocation: 21,
+},
+{
+format: 'sint16x4',
+offset: 12728,
+shaderLocation: 6,
+},
+{
+format: 'float32x3',
+offset: 5344,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'float32x3',
+offset: 22932,
+shaderLocation: 24,
+},
+{
+format: 'sint32x4',
+offset: 38624,
+shaderLocation: 13,
+},
+{
+format: 'uint32x3',
+offset: 6076,
+shaderLocation: 4,
+},
+{
+format: 'float32',
+offset: 46072,
+shaderLocation: 14,
+},
+{
+format: 'uint32x2',
+offset: 48712,
+shaderLocation: 25,
+},
+{
+format: 'float32',
+offset: 39840,
+shaderLocation: 10,
+},
+{
+format: 'float32x3',
+offset: 22764,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 34028,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x2',
+offset: 42908,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'dst-alpha',
+dstFactor: 'src-alpha-saturated'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+undefined,
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-clamp',
+depthFailOp: 'keep',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 2467,
+depthBias: 38,
+depthBiasSlopeScale: 26,
+},
+}
+);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.prepend('\u0383\u{1ffa9}\ud5ac\u{1fe6d}\ub9e4');
+let texture30 = device0.createTexture(
+{
+label: '\ua52b\u{1fadb}\ud8c1\u9ee3\ue94d\u2613\u0919\u0037',
+size: {width: 115, height: 247, depthOrArrayLayers: 23},
+mipLevelCount: 2,
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'bgra8unorm-srgb'
+],
+}
+);
+let renderBundleEncoder21 = device0.createRenderBundleEncoder(
+{
+label: '\u{1fc04}\u0970\u{1fe92}\ua681\u{1fb25}',
+colorFormats: [
+'rgba8sint',
+'rg16sint',
+'rgba8unorm-srgb',
+'bgra8unorm-srgb',
+'r32float',
+'rg32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 618,
+}
+);
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(
+0,
+0,
+7,
+0
+);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(
+buffer3,
+'uint16',
+7952,
+14476
+);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(
+buffer8,
+27504,
+buffer1,
+39260,
+48
+);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture15,
+  mipLevel: 1,
+  origin: { x: 12, y: 7, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer3,
+/* required buffer size: 2895 */{
+offset: 401,
+bytesPerRow: 124,
+},
+{width: 14, height: 21, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await adapter1.requestAdapterInfo();
+} catch {}
+let sampler26 = device0.createSampler(
+{
+label: '\u{1fd08}\u01d6\uaa41\u87d7\ub55d\u049d',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 84.063,
+maxAnisotropy: 18,
+}
+);
+try {
+computePassEncoder15.setBindGroup(
+4,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(
+40
+);
+} catch {}
+try {
+renderPassEncoder4.setViewport(
+76.53,
+0.3505,
+74.60,
+0.4287,
+0.6556,
+0.8002
+);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(
+buffer6,
+'uint32',
+7688
+);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(
+5,
+bindGroup16,
+[]
+);
+} catch {}
+let promise13 = buffer7.mapAsync(
+GPUMapMode.WRITE,
+0,
+10004
+);
+try {
+device0.queue.writeBuffer(
+buffer1,
+38588,
+new BigUint64Array(46910),
+15310,
+108
+);
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder(
+{
+}
+);
+let textureView28 = texture10.createView(
+{
+label: '\u0bcb\u{1fb54}\ua11d\u0431\u02ab\u{1fc3b}\u{1faf9}\u0998\u30e5',
+baseMipLevel: 0,
+}
+);
+let computePassEncoder17 = commandEncoder15.beginComputePass();
+let renderBundle26 = renderBundleEncoder17.finish(
+{
+label: '\u6b96\u3753\u8ab1\u0223\uaf79\u008e\u00d6\u{1fcc4}\u0c49\u{1f6bd}\u4a06'
+}
+);
+try {
+computePassEncoder17.setPipeline(
+pipeline31
+);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(
+5,
+bindGroup4,
+[]
+);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(
+40
+);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(
+328
+);
+} catch {}
+try {
+await buffer8.mapAsync(
+GPUMapMode.WRITE,
+0,
+19772
+);
+} catch {}
+try {
+commandEncoder26.clearBuffer(
+buffer5,
+2768,
+9920
+);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder26.resolveQuerySet(
+querySet5,
+852,
+248,
+buffer1,
+19456
+);
+} catch {}
+let pipeline34 = await device0.createComputePipelineAsync(
+{
+label: '\u7bb4\u94d4\u09e8\u{1fab0}\u{1fef1}\u8d58\u01d3\uf7b7\u{1fcad}\ue85b\u5bd9',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let renderPassEncoder9 = commandEncoder26.beginRenderPass(
+{
+label: '\u04bd\u4024\u1fa5\uca57\u0788',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView19,
+depthClearValue: 0.6160688945310969,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+stencilClearValue: 34334,
+},
+maxDrawCount: 106480,
+}
+);
+try {
+renderPassEncoder3.beginOcclusionQuery(
+40
+);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(
+5,
+1,
+4,
+0
+);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(
+buffer1,
+'uint16',
+33986,
+4661
+);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(
+5,
+buffer3,
+27548
+);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(
+4,
+bindGroup15
+);
+} catch {}
+offscreenCanvas8.height = 928;
+document.body.prepend('\u318e\u5c36\u0d24\u0f1d\ub973');
+let commandEncoder27 = device0.createCommandEncoder(
+{
+label: '\u{1f83d}\u0cc6\u33e7\ud08a',
+}
+);
+let textureView29 = texture6.createView(
+{
+label: '\u4a60\u4859\u{1f985}',
+format: 'rgb10a2unorm',
+baseMipLevel: 2,
+mipLevelCount: 1,
+baseArrayLayer: 23,
+arrayLayerCount: 15,
+}
+);
+let renderPassEncoder10 = commandEncoder27.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView19,
+depthClearValue: 0.2704057918938396,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+depthReadOnly: false,
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet10,
+maxDrawCount: 83752,
+}
+);
+try {
+computePassEncoder0.setBindGroup(
+0,
+bindGroup3,
+new Uint32Array(4338),
+1351,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+3,
+bindGroup9
+);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(
+80
+);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(
+3,
+bindGroup18
+);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(
+5,
+bindGroup5,
+new Uint32Array(5303),
+4419,
+0
+);
+} catch {}
+document.body.prepend('\u077a\u02af\u09ca\uadc4\u09ce\ud543');
+let bindGroupLayout10 = device0.createBindGroupLayout(
+{
+label: '\u02bb\u{1f7c0}',
+entries: [
+{
+binding: 1775,
+visibility: GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 6623,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}
+],
+}
+);
+let commandEncoder28 = device0.createCommandEncoder();
+let textureView30 = texture14.createView(
+{
+label: '\u3f2d\ufc71\u02ba',
+baseMipLevel: 4,
+baseArrayLayer: 134,
+arrayLayerCount: 24,
+}
+);
+try {
+computePassEncoder0.setBindGroup(
+0,
+bindGroup1,
+[]
+);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(
+0,
+bindGroup13
+);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder28.resolveQuerySet(
+querySet1,
+891,
+671,
+buffer3,
+7936
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 26, height: 1, depthOrArrayLayers: 141}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 153, y: 453 },
+  flipY: false,
+},
+{
+  texture: texture29,
+  mipLevel: 3,
+  origin: { x: 3, y: 0, z: 70 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 22, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend(video0);
+let videoFrame4 = new VideoFrame(img0, {timestamp: 0});
+let bindGroupLayout11 = device0.createBindGroupLayout(
+{
+label: '\u{1f710}\ucce2\u0c62\ue42e\ufb0d\u81e9\u0843',
+entries: [
+{
+binding: 8463,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+},
+{
+binding: 6792,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+}
+],
+}
+);
+let bindGroup19 = device0.createBindGroup({
+label: '\u0c0b\u0167\ua506\u675c\u6ccf\u9a47\u{1fd4a}\u0231\uf5f1',
+layout: bindGroupLayout2,
+entries: [
+
+],
+});
+let textureView31 = texture15.createView(
+{
+dimension: '2d-array',
+}
+);
+let computePassEncoder18 = commandEncoder28.beginComputePass(
+{
+label: '\u0fa8\u02d5\u{1fb45}\u3f6a\u4b99\u{1fcd6}\u{1fe9e}\u674e\u16e0\ude7a'
+}
+);
+let sampler27 = device0.createSampler(
+{
+label: '\u{1fbc6}\uffb3\u0716',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 44.899,
+lodMaxClamp: 92.851,
+maxAnisotropy: 20,
+}
+);
+try {
+computePassEncoder16.setBindGroup(
+1,
+bindGroup16
+);
+} catch {}
+try {
+computePassEncoder11.setPipeline(
+pipeline20
+);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(
+1,
+bindGroup5
+);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(
+5,
+bindGroup13
+);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(
+buffer3,
+'uint16'
+);
+} catch {}
+try {
+device0.pushErrorScope(
+'out-of-memory'
+);
+} catch {}
+let offscreenCanvas9 = new OffscreenCanvas(67, 111);
+let shaderModule14 = device0.createShaderModule(
+{
+label: '\u9ebc\u7cf5\u0213',
+code: `@group(3) @binding(591)
+var<storage, read_write> global0: array<u32>;
+
+@compute @workgroup_size(8, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool, @builtin(sample_mask) a2: u32) {
+
+}
+
+struct S20 {
+@location(6) f0: vec2<u32>,
+@location(10) f1: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(17) a0: vec2<f32>, @builtin(vertex_index) a1: u32, @location(8) a2: u32, @builtin(instance_index) a3: u32, @location(11) a4: vec2<f32>, @location(20) a5: vec3<f16>, @location(25) a6: vec2<u32>, @location(2) a7: vec3<u32>, @location(0) a8: i32, @location(16) a9: f16, @location(1) a10: vec4<f32>, @location(26) a11: vec3<f32>, @location(15) a12: u32, @location(22) a13: vec4<f32>, @location(7) a14: i32, @location(5) a15: f32, @location(9) a16: vec2<f32>, @location(4) a17: vec2<i32>, @location(27) a18: vec3<f32>, @location(21) a19: vec4<u32>, a20: S20, @location(18) a21: vec4<i32>, @location(3) a22: vec4<f16>, @location(28) a23: vec4<f32>, @location(24) a24: vec2<i32>, @location(13) a25: vec4<f32>, @location(12) a26: vec2<u32>, @location(14) a27: vec3<f32>, @location(23) a28: vec4<f16>, @location(19) a29: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+}
+);
+let bindGroup20 = device0.createBindGroup({
+label: '\u738f\u06c6\u0dc8',
+layout: bindGroupLayout4,
+entries: [
+
+],
+});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder(
+{
+label: '\udaa8\u7164\u2469\u{1fefa}\u46fc',
+colorFormats: [
+'r16uint',
+'rgba8unorm',
+'r16uint',
+'rgba8sint'
+],
+sampleCount: 657,
+}
+);
+let renderBundle27 = renderBundleEncoder3.finish(
+{
+label: '\u7b3c\uf6fc\u953a\u{1fd53}\u{1fa6e}\u41e4'
+}
+);
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setViewport(
+10.46,
+0.09922,
+3.335,
+0.5291,
+0.2964,
+0.7442
+);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(
+1,
+buffer3,
+41940,
+11566
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+3088,
+new BigUint64Array(47067),
+27076,
+3696
+);
+} catch {}
+gc();
+document.body.append('\u{1fa68}\u0d14\u{1f6cc}');
+let adapter2 = await promise3;
+try {
+offscreenCanvas9.getContext('webgpu');
+} catch {}
+let querySet26 = device0.createQuerySet(
+{
+label: '\uc604\u090c',
+type: 'occlusion',
+count: 2953,
+}
+);
+let renderBundleEncoder23 = device0.createRenderBundleEncoder(
+{
+label: '\u7cf4\u241a\u{1fcac}\u0371\ud7b7\u{1f670}\u0187\u658c\u353b\u{1f6e8}',
+colorFormats: [
+'r16float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 422,
+stencilReadOnly: true,
+}
+);
+let externalTexture1 = device0.importExternalTexture(
+{
+label: '\u28fc\u5a5f\u0659\u8613',
+source: videoFrame0,
+colorSpace: 'display-p3',
+}
+);
+try {
+renderPassEncoder8.setBindGroup(
+5,
+bindGroup3
+);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+await promise11;
+} catch {}
+document.body.append('\u{1fba7}\u{1f8ef}\u{1fdcc}\ua936\u{1f85f}\uaaa1\u{1f73f}');
+let device1 = await promise0;
+let offscreenCanvas10 = new OffscreenCanvas(353, 980);
+let texture31 = device1.createTexture(
+{
+label: '\u0b51\uddfa\u6e04\u1db7\u{1f87b}\u002f\u{1f9d2}\u24f6\uc1c4\u00ed\ud0d5',
+size: [223, 97, 1],
+mipLevelCount: 8,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+await promise13;
+} catch {}
+let commandEncoder29 = device0.createCommandEncoder(
+{
+label: '\ue536\u{1fbe6}\ubd82\u{1f769}\u{1f894}\u{1fdaf}\uf8a8\u04d6\u{1fcef}',
+}
+);
+let renderPassEncoder11 = commandEncoder29.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView19,
+depthClearValue: 0.001278355284298316,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+depthReadOnly: false,
+stencilClearValue: 11013,
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet23,
+maxDrawCount: 6096,
+}
+);
+let renderBundleEncoder24 = device0.createRenderBundleEncoder(
+{
+label: '\u2933\u{1fc3c}\uba65\u7b5a\u9a07\u0a83\ue3ba\u3684\u082b\u{1fd8d}',
+colorFormats: [
+'rg8sint',
+undefined,
+undefined,
+'rgb10a2unorm',
+'rgba8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 526,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder11.setBindGroup(
+5,
+bindGroup18
+);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+29516,
+new Float32Array(56391),
+29459,
+2400
+);
+} catch {}
+let promise14 = device0.createComputePipelineAsync(
+{
+layout: pipelineLayout0,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let texture32 = device0.createTexture(
+{
+size: {width: 2289},
+dimension: '1d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView32 = texture20.createView(
+{
+format: 'etc2-rgba8unorm',
+baseMipLevel: 1,
+baseArrayLayer: 13,
+arrayLayerCount: 29,
+}
+);
+let sampler28 = device0.createSampler(
+{
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 96.934,
+lodMaxClamp: 98.650,
+}
+);
+try {
+computePassEncoder12.setPipeline(
+pipeline14
+);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(
+4,
+bindGroup7
+);
+} catch {}
+gc();
+document.body.prepend('\u087d\u7c50\u5015\u{1fe7a}');
+try {
+await adapter1.requestAdapterInfo();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 212, height: 1, depthOrArrayLayers: 1133}
+*/
+{
+  source: img1,
+  origin: { x: 69, y: 10 },
+  flipY: false,
+},
+{
+  texture: texture29,
+  mipLevel: 0,
+  origin: { x: 21, y: 1, z: 389 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 129, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline35 = device0.createRenderPipeline(
+{
+layout: pipelineLayout9,
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 54936,
+shaderLocation: 17,
+},
+{
+format: 'float32x2',
+offset: 1356,
+shaderLocation: 1,
+},
+{
+format: 'unorm8x4',
+offset: 55648,
+shaderLocation: 25,
+},
+{
+format: 'sint16x4',
+offset: 3372,
+shaderLocation: 2,
+},
+{
+format: 'snorm8x4',
+offset: 43412,
+shaderLocation: 20,
+},
+{
+format: 'unorm16x4',
+offset: 44376,
+shaderLocation: 3,
+},
+{
+format: 'uint8x4',
+offset: 44760,
+shaderLocation: 6,
+},
+{
+format: 'sint32x2',
+offset: 7220,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x4',
+offset: 29524,
+shaderLocation: 19,
+},
+{
+format: 'float16x4',
+offset: 50148,
+shaderLocation: 24,
+}
+],
+},
+{
+arrayStride: 36296,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x4',
+offset: 24092,
+shaderLocation: 11,
+},
+{
+format: 'sint32',
+offset: 7044,
+shaderLocation: 7,
+},
+{
+format: 'uint32x3',
+offset: 4396,
+shaderLocation: 13,
+},
+{
+format: 'uint8x2',
+offset: 3108,
+shaderLocation: 26,
+},
+{
+format: 'sint32x3',
+offset: 232,
+shaderLocation: 5,
+},
+{
+format: 'unorm16x2',
+offset: 17384,
+shaderLocation: 28,
+},
+{
+format: 'float32x3',
+offset: 28264,
+shaderLocation: 16,
+},
+{
+format: 'uint32x2',
+offset: 2012,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x2',
+offset: 28972,
+shaderLocation: 12,
+},
+{
+format: 'sint32x2',
+offset: 33100,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x4',
+offset: 1616,
+shaderLocation: 9,
+},
+{
+format: 'uint8x4',
+offset: 20936,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 11352,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 4216,
+shaderLocation: 8,
+},
+{
+format: 'uint16x2',
+offset: 5956,
+shaderLocation: 21,
+},
+{
+format: 'float16x4',
+offset: 3492,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 37236,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x2',
+offset: 2036,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x4',
+offset: 5900,
+shaderLocation: 10,
+},
+{
+format: 'sint8x4',
+offset: 24684,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 21204,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 2140,
+shaderLocation: 27,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+},
+fragment: {
+module: shaderModule3,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'less',
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 3837,
+stencilWriteMask: 2414,
+depthBiasSlopeScale: 37,
+depthBiasClamp: 85,
+},
+}
+);
+let imageBitmap7 = await createImageBitmap(imageData2);
+try {
+canvas7.getContext('bitmaprenderer');
+} catch {}
+let bindGroup21 = device0.createBindGroup({
+label: '\u3369\ua185\uc7f6\u0a65\u6bd2\u{1fda8}',
+layout: bindGroupLayout7,
+entries: [
+{
+binding: 4427,
+resource: sampler2
+},
+{
+binding: 2928,
+resource: textureView23
+}
+],
+});
+let querySet27 = device0.createQuerySet(
+{
+label: '\ud1e5\u{1fcdd}\ud494\u62a5\ub941\u0ed4\u49fc',
+type: 'occlusion',
+count: 1509,
+}
+);
+let textureView33 = texture26.createView(
+{
+label: '\uc7d5\ud9a7\u11cf',
+baseMipLevel: 1,
+mipLevelCount: 2,
+}
+);
+let renderBundle28 = renderBundleEncoder4.finish(
+{
+label: '\u{1fce0}\u0271'
+}
+);
+try {
+renderPassEncoder4.beginOcclusionQuery(
+64
+);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant(
+{
+r: 873.1,
+g: 905.4,
+b: -807.5,
+a: 411.5,
+}
+);
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 5778, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(56),
+/* required buffer size: 36768 */{
+offset: 16,
+},
+{width: 2297, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline36 = await device0.createComputePipelineAsync(
+{
+label: '\u2056\u00e5\u80f6\u{1fa79}\u{1ff41}\u083f\u{1f6e2}',
+layout: pipelineLayout8,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let offscreenCanvas11 = new OffscreenCanvas(577, 418);
+let bindGroupLayout12 = device0.createBindGroupLayout(
+{
+label: '\u4ec3\u98de\uea4b\u6423\ue688\u0b83\u{1ff02}\u0da8\u75e0\u{1fe50}',
+entries: [
+{
+binding: 3552,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 6859,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+}
+],
+}
+);
+let querySet28 = device0.createQuerySet(
+{
+label: '\ufc7e\u{1f9e7}\ua414\u2de0\u{1f966}\u04fb',
+type: 'occlusion',
+count: 3567,
+}
+);
+let texture33 = device0.createTexture(
+{
+label: '\u0c5c\u{1fdf4}\u0710\u6b92\u02c3\u5ad7\u{1ffc9}\u714b\u{1fc1a}\uda5f',
+size: {width: 6970, height: 172, depthOrArrayLayers: 1},
+mipLevelCount: 10,
+sampleCount: 1,
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgb10a2unorm'
+],
+}
+);
+let renderBundleEncoder25 = device0.createRenderBundleEncoder(
+{
+label: '\u91c3\u{1f796}\u3a6f\u{1fa5f}\u4572\u2b0c\u8e3e',
+colorFormats: [
+'rgba32sint',
+'rg16float',
+'r16uint',
+'rg8unorm',
+undefined,
+'rgba16float'
+],
+sampleCount: 636,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(
+5,
+bindGroup4,
+[]
+);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(
+0,
+buffer1,
+4728,
+14591
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+30564,
+new DataView(new ArrayBuffer(56785)),
+10271,
+28
+);
+} catch {}
+let pipeline37 = await promise12;
+let commandEncoder30 = device1.createCommandEncoder(
+{
+label: '\u060e\uf68c\ua1c1\u00a9\u02ac\u08aa\u6943\u0e28',
+}
+);
+gc();
+pseudoSubmit(device1, commandEncoder30);
+offscreenCanvas7.width = 1020;
+document.body.append('\u27a5\u{1fd53}\u9a60\u{1fd05}\ue0fa\u06d7');
+let renderBundleEncoder26 = device0.createRenderBundleEncoder(
+{
+label: '\ue0a9\u8b95\u2722',
+colorFormats: [
+'r32sint',
+'rgb10a2unorm',
+undefined
+],
+sampleCount: 767,
+depthReadOnly: true,
+}
+);
+let renderBundle29 = renderBundleEncoder4.finish(
+{
+label: '\u{1f92f}\u{1f94b}\u{1fa90}\u0cc1\u05a1\u6804\ud982'
+}
+);
+let sampler29 = device0.createSampler(
+{
+label: '\u{1ff27}\ua321\ue5b1\u79a9',
+addressModeU: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 76.322,
+maxAnisotropy: 12,
+}
+);
+try {
+computePassEncoder15.setPipeline(
+pipeline20
+);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+40,
+1,
+91,
+0
+);
+} catch {}
+try {
+commandEncoder7.resolveQuerySet(
+querySet20,
+789,
+150,
+buffer1,
+37376
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+532,
+new BigUint64Array(22832),
+6494,
+1052
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+window.someLabel = texture31.label;
+} catch {}
+document.body.prepend('\u0826\ud3be\u207e');
+let promise15 = adapter1.requestAdapterInfo();
+let commandEncoder31 = device1.createCommandEncoder(
+{
+label: '\u065c\u{1feba}\ua8bb\u{1ff44}\u9316\u8f42\u1ce5\u063c\u4f8c',
+}
+);
+let commandBuffer1 = commandEncoder31.finish(
+{
+label: '\u0d38\u4173\u065d\u{1fa89}\u{1fdd2}\u3c7a\uc2b6\u{1f82f}\ub450\uf767\u087e',
+}
+);
+let promise16 = device1.queue.onSubmittedWorkDone();
+try {
+await promise15;
+} catch {}
+let imageBitmap8 = await createImageBitmap(videoFrame1);
+try {
+canvas6.getContext('2d');
+} catch {}
+let querySet29 = device0.createQuerySet(
+{
+label: '\ufd47\uce7b\u43d4',
+type: 'occlusion',
+count: 3206,
+}
+);
+let textureView34 = texture30.createView(
+{
+label: '\u364c\uf825\u6584\u{1fa27}\u90c3\u2bd4\uf8f7\u{1f927}\u0afd\u0136',
+dimension: '2d',
+baseMipLevel: 1,
+baseArrayLayer: 9,
+arrayLayerCount: 1,
+}
+);
+let renderBundle30 = renderBundleEncoder19.finish(
+{
+label: '\u0ca5\u6c9c\u069d\u{1f718}'
+}
+);
+try {
+computePassEncoder18.setBindGroup(
+2,
+bindGroup8,
+new Uint32Array(9294),
+9128,
+0
+);
+} catch {}
+try {
+computePassEncoder11.setPipeline(
+pipeline16
+);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+0,
+buffer3,
+46156,
+3086
+);
+} catch {}
+try {
+commandEncoder7.copyBufferToBuffer(
+buffer8,
+8348,
+buffer1,
+6924,
+13776
+);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder7.copyBufferToTexture(
+{
+/* bytesInLastRow: 1462 widthInBlocks: 1462 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 57416 */
+offset: 55954,
+buffer: buffer3,
+},
+{
+  texture: texture32,
+  mipLevel: 0,
+  origin: { x: 97, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 1462, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline38 = device0.createComputePipeline(
+{
+layout: pipelineLayout8,
+compute: {
+module: shaderModule9,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline39 = await device0.createRenderPipelineAsync(
+{
+label: '\u6421\uaaf5\u9e2b\u0e7f\ube22\u0d9a\u45ce\u{1f6e2}\u953b\udc5f\u6f5a',
+layout: pipelineLayout10,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 42204,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32',
+offset: 39900,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 47900,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 6860,
+shaderLocation: 22,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'front',
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16uint',
+},
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 1259,
+stencilWriteMask: 1438,
+depthBias: 22,
+depthBiasSlopeScale: 35,
+depthBiasClamp: 40,
+},
+}
+);
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+await promise16;
+} catch {}
+gc();
+document.body.append('\u109c\u{1f75c}\u{1f748}\ue272\u10ea\u{1ff93}\ucd1a');
+let texture34 = device1.createTexture(
+{
+label: '\u0221\u0be6\u38a1\u013a\u2555\udf8a\u{1fe0e}\ue1f9\u0c86',
+size: [11619],
+dimension: '1d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundleEncoder27 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgb10a2unorm',
+'rg16float',
+'rg11b10ufloat',
+'rgba8sint',
+'rgba8unorm-srgb',
+'rgba8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 19,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder27.setVertexBuffer(
+52,
+undefined
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture34,
+  mipLevel: 0,
+  origin: { x: 5184, y: 0, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(241),
+/* required buffer size: 241 */{
+offset: 241,
+bytesPerRow: 2104,
+},
+{width: 455, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend(img4);
+document.body.prepend('\u9c90\uae54\u98af\u99f4\u{1f9d3}');
+let video4 = await videoWithData();
+let renderBundle31 = renderBundleEncoder27.finish(
+{
+label: '\uca26\u00ad\u0cef\u{1f766}\u4cc2\u99e5\u3982'
+}
+);
+try {
+device1.queue.writeTexture(
+{
+  texture: texture34,
+  mipLevel: 0,
+  origin: { x: 9064, y: 1, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(72),
+/* required buffer size: 609 */{
+offset: 609,
+bytesPerRow: 1759,
+},
+{width: 378, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let renderPassEncoder12 = commandEncoder7.beginRenderPass(
+{
+label: '\u{1fc98}\u{1f969}\u07e2\ue5eb\u{1f8f4}\u57bb\u00fd',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView19,
+depthClearValue: 5.816030932223004,
+depthLoadOp: 'load',
+depthStoreOp: 'discard',
+depthReadOnly: false,
+},
+occlusionQuerySet: querySet17,
+maxDrawCount: 12928,
+}
+);
+let renderBundleEncoder28 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg16float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 61,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle32 = renderBundleEncoder28.finish();
+let sampler30 = device0.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+}
+);
+try {
+computePassEncoder15.setPipeline(
+pipeline25
+);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(
+1,
+bindGroup18
+);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+7.924,
+0.6345,
+2.559,
+0.01831,
+0.9013,
+0.9020
+);
+} catch {}
+gc();
+let shaderModule15 = device0.createShaderModule(
+{
+code: `
+
+@compute @workgroup_size(2, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S22 {
+@location(71) f0: vec2<f16>,
+@location(38) f1: vec4<f16>
+}
+struct FragmentOutput0 {
+@location(3) f0: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @location(49) a1: vec3<f16>, @location(48) a2: vec4<u32>, @location(34) a3: vec3<f16>, a4: S22, @location(72) a5: vec4<u32>, @builtin(front_facing) a6: bool, @location(103) a7: vec2<u32>, @location(61) a8: vec3<u32>, @location(90) a9: vec2<f16>, @location(36) a10: f32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S21 {
+@builtin(instance_index) f0: u32,
+@location(2) f1: vec4<f32>,
+@location(9) f2: vec2<u32>,
+@location(16) f3: vec2<f16>,
+@location(21) f4: f16,
+@location(18) f5: vec3<u32>,
+@builtin(vertex_index) f6: u32,
+@location(1) f7: vec3<u32>,
+@location(25) f8: f32,
+@location(26) f9: vec2<u32>,
+@location(13) f10: vec3<f16>,
+@location(8) f11: vec4<f32>,
+@location(5) f12: vec3<i32>,
+@location(7) f13: vec4<f32>,
+@location(11) f14: u32,
+@location(27) f15: vec3<i32>,
+@location(6) f16: vec4<u32>,
+@location(22) f17: vec3<i32>,
+@location(0) f18: vec3<f32>,
+@location(23) f19: vec3<f16>,
+@location(4) f20: vec4<u32>,
+@location(19) f21: i32,
+@location(17) f22: vec2<f32>,
+@location(14) f23: vec4<u32>,
+@location(20) f24: vec2<i32>
+}
+struct VertexOutput0 {
+@location(92) f148: vec3<f32>,
+@location(95) f149: vec4<i32>,
+@location(53) f150: vec3<i32>,
+@location(89) f151: vec2<f32>,
+@location(90) f152: vec2<f16>,
+@location(36) f153: f32,
+@location(108) f154: f32,
+@location(15) f155: f32,
+@location(61) f156: vec3<u32>,
+@location(93) f157: f16,
+@location(71) f158: vec2<f16>,
+@location(84) f159: u32,
+@location(9) f160: vec2<f32>,
+@location(56) f161: vec2<f16>,
+@location(49) f162: vec3<f16>,
+@location(6) f163: vec4<u32>,
+@location(101) f164: vec3<u32>,
+@location(17) f165: u32,
+@location(34) f166: vec3<f16>,
+@builtin(position) f167: vec4<f32>,
+@location(38) f168: vec4<f16>,
+@location(65) f169: vec2<f16>,
+@location(72) f170: vec4<u32>,
+@location(86) f171: vec4<u32>,
+@location(10) f172: vec3<f16>,
+@location(27) f173: f16,
+@location(7) f174: vec4<f32>,
+@location(83) f175: f16,
+@location(48) f176: vec4<u32>,
+@location(103) f177: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec4<u32>, @location(10) a1: vec2<f32>, @location(12) a2: i32, @location(24) a3: vec3<f32>, @location(3) a4: vec4<f16>, @location(28) a5: vec3<f16>, a6: S21) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+}
+);
+let renderBundleEncoder29 = device0.createRenderBundleEncoder(
+{
+label: '\u{1fcae}\u99bd\u2f4a\u9a4a\u0b6b\u7479\u93f0\u0140\u{1fcd7}',
+colorFormats: [
+'r32uint',
+'r32uint'
+],
+sampleCount: 752,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder5.setBindGroup(
+5,
+bindGroup10,
+new Uint32Array(8217),
+3846,
+0
+);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant(
+{
+r: 532.7,
+g: 995.8,
+b: 964.8,
+a: -306.9,
+}
+);
+} catch {}
+try {
+buffer3.destroy();
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture9,
+  mipLevel: 1,
+  origin: { x: 0, y: 1, z: 16 },
+  aspect: 'all',
+},
+arrayBuffer3,
+/* required buffer size: 2745464 */{
+offset: 788,
+bytesPerRow: 239,
+rowsPerImage: 261,
+},
+{width: 53, height: 0, depthOrArrayLayers: 45}
+);
+} catch {}
+document.body.append('\u{1fef0}\u0116\u85f6\u9464\u05bf\u0c3d\u075e\ufa96\u8f53\u{1fca1}');
+let commandEncoder32 = device1.createCommandEncoder(
+{
+label: '\u999d\uc495\u{1fbae}\u{1f636}\u0721\u{1fb72}\u{1f74f}\u{1f691}\u72c9',
+}
+);
+let texture35 = device1.createTexture(
+{
+label: '\u4ebc\u8651\u82af',
+size: [120, 120, 1],
+format: 'astc-12x10-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-12x10-unorm-srgb',
+'astc-12x10-unorm-srgb'
+],
+}
+);
+let renderBundleEncoder30 = device1.createRenderBundleEncoder(
+{
+label: '\u036e\u0106\uc17f\u{1fa90}\u0b09\u5245\u{1f8cd}\u07d8\uc7ce',
+colorFormats: [
+'rg8sint',
+'rg8sint',
+'rg16sint',
+'rgba8unorm',
+'bgra8unorm',
+'rg8uint'
+],
+sampleCount: 382,
+}
+);
+try {
+commandEncoder32.copyTextureToTexture(
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 60, y: 80, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 36, height: 30, depthOrArrayLayers: 0}
+);
+} catch {}
+let commandEncoder33 = device1.createCommandEncoder(
+{
+label: '\ub61a\u{1f825}\uefec',
+}
+);
+let querySet30 = device1.createQuerySet(
+{
+type: 'occlusion',
+count: 3762,
+}
+);
+let textureView35 = texture35.createView(
+{
+label: '\u1a2a\u59a2\u{1fcb5}\u{1ff39}',
+baseMipLevel: 0,
+}
+);
+try {
+commandEncoder33.copyTextureToTexture(
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 36, y: 10, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 60, y: 10, z: 1 },
+  aspect: 'all',
+},
+{width: 24, height: 90, depthOrArrayLayers: 0}
+);
+} catch {}
+let renderBundleEncoder31 = device1.createRenderBundleEncoder(
+{
+label: '\u5d1d\u01fd\u2a97\u0478\u054f\u{1f96c}\u0883\ucaec',
+colorFormats: [
+'r32float',
+undefined,
+'rg16float',
+'rgb10a2unorm',
+'bgra8unorm'
+],
+sampleCount: 899,
+stencilReadOnly: true,
+}
+);
+let renderBundle33 = renderBundleEncoder27.finish(
+{
+label: '\udc90\udc41\ub7a2\u{1fd16}'
+}
+);
+let sampler31 = device1.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 8.596,
+lodMaxClamp: 55.124,
+}
+);
+try {
+renderBundleEncoder30.setVertexBuffer(
+32,
+undefined,
+2557421143,
+824608727
+);
+} catch {}
+try {
+commandEncoder32.insertDebugMarker(
+'\u944b'
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture34,
+  mipLevel: 0,
+  origin: { x: 4401, y: 1, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(823),
+/* required buffer size: 823 */{
+offset: 823,
+bytesPerRow: 5156,
+},
+{width: 1251, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let querySet31 = device0.createQuerySet(
+{
+label: '\u0886\uc640\u08ba\u1200\u8bd5\u23bb\u8e2e\u3fde\u0234\uf9c5\ub739',
+type: 'occlusion',
+count: 693,
+}
+);
+let renderBundle34 = renderBundleEncoder28.finish(
+{
+label: '\u35a0\u07a7\u67fc\u0d35\u5408'
+}
+);
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(
+buffer3,
+'uint16',
+15128,
+38203
+);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(
+8,
+buffer3
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture28,
+  mipLevel: 5,
+  origin: { x: 12, y: 0, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(872),
+/* required buffer size: 872 */{
+offset: 872,
+},
+{width: 24, height: 4, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 1, depthOrArrayLayers: 35}
+*/
+{
+  source: imageBitmap4,
+  origin: { x: 136, y: 126 },
+  flipY: false,
+},
+{
+  texture: texture29,
+  mipLevel: 5,
+  origin: { x: 3, y: 0, z: 29 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 3, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline40 = device0.createComputePipeline(
+{
+label: '\u{1fbcd}\u158a\u{1fcd4}\u87d9\u7e4c\u9ba5\u0d9e\u0627\u8743\u003e',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule9,
+entryPoint: 'compute0',
+},
+}
+);
+let commandEncoder34 = device1.createCommandEncoder(
+{
+label: '\u0f9a\u0095\u8e4f',
+}
+);
+let texture36 = device1.createTexture(
+{
+label: '\u{1fe8d}\uf759\u{1f6d5}',
+size: [12199, 149, 1],
+mipLevelCount: 4,
+format: 'rg32float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let textureView36 = texture34.createView(
+{
+label: '\u512f\u35f6\u9586\u277e',
+}
+);
+try {
+commandEncoder32.copyTextureToTexture(
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 0, y: 20, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 60, y: 50, z: 1 },
+  aspect: 'all',
+},
+{width: 24, height: 20, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+adapter0.label = '\u2e65\u0190\u{1fa57}\u2da5\u{1fbeb}\ub72a\u{1fd3d}\u0487';
+} catch {}
+let textureView37 = texture36.createView(
+{
+label: '\uc6d5\ud364\ub570\u0674\u0b10\u5b0d\u{1fc93}\ub1e7\u270e\u{1fcf2}\u{1fd8c}',
+dimension: '2d-array',
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+let renderBundleEncoder32 = device1.createRenderBundleEncoder(
+{
+label: '\u{1f7af}\u88cd\u0550\u800b\u3dfa\u0ff4\u{1f7a9}\u0c84\u04c3\u{1f958}',
+colorFormats: [
+'rg32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 749,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+gpuCanvasContext5.configure(
+{
+device: device1,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm',
+'astc-8x6-unorm',
+'rgba16float'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let gpuCanvasContext7 = offscreenCanvas11.getContext('webgpu');
+let bindGroup22 = device0.createBindGroup({
+layout: bindGroupLayout2,
+entries: [
+
+],
+});
+let querySet32 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 351,
+}
+);
+try {
+computePassEncoder16.setBindGroup(
+1,
+bindGroup20,
+new Uint32Array(8986),
+3741,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(
+1,
+bindGroup4,
+[]
+);
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(
+6,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+2367
+);
+} catch {}
+try {
+renderPassEncoder6.setViewport(
+11.59,
+0.2564,
+1.926,
+0.1287,
+0.04085,
+0.06072
+);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(
+2,
+bindGroup7
+);
+} catch {}
+let buffer10 = device1.createBuffer(
+{
+label: '\u0fa2\ufd23\u9f33\uc1a6\u{1fc3e}\u0351\u05b1\u1c4e',
+size: 48425,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: false,
+}
+);
+let querySet33 = device1.createQuerySet(
+{
+label: '\u989d\u3771\u0e61',
+type: 'occlusion',
+count: 3862,
+}
+);
+let renderBundleEncoder33 = device1.createRenderBundleEncoder(
+{
+label: '\u{1f819}\u788f\u{1ff0f}',
+colorFormats: [
+'rgba8sint',
+'r32float',
+'rgba32uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 7,
+depthReadOnly: true,
+}
+);
+let renderBundle35 = renderBundleEncoder33.finish();
+try {
+renderBundleEncoder30.setVertexBuffer(
+55,
+undefined,
+3695857960
+);
+} catch {}
+let gpuCanvasContext8 = offscreenCanvas10.getContext('webgpu');
+offscreenCanvas11.height = 961;
+let textureView38 = texture29.createView(
+{
+label: '\u{1f7a4}\uf49d\u0c64\u{1fb50}\u0a8f\u{1f8b1}',
+baseMipLevel: 1,
+mipLevelCount: 1,
+}
+);
+let renderBundle36 = renderBundleEncoder3.finish();
+try {
+renderPassEncoder6.setVertexBuffer(
+40,
+undefined,
+1162718968,
+2414299685
+);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(
+buffer1,
+'uint16',
+27634,
+6130
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+536,
+new Int16Array(52459),
+31425,
+4184
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: { x: 3221, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Float32Array(arrayBuffer4),
+/* required buffer size: 375 */{
+offset: 375,
+},
+{width: 9268, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\u5f0b\u0a71\u0b7c\u4404\u8c75\u{1fd47}\u0cad\u{1f7b4}');
+let offscreenCanvas12 = new OffscreenCanvas(353, 686);
+try {
+adapter0.label = '\u{1ffce}\u{1f7f4}\u{1fc34}\u0644\u3882\u0a2a\u{1fd7a}\uaac4';
+} catch {}
+pseudoSubmit(device1, commandEncoder33);
+let sampler32 = device1.createSampler(
+{
+label: '\ubcb2\ud2ca\u059a\u{1fe85}\u{1fccf}\u01fc\uf012',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 91.176,
+lodMaxClamp: 92.228,
+maxAnisotropy: 12,
+}
+);
+try {
+commandEncoder34.copyTextureToTexture(
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 12, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 12, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 36, height: 110, depthOrArrayLayers: 0}
+);
+} catch {}
+let img6 = await imageWithData(159, 56, '#dacbdbe1', '#cc8e34c6');
+let textureView39 = texture25.createView(
+{
+label: '\u7d82\ue586\u0a72\ua519\ubb98',
+aspect: 'all',
+baseMipLevel: 0,
+}
+);
+try {
+renderPassEncoder7.setStencilReference(
+3319
+);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(
+buffer3,
+'uint16',
+30520,
+321
+);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(
+8,
+buffer6,
+8932,
+1722
+);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(
+4,
+bindGroup2
+);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(
+0,
+buffer1,
+9800
+);
+} catch {}
+try {
+adapter0.label = '\u0d82\ub8aa\u{1faee}\u0d70\u72b6\u{1fd1b}';
+} catch {}
+let bindGroup23 = device0.createBindGroup({
+label: '\u{1fec8}\u0e39\u52b1\u08df',
+layout: bindGroupLayout2,
+entries: [
+
+],
+});
+let commandEncoder35 = device0.createCommandEncoder(
+{
+}
+);
+let querySet34 = device0.createQuerySet(
+{
+label: '\u{1fe1f}\u075b\u1ec5',
+type: 'occlusion',
+count: 1611,
+}
+);
+let texture37 = device0.createTexture(
+{
+size: {width: 10972, height: 168, depthOrArrayLayers: 241},
+mipLevelCount: 7,
+dimension: '2d',
+format: 'eac-rg11unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'eac-rg11unorm'
+],
+}
+);
+let computePassEncoder19 = commandEncoder35.beginComputePass(
+{
+label: '\u{1fb79}\u8b14\u5cd1\ud59c\ua633\u075c\u09a1\u18be\u{1fadb}\u5100'
+}
+);
+let sampler33 = device0.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMaxClamp: 53.328,
+}
+);
+try {
+computePassEncoder10.setPipeline(
+pipeline25
+);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(
+4,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(
+4,
+bindGroup3,
+new Uint32Array(2128),
+1124,
+0
+);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(
+40
+);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setViewport(
+9.720,
+0.5202,
+0.3375,
+0.3842,
+0.1427,
+0.7897
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+canvas1.height = 231;
+document.body.append('\u09c9\u{1f75b}\ueea6\u4548\u97df\u5cf5\u0a5d\u3914\u5f7c');
+let img7 = await imageWithData(81, 135, '#8e96506d', '#ee547d45');
+let bindGroupLayout13 = device1.createBindGroupLayout(
+{
+entries: [
+{
+binding: 2724,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'non-filtering' },
+},
+{
+binding: 377,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+},
+{
+binding: 5399,
+visibility: 0,
+externalTexture: {},
+}
+],
+}
+);
+let texture38 = device1.createTexture(
+{
+label: '\uf655\ua7cf\u3a12\u{1fd95}\u07e0\u4431\u077a\ub966',
+size: {width: 66, height: 6, depthOrArrayLayers: 208},
+mipLevelCount: 4,
+format: 'astc-6x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-6x6-unorm-srgb'
+],
+}
+);
+let textureView40 = texture35.createView(
+{
+label: '\u7e98\u0a6f',
+format: 'astc-12x10-unorm-srgb',
+}
+);
+try {
+renderBundleEncoder31.insertDebugMarker(
+'\ufa6c'
+);
+} catch {}
+video1.height = 262;
+try {
+renderPassEncoder6.setBlendConstant(
+{
+r: 866.8,
+g: -3.746,
+b: 944.2,
+a: 627.1,
+}
+);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(
+2,
+buffer1,
+15864
+);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(
+2,
+bindGroup10
+);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(
+2,
+buffer6,
+5980,
+3786
+);
+} catch {}
+let promise17 = device0.createRenderPipelineAsync(
+{
+label: '\u0e40\u0926\ua1c9\u0474\u321f\u{1f9ec}\u6298\u6076',
+layout: pipelineLayout10,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'sint8x2',
+offset: 36740,
+shaderLocation: 20,
+},
+{
+format: 'float16x4',
+offset: 37304,
+shaderLocation: 2,
+},
+{
+format: 'float32x3',
+offset: 45488,
+shaderLocation: 24,
+},
+{
+format: 'uint32x2',
+offset: 12872,
+shaderLocation: 27,
+},
+{
+format: 'sint32x2',
+offset: 53992,
+shaderLocation: 7,
+},
+{
+format: 'snorm8x4',
+offset: 28552,
+shaderLocation: 1,
+},
+{
+format: 'unorm16x2',
+offset: 14736,
+shaderLocation: 0,
+},
+{
+format: 'unorm8x4',
+offset: 45376,
+shaderLocation: 21,
+},
+{
+format: 'uint32x2',
+offset: 6168,
+shaderLocation: 19,
+},
+{
+format: 'sint32x2',
+offset: 42836,
+shaderLocation: 13,
+},
+{
+format: 'unorm16x4',
+offset: 33244,
+shaderLocation: 18,
+},
+{
+format: 'uint16x2',
+offset: 55260,
+shaderLocation: 25,
+},
+{
+format: 'float32x3',
+offset: 20140,
+shaderLocation: 14,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 13496,
+shaderLocation: 10,
+},
+{
+format: 'sint8x2',
+offset: 18756,
+shaderLocation: 22,
+},
+{
+format: 'float16x4',
+offset: 52332,
+shaderLocation: 11,
+},
+{
+format: 'float32x3',
+offset: 24208,
+shaderLocation: 9,
+},
+{
+format: 'sint32',
+offset: 15808,
+shaderLocation: 6,
+},
+{
+format: 'sint32x3',
+offset: 46480,
+shaderLocation: 3,
+},
+{
+format: 'snorm16x2',
+offset: 40576,
+shaderLocation: 5,
+},
+{
+format: 'uint8x2',
+offset: 24852,
+shaderLocation: 4,
+},
+{
+format: 'uint8x2',
+offset: 54584,
+shaderLocation: 16,
+},
+{
+format: 'snorm16x4',
+offset: 15540,
+shaderLocation: 12,
+},
+{
+format: 'float32x2',
+offset: 38888,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 13384,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x4',
+offset: 11708,
+shaderLocation: 8,
+},
+{
+format: 'uint32x4',
+offset: 11820,
+shaderLocation: 28,
+},
+{
+format: 'uint32x3',
+offset: 10160,
+shaderLocation: 26,
+}
+],
+},
+{
+arrayStride: 41280,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 36600,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 57444,
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 19100,
+shaderLocation: 23,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: false,
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'invert',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 4053,
+stencilWriteMask: 3594,
+depthBias: 49,
+depthBiasSlopeScale: 94,
+depthBiasClamp: 58,
+},
+}
+);
+try {
+offscreenCanvas12.getContext('2d');
+} catch {}
+let sampler34 = device1.createSampler(
+{
+label: '\u495f\uef04\u038c\u0591\ua8e8\ue2de\u1f6d\u05f3\u290d\u5892',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMaxClamp: 93.195,
+}
+);
+let bindGroupLayout14 = device1.createBindGroupLayout(
+{
+label: '\u0fa4\u1a4f\ufeb0\u{1f81f}',
+entries: [
+
+],
+}
+);
+let bindGroup24 = device1.createBindGroup({
+label: '\u9847\u3aa4\u7c85',
+layout: bindGroupLayout14,
+entries: [
+
+],
+});
+let querySet35 = device1.createQuerySet(
+{
+label: '\u{1fc5c}\u3908\u0a88\u1eac\u0f59\u0ff6',
+type: 'occlusion',
+count: 4034,
+}
+);
+pseudoSubmit(device1, commandEncoder32);
+let renderBundleEncoder34 = device1.createRenderBundleEncoder(
+{
+label: '\u58b4\u2ace\u{1f9bc}\u{1fc42}\u{1fbe9}\u0433',
+colorFormats: [
+'rg11b10ufloat',
+'r16float'
+],
+sampleCount: 61,
+}
+);
+try {
+device1.queue.writeTexture(
+{
+  texture: texture38,
+  mipLevel: 3,
+  origin: { x: 0, y: 6, z: 14 },
+  aspect: 'all',
+},
+new Int8Array(arrayBuffer0),
+/* required buffer size: 8067940 */{
+offset: 82,
+bytesPerRow: 233,
+rowsPerImage: 199,
+},
+{width: 6, height: 0, depthOrArrayLayers: 175}
+);
+} catch {}
+let canvas8 = document.createElement('canvas');
+let offscreenCanvas13 = new OffscreenCanvas(118, 891);
+let texture39 = device0.createTexture(
+{
+label: '\ub95c\u8076\u0601',
+size: {width: 158, height: 101, depthOrArrayLayers: 1},
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+try {
+computePassEncoder10.setBindGroup(
+1,
+bindGroup22
+);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(
+4,
+bindGroup3,
+new Uint32Array(1365),
+99,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(
+9,
+buffer3,
+40160,
+11802
+);
+} catch {}
+let pipeline41 = await device0.createRenderPipelineAsync(
+{
+label: '\u36f3\u4dcd\u81c2\u05b2\u{1fd7a}\u{1f943}\ue879',
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule13,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 41892,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 14640,
+shaderLocation: 9,
+},
+{
+format: 'float32x2',
+offset: 28996,
+shaderLocation: 1,
+},
+{
+format: 'sint32x3',
+offset: 16332,
+shaderLocation: 21,
+},
+{
+format: 'uint32x4',
+offset: 15600,
+shaderLocation: 18,
+},
+{
+format: 'uint8x4',
+offset: 21576,
+shaderLocation: 2,
+},
+{
+format: 'sint16x4',
+offset: 15572,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x4',
+offset: 33020,
+shaderLocation: 11,
+},
+{
+format: 'float32x3',
+offset: 26420,
+shaderLocation: 8,
+},
+{
+format: 'uint8x2',
+offset: 7816,
+shaderLocation: 27,
+},
+{
+format: 'sint32',
+offset: 10372,
+shaderLocation: 5,
+},
+{
+format: 'sint32x3',
+offset: 33820,
+shaderLocation: 12,
+},
+{
+format: 'snorm16x2',
+offset: 1312,
+shaderLocation: 25,
+},
+{
+format: 'sint8x4',
+offset: 17436,
+shaderLocation: 13,
+},
+{
+format: 'float16x2',
+offset: 18896,
+shaderLocation: 23,
+},
+{
+format: 'sint16x4',
+offset: 27404,
+shaderLocation: 6,
+},
+{
+format: 'float32',
+offset: 9700,
+shaderLocation: 7,
+},
+{
+format: 'uint8x2',
+offset: 32300,
+shaderLocation: 3,
+},
+{
+format: 'sint32',
+offset: 31136,
+shaderLocation: 28,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 36924,
+shaderLocation: 14,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0xd9ad5731,
+},
+fragment: {
+module: shaderModule13,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'rg16uint',
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}
+],
+},
+}
+);
+let adapter3 = await navigator.gpu.requestAdapter();
+let img8 = await imageWithData(67, 207, '#a3642542', '#bab3fa55');
+try {
+offscreenCanvas13.getContext('bitmaprenderer');
+} catch {}
+try {
+computePassEncoder16.setPipeline(
+pipeline13
+);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(
+3,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+8.090,
+0.9775,
+4.455,
+0.00862,
+0.3071,
+0.4159
+);
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+document.body.append('\u67f0\ua909\u73d9\u0cc2');
+let bindGroup25 = device1.createBindGroup({
+label: '\udcfd\uaaba\u025e\u6836\u6d66\u5229\u027d\u{1ffb5}\u0993',
+layout: bindGroupLayout14,
+entries: [
+
+],
+});
+let renderPassEncoder13 = commandEncoder34.beginRenderPass(
+{
+label: '\u1d70\u0e7f\u52f3\u005d\u229c\u002a\u03b4\ua3a5\u0de2\uaf8d\u6097',
+colorAttachments: [
+{
+view: textureView37,
+clearValue: {
+r: 922.7,
+g: -806.6,
+b: -619.3,
+a: -378.4,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet33,
+maxDrawCount: 111784,
+}
+);
+let renderBundle37 = renderBundleEncoder31.finish(
+{
+label: '\u{1f7d0}\u{1ff95}\u0357\u51c4\u{1feac}\u0774\u085e\u{1fe4a}\ufec7\u{1fc39}'
+}
+);
+try {
+renderPassEncoder13.setBindGroup(
+1,
+bindGroup25
+);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(
+1,
+bindGroup25,
+new Uint32Array(1372),
+1269,
+0
+);
+} catch {}
+try {
+gpuCanvasContext6.configure(
+{
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16float'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+try {
+device1.queue.submit([
+commandBuffer1,
+]);
+} catch {}
+let device2 = await adapter3.requestDevice(
+{
+label: '\u590b\u012b\u84ed\ud0ad\u45f4\u612a',
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 9,
+maxColorAttachmentBytesPerSample: 60,
+maxVertexAttributes: 30,
+maxVertexBufferArrayStride: 48181,
+maxStorageTexturesPerShaderStage: 7,
+maxStorageBuffersPerShaderStage: 33,
+maxDynamicStorageBuffersPerPipelineLayout: 28079,
+maxBindingsPerBindGroup: 7811,
+maxTextureDimension1D: 13013,
+maxTextureDimension2D: 14490,
+maxVertexBuffers: 9,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 69618900,
+maxInterStageShaderVariables: 47,
+maxInterStageShaderComponents: 62,
+},
+}
+);
+let buffer11 = device0.createBuffer(
+{
+size: 8358,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let texture40 = device0.createTexture(
+{
+label: '\u027f\u{1f9b2}\u9cca',
+size: {width: 7292, height: 222, depthOrArrayLayers: 54},
+mipLevelCount: 8,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb'
+],
+}
+);
+try {
+renderPassEncoder8.setScissorRect(
+10,
+1,
+3,
+0
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+2836,
+new Int16Array(52050),
+35793,
+1748
+);
+} catch {}
+document.body.prepend('\u7abc\u0ea2\u{1fa10}\u5de9\ue2c5\u7cb6\u{1f98f}\u{1f73f}\u9d86\u083c');
+let shaderModule16 = device0.createShaderModule(
+{
+label: '\u0b32\uc8fa\u4357\ubd46\u0f0b\u{1f982}\ue985\u58cf',
+code: `
+
+@compute @workgroup_size(7, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(2) f0: vec3<i32>,
+@location(6) f1: u32
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(13) a0: vec4<i32>, @builtin(instance_index) a1: u32, @location(28) a2: f32, @location(12) a3: vec4<i32>, @location(6) a4: vec4<f32>, @location(4) a5: f32, @builtin(vertex_index) a6: u32, @location(20) a7: vec3<f16>, @location(15) a8: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let renderBundle38 = renderBundleEncoder18.finish(
+{
+label: '\u{1f7c7}\u3890\u76e5\udd30\u00f4\u8510\u729f\u{1fd5b}'
+}
+);
+try {
+renderPassEncoder10.setBlendConstant(
+{
+r: -888.8,
+g: 195.7,
+b: 115.8,
+a: 289.9,
+}
+);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(
+2,
+buffer1,
+9988,
+7273
+);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(
+6,
+buffer1,
+12568,
+5772
+);
+} catch {}
+let pipeline42 = await promise14;
+document.body.prepend(video3);
+let offscreenCanvas14 = new OffscreenCanvas(350, 487);
+let renderBundleEncoder35 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 424,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle39 = renderBundleEncoder35.finish(
+{
+
+}
+);
+let sampler35 = device2.createSampler(
+{
+label: '\u{1f80b}\u3bc8\u0f7a',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 49.305,
+compare: 'greater',
+}
+);
+document.body.append('\u6983\u02b0');
+let querySet36 = device2.createQuerySet(
+{
+label: '\u{1ffdb}\u0113\ue465\u{1fa5c}',
+type: 'occlusion',
+count: 1144,
+}
+);
+let texture41 = gpuCanvasContext5.getCurrentTexture();
+let textureView41 = texture41.createView(
+{
+label: '\u0142\u{1fe91}\uffae\u929b\uf759\u1542\u2ae1\u3e3e\u{1fc68}',
+dimension: '2d-array',
+}
+);
+let renderBundle40 = renderBundleEncoder35.finish(
+{
+label: '\ufdb0\u4068\u0925\u13f9\u2ec0\ubc61'
+}
+);
+let offscreenCanvas15 = new OffscreenCanvas(612, 238);
+pseudoSubmit(device0, commandEncoder1);
+let textureView42 = texture4.createView(
+{
+dimension: '2d',
+baseMipLevel: 3,
+mipLevelCount: 1,
+baseArrayLayer: 88,
+}
+);
+let renderBundleEncoder36 = device0.createRenderBundleEncoder(
+{
+label: '\u54b1\u2388\u0a8a\u793b\u039a\u0299',
+colorFormats: [
+'rgba16sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 441,
+stencilReadOnly: true,
+}
+);
+let sampler36 = device0.createSampler(
+{
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 81.338,
+lodMaxClamp: 83.693,
+}
+);
+try {
+renderPassEncoder4.setVertexBuffer(
+4,
+buffer6,
+6560,
+4794
+);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(
+5,
+buffer3,
+19228,
+24582
+);
+} catch {}
+let arrayBuffer6 = buffer8.getMappedRange(
+0,
+14100
+);
+let querySet37 = device2.createQuerySet(
+{
+label: '\u387b\u043e\u769f\u4bfc\ufb86\ubb5c\u06e6\u0fd1\u2581\u{1fdf4}',
+type: 'occlusion',
+count: 2612,
+}
+);
+let textureView43 = texture41.createView(
+{
+label: '\u11a9\ua905\u{1fd98}\u015b\u4f33\u093a\u08ff\ub76c\u1e36\u0dcc\u0f78',
+dimension: '2d-array',
+arrayLayerCount: 1,
+}
+);
+let renderBundle41 = renderBundleEncoder35.finish();
+video3.height = 48;
+gc();
+document.body.prepend('\ud7cd\u0d38\uf3d2\u0e75\u{1fdba}\ubc3f');
+let bindGroupLayout15 = device1.createBindGroupLayout(
+{
+entries: [
+{
+binding: 926,
+visibility: GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+},
+{
+binding: 1158,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'rgba8unorm', access: 'write-only', viewDimension: '2d-array' },
+}
+],
+}
+);
+let querySet38 = device1.createQuerySet(
+{
+label: '\u0f14\u76e9\u01bb\u1b10\uf795\ue1b4\u0365\u1c04\u{1fef1}\u0973',
+type: 'occlusion',
+count: 579,
+}
+);
+let texture42 = device1.createTexture(
+{
+label: '\u591f\u9147\ucc74\u{1f905}\ud1d6\ud29b\ufe94',
+size: {width: 12156},
+dimension: '1d',
+format: 'rgba8sint',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8sint',
+'rgba8sint',
+'rgba8sint'
+],
+}
+);
+let renderBundle42 = renderBundleEncoder33.finish(
+{
+label: '\ue052\u0950\u6f8f\u0fcb\u4977\ua132\u{1ff98}\u{1f66c}'
+}
+);
+try {
+renderPassEncoder13.setScissorRect(
+1971,
+12,
+1074,
+12
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 36, y: 40, z: 0 },
+  aspect: 'all',
+},
+new Int8Array(new ArrayBuffer(64)),
+/* required buffer size: 841 */{
+offset: 841,
+bytesPerRow: 300,
+rowsPerImage: 100,
+},
+{width: 60, height: 20, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+document.body.append('\u1f88\ud0c3\u7b07\uf129\u0311\uf0c6\u{1f916}\u{1fcaf}');
+let pipelineLayout11 = device1.createPipelineLayout(
+{
+label: '\ud7ae\uc691\u{1fb12}\u0278',
+bindGroupLayouts: [
+bindGroupLayout13,
+bindGroupLayout14
+],
+}
+);
+let commandEncoder36 = device1.createCommandEncoder(
+{
+label: '\u0f35\u9dd7\u0fe3\u{1ffcf}\u048d',
+}
+);
+try {
+renderPassEncoder13.beginOcclusionQuery(
+8
+);
+} catch {}
+try {
+renderPassEncoder13.setStencilReference(
+876
+);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(
+53,
+undefined,
+2591405364,
+1056032245
+);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(
+29,
+undefined,
+3564817191,
+423696279
+);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+await buffer10.mapAsync(
+GPUMapMode.WRITE,
+43592,
+3928
+);
+} catch {}
+let shaderModule17 = device0.createShaderModule(
+{
+label: '\u{1ff13}\u84a9\u092e\ue3df\ueed1\u{1f908}\u0511\u3b14',
+code: `@group(3) @binding(4427)
+var<storage, read_write> function2: array<u32>;
+
+@compute @workgroup_size(6, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(0) f0: vec4<f32>,
+@builtin(frag_depth) f1: f32,
+@location(2) f2: i32,
+@location(6) f3: vec3<i32>,
+@location(7) f4: vec2<u32>,
+@location(4) f5: vec3<u32>,
+@location(3) f6: f32,
+@builtin(sample_mask) f7: u32,
+@location(1) f8: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_mask) a1: u32, @builtin(sample_index) a2: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder37 = device0.createCommandEncoder(
+{
+label: '\u{1fb6d}\u05fa\ub87e\u0948\u0f7e\u{1f7db}\uce74',
+}
+);
+try {
+renderPassEncoder3.setBindGroup(
+0,
+bindGroup8
+);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(
+64
+);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(
+buffer3,
+'uint32'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+36620,
+new BigUint64Array(39140),
+20053,
+320
+);
+} catch {}
+gc();
+let pipelineLayout12 = device0.createPipelineLayout(
+{
+label: '\u0286\u{1fa5a}\u0043\u9001\u0169\u80c8\u9d4a\u7334\u7964',
+bindGroupLayouts: [
+bindGroupLayout0,
+bindGroupLayout12,
+bindGroupLayout2,
+bindGroupLayout11
+],
+}
+);
+let querySet39 = device0.createQuerySet(
+{
+label: '\u{1feaf}\u{1f81f}\u0b03\u0c52\u0e71',
+type: 'occlusion',
+count: 2881,
+}
+);
+let textureView44 = texture11.createView(
+{
+label: '\u0e45\u8ad9\u21c5\uaed6\u184d\u{1f6e8}\u0842\u0a6e',
+baseMipLevel: 1,
+baseArrayLayer: 2,
+arrayLayerCount: 1,
+}
+);
+let renderPassEncoder14 = commandEncoder37.beginRenderPass(
+{
+label: '\ua6f2\uffaa\u9ceb\u{1f9b0}',
+colorAttachments: [
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView19,
+depthReadOnly: true,
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet13,
+maxDrawCount: 93256,
+}
+);
+try {
+computePassEncoder18.setBindGroup(
+1,
+bindGroup9,
+new Uint32Array(8265),
+2982,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+2569
+);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(
+1,
+bindGroup2,
+new Uint32Array(1922),
+802,
+0
+);
+} catch {}
+let pipeline43 = await promise17;
+let gpuCanvasContext9 = canvas8.getContext('webgpu');
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(
+3,
+bindGroup25
+);
+} catch {}
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.setStencilReference(
+599
+);
+} catch {}
+document.body.prepend('\u{1f996}\u9f48\u485a\u03b1\u{1f834}\u0795\uf8ee');
+let adapter4 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let textureView45 = texture35.createView(
+{
+dimension: '2d-array',
+}
+);
+let computePassEncoder20 = commandEncoder36.beginComputePass(
+{
+
+}
+);
+let renderBundleEncoder37 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+undefined,
+'rg8sint',
+'rg11b10ufloat',
+'r8sint',
+'r16sint',
+'rgba8sint',
+undefined,
+'bgra8unorm-srgb'
+],
+sampleCount: 245,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder13.setBindGroup(
+0,
+bindGroup25
+);
+} catch {}
+try {
+renderPassEncoder13.setStencilReference(
+3345
+);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(
+40,
+undefined
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture34,
+  mipLevel: 0,
+  origin: { x: 1606, y: 1, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(48),
+/* required buffer size: 951 */{
+offset: 951,
+rowsPerImage: 297,
+},
+{width: 6243, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend('\u96e4\uacfd\ud907\u{1f9d5}\u{1fc6f}');
+let commandEncoder38 = device0.createCommandEncoder();
+try {
+renderPassEncoder14.setBindGroup(
+0,
+bindGroup21
+);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: 919.7,
+g: 563.6,
+b: -766.9,
+a: -241.8,
+}
+);
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(
+1,
+1,
+11,
+0
+);
+} catch {}
+try {
+commandEncoder38.copyBufferToBuffer(
+buffer11,
+2336,
+buffer5,
+18564,
+1428
+);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+2772,
+new BigUint64Array(31206),
+9991,
+504
+);
+} catch {}
+let gpuCanvasContext10 = offscreenCanvas14.getContext('webgpu');
+let promise19 = navigator.gpu.requestAdapter(
+{
+}
+);
+try {
+offscreenCanvas8.getContext('webgpu');
+} catch {}
+let sampler37 = device2.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 51.577,
+lodMaxClamp: 76.927,
+compare: 'less',
+maxAnisotropy: 19,
+}
+);
+try {
+device2.queue.writeTexture(
+{
+  texture: texture41,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+new Uint8Array(arrayBuffer6),
+/* required buffer size: 289 */{
+offset: 289,
+bytesPerRow: 163,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+offscreenCanvas15.getContext('bitmaprenderer');
+} catch {}
+let texture43 = device1.createTexture(
+{
+label: '\u031e\u{1fce3}\u024b\u2ebf\u9190\u68f9\u0aee\u017e',
+size: [571],
+dimension: '1d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8snorm',
+'rgba8snorm',
+'rgba8snorm'
+],
+}
+);
+let renderBundleEncoder38 = device1.createRenderBundleEncoder(
+{
+label: '\u0e32\u{1f612}\ucac0\ufa7a\uf7d2\u832b\u5e99\u0948\u02a0\u{1fe24}',
+colorFormats: [
+'rgb10a2unorm',
+'rg32float',
+'rg16sint',
+'rg32float',
+'r16uint',
+'r16uint',
+'rgba32float'
+],
+sampleCount: 89,
+}
+);
+let renderBundle43 = renderBundleEncoder37.finish(
+{
+label: '\u{1f98b}\u1361\u0c85\u{1fed4}\ue9e0\u{1f7f7}\u027a'
+}
+);
+try {
+renderPassEncoder13.beginOcclusionQuery(
+40
+);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(
+1170,
+13,
+532,
+17
+);
+} catch {}
+try {
+renderPassEncoder13.setStencilReference(
+506
+);
+} catch {}
+try {
+renderBundleEncoder30.insertDebugMarker(
+'\u1675'
+);
+} catch {}
+let querySet40 = device1.createQuerySet(
+{
+label: '\u4019\u0deb\u01c1\ufc92',
+type: 'occlusion',
+count: 1571,
+}
+);
+try {
+renderPassEncoder13.setBlendConstant(
+{
+r: 648.3,
+g: -456.0,
+b: 560.8,
+a: 536.4,
+}
+);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(
+75,
+undefined,
+745491817,
+1045375266
+);
+} catch {}
+document.body.prepend('\ueddb\ucad6\u319f\uc0f7\ue98e');
+let querySet41 = device0.createQuerySet(
+{
+label: '\u71dd\u5aa2\u{1fb22}\u7d55\u7dcc\u1ee1\u7292\ue5b8',
+type: 'occlusion',
+count: 3408,
+}
+);
+let textureView46 = texture24.createView(
+{
+dimension: '2d',
+baseMipLevel: 5,
+baseArrayLayer: 153,
+}
+);
+try {
+computePassEncoder18.setPipeline(
+pipeline30
+);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(
+buffer4,
+'uint32',
+16032,
+9569
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+5,
+buffer3,
+38092,
+352
+);
+} catch {}
+let arrayBuffer7 = buffer8.getMappedRange(
+19136,
+264
+);
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 8}
+*/
+{
+  source: imageData5,
+  origin: { x: 161, y: 56 },
+  flipY: true,
+},
+{
+  texture: texture29,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend('\u0f7d\u0c9a\uec21\ud8bb\u{1fb2d}\u90d6\u3163\ubb6d\u1994\u20f8');
+let videoFrame5 = new VideoFrame(video3, {timestamp: 0});
+let bindGroup26 = device1.createBindGroup({
+label: '\u8c73\u0a60\u1e1a\u42ca\u{1f7df}\u{1fe77}\u{1f775}\u88a1\u00fd\u4a40',
+layout: bindGroupLayout14,
+entries: [
+
+],
+});
+let commandEncoder39 = device1.createCommandEncoder();
+let texture44 = device1.createTexture(
+{
+label: '\u{1fff8}\u4c80\u0b68\u08ba\u{1fbc7}\u0844\u0e33\ub623\u0eb1\u2f94',
+size: {width: 9478, height: 158, depthOrArrayLayers: 253},
+mipLevelCount: 5,
+format: 'depth32float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'depth32float'
+],
+}
+);
+let renderBundle44 = renderBundleEncoder38.finish(
+{
+
+}
+);
+let sampler38 = device1.createSampler(
+{
+label: '\u8897\u8bb6\u4c70\u{1fd52}\ud946\u55c2\u06bf\udec4\ua18d',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 82.450,
+lodMaxClamp: 84.401,
+maxAnisotropy: 7,
+}
+);
+try {
+computePassEncoder20.setBindGroup(
+1,
+bindGroup25,
+new Uint32Array(2072),
+457,
+0
+);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(
+69,
+undefined,
+2949785516,
+924881352
+);
+} catch {}
+try {
+buffer10.destroy();
+} catch {}
+try {
+commandEncoder39.copyTextureToTexture(
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 60, y: 10, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 36, y: 30, z: 0 },
+  aspect: 'all',
+},
+{width: 24, height: 80, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device1,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let video5 = await videoWithData();
+gc();
+let offscreenCanvas16 = new OffscreenCanvas(654, 753);
+let buffer12 = device1.createBuffer(
+{
+label: '\u0c38\u0b1d\u081d\ubc52',
+size: 29165,
+usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+try {
+renderPassEncoder13.setBindGroup(
+0,
+bindGroup26,
+new Uint32Array(6829),
+3945,
+0
+);
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant(
+{
+r: -270.0,
+g: 866.4,
+b: 373.4,
+a: 571.8,
+}
+);
+} catch {}
+try {
+renderPassEncoder13.setViewport(
+1390.6,
+8.537,
+54.21,
+27.11,
+0.1102,
+0.1793
+);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(
+5,
+buffer12,
+15208,
+13366
+);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(
+0,
+bindGroup24
+);
+} catch {}
+try {
+commandEncoder39.copyTextureToTexture(
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 12, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 0, y: 10, z: 1 },
+  aspect: 'all',
+},
+{width: 108, height: 110, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext4.configure(
+{
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let textureView47 = texture9.createView(
+{
+baseMipLevel: 1,
+mipLevelCount: 1,
+baseArrayLayer: 0,
+}
+);
+let renderPassEncoder15 = commandEncoder38.beginRenderPass(
+{
+label: '\u16f1\u05f9',
+colorAttachments: [
+undefined
+],
+depthStencilAttachment: {
+view: textureView19,
+depthClearValue: 0.5865686582399001,
+depthLoadOp: 'clear',
+depthStoreOp: 'discard',
+stencilClearValue: 36165,
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet20,
+}
+);
+let renderBundleEncoder39 = device0.createRenderBundleEncoder(
+{
+label: '\u0bca\u024c\u{1f691}\u3dfe\u02ff\u02f4\u0f5d\u{1fb54}\u6a40',
+colorFormats: [
+'rgba16sint',
+'r32sint',
+'r16float',
+'rg11b10ufloat',
+undefined,
+undefined,
+'bgra8unorm',
+'rgba32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 27,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder14.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(
+buffer6,
+'uint16',
+7510
+);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(
+7,
+buffer1,
+20536,
+4056
+);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(
+0,
+bindGroup3,
+new Uint32Array(7224),
+4445,
+0
+);
+} catch {}
+try {
+gpuCanvasContext3.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 1, depthOrArrayLayers: 35}
+*/
+{
+  source: img3,
+  origin: { x: 177, y: 0 },
+  flipY: false,
+},
+{
+  texture: texture29,
+  mipLevel: 5,
+  origin: { x: 0, y: 1, z: 4 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 5, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline44 = await device0.createComputePipelineAsync(
+{
+label: '\ua9b9\u0489\u0fa8\u{1f738}',
+layout: pipelineLayout12,
+compute: {
+module: shaderModule16,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let texture45 = device1.createTexture(
+{
+label: '\u0a91\u33c5\u44c9\u714c\u41e5\u{1f6ab}\ucb1c\u3af7',
+size: [4635],
+dimension: '1d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView48 = texture35.createView(
+{
+label: '\u3c60\u{1fb43}\u74e1\u0c93\u14e5',
+format: 'astc-12x10-unorm-srgb',
+}
+);
+let sampler39 = device1.createSampler(
+{
+label: '\ue0c5\u83a6\ued18\ud824',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 69.029,
+lodMaxClamp: 94.797,
+compare: 'greater-equal',
+}
+);
+try {
+renderPassEncoder13.setBlendConstant(
+{
+r: 548.1,
+g: 393.2,
+b: -394.6,
+a: -73.69,
+}
+);
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(
+2293,
+36,
+28,
+1
+);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(
+7,
+buffer12
+);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(
+buffer12,
+'uint32',
+18380,
+4808
+);
+} catch {}
+try {
+commandEncoder39.copyTextureToTexture(
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 0, y: 30, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 0, y: 30, z: 1 },
+  aspect: 'all',
+},
+{width: 60, height: 80, depthOrArrayLayers: 0}
+);
+} catch {}
+let commandEncoder40 = device2.createCommandEncoder(
+{
+label: '\ua42e\u71e8\u9f5a\ubdb7\u060c\u18fd\ube98\u76df\u0843\ucc81\u9062',
+}
+);
+let querySet42 = device2.createQuerySet(
+{
+label: '\u81b2\u079b\u0b6d',
+type: 'occlusion',
+count: 2649,
+}
+);
+let texture46 = device2.createTexture(
+{
+label: '\u0845\ub930\u{1fddc}\u068c\u20bf\u{1fd87}\uebcb',
+size: {width: 2033, height: 1, depthOrArrayLayers: 117},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8uint',
+'r8uint'
+],
+}
+);
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture41,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint8Array(new ArrayBuffer(40)),
+/* required buffer size: 838 */{
+offset: 838,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let gpuCanvasContext11 = offscreenCanvas16.getContext('webgpu');
+offscreenCanvas9.width = 629;
+document.body.prepend('\u421c\u{1ff7f}\u107e\u0418\u6b66\u0fd9');
+let video6 = await videoWithData();
+let bindGroupLayout16 = device0.createBindGroupLayout(
+{
+label: '\u{1fe99}\u69ca\ue495\u649f\u1786\ua846',
+entries: [
+
+],
+}
+);
+let querySet43 = device0.createQuerySet(
+{
+label: '\u0d8a\u6cdc\u{1f7f3}\uf61b\u6a27',
+type: 'occlusion',
+count: 2615,
+}
+);
+pseudoSubmit(device0, commandEncoder24);
+try {
+renderPassEncoder3.setViewport(
+56.60,
+0.4413,
+7.724,
+0.4736,
+0.9072,
+0.9254
+);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(
+6,
+buffer1
+);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(
+3,
+buffer3,
+21188,
+13347
+);
+} catch {}
+let bindGroup27 = device0.createBindGroup({
+label: '\ua21b\u0af5\u{1fad8}\u0b5c\u0905\u7f3b\u01ba\u{1fe48}',
+layout: bindGroupLayout8,
+entries: [
+
+],
+});
+let texture47 = device0.createTexture(
+{
+label: '\u7710\u36e1\ue710\u0e81\u60ce',
+size: [1310, 1, 237],
+mipLevelCount: 7,
+sampleCount: 1,
+dimension: '3d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST,
+}
+);
+let renderBundle45 = renderBundleEncoder3.finish(
+{
+label: '\u7c47\u1323\ue003\u089d\u{1f91d}'
+}
+);
+let sampler40 = device0.createSampler(
+{
+label: '\u{1fe04}\u2273\u{1ffe9}\u9025\ub169\u81ea\u2fa1',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 90.915,
+lodMaxClamp: 98.771,
+compare: 'greater',
+}
+);
+try {
+computePassEncoder6.setPipeline(
+pipeline27
+);
+} catch {}
+let promise20 = device0.queue.onSubmittedWorkDone();
+document.body.prepend('\u55a1\u0b80\u969f\ued2b\u90d8');
+let commandEncoder41 = device2.createCommandEncoder(
+{
+}
+);
+let texture48 = device2.createTexture(
+{
+label: '\u{1f8aa}\u0a98\u5359\u0d7b\ua9fd\u0e52\ucde8\u0648',
+size: [164, 176, 43],
+mipLevelCount: 5,
+format: 'astc-4x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-4x4-unorm-srgb',
+'astc-4x4-unorm-srgb'
+],
+}
+);
+let renderBundleEncoder40 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg8unorm',
+'rgba16float',
+'rg8uint',
+'rgb10a2unorm',
+'rg8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 860,
+}
+);
+try {
+renderBundleEncoder40.setVertexBuffer(
+42,
+undefined,
+348624274,
+882980307
+);
+} catch {}
+try {
+await promise18;
+} catch {}
+let offscreenCanvas17 = new OffscreenCanvas(175, 512);
+let imageBitmap9 = await createImageBitmap(imageBitmap1);
+let imageData6 = new ImageData(48, 168);
+let bindGroupLayout17 = device2.createBindGroupLayout(
+{
+label: '\ud634\u{1fdd8}\u099b\u0080\u{1f722}\ue15b\u5b4c\u467e',
+entries: [
+{
+binding: 4966,
+visibility: 0,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}
+],
+}
+);
+let commandEncoder42 = device2.createCommandEncoder(
+{
+}
+);
+let querySet44 = device2.createQuerySet(
+{
+label: '\u0b2f\u0db6\u2e09\u{1ff6b}',
+type: 'occlusion',
+count: 665,
+}
+);
+let texture49 = device2.createTexture(
+{
+size: [1306],
+mipLevelCount: 1,
+dimension: '1d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32sint'
+],
+}
+);
+let textureView49 = texture41.createView(
+{
+label: '\u01c7\u6f3e\ucc9b\u77af\u{1fb8d}\u497f\u{1fd86}\ucb12',
+format: 'astc-8x6-unorm',
+}
+);
+let computePassEncoder21 = commandEncoder42.beginComputePass(
+{
+label: '\u0f45\u0076\u0788\ucba0\u0a91'
+}
+);
+canvas5.width = 81;
+let canvas9 = document.createElement('canvas');
+let texture50 = device0.createTexture(
+{
+label: '\u98bc\uf6a5\u0726\u0495\uf605\u0132\ua1ed\uf035',
+size: [122, 147, 1],
+mipLevelCount: 5,
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let texture51 = gpuCanvasContext3.getCurrentTexture();
+try {
+computePassEncoder17.setBindGroup(
+3,
+bindGroup19,
+new Uint32Array(3993),
+2724,
+0
+);
+} catch {}
+try {
+computePassEncoder11.setPipeline(
+pipeline25
+);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant(
+{
+r: 978.0,
+g: -795.9,
+b: -409.4,
+a: 84.86,
+}
+);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(
+9,
+buffer1,
+24044,
+13282
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture29,
+  mipLevel: 7,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(146039),
+/* required buffer size: 146039 */{
+offset: 215,
+bytesPerRow: 168,
+rowsPerImage: 124,
+},
+{width: 0, height: 0, depthOrArrayLayers: 8}
+);
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let sampler41 = device1.createSampler(
+{
+label: '\u958e\u1abf\u016c\u51c8\u9aa8\ub936\u060e\uc42f\u08b0\u070c',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 57.257,
+lodMaxClamp: 67.789,
+}
+);
+try {
+renderPassEncoder13.setScissorRect(
+1141,
+3,
+601,
+20
+);
+} catch {}
+try {
+renderPassEncoder13.setViewport(
+1098.5,
+35.60,
+1658.1,
+1.320,
+0.8941,
+0.9180
+);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(
+5,
+buffer12,
+10508,
+12996
+);
+} catch {}
+let buffer13 = device1.createBuffer(
+{
+label: '\uae57\u0dd9\u9828\u6f74\u0234\u{1f7ce}\uf410\u{1ffe9}\ubd06\u62a3',
+size: 34413,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let renderBundleEncoder41 = device1.createRenderBundleEncoder(
+{
+label: '\u0b43\u09ab\u0073',
+colorFormats: [
+'rgba8unorm',
+'rgba32float',
+'rg16sint',
+'r32sint',
+'rgba8uint',
+'rg8unorm',
+'r32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 733,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle46 = renderBundleEncoder41.finish(
+{
+label: '\u0d46\u8bb9\u44db'
+}
+);
+try {
+renderPassEncoder13.setBindGroup(
+1,
+bindGroup24,
+[]
+);
+} catch {}
+try {
+renderPassEncoder13.setViewport(
+2083.7,
+8.939,
+300.0,
+0.3870,
+0.1508,
+0.1870
+);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(
+buffer12,
+'uint32',
+23784
+);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(
+2,
+buffer12,
+18572,
+10313
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer13,
+21612,
+new Float32Array(36172),
+15821,
+2808
+);
+} catch {}
+canvas3.height = 1007;
+document.body.prepend('\u4f62\u0b18\ub634\u09e2');
+let adapter5 = await promise19;
+let promise21 = adapter1.requestAdapterInfo();
+let querySet45 = device2.createQuerySet(
+{
+type: 'occlusion',
+count: 3415,
+}
+);
+let texture52 = device2.createTexture(
+{
+label: '\u0030\u{1f7a0}\u{1f7b9}\uc410\u0bf9\u{1f640}\u{1fe95}',
+size: {width: 2580, height: 8, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'astc-4x4-unorm',
+usage: GPUTextureUsage.COPY_DST,
+}
+);
+let renderBundleEncoder42 = device2.createRenderBundleEncoder(
+{
+label: '\u0c5f\u{1ff44}\u4907\uaa7b',
+colorFormats: [
+'rg11b10ufloat',
+'rgba32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 267,
+depthReadOnly: true,
+}
+);
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let shaderModule18 = device0.createShaderModule(
+{
+label: '\u89eb\u0ed9\u6852\u52ec\ub09a\u{1f8f7}\u075d\u{1f931}\u463b\u02cc\u4481',
+code: `
+
+@compute @workgroup_size(8, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: vec3<u32>,
+@builtin(frag_depth) f1: f32
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(0) a0: vec3<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+}
+);
+let sampler42 = device0.createSampler(
+{
+label: '\u{1fb8e}\u02c0',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'linear',
+lodMinClamp: 56.051,
+lodMaxClamp: 82.040,
+}
+);
+try {
+renderPassEncoder8.setBindGroup(
+5,
+bindGroup10
+);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant(
+{
+r: -513.4,
+g: 135.4,
+b: 240.6,
+a: 413.7,
+}
+);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(
+4,
+bindGroup6
+);
+} catch {}
+try {
+renderBundleEncoder39.setVertexBuffer(
+1,
+buffer6,
+6524
+);
+} catch {}
+let pipeline45 = device0.createComputePipeline(
+{
+label: '\u{1fd87}\u0040\ufe1a',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+await promise21;
+} catch {}
+let shaderModule19 = device0.createShaderModule(
+{
+label: '\ufe93\u9b13\udb53\u0ff7\ud712',
+code: `@group(2) @binding(2280)
+var<storage, read_write> local3: array<u32>;
+
+@compute @workgroup_size(6, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@builtin(sample_mask) f0: u32,
+@location(6) f1: i32,
+@location(7) f2: vec3<u32>,
+@location(3) f3: i32,
+@location(4) f4: vec4<f32>,
+@location(5) f5: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(31) a0: vec3<f32>, @location(52) a1: vec2<u32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S23 {
+@builtin(vertex_index) f0: u32,
+@location(19) f1: vec2<f16>,
+@location(0) f2: vec2<u32>,
+@location(18) f3: i32,
+@location(26) f4: f32,
+@location(14) f5: vec2<i32>,
+@location(25) f6: vec4<i32>,
+@location(6) f7: vec3<i32>,
+@builtin(instance_index) f8: u32,
+@location(22) f9: vec3<u32>,
+@location(20) f10: vec4<i32>,
+@location(17) f11: u32,
+@location(10) f12: vec4<i32>,
+@location(5) f13: vec2<f32>,
+@location(9) f14: i32,
+@location(4) f15: f16,
+@location(15) f16: vec4<i32>,
+@location(1) f17: vec4<f16>,
+@location(28) f18: vec4<f16>,
+@location(7) f19: f32
+}
+struct VertexOutput0 {
+@location(75) f178: i32,
+@location(62) f179: vec3<f32>,
+@location(31) f180: vec3<f32>,
+@location(52) f181: vec2<u32>,
+@location(116) f182: vec3<u32>,
+@builtin(position) f183: vec4<f32>,
+@location(111) f184: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(27) a0: vec3<u32>, @location(11) a1: vec4<i32>, @location(23) a2: vec2<f16>, a3: S23, @location(3) a4: i32, @location(24) a5: vec3<u32>, @location(2) a6: vec3<f16>, @location(13) a7: vec2<f16>, @location(21) a8: f32, @location(8) a9: vec3<f16>, @location(12) a10: vec3<f32>, @location(16) a11: f32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture53 = device0.createTexture(
+{
+label: '\u02fe\u0ea5\ub67b\u{1fc7a}\u8418\u0547\u5fb3\u08dd\u{1f605}\u{1fcde}\u7468',
+size: [10444],
+dimension: '1d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let sampler43 = device0.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 4.601,
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(
+1,
+bindGroup19,
+new Uint32Array(4571),
+369,
+0
+);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(
+buffer6,
+'uint32',
+9444,
+1392
+);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+await buffer11.mapAsync(
+GPUMapMode.WRITE,
+0,
+852
+);
+} catch {}
+let gpuCanvasContext12 = offscreenCanvas17.getContext('webgpu');
+gc();
+let renderBundle47 = renderBundleEncoder27.finish(
+{
+label: '\u3ee6\u{1fc9f}\u{1fcee}\ucbdf'
+}
+);
+try {
+renderPassEncoder13.setBindGroup(
+2,
+bindGroup24
+);
+} catch {}
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant(
+{
+r: -317.6,
+g: 191.7,
+b: -191.5,
+a: -143.3,
+}
+);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(
+buffer12,
+'uint16',
+1672,
+23852
+);
+} catch {}
+try {
+commandEncoder39.copyBufferToBuffer(
+buffer10,
+44420,
+buffer13,
+29020,
+1368
+);
+dissociateBuffer(device1, buffer10);
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer13,
+21992,
+new BigUint64Array(45981),
+44878,
+428
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture38,
+  mipLevel: 0,
+  origin: { x: 48, y: 0, z: 10 },
+  aspect: 'all',
+},
+new Uint8Array(new ArrayBuffer(32)),
+/* required buffer size: 77799 */{
+offset: 67,
+bytesPerRow: 37,
+rowsPerImage: 15,
+},
+{width: 12, height: 6, depthOrArrayLayers: 141}
+);
+} catch {}
+let sampler44 = device1.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 14.712,
+lodMaxClamp: 73.530,
+}
+);
+try {
+renderBundleEncoder32.setBindGroup(
+4,
+bindGroup24
+);
+} catch {}
+try {
+await promise20;
+} catch {}
+document.body.prepend('\u0884\uee0e\u9aa5\u0bb4\u{1f648}\u5b7c\ub981\u{1ffca}\ub978\u0bf0');
+try {
+renderBundleEncoder7.label = '\u{1f799}\u7245\u9fc9\u0eb5\uc589\u{1f8cd}\ub66b\u25ff';
+} catch {}
+let shaderModule20 = device0.createShaderModule(
+{
+code: `@group(0) @binding(3950)
+var<storage, read_write> field2: array<u32>;
+
+@compute @workgroup_size(6, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S25 {
+@location(41) f0: vec2<f32>,
+@location(91) f1: f16,
+@location(38) f2: vec3<f16>,
+@location(71) f3: vec4<i32>,
+@location(21) f4: vec3<u32>,
+@location(63) f5: u32,
+@location(26) f6: i32,
+@location(104) f7: vec2<f16>,
+@location(45) f8: vec2<f16>,
+@location(24) f9: vec2<f16>,
+@location(107) f10: vec2<f32>,
+@location(103) f11: f32,
+@location(80) f12: vec3<u32>,
+@location(115) f13: vec2<f16>,
+@location(112) f14: vec3<f32>,
+@location(117) f15: vec4<i32>,
+@location(12) f16: vec2<u32>,
+@location(8) f17: vec3<f16>
+}
+
+@fragment
+fn fragment0(@location(10) a0: vec2<i32>, @location(46) a1: vec2<f32>, @builtin(sample_mask) a2: u32, @location(20) a3: vec2<u32>, @location(54) a4: vec4<i32>, @location(70) a5: vec2<f32>, @location(25) a6: f16, @location(97) a7: vec2<i32>, @location(9) a8: vec3<u32>, @location(15) a9: vec3<i32>, @builtin(position) a10: vec4<f32>, a11: S25, @location(83) a12: vec4<f16>, @location(39) a13: vec3<u32>, @location(34) a14: vec2<f32>, @builtin(front_facing) a15: bool, @builtin(sample_index) a16: u32) {
+
+}
+
+struct S24 {
+@location(16) f0: u32
+}
+struct VertexOutput0 {
+@location(97) f185: vec2<i32>,
+@location(117) f186: vec4<i32>,
+@location(112) f187: vec3<f32>,
+@location(20) f188: vec2<u32>,
+@location(12) f189: vec2<u32>,
+@location(10) f190: vec2<i32>,
+@location(115) f191: vec2<f16>,
+@location(80) f192: vec3<u32>,
+@location(107) f193: vec2<f32>,
+@location(46) f194: vec2<f32>,
+@location(39) f195: vec3<u32>,
+@location(45) f196: vec2<f16>,
+@location(104) f197: vec2<f16>,
+@location(70) f198: vec2<f32>,
+@location(54) f199: vec4<i32>,
+@location(63) f200: u32,
+@location(91) f201: f16,
+@location(71) f202: vec4<i32>,
+@location(9) f203: vec3<u32>,
+@location(15) f204: vec3<i32>,
+@builtin(position) f205: vec4<f32>,
+@location(8) f206: vec3<f16>,
+@location(34) f207: vec2<f32>,
+@location(26) f208: i32,
+@location(25) f209: f16,
+@location(103) f210: f32,
+@location(83) f211: vec4<f16>,
+@location(38) f212: vec3<f16>,
+@location(24) f213: vec2<f16>,
+@location(41) f214: vec2<f32>,
+@location(21) f215: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec4<i32>, @location(18) a1: vec4<i32>, @location(23) a2: vec4<i32>, @location(7) a3: vec4<i32>, @location(3) a4: vec3<f32>, @location(12) a5: f32, @location(0) a6: f32, @location(14) a7: vec4<u32>, @location(28) a8: vec4<f32>, @location(19) a9: vec4<f16>, @location(13) a10: vec2<i32>, @location(11) a11: f32, @location(9) a12: vec3<f16>, @location(15) a13: f32, @location(25) a14: i32, @location(26) a15: u32, @location(22) a16: vec4<u32>, @location(17) a17: vec4<f16>, @location(21) a18: i32, @location(5) a19: vec4<f32>, @location(27) a20: vec2<i32>, @builtin(instance_index) a21: u32, @location(1) a22: vec4<f32>, @location(20) a23: u32, @location(4) a24: vec3<f32>, a25: S24, @location(24) a26: vec2<u32>, @location(10) a27: f16, @location(2) a28: f16, @location(8) a29: i32, @builtin(vertex_index) a30: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroup28 = device0.createBindGroup({
+label: '\u0497\uf21c\u0c13\u60e6\u0871',
+layout: bindGroupLayout16,
+entries: [
+
+],
+});
+try {
+computePassEncoder19.setBindGroup(
+4,
+bindGroup1,
+new Uint32Array(5967),
+2395,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: 412.3,
+g: 242.4,
+b: 371.6,
+a: -966.7,
+}
+);
+} catch {}
+try {
+renderPassEncoder15.setViewport(
+1.236,
+0.3087,
+3.781,
+0.2010,
+0.5349,
+0.6760
+);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(
+buffer1,
+'uint32'
+);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(
+4,
+buffer1,
+16032,
+17846
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+10740,
+new BigUint64Array(7879),
+1512,
+76
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 6,
+  origin: { x: 5, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 48721 */{
+offset: 221,
+bytesPerRow: 175,
+rowsPerImage: 277,
+},
+{width: 25, height: 1, depthOrArrayLayers: 2}
+);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let computePassEncoder22 = commandEncoder39.beginComputePass(
+{
+label: '\u02af\ue049\u48eb\u27f3\u{1fae5}\u7e84\u{1fd39}'
+}
+);
+let renderBundleEncoder43 = device1.createRenderBundleEncoder(
+{
+label: '\u1e7b\u65fc\u{1f787}\u2d5f\u3721\u0cd1\u41d2',
+colorFormats: [
+'bgra8unorm',
+'rgba8uint',
+'rg16sint',
+'rgba8uint'
+],
+sampleCount: 673,
+depthReadOnly: true,
+}
+);
+let sampler45 = device1.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 33.826,
+lodMaxClamp: 58.260,
+maxAnisotropy: 4,
+}
+);
+try {
+computePassEncoder20.setBindGroup(
+4,
+bindGroup25
+);
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant(
+{
+r: -237.1,
+g: 800.3,
+b: 778.0,
+a: 529.4,
+}
+);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(
+7,
+buffer12,
+15952
+);
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(
+1,
+bindGroup26,
+new Uint32Array(7018),
+1470,
+0
+);
+} catch {}
+gc();
+document.body.prepend('\u58fa\u7c8e\uc89e');
+try {
+renderPassEncoder13.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(
+2,
+buffer12,
+8492,
+5155
+);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(
+4,
+buffer12
+);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+let gpuCanvasContext13 = canvas9.getContext('webgpu');
+let imageBitmap10 = await createImageBitmap(imageData2);
+let buffer14 = device2.createBuffer(
+{
+size: 44695,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let textureView50 = texture48.createView(
+{
+label: '\u{1f925}\u1903\u48ac\u{1f6d0}\u{1f7e1}\u0dfc\ub0a3\u{1f93c}\u8d14',
+dimension: '2d',
+baseMipLevel: 3,
+mipLevelCount: 1,
+baseArrayLayer: 9,
+}
+);
+let sampler46 = device2.createSampler(
+{
+label: '\u02bb\u0c1c\u0aaf\u06ec\u4b33\u0a07',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 89.389,
+lodMaxClamp: 91.423,
+}
+);
+try {
+commandEncoder40.clearBuffer(
+buffer14,
+4796,
+6940
+);
+dissociateBuffer(device2, buffer14);
+} catch {}
+let commandEncoder43 = device0.createCommandEncoder(
+{
+label: '\u46dd\u{1feec}\u4d5a',
+}
+);
+let querySet46 = device0.createQuerySet(
+{
+label: '\ucdc5\u066b\u2bb8\u2f8b\u2770\u7e0c\ub066\u13c1\u{1f7c8}\uc0b4',
+type: 'occlusion',
+count: 3500,
+}
+);
+let commandBuffer2 = commandEncoder43.finish(
+{
+label: '\u0ee6\uce88\u983d\u0e2e',
+}
+);
+let texture54 = device0.createTexture(
+{
+label: '\u0e46\ud7c3\u0ec5\u{1fa61}\u{1f72b}\ue583\u0ad2\u{1fe96}\u0585\u351e',
+size: {width: 899, height: 1, depthOrArrayLayers: 95},
+mipLevelCount: 10,
+dimension: '3d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rg16float',
+'rg16float'
+],
+}
+);
+try {
+computePassEncoder1.setPipeline(
+pipeline45
+);
+} catch {}
+try {
+renderPassEncoder15.setBlendConstant(
+{
+r: 210.9,
+g: -534.1,
+b: -461.3,
+a: 269.6,
+}
+);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(
+47,
+0,
+83,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer4,
+'uint32',
+15848,
+5866
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+17092,
+new Float32Array(27783),
+26925,
+616
+);
+} catch {}
+document.body.prepend('\u158d\u75ce\u{1f70e}\uf396\u0e89');
+pseudoSubmit(device1, commandEncoder39);
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(
+0,
+bindGroup25
+);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(
+2,
+bindGroup25,
+new Uint32Array(8337),
+7630,
+0
+);
+} catch {}
+try {
+renderPassEncoder13.setViewport(
+635.4,
+15.11,
+1056.9,
+8.186,
+0.08529,
+0.2448
+);
+} catch {}
+try {
+commandEncoder36.copyBufferToBuffer(
+buffer10,
+47432,
+buffer13,
+32048,
+884
+);
+dissociateBuffer(device1, buffer10);
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+commandEncoder36.clearBuffer(
+buffer13,
+2052,
+32148
+);
+dissociateBuffer(device1, buffer13);
+} catch {}
+let texture55 = device2.createTexture(
+{
+size: [5112, 152, 1],
+mipLevelCount: 12,
+format: 'eac-r11snorm',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+let sampler47 = device2.createSampler(
+{
+label: '\u{1fc2e}\ud398\u0826\uf14b\uefeb\u399e\u64ed\ufec6\ud6a9\u8ec6\u5cd7',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 18.999,
+lodMaxClamp: 33.103,
+}
+);
+try {
+device2.queue.writeBuffer(
+buffer14,
+9488,
+new Float32Array(26871),
+22532,
+1632
+);
+} catch {}
+let shaderModule21 = device1.createShaderModule(
+{
+label: '\u7001\u{1f9c5}\u0a9d\u95f1\ubafd\u912d\u{1faf2}\uefb5\u0ae9\u0c0a\ue175',
+code: `@group(0) @binding(2724)
+var<storage, read_write> parameter0: array<u32>;
+
+@compute @workgroup_size(7, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@builtin(frag_depth) f0: f32,
+@location(2) f1: f32,
+@location(3) f2: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(position) a1: vec4<f32>, @builtin(sample_mask) a2: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S26 {
+@location(24) f0: vec4<i32>,
+@location(5) f1: vec2<f16>,
+@location(29) f2: vec3<f32>,
+@location(27) f3: vec3<f16>,
+@builtin(vertex_index) f4: u32,
+@builtin(instance_index) f5: u32,
+@location(15) f6: vec2<f16>,
+@location(13) f7: vec4<i32>,
+@location(2) f8: vec4<f16>,
+@location(11) f9: vec2<u32>,
+@location(28) f10: vec4<f16>,
+@location(16) f11: i32,
+@location(21) f12: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(19) a0: vec2<i32>, @location(0) a1: f32, @location(20) a2: vec3<f32>, a3: S26, @location(3) a4: f16, @location(26) a5: vec4<f32>, @location(22) a6: vec4<f32>, @location(1) a7: u32, @location(25) a8: vec3<u32>, @location(12) a9: vec3<f32>, @location(6) a10: vec4<f32>, @location(17) a11: vec2<f32>, @location(14) a12: i32, @location(7) a13: vec3<u32>, @location(4) a14: u32, @location(8) a15: vec2<u32>, @location(10) a16: u32, @location(18) a17: u32, @location(23) a18: vec3<i32>, @location(9) a19: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let buffer15 = device1.createBuffer(
+{
+label: '\u31a7\u7bde\u383b\u{1fa49}\ubcd4\u0308\u0d55\u329e\u{1fadf}',
+size: 33972,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+let renderBundle48 = renderBundleEncoder31.finish(
+{
+label: '\u{1ffea}\u0d00'
+}
+);
+try {
+renderPassEncoder13.setBindGroup(
+0,
+bindGroup24
+);
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(
+80
+);
+} catch {}
+try {
+renderPassEncoder13.setViewport(
+2076.5,
+19.17,
+453.3,
+5.883,
+0.9223,
+0.9581
+);
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(
+1,
+bindGroup25,
+[]
+);
+} catch {}
+try {
+device1.pushErrorScope(
+'validation'
+);
+} catch {}
+try {
+commandEncoder36.copyBufferToTexture(
+{
+/* bytesInLastRow: 31680 widthInBlocks: 7920 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 36100 */
+offset: 36100,
+buffer: buffer10,
+},
+{
+  texture: texture34,
+  mipLevel: 0,
+  origin: { x: 2006, y: 1, z: 0 },
+  aspect: 'all',
+},
+{width: 7920, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder36.copyTextureToTexture(
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 24, y: 10, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 60, y: 10, z: 1 },
+  aspect: 'all',
+},
+{width: 24, height: 110, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder36.clearBuffer(
+buffer13,
+22512,
+6592
+);
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer13,
+28388,
+new Int16Array(55713),
+17,
+2120
+);
+} catch {}
+let offscreenCanvas18 = new OffscreenCanvas(928, 512);
+let commandEncoder44 = device2.createCommandEncoder(
+{
+}
+);
+let texture56 = device2.createTexture(
+{
+label: '\u{1f813}\udeb0\u{1f6e4}\u0316\u1256\u07ab\ucd03\u0846\u{1fac4}',
+size: {width: 108, height: 110, depthOrArrayLayers: 1},
+format: 'astc-6x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let computePassEncoder23 = commandEncoder44.beginComputePass(
+{
+label: '\u7b26\u{1f867}\u76e2'
+}
+);
+try {
+computePassEncoder23.end();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(img6);
+let bindGroupLayout18 = device0.createBindGroupLayout(
+{
+label: '\u3e31\u016f\ua6bf\u0983\u0464',
+entries: [
+{
+binding: 1209,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '1d' },
+},
+{
+binding: 5408,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+let buffer16 = device0.createBuffer(
+{
+label: '\u{1ff1a}\u87e9\u3a4c\u0454\u08e5\u0256\u558d\u044b\u35ae',
+size: 34988,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+try {
+renderPassEncoder11.setBindGroup(
+0,
+bindGroup2,
+new Uint32Array(5998),
+3716,
+0
+);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(
+5,
+buffer1
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer0,
+commandBuffer2,
+]);
+} catch {}
+let promise22 = device0.queue.onSubmittedWorkDone();
+let computePassEncoder24 = commandEncoder41.beginComputePass(
+{
+label: '\u0482\u29aa\u{1fab7}\u724a\u{1ffba}\ub117\u076f\ue043\ue824\ue91f\uaca9'
+}
+);
+let renderBundle49 = renderBundleEncoder35.finish(
+{
+label: '\u01e8\u0007\u0eca'
+}
+);
+try {
+commandEncoder40.copyTextureToTexture(
+{
+  texture: texture48,
+  mipLevel: 3,
+  origin: { x: 4, y: 8, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture52,
+  mipLevel: 4,
+  origin: { x: 52, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 12, height: 4, depthOrArrayLayers: 1}
+);
+} catch {}
+let adapter6 = await navigator.gpu.requestAdapter(
+{
+powerPreference: 'low-power',
+}
+);
+try {
+renderPassEncoder13.executeBundles([]);
+} catch {}
+try {
+commandEncoder36.clearBuffer(
+buffer15
+);
+dissociateBuffer(device1, buffer15);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture34,
+  mipLevel: 0,
+  origin: { x: 1048, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 169 */{
+offset: 169,
+rowsPerImage: 172,
+},
+{width: 5704, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend('\u1a81\u0fbb\ue096');
+let device3 = await adapter4.requestDevice(
+{
+label: '\u0421\uff1e\u0cd8\u093b\u0f83\u52f6',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 6,
+maxColorAttachmentBytesPerSample: 33,
+maxVertexBufferArrayStride: 62264,
+maxStorageTexturesPerShaderStage: 9,
+maxStorageBuffersPerShaderStage: 22,
+maxDynamicStorageBuffersPerPipelineLayout: 32498,
+maxBindingsPerBindGroup: 8300,
+maxTextureArrayLayers: 256,
+maxTextureDimension1D: 9260,
+maxTextureDimension2D: 8390,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 43358303,
+maxInterStageShaderVariables: 86,
+maxInterStageShaderComponents: 116,
+},
+}
+);
+let imageData7 = new ImageData(256, 120);
+let bindGroup29 = device0.createBindGroup({
+label: '\u{1fc3e}\u{1fea3}\u099b\u{1f696}\uf8af\u010c\ua543',
+layout: bindGroupLayout16,
+entries: [
+
+],
+});
+let pipelineLayout13 = device0.createPipelineLayout(
+{
+label: '\u159e\u9872\u01b7\u2fb0\ua22a\u09cc\u{1fb50}\ua370\u5ad1\u{1f97f}',
+bindGroupLayouts: [
+bindGroupLayout9,
+bindGroupLayout0,
+bindGroupLayout9,
+bindGroupLayout11,
+bindGroupLayout10,
+bindGroupLayout4
+],
+}
+);
+let commandEncoder45 = device0.createCommandEncoder(
+{
+label: '\u9630\u0c79\u66e4',
+}
+);
+let textureView51 = texture21.createView(
+{
+label: '\u0e87\uab6f\u{1f98e}\u031c\u066b\u6aa3\ufdf3\u{1fcdd}\ue611\uda22\u24e5',
+}
+);
+try {
+renderPassEncoder9.setScissorRect(
+10,
+1,
+2,
+0
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+30328,
+new Float32Array(22008),
+4403,
+1000
+);
+} catch {}
+let promise23 = device0.queue.onSubmittedWorkDone();
+let pipeline46 = await device0.createComputePipelineAsync(
+{
+label: '\u0c86\u004d\u7b4f\u0f48\ud201\u06e8',
+layout: pipelineLayout10,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.append('\u03e6\u{1f706}\u0ef9\u08ab');
+let imageData8 = new ImageData(156, 148);
+let texture57 = device1.createTexture(
+{
+label: '\u0b98\u321e\u0d6e\u3c01\u5efa\u{1f756}',
+size: [10848],
+dimension: '1d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16uint',
+'rgba16uint',
+'rgba16uint'
+],
+}
+);
+let textureView52 = texture34.createView(
+{
+label: '\u{1faea}\ud88f',
+}
+);
+let renderBundleEncoder44 = device1.createRenderBundleEncoder(
+{
+label: '\u{1fc2c}\ubd23\u{1fd92}\ub255',
+colorFormats: [
+'rgba32sint',
+'r8sint',
+'r8sint',
+'rgba16uint',
+'rgba8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 702,
+depthReadOnly: true,
+stencilReadOnly: false,
+}
+);
+try {
+renderPassEncoder13.setBindGroup(
+4,
+bindGroup25,
+new Uint32Array(9236),
+2056,
+0
+);
+} catch {}
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(
+4,
+bindGroup26,
+new Uint32Array(7893),
+6395,
+0
+);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+gpuCanvasContext12.configure(
+{
+device: device1,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+await promise22;
+} catch {}
+document.body.prepend('\u00c2\u3e96\u209c\u03af\u6ac4\u5190\u{1fb1d}\u{1f779}\u7525\ue656\u0311');
+let canvas10 = document.createElement('canvas');
+let querySet47 = device3.createQuerySet(
+{
+label: '\udf6b\u{1fa79}\u5237\ub2c9\ubc66\u04a0\u0362\u2dd7\u0a41',
+type: 'occlusion',
+count: 2883,
+}
+);
+let texture58 = device3.createTexture(
+{
+label: '\udd65\u0fc2\u2a55\u062a\u56bf\ue4c3',
+size: {width: 20, height: 20, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+sampleCount: 1,
+format: 'astc-10x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+document.body.append('\ua3fc\u9753\u1449\ufaed\u8273\u531a\u0134\u{1f601}\u0029\u{1ffc4}');
+let video7 = await videoWithData();
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let texture59 = device1.createTexture(
+{
+label: '\ud2da\u7655\u0f43',
+size: {width: 13428, height: 4, depthOrArrayLayers: 1},
+mipLevelCount: 14,
+sampleCount: 1,
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'eac-rg11snorm'
+],
+}
+);
+let renderPassEncoder16 = commandEncoder36.beginRenderPass(
+{
+label: '\ubc77\u001e\u02d9\ue62e\u0a92\u9420\u3da7\u00d7',
+colorAttachments: [
+undefined,
+{
+view: textureView37,
+clearValue: {
+r: -709.1,
+g: 0.5769,
+b: 998.4,
+a: -188.3,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet33,
+maxDrawCount: 211352,
+}
+);
+let renderBundleEncoder45 = device1.createRenderBundleEncoder(
+{
+label: '\uec09\u7e3f\u0c25\u0c11\u0c2c\u8b10\u434e\u01d7\u{1fbc5}\u06d0\u{1ff34}',
+colorFormats: [
+'r32uint',
+'r8sint',
+'rgb10a2uint',
+'rgba32uint',
+'rgba16float',
+'bgra8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 172,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder13.setBindGroup(
+0,
+bindGroup24
+);
+} catch {}
+try {
+renderPassEncoder13.end();
+} catch {}
+try {
+renderPassEncoder16.beginOcclusionQuery(
+32
+);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder16.setViewport(
+2956.7,
+21.81,
+28.97,
+5.848,
+0.5399,
+0.9439
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'astc-6x6-unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let commandEncoder46 = device3.createCommandEncoder(
+{
+label: '\u0f20\u5c74\ue8d7\u8a52\u005c\u8cf0\u25ba\ud8ff\u0420\u{1f6d1}',
+}
+);
+let commandBuffer3 = commandEncoder46.finish(
+{
+label: '\u{1f897}\u0393\u14aa\u{1f86f}\uf410\u1b8f\u0c38\udedd\u002d\u{1ffc9}\u{1ff19}',
+}
+);
+let textureView53 = texture58.createView(
+{
+label: '\u4b5f\ubd39\u8ed4\u1dc5\u00ea\u34ce\u06fc',
+mipLevelCount: 1,
+}
+);
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext14 = canvas10.getContext('webgpu');
+video6.height = 198;
+let textureView54 = texture56.createView(
+{
+label: '\u476d\ue39d\u{1fc07}\ud9d2\u{1f92d}\u025b',
+baseArrayLayer: 0,
+}
+);
+try {
+computePassEncoder21.end();
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer14,
+14584,
+new Int16Array(63010),
+24279,
+13536
+);
+} catch {}
+let videoFrame6 = new VideoFrame(img6, {timestamp: 0});
+try {
+adapter2.label = '\u9f14\u054f\u0d42\ud4bc\u{1f9ca}\u02ba\u5eab\u{1fd4e}\u2d04\u4793\u02b3';
+} catch {}
+let querySet48 = device0.createQuerySet(
+{
+label: '\u8644\u{1fefc}\u18ac\uc58c\uf0ce\u02fd\u8fff\u4532\u0b34\ucca5\uf46f',
+type: 'occlusion',
+count: 3145,
+}
+);
+let renderBundleEncoder46 = device0.createRenderBundleEncoder(
+{
+label: '\u0fd2\u7ee6\u5ada\u7011\u{1f740}\u{1fe12}\u{1f882}\u{1f790}',
+colorFormats: [
+undefined,
+'rgba32sint',
+'rgba16uint',
+'r8uint',
+undefined,
+'r32float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 93,
+}
+);
+let sampler48 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 54.128,
+lodMaxClamp: 84.733,
+compare: 'greater',
+maxAnisotropy: 12,
+}
+);
+try {
+computePassEncoder14.setBindGroup(
+0,
+bindGroup19
+);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(
+1,
+bindGroup10,
+new Uint32Array(3321),
+714,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(
+5,
+0,
+4,
+0
+);
+} catch {}
+try {
+renderPassEncoder4.setViewport(
+148.8,
+0.7805,
+21.87,
+0.03735,
+0.5440,
+0.9323
+);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(
+2,
+buffer1,
+24624,
+7176
+);
+} catch {}
+try {
+commandEncoder45.copyBufferToBuffer(
+buffer8,
+17624,
+buffer5,
+28464,
+1124
+);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder45.clearBuffer(
+buffer1,
+33740,
+5104
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder45.resolveQuerySet(
+querySet46,
+2882,
+268,
+buffer3,
+32768
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture28,
+  mipLevel: 7,
+  origin: { x: 0, y: 4, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(615),
+/* required buffer size: 615 */{
+offset: 615,
+bytesPerRow: 93,
+rowsPerImage: 13,
+},
+{width: 24, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 3, height: 1, depthOrArrayLayers: 17}
+*/
+{
+  source: img5,
+  origin: { x: 14, y: 7 },
+  flipY: false,
+},
+{
+  texture: texture29,
+  mipLevel: 6,
+  origin: { x: 1, y: 1, z: 15 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 2, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let textureView55 = texture27.createView(
+{
+label: '\u{1fd8f}\u{1f626}\u0821\u0997\u1156\ufeaf\u{1fcd3}',
+dimension: '2d',
+format: 'etc2-rgb8a1unorm',
+baseArrayLayer: 28,
+}
+);
+let renderPassEncoder17 = commandEncoder45.beginRenderPass(
+{
+label: '\u{1f683}\u036e\uf838\u0488\u0ea1\u227e\ub842\u47d9',
+colorAttachments: [
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView19,
+depthClearValue: 0.9443901530922849,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+stencilClearValue: 34368,
+},
+occlusionQuerySet: querySet19,
+maxDrawCount: 570232,
+}
+);
+let renderBundle50 = renderBundleEncoder28.finish(
+{
+label: '\u2da4\uf662\u64b5\u0aed\u287d'
+}
+);
+let sampler49 = device0.createSampler(
+{
+label: '\u2023\u{1fa19}\u0370\u3faf\u2a00\u0365\ud14c\u{1fddf}\u0c9b\u64b1',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 52.696,
+lodMaxClamp: 99.160,
+compare: 'less-equal',
+maxAnisotropy: 13,
+}
+);
+try {
+renderPassEncoder6.setBindGroup(
+0,
+bindGroup27,
+new Uint32Array(3120),
+2952,
+0
+);
+} catch {}
+try {
+renderPassEncoder17.setScissorRect(
+6,
+1,
+8,
+0
+);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(
+0,
+buffer6,
+8624,
+716
+);
+} catch {}
+document.body.append('\u{1fae2}\u003e\u0406\u{1fc60}\u0dda\u08b0\ue5c7\uedd9\u7752\u{1feb3}\uf31c');
+let adapter7 = await navigator.gpu.requestAdapter();
+pseudoSubmit(device0, commandEncoder3);
+let texture60 = device0.createTexture(
+{
+size: {width: 25, height: 25, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+renderPassEncoder17.setBlendConstant(
+{
+r: -239.2,
+g: -582.6,
+b: 50.31,
+a: 854.9,
+}
+);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+10,
+buffer1
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+26300,
+new Int16Array(31598),
+27622,
+2900
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 56, height: 1, depthOrArrayLayers: 5}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 83, y: 124 },
+  flipY: false,
+},
+{
+  texture: texture54,
+  mipLevel: 4,
+  origin: { x: 15, y: 1, z: 2 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 29, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\u0b5b\u0b05\ua7da\u0140\u0fe2\u015e\u00ec');
+let renderBundle51 = renderBundleEncoder41.finish(
+{
+
+}
+);
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(
+2,
+bindGroup24
+);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(
+6,
+buffer12,
+25044,
+734
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer13,
+5096,
+new Int16Array(30046),
+2465,
+2648
+);
+} catch {}
+document.body.prepend('\u8a81\u{1ff03}');
+let canvas11 = document.createElement('canvas');
+try {
+offscreenCanvas18.getContext('webgl2');
+} catch {}
+let texture61 = device3.createTexture(
+{
+label: '\u{1fd9b}\u{1fae9}\u0ed4\u220f\u{1ffa9}\u02e4\u{1fd48}\u9ba5\u2e64\u0e06\u099b',
+size: [297],
+dimension: '1d',
+format: 'r16sint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16sint',
+'r16sint',
+'r16sint'
+],
+}
+);
+let textureView56 = texture61.createView(
+{
+label: '\uf945\u5eb7\u0c75\u647c\u48a6\u0b50\uc4ec\uad39',
+mipLevelCount: 1,
+}
+);
+let sampler50 = device3.createSampler(
+{
+label: '\udbd9\u72c8\u354e',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 46.157,
+lodMaxClamp: 62.055,
+}
+);
+let commandBuffer4 = commandEncoder42.finish(
+{
+label: '\u0f09\u09a6',
+}
+);
+let texture62 = device2.createTexture(
+{
+label: '\u2946\u{1ffa0}\u0422\u02e3\u0280\u016b\uf300',
+size: [250, 60, 1],
+mipLevelCount: 3,
+format: 'astc-10x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x10-unorm-srgb',
+'astc-10x10-unorm'
+],
+}
+);
+let textureView57 = texture56.createView(
+{
+label: '\u328e\uf7c2\u05d3\uac4e\u2c31\u01f8\u0cba\ue4a8\u5d64\u{1fbf6}\u{1fd03}',
+dimension: '2d-array',
+}
+);
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+try {
+await promise23;
+} catch {}
+document.body.prepend('\u{1fb6c}\u9964');
+let bindGroupLayout19 = device2.createBindGroupLayout(
+{
+entries: [
+{
+binding: 510,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '2d' },
+},
+{
+binding: 4422,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+}
+],
+}
+);
+let pipelineLayout14 = device2.createPipelineLayout(
+{
+label: '\u3735\u2cdc\u3d55\u41ad\u7231\u0e22\u027f\u0fd2\ud3e2',
+bindGroupLayouts: [
+bindGroupLayout17,
+bindGroupLayout17,
+bindGroupLayout17,
+bindGroupLayout17,
+bindGroupLayout17,
+bindGroupLayout19,
+bindGroupLayout17,
+bindGroupLayout19
+],
+}
+);
+let querySet49 = device2.createQuerySet(
+{
+label: '\ubf50\u0c71\u0efd\u0b4f\u4b0b\u2b2c\u9ada',
+type: 'occlusion',
+count: 169,
+}
+);
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+commandEncoder40.copyTextureToTexture(
+{
+  texture: texture62,
+  mipLevel: 0,
+  origin: { x: 70, y: 20, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture62,
+  mipLevel: 1,
+  origin: { x: 20, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 80, height: 20, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder40.clearBuffer(
+buffer14,
+6236,
+11564
+);
+dissociateBuffer(device2, buffer14);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture62,
+  mipLevel: 0,
+  origin: { x: 70, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer3,
+/* required buffer size: 42 */{
+offset: 42,
+},
+{width: 160, height: 10, depthOrArrayLayers: 0}
+);
+} catch {}
+let device4 = await adapter6.requestDevice(
+{
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-astc',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 61,
+maxVertexBufferArrayStride: 26234,
+maxStorageTexturesPerShaderStage: 36,
+maxStorageBuffersPerShaderStage: 33,
+maxDynamicStorageBuffersPerPipelineLayout: 21388,
+maxBindingsPerBindGroup: 1829,
+maxTextureDimension1D: 10730,
+maxTextureDimension2D: 10630,
+minUniformBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 83693092,
+maxInterStageShaderVariables: 120,
+maxInterStageShaderComponents: 66,
+},
+}
+);
+try {
+canvas11.getContext('webgpu');
+} catch {}
+let pipelineLayout15 = device2.createPipelineLayout(
+{
+label: '\u0d0c\u{1f682}\u4528\u{1f667}\u0fa8\ud76c\u1555',
+bindGroupLayouts: [
+bindGroupLayout17,
+bindGroupLayout17,
+bindGroupLayout17,
+bindGroupLayout17,
+bindGroupLayout19
+],
+}
+);
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let bindGroup30 = device1.createBindGroup({
+layout: bindGroupLayout14,
+entries: [
+
+],
+});
+let commandEncoder47 = device1.createCommandEncoder(
+{
+label: '\u{1f781}\u0a11\u{1f7ee}\u0bae\u{1f89e}\u4891\uc76d\u3bc1\u055c\u13ea\u{1fcea}',
+}
+);
+let sampler51 = device1.createSampler(
+{
+label: '\u{1fbcb}\u{1fa91}\udc77\u02a5\u7ac0',
+mipmapFilter: 'nearest',
+lodMinClamp: 2.055,
+lodMaxClamp: 32.802,
+}
+);
+try {
+renderPassEncoder16.setBindGroup(
+3,
+bindGroup24
+);
+} catch {}
+try {
+commandEncoder47.copyBufferToTexture(
+{
+/* bytesInLastRow: 400 widthInBlocks: 25 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 36432 */
+offset: 36432,
+bytesPerRow: 512,
+buffer: buffer10,
+},
+{
+  texture: texture59,
+  mipLevel: 5,
+  origin: { x: 312, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 100, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder47.copyTextureToBuffer(
+{
+  texture: texture59,
+  mipLevel: 0,
+  origin: { x: 1312, y: 4, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 9376 widthInBlocks: 586 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 28320 */
+offset: 28320,
+buffer: buffer13,
+},
+{width: 2344, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+commandEncoder47.clearBuffer(
+buffer15,
+24596
+);
+dissociateBuffer(device1, buffer15);
+} catch {}
+document.body.append('\u{1fc2b}\u80c9\ued8a\uc0fd\u2088\u{1f864}\u9661\u29d1\u02fb\u0da7');
+let canvas12 = document.createElement('canvas');
+let imageBitmap11 = await createImageBitmap(videoFrame2);
+let imageData9 = new ImageData(228, 228);
+let querySet50 = device0.createQuerySet(
+{
+label: '\uf8fc\uc950\u{1fb57}\ue50c',
+type: 'occlusion',
+count: 2974,
+}
+);
+let renderBundleEncoder47 = device0.createRenderBundleEncoder(
+{
+label: '\u090c\u492c',
+colorFormats: [
+'rg32float',
+'rgba8uint',
+'bgra8unorm-srgb',
+'rg16uint',
+'r32uint',
+'r8uint',
+'rg16float',
+'rg8uint'
+],
+sampleCount: 829,
+depthReadOnly: true,
+}
+);
+let sampler52 = device0.createSampler(
+{
+label: '\ucbe3\u{1ff8b}\u088d\ufe73\u9711\u{1ff6b}\u0c80\ud25c\u513c\u07e8\u2f64',
+magFilter: 'linear',
+minFilter: 'linear',
+lodMinClamp: 89.599,
+lodMaxClamp: 94.343,
+}
+);
+try {
+computePassEncoder3.setBindGroup(
+3,
+bindGroup10,
+new Uint32Array(4749),
+388,
+0
+);
+} catch {}
+try {
+computePassEncoder3.setPipeline(
+pipeline33
+);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(
+3,
+bindGroup13,
+new Uint32Array(5490),
+3377,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(
+buffer6,
+'uint32',
+1768
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 3, height: 3, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas8,
+  origin: { x: 195, y: 700 },
+  flipY: false,
+},
+{
+  texture: texture60,
+  mipLevel: 3,
+  origin: { x: 1, y: 2, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline47 = device0.createComputePipeline(
+{
+layout: pipelineLayout3,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline48 = device0.createRenderPipeline(
+{
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 4832,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 4364,
+shaderLocation: 5,
+},
+{
+format: 'snorm16x2',
+offset: 3980,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x2',
+offset: 2832,
+shaderLocation: 16,
+},
+{
+format: 'snorm8x4',
+offset: 2156,
+shaderLocation: 12,
+},
+{
+format: 'unorm16x2',
+offset: 2632,
+shaderLocation: 11,
+},
+{
+format: 'float32',
+offset: 4684,
+shaderLocation: 27,
+},
+{
+format: 'unorm8x4',
+offset: 984,
+shaderLocation: 25,
+},
+{
+format: 'float32x2',
+offset: 1264,
+shaderLocation: 10,
+},
+{
+format: 'uint16x4',
+offset: 3772,
+shaderLocation: 4,
+},
+{
+format: 'uint32x2',
+offset: 2144,
+shaderLocation: 18,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 4744,
+shaderLocation: 26,
+},
+{
+format: 'sint16x2',
+offset: 692,
+shaderLocation: 15,
+},
+{
+format: 'snorm16x2',
+offset: 1092,
+shaderLocation: 14,
+},
+{
+format: 'float16x2',
+offset: 3940,
+shaderLocation: 17,
+},
+{
+format: 'snorm8x4',
+offset: 1292,
+shaderLocation: 9,
+},
+{
+format: 'uint8x2',
+offset: 3902,
+shaderLocation: 1,
+},
+{
+format: 'snorm16x2',
+offset: 2996,
+shaderLocation: 21,
+},
+{
+format: 'float32x3',
+offset: 136,
+shaderLocation: 8,
+},
+{
+format: 'sint32x3',
+offset: 3596,
+shaderLocation: 22,
+},
+{
+format: 'float32',
+offset: 332,
+shaderLocation: 0,
+},
+{
+format: 'uint8x2',
+offset: 3322,
+shaderLocation: 6,
+},
+{
+format: 'sint32x4',
+offset: 2784,
+shaderLocation: 3,
+},
+{
+format: 'snorm16x2',
+offset: 296,
+shaderLocation: 28,
+},
+{
+format: 'unorm8x2',
+offset: 1432,
+shaderLocation: 20,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 35576,
+shaderLocation: 23,
+},
+{
+format: 'uint8x4',
+offset: 14604,
+shaderLocation: 19,
+},
+{
+format: 'float32',
+offset: 8984,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+cullMode: 'front',
+},
+multisample: {
+mask: 0xc3e0e0fb,
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'replace',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilReadMask: 1454,
+depthBiasSlopeScale: 82,
+},
+}
+);
+let imageBitmap12 = await createImageBitmap(imageBitmap11);
+let renderBundleEncoder48 = device4.createRenderBundleEncoder(
+{
+label: '\u0be0\u3717\uc501\u002f\u0814\u10b0\u9eca\u{1f9be}\uafbf',
+colorFormats: [
+'rgb10a2uint',
+'rgba8unorm-srgb',
+'rg16uint',
+'bgra8unorm',
+'r32float',
+'rgba8sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 436,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+let renderBundleEncoder49 = device1.createRenderBundleEncoder(
+{
+label: '\u0c8b\u0bbd\u7b10\u09e1\u{1f87a}\uf4d2\u6cfd\uad48\u0eae\u{1fea8}\u83ea',
+colorFormats: [
+'rgba16float',
+'rg11b10ufloat',
+'r8uint',
+'rgba16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 127,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder16.setBindGroup(
+1,
+bindGroup25,
+new Uint32Array(3305),
+1093,
+0
+);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(
+757,
+29,
+1618,
+4
+);
+} catch {}
+try {
+commandEncoder47.clearBuffer(
+buffer13,
+11704,
+12868
+);
+dissociateBuffer(device1, buffer13);
+} catch {}
+let commandEncoder48 = device3.createCommandEncoder();
+let textureView58 = texture58.createView(
+{
+label: '\ue3b6\u{1fb5d}\u5757\u{1fb24}\ufd98',
+baseMipLevel: 1,
+}
+);
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append('\u445b\u81a6\ude0e\u90f7\ue3f6\u0d8b\u0532\u0370\u{1f994}');
+let buffer17 = device1.createBuffer(
+{
+label: '\uac73\u{1fc75}\u62f7\u2c29\u074f\u0c7c',
+size: 61366,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let renderPassEncoder18 = commandEncoder47.beginRenderPass(
+{
+label: '\u09cb\u02a3\u0289\u0bea\u6a36\u36c9\ucf58\u{1ff09}\u56be\u{1fa47}\u3de9',
+colorAttachments: [
+undefined,
+{
+view: textureView37,
+clearValue: {
+r: -326.1,
+g: 291.4,
+b: 124.6,
+a: -788.8,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+undefined
+],
+occlusionQuerySet: querySet40,
+maxDrawCount: 38072,
+}
+);
+try {
+renderPassEncoder16.setBlendConstant(
+{
+r: 324.6,
+g: 502.7,
+b: -617.0,
+a: 277.7,
+}
+);
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(
+1375
+);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+2,
+buffer12,
+2556
+);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(
+1,
+bindGroup30
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let promise24 = device1.createComputePipelineAsync(
+{
+label: '\ue110\ub251\u3ece\u{1f983}\u4135\u0863\u0d75',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule21,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let commandEncoder49 = device4.createCommandEncoder(
+{
+label: '\ue210\u373b\u525b\ucd03\ufaf2\u367a\ua1c3',
+}
+);
+let querySet51 = device4.createQuerySet(
+{
+label: '\ub328\u0c40\ufddb\u5b25\u{1f621}\ufd2f\u6a05',
+type: 'occlusion',
+count: 3832,
+}
+);
+let texture63 = device4.createTexture(
+{
+size: {width: 80, height: 310, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-8x5-unorm-srgb'
+],
+}
+);
+offscreenCanvas16.height = 543;
+let sampler53 = device0.createSampler(
+{
+label: '\u{1ff18}\u{1fbdd}\u3f5f',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 48.745,
+lodMaxClamp: 86.540,
+}
+);
+try {
+renderPassEncoder9.setBindGroup(
+4,
+bindGroup5
+);
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant(
+{
+r: -308.7,
+g: 118.2,
+b: 140.5,
+a: 448.4,
+}
+);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(
+2458
+);
+} catch {}
+try {
+renderPassEncoder3.setViewport(
+85.21,
+0.3638,
+16.47,
+0.4531,
+0.9796,
+0.9901
+);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(
+buffer3,
+'uint32',
+4044,
+27685
+);
+} catch {}
+let promise25 = device0.popErrorScope();
+let gpuCanvasContext15 = canvas12.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.prepend(video3);
+video3.height = 68;
+let device5 = await adapter7.requestDevice(
+{
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxColorAttachmentBytesPerSample: 44,
+maxVertexAttributes: 25,
+maxVertexBufferArrayStride: 22964,
+maxStorageTexturesPerShaderStage: 40,
+maxStorageBuffersPerShaderStage: 21,
+maxDynamicStorageBuffersPerPipelineLayout: 9377,
+maxBindingsPerBindGroup: 6488,
+maxTextureDimension1D: 15431,
+maxTextureDimension2D: 12105,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 11797367,
+maxInterStageShaderVariables: 20,
+maxInterStageShaderComponents: 103,
+},
+}
+);
+let renderBundleEncoder50 = device5.createRenderBundleEncoder(
+{
+colorFormats: [
+'bgra8unorm-srgb',
+'rg16uint',
+'rg16float',
+'rg16sint',
+'r16sint',
+'bgra8unorm'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 574,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let bindGroup31 = device0.createBindGroup({
+label: '\u8cf1\u{1ffeb}\u8351\u{1fcbc}',
+layout: bindGroupLayout4,
+entries: [
+
+],
+});
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(
+buffer4,
+'uint16',
+16850,
+7893
+);
+} catch {}
+try {
+querySet31.destroy();
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let bindGroup32 = device0.createBindGroup({
+label: '\u0d1d\u{1f7cd}\u0dff\u8861\u747c\u{1f72f}\ua5d8\u{1f86f}\u042a\u{1fbe9}',
+layout: bindGroupLayout7,
+entries: [
+{
+binding: 2928,
+resource: textureView55
+},
+{
+binding: 4427,
+resource: sampler19
+}
+],
+});
+let commandEncoder50 = device0.createCommandEncoder(
+{
+label: '\ua35f\u0fae\u0ed6',
+}
+);
+let querySet52 = device0.createQuerySet(
+{
+label: '\u0993\u3b6d\u5ca5\ua012',
+type: 'occlusion',
+count: 2946,
+}
+);
+let renderBundleEncoder51 = device0.createRenderBundleEncoder(
+{
+label: '\u0540\u068f\u{1f683}\u1b47\u{1ff43}\u{1fe38}\u6edf\u6bfe\u7add\ud2ed',
+colorFormats: [
+'rgba8unorm',
+'r16uint',
+'rgba16uint',
+'bgra8unorm'
+],
+sampleCount: 602,
+}
+);
+let renderBundle52 = renderBundleEncoder39.finish(
+{
+
+}
+);
+let sampler54 = device0.createSampler(
+{
+label: '\ub8ec\u0ddf\u3147\ua2e5\u6ffa',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMaxClamp: 61.153,
+maxAnisotropy: 1,
+}
+);
+try {
+computePassEncoder10.setPipeline(
+pipeline47
+);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder15.setViewport(
+6.921,
+0.7059,
+4.643,
+0.1277,
+0.5925,
+0.7978
+);
+} catch {}
+try {
+commandEncoder50.clearBuffer(
+buffer9
+);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+6340,
+new Float32Array(38954),
+19555,
+1048
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline49 = device0.createComputePipeline(
+{
+layout: pipelineLayout3,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend('\ud15f\u6cc9\u059a\u0652\u{1f809}\u50ba');
+let imageBitmap13 = await createImageBitmap(img2);
+let textureView59 = texture62.createView(
+{
+label: '\u00e8\u0ef3',
+dimension: '2d',
+format: 'astc-10x10-unorm',
+baseMipLevel: 2,
+arrayLayerCount: 1,
+}
+);
+try {
+device2.queue.writeTexture(
+{
+  texture: texture52,
+  mipLevel: 3,
+  origin: { x: 100, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer3),
+/* required buffer size: 527 */{
+offset: 527,
+rowsPerImage: 119,
+},
+{width: 208, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let renderBundleEncoder52 = device5.createRenderBundleEncoder(
+{
+label: '\u04cf\u9215\u0b01\ude37\u01b4',
+colorFormats: [
+'rgba8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 518,
+depthReadOnly: true,
+}
+);
+let commandEncoder51 = device5.createCommandEncoder(
+{
+label: '\u072d\u{1f832}\uaf55\u25ee\ub9cd\ubdfa\u0d83\u660d\u0aed\u02e6',
+}
+);
+pseudoSubmit(device5, commandEncoder51);
+try {
+gpuCanvasContext11.configure(
+{
+device: device5,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let video8 = await videoWithData();
+document.body.prepend(canvas5);
+let commandEncoder52 = device4.createCommandEncoder(
+{
+}
+);
+let texture64 = device4.createTexture(
+{
+label: '\u0d44\u{1fef3}',
+size: {width: 63, height: 63, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+dimension: '2d',
+format: 'rg8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder53 = device4.createRenderBundleEncoder(
+{
+label: '\u9e35\u{1fb42}',
+colorFormats: [
+'r8unorm',
+'rg8sint',
+'r16float',
+'rgba8sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 928,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+commandEncoder52.pushDebugGroup(
+'\ue1dd'
+);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+document.body.append('\u0146\u9d50\u0f15\u0f9a\u3ba9');
+try {
+await adapter7.requestAdapterInfo();
+} catch {}
+let querySet53 = device0.createQuerySet(
+{
+label: '\u6b9a\u54a0\uaa8a\ufc91\u46ac\u{1ffd3}\u09e3\u3ce3\u04a9\u0cff\u{1fa05}',
+type: 'occlusion',
+count: 1428,
+}
+);
+let commandBuffer5 = commandEncoder50.finish(
+{
+label: '\uebd9\u8fc8\u12ca\u9ec1\u8a83',
+}
+);
+let textureView60 = texture15.createView(
+{
+label: '\u061b\u8947\ud359\ub2f9\u9ff4\u8bdd\u27a1\u49b2\u{1ff81}\u{1f664}\u0c4a',
+baseMipLevel: 1,
+mipLevelCount: 1,
+}
+);
+try {
+computePassEncoder18.setBindGroup(
+3,
+bindGroup6,
+new Uint32Array(2270),
+1170,
+0
+);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(
+buffer1,
+'uint16',
+33662
+);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(
+84,
+undefined,
+4075741709,
+60049285
+);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(
+buffer6,
+'uint32',
+8284,
+3194
+);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(
+2,
+buffer1,
+12432
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 2,
+  origin: { x: 74, y: 0, z: 6 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer4),
+/* required buffer size: 613638 */{
+offset: 561,
+bytesPerRow: 368,
+rowsPerImage: 111,
+},
+{width: 357, height: 1, depthOrArrayLayers: 16}
+);
+} catch {}
+let pipeline50 = await device0.createComputePipelineAsync(
+{
+label: '\u570e\u272c\u0ee9\ufedc\u{1fdc4}\u07b5',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule15,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let querySet54 = device2.createQuerySet(
+{
+label: '\u7105\u299a\u12b5\u{1feff}\u0f07',
+type: 'occlusion',
+count: 1955,
+}
+);
+pseudoSubmit(device2, commandEncoder40);
+let texture65 = device2.createTexture(
+{
+label: '\u{1f7d1}\u3fc3\u2c10\u0e93',
+size: [155, 1, 995],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32float',
+'rgba32float',
+'rgba32float'
+],
+}
+);
+let renderBundle53 = renderBundleEncoder35.finish();
+try {
+commandEncoder44.copyTextureToTexture(
+{
+  texture: texture48,
+  mipLevel: 0,
+  origin: { x: 88, y: 104, z: 31 },
+  aspect: 'all',
+},
+{
+  texture: texture52,
+  mipLevel: 3,
+  origin: { x: 8, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 72, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder44.clearBuffer(
+buffer14,
+30592,
+10268
+);
+dissociateBuffer(device2, buffer14);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer14,
+4668,
+new Int16Array(56865),
+14565,
+3740
+);
+} catch {}
+try {
+gpuCanvasContext4.configure(
+{
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb',
+'rg8snorm',
+'bgra8unorm-srgb',
+'astc-8x5-unorm-srgb'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture58,
+  mipLevel: 0,
+  origin: { x: 0, y: 5, z: 0 },
+  aspect: 'all',
+},
+new Uint32Array(new ArrayBuffer(24)),
+/* required buffer size: 712 */{
+offset: 377,
+bytesPerRow: 303,
+},
+{width: 20, height: 10, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend('\u{1fca9}\uae80\u{1fba0}\ueb0b\u51a9\uede5\u{1f849}\u26c9\u0749\ue80b\u817f');
+let video9 = await videoWithData();
+let shaderModule22 = device1.createShaderModule(
+{
+label: '\udc83\u0168',
+code: `
+
+@compute @workgroup_size(6, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(1) f0: f32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S27 {
+@builtin(instance_index) f0: u32,
+@location(13) f1: vec4<f32>,
+@location(4) f2: vec4<f32>,
+@location(6) f3: vec4<f32>,
+@location(14) f4: vec2<f16>
+}
+struct VertexOutput0 {
+@location(9) f216: f16,
+@location(12) f217: i32,
+@location(1) f218: i32,
+@location(7) f219: f16,
+@location(3) f220: vec2<f32>,
+@builtin(position) f221: vec4<f32>,
+@location(2) f222: vec3<f16>,
+@location(5) f223: vec2<u32>,
+@location(16) f224: f32,
+@location(11) f225: vec3<f32>,
+@location(6) f226: vec2<f32>,
+@location(10) f227: vec2<f32>
+}
+
+@vertex
+fn vertex0(@location(1) a0: u32, @location(3) a1: vec4<f16>, @location(12) a2: vec3<u32>, @location(18) a3: f16, @location(15) a4: vec3<u32>, @builtin(vertex_index) a5: u32, @location(2) a6: vec3<f16>, @location(28) a7: vec3<u32>, @location(7) a8: vec2<i32>, a9: S27, @location(16) a10: vec3<f32>, @location(25) a11: f32, @location(0) a12: vec3<f16>, @location(17) a13: vec2<u32>, @location(24) a14: vec4<u32>, @location(29) a15: vec3<u32>, @location(20) a16: vec4<u32>, @location(19) a17: vec4<u32>, @location(23) a18: vec4<f32>, @location(21) a19: vec2<f32>, @location(8) a20: vec2<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+try {
+renderPassEncoder18.setVertexBuffer(
+2,
+buffer12
+);
+} catch {}
+let renderBundleEncoder54 = device1.createRenderBundleEncoder(
+{
+label: '\u4269\u39dd\u0e2e\u01a7\u281c\ucd05',
+colorFormats: [
+'rgb10a2unorm',
+undefined,
+'rgba8unorm-srgb',
+'rgba32sint',
+undefined,
+undefined,
+'rgba16float'
+],
+sampleCount: 72,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder30.setVertexBuffer(
+0,
+undefined
+);
+} catch {}
+let promise26 = device1.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+document.body.prepend('\u8f37\u5be1\u00bf\u0c8e\u016f\u68eb\u6457\u{1fb66}\u{1fb3e}');
+let texture66 = device5.createTexture(
+{
+label: '\ue3ed\ubdfa\u{1fc7a}\u{1fbf3}\uf934\u{1ff8e}\u{1fd37}\uc92d\u{1f668}',
+size: {width: 176, height: 1, depthOrArrayLayers: 246},
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm',
+'rgba8unorm-srgb'
+],
+}
+);
+let sampler55 = device5.createSampler(
+{
+label: '\u0d3e\u9100\u03ae\u8dc8\u0cf3\u{1face}\u0723',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 4.492,
+lodMaxClamp: 67.547,
+maxAnisotropy: 11,
+}
+);
+try {
+await promise26;
+} catch {}
+document.body.append('\u00a7\u{1fd50}\u6576\u181c');
+let buffer18 = device1.createBuffer(
+{
+label: '\u{1ff5a}\u0c08\u07b8\uc34d\ucdf7\u{1f89c}\u15eb\u05fd',
+size: 23983,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let textureView61 = texture59.createView(
+{
+label: '\u0505\u{1fd6c}\ud78e\u{1f64b}\u0484\u848f\u{1fcd7}\u{1fb6f}',
+dimension: '2d-array',
+baseMipLevel: 13,
+baseArrayLayer: 0,
+}
+);
+try {
+renderPassEncoder18.beginOcclusionQuery(
+80
+);
+} catch {}
+let img9 = await imageWithData(161, 220, '#317caceb', '#ae04ecbc');
+let querySet55 = device5.createQuerySet(
+{
+label: '\ud4e8\u75de\u0442\u0656\u2d07\ube60\u26a1\u4f73',
+type: 'occlusion',
+count: 2215,
+}
+);
+try {
+renderBundleEncoder50.setVertexBuffer(
+1,
+undefined,
+3490630750,
+506759510
+);
+} catch {}
+pseudoSubmit(device2, commandEncoder41);
+let texture67 = device2.createTexture(
+{
+label: '\u2468\u76b2\u3502\u095c\u77b5\u0b65\u0f06\u0a12',
+size: [5962],
+dimension: '1d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg16float'
+],
+}
+);
+let textureView62 = texture67.createView(
+{
+}
+);
+let renderBundle54 = renderBundleEncoder42.finish(
+{
+label: '\u171c\u30d4\u0630\u0846\u0218\u8bbd\ua1f4'
+}
+);
+let promise27 = buffer14.mapAsync(
+GPUMapMode.READ,
+0,
+29640
+);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let querySet56 = device0.createQuerySet(
+{
+label: '\u056e\u{1fe13}',
+type: 'occlusion',
+count: 3440,
+}
+);
+let renderBundleEncoder55 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgb10a2unorm'
+],
+sampleCount: 663,
+stencilReadOnly: true,
+}
+);
+let renderBundle55 = renderBundleEncoder24.finish(
+{
+label: '\uf991\u0f65\u0aad\u637c\ud0e3'
+}
+);
+let sampler56 = device0.createSampler(
+{
+label: '\u6254\u1ee3\u0dbe\uafe6\u3361\u9b89',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 87.394,
+lodMaxClamp: 93.223,
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder6.beginOcclusionQuery(
+56
+);
+} catch {}
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+27220,
+new Float32Array(42791),
+40702,
+796
+);
+} catch {}
+try {
+await promise27;
+} catch {}
+document.body.prepend('\u8c50\udb8d\u2b4b\u{1fccf}\u660a\u0281\u38db');
+let computePassEncoder25 = commandEncoder48.beginComputePass(
+{
+label: '\u{1fce8}\ua43c\u043d\u27e8'
+}
+);
+try {
+computePassEncoder25.end();
+} catch {}
+try {
+commandEncoder48.copyTextureToTexture(
+{
+  texture: texture58,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture58,
+  mipLevel: 0,
+  origin: { x: 10, y: 10, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 10, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext4.configure(
+{
+device: device3,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let textureView63 = texture66.createView(
+{
+label: '\u{1ffa0}\u{1fd06}\u087b\u5eff',
+format: 'rgba8unorm',
+baseMipLevel: 1,
+baseArrayLayer: 0,
+}
+);
+try {
+await device5.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+let querySet57 = device4.createQuerySet(
+{
+label: '\uab78\u2dc2\u89d9\u{1f72f}',
+type: 'occlusion',
+count: 2260,
+}
+);
+let texture68 = device4.createTexture(
+{
+label: '\u047f\u7cd6\u2d7f\u0df0\u0afa\u6aed\u01c1',
+size: [8300, 4, 119],
+mipLevelCount: 9,
+format: 'astc-5x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+await promise25;
+} catch {}
+let imageBitmap14 = await createImageBitmap(video7);
+let commandEncoder53 = device2.createCommandEncoder();
+pseudoSubmit(device2, commandEncoder53);
+let textureView64 = texture41.createView(
+{
+label: '\u0d4e\u03ac\u7295',
+dimension: '2d-array',
+baseMipLevel: 0,
+baseArrayLayer: 0,
+}
+);
+try {
+commandEncoder44.clearBuffer(
+buffer14,
+31388,
+7648
+);
+dissociateBuffer(device2, buffer14);
+} catch {}
+let texture69 = device5.createTexture(
+{
+label: '\u64b6\u40d9\ucf00\ub654\u{1f885}\u638e\ue4de\u0d5e\u71c2',
+size: [6784, 4, 80],
+mipLevelCount: 12,
+format: 'etc2-rgb8a1unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView65 = texture66.createView(
+{
+label: '\u{1f7d3}\u05e7\u429a',
+aspect: 'all',
+format: 'rgba8unorm',
+baseMipLevel: 1,
+mipLevelCount: 1,
+}
+);
+let externalTexture2 = device5.importExternalTexture(
+{
+source: video4,
+colorSpace: 'srgb',
+}
+);
+try {
+renderBundleEncoder52.setVertexBuffer(
+38,
+undefined,
+615725011,
+3432111235
+);
+} catch {}
+let commandEncoder54 = device2.createCommandEncoder(
+{
+label: '\u{1f78a}\u021f\u62a5',
+}
+);
+let renderBundleEncoder56 = device2.createRenderBundleEncoder(
+{
+label: '\u9f87\ub684\ucb40\ua700\u07c7\u{1fc81}\ude8c\u{1f718}\u82d3',
+colorFormats: [
+'rg32float',
+'r16float',
+'bgra8unorm',
+undefined,
+'rg32sint',
+'rgba8unorm-srgb',
+'rg8sint',
+'rgb10a2uint'
+],
+sampleCount: 583,
+}
+);
+document.body.prepend(canvas9);
+let bindGroupLayout20 = device4.createBindGroupLayout(
+{
+entries: [
+{
+binding: 1353,
+visibility: 0,
+texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+},
+{
+binding: 697,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'non-filtering' },
+}
+],
+}
+);
+let renderBundle56 = renderBundleEncoder53.finish(
+{
+label: '\uc143\uf022\u{1fb15}\u{1fc59}\u{1fd9a}'
+}
+);
+let sampler57 = device4.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+lodMaxClamp: 96.700,
+compare: 'greater',
+}
+);
+try {
+renderBundleEncoder48.setVertexBuffer(
+51,
+undefined,
+1799570204,
+134267560
+);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let bindGroup33 = device0.createBindGroup({
+label: '\ua50c\u07f7\u00d3\u0be3\ubce2\u2d10\u9fdd\u35d1\ubaf2',
+layout: bindGroupLayout2,
+entries: [
+
+],
+});
+let renderBundleEncoder57 = device0.createRenderBundleEncoder(
+{
+label: '\u{1f6b1}\u8008\udfab\u040e',
+colorFormats: [
+'r8unorm',
+'rg8sint',
+'r8unorm',
+'rg11b10ufloat',
+'bgra8unorm',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 829,
+depthReadOnly: false,
+}
+);
+let renderBundle57 = renderBundleEncoder4.finish();
+let sampler58 = device0.createSampler(
+{
+label: '\u0648\u041b\u3690\u0c26\uf06d\u295d\u{1fdf9}\u{1faed}\u5bb6\u0d91',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'nearest',
+lodMinClamp: 25.510,
+lodMaxClamp: 58.625,
+compare: 'less-equal',
+}
+);
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(
+2190
+);
+} catch {}
+try {
+renderPassEncoder12.pushDebugGroup(
+'\u6748'
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture15,
+  mipLevel: 0,
+  origin: { x: 54, y: 21, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(711),
+/* required buffer size: 711 */{
+offset: 711,
+},
+{width: 35, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend('\u0b9a\ud515\u{1f67b}');
+let pipelineLayout16 = device1.createPipelineLayout(
+{
+label: '\u{1f696}\u{1f6bf}\u0c06\u05b4\uf17f',
+bindGroupLayouts: [
+
+],
+}
+);
+let commandEncoder55 = device1.createCommandEncoder();
+let textureView66 = texture45.createView(
+{
+format: 'rg8unorm',
+}
+);
+try {
+renderPassEncoder16.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant(
+{
+r: 632.5,
+g: 942.1,
+b: -908.6,
+a: -854.2,
+}
+);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+1,
+buffer12,
+14796,
+637
+);
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(
+1,
+bindGroup30
+);
+} catch {}
+try {
+commandEncoder55.copyBufferToBuffer(
+buffer18,
+13456,
+buffer15,
+24308,
+1116
+);
+dissociateBuffer(device1, buffer18);
+dissociateBuffer(device1, buffer15);
+} catch {}
+let canvas13 = document.createElement('canvas');
+let computePassEncoder26 = commandEncoder44.beginComputePass();
+let querySet58 = device3.createQuerySet(
+{
+type: 'occlusion',
+count: 1360,
+}
+);
+let texture70 = gpuCanvasContext11.getCurrentTexture();
+let computePassEncoder27 = commandEncoder48.beginComputePass();
+try {
+gpuCanvasContext12.configure(
+{
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb',
+'astc-4x4-unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let img10 = await imageWithData(146, 189, '#880ecee2', '#0fc25ddd');
+let commandEncoder56 = device3.createCommandEncoder();
+try {
+device3.queue.submit([
+commandBuffer3,
+]);
+} catch {}
+let gpuCanvasContext16 = canvas13.getContext('webgpu');
+let textureView67 = texture63.createView(
+{
+label: '\u0d7c\u092a\u3c96\u0870\u5592\uaf0b\u0e05\u0eb0',
+dimension: '2d-array',
+format: 'astc-8x5-unorm-srgb',
+baseMipLevel: 1,
+mipLevelCount: 4,
+baseArrayLayer: 0,
+}
+);
+try {
+commandEncoder52.copyTextureToTexture(
+{
+  texture: texture63,
+  mipLevel: 6,
+  origin: { x: 8, y: 5, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture63,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext8.configure(
+{
+device: device4,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+document.body.append('\u0deb\u0313\u4bf8\u0b0c\u5ef4\ua526\u0ac9\u063f\u0792\u0451');
+let offscreenCanvas19 = new OffscreenCanvas(378, 780);
+let querySet59 = device3.createQuerySet(
+{
+label: '\u{1fadb}\u7fd2\u0d62\u6df4\u11fb\u0fcb\ubed9\ue060\u{1fe7f}\u06a0\u0a8f',
+type: 'occlusion',
+count: 1096,
+}
+);
+let textureView68 = texture58.createView(
+{
+label: '\uf1a2\u{1f85e}\u2bfe\u0722\u089d\u1631\u05e7\u02af',
+}
+);
+try {
+commandEncoder56.copyTextureToTexture(
+{
+  texture: texture58,
+  mipLevel: 1,
+  origin: { x: 0, y: 5, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture58,
+  mipLevel: 1,
+  origin: { x: 0, y: 5, z: 0 },
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture58,
+  mipLevel: 1,
+  origin: { x: 0, y: 5, z: 0 },
+  aspect: 'all',
+},
+new BigUint64Array(new ArrayBuffer(32)),
+/* required buffer size: 926 */{
+offset: 926,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let videoFrame7 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+try {
+offscreenCanvas19.getContext('webgpu');
+} catch {}
+let commandEncoder57 = device3.createCommandEncoder(
+{
+}
+);
+try {
+device3.queue.writeTexture(
+{
+  texture: texture70,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(234),
+/* required buffer size: 234 */{
+offset: 234,
+bytesPerRow: 62,
+rowsPerImage: 207,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend('\u0ab8\u{1fecb}\u30cf\u0c66\u{1f671}\u0827\u4779\u2f7a\u02f8');
+let sampler59 = device2.createSampler(
+{
+label: '\u45da\u04d7',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 9.687,
+compare: 'never',
+}
+);
+try {
+commandEncoder54.clearBuffer(
+buffer14,
+43580,
+60
+);
+dissociateBuffer(device2, buffer14);
+} catch {}
+pseudoSubmit(device0, commandEncoder6);
+let renderBundle58 = renderBundleEncoder15.finish(
+{
+label: '\u6079\u47f5\u04e0\u3bbf\uf7e7\u30d0\u{1fe05}\u5657\u00d4'
+}
+);
+try {
+renderPassEncoder4.setBlendConstant(
+{
+r: -357.6,
+g: 494.7,
+b: 910.6,
+a: 604.1,
+}
+);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(
+buffer4,
+'uint16'
+);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(
+buffer1,
+'uint16',
+23962,
+4169
+);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(
+7,
+buffer6,
+5636,
+2266
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+11780,
+new Float32Array(21242),
+2205,
+6520
+);
+} catch {}
+document.body.append('\u03ce\u7a41\u1931\u0338\u083a\ue4c0\u0e90\uf4bc\u054b');
+let commandEncoder58 = device1.createCommandEncoder();
+let querySet60 = device1.createQuerySet(
+{
+label: '\u49b6\u357f\u6262\uc1af\u2df0\u065f\u079d\u0e6d\u{1fa48}\u08f8\u049a',
+type: 'occlusion',
+count: 904,
+}
+);
+let texture71 = device1.createTexture(
+{
+size: {width: 11875},
+dimension: '1d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8unorm'
+],
+}
+);
+let textureView69 = texture36.createView(
+{
+label: '\u0a98\u24cd\u{1fc10}\u2c3e\u{1faa5}\ube7f\u0449\u3fb0',
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+let computePassEncoder28 = commandEncoder58.beginComputePass(
+{
+label: '\ue6ca\ua921\u0609\u{1fcbd}\u{1f980}\u567d\u38bb\uf650\u1a7c'
+}
+);
+try {
+renderPassEncoder16.setBlendConstant(
+{
+r: -333.9,
+g: 191.6,
+b: 460.6,
+a: -893.6,
+}
+);
+} catch {}
+try {
+commandEncoder55.copyTextureToTexture(
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 72, y: 10, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 0, y: 10, z: 1 },
+  aspect: 'all',
+},
+{width: 36, height: 100, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder55.clearBuffer(
+buffer15,
+12284
+);
+dissociateBuffer(device1, buffer15);
+} catch {}
+let imageBitmap15 = await createImageBitmap(videoFrame2);
+try {
+device5.queue.label = '\u460c\u0b89\u{1f675}\u449e\ude6e\u{1f7cf}\u045a\u916a';
+} catch {}
+let bindGroupLayout21 = device5.createBindGroupLayout(
+{
+label: '\u7269\u0f5a\u{1f8d5}\u12e7\uf765\u0415\u9196',
+entries: [
+
+],
+}
+);
+let pipelineLayout17 = device5.createPipelineLayout(
+{
+label: '\u393a\u{1f9a4}\u375c\u2485',
+bindGroupLayouts: [
+
+],
+}
+);
+let texture72 = device5.createTexture(
+{
+label: '\u056f\u{1fb3b}',
+size: {width: 170, height: 18, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'astc-10x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundle59 = renderBundleEncoder50.finish(
+{
+label: '\u0d81\u4aa8\u06ad\ucffb'
+}
+);
+document.body.append('\u4d7e\u6d13');
+let promise28 = adapter0.requestAdapterInfo();
+let bindGroupLayout22 = device1.createBindGroupLayout(
+{
+label: '\ud6e7\u2d64\ue378\ue8bf\u056d\u4047',
+entries: [
+{
+binding: 3285,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d' },
+}
+],
+}
+);
+let commandEncoder59 = device1.createCommandEncoder(
+{
+}
+);
+let querySet61 = device1.createQuerySet(
+{
+label: '\uba3c\u8f3d',
+type: 'occlusion',
+count: 543,
+}
+);
+let renderBundleEncoder58 = device1.createRenderBundleEncoder(
+{
+label: '\u08b4\u351b\u15d2\u{1ff24}\u3518\u37d0\uacc3\u5ba1\u{1f762}\uc95e',
+colorFormats: [
+'rg16uint',
+'r8uint',
+'rg8unorm',
+'r8unorm',
+'rg16uint',
+'rgba32sint',
+'r8unorm'
+],
+sampleCount: 833,
+depthReadOnly: true,
+stencilReadOnly: false,
+}
+);
+let renderBundle60 = renderBundleEncoder32.finish(
+{
+
+}
+);
+try {
+renderPassEncoder18.setBindGroup(
+0,
+bindGroup25
+);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant(
+{
+r: -528.5,
+g: -937.0,
+b: 410.8,
+a: -814.2,
+}
+);
+} catch {}
+try {
+renderPassEncoder18.setScissorRect(
+230,
+26,
+2542,
+6
+);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+8,
+buffer12,
+24248,
+2064
+);
+} catch {}
+document.body.prepend('\u0dc4\u{1fe7a}\u{1ff2a}\u0c4e\u2e3f\u0df7\u137c');
+let canvas14 = document.createElement('canvas');
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(
+0,
+0,
+6,
+1
+);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(
+72,
+undefined,
+4287579623,
+6868387
+);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(
+5,
+buffer6
+);
+} catch {}
+try {
+device0.pushErrorScope(
+'out-of-memory'
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 3, height: 3, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas14,
+  origin: { x: 38, y: 480 },
+  flipY: false,
+},
+{
+  texture: texture60,
+  mipLevel: 3,
+  origin: { x: 3, y: 1, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline51 = await device0.createComputePipelineAsync(
+{
+label: '\ufff4\u04e0\u070a\ud983\u6a4a\u73b3\u98d0\u3651\u{1fb53}\u{1fc16}',
+layout: 'auto',
+compute: {
+module: shaderModule19,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageData10 = new ImageData(212, 200);
+let commandEncoder60 = device1.createCommandEncoder(
+{
+}
+);
+let textureView70 = texture43.createView(
+{
+label: '\u8f48\ua7f7\u6b1f\ucf55\ue7dc\u{1fb3f}',
+mipLevelCount: 1,
+}
+);
+let computePassEncoder29 = commandEncoder55.beginComputePass(
+{
+
+}
+);
+let renderPassEncoder19 = commandEncoder60.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView69,
+clearValue: {
+r: 774.7,
+g: 974.9,
+b: -20.40,
+a: -683.3,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+undefined,
+undefined
+],
+occlusionQuerySet: querySet60,
+maxDrawCount: 424424,
+}
+);
+try {
+renderPassEncoder18.setScissorRect(
+453,
+13,
+558,
+24
+);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(
+buffer12,
+'uint32',
+4200
+);
+} catch {}
+try {
+renderBundleEncoder58.setVertexBuffer(
+3,
+buffer12,
+22904
+);
+} catch {}
+let pipeline52 = device1.createRenderPipeline(
+{
+layout: pipelineLayout16,
+vertex: {
+module: shaderModule21,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1644,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 1632,
+shaderLocation: 21,
+},
+{
+format: 'float32x2',
+offset: 960,
+shaderLocation: 27,
+},
+{
+format: 'unorm8x2',
+offset: 898,
+shaderLocation: 22,
+},
+{
+format: 'sint16x4',
+offset: 560,
+shaderLocation: 16,
+},
+{
+format: 'sint8x2',
+offset: 614,
+shaderLocation: 14,
+},
+{
+format: 'snorm8x2',
+offset: 1476,
+shaderLocation: 29,
+},
+{
+format: 'unorm8x2',
+offset: 1152,
+shaderLocation: 15,
+},
+{
+format: 'snorm8x2',
+offset: 1324,
+shaderLocation: 20,
+},
+{
+format: 'float32x3',
+offset: 840,
+shaderLocation: 26,
+},
+{
+format: 'snorm8x4',
+offset: 388,
+shaderLocation: 12,
+},
+{
+format: 'sint8x4',
+offset: 980,
+shaderLocation: 23,
+},
+{
+format: 'uint16x2',
+offset: 308,
+shaderLocation: 11,
+},
+{
+format: 'sint32x3',
+offset: 1160,
+shaderLocation: 24,
+},
+{
+format: 'unorm8x4',
+offset: 728,
+shaderLocation: 5,
+},
+{
+format: 'sint32x2',
+offset: 296,
+shaderLocation: 13,
+},
+{
+format: 'snorm8x4',
+offset: 540,
+shaderLocation: 28,
+},
+{
+format: 'snorm16x2',
+offset: 992,
+shaderLocation: 17,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 1024,
+shaderLocation: 0,
+},
+{
+format: 'uint32x3',
+offset: 332,
+shaderLocation: 18,
+},
+{
+format: 'uint32',
+offset: 544,
+shaderLocation: 25,
+},
+{
+format: 'uint32x4',
+offset: 460,
+shaderLocation: 10,
+},
+{
+format: 'unorm16x4',
+offset: 248,
+shaderLocation: 3,
+},
+{
+format: 'sint32x2',
+offset: 64,
+shaderLocation: 9,
+},
+{
+format: 'uint8x2',
+offset: 1016,
+shaderLocation: 8,
+},
+{
+format: 'sint32x2',
+offset: 1280,
+shaderLocation: 19,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 900,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 4676,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x4',
+offset: 4568,
+shaderLocation: 6,
+},
+{
+format: 'uint16x2',
+offset: 1336,
+shaderLocation: 7,
+},
+{
+format: 'uint32',
+offset: 1124,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x4',
+offset: 8600,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule21,
+entryPoint: 'fragment0',
+targets: [
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'less',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'never',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-wrap',
+},
+stencilWriteMask: 1627,
+depthBiasSlopeScale: 60,
+depthBiasClamp: 28,
+},
+}
+);
+document.body.append('\u6d41\u7a76\u8bd8');
+let video10 = await videoWithData();
+let bindGroupLayout23 = device1.createBindGroupLayout(
+{
+label: '\u04a4\u{1fdc2}\u0ea9\u8ec8\u{1fc5d}\ue2b3\u0690\u823c\u{1f805}',
+entries: [
+{
+binding: 3325,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rg32uint', access: 'write-only', viewDimension: '2d-array' },
+},
+{
+binding: 2884,
+visibility: 0,
+texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+}
+],
+}
+);
+let querySet62 = device1.createQuerySet(
+{
+label: '\u04c5\u{1ff5b}\u0e27\u5151\u46f0',
+type: 'occlusion',
+count: 2828,
+}
+);
+let textureView71 = texture43.createView(
+{
+label: '\u1874\u{1f746}\u4d4e\u4dfe\u{1f6ed}\ueb43',
+baseMipLevel: 0,
+}
+);
+try {
+renderPassEncoder19.setBindGroup(
+2,
+bindGroup26
+);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(
+buffer12,
+'uint32',
+13732
+);
+} catch {}
+try {
+commandEncoder59.copyBufferToBuffer(
+buffer18,
+12232,
+buffer13,
+28764,
+5016
+);
+dissociateBuffer(device1, buffer18);
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+canvas14.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder61 = device3.createCommandEncoder(
+{
+label: '\u32a7\ue840\u{1fc73}\u48c5',
+}
+);
+let texture73 = device3.createTexture(
+{
+size: [6935],
+dimension: '1d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+let renderBundleEncoder59 = device3.createRenderBundleEncoder(
+{
+colorFormats: [
+'r8unorm'
+],
+sampleCount: 194,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+let externalTexture3 = device3.importExternalTexture(
+{
+label: '\u48b2\u0f66\u0f0a\udaed\u786b\u113c\u0ad0',
+source: videoFrame7,
+}
+);
+try {
+commandEncoder61.copyTextureToTexture(
+{
+  texture: texture58,
+  mipLevel: 1,
+  origin: { x: 0, y: 5, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture58,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 0, height: 5, depthOrArrayLayers: 0}
+);
+} catch {}
+pseudoSubmit(device3, commandEncoder61);
+let textureView72 = texture58.createView(
+{
+label: '\u{1f94b}\u0fda\u7fa3\uf014',
+dimension: '2d-array',
+mipLevelCount: 1,
+}
+);
+offscreenCanvas18.width = 460;
+let canvas15 = document.createElement('canvas');
+let bindGroupLayout24 = pipeline29.getBindGroupLayout(3);
+let sampler60 = device0.createSampler(
+{
+label: '\u0f60\u179e\u0c2e\u{1fcea}\u0fb6\u{1ffd7}\u{1f6ae}\ubf87\u{1fe88}',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 75.061,
+maxAnisotropy: 14,
+}
+);
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(
+4,
+buffer6
+);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(
+1,
+buffer3,
+44020,
+6041
+);
+} catch {}
+let promise29 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 899, height: 1, depthOrArrayLayers: 95}
+*/
+{
+  source: video9,
+  origin: { x: 1, y: 7 },
+  flipY: true,
+},
+{
+  texture: texture54,
+  mipLevel: 0,
+  origin: { x: 492, y: 1, z: 50 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 9, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await promise28;
+} catch {}
+let bindGroup34 = device5.createBindGroup({
+label: '\uc3e1\u{1fdb0}',
+layout: bindGroupLayout21,
+entries: [
+
+],
+});
+try {
+window.someLabel = device3.label;
+} catch {}
+let renderBundle61 = renderBundleEncoder59.finish(
+{
+label: '\u{1fc90}\u08eb\u{1f747}\ubba8\u046e\u083e'
+}
+);
+try {
+commandEncoder56.copyTextureToTexture(
+{
+  texture: texture58,
+  mipLevel: 0,
+  origin: { x: 10, y: 5, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture58,
+  mipLevel: 1,
+  origin: { x: 0, y: 5, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise30 = device3.queue.onSubmittedWorkDone();
+try {
+await promise29;
+} catch {}
+try {
+await adapter1.requestAdapterInfo();
+} catch {}
+try {
+device2.queue.label = '\u{1f661}\u{1fe24}\ud94d\u33a7\u{1fed6}\u010b';
+} catch {}
+let shaderModule23 = device2.createShaderModule(
+{
+label: '\u1e37\u{1f99e}\u1f62\u8ffe\ue3ac\u0486\u0656\u23a4\u47b8',
+code: `@group(4) @binding(4966)
+var<storage, read_write> parameter1: array<u32>;
+@group(7) @binding(510)
+var<storage, read_write> i0: array<u32>;
+@group(6) @binding(4966)
+var<storage, read_write> type1: array<u32>;
+@group(5) @binding(510)
+var<storage, read_write> global1: array<u32>;
+
+@compute @workgroup_size(1, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S28 {
+@builtin(sample_index) f0: u32
+}
+struct FragmentOutput0 {
+@location(2) f0: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, a1: S28) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+}
+);
+let commandEncoder62 = device2.createCommandEncoder(
+{
+label: '\u50c6\u{1fb19}',
+}
+);
+let textureView73 = texture55.createView(
+{
+label: '\u6686\u0850\u79cd',
+mipLevelCount: 2,
+}
+);
+let computePassEncoder30 = commandEncoder62.beginComputePass(
+{
+label: '\u7533\u{1f922}\u04ef'
+}
+);
+let externalTexture4 = device2.importExternalTexture(
+{
+label: '\u{1fdd1}\uc3ed\u038a\ua294',
+source: videoFrame2,
+colorSpace: 'display-p3',
+}
+);
+try {
+commandEncoder54.clearBuffer(
+buffer14,
+19420,
+25092
+);
+dissociateBuffer(device2, buffer14);
+} catch {}
+try {
+device2.queue.submit([
+commandBuffer4,
+]);
+} catch {}
+pseudoSubmit(device0, commandEncoder2);
+let texture74 = device0.createTexture(
+{
+label: '\u1f66\ue444\u{1ffee}\u4cc1\u0b68\u{1f95b}\u0db3\uae42\u3d56',
+size: {width: 1101, height: 1, depthOrArrayLayers: 54},
+mipLevelCount: 9,
+dimension: '3d',
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'r16uint'
+],
+}
+);
+let textureView74 = texture50.createView(
+{
+dimension: '2d',
+baseMipLevel: 1,
+mipLevelCount: 1,
+}
+);
+let computePassEncoder31 = commandEncoder15.beginComputePass(
+{
+label: '\u{1f744}\u{1f82f}\u996f\u4e4a\u0f92\u4b8c\u07bc\u{1f629}\u{1fea5}\u{1f84e}'
+}
+);
+let renderBundleEncoder60 = device0.createRenderBundleEncoder(
+{
+label: '\u6dfb\u0b26\u{1f828}\u8278\ud812\u9449\u02d0\u1aab\u03c3\u{1fb67}\u4a0c',
+colorFormats: [
+'rg32float',
+'rg11b10ufloat',
+'rgb10a2uint',
+undefined,
+'rgba16sint',
+'rg32sint',
+'rgb10a2unorm'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 241,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder18.setBindGroup(
+3,
+bindGroup8
+);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(
+56
+);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(
+10,
+1,
+4,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.setViewport(
+1.798,
+0.9659,
+1.482,
+0.00658,
+0.3890,
+0.6273
+);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(
+7,
+buffer6,
+184,
+791
+);
+} catch {}
+let gpuCanvasContext17 = canvas15.getContext('webgpu');
+let commandEncoder63 = device3.createCommandEncoder(
+{
+label: '\u{1ff6a}\ue3a6\u{1fab1}\u0f15\udf30\u6077\u{1fc60}\uaae5',
+}
+);
+let querySet63 = device3.createQuerySet(
+{
+label: '\u{1fc2b}\u0ab6',
+type: 'occlusion',
+count: 1078,
+}
+);
+let promise31 = device3.popErrorScope();
+document.body.append('\ue3bf\u{1f99e}\ud991');
+let bindGroup35 = device0.createBindGroup({
+label: '\u0348\uf69a\u0dfc\u{1ff93}\u9379',
+layout: bindGroupLayout4,
+entries: [
+
+],
+});
+let querySet64 = device0.createQuerySet(
+{
+label: '\u5e6b\u6ecc',
+type: 'occlusion',
+count: 2691,
+}
+);
+pseudoSubmit(device0, commandEncoder35);
+let textureView75 = texture32.createView(
+{
+label: '\u007d\ud324\u02bf',
+}
+);
+try {
+renderPassEncoder8.end();
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(
+2,
+1,
+10,
+0
+);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(
+buffer6,
+'uint16',
+10242,
+125
+);
+} catch {}
+try {
+await buffer16.mapAsync(
+GPUMapMode.WRITE,
+0,
+7864
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 56, height: 1, depthOrArrayLayers: 5}
+*/
+{
+  source: canvas1,
+  origin: { x: 32, y: 230 },
+  flipY: false,
+},
+{
+  texture: texture54,
+  mipLevel: 4,
+  origin: { x: 3, y: 0, z: 2 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 45, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline53 = await device0.createComputePipelineAsync(
+{
+label: '\u040f\u0f2b\u0bc5\u05b9',
+layout: pipelineLayout12,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+},
+}
+);
+let pipeline54 = device0.createRenderPipeline(
+{
+label: '\u46c3\u9533\u1b14\u0ea9\u036b\u8e30\u{1fdd4}\u0d70\u{1f6ec}\u5c47',
+layout: pipelineLayout8,
+vertex: {
+module: shaderModule12,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 40196,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x2',
+offset: 11036,
+shaderLocation: 27,
+},
+{
+format: 'sint32',
+offset: 35424,
+shaderLocation: 6,
+},
+{
+format: 'sint16x2',
+offset: 32644,
+shaderLocation: 14,
+},
+{
+format: 'float32x2',
+offset: 31256,
+shaderLocation: 0,
+},
+{
+format: 'uint32x4',
+offset: 20016,
+shaderLocation: 12,
+},
+{
+format: 'uint8x2',
+offset: 9794,
+shaderLocation: 26,
+},
+{
+format: 'uint32x4',
+offset: 21068,
+shaderLocation: 9,
+},
+{
+format: 'unorm8x2',
+offset: 19096,
+shaderLocation: 23,
+},
+{
+format: 'float32',
+offset: 13052,
+shaderLocation: 5,
+},
+{
+format: 'float32x4',
+offset: 16840,
+shaderLocation: 15,
+},
+{
+format: 'sint16x2',
+offset: 34676,
+shaderLocation: 4,
+},
+{
+format: 'unorm16x2',
+offset: 8056,
+shaderLocation: 21,
+},
+{
+format: 'unorm8x4',
+offset: 2868,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 43180,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 22902,
+shaderLocation: 19,
+},
+{
+format: 'sint32',
+offset: 29796,
+shaderLocation: 10,
+},
+{
+format: 'unorm8x4',
+offset: 3280,
+shaderLocation: 3,
+},
+{
+format: 'snorm8x4',
+offset: 18184,
+shaderLocation: 11,
+},
+{
+format: 'float32',
+offset: 24264,
+shaderLocation: 17,
+},
+{
+format: 'float32',
+offset: 4344,
+shaderLocation: 13,
+},
+{
+format: 'sint32x4',
+offset: 25540,
+shaderLocation: 1,
+},
+{
+format: 'uint16x4',
+offset: 26080,
+shaderLocation: 28,
+},
+{
+format: 'float32x4',
+offset: 780,
+shaderLocation: 8,
+},
+{
+format: 'uint16x2',
+offset: 21920,
+shaderLocation: 2,
+},
+{
+format: 'sint16x4',
+offset: 9104,
+shaderLocation: 24,
+},
+{
+format: 'uint32x2',
+offset: 37076,
+shaderLocation: 16,
+},
+{
+format: 'uint32',
+offset: 7740,
+shaderLocation: 18,
+},
+{
+format: 'sint16x4',
+offset: 32752,
+shaderLocation: 22,
+},
+{
+format: 'uint16x2',
+offset: 6316,
+shaderLocation: 25,
+}
+],
+},
+{
+arrayStride: 26948,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 21264,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 29988,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 50784,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 5208,
+shaderLocation: 20,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0x286a8d42,
+},
+fragment: {
+module: shaderModule12,
+entryPoint: 'fragment0',
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+failOp: 'increment-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilReadMask: 1406,
+depthBias: 42,
+depthBiasSlopeScale: 13,
+depthBiasClamp: 5,
+},
+}
+);
+let buffer19 = device0.createBuffer(
+{
+label: '\udd1d\u7e86\u{1fbc1}\ue93c\u0134\u01a5\u01cf\u{1f7b1}\u80da',
+size: 44872,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+mappedAtCreation: true,
+}
+);
+try {
+computePassEncoder1.setPipeline(
+pipeline36
+);
+} catch {}
+try {
+renderPassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(
+64
+);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(
+buffer4,
+'uint16',
+6246,
+485
+);
+} catch {}
+try {
+gpuCanvasContext13.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth24plus',
+'rg8sint',
+'eac-r11snorm',
+'etc2-rgb8unorm-srgb'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let promise32 = device0.createRenderPipelineAsync(
+{
+label: '\u00fd\u{1f785}\u308e\u04c6\u3c69\u{1f764}\u96e1',
+layout: 'auto',
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 16460,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 30756,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 24850,
+shaderLocation: 20,
+},
+{
+format: 'snorm8x4',
+offset: 11300,
+shaderLocation: 9,
+},
+{
+format: 'float32',
+offset: 27536,
+shaderLocation: 3,
+},
+{
+format: 'snorm8x4',
+offset: 28692,
+shaderLocation: 12,
+},
+{
+format: 'float32',
+offset: 10208,
+shaderLocation: 23,
+},
+{
+format: 'uint32x4',
+offset: 4488,
+shaderLocation: 26,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 14060,
+shaderLocation: 10,
+},
+{
+format: 'sint16x4',
+offset: 25180,
+shaderLocation: 7,
+},
+{
+format: 'float32x3',
+offset: 26304,
+shaderLocation: 19,
+},
+{
+format: 'unorm8x4',
+offset: 19836,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 29512,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 19380,
+shaderLocation: 6,
+},
+{
+format: 'float32',
+offset: 22452,
+shaderLocation: 1,
+},
+{
+format: 'float32',
+offset: 21128,
+shaderLocation: 0,
+},
+{
+format: 'unorm8x2',
+offset: 14686,
+shaderLocation: 25,
+},
+{
+format: 'uint32x3',
+offset: 21280,
+shaderLocation: 13,
+},
+{
+format: 'sint32x3',
+offset: 8508,
+shaderLocation: 18,
+},
+{
+format: 'sint16x2',
+offset: 16340,
+shaderLocation: 5,
+},
+{
+format: 'uint32x2',
+offset: 22696,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 36280,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 4292,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 3812,
+shaderLocation: 21,
+},
+{
+format: 'snorm16x2',
+offset: 2360,
+shaderLocation: 28,
+}
+],
+},
+{
+arrayStride: 62296,
+attributes: [
+{
+format: 'unorm8x2',
+offset: 39428,
+shaderLocation: 27,
+},
+{
+format: 'uint32x3',
+offset: 55116,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 61600,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 58524,
+shaderLocation: 8,
+},
+{
+format: 'sint8x4',
+offset: 7812,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x4',
+offset: 33976,
+shaderLocation: 17,
+},
+{
+format: 'snorm8x4',
+offset: 19484,
+shaderLocation: 24,
+},
+{
+format: 'uint16x2',
+offset: 34844,
+shaderLocation: 15,
+},
+{
+format: 'sint8x4',
+offset: 26488,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 35892,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 10984,
+shaderLocation: 14,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule3,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+},
+stencilReadMask: 3583,
+stencilWriteMask: 43,
+depthBias: 62,
+depthBiasSlopeScale: 98,
+depthBiasClamp: 15,
+},
+}
+);
+canvas3.width = 613;
+document.body.prepend('\uafcb\u{1f6d5}\ub0e8\u3766\u{1fc63}\u0693\u0b54');
+let texture75 = device3.createTexture(
+{
+label: '\u010e\u1cfc\uda47\ub888\udec0\ua5db\ud20f\u{1feb7}\u0d41\udd87',
+size: [228, 100, 1],
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView76 = texture75.createView(
+{
+label: '\u08d9\u0aaa\u07b8\u069a',
+dimension: '2d-array',
+}
+);
+let renderBundle62 = renderBundleEncoder59.finish(
+{
+
+}
+);
+try {
+gpuCanvasContext10.configure(
+{
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'bgra8unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+await promise31;
+} catch {}
+document.body.append('\u080c\ue951\ua81b\u039d\u1ccc');
+let imageData11 = new ImageData(56, 244);
+let textureView77 = texture44.createView(
+{
+label: '\u011e\u6571\u6877\u79a0\u034e\u0ef3\u021a\u054f\u{1f9c1}',
+dimension: '2d',
+aspect: 'depth-only',
+baseMipLevel: 0,
+mipLevelCount: 3,
+baseArrayLayer: 188,
+}
+);
+let computePassEncoder32 = commandEncoder59.beginComputePass();
+let renderBundleEncoder61 = device1.createRenderBundleEncoder(
+{
+label: '\uccbc\u7c06\u{1fde6}',
+colorFormats: [
+'rg16sint',
+'rg8sint',
+'rg32uint',
+'rg16sint',
+'r8uint',
+'rg32uint'
+],
+sampleCount: 270,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle63 = renderBundleEncoder61.finish(
+{
+label: '\u3e42\u0160\u9210\u0167\u5f50'
+}
+);
+try {
+computePassEncoder28.setBindGroup(
+1,
+bindGroup30
+);
+} catch {}
+try {
+computePassEncoder29.setBindGroup(
+4,
+bindGroup24,
+new Uint32Array(3340),
+2778,
+0
+);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(
+4,
+bindGroup26
+);
+} catch {}
+try {
+renderPassEncoder19.setViewport(
+1818.7,
+24.23,
+455.6,
+9.912,
+0.5579,
+0.5829
+);
+} catch {}
+let pipeline55 = await promise24;
+canvas5.width = 290;
+document.body.append('\u0a11\u702f\u2208\u4292\ud58f\u0c7b\u0c23\u4e72');
+let textureView78 = texture46.createView(
+{
+baseMipLevel: 3,
+mipLevelCount: 1,
+}
+);
+let renderBundleEncoder62 = device2.createRenderBundleEncoder(
+{
+label: '\ud684\u63c8\u{1fb7e}\u0c66',
+colorFormats: [
+undefined,
+'r16uint',
+'rgba32uint',
+'rg32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 509,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle64 = renderBundleEncoder62.finish(
+{
+label: '\ub98b\ud4bc\uf4c6\u2f74\u5890'
+}
+);
+let shaderModule24 = device0.createShaderModule(
+{
+label: '\u9510\u0ab4\u9c5e\u{1fc01}\ue4c8\udcc9\u{1ff13}\u2f95\u{1f8c6}',
+code: `
+
+@compute @workgroup_size(8, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S30 {
+@location(90) f0: f16,
+@location(86) f1: i32,
+@location(66) f2: vec3<f32>,
+@location(88) f3: f16,
+@location(77) f4: vec2<u32>,
+@location(67) f5: vec2<u32>,
+@location(87) f6: f32,
+@location(10) f7: vec4<f32>,
+@location(40) f8: vec2<f32>,
+@location(104) f9: vec4<i32>,
+@location(2) f10: vec4<f32>,
+@location(43) f11: vec4<u32>,
+@location(81) f12: vec3<f32>,
+@location(8) f13: vec4<f16>,
+@location(31) f14: vec2<f16>,
+@builtin(sample_mask) f15: u32,
+@location(17) f16: vec4<f32>,
+@location(110) f17: vec2<i32>,
+@location(28) f18: vec4<f32>,
+@location(39) f19: vec4<i32>
+}
+struct FragmentOutput0 {
+@location(2) f0: i32,
+@location(7) f1: vec3<u32>,
+@location(4) f2: vec3<i32>,
+@location(6) f3: i32,
+@location(1) f4: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(102) a0: vec2<u32>, @location(45) a1: vec4<u32>, a2: S30, @location(75) a3: vec3<i32>, @location(21) a4: vec3<f16>, @location(106) a5: vec4<f16>, @location(64) a6: vec3<u32>, @builtin(sample_index) a7: u32, @builtin(front_facing) a8: bool, @builtin(position) a9: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S29 {
+@location(7) f0: vec3<u32>
+}
+struct VertexOutput0 {
+@location(45) f228: vec4<u32>,
+@location(64) f229: vec3<u32>,
+@location(21) f230: vec3<f16>,
+@location(28) f231: vec4<f32>,
+@location(110) f232: vec2<i32>,
+@location(40) f233: vec2<f32>,
+@builtin(position) f234: vec4<f32>,
+@location(31) f235: vec2<f16>,
+@location(17) f236: vec4<f32>,
+@location(88) f237: f16,
+@location(102) f238: vec2<u32>,
+@location(67) f239: vec2<u32>,
+@location(43) f240: vec4<u32>,
+@location(77) f241: vec2<u32>,
+@location(81) f242: vec3<f32>,
+@location(90) f243: f16,
+@location(66) f244: vec3<f32>,
+@location(10) f245: vec4<f32>,
+@location(86) f246: i32,
+@location(8) f247: vec4<f16>,
+@location(75) f248: vec3<i32>,
+@location(2) f249: vec4<f32>,
+@location(106) f250: vec4<f16>,
+@location(104) f251: vec4<i32>,
+@location(87) f252: f32,
+@location(39) f253: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(25) a0: vec3<f16>, @location(11) a1: vec4<u32>, a2: S29, @location(1) a3: vec3<u32>, @location(9) a4: vec3<f32>, @location(0) a5: f16, @location(8) a6: f16, @location(5) a7: vec4<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroup36 = device0.createBindGroup({
+label: '\u33a8\u6ed0\u6da1\ueaee\u037e\ueb3b\u0ffa\u0d15\u{1fc55}\uacd7\u0904',
+layout: bindGroupLayout6,
+entries: [
+{
+binding: 7741,
+resource: {
+buffer: buffer3,
+offset: 37120,
+size: 2300,
+}
+},
+{
+binding: 4867,
+resource: textureView39
+}
+],
+});
+let texture76 = device0.createTexture(
+{
+size: {width: 8208, height: 204, depthOrArrayLayers: 1},
+mipLevelCount: 12,
+format: 'etc2-rgb8a1unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder63 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg32uint',
+undefined,
+'rgba8uint',
+'r8uint',
+'r8unorm',
+'rg16uint',
+'rgba8unorm'
+],
+sampleCount: 532,
+}
+);
+let renderBundle65 = renderBundleEncoder51.finish(
+{
+label: '\u0781\u0bc9\u271b'
+}
+);
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(
+1,
+bindGroup17
+);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(
+4,
+bindGroup27,
+new Uint32Array(9265),
+6521,
+0
+);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant(
+{
+r: -93.32,
+g: 161.6,
+b: -343.8,
+a: 34.04,
+}
+);
+} catch {}
+try {
+renderPassEncoder3.setViewport(
+146.4,
+0.1505,
+49.72,
+0.8491,
+0.9648,
+0.9833
+);
+} catch {}
+try {
+renderBundleEncoder46.setBindGroup(
+4,
+bindGroup6,
+[]
+);
+} catch {}
+try {
+renderBundleEncoder55.setVertexBuffer(
+7,
+buffer19,
+25820
+);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+try {
+await buffer16.mapAsync(
+GPUMapMode.WRITE,
+31160,
+2832
+);
+} catch {}
+try {
+commandEncoder0.copyTextureToBuffer(
+{
+  texture: texture50,
+  mipLevel: 1,
+  origin: { x: 15, y: 46, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 360 widthInBlocks: 45 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 48160 */
+offset: 45240,
+bytesPerRow: 512,
+buffer: buffer3,
+},
+{width: 45, height: 6, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture37,
+  mipLevel: 1,
+  origin: { x: 44, y: 0, z: 82 },
+  aspect: 'all',
+},
+new Float32Array(arrayBuffer7),
+/* required buffer size: 78822 */{
+offset: 323,
+bytesPerRow: 19681,
+},
+{width: 4864, height: 16, depthOrArrayLayers: 1}
+);
+} catch {}
+gc();
+let querySet65 = device0.createQuerySet(
+{
+label: '\uf399\u751e\u1d82\u0aa7\u9f00\u0d74',
+type: 'occlusion',
+count: 3404,
+}
+);
+let textureView79 = texture20.createView(
+{
+label: '\u032d\u5ebe\u{1f79e}\u0341\u{1f8aa}\u{1f9b2}\u0818\udce3\u{1f88c}',
+dimension: '2d',
+baseMipLevel: 1,
+baseArrayLayer: 69,
+}
+);
+let sampler61 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 28.413,
+maxAnisotropy: 13,
+}
+);
+try {
+renderPassEncoder14.beginOcclusionQuery(
+72
+);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(
+6,
+buffer3,
+24460
+);
+} catch {}
+try {
+querySet26.destroy();
+} catch {}
+try {
+commandEncoder0.copyBufferToTexture(
+{
+/* bytesInLastRow: 40112 widthInBlocks: 2507 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 29504 */
+offset: 29504,
+rowsPerImage: 194,
+buffer: buffer0,
+},
+{
+  texture: texture16,
+  mipLevel: 1,
+  origin: { x: 641, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 2507, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline56 = device0.createRenderPipeline(
+{
+label: '\u92b1\u3c7f\ua83c\u0f16\u8114\u6dde\u{1f7b1}\u{1ff51}',
+layout: pipelineLayout9,
+vertex: {
+module: shaderModule6,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 28048,
+attributes: [
+{
+format: 'snorm8x4',
+offset: 23368,
+shaderLocation: 23,
+},
+{
+format: 'uint32x4',
+offset: 17328,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x4',
+offset: 25772,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x2',
+offset: 1620,
+shaderLocation: 6,
+},
+{
+format: 'sint32x3',
+offset: 25900,
+shaderLocation: 11,
+},
+{
+format: 'sint32x3',
+offset: 19736,
+shaderLocation: 18,
+},
+{
+format: 'uint32x4',
+offset: 20896,
+shaderLocation: 15,
+},
+{
+format: 'snorm16x4',
+offset: 8424,
+shaderLocation: 13,
+},
+{
+format: 'uint8x4',
+offset: 14052,
+shaderLocation: 24,
+},
+{
+format: 'uint32',
+offset: 9640,
+shaderLocation: 17,
+},
+{
+format: 'unorm16x4',
+offset: 25648,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x4',
+offset: 11628,
+shaderLocation: 20,
+},
+{
+format: 'uint32',
+offset: 6900,
+shaderLocation: 21,
+},
+{
+format: 'uint32',
+offset: 6464,
+shaderLocation: 16,
+},
+{
+format: 'uint32x4',
+offset: 1528,
+shaderLocation: 5,
+},
+{
+format: 'snorm16x2',
+offset: 15072,
+shaderLocation: 14,
+},
+{
+format: 'unorm16x2',
+offset: 16940,
+shaderLocation: 25,
+},
+{
+format: 'float32x4',
+offset: 19784,
+shaderLocation: 2,
+},
+{
+format: 'sint8x2',
+offset: 6578,
+shaderLocation: 26,
+},
+{
+format: 'uint32x2',
+offset: 9824,
+shaderLocation: 1,
+},
+{
+format: 'sint32',
+offset: 25220,
+shaderLocation: 28,
+},
+{
+format: 'sint32',
+offset: 9292,
+shaderLocation: 19,
+},
+{
+format: 'uint8x4',
+offset: 9140,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 12100,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 8940,
+shaderLocation: 27,
+},
+{
+format: 'unorm8x2',
+offset: 2082,
+shaderLocation: 0,
+},
+{
+format: 'uint32',
+offset: 5452,
+shaderLocation: 10,
+},
+{
+format: 'unorm16x2',
+offset: 3780,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 55448,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+attributes: [
+
+],
+},
+{
+arrayStride: 47156,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 15700,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 42836,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 3176,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 49640,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+attributes: [
+
+],
+},
+{
+arrayStride: 652,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x3',
+offset: 100,
+shaderLocation: 8,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0xbdeb0a20,
+},
+fragment: {
+module: shaderModule6,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'invert',
+},
+stencilWriteMask: 580,
+depthBias: 15,
+depthBiasSlopeScale: 81,
+},
+}
+);
+try {
+device0.destroy();
+} catch {}
+let texture77 = device3.createTexture(
+{
+label: '\u84db\ueacd\u9d6a\u0d95\uaf80\u0f35',
+size: {width: 5570, height: 1, depthOrArrayLayers: 65},
+mipLevelCount: 12,
+dimension: '2d',
+format: 'rg32float',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rg32float',
+'rg32float'
+],
+}
+);
+let renderBundleEncoder64 = device3.createRenderBundleEncoder(
+{
+label: '\uc9ef\u04ff\u{1f924}\u14e3\u1954\u952f\u7db6\u18dd\u8de0\u058a',
+colorFormats: [
+'rg16sint',
+'r16uint',
+'rg8sint',
+'rg8sint',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 840,
+stencilReadOnly: true,
+}
+);
+try {
+gpuCanvasContext15.configure(
+{
+device: device3,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rg16float'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let img11 = await imageWithData(282, 84, '#89827243', '#3f3e5b0c');
+offscreenCanvas8.height = 315;
+let pipelineLayout18 = device2.createPipelineLayout(
+{
+label: '\uf1e7\ua0d9\u0b38\ubf46\u{1faf1}\u{1f96b}\u0f8a\u06c2',
+bindGroupLayouts: [
+bindGroupLayout17,
+bindGroupLayout19,
+bindGroupLayout17,
+bindGroupLayout17,
+bindGroupLayout19,
+bindGroupLayout17,
+bindGroupLayout17
+],
+}
+);
+let textureView80 = texture48.createView(
+{
+label: '\u0c39\u0519\udbe3\u0bd0\u938d\u{1fcdb}\u6569\u{1f631}\u07ca\u03e7\u{1fa37}',
+baseMipLevel: 4,
+baseArrayLayer: 25,
+arrayLayerCount: 3,
+}
+);
+try {
+commandEncoder54.clearBuffer(
+buffer14,
+32188,
+4460
+);
+dissociateBuffer(device2, buffer14);
+} catch {}
+try {
+gpuCanvasContext14.configure(
+{
+device: device2,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'etc2-rgb8a1unorm',
+'r8uint',
+'astc-5x4-unorm-srgb'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let pipeline57 = device2.createComputePipeline(
+{
+label: '\u25d8\u0ac5\u142c\u98a9\ucc04\u3e16\u0a80\u0c9f\u{1f696}\ua074',
+layout: pipelineLayout15,
+compute: {
+module: shaderModule23,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let video11 = await videoWithData();
+offscreenCanvas15.width = 795;
+let commandEncoder64 = device3.createCommandEncoder();
+try {
+device3.queue.writeTexture(
+{
+  texture: texture70,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(24),
+/* required buffer size: 567 */{
+offset: 567,
+bytesPerRow: 288,
+rowsPerImage: 166,
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend(video8);
+let buffer20 = device4.createBuffer(
+{
+label: '\u09f8\ua1e8\u6e88\u85e8\u{1f7e9}\u4b98\u04d1\ub24c',
+size: 23552,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+mappedAtCreation: true,
+}
+);
+let textureView81 = texture68.createView(
+{
+label: '\u04c7\ue270\u0eeb\u084e\u485d\u{1fb07}\u227b\u{1ff3a}\uae92',
+dimension: '2d',
+baseMipLevel: 3,
+baseArrayLayer: 16,
+}
+);
+try {
+computePassEncoder32.setPipeline(
+pipeline55
+);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(
+4,
+bindGroup30,
+new Uint32Array(6232),
+5598,
+0
+);
+} catch {}
+let imageBitmap16 = await createImageBitmap(imageBitmap0);
+let commandEncoder65 = device4.createCommandEncoder();
+let renderBundleEncoder65 = device4.createRenderBundleEncoder(
+{
+label: '\uf700\u4bc1\uf93b\u084c\ua32d\u98b1\u{1fd68}\uf08f\u14aa\ua915',
+colorFormats: [
+'r32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 149,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+gc();
+let adapter8 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let pipelineLayout19 = device4.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout20,
+bindGroupLayout20
+],
+}
+);
+document.body.prepend('\u7931\udd56\u0e22\u4257\u74c7\u{1f6e8}');
+try {
+window.someLabel = buffer20.label;
+} catch {}
+let computePassEncoder33 = commandEncoder52.beginComputePass(
+{
+
+}
+);
+let promise33 = device4.queue.onSubmittedWorkDone();
+let promise34 = adapter3.requestAdapterInfo();
+let bindGroup37 = device1.createBindGroup({
+label: '\u09cc\u0ed2\u05d1\u{1f7f1}\u78d6\u0400\u8102\u0ad8\u9934\u0a98',
+layout: bindGroupLayout14,
+entries: [
+
+],
+});
+let querySet66 = device1.createQuerySet(
+{
+type: 'occlusion',
+count: 320,
+}
+);
+try {
+renderPassEncoder18.setScissorRect(
+2951,
+34,
+4,
+2
+);
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(
+3,
+bindGroup30,
+new Uint32Array(241),
+189,
+0
+);
+} catch {}
+try {
+renderBundleEncoder58.setVertexBuffer(
+1,
+buffer12,
+3312,
+5533
+);
+} catch {}
+try {
+computePassEncoder32.insertDebugMarker(
+'\ua446'
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 24, y: 30, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 109 */{
+offset: 109,
+bytesPerRow: 330,
+rowsPerImage: 82,
+},
+{width: 84, height: 30, depthOrArrayLayers: 0}
+);
+} catch {}
+video10.width = 263;
+try {
+renderPassEncoder18.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(
+2619,
+35,
+39,
+0
+);
+} catch {}
+try {
+renderPassEncoder19.setStencilReference(
+1136
+);
+} catch {}
+let pipeline58 = await device1.createComputePipelineAsync(
+{
+label: '\u7000\u5664\u0a82\u{1fb2c}',
+layout: 'auto',
+compute: {
+module: shaderModule22,
+entryPoint: 'compute0',
+},
+}
+);
+let videoFrame8 = new VideoFrame(imageBitmap16, {timestamp: 0});
+let bindGroup38 = device1.createBindGroup({
+label: '\ue593\u60ae\u3778\ua82c\u{1fddb}\u771e\uf509\u0770',
+layout: bindGroupLayout14,
+entries: [
+
+],
+});
+let buffer21 = device1.createBuffer(
+{
+label: '\u0a40\u57e1\ub6b4\u2708\u0645',
+size: 17581,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+}
+);
+let commandEncoder66 = device1.createCommandEncoder(
+{
+label: '\u443a\u8b04\u0b1b\u{1ff1a}\u{1fdc9}\ubb44\uee2c\u0aa7\u0dc6',
+}
+);
+let texture78 = device1.createTexture(
+{
+label: '\u8af2\u2c5c\uf120\u0815',
+size: {width: 1157, height: 1, depthOrArrayLayers: 172},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+let textureView82 = texture43.createView(
+{
+label: '\u{1ff35}\ue587\u{1fd61}\u{1fd66}\u0d79\u08a7\u{1fe22}',
+mipLevelCount: 1,
+}
+);
+let sampler62 = device1.createSampler(
+{
+label: '\ubf33\u0c01\u939b\uf821',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 72.278,
+lodMaxClamp: 79.016,
+maxAnisotropy: 12,
+}
+);
+try {
+computePassEncoder29.setPipeline(
+pipeline58
+);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+82,
+undefined,
+1135354750,
+372636559
+);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(
+0,
+bindGroup25
+);
+} catch {}
+try {
+commandEncoder66.clearBuffer(
+buffer15
+);
+dissociateBuffer(device1, buffer15);
+} catch {}
+try {
+commandEncoder66.insertDebugMarker(
+'\u4305'
+);
+} catch {}
+document.body.prepend(canvas8);
+let offscreenCanvas20 = new OffscreenCanvas(555, 685);
+let texture79 = device1.createTexture(
+{
+label: '\u33e8\u03a0\u516a\ub588',
+size: {width: 240, height: 16, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+sampleCount: 1,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_DST,
+}
+);
+try {
+renderPassEncoder18.setBindGroup(
+1,
+bindGroup26,
+new Uint32Array(7425),
+4232,
+0
+);
+} catch {}
+try {
+renderPassEncoder16.beginOcclusionQuery(
+56
+);
+} catch {}
+try {
+renderPassEncoder18.setScissorRect(
+2761,
+34,
+45,
+1
+);
+} catch {}
+try {
+renderPassEncoder16.setViewport(
+508.9,
+30.26,
+1794.2,
+5.769,
+0.4341,
+0.6085
+);
+} catch {}
+try {
+renderBundleEncoder45.pushDebugGroup(
+'\u34b6'
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 36, height: 1, depthOrArrayLayers: 5}
+*/
+{
+  source: canvas7,
+  origin: { x: 123, y: 104 },
+  flipY: true,
+},
+{
+  texture: texture78,
+  mipLevel: 5,
+  origin: { x: 21, y: 0, z: 4 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 2, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline59 = device1.createRenderPipeline(
+{
+label: '\u{1fc68}\u07dc\u51b0\u097c\u2020\u1f3a\u6686\u{1f8cf}\u451b',
+layout: pipelineLayout11,
+vertex: {
+module: shaderModule21,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 5380,
+attributes: [
+{
+format: 'sint32x2',
+offset: 408,
+shaderLocation: 19,
+},
+{
+format: 'uint32x4',
+offset: 1448,
+shaderLocation: 1,
+},
+{
+format: 'unorm8x2',
+offset: 3400,
+shaderLocation: 29,
+},
+{
+format: 'snorm16x2',
+offset: 1076,
+shaderLocation: 28,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 3188,
+shaderLocation: 3,
+},
+{
+format: 'uint32',
+offset: 536,
+shaderLocation: 10,
+},
+{
+format: 'unorm8x4',
+offset: 1864,
+shaderLocation: 22,
+},
+{
+format: 'uint32x4',
+offset: 3056,
+shaderLocation: 4,
+},
+{
+format: 'uint32x3',
+offset: 1744,
+shaderLocation: 18,
+},
+{
+format: 'sint8x2',
+offset: 1620,
+shaderLocation: 21,
+},
+{
+format: 'sint8x4',
+offset: 3828,
+shaderLocation: 14,
+},
+{
+format: 'sint8x4',
+offset: 2676,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 24836,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 18948,
+shaderLocation: 20,
+},
+{
+format: 'uint16x4',
+offset: 1564,
+shaderLocation: 11,
+},
+{
+format: 'sint16x4',
+offset: 2468,
+shaderLocation: 13,
+},
+{
+format: 'unorm16x4',
+offset: 6056,
+shaderLocation: 6,
+},
+{
+format: 'sint32x3',
+offset: 2020,
+shaderLocation: 16,
+},
+{
+format: 'uint8x4',
+offset: 14648,
+shaderLocation: 8,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 23624,
+shaderLocation: 26,
+},
+{
+format: 'snorm16x4',
+offset: 11496,
+shaderLocation: 15,
+},
+{
+format: 'snorm8x4',
+offset: 11160,
+shaderLocation: 17,
+},
+{
+format: 'snorm16x2',
+offset: 23496,
+shaderLocation: 0,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 16072,
+shaderLocation: 27,
+},
+{
+format: 'uint8x2',
+offset: 13244,
+shaderLocation: 25,
+},
+{
+format: 'sint8x2',
+offset: 16680,
+shaderLocation: 24,
+},
+{
+format: 'sint8x4',
+offset: 24056,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 26148,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x2',
+offset: 2752,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 16964,
+attributes: [
+{
+format: 'uint16x4',
+offset: 8640,
+shaderLocation: 7,
+},
+{
+format: 'float32x2',
+offset: 9748,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 1380,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 576,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule21,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'one-minus-dst',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'one-minus-dst',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'one-minus-dst',
+dstFactor: 'dst'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rg8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 1424,
+stencilWriteMask: 3471,
+depthBias: 31,
+depthBiasClamp: 63,
+},
+}
+);
+let bindGroup39 = device5.createBindGroup({
+layout: bindGroupLayout21,
+entries: [
+
+],
+});
+let texture80 = device5.createTexture(
+{
+label: '\ueb21\u00fe\uf751\u4032\uf957\ucd8c\u{1f872}\ub352\u92e7\u{1fa74}\u0abf',
+size: {width: 5064, height: 60, depthOrArrayLayers: 30},
+mipLevelCount: 10,
+format: 'astc-8x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-8x6-unorm',
+'astc-8x6-unorm'
+],
+}
+);
+let renderBundle66 = renderBundleEncoder50.finish(
+{
+label: '\u{1ff2e}\uabc5\uf71c\u9f64\u4519\u27ca\ue1d6'
+}
+);
+try {
+await device5.queue.onSubmittedWorkDone();
+} catch {}
+let texture81 = device3.createTexture(
+{
+label: '\u{1ffd7}\u748a\u8b91\u4798\u{1f647}\ueabd\u{1fb0d}\ud8b5\u6a0d',
+size: [7950, 168, 93],
+mipLevelCount: 5,
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x8-unorm',
+'astc-10x8-unorm',
+'astc-10x8-unorm-srgb'
+],
+}
+);
+let renderBundleEncoder66 = device3.createRenderBundleEncoder(
+{
+label: '\u514d\u70d3\u95a0\u041b',
+colorFormats: [
+'rgba32uint',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 884,
+}
+);
+try {
+renderBundleEncoder66.setVertexBuffer(
+73,
+undefined,
+3417189814,
+512749849
+);
+} catch {}
+let canvas16 = document.createElement('canvas');
+let texture82 = device3.createTexture(
+{
+label: '\u9d63\u94ce\u{1f992}\u113b\u0d14\u636a\u0bcf\u3c17\u6dc1\u{1fe98}\ub9e8',
+size: [90, 1, 554],
+mipLevelCount: 4,
+sampleCount: 1,
+dimension: '3d',
+format: 'rgba32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba32uint',
+'rgba32uint',
+'rgba32uint'
+],
+}
+);
+try {
+commandEncoder57.copyTextureToTexture(
+{
+  texture: texture75,
+  mipLevel: 0,
+  origin: { x: 0, y: 64, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture75,
+  mipLevel: 0,
+  origin: { x: 144, y: 76, z: 0 },
+  aspect: 'all',
+},
+{width: 64, height: 16, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend(img5);
+let img12 = await imageWithData(76, 275, '#f1f75d21', '#531e7b31');
+let bindGroupLayout25 = device5.createBindGroupLayout(
+{
+label: '\u0e27\u8900\u{1fa9f}\u{1fd46}\u01fd\u9f6c\u07af\u0dbb\u778b\u{1fe37}\u{1f86e}',
+entries: [
+{
+binding: 200,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '2d-array' },
+}
+],
+}
+);
+let texture83 = device5.createTexture(
+{
+label: '\u0e86\u{1ff22}\u04c6\u3d94\u7edd',
+size: {width: 865, height: 1, depthOrArrayLayers: 1495},
+mipLevelCount: 11,
+dimension: '3d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8snorm',
+'rg8snorm'
+],
+}
+);
+let texture84 = gpuCanvasContext1.getCurrentTexture();
+document.body.prepend('\uee6c\u0ebf\u{1f906}\u8a94\u19ba\u1276\u0c9b\u0eba\u0106\u{1fdef}');
+let offscreenCanvas21 = new OffscreenCanvas(660, 271);
+let texture85 = gpuCanvasContext14.getCurrentTexture();
+try {
+commandEncoder49.copyTextureToTexture(
+{
+  texture: texture63,
+  mipLevel: 0,
+  origin: { x: 56, y: 195, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture63,
+  mipLevel: 1,
+  origin: { x: 8, y: 25, z: 0 },
+  aspect: 'all',
+},
+{width: 16, height: 105, depthOrArrayLayers: 1}
+);
+} catch {}
+let bindGroupLayout26 = pipeline57.getBindGroupLayout(3);
+try {
+buffer14.destroy();
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16float',
+'rgba16float',
+'rgba16float',
+'rgba16uint'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let gpuCanvasContext18 = canvas16.getContext('webgpu');
+let gpuCanvasContext19 = offscreenCanvas20.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let renderPassEncoder20 = commandEncoder0.beginRenderPass(
+{
+label: '\ubaf9\u124a\uc58b',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView19,
+depthClearValue: -0.3459070079365585,
+depthLoadOp: 'load',
+depthStoreOp: 'store',
+stencilClearValue: 57853,
+stencilReadOnly: false,
+},
+maxDrawCount: 269760,
+}
+);
+let renderBundleEncoder67 = device0.createRenderBundleEncoder(
+{
+label: '\u0135\u555f\u2b09\u1630\u0196\u{1fbc5}\u{1fb0b}\u{1fb39}',
+colorFormats: [
+'rg32uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 742,
+depthReadOnly: false,
+}
+);
+try {
+renderPassEncoder12.beginOcclusionQuery(
+48
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 112, height: 1, depthOrArrayLayers: 11}
+*/
+{
+  source: video2,
+  origin: { x: 8, y: 8 },
+  flipY: false,
+},
+{
+  texture: texture54,
+  mipLevel: 3,
+  origin: { x: 14, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 7, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\u0164\u{1f74f}\u1f57');
+let imageData12 = new ImageData(152, 104);
+pseudoSubmit(device1, commandEncoder47);
+let renderPassEncoder21 = commandEncoder66.beginRenderPass(
+{
+label: '\u0b97\u0716\u{1fbcb}\u{1fdce}\u09ab\u44c0\u3284\u0369\u677e\u6e31',
+colorAttachments: [
+undefined,
+undefined,
+{
+view: textureView69,
+clearValue: {
+r: -841.1,
+g: -573.4,
+b: 956.6,
+a: 788.0,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined
+],
+occlusionQuerySet: querySet40,
+maxDrawCount: 178336,
+}
+);
+let sampler63 = device1.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 27.809,
+lodMaxClamp: 98.106,
+maxAnisotropy: 5,
+}
+);
+try {
+renderPassEncoder18.beginOcclusionQuery(
+16
+);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(
+1804,
+30,
+384,
+3
+);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(
+1,
+buffer12,
+11800,
+11027
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer15,
+5520,
+new Float32Array(33621),
+27451
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline60 = device1.createRenderPipeline(
+{
+label: '\u21a6\u8276\ua027\uee04',
+layout: pipelineLayout16,
+vertex: {
+module: shaderModule21,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 3360,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 1752,
+shaderLocation: 20,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 524,
+shaderLocation: 0,
+},
+{
+format: 'float32x4',
+offset: 2360,
+shaderLocation: 29,
+},
+{
+format: 'float16x2',
+offset: 1848,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x4',
+offset: 1180,
+shaderLocation: 15,
+},
+{
+format: 'sint8x2',
+offset: 548,
+shaderLocation: 19,
+},
+{
+format: 'uint32',
+offset: 3080,
+shaderLocation: 1,
+},
+{
+format: 'uint32x2',
+offset: 2332,
+shaderLocation: 8,
+},
+{
+format: 'uint32x4',
+offset: 3004,
+shaderLocation: 10,
+},
+{
+format: 'sint32x3',
+offset: 240,
+shaderLocation: 23,
+},
+{
+format: 'uint16x2',
+offset: 704,
+shaderLocation: 7,
+},
+{
+format: 'sint32',
+offset: 2504,
+shaderLocation: 21,
+},
+{
+format: 'snorm8x4',
+offset: 1332,
+shaderLocation: 2,
+},
+{
+format: 'uint32x3',
+offset: 2600,
+shaderLocation: 11,
+},
+{
+format: 'sint32x2',
+offset: 3072,
+shaderLocation: 14,
+},
+{
+format: 'snorm16x4',
+offset: 1476,
+shaderLocation: 26,
+},
+{
+format: 'uint8x4',
+offset: 2044,
+shaderLocation: 25,
+},
+{
+format: 'sint8x2',
+offset: 1502,
+shaderLocation: 24,
+},
+{
+format: 'float16x4',
+offset: 2464,
+shaderLocation: 17,
+},
+{
+format: 'sint16x2',
+offset: 3024,
+shaderLocation: 9,
+},
+{
+format: 'float32x3',
+offset: 580,
+shaderLocation: 22,
+},
+{
+format: 'float32x4',
+offset: 720,
+shaderLocation: 28,
+}
+],
+},
+{
+arrayStride: 11172,
+attributes: [
+
+],
+},
+{
+arrayStride: 22624,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 348,
+shaderLocation: 18,
+},
+{
+format: 'uint8x4',
+offset: 8360,
+shaderLocation: 4,
+},
+{
+format: 'float32x3',
+offset: 6728,
+shaderLocation: 27,
+},
+{
+format: 'float32x2',
+offset: 7680,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 24604,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 23428,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 22004,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 1016,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32',
+offset: 980,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x2',
+offset: 448,
+shaderLocation: 6,
+},
+{
+format: 'sint8x4',
+offset: 196,
+shaderLocation: 13,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+frontFace: 'ccw',
+unclippedDepth: false,
+},
+fragment: {
+module: shaderModule21,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+undefined,
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'one',
+dstFactor: 'one-minus-dst-alpha'
+},
+},
+format: 'r16float',
+},
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'replace',
+depthFailOp: 'keep',
+passOp: 'zero',
+},
+stencilReadMask: 1614,
+stencilWriteMask: 2593,
+depthBias: 86,
+depthBiasSlopeScale: 31,
+},
+}
+);
+document.body.append('\ubf93\u73d9\u0c13\ue4d0\u9040\u7ada\u{1f778}\u{1f9d1}\u0688\ua2d5');
+let device6 = await adapter5.requestDevice(
+{
+label: '\u7b4b\u7e0d\u55e3\u2e7d\u3ae0\u2156\u8d45',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 54,
+maxVertexAttributes: 21,
+maxVertexBufferArrayStride: 15750,
+maxStorageTexturesPerShaderStage: 19,
+maxStorageBuffersPerShaderStage: 22,
+maxDynamicStorageBuffersPerPipelineLayout: 13004,
+maxBindingsPerBindGroup: 3037,
+maxTextureDimension1D: 14078,
+maxTextureDimension2D: 11077,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 163602054,
+maxInterStageShaderVariables: 76,
+maxInterStageShaderComponents: 101,
+},
+}
+);
+try {
+offscreenCanvas21.getContext('2d');
+} catch {}
+let textureView83 = texture34.createView(
+{
+label: '\u78c5\u0fa0\u{1fddb}\u{1fc29}',
+}
+);
+try {
+renderPassEncoder21.setBindGroup(
+2,
+bindGroup30
+);
+} catch {}
+try {
+renderPassEncoder21.beginOcclusionQuery(
+80
+);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(
+69
+);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(
+0,
+bindGroup38
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 72, height: 1, depthOrArrayLayers: 10}
+*/
+{
+  source: video10,
+  origin: { x: 2, y: 1 },
+  flipY: true,
+},
+{
+  texture: texture78,
+  mipLevel: 4,
+  origin: { x: 27, y: 0, z: 9 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 13, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let imageData13 = new ImageData(236, 108);
+let bindGroupLayout27 = device3.createBindGroupLayout(
+{
+entries: [
+
+],
+}
+);
+let renderBundle67 = renderBundleEncoder64.finish();
+try {
+device3.queue.writeTexture(
+{
+  texture: texture75,
+  mipLevel: 0,
+  origin: { x: 112, y: 8, z: 0 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer3),
+/* required buffer size: 6845 */{
+offset: 569,
+bytesPerRow: 356,
+},
+{width: 56, height: 72, depthOrArrayLayers: 1}
+);
+} catch {}
+let imageData14 = new ImageData(104, 232);
+let computePassEncoder34 = commandEncoder56.beginComputePass(
+{
+
+}
+);
+let renderBundleEncoder68 = device3.createRenderBundleEncoder(
+{
+label: '\u3651\u0c75\u5469\u{1fb5a}',
+colorFormats: [
+'r32float',
+'r16float',
+'rgba8sint',
+'rgba32sint'
+],
+sampleCount: 377,
+depthReadOnly: true,
+}
+);
+let externalTexture5 = device3.importExternalTexture(
+{
+label: '\uce16\ufc71\uc5c7',
+source: videoFrame3,
+colorSpace: 'display-p3',
+}
+);
+let promise35 = device3.popErrorScope();
+gc();
+let texture86 = device1.createTexture(
+{
+label: '\u01bb\u0631\ub2e7',
+size: [155, 134, 84],
+mipLevelCount: 5,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+let textureView84 = texture44.createView(
+{
+label: '\u09fb\u4879\u3760\u{1f7c2}\u{1f8d7}\ud14b\u{1f763}\ub1b4\u9c5a',
+dimension: '2d',
+mipLevelCount: 2,
+baseArrayLayer: 238,
+}
+);
+try {
+computePassEncoder29.setPipeline(
+pipeline55
+);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(
+175
+);
+} catch {}
+try {
+renderPassEncoder19.setViewport(
+1408.8,
+27.62,
+894.2,
+2.592,
+0.6259,
+0.8147
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer15,
+8240,
+new Int16Array(20192),
+19515,
+368
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let textureView85 = texture78.createView(
+{
+label: '\u03fd\u05ef\u80e7',
+baseMipLevel: 2,
+}
+);
+try {
+renderPassEncoder21.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(
+3992
+);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(
+1,
+buffer12,
+8448,
+19563
+);
+} catch {}
+try {
+texture44.destroy();
+} catch {}
+try {
+computePassEncoder29.insertDebugMarker(
+'\u91d8'
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture79,
+  mipLevel: 3,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+},
+new DataView(new ArrayBuffer(72)),
+/* required buffer size: 268 */{
+offset: 268,
+},
+{width: 8, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let promise36 = device1.queue.onSubmittedWorkDone();
+let pipeline61 = device1.createRenderPipeline(
+{
+label: '\u9aa3\uc115\u{1fd37}',
+layout: pipelineLayout16,
+vertex: {
+module: shaderModule21,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 18044,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32',
+offset: 6920,
+shaderLocation: 22,
+},
+{
+format: 'snorm8x4',
+offset: 12408,
+shaderLocation: 2,
+},
+{
+format: 'float16x2',
+offset: 11128,
+shaderLocation: 5,
+},
+{
+format: 'float32',
+offset: 1760,
+shaderLocation: 3,
+},
+{
+format: 'sint32x4',
+offset: 14664,
+shaderLocation: 21,
+},
+{
+format: 'unorm16x2',
+offset: 8596,
+shaderLocation: 26,
+},
+{
+format: 'sint16x4',
+offset: 14444,
+shaderLocation: 13,
+},
+{
+format: 'snorm8x2',
+offset: 15304,
+shaderLocation: 20,
+},
+{
+format: 'float32',
+offset: 6752,
+shaderLocation: 28,
+},
+{
+format: 'snorm16x2',
+offset: 7396,
+shaderLocation: 0,
+},
+{
+format: 'uint32',
+offset: 6508,
+shaderLocation: 8,
+},
+{
+format: 'uint32x2',
+offset: 12560,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x4',
+offset: 3360,
+shaderLocation: 17,
+},
+{
+format: 'sint32',
+offset: 1860,
+shaderLocation: 14,
+},
+{
+format: 'float16x2',
+offset: 14912,
+shaderLocation: 27,
+},
+{
+format: 'uint32x4',
+offset: 11884,
+shaderLocation: 10,
+},
+{
+format: 'sint8x2',
+offset: 10696,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 26096,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x4',
+offset: 212,
+shaderLocation: 9,
+},
+{
+format: 'uint32x2',
+offset: 12936,
+shaderLocation: 7,
+},
+{
+format: 'uint32x2',
+offset: 13128,
+shaderLocation: 1,
+},
+{
+format: 'unorm8x4',
+offset: 1896,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 12712,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 22528,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x2',
+offset: 258,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 19084,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 3332,
+shaderLocation: 29,
+},
+{
+format: 'float16x4',
+offset: 8004,
+shaderLocation: 15,
+},
+{
+format: 'uint32x4',
+offset: 6104,
+shaderLocation: 25,
+}
+],
+},
+{
+arrayStride: 24504,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x4',
+offset: 8448,
+shaderLocation: 24,
+},
+{
+format: 'uint8x2',
+offset: 12682,
+shaderLocation: 18,
+},
+{
+format: 'unorm16x4',
+offset: 19340,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 21964,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 20624,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 20376,
+attributes: [
+{
+format: 'sint8x2',
+offset: 6116,
+shaderLocation: 19,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule21,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+{
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater',
+depthFailOp: 'invert',
+},
+stencilReadMask: 3289,
+depthBias: 18,
+depthBiasSlopeScale: 4,
+},
+}
+);
+let shaderModule25 = device4.createShaderModule(
+{
+label: '\u0906\u150b\u0b73\u{1f731}\u03e7\u059b\u3ceb\u4d1f\ue7d0',
+code: `
+
+@compute @workgroup_size(2, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(front_facing) a1: bool) {
+
+}
+
+
+
+@vertex
+fn vertex0(@location(4) a0: vec4<u32>, @location(8) a1: f32, @builtin(vertex_index) a2: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let buffer22 = device4.createBuffer(
+{
+label: '\ub1b4\u00e5\uaff9\u414e\u0f1a\u0c9d\u{1fa1c}',
+size: 40144,
+usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+}
+);
+let commandEncoder67 = device4.createCommandEncoder(
+{
+label: '\u689e\u01f0\u6297',
+}
+);
+try {
+commandEncoder65.resolveQuerySet(
+querySet51,
+959,
+184,
+buffer22,
+2048
+);
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let videoFrame9 = new VideoFrame(offscreenCanvas13, {timestamp: 0});
+let renderBundleEncoder69 = device5.createRenderBundleEncoder(
+{
+label: '\u0108\u3b67\u9ba3\u578a\uf9bf\u430a\u0581\u528b',
+colorFormats: [
+undefined,
+undefined,
+'bgra8unorm-srgb'
+],
+sampleCount: 576,
+stencilReadOnly: true,
+}
+);
+document.body.append('\u965e\u9bb5\uc8e4\u004a\u5520\u0bc9\u0f24\u4d61\ua584\u0c17\uc061');
+document.body.prepend('\u12ff\u786b\u0110\u7a1c\u{1fee0}\ud3cc\u19d9\u07e6\u01fd');
+let promise37 = adapter8.requestDevice(
+{
+label: '\ue09a\u042f',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'indirect-first-instance',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 7,
+maxColorAttachmentBytesPerSample: 37,
+maxVertexAttributes: 18,
+maxVertexBufferArrayStride: 31002,
+maxStorageTexturesPerShaderStage: 14,
+maxStorageBuffersPerShaderStage: 30,
+maxDynamicStorageBuffersPerPipelineLayout: 22363,
+maxBindingsPerBindGroup: 4454,
+maxTextureDimension1D: 12876,
+maxTextureDimension2D: 9746,
+maxVertexBuffers: 9,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 160532365,
+maxInterStageShaderVariables: 75,
+maxInterStageShaderComponents: 98,
+},
+}
+);
+try {
+computePassEncoder29.setBindGroup(
+3,
+bindGroup37,
+new Uint32Array(9915),
+8993,
+0
+);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(
+buffer12,
+'uint16',
+8676,
+8700
+);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(
+1,
+bindGroup24
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 144, height: 1, depthOrArrayLayers: 21}
+*/
+{
+  source: canvas6,
+  origin: { x: 104, y: 35 },
+  flipY: false,
+},
+{
+  texture: texture78,
+  mipLevel: 3,
+  origin: { x: 12, y: 0, z: 10 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 123, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline62 = device1.createRenderPipeline(
+{
+label: '\u0d21\uffe0',
+layout: 'auto',
+vertex: {
+module: shaderModule21,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 8544,
+attributes: [
+{
+format: 'uint32x3',
+offset: 4680,
+shaderLocation: 4,
+},
+{
+format: 'float32x4',
+offset: 2336,
+shaderLocation: 27,
+},
+{
+format: 'sint32x2',
+offset: 3992,
+shaderLocation: 24,
+},
+{
+format: 'sint8x2',
+offset: 4366,
+shaderLocation: 23,
+},
+{
+format: 'uint32x2',
+offset: 1920,
+shaderLocation: 18,
+},
+{
+format: 'uint32x4',
+offset: 472,
+shaderLocation: 25,
+},
+{
+format: 'uint32x3',
+offset: 7700,
+shaderLocation: 8,
+},
+{
+format: 'float32x2',
+offset: 3252,
+shaderLocation: 22,
+},
+{
+format: 'snorm8x2',
+offset: 5466,
+shaderLocation: 29,
+},
+{
+format: 'uint32x3',
+offset: 6096,
+shaderLocation: 11,
+},
+{
+format: 'float16x2',
+offset: 1384,
+shaderLocation: 12,
+},
+{
+format: 'uint32x4',
+offset: 3636,
+shaderLocation: 7,
+},
+{
+format: 'float32',
+offset: 4700,
+shaderLocation: 20,
+},
+{
+format: 'float32x4',
+offset: 812,
+shaderLocation: 0,
+},
+{
+format: 'uint16x2',
+offset: 5768,
+shaderLocation: 10,
+},
+{
+format: 'unorm16x2',
+offset: 600,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 4272,
+attributes: [
+{
+format: 'snorm8x2',
+offset: 478,
+shaderLocation: 3,
+},
+{
+format: 'sint32x2',
+offset: 3676,
+shaderLocation: 19,
+},
+{
+format: 'sint32x2',
+offset: 4092,
+shaderLocation: 16,
+},
+{
+format: 'sint32x3',
+offset: 2556,
+shaderLocation: 21,
+}
+],
+},
+{
+arrayStride: 26668,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 15524,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 12336,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 23752,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 20444,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x2',
+offset: 20496,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 6812,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 2328,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x4',
+offset: 680,
+shaderLocation: 28,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 5236,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'float32x2',
+offset: 4152,
+shaderLocation: 5,
+},
+{
+format: 'uint32x3',
+offset: 26396,
+shaderLocation: 1,
+},
+{
+format: 'snorm8x4',
+offset: 14900,
+shaderLocation: 26,
+}
+],
+},
+{
+arrayStride: 20376,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 23860,
+attributes: [
+
+],
+},
+{
+arrayStride: 14100,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x4',
+offset: 5332,
+shaderLocation: 13,
+}
+],
+}
+]
+},
+multisample: {
+mask: 0x2ae1cca9,
+},
+fragment: {
+module: shaderModule21,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'invert',
+depthFailOp: 'invert',
+},
+stencilBack: {
+compare: 'not-equal',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilReadMask: 220,
+stencilWriteMask: 1168,
+depthBiasSlopeScale: 92,
+depthBiasClamp: 56,
+},
+}
+);
+let buffer23 = device6.createBuffer(
+{
+label: '\u06d3\u03dc\uc014\u0dc1\u{1fafe}\u9534\u0605\u0981',
+size: 53208,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+let commandEncoder68 = device6.createCommandEncoder(
+{
+label: '\u62e7\ue15a\u{1f933}\u{1f636}\u617a\u0bf5\u2b77\u{1fd1d}',
+}
+);
+try {
+gpuCanvasContext3.configure(
+{
+device: device6,
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8uint',
+'rgba8uint',
+'rgba8uint'
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+document.body.prepend(img10);
+let promise38 = navigator.gpu.requestAdapter(
+{
+}
+);
+let offscreenCanvas22 = new OffscreenCanvas(932, 75);
+let computePassEncoder35 = commandEncoder65.beginComputePass();
+let renderBundleEncoder70 = device4.createRenderBundleEncoder(
+{
+label: '\ufcee\ubc1d\ubb91\u4e3f\u01f9\u0166\u0183',
+colorFormats: [
+'rgba8sint',
+'bgra8unorm-srgb',
+'rgb10a2uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 603,
+depthReadOnly: false,
+}
+);
+let renderBundle68 = renderBundleEncoder65.finish(
+{
+
+}
+);
+try {
+commandEncoder49.copyTextureToTexture(
+{
+  texture: texture68,
+  mipLevel: 8,
+  origin: { x: 10, y: 0, z: 23 },
+  aspect: 'all',
+},
+{
+  texture: texture68,
+  mipLevel: 3,
+  origin: { x: 445, y: 0, z: 42 },
+  aspect: 'all',
+},
+{width: 15, height: 0, depthOrArrayLayers: 30}
+);
+} catch {}
+let canvas17 = document.createElement('canvas');
+let imageBitmap17 = await createImageBitmap(canvas6);
+let bindGroupLayout28 = device5.createBindGroupLayout(
+{
+label: '\u0c96\u7f27\u33eb\u2fe5\u0f97',
+entries: [
+
+],
+}
+);
+let pipelineLayout20 = device5.createPipelineLayout(
+{
+label: '\u84da\u1801',
+bindGroupLayouts: [
+bindGroupLayout28,
+bindGroupLayout25,
+bindGroupLayout21
+],
+}
+);
+let renderBundle69 = renderBundleEncoder50.finish();
+try {
+renderBundleEncoder69.setVertexBuffer(
+92,
+undefined,
+2579950211,
+512339282
+);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture80,
+  mipLevel: 5,
+  origin: { x: 96, y: 6, z: 3 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 919661 */{
+offset: 689,
+bytesPerRow: 201,
+rowsPerImage: 254,
+},
+{width: 16, height: 0, depthOrArrayLayers: 19}
+);
+} catch {}
+gc();
+document.body.append('\u7f71\u4f55\u0993\u05e6\u0a78\u{1faa1}\u744c\u{1f90b}');
+try {
+offscreenCanvas22.getContext('webgpu');
+} catch {}
+let textureView86 = texture62.createView(
+{
+label: '\u2da9\u{1f9bc}\u{1fa42}\u{1fa3c}\ua76e\u0b53\u010e',
+baseMipLevel: 2,
+}
+);
+let renderPassEncoder22 = commandEncoder54.beginRenderPass(
+{
+label: '\u0fd0\ucf18\ued98\u03bd\ueca5\u7fa9\u92ad\u049b\u0e01\u{1fd7e}\u{1ff67}',
+colorAttachments: [
+{
+view: textureView78,
+depthSlice: 8,
+clearValue: {
+r: -415.6,
+g: 46.89,
+b: -201.1,
+a: -80.84,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView78,
+depthSlice: 4,
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView78,
+depthSlice: 1,
+clearValue: {
+r: 182.5,
+g: -217.4,
+b: -649.8,
+a: -60.51,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView78,
+depthSlice: 13,
+clearValue: {
+r: -792.1,
+g: 147.8,
+b: 794.9,
+a: 108.0,
+},
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet44,
+maxDrawCount: 87056,
+}
+);
+let renderBundle70 = renderBundleEncoder62.finish();
+let sampler64 = device2.createSampler(
+{
+label: '\u0a3f\ufcce\ub026\u0e33\u{1f74b}\u{1fa1b}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 17.479,
+}
+);
+try {
+renderPassEncoder22.beginOcclusionQuery(
+40
+);
+} catch {}
+try {
+computePassEncoder26.insertDebugMarker(
+'\u09ad'
+);
+} catch {}
+try {
+gpuCanvasContext3.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16float'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let pipeline63 = device2.createRenderPipeline(
+{
+label: '\uc884\uaae5\uec17\u27a9\u{1f776}\u94a6\u{1fe23}\u{1faa9}',
+layout: pipelineLayout15,
+vertex: {
+module: shaderModule23,
+entryPoint: 'vertex0',
+buffers: [
+
+]
+},
+primitive: {
+topology: 'line-list',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule23,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+}
+);
+try {
+window.someLabel = device2.label;
+} catch {}
+let textureView87 = texture49.createView(
+{
+label: '\u330a\u1193\u{1fad9}\u7403\uaa67\u{1fc6f}\u032e',
+}
+);
+try {
+renderPassEncoder22.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder22.setStencilReference(
+3411
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture49,
+  mipLevel: 0,
+  origin: { x: 276, y: 1, z: 0 },
+  aspect: 'all',
+},
+new BigUint64Array(arrayBuffer0),
+/* required buffer size: 137 */{
+offset: 137,
+},
+{width: 614, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline64 = device2.createRenderPipeline(
+{
+label: '\u{1f6da}\u0758\u7581\u050a\ude6a\u0368',
+layout: pipelineLayout18,
+vertex: {
+module: shaderModule23,
+entryPoint: 'vertex0',
+buffers: [
+
+]
+},
+primitive: {
+topology: 'line-strip',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x57f5696a,
+},
+fragment: {
+module: shaderModule23,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'replace',
+depthFailOp: 'zero',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'replace',
+depthFailOp: 'replace',
+passOp: 'replace',
+},
+stencilReadMask: 1036,
+depthBias: 6,
+depthBiasSlopeScale: 28,
+depthBiasClamp: 57,
+},
+}
+);
+let renderBundle71 = renderBundleEncoder42.finish(
+{
+label: '\udc15\u4a45'
+}
+);
+try {
+computePassEncoder26.setPipeline(
+pipeline57
+);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([]);
+} catch {}
+let imageData15 = new ImageData(44, 44);
+let querySet67 = device2.createQuerySet(
+{
+type: 'occlusion',
+count: 2170,
+}
+);
+let textureView88 = texture46.createView(
+{
+label: '\u7091\u0b86\u3c3a',
+aspect: 'all',
+baseMipLevel: 2,
+mipLevelCount: 2,
+}
+);
+let renderBundle72 = renderBundleEncoder62.finish(
+{
+label: '\u{1fe05}\u4986\ua890'
+}
+);
+let pipeline65 = await device2.createComputePipelineAsync(
+{
+layout: pipelineLayout18,
+compute: {
+module: shaderModule23,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline66 = await device2.createRenderPipelineAsync(
+{
+label: '\ufe63\u096a\u{1fdba}\u8faa\ub9e4\ua0f4\u4e3b\ubdec\uf450\u{1fb7c}',
+layout: 'auto',
+vertex: {
+module: shaderModule23,
+entryPoint: 'vertex0',
+buffers: [
+
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x62fae1d7,
+},
+fragment: {
+module: shaderModule23,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+{
+format: 'r32sint',
+writeMask: 0,
+},
+undefined,
+undefined,
+undefined
+],
+},
+}
+);
+let gpuCanvasContext20 = canvas17.getContext('webgpu');
+try {
+await promise34;
+} catch {}
+let bindGroupLayout29 = device1.createBindGroupLayout(
+{
+label: '\u{1f99a}\u057c\u{1f8fb}',
+entries: [
+{
+binding: 251,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'filtering' },
+},
+{
+binding: 60,
+visibility: 0,
+storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '3d' },
+}
+],
+}
+);
+let querySet68 = device1.createQuerySet(
+{
+type: 'occlusion',
+count: 344,
+}
+);
+let texture87 = device1.createTexture(
+{
+label: '\u0bd2\u019c\u007a\ubc03\u{1fe06}\u027a',
+size: [48, 508, 1],
+mipLevelCount: 8,
+format: 'eac-r11unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'eac-r11unorm'
+],
+}
+);
+let textureView89 = texture31.createView(
+{
+label: '\u3304\u42e7\u{1fb68}\u0943\u6384\u4b40\ue44a',
+aspect: 'depth-only',
+baseMipLevel: 6,
+mipLevelCount: 1,
+}
+);
+let externalTexture6 = device1.importExternalTexture(
+{
+label: '\u70df\u4caa\u4dca\u{1f6da}\u8ec8',
+source: video7,
+}
+);
+try {
+renderPassEncoder19.setScissorRect(
+901,
+1,
+171,
+4
+);
+} catch {}
+try {
+renderPassEncoder19.setStencilReference(
+2479
+);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(
+3,
+bindGroup30
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer13,
+5888,
+new Float32Array(65383),
+35678,
+2676
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 578, height: 1, depthOrArrayLayers: 86}
+*/
+{
+  source: video3,
+  origin: { x: 2, y: 3 },
+  flipY: true,
+},
+{
+  texture: texture78,
+  mipLevel: 1,
+  origin: { x: 4, y: 0, z: 73 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 13, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\u{1fdeb}\u6c2c\ude17\u04dd');
+let video12 = await videoWithData();
+let bindGroup40 = device5.createBindGroup({
+label: '\u0213\u6e4a',
+layout: bindGroupLayout28,
+entries: [
+
+],
+});
+let textureView90 = texture84.createView(
+{
+label: '\u5213\u838b\uf515',
+dimension: '2d-array',
+}
+);
+let promise39 = device5.queue.onSubmittedWorkDone();
+try {
+await promise36;
+} catch {}
+document.body.prepend('\u3664\u82e6\u7521\u6c9a\u0213');
+let texture88 = device3.createTexture(
+{
+label: '\u09c4\u0cd4\uebcc\ua97c\u05f2\ud820\ue7af\ubd7b\ub81d\u72c6\u{1fa7c}',
+size: [56, 420, 1],
+format: 'eac-r11snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundle73 = renderBundleEncoder59.finish(
+{
+label: '\u074d\u2e84'
+}
+);
+try {
+renderBundleEncoder68.setVertexBuffer(
+43,
+undefined,
+1530543682,
+445853113
+);
+} catch {}
+try {
+commandEncoder63.copyTextureToTexture(
+{
+  texture: texture58,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture58,
+  mipLevel: 0,
+  origin: { x: 0, y: 5, z: 1 },
+  aspect: 'all',
+},
+{width: 0, height: 10, depthOrArrayLayers: 0}
+);
+} catch {}
+let commandEncoder69 = device6.createCommandEncoder(
+{
+label: '\u05a8\u92c6\u04cd',
+}
+);
+let querySet69 = device6.createQuerySet(
+{
+label: '\u0f8c\u{1fe3e}\u{1f63c}',
+type: 'occlusion',
+count: 3811,
+}
+);
+let texture89 = device6.createTexture(
+{
+label: '\u0920\udbf4',
+size: [61, 2, 172],
+mipLevelCount: 5,
+dimension: '3d',
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+commandEncoder69.clearBuffer(
+buffer23
+);
+dissociateBuffer(device6, buffer23);
+} catch {}
+try {
+commandEncoder68.pushDebugGroup(
+'\u{1fca7}'
+);
+} catch {}
+video7.width = 13;
+let texture90 = device3.createTexture(
+{
+label: '\u485b\u46be',
+size: {width: 5811},
+dimension: '1d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg8unorm'
+],
+}
+);
+try {
+renderBundleEncoder68.setVertexBuffer(
+69,
+undefined,
+657221540,
+2904951555
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture90,
+  mipLevel: 0,
+  origin: { x: 216, y: 0, z: 1 },
+  aspect: 'all',
+},
+new BigInt64Array(new ArrayBuffer(48)),
+/* required buffer size: 269 */{
+offset: 269,
+},
+{width: 5017, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+renderPassEncoder22.setBlendConstant(
+{
+r: -752.3,
+g: 95.02,
+b: 886.5,
+a: 439.3,
+}
+);
+} catch {}
+try {
+renderPassEncoder22.setScissorRect(
+0,
+1,
+99,
+0
+);
+} catch {}
+try {
+renderPassEncoder22.setStencilReference(
+657
+);
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(
+90,
+undefined,
+4242406770,
+31344877
+);
+} catch {}
+try {
+gpuCanvasContext12.configure(
+{
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'eac-r11snorm',
+'rgba8unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+gc();
+let bindGroupLayout30 = device4.createBindGroupLayout(
+{
+label: '\u9032\u8dcc\ufe13\u06a8\udc37\u4342\u{1fac4}\u0693\u0217\u2ffe',
+entries: [
+{
+binding: 277,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+let renderBundleEncoder71 = device4.createRenderBundleEncoder(
+{
+label: '\u91e4\u09dd\u90fd',
+colorFormats: [
+'rg16float',
+'rgb10a2uint',
+'rg32sint',
+'rg8sint',
+'bgra8unorm',
+'r16uint',
+undefined
+],
+sampleCount: 578,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder70.pushDebugGroup(
+'\u{1fc8a}'
+);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let texture91 = device5.createTexture(
+{
+label: '\u27e9\u8f36\ubaa9\u03b0\u{1fe29}\ufb77\u513a\uc9d2',
+size: [19, 3, 207],
+mipLevelCount: 7,
+dimension: '3d',
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'r32uint',
+'r32uint'
+],
+}
+);
+let renderBundleEncoder72 = device5.createRenderBundleEncoder(
+{
+label: '\u{1f7ed}\uf978\u4492',
+colorFormats: [
+'r8unorm',
+'bgra8unorm',
+'rgba8unorm',
+'rg32uint'
+],
+sampleCount: 215,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder52.setBindGroup(
+0,
+bindGroup39
+);
+} catch {}
+try {
+await adapter8.requestAdapterInfo();
+} catch {}
+let bindGroup41 = device3.createBindGroup({
+label: '\u1910\udd3e\u{1f6b0}\u5740\u0170\u5015',
+layout: bindGroupLayout27,
+entries: [
+
+],
+});
+let renderBundleEncoder73 = device3.createRenderBundleEncoder(
+{
+label: '\ud3c8\ub367\u0c29\ud724\u896d\u7db3\u08d8\u{1fcc8}\u9129\u0f6e\u{1f8bb}',
+colorFormats: [
+'r32uint',
+'rgb10a2unorm'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 566,
+depthReadOnly: true,
+}
+);
+let sampler65 = device3.createSampler(
+{
+label: '\u98da\u8de4\ufdda\u{1fb94}\u{1f659}\uf8cd',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 90.753,
+maxAnisotropy: 15,
+}
+);
+try {
+renderBundleEncoder73.setBindGroup(
+1,
+bindGroup41
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture75,
+  mipLevel: 0,
+  origin: { x: 72, y: 0, z: 0 },
+  aspect: 'all',
+},
+new DataView(arrayBuffer5),
+/* required buffer size: 19276 */{
+offset: 619,
+bytesPerRow: 861,
+},
+{width: 144, height: 88, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+try {
+await adapter3.requestAdapterInfo();
+} catch {}
+let bindGroupLayout31 = device6.createBindGroupLayout(
+{
+label: '\u0e35\u047a\uebea\u90ec\u0b04\u{1fd39}\u9475\u{1fef9}',
+entries: [
+
+],
+}
+);
+let textureView91 = texture89.createView(
+{
+label: '\u651a\u7551\u{1fd9c}\uadbb',
+baseMipLevel: 2,
+}
+);
+let computePassEncoder36 = commandEncoder68.beginComputePass(
+{
+label: '\u{1f706}\u{1fe3d}\uf279\ube08\ub680\uea1c\u485b\ue85d'
+}
+);
+let shaderModule26 = device2.createShaderModule(
+{
+label: '\u8b40\u38b2\u8599\u2a9d',
+code: `
+
+@compute @workgroup_size(3, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S32 {
+@location(42) f0: vec3<f16>,
+@location(16) f1: vec2<f16>
+}
+
+@fragment
+fn fragment0(@location(18) a0: u32, a1: S32, @location(19) a2: vec3<f16>) {
+
+}
+
+struct S31 {
+@location(24) f0: vec4<i32>,
+@location(10) f1: vec4<i32>,
+@location(16) f2: vec3<f16>,
+@location(27) f3: vec3<u32>,
+@location(7) f4: vec3<f16>,
+@location(19) f5: vec4<i32>,
+@location(6) f6: vec2<f32>,
+@location(29) f7: vec2<f32>,
+@location(1) f8: vec3<i32>,
+@location(28) f9: vec2<f32>,
+@location(22) f10: vec3<f32>,
+@location(3) f11: vec2<f32>,
+@location(20) f12: vec3<u32>,
+@location(25) f13: vec4<f32>,
+@location(23) f14: vec4<i32>,
+@location(21) f15: f32,
+@location(5) f16: vec4<f32>
+}
+struct VertexOutput0 {
+@location(2) f254: f16,
+@location(3) f255: vec3<i32>,
+@location(39) f256: vec4<u32>,
+@location(31) f257: vec3<f32>,
+@location(25) f258: i32,
+@location(28) f259: f16,
+@location(41) f260: i32,
+@location(18) f261: u32,
+@location(26) f262: i32,
+@location(46) f263: vec2<f16>,
+@location(43) f264: vec3<f32>,
+@location(10) f265: vec2<u32>,
+@location(30) f266: vec4<i32>,
+@location(19) f267: vec3<f16>,
+@location(1) f268: vec4<i32>,
+@location(32) f269: i32,
+@location(17) f270: i32,
+@location(23) f271: vec4<i32>,
+@location(27) f272: vec4<u32>,
+@location(5) f273: vec3<f16>,
+@location(44) f274: vec2<f32>,
+@location(16) f275: vec2<f16>,
+@location(13) f276: vec3<f32>,
+@location(7) f277: f16,
+@location(42) f278: vec3<f16>,
+@location(14) f279: vec3<f32>,
+@builtin(position) f280: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec3<i32>, @location(17) a1: vec4<f32>, @location(0) a2: vec2<i32>, @location(8) a3: f32, @location(11) a4: vec3<u32>, @location(4) a5: vec3<i32>, @builtin(vertex_index) a6: u32, @location(12) a7: f32, @location(9) a8: vec3<u32>, @location(13) a9: i32, a10: S31, @location(2) a11: vec4<i32>, @location(26) a12: vec2<f16>, @location(15) a13: vec4<u32>, @location(18) a14: vec2<f16>, @builtin(instance_index) a15: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+pseudoSubmit(device2, commandEncoder62);
+try {
+renderPassEncoder22.setVertexBuffer(
+4,
+undefined
+);
+} catch {}
+try {
+device1.label = '\u8d23\uaf0b\u00ef\u0ca8\uf78b\u05d0\u0650\u85b0\ucfa5';
+} catch {}
+let bindGroup42 = device1.createBindGroup({
+label: '\u94ac\u8450\u1d63\u0fae\ubdd0\u38bb\u4af8',
+layout: bindGroupLayout14,
+entries: [
+
+],
+});
+let sampler66 = device1.createSampler(
+{
+label: '\u035d\u{1faec}\u{1feae}\u03f0\u03c2\u3960\u7615\u{1fc17}\u0810\u01ba',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 61.912,
+lodMaxClamp: 80.625,
+}
+);
+try {
+computePassEncoder29.setBindGroup(
+4,
+bindGroup30,
+new Uint32Array(6989),
+4633,
+0
+);
+} catch {}
+try {
+computePassEncoder29.setPipeline(
+pipeline58
+);
+} catch {}
+try {
+renderPassEncoder21.setViewport(
+1062.0,
+14.57,
+32.75,
+10.10,
+0.5983,
+0.6020
+);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+0,
+buffer12
+);
+} catch {}
+let textureView92 = texture58.createView(
+{
+label: '\u4279\u0126\u1824\u0a11\u9396\u04c3\u{1f6f2}\u0828\u17de\ued22',
+dimension: '2d-array',
+mipLevelCount: 1,
+}
+);
+let sampler67 = device3.createSampler(
+{
+label: '\u0034\ud90a\u5dcb\u1e03',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 42.287,
+lodMaxClamp: 96.371,
+maxAnisotropy: 1,
+}
+);
+try {
+device3.pushErrorScope(
+'out-of-memory'
+);
+} catch {}
+let texture92 = device4.createTexture(
+{
+label: '\u081b\u8a8b\u7f24\u0b10\u0a95\u09d1\u5b38',
+size: [916, 1, 1105],
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16uint',
+'rgba16uint',
+'rgba16uint'
+],
+}
+);
+let textureView93 = texture64.createView(
+{
+label: '\u0715\u{1fdc7}\u0bcd\uc505\ud43d\u0d88\ufffb\udd9b\u8308',
+dimension: '2d-array',
+baseMipLevel: 2,
+mipLevelCount: 3,
+baseArrayLayer: 0,
+}
+);
+let computePassEncoder37 = commandEncoder49.beginComputePass(
+{
+
+}
+);
+let renderBundle74 = renderBundleEncoder48.finish(
+{
+label: '\ub129\u{1f916}\u5cd6\uccf7\u{1fcc7}\u0845'
+}
+);
+let pipeline67 = device4.createRenderPipeline(
+{
+label: '\u0c8a\u029d\u{1fb6e}\u5d4e\u077f\u08ee\u5da1\u0744',
+layout: pipelineLayout19,
+vertex: {
+module: shaderModule25,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 3116,
+attributes: [
+{
+format: 'uint32x2',
+offset: 1876,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 13944,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 9234,
+shaderLocation: 8,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x95953c4f,
+},
+fragment: {
+module: shaderModule25,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'less',
+failOp: 'invert',
+depthFailOp: 'replace',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'invert',
+},
+stencilReadMask: 3071,
+stencilWriteMask: 123,
+depthBias: 87,
+depthBiasSlopeScale: 37,
+depthBiasClamp: 86,
+},
+}
+);
+let textureView94 = texture49.createView(
+{
+baseArrayLayer: 0,
+}
+);
+let sampler68 = device2.createSampler(
+{
+label: '\u0927\u086a\u6198\uadb4\u{1ff17}\u2837\u11ab\uf121\u8a20',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 87.700,
+lodMaxClamp: 88.357,
+}
+);
+let pipeline68 = await device2.createRenderPipelineAsync(
+{
+label: '\u9954\uae3a\u98ad\ua9e7\u660c\u{1f733}\u83fd\ufc5b\ufe4c',
+layout: pipelineLayout15,
+vertex: {
+module: shaderModule26,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 32096,
+attributes: [
+{
+format: 'float16x2',
+offset: 24740,
+shaderLocation: 6,
+},
+{
+format: 'sint8x2',
+offset: 19354,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 1140,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x3',
+offset: 364,
+shaderLocation: 20,
+},
+{
+format: 'snorm8x2',
+offset: 428,
+shaderLocation: 25,
+},
+{
+format: 'unorm16x2',
+offset: 332,
+shaderLocation: 21,
+},
+{
+format: 'sint8x4',
+offset: 428,
+shaderLocation: 14,
+},
+{
+format: 'sint8x2',
+offset: 1108,
+shaderLocation: 4,
+},
+{
+format: 'sint32',
+offset: 1004,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x4',
+offset: 860,
+shaderLocation: 16,
+},
+{
+format: 'uint32x4',
+offset: 548,
+shaderLocation: 27,
+},
+{
+format: 'uint32x2',
+offset: 308,
+shaderLocation: 9,
+},
+{
+format: 'float32x3',
+offset: 308,
+shaderLocation: 18,
+},
+{
+format: 'sint8x4',
+offset: 876,
+shaderLocation: 24,
+}
+],
+},
+{
+arrayStride: 9232,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x4',
+offset: 8716,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 20424,
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x4',
+offset: 25900,
+shaderLocation: 0,
+},
+{
+format: 'unorm16x2',
+offset: 32680,
+shaderLocation: 5,
+},
+{
+format: 'snorm16x2',
+offset: 2680,
+shaderLocation: 17,
+},
+{
+format: 'float16x4',
+offset: 39724,
+shaderLocation: 26,
+},
+{
+format: 'sint8x2',
+offset: 34624,
+shaderLocation: 13,
+},
+{
+format: 'sint32x3',
+offset: 32864,
+shaderLocation: 23,
+},
+{
+format: 'sint32x2',
+offset: 43724,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 41432,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x4',
+offset: 29464,
+shaderLocation: 15,
+},
+{
+format: 'float32',
+offset: 11584,
+shaderLocation: 22,
+},
+{
+format: 'float16x4',
+offset: 39444,
+shaderLocation: 28,
+},
+{
+format: 'sint32x4',
+offset: 37940,
+shaderLocation: 10,
+},
+{
+format: 'uint32x2',
+offset: 38668,
+shaderLocation: 11,
+},
+{
+format: 'float32x2',
+offset: 22076,
+shaderLocation: 12,
+},
+{
+format: 'unorm8x2',
+offset: 19694,
+shaderLocation: 3,
+},
+{
+format: 'unorm16x2',
+offset: 31172,
+shaderLocation: 29,
+}
+],
+},
+{
+arrayStride: 1516,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 22700,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x2',
+offset: 35784,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0xa0caed18,
+},
+fragment: {
+module: shaderModule26,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'never',
+failOp: 'keep',
+depthFailOp: 'invert',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 271,
+stencilWriteMask: 3082,
+depthBias: 79,
+depthBiasClamp: 10,
+},
+}
+);
+let texture93 = device6.createTexture(
+{
+label: '\u0a73\ud4d0\u04b0\u{1fb62}\u{1f825}\u{1fc11}\u84c7\u5910\u0461\u6353',
+size: {width: 177, height: 2, depthOrArrayLayers: 39},
+mipLevelCount: 2,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'depth24plus-stencil8',
+'depth24plus-stencil8',
+'depth24plus-stencil8'
+],
+}
+);
+try {
+computePassEncoder36.end();
+} catch {}
+let bindGroup43 = device5.createBindGroup({
+label: '\u0abc\uaa0d\u0eae\u0fd0\u51d9\uc5ca\u0e95\u093b\u1c27',
+layout: bindGroupLayout21,
+entries: [
+
+],
+});
+let buffer24 = device5.createBuffer(
+{
+label: '\ue4d6\uee5b',
+size: 12300,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+let commandEncoder70 = device5.createCommandEncoder(
+{
+label: '\u01eb\u{1f7b0}\u0069\u0028\u2b22\uf7e4',
+}
+);
+let textureView95 = texture91.createView(
+{
+label: '\u7648\u09a8\u3197\u{1f6f8}\u6dae',
+format: 'r32uint',
+baseMipLevel: 6,
+}
+);
+let sampler69 = device5.createSampler(
+{
+label: '\u{1fc83}\u3698\u8c96',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 64.541,
+lodMaxClamp: 71.292,
+maxAnisotropy: 20,
+}
+);
+try {
+commandEncoder70.copyTextureToTexture(
+{
+  texture: texture69,
+  mipLevel: 11,
+  origin: { x: 0, y: 0, z: 7 },
+  aspect: 'all',
+},
+{
+  texture: texture69,
+  mipLevel: 6,
+  origin: { x: 48, y: 0, z: 9 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 66}
+);
+} catch {}
+let renderBundleEncoder74 = device6.createRenderBundleEncoder(
+{
+label: '\u0bb1\u0be1\ub2f2\u7b07\u0076\u7152',
+colorFormats: [
+'rg16uint',
+undefined
+],
+sampleCount: 155,
+depthReadOnly: true,
+}
+);
+let renderBundle75 = renderBundleEncoder74.finish(
+{
+label: '\u{1f6b1}\u529d\uc3bf\u6894\u3370\u0673\u9d91\u087c\u{1fc2d}\u9ec4\u0c3a'
+}
+);
+let commandBuffer6 = commandEncoder70.finish(
+{
+}
+);
+let texture94 = device5.createTexture(
+{
+label: '\u055f\u{1fc90}\u5b04\u091f\u4bb4\u0cf5\ube28\u{1faea}',
+size: {width: 8808, height: 6, depthOrArrayLayers: 51},
+mipLevelCount: 2,
+format: 'astc-8x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundle76 = renderBundleEncoder72.finish();
+try {
+device5.queue.writeTexture(
+{
+  texture: texture69,
+  mipLevel: 11,
+  origin: { x: 0, y: 0, z: 62 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 69558 */{
+offset: 705,
+bytesPerRow: 281,
+rowsPerImage: 35,
+},
+{width: 4, height: 4, depthOrArrayLayers: 8}
+);
+} catch {}
+try {
+await device5.queue.onSubmittedWorkDone();
+} catch {}
+canvas7.height = 949;
+document.body.prepend('\u2170\ub2d0\u{1f857}\u{1fb5b}');
+let texture95 = device1.createTexture(
+{
+label: '\u29bf\ub43c\u745a\u34b9\u0a44\uf6bf\u{1f9da}',
+size: [6378],
+dimension: '1d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let renderBundle77 = renderBundleEncoder27.finish(
+{
+label: '\u478f\ude37\u0cc2\u{1feea}'
+}
+);
+try {
+computePassEncoder28.setPipeline(
+pipeline58
+);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(
+buffer12,
+'uint32',
+6484,
+16258
+);
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(
+2,
+bindGroup26
+);
+} catch {}
+try {
+device1.pushErrorScope(
+'validation'
+);
+} catch {}
+try {
+gpuCanvasContext13.configure(
+{
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-5x5-unorm-srgb',
+'etc2-rgba8unorm-srgb',
+'rgba8unorm-srgb',
+'rg8uint'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer13,
+21904,
+new DataView(new ArrayBuffer(52760)),
+34149,
+524
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture79,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer6,
+/* required buffer size: 463 */{
+offset: 463,
+bytesPerRow: 259,
+rowsPerImage: 218,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let offscreenCanvas23 = new OffscreenCanvas(776, 149);
+let imageBitmap18 = await createImageBitmap(offscreenCanvas20);
+let pipelineLayout21 = device5.createPipelineLayout(
+{
+label: '\u54cb\u{1f868}\u0412\u388c\ue1bb\u{1f88c}\u{1faed}\uc540\uc29b\u{1fc9c}',
+bindGroupLayouts: [
+bindGroupLayout25,
+bindGroupLayout25,
+bindGroupLayout28
+],
+}
+);
+let querySet70 = device5.createQuerySet(
+{
+label: '\u0660\uba13\u0e6a\u0670\u781b\uce79\ubd76\u{1fd72}',
+type: 'occlusion',
+count: 2871,
+}
+);
+let commandEncoder71 = device6.createCommandEncoder(
+{
+label: '\u0223\u{1fa3e}\u007a\ue7bb\u3451\u{1f71b}\u06e5\u0602\ue8f6\ub61d',
+}
+);
+let texture96 = device6.createTexture(
+{
+label: '\u3d18\ue0a8\u3fb9\u5ed5\u5ebc\u{1fe06}\ud04e\u0091\u4d6a',
+size: [3500, 5, 1],
+mipLevelCount: 11,
+format: 'astc-5x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-5x5-unorm-srgb',
+'astc-5x5-unorm-srgb'
+],
+}
+);
+let renderBundleEncoder75 = device1.createRenderBundleEncoder(
+{
+label: '\u530e\ua61a\u6bc1\u6e0e',
+colorFormats: [
+'r32uint',
+'rgba8sint',
+'rg32float',
+'rgba16float'
+],
+sampleCount: 947,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(
+2750,
+15,
+272,
+17
+);
+} catch {}
+try {
+renderPassEncoder16.setViewport(
+402.6,
+9.548,
+2099.6,
+14.65,
+0.3021,
+0.4442
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer15,
+1192,
+new DataView(new ArrayBuffer(4047)),
+361,
+3064
+);
+} catch {}
+let computePassEncoder38 = commandEncoder67.beginComputePass();
+let sampler70 = device4.createSampler(
+{
+label: '\u0ca0\u{1fd1f}\uc2ab\u9242',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+maxAnisotropy: 15,
+}
+);
+let pipeline69 = device4.createComputePipeline(
+{
+label: '\u6513\u0fd2\u{1fd27}\u{1f68e}\u05dd\u0783\u0ec2',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule25,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let video13 = await videoWithData();
+let commandEncoder72 = device5.createCommandEncoder(
+{
+}
+);
+let texture97 = device5.createTexture(
+{
+size: {width: 104, height: 76, depthOrArrayLayers: 155},
+mipLevelCount: 2,
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder39 = commandEncoder72.beginComputePass(
+{
+
+}
+);
+let offscreenCanvas24 = new OffscreenCanvas(805, 962);
+document.body.prepend('\u0502\u0dee\u6028\u01e8\u{1f7df}\u0e04\u{1f8fe}\u{1fdbb}\u{1f8b7}');
+let commandEncoder73 = device1.createCommandEncoder(
+{
+label: '\u{1fd54}\u32cc\u2efb\ubcff\u{1fc18}\u2c97\u{1f776}\u{1f703}\u06d2\ub95a\u4891',
+}
+);
+let sampler71 = device1.createSampler(
+{
+label: '\u0ddb\u0458\u02ec\u0fad',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 68.702,
+maxAnisotropy: 10,
+}
+);
+try {
+renderPassEncoder18.setScissorRect(
+758,
+25,
+1230,
+6
+);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(
+4,
+bindGroup37
+);
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(
+7,
+buffer12
+);
+} catch {}
+let pipeline70 = await device1.createComputePipelineAsync(
+{
+label: '\ud885\u{1f75d}\u0a4b\u{1fd43}\ua862\u8ec3\ua99e\u3df6\u0f56\u0b27\uf4f8',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule21,
+entryPoint: 'compute0',
+},
+}
+);
+let pipeline71 = await device1.createRenderPipelineAsync(
+{
+label: '\u08e1\u0436\ua71a\u610e\u3dbf\u08b8\u95f9\ue58a\u{1f69d}',
+layout: pipelineLayout11,
+vertex: {
+module: shaderModule22,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 12996,
+shaderLocation: 13,
+},
+{
+format: 'uint32',
+offset: 2692,
+shaderLocation: 15,
+},
+{
+format: 'uint16x4',
+offset: 12108,
+shaderLocation: 12,
+},
+{
+format: 'unorm16x2',
+offset: 1152,
+shaderLocation: 25,
+},
+{
+format: 'snorm16x4',
+offset: 19696,
+shaderLocation: 16,
+},
+{
+format: 'snorm8x4',
+offset: 9064,
+shaderLocation: 14,
+},
+{
+format: 'uint32x2',
+offset: 26540,
+shaderLocation: 29,
+},
+{
+format: 'uint32',
+offset: 12572,
+shaderLocation: 19,
+},
+{
+format: 'float32x3',
+offset: 22856,
+shaderLocation: 4,
+},
+{
+format: 'float16x2',
+offset: 8196,
+shaderLocation: 6,
+},
+{
+format: 'float16x4',
+offset: 19728,
+shaderLocation: 3,
+},
+{
+format: 'uint16x2',
+offset: 10792,
+shaderLocation: 1,
+},
+{
+format: 'unorm16x4',
+offset: 20916,
+shaderLocation: 18,
+},
+{
+format: 'uint32x2',
+offset: 6360,
+shaderLocation: 28,
+},
+{
+format: 'uint32',
+offset: 13628,
+shaderLocation: 17,
+},
+{
+format: 'sint8x2',
+offset: 4608,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x2',
+offset: 23536,
+shaderLocation: 0,
+},
+{
+format: 'uint32x2',
+offset: 12612,
+shaderLocation: 24,
+},
+{
+format: 'uint32x3',
+offset: 4012,
+shaderLocation: 20,
+},
+{
+format: 'float32x4',
+offset: 14648,
+shaderLocation: 8,
+},
+{
+format: 'unorm8x2',
+offset: 8694,
+shaderLocation: 21,
+},
+{
+format: 'float32x4',
+offset: 21004,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 15596,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0xdbced0f8,
+},
+fragment: {
+module: shaderModule22,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.BLUE,
+}
+],
+},
+depthStencil: {
+format: 'stencil8',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-clamp',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 2633,
+depthBias: 10,
+depthBiasSlopeScale: 94,
+depthBiasClamp: 87,
+},
+}
+);
+let bindGroup44 = device6.createBindGroup({
+label: '\u0a35\ua7d7\u26b8\u09b9',
+layout: bindGroupLayout31,
+entries: [
+
+],
+});
+let renderPassEncoder23 = commandEncoder73.beginRenderPass(
+{
+label: '\u{1fcf4}\u4282',
+colorAttachments: [
+undefined,
+{
+view: textureView37,
+loadOp: 'load',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet61,
+maxDrawCount: 136952,
+}
+);
+let renderBundle78 = renderBundleEncoder43.finish(
+{
+
+}
+);
+try {
+renderBundleEncoder45.setBindGroup(
+0,
+bindGroup38
+);
+} catch {}
+let pipeline72 = await device1.createRenderPipelineAsync(
+{
+layout: pipelineLayout11,
+vertex: {
+module: shaderModule21,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 16104,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x2',
+offset: 7820,
+shaderLocation: 5,
+},
+{
+format: 'uint8x4',
+offset: 5284,
+shaderLocation: 1,
+},
+{
+format: 'snorm16x2',
+offset: 9964,
+shaderLocation: 20,
+},
+{
+format: 'float32x3',
+offset: 15336,
+shaderLocation: 15,
+},
+{
+format: 'snorm16x4',
+offset: 3736,
+shaderLocation: 27,
+},
+{
+format: 'snorm8x2',
+offset: 1844,
+shaderLocation: 29,
+},
+{
+format: 'sint32',
+offset: 15128,
+shaderLocation: 14,
+},
+{
+format: 'snorm16x2',
+offset: 11700,
+shaderLocation: 2,
+},
+{
+format: 'sint16x2',
+offset: 8424,
+shaderLocation: 24,
+},
+{
+format: 'sint16x2',
+offset: 8868,
+shaderLocation: 13,
+},
+{
+format: 'float32x4',
+offset: 3312,
+shaderLocation: 28,
+},
+{
+format: 'float16x4',
+offset: 6696,
+shaderLocation: 17,
+},
+{
+format: 'unorm16x4',
+offset: 2396,
+shaderLocation: 26,
+},
+{
+format: 'unorm16x4',
+offset: 6780,
+shaderLocation: 12,
+},
+{
+format: 'unorm8x4',
+offset: 11120,
+shaderLocation: 0,
+},
+{
+format: 'sint8x4',
+offset: 1320,
+shaderLocation: 19,
+},
+{
+format: 'sint16x4',
+offset: 9604,
+shaderLocation: 21,
+},
+{
+format: 'snorm16x2',
+offset: 15152,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 18940,
+attributes: [
+{
+format: 'snorm8x4',
+offset: 1544,
+shaderLocation: 6,
+},
+{
+format: 'sint8x4',
+offset: 13172,
+shaderLocation: 9,
+},
+{
+format: 'uint32x3',
+offset: 7068,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x4',
+offset: 14364,
+shaderLocation: 22,
+},
+{
+format: 'uint32x2',
+offset: 13260,
+shaderLocation: 18,
+},
+{
+format: 'sint16x4',
+offset: 7464,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x2',
+offset: 13468,
+shaderLocation: 16,
+},
+{
+format: 'uint32x4',
+offset: 8388,
+shaderLocation: 25,
+}
+],
+},
+{
+arrayStride: 11312,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x3',
+offset: 6560,
+shaderLocation: 7,
+},
+{
+format: 'uint16x4',
+offset: 7232,
+shaderLocation: 8,
+},
+{
+format: 'uint8x2',
+offset: 9350,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x3',
+offset: 20436,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule21,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.RED,
+},
+{
+format: 'rg8unorm',
+writeMask: GPUColorWrite.ALL,
+},
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+failOp: 'zero',
+depthFailOp: 'decrement-wrap',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilReadMask: 3008,
+stencilWriteMask: 857,
+depthBiasSlopeScale: 32,
+},
+}
+);
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+try {
+await promise35;
+} catch {}
+let img13 = await imageWithData(92, 119, '#03a57225', '#9ea02c51');
+let renderBundle79 = renderBundleEncoder74.finish(
+{
+label: '\uf7da\u0169\uba6b\u6e01\u0ab6'
+}
+);
+try {
+buffer23.unmap();
+} catch {}
+try {
+device6.queue.writeBuffer(
+buffer23,
+48192,
+new Float32Array(64684),
+33407,
+792
+);
+} catch {}
+let canvas18 = document.createElement('canvas');
+let bindGroupLayout32 = device1.createBindGroupLayout(
+{
+label: '\u5b6e\u00c0\ua11e\u2524\uba04\ub8d4\u{1f622}\u026f\u5c2c\u0736',
+entries: [
+{
+binding: 366,
+visibility: 0,
+storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '2d' },
+},
+{
+binding: 4696,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let textureView96 = texture34.createView(
+{
+label: '\u0400\u77cf',
+}
+);
+let renderBundleEncoder76 = device1.createRenderBundleEncoder(
+{
+label: '\u471e\ub711\u{1fa90}\u0aa7\u0040\u2ea9\u{1fa41}\uea41\u{1fbc9}\u{1f869}\u077f',
+colorFormats: [
+'rgba32float'
+],
+sampleCount: 523,
+depthReadOnly: true,
+}
+);
+let sampler72 = device1.createSampler(
+{
+label: '\u5f30\u096a\u8834\u0984\uf100\u0b9f\u3e64',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 89.259,
+lodMaxClamp: 92.697,
+}
+);
+try {
+renderPassEncoder19.setVertexBuffer(
+10,
+buffer12,
+17716,
+2294
+);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let computePassEncoder40 = commandEncoder64.beginComputePass();
+let offscreenCanvas25 = new OffscreenCanvas(229, 252);
+let sampler73 = device2.createSampler(
+{
+label: '\u{1f75c}\u9180\u1a60\u007e\ue952\u3b21\u41ab\u3468\u6697',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 91.498,
+compare: 'greater-equal',
+maxAnisotropy: 3,
+}
+);
+try {
+renderPassEncoder22.setStencilReference(
+3034
+);
+} catch {}
+canvas14.height = 370;
+let offscreenCanvas26 = new OffscreenCanvas(410, 536);
+document.body.prepend('\u15d9\u0cd5\u00ad\u5d8f\u025b\u2b03\u55bc\u{1fa86}\u0f5f');
+let textureView97 = texture6.createView(
+{
+label: '\u{1f712}\u00a0\u0a6d\u03dc\u84c4\u118f',
+dimension: '2d',
+baseMipLevel: 5,
+baseArrayLayer: 20,
+}
+);
+let renderBundle80 = renderBundleEncoder14.finish(
+{
+label: '\ud539\udb1c\uf6d1\u03eb'
+}
+);
+let sampler74 = device0.createSampler(
+{
+label: '\u7529\u{1fe53}\u0e45\ude0c\u6584\u724f',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+lodMinClamp: 52.797,
+lodMaxClamp: 69.231,
+}
+);
+try {
+computePassEncoder6.setBindGroup(
+4,
+bindGroup6,
+[]
+);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(
+4,
+bindGroup20,
+new Uint32Array(6853),
+533,
+0
+);
+} catch {}
+try {
+renderPassEncoder11.end();
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(
+1,
+buffer1,
+30376,
+2053
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+10904,
+new Float32Array(35475),
+25742,
+100
+);
+} catch {}
+video8.height = 271;
+let video14 = await videoWithData();
+let querySet71 = device1.createQuerySet(
+{
+type: 'occlusion',
+count: 2935,
+}
+);
+let textureView98 = texture34.createView(
+{
+label: '\u{1fe99}\u888c\u0551\u{1f9ad}\ub616\ub0c3\u7851\uf409\u{1f66c}\u047f',
+}
+);
+let renderBundleEncoder77 = device1.createRenderBundleEncoder(
+{
+label: '\u9650\u8511\u3259\u02a8\u{1fae5}',
+colorFormats: [
+'r32uint',
+undefined,
+'rgba8uint',
+'bgra8unorm-srgb',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 940,
+depthReadOnly: true,
+stencilReadOnly: false,
+}
+);
+let renderBundle81 = renderBundleEncoder38.finish(
+{
+label: '\u0b9a\u00bb\u0634\u36c7\u5236'
+}
+);
+try {
+renderPassEncoder16.setScissorRect(
+584,
+31,
+1128,
+0
+);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(
+6,
+buffer12,
+176,
+19143
+);
+} catch {}
+try {
+renderBundleEncoder49.setIndexBuffer(
+buffer12,
+'uint16',
+21608,
+4596
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 18, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 57, y: 3 },
+  flipY: true,
+},
+{
+  texture: texture78,
+  mipLevel: 6,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 17, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let offscreenCanvas27 = new OffscreenCanvas(347, 44);
+let img14 = await imageWithData(109, 42, '#b24a3a90', '#10005f80');
+let imageData16 = new ImageData(196, 176);
+let bindGroupLayout33 = device2.createBindGroupLayout(
+{
+label: '\u38f0\u{1fb22}\ubef4\u{1f8d9}\u2197\ud1ef\u079f',
+entries: [
+{
+binding: 3074,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+},
+{
+binding: 6648,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'non-filtering' },
+},
+{
+binding: 4419,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+}
+],
+}
+);
+let querySet72 = device2.createQuerySet(
+{
+label: '\u5822\ucd47\u8051\u1cfa\u{1fa73}\u015e\u0ba5',
+type: 'occlusion',
+count: 1508,
+}
+);
+let texture98 = gpuCanvasContext1.getCurrentTexture();
+let renderBundle82 = renderBundleEncoder35.finish(
+{
+label: '\u0b7e\u0e8a\u636f\ud137\u0c3c\uc23c\u78fc\u0b49\u09af'
+}
+);
+try {
+renderPassEncoder22.beginOcclusionQuery(
+72
+);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(
+13,
+undefined,
+215721296,
+2007096318
+);
+} catch {}
+let gpuCanvasContext21 = offscreenCanvas27.getContext('webgpu');
+let img15 = await imageWithData(72, 292, '#550e09e0', '#903dd59e');
+try {
+offscreenCanvas26.getContext('webgl2');
+} catch {}
+let texture99 = device2.createTexture(
+{
+size: [8268, 12, 119],
+mipLevelCount: 13,
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-12x12-unorm-srgb',
+'astc-12x12-unorm'
+],
+}
+);
+let video15 = await videoWithData();
+let buffer25 = device6.createBuffer(
+{
+label: '\u0c2d\u6cf9\uf3c0\u{1fa98}\uffcb\u{1ff9b}\ufe1b\u4218\u9b08\u{1f837}\ucf70',
+size: 56275,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+}
+);
+let commandBuffer7 = commandEncoder71.finish(
+{
+label: '\u0504\ue2b4\u04b5\u02b2\u0877\u2694\u{1fc4b}\u{1ff1c}\u{1ff67}\u0e8a',
+}
+);
+let texture100 = device6.createTexture(
+{
+label: '\u30bb\u163e\u6dbb\u672f\u{1f9aa}\u4633\u3d20\ua695',
+size: [121, 1, 1083],
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgba8unorm',
+'rgba8unorm-srgb',
+'rgba8unorm'
+],
+}
+);
+let renderBundleEncoder78 = device6.createRenderBundleEncoder(
+{
+label: '\ueda4\u77aa\u7098\u09a4\u08d6\uc3cb\u{1f62f}\u0200\ud4f1',
+colorFormats: [
+'rg16float',
+undefined,
+'rgba8sint',
+'r32sint',
+undefined,
+'rg32sint',
+'rg16sint',
+'rg8sint'
+],
+sampleCount: 840,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle83 = renderBundleEncoder78.finish(
+{
+label: '\ua93b\u5449\ua373\u0b98\u877e\u0012\u{1feb5}\u0e47'
+}
+);
+let externalTexture7 = device6.importExternalTexture(
+{
+label: '\u37df\u{1fea1}\u0637\u99bd\u0f17\u4029\u0328\ua097\ue023\u7fd5',
+source: videoFrame5,
+colorSpace: 'display-p3',
+}
+);
+try {
+commandEncoder68.copyBufferToBuffer(
+buffer25,
+49476,
+buffer23,
+29752,
+1940
+);
+dissociateBuffer(device6, buffer25);
+dissociateBuffer(device6, buffer23);
+} catch {}
+let querySet73 = device4.createQuerySet(
+{
+label: '\ubee5\u06d4\u43fc\u833b\u0387\u{1ff06}\u{1ff77}',
+type: 'occlusion',
+count: 2029,
+}
+);
+let renderBundle84 = renderBundleEncoder48.finish();
+try {
+device4.pushErrorScope(
+'out-of-memory'
+);
+} catch {}
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+let imageBitmap19 = await createImageBitmap(imageBitmap12);
+try {
+device0.label = '\u{1f638}\u0d36';
+} catch {}
+let offscreenCanvas28 = new OffscreenCanvas(1004, 259);
+document.body.prepend('\u0d50\u176e\ue980\u8de3\u{1f9eb}\u09d4\u{1fe71}\ufd19');
+let adapter9 = await promise38;
+let offscreenCanvas29 = new OffscreenCanvas(184, 753);
+let querySet74 = device4.createQuerySet(
+{
+label: '\u048e\ubafd\u7ebc\u0067\u5c37\u78dc\u029c\u0bf9\u0a97\u0923',
+type: 'occlusion',
+count: 3364,
+}
+);
+try {
+renderBundleEncoder70.setVertexBuffer(
+2,
+buffer22,
+4500,
+34412
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture92,
+  mipLevel: 0,
+  origin: { x: 448, y: 1, z: 276 },
+  aspect: 'all',
+},
+arrayBuffer5,
+/* required buffer size: 11931788 */{
+offset: 428,
+bytesPerRow: 3551,
+rowsPerImage: 280,
+},
+{width: 438, height: 0, depthOrArrayLayers: 13}
+);
+} catch {}
+let pipeline73 = device4.createComputePipeline(
+{
+layout: pipelineLayout19,
+compute: {
+module: shaderModule25,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let commandEncoder74 = device4.createCommandEncoder(
+{
+label: '\u16aa\ub3ba\u6621\u00e0\uda57\u{1fb21}\u0021\u{1fa42}',
+}
+);
+let texture101 = device4.createTexture(
+{
+label: '\u{1fb36}\u{1f7cf}\u39dd\u0f0d',
+size: [7912, 8, 1],
+mipLevelCount: 7,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-8x8-unorm-srgb'
+],
+}
+);
+let textureView99 = texture63.createView(
+{
+label: '\u8c2a\u0a7f\u3a55\u085c\u9736\u01af\u46c7\u{1f81e}\u1cfa',
+baseMipLevel: 4,
+mipLevelCount: 2,
+}
+);
+let computePassEncoder41 = commandEncoder74.beginComputePass(
+{
+label: '\ub876\u{1f928}'
+}
+);
+let renderBundle85 = renderBundleEncoder65.finish();
+try {
+renderBundleEncoder71.setVertexBuffer(
+3,
+buffer22,
+3252,
+11007
+);
+} catch {}
+try {
+renderBundleEncoder70.popDebugGroup();
+} catch {}
+let pipeline74 = device4.createRenderPipeline(
+{
+label: '\ue7a1\u{1fa9d}\ufb11\ua0b6\u{1f957}\u4f49\ua750\uc555',
+layout: pipelineLayout19,
+vertex: {
+module: shaderModule25,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 8788,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 3292,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 21740,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 6700,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 20164,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 20240,
+attributes: [
+{
+format: 'uint32x4',
+offset: 4880,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule25,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthCompare: 'always',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'keep',
+depthFailOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+depthBias: 92,
+depthBiasClamp: 9,
+},
+}
+);
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+document.body.prepend(video3);
+document.body.prepend('\u0dc2\u0d76\u2a0a\uecd2\ua5ee');
+let offscreenCanvas30 = new OffscreenCanvas(340, 353);
+let querySet75 = device6.createQuerySet(
+{
+label: '\u{1f754}\u0551\u13ce\u02f6\u90c7\u06d7\uf880',
+type: 'occlusion',
+count: 2648,
+}
+);
+let texture102 = device6.createTexture(
+{
+label: '\u0d91\u0230\u08ff\u{1faaa}\u50ab\ude43\u{1fdc3}\uc2d8',
+size: {width: 5390, height: 4, depthOrArrayLayers: 1},
+format: 'astc-5x4-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let textureView100 = texture100.createView(
+{
+baseMipLevel: 1,
+}
+);
+let computePassEncoder42 = commandEncoder68.beginComputePass(
+{
+label: '\u088b\u700a\u{1f6f5}\u913a\u6a26\u5c63\u09be\u0eae\u27b1'
+}
+);
+try {
+computePassEncoder42.setBindGroup(
+5,
+bindGroup44,
+new Uint32Array(2463),
+1233,
+0
+);
+} catch {}
+try {
+await buffer23.mapAsync(
+GPUMapMode.READ,
+0,
+37192
+);
+} catch {}
+try {
+device6.queue.writeTexture(
+{
+  texture: texture96,
+  mipLevel: 3,
+  origin: { x: 40, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Float32Array(arrayBuffer2),
+/* required buffer size: 956 */{
+offset: 956,
+},
+{width: 370, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await promise30;
+} catch {}
+let videoFrame10 = new VideoFrame(videoFrame7, {timestamp: 0});
+try {
+await promise39;
+} catch {}
+let querySet76 = device6.createQuerySet(
+{
+label: '\u{1f799}\u0636\u3a78\u6fc0\u{1fc97}\u13ed\u{1f669}',
+type: 'occlusion',
+count: 2891,
+}
+);
+let texture103 = device6.createTexture(
+{
+label: '\u0789\u0420\u{1fa1c}\u3b29\u003b',
+size: [221, 1, 963],
+mipLevelCount: 5,
+sampleCount: 1,
+dimension: '3d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb10a2uint',
+'rgb10a2uint'
+],
+}
+);
+let computePassEncoder43 = commandEncoder69.beginComputePass();
+try {
+device6.queue.writeBuffer(
+buffer25,
+7404,
+new Int16Array(33886),
+23343,
+7552
+);
+} catch {}
+let gpuCanvasContext22 = canvas18.getContext('webgpu');
+let canvas19 = document.createElement('canvas');
+try {
+adapter2.label = '\u0faa\ud2ec\u2edc\u4309\u0058\u07e4\u05f1\u6285\u{1f7b5}\u{1fa1c}\ue532';
+} catch {}
+let bindGroupLayout34 = device1.createBindGroupLayout(
+{
+label: '\u{1fea3}\u263e\ubb68\u0c83\u{1fede}\u{1fd47}\u5501\u762b',
+entries: [
+
+],
+}
+);
+let texture104 = gpuCanvasContext13.getCurrentTexture();
+let textureView101 = texture44.createView(
+{
+label: '\u{1f675}\ua6e0\u0774\u9b9b\u2199\u0f09\u8ac2\u56e8\u04df',
+aspect: 'depth-only',
+mipLevelCount: 1,
+baseArrayLayer: 142,
+arrayLayerCount: 76,
+}
+);
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(
+buffer12,
+'uint32',
+15480,
+11753
+);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(
+7,
+buffer12,
+676,
+12057
+);
+} catch {}
+try {
+renderBundleEncoder49.setBindGroup(
+1,
+bindGroup42
+);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer13,
+18724,
+new Int16Array(11970),
+11183,
+156
+);
+} catch {}
+let promise40 = device1.queue.onSubmittedWorkDone();
+let pipeline75 = device1.createComputePipeline(
+{
+label: '\u002e\u09e7\u8a06',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule22,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+let offscreenCanvas31 = new OffscreenCanvas(257, 796);
+let shaderModule27 = device4.createShaderModule(
+{
+label: '\u460b\u{1f798}',
+code: `
+
+@compute @workgroup_size(4, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: vec3<i32>,
+@location(3) f1: vec3<f32>,
+@location(5) f2: i32,
+@location(2) f3: vec4<i32>,
+@location(7) f4: vec3<f32>,
+@location(0) f5: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_mask) a1: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(13) a0: vec2<i32>, @location(3) a1: u32, @location(5) a2: vec4<f32>, @location(1) a3: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame8,
+  origin: { x: 6, y: 57 },
+  flipY: false,
+},
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let img16 = await imageWithData(42, 10, '#55b2d751', '#30dc6b9d');
+let bindGroup45 = device6.createBindGroup({
+layout: bindGroupLayout31,
+entries: [
+
+],
+});
+let bindGroupLayout35 = device1.createBindGroupLayout(
+{
+label: '\u00b5\u42ff',
+entries: [
+{
+binding: 3311,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'filtering' },
+},
+{
+binding: 1880,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let textureView102 = texture31.createView(
+{
+label: '\u320a\ue472\u0fa1\u0319\u5541\u{1fd46}\u0b5e\u0963\u75ff\u2793\u0c4f',
+dimension: '2d-array',
+aspect: 'depth-only',
+baseMipLevel: 7,
+}
+);
+let renderBundleEncoder79 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+'r16sint',
+'rgba32float',
+'bgra8unorm',
+'bgra8unorm',
+'r8sint',
+'r8uint',
+'rg11b10ufloat'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 123,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle86 = renderBundleEncoder44.finish(
+{
+label: '\u7064\u1359\u0ebd\u0e94\u4555\ud027'
+}
+);
+let sampler75 = device1.createSampler(
+{
+label: '\u{1f823}\u06bc\u0216\u{1fa8c}\u6784\u{1ffb8}\u9af6\u12b8',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 1.514,
+lodMaxClamp: 6.558,
+maxAnisotropy: 3,
+}
+);
+try {
+buffer21.destroy();
+} catch {}
+let img17 = await imageWithData(56, 141, '#4097364c', '#8180032f');
+let bindGroupLayout36 = pipeline70.getBindGroupLayout(1);
+let texture105 = device1.createTexture(
+{
+size: [9615, 5, 13],
+format: 'astc-5x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-5x5-unorm-srgb'
+],
+}
+);
+let renderBundle87 = renderBundleEncoder31.finish(
+{
+label: '\u9fd5\ub6f0\u9097\u{1fb07}\u06a4\u93f0\u9c1f'
+}
+);
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 1157, height: 1, depthOrArrayLayers: 172}
+*/
+{
+  source: imageData2,
+  origin: { x: 0, y: 40 },
+  flipY: true,
+},
+{
+  texture: texture78,
+  mipLevel: 0,
+  origin: { x: 278, y: 0, z: 80 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 36, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\u{1ff63}\u44f0\u63eb\u9700\u{1fef1}\u0894');
+let imageBitmap20 = await createImageBitmap(img14);
+let bindGroup46 = device6.createBindGroup({
+label: '\u8a03\u2228\u0192\u059a\u084c\u2550\udeda\ud56e\uf5ed',
+layout: bindGroupLayout31,
+entries: [
+
+],
+});
+let buffer26 = device6.createBuffer(
+{
+label: '\u{1fd25}\u0455\u{1f86a}\u05ee\u03de',
+size: 25330,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+pseudoSubmit(device6, commandEncoder69);
+let textureView103 = texture102.createView(
+{
+label: '\u081d\uc370\uc157\u0488\ue092\u2a17\u54dc\u0e86\uc71b',
+dimension: '2d-array',
+baseArrayLayer: 0,
+arrayLayerCount: 1,
+}
+);
+let renderBundle88 = renderBundleEncoder74.finish(
+{
+label: '\u5292\uac64\u0fd9\u{1ff04}\u03c4\u0a7e\u58af'
+}
+);
+let sampler76 = device6.createSampler(
+{
+label: '\u6224\u1e60\u0643\u040a\u4b80\u{1ff9a}\u5241',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+lodMinClamp: 10.960,
+lodMaxClamp: 56.707,
+}
+);
+try {
+querySet75.destroy();
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+gc();
+let video16 = await videoWithData();
+let texture106 = device1.createTexture(
+{
+label: '\u2f0b\u0b6f\u2763\u233b\u4166',
+size: [12248, 256, 235],
+mipLevelCount: 4,
+format: 'eac-r11unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'eac-r11unorm'
+],
+}
+);
+let renderBundle89 = renderBundleEncoder79.finish(
+{
+
+}
+);
+try {
+renderPassEncoder16.setBindGroup(
+4,
+bindGroup42
+);
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(
+976
+);
+} catch {}
+try {
+renderBundleEncoder58.setBindGroup(
+0,
+bindGroup30,
+new Uint32Array(7638),
+3083,
+0
+);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(
+6,
+buffer12,
+20324,
+6396
+);
+} catch {}
+try {
+renderBundleEncoder45.popDebugGroup();
+} catch {}
+let pipeline76 = await device1.createComputePipelineAsync(
+{
+label: '\u8247\u0d68\ud3f4\u55b6\u{1f7c1}\uc97a\u6aae',
+layout: 'auto',
+compute: {
+module: shaderModule22,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.append('\u45d1\u0119\u2c29\u0930');
+let pipelineLayout22 = device1.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout22,
+bindGroupLayout36,
+bindGroupLayout29
+],
+}
+);
+try {
+renderPassEncoder16.setBindGroup(
+4,
+bindGroup42
+);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(
+buffer12,
+'uint16',
+23640,
+1642
+);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+4,
+buffer12,
+828,
+9897
+);
+} catch {}
+try {
+renderBundleEncoder75.setVertexBuffer(
+1,
+buffer12,
+14084
+);
+} catch {}
+document.body.append('\u0086\u0e5d\u090f\u711f\u{1f66d}\u0068\u0172\u4a75\ud322');
+let video17 = await videoWithData();
+let buffer27 = device1.createBuffer(
+{
+label: '\uadd7\uea74\u{1ff9d}',
+size: 38176,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+}
+);
+let commandEncoder75 = device1.createCommandEncoder(
+{
+label: '\u45c9\u6843\u{1f6d7}\u08c6\u0f08\ud986',
+}
+);
+let querySet77 = device1.createQuerySet(
+{
+type: 'occlusion',
+count: 3491,
+}
+);
+let sampler77 = device1.createSampler(
+{
+label: '\u{1fd13}\u5781\u541d\ub0b8\u1e17\u9b79',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 26.650,
+lodMaxClamp: 33.454,
+maxAnisotropy: 4,
+}
+);
+try {
+renderPassEncoder16.beginOcclusionQuery(
+8
+);
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(
+2585,
+19,
+248,
+12
+);
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(
+372
+);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(
+buffer12,
+'uint32',
+14344
+);
+} catch {}
+try {
+commandEncoder75.copyBufferToBuffer(
+buffer10,
+15224,
+buffer15,
+26036,
+4284
+);
+dissociateBuffer(device1, buffer10);
+dissociateBuffer(device1, buffer15);
+} catch {}
+try {
+commandEncoder75.copyTextureToTexture(
+{
+  texture: texture78,
+  mipLevel: 1,
+  origin: { x: 374, y: 0, z: 20 },
+  aspect: 'all',
+},
+{
+  texture: texture78,
+  mipLevel: 0,
+  origin: { x: 120, y: 0, z: 17 },
+  aspect: 'all',
+},
+{width: 182, height: 1, depthOrArrayLayers: 44}
+);
+} catch {}
+try {
+commandEncoder75.clearBuffer(
+buffer13,
+32016,
+2300
+);
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 1157, height: 1, depthOrArrayLayers: 172}
+*/
+{
+  source: imageData12,
+  origin: { x: 2, y: 52 },
+  flipY: true,
+},
+{
+  texture: texture78,
+  mipLevel: 0,
+  origin: { x: 755, y: 0, z: 39 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 149, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let gpuCanvasContext23 = canvas19.getContext('webgpu');
+let adapter10 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let querySet78 = device1.createQuerySet(
+{
+label: '\u5627\u{1fcab}',
+type: 'occlusion',
+count: 825,
+}
+);
+pseudoSubmit(device1, commandEncoder66);
+let texture107 = device1.createTexture(
+{
+size: [10568, 4, 125],
+mipLevelCount: 11,
+dimension: '2d',
+format: 'etc2-rgb8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderPassEncoder24 = commandEncoder75.beginRenderPass(
+{
+label: '\u{1f8c4}\ua7e4\u{1fa50}\u0e47\u7531',
+colorAttachments: [
+{
+view: textureView69,
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet78,
+maxDrawCount: 20168,
+}
+);
+try {
+renderPassEncoder16.setBindGroup(
+3,
+bindGroup24
+);
+} catch {}
+try {
+renderPassEncoder18.end();
+} catch {}
+try {
+renderPassEncoder24.setBlendConstant(
+{
+r: -49.77,
+g: 647.7,
+b: 541.8,
+a: 270.9,
+}
+);
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(
+1187,
+21,
+889,
+11
+);
+} catch {}
+try {
+offscreenCanvas30.getContext('bitmaprenderer');
+} catch {}
+try {
+window.someLabel = externalTexture4.label;
+} catch {}
+let buffer28 = device2.createBuffer(
+{
+label: '\u0864\udf70\uac05\ue184\uc179',
+size: 47399,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let renderBundle90 = renderBundleEncoder56.finish();
+try {
+renderPassEncoder22.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder22.setViewport(
+15.00,
+0.8298,
+84.66,
+0.04147,
+0.4019,
+0.5542
+);
+} catch {}
+try {
+computePassEncoder26.insertDebugMarker(
+'\u5c29'
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture41,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer7),
+/* required buffer size: 366 */{
+offset: 366,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\u836e\u2197\u52d7\u6536\u0dc2\u0dad');
+let pipelineLayout23 = device3.createPipelineLayout(
+{
+label: '\u74b7\u017a\uc4f4\u8735\u{1fa0e}',
+bindGroupLayouts: [
+bindGroupLayout27,
+bindGroupLayout27,
+bindGroupLayout27,
+bindGroupLayout27,
+bindGroupLayout27,
+bindGroupLayout27
+],
+}
+);
+let texture108 = device3.createTexture(
+{
+label: '\ub97a\ub7d5\u0753\u000c\u1468\u0376\u05fb\u03f7\u02c2\u{1f6ff}\u0105',
+size: [1506, 1, 62],
+mipLevelCount: 6,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16float',
+'rgba16float',
+'rgba16float'
+],
+}
+);
+try {
+renderBundleEncoder73.setVertexBuffer(
+73,
+undefined,
+14967768,
+213192806
+);
+} catch {}
+let gpuCanvasContext24 = offscreenCanvas29.getContext('webgpu');
+try {
+await promise33;
+} catch {}
+let buffer29 = device3.createBuffer(
+{
+label: '\u{1fdc0}\u{1fad5}\u08b4\ub3ad\udc54\u6834\u82c0\u3ede',
+size: 39363,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let textureView104 = texture70.createView(
+{
+label: '\u2d64\u58e2\u{1fd66}\u92fe\u{1f843}',
+dimension: '2d-array',
+}
+);
+try {
+buffer29.unmap();
+} catch {}
+document.body.append('\u0e1a\u518e\ue35f\u03e0');
+let bindGroup47 = device3.createBindGroup({
+label: '\ue405\uff9c\u672e\u9b45\u02b2\u096b\u601e\u5493',
+layout: bindGroupLayout27,
+entries: [
+
+],
+});
+try {
+commandEncoder57.clearBuffer(
+buffer29,
+12864,
+19964
+);
+dissociateBuffer(device3, buffer29);
+} catch {}
+try {
+gpuCanvasContext10.configure(
+{
+device: device3,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgba16float',
+'rgba16float',
+'rg16uint'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer29,
+23932,
+new DataView(new ArrayBuffer(52877)),
+37800,
+3732
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture75,
+  mipLevel: 0,
+  origin: { x: 4, y: 20, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 920 */{
+offset: 920,
+bytesPerRow: 1098,
+rowsPerImage: 159,
+},
+{width: 224, height: 52, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext25 = offscreenCanvas23.getContext('webgpu');
+canvas19.height = 660;
+document.body.append('\u{1fffa}\u04c5\u0b05\udb38\ud646');
+let imageData17 = new ImageData(220, 236);
+let buffer30 = device4.createBuffer(
+{
+size: 58210,
+usage: GPUBufferUsage.MAP_READ,
+}
+);
+let querySet79 = device4.createQuerySet(
+{
+type: 'occlusion',
+count: 3338,
+}
+);
+let renderBundleEncoder80 = device4.createRenderBundleEncoder(
+{
+label: '\u0445\u059a\u2c2a\u{1f9dc}\ufcf1\u2601\u0069\u{1fe6e}\uc875',
+colorFormats: [
+'rg16float'
+],
+sampleCount: 913,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+device4.queue.writeTexture(
+{
+  texture: texture63,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 43 */{
+offset: 43,
+rowsPerImage: 244,
+},
+{width: 8, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let gpuCanvasContext26 = offscreenCanvas24.getContext('webgpu');
+try {
+gpuCanvasContext24.unconfigure();
+} catch {}
+try {
+await promise40;
+} catch {}
+let texture109 = device4.createTexture(
+{
+label: '\u8ee9\ub9cd\ub0a8\u0cd9\u0be1\ue913\u{1f933}\u07eb\u0fe1\u{1fcd5}\u0ded',
+size: {width: 135, height: 145, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'astc-5x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-5x5-unorm-srgb',
+'astc-5x5-unorm-srgb'
+],
+}
+);
+let textureView105 = texture63.createView(
+{
+label: '\u1989\u06cc',
+dimension: '2d-array',
+}
+);
+try {
+buffer20.destroy();
+} catch {}
+try {
+buffer22.unmap();
+} catch {}
+gc();
+let pipelineLayout24 = device6.createPipelineLayout(
+{
+label: '\ub115\u083b\u0e8b\ube1e\u723f\u5394\u{1f61b}',
+bindGroupLayouts: [
+bindGroupLayout31,
+bindGroupLayout31,
+bindGroupLayout31,
+bindGroupLayout31,
+bindGroupLayout31,
+bindGroupLayout31,
+bindGroupLayout31
+],
+}
+);
+let texture110 = device6.createTexture(
+{
+label: '\u028d\u{1f93a}\u8703\u78ab\u26a0\ud903\u021b\u{1fdfb}\u6cf4',
+size: {width: 216, height: 204, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let renderBundle91 = renderBundleEncoder74.finish(
+{
+label: '\ufe3b\u{1f840}\u{1fd50}\u03ac'
+}
+);
+let sampler78 = device6.createSampler(
+{
+label: '\u805f\u05b8\uf441\u0285\u0d60\ua0c4',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 95.730,
+lodMaxClamp: 99.714,
+}
+);
+try {
+computePassEncoder42.end();
+} catch {}
+try {
+commandEncoder68.copyTextureToTexture(
+{
+  texture: texture96,
+  mipLevel: 4,
+  origin: { x: 85, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture96,
+  mipLevel: 0,
+  origin: { x: 770, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 95, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device6.queue.submit([
+commandBuffer7,
+]);
+} catch {}
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas32 = new OffscreenCanvas(748, 76);
+let commandEncoder76 = device6.createCommandEncoder(
+{
+label: '\u42b8\u1fc4\u04ac\ue71b\ua93f',
+}
+);
+let textureView106 = texture89.createView(
+{
+label: '\u{1ff7e}\u0fa0\uc14d\u2b5e\u58a7\uc442\u9209',
+baseMipLevel: 3,
+mipLevelCount: 1,
+baseArrayLayer: 0,
+}
+);
+let renderBundle92 = renderBundleEncoder78.finish(
+{
+label: '\u950a\u{1fe76}\u0f93\u0a78\u7e2b\ue606\u{1f86c}\u0c34\u0630'
+}
+);
+try {
+buffer25.destroy();
+} catch {}
+try {
+commandEncoder76.resolveQuerySet(
+querySet69,
+201,
+2972,
+buffer25,
+11520
+);
+} catch {}
+try {
+computePassEncoder43.insertDebugMarker(
+'\uc3cf'
+);
+} catch {}
+try {
+device6.queue.writeBuffer(
+buffer26,
+3000,
+new DataView(new ArrayBuffer(23400)),
+4241,
+8632
+);
+} catch {}
+let offscreenCanvas33 = new OffscreenCanvas(826, 44);
+let bindGroup48 = device4.createBindGroup({
+layout: bindGroupLayout30,
+entries: [
+{
+binding: 277,
+resource: sampler57
+}
+],
+});
+let querySet80 = device4.createQuerySet(
+{
+label: '\u{1f9f7}\u0ef7\u552a\u{1f90d}\ua991\u048f\u0091\u0b4c\u3c5d',
+type: 'occlusion',
+count: 1113,
+}
+);
+try {
+computePassEncoder41.setPipeline(
+pipeline69
+);
+} catch {}
+try {
+renderBundleEncoder80.setVertexBuffer(
+0,
+buffer22,
+30252,
+6238
+);
+} catch {}
+let promise41 = device4.queue.onSubmittedWorkDone();
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 150, y: 39 },
+  flipY: false,
+},
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise42 = device4.createRenderPipelineAsync(
+{
+layout: pipelineLayout19,
+vertex: {
+module: shaderModule27,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1832,
+attributes: [
+{
+format: 'uint16x2',
+offset: 232,
+shaderLocation: 3,
+},
+{
+format: 'uint32x2',
+offset: 1820,
+shaderLocation: 1,
+},
+{
+format: 'unorm8x4',
+offset: 1272,
+shaderLocation: 5,
+},
+{
+format: 'sint8x2',
+offset: 880,
+shaderLocation: 13,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule27,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'rg11b10ufloat',
+writeMask: 0,
+},
+undefined,
+{
+format: 'r32sint',
+writeMask: 0,
+},
+{
+format: 'rg8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r32sint',
+},
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+let shaderModule28 = device5.createShaderModule(
+{
+label: '\u049e\u6197\u53bc\ua15e\u38d5\u{1fa20}\u01e6',
+code: `
+
+@compute @workgroup_size(7, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(0) f0: f32,
+@location(3) f1: vec3<f32>,
+@location(7) f2: vec2<i32>,
+@location(6) f3: vec4<u32>,
+@location(4) f4: i32,
+@builtin(sample_mask) f5: u32,
+@location(5) f6: vec4<u32>,
+@builtin(frag_depth) f7: f32,
+@location(1) f8: i32
+}
+
+@fragment
+fn fragment0(@location(11) a0: vec2<f16>, @builtin(sample_index) a1: u32, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@builtin(position) f281: vec4<f32>,
+@location(11) f282: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec4<f16>, @location(12) a1: vec4<f16>, @location(17) a2: i32, @location(2) a3: vec4<f16>, @location(9) a4: vec3<i32>, @location(20) a5: vec3<f16>, @location(15) a6: i32, @location(16) a7: vec2<i32>, @location(23) a8: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroup49 = device5.createBindGroup({
+label: '\u0416\u{1fc03}\u9ef3\u{1fd12}\u0c40\u2fac',
+layout: bindGroupLayout21,
+entries: [
+
+],
+});
+let texture111 = device5.createTexture(
+{
+label: '\uff4a\u7318\u{1f790}\u0284',
+size: [11026, 1, 88],
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32float'
+],
+}
+);
+let gpuCanvasContext27 = offscreenCanvas32.getContext('webgpu');
+document.body.append('\u{1f730}\u{1fa8d}\u067f\u05c3');
+let querySet81 = device5.createQuerySet(
+{
+type: 'occlusion',
+count: 3007,
+}
+);
+let texture112 = device5.createTexture(
+{
+label: '\ufc62\u2c45',
+size: [14722],
+dimension: '1d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+try {
+renderBundleEncoder69.setVertexBuffer(
+12,
+undefined
+);
+} catch {}
+document.body.append('\u{1fa1b}\u1f4c\u6e39\ub73c\u{1fe09}\u04bc\u0843\u1304');
+let img18 = await imageWithData(160, 237, '#9b0a895b', '#96ca8c4b');
+let renderBundleEncoder81 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+'r16sint',
+'rg16uint',
+'r8uint',
+'rgb10a2uint',
+'r8sint',
+'r16float',
+undefined,
+'bgra8unorm-srgb'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 340,
+}
+);
+try {
+renderPassEncoder16.setBindGroup(
+4,
+bindGroup38,
+new Uint32Array(7599),
+4794,
+0
+);
+} catch {}
+try {
+renderPassEncoder21.beginOcclusionQuery(
+40
+);
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant(
+{
+r: -250.4,
+g: -439.6,
+b: 676.0,
+a: 121.4,
+}
+);
+} catch {}
+try {
+renderBundleEncoder76.setIndexBuffer(
+buffer12,
+'uint16'
+);
+} catch {}
+try {
+renderBundleEncoder77.setVertexBuffer(
+0,
+buffer12,
+20312,
+5904
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture78,
+  mipLevel: 2,
+  origin: { x: 57, y: 1, z: 12 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 5138356 */{
+offset: 106,
+bytesPerRow: 1581,
+rowsPerImage: 130,
+},
+{width: 92, height: 0, depthOrArrayLayers: 26}
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 289, height: 1, depthOrArrayLayers: 43}
+*/
+{
+  source: video1,
+  origin: { x: 3, y: 0 },
+  flipY: true,
+},
+{
+  texture: texture78,
+  mipLevel: 2,
+  origin: { x: 70, y: 0, z: 2 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 2, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline77 = await device1.createRenderPipelineAsync(
+{
+label: '\u3e7c\ua8da',
+layout: pipelineLayout16,
+vertex: {
+module: shaderModule21,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 2256,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 1312,
+shaderLocation: 25,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 23736,
+shaderLocation: 12,
+},
+{
+format: 'sint32x4',
+offset: 20528,
+shaderLocation: 14,
+},
+{
+format: 'float32x2',
+offset: 19296,
+shaderLocation: 26,
+},
+{
+format: 'uint32',
+offset: 4320,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 23968,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 9160,
+shaderLocation: 17,
+},
+{
+format: 'unorm8x2',
+offset: 18310,
+shaderLocation: 6,
+},
+{
+format: 'float32x2',
+offset: 6372,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 5592,
+attributes: [
+{
+format: 'snorm16x4',
+offset: 1440,
+shaderLocation: 15,
+},
+{
+format: 'sint16x4',
+offset: 20,
+shaderLocation: 13,
+},
+{
+format: 'uint16x4',
+offset: 5056,
+shaderLocation: 1,
+},
+{
+format: 'float32x4',
+offset: 3368,
+shaderLocation: 29,
+},
+{
+format: 'uint8x4',
+offset: 3756,
+shaderLocation: 10,
+},
+{
+format: 'sint32x4',
+offset: 1328,
+shaderLocation: 19,
+},
+{
+format: 'sint16x2',
+offset: 3848,
+shaderLocation: 24,
+},
+{
+format: 'uint32x2',
+offset: 5228,
+shaderLocation: 7,
+},
+{
+format: 'sint16x2',
+offset: 240,
+shaderLocation: 23,
+},
+{
+format: 'uint16x2',
+offset: 2448,
+shaderLocation: 18,
+},
+{
+format: 'snorm8x4',
+offset: 2988,
+shaderLocation: 28,
+},
+{
+format: 'uint8x2',
+offset: 3974,
+shaderLocation: 4,
+},
+{
+format: 'unorm16x2',
+offset: 1344,
+shaderLocation: 3,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 2964,
+shaderLocation: 22,
+},
+{
+format: 'unorm8x2',
+offset: 1468,
+shaderLocation: 2,
+},
+{
+format: 'sint8x2',
+offset: 970,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x2',
+offset: 5440,
+shaderLocation: 20,
+},
+{
+format: 'uint16x2',
+offset: 1100,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 11012,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x4',
+offset: 4172,
+shaderLocation: 21,
+},
+{
+format: 'float16x4',
+offset: 1568,
+shaderLocation: 5,
+},
+{
+format: 'sint32x3',
+offset: 5648,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x2',
+offset: 8856,
+shaderLocation: 27,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule21,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'invert',
+depthFailOp: 'zero',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'not-equal',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 242,
+stencilWriteMask: 2207,
+depthBias: 100,
+depthBiasSlopeScale: 85,
+depthBiasClamp: 12,
+},
+}
+);
+document.body.append('\u3234\ubb7a\ub011\u08dc\u3037\u0909\u{1fadd}\u01ad');
+let adapter11 = await navigator.gpu.requestAdapter(
+{
+powerPreference: 'high-performance',
+}
+);
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+let img19 = await imageWithData(230, 232, '#e22a55d2', '#b2e60392');
+let imageData18 = new ImageData(216, 208);
+let renderPassEncoder25 = commandEncoder76.beginRenderPass(
+{
+label: '\u{1f663}\u0523\u03d6\u9d11',
+colorAttachments: [
+{
+view: textureView100,
+depthSlice: 357,
+clearValue: {
+r: -121.5,
+g: 789.0,
+b: 846.9,
+a: -934.9,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+undefined,
+undefined,
+{
+view: textureView100,
+depthSlice: 531,
+clearValue: {
+r: 929.4,
+g: -674.8,
+b: -474.1,
+a: -907.8,
+},
+loadOp: 'load',
+storeOp: 'store'
+}
+],
+maxDrawCount: 186824,
+}
+);
+let renderBundleEncoder82 = device6.createRenderBundleEncoder(
+{
+colorFormats: [
+'r16float',
+'rg16sint',
+undefined,
+'rg11b10ufloat'
+],
+sampleCount: 106,
+depthReadOnly: false,
+}
+);
+let sampler79 = device6.createSampler(
+{
+label: '\uce3f\u0a70\ue72d\u{1f8c6}\u7801\u{1ffbe}\u07cc',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 95.403,
+lodMaxClamp: 95.950,
+}
+);
+try {
+renderPassEncoder25.setScissorRect(
+55,
+1,
+2,
+0
+);
+} catch {}
+try {
+renderPassEncoder25.setStencilReference(
+2986
+);
+} catch {}
+try {
+commandEncoder68.copyBufferToTexture(
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 3344 */
+offset: 3344,
+rowsPerImage: 14,
+buffer: buffer25,
+},
+{
+  texture: texture96,
+  mipLevel: 10,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device6, buffer25);
+} catch {}
+try {
+commandEncoder68.copyTextureToBuffer(
+{
+  texture: texture110,
+  mipLevel: 0,
+  origin: { x: 12, y: 12, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 96 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 53680 */
+offset: 53680,
+bytesPerRow: 256,
+buffer: buffer25,
+},
+{width: 72, height: 48, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device6, buffer25);
+} catch {}
+try {
+commandEncoder68.clearBuffer(
+buffer23
+);
+dissociateBuffer(device6, buffer23);
+} catch {}
+document.body.append('\u91fd\u{1ff4f}\u63e7\u{1ffc3}\u0c88');
+let offscreenCanvas34 = new OffscreenCanvas(493, 20);
+let img20 = await imageWithData(90, 30, '#4a13d5ac', '#cb5c64f9');
+let texture113 = device6.createTexture(
+{
+label: '\u{1fc97}\ue026\u{1febb}\u0883\u0e9b\u{1fbd5}\u0ea2\u{1feb6}\u{1f703}\u0945',
+size: [1018],
+dimension: '1d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16uint'
+],
+}
+);
+try {
+commandEncoder68.copyBufferToBuffer(
+buffer25,
+25928,
+buffer26,
+9416,
+11148
+);
+dissociateBuffer(device6, buffer25);
+dissociateBuffer(device6, buffer26);
+} catch {}
+try {
+commandEncoder68.copyTextureToTexture(
+{
+  texture: texture96,
+  mipLevel: 5,
+  origin: { x: 65, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture96,
+  mipLevel: 3,
+  origin: { x: 15, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 20, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder68.clearBuffer(
+buffer25,
+4452,
+51184
+);
+dissociateBuffer(device6, buffer25);
+} catch {}
+try {
+renderBundleEncoder82.pushDebugGroup(
+'\u{1fd05}'
+);
+} catch {}
+try {
+device6.queue.writeBuffer(
+buffer26,
+24208,
+new Float32Array(38556),
+37715,
+248
+);
+} catch {}
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+try {
+window.someLabel = renderPassEncoder16.label;
+} catch {}
+let buffer31 = device1.createBuffer(
+{
+label: '\ue05c\uad25\u021a\u3b75\u60a2\u{1f79d}\u01e6',
+size: 52187,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX,
+}
+);
+let renderBundleEncoder83 = device1.createRenderBundleEncoder(
+{
+label: '\ufaf6\u0109\u{1ffa2}\ua142\u6e63\u001f\u0c22\ue578\ubc05',
+colorFormats: [
+'rgba8unorm',
+'rgba32float',
+'rg8uint',
+'rg11b10ufloat',
+'r8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 378,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder21.setBindGroup(
+4,
+bindGroup24
+);
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(
+1308,
+8,
+346,
+28
+);
+} catch {}
+try {
+renderPassEncoder19.setViewport(
+856.7,
+6.668,
+762.2,
+12.02,
+0.2469,
+0.5340
+);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+5,
+buffer12,
+27476,
+444
+);
+} catch {}
+try {
+renderBundleEncoder77.setBindGroup(
+0,
+bindGroup30
+);
+} catch {}
+let promise43 = device1.createRenderPipelineAsync(
+{
+label: '\u{1f8c7}\u{1f8ea}\u0638\u0622\u4198\u0f24\ue565\u{1f72c}',
+layout: pipelineLayout22,
+vertex: {
+module: shaderModule21,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 11884,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 7784,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32',
+offset: 16352,
+shaderLocation: 19,
+},
+{
+format: 'unorm16x4',
+offset: 24968,
+shaderLocation: 27,
+},
+{
+format: 'unorm16x2',
+offset: 18804,
+shaderLocation: 26,
+},
+{
+format: 'uint32',
+offset: 10720,
+shaderLocation: 10,
+},
+{
+format: 'unorm16x2',
+offset: 13480,
+shaderLocation: 17,
+},
+{
+format: 'float32x3',
+offset: 10408,
+shaderLocation: 28,
+},
+{
+format: 'snorm8x4',
+offset: 7684,
+shaderLocation: 15,
+},
+{
+format: 'sint8x2',
+offset: 2144,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x4',
+offset: 2688,
+shaderLocation: 6,
+},
+{
+format: 'uint8x4',
+offset: 14052,
+shaderLocation: 7,
+},
+{
+format: 'float32',
+offset: 12000,
+shaderLocation: 3,
+},
+{
+format: 'float32x4',
+offset: 12464,
+shaderLocation: 20,
+},
+{
+format: 'sint8x2',
+offset: 12530,
+shaderLocation: 13,
+},
+{
+format: 'sint32x4',
+offset: 1844,
+shaderLocation: 14,
+},
+{
+format: 'float32',
+offset: 28192,
+shaderLocation: 12,
+},
+{
+format: 'uint8x4',
+offset: 10476,
+shaderLocation: 11,
+},
+{
+format: 'float32x2',
+offset: 16920,
+shaderLocation: 22,
+},
+{
+format: 'snorm16x2',
+offset: 20240,
+shaderLocation: 29,
+},
+{
+format: 'uint16x4',
+offset: 5312,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x2',
+offset: 24114,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 10260,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 896,
+shaderLocation: 0,
+},
+{
+format: 'uint16x4',
+offset: 4132,
+shaderLocation: 18,
+},
+{
+format: 'sint32x4',
+offset: 4144,
+shaderLocation: 16,
+},
+{
+format: 'uint32x2',
+offset: 632,
+shaderLocation: 25,
+},
+{
+format: 'float16x4',
+offset: 10224,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 25420,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x4',
+offset: 348,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 22728,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 15644,
+shaderLocation: 21,
+},
+{
+format: 'sint32',
+offset: 8596,
+shaderLocation: 24,
+}
+],
+},
+{
+arrayStride: 3524,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 11528,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 5772,
+shaderLocation: 8,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule21,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+{
+format: 'r16float',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'zero',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-wrap',
+},
+stencilWriteMask: 105,
+depthBias: 90,
+depthBiasSlopeScale: 91,
+depthBiasClamp: 80,
+},
+}
+);
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+offscreenCanvas7.width = 341;
+document.body.prepend('\u9b9e\u650b\u0100');
+let commandEncoder77 = device4.createCommandEncoder(
+{
+label: '\u8827\u11d1\ua216\ud2c6\u28d6\u0d37\u0cdf\u98db\u8767\u0681',
+}
+);
+try {
+computePassEncoder35.setPipeline(
+pipeline73
+);
+} catch {}
+try {
+renderBundleEncoder71.setBindGroup(
+1,
+bindGroup48
+);
+} catch {}
+try {
+gpuCanvasContext22.unconfigure();
+} catch {}
+let adapter12 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let canvas20 = document.createElement('canvas');
+let offscreenCanvas35 = new OffscreenCanvas(274, 365);
+let texture114 = device2.createTexture(
+{
+label: '\u78b4\u{1fed0}\u0015\u50f5\u1546',
+size: [89, 1, 110],
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth24plus-stencil8',
+'depth24plus-stencil8',
+'depth24plus-stencil8'
+],
+}
+);
+let renderBundle93 = renderBundleEncoder42.finish(
+{
+
+}
+);
+try {
+device2.queue.writeTexture(
+{
+  texture: texture41,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(413),
+/* required buffer size: 413 */{
+offset: 413,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline78 = await device2.createComputePipelineAsync(
+{
+label: '\u0062\ua11f\ua576\u67fc\u{1fe95}',
+layout: pipelineLayout14,
+compute: {
+module: shaderModule23,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+await promise41;
+} catch {}
+let querySet82 = device4.createQuerySet(
+{
+label: '\u0967\uffea\u0814\ua406',
+type: 'occlusion',
+count: 2798,
+}
+);
+let computePassEncoder44 = commandEncoder77.beginComputePass(
+{
+label: '\u06a9\u0679\ue6b2\u1086\u{1ff05}\u18b5\u032b\u02b2\u794c\u06af'
+}
+);
+try {
+computePassEncoder33.setPipeline(
+pipeline73
+);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+let imageData19 = new ImageData(120, 32);
+document.body.append('\u6fa5\u0d11\u24d8\u9cf0\u0f8a\u099c\u0e76\udd20\u0049');
+try {
+offscreenCanvas34.getContext('webgl2');
+} catch {}
+let sampler80 = device4.createSampler(
+{
+label: '\u{1f6bb}\u0d38\u{1fbb2}\ubba6\ue85e\u9d1d\u007e\u0506',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMaxClamp: 68.252,
+}
+);
+try {
+device4.queue.writeTexture(
+{
+  texture: texture92,
+  mipLevel: 1,
+  origin: { x: 4, y: 0, z: 274 },
+  aspect: 'all',
+},
+new Uint8Array(arrayBuffer0),
+/* required buffer size: 40571808 */{
+offset: 618,
+bytesPerRow: 3785,
+rowsPerImage: 233,
+},
+{width: 445, height: 1, depthOrArrayLayers: 47}
+);
+} catch {}
+let imageBitmap21 = await createImageBitmap(imageBitmap18);
+try {
+computePassEncoder29.setBindGroup(
+1,
+bindGroup26,
+[]
+);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(
+4,
+bindGroup25
+);
+} catch {}
+try {
+renderPassEncoder24.setViewport(
+1262.9,
+28.31,
+1554.3,
+6.166,
+0.4816,
+0.9222
+);
+} catch {}
+try {
+renderBundleEncoder58.setBindGroup(
+0,
+bindGroup30
+);
+} catch {}
+let pipeline79 = device1.createRenderPipeline(
+{
+label: '\u975e\u00ed\u2058\u0c59\u2372\u086f\u2e36\u15dd',
+layout: 'auto',
+vertex: {
+module: shaderModule22,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 27788,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 23568,
+shaderLocation: 8,
+},
+{
+format: 'unorm16x4',
+offset: 6872,
+shaderLocation: 16,
+},
+{
+format: 'uint32',
+offset: 25728,
+shaderLocation: 12,
+},
+{
+format: 'uint32x3',
+offset: 4960,
+shaderLocation: 28,
+},
+{
+format: 'snorm8x4',
+offset: 4928,
+shaderLocation: 0,
+},
+{
+format: 'float32x4',
+offset: 3852,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 2612,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x2',
+offset: 1842,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x4',
+offset: 436,
+shaderLocation: 14,
+},
+{
+format: 'uint16x2',
+offset: 748,
+shaderLocation: 15,
+},
+{
+format: 'float32x2',
+offset: 1184,
+shaderLocation: 6,
+},
+{
+format: 'uint8x4',
+offset: 588,
+shaderLocation: 1,
+},
+{
+format: 'unorm8x2',
+offset: 1780,
+shaderLocation: 23,
+},
+{
+format: 'float32x4',
+offset: 1276,
+shaderLocation: 2,
+},
+{
+format: 'uint16x4',
+offset: 164,
+shaderLocation: 19,
+},
+{
+format: 'snorm8x4',
+offset: 1692,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 25288,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x2',
+offset: 24992,
+shaderLocation: 21,
+},
+{
+format: 'uint32x4',
+offset: 7384,
+shaderLocation: 20,
+},
+{
+format: 'snorm8x4',
+offset: 11056,
+shaderLocation: 4,
+},
+{
+format: 'uint32x2',
+offset: 17828,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 11916,
+shaderLocation: 3,
+},
+{
+format: 'snorm16x2',
+offset: 14044,
+shaderLocation: 25,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+
+],
+},
+{
+arrayStride: 24320,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 22564,
+shaderLocation: 24,
+},
+{
+format: 'uint16x2',
+offset: 11240,
+shaderLocation: 29,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule22,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+}
+);
+document.body.prepend('\u065e\u0893\u04b7\uedf9');
+let imageData20 = new ImageData(32, 24);
+try {
+offscreenCanvas25.getContext('bitmaprenderer');
+} catch {}
+let texture115 = device3.createTexture(
+{
+label: '\u4658\uf089\u4958\u{1fe68}\u43d1\u71aa\u{1fa1d}',
+size: [2376, 30, 1],
+format: 'astc-12x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-12x10-unorm-srgb',
+'astc-12x10-unorm-srgb',
+'astc-12x10-unorm'
+],
+}
+);
+let sampler81 = device3.createSampler(
+{
+label: '\ubdba\ueac4\u0bb5\ua9b1\u9b91\u4d14\uebae\u0bbc\ufe4f\u{1ff66}\u054c',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+lodMaxClamp: 25.956,
+}
+);
+try {
+renderBundleEncoder68.setBindGroup(
+0,
+bindGroup47
+);
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+try {
+commandEncoder57.copyTextureToTexture(
+{
+  texture: texture75,
+  mipLevel: 0,
+  origin: { x: 172, y: 12, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture75,
+  mipLevel: 0,
+  origin: { x: 148, y: 4, z: 1 },
+  aspect: 'all',
+},
+{width: 24, height: 72, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder63.clearBuffer(
+buffer29,
+17156,
+2044
+);
+dissociateBuffer(device3, buffer29);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture82,
+  mipLevel: 2,
+  origin: { x: 2, y: 1, z: 6 },
+  aspect: 'all',
+},
+new ArrayBuffer(4497993),
+/* required buffer size: 4497993 */{
+offset: 669,
+bytesPerRow: 454,
+rowsPerImage: 78,
+},
+{width: 17, height: 0, depthOrArrayLayers: 128}
+);
+} catch {}
+let buffer32 = device3.createBuffer(
+{
+size: 7192,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+let commandEncoder78 = device3.createCommandEncoder(
+{
+}
+);
+let texture116 = device3.createTexture(
+{
+label: '\u06c5\ud993\u6d5e',
+size: [117, 205, 1],
+mipLevelCount: 7,
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rg8snorm',
+'rg8snorm',
+'rg8snorm'
+],
+}
+);
+let computePassEncoder45 = commandEncoder57.beginComputePass(
+{
+label: '\u01cc\u68fa\u44bb\ub474\u4d6e\u71d9\u{1f794}\u2f9e\u0e05\u{1fd3e}'
+}
+);
+let renderBundle94 = renderBundleEncoder64.finish(
+{
+label: '\u382a\u1613\u24ec\u0958\u0566\ue574\u{1fc32}\ucaa3\u1728\u050c'
+}
+);
+try {
+device3.queue.writeTexture(
+{
+  texture: texture58,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint16Array(new ArrayBuffer(56)),
+/* required buffer size: 989 */{
+offset: 989,
+bytesPerRow: 130,
+},
+{width: 0, height: 5, depthOrArrayLayers: 0}
+);
+} catch {}
+let videoFrame11 = new VideoFrame(video14, {timestamp: 0});
+let textureView107 = texture64.createView(
+{
+label: '\u08b2\u35b1',
+dimension: '2d-array',
+mipLevelCount: 1,
+}
+);
+let renderBundleEncoder84 = device4.createRenderBundleEncoder(
+{
+label: '\u0528\u0914',
+colorFormats: [
+'rg11b10ufloat',
+'r8unorm',
+'rgba8unorm-srgb',
+'rgb10a2uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 589,
+}
+);
+let renderBundle95 = renderBundleEncoder84.finish();
+let sampler82 = device4.createSampler(
+{
+label: '\u0a75\u1838',
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 16.736,
+lodMaxClamp: 92.208,
+compare: 'less',
+}
+);
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 0, y: 4 },
+  flipY: true,
+},
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+offscreenCanvas31.height = 801;
+try {
+renderPassEncoder21.setBindGroup(
+4,
+bindGroup30
+);
+} catch {}
+try {
+renderBundleEncoder77.setVertexBuffer(
+0,
+buffer31,
+5244,
+11523
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer13,
+31540,
+new DataView(new ArrayBuffer(666)),
+499,
+136
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture59,
+  mipLevel: 13,
+  origin: { x: 0, y: 4, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 325 */{
+offset: 325,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let textureView108 = texture56.createView(
+{
+label: '\u{1f6fb}\u3fbf',
+dimension: '2d-array',
+aspect: 'all',
+}
+);
+try {
+computePassEncoder26.setPipeline(
+pipeline57
+);
+} catch {}
+try {
+device2.destroy();
+} catch {}
+document.body.prepend('\u0faf\u0d58\uc91c\u5af6');
+let bindGroup50 = device5.createBindGroup({
+label: '\u3ae2\u0a39\u08c8\u81f6\u2c51\u7de3\u074c\u0e45',
+layout: bindGroupLayout28,
+entries: [
+
+],
+});
+let renderBundleEncoder85 = device5.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba16uint',
+'rg32uint',
+'rgba16float',
+'rgba8sint',
+undefined,
+'rg32float',
+'rg8unorm'
+],
+sampleCount: 433,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder52.setBindGroup(
+1,
+bindGroup40,
+new Uint32Array(4914),
+711,
+0
+);
+} catch {}
+try {
+device5.pushErrorScope(
+'out-of-memory'
+);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture97,
+  mipLevel: 0,
+  origin: { x: 60, y: 8, z: 25 },
+  aspect: 'all',
+},
+new ArrayBuffer(24),
+/* required buffer size: 5551952 */{
+offset: 833,
+bytesPerRow: 161,
+rowsPerImage: 278,
+},
+{width: 0, height: 32, depthOrArrayLayers: 125}
+);
+} catch {}
+let promise44 = device5.queue.onSubmittedWorkDone();
+let shaderModule29 = device1.createShaderModule(
+{
+label: '\u063f\u0745\u{1f94b}\u83b4\u32bc\u5acf',
+code: `
+
+@compute @workgroup_size(1, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0() {
+
+}
+
+struct S33 {
+@location(26) f0: f32,
+@location(6) f1: vec3<i32>,
+@location(19) f2: vec4<f16>,
+@location(0) f3: u32,
+@builtin(instance_index) f4: u32,
+@location(20) f5: vec4<i32>,
+@location(29) f6: f16,
+@location(5) f7: vec3<i32>,
+@location(8) f8: vec2<i32>,
+@location(7) f9: vec2<u32>,
+@location(22) f10: vec2<i32>,
+@builtin(vertex_index) f11: u32,
+@location(18) f12: f16,
+@location(1) f13: f32,
+@location(21) f14: vec4<i32>,
+@location(11) f15: vec4<f32>,
+@location(14) f16: vec3<f32>,
+@location(23) f17: vec2<u32>,
+@location(13) f18: vec2<u32>,
+@location(24) f19: i32,
+@location(2) f20: vec3<f32>,
+@location(4) f21: u32,
+@location(3) f22: u32,
+@location(16) f23: vec2<f16>,
+@location(27) f24: vec3<f32>,
+@location(10) f25: vec3<f16>,
+@location(17) f26: vec2<u32>,
+@location(25) f27: vec3<f16>,
+@location(9) f28: vec2<u32>,
+@location(15) f29: vec3<i32>
+}
+struct VertexOutput0 {
+@location(5) f283: vec3<f16>,
+@builtin(position) f284: vec4<f32>,
+@location(4) f285: vec3<i32>,
+@location(1) f286: vec2<f16>,
+@location(6) f287: vec3<f16>,
+@location(8) f288: vec4<i32>,
+@location(7) f289: u32,
+@location(15) f290: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(12) a0: vec3<i32>, a1: S33, @location(28) a2: vec2<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let textureView109 = texture87.createView(
+{
+baseMipLevel: 1,
+mipLevelCount: 6,
+baseArrayLayer: 0,
+}
+);
+try {
+computePassEncoder32.setPipeline(
+pipeline75
+);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(
+3,
+bindGroup26,
+[]
+);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(
+4,
+bindGroup24,
+new Uint32Array(1382),
+891,
+0
+);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder23.setBlendConstant(
+{
+r: 561.8,
+g: -548.9,
+b: 108.7,
+a: -619.0,
+}
+);
+} catch {}
+try {
+renderPassEncoder16.setViewport(
+1166.6,
+31.90,
+1808.3,
+4.387,
+0.8636,
+0.8822
+);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(
+buffer12,
+'uint32',
+25540,
+3231
+);
+} catch {}
+try {
+renderBundleEncoder76.setBindGroup(
+4,
+bindGroup30,
+new Uint32Array(6248),
+5708,
+0
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer13,
+25624,
+new BigUint64Array(22180),
+10714,
+776
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 48, y: 80, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer7,
+/* required buffer size: 1078 */{
+offset: 998,
+bytesPerRow: 293,
+},
+{width: 60, height: 10, depthOrArrayLayers: 1}
+);
+} catch {}
+let gpuCanvasContext28 = canvas20.getContext('webgpu');
+let videoFrame12 = new VideoFrame(img9, {timestamp: 0});
+let gpuCanvasContext29 = offscreenCanvas31.getContext('webgpu');
+let shaderModule30 = device5.createShaderModule(
+{
+label: '\u0278\u1020\ubd31\u{1ff4f}\u19cb',
+code: `
+
+@compute @workgroup_size(5, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S35 {
+@builtin(sample_mask) f0: u32,
+@builtin(position) f1: vec4<f32>
+}
+struct FragmentOutput0 {
+@location(2) f0: f32,
+@location(0) f1: i32,
+@location(6) f2: u32,
+@location(5) f3: vec3<u32>,
+@location(1) f4: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool, a2: S35) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S34 {
+@location(10) f0: vec4<u32>,
+@location(1) f1: vec3<f32>,
+@location(23) f2: vec4<i32>,
+@location(19) f3: vec2<i32>,
+@builtin(vertex_index) f4: u32,
+@location(21) f5: vec2<u32>,
+@location(18) f6: vec2<i32>,
+@location(24) f7: vec2<i32>,
+@location(2) f8: vec4<u32>,
+@location(16) f9: vec2<i32>,
+@location(7) f10: vec2<f16>,
+@location(13) f11: vec3<f16>,
+@location(4) f12: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(12) a0: u32, @location(9) a1: u32, a2: S34, @location(17) a3: vec4<f32>, @location(8) a4: f16, @location(14) a5: vec2<f16>, @location(15) a6: vec3<i32>, @location(3) a7: vec3<f16>, @location(5) a8: vec3<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+}
+);
+let texture117 = device5.createTexture(
+{
+label: '\u7db3\u8bd4\uc404\u3487\ua32c\u0132\u0334\u5602\u07e8\ud238',
+size: {width: 8, height: 149, depthOrArrayLayers: 140},
+mipLevelCount: 2,
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let sampler83 = device5.createSampler(
+{
+label: '\u{1f913}\u0a6c\u7449\u3ae0',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 69.539,
+lodMaxClamp: 88.944,
+}
+);
+try {
+device5.queue.writeTexture(
+{
+  texture: texture80,
+  mipLevel: 9,
+  origin: { x: 8, y: 0, z: 3 },
+  aspect: 'all',
+},
+arrayBuffer7,
+/* required buffer size: 1052560 */{
+offset: 34,
+bytesPerRow: 263,
+rowsPerImage: 174,
+},
+{width: 0, height: 0, depthOrArrayLayers: 24}
+);
+} catch {}
+document.body.prepend(canvas3);
+let bindGroupLayout37 = device3.createBindGroupLayout(
+{
+label: '\u{1fcf1}\uf821\u9d53\u0ff5\u02a4\uf8e7\uf978\ub0d5',
+entries: [
+
+],
+}
+);
+let querySet83 = device3.createQuerySet(
+{
+label: '\u021f\u9a63\uc64c\u9656',
+type: 'occlusion',
+count: 1537,
+}
+);
+let renderBundle96 = renderBundleEncoder64.finish(
+{
+label: '\u40dc\u{1f7a8}\u13c1\u7bce\u{1fb02}\u{1f92e}\u02b6'
+}
+);
+let sampler84 = device3.createSampler(
+{
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 7.130,
+lodMaxClamp: 73.271,
+}
+);
+try {
+computePassEncoder27.setBindGroup(
+3,
+bindGroup47,
+new Uint32Array(1385),
+996,
+0
+);
+} catch {}
+try {
+renderBundleEncoder73.setVertexBuffer(
+83,
+undefined,
+2366574965,
+750762307
+);
+} catch {}
+try {
+commandEncoder78.clearBuffer(
+buffer32
+);
+dissociateBuffer(device3, buffer32);
+} catch {}
+try {
+commandEncoder78.insertDebugMarker(
+'\u9f7c'
+);
+} catch {}
+let bindGroupLayout38 = device5.createBindGroupLayout(
+{
+label: '\u4626\u098c',
+entries: [
+
+],
+}
+);
+let sampler85 = device5.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 17.468,
+lodMaxClamp: 21.121,
+}
+);
+try {
+computePassEncoder39.setBindGroup(
+1,
+bindGroup50,
+new Uint32Array(4256),
+1279,
+0
+);
+} catch {}
+try {
+renderBundleEncoder69.setBindGroup(
+3,
+bindGroup50,
+new Uint32Array(4426),
+3249,
+0
+);
+} catch {}
+try {
+gpuCanvasContext28.configure(
+{
+device: device5,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'astc-12x12-unorm-srgb',
+'astc-10x8-unorm-srgb',
+'astc-10x6-unorm',
+'astc-8x6-unorm'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+document.body.append('\ub8ff\u4dfd\u46d9\ucfbf\uda62\u{1f792}\u01fa\u0a8d\u0129\u3907');
+let video18 = await videoWithData();
+try {
+window.someLabel = buffer20.label;
+} catch {}
+let shaderModule31 = device4.createShaderModule(
+{
+label: '\u{1f9b7}\u{1fa5c}\u{1f91b}',
+code: `
+
+@compute @workgroup_size(5, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S36 {
+@builtin(sample_mask) f0: u32,
+@builtin(front_facing) f1: bool
+}
+struct FragmentOutput0 {
+@location(5) f0: vec2<i32>,
+@location(1) f1: vec4<u32>,
+@location(2) f2: vec2<i32>,
+@location(7) f3: vec4<f32>,
+@location(6) f4: i32
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, a1: S36, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(2) a0: vec2<u32>, @location(14) a1: vec2<u32>, @location(3) a2: u32, @location(12) a3: vec2<u32>, @location(0) a4: u32, @location(5) a5: vec4<u32>, @location(9) a6: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+try {
+renderBundleEncoder80.setBindGroup(
+8,
+bindGroup48
+);
+} catch {}
+try {
+renderBundleEncoder80.setBindGroup(
+6,
+bindGroup48,
+new Uint32Array(3162),
+1665,
+0
+);
+} catch {}
+try {
+texture63.destroy();
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture92,
+  mipLevel: 0,
+  origin: { x: 35, y: 0, z: 864 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 79664476 */{
+offset: 916,
+bytesPerRow: 6946,
+rowsPerImage: 244,
+},
+{width: 854, height: 1, depthOrArrayLayers: 48}
+);
+} catch {}
+let pipeline80 = await promise42;
+let querySet84 = device4.createQuerySet(
+{
+label: '\u{1fa29}\u749e\u{1f971}\u8349\u0db0\u0fe2\u098e\u09bf\u0063\u05df\u272d',
+type: 'occlusion',
+count: 1278,
+}
+);
+let texture118 = device4.createTexture(
+{
+label: '\uac54\u{1fa27}',
+size: [60, 256, 255],
+mipLevelCount: 5,
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x8-unorm',
+'astc-10x8-unorm-srgb'
+],
+}
+);
+let renderBundleEncoder86 = device4.createRenderBundleEncoder(
+{
+label: '\u{1f83c}\u{1ffe5}\ue23e\u006f\u4205\u4576\uf663\u0d6a\u{1fac2}\u10f7',
+colorFormats: [
+'rg16uint',
+'r16float',
+'bgra8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 782,
+}
+);
+try {
+renderBundleEncoder86.setVertexBuffer(
+7,
+buffer22,
+35804,
+2975
+);
+} catch {}
+video11.height = 68;
+let bindGroupLayout39 = device1.createBindGroupLayout(
+{
+label: '\uaf46\u6f0a\u{1fe0a}\u0ca5\u0a17\ud613',
+entries: [
+
+],
+}
+);
+let texture119 = device1.createTexture(
+{
+label: '\u8552\u4a14\u0e42\u{1ffc0}\ua3cc\u098d\u0c45\ue744\u47ff\u6630\u{1f914}',
+size: [6372, 244, 1],
+mipLevelCount: 9,
+sampleCount: 1,
+format: 'eac-r11unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'eac-r11unorm'
+],
+}
+);
+let renderBundle97 = renderBundleEncoder38.finish(
+{
+label: '\u{1fba0}\u074a\u{1fef0}\u{1facf}'
+}
+);
+try {
+renderPassEncoder23.executeBundles([]);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer31,
+40052,
+new DataView(new ArrayBuffer(33076)),
+30358,
+2136
+);
+} catch {}
+try {
+window.someLabel = renderPassEncoder15.label;
+} catch {}
+let device7 = await adapter12.requestDevice(
+{
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxBindGroups: 6,
+maxColorAttachmentBytesPerSample: 54,
+maxVertexAttributes: 29,
+maxVertexBufferArrayStride: 36483,
+maxStorageTexturesPerShaderStage: 33,
+maxStorageBuffersPerShaderStage: 20,
+maxDynamicStorageBuffersPerPipelineLayout: 2626,
+maxBindingsPerBindGroup: 7774,
+maxTextureDimension1D: 14635,
+maxTextureDimension2D: 12675,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 155037204,
+maxInterStageShaderVariables: 88,
+maxInterStageShaderComponents: 84,
+},
+}
+);
+let bindGroupLayout40 = device7.createBindGroupLayout(
+{
+label: '\u99e7\u2ddd\u0cdc\u110b\u0e8b\u0edb\u0f9b\u08ae\u5122\u0a9b\u0ba3',
+entries: [
+{
+binding: 1749,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+},
+{
+binding: 5872,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+},
+{
+binding: 3532,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+}
+],
+}
+);
+let buffer33 = device7.createBuffer(
+{
+label: '\u03e3\u0e68\u0d85\u00f2\u90d9\u{1fc90}',
+size: 54049,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let commandEncoder79 = device7.createCommandEncoder(
+{
+label: '\u{1f6c9}\u{1fa9f}\u0447\u{1ff2f}\u0df6\u5f72\u6133\ue9e6\u0b0b\u{1ff94}',
+}
+);
+let sampler86 = device7.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 79.228,
+compare: 'greater',
+}
+);
+try {
+commandEncoder79.clearBuffer(
+buffer33,
+18836,
+3340
+);
+dissociateBuffer(device7, buffer33);
+} catch {}
+try {
+commandEncoder79.pushDebugGroup(
+'\u{1fb1f}'
+);
+} catch {}
+let gpuCanvasContext30 = offscreenCanvas35.getContext('webgpu');
+let imageData21 = new ImageData(116, 8);
+let pipelineLayout25 = device7.createPipelineLayout(
+{
+label: '\u{1fb7c}\ua5dd\u13de\ue37c\u3c44\u0c06\u0938\u0894\u0752\uc1a7',
+bindGroupLayouts: [
+bindGroupLayout40,
+bindGroupLayout40,
+bindGroupLayout40,
+bindGroupLayout40,
+bindGroupLayout40
+],
+}
+);
+let renderBundleEncoder87 = device7.createRenderBundleEncoder(
+{
+label: '\u0a71\ued30\u{1fc4f}\u8ff9\u9832',
+colorFormats: [
+'r8unorm',
+'rgba16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 422,
+depthReadOnly: true,
+}
+);
+let renderBundle98 = renderBundleEncoder87.finish(
+{
+label: '\u{1fffd}\uc926\u5ecf\udac9\ua973\u{1ffb0}\u15f3\u0d83\u639b\ue952'
+}
+);
+document.body.append('\u{1fa66}\u045d\ua3b9');
+try {
+adapter10.label = '\u0119\u{1ff90}\uc186\u{1f9b8}\u7bf3\u2d34';
+} catch {}
+let bindGroup51 = device4.createBindGroup({
+label: '\u81c0\u70c9\ue45c\ufe39\u0144\u{1f602}\u9732\u0983',
+layout: bindGroupLayout30,
+entries: [
+{
+binding: 277,
+resource: sampler82
+}
+],
+});
+try {
+computePassEncoder44.setPipeline(
+pipeline73
+);
+} catch {}
+try {
+renderBundleEncoder71.setBindGroup(
+0,
+bindGroup51,
+new Uint32Array(8351),
+1798,
+0
+);
+} catch {}
+try {
+renderBundleEncoder71.setVertexBuffer(
+6,
+buffer22,
+39268,
+703
+);
+} catch {}
+let pipeline81 = await device4.createComputePipelineAsync(
+{
+label: '\u0b6e\u{1fce5}\u630c\u400a',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule25,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+canvas2.width = 93;
+document.body.prepend('\ub5e6\u0f4e\u07f3\u6340\u05dd\u1ce6\u389a\u5f52');
+let bindGroup52 = device5.createBindGroup({
+layout: bindGroupLayout28,
+entries: [
+
+],
+});
+let textureView110 = texture97.createView(
+{
+label: '\u7516\u4b6d\u7b7a\u6d9c\u0ed2\u1acf\u00e5\u{1fe24}\u5986',
+dimension: '2d',
+baseMipLevel: 1,
+baseArrayLayer: 47,
+}
+);
+try {
+renderBundleEncoder85.setVertexBuffer(
+91,
+undefined,
+2547064050
+);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+try {
+device5.queue.writeBuffer(
+buffer24,
+11932,
+new DataView(new ArrayBuffer(45990)),
+21427,
+204
+);
+} catch {}
+let pipeline82 = device5.createRenderPipeline(
+{
+label: '\u060c\u{1ffa0}\u007a\u9ae2\ua93a',
+layout: pipelineLayout17,
+vertex: {
+module: shaderModule30,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 3144,
+shaderLocation: 21,
+},
+{
+format: 'sint32x4',
+offset: 4484,
+shaderLocation: 24,
+},
+{
+format: 'sint8x2',
+offset: 16722,
+shaderLocation: 18,
+},
+{
+format: 'sint32x4',
+offset: 11316,
+shaderLocation: 23,
+},
+{
+format: 'uint8x4',
+offset: 9648,
+shaderLocation: 10,
+},
+{
+format: 'unorm16x2',
+offset: 12896,
+shaderLocation: 1,
+},
+{
+format: 'uint8x4',
+offset: 17284,
+shaderLocation: 12,
+},
+{
+format: 'uint16x4',
+offset: 3736,
+shaderLocation: 2,
+},
+{
+format: 'sint32x4',
+offset: 3136,
+shaderLocation: 19,
+},
+{
+format: 'snorm8x4',
+offset: 3812,
+shaderLocation: 4,
+},
+{
+format: 'float32x2',
+offset: 7316,
+shaderLocation: 8,
+},
+{
+format: 'float32x3',
+offset: 22556,
+shaderLocation: 13,
+},
+{
+format: 'sint32x4',
+offset: 6288,
+shaderLocation: 16,
+},
+{
+format: 'float32',
+offset: 13484,
+shaderLocation: 7,
+},
+{
+format: 'sint8x2',
+offset: 17400,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x4',
+offset: 1064,
+shaderLocation: 14,
+},
+{
+format: 'float32x4',
+offset: 12048,
+shaderLocation: 17,
+},
+{
+format: 'uint32x2',
+offset: 17776,
+shaderLocation: 9,
+},
+{
+format: 'float32',
+offset: 14444,
+shaderLocation: 3,
+},
+{
+format: 'snorm16x2',
+offset: 17524,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+},
+}
+);
+let gpuCanvasContext31 = offscreenCanvas33.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.append('\u9757\u{1f739}\u0899\u8be4\u05dc\u0b4a\u0935\u{1f776}\u08e7');
+let offscreenCanvas36 = new OffscreenCanvas(121, 999);
+try {
+offscreenCanvas36.getContext('webgl');
+} catch {}
+let bindGroup53 = device6.createBindGroup({
+layout: bindGroupLayout31,
+entries: [
+
+],
+});
+let texture120 = device6.createTexture(
+{
+label: '\u04a4\u57ce\u0cec',
+size: [5625, 190, 208],
+mipLevelCount: 7,
+sampleCount: 1,
+format: 'astc-5x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-5x5-unorm'
+],
+}
+);
+let textureView111 = texture110.createView(
+{
+label: '\udf62\u0894\u{1f697}\u{1fb96}\u{1fee6}\u{1facd}',
+dimension: '2d-array',
+aspect: 'all',
+baseMipLevel: 6,
+}
+);
+let sampler87 = device6.createSampler(
+{
+label: '\u0ad8\u{1fae4}\u16f7\u06cd\ue384\u0cdb\u0bf6\u{1ff91}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 46.030,
+lodMaxClamp: 67.369,
+compare: 'less',
+}
+);
+try {
+renderPassEncoder25.setBindGroup(
+7,
+bindGroup53,
+new Uint32Array(5894),
+5470,
+0
+);
+} catch {}
+try {
+renderBundleEncoder82.setBindGroup(
+6,
+bindGroup53,
+new Uint32Array(1161),
+610,
+0
+);
+} catch {}
+let bindGroup54 = device6.createBindGroup({
+label: '\u{1ff86}\u2ccd\u{1f9e3}\u{1fe2e}\u027c',
+layout: bindGroupLayout31,
+entries: [
+
+],
+});
+let computePassEncoder46 = commandEncoder68.beginComputePass(
+{
+label: '\u162b\u{1fc96}\u{1fccc}\u181e\u04eb\u4e82'
+}
+);
+try {
+computePassEncoder46.setBindGroup(
+7,
+bindGroup54,
+new Uint32Array(6509),
+4527,
+0
+);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(
+6,
+bindGroup46,
+new Uint32Array(6827),
+2103,
+0
+);
+} catch {}
+try {
+renderBundleEncoder82.setIndexBuffer(
+buffer25,
+'uint32',
+7912,
+40261
+);
+} catch {}
+let device8 = await promise37;
+try {
+renderPassEncoder25.setStencilReference(
+3748
+);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(
+6,
+buffer26
+);
+} catch {}
+try {
+device6.queue.writeTexture(
+{
+  texture: texture96,
+  mipLevel: 10,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(844),
+/* required buffer size: 844 */{
+offset: 844,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let imageData22 = new ImageData(144, 96);
+let texture121 = device7.createTexture(
+{
+label: '\u{1f633}\u09e2\u{1f74b}\u0997\u0371',
+size: {width: 4181},
+dimension: '1d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8snorm',
+'rg8snorm'
+],
+}
+);
+let sampler88 = device7.createSampler(
+{
+label: '\uc677\ucbd0\u6528\u{1feaf}\u{1fbc0}\u780a\u04f0',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 60.769,
+maxAnisotropy: 9,
+}
+);
+try {
+gpuCanvasContext24.configure(
+{
+device: device7,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x10-unorm-srgb'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+await promise44;
+} catch {}
+gc();
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+try {
+offscreenCanvas28.getContext('bitmaprenderer');
+} catch {}
+canvas8.height = 813;
+document.body.append('\u07de\u0c65\u{1f74d}\uf5c3');
+let imageBitmap22 = await createImageBitmap(videoFrame6);
+let imageData23 = new ImageData(20, 176);
+try {
+adapter7.label = '\u95c1\uaf5a\u4a19\u54a7\ueb42';
+} catch {}
+let renderBundleEncoder88 = device8.createRenderBundleEncoder(
+{
+label: '\ub69c\u60f8\uac9d\u{1f64a}\u{1fdac}\u{1fe88}\u0e9b\u0f47\u{1f96b}',
+colorFormats: [
+'rg32sint',
+'rg8unorm',
+'rg8uint',
+'r16sint'
+],
+sampleCount: 355,
+}
+);
+document.body.append('\u9443\u93b2\ufec6');
+let imageData24 = new ImageData(108, 8);
+document.body.append('\uae63\uf8f4\u0e95\u5934\ua78b\u{1ff5b}\ud4f9');
+let querySet85 = device4.createQuerySet(
+{
+label: '\ueeb4\u0f1c',
+type: 'occlusion',
+count: 3135,
+}
+);
+let renderBundleEncoder89 = device4.createRenderBundleEncoder(
+{
+label: '\uf3f3\u6a92',
+colorFormats: [
+'r8sint',
+'r32float',
+'rg8sint',
+'bgra8unorm',
+'r16uint'
+],
+sampleCount: 58,
+depthReadOnly: true,
+}
+);
+let promise45 = navigator.gpu.requestAdapter(
+{
+}
+);
+let commandEncoder80 = device5.createCommandEncoder(
+{
+label: '\u{1facd}\u04bb\u0da0\u{1fdfa}\u8e2a',
+}
+);
+let texture122 = gpuCanvasContext2.getCurrentTexture();
+try {
+commandEncoder80.copyTextureToTexture(
+{
+  texture: texture122,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture122,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas16,
+  origin: { x: 103, y: 38 },
+  flipY: true,
+},
+{
+  texture: texture122,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\u{1f8d0}\ue20b\u{1fdd6}\u{1fb94}');
+let video19 = await videoWithData();
+let texture123 = device6.createTexture(
+{
+label: '\u{1f9c2}\uade4\u0732\u373b\u{1f8be}\u5008\u379c\ub1a5\u0021\u0fb8\u00b1',
+size: [2216, 5, 20],
+mipLevelCount: 2,
+format: 'astc-8x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-8x5-unorm-srgb',
+'astc-8x5-unorm',
+'astc-8x5-unorm-srgb'
+],
+}
+);
+let renderBundleEncoder90 = device6.createRenderBundleEncoder(
+{
+label: '\u07e2\u4570\u9bdf\u0c83\ub8a5\u0ed8\u0796\u0bfe',
+colorFormats: [
+'rgba8unorm',
+'r16sint',
+'rg16sint',
+'rgb10a2uint',
+'rgba16float',
+'r16float',
+'rgb10a2unorm'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 137,
+}
+);
+try {
+computePassEncoder46.setBindGroup(
+1,
+bindGroup45,
+new Uint32Array(8608),
+4315,
+0
+);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(
+1,
+bindGroup45,
+new Uint32Array(8698),
+2042,
+0
+);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(
+94,
+undefined,
+1765563139,
+2155808210
+);
+} catch {}
+try {
+renderBundleEncoder82.setVertexBuffer(
+2,
+buffer26,
+23304,
+1618
+);
+} catch {}
+  log('the end')
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -1434,6 +1434,8 @@ void CommandEncoder::copyTextureToBuffer(const WGPUImageCopyTexture& source, con
         for (uint32_t layer = 0; layer < copySize.depthOrArrayLayers; ++layer) {
             auto destinationOffset = static_cast<NSUInteger>(destination.layout.offset + layer * destinationBytesPerImage);
             NSUInteger sourceSlice = source.origin.z + layer;
+            if (destinationOffset + widthForMetal * blockSize > destinationBuffer.length)
+                continue;
             [m_blitCommandEncoder
                 copyFromTexture:sourceTexture.texture()
                 sourceSlice:sourceSlice

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -752,6 +752,9 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, void* data, si
         for (uint32_t layer = 0; layer < size.depthOrArrayLayers; ++layer) {
             NSUInteger sourceOffset = layer * bytesPerImage;
             NSUInteger destinationSlice = destination.origin.z + layer;
+            if (sourceOffset + widthForMetal * blockSize > temporaryBuffer.length)
+                continue;
+
             [m_blitCommandEncoder
                 copyFromBuffer:temporaryBuffer
                 sourceOffset:sourceOffset


### PR DESCRIPTION
#### 3e223a775bcb5b78ead4a62810d4993540c1088c
<pre>
[WebGPU] Queue::writeTexture can fail for some 1D texture copies
<a href="https://bugs.webkit.org/show_bug.cgi?id=272911">https://bugs.webkit.org/show_bug.cgi?id=272911</a>
&lt;radar://126621087&gt;

Reviewed by Tadeu Zagallo.

Add two missing checks which failed the Metal validation layer.

* LayoutTests/TestExpectations:
* LayoutTests/fast/webgpu/fuzz-272911-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-272911.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::copyTextureToBuffer):
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::writeTexture):

Canonical link: <a href="https://commits.webkit.org/277841@main">https://commits.webkit.org/277841@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11fd4ef45d52d8dc2030e5563bf69d6485ec0212

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27923 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51399 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44777 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33860 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25453 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39839 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25577 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42031 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20937 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23051 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43206 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6768 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44993 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53308 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23759 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20052 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47129 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25025 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42237 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46061 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10730 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25829 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24746 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->