### PR TITLE
[GTK] Adopt GtkPrintSettings refs

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.cpp
@@ -474,7 +474,7 @@ static void webkitPrintOperationSendPagesToPrintPortal(WebKitPrintOperation* pri
         return;
     }
 
-    GRefPtr<GtkPrintSettings> modifiedPrintSettings(gtk_print_settings_copy(printSettings));
+    GRefPtr<GtkPrintSettings> modifiedPrintSettings = adoptGRef(gtk_print_settings_copy(printSettings));
     gtk_print_settings_set(modifiedPrintSettings.get(), GTK_PRINT_SETTINGS_OUTPUT_URI, uri.get());
 
     priv->printJob = adoptGRef(gtk_print_job_new(jobName.get(), filePrinter.get(), modifiedPrintSettings.get(), pageSetup));
@@ -614,7 +614,7 @@ static void webkitPrintOperationPreparePrint(WebKitPrintOperation* printOperatio
 
     const char* title = _("Print Web Page");
     GRefPtr<GtkPageSetup> pageSetup = priv->pageSetup ? priv->pageSetup : adoptGRef(gtk_page_setup_new());
-    GRefPtr<GtkPrintSettings> printSettings(priv->printSettings ? gtk_print_settings_copy(priv->printSettings.get()) : gtk_print_settings_new());
+    GRefPtr<GtkPrintSettings> printSettings = adoptGRef(priv->printSettings ? gtk_print_settings_copy(priv->printSettings.get()) : gtk_print_settings_new());
 
     GRefPtr<GVariant> arguments(g_variant_new("(ss@a{sv}@a{sv}a{sv})", "", title, gtk_print_settings_to_gvariant(printSettings.get()), gtk_page_setup_to_gvariant(pageSetup.get()), &options));
 


### PR DESCRIPTION
#### 24f45bcee58bc22ec40c611428622e6ecb5475c6
<pre>
[GTK] Adopt GtkPrintSettings refs
<a href="https://bugs.webkit.org/show_bug.cgi?id=272917">https://bugs.webkit.org/show_bug.cgi?id=272917</a>

Reviewed by Michael Catanzaro.

They&apos;re transfer full, so the GRefPtr should adopt them, and not add an
extra ref on top.

* Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.cpp:
(webkitPrintOperationSendPagesToPrintPortal):
(webkitPrintOperationPreparePrint):

Canonical link: <a href="https://commits.webkit.org/277732@main">https://commits.webkit.org/277732@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77a3a1e97835b826dd8153795e7686a5e4346d9a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51017 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44394 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33477 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25062 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39485 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48911 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25229 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41742 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20629 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22709 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6385 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44665 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43380 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52921 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23376 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19718 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46817 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24641 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41931 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Skipped layout-tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45731 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10682 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25446 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24364 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->