### PR TITLE
Add CryptoKit implementations for HMAC/HKDF in WebKit

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2687,6 +2687,8 @@ crypto/subtle/ecdh-import-pkcs8-key-p384-validate-ecprivatekey-parameters-public
 crypto/subtle/ecdsa-import-pkcs8-key-p256-validate-ecprivatekey-parameters-publickey.html [ Skip ]
 crypto/subtle/ecdsa-import-pkcs8-key-p384-validate-ecprivatekey-parameters-publickey.html [ Skip ]
 crypto/subtle/ecdh-import-spki-key-ecdh-identifier.html [ Skip ]
+crypto/subtle/hmac-import-key-verify-sha224.html [ Skip ]
+crypto/subtle/hmac-import-key-sign-sha224.html [ Skip ]
 crypto/subtle/rsa-pss-generate-export-key-jwk-sha1.html [ Skip ]
 crypto/subtle/rsa-pss-generate-export-key-jwk-sha224.html [ Skip ]
 crypto/subtle/rsa-pss-generate-export-key-jwk-sha256.html [ Skip ]
@@ -2712,7 +2714,6 @@ crypto/workers/subtle/rsa-pss-import-key-sign.html [ Skip ]
 crypto/workers/subtle/rsa-pss-import-key-verify.html [ Skip ]
 http/wpt/crypto/rsa-pss-crash.any.html [ Skip ]
 http/wpt/crypto/rsa-pss-crash.any.worker.html [ Skip ]
-
 editing/deleting/delete-emoji.html [ Slow ]
 
 # New emoji requires system support.

--- a/LayoutTests/crypto/subtle/hkdf-derive-bits-length-limits-expected.txt
+++ b/LayoutTests/crypto/subtle/hkdf-derive-bits-length-limits-expected.txt
@@ -6,9 +6,6 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 PASS deriveBits("sha-1", 0) rejected promise  with OperationError: The operation failed for an operation-specific reason.
 PASS Bit derivations for SHA-1 with minimum, maximum and HashLen lengths all passed
 PASS deriveBits("sha-1", 256 * 20 * 8) rejected promise  with OperationError: The operation failed for an operation-specific reason.
-PASS deriveBits("sha-224", 0) rejected promise  with OperationError: The operation failed for an operation-specific reason.
-PASS Bit derivations for SHA-224 with minimum, maximum and HashLen lengths all passed
-PASS deriveBits("sha-224", 256 * 28 * 8) rejected promise  with OperationError: The operation failed for an operation-specific reason.
 PASS deriveBits("sha-256", 0) rejected promise  with OperationError: The operation failed for an operation-specific reason.
 PASS Bit derivations for SHA-256 with minimum, maximum and HashLen lengths all passed
 PASS deriveBits("sha-256", 256 * 32 * 8) rejected promise  with OperationError: The operation failed for an operation-specific reason.

--- a/LayoutTests/crypto/subtle/hkdf-derive-bits-length-limits.html
+++ b/LayoutTests/crypto/subtle/hkdf-derive-bits-length-limits.html
@@ -43,18 +43,6 @@ crypto.subtle.importKey("raw", rawKey, "HKDF", nonExtractable, ["deriveBits"]).t
             });
         });
     }).then(function(result) {
-        // SHA-224, hash output length is 28 bytes
-        return shouldReject('deriveBits("sha-224", 0)').then(function(result) {
-            return Promise.all([
-                deriveBits("sha-224", 8),
-                deriveBits("sha-224", 28 * 8),
-                deriveBits("sha-224", 255 * 28 * 8)
-            ]).then(function(result) {
-                testPassed("Bit derivations for SHA-224 with minimum, maximum and HashLen lengths all passed");
-                return shouldReject('deriveBits("sha-224", 256 * 28 * 8)');
-            });
-        });
-    }).then(function(result) {
         // SHA-256, hash output length is 32 bytes
         return shouldReject('deriveBits("sha-256", 0)').then(function(result) {
             return Promise.all([

--- a/Source/WebCore/Modules/webauthn/fido/Pin.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/Pin.cpp
@@ -68,7 +68,8 @@ static bool hasAtLeastFourCodepoints(const String& pin)
 // makePinAuth returns `LEFT(HMAC-SHA-256(secret, data), 16)`.
 static Vector<uint8_t> makePinAuth(const CryptoKeyHMAC& key, const Vector<uint8_t>& data)
 {
-    auto result = CryptoAlgorithmHMAC::platformSign(key, data);
+    // FIXME: enable cryptoKit when it's enabled for SubtleCryptoAPI rdar://126352502
+    auto result = CryptoAlgorithmHMAC::platformSign(key, data, UseCryptoKit::No);
     ASSERT(!result.hasException());
     auto pinAuth = result.releaseReturnValue();
     pinAuth.shrink(16);
@@ -351,7 +352,8 @@ std::optional<SetPinRequest> SetPinRequest::tryCreate(const String& inputPin, co
     auto newPinEnc = CryptoAlgorithmAESCBC::platformEncrypt({ }, *sharedKey, paddedPin, CryptoAlgorithmAESCBC::Padding::No);
     ASSERT(!newPinEnc.hasException());
 
-    auto pinUvAuthParam = CryptoAlgorithmHMAC::platformSign(*hmacKey, newPinEnc.returnValue());
+    // FIXME: enable cryptoKit when it's enabled for SubtleCryptoAPI rdar://126352502
+    auto pinUvAuthParam = CryptoAlgorithmHMAC::platformSign(*hmacKey, newPinEnc.returnValue(), UseCryptoKit::No);
     ASSERT(!pinUvAuthParam.hasException());
 
     return SetPinRequest(sharedKey.releaseNonNull(), WTFMove(coseKey), newPinEnc.releaseReturnValue(), pinUvAuthParam.releaseReturnValue());

--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		93B38EC025821CD800198E63 /* SpeechSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 93B38EBF25821CD700198E63 /* SpeechSoftLink.mm */; };
 		94A41E732BB1E10D00DA715C /* UnsafeOverlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A41E702BB1E10D00DA715C /* UnsafeOverlays.swift */; };
 		94C759082B990D69000CC511 /* PALSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 94C759072B990D62000CC511 /* PALSwift.h */; };
+		94E867A32BD191FC000EF470 /* PALSwiftUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 94E8679F2BD18EBC000EF470 /* PALSwiftUtils.h */; };
 		94F4AA022B730D2C006DFFDE /* CryptoKitShim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F4AA012B730D2C006DFFDE /* CryptoKitShim.swift */; };
 		A1038D332AB12BF100F57BA4 /* WebAVContentKeyGrouping.h in Headers */ = {isa = PBXBuildFile; fileRef = A1038D322AB12BF100F57BA4 /* WebAVContentKeyGrouping.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A1038D4F2AB21FBB00F57BA4 /* WebAVContentKeyReportGroupExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = A1038D4D2AB21FBB00F57BA4 /* WebAVContentKeyReportGroupExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -627,6 +628,7 @@
 		94A41E702BB1E10D00DA715C /* UnsafeOverlays.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UnsafeOverlays.swift; path = pal/PALSwift/UnsafeOverlays.swift; sourceTree = SOURCE_ROOT; };
 		94C759022B990D31000CC511 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		94C759072B990D62000CC511 /* PALSwift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PALSwift.h; sourceTree = "<group>"; };
+		94E8679F2BD18EBC000EF470 /* PALSwiftUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PALSwiftUtils.h; sourceTree = "<group>"; };
 		94F4AA012B730D2C006DFFDE /* CryptoKitShim.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CryptoKitShim.swift; path = pal/PALSwift/CryptoKitShim.swift; sourceTree = SOURCE_ROOT; };
 		A10265881F56747A00B4C844 /* HIToolboxSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HIToolboxSPI.h; sourceTree = "<group>"; };
 		A102658D1F567E9D00B4C844 /* HIServicesSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HIServicesSPI.h; sourceTree = "<group>"; };
@@ -1001,6 +1003,7 @@
 				1C4876D71F8D7F4E00CCEEBD /* Logging.h */,
 				94C759022B990D31000CC511 /* module.modulemap */,
 				94C759072B990D62000CC511 /* PALSwift.h */,
+				94E8679F2BD18EBC000EF470 /* PALSwiftUtils.h */,
 				A3C66CDA1F462D6A009E6EE9 /* SessionID.cpp */,
 				A3C66CDB1F462D6A009E6EE9 /* SessionID.h */,
 				1C5C57DF27571A25003B540D /* ThreadGlobalData.cpp */,
@@ -1463,6 +1466,7 @@
 				DD20DD1327BC90D60093D175 /* OutputContext.h in Headers */,
 				DD20DD1427BC90D60093D175 /* OutputDevice.h in Headers */,
 				94C759082B990D69000CC511 /* PALSwift.h in Headers */,
+				94E867A32BD191FC000EF470 /* PALSwiftUtils.h in Headers */,
 				DD20DE0227BC90D80093D175 /* PassKitInstallmentsSPI.h in Headers */,
 				DD20DD2227BC90D60093D175 /* PassKitSoftLink.h in Headers */,
 				DD20DE0327BC90D80093D175 /* PassKitSPI.h in Headers */,

--- a/Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift
+++ b/Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift
@@ -235,7 +235,8 @@ extension Curve25519.Signing.PrivateKey {
         if span.empty() {
             return try self.signature(for: Data.empty()).copyToVectorUInt8()
         }
-        return try self.signature(for: Data.temporaryDataFromSpan(spanNoCopy: span)).copyToVectorUInt8()
+        return try self.signature(for: Data.temporaryDataFromSpan(spanNoCopy: span))
+            .copyToVectorUInt8()
     }
 }
 
@@ -250,8 +251,11 @@ extension Curve25519.Signing.PublicKey {
         if signature.empty() || data.empty() {
             return false
         }
-        return self.isValidSignature(Data.temporaryDataFromSpan(spanNoCopy: signature), for: Data.temporaryDataFromSpan(spanNoCopy: data))
+        return self.isValidSignature(
+            Data.temporaryDataFromSpan(spanNoCopy: signature),
+            for: Data.temporaryDataFromSpan(spanNoCopy: data))
     }
+
 }
 
 extension Curve25519.KeyAgreement.PrivateKey {
@@ -265,8 +269,44 @@ extension Curve25519.KeyAgreement.PrivateKey {
         if pubSpan.empty() {
             throw UnsafeErrors.emptySpan
         }
-        let pub =  try Curve25519.KeyAgreement.PublicKey(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: pubSpan))
+        let pub = try Curve25519.KeyAgreement.PublicKey(
+            rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: pubSpan))
         return try self.sharedSecretFromKeyAgreement(with: pub).copyToVectorUInt8()
+    }
+}
+
+extension CryptoKit.HMAC {
+    static func authenticationCode(
+        data: SpanConstUInt8,
+        key: SpanConstUInt8
+    ) -> VectorUInt8 {
+        return self.authenticationCode(
+            for: Data.temporaryDataFromSpan(spanNoCopy: data),
+            using: SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: key))
+        ).copyToVectorUInt8()
+    }
+    static func isValidAuthenticationCode(
+        mac: SpanConstUInt8, data: SpanConstUInt8, key: SpanConstUInt8
+    ) -> Bool {
+        return Self.isValidAuthenticationCode(
+            Data.temporaryDataFromSpan(spanNoCopy: mac),
+            authenticating: Data.temporaryDataFromSpan(spanNoCopy: data),
+            using: SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: key)))
+    }
+}
+
+extension CryptoKit.HKDF {
+    static func deriveKey(
+        inputKeyMaterial: SpanConstUInt8, salt: SpanConstUInt8, info: SpanConstUInt8,
+        outputByteCount: Int
+    ) -> VectorUInt8 {
+        return Self.deriveKey(
+            inputKeyMaterial: SymmetricKey(
+                data: Data.temporaryDataFromSpan(spanNoCopy: inputKeyMaterial)),
+            salt: Data.temporaryDataFromSpan(spanNoCopy: salt),
+            info: Data.temporaryDataFromSpan(spanNoCopy: info), outputByteCount: outputByteCount
+        ).copyToVectorUInt8()
+
     }
 }
 

--- a/Source/WebCore/PAL/pal/PALSwiftUtils.h
+++ b/Source/WebCore/PAL/pal/PALSwiftUtils.h
@@ -25,24 +25,36 @@
 
 #pragma once
 
-#include <cstdint>
-#include <wtf/Vector.h>
+#if HAVE(SWIFT_CPP_INTEROP)
+#include "PALSwift.h"
 
-namespace Cpp {
-
-using VectorUInt8 = WTF::Vector<uint8_t>;
-using SpanConstUInt8 = std::span<const uint8_t>;
-using OptionalVectorUInt8 = std::optional<WTF::Vector<uint8_t>>;
-
-
-// FIXME: remove when swift support is available rdar://118026392
-inline OptionalVectorUInt8 makeOptional(VectorUInt8 val)
+namespace WebCore {
+inline PAL::HashFunction toCKHashFunction(CryptoAlgorithmIdentifier hash)
 {
-    return val;
+    switch (hash) {
+    case CryptoAlgorithmIdentifier::SHA_256:
+        return PAL::HashFunction::sha256();
+        break;
+    case CryptoAlgorithmIdentifier::SHA_384:
+        return PAL::HashFunction::sha384();
+        break;
+    case CryptoAlgorithmIdentifier::SHA_512:
+        return PAL::HashFunction::sha512();
+        break;
+    case CryptoAlgorithmIdentifier::SHA_1:
+        return PAL::HashFunction::sha1();
+        break;
+    default:
+        break;
+    }
+    ASSERT_NOT_REACHED();
+    return PAL::HashFunction::sha512();
 }
 
-} // Cpp
+inline bool isValidHashParameter(CryptoAlgorithmIdentifier hash)
+{
+    return hash == CryptoAlgorithmIdentifier::SHA_1 || hash == CryptoAlgorithmIdentifier::SHA_256 || hash == CryptoAlgorithmIdentifier::SHA_512 || hash == CryptoAlgorithmIdentifier::SHA_384;
+}
 
-#ifndef __swift__
-#include "PALSwift-Generated.h"
+} // WebCore
 #endif

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.cpp
@@ -50,9 +50,10 @@ void CryptoAlgorithmHKDF::deriveBits(const CryptoAlgorithmParameters& parameters
         return;
     }
 
+    UseCryptoKit useCryptoKit = context.settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
     dispatchOperationInWorkQueue(workQueue, context, WTFMove(callback), WTFMove(exceptionCallback),
-        [parameters = crossThreadCopy(downcast<CryptoAlgorithmHkdfParams>(parameters)), baseKey = WTFMove(baseKey), length] {
-            return platformDeriveBits(parameters, downcast<CryptoKeyRaw>(baseKey.get()), length);
+        [parameters = crossThreadCopy(downcast<CryptoAlgorithmHkdfParams>(parameters)), baseKey = WTFMove(baseKey), length, useCryptoKit] {
+            return platformDeriveBits(parameters, downcast<CryptoKeyRaw>(baseKey.get()), length, useCryptoKit);
         });
 }
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.h
@@ -46,7 +46,7 @@ private:
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
     ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
 
-    static ExceptionOr<Vector<uint8_t>> platformDeriveBits(const CryptoAlgorithmHkdfParams&, const CryptoKeyRaw&, size_t);
+    static ExceptionOr<Vector<uint8_t>> platformDeriveBits(const CryptoAlgorithmHkdfParams&, const CryptoKeyRaw&, size_t, UseCryptoKit);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.cpp
@@ -57,17 +57,19 @@ CryptoAlgorithmIdentifier CryptoAlgorithmHMAC::identifier() const
 
 void CryptoAlgorithmHMAC::sign(const CryptoAlgorithmParameters&, Ref<CryptoKey>&& key, Vector<uint8_t>&& data, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
+    UseCryptoKit useCryptoKit = context.settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
     dispatchOperationInWorkQueue(workQueue, context, WTFMove(callback), WTFMove(exceptionCallback),
-        [key = WTFMove(key), data = WTFMove(data)] {
-            return platformSign(downcast<CryptoKeyHMAC>(key.get()), data);
+        [key = WTFMove(key), data = WTFMove(data), useCryptoKit] {
+            return platformSign(downcast<CryptoKeyHMAC>(key.get()), data, useCryptoKit);
         });
 }
 
 void CryptoAlgorithmHMAC::verify(const CryptoAlgorithmParameters&, Ref<CryptoKey>&& key, Vector<uint8_t>&& signature, Vector<uint8_t>&& data, BoolCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
+    UseCryptoKit useCryptoKit = context.settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
     dispatchOperationInWorkQueue(workQueue, context, WTFMove(callback), WTFMove(exceptionCallback),
-        [key = WTFMove(key), signature = WTFMove(signature), data = WTFMove(data)] {
-            return platformVerify(downcast<CryptoKeyHMAC>(key.get()), signature, data);
+        [key = WTFMove(key), signature = WTFMove(signature), data = WTFMove(data), useCryptoKit] {
+            return platformVerify(downcast<CryptoKeyHMAC>(key.get()), signature, data, useCryptoKit);
         });
 }
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.h
@@ -38,8 +38,8 @@ public:
     static Ref<CryptoAlgorithm> create();
 
     // Operations can be performed directly.
-    static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoKeyHMAC&, const Vector<uint8_t>&);
-    static ExceptionOr<bool> platformVerify(const CryptoKeyHMAC&, const Vector<uint8_t>&, const Vector<uint8_t>&);
+    static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoKeyHMAC&, const Vector<uint8_t>&, UseCryptoKit);
+    static ExceptionOr<bool> platformVerify(const CryptoKeyHMAC&, const Vector<uint8_t>&, const Vector<uint8_t>&, UseCryptoKit);
 
 private:
     CryptoAlgorithmHMAC() = default;

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESGCMMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESGCMMac.cpp
@@ -95,6 +95,7 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESGCM::platformEncrypt(const Crypto
 
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESGCM::platformDecrypt(const CryptoAlgorithmAesGcmParams& parameters, const CryptoKeyAES& key, const Vector<uint8_t>& cipherText)
 {
+    // FIXME: Add decrypt with CryptoKit once rdar://92701544 is resolved.
     return decyptAESGCM(parameters.ivVector(), key.key(), cipherText, parameters.additionalDataVector(), parameters.tagLength.value_or(0) / 8);
 }
 

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESKWMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESKWMac.cpp
@@ -64,7 +64,7 @@ static ExceptionOr<Vector<uint8_t>> unwrapKeyAESKW(const Vector<uint8_t>& key, c
 static ExceptionOr<Vector<uint8_t>> wrapKeyAESKWCryptoKit(const Vector<uint8_t>& key, const Vector<uint8_t>& data)
 {
     auto rv = PAL::AesKw::wrap(data.span(), key.span());
-    if (!rv.getErrCode().isSuccess())
+    if (!rv.getErrorCode().isSuccess())
         return Exception { ExceptionCode::OperationError };
     return WTFMove(*rv.getResult());
 }
@@ -72,7 +72,7 @@ static ExceptionOr<Vector<uint8_t>> wrapKeyAESKWCryptoKit(const Vector<uint8_t>&
 static ExceptionOr<Vector<uint8_t>> unwrapKeyAESKWCryptoKit(const Vector<uint8_t>& key, const Vector<uint8_t>& data)
 {
     auto rv = PAL::AesKw::unwrap(data.span(), key.span());
-    if (!rv.getErrCode().isSuccess())
+    if (!rv.getErrorCode().isSuccess())
         return Exception { ExceptionCode::OperationError };
     return WTFMove(*rv.getResult());
 }

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDHMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDHMac.cpp
@@ -56,12 +56,12 @@ static std::optional<Vector<uint8_t>> platformDeriveBitsCC(const CryptoKeyEC& ba
 #if HAVE(SWIFT_CPP_INTEROP)
 static std::optional<Vector<uint8_t>> platformDeriveBitsCryptoKit(const CryptoKeyEC& baseKey, const CryptoKeyEC& publicKey)
 {
-    const auto* priv = std::get_if<CKPlatformECKeyContainer>(&baseKey.platformKey());
+    const auto* priv  = std::get_if<CKPlatformECKeyContainer>(&baseKey.platformKey());
     const auto* pub = std::get_if<CKPlatformECKeyContainer>(&publicKey.platformKey());
     if (!priv || !pub)
         return std::nullopt;
     auto rv = (*priv)->deriveBits(*pub);
-    if (!(rv.getErrCode().isSuccess() && rv.getKeyBytes()))
+    if (!(rv.getErrorCode().isSuccess() && rv.getKeyBytes()))
         return std::nullopt;
     return rv.getKeyBytes();
 }

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp
@@ -31,36 +31,12 @@
 #include "CryptoAlgorithmEcdsaParams.h"
 #include "CryptoDigestAlgorithm.h"
 #include "CryptoKeyEC.h"
+#if HAVE(SWIFT_CPP_INTEROP)
+#include <pal/PALSwiftUtils.h>
+#endif
 
 namespace WebCore {
 #if HAVE(SWIFT_CPP_INTEROP)
-
-static PAL::HashFunction toCKHashFunction(CryptoAlgorithmIdentifier hash)
-{
-    switch (hash) {
-    case CryptoAlgorithmIdentifier::SHA_256:
-        return PAL::HashFunction::sha256();
-        break;
-    case CryptoAlgorithmIdentifier::SHA_384:
-        return PAL::HashFunction::sha384();
-        break;
-    case CryptoAlgorithmIdentifier::SHA_512:
-        return PAL::HashFunction::sha512();
-        break;
-    case CryptoAlgorithmIdentifier::SHA_1:
-        return PAL::HashFunction::sha1();
-        break;
-    default:
-        break;
-    }
-    ASSERT_NOT_REACHED();
-    return PAL::HashFunction::sha512();
-}
-
-static bool isValidHashParameter(CryptoAlgorithmIdentifier hash)
-{
-    return hash == CryptoAlgorithmIdentifier::SHA_256 || hash == CryptoAlgorithmIdentifier::SHA_512 || hash == CryptoAlgorithmIdentifier::SHA_384 || hash == CryptoAlgorithmIdentifier::SHA_1;
-}
 
 static ExceptionOr<Vector<uint8_t>> signECDSACryptoKit(CryptoAlgorithmIdentifier hash, const PlatformECKeyContainer& key, const Vector<uint8_t>& data)
 {
@@ -70,7 +46,7 @@ static ExceptionOr<Vector<uint8_t>> signECDSACryptoKit(CryptoAlgorithmIdentifier
     if (!isValidHashParameter(hash))
         return Exception { ExceptionCode::OperationError };
     auto rv = (*priv)->sign(data.span(), toCKHashFunction(hash));
-    if (!(rv.getErrCode().isSuccess() && rv.getSignature()))
+    if (!(rv.getErrorCode().isSuccess() && rv.getSignature()))
         return Exception { ExceptionCode::OperationError };
     return *rv.getSignature();
 }
@@ -82,7 +58,7 @@ static ExceptionOr<bool> verifyECDSACryptoKit(CryptoAlgorithmIdentifier hash, co
         return Exception { ExceptionCode::OperationError };
     if (!isValidHashParameter(hash))
         return Exception { ExceptionCode::OperationError };
-    return (*pub)->verify(data.span(), signature.span(), toCKHashFunction(hash)).getErrCode().isSuccess();
+    return (*pub)->verify(data.span(), signature.span(), toCKHashFunction(hash)).getErrorCode().isSuccess();
 }
 #endif
 

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp
@@ -66,7 +66,7 @@ static ExceptionOr<Vector<uint8_t>> signEd25519CryptoKit(const Vector<uint8_t>&s
     if (sk.size() != ed25519KeySize)
         return Exception { ExceptionCode::OperationError };
     auto rv = PAL::EdKey::sign(PAL::EdSigningAlgorithm::ed25519(), sk.span(), data.span());
-    if (!rv.getErrCode().isSuccess())
+    if (!rv.getErrorCode().isSuccess())
         return Exception { ExceptionCode::OperationError };
     if (!rv.getSignature())
         return Exception { ExceptionCode::OperationError };
@@ -78,7 +78,7 @@ static ExceptionOr<bool>  verifyEd25519CryptoKit(const Vector<uint8_t>& pubKey, 
     if (pubKey.size() != ed25519KeySize || signature.size() != ed25519SignatureSize)
         return false;
     auto rv = PAL::EdKey::verify(PAL::EdSigningAlgorithm::ed25519(), pubKey.span(), signature.span(), data.span());
-    return rv.getErrCode().isSuccess();
+    return rv.getErrorCode().isSuccess();
 }
 #endif
 

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACMac.cpp
@@ -29,6 +29,9 @@
 #include "CryptoKeyHMAC.h"
 #include "CryptoUtilitiesCocoa.h"
 #include <CommonCrypto/CommonHMAC.h>
+#if HAVE(SWIFT_CPP_INTEROP)
+#include <pal/PALSwiftUtils.h>
+#endif
 #include <wtf/CryptographicUtilities.h>
 
 namespace WebCore {
@@ -51,7 +54,22 @@ static std::optional<CCHmacAlgorithm> commonCryptoHMACAlgorithm(CryptoAlgorithmI
     }
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHMAC& key, const Vector<uint8_t>& data)
+#if HAVE(SWIFT_CPP_INTEROP)
+static ExceptionOr<Vector<uint8_t>> platformSignCryptoKit(const CryptoKeyHMAC& key, const Vector<uint8_t>& data)
+{
+    if (!isValidHashParameter(key.hashAlgorithmIdentifier()))
+        return Exception { ExceptionCode::OperationError };
+    return PAL::HMAC::sign(key.key().span(), data.span(), toCKHashFunction(key.hashAlgorithmIdentifier()));
+}
+static ExceptionOr<bool> platformVerifyCryptoKit(const CryptoKeyHMAC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
+{
+    if (!isValidHashParameter(key.hashAlgorithmIdentifier()))
+        return Exception { ExceptionCode::OperationError };
+    return PAL::HMAC::verify(signature.span(), key.key().span(), data.span(), toCKHashFunction(key.hashAlgorithmIdentifier()));
+}
+#endif
+
+static ExceptionOr<Vector<uint8_t>> platformSignCC(const CryptoKeyHMAC& key, const Vector<uint8_t>& data)
 {
     auto algorithm = commonCryptoHMACAlgorithm(key.hashAlgorithmIdentifier());
     if (!algorithm)
@@ -60,7 +78,7 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHM
     return calculateHMACSignature(*algorithm, key.key(), data.span());
 }
 
-ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerify(const CryptoKeyHMAC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
+static ExceptionOr<bool> platformVerifyCC(const CryptoKeyHMAC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
 {
     auto algorithm = commonCryptoHMACAlgorithm(key.hashAlgorithmIdentifier());
     if (!algorithm)
@@ -71,4 +89,25 @@ ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerify(const CryptoKeyHMAC& key, 
     return signature.size() == expectedSignature.size() && !constantTimeMemcmp(expectedSignature.data(), signature.data(), expectedSignature.size());
 }
 
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHMAC& key, const Vector<uint8_t>& data, UseCryptoKit useCryptoKit)
+{
+#if HAVE(SWIFT_CPP_INTEROP)
+    if (useCryptoKit == UseCryptoKit::Yes)
+        return platformSignCryptoKit(key, data);
+#else
+    UNUSED_PARAM(useCryptoKit);
+#endif
+    return platformSignCC(key, data);
+}
+
+ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerify(const CryptoKeyHMAC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data, UseCryptoKit useCryptoKit)
+{
+#if HAVE(SWIFT_CPP_INTEROP)
+    if (useCryptoKit == UseCryptoKit::Yes)
+        return platformVerifyCryptoKit(key, signature, data);
+#else
+    UNUSED_PARAM(useCryptoKit);
+#endif
+    return platformVerifyCC(key, signature, data);
+}
 } // namespace WebCore

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmX25519Cocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmX25519Cocoa.cpp
@@ -34,7 +34,7 @@ static std::optional<Vector<uint8_t>> deriveBitsCryptoKit(const Vector<uint8_t>&
     if (baseKey.size() != ed25519KeySize || publicKey.size() != ed25519KeySize)
         return std::nullopt;
     auto rv = PAL::EdKey::deriveBits(PAL::EdKeyAgreementAlgorithm::x25519(), baseKey.span(), publicKey.span());
-    if (!rv.getErrCode().isSuccess())
+    if (!rv.getErrorCode().isSuccess())
         return std::nullopt;
     if (!rv.getKeyBytes())
         return std::nullopt;

--- a/Source/WebCore/crypto/cocoa/CryptoKeyECMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyECMac.cpp
@@ -151,7 +151,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportRaw(CryptoAlgorithmIdentifier ide
 #if HAVE(SWIFT_CPP_INTEROP)
     if (useCryptoKit == UseCryptoKit::Yes) {
         auto rv = PAL::ECKey::importX963Pub(keyData.span(), namedCurveToCryptoKitCurve(curve));
-        if (!(rv.getErrCode().isSuccess() && rv.getKey()))
+        if (!(rv.getErrorCode().isSuccess() && rv.getKey()))
             return nullptr;
         return create(identifier, curve, CryptoKeyType::Public, toCKPlatformECKeyContainer(rv.getKey().get()), extractable, usages);
     }
@@ -177,7 +177,7 @@ Vector<uint8_t> CryptoKeyEC::platformExportRaw(UseCryptoKit useCryptoKit) const
         if (!pub)
             return { };
         auto rv = (*pub)->exportX963Pub();
-        if (!(rv.getErrCode().isSuccess() && rv.getKeyBytes()))
+        if (!(rv.getErrorCode().isSuccess() && rv.getKeyBytes()))
             return { };
         if (rv.getKeyBytes()->size() != expectedSize)
             return { };
@@ -225,7 +225,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPrivate(CryptoAlgorithmIdentif
 #if HAVE(SWIFT_CPP_INTEROP)
     if (useCryptoKit == UseCryptoKit::Yes) {
         auto rv = PAL::ECKey::importX963Private(binaryInput.span(), namedCurveToCryptoKitCurve(curve));
-        if (!(rv.getErrCode().isSuccess() && rv.getKey()))
+        if (!(rv.getErrorCode().isSuccess() && rv.getKey()))
             return nullptr;
         return create(identifier, curve, CryptoKeyType::Private, toCKPlatformECKeyContainer(rv.getKey().get()), extractable, usages);
     }
@@ -258,14 +258,14 @@ bool CryptoKeyEC::platformAddFieldElements(JsonWebKey& jwk, UseCryptoKit useCryp
         switch (type()) {
         case CryptoKeyType::Public: {
             auto rv = (*pubOrPriv)->exportX963Pub();
-            if (!(rv.getErrCode().isSuccess() && rv.getKeyBytes()))
+            if (!(rv.getErrorCode().isSuccess() && rv.getKeyBytes()))
                 return false;
             result = *rv.getKeyBytes();
             break;
         }
         case CryptoKeyType::Private: {
             auto rv = (*pubOrPriv)->exportX963Private();
-            if (!(rv.getErrCode().isSuccess() && rv.getKeyBytes()))
+            if (!(rv.getErrorCode().isSuccess() && rv.getKeyBytes()))
                 return false;
             result = *rv.getKeyBytes();
             break;
@@ -382,7 +382,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportSpki(CryptoAlgorithmIdentifier id
     // CryptoKit can read pure compressed so no need for index++ here.
     if (useCryptoKit == UseCryptoKit::Yes) {
         auto rv = PAL::ECKey::importCompressedPub(keyData.subspan(index, keyData.size() - index), namedCurveToCryptoKitCurve(curve));
-        if (!(rv.getErrCode().isSuccess() && rv.getKey()))
+        if (!(rv.getErrorCode().isSuccess() && rv.getKey()))
             return nullptr;
         return create(identifier, curve, CryptoKeyType::Public, toCKPlatformECKeyContainer(rv.getKey().get()), extractable, usages);
     }
@@ -411,7 +411,7 @@ Vector<uint8_t> CryptoKeyEC::platformExportSpki(UseCryptoKit useCryptoKit) const
         if (!pub)
             return { };
         auto rv = (*pub)->exportX963Pub();
-        if (!(rv.getErrCode().isSuccess() && rv.getKeyBytes()))
+        if (!(rv.getErrorCode().isSuccess() && rv.getKeyBytes()))
             return { };
         if (rv.getKeyBytes()->size() != expectedKeySize)
             return { };
@@ -513,7 +513,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportPkcs8(CryptoAlgorithmIdentifier i
 #if HAVE(SWIFT_CPP_INTEROP)
     if (useCryptoKit == UseCryptoKit::Yes) {
         auto rv = PAL::ECKey::importX963Private(keyBinary.span(), namedCurveToCryptoKitCurve(curve));
-        if (!(rv.getErrCode().isSuccess() && rv.getKey()))
+        if (!(rv.getErrorCode().isSuccess() && rv.getKey()))
             return nullptr;
         return create(identifier, curve, CryptoKeyType::Private, toCKPlatformECKeyContainer(rv.getKey().get()), extractable, usages);
     }
@@ -542,7 +542,7 @@ Vector<uint8_t> CryptoKeyEC::platformExportPkcs8(UseCryptoKit useCryptoKit) cons
         if (!priv)
             return { };
         auto rv = (*priv)->exportX963Private();
-        if (!(rv.getErrCode().isSuccess() && rv.getKeyBytes()))
+        if (!(rv.getErrorCode().isSuccess() && rv.getKeyBytes()))
             return { };
         if (rv.getKeyBytes()->size() != expectedKeySize)
             return { };

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmHKDFGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmHKDFGCrypt.cpp
@@ -150,7 +150,7 @@ static std::optional<Vector<uint8_t>> gcryptDeriveBits(const Vector<uint8_t>& ke
     return output;
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHKDF::platformDeriveBits(const CryptoAlgorithmHkdfParams& parameters, const CryptoKeyRaw& key, size_t length)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHKDF::platformDeriveBits(const CryptoAlgorithmHkdfParams& parameters, const CryptoKeyRaw& key, size_t length, UseCryptoKit)
 {
     auto output = gcryptDeriveBits(key.key(), parameters.saltVector(), parameters.infoVector(), length / 8, parameters.hashIdentifier);
     if (!output)

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmHMACGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmHMACGCrypt.cpp
@@ -80,7 +80,7 @@ static std::optional<Vector<uint8_t>> calculateSignature(int algorithm, const Ve
     return signature;
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHMAC& key, const Vector<uint8_t>& data)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHMAC& key, const Vector<uint8_t>& data, UseCryptoKit)
 {
     auto algorithm = getGCryptDigestAlgorithm(key.hashAlgorithmIdentifier());
     if (algorithm == GCRY_MAC_NONE)
@@ -92,7 +92,7 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHM
     return WTFMove(*result);
 }
 
-ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerify(const CryptoKeyHMAC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
+ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerify(const CryptoKeyHMAC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data, UseCryptoKit)
 {
     auto algorithm = getGCryptDigestAlgorithm(key.hashAlgorithmIdentifier());
     if (algorithm == GCRY_MAC_NONE)

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmHKDFOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmHKDFOpenSSL.cpp
@@ -33,7 +33,7 @@
 
 namespace WebCore {
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHKDF::platformDeriveBits(const CryptoAlgorithmHkdfParams& parameters, const CryptoKeyRaw& key, size_t length)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHKDF::platformDeriveBits(const CryptoAlgorithmHkdfParams& parameters, const CryptoKeyRaw& key, size_t length, UseCryptoKit)
 {
     auto algorithm = digestAlgorithm(parameters.hashIdentifier);
     if (!algorithm)

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmHMACOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmHMACOpenSSL.cpp
@@ -57,7 +57,7 @@ static std::optional<Vector<uint8_t>> calculateSignature(const EVP_MD* algorithm
     return cipherText;
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHMAC& key, const Vector<uint8_t>& data)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHMAC& key, const Vector<uint8_t>& data, UseCryptoKit)
 {
     auto algorithm = digestAlgorithm(key.hashAlgorithmIdentifier());
     if (!algorithm)
@@ -69,7 +69,7 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHM
     return WTFMove(*result);
 }
 
-ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerify(const CryptoKeyHMAC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
+ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerify(const CryptoKeyHMAC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data, UseCryptoKit)
 {
     auto algorithm = digestAlgorithm(key.hashAlgorithmIdentifier());
     if (!algorithm)


### PR DESCRIPTION
#### be5cbef50e65beef09ae6956defb911329c8cb29
<pre>
Add CryptoKit implementations for HMAC/HKDF in WebKit
<a href="https://rdar.apple.com/126689803">rdar://126689803</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=272879">https://bugs.webkit.org/show_bug.cgi?id=272879</a>

Reviewed by Alex Christensen.

Add HMAC/HKDF implementations using CryptoKit. Still disabled by
default.

Also:
- disabled some sha224 tests. It&apos;s not part of the webcrypto standard
  anymore.(since 2017)
- Renamed some Swift classes to not use acronyms.

* Source/WebCore/Modules/webauthn/fido/Pin.cpp:
(fido::pin::makePinAuth):
(fido::pin::SetPinRequest::tryCreate):
* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/pal/PALSwift.h:
* Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift:
(HMAC.sign(_:data:hashFunction:)):
(HMAC.verify(_:key:data:hashFunction:)):
(HKDF.deriveBits(_:salt:info:outputByteCount:hashFunction:)):
* Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift:
(CryptoKit.isValidAuthenticationCode(_:data:key:)):
(CryptoKit.deriveKey(_:salt:info:outputByteCount:)):
* Source/WebCore/PAL/pal/PALSwiftUtils.h: Copied from Source/WebCore/PAL/pal/PALSwift.h.
(WebCore::toCKHashFunction):
(WebCore::isValidHashParameter):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.cpp:
(WebCore::CryptoAlgorithmHKDF::deriveBits):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.cpp:
(WebCore::CryptoAlgorithmHMAC::sign):
(WebCore::CryptoAlgorithmHMAC::verify):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.h:
* Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp:
(WebCore::toCKHashFunction): Deleted.
(WebCore::isValidHashParameter): Deleted.
* Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFMac.cpp:
(WebCore::platformDeriveBitsCC):
(WebCore::platformDeriveBitsCryptoKit):
(WebCore::CryptoAlgorithmHKDF::platformDeriveBits):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACMac.cpp:
(WebCore::platformSignCryptoKit):
(WebCore::platformVerifyCryptoKit):
(WebCore::platformSignCC):
(WebCore::platformVerifyCC):
(WebCore::CryptoAlgorithmHMAC::platformSign):
(WebCore::CryptoAlgorithmHMAC::platformVerify):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmHKDFGCrypt.cpp:
(WebCore::CryptoAlgorithmHKDF::platformDeriveBits):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmHMACGCrypt.cpp:
(WebCore::CryptoAlgorithmHMAC::platformSign):
(WebCore::CryptoAlgorithmHMAC::platformVerify):
* Source/WebCore/crypto/openssl/CryptoAlgorithmHKDFOpenSSL.cpp:
(WebCore::CryptoAlgorithmHKDF::platformDeriveBits):
* Source/WebCore/crypto/openssl/CryptoAlgorithmHMACOpenSSL.cpp:
(WebCore::CryptoAlgorithmHMAC::platformSign):
(WebCore::CryptoAlgorithmHMAC::platformVerify):

Canonical link: <a href="https://commits.webkit.org/277888@main">https://commits.webkit.org/277888@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d153ccab368c40cf9a984677475f604ae48eb7be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51801 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51521 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44900 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51139 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33995 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25575 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39923 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49416 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25698 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42112 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21024 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23161 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43292 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6889 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45092 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43782 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53432 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23885 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20154 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47227 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25148 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42321 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46174 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25956 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6978 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24868 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->