### PR TITLE
Disable KVC ivar access for WebKit API objects

### DIFF
--- a/Source/WebKit/Shared/Cocoa/WKObject.h
+++ b/Source/WebKit/Shared/Cocoa/WKObject.h
@@ -23,12 +23,15 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+
+#import "Logging.h"
 #import "WKFoundation.h"
 
 #import <type_traits>
 #import <wtf/ObjCRuntimeExtras.h>
 #import <wtf/RefPtr.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/spi/cocoa/objcSPI.h>
 
 namespace API {
@@ -159,3 +162,18 @@ using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
 using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
 
 #endif // HAVE(OBJC_CUSTOM_DEALLOC)
+
+#define WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS \
++ (BOOL)accessInstanceVariablesDirectly \
+{ \
+    if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::ThrowOnKVCInstanceVariableAccess)) { \
+        static bool didLogFault; \
+        if (!didLogFault) { \
+            didLogFault = true; \
+            RELEASE_LOG_FAULT(API, "Do not access private instance variables of %{public}s via key-value coding. This will raise an exception when linking against newer SDKs.", class_getName(self)); \
+        } \
+        return YES; \
+    } \
+    return NO; \
+} \
+using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm
@@ -34,6 +34,8 @@
     API::ObjectStorage<WebKit::WebBackForwardList> _list;
 }
 
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
+
 - (void)dealloc
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKBackForwardList.class, self))

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm
@@ -33,6 +33,8 @@
     API::ObjectStorage<WebKit::WebBackForwardListItem> _item;
 }
 
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
+
 - (void)dealloc
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKBackForwardListItem.class, self))

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm
@@ -56,6 +56,8 @@ static WKErrorCode toWKErrorCode(const std::error_code& error)
 
 @implementation WKContentRuleListStore
 
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
+
 - (void)dealloc
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKContentRuleListStore.class, self))

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm
@@ -31,6 +31,8 @@
 
 @implementation WKContentWorld
 
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
+
 + (WKContentWorld *)pageWorld
 {
     return wrapper(API::ContentWorld::pageContentWorld());

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfo.mm
@@ -32,6 +32,8 @@
 
 @implementation WKContextMenuElementInfo
 
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
+
 - (void)dealloc
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKContextMenuElementInfo.class, self))

--- a/Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm
@@ -182,6 +182,8 @@ private:
 
 @implementation WKDownload
 
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
+
 - (void)cancel:(void (^)(NSData *resumeData))completionHandler
 {
     _download->cancel([completionHandler = makeBlockPtr(completionHandler)] (auto* data) {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFindConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFindConfiguration.mm
@@ -26,7 +26,11 @@
 #import "config.h"
 #import "WKFindConfiguration.h"
 
+#import "WKObject.h"
+
 @implementation WKFindConfiguration
+
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (instancetype)init
 {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFindResult.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFindResult.mm
@@ -26,7 +26,11 @@
 #import "config.h"
 #import "WKFindResultInternal.h"
 
+#import "WKObject.h"
+
 @implementation WKFindResult
+
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (instancetype)init
 {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
@@ -35,6 +35,8 @@
 
 @implementation WKFrameInfo
 
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
+
 - (void)dealloc
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKFrameInfo.class, self))

--- a/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm
@@ -66,6 +66,8 @@ private:
     HashMap<CFTypeRef, std::unique_ptr<WKHTTPCookieStoreObserver>> _observers;
 }
 
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
+
 - (void)dealloc
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKHTTPCookieStore.class, self))

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigation.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigation.mm
@@ -34,6 +34,8 @@
     API::ObjectStorage<API::Navigation> _navigation;
 }
 
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
+
 - (void)dealloc
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKNavigation.class, self))

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm
@@ -31,6 +31,8 @@
 
 @implementation WKNavigationResponse
 
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
+
 - (void)dealloc
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKNavigationResponse.class, self))

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPDFConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPDFConfiguration.mm
@@ -26,7 +26,11 @@
 #import "config.h"
 #import "WKPDFConfiguration.h"
 
+#import "WKObject.h"
+
 @implementation WKPDFConfiguration
+
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (instancetype)init
 {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -39,6 +39,8 @@
 
 @implementation WKPreferences
 
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
+
 - (instancetype)init
 {
     if (!(self = [super init]))

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -92,6 +92,8 @@ static RetainPtr<WKProcessPool>& sharedProcessPool()
 #endif // PLATFORM(IOS_FAMILY)
 }
 
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
+
 - (instancetype)_initWithConfiguration:(_WKProcessPoolConfiguration *)configuration
 {
     if (!(self = [super init]))

--- a/Source/WebKit/UIProcess/API/Cocoa/WKSecurityOrigin.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKSecurityOrigin.mm
@@ -33,6 +33,8 @@
 
 @implementation WKSecurityOrigin
 
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
+
 - (void)dealloc
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKSecurityOrigin.class, self))

--- a/Source/WebKit/UIProcess/API/Cocoa/WKSnapshotConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKSnapshotConfiguration.mm
@@ -26,6 +26,8 @@
 #import "config.h"
 #import "WKSnapshotConfigurationPrivate.h"
 
+#import "WKObject.h"
+
 @implementation WKSnapshotConfiguration {
 #if PLATFORM(MAC)
     BOOL _includesSelectionHighlighting;
@@ -33,6 +35,8 @@
 #endif
     BOOL _usesTransparentBackground;
 }
+
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (instancetype)init
 {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
@@ -51,6 +51,8 @@
 
 @implementation WKUserContentController
 
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
+
 - (instancetype)init
 {
     if (!(self = [super init]))

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserScript.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserScript.mm
@@ -33,6 +33,8 @@
 
 @implementation WKUserScript
 
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
+
 - (instancetype)initWithSource:(NSString *)source injectionTime:(WKUserScriptInjectionTime)injectionTime forMainFrameOnly:(BOOL)forMainFrameOnly
 {
     return [self initWithSource:source injectionTime:injectionTime forMainFrameOnly:forMainFrameOnly inContentWorld:WKContentWorld.pageWorld];

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -256,6 +256,8 @@ RetainPtr<NSError> nsErrorFromExceptionDetails(const WebCore::ExceptionDetails& 
 
 @implementation WKWebView
 
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
+
 - (instancetype)initWithFrame:(CGRect)frame
 {
     return [self initWithFrame:frame configuration:adoptNS([[WKWebViewConfiguration alloc] init]).get()];

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -95,6 +95,8 @@ WebKit::DragLiftDelay fromWKDragLiftDelay(_WKDragLiftDelay delay)
 
 @implementation WKWebViewConfiguration
 
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
+
 - (instancetype)init
 {
     if (!(self = [super init]))

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -132,6 +132,8 @@ static WebCore::ModalContainerObservationPolicy coreModalContainerObservationPol
 
 @implementation WKWebpagePreferences
 
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
+
 + (instancetype)defaultPreferences
 {
     return adoptNS([[self alloc] init]).autorelease();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
@@ -59,6 +59,8 @@ NSString * const _WKWebsiteDataTypeFileSystem = WKWebsiteDataTypeFileSystem;
 
 @implementation WKWebsiteDataRecord
 
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
+
 - (void)dealloc
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKWebsiteDataRecord.class, self))

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -348,6 +348,8 @@ private:
     RetainPtr<NSArray> _proxyConfigurations;
 }
 
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
+
 + (WKWebsiteDataStore *)defaultDataStore
 {
     return wrapper(WebKit::WebsiteDataStore::defaultDataStore()).autorelease();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWindowFeatures.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWindowFeatures.mm
@@ -32,6 +32,8 @@
 
 @implementation WKWindowFeatures
 
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
+
 - (void)dealloc
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKWindowFeatures.class, self))


### PR DESCRIPTION
#### 9665d3e51496261604635f0e46af865ca22d4b34
<pre>
Disable KVC ivar access for WebKit API objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=272928">https://bugs.webkit.org/show_bug.cgi?id=272928</a>
<a href="https://rdar.apple.com/126713783">rdar://126713783</a>

Reviewed by Brady Eidson.

Some apps are using KVC to change state associated with private member variables of WebKit API
objects (e.g. 277266@main). This is private API usage and we should disallow it.

On old SDKs we log a fault when we detect problematic access. When linking against newer SDKs, we
allow Foundation to throw an exception.

* Source/WebKit/Shared/Cocoa/WKObject.h:
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfo.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKFindConfiguration.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKFindResult.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKNavigation.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKPDFConfiguration.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKSecurityOrigin.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKSnapshotConfiguration.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKUserScript.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKWindowFeatures.mm:

Canonical link: <a href="https://commits.webkit.org/277751@main">https://commits.webkit.org/277751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b0e812e8e4cfc2cda2a7df5b48a117194bb5e6b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27559 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51301 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51035 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44412 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25080 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39506 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48929 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41756 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20647 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6403 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43394 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52939 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23394 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19735 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46831 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24659 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41945 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45745 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10689 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25464 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24382 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->