### PR TITLE
REGRESSION(277450@main): OOB array read with SVG animation where keyPoints = 0.

### DIFF
--- a/LayoutTests/svg/animations/animate-zero-keyPoints-should-not-crash-expected.txt
+++ b/LayoutTests/svg/animations/animate-zero-keyPoints-should-not-crash-expected.txt
@@ -1,0 +1,2 @@
+Passes if it does not crash.
+

--- a/LayoutTests/svg/animations/animate-zero-keyPoints-should-not-crash.html
+++ b/LayoutTests/svg/animations/animate-zero-keyPoints-should-not-crash.html
@@ -1,0 +1,12 @@
+<body>
+    <svg zoomAndPan="magnify">
+        <text>
+            Passes if it does not crash.
+            <animateMotion path="m 1,0" keyPoints="0" keyTimes="0" restart="always"/>
+        </text>
+    </svg>
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+    </script>
+</body>

--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -393,7 +393,7 @@ static inline double solveEpsilon(double duration) { return 1 / (200 * duration)
 
 const Vector<float>& SVGAnimationElement::keyTimes() const
 {
-    return calcMode() == CalcMode::Paced ? m_keyTimesForPaced : m_keyTimesFromAttribute;
+    return (calcMode() == CalcMode::Paced && animationMode() != AnimationMode::Path) ? m_keyTimesForPaced : m_keyTimesFromAttribute;
 }
 
 unsigned SVGAnimationElement::calculateKeyTimesIndex(float percent) const
@@ -589,7 +589,7 @@ void SVGAnimationElement::startedActiveInterval()
         if (calcMode == CalcMode::Paced && m_animationValid)
             calculateKeyTimesForCalcModePaced();
     } else if (animationMode == AnimationMode::Path)
-        m_animationValid = calcMode == CalcMode::Paced || !hasAttributeWithoutSynchronization(SVGNames::keyPointsAttr) || (keyTimes.size() > 1 && keyTimes.size() == m_keyPoints.size());
+        m_animationValid = !hasAttributeWithoutSynchronization(SVGNames::keyPointsAttr) || (keyTimes.size() > 1 && keyTimes.size() == m_keyPoints.size());
 }
 
 void SVGAnimationElement::updateAnimation(float percent, unsigned repeatCount)


### PR DESCRIPTION
#### 53e67f679530f17b29fa09c1ca2af78cb1b0e0e4
<pre>
REGRESSION(277450@main): OOB array read with SVG animation where keyPoints = 0.
<a href="https://bugs.webkit.org/show_bug.cgi?id=272929">https://bugs.webkit.org/show_bug.cgi?id=272929</a>
<a href="https://rdar.apple.com/126636733">rdar://126636733</a>

Reviewed by Said Abou-Hallawa.

This change makes a couple additional, similar changes to the original changes
to better track the SVG spec. (See the original bug for more information.)

* LayoutTests/svg/animations/animate-zero-keyPoints-should-not-crash-expected.txt: Added.
* LayoutTests/svg/animations/animate-zero-keyPoints-should-not-crash.html: Added.
* Source/WebCore/svg/SVGAnimationElement.cpp:
(WebCore::SVGAnimationElement::keyTimes const):
(WebCore::SVGAnimationElement::startedActiveInterval):

Canonical link: <a href="https://commits.webkit.org/278212@main">https://commits.webkit.org/278212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1a7f24f7858af91980c66c3e844390c392b9bec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49785 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/1994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53031 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/465 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/31 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40627 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51885 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26622 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42850 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21743 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24073 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30 "Found 1 new test failure: http/tests/media/hls/track-webvtt-multitracks.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8158 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45979 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/42 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54612 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24879 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/33 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48013 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26139 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42979 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47040 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10937 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26994 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25867 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->