### PR TITLE
Ensure RemoteScrollbarsController is used by scrollable areas with async scrolling

### DIFF
--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbars-controller-type-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbars-controller-type-expected.txt
@@ -1,0 +1,9 @@
+Ensure scrollbars controller state is correct for scroller type
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS window.internals.scrollbarsControllerTypeForNode(svgScroller) is "ScrollbarsControllerMac"
+PASS window.internals.scrollbarsControllerTypeForNode(scroller) is "RemoteScrollbarsController"
+PASS window.internals.scrollbarsControllerTypeForNode() is "RemoteScrollbarsController"
+

--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbars-controller-type.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbars-controller-type.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ MockScrollbarsEnabled=false AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        body {
+            height: 1000px;
+        }
+        .scroller {
+            width: 100px;
+            height: 100px;
+            border: 1px solid black;
+            overflow: scroll;
+        }
+        .contents {
+            width: 100%;
+            height: 200%;
+        }
+    </style>
+    <script src="../../../../resources/js-test.js"></script>
+    <script src="../../../../resources/ui-helper.js"></script>
+    
+    <script>
+        jsTestIsAsync = true;
+
+        if (window.internals)
+            internals.setUsesOverlayScrollbars(true);
+
+        async function doTest()
+        {
+            description('Ensure scrollbars controller state is correct for scroller type');
+            if (window.testRunner)
+                testRunner.waitUntilDone();
+            await UIHelper.renderingUpdate();
+            svgScroller = document.getElementById('svgScroller');
+            shouldBeEqualToString('window.internals.scrollbarsControllerTypeForNode(svgScroller)', 'ScrollbarsControllerMac');
+
+            scroller = document.getElementById('scroller');
+            shouldBeEqualToString('window.internals.scrollbarsControllerTypeForNode(scroller)', window.internals.isUsingUISideCompositing() ? 'RemoteScrollbarsController' : 'ScrollbarsControllerMac');
+            shouldBeEqualToString('window.internals.scrollbarsControllerTypeForNode()', window.internals.isUsingUISideCompositing() ? 'RemoteScrollbarsController' : 'ScrollbarsControllerMac');
+
+            testRunner.notifyDone();
+        }
+
+        window.addEventListener('load', () => {
+            doTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div id="scroller" class="scroller">
+        <div class="contents"></div>
+    </div>
+
+    <svg id="hello" width="400" height="400">
+        <foreignObject x="0" y="0" width="400" height="400">
+
+            <div id="svgScroller" class="scroller">
+                <div class="contents">
+                </div>
+            </div>
+        </foreignObject>
+    </svg>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/platform/mac-monterey-wk2/fast/scrolling/mac/scrollbars/scrollbars-controller-type-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2/fast/scrolling/mac/scrollbars/scrollbars-controller-type-expected.txt
@@ -1,0 +1,9 @@
+Ensure scrollbars controller state is correct for scroller type
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS window.internals.scrollbarsControllerTypeForNode(svgScroller) is "ScrollbarsControllerMac"
+PASS window.internals.scrollbarsControllerTypeForNode(scroller) is "ScrollbarsControllerMac"
+PASS window.internals.scrollbarsControllerTypeForNode() is "ScrollbarsControllerMac"
+

--- a/LayoutTests/platform/mac-ventura-wk2/fast/scrolling/mac/scrollbars/scrollbars-controller-type-expected.txt
+++ b/LayoutTests/platform/mac-ventura-wk2/fast/scrolling/mac/scrollbars/scrollbars-controller-type-expected.txt
@@ -1,0 +1,9 @@
+Ensure scrollbars controller state is correct for scroller type
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS window.internals.scrollbarsControllerTypeForNode(svgScroller) is "ScrollbarsControllerMac"
+PASS window.internals.scrollbarsControllerTypeForNode(scroller) is "ScrollbarsControllerMac"
+PASS window.internals.scrollbarsControllerTypeForNode() is "ScrollbarsControllerMac"
+

--- a/Source/WebCore/page/ChromeClient.cpp
+++ b/Source/WebCore/page/ChromeClient.cpp
@@ -50,9 +50,10 @@ RefPtr<ImageBuffer> ChromeClient::sinkIntoImageBuffer(std::unique_ptr<WebCore::S
     return SerializedImageBuffer::sinkIntoImageBuffer(WTFMove(imageBuffer));
 }
 
-std::unique_ptr<ScrollbarsController> ChromeClient::createScrollbarsController(Page&, ScrollableArea&) const
+
+void ChromeClient::ensureScrollbarsController(Page&, ScrollableArea& area) const
 {
-    return nullptr;
+    area.ScrollableArea::createScrollbarsController();
 }
 
 }

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -433,7 +433,7 @@ public:
     virtual bool layerTreeStateIsFrozen() const { return false; }
 
     virtual RefPtr<ScrollingCoordinator> createScrollingCoordinator(Page&) const { return nullptr; }
-    WEBCORE_EXPORT virtual std::unique_ptr<ScrollbarsController> createScrollbarsController(Page&, ScrollableArea&) const;
+    WEBCORE_EXPORT virtual void ensureScrollbarsController(Page&, ScrollableArea&) const;
 
     virtual bool canEnterVideoFullscreen(HTMLMediaElementEnums::VideoFullscreenMode) const { return false; }
     virtual bool supportsVideoFullscreen(HTMLMediaElementEnums::VideoFullscreenMode) { return false; }

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -5599,14 +5599,10 @@ void LocalFrameView::setScrollingPerformanceTestingEnabled(bool scrollingPerform
 void LocalFrameView::createScrollbarsController()
 {
     auto* page = m_frame->page();
-    if (page) {
-        if (auto scrollbarController = page->chrome().client().createScrollbarsController(*page, *this)) {
-            setScrollbarsController(WTFMove(scrollbarController));
-            return;
-        }
-    }
+    if (!page)
+        return;
 
-    ScrollView::createScrollbarsController();
+    page->chrome().client().ensureScrollbarsController(*page, *this);
 }
 
 void LocalFrameView::didAddScrollbar(Scrollbar* scrollbar, ScrollbarOrientation orientation)

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -224,6 +224,8 @@ public:
     ScrollAnimator* existingScrollAnimator() const { return m_scrollAnimator.get(); }
 
     WEBCORE_EXPORT ScrollbarsController& scrollbarsController() const;
+    ScrollbarsController* existingScrollbarsController() const { return m_scrollbarsController.get(); }
+    WEBCORE_EXPORT virtual void createScrollbarsController();
 
     virtual bool isActive() const = 0;
     WEBCORE_EXPORT virtual void invalidateScrollbar(Scrollbar&, const IntRect&);
@@ -434,6 +436,8 @@ public:
     virtual void updateScrollPositionForScrollAnchoringController() { }
     virtual void invalidateScrollAnchoringElement() { }
 
+    WEBCORE_EXPORT void setScrollbarsController(std::unique_ptr<ScrollbarsController>&&);
+
 protected:
     WEBCORE_EXPORT ScrollableArea();
     WEBCORE_EXPORT virtual ~ScrollableArea();
@@ -451,9 +455,6 @@ protected:
 #endif
 
     bool hasLayerForScrollCorner() const;
-
-    WEBCORE_EXPORT virtual void createScrollbarsController();
-    WEBCORE_EXPORT void setScrollbarsController(std::unique_ptr<ScrollbarsController>&&);
 
     WEBCORE_EXPORT LayoutRect getRectToExposeForScrollIntoView(const LayoutRect& visibleBounds, const LayoutRect& exposeRect, const ScrollAlignment& alignX, const ScrollAlignment& alignY, const std::optional<LayoutRect> = std::nullopt) const;
 

--- a/Source/WebCore/platform/ScrollbarsController.h
+++ b/Source/WebCore/platform/ScrollbarsController.h
@@ -52,6 +52,10 @@ public:
     bool scrollbarAnimationsUnsuspendedByUserInteraction() const { return m_scrollbarAnimationsUnsuspendedByUserInteraction; }
     void setScrollbarAnimationsUnsuspendedByUserInteraction(bool unsuspended) { m_scrollbarAnimationsUnsuspendedByUserInteraction = unsuspended; }
     
+    WEBCORE_EXPORT virtual bool isRemoteScrollbarsController() const { return false; }
+    WEBCORE_EXPORT virtual bool isScrollbarsControllerMac() const { return false; }
+    WEBCORE_EXPORT virtual bool isScrollbarsControllerMock() const { return false; }
+
     bool shouldSuspendScrollbarAnimations() const;
 
     virtual void notifyContentAreaScrolled(const FloatSize&) { }
@@ -92,7 +96,7 @@ public:
 
     WEBCORE_EXPORT virtual String horizontalScrollbarStateForTesting() const { return emptyString(); }
     WEBCORE_EXPORT virtual String verticalScrollbarStateForTesting() const { return emptyString(); }
-    
+
     WEBCORE_EXPORT virtual void setScrollbarVisibilityState(ScrollbarOrientation, bool) { }
 
     WEBCORE_EXPORT virtual bool shouldDrawIntoScrollbarLayer(Scrollbar&) const { return true; }

--- a/Source/WebCore/platform/mac/ScrollbarsControllerMac.h
+++ b/Source/WebCore/platform/mac/ScrollbarsControllerMac.h
@@ -49,6 +49,8 @@ public:
     explicit ScrollbarsControllerMac(ScrollableArea&);
     ~ScrollbarsControllerMac();
 
+    bool isScrollbarsControllerMac() const final { return true; }
+
     void notifyContentAreaScrolled(const FloatSize& delta) final;
 
     void cancelAnimations() final;
@@ -124,5 +126,9 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ScrollbarsControllerMac)
+    static bool isType(const WebCore::ScrollbarsController& controller) { return controller.isScrollbarsControllerMac(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/mock/ScrollbarsControllerMock.h
+++ b/Source/WebCore/platform/mock/ScrollbarsControllerMock.h
@@ -45,6 +45,7 @@ class ScrollbarsControllerMock final : public ScrollbarsController {
 public:
     ScrollbarsControllerMock(ScrollableArea&, Function<void(const String&)>&&);
     virtual ~ScrollbarsControllerMock();
+    bool isScrollbarsControllerMock() const final { return true; }
 
 private:
 
@@ -67,3 +68,6 @@ private:
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ScrollbarsControllerMock)
+    static bool isType(const WebCore::ScrollbarsController& controller) { return controller.isScrollbarsControllerMock(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -5303,6 +5303,8 @@ ScrollingNodeID RenderLayerCompositor::updateScrollingNodeForScrollingRole(Rende
             if (auto* scrollableArea = layer.scrollableArea())
                 scrollingCoordinator->setScrollingNodeScrollableAreaGeometry(newNodeID, *scrollableArea);
         }
+        if (auto* scrollableArea = layer.scrollableArea())
+            page().chrome().client().ensureScrollbarsController(page(), *scrollableArea);
     }
 
     return newNodeID;

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -847,14 +847,7 @@ bool RenderLayerScrollableArea::canShowNonOverlayScrollbars() const
 
 void RenderLayerScrollableArea::createScrollbarsController()
 {
-    if (usesAsyncScrolling()) {
-        if (auto scrollbarController = m_layer.page().chrome().client().createScrollbarsController(m_layer.page(), *this)) {
-            setScrollbarsController(WTFMove(scrollbarController));
-            return;
-        }
-    }
-
-    ScrollableArea::createScrollbarsController();
+    m_layer.page().chrome().client().ensureScrollbarsController(m_layer.page(), *this);
 }
 
 static inline RenderElement* rendererForScrollbar(RenderLayerModelObject& renderer)

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -199,6 +199,7 @@
 #include "SWClientConnection.h"
 #include "ScriptController.h"
 #include "ScriptedAnimationController.h"
+#include "ScrollbarsControllerMock.h"
 #include "ScrollingCoordinator.h"
 #include "ScrollingMomentumCalculator.h"
 #include "SecurityOrigin.h"
@@ -356,6 +357,7 @@
 
 #if PLATFORM(MAC)
 #include "GraphicsChecksMac.h"
+#include "ScrollbarsControllerMac.h"
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -3381,6 +3383,27 @@ ExceptionOr<String> Internals::verticalScrollbarState(Node* node) const
 
     auto* scrollableArea = areaOrException.releaseReturnValue();
     return scrollableArea->verticalScrollbarStateForTesting();
+}
+
+static String scrollbarsControllerTypeString(ScrollbarsController& controller)
+{
+#if PLATFORM(MAC)
+    if (is<ScrollbarsControllerMac>(controller))
+        return "ScrollbarsControllerMac"_s;
+#endif
+    if (is<ScrollbarsControllerMock>(controller))
+        return "ScrollbarsControllerMock"_s;
+    return "RemoteScrollbarsController"_s;
+}
+
+ExceptionOr<String> Internals::scrollbarsControllerTypeForNode(Node* node) const
+{
+    auto areaOrException = scrollableAreaForNode(node);
+    if (areaOrException.hasException())
+        return areaOrException.releaseException();
+
+    auto* scrollableArea = areaOrException.releaseReturnValue();
+    return scrollbarsControllerTypeString(scrollableArea->scrollbarsController());
 }
 
 ExceptionOr<String> Internals::scrollingStateTreeAsText() const

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -515,6 +515,8 @@ public:
     ExceptionOr<String> horizontalScrollbarState(Node*) const;
     ExceptionOr<String> verticalScrollbarState(Node*) const;
 
+    ExceptionOr<String> scrollbarsControllerTypeForNode(Node*) const;
+
     ExceptionOr<String> scrollingStateTreeAsText() const;
     ExceptionOr<String> scrollingTreeAsText() const;
     ExceptionOr<bool> haveScrollingTree() const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -713,6 +713,8 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     boolean scrollbarUsingDarkAppearance(optional Node? node = null);
     DOMString horizontalScrollbarState(optional Node? node = null);
     DOMString verticalScrollbarState(optional Node? node = null);
+    
+    DOMString scrollbarsControllerTypeForNode(optional Node? node = null);
 
     DOMString scrollingStateTreeAsText();
     DOMString scrollingTreeAsText();

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1668,12 +1668,7 @@ void UnifiedPDFPlugin::createScrollbarsController()
     if (!page)
         return;
 
-    if (auto scrollbarController = page->chrome().client().createScrollbarsController(*page, *this)) {
-        setScrollbarsController(WTFMove(scrollbarController));
-        return;
-    }
-
-    PDFPluginBase::createScrollbarsController();
+    page->chrome().client().ensureScrollbarsController(*page, *this);
 }
 
 DelegatedScrollingMode UnifiedPDFPlugin::scrollingMode() const

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -297,7 +297,7 @@ private:
 #endif
 
 #if PLATFORM(MAC)
-    std::unique_ptr<WebCore::ScrollbarsController> createScrollbarsController(WebCore::Page&, WebCore::ScrollableArea&) const final;
+    void ensureScrollbarsController(WebCore::Page&, WebCore::ScrollableArea&) const final;
 #endif
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h
@@ -60,6 +60,8 @@ public:
 
     void updateScrollbarStyle() final;
 
+    bool isRemoteScrollbarsController() const final { return true; }
+
 private:
     bool m_horizontalOverlayScrollbarIsVisible { false };
     bool m_verticalOverlayScrollbarIsVisible { false };
@@ -70,5 +72,9 @@ private:
 };
 
 } // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::RemoteScrollbarsController)
+    static bool isType(const WebCore::ScrollbarsController& controller) { return controller.isRemoteScrollbarsController(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 5b9a2467dd21e23e6ac66ee621f68b35611b0f6d
<pre>
Ensure RemoteScrollbarsController is used by scrollable areas with async scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=272935">https://bugs.webkit.org/show_bug.cgi?id=272935</a>
<a href="https://rdar.apple.com/126719107">rdar://126719107</a>

Reviewed by Simon Fraser.

After <a href="https://commits.webkit.org/277015@main">https://commits.webkit.org/277015@main</a> added use of usesAsyncScrolling to determine the scrollbars
controller type, and since usesAsyncScrolling is not correct prior to layer creation, ensure creation of
a RemoteScrollbarsController after layer creation if the scrollable area does use async scrolling.

* Source/WebCore/platform/ScrollableArea.h:
(WebCore::ScrollableArea::updateScrollbarsControllerForLayerCreation):
(WebCore::ScrollableArea::hasRemoteScrollbarsController):
* Source/WebCore/platform/ScrollbarsController.h:
(WebCore::ScrollbarsController::isRemoteScrollbarsController):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateScrollingNodeForScrollingRole):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::updateScrollbarsControllerForLayerCreation):
(WebCore::RenderLayerScrollableArea::createScrollbarsController):
* Source/WebCore/rendering/RenderLayerScrollableArea.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createScrollbarsController const):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h:

Canonical link: <a href="https://commits.webkit.org/278517@main">https://commits.webkit.org/278517@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbaeffd591d3d2f1a2b9a3aa6ed35cd357652dec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50711 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3028 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53970 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1402 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53014 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1052 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41325 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27657 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43684 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22447 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25028 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/940 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9152 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47009 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55560 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25813 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/894 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48738 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27070 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43804 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47801 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11131 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27938 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26802 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->