### PR TITLE
Optionally include text content in InteractionRegions

### DIFF
--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -572,6 +572,20 @@ void InteractionRegionOverlay::drawRect(PageOverlay&, GraphicsContext& context, 
             context.setFillGradient(makeGradient(gradientData(defaultRadius)));
             context.fillRect(dirtyRect);
         }
+
+#if ENABLE(INTERACTION_REGION_TEXT_CONTENT)
+        FontCascadeDescription fontDescription;
+        fontDescription.setOneFamily("Helvetica"_s);
+        fontDescription.setSpecifiedSize(10);
+        fontDescription.setComputedSize(10);
+        fontDescription.setWeight(FontSelectionValue(500));
+        FontCascade font(WTFMove(fontDescription));
+        font.update(nullptr);
+
+        TextRun textRun = TextRun(region->text);
+        context.setFillColor(Color::black);
+        context.drawText(font, textRun, region->rectInLayerCoordinates.location());
+#endif
     }
 
     stateSaver.restore();

--- a/Source/WebCore/page/InteractionRegion.h
+++ b/Source/WebCore/page/InteractionRegion.h
@@ -62,6 +62,9 @@ struct InteractionRegion {
     OptionSet<CornerMask> maskedCorners { };
     ContentHint contentHint { ContentHint::Default };
     std::optional<Path> clipPath { std::nullopt };
+#if ENABLE(INTERACTION_REGION_TEXT_CONTENT)
+    String text { };
+#endif
 
     WEBCORE_EXPORT ~InteractionRegion();
 };
@@ -75,6 +78,9 @@ inline bool operator==(const InteractionRegion& a, const InteractionRegion& b)
         && a.cornerRadius == b.cornerRadius
         && a.maskedCorners == b.maskedCorners
         && a.clipPath.has_value() == b.clipPath.has_value()
+#if ENABLE(INTERACTION_REGION_TEXT_CONTENT)
+        && a.text == b.text
+#endif
         && (!a.clipPath || &a.clipPath.value() == &b.clipPath.value());
 }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5890,6 +5890,9 @@ struct WebCore::InteractionRegion {
     OptionSet<WebCore::InteractionRegion::CornerMask> maskedCorners;
     WebCore::InteractionRegion::ContentHint contentHint;
     std::optional<WebCore::Path> clipPath;
+#if ENABLE(INTERACTION_REGION_TEXT_CONTENT)
+    String text;
+#endif
 };
 
 [Nested, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::Region::Span {


### PR DESCRIPTION
#### d40bf74e2c8fb3403b34791855c7f37db85852ee
<pre>
Optionally include text content in InteractionRegions
<a href="https://bugs.webkit.org/show_bug.cgi?id=272946">https://bugs.webkit.org/show_bug.cgi?id=272946</a>
<a href="https://rdar.apple.com/126723064">rdar://126723064</a>

Reviewed by Wenson Hsieh.

* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::InteractionRegionOverlay::drawRect):
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionTextContentForNode):
(WebCore::interactionRegionForRenderedRegion):
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/InteractionRegion.h:
(WebCore::operator==):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
Add a runtime-disabled InteractionRegion extension to extract and include the text
content of a region. Expose it in the debug overlay.

Canonical link: <a href="https://commits.webkit.org/277750@main">https://commits.webkit.org/277750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f72fc61de23d516394253d2d4cb0faa4789c5527

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51065 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44442 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50682 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25110 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39534 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48959 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25275 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41773 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20664 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22754 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42954 "Found 1 new test failure: fast/css/viewport-height-outline.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6433 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44705 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52970 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23424 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19757 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46855 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24689 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41967 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45770 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10687 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25494 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24412 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->