### PR TITLE
[JSC] Micro-optimize stricteq in Baseline JIT with bitwise-comparable constants

### DIFF
--- a/JSTests/stress/jstrict-eq-constant-simple.js
+++ b/JSTests/stress/jstrict-eq-constant-simple.js
@@ -1,0 +1,45 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test1(a) {
+    if (a === true)
+        return true;
+    return false;
+}
+noInline(test1);
+
+function test2(a) {
+    if (a === false)
+        return true;
+    return false;
+}
+noInline(test2);
+
+function test3(a) {
+    if (a === null)
+        return true;
+    return false;
+}
+noInline(test3);
+
+function test4(a) {
+    if (a === void 0)
+        return true;
+    return false;
+}
+noInline(test4);
+
+for (var i = 0; i < 1e6; ++i) {
+    shouldBe(test1(42), false);
+    shouldBe(test1(true), true);
+    shouldBe(test2(42), false);
+    shouldBe(test2(false), true);
+    shouldBe(test3(42), false);
+    shouldBe(test3(undefined), false);
+    shouldBe(test3(null), true);
+    shouldBe(test4(42), false);
+    shouldBe(test4(null), false);
+    shouldBe(test4(undefined), true);
+}

--- a/JSTests/stress/jstrict-neq-constant-simple.js
+++ b/JSTests/stress/jstrict-neq-constant-simple.js
@@ -1,0 +1,45 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test1(a) {
+    if (a !== true)
+        return true;
+    return false;
+}
+noInline(test1);
+
+function test2(a) {
+    if (a !== false)
+        return true;
+    return false;
+}
+noInline(test2);
+
+function test3(a) {
+    if(a !== null)
+        return true;
+    return false;
+}
+noInline(test3);
+
+function test4(a) {
+    if (a !== void 0)
+        return true;
+    return false;
+}
+noInline(test4);
+
+for (var i = 0; i < 1e6; ++i) {
+    shouldBe(test1(42), true);
+    shouldBe(test1(true), false);
+    shouldBe(test2(42), true);
+    shouldBe(test2(false), false);
+    shouldBe(test3(42), true);
+    shouldBe(test3(undefined), true);
+    shouldBe(test3(null), false);
+    shouldBe(test4(42), true);
+    shouldBe(test4(null), true);
+    shouldBe(test4(undefined), false);
+}

--- a/JSTests/stress/strict-eq-constant-simple.js
+++ b/JSTests/stress/strict-eq-constant-simple.js
@@ -1,0 +1,37 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test1(a) {
+    return a === true;
+}
+noInline(test1);
+
+function test2(a) {
+    return a === false;
+}
+noInline(test2);
+
+function test3(a) {
+    return a === null;
+}
+noInline(test3);
+
+function test4(a) {
+    return a === void 0;
+}
+noInline(test4);
+
+for (var i = 0; i < 1e6; ++i) {
+    shouldBe(test1(42), false);
+    shouldBe(test1(true), true);
+    shouldBe(test2(42), false);
+    shouldBe(test2(false), true);
+    shouldBe(test3(42), false);
+    shouldBe(test3(undefined), false);
+    shouldBe(test3(null), true);
+    shouldBe(test4(42), false);
+    shouldBe(test4(null), false);
+    shouldBe(test4(undefined), true);
+}

--- a/JSTests/stress/strict-neq-constant-simple.js
+++ b/JSTests/stress/strict-neq-constant-simple.js
@@ -1,0 +1,37 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test1(a) {
+    return a !== true;
+}
+noInline(test1);
+
+function test2(a) {
+    return a !== false;
+}
+noInline(test2);
+
+function test3(a) {
+    return a !== null;
+}
+noInline(test3);
+
+function test4(a) {
+    return a !== void 0;
+}
+noInline(test4);
+
+for (var i = 0; i < 1e6; ++i) {
+    shouldBe(test1(42), true);
+    shouldBe(test1(true), false);
+    shouldBe(test2(42), true);
+    shouldBe(test2(false), false);
+    shouldBe(test3(42), true);
+    shouldBe(test3(undefined), true);
+    shouldBe(test3(null), false);
+    shouldBe(test4(42), true);
+    shouldBe(test4(null), true);
+    shouldBe(test4(undefined), false);
+}


### PR DESCRIPTION
#### 05eebf3077771836e4602ceaac0926ba9d5367b7
<pre>
[JSC] Micro-optimize stricteq in Baseline JIT with bitwise-comparable constants
<a href="https://bugs.webkit.org/show_bug.cgi?id=272948">https://bugs.webkit.org/show_bug.cgi?id=272948</a>
<a href="https://rdar.apple.com/126726702">rdar://126726702</a>

Reviewed by Keith Miller.

We observed stricteq with true / false / void 0 / null cases in the wild, so let&apos;s have some optimized code generation even in baseline JIT since it is simple.

* JSTests/stress/jstrict-eq-constant-simple.js: Added.
(shouldBe):
(test1):
(test2):
(test3):
(test4):
* JSTests/stress/jstrict-neq-constant-simple.js: Added.
(shouldBe):
(test1):
(test2):
(test3):
(test4):
* JSTests/stress/strict-eq-constant-simple.js: Added.
(shouldBe):
(test1):
(test2):
(test3):
(test4):
* JSTests/stress/strict-neq-constant-simple.js: Added.
(shouldBe):
(test1):
(test2):
(test3):
(test4):
* Source/JavaScriptCore/jit/JITOpcodes.cpp:
(JSC::JIT::compileOpStrictEq):
(JSC::JIT::compileOpStrictEqJump):

Canonical link: <a href="https://commits.webkit.org/277852@main">https://commits.webkit.org/277852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06c09b86559a22e17649ba5f7fbdbfb8f583f34f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/48788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27998 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/51751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51474 "Failed to checkout and rebase branch from PR 27492") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/44854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25529 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/51474 "Failed to checkout and rebase branch from PR 27492") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/49370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/25641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/51751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/51474 "Failed to checkout and rebase branch from PR 27492") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/23107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/51751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-skia~~](https://ews-build.webkit.org/#/builders/52/builds/6843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/42087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/51751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53384 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/48279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/23838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/25101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/51751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/25909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55773 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6958 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/24822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/11480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->