### PR TITLE
Refine heuristic to allow pages to run in the background

### DIFF
--- a/Source/WebKit/Shared/WebEvent.cpp
+++ b/Source/WebKit/Shared/WebEvent.cpp
@@ -29,6 +29,8 @@
 #include "Decoder.h"
 #include "Encoder.h"
 #include "WebCoreArgumentCoders.h"
+#include "WebKeyboardEvent.h"
+#include <WebCore/WindowsKeyboardCodes.h>
 
 namespace WebKit {
 
@@ -46,6 +48,23 @@ WebEvent::WebEvent(WebEventType type, OptionSet<WebEventModifier> modifiers, Wal
     , m_timestamp(timestamp)
     , m_authorizationToken(WTF::UUID::createVersion4())
 {
+}
+
+// https://html.spec.whatwg.org/multipage/interaction.html#activation-triggering-input-event
+bool WebEvent::isActivationTriggeringEvent() const
+{
+    switch (type()) {
+    case WebEventType::MouseDown:
+#if ENABLE(TOUCH_EVENTS)
+    case WebEventType::TouchEnd:
+#endif
+        return true;
+    case WebEventType::KeyDown:
+        return downcast<WebKeyboardEvent>(*this).windowsVirtualKeyCode() != VK_ESCAPE;
+    default:
+        break;
+    }
+    return false;
 }
 
 TextStream& operator<<(TextStream& ts, WebEventType eventType)

--- a/Source/WebKit/Shared/WebEvent.h
+++ b/Source/WebKit/Shared/WebEvent.h
@@ -64,6 +64,7 @@ public:
 
     WallTime timestamp() const { return m_timestamp; }
 
+    bool isActivationTriggeringEvent() const;
     WTF::UUID authorizationToken() const { return m_authorizationToken; }
 
 private:

--- a/Source/WebKit/Shared/WebKeyboardEvent.h
+++ b/Source/WebKit/Shared/WebKeyboardEvent.h
@@ -113,3 +113,7 @@ private:
 };
 
 } // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebKeyboardEvent)
+static bool isType(const WebKit::WebEvent& event) { return WebKit::WebKeyboardEvent::isKeyboardEventType(event.type()); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -289,6 +289,8 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
 #endif
 
     MonotonicTime didFinishDocumentLoadForMainFrameTimestamp;
+    MonotonicTime lastActivationTimestamp;
+    MonotonicTime didCommitLoadForMainFrameTimestamp;
 
 #if ENABLE(UI_SIDE_COMPOSITING)
     VisibleContentRectUpdateInfo lastVisibleContentRectUpdate;


### PR DESCRIPTION
#### f36bb396c3e5260f5fe9d19397e083d3e64d3844
<pre>
Refine heuristic to allow pages to run in the background
<a href="https://bugs.webkit.org/show_bug.cgi?id=272950">https://bugs.webkit.org/show_bug.cgi?id=272950</a>

Reviewed by Ben Nham.

Refine heuristic to allow pages to run in the background so that title changes
only grant background running time if:
- There was no main frame load commit in the last 5 seconds
- There was no user activation in the last 5 seconds

Our previous heuristic was too permissive.

* Source/WebKit/Shared/WebEvent.cpp:
(WebKit::WebEvent::isActivationTriggeringEvent const):
* Source/WebKit/Shared/WebEvent.h:
* Source/WebKit/Shared/WebKeyboardEvent.h:
(isType):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::sendMouseEvent):
(WebKit::WebPageProxy::sendKeyEvent):
(WebKit::WebPageProxy::sendPreventableTouchEvent):
(WebKit::WebPageProxy::sendUnpreventableTouchEvent):
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::didReceiveTitleForFrame):
* Source/WebKit/UIProcess/WebPageProxyInternals.h:

Canonical link: <a href="https://commits.webkit.org/277772@main">https://commits.webkit.org/277772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43f791ea268acf7f505f1a2df29f4dacb5f3c967

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48389 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51347 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51077 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44454 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33537 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25122 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39541 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48971 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25286 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 15 new passes 7 flakes 3 failures; Uploaded test results; 16 new passes 10 flakes 5 failures; Running compile-webkit-without-change") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41779 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20674 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22767 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6445 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44714 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43425 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52982 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23436 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19774 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46863 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24701 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41975 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45779 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25506 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6918 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24424 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->