### PR TITLE
REGRESSION(r290676?): [ iOS ] media/video-played-ranges-1.html is a flaky text failure

### DIFF
--- a/LayoutTests/media/video-played-collapse.html
+++ b/LayoutTests/media/video-played-collapse.html
@@ -63,7 +63,7 @@
                 runSilently("video.currentTime = " + startTime);
 
                 waitForEventOnce("seeked", function() {
-                    playForMillisecs(secToMilli(expectedEndTimes[1] - startTime + 0.1)); // Triggers pause()
+                    playForMillisecs(secToMilli(expectedEndTimes[1] - startTime + 0.5)); // Triggers pause()
                 });
             }
 

--- a/LayoutTests/media/video-played.js
+++ b/LayoutTests/media/video-played.js
@@ -32,9 +32,12 @@ function testRanges()
 
     testExpected("video.played.length", timeRangeCount);
     
+    // We skip played range at index 0 as it's the value of currentTime following a call to play() immediately followed by pause().
+    // The test assume that currentTime would have progressed by less than 0.01s. Experimentation shows that it could be greater than this value.
+    // Using 0.5s for now.
     for (i = 0; i < timeRangeCount; i++) {
         testExpected("video.played.start(" + (i) + ").toFixed(2)", expectedStartTimes[i]);
-        testExpected("video.played.end("   + (i) + ").toFixed(2)", expectedEndTimes[i]);
+        testExpected("video.played.end("   + (i) + ").toFixed(2) - expectedEndTimes[i] <= 0.5", true);
     }
 }
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -6744,8 +6744,6 @@ webkit.org/b/245600 fast/attachment/attachment-wrapping-action.html [ ImageOnlyF
 
 webkit.org/b/245686 fast/text/system-font-fallback.html [ ImageOnlyFailure ]
 
-webkit.org/b/245710 media/video-played-reset.html [ Pass Failure ]
-
 webkit.org/b/237547 fast/canvas/webgl/gl-teximage-imagebitmap-memory.html [ Pass Timeout ]
 
 webkit.org/b/245745 [ Debug ] svg/compositing/inline-svg-non-integer-position-display-inline-composited.html [ Skip ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -516,8 +516,6 @@ webkit.org/b/114302 platform/mac-wk2/plugins/mouse-events-scaled-iframe.html [ P
 
 webkit.org/b/114572 platform/mac-wk2/plugins/mouse-events-scaled.html [ Pass Failure ]
 
-webkit.org/b/117962 media/video-played-collapse.html [ Pass Failure ]
-
 webkit.org/b/136109 fast/multicol/mixed-opacity-fixed-test.html  [ ImageOnlyFailure ]
 
 # Reference expectation doesn't end up in compositing code path, leading to antialiasing differences.

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -715,7 +715,6 @@ webkit.org/b/137368 media/video-controls-no-scripting.html [ Pass Failure ]
 ## --- Start flaky media tests ---
 webkit.org/b/34331 http/tests/media/video-referer.html [ Pass Timeout ]
 webkit.org/b/82976 media/W3C/video/networkState/networkState_during_progress.html [ Pass Failure ]
-webkit.org/b/85525 media/video-played-reset.html [ Pass Failure ]
 webkit.org/b/112659 media/video-playing-and-pause.html [ Failure Timeout ]
 webkit.org/b/114744 media/video-layer-crash.html [ Pass Timeout Failure ]
 webkit.org/b/115048 media/media-element-play-after-eos.html [ Pass Timeout ]
@@ -1996,8 +1995,6 @@ js/dom/Promise-reject-large-string.html [ DumpJSConsoleLogInStdErr ]
 
 webkit.org/b/225670 webaudio/AudioContext/audiocontext-close-basic.html [ Slow ]
 
-webkit.org/b/223645 [ Monterey+ ] media/video-played-ranges-1.html [ Pass Failure ]
-
 # rdar://80345970 ([ Mac ] imported/w3c/web-platform-tests/workers/Worker-terminate-forever-during-evaluation.html is a flaky failure)
 imported/w3c/web-platform-tests/workers/Worker-terminate-forever-during-evaluation.html [ Pass Failure Crash ]
 
@@ -2022,8 +2019,6 @@ http/tests/preload/onload_event.html [ Pass Failure ]
 
 # rdar://80347712 ([ Monterey ] media/video-src-blob-replay.html is a flaky timeout)
 [ Monterey ] media/video-src-blob-replay.html [ Timeout ]
-
-webkit.org/b/226520 media/video-played-collapse.html [ Pass Timeout Failure ]
 
 webkit.org/b/271732 [ Ventura+ ] http/tests/workers/service/openwindow-from-notification-click.html [ Pass Failure Crash ]
 


### PR DESCRIPTION
#### 8715d40f1d7038e9f43619d153210883228d17a6
<pre>
REGRESSION(r290676?): [ iOS ] media/video-played-ranges-1.html is a flaky text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=238771">https://bugs.webkit.org/show_bug.cgi?id=238771</a>
<a href="https://rdar.apple.com/91262784">rdar://91262784</a>

Reviewed by Eric Carlson.

The test failed due to bug 270618 which was fixed in 276761@main.
However, amend test as it assumes that the value of currentTime would only progressed
by less than 0.01 following a call to play(); pause();
While likely, this isn&apos;t guaranteed particularly on a busy sytem as playback progress
happens completely in parallel to the main thread.

* LayoutTests/media/video-played-ranges-1-expected.txt:
* LayoutTests/media/video-played-reset-expected.txt:
* LayoutTests/media/video-played.js:
(testRanges):
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/277800@main">https://commits.webkit.org/277800@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7cb58662e9687c75c79df8976bd33e4eb23facb7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51387 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51103 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44480 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39565 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48997 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25314 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41805 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20695 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22798 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42981 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Passed layout tests; 10 flakes 6 failures; Uploaded test results; 9 flakes 4 failures; Running compile-webkit-without-change") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6471 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44738 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43458 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53008 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23462 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19793 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46891 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24727 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42001 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45808 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10714 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25532 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24450 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->