### PR TITLE
[JSC] Thread concurrency in DFG finalization to avoid using concurrent version

### DIFF
--- a/Source/JavaScriptCore/bytecode/ObjectPropertyCondition.cpp
+++ b/Source/JavaScriptCore/bytecode/ObjectPropertyCondition.cpp
@@ -122,8 +122,7 @@ bool ObjectPropertyCondition::isWatchableAssumingImpurePropertyWatchpoint(
     return isWatchableAssumingImpurePropertyWatchpoint(m_object->structure(), effort);
 }
 
-bool ObjectPropertyCondition::isWatchable(
-    Structure* structure, PropertyCondition::WatchabilityEffort effort) const
+bool ObjectPropertyCondition::isWatchable(Structure* structure, PropertyCondition::WatchabilityEffort effort) const
 {
     return m_condition.isWatchable(structure, m_object, effort);
 }
@@ -132,8 +131,14 @@ bool ObjectPropertyCondition::isWatchable(PropertyCondition::WatchabilityEffort 
 {
     if (!*this)
         return false;
-    
     return isWatchable(m_object->structure(), effort);
+}
+
+bool ObjectPropertyCondition::isWatchable(PropertyCondition::WatchabilityEffort effort, Concurrency concurrency) const
+{
+    if (!*this)
+        return false;
+    return m_condition.isWatchable(m_object->structure(), m_object, effort, concurrency);
 }
 
 bool ObjectPropertyCondition::isStillLive(VM& vm) const

--- a/Source/JavaScriptCore/bytecode/ObjectPropertyCondition.h
+++ b/Source/JavaScriptCore/bytecode/ObjectPropertyCondition.h
@@ -265,11 +265,9 @@ public:
 
     // This means that it's still valid and we could enforce validity by setting a transition
     // watchpoint on the structure, and a value change watchpoint if we're Equivalence.
-    bool isWatchable(
-        Structure*,
-        PropertyCondition::WatchabilityEffort) const;
-    bool isWatchable(
-        PropertyCondition::WatchabilityEffort) const;
+    bool isWatchable(Structure*, PropertyCondition::WatchabilityEffort) const;
+    bool isWatchable(PropertyCondition::WatchabilityEffort) const;
+    bool isWatchable(PropertyCondition::WatchabilityEffort, Concurrency) const;
     
     bool watchingRequiresStructureTransitionWatchpoint() const
     {

--- a/Source/JavaScriptCore/bytecode/PropertyCondition.h
+++ b/Source/JavaScriptCore/bytecode/PropertyCondition.h
@@ -331,8 +331,8 @@ public:
     
     // This means that it's still valid and we could enforce validity by setting a transition
     // watchpoint on the structure.
-    bool isWatchable(
-        Structure*, JSObject*, WatchabilityEffort) const;
+    bool isWatchable(Structure*, JSObject*, WatchabilityEffort) const;
+    bool isWatchable(Structure*, JSObject*, WatchabilityEffort, Concurrency) const;
     
     bool watchingRequiresStructureTransitionWatchpoint() const
     {
@@ -364,7 +364,7 @@ public:
     PropertyCondition attemptToMakeReplacementWithoutBarrier(JSObject* base) const;
 
 private:
-    bool isWatchableWhenValid(Structure*, WatchabilityEffort) const;
+    bool isWatchableWhenValid(Structure*, WatchabilityEffort, Concurrency) const;
 
     Header m_header;
     union {

--- a/Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.cpp
@@ -37,7 +37,7 @@ namespace JSC { namespace DFG {
 bool ArrayBufferViewWatchpointAdaptor::add(CodeBlock* codeBlock, JSArrayBufferView* view, WatchpointCollector& collector)
 {
     return collector.addWatchpoint([&](CodeBlockJettisoningWatchpoint& watchpoint) {
-        if (hasBeenInvalidated(view))
+        if (hasBeenInvalidated(view, collector.concurrency()))
             return false;
 
         // view is already frozen. If it is deallocated, jettisoning happens.
@@ -58,7 +58,7 @@ bool ArrayBufferViewWatchpointAdaptor::add(CodeBlock* codeBlock, JSArrayBufferVi
 bool SymbolTableAdaptor::add(CodeBlock* codeBlock, SymbolTable* symbolTable, WatchpointCollector& collector)
 {
     return collector.addWatchpoint([&](CodeBlockJettisoningWatchpoint& watchpoint) {
-        if (hasBeenInvalidated(symbolTable))
+        if (hasBeenInvalidated(symbolTable, collector.concurrency()))
             return false;
 
         // symbolTable is already frozen strongly.
@@ -71,7 +71,7 @@ bool SymbolTableAdaptor::add(CodeBlock* codeBlock, SymbolTable* symbolTable, Wat
 bool FunctionExecutableAdaptor::add(CodeBlock* codeBlock, FunctionExecutable* executable, WatchpointCollector& collector)
 {
     return collector.addWatchpoint([&](CodeBlockJettisoningWatchpoint& watchpoint) {
-        if (hasBeenInvalidated(executable))
+        if (hasBeenInvalidated(executable, collector.concurrency()))
             return false;
 
         // executable is already frozen strongly.
@@ -88,7 +88,7 @@ bool AdaptiveStructureWatchpointAdaptor::add(CodeBlock* codeBlock, const ObjectP
     switch (key.kind()) {
     case PropertyCondition::Equivalence: {
         return collector.addAdaptiveInferredPropertyValueWatchpoint([&](AdaptiveInferredPropertyValueWatchpoint& watchpoint) {
-            if (hasBeenInvalidated(key))
+            if (hasBeenInvalidated(key, collector.concurrency()))
                 return false;
 
             watchpoint.initialize(key, codeBlock);
@@ -98,7 +98,7 @@ bool AdaptiveStructureWatchpointAdaptor::add(CodeBlock* codeBlock, const ObjectP
     }
     default: {
         return collector.addAdaptiveStructureWatchpoint([&](AdaptiveStructureWatchpoint& watchpoint) {
-            if (hasBeenInvalidated(key))
+            if (hasBeenInvalidated(key, collector.concurrency()))
                 return false;
 
             watchpoint.initialize(key, codeBlock);


### PR DESCRIPTION
#### 89f0eb31727334314b00125e000b064215d07cb7
<pre>
[JSC] Thread concurrency in DFG finalization to avoid using concurrent version
<a href="https://bugs.webkit.org/show_bug.cgi?id=272959">https://bugs.webkit.org/show_bug.cgi?id=272959</a>
<a href="https://rdar.apple.com/126737554">rdar://126737554</a>

Reviewed by Keith Miller.

DFG finalization always happens on the main thread. So by threading concurrency parameter correctly to ObjectPropertyCondition,
we can avoid using getDirectConcurrently with locking.

* Source/JavaScriptCore/bytecode/ObjectPropertyCondition.cpp:
(JSC::ObjectPropertyCondition::isWatchable const):
* Source/JavaScriptCore/bytecode/ObjectPropertyCondition.h:
* Source/JavaScriptCore/bytecode/PropertyCondition.cpp:
(JSC::PropertyCondition::isWatchableWhenValid const):
(JSC::PropertyCondition::isWatchableAssumingImpurePropertyWatchpoint const):
(JSC::PropertyCondition::isWatchable const):
* Source/JavaScriptCore/bytecode/PropertyCondition.h:
* Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.cpp:
(JSC::DFG::ArrayBufferViewWatchpointAdaptor::add):
(JSC::DFG::SymbolTableAdaptor::add):
(JSC::DFG::FunctionExecutableAdaptor::add):
(JSC::DFG::AdaptiveStructureWatchpointAdaptor::add):
* Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.h:
(JSC::DFG::SetPointerAdaptor::add):
(JSC::DFG::SetPointerAdaptor::hasBeenInvalidated):
(JSC::DFG::SymbolTableAdaptor::hasBeenInvalidated):
(JSC::DFG::FunctionExecutableAdaptor::hasBeenInvalidated):
(JSC::DFG::ArrayBufferViewWatchpointAdaptor::hasBeenInvalidated):
(JSC::DFG::AdaptiveStructureWatchpointAdaptor::hasBeenInvalidated):

Canonical link: <a href="https://commits.webkit.org/277765@main">https://commits.webkit.org/277765@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8648af29b239a9232381ee053ea4c0f70713326

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27729 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51205 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44583 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33665 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25252 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49100 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/25404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/20781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/22882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6574 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/41814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/44821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53111 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/48008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/23564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/19878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/24829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/45894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/25634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55503 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6909 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/24552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/11415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->