### PR TITLE
Adopt NSTextPlaceholders for Mac.

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/NSTextInputContextSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSTextInputContextSPI.h
@@ -28,8 +28,40 @@
 #if USE(APPLE_INTERNAL_SDK)
 
 #import <AppKit/NSTextInputContext_Private.h>
+#import <AppKit/NSTextPlaceholder_Private.h>
 
-#else
+#if HAVE(NSTEXTPLACEHOLDER_RECTS)
+// Staging for rdar://126696059
+@interface NSTextSelectionRect : NSObject
+@property (nonatomic, readonly) NSRect rect;
+@property (nonatomic, readonly) NSWritingDirection writingDirection;
+@property (nonatomic, readonly) BOOL isVertical;
+@property (nonatomic, readonly) NSAffineTransform *transform;
+@end
+
+@interface NSTextPlaceholder (staging_126696059)
+@property (nonatomic, readonly) NSArray<NSTextSelectionRect *> *rects;
+@end
+
+@protocol NSTextInputClient_Async_staging_126696059
+@optional
+- (void)insertTextPlaceholderWithSize:(CGSize)size completionHandler:(void (^)(NSTextPlaceholder *))completionHandler;
+- (void)removeTextPlaceholder:(NSTextPlaceholder *)placeholder willInsertText:(BOOL)willInsertText completionHandler:(void (^)(void))completionHandler;
+@end
+#endif // HAVE(NSTEXTPLACEHOLDER_RECTS)
+
+#else // !USE(APPLE_INTERNAL_SDK)
+
+@interface NSTextSelectionRect : NSObject
+@property (nonatomic, readonly) NSRect rect;
+@property (nonatomic, readonly) NSWritingDirection writingDirection;
+@property (nonatomic, readonly) BOOL isVertical;
+@property (nonatomic, readonly) NSAffineTransform *transform;
+@end
+
+@interface NSTextPlaceholder : NSObject
+@property (nonatomic, readonly) NSArray<NSTextSelectionRect *> *rects;
+@end
 
 @interface NSTextInputContext ()
 - (void)handleEvent:(NSEvent *)event completionHandler:(void(^)(BOOL handled))completionHandler;
@@ -41,7 +73,7 @@
 #endif
 @end
 
-#endif
+#endif // USE(APPLE_INTERNAL_SDK)
 
 APPKIT_EXTERN NSString *NSTextInsertionUndoableAttributeName;
 APPKIT_EXTERN NSString *NSTextInputReplacementRangeAttributeName;

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -438,6 +438,8 @@ UIProcess/Cocoa/WKEditCommand.mm
 UIProcess/Cocoa/WKFullKeyboardAccessWatcher.mm
 UIProcess/Cocoa/WKReloadFrameErrorRecoveryAttempter.mm
 UIProcess/Cocoa/WKTextExtractionUtilities.mm
+UIProcess/Cocoa/WKTextPlaceholder.mm
+UIProcess/Cocoa/WKTextSelectionRect.mm
 UIProcess/Cocoa/WKWebViewContentProviderRegistry.mm
 UIProcess/Cocoa/XPCConnectionTerminationWatchdog.mm
 
@@ -525,7 +527,6 @@ UIProcess/ios/WKTapHighlightView.mm
 UIProcess/ios/WKTextInteractionWrapper.mm
 UIProcess/ios/WKTouchActionGestureRecognizer.mm
 UIProcess/ios/WKTouchEventsGestureRecognizer.mm
-UIProcess/ios/WKTextSelectionRect.mm
 UIProcess/ios/WKUSDPreviewView.mm
 UIProcess/ios/WKVelocityTrackingScrollView.mm
 UIProcess/ios/WKVideoView.mm

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -43,6 +43,7 @@
 #import "_WKFrameHandleInternal.h"
 #import "_WKHitTestResultInternal.h"
 #import <pal/spi/mac/NSTextFinderSPI.h>
+#import <pal/spi/mac/NSTextInputContextSPI.h>
 #import <pal/spi/mac/NSViewSPI.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 
@@ -687,6 +688,16 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (NSArray *)validAttributesForMarkedText
 {
     return _impl->validAttributesForMarkedText();
+}
+
+- (void)insertTextPlaceholderWithSize:(CGSize)size completionHandler:(void (^)(NSTextPlaceholder *))completionHandler
+{
+    _impl->insertTextPlaceholderWithSize(size, completionHandler);
+}
+
+- (void)removeTextPlaceholder:(NSTextPlaceholder *)placeholder willInsertText:(BOOL)willInsertText completionHandler:(void (^)(void))completionHandler
+{
+    _impl->removeTextPlaceholder(placeholder, willInsertText, completionHandler);
 }
 
 #if ENABLE(DRAG_SUPPORT)

--- a/Source/WebKit/UIProcess/Cocoa/WKTextPlaceholder.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextPlaceholder.h
@@ -24,18 +24,23 @@
  */
 
 #if PLATFORM(IOS_FAMILY)
-
 #import <UIKit/UIKit.h>
+#else
+#import <pal/spi/mac/NSTextInputContextSPI.h>
+#endif
 
 namespace WebCore {
-class SelectionGeometry;
+struct ElementContext;
 }
 
-@interface WKTextSelectionRect : UITextSelectionRect
+#if PLATFORM(IOS_FAMILY)
+@interface WKTextPlaceholder : UITextPlaceholder
+#elif PLATFORM(MAC)
+@interface WKTextPlaceholder : NSTextPlaceholder
+#endif
 
-- (instancetype)initWithCGRect:(CGRect)rect;
-- (instancetype)initWithSelectionGeometry:(const WebCore::SelectionGeometry&)selectionGeometry scaleFactor:(CGFloat)scaleFactor;
+- (instancetype)initWithElementContext:(const WebCore::ElementContext&)context;
+
+@property (nonatomic, readonly) const WebCore::ElementContext& elementContext;
 
 @end
-
-#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/Cocoa/WKTextPlaceholder.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextPlaceholder.mm
@@ -26,10 +26,11 @@
 #import "config.h"
 #import "WKTextPlaceholder.h"
 
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(COCOA)
 
 #import "WKTextSelectionRect.h"
 #import <WebCore/ElementContext.h>
+#import <pal/spi/mac/NSTextInputContextSPI.h>
 
 @implementation WKTextPlaceholder {
     WebCore::ElementContext _elementContext;
@@ -48,11 +49,19 @@
     return _elementContext;
 }
 
+#if PLATFORM(IOS_FAMILY)
 - (NSArray<UITextSelectionRect *> *)rects
+#elif PLATFORM(MAC)
+- (NSArray<NSTextSelectionRect *> *)rects
+#endif
 {
+#if PLATFORM(IOS_FAMILY)
     return @[ adoptNS([[WKTextSelectionRect alloc] initWithCGRect:_elementContext.boundingRect]).get() ];
+#else
+    return @[ (NSTextSelectionRect *)adoptNS([[WKTextSelectionRect alloc] initWithCGRect:_elementContext.boundingRect]).get() ];
+#endif
 }
 
 @end
 
-#endif // PLATFORM(IOS_FAMILY)
+#endif // PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.h
@@ -23,20 +23,34 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(COCOA)
 
+#if PLATFORM(IOS_FAMILY)
 #import <UIKit/UIKit.h>
+#else
+#import <pal/spi/mac/NSTextInputContextSPI.h>
+#endif
 
 namespace WebCore {
-struct ElementContext;
+class SelectionGeometry;
 }
 
-@interface WKTextPlaceholder : UITextPlaceholder
+#if PLATFORM(IOS_FAMILY)
+@interface WKTextSelectionRect : UITextSelectionRect
+#else
+@interface WKTextSelectionRect : NSObject // FIXME: Change to NSTextSelectionRect after rdar://126379463 lands
+#endif
 
-- (instancetype)initWithElementContext:(const WebCore::ElementContext&)context;
+- (instancetype)initWithCGRect:(CGRect)rect;
+- (instancetype)initWithSelectionGeometry:(const WebCore::SelectionGeometry&)selectionGeometry scaleFactor:(CGFloat)scaleFactor;
 
-@property (nonatomic, readonly) const WebCore::ElementContext& elementContext;
+#if PLATFORM(MAC)
+@property (nonatomic, readonly) NSRect rect;
+@property (nonatomic, readonly) NSWritingDirection writingDirection;
+@property (nonatomic, readonly) BOOL isVertical;
+@property (nonatomic, readonly) NSAffineTransform *transform;
+#endif
 
 @end
 
-#endif // PLATFORM(IOS_FAMILY)
+#endif // PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.mm
@@ -27,8 +27,8 @@
 #import "WKTextSelectionRect.h"
 
 #if PLATFORM(IOS_FAMILY)
-
 #import "UIKitSPI.h"
+#endif
 #import <WebCore/SelectionGeometry.h>
 
 #if HAVE(UI_TEXT_SELECTION_RECT_CUSTOM_HANDLE_INFO)
@@ -98,6 +98,7 @@
     return self;
 }
 
+#if PLATFORM(IOS_FAMILY)
 - (UIBezierPath *)_path
 {
     if (_selectionGeometry.behavior() == WebCore::SelectionRenderingBehavior::CoalesceBoundingRects)
@@ -118,6 +119,19 @@
     return result;
 }
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+- (UITextWritingDirection)writingDirection
+{
+    return _selectionGeometry.direction() == WebCore::TextDirection::LTR ? UITextWritingDirectionLeftToRight : UITextWritingDirectionRightToLeft;
+}
+ALLOW_DEPRECATED_DECLARATIONS_END
+
+- (UITextRange *)range
+{
+    return nil;
+}
+#endif
+
 #if HAVE(UI_TEXT_SELECTION_RECT_CUSTOM_HANDLE_INFO)
 
 - (WKTextSelectionRectCustomHandleInfo *)_customHandleInfo
@@ -131,24 +145,11 @@
 #endif
     return adoptNS([[WKTextSelectionRectCustomHandleInfo alloc] initWithFloatQuad:scaledQuad isHorizontal:_selectionGeometry.isHorizontal()]).autorelease();
 }
-
 #endif // HAVE(UI_TEXT_SELECTION_RECT_CUSTOM_HANDLE_INFO)
 
 - (CGRect)rect
 {
     return _selectionGeometry.rect();
-}
-
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-- (UITextWritingDirection)writingDirection
-{
-    return _selectionGeometry.direction() == WebCore::TextDirection::LTR ? UITextWritingDirectionLeftToRight : UITextWritingDirectionRightToLeft;
-}
-ALLOW_DEPRECATED_DECLARATIONS_END
-
-- (UITextRange *)range
-{
-    return nil;
 }
 
 - (BOOL)containsStart
@@ -172,5 +173,3 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 @end
-
-#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -12537,6 +12537,26 @@ void WebPageProxy::storeAppHighlight(const WebCore::AppHighlight& highlight)
 }
 #endif
 
+#if PLATFORM(COCOA)
+void WebPageProxy::insertTextPlaceholder(const IntSize& size, CompletionHandler<void(const std::optional<ElementContext>&)>&& completionHandler)
+{
+    if (!hasRunningProcess()) {
+        completionHandler({ });
+        return;
+    }
+    sendWithAsyncReply(Messages::WebPage::InsertTextPlaceholder { size }, WTFMove(completionHandler));
+}
+
+void WebPageProxy::removeTextPlaceholder(const ElementContext& placeholder, CompletionHandler<void()>&& completionHandler)
+{
+    if (!hasRunningProcess()) {
+        completionHandler();
+        return;
+    }
+    sendWithAsyncReply(Messages::WebPage::RemoveTextPlaceholder { placeholder }, WTFMove(completionHandler));
+}
+#endif
+
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
 void WebPageProxy::removeTextIndicatorStyleForID(const WTF::UUID& uuid)
 {

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -945,9 +945,6 @@ public:
         
     void setScreenIsBeingCaptured(bool);
 
-    void insertTextPlaceholder(const WebCore::IntSize&, CompletionHandler<void(const std::optional<WebCore::ElementContext>&)>&&);
-    void removeTextPlaceholder(const WebCore::ElementContext&, CompletionHandler<void()>&&);
-
     double displayedContentScale() const;
     const WebCore::FloatRect& exposedContentRect() const;
     const WebCore::FloatRect& unobscuredContentRect() const;
@@ -1067,6 +1064,11 @@ public:
     void didConcludeDrop();
 #endif
 #endif // PLATFORM(IOS_FAMILY)
+
+#if PLATFORM(COCOA)
+    void insertTextPlaceholder(const WebCore::IntSize&, CompletionHandler<void(const std::optional<WebCore::ElementContext>&)>&&);
+    void removeTextPlaceholder(const WebCore::ElementContext&, CompletionHandler<void()>&&);
+#endif
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
     void getTextIndicatorForID(WTF::UUID&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -10544,8 +10544,8 @@ static WebKit::DocumentEditingContextRequest toWebRequest(id request)
 - (void)removeTextPlaceholder:(UITextPlaceholder *)placeholder willInsertText:(BOOL)willInsertText completionHandler:(void (^)(void))completionHandler
 {
     // FIXME: Implement support for willInsertText. See <https://bugs.webkit.org/show_bug.cgi?id=208747>.
-    if (auto* wkTextPlaceholder = dynamic_objc_cast<WKTextPlaceholder>(placeholder))
-        _page->removeTextPlaceholder(wkTextPlaceholder.elementContext, makeBlockPtr(completionHandler));
+    if (RetainPtr wkTextPlaceholder = dynamic_objc_cast<WKTextPlaceholder>(placeholder))
+        _page->removeTextPlaceholder([wkTextPlaceholder elementContext], makeBlockPtr(completionHandler));
     else
         completionHandler();
 }

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -395,24 +395,6 @@ void WebPageProxy::replaceSelectedText(const String& oldText, const String& newT
     m_process->send(Messages::WebPage::ReplaceSelectedText(oldText, newText), webPageID());
 }
 
-void WebPageProxy::insertTextPlaceholder(const IntSize& size, CompletionHandler<void(const std::optional<ElementContext>&)>&& completionHandler)
-{
-    if (!hasRunningProcess()) {
-        completionHandler({ });
-        return;
-    }
-    sendWithAsyncReply(Messages::WebPage::InsertTextPlaceholder { size }, WTFMove(completionHandler));
-}
-
-void WebPageProxy::removeTextPlaceholder(const ElementContext& placeholder, CompletionHandler<void()>&& completionHandler)
-{
-    if (!hasRunningProcess()) {
-        completionHandler();
-        return;
-    }
-    sendWithAsyncReply(Messages::WebPage::RemoveTextPlaceholder { placeholder }, WTFMove(completionHandler));
-}
-
 void WebPageProxy::requestAutocorrectionData(const String& textForAutocorrection, CompletionHandler<void(WebAutocorrectionData)>&& callback)
 {
     if (!hasRunningProcess()) {

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -58,6 +58,8 @@ OBJC_CLASS NSImmediateActionGestureRecognizer;
 OBJC_CLASS NSMenu;
 OBJC_CLASS NSPopover;
 OBJC_CLASS NSTextInputContext;
+OBJC_CLASS NSTextPlaceholder;
+OBJC_CLASS NSTextSelectionRect;
 OBJC_CLASS NSView;
 OBJC_CLASS QLPreviewPanel;
 OBJC_CLASS WKAccessibilitySettingsObserver;
@@ -527,6 +529,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     RefPtr<ViewSnapshot> takeViewSnapshot();
     void saveBackForwardSnapshotForCurrentItem();
     void saveBackForwardSnapshotForItem(WebBackForwardListItem&);
+
+    void insertTextPlaceholderWithSize(CGSize, void(^completionHandler)(NSTextPlaceholder *));
+    void removeTextPlaceholder(NSTextPlaceholder *, bool willInsertText, void(^completionHandler)());
 
     WKSafeBrowsingWarning *safeBrowsingWarning() { return m_safeBrowsingWarning.get(); }
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2349,7 +2349,6 @@
 		CE11AD521CBC482F00681EE5 /* CodeSigning.h in Headers */ = {isa = PBXBuildFile; fileRef = CE11AD511CBC482F00681EE5 /* CodeSigning.h */; };
 		CE1A0BD71A48E6C60054EF74 /* TextInputSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = CE1A0BD11A48E6C60054EF74 /* TextInputSPI.h */; };
 		CE21215F240EE571006ED443 /* WKTextPlaceholder.h in Headers */ = {isa = PBXBuildFile; fileRef = CE21215D240EE571006ED443 /* WKTextPlaceholder.h */; };
-		CE212160240EE571006ED443 /* WKTextPlaceholder.mm in Sources */ = {isa = PBXBuildFile; fileRef = CE21215E240EE571006ED443 /* WKTextPlaceholder.mm */; };
 		CE45945C240F88550078019F /* WKTextSelectionRect.h in Headers */ = {isa = PBXBuildFile; fileRef = CE45945A240F85B90078019F /* WKTextSelectionRect.h */; };
 		CE550E152283752200D28791 /* InsertTextOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = CE550E12228373C800D28791 /* InsertTextOptions.h */; };
 		CE5B4C8821B73D870022E64F /* WKSyntheticFlagsChangedWebEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = CE5B4C8621B73D870022E64F /* WKSyntheticFlagsChangedWebEvent.h */; };
@@ -7889,10 +7888,10 @@
 		CE11AD4F1CBC47F800681EE5 /* CodeSigning.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CodeSigning.mm; sourceTree = "<group>"; };
 		CE11AD511CBC482F00681EE5 /* CodeSigning.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CodeSigning.h; sourceTree = "<group>"; };
 		CE1A0BD11A48E6C60054EF74 /* TextInputSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextInputSPI.h; sourceTree = "<group>"; };
-		CE21215D240EE571006ED443 /* WKTextPlaceholder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKTextPlaceholder.h; path = ios/WKTextPlaceholder.h; sourceTree = "<group>"; };
-		CE21215E240EE571006ED443 /* WKTextPlaceholder.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKTextPlaceholder.mm; path = ios/WKTextPlaceholder.mm; sourceTree = "<group>"; };
-		CE45945A240F85B90078019F /* WKTextSelectionRect.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKTextSelectionRect.h; path = ios/WKTextSelectionRect.h; sourceTree = "<group>"; };
-		CE45945B240F85B90078019F /* WKTextSelectionRect.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKTextSelectionRect.mm; path = ios/WKTextSelectionRect.mm; sourceTree = "<group>"; };
+		CE21215D240EE571006ED443 /* WKTextPlaceholder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKTextPlaceholder.h; sourceTree = "<group>"; };
+		CE21215E240EE571006ED443 /* WKTextPlaceholder.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKTextPlaceholder.mm; sourceTree = "<group>"; };
+		CE45945A240F85B90078019F /* WKTextSelectionRect.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKTextSelectionRect.h; sourceTree = "<group>"; };
+		CE45945B240F85B90078019F /* WKTextSelectionRect.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKTextSelectionRect.mm; sourceTree = "<group>"; };
 		CE550E12228373C800D28791 /* InsertTextOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InsertTextOptions.h; sourceTree = "<group>"; };
 		CE5B4C8621B73D870022E64F /* WKSyntheticFlagsChangedWebEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKSyntheticFlagsChangedWebEvent.h; path = ios/WKSyntheticFlagsChangedWebEvent.h; sourceTree = "<group>"; };
 		CE5B4C8721B73D870022E64F /* WKSyntheticFlagsChangedWebEvent.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKSyntheticFlagsChangedWebEvent.mm; path = ios/WKSyntheticFlagsChangedWebEvent.mm; sourceTree = "<group>"; };
@@ -9541,6 +9540,10 @@
 				F48EC3562B7585A300D1B886 /* WKTextExtractionUtilities.h */,
 				F48EC3542B7585A300D1B886 /* WKTextExtractionUtilities.mm */,
 				4447F01F2BC833F0006988E9 /* WKTextIndicatorStyleType.h */,
+				CE21215D240EE571006ED443 /* WKTextPlaceholder.h */,
+				CE21215E240EE571006ED443 /* WKTextPlaceholder.mm */,
+				CE45945A240F85B90078019F /* WKTextSelectionRect.h */,
+				CE45945B240F85B90078019F /* WKTextSelectionRect.mm */,
 				2D7AAFD218C8640600A7ACD4 /* WKWebViewContentProvider.h */,
 				2DC6D9C118C44A610043BAD4 /* WKWebViewContentProviderRegistry.h */,
 				2DC6D9C218C44A610043BAD4 /* WKWebViewContentProviderRegistry.mm */,
@@ -11075,10 +11078,6 @@
 				F4E8912F2AB7C344005AEBC3 /* WKTapHighlightView.mm */,
 				F4C359512AF18F620083B0EA /* WKTextInteractionWrapper.h */,
 				F4C359522AF18F620083B0EA /* WKTextInteractionWrapper.mm */,
-				CE21215D240EE571006ED443 /* WKTextPlaceholder.h */,
-				CE21215E240EE571006ED443 /* WKTextPlaceholder.mm */,
-				CE45945A240F85B90078019F /* WKTextSelectionRect.h */,
-				CE45945B240F85B90078019F /* WKTextSelectionRect.mm */,
 				71A676A422C62318007D6295 /* WKTouchActionGestureRecognizer.h */,
 				71A676A522C62318007D6295 /* WKTouchActionGestureRecognizer.mm */,
 				F4F4757F2A4F3D6D0004197B /* WKTouchEventsGestureRecognizer.h */,
@@ -19843,7 +19842,6 @@
 				5CA26D83217AD1B800F97A35 /* WKSafeBrowsingWarning.mm in Sources */,
 				1DB01944211CF005009FB3E8 /* WKShareSheet.mm in Sources */,
 				7A78FF332241919B0096483E /* WKStorageAccessAlert.mm in Sources */,
-				CE212160240EE571006ED443 /* WKTextPlaceholder.mm in Sources */,
 				C14D306924B79BE000480387 /* XPCEndpoint.mm in Sources */,
 				C14D306A24B79BE400480387 /* XPCEndpointClient.mm in Sources */,
 			);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -854,15 +854,17 @@ public:
 
     bool handlesPageScaleGesture();
 
+#if PLATFORM(COCOA)
+    void insertTextPlaceholder(const WebCore::IntSize&, CompletionHandler<void(const std::optional<WebCore::ElementContext>&)>&&);
+    void removeTextPlaceholder(const WebCore::ElementContext&, CompletionHandler<void()>&&);
+#endif
+
 #if PLATFORM(IOS_FAMILY)
     void textInputContextsInRect(WebCore::FloatRect, CompletionHandler<void(const Vector<WebCore::ElementContext>&)>&&);
     void focusTextInputContextAndPlaceCaret(const WebCore::ElementContext&, const WebCore::IntPoint&, CompletionHandler<void(bool)>&&);
 
     bool shouldRevealCurrentSelectionAfterInsertion() const { return m_shouldRevealCurrentSelectionAfterInsertion; }
     void setShouldRevealCurrentSelectionAfterInsertion(bool);
-
-    void insertTextPlaceholder(const WebCore::IntSize&, CompletionHandler<void(const std::optional<WebCore::ElementContext>&)>&&);
-    void removeTextPlaceholder(const WebCore::ElementContext&, CompletionHandler<void()>&&);
 
     WebCore::FloatSize screenSize() const;
     WebCore::FloatSize availableScreenSize() const;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -135,8 +135,6 @@ messages -> WebPage LegacyReceiver {
     RequestDocumentEditingContext(struct WebKit::DocumentEditingContextRequest request) -> (struct WebKit::DocumentEditingContext response)
 GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType command)
     SetShouldRevealCurrentSelectionAfterInsertion(bool shouldRevealCurrentSelectionAfterInsertion)
-    InsertTextPlaceholder(WebCore::IntSize size) -> (std::optional<WebCore::ElementContext> placeholder)
-    RemoveTextPlaceholder(struct WebCore::ElementContext placeholder) -> ()
     TextInputContextsInRect(WebCore::FloatRect rect) -> (Vector<WebCore::ElementContext> contexts)
     FocusTextInputContextAndPlaceCaret(struct WebCore::ElementContext context, WebCore::IntPoint point) -> (bool success)
     ClearServiceWorkerEntitlementOverride() -> ()
@@ -375,6 +373,11 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     DidConcludeDrop()
 #endif
 
+#if PLATFORM(COCOA)
+    InsertTextPlaceholder(WebCore::IntSize size) -> (std::optional<WebCore::ElementContext> placeholder)
+    RemoveTextPlaceholder(struct WebCore::ElementContext placeholder) -> ()
+#endif
+    
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
     GetTextIndicatorForID(WTF::UUID uuid) -> (std::optional<WebCore::TextIndicatorData> textIndicator)
     UpdateTextIndicatorStyleVisibilityForID(WTF::UUID uuid, bool visible) -> ()

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -153,7 +153,6 @@
 #import <WebCore/StyleProperties.h>
 #import <WebCore/TextIndicator.h>
 #import <WebCore/TextIterator.h>
-#import <WebCore/TextPlaceholderElement.h>
 #import <WebCore/UserAgent.h>
 #import <WebCore/UserGestureIndicator.h>
 #import <WebCore/ViewportArguments.h>
@@ -4877,26 +4876,6 @@ bool WebPage::platformPrefersTextLegibilityBasedZoomScaling() const
 #else
     return false;
 #endif
-}
-
-void WebPage::insertTextPlaceholder(const IntSize& size, CompletionHandler<void(const std::optional<WebCore::ElementContext>&)>&& completionHandler)
-{
-    // Inserting the placeholder may run JavaScript, which can do anything, including frame destruction.
-    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
-    if (!frame)
-        return completionHandler({ });
-
-    auto placeholder = frame->editor().insertTextPlaceholder(size);
-    completionHandler(placeholder ? contextForElement(*placeholder) : std::nullopt);
-}
-
-void WebPage::removeTextPlaceholder(const ElementContext& placeholder, CompletionHandler<void()>&& completionHandler)
-{
-    if (auto element = elementForContext(placeholder)) {
-        if (RefPtr frame = element->document().frame())
-            frame->editor().removeTextPlaceholder(downcast<TextPlaceholderElement>(*element));
-    }
-    completionHandler();
 }
 
 void WebPage::updateSelectionWithDelta(int64_t locationDelta, int64_t lengthDelta, CompletionHandler<void()>&& completionHandler)

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -247,6 +247,7 @@ Tests/WebKitCocoa/StorageQuota.mm
 Tests/WebKitCocoa/StoreBlobThenDelete.mm
 Tests/WebKitCocoa/SystemColors.mm
 Tests/WebKitCocoa/SystemPreview.mm
+Tests/WebKitCocoa/TextPlaceholderTests.mm
 Tests/WebKitCocoa/TLSDeprecation.mm
 Tests/WebKitCocoa/TabOutOfWebView.mm
 Tests/WebKitCocoa/TestAwakener.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -2420,6 +2420,7 @@
 		44CDE4D326EE6E41009F6ACB /* TypeCastsCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = TypeCastsCocoa.mm; sourceTree = "<group>"; };
 		44CF31FB24993F66009CB6CB /* ContextMenuAction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ContextMenuAction.cpp; sourceTree = "<group>"; };
 		44D5008D26FE9ED6000EB12F /* RetainPtrARC.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = RetainPtrARC.mm; path = ns/RetainPtrARC.mm; sourceTree = "<group>"; };
+		44DBE9512BD2272900307F65 /* TextPlaceholderTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TextPlaceholderTests.mm; sourceTree = "<group>"; };
 		46061545275824B400AB613D /* WebLocks.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebLocks.mm; sourceTree = "<group>"; };
 		460C2FC827039D7D0047EF11 /* ServiceWorkerPageProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ServiceWorkerPageProtocol.h; sourceTree = "<group>"; };
 		4612C2B8210A6ABF00B788A6 /* LoadFileThenReload.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = LoadFileThenReload.mm; sourceTree = "<group>"; };
@@ -4275,6 +4276,7 @@
 				F4CD74C820FDB49600DE3794 /* TestURLSchemeHandler.mm */,
 				2D9846FB28AE0F2F00CBA70C /* TextFragments.mm */,
 				9B02E0D5235FA47D004044B2 /* TextManipulation.mm */,
+				44DBE9512BD2272900307F65 /* TextPlaceholderTests.mm */,
 				5C16F8FB230C942B0074C4A8 /* TextSize.mm */,
 				C22FA32A228F8708009D7988 /* TextWidth.mm */,
 				F3CEF6B82808F2D3001E23A5 /* TimeZoneOverride.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextPlaceholderTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextPlaceholderTests.mm
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#import "config.h"
+
+#if HAVE(NSTEXTPLACEHOLDER_RECTS)
+
+#import "PlatformUtilities.h"
+#import "Test.h"
+#import "TestWKWebView.h"
+#import "WKWebViewConfigurationExtras.h"
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WKWebViewPrivateForTesting.h>
+#import <wtf/RetainPtr.h>
+#import <wtf/Vector.h>
+
+#if PLATFORM(MAC)
+#import <pal/spi/mac/NSTextInputContextSPI.h>
+#endif
+
+RetainPtr<WKWebView> createWebViewForNSTextPlaceholder()
+{
+    WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration]);
+    [webView synchronouslyLoadHTMLString:@"<body contenteditable>Test</body><script>document.body.focus()</script>"];
+    return webView;
+}
+
+TEST(NSTextPlaceholder, InsertTextPlaceholder)
+{
+    auto webView = createWebViewForNSTextPlaceholder();
+
+    __block bool isDone = false;
+    [(id<NSTextInputClient_Async_staging_126696059>)webView.get() insertTextPlaceholderWithSize:CGSizeMake(50, 100) completionHandler:^(NSTextPlaceholder * placeholder) {
+        EXPECT_WK_STREQ("<div style=\"display: inline-block; vertical-align: top; visibility: hidden !important; width: 50px; height: 100px;\"></div>Test<script>document.body.focus()</script>", [webView stringByEvaluatingJavaScript:@"document.body.innerHTML"]);
+        isDone = true;
+    }];
+    TestWebKitAPI::Util::run(&isDone);
+}
+
+TEST(NSTextPlaceholder, InsertAndRemoveTextPlaceholderWithoutIncomingText)
+{
+    auto webView = createWebViewForNSTextPlaceholder();
+
+    __block bool isDone = false;
+    [(id<NSTextInputClient_Async_staging_126696059>)webView.get() insertTextPlaceholderWithSize:CGSizeMake(50, 100) completionHandler:^(NSTextPlaceholder *placeholder) {
+        EXPECT_WK_STREQ("<div style=\"display: inline-block; vertical-align: top; visibility: hidden !important; width: 50px; height: 100px;\"></div>Test<script>document.body.focus()</script>", [webView stringByEvaluatingJavaScript:@"document.body.innerHTML"]);
+        [(id<NSTextInputClient_Async_staging_126696059>)webView.get() removeTextPlaceholder:placeholder willInsertText:NO completionHandler:^{
+            EXPECT_WK_STREQ("Test<script>document.body.focus()</script>", [webView stringByEvaluatingJavaScript:@"document.body.innerHTML"]);
+            isDone = true;
+        }];
+    }];
+    TestWebKitAPI::Util::run(&isDone);
+}
+
+TEST(NSTextPlaceholder, InsertAndRemoveTextPlaceholderWithIncomingText)
+{
+    auto webView = createWebViewForNSTextPlaceholder();
+
+    __block bool isDone = false;
+    [(id<NSTextInputClient_Async_staging_126696059>)webView.get() insertTextPlaceholderWithSize:CGSizeMake(50, 100) completionHandler:^(NSTextPlaceholder *placeholder) {
+        EXPECT_WK_STREQ("<div style=\"display: inline-block; vertical-align: top; visibility: hidden !important; width: 50px; height: 100px;\"></div>Test<script>document.body.focus()</script>", [webView stringByEvaluatingJavaScript:@"document.body.innerHTML"]);
+        [(id<NSTextInputClient_Async_staging_126696059>)webView.get() removeTextPlaceholder:placeholder willInsertText:YES completionHandler:^{
+            EXPECT_WK_STREQ("Test<script>document.body.focus()</script>", [webView stringByEvaluatingJavaScript:@"document.body.innerHTML"]);
+            isDone = true;
+        }];
+    }];
+    TestWebKitAPI::Util::run(&isDone);
+}
+
+#endif


### PR DESCRIPTION
#### d94443d3d4bf19b813546e7089bb65f4a00b58c3
<pre>
Adopt NSTextPlaceholders for Mac.
<a href="https://bugs.webkit.org/show_bug.cgi?id=272961">https://bugs.webkit.org/show_bug.cgi?id=272961</a>
<a href="https://rdar.apple.com/126696059">rdar://126696059</a>

Reviewed by Wenson Hsieh.

Adopt NSTextPlaceholders which is a parallel of UITextPlaceholders.
Move the now common code to Cocoa to allow for code sharing.

* Source/WebCore/PAL/pal/spi/mac/NSTextInputContextSPI.h:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView insertTextPlaceholderWithSize:completionHandler:]):
(-[WKWebView removeTextPlaceholder:willInsertText:completionHandler:]):
* Source/WebKit/UIProcess/Cocoa/WKTextPlaceholder.h: Renamed from Source/WebKit/UIProcess/ios/WKTextPlaceholder.h.
* Source/WebKit/UIProcess/Cocoa/WKTextPlaceholder.mm: Renamed from Source/WebKit/UIProcess/ios/WKTextPlaceholder.mm.
(-[WKTextPlaceholder initWithElementContext:]):
(-[WKTextPlaceholder elementContext]):
(-[WKTextPlaceholder rects]):
* Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.h: Renamed from Source/WebKit/UIProcess/ios/WKTextSelectionRect.h.
* Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.mm: Renamed from Source/WebKit/UIProcess/ios/WKTextSelectionRect.mm.
(-[WKTextSelectionRectCustomHandleInfo initWithFloatQuad:isHorizontal:]):
(-[WKTextSelectionRectCustomHandleInfo bottomLeft]):
(-[WKTextSelectionRectCustomHandleInfo topLeft]):
(-[WKTextSelectionRectCustomHandleInfo bottomRight]):
(-[WKTextSelectionRectCustomHandleInfo topRight]):
(-[WKTextSelectionRect initWithCGRect:]):
(-[WKTextSelectionRect initWithSelectionGeometry:scaleFactor:]):
(-[WKTextSelectionRect _path]):
(-[WKTextSelectionRect writingDirection]):
(-[WKTextSelectionRect range]):
(-[WKTextSelectionRect _customHandleInfo]):
(-[WKTextSelectionRect rect]):
(-[WKTextSelectionRect containsStart]):
(-[WKTextSelectionRect containsEnd]):
(-[WKTextSelectionRect isVertical]):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::insertTextPlaceholder):
(WebKit::WebPageProxy::removeTextPlaceholder):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/AppKitSoftLink.h:
* Source/WebKit/UIProcess/ios/AppKitSoftLink.mm:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::insertTextPlaceholder): Deleted.
(WebKit::WebPageProxy::removeTextPlaceholder): Deleted.
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::insertTextPlaceholderWithSize):
(WebKit::WebViewImpl::removeTextPlaceholder):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::insertTextPlaceholder):
(WebKit::WebPage::removeTextPlaceholder):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::insertTextPlaceholder): Deleted.
(WebKit::WebPage::removeTextPlaceholder): Deleted.
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextPlaceholderTests.mm: Added.

Canonical link: <a href="https://commits.webkit.org/277879@main">https://commits.webkit.org/277879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74576adbce24210dec8ee756bb5e75d68bb3e5d8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48815 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51501 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44881 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51120 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25556 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39904 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49397 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42093 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21005 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23137 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6870 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45068 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43764 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53413 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23866 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20135 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47208 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25129 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46152 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10758 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25937 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24849 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->