### PR TITLE
Web Inspector: Fix issues with go to property arrow in Computed CSS pane when details sidebar is unified

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/GeneralStyleDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/GeneralStyleDetailsSidebarPanel.js
@@ -86,7 +86,6 @@ WI.GeneralStyleDetailsSidebarPanel = class GeneralStyleDetailsSidebarPanel exten
         if (!domNode || domNode.destroyed)
             return;
 
-        this.contentView.element.scrollTop = 0;
         this._panel.markAsNeedsRefresh(domNode);
 
         if (this._forcedPseudoClassContainerToggledSetting)

--- a/Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationEditor.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationEditor.js
@@ -60,7 +60,11 @@ WI.SpreadsheetCSSStyleDeclarationEditor = class SpreadsheetCSSStyleDeclarationEd
         if (!this._style)
             return;
 
-        this.element.addEventListener("focus", () => { this.focused = true; }, true);
+        this.element.addEventListener("focus", () => {
+            if (!this._suppressBlur)
+                this.focused = true;
+        }, true);
+
         this.element.addEventListener("blur", (event) => {
             let focusedElement = event.relatedTarget;
             if (focusedElement && this.element.contains(focusedElement))

--- a/Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.js
@@ -212,6 +212,11 @@ WI.SpreadsheetCSSStyleDeclarationSection = class SpreadsheetCSSStyleDeclarationS
 
         return false;
     }
+    
+    deselectProperties() 
+    {
+        this._propertiesEditor.deselectProperties();
+    }
 
     // SpreadsheetRuleHeaderField delegate
 

--- a/Source/WebInspectorUI/UserInterface/Views/SpreadsheetRulesStyleDetailsPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SpreadsheetRulesStyleDetailsPanel.js
@@ -90,8 +90,8 @@ WI.SpreadsheetRulesStyleDetailsPanel = class SpreadsheetRulesStyleDetailsPanel e
         }
 
         for (let section of this._sections) {
-            if (section.highlightProperty(property))
-                return;
+            section.deselectProperties();
+            section.highlightProperty(property);
         }
     }
 


### PR DESCRIPTION
#### b8288eb0b2ed4be5bac8f8a4765a751cf62b2e0b
<pre>
Web Inspector: Fix issues with go to property arrow in Computed CSS pane when details sidebar is unified
<a href="https://bugs.webkit.org/show_bug.cgi?id=272876">https://bugs.webkit.org/show_bug.cgi?id=272876</a>

Reviewed by Devin Rousso.

When using the Elements tab of the Inspector, the Computed pane has a button to jump to
the respective CSS property. This works well with the default two-column view, but when
&quot;show independent Styles sidebar&quot; is disabled, it can fail to scroll the respective CSS
into view or replace it with white space.

This commit fixes this problem:
- When opening details panes, do not reset the scroll position.
- Fix a bug that meant that focused/highlighted properties failed to update the layout when
  being initialised (this also can happen for other reasons,
  but is outside the scope of this commit).
- Ensure that all previous properties are always deselected, as occurs already in the
  two-column view.

Combined changes:
* Source/WebInspectorUI/UserInterface/Views/GeneralStyleDetailsSidebarPanel.js:
(WI.GeneralStyleDetailsSidebarPanel.prototype.layout):
* Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationEditor.js:
(WI.SpreadsheetCSSStyleDeclarationEditor):
(WI.SpreadsheetCSSStyleDeclarationEditor.prototype.initialLayout):
(WI.SpreadsheetCSSStyleDeclarationEditor.prototype.selectProperties):
* Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.js:
(WI.SpreadsheetCSSStyleDeclarationSection.prototype.deselectProperties):
* Source/WebInspectorUI/UserInterface/Views/SpreadsheetRulesStyleDetailsPanel.js:
(WI.SpreadsheetRulesStyleDetailsPanel.prototype.scrollToSectionAndHighlightProperty):
* Source/WebInspectorUI/UserInterface/Views/StyleDetailsPanel.js:

Canonical link: <a href="https://commits.webkit.org/278686@main">https://commits.webkit.org/278686@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4c83291a0ebac41e25a81ab060d3375efe73520

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50574 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29871 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53833 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1264 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/915 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41228 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52673 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27516 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43552 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22338 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24910 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/811 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8952 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46896 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/872 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55422 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25674 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/776 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48642 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26933 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43700 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47695 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11217 "Built successfully and passed tests") | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27798 "Hash c4c83291 for PR 27503 does not build (failure)") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26665 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->