### PR TITLE
[iOS] navigator.language returns the system language instead of the preferred language for the app

### DIFF
--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -51,25 +51,24 @@
 
 namespace WebKit {
 
+static Vector<String>& overrideLanguagesFromBootstrap()
+{
+    static NeverDestroyed<Vector<String>> languages;
+    return languages;
+}
+
+static void stageOverrideLanguagesForMainThread(Vector<String>&& languages)
+{
+    RELEASE_ASSERT(overrideLanguagesFromBootstrap().isEmpty());
+    overrideLanguagesFromBootstrap().swap(languages);
+}
+
 static void setAppleLanguagesPreference()
 {
-    auto bootstrap = adoptOSObject(xpc_copy_bootstrap());
-    if (!bootstrap)
+    if (overrideLanguagesFromBootstrap().isEmpty())
         return;
-
-    if (xpc_object_t languages = xpc_dictionary_get_value(bootstrap.get(), "OverrideLanguages")) {
-        @autoreleasepool {
-            Vector<String> newLanguages;
-            xpc_array_apply(languages, makeBlockPtr([&newLanguages](size_t index, xpc_object_t value) {
-                newLanguages.append(String::fromUTF8(xpc_string_get_string_ptr(value)));
-                return true;
-            }).get());
-
-            LOG_WITH_STREAM(Language, stream << "Bootstrap message contains OverrideLanguages: " << newLanguages);
-            overrideUserPreferredLanguages(newLanguages);
-        }
-    } else
-        LOG(Language, "Bootstrap message does not contain OverrideLanguages");
+    LOG_WITH_STREAM(Language, stream << "Overriding user prefered language: " << overrideLanguagesFromBootstrap());
+    overrideUserPreferredLanguages(overrideLanguagesFromBootstrap());
 }
 
 static void initializeCFPrefs()
@@ -191,6 +190,19 @@ void XPCServiceEventHandler(xpc_connection_t peer)
 
             bool disableLogging = xpc_dictionary_get_bool(event, "disable-logging");
             initializeLogd(disableLogging);
+
+            if (xpc_object_t languages = xpc_dictionary_get_value(event, "OverrideLanguages")) {
+                Vector<String> newLanguages;
+                @autoreleasepool {
+                    xpc_array_apply(languages, makeBlockPtr([&newLanguages](size_t index, xpc_object_t value) {
+                        newLanguages.append(String::fromUTF8(xpc_string_get_string_ptr(value)));
+                        return true;
+                    }).get());
+                }
+                LOG_WITH_STREAM(Language, stream << "Bootstrap message contains OverrideLanguages: " << newLanguages);
+                stageOverrideLanguagesForMainThread(WTFMove(newLanguages));
+            } else
+                LOG(Language, "Bootstrap message does not contain OverrideLanguages");
 
 #if __has_include(<WebKitAdditions/DyldCallbackAdditions.h>) && PLATFORM(IOS)
             register_for_dlsym_callbacks();

--- a/Tools/TestWebKitAPI/Tests/WebKit/OverrideAppleLanguagesPreference.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/OverrideAppleLanguagesPreference.mm
@@ -25,14 +25,14 @@
 
 #import "config.h"
 
-#if WK_HAVE_C_SPI
-
 #import "PlatformUtilities.h"
 #import "TestWKWebView.h"
 #import <WebKit/PreferenceObserver.h>
 #import <wtf/ObjCRuntimeExtras.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/StringBuilder.h>
+
+#if WK_HAVE_C_SPI
 
 TEST(WebKit, OverrideAppleLanguagesPreference)
 {
@@ -55,6 +55,19 @@ TEST(WebKit, OverrideAppleLanguagesPreference)
 }
 
 #endif // WK_HAVE_C_SPI
+
+TEST(WebKit, OverrideAppleLanguagesPreferenceAffectsNavigatorLanguage)
+{
+    NSDictionary *dict = @{
+        @"AppleLanguages": @[ @"en-GB" ],
+    };
+    [[NSUserDefaults standardUserDefaults] setVolatileDomain:dict forName:NSArgumentDomain];
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+
+    EXPECT_WK_STREQ("en-GB", [webView stringByEvaluatingJavaScript:@"window.navigator.language"]);
+}
 
 // On older macOSes, CFPREFS_DIRECT_MODE is disabled and the WebProcess does not see the updated AppleLanguages
 // after the AppleLanguagePreferencesChangedNotification notification.


### PR DESCRIPTION
#### 4ce66f9fa313134f44de67cc943bc11e6e5b4ffd
<pre>
[iOS] navigator.language returns the system language instead of the preferred language for the app
<a href="https://bugs.webkit.org/show_bug.cgi?id=272965">https://bugs.webkit.org/show_bug.cgi?id=272965</a>
&lt;<a href="https://rdar.apple.com/126555755">rdar://126555755</a>&gt;

Reviewed by Per Arne Vollan and Chris Dumez.

The bug was caused by WebKit2 failing to set the language override in setAppleLanguagesPreference
because xpc_connection_set_bootstrap / xpc_copy_bootstrap no longer work in iOS 17.4 and later when
ExtensionKit is used. Specifically, the XPC connection we have with ExtensionKit is an anonymous
XPC connection, and not the XPC connection used to launch the XPC service.

Fixed the bug by attaching the language override to WebKit&apos;s &quot;bootstrap&quot; message.

* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::overrideLanguagesFromBootstrap): Added.
(WebKit::stageOverrideLanguagesForMainThread): Added.
(WebKit::setAppleLanguagesPreference):
(WebKit::XPCServiceEventHandler):

* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::ProcessLauncher::finishLaunchingProcess):

* Tools/TestWebKitAPI/Tests/WebKit/OverrideAppleLanguagesPreference.mm:
(TEST(WebKit, OverrideAppleLanguagesPreferenceAffectsNavigatorLanguage)): Added.

Canonical link: <a href="https://commits.webkit.org/277733@main">https://commits.webkit.org/277733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/922db014b3995a604e76da091c73f6c193281efd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48419 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51107 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44484 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50725 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25153 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39570 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25312 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41797 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20699 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22796 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6475 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44736 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43447 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53012 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23466 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19796 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46894 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24731 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45807 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25536 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6892 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24454 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->