### PR TITLE
[WebCore] AbstractLineBuilder::m_wrapOpportunityList should have inlineCapacity coverting most of cases

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/AbstractLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/AbstractLineBuilder.cpp
@@ -44,7 +44,7 @@ AbstractLineBuilder::AbstractLineBuilder(InlineFormattingContext& inlineFormatti
 
 void AbstractLineBuilder::reset()
 {
-    m_wrapOpportunityList = { };
+    m_wrapOpportunityList.shrink(0);
     m_partialLeadingTextItem = { };
     m_previousLine = { };
 }

--- a/Source/WebCore/layout/formattingContexts/inline/AbstractLineBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/AbstractLineBuilder.h
@@ -74,7 +74,7 @@ protected:
     Line m_line;
     InlineRect m_lineLogicalRect;
     const InlineItemList& m_inlineItemList;
-    Vector<const InlineItem*> m_wrapOpportunityList;
+    Vector<const InlineItem*, 32> m_wrapOpportunityList;
     std::optional<InlineTextItem> m_partialLeadingTextItem;
     std::optional<PreviousLine> m_previousLine { };
 


### PR DESCRIPTION
#### faeb8e9159788867f142074876979f39af8ebeb0
<pre>
[WebCore] AbstractLineBuilder::m_wrapOpportunityList should have inlineCapacity coverting most of cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=272966">https://bugs.webkit.org/show_bug.cgi?id=272966</a>
<a href="https://rdar.apple.com/126741662">rdar://126741662</a>

Reviewed by Alan Baradlay.

We found that AbstractLineBuilder::m_wrapOpportunityList is causing frequent malloc and free in the hot path.
This patch adds 32 inlineCapacity and uses `shrink(0)` to keep once-allocated capacity during LineBuilder&apos;s lifetime.
This 32 number gets picked from data collection in existing benchmarks.

* Source/WebCore/layout/formattingContexts/inline/AbstractLineBuilder.cpp:
(WebCore::Layout::AbstractLineBuilder::reset):
* Source/WebCore/layout/formattingContexts/inline/AbstractLineBuilder.h:

Canonical link: <a href="https://commits.webkit.org/277744@main">https://commits.webkit.org/277744@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9d61295bf465ce40e8e3742028f88fc8c64a9ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51108 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44485 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50726 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25154 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39571 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41798 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20700 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22802 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6476 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44742 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43448 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53013 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23467 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19798 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46895 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24732 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41994 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45809 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25537 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6897 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24455 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->