### PR TITLE
Update webrtc build and code to prepare for tvOS

### DIFF
--- a/LayoutTests/platform/mac-monterey-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-monterey-wk2/TestExpectations
@@ -52,6 +52,16 @@ http/tests/paymentrequest/ApplePayPaymentCompleteDetails-orderDetails.https.html
 
 webkit.org/b/268124 imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_document_cookie.https.window.html [ Failure ]
 
+# AV1 is not enabled
+imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?av1 [ Skip ]
+imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?av1 [ Skip ]
+imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.html?av1 [ Skip ]
+imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker.html?av1 [ Skip ]
+imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?av1 [ Skip ]
+imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.worker.html?av1 [ Skip ]
+imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?av1 [ Skip ]
+imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?av1 [ Skip ]
+
 # 0.01% image results and missing reference.
 imported/w3c/web-platform-tests/svg/painting/reftests/percentage-attribute.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/percentage.svg [ ImageOnlyFailure ]

--- a/Source/ThirdParty/libwebrtc/Configurations/libaom.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/libaom.xcconfig
@@ -36,7 +36,8 @@ X86_FILES = *_sse2.c *_ssse3.c *_sse4.c *_avx2.c *_avx2.cc *_avx.c *.asm
 EXCLUDED_SOURCE_FILE_NAMES[arch=x86_64] = $(ARM_FILES) $(EXCLUDED_SOURCE_FILE_NAMES_$(WK_IS_CATALYST));
 EXCLUDED_SOURCE_FILE_NAMES_YES = *_sse4.c *_avx.c;
 EXCLUDED_SOURCE_FILE_NAMES[arch=arm64*] = $(X86_FILES) *_mmx.c
+EXCLUDED_SOURCE_FILE_NAMES[sdk=appletvos*] = $(X86_FILES) *_mmx.c hash_arm_crc32.c *_neon_dotprod.c
 EXCLUDED_SOURCE_FILE_NAMES[sdk=iphonesimulator*][arch=x86_64] = $(ARM_FILES) $(X86_FILES)
-EXCLUDED_SOURCE_FILE_NAMES[sdk=iphoneos*] =  $(X86_FILES) *_mmx.c hash_arm_crc32.c *_neon_dotprod.c
+EXCLUDED_SOURCE_FILE_NAMES[sdk=iphoneos*] = $(X86_FILES) *_mmx.c hash_arm_crc32.c *_neon_dotprod.c
 
 OTHER_LDFLAGS = $(inherited) $(SOURCE_VERSION_LDFLAGS);

--- a/Source/ThirdParty/libwebrtc/Configurations/libvpx.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/libvpx.xcconfig
@@ -11,7 +11,8 @@ X86_FILES = *_sse2.c *_ssse3.c *_sse4.c *_avx2.c *_avx2.cc *_avx.c *.asm
 EXCLUDED_SOURCE_FILE_NAMES[arch=x86_64] = $(ARM_FILES) $(EXCLUDED_SOURCE_FILE_NAMES_$(WK_IS_CATALYST))
 EXCLUDED_SOURCE_FILE_NAMES_YES = *_sse4.c *_avx.c
 EXCLUDED_SOURCE_FILE_NAMES[arch=arm64*] = $(X86_FILES) *_mmx.c
+EXCLUDED_SOURCE_FILE_NAMES[sdk=appletvos*] = $(X86_FILES) *_mmx.c *_neon_dotprod.c
 EXCLUDED_SOURCE_FILE_NAMES[sdk=iphonesimulator*][arch=x86_64] = $(ARM_FILES) $(X86_FILES)
-EXCLUDED_SOURCE_FILE_NAMES[sdk=iphoneos*] =  $(X86_FILES) *_mmx.c *_neon_dotprod.c
+EXCLUDED_SOURCE_FILE_NAMES[sdk=iphoneos*] = $(X86_FILES) *_mmx.c *_neon_dotprod.c
 
 OTHER_LDFLAGS = $(inherited) $(SOURCE_VERSION_LDFLAGS);

--- a/Source/WebCore/platform/VideoDecoder.cpp
+++ b/Source/WebCore/platform/VideoDecoder.cpp
@@ -83,10 +83,12 @@ void VideoDecoder::createLocalDecoder(const String& codecName, const Config& con
         LibWebRTCVPXVideoDecoder::create(LibWebRTCVPXVideoDecoder::Type::VP9_P2, config, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback));
         return;
     }
+#if ENABLE(AV1)
     if (codecName.startsWith("av01."_s)) {
         LibWebRTCVPXVideoDecoder::create(LibWebRTCVPXVideoDecoder::Type::AV1, config, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback));
         return;
     }
+#endif
 #elif USE(GSTREAMER)
     GStreamerVideoDecoder::create(codecName, config, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback));
     return;

--- a/Source/WebCore/platform/VideoEncoder.cpp
+++ b/Source/WebCore/platform/VideoEncoder.cpp
@@ -69,10 +69,12 @@ void VideoEncoder::createLocalEncoder(const String& codecName, const Config& con
         LibWebRTCVPXVideoEncoder::create(LibWebRTCVPXVideoEncoder::Type::VP9_P2, config, WTFMove(callback), WTFMove(descriptionCallback), WTFMove(outputCallback), WTFMove(postCallback));
         return;
     }
+#if ENABLE(AV1)
     if (codecName.startsWith("av01."_s)) {
         LibWebRTCVPXVideoEncoder::create(LibWebRTCVPXVideoEncoder::Type::AV1, config, WTFMove(callback), WTFMove(descriptionCallback), WTFMove(outputCallback), WTFMove(postCallback));
         return;
     }
+#endif
 #elif USE(GSTREAMER)
     GStreamerVideoEncoder::create(codecName, config, WTFMove(callback), WTFMove(descriptionCallback), WTFMove(outputCallback), WTFMove(postCallback));
     return;

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
@@ -163,8 +163,10 @@ static UniqueRef<webrtc::VideoDecoder> createInternalDecoder(LibWebRTCVPXVideoDe
         return makeUniqueRefFromNonNullUniquePtr(webrtc::VP9Decoder::Create());
     case LibWebRTCVPXVideoDecoder::Type::VP9_P2:
         return makeUniqueRefFromNonNullUniquePtr(webrtc::VP9Decoder::Create());
+#if ENABLE(AV1)
     case LibWebRTCVPXVideoDecoder::Type::AV1:
         return createLibWebRTCDav1dDecoder();
+#endif
     }
 }
 

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.h
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.h
@@ -42,7 +42,9 @@ public:
         VP8,
         VP9,
         VP9_P2,
+#if ENABLE(AV1)
         AV1
+#endif
     };
     static void create(Type, const Config&, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
 

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
@@ -149,8 +149,10 @@ static UniqueRef<webrtc::VideoEncoder> createInternalEncoder(LibWebRTCVPXVideoEn
         return makeUniqueRefFromNonNullUniquePtr(webrtc::VP9Encoder::Create());
     case LibWebRTCVPXVideoEncoder::Type::VP9_P2:
         return makeUniqueRefFromNonNullUniquePtr(webrtc::VP9Encoder::Create(cricket::CreateVideoCodec(webrtc::SdpVideoFormat { cricket::kVp9CodecName, { { "profile-id", "2" } } } )));
+#if ENABLE(AV1)
     case LibWebRTCVPXVideoEncoder::Type::AV1:
         return makeUniqueRefFromNonNullUniquePtr(webrtc::CreateLibaomAv1Encoder());
+#endif
     }
 }
 
@@ -214,10 +216,12 @@ int LibWebRTCVPXInternalVideoEncoder::initialize(LibWebRTCVPXVideoEncoder::Type 
         videoCodec.codecType = webrtc::kVideoCodecVP9;
         videoCodec.VP9()->numberOfSpatialLayers = 1;
         break;
+#if ENABLE(AV1)
     case LibWebRTCVPXVideoEncoder::Type::AV1:
         videoCodec.codecType = webrtc::kVideoCodecAV1;
         videoCodec.qpMax = 56; // default qp max
         break;
+#endif
     }
 
     if (auto error = m_internalEncoder->InitEncode(&videoCodec, webrtc::VideoEncoder::Settings { webrtc::VideoEncoder::Capabilities { true }, static_cast<int>(webrtc::CpuInfo::DetectNumberOfCores()), defaultPayloadSize }))

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.h
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.h
@@ -42,7 +42,9 @@ public:
         VP8,
         VP9,
         VP9_P2,
+#if ENABLE(AV1)
         AV1
+#endif
     };
     static void create(Type, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&, PostTaskCallback&&);
 

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDav1dDecoder.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDav1dDecoder.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "LibWebRTCDav1dDecoder.h"
 
-#if USE(LIBWEBRTC)
+#if USE(LIBWEBRTC) && ENABLE(AV1)
 
 #include "LibWebRTCMacros.h"
 #include "Logging.h"

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDav1dDecoder.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDav1dDecoder.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if USE(LIBWEBRTC)
+#if USE(LIBWEBRTC) && ENABLE(AV1)
 
 ALLOW_UNUSED_PARAMETERS_BEGIN
 ALLOW_COMMA_BEGIN
@@ -41,4 +41,4 @@ WEBCORE_EXPORT UniqueRef<webrtc::VideoDecoder> createLibWebRTCDav1dDecoder();
 
 } // namespace WebCore
 
-#endif
+#endif // USE(LIBWEBRTC) && ENABLE(AV1)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1421,13 +1421,11 @@ struct WebCore::WebCodecsEncodedAudioChunkData {
 #endif
 
 header: <WebCore/VideoEncoderScalabilityMode.h>
-#if ENABLE(WEB_CODECS)
 enum class WebCore::VideoEncoderScalabilityMode : uint8_t {
     L1T1,
     L1T2,
     L1T3
 }
-#endif
 
 struct WebCore::HTMLModelElementCamera {
     double pitch;

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -561,6 +561,7 @@ LibWebRTCCodecs::Encoder* LibWebRTCCodecs::createEncoder(VideoCodecType type, co
     return createEncoderInternal(type, { }, parameters, true, true, VideoEncoderScalabilityMode::L1T1, [](auto*) { });
 }
 
+#if ENABLE(WEB_CODECS)
 void LibWebRTCCodecs::createEncoderAndWaitUntilInitialized(VideoCodecType type, const String& codec, const std::map<std::string, std::string>& parameters, const VideoEncoder::Config& config, Function<void(Encoder*)>&& callback)
 {
     createEncoderInternal(type, codec, parameters, config.isRealtime, config.useAnnexB, config.scalabilityMode, [config, callback = WTFMove(callback)] (auto* encoder) {
@@ -572,6 +573,7 @@ void LibWebRTCCodecs::createEncoderAndWaitUntilInitialized(VideoCodecType type, 
         callback(encoder);
     });
 }
+#endif // ENABLE(WEB_CODECS)
 
 static void createRemoteEncoder(LibWebRTCCodecs::Encoder& encoder, IPC::Connection& connection, const Vector<std::pair<String, String>>& parameters, Function<void(bool)>&& callback)
 {
@@ -728,6 +730,7 @@ void LibWebRTCCodecs::registerEncodedVideoFrameCallback(Encoder& encoder, Encode
     encoder.encoderCallback = WTFMove(callback);
 }
 
+#if ENABLE(WEB_CODECS)
 void LibWebRTCCodecs::registerEncoderDescriptionCallback(Encoder& encoder, DescriptionCallback&& callback)
 {
     Locker locker { encoder.encodedImageCallbackLock };
@@ -735,6 +738,7 @@ void LibWebRTCCodecs::registerEncoderDescriptionCallback(Encoder& encoder, Descr
     ASSERT(!encoder.encodedImageCallback);
     encoder.descriptionCallback = WTFMove(callback);
 }
+#endif
 
 void LibWebRTCCodecs::setEncodeRates(Encoder& encoder, uint32_t bitRate, uint32_t frameRate)
 {
@@ -801,12 +805,14 @@ void LibWebRTCCodecs::setEncodingConfiguration(WebKit::VideoEncoderIdentifier id
 
     Locker locker { AdoptLock, encoder->encodedImageCallbackLock };
 
+#if ENABLE(WEB_CODECS)
     if (encoder->descriptionCallback) {
         std::optional<Vector<uint8_t>> decoderDescriptionData;
         if (description.size())
             decoderDescriptionData = Vector<uint8_t> { description };
         encoder->descriptionCallback(WebCore::VideoEncoderActiveConfiguration { { }, { }, { }, { }, { }, WTFMove(decoderDescriptionData), WTFMove(colorSpace) });
     }
+#endif
 }
 
 CVPixelBufferPoolRef LibWebRTCCodecs::pixelBufferPool(size_t width, size_t height, OSType type)

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -39,6 +39,7 @@
 #include "VideoEncoderIdentifier.h"
 #include "WorkQueueMessageReceiver.h"
 #include <WebCore/VideoEncoder.h>
+#include <WebCore/VideoEncoderScalabilityMode.h>
 #include <map>
 #include <wtf/Deque.h>
 #include <wtf/HashMap.h>
@@ -113,7 +114,9 @@ public:
     void registerDecodeFrameCallback(Decoder&, void* decodedImageCallback);
     void registerDecodedVideoFrameCallback(Decoder&, DecoderCallback&&);
 
+#if ENABLE(WEB_CODECS)
     using DescriptionCallback = Function<void(WebCore::VideoEncoderActiveConfiguration&&)>;
+#endif
     using EncoderCallback = Function<void(std::span<const uint8_t>, bool isKeyFrame, int64_t timestamp, std::optional<uint64_t> duration, std::optional<unsigned> temporalIndex)>;
     struct EncoderInitializationData {
         uint16_t width;
@@ -133,7 +136,9 @@ public:
         std::optional<EncoderInitializationData> initializationData;
         void* encodedImageCallback WTF_GUARDED_BY_LOCK(encodedImageCallbackLock) { nullptr };
         EncoderCallback encoderCallback;
+#if ENABLE(WEB_CODECS)
         DescriptionCallback descriptionCallback;
+#endif
         Lock encodedImageCallbackLock;
         RefPtr<IPC::Connection> connection;
         SharedVideoFrameWriter sharedVideoFrameWriter;
@@ -144,7 +149,9 @@ public:
     };
 
     Encoder* createEncoder(VideoCodecType, const std::map<std::string, std::string>&);
+#if ENABLE(WEB_CODECS)
     void createEncoderAndWaitUntilInitialized(VideoCodecType, const String& codec, const std::map<std::string, std::string>&, const WebCore::VideoEncoder::Config&, Function<void(Encoder*)>&&);
+#endif
     int32_t releaseEncoder(Encoder&);
     int32_t initializeEncoder(Encoder&, uint16_t width, uint16_t height, unsigned startBitrate, unsigned maxBitrate, unsigned minBitrate, uint32_t maxFramerate);
     int32_t encodeFrame(Encoder&, const WebCore::VideoFrame&, int64_t timestamp, std::optional<uint64_t> duration, bool shouldEncodeAsKeyFrame, Function<void(bool)>&&);
@@ -152,7 +159,9 @@ public:
     void flushEncoder(Encoder&, Function<void()>&&);
     void registerEncodeFrameCallback(Encoder&, void* encodedImageCallback);
     void registerEncodedVideoFrameCallback(Encoder&, EncoderCallback&&);
+#if ENABLE(WEB_CODECS)
     void registerEncoderDescriptionCallback(Encoder&, DescriptionCallback&&);
+#endif
     void setEncodeRates(Encoder&, uint32_t bitRate, uint32_t frameRate);
 
     CVPixelBufferPoolRef pixelBufferPool(size_t width, size_t height, OSType);


### PR DESCRIPTION
#### bbca2d7c1fe0a5db650202e53d2f4bbef81cc28a
<pre>
Update webrtc build and code to prepare for tvOS
<a href="https://rdar.apple.com/126747824">rdar://126747824</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=272974">https://bugs.webkit.org/show_bug.cgi?id=272974</a>

Reviewed by Andy Estes and Elliott Williams.

Compile out some libwebrtc code in case AV1 is not supported, as is the case in tvOS, where dav1d is not needed.
Ditto for some WEB_CODECS code specific code.
Update xcconfig files for tvOS.

* LayoutTests/platform/mac-monterey-wk2/TestExpectations: Skipping AV1 tests as ENABLE(AV1) is not 1 in Monterey.
* Source/ThirdParty/libwebrtc/Configurations/libaom.xcconfig:
* Source/ThirdParty/libwebrtc/Configurations/libvpx.xcconfig:
* Source/WebCore/platform/VideoDecoder.cpp:
(WebCore::VideoDecoder::createLocalDecoder):
* Source/WebCore/platform/VideoEncoder.cpp:
(WebCore::VideoEncoder::createLocalEncoder):
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp:
(WebCore::createInternalDecoder):
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.h:
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp:
(WebCore::createInternalEncoder):
(WebCore::LibWebRTCVPXInternalVideoEncoder::initialize):
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.h:
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDav1dDecoder.cpp:
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDav1dDecoder.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::LibWebRTCCodecs::setEncodingConfiguration):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:

Canonical link: <a href="https://commits.webkit.org/278103@main">https://commits.webkit.org/278103@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8996c31f599a2b25c41511fe7b7fbe24c173bee8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28786 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52743 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/177 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51808 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34804 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26406 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40411 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51604 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26323 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42648 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21530 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23783 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43832 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7873 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45697 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54255 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24587 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20766 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47783 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25858 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46806 "Found 4 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/menulist, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/listbox, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/value/basic (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10872 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26698 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25581 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->