### PR TITLE
Remove notify option NOTIFY_OPT_LOOPBACK in WebKit

### DIFF
--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -109,6 +109,7 @@ public:
     virtual void preferenceDidUpdate(const String& domain, const String& key, const std::optional<String>& encodedValue);
     void preferencesDidUpdate(HashMap<String, std::optional<String>> domainlessPreferences, HashMap<std::pair<String, String>, std::optional<String>> preferences);
 #endif
+    static void setNotifyOptions();
 
 protected:
     explicit AuxiliaryProcess();

--- a/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
@@ -39,6 +39,7 @@
 #import <objc/runtime.h>
 #import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <pal/spi/cocoa/NSKeyedUnarchiverSPI.h>
+#import <pal/spi/cocoa/NotifySPI.h>
 #import <wtf/FileSystem.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/cocoa/Entitlements.h>
@@ -335,5 +336,13 @@ bool AuxiliaryProcess::isSystemWebKit()
     return isSystemWebKit;
 }
 
+void AuxiliaryProcess::setNotifyOptions()
+{
+#if ENABLE(NOTIFY_BLOCKING)
+    notify_set_options(NOTIFY_OPT_DISPATCH);
+#elif ENABLE(NOTIFY_FILTERING)
+    notify_set_options(NOTIFY_OPT_DISPATCH | NOTIFY_OPT_REGEN | NOTIFY_OPT_FILTERED);
+#endif
+}
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -34,7 +34,6 @@
 #import <mach/mach.h>
 #import <pal/spi/cf/CFUtilitiesSPI.h>
 #import <pal/spi/cocoa/LaunchServicesSPI.h>
-#import <pal/spi/cocoa/NotifySPI.h>
 #import <sys/sysctl.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/Language.h>
@@ -104,42 +103,6 @@ static void initializeLogd(bool disableLogging)
     RELEASE_LOG(Process, "Initialized logd %s", stringWithSpaces);
 }
 
-#if ENABLE(NOTIFY_BLOCKING)
-static bool shouldRestrictNotifyd()
-{
-    static dispatch_once_t once;
-    static bool hasEntitlement = false;
-    dispatch_once(&once, ^{
-        xpc_object_t entitlement = xpc_copy_entitlement_for_token("com.apple.developer.web-browser-engine.restrict.notifyd", nullptr);
-        if (entitlement == XPC_BOOL_TRUE)
-            hasEntitlement = true;
-        if (entitlement)
-            xpc_release(entitlement);
-    });
-    return hasEntitlement;
-}
-#endif
-
-static void setNotifyOptions()
-{
-    static bool hasSetOptions = false;
-    if (hasSetOptions)
-        return;
-    hasSetOptions = true;
-
-    uint32_t opts = 0;
-#if ENABLE(NOTIFY_FILTERING)
-    opts |= NOTIFY_OPT_DISPATCH | NOTIFY_OPT_REGEN | NOTIFY_OPT_FILTERED;
-#endif
-#if ENABLE(NOTIFY_BLOCKING)
-    if (shouldRestrictNotifyd())
-        opts |= NOTIFY_OPT_LOOPBACK;
-#endif
-    if (!opts)
-        return;
-    notify_set_options(opts);
-}
-
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
 
 NEVER_INLINE NO_RETURN_DUE_TO_CRASH static void crashDueWebKitFrameworkVersionMismatch()
@@ -186,8 +149,6 @@ void XPCServiceEventHandler(xpc_connection_t peer)
             return;
         }
         if (!strcmp(messageName, "bootstrap")) {
-            setNotifyOptions();
-
             bool disableLogging = xpc_dictionary_get_bool(event, "disable-logging");
             initializeLogd(disableLogging);
 
@@ -281,8 +242,6 @@ void XPCServiceEventHandler(xpc_connection_t peer)
 
 int XPCServiceMain(int, const char**)
 {
-    setNotifyOptions();
-
     auto bootstrap = adoptOSObject(xpc_copy_bootstrap());
 
     if (bootstrap) {

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -564,6 +564,8 @@ static bool applySandbox(const AuxiliaryProcessInitializationParameters& paramet
         CRASH();
     }
 
+    AuxiliaryProcess::setNotifyOptions();
+
 #if USE(CACHE_COMPILED_SANDBOX)
     // The plugin process's DARWIN_USER_TEMP_DIR and DARWIN_USER_CACHE_DIR sandbox parameters are randomized so
     // so the compiled sandbox should not be cached because it won't be reused.


### PR DESCRIPTION
#### e57afcae14d0fb780c8a2d8e74c63b2c8a8a7c6c
<pre>
Remove notify option NOTIFY_OPT_LOOPBACK in WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=272977">https://bugs.webkit.org/show_bug.cgi?id=272977</a>
<a href="https://rdar.apple.com/126484077">rdar://126484077</a>

Reviewed by Sihui Liu.

Remove notify option NOTIFY_OPT_LOOPBACK in WebKit, since this feature is now enabled with an
entitlement. This patch effectively reverts &lt;<a href="https://commits.webkit.org/275186@main">https://commits.webkit.org/275186@main</a>&gt;. The
NOTIFY_OPT_DISPATCH applies regardless of whether NOTIFY_BLOCKING is enabled.

* Source/WebKit/Shared/AuxiliaryProcess.h:
* Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm:
(WebKit::AuxiliaryProcess::setNotifyOptions):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::XPCServiceEventHandler):
(WebKit::XPCServiceMain):
(WebKit::shouldRestrictNotifyd): Deleted.
(WebKit::setNotifyOptions): Deleted.
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::applySandbox):
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:

Canonical link: <a href="https://commits.webkit.org/278639@main">https://commits.webkit.org/278639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e8f10623f81c6dabb60c78223b79b5e33319cdc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54424 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1857 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1531 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41674 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28102 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44101 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22791 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25424 "Passed tests") | | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47404 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1430 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56020 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1321 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49069 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27525 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44168 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48208 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11194 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28406 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27256 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->