### PR TITLE
[MSE][GStreamer] Early flushes may deadlock in WebKitMediaSrc

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3085,6 +3085,9 @@ void MediaPlayerPrivateGStreamer::createGSTPlayBin(const URL& url)
             g_object_set(m_pipeline.get(), "audio-filter", scale, nullptr);
     }
 
+    if (isMediaSource())
+        addPlaysinkQuirksForEarlyMediaSourceFlushes();
+
     if (!player->isVideoPlayer())
         return;
 
@@ -3130,6 +3133,49 @@ void MediaPlayerPrivateGStreamer::setupCodecProbe(GstElement* element)
 #else
     UNUSED_PARAM(element);
 #endif
+}
+
+void MediaPlayerPrivateGStreamer::addPlaysinkQuirksForEarlyMediaSourceFlushes()
+{
+    ASSERT(isMediaSource());
+    GRefPtr<GstElement> playsink = adoptGRef(gst_bin_get_by_name(GST_BIN(m_pipeline.get()), "playsink"));
+    g_signal_connect_swapped(playsink.get(), "pad-added", G_CALLBACK(+[](MediaPlayerPrivateGStreamer* player, GstPad* newPad) {
+        GST_DEBUG_OBJECT(newPad, "New pad on playsink!");
+
+        g_signal_connect(newPad, "notify::caps", G_CALLBACK(+[](GstPad* pad, GParamSpec*, MediaPlayerPrivateGStreamer* player) {
+            if (player->isPlayerShuttingDown())
+                return;
+
+            GRefPtr<GstStream> stream = adoptGRef(gst_pad_get_stream(pad));
+            if (!stream)
+                return;
+
+            GST_DEBUG_OBJECT(pad, "Notifying WebKitMediaSrc about playsink CAPS on '%s'", gst_stream_get_stream_id(stream.get()));
+            webKitMediaSrcNotifyCaps(WEBKIT_MEDIA_SRC(player->m_source.get()), String::fromLatin1(gst_stream_get_stream_id(stream.get())));
+        }), player);
+
+        gst_pad_add_probe(newPad, GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM, reinterpret_cast<GstPadProbeCallback>(+[](GstPad* pad, GstPadProbeInfo* info, MediaPlayerPrivateGStreamer* player) {
+            ASSERT(GST_PAD_PROBE_INFO_TYPE(info) & GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM);
+            if (player->isPlayerShuttingDown())
+                return GST_PAD_PROBE_REMOVE;
+
+            auto* event = GST_PAD_PROBE_INFO_EVENT(info);
+            auto eventType = GST_EVENT_TYPE(event);
+            auto* element = gst_pad_get_parent_element(pad);
+            auto* elementName = gst_element_get_name(element);
+            GST_DEBUG_OBJECT(pad, "<%s:%s> received event '%s'", elementName, gst_pad_get_name(pad), gst_event_type_get_name(eventType));
+            if (eventType == GST_EVENT_STREAM_START) {
+                GstStream* stream = nullptr;
+                gst_event_parse_stream(event, &stream);
+                ASSERT(stream);
+                GST_DEBUG_OBJECT(pad, "Notifying WebKitMediaSrc about STREAM_START on '%s' and stream_id '%s'", elementName, gst_stream_get_stream_id(stream));
+                webKitMediaSrcNotifyStreamStart(WEBKIT_MEDIA_SRC(player->m_source.get()), String::fromLatin1(gst_stream_get_stream_id(stream)));
+                gst_object_unref(stream);
+                return GST_PAD_PROBE_REMOVE;
+            }
+            return GST_PAD_PROBE_OK;
+        }), player, nullptr);
+    }), this);
 }
 
 void MediaPlayerPrivateGStreamer::configureAudioDecoder(GstElement* decoder)

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -538,6 +538,8 @@ private:
     void configureMediaStreamAudioTracks();
     void invalidateCachedPositionOnNextIteration() const;
 
+    void addPlaysinkQuirksForEarlyMediaSourceFlushes();
+
     Atomic<bool> m_isPlayerShuttingDown;
     GRefPtr<GstElement> m_textSink;
     GUniquePtr<GstStructure> m_mediaLocations;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -74,6 +74,34 @@ struct WebKitMediaSrcPrivate {
         return stream;
     }
 
+    using StreamID = String;
+    struct EarlyFlushQuirk {
+        HashMap<StreamID, bool> streamStarts;
+        HashMap<StreamID, bool> capsNotifications;
+        Condition condition;
+
+        unsigned numStreamStarts()
+        {
+            return streamStarts.size();
+        }
+
+        unsigned numCaps()
+        {
+            return capsNotifications.size();
+        }
+
+        bool hasStreamStart(const StreamID& stream)
+        {
+            return streamStarts.find(stream) != streamStarts.end();
+        }
+
+        bool hasCapsNotification(const StreamID& stream)
+        {
+            return capsNotifications.find(stream) != capsNotifications.end();
+        }
+    };
+    DataMutex<EarlyFlushQuirk> earlyFlushQuirk;
+
     // Used for stream-start events, shared by all streams.
     const unsigned groupId { gst_util_group_id_next() };
 
@@ -98,7 +126,7 @@ static gboolean webKitMediaSrcActivateMode(GstPad*, GstObject*, GstPadMode, gboo
 static void webKitMediaSrcLoop(void*);
 static void webKitMediaSrcTearDownStream(WebKitMediaSrc* source, const AtomString& name);
 static void webKitMediaSrcGetProperty(GObject*, unsigned propId, GValue*, GParamSpec*);
-static void webKitMediaSrcStreamFlush(Stream*, bool isSeekingFlush);
+static void webKitMediaSrcStreamFlush(Stream*, bool isSeekingFlush, bool isTearingDown = false);
 static gboolean webKitMediaSrcSendEvent(GstElement*, GstEvent*);
 static RefPtr<MediaPlayerPrivateGStreamerMSE> webKitMediaSrcPlayer(WebKitMediaSrc*);
 
@@ -372,7 +400,7 @@ static void webKitMediaSrcTearDownStream(WebKitMediaSrc* source, const AtomStrin
     GST_DEBUG_OBJECT(source, "Tearing down stream '%s'", name.string().utf8().data());
 
     // Flush the source element **and** downstream. We want to stop the streaming thread and for that we need all elements downstream to be idle.
-    webKitMediaSrcStreamFlush(stream, false);
+    webKitMediaSrcStreamFlush(stream, false, true);
     // Stop the thread now.
     gst_pad_set_active(stream->pad.get(), false);
 
@@ -604,12 +632,53 @@ static void webKitMediaSrcLoop(void* userData)
         ASSERT_NOT_REACHED();
 }
 
-static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush)
+void webKitMediaSrcNotifyStreamStart(WebKitMediaSrc* source, const String& streamName)
+{
+    GST_DEBUG_OBJECT(source, "Notified about STREAM_START from stream '%s'", streamName.utf8().data());
+    DataMutexLocker earlyFlushQuirk { source->priv->earlyFlushQuirk };
+    earlyFlushQuirk->streamStarts.add(streamName, true);
+    earlyFlushQuirk->condition.notifyAll();
+}
+
+void webKitMediaSrcNotifyCaps(WebKitMediaSrc* source, const String& streamName)
+{
+    GST_DEBUG_OBJECT(source, "Notified about CAPS from stream '%s'", streamName.utf8().data());
+    DataMutexLocker earlyFlushQuirk { source->priv->earlyFlushQuirk };
+    earlyFlushQuirk->capsNotifications.add(streamName, true);
+    earlyFlushQuirk->condition.notifyAll();
+}
+
+void waitForEarlyFlushConditions(Stream* stream)
+{
+    for (auto& [k, s] : stream->source->priv->streams) {
+        DataMutexLocker earlyFlushQuirk { s->source->priv->earlyFlushQuirk };
+        DataMutexLocker streamingMembers { s->streamingMembersDataMutex };
+
+        if (streamingMembers->hasPushedFirstBuffer && !earlyFlushQuirk->hasStreamStart(s->track->stringId().string())) {
+            earlyFlushQuirk->condition.wait(earlyFlushQuirk.mutex(), [&]() {
+                return earlyFlushQuirk->hasStreamStart(s->track->stringId().string());
+            });
+        }
+    }
+
+    DataMutexLocker earlyFlushQuirk { stream->source->priv->earlyFlushQuirk };
+    if (earlyFlushQuirk->numStreamStarts() == stream->source->priv->streams.size() && !earlyFlushQuirk->hasCapsNotification(stream->track->stringId().string())) {
+        earlyFlushQuirk->condition.wait(earlyFlushQuirk.mutex(), [&]() {
+            return earlyFlushQuirk->numCaps() == earlyFlushQuirk->numStreamStarts();
+        });
+    }
+    GST_DEBUG_OBJECT(stream->pad.get(), "Finished waiting for STREAM_START CAPS while flushing '%s'", stream->track->stringId().string().utf8().data());
+}
+
+static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush, bool isTearingDown)
 {
     ASSERT(isMainThread());
     bool skipFlush = false;
     GST_DEBUG_OBJECT(stream->source, "Flush requested for stream '%s'. isSeekingFlush = %s",
         stream->track->stringId().string().utf8().data(), boolForPrinting(isSeekingFlush));
+
+    if (!isTearingDown)
+        waitForEarlyFlushConditions(stream);
 
     {
         DataMutexLocker streamingMembers { stream->streamingMembersDataMutex };

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.h
@@ -67,6 +67,9 @@ void webKitMediaSrcFlush(WebKitMediaSrc*, const AtomString& streamName);
 
 void webKitMediaSrcSetPlayer(WebKitMediaSrc*, ThreadSafeWeakPtr<WebCore::MediaPlayerPrivateGStreamerMSE>&&);
 
+void webKitMediaSrcNotifyStreamStart(WebKitMediaSrc*, const String& streamName);
+void webKitMediaSrcNotifyCaps(WebKitMediaSrc*, const String& streamName);
+
 G_END_DECLS
 
 namespace WTF {


### PR DESCRIPTION
#### 7ca79ca60fe7b54a32efbdfedd6ccd58b815c8d2
<pre>
[MSE][GStreamer] Early flushes may deadlock on FLUSH_STOP
<a href="https://bugs.webkit.org/show_bug.cgi?id=272975">https://bugs.webkit.org/show_bug.cgi?id=272975</a>

Reviewed by NOBODY (OOPS!).

WIP patch for fixing early flush race conditions.
This synchronizes webkitmediasrc with the playsink to only allow FLUSH_START
to be sent once both STREAM_START has been handled in the playsink, and when
playsink has also emitted the pads for each stream out of webkitmediasrc.

This is only a work-in-progress as a result of experimentation and debugging
this issue. It needs to be refactored and probably have the code moved to avoid
layering violations.

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::createGSTPlayBin):
(WebCore::MediaPlayerPrivateGStreamer::addPlaysinkQuirksForEarlyMediaSourceFlushes):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:
(WebKitMediaSrcPrivate::EarlyFlushQuirk::numStreamStarts):
(WebKitMediaSrcPrivate::EarlyFlushQuirk::numCaps):
(WebKitMediaSrcPrivate::EarlyFlushQuirk::hasStreamStart):
(WebKitMediaSrcPrivate::EarlyFlushQuirk::hasCapsNotification):
(webKitMediaSrcTearDownStream):
(webKitMediaSrcLoop):
(webKitMediaSrcNotifyStreamStart):
(webKitMediaSrcNotifyCaps):
(waitForEarlyFlushConditions):
(webKitMediaSrcStreamFlush):
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ca79ca60fe7b54a32efbdfedd6ccd58b815c8d2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48447 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51135 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44512 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39601 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41820 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20724 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22821 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43058 "Found 1 new test failure: fast/css/viewport-height-outline.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6504 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44763 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43471 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53040 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23494 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19820 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46918 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24759 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42016 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45835 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25564 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24482 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->