### PR TITLE
[GTK][WPE] AX: Support AXActiveElement and AXSelectedChildren for comboboxes, lists and listboxes.

### DIFF
--- a/Source/WebCore/SourcesGTK.txt
+++ b/Source/WebCore/SourcesGTK.txt
@@ -24,6 +24,7 @@
 accessibility/atspi/AccessibilityAtspi.cpp
 accessibility/atspi/AccessibilityObjectAtspi.cpp
 accessibility/atspi/AccessibilityObjectActionAtspi.cpp
+accessibility/atspi/AccessibilityObjectActiveDescendantAtspi.cpp
 accessibility/atspi/AccessibilityObjectCollectionAtspi.cpp
 accessibility/atspi/AccessibilityObjectComponentAtspi.cpp
 accessibility/atspi/AccessibilityObjectDocumentAtspi.cpp

--- a/Source/WebCore/SourcesWPE.txt
+++ b/Source/WebCore/SourcesWPE.txt
@@ -24,6 +24,7 @@
 accessibility/atspi/AccessibilityAtspi.cpp
 accessibility/atspi/AccessibilityObjectAtspi.cpp
 accessibility/atspi/AccessibilityObjectActionAtspi.cpp
+accessibility/atspi/AccessibilityObjectActiveDescendantAtspi.cpp
 accessibility/atspi/AccessibilityObjectCollectionAtspi.cpp
 accessibility/atspi/AccessibilityObjectComponentAtspi.cpp
 accessibility/atspi/AccessibilityObjectDocumentAtspi.cpp

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -364,8 +364,7 @@ AXCoreObject* AXCoreObject::activeDescendant() const
     if (!activeDescendants.isEmpty())
         return activeDescendants[0].get();
 
-#if PLATFORM(COCOA)
-    // In COCOA, when the active descendant changes for a combobox, the target
+    // When the active descendant changes for a combobox, the target
     // of the notification is the owned or controlled element of the combobox
     // if exists, most commonly a list or listbox (seee AXObjectCache::handleActiveDescendantChange).
     // Thus, a client could request the new active descendant from the list or
@@ -384,7 +383,6 @@ AXCoreObject* AXCoreObject::activeDescendant() const
         if (combobox != controllers.end())
             return (*combobox)->activeDescendant();
     }
-#endif
 
     return nullptr;
 }

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2340,7 +2340,6 @@ void AXObjectCache::handleActiveDescendantChange(Element& element, const AtomStr
 #endif
         target = object;
     } else if (object->isComboBox()) {
-#if PLATFORM(COCOA)
         // If the combobox's activeDescendant is inside a descendant owned or controlled by the combobox, that descendant should be the target of the notification and not the combobox itself.
         if (auto* ownedObject = Accessibility::findRelatedObjectInAncestry(*object, AXRelationType::OwnerFor, *activeDescendant))
             target = ownedObject;
@@ -2348,7 +2347,6 @@ void AXObjectCache::handleActiveDescendantChange(Element& element, const AtomStr
             target = controlledObject;
         else
             target = object;
-#endif
     } else if (object->supportsActiveDescendant())
         target = object;
     else {
@@ -2366,7 +2364,6 @@ void AXObjectCache::handleActiveDescendantChange(Element& element, const AtomStr
         return;
 
     if (target == object) {
-#if PLATFORM(COCOA)
         if (target->isComboBox()) {
             // The combobox does not own or control the element to which activeDescendant belongs.
             // Establish this implicit relationship.
@@ -2376,7 +2373,6 @@ void AXObjectCache::handleActiveDescendantChange(Element& element, const AtomStr
             if (controlled)
                 addRelation(target.get(), controlled.get(), AXRelationType::ControllerFor);
         }
-#endif // PLATFORM(COCOA)
     } else {
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
         updateIsolatedTree(target.get(), AXNotification::AXActiveDescendantChanged);

--- a/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
@@ -136,8 +136,12 @@ void AXObjectCache::postPlatformNotification(AXCoreObject* coreObject, AXNotific
         wrapper->stateChanged("required", coreObject->isRequired());
         break;
     case AXActiveDescendantChanged:
-        if (auto* descendant = coreObject->activeDescendant())
-            platformHandleFocusedUIElementChanged(nullptr, descendant->node());
+        if (auto* descendant = coreObject->activeDescendant()) {
+            if (coreObject->isComboBox() || coreObject->canBeControlledBy(AccessibilityRole::ComboBox))
+                wrapper->activeDescendantChanged();
+            else
+                platformHandleFocusedUIElementChanged(nullptr, descendant->node());
+        }
         break;
     case AXChildrenChanged:
         coreObject->updateChildrenIfNecessary();

--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
@@ -532,6 +532,25 @@ void AccessibilityAtspi::valueChanged(AccessibilityObjectAtspi& atspiObject, dou
         g_variant_new("(siiva{sv})", "accessible-value", 0, 0, g_variant_new_double(value), nullptr), nullptr);
 }
 
+void AccessibilityAtspi::activeDescendantChanged(AccessibilityObjectAtspi& atspiObject)
+{
+#if ENABLE(DEVELOPER_MODE)
+    notifyActiveDescendantChanged(atspiObject);
+#endif
+
+    if (!m_connection)
+        return;
+
+    if (!shouldEmitSignal("Object", "ActiveDescendantChanged"))
+        return;
+
+    auto* activeDescendant = atspiObject.activeDescendant();
+    ASSERT(activeDescendant);
+
+    g_dbus_connection_emit_signal(m_connection.get(), nullptr, atspiObject.path().utf8().data(), "org.a11y.atspi.Event.Object", "ActiveDescendantChanged",
+        g_variant_new("(siiva{sv})", "", activeDescendant->indexInParent(), 0, g_variant_new("(so)", uniqueName(), activeDescendant->path().utf8().data()), nullptr), nullptr);
+}
+
 void AccessibilityAtspi::selectionChanged(AccessibilityObjectAtspi& atspiObject)
 {
 #if ENABLE(DEVELOPER_MODE)
@@ -867,6 +886,11 @@ void AccessibilityAtspi::notifyStateChanged(AccessibilityObjectAtspi& atspiObjec
         return;
     
     notify(atspiObject, notification, value);
+}
+
+void AccessibilityAtspi::notifyActiveDescendantChanged(AccessibilityObjectAtspi& atspiObject) const
+{
+    notify(atspiObject, "AXActiveElementChanged", nullptr);
 }
 
 void AccessibilityAtspi::notifySelectionChanged(AccessibilityObjectAtspi& atspiObject) const

--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspi.h
@@ -76,6 +76,8 @@ public:
 
     void valueChanged(AccessibilityObjectAtspi&, double);
 
+    void activeDescendantChanged(AccessibilityObjectAtspi&);
+
     void selectionChanged(AccessibilityObjectAtspi&);
 
     void loadEvent(AccessibilityObjectAtspi&, CString&&);
@@ -114,6 +116,7 @@ private:
 
 #if ENABLE(DEVELOPER_MODE)
     void notify(AccessibilityObjectAtspi&, const char*, NotificationObserverParameter) const;
+    void notifyActiveDescendantChanged(AccessibilityObjectAtspi&) const;
     void notifyStateChanged(AccessibilityObjectAtspi&, const char*, bool) const;
     void notifySelectionChanged(AccessibilityObjectAtspi&) const;
     void notifyMenuSelectionChanged(AccessibilityObjectAtspi&) const;

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectActiveDescendantAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectActiveDescendantAtspi.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "AccessibilityObjectAtspi.h"
+
+#if USE(ATSPI)
+
+#include "AccessibilityAtspi.h"
+#include "AccessibilityObject.h" // NOLINT: check-webkit-style has problems with files that do not have primary header
+
+namespace WebCore {
+
+AccessibilityObjectAtspi* AccessibilityObjectAtspi::activeDescendant() const
+{
+    if (!m_coreObject)
+        return nullptr;
+
+    if (auto* activeDescendant = m_coreObject->activeDescendant())
+        return activeDescendant->wrapper();
+
+    return nullptr;
+}
+
+void AccessibilityObjectAtspi::activeDescendantChanged()
+{
+    AccessibilityAtspi::singleton().activeDescendantChanged(*this);
+}
+
+} // namespace WebCore
+
+#endif // USE(ATSPI)

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
@@ -74,6 +74,7 @@ public:
     void elementDestroyed();
     void cacheDestroyed();
 
+    int indexInParent() const;
     int indexInParentForChildrenChanged(AccessibilityAtspi::ChildrenChanged);
 
     const String& path();
@@ -141,7 +142,11 @@ public:
     WEBCORE_EXPORT String documentAttribute(const String&) const;
     void loadEvent(const char*);
 
+    WEBCORE_EXPORT AccessibilityObjectAtspi* activeDescendant() const;
+    void activeDescendantChanged();
+
     WEBCORE_EXPORT unsigned selectionCount() const;
+    WEBCORE_EXPORT Vector<RefPtr<AccessibilityObjectAtspi>> selectedChildren() const;
     WEBCORE_EXPORT AccessibilityObjectAtspi* selectedChild(unsigned) const;
     WEBCORE_EXPORT bool setChildSelected(unsigned, bool) const;
     WEBCORE_EXPORT bool clearSelection() const;
@@ -165,7 +170,6 @@ private:
     AccessibilityObjectAtspi(AXCoreObject*, AccessibilityRootAtspi*);
 
     Vector<RefPtr<AccessibilityObjectAtspi>> wrapperVector(const Vector<RefPtr<AXCoreObject>>&) const;
-    int indexInParent() const;
     void childAdded(AccessibilityObjectAtspi&);
     void childRemoved(AccessibilityObjectAtspi&);
 

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectSelectionAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectSelectionAtspi.cpp
@@ -86,6 +86,18 @@ unsigned AccessibilityObjectAtspi::selectionCount() const
     return selectedChildren ? selectedChildren->size() : 0;
 }
 
+Vector<RefPtr<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::selectedChildren() const
+{
+    if (!m_coreObject)
+        return { };
+
+    auto selectedChildren = m_coreObject->selectedChildren();
+    if (!selectedChildren)
+        return { };
+
+    return wrapperVector(*selectedChildren);
+}
+
 AccessibilityObjectAtspi* AccessibilityObjectAtspi::selectedChild(unsigned index) const
 {
     if (!m_coreObject)

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
@@ -131,8 +131,6 @@ JSValueRef AccessibilityUIElement::mathRootRadicand() const { return { }; }
 unsigned AccessibilityUIElement::numberOfCharacters() const { return 0; }
 JSValueRef AccessibilityUIElement::columns() { return { }; }
 JSRetainPtr<JSStringRef> AccessibilityUIElement::dateValue() { return nullptr; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::activeElement() const { return nullptr; }
-JSValueRef AccessibilityUIElement::selectedChildren() const { return { }; }
 #endif // !PLATFORM(MAC))
 
 #if !PLATFORM(COCOA)
@@ -176,6 +174,8 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::flowFromElementAtIndex(un
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaLabelledByElementAtIndex(unsigned) { return nullptr; }
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::labelForElementAtIndex(unsigned) { return nullptr; }
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::ownerElementAtIndex(unsigned) { return nullptr; }
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::activeElement() const { return nullptr; }
+JSValueRef AccessibilityUIElement::selectedChildren() const { return { }; }
 #endif // PLATFORM(IOS_FAMILY)
 
 #if PLATFORM(WIN) || PLATFORM(PLAYSTATION)
@@ -192,6 +192,8 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::flowFromElementAtIndex(un
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaLabelledByElementAtIndex(unsigned) { return nullptr; }
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::labelForElementAtIndex(unsigned) { return nullptr; }
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::ownerElementAtIndex(unsigned) { return nullptr; }
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::activeElement() const { return nullptr; }
+JSValueRef AccessibilityUIElement::selectedChildren() const { return { }; }
 #endif // PLATFORM(WIN) || PLATFORM(PLAYSTATION)
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
@@ -1508,6 +1508,23 @@ void AccessibilityUIElement::clearSelectedChildren() const
     m_element->clearSelection();
 }
 
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::activeElement() const
+{
+    m_element->updateBackingStore();
+    if (auto* activeDescendant = m_element->activeDescendant())
+        return AccessibilityUIElement::create(activeDescendant);
+    return nullptr;
+}
+
+JSValueRef AccessibilityUIElement::selectedChildren() const
+{
+    if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Selection))
+        makeJSArray({ });
+
+    m_element->updateBackingStore();
+    return makeJSArray(elementsVector(m_element->selectedChildren()));
+}
+
 JSRetainPtr<JSStringRef> AccessibilityUIElement::accessibilityValue() const
 {
     return JSStringCreateWithCharacters(nullptr, 0);


### PR DESCRIPTION
#### d81e219170a2d89c07bff1c116ec69597757f32c
<pre>
[GTK][WPE] AX: Support AXActiveElement and AXSelectedChildren for comboboxes, lists and listboxes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=272981">https://bugs.webkit.org/show_bug.cgi?id=272981</a>

Reviewed by Adrian Perez de Castro.

Similarly to the Mac implementation added in 277649@main.

* Source/WebCore/SourcesGTK.txt:
* Source/WebCore/SourcesWPE.txt:
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::activeDescendant const):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleActiveDescendantChange):
* Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp:
(WebCore::AXObjectCache::postPlatformNotification):
* Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp:
(WebCore::AccessibilityAtspi::activeDescendantChanged):
(WebCore::AccessibilityAtspi::notifyActiveDescendantChanged const):
* Source/WebCore/accessibility/atspi/AccessibilityAtspi.h:
* Source/WebCore/accessibility/atspi/AccessibilityObjectActiveDescendantAtspi.cpp: Added.
(WebCore::AccessibilityObjectAtspi::activeDescendant const):
(WebCore::AccessibilityObjectAtspi::activeDescendantChanged):
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h:
* Source/WebCore/accessibility/atspi/AccessibilityObjectSelectionAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::selectedChildren const):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp:
(WTR::AccessibilityUIElement::dateValue):
(WTR::AccessibilityUIElement::activeElement const):
(WTR::AccessibilityUIElement::selectedChildren const):
* Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp:
(WTR::AccessibilityUIElement::activeElement const):
(WTR::AccessibilityUIElement::selectedChildren const):

Canonical link: <a href="https://commits.webkit.org/277921@main">https://commits.webkit.org/277921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d587807d8792b8dd593d9564be53d254a6d31a6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48665 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27876 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51352 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44730 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50970 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33813 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25406 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39796 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49247 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41993 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20893 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23015 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43171 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6721 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44953 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53260 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20009 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47089 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24978 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42198 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46019 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10781 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25782 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24699 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->