### PR TITLE
[GLIB] Modernize some argument coders

### DIFF
--- a/Source/WebKit/Platform/IPC/glib/ArgumentCodersGlib.h
+++ b/Source/WebKit/Platform/IPC/glib/ArgumentCodersGlib.h
@@ -46,13 +46,13 @@ template<> struct ArgumentCoder<GUniquePtr<char*>> {
     {
         auto length = decoder.decode<unsigned>();
 
-        if (!length)
+        if (UNLIKELY(!length))
             return std::nullopt;
 
         GUniquePtr<char*>strv(g_new0(char*, *length + 1));
         for (uint32_t i = 0; i < *length; i++) {
             auto strOptional = decoder.decode<CString>();
-            if (!strOptional)
+            if (UNLIKELY(!strOptional))
                 return std::nullopt;
 
             strv.get()[i] = g_strdup(strOptional->data());
@@ -62,4 +62,4 @@ template<> struct ArgumentCoder<GUniquePtr<char*>> {
     }
 };
 
-}
+} // namespace IPC

--- a/Source/WebKit/Shared/gtk/ArgumentCodersGtk.cpp
+++ b/Source/WebKit/Shared/gtk/ArgumentCodersGtk.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ArgumentCodersGtk.h"
 
+#include "ArgumentCodersGLib.h"
 #include "WebCoreArgumentCoders.h"
 #include <WebCore/GraphicsContext.h>
 #include <WebCore/Image.h>
@@ -38,77 +39,36 @@ namespace IPC {
 using namespace WebCore;
 using namespace WebKit;
 
-static void encodeGKeyFile(Encoder& encoder, GKeyFile* keyFile)
-{
-    gsize dataSize;
-    GUniquePtr<char> data(g_key_file_to_data(keyFile, &dataSize, 0));
-    encoder << std::span<const uint8_t>(reinterpret_cast<uint8_t*>(data.get()), dataSize);
-}
-
-static WARN_UNUSED_RETURN bool decodeGKeyFile(Decoder& decoder, GUniquePtr<GKeyFile>& keyFile)
-{
-    std::span<const uint8_t> dataReference;
-    if (!decoder.decode(dataReference))
-        return false;
-
-    if (!dataReference.size())
-        return true;
-
-    keyFile.reset(g_key_file_new());
-    if (!g_key_file_load_from_data(keyFile.get(), reinterpret_cast<const gchar*>(dataReference.data()), dataReference.size(), G_KEY_FILE_NONE, 0)) {
-        keyFile.reset();
-        return false;
-    }
-
-    return true;
-}
-
 void ArgumentCoder<GRefPtr<GtkPrintSettings>>::encode(Encoder& encoder, const GRefPtr<GtkPrintSettings>& argument)
 {
     GRefPtr<GtkPrintSettings> printSettings = argument ? argument : adoptGRef(gtk_print_settings_new());
-    GUniquePtr<GKeyFile> keyFile(g_key_file_new());
-    gtk_print_settings_to_key_file(printSettings.get(), keyFile.get(), "Print Settings");
-    encodeGKeyFile(encoder, keyFile.get());
+    GRefPtr<GVariant> variant = adoptGRef(gtk_print_settings_to_gvariant(printSettings.get()));
+    encoder << variant;
 }
 
 std::optional<GRefPtr<GtkPrintSettings>> ArgumentCoder<GRefPtr<GtkPrintSettings>>::decode(Decoder& decoder)
 {
-    GUniquePtr<GKeyFile> keyFile;
-    if (!decodeGKeyFile(decoder, keyFile))
+    auto variant = decoder.decode<GRefPtr<GVariant>>();
+    if (UNLIKELY(!variant))
         return std::nullopt;
 
-    GRefPtr<GtkPrintSettings> printSettings = adoptGRef(gtk_print_settings_new());
-    if (!keyFile)
-        return printSettings;
-
-    if (!gtk_print_settings_load_key_file(printSettings.get(), keyFile.get(), "Print Settings", nullptr))
-        return std::nullopt;
-
-    return printSettings;
+    return gtk_print_settings_new_from_gvariant(variant->get());
 }
 
 void ArgumentCoder<GRefPtr<GtkPageSetup>>::encode(Encoder& encoder, const GRefPtr<GtkPageSetup>& argument)
 {
     GRefPtr<GtkPageSetup> pageSetup = argument ? argument : adoptGRef(gtk_page_setup_new());
-    GUniquePtr<GKeyFile> keyFile(g_key_file_new());
-    gtk_page_setup_to_key_file(pageSetup.get(), keyFile.get(), "Page Setup");
-    encodeGKeyFile(encoder, keyFile.get());
+    GRefPtr<GVariant> variant = adoptGRef(gtk_page_setup_to_gvariant(pageSetup.get()));
+    encoder << variant;
 }
 
 std::optional<GRefPtr<GtkPageSetup>> ArgumentCoder<GRefPtr<GtkPageSetup>>::decode(Decoder& decoder)
 {
-    GUniquePtr<GKeyFile> keyFile;
-    if (!decodeGKeyFile(decoder, keyFile))
+    auto variant = decoder.decode<GRefPtr<GVariant>>();
+    if (UNLIKELY(!variant))
         return std::nullopt;
 
-    GRefPtr<GtkPageSetup> pageSetup = adoptGRef(gtk_page_setup_new());
-    if (!keyFile)
-        return pageSetup;
-
-    if (!gtk_page_setup_load_key_file(pageSetup.get(), keyFile.get(), "Page Setup", nullptr))
-        return std::nullopt;
-
-    return pageSetup;
+    return gtk_page_setup_new_from_gvariant(variant->get());
 }
 
 }


### PR DESCRIPTION
#### 5fc7a2593e690290b50e9c9f8d30aab3374798d5
<pre>
[GLIB] Modernize some argument coders
<a href="https://bugs.webkit.org/show_bug.cgi?id=272983">https://bugs.webkit.org/show_bug.cgi?id=272983</a>

Reviewed by Michael Catanzaro.

Move some of the argument coders uses for GLib and GTK types
to use the modern ArgumentCoder API. Remove the GKeyFile coders,
as one can actually use GVariant for serialization of GTK printing
structs and we already have a GVariant serializer.

Also add UNLIKELY() for the std::nullopt bailout cases that can be
optimized.

* Source/WebKit/Platform/IPC/glib/ArgumentCodersGlib.h:
* Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp:
(IPC::ArgumentCoder&lt;GRefPtr&lt;GVariant&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;GTlsCertificate&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;GTlsCertificateFlags&gt;::decode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;GUnixFDList&gt;&gt;::decode):
* Source/WebKit/Shared/gtk/ArgumentCodersGtk.cpp:
(IPC::ArgumentCoder&lt;GRefPtr&lt;GtkPrintSettings&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;GtkPrintSettings&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;GtkPageSetup&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;GtkPageSetup&gt;&gt;::decode):
(IPC::encodeGKeyFile): Deleted.
(IPC::decodeGKeyFile): Deleted.

Canonical link: <a href="https://commits.webkit.org/277967@main">https://commits.webkit.org/277967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2e9fd6d64bf6a9204f3b9cccf6e1e0ffd29a2f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48998 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51686 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45068 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25739 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40053 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25855 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42242 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21161 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23313 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7053 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45239 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43916 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53596 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24049 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20302 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47365 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25312 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42450 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46331 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10799 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26121 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25032 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->