### PR TITLE
[GLIB] Generate the serialization of UserMessage

### DIFF
--- a/Source/WebKit/Shared/glib/UserMessage.serialization.in
+++ b/Source/WebKit/Shared/glib/UserMessage.serialization.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Igalia S.L.
+# Copyright (C) 2023-2024 Igalia, S.L.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -22,9 +22,20 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-header: "UserMessage.h"
-enum class WebKit::UserMessageType : uint8_t {
-     Null,
-     Message,
-     Error,
+[CreateUsing=fromIPCData] struct WebKit::UserMessage {
+    std::variant<WebKit::UserMessage::NullMessage, WebKit::UserMessage::ErrorMessage, WebKit::UserMessage::DataMessage> toIPCData();
+}
+
+[Nested] struct WebKit::UserMessage::NullMessage {
+};
+
+[Nested] struct WebKit::UserMessage::ErrorMessage {
+    CString name;
+    uint32_t errorCode;
+};
+
+[Nested] struct WebKit::UserMessage::DataMessage {
+    CString name;
+    GRefPtr<GVariant> parameters;
+    GRefPtr<GUnixFDList> fileDescriptors;
 };


### PR DESCRIPTION
#### 1a98138e00f6081207550bd007e29a4c7bc1bd25
<pre>
[GLIB] Generate the serialization of UserMessage
<a href="https://bugs.webkit.org/show_bug.cgi?id=272985">https://bugs.webkit.org/show_bug.cgi?id=272985</a>

Reviewed by Michael Catanzaro.

Add a couple of helper data structures for each of the
different types of messages, and use a variant for
serialization, to avoid replicating by hand what the
generated code will do for a variant type.

* Source/WebKit/Shared/glib/UserMessage.cpp:
(WebKit::UserMessage::toIPCData const):
(WebKit::UserMessage::fromIPCData):
(WebKit::UserMessage::encode const): Deleted.
(WebKit::UserMessage::decode): Deleted.
* Source/WebKit/Shared/glib/UserMessage.h:
(WebKit::UserMessage::UserMessage):
* Source/WebKit/Shared/glib/UserMessage.serialization.in:

Canonical link: <a href="https://commits.webkit.org/277945@main">https://commits.webkit.org/277945@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07fa31a39579b88f0b586325fb0a5a2123a9a0d1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28164 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51638 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45021 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34121 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25692 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40015 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49808 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25809 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42203 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21123 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23269 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7006 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45197 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53549 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24002 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20260 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47325 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25265 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42412 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46288 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10789 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26074 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24985 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->