### PR TITLE
[visionOS] Add more logging to LinearMediaPlayer

### DIFF
--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
@@ -151,6 +151,8 @@ enum LinearMediaPlayerErrors: Error {
     }
 
     func makeViewController() -> PlayableViewController {
+        Logger.linearMediaPlayer.log("\(#function)")
+
         let viewController = PlayableViewController()
 #if canImport(LinearMediaKit, _version: 205)
         viewController.playable = self
@@ -478,78 +480,98 @@ extension WKSLinearMediaPlayer: @retroactive Playable {
     }
 
     public func play() {
+        Logger.linearMediaPlayer.log("\(#function)")
         delegate?.linearMediaPlayerPlay?(self)
     }
 
     public func pause() {
+        Logger.linearMediaPlayer.log("\(#function)")
         delegate?.linearMediaPlayerPause?(self)
     }
 
     public func togglePlayback() {
+        Logger.linearMediaPlayer.log("\(#function)")
         delegate?.linearMediaPlayerTogglePlayback?(self)
     }
 
     public func setPlaybackRate(_ rate: Double) {
+        Logger.linearMediaPlayer.log("\(#function) \(rate)")
         delegate?.linearMediaPlayer?(self, setPlaybackRate: rate)
     }
 
     public func seek(to time: TimeInterval) {
+        Logger.linearMediaPlayer.log("\(#function) \(time)")
         delegate?.linearMediaPlayer?(self, seekToTime: time)
     }
 
     public func seek(delta: TimeInterval) {
+        Logger.linearMediaPlayer.log("\(#function) \(delta)")
         delegate?.linearMediaPlayer?(self, seekByDelta: delta)
     }
 
     public func seek(to destination: TimeInterval, from source: TimeInterval, metadata: SeekMetadata) -> TimeInterval {
-        delegate?.linearMediaPlayer?(self, seekToDestination: destination, fromSource: source) ?? TimeInterval.zero
+        Logger.linearMediaPlayer.log("\(#function) destination=\(destination) source=\(source)")
+        return delegate?.linearMediaPlayer?(self, seekToDestination: destination, fromSource: source) ?? TimeInterval.zero
     }
 
     public func completeTrimming(commitChanges: Bool) {
+        Logger.linearMediaPlayer.log("\(#function) \(commitChanges)")
         delegate?.linearMediaPlayer?(self, completeTrimming: commitChanges)
     }
 
     public func updateStartTime(_ time: TimeInterval) {
+        Logger.linearMediaPlayer.log("\(#function) \(time)")
         delegate?.linearMediaPlayer?(self, updateStartTime: time)
     }
 
     public func updateEndTime(_ time: TimeInterval) {
+        Logger.linearMediaPlayer.log("\(#function) \(time)")
         delegate?.linearMediaPlayer?(self, updateEndTime: time)
     }
 
     public func beginEditingVolume() {
+        Logger.linearMediaPlayer.log("\(#function)")
         delegate?.linearMediaPlayerBeginEditingVolume?(self)
     }
 
     public func endEditingVolume() {
+        Logger.linearMediaPlayer.log("\(#function)")
         delegate?.linearMediaPlayerEndEditingVolume?(self)
     }
 
     public func setAudioTrack(_ newTrack: Track?) {
+        Logger.linearMediaPlayer.log("\(#function) \(newTrack?.localizedDisplayName ?? "nil")")
         delegate?.linearMediaPlayer?(self, setAudioTrack: newTrack as? WKSLinearMediaTrack)
     }
 
     public func setLegibleTrack(_ newTrack: Track?) {
+        Logger.linearMediaPlayer.log("\(#function) \(newTrack?.localizedDisplayName ?? "nil")")
         delegate?.linearMediaPlayer?(self, setLegibleTrack: newTrack as? WKSLinearMediaTrack)
     }
 
     public func skipActiveInterstitial() {
+        Logger.linearMediaPlayer.log("\(#function)")
         delegate?.linearMediaPlayerSkipActiveInterstitial?(self)
     }
 
     public func setCaptionContentInsets(_ insets: UIEdgeInsets) {
+        Logger.linearMediaPlayer.log("\(#function) \(NSCoder.string(for: insets))")
         delegate?.linearMediaPlayer?(self, setCaptionContentInsets: insets)
     }
 
     public func updateVideoBounds(_ bounds: CGRect) {
+        Logger.linearMediaPlayer.log("\(#function) \(NSCoder.string(for: bounds))")
         delegate?.linearMediaPlayer?(self, updateVideoBounds: bounds)
     }
 
     public func updateViewingMode(_ mode: ViewingMode?) {
-        delegate?.linearMediaPlayer?(self, update: .init(mode))
+        let viewingMode = WKSLinearMediaViewingMode(mode)
+        Logger.linearMediaPlayer.log("\(#function) \(viewingMode)")
+        delegate?.linearMediaPlayer?(self, update: viewingMode)
     }
 
     public func togglePip() {
+        Logger.linearMediaPlayer.log("\(#function)")
         delegate?.linearMediaPlayerTogglePip?(self)
     }
 
@@ -634,56 +656,67 @@ extension WKSLinearMediaPlayer: @retroactive Playable {
     }
 
     public func setTimeResolverInterval(_ interval: TimeInterval) {
+        Logger.linearMediaPlayer.log("\(#function) \(interval)")
         delegate?.linearMediaPlayer?(self, setTimeResolverInterval: interval)
     }
 
     public func setTimeResolverResolution(_ resolution: TimeInterval) {
+        Logger.linearMediaPlayer.log("\(#function) \(resolution)")
         delegate?.linearMediaPlayer?(self, setTimeResolverResolution: resolution)
     }
 
     public func setThumbnailSize(_ size: CGSize) {
+        Logger.linearMediaPlayer.log("\(#function) \(NSCoder.string(for: size))")
         delegate?.linearMediaPlayer?(self, setThumbnailSize: size)
     }
 
     public func seekThumbnail(to time: TimeInterval) {
+        Logger.linearMediaPlayer.log("\(#function) \(time)")
         delegate?.linearMediaPlayer?(self, seekThumbnailToTime: time)
     }
 
     public func beginScrubbing() {
+        Logger.linearMediaPlayer.log("\(#function)")
         delegate?.linearMediaPlayerBeginScrubbing?(self)
     }
 
     public func endScrubbing() {
+        Logger.linearMediaPlayer.log("\(#function)")
         delegate?.linearMediaPlayerEndScrubbing?(self)
     }
 
     public func beginScanningForward() {
+        Logger.linearMediaPlayer.log("\(#function)")
         delegate?.linearMediaPlayerBeginScanningForward?(self)
     }
 
     public func endScanningForward() {
+        Logger.linearMediaPlayer.log("\(#function)")
         delegate?.linearMediaPlayerEndScanningForward?(self)
     }
 
     public func beginScanningBackward() {
+        Logger.linearMediaPlayer.log("\(#function)")
         delegate?.linearMediaPlayerBeginScanningBackward?(self)
     }
 
     public func endScanningBackward() {
+        Logger.linearMediaPlayer.log("\(#function)")
         delegate?.linearMediaPlayerEndScanningBackward?(self)
     }
 
     public func setVolume(_ volume: Double) {
+        Logger.linearMediaPlayer.log("\(#function) \(volume)")
         delegate?.linearMediaPlayer?(self, setVolume: volume)
     }
 
     public func setIsMuted(_ value: Bool) {
+        Logger.linearMediaPlayer.log("\(#function) \(value)")
         delegate?.linearMediaPlayer?(self, setMuted: value)
     }
 
     public func setVideoReceiverEndpoint(_ endpoint: xpc_object_t) {
         Logger.linearMediaPlayer.log("\(#function)")
-
         delegate?.linearMediaPlayer?(self, setVideoReceiverEndpoint: endpoint)
     }
 }

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift
@@ -139,7 +139,7 @@ extension WKSLinearMediaPresentationState: CustomStringConvertible {
     }
 }
 
-extension WKSLinearMediaViewingMode {
+extension WKSLinearMediaViewingMode: CustomStringConvertible {
     init(_ viewingMode: ViewingMode?) {
         switch viewingMode {
         case .mono?:
@@ -169,6 +169,23 @@ extension WKSLinearMediaViewingMode {
             .immersive
         case .spatial:
             .spatial
+        @unknown default:
+            fatalError()
+        }
+    }
+
+    public var description: String {
+        switch self {
+        case .none:
+            return "none"
+        case .mono:
+            return "mono"
+        case .stereo:
+            return "stereo"
+        case .immersive:
+            return "immersive"
+        case .spatial:
+            return "spatial"
         @unknown default:
             fatalError()
         }


### PR DESCRIPTION
#### 00dc98158062cb0aa544da816c30ecb44f0a4422
<pre>
[visionOS] Add more logging to LinearMediaPlayer
<a href="https://bugs.webkit.org/show_bug.cgi?id=272999">https://bugs.webkit.org/show_bug.cgi?id=272999</a>
<a href="https://rdar.apple.com/126763295">rdar://126763295</a>

Reviewed by Eric Carlson.

Added log messages to Playable entry points in LinearMediaPlayer.

* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift:
(WKSLinearMediaPlayer.makeViewController):
(WKSLinearMediaPlayer.play):
(WKSLinearMediaPlayer.pause):
(WKSLinearMediaPlayer.togglePlayback):
(WKSLinearMediaPlayer.setPlaybackRate(_:)):
(WKSLinearMediaPlayer.seek(to:)):
(WKSLinearMediaPlayer.seek(_:)):
(WKSLinearMediaPlayer.seek(to:from:metadata:)):
(WKSLinearMediaPlayer.completeTrimming(_:)):
(WKSLinearMediaPlayer.updateStartTime(_:)):
(WKSLinearMediaPlayer.updateEndTime(_:)):
(WKSLinearMediaPlayer.beginEditingVolume):
(WKSLinearMediaPlayer.endEditingVolume):
(WKSLinearMediaPlayer.setAudioTrack(_:)):
(WKSLinearMediaPlayer.setLegibleTrack(_:)):
(WKSLinearMediaPlayer.skipActiveInterstitial):
(WKSLinearMediaPlayer.setCaptionContentInsets(_:)):
(WKSLinearMediaPlayer.updateVideoBounds(_:)):
(WKSLinearMediaPlayer.updateViewingMode(_:)):
(WKSLinearMediaPlayer.togglePip):
(WKSLinearMediaPlayer.setTimeResolverInterval(_:)):
(WKSLinearMediaPlayer.setTimeResolverResolution(_:)):
(WKSLinearMediaPlayer.setThumbnailSize(_:)):
(WKSLinearMediaPlayer.seekThumbnail(to:)):
(WKSLinearMediaPlayer.beginScrubbing):
(WKSLinearMediaPlayer.endScrubbing):
(WKSLinearMediaPlayer.beginScanningForward):
(WKSLinearMediaPlayer.endScanningForward):
(WKSLinearMediaPlayer.beginScanningBackward):
(WKSLinearMediaPlayer.endScanningBackward):
(WKSLinearMediaPlayer.setVolume(_:)):
(WKSLinearMediaPlayer.setIsMuted(_:)):
(WKSLinearMediaPlayer.setVideoReceiverEndpoint(_:)):
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift:
(WKSLinearMediaViewingMode.description):

Canonical link: <a href="https://commits.webkit.org/277761@main">https://commits.webkit.org/277761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85f03ad24308971f00e2ea02355db37a538cabee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48486 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51446 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51174 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44551 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25221 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39646 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25379 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41849 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20758 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22860 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6543 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44796 "Found 1 new API test failure: TestWebKitAPI.ElementTargeting.ReplacedRendererSizeIgnoresPageScaleAndZoom (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43505 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53079 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23533 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/19861 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46957 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24798 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42048 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45869 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10698 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25603 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24521 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->