### PR TITLE
Update AutomaticThread::name() to return an ASCIILiteral

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -228,9 +228,9 @@ public:
     {
     }
 
-    const char* name() const final
+    ASCIILiteral name() const final
     {
-        return "JSC Heap Collector Thread";
+        return "JSC Heap Collector Thread"_s;
     }
     
 private:

--- a/Source/JavaScriptCore/heap/HeapHelperPool.cpp
+++ b/Source/JavaScriptCore/heap/HeapHelperPool.cpp
@@ -39,9 +39,9 @@ ParallelHelperPool& heapHelperPool()
         initializeHelperPoolOnceFlag,
         [] {
 #if OS(LINUX)
-            const char* threadName = "HeapHelper";
+            constexpr auto threadName = "HeapHelper"_s;
 #else
-            const char* threadName = "Heap Helper Thread";
+            constexpr auto threadName = "Heap Helper Thread"_s;
 #endif
             helperPool = new ParallelHelperPool(threadName);
             helperPool->ensureThreads(Options::numberOfGCMarkers() - 1);

--- a/Source/JavaScriptCore/jit/JITWorklistThread.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklistThread.cpp
@@ -62,12 +62,13 @@ JITWorklistThread::JITWorklistThread(const AbstractLocker& locker, JITWorklist& 
     , m_worklist(worklist)
 {
 }
-const char* JITWorklistThread::name() const
+
+ASCIILiteral JITWorklistThread::name() const
 {
 #if OS(LINUX)
-    return "JITWorker";
+    return "JITWorker"_s;
 #else
-    return "JIT Worklist Helper Thread";
+    return "JIT Worklist Helper Thread"_s;
 #endif
 }
 

--- a/Source/JavaScriptCore/jit/JITWorklistThread.h
+++ b/Source/JavaScriptCore/jit/JITWorklistThread.h
@@ -50,7 +50,7 @@ class JITWorklistThread final : public AutomaticThread {
 public:
     JITWorklistThread(const AbstractLocker&, JITWorklist&);
 
-    const char* name() const final;
+    ASCIILiteral name() const final;
 
     State state() const { return m_state; }
 

--- a/Source/JavaScriptCore/runtime/VMTraps.cpp
+++ b/Source/JavaScriptCore/runtime/VMTraps.cpp
@@ -256,9 +256,9 @@ public:
         });
     }
 
-    const char* name() const final
+    ASCIILiteral name() const final
     {
-        return "JSC VMTraps Signal Sender Thread";
+        return "JSC VMTraps Signal Sender Thread"_s;
     }
 
     VMTraps& traps() { return m_vm.traps(); }

--- a/Source/JavaScriptCore/wasm/WasmWorklist.cpp
+++ b/Source/JavaScriptCore/wasm/WasmWorklist.cpp
@@ -130,9 +130,9 @@ private:
         return complete(Locker { *worklist.m_lock });
     }
 
-    const char* name() const final
+    ASCIILiteral name() const final
     {
-        return "Wasm Worklist Helper Thread";
+        return "Wasm Worklist Helper Thread"_s;
     }
 
 public:

--- a/Source/WTF/wtf/AutomaticThread.h
+++ b/Source/WTF/wtf/AutomaticThread.h
@@ -126,7 +126,7 @@ public:
 
     void join();
 
-    virtual const char* name() const { return "WTF::AutomaticThread"; }
+    virtual ASCIILiteral name() const { return "WTF::AutomaticThread"_s; }
 
 protected:
     // This logically creates the thread, but in reality the thread won't be created until someone

--- a/Source/WTF/wtf/ParallelHelperPool.cpp
+++ b/Source/WTF/wtf/ParallelHelperPool.cpp
@@ -121,10 +121,10 @@ void ParallelHelperClient::runTask(const RefPtr<SharedTask<void ()>>& task)
     }
 }
 
-ParallelHelperPool::ParallelHelperPool(CString&& threadName)
+ParallelHelperPool::ParallelHelperPool(ASCIILiteral threadName)
     : m_lock(Box<Lock>::create())
     , m_workAvailableCondition(AutomaticThreadCondition::create())
-    , m_threadName(WTFMove(threadName))
+    , m_threadName(threadName)
 {
 }
 
@@ -176,9 +176,9 @@ public:
     {
     }
     
-    const char* name() const final
+    ASCIILiteral name() const final
     {
-        return m_pool.m_threadName.data();
+        return m_pool.m_threadName;
     }
 
 private:

--- a/Source/WTF/wtf/ParallelHelperPool.h
+++ b/Source/WTF/wtf/ParallelHelperPool.h
@@ -66,7 +66,7 @@ class ParallelHelperClient;
 
 class ParallelHelperPool : public ThreadSafeRefCounted<ParallelHelperPool> {
 public:
-    WTF_EXPORT_PRIVATE ParallelHelperPool(CString&& threadName);
+    WTF_EXPORT_PRIVATE ParallelHelperPool(ASCIILiteral threadName);
     WTF_EXPORT_PRIVATE ~ParallelHelperPool();
 
     WTF_EXPORT_PRIVATE void ensureThreads(unsigned numThreads);
@@ -93,7 +93,7 @@ private:
     
     Vector<ParallelHelperClient*> m_clients WTF_GUARDED_BY_LOCK(*m_lock);
     Vector<RefPtr<AutomaticThread>> m_threads;
-    CString m_threadName;
+    ASCIILiteral m_threadName;
     unsigned m_numThreads { 0 }; // This can be larger than m_threads.size() because we start threads only once there is work.
     bool m_isDying { false };
 };

--- a/Source/WTF/wtf/WorkerPool.cpp
+++ b/Source/WTF/wtf/WorkerPool.cpp
@@ -71,7 +71,7 @@ public:
         return m_pool.shouldSleep(locker);
     }
 
-    const char* name() const final
+    ASCIILiteral name() const final
     {
         return m_pool.name();
     }


### PR DESCRIPTION
#### 2520dbab9e5a68d7b0ed4bf669b024800f8dfae3
<pre>
Update AutomaticThread::name() to return an ASCIILiteral
<a href="https://bugs.webkit.org/show_bug.cgi?id=273001">https://bugs.webkit.org/show_bug.cgi?id=273001</a>

Reviewed by Darin Adler.

Update AutomaticThread::name() to return an ASCIILiteral instead of
a raw pointer.

* Source/JavaScriptCore/heap/Heap.cpp:
* Source/JavaScriptCore/heap/HeapHelperPool.cpp:
(JSC::heapHelperPool):
* Source/JavaScriptCore/jit/JITWorklistThread.cpp:
(JSC::JITWorklistThread::name const):
* Source/JavaScriptCore/jit/JITWorklistThread.h:
* Source/JavaScriptCore/runtime/VMTraps.cpp:
* Source/JavaScriptCore/wasm/WasmWorklist.cpp:
* Source/WTF/wtf/AutomaticThread.h:
* Source/WTF/wtf/ParallelHelperPool.cpp:
(WTF::ParallelHelperPool::ParallelHelperPool):
* Source/WTF/wtf/ParallelHelperPool.h:
* Source/WTF/wtf/WorkerPool.cpp:

Canonical link: <a href="https://commits.webkit.org/277767@main">https://commits.webkit.org/277767@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c18ce11968158219a6a05c3f1cdd05499877d7f0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48492 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51179 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44556 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33639 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25226 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39651 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25383 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41851 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20762 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22864 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6548 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/41788 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44800 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43507 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53084 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/47982 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23538 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19864 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46959 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24803 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42050 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45871 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25608 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55477 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6913 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24526 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11408 "Passed tests") | 
<!--EWS-Status-Bubble-End-->