### PR TITLE
testRunner.queueReload should use same load mechanism as original load when running tests with --site-isolation

### DIFF
--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -205,6 +205,7 @@ public:
     void setShouldDownloadContentDispositionAttachments(bool shouldDownload) { m_shouldDownloadContentDispositionAttachments = shouldDownload; }
 
     bool isCurrentInvocation(TestInvocation* invocation) const { return invocation == m_currentInvocation.get(); }
+    TestInvocation* currentInvocation() { return m_currentInvocation.get(); }
 
     void setShouldDecideNavigationPolicyAfterDelay(bool value) { m_shouldDecideNavigationPolicyAfterDelay = value; }
     void setShouldDecideResponsePolicyAfterDelay(bool value) { m_shouldDecideResponsePolicyAfterDelay = value; }

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -106,6 +106,8 @@ public:
 
     void willCreateNewPage();
 
+    void loadTestInCrossOriginIframe();
+
 private:
     WKRetainPtr<WKMutableDictionaryRef> createTestSettingsDictionary();
 

--- a/Tools/WebKitTestRunner/WorkQueueManager.cpp
+++ b/Tools/WebKitTestRunner/WorkQueueManager.cpp
@@ -29,6 +29,7 @@
 #include "PlatformWebView.h"
 #include "StringFunctions.h"
 #include "TestController.h"
+#include "TestInvocation.h"
 #include <WebKit/WKPage.h>
 #include <WebKit/WKPagePrivate.h>
 #include <WebKit/WKRetainPtr.h>
@@ -198,7 +199,10 @@ void WorkQueueManager::queueReload()
     public:
         WorkQueueItem::Type invoke() const
         {
-            WKPageReload(mainPage());
+            if (auto* currentInvocation = TestController::singleton().currentInvocation(); currentInvocation && currentInvocation->options().runInCrossOriginFrame())
+                currentInvocation->loadTestInCrossOriginIframe();
+            else
+                WKPageReload(mainPage());
             return WorkQueueItem::Loading;
         }
     };


### PR DESCRIPTION
#### 7f02621085bc6bbb17a41a54b5e922c5476bf7ea
<pre>
testRunner.queueReload should use same load mechanism as original load when running tests with --site-isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=273005">https://bugs.webkit.org/show_bug.cgi?id=273005</a>
<a href="https://rdar.apple.com/126768112">rdar://126768112</a>

Reviewed by Sihui Liu and Charlie Wolfe.

This is one of at least two things needed to get http/tests/navigation/useragent-reload.py working with --site-isolation

* Tools/WebKitTestRunner/TestController.h:
(WTR::TestController::currentInvocation):
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::loadTestInCrossOriginIframe):
(WTR::TestInvocation::invoke):
* Tools/WebKitTestRunner/TestInvocation.h:
* Tools/WebKitTestRunner/WorkQueueManager.cpp:
(WTR::WorkQueueManager::queueReload):

Canonical link: <a href="https://commits.webkit.org/277890@main">https://commits.webkit.org/277890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c91beefbf5605654152b967dfbb7853b275185e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51455 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51183 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44567 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50801 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33643 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25230 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39654 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49078 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25385 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41853 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20768 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22866 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43026 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6552 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44802 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43509 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53089 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23542 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19866 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46960 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24807 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42052 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45887 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25612 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6980 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24530 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->