### PR TITLE
[webkitscmpy] Read and write BitBucket comments

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
@@ -23,6 +23,7 @@
 import re
 import sys
 
+from collections import defaultdict
 from datetime import datetime
 from webkitcorepy import decorators, string_utils, CallByNeed
 from webkitscmpy import Commit, Contributor, PullRequest
@@ -256,10 +257,24 @@ class BitBucket(Scm):
             pull_request._approvers = got._approvers if got else []
             return pull_request
 
-        def comment(self, pull_request, content, parent=None):
+        def comment(self, pull_request, content, parent=None, on_file=None):
+            if parent and on_file:
+                sys.stderr.write('Cannot reply to a comment on a specific file\n')
+                return None
+
             data = dict(text=content)
             if parent:
                 data['parent'] = dict(id=parent)
+            elif on_file:
+                data['anchor'] = dict(
+                    diffType='EFFECTIVE',
+                    path=on_file['path'],
+                )
+                if on_file.get('line'):
+                    data['anchor']['line'] = on_file['line']
+                    if on_file.get('type'):
+                        data['anchor']['lineType'] = on_file['type']
+                    data['anchor']['fileType'] = on_file.get('fileType', 'TO')
 
             response = requests.post(
                 'https://{domain}/rest/api/1.0/projects/{project}/repos/{name}/pull-requests/{id}/comments'.format(
@@ -299,6 +314,8 @@ class BitBucket(Scm):
 
         def comments(self, pull_request):
             for action in reversed(self.repository.request('pull-requests/{}/activities'.format(pull_request.number)) or []):
+                if action.get('commentAnchor'):
+                    continue
                 comment = action.get('comment', {})
                 user = comment.get('author', {})
                 if not comment or not user or not comment.get('text'):
@@ -322,40 +339,171 @@ class BitBucket(Scm):
                         content=comment.get('text'),
                     )
 
+        @classmethod
+        def _position_converters(cls, json_diff):
+            absolute_to_relative = dict(
+                source=defaultdict(lambda: defaultdict(lambda: None)),
+                destination=defaultdict(lambda: defaultdict(lambda: None))
+            )
+            relative_to_absolute = defaultdict(lambda: defaultdict(list))
+
+            for diff in json_diff.get('diffs', []):
+                destination = diff.get('destination', {}).get('toString')
+                source = diff.get('source', {}).get('toString')
+
+                count = -1
+                for hunk in diff.get('hunks', []):
+                    count += 1
+                    for segment in hunk.get('segments', []):
+                        for line in segment.get('lines', []):
+                            count += 1
+                            source_pos = line.get('source')
+                            dest_pos = line.get('destination')
+                            if segment.get('type') == 'REMOVED':
+                                dest_pos = None
+                            if segment.get('type') == 'ADDED':
+                                source_pos = None
+
+                            if dest_pos:
+                                absolute_to_relative['destination'][source][dest_pos] = count
+                            if source_pos:
+                                absolute_to_relative['source'][source][source_pos] = count
+
+                            if dest_pos:
+                                relative_to_absolute[source][count] = {'to': dest_pos}
+                            elif source_pos:
+                                relative_to_absolute[source][count] = {'from': source_pos}
+                            if segment.get('type'):
+                                relative_to_absolute[source][count]['type'] = segment['type']
+
+            return absolute_to_relative, relative_to_absolute
+
+        def _diff_comments(self, pull_request, json_diff, ids=False):
+            if not json_diff:
+                return None
+
+            relative_pos_mapping, _ = self._position_converters(json_diff)
+            comment_lines = defaultdict(lambda: defaultdict(list))
+            for action in self.repository.request('pull-requests/{}/activities'.format(pull_request.number)) or []:
+                comment = action.get('comment', {})
+                user = comment.get('author', {})
+                comment_id = comment.get('id')
+
+                anchor = action.get('commentAnchor')
+                if not comment or not anchor or not comment_id or not user:
+                    continue
+
+                path = anchor.get('path')
+                if not path:
+                    continue
+
+                if anchor.get('lineType') == 'REMOVED':
+                    position = relative_pos_mapping['source'][path].get(anchor.get('line'))
+                else:
+                    position = relative_pos_mapping['destination'][path].get(anchor.get('line'))
+                if not position and anchor.get('line'):
+                    continue
+
+                comments = [dict(
+                    text=comment.get('text', ''),
+                    user=user,
+                    id=comment_id,
+                    depth=0,
+                )] + self._children_for_comment(comment)
+
+                for comment in comments:
+                    if ids:
+                        comment_lines[path][position].append(comment['id'])
+                    else:
+                        author = self.repository.contributors.create(
+                            comment['user']['displayName'], comment['user']['emailAddress'],
+                            bitbucket=comment['user'].get('name', None),
+                        )
+                        whitespace = ' ' * 4 * comment['depth']
+                        body = '\n{}'.format(whitespace).join(comment.get('text', '').rstrip().splitlines())
+                        if author:
+                            body = '{}{}: {}'.format(whitespace, author, body)
+                        comment_lines[path][position].append(body)
+
+            return comment_lines
+
         def review(self, pull_request, comment=None, approve=None, diff_comments=None):
+            if not comment and approve is None and not diff_comments:
+                raise self.repository.Exception('No review comment or approval provided')
+
             failed = False
             if comment and not self.comment(pull_request, comment):
                 failed = True
+
+            if diff_comments:
+                diff_json = self.repository.request('pull-requests/{}/diff?contextLines={}'.format(pull_request.number, self.repository.DIFF_CONTEXT))
+                if diff_json:
+                    existing_comments = self._diff_comments(pull_request, diff_json, ids=True)
+                    _, absolute_pos_mapping = self._position_converters(diff_json)
+
+                    for file, line_comments in diff_comments.items():
+                        for relative_position, comments in line_comments.items():
+                            body = '\n'.join(comments)
+                            responding_to = (existing_comments.get(file) or {}).get(relative_position, None)
+                            absolute_position = (absolute_pos_mapping.get(file) or {}).get(relative_position, None)
+                            if not absolute_position:
+                                responding_to = (existing_comments.get(file) or {}).get(None, [])
+
+                            if responding_to:
+                                # FIXME: We should allow replies to specific comments
+                                failed = not self.comment(pull_request, body, parent=responding_to[-1])
+                            elif absolute_position:
+                                for candidate in ['to', 'from']:
+                                    if candidate not in absolute_position:
+                                        continue
+                                    failed = not self.comment(pull_request, body, on_file=dict(
+                                        path=file,
+                                        line=absolute_position[candidate],
+                                        fileType=candidate.upper(),
+                                        type=absolute_position.get('type'),
+                                    ))
+                                    break
+                                else:
+
+                                    failed = True
+                            else:
+                                failed = not self.comment(pull_request, body, on_file=dict(path=file))
+
+                else:
+                    sys.stderr.write('Failed to fetch metadata require to make inline comments\n')
+                    failed = True
 
             user_slug = self.repository.whoami()
             if not user_slug:
                 sys.stderr.write('Failed to determine Bitbucket username for current session\n')
                 return None
-            response = requests.put(
-                'https://{domain}/rest/api/1.0/projects/{project}/repos/{name}/pull-requests/{id}/participants/{userSlug}'.format(
-                    domain=self.repository.domain,
-                    project=self.repository.project,
-                    name=self.repository.name,
-                    id=pull_request.number,
-                    userSlug=user_slug,
-                ), json=dict(
-                    user=dict(name=user_slug),
-                    approved=bool(approve),
-                    status={
-                        True: 'APPROVED',
-                        False: 'NEEDS_WORK',
-                    }.get(approve, 'UNAPPROVED'),
-                ),
-            )
-            if response.status_code // 100 != 2:
-                sys.stderr.write("Failed to {} '{}'\n".format(
-                    'approve' if approve else 'reject',
-                    pull_request,
-                ))
-                return None
 
-            pull_request._approvers = None
-            pull_request._blockers = None
+            if approve is not None:
+                response = requests.put(
+                    'https://{domain}/rest/api/1.0/projects/{project}/repos/{name}/pull-requests/{id}/participants/{userSlug}'.format(
+                        domain=self.repository.domain,
+                        project=self.repository.project,
+                        name=self.repository.name,
+                        id=pull_request.number,
+                        userSlug=user_slug,
+                    ), json=dict(
+                        user=dict(name=user_slug),
+                        approved=bool(approve),
+                        status={
+                            True: 'APPROVED',
+                            False: 'NEEDS_WORK',
+                        }.get(approve, 'UNAPPROVED'),
+                    ),
+                )
+                if response.status_code // 100 != 2:
+                    sys.stderr.write("Failed to {} '{}'\n".format(
+                        'approve' if approve else 'reject',
+                        pull_request,
+                    ))
+                    failed = True
+                else:
+                    pull_request._approvers = None
+                    pull_request._blockers = None
 
             return None if failed else pull_request
 
@@ -380,6 +528,23 @@ class BitBucket(Scm):
                     ).get(status.get('state'), 'error'),
                     description=status.get('description'),
                 )
+
+        def diff(self, pull_request, comments=False, diff_comments=None):
+            response = self.repository.request('pull-requests/{}/diff?contextLines={}'.format(pull_request.number, self.repository.DIFF_CONTEXT))
+            if not response:
+                sys.stderr.write('Failed to retrieve diff of {} with status code\n'.format(pull_request))
+                return
+
+            def generator(repository=self.repository, json_diff=response):
+                for line in self.repository.json_to_diff(response).splitlines():
+                    yield line
+
+            comment_lines = defaultdict(lambda: defaultdict(list))
+            if comments:
+                comment_lines = self._diff_comments(pull_request, response)
+
+            for line in self.repository.insert_diff_comments(generator, comments=comment_lines):
+                yield line
 
 
     @classmethod


### PR DESCRIPTION
#### 202bb7baa3ad3688b5fb23f74782cd7ee52ced18
<pre>
[webkitscmpy] Read and write BitBucket comments
<a href="https://bugs.webkit.org/show_bug.cgi?id=273007">https://bugs.webkit.org/show_bug.cgi?id=273007</a>
<a href="https://rdar.apple.com/126769869">rdar://126769869</a>

Reviewed by Elliott Williams.

Provide Python functions to both write and read in-line PR comments.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/bitbucket.py:
(BitBucket.request): Mock endpoints to write and read PR comments.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py:
(BitBucket.PRGenerator.comment): Allow comments to define an anchor.
(BitBucket.PRGenerator.comments): Skip actions which have &apos;commentAnchor&apos;.
(BitBucket.PRGenerator._position_converters): Provide dictionaries to convert from
relative to absolute diff positions and visa versa.
(BitBucket.PRGenerator._diff_comments): Return a list of comments anchored to a relative
diff position.
(BitBucket.PRGenerator.review): Add &apos;diff_comments&apos; argument.
(BitBucket.PRGenerator.diff): Added.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:

Canonical link: <a href="https://commits.webkit.org/278406@main">https://commits.webkit.org/278406@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cd28709dacfcd14da4c92ef36e366d9484883f2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53723 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/1154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52767 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36006 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/804 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41161 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52563 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/27421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/43446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/22266 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/50315 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/24831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8842 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55312 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/25562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48567 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/50485 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/26823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/43604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47610 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/27687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7294 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/26555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->