### PR TITLE
Update CommaPrinter to take in an ASCIILiteral

### DIFF
--- a/Source/JavaScriptCore/b3/B3CaseCollection.cpp
+++ b/Source/JavaScriptCore/b3/B3CaseCollection.cpp
@@ -39,7 +39,7 @@ void CaseCollection::dump(PrintStream& out) const
     CommaPrinter comma;
     for (SwitchCase switchCase : *this)
         out.print(comma, switchCase);
-    out.print(comma, "default->", fallThrough());
+    out.print(comma, "default->"_s, fallThrough());
 }
 
 } } // namespace JSC::B3

--- a/Source/JavaScriptCore/b3/B3Effects.cpp
+++ b/Source/JavaScriptCore/b3/B3Effects.cpp
@@ -87,27 +87,27 @@ bool Effects::interferes(const Effects& other) const
 
 void Effects::dump(PrintStream& out) const
 {
-    CommaPrinter comma("|");
+    CommaPrinter comma("|"_s);
     if (terminal)
-        out.print(comma, "Terminal");
+        out.print(comma, "Terminal"_s);
     if (exitsSideways)
-        out.print(comma, "ExitsSideways");
+        out.print(comma, "ExitsSideways"_s);
     if (controlDependent)
-        out.print(comma, "ControlDependent");
+        out.print(comma, "ControlDependent"_s);
     if (writesLocalState)
-        out.print(comma, "WritesLocalState");
+        out.print(comma, "WritesLocalState"_s);
     if (readsLocalState)
-        out.print(comma, "ReadsLocalState");
+        out.print(comma, "ReadsLocalState"_s);
     if (writesPinned)
-        out.print(comma, "WritesPinned");
+        out.print(comma, "WritesPinned"_s);
     if (readsPinned)
-        out.print(comma, "ReadsPinned");
+        out.print(comma, "ReadsPinned"_s);
     if (fence)
-        out.print(comma, "Fence");
+        out.print(comma, "Fence"_s);
     if (writes)
-        out.print(comma, "Writes:", writes);
+        out.print(comma, "Writes:"_s, writes);
     if (reads)
-        out.print(comma, "Reads:", reads);
+        out.print(comma, "Reads:"_s, reads);
 }
 
 } } // namespace JSC::B3

--- a/Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp
+++ b/Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp
@@ -121,11 +121,11 @@ public:
 
     void dump(PrintStream& out) const
     {
-        out.print("{");
+        out.print("{"_s);
         CommaPrinter comma;
         for (auto& entry : m_map)
-            out.print(comma, pointerDump(entry.key), "=>", pointerListDump(entry.value));
-        out.print("}");
+            out.print(comma, pointerDump(entry.key), "=>"_s, pointerListDump(entry.value));
+        out.print("}"_s);
     }
     
 private:

--- a/Source/JavaScriptCore/b3/B3Kind.cpp
+++ b/Source/JavaScriptCore/b3/B3Kind.cpp
@@ -36,17 +36,17 @@ void Kind::dump(PrintStream& out) const
 {
     out.print(m_opcode);
     
-    CommaPrinter comma(", ", "<");
+    CommaPrinter comma(", "_s, "<"_s);
     if (isChill())
-        out.print(comma, "Chill");
+        out.print(comma, "Chill"_s);
     if (traps())
-        out.print(comma, "Traps");
+        out.print(comma, "Traps"_s);
     if (isSensitiveToNaN())
-        out.print(comma, "SensitiveToNaN");
+        out.print(comma, "SensitiveToNaN"_s);
     if (isCloningForbidden())
-        out.print(comma, "CloningForbidden");
+        out.print(comma, "CloningForbidden"_s);
     if (comma.didPrint())
-        out.print(">");
+        out.print(">"_s);
 }
 
 } } // namespace JSC::B3

--- a/Source/JavaScriptCore/b3/B3PatchpointValue.cpp
+++ b/Source/JavaScriptCore/b3/B3PatchpointValue.cpp
@@ -37,18 +37,18 @@ PatchpointValue::~PatchpointValue()
 void PatchpointValue::dumpMeta(CommaPrinter& comma, PrintStream& out) const
 {
     Base::dumpMeta(comma, out);
-    out.print(comma, "resultConstraints = ");
-    out.print(resultConstraints.size() > 1 ? "[" : "");
+    out.print(comma, "resultConstraints = "_s);
+    out.print(resultConstraints.size() > 1 ? "["_s : ""_s);
 
     CommaPrinter constraintComma;
     for (const auto& constraint : resultConstraints)
         out.print(constraintComma, constraint);
-    out.print(resultConstraints.size() > 1 ? "]" : "");
+    out.print(resultConstraints.size() > 1 ? "]"_s : ""_s);
 
     if (numGPScratchRegisters)
-        out.print(comma, "numGPScratchRegisters = ", numGPScratchRegisters);
+        out.print(comma, "numGPScratchRegisters = "_s, numGPScratchRegisters);
     if (numFPScratchRegisters)
-        out.print(comma, "numFPScratchRegisters = ", numFPScratchRegisters);
+        out.print(comma, "numFPScratchRegisters = "_s, numFPScratchRegisters);
 }
 
 PatchpointValue::PatchpointValue(Type type, Origin origin, Kind kind)

--- a/Source/JavaScriptCore/b3/B3SSACalculator.cpp
+++ b/Source/JavaScriptCore/b3/B3SSACalculator.cpp
@@ -41,11 +41,11 @@ void SSACalculator::Variable::dumpVerbose(PrintStream& out) const
 {
     dump(out);
     if (!m_blocksWithDefs.isEmpty()) {
-        out.print("(defs: ");
+        out.print("(defs: "_s);
         CommaPrinter comma;
         for (BasicBlock* block : m_blocksWithDefs)
             out.print(comma, *block);
-        out.print(")");
+        out.print(")"_s);
     }
 }
 
@@ -110,39 +110,39 @@ SSACalculator::Def* SSACalculator::reachingDefAtTail(BasicBlock* startingBlock, 
 
 void SSACalculator::dump(PrintStream& out) const
 {
-    out.print("<Variables: [");
+    out.print("<Variables: ["_s);
     CommaPrinter comma;
     for (unsigned i = 0; i < m_variables.size(); ++i) {
         out.print(comma);
         m_variables[i].dumpVerbose(out);
     }
-    out.print("], Defs: [");
+    out.print("], Defs: ["_s);
     comma = CommaPrinter();
     for (Def* def : const_cast<SSACalculator*>(this)->m_defs)
         out.print(comma, *def);
-    out.print("], Phis: [");
+    out.print("], Phis: ["_s);
     comma = CommaPrinter();
     for (Def* def : const_cast<SSACalculator*>(this)->m_phis)
         out.print(comma, *def);
-    out.print("], Block data: [");
+    out.print("], Block data: ["_s);
     comma = CommaPrinter();
     for (unsigned blockIndex = 0; blockIndex < m_proc.size(); ++blockIndex) {
         BasicBlock* block = m_proc[blockIndex];
         if (!block)
             continue;
         
-        out.print(comma, *block, "=>(");
-        out.print("Defs: {");
+        out.print(comma, *block, "=>("_s);
+        out.print("Defs: {"_s);
         CommaPrinter innerComma;
         for (auto entry : m_data[block].m_defs)
-            out.print(innerComma, *entry.key, "->", *entry.value);
-        out.print("}, Phis: {");
+            out.print(innerComma, *entry.key, "->"_s, *entry.value);
+        out.print("}, Phis: {"_s);
         innerComma = CommaPrinter();
         for (Def* def : m_data[block].m_phis)
             out.print(innerComma, *def);
-        out.print("})");
+        out.print("})"_s);
     }
-    out.print("]>");
+    out.print("]>"_s);
 }
 
 } } // namespace JSC::B3

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -258,9 +258,9 @@ void Value::dumpChildren(CommaPrinter& comma, PrintStream& out) const
 
 void Value::deepDump(const Procedure* proc, PrintStream& out) const
 {
-    out.print(m_type, " ", dumpPrefix, m_index, " = ", m_kind);
+    out.print(m_type, " "_s, dumpPrefix, m_index, " = "_s, m_kind);
 
-    out.print("(");
+    out.print("("_s);
     CommaPrinter comma;
     dumpChildren(comma, out);
 
@@ -282,7 +282,7 @@ void Value::deepDump(const Procedure* proc, PrintStream& out) const
     }
 #endif
 
-    out.print(")");
+    out.print(")"_s);
 }
 
 void Value::dumpSuccessors(const BasicBlock* block, PrintStream& out) const

--- a/Source/JavaScriptCore/b3/air/AirKind.cpp
+++ b/Source/JavaScriptCore/b3/air/AirKind.cpp
@@ -36,11 +36,11 @@ void Kind::dump(PrintStream& out) const
 {
     out.print(opcode);
     
-    CommaPrinter comma(", ", "<");
+    CommaPrinter comma(", "_s, "<"_s);
     if (effects)
         out.print(comma, "Effects");
     if (comma.didPrint())
-        out.print(">");
+        out.print(">"_s);
 }
 
 } } } // namespace JSC::B3::Air

--- a/Source/JavaScriptCore/b3/air/AirUseCounts.h
+++ b/Source/JavaScriptCore/b3/air/AirUseCounts.h
@@ -109,11 +109,11 @@ public:
 
     void dump(PrintStream& out) const
     {
-        CommaPrinter comma(", ");
+        CommaPrinter comma(", "_s);
         for (unsigned i = 0; i < m_gpNumWarmUsesAndDefs.size(); ++i)
-            out.print(comma, AbsoluteTmpMapper<GP>::tmpFromAbsoluteIndex(i), "=> {numWarmUsesAndDefs=", m_gpNumWarmUsesAndDefs[i], ", isConstDef=", m_gpConstDefs.quickGet(i), "}");
+            out.print(comma, AbsoluteTmpMapper<GP>::tmpFromAbsoluteIndex(i), "=> {numWarmUsesAndDefs="_s, m_gpNumWarmUsesAndDefs[i], ", isConstDef="_s, m_gpConstDefs.quickGet(i), "}"_s);
         for (unsigned i = 0; i < m_fpNumWarmUsesAndDefs.size(); ++i)
-            out.print(comma, AbsoluteTmpMapper<FP>::tmpFromAbsoluteIndex(i), "=> {numWarmUsesAndDefs=", m_fpNumWarmUsesAndDefs[i], ", isConstDef=", m_fpConstDefs.quickGet(i), "}");
+            out.print(comma, AbsoluteTmpMapper<FP>::tmpFromAbsoluteIndex(i), "=> {numWarmUsesAndDefs="_s, m_fpNumWarmUsesAndDefs[i], ", isConstDef="_s, m_fpConstDefs.quickGet(i), "}"_s);
     }
 
 private:

--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -1208,38 +1208,38 @@ bool AccessCase::canReplace(const AccessCase& other) const
 
 void AccessCase::dump(PrintStream& out) const
 {
-    out.print("\n", m_type, ": {");
+    out.print("\n"_s, m_type, ": {"_s);
 
     Indenter indent;
     CommaPrinter comma;
 
     out.print(comma, m_state);
 
-    out.print(comma, "ident = '", m_identifier, "'");
+    out.print(comma, "ident = '"_s, m_identifier, "'"_s);
     if (isValidOffset(m_offset))
-        out.print(comma, "offset = ", m_offset);
+        out.print(comma, "offset = "_s, m_offset);
 
     ++indent;
 
     if (m_polyProtoAccessChain) {
-        out.print("\n", indent, "prototype access chain = ");
+        out.print("\n"_s, indent, "prototype access chain = "_s);
         m_polyProtoAccessChain->dump(structure(), out);
     } else {
         if (m_type == Transition || m_type == Delete || m_type == SetPrivateBrand)
-            out.print("\n", indent, "from structure = ", pointerDump(structure()),
-                "\n", indent, "to structure = ", pointerDump(newStructure()));
+            out.print("\n"_s, indent, "from structure = "_s, pointerDump(structure()),
+                "\n"_s, indent, "to structure = "_s, pointerDump(newStructure()));
         else if (m_structureID)
-            out.print("\n", indent, "structure = ", pointerDump(m_structureID.get()));
+            out.print("\n"_s, indent, "structure = "_s, pointerDump(m_structureID.get()));
     }
 
     if (!m_conditionSet.isEmpty())
-        out.print("\n", indent, "conditions = ", m_conditionSet);
+        out.print("\n"_s, indent, "conditions = "_s, m_conditionSet);
 
     const_cast<AccessCase*>(this)->runWithDowncast([&](auto* accessCase) {
         accessCase->dumpImpl(out, comma, indent);
     });
 
-    out.print("}");
+    out.print("}"_s);
 }
 
 bool AccessCase::visitWeak(VM& vm) const

--- a/Source/JavaScriptCore/bytecode/ArrayProfile.cpp
+++ b/Source/JavaScriptCore/bytecode/ArrayProfile.cpp
@@ -53,71 +53,71 @@ const ArrayModes typedArrayModes[NumberOfTypedArrayTypesExcludingDataView] = {
 void dumpArrayModes(PrintStream& out, ArrayModes arrayModes)
 {
     if (!arrayModes) {
-        out.print("<empty>");
+        out.print("<empty>"_s);
         return;
     }
     
     if (arrayModes == ALL_ARRAY_MODES) {
-        out.print("TOP");
+        out.print("TOP"_s);
         return;
     }
     
-    CommaPrinter comma("|");
+    CommaPrinter comma("|"_s);
     if (arrayModes & asArrayModesIgnoringTypedArrays(NonArray))
-        out.print(comma, "NonArray");
+        out.print(comma, "NonArray"_s);
     if (arrayModes & asArrayModesIgnoringTypedArrays(NonArrayWithInt32))
-        out.print(comma, "NonArrayWithInt32");
+        out.print(comma, "NonArrayWithInt32"_s);
     if (arrayModes & asArrayModesIgnoringTypedArrays(NonArrayWithDouble))
-        out.print(comma, "NonArrayWithDouble");
+        out.print(comma, "NonArrayWithDouble"_s);
     if (arrayModes & asArrayModesIgnoringTypedArrays(NonArrayWithContiguous))
-        out.print(comma, "NonArrayWithContiguous");
+        out.print(comma, "NonArrayWithContiguous"_s);
     if (arrayModes & asArrayModesIgnoringTypedArrays(NonArrayWithArrayStorage))
-        out.print(comma, "NonArrayWithArrayStorage");
+        out.print(comma, "NonArrayWithArrayStorage"_s);
     if (arrayModes & asArrayModesIgnoringTypedArrays(NonArrayWithSlowPutArrayStorage))
-        out.print(comma, "NonArrayWithSlowPutArrayStorage");
+        out.print(comma, "NonArrayWithSlowPutArrayStorage"_s);
     if (arrayModes & asArrayModesIgnoringTypedArrays(ArrayClass))
-        out.print(comma, "ArrayClass");
+        out.print(comma, "ArrayClass"_s);
     if (arrayModes & asArrayModesIgnoringTypedArrays(ArrayWithUndecided))
-        out.print(comma, "ArrayWithUndecided");
+        out.print(comma, "ArrayWithUndecided"_s);
     if (arrayModes & asArrayModesIgnoringTypedArrays(ArrayWithInt32))
-        out.print(comma, "ArrayWithInt32");
+        out.print(comma, "ArrayWithInt32"_s);
     if (arrayModes & asArrayModesIgnoringTypedArrays(ArrayWithDouble))
-        out.print(comma, "ArrayWithDouble");
+        out.print(comma, "ArrayWithDouble"_s);
     if (arrayModes & asArrayModesIgnoringTypedArrays(ArrayWithContiguous))
-        out.print(comma, "ArrayWithContiguous");
+        out.print(comma, "ArrayWithContiguous"_s);
     if (arrayModes & asArrayModesIgnoringTypedArrays(ArrayWithArrayStorage))
-        out.print(comma, "ArrayWithArrayStorage");
+        out.print(comma, "ArrayWithArrayStorage"_s);
     if (arrayModes & asArrayModesIgnoringTypedArrays(ArrayWithSlowPutArrayStorage))
-        out.print(comma, "ArrayWithSlowPutArrayStorage");
+        out.print(comma, "ArrayWithSlowPutArrayStorage"_s);
     if (arrayModes & asArrayModesIgnoringTypedArrays(CopyOnWriteArrayWithInt32))
-        out.print(comma, "CopyOnWriteArrayWithInt32");
+        out.print(comma, "CopyOnWriteArrayWithInt32"_s);
     if (arrayModes & asArrayModesIgnoringTypedArrays(CopyOnWriteArrayWithDouble))
-        out.print(comma, "CopyOnWriteArrayWithDouble");
+        out.print(comma, "CopyOnWriteArrayWithDouble"_s);
     if (arrayModes & asArrayModesIgnoringTypedArrays(CopyOnWriteArrayWithContiguous))
-        out.print(comma, "CopyOnWriteArrayWithContiguous");
+        out.print(comma, "CopyOnWriteArrayWithContiguous"_s);
 
     if (arrayModes & Int8ArrayMode)
-        out.print(comma, "Int8ArrayMode");
+        out.print(comma, "Int8ArrayMode"_s);
     if (arrayModes & Int16ArrayMode)
-        out.print(comma, "Int16ArrayMode");
+        out.print(comma, "Int16ArrayMode"_s);
     if (arrayModes & Int32ArrayMode)
-        out.print(comma, "Int32ArrayMode");
+        out.print(comma, "Int32ArrayMode"_s);
     if (arrayModes & Uint8ArrayMode)
-        out.print(comma, "Uint8ArrayMode");
+        out.print(comma, "Uint8ArrayMode"_s);
     if (arrayModes & Uint8ClampedArrayMode)
-        out.print(comma, "Uint8ClampedArrayMode");
+        out.print(comma, "Uint8ClampedArrayMode"_s);
     if (arrayModes & Uint16ArrayMode)
-        out.print(comma, "Uint16ArrayMode");
+        out.print(comma, "Uint16ArrayMode"_s);
     if (arrayModes & Uint32ArrayMode)
-        out.print(comma, "Uint32ArrayMode");
+        out.print(comma, "Uint32ArrayMode"_s);
     if (arrayModes & Float32ArrayMode)
-        out.print(comma, "Float32ArrayMode");
+        out.print(comma, "Float32ArrayMode"_s);
     if (arrayModes & Float64ArrayMode)
-        out.print(comma, "Float64ArrayMode");
+        out.print(comma, "Float64ArrayMode"_s);
     if (arrayModes & BigInt64ArrayMode)
-        out.print(comma, "BigInt64ArrayMode");
+        out.print(comma, "BigInt64ArrayMode"_s);
     if (arrayModes & BigUint64ArrayMode)
-        out.print(comma, "BigUint64ArrayMode");
+        out.print(comma, "BigUint64ArrayMode"_s);
 }
 
 void ArrayProfile::computeUpdatedPrediction(CodeBlock* codeBlock)
@@ -183,15 +183,15 @@ CString ArrayProfile::briefDescriptionWithoutUpdating()
     if (m_observedArrayModes)
         out.print(comma, ArrayModesDump(m_observedArrayModes));
     if (m_arrayProfileFlags.contains(ArrayProfileFlag::MayStoreHole))
-        out.print(comma, "Hole");
+        out.print(comma, "Hole"_s);
     if (m_arrayProfileFlags.contains(ArrayProfileFlag::OutOfBounds))
-        out.print(comma, "OutOfBounds");
+        out.print(comma, "OutOfBounds"_s);
     if (m_arrayProfileFlags.contains(ArrayProfileFlag::MayInterceptIndexedAccesses))
-        out.print(comma, "Intercept");
+        out.print(comma, "Intercept"_s);
     if (!m_arrayProfileFlags.contains(ArrayProfileFlag::UsesNonOriginalArrayStructures))
-        out.print(comma, "Original");
+        out.print(comma, "Original"_s);
     if (!m_arrayProfileFlags.contains(ArrayProfileFlag::MayBeResizableOrGrowableSharedTypedArray))
-        out.print(comma, "Resizable");
+        out.print(comma, "Resizable"_s);
 
     return out.toCString();
 }

--- a/Source/JavaScriptCore/bytecode/CallLinkStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkStatus.cpp
@@ -427,26 +427,26 @@ void CallLinkStatus::filter(JSValue value)
 void CallLinkStatus::dump(PrintStream& out) const
 {
     if (!isSet()) {
-        out.print("Not Set");
+        out.print("Not Set"_s);
         return;
     }
     
     CommaPrinter comma;
     
     if (m_isProved)
-        out.print(comma, "Statically Proved");
+        out.print(comma, "Statically Proved"_s);
     
     if (m_couldTakeSlowPath)
-        out.print(comma, "Could Take Slow Path");
+        out.print(comma, "Could Take Slow Path"_s);
     
     if (m_isBasedOnStub)
-        out.print(comma, "Based On Stub");
+        out.print(comma, "Based On Stub"_s);
     
     if (!m_variants.isEmpty())
         out.print(comma, listDump(m_variants));
     
     if (m_maxArgumentCountIncludingThisForVarargs)
-        out.print(comma, "maxArgumentCountIncludingThisForVarargs = ", m_maxArgumentCountIncludingThisForVarargs);
+        out.print(comma, "maxArgumentCountIncludingThisForVarargs = "_s, m_maxArgumentCountIncludingThisForVarargs);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/ExitFlag.cpp
+++ b/Source/JavaScriptCore/bytecode/ExitFlag.cpp
@@ -33,15 +33,15 @@ namespace JSC {
 void ExitFlag::dump(PrintStream& out) const
 {
     if (!m_bits) {
-        out.print("false");
+        out.print("false"_s);
         return;
     }
     
-    CommaPrinter comma("|");
+    CommaPrinter comma("|"_s);
     if (isSet(ExitFromNotInlined))
-        out.print(comma, "notInlined");
+        out.print(comma, "notInlined"_s);
     if (isSet(ExitFromInlined))
-        out.print(comma, "inlined");
+        out.print(comma, "inlined"_s);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -4780,11 +4780,11 @@ DEFINE_VISIT_AGGREGATE(PolymorphicAccess);
 
 void PolymorphicAccess::dump(PrintStream& out) const
 {
-    out.print(RawPointer(this), ":[");
+    out.print(RawPointer(this), ":["_s);
     CommaPrinter comma;
     for (auto& entry : m_list)
         out.print(comma, *entry);
-    out.print("]");
+    out.print("]"_s);
 }
 
 void InlineCacheHandler::aboutToDie()

--- a/Source/JavaScriptCore/bytecode/OperandsInlines.h
+++ b/Source/JavaScriptCore/bytecode/OperandsInlines.h
@@ -41,42 +41,42 @@ inline void Operand::dump(PrintStream& out) const
 template<typename T, typename U>
 void Operands<T, U>::dumpInContext(PrintStream& out, DumpContext* context) const
 {
-    CommaPrinter comma(" ");
+    CommaPrinter comma(" "_s);
     for (size_t argumentIndex = numberOfArguments(); argumentIndex--;) {
         if (!argument(argumentIndex))
             continue;
-        out.print(comma, "arg", argumentIndex, ":", inContext(argument(argumentIndex), context));
+        out.print(comma, "arg"_s, argumentIndex, ":"_s, inContext(argument(argumentIndex), context));
     }
     for (size_t localIndex = 0; localIndex < numberOfLocals(); ++localIndex) {
         if (!local(localIndex))
             continue;
-        out.print(comma, "loc", localIndex, ":", inContext(local(localIndex), context));
+        out.print(comma, "loc"_s, localIndex, ":"_s, inContext(local(localIndex), context));
     }
     for (size_t tmpIndex = 0; tmpIndex < numberOfTmps(); ++tmpIndex) {
         if (!tmp(tmpIndex))
             continue;
-        out.print(comma, "tmp", tmpIndex, ":", inContext(tmp(tmpIndex), context));
+        out.print(comma, "tmp"_s, tmpIndex, ":"_s, inContext(tmp(tmpIndex), context));
     }
 }
 
 template<typename T, typename U>
 void Operands<T, U>::dump(PrintStream& out) const
 {
-    CommaPrinter comma(" ");
+    CommaPrinter comma(" "_s);
     for (size_t argumentIndex = numberOfArguments(); argumentIndex--;) {
         if (!argument(argumentIndex))
             continue;
-        out.print(comma, "arg", argumentIndex, ":", argument(argumentIndex));
+        out.print(comma, "arg"_s, argumentIndex, ":"_s, argument(argumentIndex));
     }
     for (size_t localIndex = 0; localIndex < numberOfLocals(); ++localIndex) {
         if (!local(localIndex))
             continue;
-        out.print(comma, "loc", localIndex, ":", local(localIndex));
+        out.print(comma, "loc"_s, localIndex, ":"_s, local(localIndex));
     }
     for (size_t tmpIndex = 0; tmpIndex < numberOfTmps(); ++tmpIndex) {
         if (!tmp(tmpIndex))
             continue;
-        out.print(comma, "tmp", tmpIndex, ":", tmp(tmpIndex));
+        out.print(comma, "tmp"_s, tmpIndex, ":"_s, tmp(tmpIndex));
     }
 }
 

--- a/Source/JavaScriptCore/bytecode/PutByIdFlags.cpp
+++ b/Source/JavaScriptCore/bytecode/PutByIdFlags.cpp
@@ -34,11 +34,11 @@ namespace WTF {
 using namespace JSC;
 
 void printInternal(PrintStream& out, PutByIdFlags flags) {
-    CommaPrinter comma("|");
+    CommaPrinter comma("|"_s);
     if (flags.isDirect())
-        out.print(comma, "IsDirect");
+        out.print(comma, "IsDirect"_s);
     if (flags.ecmaMode().isStrict())
-        out.print(comma, "Strict");
+        out.print(comma, "Strict"_s);
 }
 
 } // namespace WTF

--- a/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
@@ -58,7 +58,7 @@ namespace JSC {
 struct PrettyPrinter {
     PrettyPrinter(PrintStream& out)
         : out(out)
-        , separator("|")
+        , separator("|"_s)
     { }
     
     template<typename T>

--- a/Source/JavaScriptCore/bytecode/StructureSet.cpp
+++ b/Source/JavaScriptCore/bytecode/StructureSet.cpp
@@ -53,9 +53,9 @@ bool StructureSet::isStillAlive(VM& vm) const
 void StructureSet::dumpInContext(PrintStream& out, DumpContext* context) const
 {
     CommaPrinter comma;
-    out.print("[");
+    out.print("["_s);
     forEach([&] (Structure* structure) { out.print(comma, inContext(*structure, context)); });
-    out.print("]");
+    out.print("]"_s);
 }
 
 void StructureSet::dump(PrintStream& out) const

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -5417,7 +5417,7 @@ void AbstractInterpreter<AbstractStateType>::dump(PrintStream& out) const
 template<typename AbstractStateType>
 void AbstractInterpreter<AbstractStateType>::dump(PrintStream& out)
 {
-    CommaPrinter comma(" ");
+    CommaPrinter comma(" "_s);
     HashSet<NodeFlowProjection> seen;
     if (m_graph.m_form == SSA) {
         for (NodeFlowProjection node : m_state.block()->ssa->liveAtHead) {
@@ -5425,7 +5425,7 @@ void AbstractInterpreter<AbstractStateType>::dump(PrintStream& out)
             AbstractValue& value = forNode(node);
             if (value.isClear())
                 continue;
-            out.print(comma, node, ":", value);
+            out.print(comma, node, ":"_s, value);
         }
     }
     for (size_t i = 0; i < m_state.block()->size(); ++i) {
@@ -5435,7 +5435,7 @@ void AbstractInterpreter<AbstractStateType>::dump(PrintStream& out)
                 AbstractValue& value = forNode(nodeProjection);
                 if (value.isClear())
                     return;
-                out.print(comma, nodeProjection, ":", value);
+                out.print(comma, nodeProjection, ":"_s, value);
             });
     }
     if (m_graph.m_form == SSA) {
@@ -5445,7 +5445,7 @@ void AbstractInterpreter<AbstractStateType>::dump(PrintStream& out)
             AbstractValue& value = forNode(node);
             if (value.isClear())
                 continue;
-            out.print(comma, node, ":", value);
+            out.print(comma, node, ":"_s, value);
         }
     }
 }

--- a/Source/JavaScriptCore/dfg/DFGBlockSet.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBlockSet.cpp
@@ -32,9 +32,9 @@ namespace JSC { namespace DFG {
 
 void BlockSet::dump(PrintStream& out) const
 {
-    CommaPrinter comma(" ");
+    CommaPrinter comma(" "_s);
     for (BlockIndex blockIndex = m_set.findBit(0, true); blockIndex < m_set.size(); blockIndex = m_set.findBit(blockIndex + 1, true))
-        out.print(comma, "#", blockIndex);
+        out.print(comma, "#"_s, blockIndex);
 }
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGFlowMap.h
+++ b/Source/JavaScriptCore/dfg/DFGFlowMap.h
@@ -132,13 +132,13 @@ void printInternal(PrintStream& out, const JSC::DFG::FlowMap<T>& map)
     for (unsigned i = 0; i < map.graph().maxNodeCount(); ++i) {
         if (JSC::DFG::Node* node = map.graph().nodeAt(i)) {
             if (const T& value = map.at(node))
-                out.print(comma, node, "=>", value);
+                out.print(comma, node, "=>"_s, value);
         }
     }
     for (unsigned i = 0; i < map.graph().maxNodeCount(); ++i) {
         if (JSC::DFG::Node* node = map.graph().nodeAt(i)) {
             if (const T& value = map.atShadow(node))
-                out.print(comma, "shadow(", node, ")=>", value);
+                out.print(comma, "shadow("_s, node, ")=>"_s, value);
         }
     }
 }

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -205,8 +205,8 @@ void Graph::dump(PrintStream& out, const char* prefixStr, Node* node, DumpContex
     if (node->hasResult() && node->hasVirtualRegister() && node->virtualRegister().isValid())
         out.print(node->virtualRegister());
     else
-        out.print("-");
-    out.print(">\t", opName(op), "(");
+        out.print("-"_s);
+    out.print(">\t"_s, opName(op), "("_s);
     CommaPrinter comma;
     if (node->flags() & NodeHasVarArgs) {
         for (unsigned childIdx = node->firstChild(); childIdx < node->firstChild() + node->numChildren(); childIdx++) {
@@ -228,17 +228,17 @@ void Graph::dump(PrintStream& out, const char* prefixStr, Node* node, DumpContex
     if (node->prediction())
         out.print(comma, SpeculationDump(node->prediction()));
     if (node->hasNumberOfArgumentsToSkip())
-        out.print(comma, "numberOfArgumentsToSkip = ", node->numberOfArgumentsToSkip());
+        out.print(comma, "numberOfArgumentsToSkip = "_s, node->numberOfArgumentsToSkip());
     if (node->hasNumberOfBoundArguments())
-        out.print(comma, "numberOfBoundArguments = ", node->numberOfBoundArguments());
+        out.print(comma, "numberOfBoundArguments = "_s, node->numberOfBoundArguments());
     if (node->hasArrayMode())
         out.print(comma, node->arrayMode());
     if (node->hasArithUnaryType())
-        out.print(comma, "Type:", node->arithUnaryType());
+        out.print(comma, "Type:"_s, node->arithUnaryType());
     if (node->hasArithMode())
         out.print(comma, node->arithMode());
     if (node->hasArithRoundingMode())
-        out.print(comma, "Rounding:", node->arithRoundingMode());
+        out.print(comma, "Rounding:"_s, node->arithRoundingMode());
     if (node->hasScopeOffset())
         out.print(comma, node->scopeOffset());
     if (node->hasDirectArgumentsOffset())
@@ -246,11 +246,11 @@ void Graph::dump(PrintStream& out, const char* prefixStr, Node* node, DumpContex
     if (node->hasArgumentIndex())
         out.print(comma, node->argumentIndex());
     if (node->hasRegisterPointer())
-        out.print(comma, "global", "(", RawPointer(node->variablePointer()), ")");
+        out.print(comma, "global", "("_s, RawPointer(node->variablePointer()), ")"_s);
     if (node->hasIdentifier() && node->identifierNumber() != UINT32_MAX)
-        out.print(comma, "id", node->identifierNumber(), "{", identifiers()[node->identifierNumber()], "}");
+        out.print(comma, "id"_s, node->identifierNumber(), "{"_s, identifiers()[node->identifierNumber()], "}"_s);
     if (node->hasCacheableIdentifier() && node->cacheableIdentifier())
-        out.print(comma, "cachable-id {", node->cacheableIdentifier(), "}");
+        out.print(comma, "cachable-id {"_s, node->cacheableIdentifier(), "}"_s);
     if (node->hasPromotedLocationDescriptor())
         out.print(comma, node->promotedLocationDescriptor());
     if (node->hasClassInfo())
@@ -264,25 +264,25 @@ void Graph::dump(PrintStream& out, const char* prefixStr, Node* node, DumpContex
     if (node->hasTransition()) {
         out.print(comma, pointerDumpInContext(node->transition(), context));
 #if USE(JSVALUE64)
-        out.print(", ID:", node->transition()->next->id().bits());
+        out.print(", ID:"_s, node->transition()->next->id().bits());
 #else
-        out.print(", ID:", RawPointer(node->transition()->next.get()));
+        out.print(", ID:"_s, RawPointer(node->transition()->next.get()));
 #endif
     }
     if (node->hasCellOperand()) {
         if (!node->cellOperand()->value() || !node->cellOperand()->value().isCell())
-            out.print(comma, "invalid cell operand: ", node->cellOperand()->value());
+            out.print(comma, "invalid cell operand: "_s, node->cellOperand()->value());
         else {
             out.print(comma, pointerDump(node->cellOperand()->value().asCell()));
             if (node->cellOperand()->value().isCell()) {
                 CallVariant variant(node->cellOperand()->value().asCell());
                 if (ExecutableBase* executable = variant.executable()) {
                     if (executable->isHostFunction())
-                        out.print(comma, "<host function>");
+                        out.print(comma, "<host function>"_s);
                     else if (FunctionExecutable* functionExecutable = jsDynamicCast<FunctionExecutable*>(executable))
                         out.print(comma, FunctionExecutableDump(functionExecutable));
                     else
-                        out.print(comma, "<non-function executable>");
+                        out.print(comma, "<non-function executable>"_s);
                 }
             }
         }
@@ -293,8 +293,8 @@ void Graph::dump(PrintStream& out, const char* prefixStr, Node* node, DumpContex
         out.print(comma, node->structureFlags());
     if (node->hasStorageAccessData()) {
         StorageAccessData& storageAccessData = node->storageAccessData();
-        out.print(comma, "id", storageAccessData.identifierNumber, "{", identifiers()[storageAccessData.identifierNumber], "}");
-        out.print(", ", static_cast<ptrdiff_t>(storageAccessData.offset));
+        out.print(comma, "id"_s, storageAccessData.identifierNumber, "{"_s, identifiers()[storageAccessData.identifierNumber], "}"_s);
+        out.print(", "_s, static_cast<ptrdiff_t>(storageAccessData.offset));
     }
     if (node->hasMultiGetByOffsetData()) {
         MultiGetByOffsetData& data = node->multiGetByOffsetData();
@@ -304,42 +304,42 @@ void Graph::dump(PrintStream& out, const char* prefixStr, Node* node, DumpContex
     }
     if (node->hasMultiPutByOffsetData()) {
         MultiPutByOffsetData& data = node->multiPutByOffsetData();
-        out.print(comma, "id", data.identifierNumber, "{", identifiers()[data.identifierNumber], "}");
+        out.print(comma, "id"_s, data.identifierNumber, "{"_s, identifiers()[data.identifierNumber], "}"_s);
         for (unsigned i = 0; i < data.variants.size(); ++i)
             out.print(comma, inContext(data.variants[i], context));
     }
     if (node->hasMultiDeleteByOffsetData()) {
         MultiDeleteByOffsetData& data = node->multiDeleteByOffsetData();
-        out.print(comma, "id", data.identifierNumber, "{", identifiers()[data.identifierNumber], "}");
+        out.print(comma, "id"_s, data.identifierNumber, "{"_s, identifiers()[data.identifierNumber], "}"_s);
         for (unsigned i = 0; i < data.variants.size(); ++i)
             out.print(comma, inContext(data.variants[i], context));
     }
     if (node->hasMatchStructureData()) {
         for (MatchStructureVariant& variant : node->matchStructureData().variants)
-            out.print(comma, inContext(*variant.structure.get(), context), "=>", variant.result);
+            out.print(comma, inContext(*variant.structure.get(), context), "=>"_s, variant.result);
     }
     ASSERT(node->hasVariableAccessData(*this) == node->accessesStack(*this));
     if (node->hasVariableAccessData(*this)) {
         VariableAccessData* variableAccessData = node->tryGetVariableAccessData();
         if (variableAccessData) {
             Operand operand = variableAccessData->operand();
-            out.print(comma, variableAccessData->operand(), "(", VariableAccessDataDump(*this, variableAccessData), ")");
+            out.print(comma, variableAccessData->operand(), "("_s, VariableAccessDataDump(*this, variableAccessData), ")"_s);
             operand = variableAccessData->machineLocal();
             if (operand.isValid())
-                out.print(comma, "machine:", operand);
+                out.print(comma, "machine:"_s, operand);
         }
     }
     if (node->hasStackAccessData()) {
         StackAccessData* data = node->stackAccessData();
         out.print(comma, data->operand);
         if (data->machineLocal.isValid())
-            out.print(comma, "machine:", data->machineLocal);
+            out.print(comma, "machine:"_s, data->machineLocal);
         out.print(comma, data->format);
     }
     if (node->hasUnlinkedOperand())
         out.print(comma, node->unlinkedOperand());
     if (node->hasVectorLengthHint())
-        out.print(comma, "vectorLengthHint = ", node->vectorLengthHint());
+        out.print(comma, "vectorLengthHint = "_s, node->vectorLengthHint());
     if (node->hasLazyJSValue())
         out.print(comma, node->lazyJSValue());
     if (node->hasIndexingType())
@@ -347,7 +347,7 @@ void Graph::dump(PrintStream& out, const char* prefixStr, Node* node, DumpContex
     if (node->hasTypedArrayType())
         out.print(comma, node->typedArrayType());
     if (node->hasPhi())
-        out.print(comma, "^", node->phi()->index());
+        out.print(comma, "^"_s, node->phi()->index());
     if (node->hasExecutionCounter())
         out.print(comma, RawPointer(node->executionCounter()));
     if (node->hasWatchpointSet())
@@ -357,30 +357,30 @@ void Graph::dump(PrintStream& out, const char* prefixStr, Node* node, DumpContex
     if (node->hasObjectMaterializationData())
         out.print(comma, node->objectMaterializationData());
     if (node->hasCallVarargsData())
-        out.print(comma, "firstVarArgOffset = ", node->callVarargsData()->firstVarArgOffset);
+        out.print(comma, "firstVarArgOffset = "_s, node->callVarargsData()->firstVarArgOffset);
     if (node->hasLoadVarargsData()) {
         LoadVarargsData* data = node->loadVarargsData();
-        out.print(comma, "start = ", data->start, ", count = ", data->count);
+        out.print(comma, "start = "_s, data->start, ", count = "_s, data->count);
         if (data->machineStart.isValid())
             out.print(", machineStart = ", data->machineStart);
         if (data->machineCount.isValid())
-            out.print(", machineCount = ", data->machineCount);
-        out.print(", offset = ", data->offset, ", mandatoryMinimum = ", data->mandatoryMinimum);
-        out.print(", limit = ", data->limit);
+            out.print(", machineCount = "_s, data->machineCount);
+        out.print(", offset = "_s, data->offset, ", mandatoryMinimum = "_s, data->mandatoryMinimum);
+        out.print(", limit = "_s, data->limit);
     }
     if (node->hasIsInternalPromise())
-        out.print(comma, "isInternalPromise = ", node->isInternalPromise());
+        out.print(comma, "isInternalPromise = "_s, node->isInternalPromise());
     if (node->hasInternalFieldIndex())
-        out.print(comma, "internalFieldIndex = ", node->internalFieldIndex());
+        out.print(comma, "internalFieldIndex = "_s, node->internalFieldIndex());
     if (node->hasCallDOMGetterData()) {
         CallDOMGetterData* data = node->callDOMGetterData();
-        out.print(comma, "id", data->identifierNumber, "{", identifiers()[data->identifierNumber], "}");
-        out.print(", domJIT = ", RawPointer(data->domJIT));
+        out.print(comma, "id"_s, data->identifierNumber, "{"_s, identifiers()[data->identifierNumber], "}"_s);
+        out.print(", domJIT = "_s, RawPointer(data->domJIT));
     }
     if (node->hasIgnoreLastIndexIsWritable())
-        out.print(comma, "ignoreLastIndexIsWritable = ", node->ignoreLastIndexIsWritable());
+        out.print(comma, "ignoreLastIndexIsWritable = "_s, node->ignoreLastIndexIsWritable());
     if (node->hasIntrinsic())
-        out.print(comma, "intrinsic = ", node->intrinsic());
+        out.print(comma, "intrinsic = "_s, node->intrinsic());
     if (node->isConstant())
         out.print(comma, pointerDumpInContext(node->constant(), context));
     if (node->hasCallLinkStatus())
@@ -392,19 +392,19 @@ void Graph::dump(PrintStream& out, const char* prefixStr, Node* node, DumpContex
     if (node->hasPutByStatus())
         out.print(comma, *node->putByStatus());
     if (node->hasEnumeratorMetadata())
-        out.print(comma, "enumeratorModes = ", node->enumeratorMetadata().toRaw());
+        out.print(comma, "enumeratorModes = "_s, node->enumeratorMetadata().toRaw());
     if (node->hasExtractOffset())
-        out.print(comma, "<<", node->extractOffset());
+        out.print(comma, "<<"_s, node->extractOffset());
     if (node->isJump())
-        out.print(comma, "T:", *node->targetBlock());
+        out.print(comma, "T:"_s, *node->targetBlock());
     if (node->isBranch())
-        out.print(comma, "T:", node->branchData()->taken, ", F:", node->branchData()->notTaken);
+        out.print(comma, "T:"_s, node->branchData()->taken, ", F:"_s, node->branchData()->notTaken);
     if (node->isSwitch()) {
         SwitchData* data = node->switchData();
         out.print(comma, data->kind);
         for (unsigned i = 0; i < data->cases.size(); ++i)
-            out.print(comma, inContext(data->cases[i].value, context), ":", data->cases[i].target);
-        out.print(comma, "default:", data->fallThrough);
+            out.print(comma, inContext(data->cases[i].value, context), ":"_s, data->cases[i].target);
+        out.print(comma, "default:"_s, data->fallThrough);
     }
     if (node->isEntrySwitch()) {
         EntrySwitchData* data = node->entrySwitchData();
@@ -415,30 +415,30 @@ void Graph::dump(PrintStream& out, const char* prefixStr, Node* node, DumpContex
     ClobberSet writes;
     addReadsAndWrites(*this, node, reads, writes);
     if (!reads.isEmpty())
-        out.print(comma, "R:", sortedListDump(reads.direct(), ","));
+        out.print(comma, "R:"_s, sortedListDump(reads.direct(), ","_s));
     if (!writes.isEmpty())
-        out.print(comma, "W:", sortedListDump(writes.direct(), ","));
+        out.print(comma, "W:"_s, sortedListDump(writes.direct(), ","_s));
     ExitMode exitMode = mayExit(*this, node);
     if (exitMode != DoesNotExit)
         out.print(comma, exitMode);
     if (clobbersExitState(*this, node))
-        out.print(comma, "ClobbersExit");
+        out.print(comma, "ClobbersExit"_s);
     if (node->origin.isSet()) {
         out.print(comma, node->origin.semantic.bytecodeIndex());
         if (node->origin.semantic != node->origin.forExit && node->origin.forExit.isSet())
-            out.print(comma, "exit: ", node->origin.forExit);
+            out.print(comma, "exit: "_s, node->origin.forExit);
     }
-    out.print(comma, node->origin.exitOK ? "ExitValid" : "ExitInvalid");
+    out.print(comma, node->origin.exitOK ? "ExitValid"_s : "ExitInvalid"_s);
     if (node->origin.wasHoisted)
-        out.print(comma, "WasHoisted");
+        out.print(comma, "WasHoisted"_s);
     out.print(")");
 
     if (node->accessesStack(*this) && node->tryGetVariableAccessData())
-        out.print("  predicting ", SpeculationDump(node->tryGetVariableAccessData()->prediction()));
+        out.print("  predicting "_s, SpeculationDump(node->tryGetVariableAccessData()->prediction()));
     else if (node->hasHeapPrediction())
-        out.print("  predicting ", SpeculationDump(node->getHeapPrediction()));
+        out.print("  predicting "_s, SpeculationDump(node->getHeapPrediction()));
     
-    out.print("\n");
+    out.print("\n"_s);
 }
 
 bool Graph::terminalsAreValid()

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -3775,7 +3775,7 @@ CString nodeMapDump(const T& nodeMap, DumpContext* context = nullptr)
     StringPrintStream out;
     CommaPrinter comma;
     for(unsigned i = 0; i < keys.size(); ++i)
-        out.print(comma, keys[i], "=>", inContext(nodeMap.get(keys[i]), context));
+        out.print(comma, keys[i], "=>"_s, inContext(nodeMap.get(keys[i]), context));
     return out.toCString();
 }
 
@@ -3791,7 +3791,7 @@ CString nodeValuePairListDump(const T& nodeValuePairList, DumpContext* context =
     StringPrintStream out;
     CommaPrinter comma;
     for (const auto& pair : sortedList)
-        out.print(comma, pair.node, "=>", inContext(pair.value, context));
+        out.print(comma, pair.node, "=>"_s, inContext(pair.value, context));
     return out.toCString();
 }
 

--- a/Source/JavaScriptCore/dfg/DFGNodeFlags.cpp
+++ b/Source/JavaScriptCore/dfg/DFGNodeFlags.cpp
@@ -36,30 +36,30 @@ namespace JSC { namespace DFG {
 void dumpNodeFlags(PrintStream& actualOut, NodeFlags flags)
 {
     StringPrintStream out;
-    CommaPrinter comma("|");
+    CommaPrinter comma("|"_s);
     
     if (flags & NodeResultMask) {
         switch (flags & NodeResultMask) {
         case NodeResultJS:
-            out.print(comma, "JS");
+            out.print(comma, "JS"_s);
             break;
         case NodeResultNumber:
-            out.print(comma, "Number");
+            out.print(comma, "Number"_s);
             break;
         case NodeResultDouble:
-            out.print(comma, "Double");
+            out.print(comma, "Double"_s);
             break;
         case NodeResultInt32:
-            out.print(comma, "Int32");
+            out.print(comma, "Int32"_s);
             break;
         case NodeResultInt52:
-            out.print(comma, "Int52");
+            out.print(comma, "Int52"_s);
             break;
         case NodeResultBoolean:
-            out.print(comma, "Boolean");
+            out.print(comma, "Boolean"_s);
             break;
         case NodeResultStorage:
-            out.print(comma, "Storage");
+            out.print(comma, "Storage"_s);
             break;
         default:
             RELEASE_ASSERT_NOT_REACHED();
@@ -68,63 +68,63 @@ void dumpNodeFlags(PrintStream& actualOut, NodeFlags flags)
     }
     
     if (flags & NodeMustGenerate)
-        out.print(comma, "MustGen");
+        out.print(comma, "MustGen"_s);
     
     if (flags & NodeHasVarArgs)
-        out.print(comma, "VarArgs");
+        out.print(comma, "VarArgs"_s);
     
     if (flags & NodeResultMask) {
         if (!(flags & NodeBytecodeUsesAsNumber))
-            out.print(comma, "PureInt");
+            out.print(comma, "PureInt"_s);
         else
-            out.print(comma, "PureNum");
+            out.print(comma, "PureNum"_s);
         if (flags & NodeBytecodeNeedsNegZero)
-            out.print(comma, "NeedsNegZero");
+            out.print(comma, "NeedsNegZero"_s);
         if (flags & NodeBytecodeNeedsNaNOrInfinity)
-            out.print(comma, "NeedsNaNOrInfinity");
+            out.print(comma, "NeedsNaNOrInfinity"_s);
         if (flags & NodeBytecodeUsesAsOther)
-            out.print(comma, "UseAsOther");
+            out.print(comma, "UseAsOther"_s);
     }
 
     if (flags & NodeMayHaveDoubleResult)
-        out.print(comma, "MayHaveDoubleResult");
+        out.print(comma, "MayHaveDoubleResult"_s);
 
     if (flags & NodeMayHaveBigInt32Result)
-        out.print(comma, "MayHaveBigInt32Result");
+        out.print(comma, "MayHaveBigInt32Result"_s);
 
     if (flags & NodeMayHaveHeapBigIntResult)
-        out.print(comma, "MayHaveHeapBigIntResult");
+        out.print(comma, "MayHaveHeapBigIntResult"_s);
 
     if (flags & NodeMayHaveNonNumericResult)
-        out.print(comma, "MayHaveNonNumericResult");
+        out.print(comma, "MayHaveNonNumericResult"_s);
 
     if (flags & NodeMayOverflowInt52)
-        out.print(comma, "MayOverflowInt52");
+        out.print(comma, "MayOverflowInt52"_s);
 
     if (flags & NodeMayOverflowInt32InBaseline)
-        out.print(comma, "MayOverflowInt32InBaseline");
+        out.print(comma, "MayOverflowInt32InBaseline"_s);
 
     if (flags & NodeMayOverflowInt32InDFG)
-        out.print(comma, "MayOverflowInt32InDFG");
+        out.print(comma, "MayOverflowInt32InDFG"_s);
 
     if (flags & NodeMayNegZeroInBaseline)
-        out.print(comma, "MayNegZeroInBaseline");
+        out.print(comma, "MayNegZeroInBaseline"_s);
     
     if (flags & NodeMayNegZeroInDFG)
-        out.print(comma, "MayNegZeroInDFG");
+        out.print(comma, "MayNegZeroInDFG"_s);
     
     if (flags & NodeBytecodeUsesAsInt)
-        out.print(comma, "UseAsInt");
+        out.print(comma, "UseAsInt"_s);
 
     if (flags & NodeBytecodePrefersArrayIndex)
-        out.print(comma, "ReallyWantsInt");
+        out.print(comma, "ReallyWantsInt"_s);
     
     if (flags & NodeIsFlushed)
-        out.print(comma, "IsFlushed");
+        out.print(comma, "IsFlushed"_s);
     
     CString string = out.toCString();
     if (!string.length())
-        actualOut.print("<empty>");
+        actualOut.print("<empty>"_s);
     else
         actualOut.print(string);
 }

--- a/Source/JavaScriptCore/dfg/DFGOSREntry.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSREntry.cpp
@@ -75,15 +75,15 @@ void OSREntryData::dumpInContext(PrintStream& out, DumpContext* context) const
     
     CommaPrinter comma;
     for (size_t argumentIndex = m_expectedValues.numberOfArguments(); argumentIndex--;) {
-        out.print(comma, "arg", argumentIndex, ":");
+        out.print(comma, "arg"_s, argumentIndex, ":"_s);
         printOperand(virtualRegisterForArgumentIncludingThis(argumentIndex));
     }
     for (size_t localIndex = 0; localIndex < m_expectedValues.numberOfLocals(); ++localIndex) {
-        out.print(comma, "loc", localIndex, ":");
+        out.print(comma, "loc"_s, localIndex, ":"_s);
         printOperand(virtualRegisterForLocal(localIndex));
     }
     
-    out.print("], machine stack used = ", m_machineStackUsed);
+    out.print("], machine stack used = "_s, m_machineStackUsed);
 }
 
 void OSREntryData::dump(PrintStream& out) const

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -279,50 +279,50 @@ public:
     {
         switch (m_kind) {
         case Kind::Escaped:
-            out.print("Escaped");
+            out.print("Escaped"_s);
             break;
 
         case Kind::Object:
-            out.print("Object");
+            out.print("Object"_s);
             break;
 
         case Kind::Function:
-            out.print("Function");
+            out.print("Function"_s);
             break;
 
         case Kind::GeneratorFunction:
-            out.print("GeneratorFunction");
+            out.print("GeneratorFunction"_s);
             break;
 
         case Kind::AsyncFunction:
-            out.print("AsyncFunction");
+            out.print("AsyncFunction"_s);
             break;
 
         case Kind::InternalFieldObject:
-            out.print("InternalFieldObject");
+            out.print("InternalFieldObject"_s);
             break;
 
         case Kind::AsyncGeneratorFunction:
-            out.print("AsyncGeneratorFunction");
+            out.print("AsyncGeneratorFunction"_s);
             break;
 
         case Kind::Activation:
-            out.print("Activation");
+            out.print("Activation"_s);
             break;
 
         case Kind::RegExpObject:
-            out.print("RegExpObject");
+            out.print("RegExpObject"_s);
             break;
         }
-        out.print("Allocation(");
+        out.print("Allocation("_s);
         if (!m_structuresForMaterialization.isEmpty())
             out.print(inContext(m_structuresForMaterialization.toStructureSet(), context));
         if (!m_fields.isEmpty()) {
             if (!m_structuresForMaterialization.isEmpty())
                 out.print(", ");
-            out.print(mapDump(m_fields, " => #", ", "));
+            out.print(mapDump(m_fields, " => #"_s, ", "_s));
         }
-        out.print(")");
+        out.print(")"_s);
     }
 
 private:

--- a/Source/JavaScriptCore/dfg/DFGPureValue.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPureValue.cpp
@@ -35,7 +35,7 @@ namespace JSC { namespace DFG {
 void PureValue::dump(PrintStream& out) const
 {
     out.print(Graph::opName(op()));
-    out.print("(");
+    out.print("("_s);
     CommaPrinter comma;
     if (isVarargs()) {
         for (unsigned i = 0; i < m_children.numChildren(); ++i)
@@ -48,7 +48,7 @@ void PureValue::dump(PrintStream& out) const
     }
     if (m_info)
         out.print(comma, m_info);
-    out.print(")");
+    out.print(")"_s);
 }
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGSSACalculator.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSSACalculator.cpp
@@ -43,11 +43,11 @@ void SSACalculator::Variable::dumpVerbose(PrintStream& out) const
 {
     dump(out);
     if (!m_blocksWithDefs.isEmpty()) {
-        out.print("(defs: ");
+        out.print("(defs: "_s);
         CommaPrinter comma;
         for (BasicBlock* block : m_blocksWithDefs)
             out.print(comma, *block);
-        out.print(")");
+        out.print(")"_s);
     }
 }
 
@@ -109,39 +109,39 @@ SSACalculator::Def* SSACalculator::reachingDefAtTail(BasicBlock* block, Variable
 
 void SSACalculator::dump(PrintStream& out) const
 {
-    out.print("<Variables: [");
+    out.print("<Variables: ["_s);
     CommaPrinter comma;
     for (unsigned i = 0; i < m_variables.size(); ++i) {
         out.print(comma);
         m_variables[i].dumpVerbose(out);
     }
-    out.print("], \nDefs: [");
+    out.print("], \nDefs: ["_s);
     comma = CommaPrinter();
     for (Def* def : const_cast<SSACalculator*>(this)->m_defs)
         out.print(comma, *def);
-    out.print("], \nPhis: [");
+    out.print("], \nPhis: ["_s);
     comma = CommaPrinter();
     for (Def* def : const_cast<SSACalculator*>(this)->m_phis)
         out.print(comma, *def);
-    out.print("], \nBlock data: [");
-    comma = CommaPrinter(",\n");
+    out.print("], \nBlock data: ["_s);
+    comma = CommaPrinter(",\n"_s);
     for (BlockIndex blockIndex = 0; blockIndex < m_graph.numBlocks(); ++blockIndex) {
         BasicBlock* block = m_graph.block(blockIndex);
         if (!block)
             continue;
         
-        out.print(comma, *block, "=>(");
+        out.print(comma, *block, "=>("_s);
         out.print("Defs: {");
         CommaPrinter innerComma;
         for (auto entry : m_data[block].m_defs)
-            out.print(innerComma, *entry.key, "->", *entry.value);
-        out.print("}, Phis: {");
+            out.print(innerComma, *entry.key, "->"_s, *entry.value);
+        out.print("}, Phis: {"_s);
         innerComma = CommaPrinter();
         for (Def* def : m_data[block].m_phis)
             out.print(innerComma, *def);
-        out.print("})");
+        out.print("})"_s);
     }
-    out.print("]>");
+    out.print("]>"_s);
 }
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/heap/CodeBlockSet.cpp
+++ b/Source/JavaScriptCore/heap/CodeBlockSet.cpp
@@ -69,14 +69,14 @@ bool CodeBlockSet::isCurrentlyExecuting(CodeBlock* codeBlock)
 void CodeBlockSet::dump(PrintStream& out) const
 {
     CommaPrinter comma;
-    out.print("{codeBlocks = [");
+    out.print("{codeBlocks = ["_s);
     for (CodeBlock* codeBlock : m_codeBlocks)
         out.print(comma, pointerDump(codeBlock));
-    out.print("], currentlyExecuting = [");
+    out.print("], currentlyExecuting = ["_s);
     comma = CommaPrinter();
     for (CodeBlock* codeBlock : m_currentlyExecuting)
         out.print(comma, pointerDump(codeBlock));
-    out.print("]}");
+    out.print("]}"_s);
 }
 
 void CodeBlockSet::add(CodeBlock* codeBlock)

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -1508,7 +1508,7 @@ NEVER_INLINE bool Heap::runFixpointPhase(GCConductor conn)
             [] (const char* a, const char* b) -> bool {
                 return strcmp(a, b) < 0;
             },
-            ":", " ");
+            ":"_s, " "_s);
         
         dataLog("v=", bytesVisited() / 1024, "kb (", perVisitorDump, ") o=", m_opaqueRoots.size(), " b=", m_barriersExecuted, " ");
     }

--- a/Source/JavaScriptCore/heap/MarkedBlock.cpp
+++ b/Source/JavaScriptCore/heap/MarkedBlock.cpp
@@ -385,7 +385,7 @@ void MarkedBlock::Handle::dumpState(PrintStream& out)
     directory()->forEachBitVectorWithName(
         Locker { directory()->bitvectorLock() },
         [&](auto vectorRef, const char* name) {
-            out.print(comma, name, ":", vectorRef[index()] ? "YES" : "no");
+            out.print(comma, name, ":"_s, vectorRef[index()] ? "YES"_s : "no"_s);
         });
 }
 

--- a/Source/JavaScriptCore/interpreter/ShadowChicken.cpp
+++ b/Source/JavaScriptCore/interpreter/ShadowChicken.cpp
@@ -479,14 +479,14 @@ void ShadowChicken::reset()
 
 void ShadowChicken::dump(PrintStream& out) const
 {
-    out.print("{stack = [", listDump(m_stack), "], log = [");
+    out.print("{stack = ["_s, listDump(m_stack), "], log = ["_s);
     
     CommaPrinter comma;
     unsigned limit = static_cast<unsigned>(m_logCursor - m_log);
-    out.print("\n");
+    out.print("\n"_s);
     for (unsigned i = 0; i < limit; ++i)
-        out.print("\t", comma, "[", i, "] ", m_log[i], "\n");
-    out.print("]}");
+        out.print("\t"_s, comma, "["_s, i, "] "_s, m_log[i], "\n"_s);
+    out.print("]}"_s);
 }
 
 JSArray* ShadowChicken::functionsOnStack(JSGlobalObject* globalObject, CallFrame* callFrame)

--- a/Source/JavaScriptCore/jit/RegisterSet.h
+++ b/Source/JavaScriptCore/jit/RegisterSet.h
@@ -150,7 +150,7 @@ public:
     void dump(PrintStream& out) const
     {
         CommaPrinter comma;
-        out.print("[");
+        out.print("["_s);
         for (Reg reg = Reg::first(); reg <= Reg::last(); reg = reg.next()) {
             if (!m_bits.get(reg.index()) && !m_upperBits.get(reg.index()))
                 continue;
@@ -163,7 +163,7 @@ public:
             else
                 out.print("↑");
         }
-        out.print("]");
+        out.print("]"_s);
     }
 
     friend constexpr bool operator==(const RegisterSetBuilder&, const RegisterSetBuilder&) = default;
@@ -401,7 +401,7 @@ public:
     void dump(PrintStream& out) const
     {
         CommaPrinter comma;
-        out.print("[");
+        out.print("["_s);
         for (Reg reg = Reg::first(); reg <= Reg::last(); reg = reg.next()) {
             if (!m_bits.get(reg.index()) && !m_upperBits.get(reg.index()))
                 continue;
@@ -414,7 +414,7 @@ public:
             else
                 out.print("↑");
         }
-        out.print("]");
+        out.print("]"_s);
     }
 
     friend constexpr bool operator==(const RegisterSet&, const RegisterSet&) = default;

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -3513,7 +3513,7 @@ int main(int argc, char** argv WTF_TZONE_EXTRA_MAIN_ARGS)
 
     if (getenv("JSCTEST_CrashReportArgV")) {
         StringPrintStream out;
-        CommaPrinter space(" ");
+        CommaPrinter space(" "_s);
         for (int i = 0; i < argc; ++i)
             out.print(space, argv[i]);
         WTF::setCrashLogMessage(out.toCString().data());

--- a/Source/JavaScriptCore/parser/VariableEnvironment.cpp
+++ b/Source/JavaScriptCore/parser/VariableEnvironment.cpp
@@ -208,9 +208,9 @@ bool VariableEnvironment::declarePrivateMethod(const RefPtr<UniquedStringImpl>& 
 
 void VariableEnvironment::dump(PrintStream& out) const
 {
-    CommaPrinter comma(", ");
+    CommaPrinter comma(", "_s);
     for (auto& pair : m_map)
-        out.print(comma, pair.key, " => ", pair.value);
+        out.print(comma, pair.key, " => "_s, pair.value);
 }
 
 void CompactTDZEnvironment::sortCompact(Compact& compact)

--- a/Source/JavaScriptCore/runtime/ExecutableBase.cpp
+++ b/Source/JavaScriptCore/runtime/ExecutableBase.cpp
@@ -49,7 +49,7 @@ void ExecutableBase::dump(PrintStream& out) const
     switch (type()) {
     case NativeExecutableType: {
         NativeExecutable* native = jsCast<NativeExecutable*>(realThis);
-        out.print("NativeExecutable:", RawPointer(native->function().taggedPtr()), "/", RawPointer(native->constructor().taggedPtr()));
+        out.print("NativeExecutable:"_s, RawPointer(native->function().taggedPtr()), "/"_s, RawPointer(native->constructor().taggedPtr()));
         return;
     }
     case EvalExecutableType: {
@@ -57,7 +57,7 @@ void ExecutableBase::dump(PrintStream& out) const
         if (CodeBlock* codeBlock = eval->codeBlock())
             out.print(*codeBlock);
         else
-            out.print("EvalExecutable w/o CodeBlock");
+            out.print("EvalExecutable w/o CodeBlock"_s);
         return;
     }
     case ProgramExecutableType: {
@@ -65,7 +65,7 @@ void ExecutableBase::dump(PrintStream& out) const
         if (CodeBlock* codeBlock = eval->codeBlock())
             out.print(*codeBlock);
         else
-            out.print("ProgramExecutable w/o CodeBlock");
+            out.print("ProgramExecutable w/o CodeBlock"_s);
         return;
     }
     case ModuleProgramExecutableType: {
@@ -73,15 +73,15 @@ void ExecutableBase::dump(PrintStream& out) const
         if (CodeBlock* codeBlock = executable->codeBlock())
             out.print(*codeBlock);
         else
-            out.print("ModuleProgramExecutable w/o CodeBlock");
+            out.print("ModuleProgramExecutable w/o CodeBlock"_s);
         return;
     }
     case FunctionExecutableType: {
         FunctionExecutable* function = jsCast<FunctionExecutable*>(realThis);
         if (!function->eitherCodeBlock())
-            out.print("FunctionExecutable w/o CodeBlock");
+            out.print("FunctionExecutable w/o CodeBlock"_s);
         else {
-            CommaPrinter comma("/");
+            CommaPrinter comma("/"_s);
             if (function->codeBlockForCall())
                 out.print(comma, *function->codeBlockForCall());
             if (function->codeBlockForConstruct())

--- a/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/Source/JavaScriptCore/runtime/Structure.cpp
@@ -1417,41 +1417,41 @@ void Structure::dump(PrintStream& out) const
     
     const_cast<Structure*>(this)->forEachPropertyConcurrently(
         [&] (const PropertyTableEntry& entry) -> bool {
-            out.print(comma, entry.key(), ":", static_cast<int>(entry.offset()));
+            out.print(comma, entry.key(), ":"_s, static_cast<int>(entry.offset()));
             return true;
         });
 
-    out.print("}, ", IndexingTypeDump(indexingMode()));
+    out.print("}, "_s, IndexingTypeDump(indexingMode()));
 
-    out.print(", ", TransitionKindDump(transitionKind()));
+    out.print(", "_s, TransitionKindDump(transitionKind()));
 
     if (hasPolyProto())
-        out.print(", PolyProto offset:", knownPolyProtoOffset);
+        out.print(", PolyProto offset:"_s, knownPolyProtoOffset);
     else if (m_prototype.get().isCell())
-        out.print(", Proto:", RawPointer(m_prototype.get().asCell()));
+        out.print(", Proto:"_s, RawPointer(m_prototype.get().asCell()));
 
     switch (dictionaryKind()) {
     case NoneDictionaryKind:
         if (hasBeenDictionary())
-            out.print(", Has been dictionary");
+            out.print(", Has been dictionary"_s);
         break;
     case CachedDictionaryKind:
-        out.print(", Dictionary");
+        out.print(", Dictionary"_s);
         break;
     case UncachedDictionaryKind:
-        out.print(", UncacheableDictionary");
+        out.print(", UncacheableDictionary"_s);
         break;
     }
 
     if (transitionWatchpointSetIsStillValid())
-        out.print(", Leaf");
+        out.print(", Leaf"_s);
     else if (transitionWatchpointIsLikelyToBeFired())
-        out.print(", Shady leaf");
+        out.print(", Shady leaf"_s);
     
     if (transitionWatchpointSet().isBeingWatched())
-        out.print(" (Watched)");
+        out.print(" (Watched)"_s);
 
-    out.print("]");
+    out.print("]"_s);
 }
 
 void Structure::dumpInContext(PrintStream& out, DumpContext* context) const

--- a/Source/JavaScriptCore/runtime/SymbolTable.cpp
+++ b/Source/JavaScriptCore/runtime/SymbolTable.cpp
@@ -334,10 +334,10 @@ void SymbolTable::dump(PrintStream& out) const
     Base::dump(out);
 
     CommaPrinter comma;
-    out.print(" <");
+    out.print(" <"_s);
     for (auto& iter : m_map)
-        out.print(comma, *iter.key, ": ", iter.value.varOffset());
-    out.println(">");
+        out.print(comma, *iter.key, ": "_s, iter.value.varOffset());
+    out.println(">"_s);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
@@ -2294,7 +2294,7 @@ void LLIntGenerator::dump(const ControlStack& controlStack, const Stack* stack)
     dataLogLn("Control stack: stackSize:(", m_stackSize.value(), ")");
     for (size_t i = controlStack.size(); i--;) {
         dataLog("  ", controlStack[i].controlData, ": ");
-        CommaPrinter comma(", ", "");
+        CommaPrinter comma(", "_s, ""_s);
         dumpExpressionStack(comma, *stack);
         stack = &controlStack[i].enclosedExpressionStack;
         dataLogLn();

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -5211,7 +5211,7 @@ void OMGIRGenerator::dump(const ControlStack& controlStack, const Stack* express
     ASSERT(controlStack.size());
     for (size_t i = controlStack.size(); i--;) {
         dataLog("  ", controlStack[i].controlData, ": ");
-        CommaPrinter comma(", ", "");
+        CommaPrinter comma(", "_s, ""_s);
         dumpExpressionStack(comma, *expressionStack);
         expressionStack = &controlStack[i].enclosedExpressionStack;
         dataLogLn();

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -78,19 +78,19 @@ String FunctionSignature::toString() const
 void FunctionSignature::dump(PrintStream& out) const
 {
     {
-        out.print("(");
+        out.print("("_s);
         CommaPrinter comma;
         for (FunctionArgCount arg = 0; arg < argumentCount(); ++arg)
             out.print(comma, makeString(argumentType(arg).kind));
-        out.print(")");
+        out.print(")"_s);
     }
 
     {
         CommaPrinter comma;
-        out.print(" -> [");
+        out.print(" -> ["_s);
         for (FunctionArgCount ret = 0; ret < returnCount(); ++ret)
             out.print(comma, makeString(returnType(ret).kind));
-        out.print("]");
+        out.print("]"_s);
     }
 }
 
@@ -101,13 +101,13 @@ String StructType::toString() const
 
 void StructType::dump(PrintStream& out) const
 {
-    out.print("(");
+    out.print("("_s);
     CommaPrinter comma;
     for (StructFieldCount fieldIndex = 0; fieldIndex < fieldCount(); ++fieldIndex) {
         out.print(comma, makeString(field(fieldIndex).type));
-        out.print(comma, field(fieldIndex).mutability ? "immutable" : "mutable");
+        out.print(comma, field(fieldIndex).mutability ? "immutable"_s : "mutable"_s);
     }
-    out.print(")");
+    out.print(")"_s);
 }
 
 StructType::StructType(FieldType* payload, StructFieldCount fieldCount, const FieldType* fieldTypes)
@@ -140,11 +140,11 @@ String ArrayType::toString() const
 
 void ArrayType::dump(PrintStream& out) const
 {
-    out.print("(");
+    out.print("("_s);
     CommaPrinter comma;
     out.print(comma, makeString(elementType().type));
-    out.print(comma, elementType().mutability ? "immutable" : "mutable");
-    out.print(")");
+    out.print(comma, elementType().mutability ? "immutable"_s : "mutable"_s);
+    out.print(")"_s);
 }
 
 String RecursionGroup::toString() const
@@ -154,13 +154,13 @@ String RecursionGroup::toString() const
 
 void RecursionGroup::dump(PrintStream& out) const
 {
-    out.print("(");
+    out.print("("_s);
     CommaPrinter comma;
     for (RecursionGroupCount typeIndex = 0; typeIndex < typeCount(); ++typeIndex) {
         out.print(comma);
         TypeInformation::get(type(typeIndex)).dump(out);
     }
-    out.print(")");
+    out.print(")"_s);
 }
 
 String Projection::toString() const
@@ -170,14 +170,14 @@ String Projection::toString() const
 
 void Projection::dump(PrintStream& out) const
 {
-    out.print("(");
+    out.print("("_s);
     CommaPrinter comma;
     if (isPlaceholder())
-        out.print("<current-rec-group>");
+        out.print("<current-rec-group>"_s);
     else
         TypeInformation::get(recursionGroup()).dump(out);
-    out.print(".", index());
-    out.print(")");
+    out.print("."_s, index());
+    out.print(")"_s);
 }
 
 String Subtype::toString() const
@@ -187,14 +187,14 @@ String Subtype::toString() const
 
 void Subtype::dump(PrintStream& out) const
 {
-    out.print("(");
+    out.print("("_s);
     CommaPrinter comma;
     if (supertypeCount() > 0) {
         TypeInformation::get(firstSuperType()).dump(out);
         out.print(comma);
     }
     TypeInformation::get(underlyingType()).dump(out);
-    out.print(")");
+    out.print(")"_s);
 }
 
 void StorageType::dump(PrintStream& out) const

--- a/Source/WTF/wtf/BackwardsGraph.h
+++ b/Source/WTF/wtf/BackwardsGraph.h
@@ -161,17 +161,17 @@ public:
             Node node = this->node(i);
             if (!node)
                 continue;
-            out.print(dump(node), ":\n");
-            out.print("    Preds: ");
+            out.print(dump(node), ":\n"_s);
+            out.print("    Preds: "_s);
             CommaPrinter comma;
             for (Node predecessor : predecessors(node))
                 out.print(comma, dump(predecessor));
-            out.print("\n");
-            out.print("    Succs: ");
+            out.print("\n"_s);
+            out.print("    Succs: "_s);
             comma = CommaPrinter();
             for (Node successor : successors(node))
                 out.print(comma, dump(successor));
-            out.print("\n");
+            out.print("\n"_s);
         }
     }
 

--- a/Source/WTF/wtf/CommaPrinter.h
+++ b/Source/WTF/wtf/CommaPrinter.h
@@ -32,7 +32,7 @@ namespace WTF {
 class CommaPrinter final {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    CommaPrinter(const char* comma = ", ", const char* start = "")
+    CommaPrinter(ASCIILiteral comma = ", "_s, ASCIILiteral start = ""_s)
         : m_comma(comma)
         , m_start(start)
         , m_didPrint(false)
@@ -53,8 +53,8 @@ public:
     bool didPrint() const { return m_didPrint; }
     
 private:
-    const char* m_comma;
-    const char* m_start;
+    ASCIILiteral m_comma;
+    ASCIILiteral m_start;
     mutable bool m_didPrint;
 };
 

--- a/Source/WTF/wtf/Dominators.h
+++ b/Source/WTF/wtf/Dominators.h
@@ -285,11 +285,11 @@ public:
             if (m_data[blockIndex].preNumber == UINT_MAX)
                 continue;
             
-            out.print("    Block #", blockIndex, ": idom = ", m_graph.dump(m_data[blockIndex].idomParent), ", idomKids = [");
+            out.print("    Block #"_s, blockIndex, ": idom = "_s, m_graph.dump(m_data[blockIndex].idomParent), ", idomKids = ["_s);
             CommaPrinter comma;
             for (unsigned i = 0; i < m_data[blockIndex].idomKids.size(); ++i)
                 out.print(comma, m_graph.dump(m_data[blockIndex].idomKids[i]));
-            out.print("], pre/post = ", m_data[blockIndex].preNumber, "/", m_data[blockIndex].postNumber, "\n");
+            out.print("], pre/post = "_s, m_data[blockIndex].preNumber, "/"_s, m_data[blockIndex].postNumber, "\n"_s);
         }
     }
     

--- a/Source/WTF/wtf/JSONValues.cpp
+++ b/Source/WTF/wtf/JSONValues.cpp
@@ -610,25 +610,25 @@ void Value::dump(PrintStream& out) const
     }
     case Type::Object: {
         auto& object = *static_cast<const ObjectBase*>(this);
-        CommaPrinter comma(",");
-        out.print("{");
+        CommaPrinter comma(","_s);
+        out.print("{"_s);
         for (const auto& key : object.m_order) {
             auto findResult = object.m_map.find(key);
             ASSERT(findResult != object.m_map.end());
             StringBuilder builder;
             builder.appendQuotedJSONString(findResult->key);
-            out.print(comma, builder.toString(), ":", findResult->value.get());
+            out.print(comma, builder.toString(), ":"_s, findResult->value.get());
         }
-        out.print("}");
+        out.print("}"_s);
         break;
     }
     case Type::Array: {
         auto& array = *static_cast<const ArrayBase*>(this);
-        CommaPrinter comma(",");
-        out.print("[");
+        CommaPrinter comma(","_s);
+        out.print("["_s);
         for (auto& value : array.m_map)
             out.print(comma, value.get());
-        out.print("]");
+        out.print("]"_s);
         break;
     }
     default:

--- a/Source/WTF/wtf/ListDump.h
+++ b/Source/WTF/wtf/ListDump.h
@@ -34,7 +34,7 @@ namespace WTF {
 template<typename T>
 class ListDump {
 public:
-    ListDump(const T& list, const char* comma)
+    ListDump(const T& list, ASCIILiteral comma)
         : m_list(list)
         , m_comma(comma)
     {
@@ -54,7 +54,7 @@ private:
 template<typename T>
 class PointerListDump {
 public:
-    PointerListDump(const T& list, const char* comma)
+    PointerListDump(const T& list, ASCIILiteral comma)
         : m_list(list)
         , m_comma(comma)
     {
@@ -74,7 +74,7 @@ private:
 template<typename T>
 class MapDump {
 public:
-    MapDump(const T& map, const char* arrow, const char* comma)
+    MapDump(const T& map, ASCIILiteral arrow, ASCIILiteral comma)
         : m_map(map)
         , m_arrow(arrow)
         , m_comma(comma)
@@ -89,24 +89,24 @@ public:
     
 private:
     const T& m_map;
-    const char* m_arrow;
+    ASCIILiteral m_arrow;
     CommaPrinter m_comma;
 };
 
 template<typename T>
-ListDump<T> listDump(const T& list, const char* comma = ", ")
+ListDump<T> listDump(const T& list, ASCIILiteral comma = ", "_s)
 {
     return ListDump<T>(list, comma);
 }
 
 template<typename T>
-PointerListDump<T> pointerListDump(const T& list, const char* comma = ", ")
+PointerListDump<T> pointerListDump(const T& list, ASCIILiteral comma = ", "_s)
 {
     return PointerListDump<T>(list, comma);
 }
 
 template<typename T, typename Comparator>
-CString sortedListDump(const T& list, const Comparator& comparator, const char* comma = ", ")
+CString sortedListDump(const T& list, const Comparator& comparator, ASCIILiteral comma = ", "_s)
 {
     Vector<typename T::ValueType> myList;
     myList.appendRange(list.begin(), list.end());
@@ -119,19 +119,19 @@ CString sortedListDump(const T& list, const Comparator& comparator, const char* 
 }
 
 template<typename T>
-CString sortedListDump(const T& list, const char* comma = ", ")
+CString sortedListDump(const T& list, ASCIILiteral comma = ", "_s)
 {
     return sortedListDump(list, std::less<>(), comma);
 }
 
 template<typename T>
-MapDump<T> mapDump(const T& map, const char* arrow = "=>", const char* comma = ", ")
+MapDump<T> mapDump(const T& map, ASCIILiteral arrow = "=>"_s, ASCIILiteral comma = ", "_s)
 {
     return MapDump<T>(map, arrow, comma);
 }
 
 template<typename T, typename Comparator>
-CString sortedMapDump(const T& map, const Comparator& comparator, const char* arrow = "=>", const char* comma = ", ")
+CString sortedMapDump(const T& map, const Comparator& comparator, ASCIILiteral arrow = "=>"_s, ASCIILiteral comma = ", "_s)
 {
     Vector<typename T::KeyType> keys;
     for (auto iter = map.begin(); iter != map.end(); ++iter)
@@ -147,7 +147,7 @@ CString sortedMapDump(const T& map, const Comparator& comparator, const char* ar
 template<typename T, typename U>
 class ListDumpInContext {
 public:
-    ListDumpInContext(const T& list, U* context, const char* comma)
+    ListDumpInContext(const T& list, U* context, ASCIILiteral comma)
         : m_list(list)
         , m_context(context)
         , m_comma(comma)
@@ -168,7 +168,7 @@ private:
 
 template<typename T, typename U>
 ListDumpInContext<T, U> listDumpInContext(
-    const T& list, U* context, const char* comma = ", ")
+    const T& list, U* context, ASCIILiteral comma = ", "_s)
 {
     return ListDumpInContext<T, U>(list, context, comma);
 }

--- a/Source/WTF/wtf/NaturalLoops.h
+++ b/Source/WTF/wtf/NaturalLoops.h
@@ -342,11 +342,11 @@ public:
 
     void dump(PrintStream& out) const
     {
-        out.print("NaturalLoops:{");
+        out.print("NaturalLoops:{"_s);
         CommaPrinter comma;
         for (unsigned i = 0; i < m_loops.size(); ++i)
             out.print(comma, m_loops[i]);
-        out.print("}");
+        out.print("}"_s);
     }
     
 private:

--- a/Source/WTF/wtf/SingleRootGraph.h
+++ b/Source/WTF/wtf/SingleRootGraph.h
@@ -261,17 +261,17 @@ public:
             Node node = this->node(i);
             if (!node)
                 continue;
-            out.print(dump(node), ":\n");
-            out.print("    Preds: ");
+            out.print(dump(node), ":\n"_s);
+            out.print("    Preds: "_s);
             CommaPrinter comma;
             for (Node predecessor : predecessors(node))
                 out.print(comma, dump(predecessor));
-            out.print("\n");
-            out.print("    Succs: ");
+            out.print("\n"_s);
+            out.print("    Succs: "_s);
             comma = CommaPrinter();
             for (Node successor : successors(node))
                 out.print(comma, dump(successor));
-            out.print("\n");
+            out.print("\n"_s);
         }
     }
 


### PR DESCRIPTION
#### b0038706180d5e844baafb17408b0e593d24f925
<pre>
Update CommaPrinter to take in an ASCIILiteral
<a href="https://bugs.webkit.org/show_bug.cgi?id=273014">https://bugs.webkit.org/show_bug.cgi?id=273014</a>

Reviewed by Keith Miller.

Update CommaPrinter to take in an ASCIILiteral instead of a raw pointer.

* Source/JavaScriptCore/b3/B3CaseCollection.cpp:
(JSC::B3::CaseCollection::dump const):
* Source/JavaScriptCore/b3/B3Effects.cpp:
(JSC::B3::Effects::dump const):
* Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp:
* Source/JavaScriptCore/b3/B3Kind.cpp:
(JSC::B3::Kind::dump const):
* Source/JavaScriptCore/b3/B3PatchpointValue.cpp:
(JSC::B3::PatchpointValue::dumpMeta const):
* Source/JavaScriptCore/b3/B3SSACalculator.cpp:
(JSC::B3::SSACalculator::Variable::dumpVerbose const):
(JSC::B3::SSACalculator::dump const):
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::deepDump const):
* Source/JavaScriptCore/b3/air/AirKind.cpp:
(JSC::B3::Air::Kind::dump const):
* Source/JavaScriptCore/b3/air/AirUseCounts.h:
(JSC::B3::Air::UseCounts::dump const):
* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::dump const):
* Source/JavaScriptCore/bytecode/ArrayProfile.cpp:
(JSC::dumpArrayModes):
(JSC::ArrayProfile::briefDescriptionWithoutUpdating):
* Source/JavaScriptCore/bytecode/CallLinkStatus.cpp:
(JSC::CallLinkStatus::dump const):
* Source/JavaScriptCore/bytecode/ExitFlag.cpp:
(JSC::ExitFlag::dump const):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::PolymorphicAccess::dump const):
* Source/JavaScriptCore/bytecode/OperandsInlines.h:
(JSC::U&gt;::dumpInContext const):
(JSC::U&gt;::dump const):
* Source/JavaScriptCore/bytecode/PutByIdFlags.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/bytecode/SpeculatedType.cpp:
(JSC::PrettyPrinter::PrettyPrinter):
* Source/JavaScriptCore/bytecode/StructureSet.cpp:
(JSC::StructureSet::dumpInContext const):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::dump):
* Source/JavaScriptCore/dfg/DFGBlockSet.cpp:
(JSC::DFG::BlockSet::dump const):
* Source/JavaScriptCore/dfg/DFGFlowMap.h:
(WTF::printInternal):
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::dump):
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::nodeMapDump):
(JSC::DFG::nodeValuePairListDump):
* Source/JavaScriptCore/dfg/DFGNodeFlags.cpp:
(JSC::DFG::dumpNodeFlags):
* Source/JavaScriptCore/dfg/DFGOSREntry.cpp:
(JSC::DFG::OSREntryData::dumpInContext const):
* Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp:
* Source/JavaScriptCore/dfg/DFGPureValue.cpp:
(JSC::DFG::PureValue::dump const):
* Source/JavaScriptCore/dfg/DFGSSACalculator.cpp:
(JSC::DFG::SSACalculator::Variable::dumpVerbose const):
(JSC::DFG::SSACalculator::dump const):
* Source/JavaScriptCore/heap/CodeBlockSet.cpp:
(JSC::CodeBlockSet::dump const):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::runFixpointPhase):
* Source/JavaScriptCore/heap/MarkedBlock.cpp:
(JSC::MarkedBlock::Handle::dumpState):
* Source/JavaScriptCore/interpreter/ShadowChicken.cpp:
(JSC::ShadowChicken::dump const):
* Source/JavaScriptCore/jit/RegisterSet.h:
* Source/JavaScriptCore/jsc.cpp:
(main):
* Source/JavaScriptCore/parser/VariableEnvironment.cpp:
(JSC::VariableEnvironment::dump const):
* Source/JavaScriptCore/runtime/ExecutableBase.cpp:
(JSC::ExecutableBase::dump const):
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::Structure::dump const):
* Source/JavaScriptCore/runtime/SymbolTable.cpp:
(JSC::SymbolTable::dump const):
* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::dump):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::dump):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::FunctionSignature::dump const):
(JSC::Wasm::StructType::dump const):
(JSC::Wasm::ArrayType::dump const):
(JSC::Wasm::RecursionGroup::dump const):
(JSC::Wasm::Projection::dump const):
(JSC::Wasm::Subtype::dump const):
* Source/WTF/wtf/BackwardsGraph.h:
(WTF::BackwardsGraph::dump const):
* Source/WTF/wtf/CommaPrinter.h:
* Source/WTF/wtf/Dominators.h:
(WTF::Dominators::dump const):
* Source/WTF/wtf/JSONValues.cpp:
(WTF::JSONImpl::Value::dump const):
* Source/WTF/wtf/ListDump.h:
(WTF::ListDump::ListDump):
(WTF::PointerListDump::PointerListDump):
(WTF::MapDump::MapDump):
(WTF::listDump):
(WTF::pointerListDump):
(WTF::sortedListDump):
(WTF::mapDump):
(WTF::sortedMapDump):
(WTF::ListDumpInContext::ListDumpInContext):
(WTF::listDumpInContext):
* Source/WTF/wtf/NaturalLoops.h:
(WTF::NaturalLoops::dump const):
* Source/WTF/wtf/SingleRootGraph.h:
(WTF::SingleRootGraph::dump const):

Canonical link: <a href="https://commits.webkit.org/277774@main">https://commits.webkit.org/277774@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2063b95ce778e6376105766f23e1f68a8af0c31e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48524 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27735 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51485 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51211 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44589 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39671 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49106 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25411 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20785 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22889 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6580 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/41820 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44829 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43531 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53117 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/48014 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19884 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46980 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24835 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42078 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/45908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25640 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55509 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6919 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24558 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11416 "Passed tests") | 
<!--EWS-Status-Bubble-End-->