### PR TITLE
Hardened Mach exception signing key can't be zero

### DIFF
--- a/Source/WTF/wtf/CryptographicallyRandomNumber.cpp
+++ b/Source/WTF/wtf/CryptographicallyRandomNumber.cpp
@@ -57,15 +57,15 @@ class ARC4RandomNumberGenerator {
 public:
     ARC4RandomNumberGenerator() = default;
 
-    uint32_t randomNumber();
+    template<typename IntegerType>
+    IntegerType randomNumber();
     void randomValues(std::span<uint8_t>);
 
 private:
     inline void addRandomData(std::span<const uint8_t, 128>);
     void stir() WTF_REQUIRES_LOCK(m_lock);
     void stirIfNeeded() WTF_REQUIRES_LOCK(m_lock);
-    inline uint8_t getByte();
-    inline uint32_t getWord();
+    inline uint8_t getByte() WTF_REQUIRES_LOCK(m_lock);
 
     Lock m_lock;
     ARC4Stream m_stream;
@@ -121,30 +121,25 @@ uint8_t ARC4RandomNumberGenerator::getByte()
     return (m_stream.s[(si + sj) & 0xff]);
 }
 
-uint32_t ARC4RandomNumberGenerator::getWord()
-{
-    uint32_t val;
-    val = getByte() << 24;
-    val |= getByte() << 16;
-    val |= getByte() << 8;
-    val |= getByte();
-    return val;
-}
-
-uint32_t ARC4RandomNumberGenerator::randomNumber()
+template<typename IntegerType>
+IntegerType ARC4RandomNumberGenerator::randomNumber()
 {
     Locker locker { m_lock };
 
-    m_count -= 4;
-    stirIfNeeded();
-    return getWord();
+    IntegerType val = 0;
+    for (unsigned i = 0; i < sizeof(IntegerType); ++i) {
+        m_count--;
+        stirIfNeeded();
+        val = (val << 8) | getByte();
+    }
+
+    return val;
 }
 
 void ARC4RandomNumberGenerator::randomValues(std::span<uint8_t> buffer)
 {
     Locker locker { m_lock };
 
-    stirIfNeeded();
     for (auto& byte : WTF::makeReversedRange(buffer)) {
         m_count--;
         stirIfNeeded();
@@ -167,9 +162,14 @@ ARC4RandomNumberGenerator& sharedRandomNumberGenerator()
 
 }
 
+template<> uint8_t cryptographicallyRandomNumber<uint8_t>()
+{
+    return sharedRandomNumberGenerator().randomNumber<uint8_t>();
+}
+
 template<> unsigned cryptographicallyRandomNumber<unsigned>()
 {
-    return sharedRandomNumberGenerator().randomNumber();
+    return sharedRandomNumberGenerator().randomNumber<unsigned>();
 }
 
 void cryptographicallyRandomValues(std::span<uint8_t> buffer)
@@ -179,8 +179,7 @@ void cryptographicallyRandomValues(std::span<uint8_t> buffer)
 
 template<> uint64_t cryptographicallyRandomNumber<uint64_t>()
 {
-    uint64_t high = cryptographicallyRandomNumber<unsigned>();
-    return (high << 32) | cryptographicallyRandomNumber<unsigned>();
+    return sharedRandomNumberGenerator().randomNumber<uint64_t>();
 }
 
 double cryptographicallyRandomUnitInterval()

--- a/Source/WTF/wtf/CryptographicallyRandomNumber.h
+++ b/Source/WTF/wtf/CryptographicallyRandomNumber.h
@@ -32,6 +32,8 @@ namespace WTF {
 
 template<typename IntegerType> IntegerType cryptographicallyRandomNumber() = delete;
 
+template<> WTF_EXPORT_PRIVATE uint8_t cryptographicallyRandomNumber<uint8_t>();
+
 // Returns a cryptographically secure pseudo-random number in the range [0, UINT_MAX].
 template<> WTF_EXPORT_PRIVATE unsigned cryptographicallyRandomNumber<unsigned>();
 


### PR DESCRIPTION
#### 9155990f356664ef6263fb7796ad4e09aa46aeff
<pre>
Hardened Mach exception signing key can&apos;t be zero
<a href="https://bugs.webkit.org/show_bug.cgi?id=273003">https://bugs.webkit.org/show_bug.cgi?id=273003</a>
<a href="https://rdar.apple.com/125605825">rdar://125605825</a>

Reviewed by Yusuke Suzuki.

This patch fixes a bug where the ARM64E ABI doesn&apos;t allow the pointer (1st) argument
of `ptrauth_blend_discriminator` to be zero. It also adds a new overload of
`cryptographicallyRandomNumber` for `uint8_t`, since there&apos;s no point in wasting bits
while trying to get a non-zero key.

* Source/WTF/wtf/CryptographicallyRandomNumber.cpp:
(WTF::cryptographicallyRandomNumber&lt;uint8_t&gt;):
(WTF::cryptographicallyRandomNumber&lt;unsigned&gt;):
(WTF::cryptographicallyRandomNumber&lt;uint64_t&gt;):
* Source/WTF/wtf/CryptographicallyRandomNumber.h:
* Source/WTF/wtf/threads/Signals.cpp:
(WTF::SignalHandlers::initialize):

Canonical link: <a href="https://commits.webkit.org/277778@main">https://commits.webkit.org/277778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7e4ddffc2d7ca8e870591915fe00371d63b647c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27740 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51216 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44594 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25263 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39677 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49111 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25418 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41873 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20790 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22896 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43047 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6585 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/41825 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44835 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43534 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53122 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/48019 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23575 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19886 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46986 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24840 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45907 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10704 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25645 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55514 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24563 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11417 "Passed tests") | 
<!--EWS-Status-Bubble-End-->