### PR TITLE
[UnifiedPDF] Do more fine-grained tile invalidation

### DIFF
--- a/Source/WebCore/platform/graphics/TiledBacking.h
+++ b/Source/WebCore/platform/graphics/TiledBacking.h
@@ -87,7 +87,7 @@ public:
     virtual void setVisibleRect(const FloatRect&) = 0;
     virtual FloatRect visibleRect() const = 0;
 
-    // Only used to update the tile coverage map. 
+    // Only used to update the tile coverage map.
     virtual void setLayoutViewportRect(std::optional<FloatRect>) = 0;
 
     virtual void setCoverageRect(const FloatRect&) = 0;
@@ -127,6 +127,8 @@ public:
     virtual void didEndLiveResize() = 0;
 
     virtual IntSize tileSize() const = 0;
+    // The returned rect is in the same coordinate space as the tileClip rect argument to willRepaintTile().
+    virtual FloatRect rectForTile(TileIndex) const = 0;
 
     virtual void revalidateTiles() = 0;
 

--- a/Source/WebCore/platform/graphics/ca/TileController.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileController.cpp
@@ -603,6 +603,11 @@ IntSize TileController::tileSize() const
     return tileGrid().tileSize();
 }
 
+FloatRect TileController::rectForTile(TileIndex tileIndex) const
+{
+    return tileGrid().rectForTile(tileIndex);
+}
+
 IntSize TileController::computeTileSize()
 {
     if (m_inLiveResize || m_tileSizeLocked)

--- a/Source/WebCore/platform/graphics/ca/TileController.h
+++ b/Source/WebCore/platform/graphics/ca/TileController.h
@@ -112,6 +112,7 @@ public:
     void didEndLiveResize() final;
 
     IntSize tileSize() const final;
+    FloatRect rectForTile(TileIndex) const final;
     IntRect bounds() const final;
     IntRect boundsWithoutMargin() const final;
     bool hasMargins() const final;

--- a/Source/WebCore/platform/graphics/ca/TileGrid.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.cpp
@@ -75,6 +75,11 @@ TileGrid::~TileGrid()
         tile.layer->setOwner(nullptr);
 }
 
+FloatRect TileGrid::rectForTile(TileIndex tileIndex) const
+{
+    return rectForTileIndex(tileIndex);
+}
+
 void TileGrid::setIsZoomedOutTileGrid(bool isZoomedOutGrid)
 {
     if (isZoomedOutGrid)

--- a/Source/WebCore/platform/graphics/ca/TileGrid.h
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.h
@@ -82,6 +82,7 @@ public:
     IntRect extent() const;
     
     IntSize tileSize() const { return m_tileSize; }
+    FloatRect rectForTile(TileIndex) const;
 
     double retainedTileBackingStoreMemory() const;
     unsigned blankPixelCount() const;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.h
@@ -38,6 +38,8 @@ namespace WebKit {
 struct PerPageInfo {
     PDFDocumentLayout::PageIndex pageIndex { 0 };
     WebCore::FloatRect pageBounds;
+
+    bool operator==(const PerPageInfo&) const = default;
 };
 
 struct PDFPageCoverage {
@@ -45,6 +47,8 @@ struct PDFPageCoverage {
     float deviceScaleFactor { 1 };
     float pdfDocumentScale { 1 };
     float tilingScaleFactor { 1 };
+
+    bool operator==(const PDFPageCoverage&) const = default;
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const PerPageInfo&);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -667,9 +667,6 @@ void UnifiedPDFPlugin::updateLayerHierarchy()
     m_contentsLayer->setSize(documentSize());
     m_contentsLayer->setNeedsDisplay();
 
-    if (RefPtr asyncRenderer = asyncRendererIfExists())
-        asyncRenderer->layoutConfigurationChanged();
-
     updatePageBackgroundLayers();
     updateSnapOffsets();
 
@@ -1162,9 +1159,6 @@ void UnifiedPDFPlugin::setScaleFactor(double scale, std::optional<WebCore::IntPo
 #if ENABLE(UNIFIED_PDF_DATA_DETECTION)
     didInvalidateDataDetectorHighlightOverlayRects();
 #endif
-
-    if (RefPtr asyncRenderer = asyncRendererIfExists())
-        asyncRenderer->layoutConfigurationChanged();
 
     auto scrolledContentsPoint = roundedIntPoint(convertUp(CoordinateSpace::Contents, CoordinateSpace::ScrolledContents, FloatPoint { zoomContentsOrigin }));
     auto newScrollPosition = IntPoint { scrolledContentsPoint - originInPluginCoordinates };

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
@@ -113,6 +113,7 @@ public:
     void willStartLiveResize() final { };
     void didEndLiveResize() final { };
     IntSize tileSize() const final { return m_tileGrid.tilePixelSize(); }
+    FloatRect rectForTile(TileIndex) const { return { }; }
     void revalidateTiles() final { }
     IntRect tileGridExtent() const final { return { }; }
     void setScrollingPerformanceTestingEnabled(bool flag) final { }


### PR DESCRIPTION
#### 8feb3943337028bf46df4837262ae202e7fe30db
<pre>
[UnifiedPDF] Do more fine-grained tile invalidation
<a href="https://bugs.webkit.org/show_bug.cgi?id=273016">https://bugs.webkit.org/show_bug.cgi?id=273016</a>
<a href="https://rdar.apple.com/126779250">rdar://126779250</a>

Reviewed by Tim Horton.

AsyncPDFRenderer&apos;s tile invalidation was based on the PDFConfigurationIdentifier changing,
which happened on scaling and layout changes. However, some kinds of layout (e.g. window
resize without automatic resizing) don&apos;t change the per-tile PDF contents, so in those cases
we can preserve rendered tiles, which can avoid large amounts of re-rendering for PDFs
which are expensive to render.

We can compare `TileRenderInfo`s to know if a tile has changed, since `PDFPageCoverage`
gives us page-relative rects for this tile.

Remove PDFConfigurationIdentifiers which we no longer need. Make it possible to test `TileRenderInfo`
for painting equality (which ignores the optional clip rect), and implement `renderInfoForTile()` which
allows us to compute a `TileRenderInfo` from the current state of the PDF and tile grid (we need
`rectForTile()` for this, which is added to `TiledBacking`).

Now `willRepaintTile()` can ask if we have a valid cached tile using more data than just
the tile index. `enqueueTilePaintIfNecessary()` can also early return if we have an existing
queued paint which is valid, and `didCompleteTileRender()` can ask whether the paint we
just completed asynchronously is still valid.

We do need a new identifier, PDFContentsVersionIdentifier, which increments when the PDF
contents change (e.g. an annotation update); this allows us to ask whether an enqueued
tile paint is still valid (e.g. for partial updates on form control changes).

* Source/WebCore/platform/graphics/TiledBacking.h:
* Source/WebCore/platform/graphics/ca/TileController.cpp:
(WebCore::TileController::rectForTile const):
* Source/WebCore/platform/graphics/ca/TileController.h:
* Source/WebCore/platform/graphics/ca/TileGrid.cpp:
(WebCore::TileGrid::rectForTile const):
* Source/WebCore/platform/graphics/ca/TileGrid.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
(WebKit::AsyncPDFRenderer::TileRenderInfo::equivalentForPainting const):
(WebKit::AsyncPDFRenderer::renderInfoForTile):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::AsyncPDFRenderer):
(WebKit::AsyncPDFRenderer::renderInfoIsValidForTile const):
(WebKit::AsyncPDFRenderer::willRepaintTile):
(WebKit::AsyncPDFRenderer::tilingScaleFactorDidChange):
(WebKit::AsyncPDFRenderer::enqueueTilePaintIfNecessary):
(WebKit::AsyncPDFRenderer::renderInfoForTile const):
(WebKit::AsyncPDFRenderer::enqueuePaintWithClip):
(WebKit::AsyncPDFRenderer::paintPDFIntoBuffer):
(WebKit::AsyncPDFRenderer::didCompleteTileRender):
(WebKit::AsyncPDFRenderer::paintTilesForPage):
(WebKit::AsyncPDFRenderer::pdfContentChangedInRect):
(WebKit::AsyncPDFRenderer::layoutConfigurationChanged): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::updateLayerHierarchy):
(WebKit::UnifiedPDFPlugin::setScaleFactor):
* Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp:

Canonical link: <a href="https://commits.webkit.org/277837@main">https://commits.webkit.org/277837@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2edbeade52b4aec788c7a9b8f5636a5c84e683e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48562 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51249 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44627 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50867 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25302 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39708 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49144 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41893 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20805 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22917 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43066 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6618 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44855 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43555 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53156 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23608 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19909 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46998 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24874 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42099 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45922 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10732 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25678 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24596 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->