### PR TITLE
[WebGPU] runClearEncoder may clear wrong depth slice for 3D textures

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2090,6 +2090,8 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-272903.html [ Pass Failure ]
 [ Debug ] fast/webgpu/fuzz-272911.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-272911.html [ Pass Failure ]
+[ Debug ] fast/webgpu/fuzz-273017.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-273017.html [ Pass Failure ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/fuzz-273017-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-273017-expected.txt
@@ -1,0 +1,675 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 982x5202
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x5202
+  RenderBlock {HTML} at (0,0) size 785x5202 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x5186
+      RenderText {#text} at (32,137) size 26x17
+        text run at (32,137) width 26: "\x{C1AA}\x{C94}"
+      RenderText {#text} at (57,137) size 87x17
+        text run at (57,137) width 87: "\x{4F78}\x{D83F}\x{DE8B}\x{D83F}\x{DDDC}\x{9E7}\x{C52}\x{63A9}\x{77E1}"
+      RenderText {#text} at (443,137) size 62x17
+        text run at (443,137) width 62: "\x{910F}\x{742A}\x{B92}\x{D83D}\x{DE81}"
+      RenderText {#text} at (504,137) size 65x17
+        text run at (504,137) width 65: "\x{D75}\x{BE26}\x{D83E}\x{DED9}\x{2ABB}"
+      RenderText {#text} at (568,137) size 98x17
+        text run at (568,137) width 98: "\x{A76}\x{44CD}\x{DF6}\x{4F0}\x{1C62}\x{FD8}\x{235A}\x{173E}\x{D83F}\x{DED7}"
+      RenderText {#text} at (665,137) size 72x17
+        text run at (665,137) width 72: "\x{D83E}\x{DD5B}\x{200B}\x{D83D}\x{DFEA}\x{1A46}\x{AB6F}\x{D83F}\x{DF12}"
+      RenderText {#text} at (300,296) size 63x17
+        text run at (300,296) width 15: "\x{34E5}"
+        text run at (315,296) width 11 RTL: "\x{85D}"
+        text run at (325,296) width 38: "\x{F632}\x{B956}\x{FFC}"
+      RenderText {#text} at (362,296) size 123x17
+        text run at (362,296) width 123: "\x{4E06}\x{CECA}\x{D83F}\x{DED1}\x{E430}\x{96AB}\x{85DD}\x{575E}\x{1D9}\x{879E}"
+      RenderText {#text} at (484,296) size 79x17
+        text run at (484,296) width 79: "\x{D83E}\x{DCE2}\x{AD5}\x{8870}\x{20C7}\x{B348}\x{AD31}"
+      RenderText {#text} at (562,296) size 45x17
+        text run at (562,296) width 35: "\x{C6E8}\x{D83E}\x{DC2A}\x{A026}"
+        text run at (596,296) width 11 RTL: "\x{7DA}"
+      RenderText {#text} at (606,296) size 82x17
+        text run at (606,296) width 16: "\x{3FBE}"
+        text run at (621,296) width 10 RTL: "\x{72F}\x{82B}"
+        text run at (630,296) width 58: "\x{91B1}\x{1F7}\x{D83F}\x{DC56}\x{ED0}\x{77B4}"
+      RenderText {#text} at (600,454) size 70x17
+        text run at (600,454) width 70: "\x{9AA}\x{4946}\x{4B32}\x{D83E}\x{DCA5}\x{908}\x{D83F}\x{DF1A}"
+      RenderImage {IMG} at (284,592) size 21x165
+      RenderText {#text} at (305,744) size 80x17
+        text run at (305,744) width 80: "\x{3091}\x{9AD}\x{ABA2}\x{CFD}\x{D83D}\x{DF95}\x{B13}\x{4B0E}"
+      RenderText {#text} at (384,744) size 154x17
+        text run at (384,744) width 63: "\x{C22}\x{4C66}\x{A99C}\x{D83E}\x{DEB0}"
+        text run at (446,744) width 15 RTL: "\x{6FA}"
+        text run at (460,744) width 78: "\x{F675}\x{5712}\x{E343}\x{A88A}\x{4B4}\x{608C}"
+      RenderText {#text} at (553,744) size 36x17
+        text run at (553,744) width 36: "\x{55A7}\x{D83F}\x{DF2E}\x{2DD8}"
+      RenderText {#text} at (588,744) size 107x17
+        text run at (588,744) width 60: "\x{D83E}\x{DC95}\x{16CF}\x{C63A}\x{82D}\x{A2F8}\x{D83D}\x{DFD8}"
+        text run at (647,744) width 12 RTL: "\x{86B}"
+        text run at (658,744) width 37: "\x{A737}\x{D83F}\x{DF22}\x{D83F}\x{DFBF}"
+      RenderText {#text} at (0,744) size 762x181
+        text run at (694,744) width 68: "\x{1401}\x{CD2}\x{B6E4}\x{8940}\x{AF27}"
+        text run at (0,908) width 57: "\x{CAE4}\x{90}\x{8DB9}\x{1EC8}\x{FF00}"
+      RenderText {#text} at (72,908) size 37x17
+        text run at (72,908) width 27: "\x{B66D}\x{592}\x{D83F}\x{DEDD}"
+        text run at (98,908) width 11 RTL: "\x{64A}"
+      RenderText {#text} at (457,908) size 94x17
+        text run at (457,908) width 94: "\x{5D93}\x{D7F}\x{5957}\x{D83E}\x{DE78}\x{51B}\x{E8D}\x{D7C}"
+      RenderText {#text} at (550,908) size 120x17
+        text run at (550,908) width 120: "\x{7195}\x{556F}\x{D83E}\x{DCAE}\x{ED7}\x{D83F}\x{DC74}\x{D83F}\x{DC9A}\x{D83F}\x{DF3F}\x{D83E}\x{DE67}\x{C08D}\x{2E51}"
+      RenderText {#text} at (0,908) size 755x175
+        text run at (669,908) width 86: "\x{D83E}\x{DF48}\x{25CA}\x{5554}\x{4281}\x{D83F}\x{DF60}\x{E4EE}\x{434E}"
+        text run at (0,1066) width 20 RTL: "\x{FD79}"
+        text run at (19,1066) width 26: "\x{CAA}\x{C890}"
+      RenderText {#text} at (44,1066) size 42x17
+        text run at (44,1066) width 42: "\x{C93}\x{D83D}\x{DE93}\x{995}"
+      RenderText {#text} at (385,1066) size 99x17
+        text run at (385,1066) width 99: "\x{140}\x{30B}\x{D83F}\x{DD8B}\x{E03E}\x{D83E}\x{DF2B}\x{75AD}\x{D83E}\x{DCE1}\x{E7C2}\x{CF21}\x{420}"
+      RenderText {#text} at (483,1066) size 22x17
+        text run at (483,1066) width 22: "\x{D83E}\x{DF49}\x{6}"
+      RenderText {#text} at (504,1066) size 108x17
+        text run at (504,1066) width 108: "\x{C24}\x{4EF}\x{D83F}\x{DED8}\x{30C9}\x{6D71}\x{40B1}\x{D83E}\x{DEF4}\x{F888}"
+      RenderText {#text} at (611,1066) size 115x17
+        text run at (611,1066) width 115: "\x{6EDD}\x{D83E}\x{DD93}\x{929}\x{6982}\x{C1A}\x{E97}\x{4E1}\x{2813}\x{3ED}\x{585}"
+      RenderText {#text} at (0,1066) size 751x42
+        text run at (725,1066) width 26: "\x{EFCC}\x{4DA1}"
+        text run at (0,1091) width 44: "\x{13B}\x{D83E}\x{DC1C}\x{55D6}\x{A35}"
+      RenderText {#text} at (0,1501) size 86x17
+        text run at (0,1501) width 8: "\x{663}"
+        text run at (7,1501) width 79: "\x{73A6}\x{D83D}\x{DF18}\x{F3F}\x{B3C}\x{38BB}\x{B45}\x{823}\x{D83F}\x{DC95}"
+      RenderText {#text} at (85,1501) size 63x17
+        text run at (85,1501) width 63: "\x{4592}\x{21E7}\x{8DB}\x{B90B}\x{499}"
+      RenderText {#text} at (147,1501) size 107x17
+        text run at (147,1501) width 22: "\x{D83F}\x{DD08}\x{D840}"
+        text run at (168,1501) width 15 RTL: "\x{8BE}"
+        text run at (182,1501) width 72: "\x{6A31}\x{407}\x{975}\x{D83F}\x{DFC9}\x{8716}\x{D83F}\x{DE6D}"
+      RenderText {#text} at (253,1501) size 32x17
+        text run at (253,1501) width 32: "\x{2D8F}\x{F772}"
+      RenderText {#text} at (284,1501) size 11x17
+        text run at (284,1501) width 11: "\x{517}\x{343}"
+      RenderText {#text} at (294,1501) size 42x17
+        text run at (294,1501) width 42: "\x{DDBE}\x{5A81}\x{8744}"
+      RenderText {#text} at (335,1501) size 29x17
+        text run at (335,1501) width 29: "\x{A2C5}\x{B79D}\x{B9}"
+      RenderText {#text} at (363,1501) size 72x17
+        text run at (363,1501) width 72: "\x{B3A7}\x{E810}\x{AFF5}\x{B583}\x{46FD}"
+      RenderText {#text} at (434,1501) size 81x17
+        text run at (434,1501) width 81: "\x{1A23}\x{991C}\x{FD7}\x{D83F}\x{DEE9}\x{D83E}\x{DC87}\x{BEF1}\x{D83E}\x{DF30}"
+      RenderText {#text} at (514,1501) size 72x17
+        text run at (514,1501) width 72: "\x{BC91}\x{AD3}\x{D4C}\x{95A}\x{C81E}\x{90A}"
+      RenderText {#text} at (585,1501) size 108x17
+        text run at (585,1501) width 37: "\x{648D}\x{D83E}\x{DCFE}\x{EED5}"
+        text run at (621,1501) width 9 RTL: "\x{7D6}"
+        text run at (629,1501) width 64: "\x{FE45}\x{1A75}\x{EBF6}\x{5997}\x{1B95}\x{C3C}"
+      RenderText {#text} at (213,2180) size 110x17
+        text run at (213,2180) width 15: "\x{730E}"
+        text run at (228,2180) width 22 RTL: "\x{893}\x{63B}"
+        text run at (249,2180) width 74: "\x{37B0}\x{D83D}\x{DF13}\x{7144}\x{A748}\x{D83D}\x{DEA3}\x{654}"
+      RenderHTMLCanvas {CANVAS} at (322,1523) size 301x670
+      RenderText {#text} at (622,2180) size 53x17
+        text run at (622,2180) width 23: "\x{EAD5}\x{D5A}"
+        text run at (644,2180) width 24 RTL: "\x{8B8}\x{FBA}"
+        text run at (667,2180) width 8: "\x{FF}"
+      RenderText {#text} at (674,2180) size 46x17
+        text run at (674,2180) width 46: "\x{4E04}\x{4715}\x{2ED7}"
+      RenderText {#text} at (0,2180) size 739x45
+        text run at (719,2180) width 20: "\x{EDB}\x{A016}"
+        text run at (0,2208) width 51: "\x{4EE}\x{D83D}\x{DF66}\x{E14F}\x{25B}\x{F27C}"
+      RenderText {#text} at (50,2208) size 123x17
+        text run at (50,2208) width 12 RTL: "\x{88F}"
+        text run at (61,2208) width 66: "\x{56DE}\x{75E3}\x{8FF1}\x{D83E}\x{DDF9}"
+        text run at (126,2208) width 11 RTL: "\x{803}"
+        text run at (136,2208) width 37: "\x{185E}\x{4350}\x{295}\x{D83D}\x{DF2A}"
+      RenderText {#text} at (172,2208) size 70x17
+        text run at (172,2208) width 51: "\x{2AF}\x{34CD}\x{725A}\x{D83D}\x{DE76}"
+        text run at (222,2208) width 20 RTL: "\x{FD02}"
+      RenderText {#text} at (241,2208) size 126x17
+        text run at (241,2208) width 38: "\x{D665}\x{9AD8}\x{296}"
+        text run at (278,2208) width 12 RTL: "\x{FB37}"
+        text run at (289,2208) width 67: "\x{BEE8}\x{D83F}\x{DE77}\x{D359}\x{9A67}\x{D83F}\x{DE37}"
+        text run at (355,2208) width 12 RTL: "\x{5FC}"
+      RenderText {#text} at (366,2208) size 57x17
+        text run at (366,2208) width 57: "\x{A5ED}\x{C406}\x{162E}\x{9661}"
+      RenderText {#text} at (422,2208) size 64x17
+        text run at (422,2208) width 64: "\x{FFE}\x{3ACD}\x{4A37}\x{EEAE}\x{D83E}\x{DC79}"
+      RenderText {#text} at (485,2208) size 124x17
+        text run at (485,2208) width 124: "\x{A1}\x{55C}\x{F41D}\x{AA95}\x{3A64}\x{F68F}\x{D83D}\x{DF3B}\x{DA00}\x{855B}\x{C24D}\x{447D}"
+      RenderText {#text} at (608,2208) size 122x17
+        text run at (608,2208) width 122: "\x{F315}\x{41E}\x{DD54}\x{D83E}\x{DDE2}\x{D83D}\x{DEE9}\x{5B24}\x{BBB7}\x{A8A2}\x{24F}"
+      RenderText {#text} at (0,2208) size 760x224
+        text run at (729,2208) width 31: "\x{9C9D}\x{BB35}"
+        text run at (0,2415) width 52: "\x{431F}\x{D83E}\x{DFBF}\x{9FE}\x{4545}"
+      RenderText {#text} at (51,2415) size 138x17
+        text run at (51,2415) width 71: "\x{B606}\x{C420}\x{C27D}\x{308}\x{886E}\x{563}"
+        text run at (121,2415) width 14 RTL: "\x{77D}"
+        text run at (134,2415) width 55: "\x{3948}\x{5EF4}\x{A28E}\x{BAB6}"
+      RenderText {#text} at (204,2415) size 114x17
+        text run at (204,2415) width 114: "\x{CFC9}\x{AB02}\x{BFB0}\x{D83F}\x{DE32}\x{3CC0}\x{8AD8}\x{2711}\x{4D25}"
+      RenderText {#text} at (317,2415) size 104x17
+        text run at (317,2415) width 104: "\x{19EE}\x{9E44}\x{E64A}\x{D83E}\x{DC17}\x{D83E}\x{DE59}\x{62A1}\x{1F7}\x{7F8F}"
+      RenderText {#text} at (420,2415) size 46x17
+        text run at (420,2415) width 46: "\x{2458}\x{D83E}\x{DDEF}\x{27C8}"
+      RenderText {#text} at (465,2415) size 28x17
+        text run at (465,2415) width 28: "\x{C985}\x{1645}"
+      RenderImage {IMG} at (492,2227) size 182x201
+      RenderText {#text} at (673,2415) size 61x17
+        text run at (673,2415) width 61: "\x{D83F}\x{DE63}\x{D83D}\x{DEC6}\x{3355}\x{D83E}\x{DF0E}\x{17A6}"
+      RenderText {#text} at (290,2554) size 67x17
+        text run at (290,2554) width 67: "\x{89}\x{4AC3}\x{9A87}\x{E4F1}\x{8154}"
+      RenderText {#text} at (356,2554) size 120x17
+        text run at (356,2554) width 72: "\x{D83E}\x{DE82}\x{1D98}\x{629D}\x{AE61}\x{7BCB}"
+        text run at (427,2554) width 14 RTL: "\x{852}"
+        text run at (440,2554) width 36: "\x{B2BB}\x{28EC}\x{29B1}"
+      RenderText {#text} at (475,2554) size 51x17
+        text run at (475,2554) width 51: "\x{D83D}\x{DF4E}\x{D83F}\x{DC12}\x{634B}\x{6008}"
+      RenderText {#text} at (525,2554) size 118x17
+        text run at (525,2554) width 118: "\x{278}\x{4C70}\x{905}\x{D83E}\x{DD64}\x{D83E}\x{DED5}\x{A441}\x{D83F}\x{DE86}\x{D83E}\x{DFDA}\x{D83F}\x{DFAB}"
+      RenderText {#text} at (0,2554) size 767x175
+        text run at (642,2554) width 71: "\x{2F6C}\x{9192}\x{586B}\x{291}\x{4D45}"
+        text run at (712,2554) width 25 RTL: "\x{FD21}"
+        text run at (736,2554) width 31: "\x{CF1C}\x{8A0B}"
+        text run at (0,2712) width 11: "\x{E4C8}"
+      RenderImage {IMG} at (10,2573) size 295x152
+      RenderText {#text} at (304,2712) size 88x17
+        text run at (304,2712) width 40: "\x{A78E}\x{63A3}\x{C4AF}"
+        text run at (343,2712) width 10 RTL: "\x{843}"
+        text run at (352,2712) width 40: "\x{30B2}\x{AE1B}\x{A810}"
+      RenderText {#text} at (391,2712) size 26x17
+        text run at (391,2712) width 26: "\x{D83D}\x{DEED}\x{98D1}"
+      RenderText {#text} at (416,2712) size 103x17
+        text run at (416,2712) width 103: "\x{C934}\x{C655}\x{1CA}\x{ACA}\x{D83E}\x{DC1C}'\x{D83E}\x{DD9D}\x{D83F}\x{DC62}"
+      RenderText {#text} at (518,2712) size 81x17
+        text run at (518,2712) width 27: "\x{BCE}\x{3CEB}"
+        text run at (544,2712) width 9 RTL: "\x{5E8}"
+        text run at (552,2712) width 47: "\x{397B}\x{F98}\x{A58}\x{2104}"
+      RenderImage {IMG} at (300,2765) size 26x233
+      RenderText {#text} at (626,2985) size 70x17
+        text run at (626,2985) width 55: "\x{D83D}\x{DEF7}\x{83C5}\x{D83E}\x{DDE1}"
+        text run at (681,2985) width 15 RTL: "\x{5D4}\x{846}"
+      RenderText {#text} at (0,2985) size 756x252
+        text run at (695,2985) width 61: "\x{D8E}\x{9EB9}\x{9FD5}\x{D83F}\x{DE5F}"
+        text run at (0,3220) width 53: "\x{88DA}\x{655}\x{D83F}\x{DF38}\x{B757}\x{3D8}\x{FE2A}"
+      RenderText {#text} at (52,3220) size 48x17
+        text run at (52,3220) width 48: "\x{2602}\x{5A15}\x{1797}\x{A38}"
+      RenderText {#text} at (99,3220) size 52x17
+        text run at (99,3220) width 52: "\x{DA07}\x{547E}\x{D83D}\x{DF3C}\x{8CAF}"
+      RenderImage {IMG} at (150,3004) size 247x229
+      RenderText {#text} at (396,3220) size 47x17
+        text run at (396,3220) width 47: "\x{D83F}\x{DC3E}\x{262}\x{3E0D}\x{E7E9}"
+      RenderText {#text} at (442,3220) size 103x17
+        text run at (442,3220) width 27: "\x{D851}\x{5F41}"
+        text run at (468,3220) width 20 RTL: "\x{837}"
+        text run at (487,3220) width 58: "\x{B48}\x{D83E}\x{DCB0}\x{BDCB}\x{B8EC}"
+      RenderText {#text} at (544,3220) size 46x17
+        text run at (544,3220) width 46: "\x{7A6}\x{90EE}\x{548D}\x{B538}"
+      RenderText {#text} at (589,3220) size 60x17
+        text run at (589,3220) width 8: "\x{31F}"
+        text run at (596,3220) width 8 RTL: "\x{676}"
+        text run at (603,3220) width 46: "\x{7053}\x{2F9B}\x{305}\x{657A}"
+      RenderText {#text} at (648,3220) size 105x17
+        text run at (648,3220) width 63: "\x{A6B}\x{AA0}\x{4013}\x{8F6E}\x{A9D1}\x{6DB}"
+        text run at (710,3220) width 6 RTL: "\x{FE97}"
+        text run at (715,3220) width 38: "\x{7754}\x{2FAF}\x{D83D}\x{DF4C}"
+      RenderText {#text} at (0,3220) size 764x47
+        text run at (752,3220) width 12: "\x{2EF8}"
+        text run at (0,3250) width 15: "\x{37A9}"
+      RenderText {#text} at (0,3421) size 56x17
+        text run at (0,3421) width 56: "\x{D83F}\x{DC0D}\x{67DC}\x{6EA3}\x{3A79}"
+      RenderText {#text} at (55,3421) size 67x17
+        text run at (55,3421) width 67: "\x{1}\x{CA89}\x{7852}\x{BDBC}\x{BED}"
+      RenderText {#text} at (0,3834) size 55x17
+        text run at (0,3834) width 55: "\x{3EA}\x{5659}\x{B224}\x{5A3A}"
+      RenderImage {IMG} at (54,3788) size 47x59
+      RenderText {#text} at (100,3834) size 93x17
+        text run at (100,3834) width 93: "\x{7D65}\x{4D20}\x{898}\x{D83F}\x{DE70}\x{B767}\x{90C}\x{4CCF}"
+      RenderText {#text} at (527,3834) size 122x17
+        text run at (527,3834) width 122: "\x{8AA4}\x{A3E}\x{B9F}\x{1F10}\x{E49}\x{D83F}\x{DF44}\x{B78}\x{CE88}\x{19F5}\x{D83D}\x{DEC0}"
+      RenderText {#text} at (648,3834) size 93x17
+        text run at (648,3834) width 67: "\x{DAB}\x{B758}\x{E82}\x{339}\x{D754}\x{98B}"
+        text run at (714,3834) width 12 RTL: "\x{895}"
+        text run at (725,3834) width 16: "\x{B544}"
+      RenderText {#text} at (0,3973) size 117x17
+        text run at (0,3973) width 117: "\x{5DE9}\x{BAC7}\x{615A}\x{443}\x{D83E}\x{DC0B}\x{5AE9}\x{FB8}\x{3E2D}\x{45A8}"
+      RenderImage {IMG} at (116,3920) size 156x66
+      RenderText {#text} at (271,3973) size 111x17
+        text run at (271,3973) width 111: "\x{4456}\x{763D}\x{6858}\x{3197}\x{7B4A}\x{A6C5}\x{13D1}\x{AE2C}"
+      RenderText {#text} at (381,3973) size 82x17
+        text run at (381,3973) width 82: "\x{4907}\x{B652}\x{D83E}\x{DE43}\x{CBD5}\x{C520}\x{459}"
+      RenderImage {IMG} at (462,3859) size 288x127
+      RenderText {#text} at (0,4001) size 120x17
+        text run at (0,4001) width 120: "\x{D83F}\x{DDA7}\x{363}\x{D83E}\x{DC47}\x{5E75}\x{D83F}\x{DE23}\x{1AE}\x{A8E5}\x{D83F}\x{DEF3}\x{48DF}\x{5107}"
+      RenderText {#text} at (119,4001) size 27x17
+        text run at (119,4001) width 27: "\x{E95D}\x{BA46}"
+      RenderText {#text} at (145,4001) size 110x17
+        text run at (145,4001) width 99: "\x{6D9B}\x{D83D}\x{DE24}\x{8BA2}\x{6CE6}\x{E9B}\x{D83E}\x{DFA8}\x{1361}\x{22DE}"
+        text run at (243,4001) width 12 RTL: "\x{621}\x{709}"
+      RenderText {#text} at (254,4001) size 35x17
+        text run at (254,4001) width 35: "\x{D83F}\x{DD69}\x{5660}\x{A0E6}"
+      RenderText {#text} at (288,4001) size 84x17
+        text run at (288,4001) width 84: "\x{6B8D}\x{CD3F}{\x{BA63}\x{D83F}\x{DC58}\x{D83E}\x{DE79}"
+      RenderText {#text} at (371,4001) size 79x17
+        text run at (371,4001) width 79: "\x{6BB9}\x{D83F}\x{DEA4}\x{2C97}\x{2972}\x{1BF}\x{DE85}\x{CFE7}"
+      RenderText {#text} at (449,4001) size 67x17
+        text run at (449,4001) width 67: "\x{EF1}\x{B007}\x{3F51}\x{261D}\x{D83F}\x{DC63}"
+      RenderText {#text} at (515,4001) size 76x17
+        text run at (515,4001) width 44: "\x{98B8}\x{29B}\x{9DD}\x{D83E}\x{DF77}"
+        text run at (558,4001) width 12 RTL: "\x{812}"
+        text run at (569,4001) width 22: "\x{970}\x{4E6C}"
+      RenderText {#text} at (590,4001) size 140x17
+        text run at (590,4001) width 140: "\x{D83D}\x{DFE5}\x{D83E}\x{DC26}\x{61CA}\x{D83E}\x{DE1C}\x{D83E}\x{DC4B}\x{8674}\x{3056}\x{1992}\x{37B8}\x{8F24}"
+      RenderImage {IMG} at (0,4272) size 76x41
+      RenderText {#text} at (76,4300) size 26x17
+        text run at (76,4300) width 26: "\x{E444}\x{8A50}"
+      RenderText {#text} at (101,4300) size 123x17
+        text run at (101,4300) width 123: "\x{6E4}\x{312}\x{D83E}\x{DDBF}\x{D3EF}\x{2A01}\x{8F1B}\x{24D5}\x{D83F}\x{DD89}\x{CE5}\x{4551}"
+      RenderImage {IMG} at (223,4251) size 56x62
+      RenderText {#text} at (278,4300) size 31x17
+        text run at (278,4300) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (308,4300) size 81x17
+        text run at (308,4300) width 81: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (388,4300) size 69x17
+        text run at (388,4300) width 7 RTL: "\x{692}"
+        text run at (394,4300) width 63: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (0,4363) size 298x170
+      RenderText {#text} at (298,4520) size 103x17
+        text run at (298,4520) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (438,4520) size 100x17
+        text run at (438,4520) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (537,4520) size 117x17
+        text run at (537,4520) width 32: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (568,4520) width 10 RTL: "\x{79B}"
+        text run at (577,4520) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (0,4540) size 292x253
+      RenderText {#text} at (292,4780) size 103x17
+        text run at (292,4780) width 103: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (394,4780) size 105x17
+        text run at (394,4780) width 105: "\x{10D}\x{BA96}\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (498,4780) size 102x17
+        text run at (498,4780) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (599,4780) size 116x17
+        text run at (599,4780) width 116: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (0,4811) size 34x17
+        text run at (0,4811) width 34: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (33,4811) size 120x17
+        text run at (33,4811) width 26: "\x{24BF}\x{B00}"
+        text run at (58,4811) width 12 RTL: "\x{5FF}"
+        text run at (69,4811) width 14: "\x{2FA}\x{B13}"
+        text run at (82,4811) width 11 RTL: "\x{8BC}"
+        text run at (92,4811) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (152,4811) size 88x17
+        text run at (152,4811) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (239,4811) size 88x17
+        text run at (239,4811) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (326,4811) size 22x17
+        text run at (326,4811) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (347,4811) size 111x17
+        text run at (347,4811) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (457,4811) size 79x17
+        text run at (457,4811) width 79: "\x{ECB8}\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (535,4811) size 85x17
+        text run at (535,4811) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+      RenderText {#text} at (619,4811) size 100x17
+        text run at (619,4811) width 80: "\x{D83F}\x{DD83}\x{D83F}\x{DD58}\x{6EE2}\x{47A3}\x{10B}\x{2CC7}\x{BC62}"
+        text run at (698,4811) width 10 RTL: "\x{67F}"
+        text run at (707,4811) width 12: "\x{D83F}\x{DC12}"
+      RenderText {#text} at (0,4811) size 752x45
+        text run at (718,4811) width 34: "\x{F24}\x{A756}\x{4864}"
+        text run at (0,4839) width 116: "\x{D83D}\x{DF2C}\x{D83E}\x{DD04}\x{D83D}\x{DFF9}\x{D83E}\x{DD6D}\x{D83D}\x{DF33}\x{9AA9}\x{FF4C}\x{D83E}\x{DEAD}"
+      RenderText {#text} at (115,4839) size 52x17
+        text run at (115,4839) width 27: "\x{84E2}\x{D83E}\x{DCB2}"
+        text run at (141,4839) width 11 RTL: "\x{793}"
+        text run at (151,4839) width 16: "\x{812B}"
+      RenderText {#text} at (166,4839) size 119x17
+        text run at (166,4839) width 119: "\x{CD98}\x{D83E}\x{DEF8}\x{D83E}\x{DDA7}\x{AF08}\x{4EB8}\x{1243}\x{B2E}\x{FF7}"
+      RenderText {#text} at (284,4839) size 96x17
+        text run at (284,4839) width 96: "\x{1E56}\x{DB7F}\x{3BE0}\x{9F86}\x{4C4D}\x{D83F}\x{DCB1}\x{D83E}\x{DD9F}"
+      RenderText {#text} at (379,4839) size 60x17
+        text run at (379,4839) width 16: "\x{AC6C}"
+        text run at (394,4839) width 15 RTL: "\x{84C}"
+        text run at (408,4839) width 31: "\x{3CFB}\x{C01}"
+      RenderText {#text} at (438,4839) size 84x17
+        text run at (438,4839) width 84: "\x{C96F}\x{CFE}\x{D83E}\x{DD4C}\x{2EB1}\x{BFB}\x{D83F}\x{DFDA}"
+      RenderText {#text} at (521,4839) size 74x17
+        text run at (521,4839) width 74: "\x{966}\x{D83D}\x{DE44}\x{F51D}\x{D83E}\x{DF45}\x{F91}\x{2772}\x{D83F}\x{DF3B}"
+      RenderText {#text} at (594,4839) size 89x17
+        text run at (594,4839) width 67: "\x{94A5}\x{8A96}\x{6D75}\x{D83F}\x{DC81}\x{180}"
+        text run at (660,4839) width 12 RTL: "\x{6A6}"
+        text run at (671,4839) width 12: "\x{D83F}\x{DC37}"
+      RenderText {#text} at (682,4839) size 78x17
+        text run at (682,4839) width 58: "\x{EA1}\x{FB1}\x{A34}\x{5543}\x{D83F}\x{DF64}"
+        text run at (739,4839) width 13 RTL: "\x{801}"
+        text run at (751,4839) width 9: "\x{2EE1}"
+      RenderText {#text} at (0,4865) size 34x17
+        text run at (0,4865) width 34: "\x{1498}\x{D83F}\x{DE40}\x{D83E}\x{DC29}"
+      RenderText {#text} at (33,4865) size 23x17
+        text run at (33,4865) width 23: "\x{3040}\x{D83E}\x{DE44}"
+      RenderText {#text} at (55,4865) size 74x17
+        text run at (55,4865) width 74: "\x{D83F}\x{DF07}\x{DE60}\x{958}\x{D83F}\x{DD30}\x{4AC5}\x{3F37}"
+      RenderText {#text} at (128,4865) size 133x17
+        text run at (128,4865) width 133: "\x{7F0}\x{9CF}\x{C47A}\x{D74}\x{161C}\x{1F13}\x{97BB}\x{4FF7}\x{3AEF}\x{D83E}\x{DC98}\x{DDA}"
+      RenderText {#text} at (260,4865) size 111x17
+        text run at (260,4865) width 111: "\x{E60A}\x{5E72}\x{FAFC}\x{A318}\x{960}\x{9825}\x{265E}\x{6633}\x{6C91}"
+      RenderText {#text} at (370,4865) size 109x17
+        text run at (370,4865) width 61: "\x{739A}\x{2679}\x{24C2}\x{4019}"
+        text run at (430,4865) width 12 RTL: "\x{5C9}"
+        text run at (441,4865) width 38: "\x{CEE6}\x{D83E}\x{DF11}\x{A44}"
+      RenderText {#text} at (478,4865) size 32x17
+        text run at (478,4865) width 32: "\x{A89}\x{D83E}\x{DE59}\x{D83E}\x{DE6F}"
+      RenderText {#text} at (509,4865) size 83x17
+        text run at (509,4865) width 68: "\x{C1D6}\x{DC6A}\x{6930}\x{9921}\x{432}\x{ED}"
+        text run at (576,4865) width 5 RTL: "\x{701}"
+        text run at (580,4865) width 12: "\x{C84}"
+      RenderText {#text} at (591,4865) size 98x17
+        text run at (591,4865) width 98: "\x{D83D}\x{DE53}\x{D83F}\x{DC79}\x{C460}\x{BEF2}\x{4C04}\x{156}\x{372}\x{47A}"
+      RenderText {#text} at (688,4865) size 23x17
+        text run at (688,4865) width 23: "\x{D83E}\x{DC7C}\x{D83F}\x{DC5B}"
+      RenderText {#text} at (0,4865) size 756x43
+        text run at (710,4865) width 46: "\x{37FE}\x{9416}\x{9668}"
+        text run at (0,4891) width 54: "\x{E6B0}\x{F1F}\x{E27B}\x{B1B}\x{6F8B}"
+      RenderText {#text} at (53,4891) size 89x17
+        text run at (53,4891) width 89: "\x{533}\x{D83F}\x{DDD9}\x{C481}\x{C5EC}\x{A889}\x{49D9}\x{D83F}\x{DEBB}"
+      RenderText {#text} at (141,4891) size 120x17
+        text run at (141,4891) width 16: "\x{589C}"
+        text run at (156,4891) width 12 RTL: "\x{5CC}"
+        text run at (167,4891) width 49: "\x{1FF}\x{8296}\x{D83F}\x{DD87}\x{C9CD}"
+        text run at (215,4891) width 11 RTL: "\x{5E1}"
+        text run at (225,4891) width 12: "\x{EB97}"
+        text run at (236,4891) width 14 RTL: "\x{8B6}"
+        text run at (249,4891) width 12: "\x{D83E}\x{DE33}"
+      RenderText {#text} at (260,4891) size 70x17
+        text run at (260,4891) width 70: "\x{29E}\x{3AD8}\x{911F}\x{4170}\x{89AC}"
+      RenderText {#text} at (329,4891) size 127x17
+        text run at (329,4891) width 127: "\x{DAE}\x{D83E}\x{DFD0}\x{D676}\x{7A82}\x{D83F}\x{DC92}\x{D33}\x{99C8}\x{D83E}\x{DD52}\x{8FDE}\x{140}"
+      RenderText {#text} at (455,4891) size 145x17
+        text run at (455,4891) width 128: "\x{D83E}\x{DCB1}\x{D83E}\x{DCB7}\x{D83F}\x{DDE3}\x{B97C}\x{C855}\x{CD5B}\x{CF1}\x{C54C}\x{4043}\x{1535}"
+        text run at (587,4891) width 13 RTL: "\x{83D}"
+      RenderText {#text} at (582,4891) size 84x17
+        text run at (582,4891) width 6 RTL: "\x{5D5}"
+        text run at (599,4891) width 67: "\x{5E92}\x{1E8A}\x{9A39}\x{D29}\x{D83F}\x{DEBA}"
+      RenderText {#text} at (665,4891) size 31x17
+        text run at (665,4891) width 31: "\x{47B5}\x{8C8D}"
+      RenderText {#text} at (0,4891) size 764x45
+        text run at (695,4891) width 69: "\x{275C}\x{145}\x{C5C7}\x{F654}\x{DAD7}\x{BDD7}"
+        text run at (0,4919) width 19: "n\x{F047}"
+      RenderText {#text} at (18,4919) size 120x17
+        text run at (18,4919) width 28: "\x{ABB4}\x{AACB}\x{A19}"
+        text run at (45,4919) width 15 RTL: "\x{717}"
+        text run at (59,4919) width 79: "\x{E620}\x{D83E}\x{DC2C}\x{D83D}\x{DE54}\x{2C3}\x{BD07}\x{536}\x{4AFF}"
+      RenderText {#text} at (137,4919) size 63x17
+        text run at (137,4919) width 32: "\x{D83E}\x{DDCC}\x{D83E}\x{DC21}"
+        text run at (168,4919) width 17 RTL: "\x{6BE}\x{769}"
+        text run at (184,4919) width 16: "\x{41BE}"
+      RenderText {#text} at (199,4919) size 41x17
+        text run at (199,4919) width 15 RTL: "\x{808}"
+        text run at (213,4919) width 27: "\x{D83E}\x{DE4B}\x{4961}"
+      RenderText {#text} at (239,4919) size 48x17
+        text run at (239,4919) width 48: "\x{2CE9}\x{E5A6}\x{7C86}\x{10}"
+      RenderText {#text} at (286,4919) size 140x17
+        text run at (286,4919) width 140: "\x{D83F}\x{DE92}\x{E10B}\x{E644}\x{346D}\x{DD9}\x{EC1}\x{1D39}\x{BAE0}\x{CCC}\x{D0A}\x{272D}"
+      RenderText {#text} at (425,4919) size 144x17
+        text run at (425,4919) width 144: "\x{8E33}\x{F5F6}\x{D83E}\x{DD52}\x{542C}\x{AE0C}\x{33F}\x{B49F}\x{D83E}\x{DCA8}\x{DA4}\x{D83F}\x{DC82}\x{6138}"
+      RenderText {#text} at (568,4919) size 102x17
+        text run at (568,4919) width 33: "\x{D83F}\x{DF2D}\x{F4A7}\x{E7C6}"
+        text run at (600,4919) width 10 RTL: "\x{639}"
+        text run at (609,4919) width 27: "\x{FDD}\x{8C02}"
+        text run at (635,4919) width 5 RTL: "\x{627}"
+        text run at (639,4919) width 31: "\x{64C5}\x{3878}"
+      RenderText {#text} at (0,4919) size 768x44
+        text run at (669,4919) width 99: "\x{911D}\x{B0A}\x{D83E}\x{DF5D}\x{530D}\x{D6F0}\x{302}\x{9DF7}\x{D18}"
+        text run at (0,4946) width 15: "\x{B088}\x{EC9}"
+      RenderText {#text} at (14,4946) size 27x17
+        text run at (14,4946) width 12: "\x{D83F}\x{DDBE}"
+        text run at (35,4946) width 6 RTL: "\x{6C0}"
+      RenderText {#text} at (25,4946) size 76x17
+        text run at (25,4946) width 11 RTL: "\x{6D1}"
+        text run at (40,4946) width 61: "\x{B7EC}\x{DC39}\x{73EF}\x{1F90}\x{D83E}\x{DFE6}"
+      RenderText {#text} at (100,4946) size 132x17
+        text run at (100,4946) width 111: "\x{326D}\x{F53}\x{D83E}\x{DCAB}\x{482}\x{D83E}\x{DFFE}\x{B32F}\x{D83F}\x{DD03}\x{5C3E}\x{3D9C}"
+        text run at (210,4946) width 22 RTL: "\x{FCFC}"
+      RenderText {#text} at (231,4946) size 102x17
+        text run at (231,4946) width 77: "\x{8950}\x{4E2A}\x{EDC}\x{D83E}\x{DCD7}\x{D83F}\x{DD84}\x{44E}"
+        text run at (307,4946) width 11 RTL: "\x{848}"
+        text run at (317,4946) width 16: "\x{AF80}"
+      RenderText {#text} at (332,4946) size 129x17
+        text run at (332,4946) width 129: "\x{54D7}\x{E79C}\x{8C16}\x{63C6}\x{F54D}\x{8CEB}\x{8E6}\x{D83E}\x{DD1E}\x{F5BB}\x{AD09}"
+      RenderText {#text} at (460,4946) size 95x17
+        text run at (460,4946) width 95: "\x{D07B}\x{D83D}\x{DEBF}\x{C5}\x{D83E}\x{DCF7}\x{F8}\x{4AC9}\x{6E8E}"
+      RenderText {#text} at (554,4946) size 112x17
+        text run at (554,4946) width 112: "\x{C7FE}\x{AE4D}\x{4827}\x{BA55}\x{62AD}\x{FBA}\x{6065}\x{4EFC}"
+      RenderText {#text} at (0,4946) size 755x45
+        text run at (665,4946) width 90: "\x{10C6}\x{4BF}\x{BBE4}\x{D3B}\x{A0A}\x{B8E}\x{1487}\x{D83F}\x{DC7C}"
+        text run at (0,4974) width 32: "\x{23D}\x{1AA}\x{8F3F}"
+      RenderText {#text} at (31,4974) size 36x17
+        text run at (31,4974) width 36: "\x{328}\x{E96}\x{D83F}\x{DF71}\x{F10F}"
+      RenderText {#text} at (66,4974) size 88x17
+        text run at (66,4974) width 88: "\x{614A}\x{C870}\x{E997}\x{D83F}\x{DE46}\x{2D8B}\x{B80}\x{EFC4}"
+      RenderText {#text} at (153,4974) size 140x17
+        text run at (153,4974) width 140: "\x{496B}\x{D83F}\x{DE84}\x{D3D8}\x{D83D}\x{DF44}\x{1244}\x{D83E}\x{DD7C}\x{3C8A}\x{D73F}\x{E6DF}\x{D83F}\x{DD5E}"
+      RenderText {#text} at (292,4974) size 11x17
+        text run at (292,4974) width 11: "\x{2995}\x{F7D}"
+      RenderText {#text} at (302,4974) size 60x17
+        text run at (302,4974) width 60: "\x{515D}\x{DEA}k\x{D83F}\x{DDE9}\x{D099}"
+      RenderText {#text} at (361,4974) size 83x17
+        text run at (361,4974) width 83: "\x{4936}\x{A04}\x{D83D}\x{DE68}\x{7F8E}\x{5145}\x{3B80}"
+      RenderText {#text} at (443,4974) size 42x17
+        text run at (443,4974) width 42: "\x{B92B}\x{B663}\x{D83F}\x{DF52}"
+      RenderText {#text} at (484,4974) size 32x17
+        text run at (484,4974) width 32: "\x{D83F}\x{DD45}\x{4C8}\x{1500}"
+      RenderText {#text} at (515,4974) size 103x17
+        text run at (515,4974) width 11 RTL: "\x{649}"
+        text run at (525,4974) width 93: "Y\x{E2}\x{D83D}\x{DFCF}\x{BE7}\x{E856}\x{D83D}\x{DF5D}\x{96CF}\x{76BA}"
+      RenderText {#text} at (617,4974) size 71x17
+        text run at (617,4974) width 71: "\x{3190}\x{B978}\x{898}\x{AD2C}\x{CF05}"
+      RenderText {#text} at (687,4974) size 49x17
+        text run at (687,4974) width 49: "\x{D83F}\x{DC2C}\x{DDE0}\x{2E3F}\x{3B9A}"
+      RenderText {#text} at (0,5002) size 78x17
+        text run at (0,5002) width 31: "\x{D83E}\x{DE42}\x{A6E}\x{D9FC}"
+        text run at (30,5002) width 18 RTL: "\x{FC17}"
+        text run at (47,5002) width 31: "\x{24A9}\x{5434}"
+      RenderText {#text} at (77,5002) size 138x17
+        text run at (77,5002) width 138: "\x{8EB0}\x{D83F}\x{DCBB}\x{8B92}\x{4961}\x{D83F}\x{DE5F}\x{815F}\x{1496}\x{75DF}\x{F135}\x{D83E}\x{DCAE}\x{AB94}"
+      RenderText {#text} at (214,5002) size 119x17
+        text run at (214,5002) width 119: "\x{7}\x{F4E}\x{E9C5}\x{D83E}\x{DD16}\x{FF4}\x{C8B2}\x{8885}\x{1181}\x{D83F}\x{DDD6}"
+      RenderText {#text} at (332,5002) size 138x17
+        text run at (332,5002) width 138: "\x{F40D}\x{D83E}\x{DE7B}\x{D83F}\x{DE68}\x{481}\x{1242}\x{BA41}\x{8A50}\x{D83F}\x{DD54}\x{2F2A}\x{D83D}\x{DE49}"
+      RenderText {#text} at (469,5002) size 137x17
+        text run at (469,5002) width 137: "\x{884F}\x{146B}\x{D9C5}\x{D83E}\x{DF3C}\x{40EA}\x{BCD5}\x{5E1B}\x{A59}\x{D83E}\x{DCDD}\x{D83F}\x{DDF0}\x{7C60}"
+      RenderText {#text} at (605,5002) size 119x17
+        text run at (605,5002) width 119: "\x{5BB}\x{D83D}\x{DF58}\x{994}\x{D6F}\x{D83F}\x{DCBF}\x{1E35}\x{DD08}\x{90FE}\x{16AD}\x{B0D1}\x{5E87}"
+      RenderText {#text} at (0,5002) size 758x45
+        text run at (723,5002) width 35: "\x{78F9}\x{D83F}\x{DC10}\x{A0E3}"
+        text run at (0,5030) width 15: "\x{5AFC}"
+      RenderText {#text} at (15,5030) size 130x17
+        text run at (15,5030) width 130: "\x{5084}\x{BECB}\x{6B64}\x{D83E}\x{DC65}\x{D72B}\x{7CD8}\x{D83F}\x{DC17}\x{9C6}\x{D83F}\x{DEF6}\x{7A6}"
+      RenderText {#text} at (144,5030) size 67x17
+        text run at (144,5030) width 67: "\x{21AA}\x{C3A9}\x{32C1}\x{1E22}\x{D00}"
+      RenderText {#text} at (210,5030) size 111x17
+        text run at (210,5030) width 10 RTL: "\x{682}"
+        text run at (219,5030) width 102: "\x{78A3}\x{E49}\x{B61}\x{C2}\x{E55}\x{555}\x{3F5}\x{A4E9}\x{34EC}\x{D83E}\x{DE4D}"
+      RenderText {#text} at (320,5030) size 96x17
+        text run at (320,5030) width 42: "\x{5699}\x{8FFA}\x{F786}"
+        text run at (361,5030) width 9 RTL: "\x{685}"
+        text run at (369,5030) width 47: "\x{1D3F}\x{DB6B}\x{BF05}\x{4083}"
+      RenderText {#text} at (415,5030) size 35x17
+        text run at (415,5030) width 31: "\x{7F14}\x{9D87}"
+        text run at (445,5030) width 5 RTL: "\x{627}"
+      RenderText {#text} at (449,5030) size 53x17
+        text run at (449,5030) width 53: "\x{D83F}\x{DD01}\x{4ED3}\x{60F4}\x{2C4D}"
+      RenderText {#text} at (501,5030) size 52x17
+        text run at (501,5030) width 52: "\x{D404}\x{ADEF}\x{558}\x{D83F}\x{DC9A}"
+      RenderText {#text} at (552,5030) size 73x17
+        text run at (552,5030) width 12: "\x{D83E}\x{DF0D}"
+        text run at (563,5030) width 12 RTL: "\x{5EA}"
+        text run at (574,5030) width 51: "\x{1211}\x{EE55}\x{1C8A}\x{D83F}\x{DEAD}"
+      RenderText {#text} at (0,5030) size 744x42
+        text run at (624,5030) width 120: "\x{D83E}\x{DE97}\x{AFC9}\x{D83F}\x{DC32}\x{D83F}\x{DD2F}\x{20A}\x{F3F1}\x{D83E}\x{DD8F}\x{2E70}\x{3838}"
+        text run at (0,5055) width 11: "\x{D83E}\x{DF9C}"
+      RenderText {#text} at (10,5055) size 121x17
+        text run at (10,5055) width 121: "\x{D83E}\x{DC74}\x{D83D}\x{DF80}\x{FAE}\x{EA64}\x{525}\x{D83F}\x{DF92}\x{D83E}\x{DE4A}\x{4F6}\x{D83F}\x{DE5D}\x{D83E}\x{DF5C}\x{88DC}"
+      RenderText {#text} at (130,5055) size 38x17
+        text run at (130,5055) width 38: "\x{6B58}\x{CF96}\x{168B}"
+      RenderText {#text} at (167,5055) size 108x17
+        text run at (167,5055) width 50: "\x{B850}\x{D83D}\x{DF15}\x{850E}\x{C90}"
+        text run at (216,5055) width 8 RTL: "\x{6C1}"
+        text run at (223,5055) width 52: "\x{D83F}\x{DF5B}\x{6949}\x{4E7E}\x{9BA}"
+      RenderText {#text} at (274,5055) size 110x17
+        text run at (274,5055) width 12: "\x{D83E}\x{DC0E}"
+        text run at (285,5055) width 10 RTL: "\x{7D5}"
+        text run at (294,5055) width 90: "\x{3ADE}\x{D83D}\x{DFBF}\x{55B}\x{D83E}\x{DFD0}\x{F3C9}\x{AFC}\x{D83F}\x{DEA7}\x{FD5}\x{B6C}"
+      RenderText {#text} at (383,5055) size 57x17
+        text run at (383,5055) width 57: "\x{945}\x{5DA4}\x{D83E}\x{DDEE}\x{53A}"
+      RenderText {#text} at (439,5055) size 107x17
+        text run at (439,5055) width 107: "\x{81F7}\x{48AB}\x{2610}\x{6F92}\x{D83E}\x{DC73}\x{8881}\x{45F}\x{F920}"
+      RenderText {#text} at (545,5055) size 128x17
+        text run at (545,5055) width 128: "\x{E4B}\x{DD7}\x{736}\x{F5A}\x{7373}\x{532}\x{D83E}\x{DC9E}\x{D83E}\x{DE64}\x{274A}\x{CBF1}\x{6AA5}"
+      RenderText {#text} at (0,5055) size 751x45
+        text run at (672,5055) width 79: "\x{DEDD}\x{DC4D}\x{D83F}\x{DEBA}\x{D83F}\x{DE46}\x{F56F}\x{141D}\x{BA38}"
+        text run at (0,5083) width 48: "\x{E100}\x{E5A4}\x{E4D8}\x{6679}"
+      RenderText {#text} at (47,5083) size 51x17
+        text run at (47,5083) width 51: "\x{8AC3}\x{5294}\x{E15}\x{F006}"
+      RenderText {#text} at (97,5083) size 123x17
+        text run at (97,5083) width 123: "\x{F769}\x{D83E}\x{DCA1}\x{D83E}\x{DDF9}\x{25AE}\x{72E5}\x{D83E}\x{DCCF}\x{4A8C}\x{D1F0}\x{D83E}\x{DC81}\x{1C7A}"
+      RenderText {#text} at (219,5083) size 118x17
+        text run at (219,5083) width 22: "\x{D83F}\x{DEF5}\x{F8EC}"
+        text run at (240,5083) width 11 RTL: "\x{6D0}"
+        text run at (250,5083) width 16: "\x{487A}"
+        text run at (265,5083) width 7 RTL: "\x{693}"
+        text run at (271,5083) width 66: "\x{F3C}\x{9485}\x{673D}\x{D83E}\x{DCAB}\x{81DF}"
+      RenderText {#text} at (336,5083) size 130x17
+        text run at (336,5083) width 109: "\x{4A16}\x{82C6}\x{643C}\x{D83D}\x{DEB5}\x{135B}\x{DB59}\x{D83F}\x{DF91}\x{EA82}"
+        text run at (444,5083) width 11 RTL: "\x{752}"
+        text run at (454,5083) width 12: "\x{D83E}\x{DC78}"
+      RenderText {#text} at (465,5083) size 22x17
+        text run at (465,5083) width 22: "\x{94EA}\x{227}"
+      RenderText {#text} at (486,5083) size 124x17
+        text run at (486,5083) width 66: "\x{BA4}\x{1557}\x{E7B2}\x{E3DF}\x{D83D}\x{DE1A}"
+        text run at (551,5083) width 18 RTL: "\x{FCFA}"
+        text run at (568,5083) width 42: "\x{82F5}\x{A7BB}\x{C572}"
+      RenderText {#text} at (609,5083) size 105x17
+        text run at (609,5083) width 105: "\x{EDFC}\x{EFEA}\x{99D}\x{BD3D}\x{A907}\x{CBD}\x{D83F}\x{DF12}\x{918}\x{53F}\x{F1}"
+      RenderText {#text} at (713,5083) size 30x17
+        text run at (713,5083) width 23: "\x{AF5}\x{DCE}"
+        text run at (735,5083) width 8 RTL: "\x{84B}"
+      RenderText {#text} at (0,5083) size 758x45
+        text run at (742,5083) width 16: "\x{D83D}\x{DF05}"
+        text run at (0,5111) width 102: "\x{6B6B}\x{A57}\x{D83F}\x{DE71}\x{A8A}\x{FAB9}\x{2E87}\x{E26D}\x{9DC0}"
+      RenderText {#text} at (101,5111) size 127x17
+        text run at (101,5111) width 127: "\x{C1F9}\x{D83F}\x{DE33}\x{F143}\x{815B}\x{D83E}\x{DCFB}\x{AE3E}\x{4D6}\x{246}\x{D83D}\x{DF03}\x{B53D}"
+      RenderText {#text} at (227,5111) size 128x17
+        text run at (227,5111) width 128: "\x{D83E}\x{DCCB}\x{A4F7}\x{3F2}\x{4A5}\x{F49}\x{6D02}\x{2BE1}\x{1DAF}\x{D83E}\x{DE79}\x{3F1D}\x{B2D}"
+      RenderText {#text} at (354,5111) size 44x17
+        text run at (354,5111) width 44: "\x{E6FD}\x{D83E}\x{DCEA}\x{C86}\x{D83D}\x{DFB6}"
+      RenderText {#text} at (397,5111) size 94x17
+        text run at (397,5111) width 94: "\x{8550}\x{315}\x{D83F}\x{DEBE}\x{9D59}\x{A8E0}\x{D29}\x{DD57}\x{3736}"
+      RenderText {#text} at (490,5111) size 40x17
+        text run at (490,5111) width 40: "\x{978}\x{16F}\x{A1C}\x{9FCF}"
+      RenderText {#text} at (529,5111) size 121x17
+        text run at (529,5111) width 121: "\x{445}\x{C7E}\x{49B4}\x{F256}\x{9EB}\x{E2B3}\x{7D5D}\x{D83D}\x{DF3A}\x{D83F}\x{DDB5}\x{F993}"
+      RenderText {#text} at (649,5111) size 90x17
+        text run at (649,5111) width 90: "\x{203}\x{799B}\x{D83F}\x{DF95}\x{6834}\x{4A6E}\x{D83F}\x{DEEA}\x{634E}"
+      RenderText {#text} at (0,5111) size 754x45
+        text run at (738,5111) width 16: "\x{B821}"
+        text run at (0,5139) width 48: "\x{A615}\x{1D6}\x{4E7}\x{E06C}q"
+      RenderText {#text} at (47,5139) size 57x17
+        text run at (47,5139) width 57: "\x{D83E}\x{DEC0}\x{FAA}\x{D83D}\x{DED3}\x{474A}"
+      RenderText {#text} at (103,5139) size 117x17
+        text run at (103,5139) width 117: "\x{F198}\x{27BB}\x{5D7A}\x{AA7}\x{AF9C}\x{1EE4}\x{23C2}\x{35DA}\x{E551}"
+      RenderText {#text} at (219,5139) size 27x17
+        text run at (219,5139) width 27: "\x{5A8F}\x{D67}"
+      RenderText {#text} at (245,5139) size 25x17
+        text run at (245,5139) width 25: "\x{422F}\x{F34}"
+      RenderText {#text} at (269,5139) size 113x17
+        text run at (269,5139) width 113: "\x{4E0B}\x{AD32}\x{9EF}\x{92F2}\x{6147}\x{A0D8}\x{D83E}\x{DDCE}\x{D63F}"
+      RenderText {#text} at (381,5139) size 97x17
+        text run at (381,5139) width 16: "\x{D83E}\x{DF77}\x{2D42}"
+        text run at (396,5139) width 15 RTL: "\x{FC9D}"
+        text run at (410,5139) width 68: "\x{56AB}\x{38D3}\x{32E0}\x{1EF}\x{D6B}"
+      RenderText {#text} at (477,5139) size 20x17
+        text run at (477,5139) width 20: "\x{10}\x{E8A}"
+      RenderText {#text} at (496,5139) size 122x17
+        text run at (496,5139) width 23: "\x{D83E}\x{DC7F}\x{E324}"
+        text run at (518,5139) width 12 RTL: "\x{88A}"
+        text run at (529,5139) width 89: "\x{F2E}\x{9192}\x{B089}\x{E52B}\x{D83E}\x{DE89}\x{D83D}\x{DFBF}\x{8FA8}"
+      RenderText {#text} at (617,5139) size 77x17
+        text run at (617,5139) width 77: "\x{BAB5}\x{D028}\x{E7E}\x{D83F}\x{DC2F}\x{E14}\x{38B9}"
+      RenderText {#text} at (693,5139) size 50x17
+        text run at (693,5139) width 50: "\x{34E}\x{A22F}\x{24F}\x{D83E}\x{DC0E}\x{7F63}"
+      RenderText {#text} at (0,5139) size 758x42
+        text run at (742,5139) width 16: "\x{725E}"
+        text run at (0,5164) width 52: "\x{3512}\x{89F2}\x{E971}\x{F91}"
+        text run at (51,5164) width 10 RTL: "\x{5E4}"
+      RenderText {#text} at (60,5164) size 46x17
+        text run at (60,5164) width 46: "\x{F2C1}\x{570}\x{178}\x{91C7}"
+layer at (8,142) size 16x16
+  RenderVideo {VIDEO} at (0,134) size 16x16
+layer at (24,142) size 16x16
+  RenderVideo {VIDEO} at (16,134) size 16x16
+layer at (151,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (143,0) size 300x150
+layer at (8,167) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,159) size 300x150
+layer at (8,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,317) size 300x150
+layer at (308,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,317) size 300x150
+layer at (8,481) size 284x284
+  RenderVideo {VIDEO} at (0,473) size 284x284
+layer at (546,749) size 16x16
+  RenderVideo {VIDEO} at (537,741) size 17x16
+layer at (65,913) size 16x16
+  RenderVideo {VIDEO} at (56,905) size 17x16
+layer at (116,779) size 349x150
+  RenderHTMLCanvas {CANVAS} at (108,771) size 350x150
+layer at (93,937) size 300x150
+  RenderHTMLCanvas {CANVAS} at (85,929) size 301x150
+layer at (8,1120) size 885x385
+  RenderHTMLCanvas {CANVAS} at (0,1112) size 885x385
+layer at (8,1988) size 213x213
+  RenderVideo {VIDEO} at (0,1980) size 213x213
+layer at (196,2420) size 16x16
+  RenderVideo {VIDEO} at (188,2412) size 17x16
+layer at (8,2448) size 290x127
+  RenderHTMLCanvas {CANVAS} at (0,2440) size 290x127
+layer at (8,2856) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,2848) size 300x150
+layer at (334,2739) size 300x267
+  RenderHTMLCanvas {CANVAS} at (326,2731) size 300x267
+layer at (8,3276) size 974x150
+  RenderHTMLCanvas {CANVAS} at (0,3268) size 974x150
+layer at (8,3447) size 905x349
+  RenderHTMLCanvas {CANVAS} at (0,3439) size 905x349
+layer at (200,3832) size 335x23
+  RenderHTMLCanvas {CANVAS} at (192,3824) size 336x23
+layer at (748,3839) size 16x16
+  RenderVideo {VIDEO} at (740,3831) size 17x16
+layer at (465,4030) size 291x291
+  RenderVideo {VIDEO} at (456,4022) size 292x291
+layer at (408,4328) size 38x213
+  RenderVideo {VIDEO} at (400,4320) size 39x213

--- a/LayoutTests/fast/webgpu/fuzz-273017.html
+++ b/LayoutTests/fast/webgpu/fuzz-273017.html
@@ -1,0 +1,41237 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUCommandEncoder} commandEncoder
+ */
+function pseudoSubmit(device, commandEncoder) {
+  device.pushErrorScope('validation');
+  commandEncoder.clearBuffer(device.createBuffer({size: 0, usage: 0}), 0, 0);
+  device.popErrorScope().then(() => {});
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let device0 = await adapter0.requestDevice(
+{
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 9,
+maxColorAttachmentBytesPerSample: 54,
+maxVertexAttributes: 17,
+maxVertexBufferArrayStride: 35303,
+maxStorageTexturesPerShaderStage: 28,
+maxStorageBuffersPerShaderStage: 38,
+maxDynamicStorageBuffersPerPipelineLayout: 9145,
+maxBindingsPerBindGroup: 2933,
+maxTextureDimension1D: 9372,
+maxTextureDimension2D: 10417,
+maxVertexBuffers: 10,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 184334779,
+maxInterStageShaderVariables: 56,
+maxInterStageShaderComponents: 66,
+},
+}
+);
+let texture0 = device0.createTexture(
+{
+label: '\ua879\udf64\u04f8\u{1fafe}\ua3f8\u514f\u08c9\u{1ff5d}',
+size: {width: 120, height: 110, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-6x5-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-6x5-unorm'
+],
+}
+);
+let textureView0 = texture0.createView(
+{
+label: '\uc960\u0ad1\u207c\ue366\u{1f93a}\u0cb2\u3dc6',
+aspect: 'all',
+baseMipLevel: 2,
+}
+);
+document.body.append('\u0536\u1c68');
+let imageData0 = new ImageData(24, 104);
+let promise0 = device0.queue.onSubmittedWorkDone();
+let video0 = await videoWithData();
+let texture1 = device0.createTexture(
+{
+label: '\u{1fc37}\u463c\ud48e',
+size: [718, 1, 201],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb10a2uint',
+'rgb10a2uint'
+],
+}
+);
+let textureView1 = texture1.createView(
+{
+label: '\u0a09\u60cc\ud014\u0707\u094c\u45bd\u09e5',
+format: 'rgb10a2uint',
+baseMipLevel: 2,
+arrayLayerCount: 1,
+}
+);
+let sampler0 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+lodMinClamp: 36.658,
+lodMaxClamp: 82.677,
+}
+);
+gc();
+document.body.append('\ud1a2\u9f8a\u919c\u{1fa0e}\u{1fddc}\u2527\u571c\u{1fd7d}');
+let imageBitmap0 = await createImageBitmap(imageData0);
+let imageData1 = new ImageData(200, 160);
+gc();
+document.body.append('\u8aa1\u7f21\ueaf8\u{1f9e6}\u{1feca}\u0b9c\u0e06\uecdf');
+let offscreenCanvas0 = new OffscreenCanvas(446, 329);
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+let adapter1 = await navigator.gpu.requestAdapter();
+let querySet0 = device0.createQuerySet(
+{
+label: '\u{1fc4e}\u{1fb3d}\u57b7\u3b1c\ubdf7\u{1f63a}',
+type: 'occlusion',
+count: 524,
+}
+);
+let sampler1 = device0.createSampler(
+{
+label: '\u0583\udeab',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMaxClamp: 97.413,
+}
+);
+let texture2 = device0.createTexture(
+{
+label: '\u{1fb2b}\u08e9\u9ddb\u7a42\u04b0\u{1f87b}\u{1f617}\u44a2\u0162\u{1f7c4}\u{1fa80}',
+size: {width: 80, height: 2, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView2 = texture0.createView(
+{
+dimension: '2d-array',
+format: 'astc-6x5-unorm',
+baseMipLevel: 0,
+mipLevelCount: 2,
+}
+);
+let querySet1 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 4039,
+}
+);
+try {
+querySet0.destroy();
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+await promise0;
+} catch {}
+let renderBundleEncoder0 = device0.createRenderBundleEncoder(
+{
+label: '\u0635\u{1faaa}\u295c\udef7\u3722\u02c3\u{1fd1e}\u91fc\u69fe\u0388\ue9e7',
+colorFormats: [
+'r8uint',
+undefined,
+'r16float'
+],
+sampleCount: 878,
+}
+);
+try {
+renderBundleEncoder0.setVertexBuffer(
+75,
+undefined,
+464920828,
+2348166871
+);
+} catch {}
+try {
+window.someLabel = textureView0.label;
+} catch {}
+let commandEncoder0 = device0.createCommandEncoder(
+{
+label: '\u{1f87f}\u{1fc2f}\ud3e8\u1d58',
+}
+);
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let canvas0 = document.createElement('canvas');
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder1 = device0.createCommandEncoder(
+{
+}
+);
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+let querySet2 = device0.createQuerySet(
+{
+label: '\u0f1d\ue1da\u04c7\u05a0\u0d8c\u8ac1\u44af\u{1fb6b}\uebc1',
+type: 'occlusion',
+count: 1893,
+}
+);
+let texture3 = device0.createTexture(
+{
+label: '\u9a77\u0ced\u0f96\u977c\u2661\u{1fd14}',
+size: {width: 8772, height: 132, depthOrArrayLayers: 70},
+mipLevelCount: 2,
+format: 'astc-6x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-6x6-unorm-srgb',
+'astc-6x6-unorm'
+],
+}
+);
+let textureView3 = texture1.createView(
+{
+label: '\u{1fd20}\u{1fee3}\u4261\u0bab\ufdb9\u549b',
+baseMipLevel: 0,
+mipLevelCount: 2,
+}
+);
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+await promise1;
+} catch {}
+let renderBundle0 = renderBundleEncoder0.finish(
+{
+label: '\u942c\u096e\u718f\udd23\u0432\u{1fd4f}\u50fe\ub9dc\u0c69'
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 2,
+  origin: { x: 6, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(new ArrayBuffer(0)),
+/* required buffer size: 372 */{
+offset: 372,
+bytesPerRow: 184,
+rowsPerImage: 163,
+},
+{width: 9, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\u07e3\u64c7\ub5f6\u059d\u{1f78e}\u4d3c');
+let img0 = await imageWithData(242, 70, '#23eca73f', '#6c60e3cd');
+let sampler2 = device0.createSampler(
+{
+label: '\u{1fd31}\u{1f7a3}\u6d97\u{1fd12}\u0409',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 38.558,
+compare: 'greater-equal',
+maxAnisotropy: 6,
+}
+);
+try {
+commandEncoder1.copyTextureToTexture(
+{
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 24, y: 0, z: 64 },
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 42, y: 36, z: 41 },
+  aspect: 'all',
+},
+{width: 4110, height: 12, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 3180, y: 24, z: 47 },
+  aspect: 'all',
+},
+new Int16Array(new ArrayBuffer(48)),
+/* required buffer size: 510568 */{
+offset: 100,
+bytesPerRow: 1830,
+rowsPerImage: 273,
+},
+{width: 648, height: 36, depthOrArrayLayers: 2}
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture4 = device0.createTexture(
+{
+label: '\u0fdf\u002d\u0658\u0872\u{1fb3b}\ufd66\u410d',
+size: {width: 4023, height: 33, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+sampleCount: 1,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'stencil8'
+],
+}
+);
+let renderBundle1 = renderBundleEncoder0.finish(
+{
+label: '\u{1fa6e}\u9d5e\u05d7\u0471'
+}
+);
+let sampler3 = device0.createSampler(
+{
+label: '\ue001\u{1fbe6}\u0c23\uddfd\ufecc\u0850\u{1ffb1}\uca15\u2f14\u724b',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 20.122,
+lodMaxClamp: 80.885,
+}
+);
+let bindGroupLayout0 = device0.createBindGroupLayout(
+{
+label: '\u47e7\u{1fa08}\uf612\ufcda\u6de9\u3fa6\u07ca\ubea6\u62ab\u0445',
+entries: [
+{
+binding: 1014,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+},
+{
+binding: 2555,
+visibility: 0,
+sampler: { type: 'filtering' },
+},
+{
+binding: 2494,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '2d-array' },
+}
+],
+}
+);
+let querySet3 = device0.createQuerySet(
+{
+label: '\ua28a\uc0e6\u0c78\u6996\u{1fc2a}\u0356\u709b\uf24b\u6fd4',
+type: 'occlusion',
+count: 4019,
+}
+);
+let textureView4 = texture1.createView(
+{
+label: '\u377a\uf987\ufaeb\ua7ce\u{1f96f}\u3104\uf9b7',
+baseMipLevel: 1,
+}
+);
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let gpuCanvasContext1 = canvas0.getContext('webgpu');
+offscreenCanvas0.width = 745;
+document.body.append('\u9d57\ua732\u9996\u{1fccd}\u6309\u0ccf\u0947');
+let video1 = await videoWithData();
+let commandEncoder2 = device0.createCommandEncoder(
+{
+label: '\u11ff\u0e68\u{1f972}\u9c0a\u09ba\ua336\uda3e\u409c',
+}
+);
+let texture5 = device0.createTexture(
+{
+label: '\u{1f60b}\u1e3e\ud938\u796c\ua4e1\u0074\uffbb\u{1f9d3}\u0d53\u81c2\u{1feb1}',
+size: [6210],
+dimension: '1d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb10a2uint'
+],
+}
+);
+let renderBundle2 = renderBundleEncoder0.finish();
+let externalTexture0 = device0.importExternalTexture(
+{
+label: '\u74e0\u{1fc89}\u{1fbb7}\u7523\uf43a\udede\u477e\u8872\u05d1\u0912',
+source: video1,
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: { x: 3, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(1019),
+/* required buffer size: 1019 */{
+offset: 798,
+bytesPerRow: 173,
+},
+{width: 48, height: 2, depthOrArrayLayers: 1}
+);
+} catch {}
+let canvas1 = document.createElement('canvas');
+let offscreenCanvas1 = new OffscreenCanvas(890, 925);
+try {
+canvas1.getContext('2d');
+} catch {}
+let renderBundleEncoder1 = device0.createRenderBundleEncoder(
+{
+label: '\uae17\u0cc9',
+colorFormats: [
+undefined
+],
+sampleCount: 153,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler4 = device0.createSampler(
+{
+label: '\u{1ffc6}\u4da4\u0b26\u083a\u0076',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMaxClamp: 91.052,
+}
+);
+try {
+commandEncoder1.copyTextureToTexture(
+{
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 618, y: 6, z: 21 },
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 390, y: 36, z: 0 },
+  aspect: 'all',
+},
+{width: 3756, height: 0, depthOrArrayLayers: 3}
+);
+} catch {}
+let imageData2 = new ImageData(84, 104);
+let bindGroupLayout1 = device0.createBindGroupLayout(
+{
+entries: [
+
+],
+}
+);
+let pipelineLayout0 = device0.createPipelineLayout(
+{
+label: '\ue95f\ud25b\u0e0a\uf6f2\u0415',
+bindGroupLayouts: [
+bindGroupLayout0,
+bindGroupLayout1,
+bindGroupLayout0
+],
+}
+);
+let commandEncoder3 = device0.createCommandEncoder(
+{
+label: '\uae3e\u5d5c\u714e\u8619\u{1ffdd}\u{1fa68}\u3997',
+}
+);
+let textureView5 = texture0.createView(
+{
+label: '\u0d30\u{1f687}\u0e23\u3cd9\u17d2\u12fe\udfba',
+baseMipLevel: 1,
+mipLevelCount: 1,
+}
+);
+let renderBundle3 = renderBundleEncoder1.finish(
+{
+label: '\u471d\u99c4'
+}
+);
+let externalTexture1 = device0.importExternalTexture(
+{
+label: '\u9c2e\u4eb2\ucf25\u1f3c\u{1fbcc}\u0fbc\u3613\u066d\u{1fddb}\u06db',
+source: video0,
+colorSpace: 'srgb',
+}
+);
+document.body.append('\u43b2\u{1f64b}');
+let buffer0 = device0.createBuffer(
+{
+label: '\u{1fea4}\u0b91\u1565\u{1faf4}\u7b8b',
+size: 48782,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let commandBuffer0 = commandEncoder1.finish(
+{
+label: '\u0934\u0201\u{1ff5e}\u{1fce7}\ufb5c\u00bf\u3fd2',
+}
+);
+try {
+commandEncoder0.copyBufferToTexture(
+{
+/* bytesInLastRow: 31 widthInBlocks: 31 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 12859 */
+offset: 12859,
+buffer: buffer0,
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: { x: 33, y: 2, z: 0 },
+  aspect: 'all',
+},
+{width: 31, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder0.insertDebugMarker(
+'\u{1fba8}'
+);
+} catch {}
+let computePassEncoder0 = commandEncoder0.beginComputePass();
+let renderBundleEncoder2 = device0.createRenderBundleEncoder(
+{
+label: '\u15cd\u06cf\u0a94\u{1fa24}\ufc7c\u0676\udd95\u13e8',
+colorFormats: [
+'r16float',
+'rgba32uint',
+'rg16uint',
+'rgba16sint',
+'rgba8unorm',
+'rg32sint'
+],
+sampleCount: 236,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+let renderBundle4 = renderBundleEncoder2.finish();
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 1,
+  origin: { x: 24, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint16Array(new ArrayBuffer(0)),
+/* required buffer size: 978 */{
+offset: 978,
+},
+{width: 15, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture6 = device0.createTexture(
+{
+label: '\u{1f89d}\u{1f7e4}\u0daf',
+size: [92, 4, 41],
+mipLevelCount: 4,
+format: 'etc2-rgb8a1unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let textureView6 = texture0.createView(
+{
+label: '\u09dd\u0dfe\u0489\u12f6\u75e0\u6b39\u{1fb85}\u017f\u0482\u8810\u26df',
+dimension: '2d-array',
+baseMipLevel: 2,
+baseArrayLayer: 0,
+}
+);
+try {
+commandEncoder2.copyBufferToTexture(
+{
+/* bytesInLastRow: 62 widthInBlocks: 62 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 25567 */
+offset: 25505,
+rowsPerImage: 171,
+buffer: buffer0,
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: { x: 5, y: 1, z: 0 },
+  aspect: 'all',
+},
+{width: 62, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+video0.width = 237;
+document.body.prepend('\ud1d6\u{1fd9a}');
+let adapter2 = await navigator.gpu.requestAdapter();
+let sampler5 = device0.createSampler(
+{
+label: '\u9949\ue23f\u6689\u0cce',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 98.380,
+lodMaxClamp: 98.914,
+}
+);
+try {
+buffer0.unmap();
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 1,
+  origin: { x: 9, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(72),
+/* required buffer size: 912 */{
+offset: 912,
+bytesPerRow: 254,
+},
+{width: 13, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let computePassEncoder1 = commandEncoder3.beginComputePass(
+{
+label: '\u0419\u5e1d\u4a66'
+}
+);
+let renderBundleEncoder3 = device0.createRenderBundleEncoder(
+{
+label: '\u1429\u0dca\u67df\u1099\u121b',
+colorFormats: [
+'rgba8unorm',
+'rgb10a2uint',
+'rg32uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 676,
+depthReadOnly: true,
+}
+);
+let commandEncoder4 = device0.createCommandEncoder(
+{
+label: '\u{1f823}\u005f\u8c03',
+}
+);
+let querySet4 = device0.createQuerySet(
+{
+label: '\u008a\u67c4\u48b0',
+type: 'occlusion',
+count: 2071,
+}
+);
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let querySet5 = device0.createQuerySet(
+{
+label: '\u5a2e\u639c',
+type: 'occlusion',
+count: 1339,
+}
+);
+let textureView7 = texture1.createView(
+{
+label: '\u3f58\u{1fd68}\uec00\u0c1b\u0415',
+baseMipLevel: 3,
+arrayLayerCount: 1,
+}
+);
+try {
+commandEncoder4.copyBufferToTexture(
+{
+/* bytesInLastRow: 4023 widthInBlocks: 4023 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 4276 */
+offset: 4276,
+buffer: buffer0,
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 0, y: 11, z: 0 },
+  aspect: 'all',
+},
+{width: 4023, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let shaderModule0 = device0.createShaderModule(
+{
+label: '\ue5bf\u1aac\u0cec\u2d4a\u0bd6\u7904\u{1f616}\u0a01',
+code: `@group(0) @binding(2555)
+var<storage, read_write> parameter0: array<u32>;
+
+@compute @workgroup_size(7, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(1) f0: i32,
+@location(0) f1: vec4<f32>,
+@location(4) f2: vec4<u32>,
+@location(6) f3: vec2<u32>,
+@location(2) f4: vec2<f32>,
+@location(3) f5: f32
+}
+
+@fragment
+fn fragment0(@location(1) a0: vec2<f32>, @location(29) a1: vec4<u32>, @location(37) a2: vec3<f32>, @location(10) a3: vec4<f32>, @location(40) a4: vec2<u32>, @builtin(sample_index) a5: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S0 {
+@location(1) f0: vec2<f16>,
+@location(2) f1: f16,
+@location(16) f2: f32,
+@location(13) f3: vec2<i32>,
+@location(9) f4: vec4<f16>,
+@location(5) f5: f16,
+@location(11) f6: vec3<f16>,
+@location(10) f7: vec2<u32>,
+@location(12) f8: i32,
+@location(14) f9: vec4<u32>,
+@location(4) f10: vec3<f16>
+}
+struct VertexOutput0 {
+@builtin(position) f0: vec4<f32>,
+@location(40) f1: vec2<u32>,
+@location(23) f2: vec3<u32>,
+@location(42) f3: vec2<i32>,
+@location(1) f4: vec2<f32>,
+@location(33) f5: f32,
+@location(10) f6: vec4<f32>,
+@location(29) f7: vec4<u32>,
+@location(2) f8: vec2<i32>,
+@location(24) f9: vec4<f16>,
+@location(4) f10: vec4<u32>,
+@location(37) f11: vec3<f32>,
+@location(21) f12: vec4<i32>,
+@location(32) f13: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec2<f16>, @builtin(vertex_index) a1: u32, @location(0) a2: vec4<u32>, @location(6) a3: vec3<i32>, @location(3) a4: vec2<f16>, @location(7) a5: vec2<f16>, @location(15) a6: vec2<u32>, a7: S0, @builtin(instance_index) a8: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder5 = device0.createCommandEncoder(
+{
+label: '\u4e5d\u{1fa50}\u4704\u{1fff6}',
+}
+);
+let textureView8 = texture3.createView(
+{
+label: '\u0d61\u0836\u{1ff9d}\u72bf\u6010',
+format: 'astc-6x6-unorm-srgb',
+baseArrayLayer: 59,
+}
+);
+let renderBundleEncoder4 = device0.createRenderBundleEncoder(
+{
+label: '\u{1f6dc}\u1374\u054d\ued57',
+colorFormats: [
+'r32float',
+'r8uint',
+undefined,
+'rgba32uint',
+'rg8unorm',
+'rgba32float',
+'rg16float'
+],
+sampleCount: 750,
+}
+);
+let sampler6 = device0.createSampler(
+{
+label: '\u{1faa5}\u55ea',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 75.741,
+compare: 'always',
+maxAnisotropy: 8,
+}
+);
+try {
+renderBundleEncoder4.setVertexBuffer(
+22,
+undefined
+);
+} catch {}
+let pipeline0 = await device0.createComputePipelineAsync(
+{
+label: '\u2c0f\u{1fb97}\u{1fb17}\u3ab9\ucce3\ubb9e',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend('\u82d0\u5afa\u0074\u6c3a\u072c\ua80b\u{1faf8}\u0d40\u6760\u0e6d\u{1fc2a}');
+let img1 = await imageWithData(7, 176, '#6239b169', '#260550b5');
+let buffer1 = device0.createBuffer(
+{
+label: '\u9894\u023b\ufc7f\ua255\uc9a2\u0499',
+size: 8564,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+}
+);
+let commandEncoder6 = device0.createCommandEncoder(
+{
+}
+);
+let texture7 = device0.createTexture(
+{
+size: {width: 698, height: 1, depthOrArrayLayers: 255},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rgb9e5ufloat',
+'rgb9e5ufloat'
+],
+}
+);
+let computePassEncoder2 = commandEncoder6.beginComputePass(
+{
+label: '\u{1fb03}\u{1fc56}\u9a44\u{1fa81}\u0893\u0f3e\uc82e\u9a57\u630c\u6981\u0779'
+}
+);
+try {
+texture6.destroy();
+} catch {}
+try {
+commandEncoder0.pushDebugGroup(
+'\ube44'
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let bindGroup0 = device0.createBindGroup({
+layout: bindGroupLayout1,
+entries: [
+
+],
+});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder(
+{
+label: '\u0ed1\u0e92\u08fe\u{1fb5d}\u0237\u{1f7d2}\u{1fe93}\u4394\u06e6',
+colorFormats: [
+'rg32sint',
+'rg32uint',
+undefined,
+'rgba8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 21,
+}
+);
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder0.popDebugGroup();
+} catch {}
+let commandEncoder7 = device0.createCommandEncoder(
+{
+label: '\u{1fc0d}\u76ca\u2074\u0a54\u51ab\u{1fea8}',
+}
+);
+let computePassEncoder3 = commandEncoder2.beginComputePass(
+{
+label: '\u49a6\u9d79\u0b19\uac7f\ud26b\u4abc\u{1f926}\uf1f9\u9961'
+}
+);
+let renderBundleEncoder6 = device0.createRenderBundleEncoder(
+{
+label: '\u{1ff15}\u047f\u0aee\u042f\ue046\u04fb\u3799',
+colorFormats: [
+undefined,
+'rg32uint',
+'r8sint',
+'r32float',
+'rgba16sint',
+'rg32sint',
+undefined,
+'rgba8unorm-srgb'
+],
+sampleCount: 762,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle5 = renderBundleEncoder6.finish();
+try {
+commandEncoder7.clearBuffer(
+buffer1,
+1724
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline1 = device0.createRenderPipeline(
+{
+label: '\u{1f6f5}\u01bb\u1870\ue950\ud421\u3c54',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 17524,
+attributes: [
+{
+format: 'unorm8x2',
+offset: 7700,
+shaderLocation: 3,
+},
+{
+format: 'uint32',
+offset: 12944,
+shaderLocation: 15,
+},
+{
+format: 'float32x3',
+offset: 7224,
+shaderLocation: 2,
+},
+{
+format: 'sint16x2',
+offset: 5084,
+shaderLocation: 6,
+},
+{
+format: 'snorm16x4',
+offset: 13724,
+shaderLocation: 5,
+},
+{
+format: 'snorm16x4',
+offset: 6296,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x4',
+offset: 7336,
+shaderLocation: 1,
+},
+{
+format: 'unorm16x2',
+offset: 3128,
+shaderLocation: 9,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 2256,
+shaderLocation: 16,
+},
+{
+format: 'uint32',
+offset: 15904,
+shaderLocation: 0,
+},
+{
+format: 'uint8x4',
+offset: 2388,
+shaderLocation: 14,
+},
+{
+format: 'uint32x3',
+offset: 416,
+shaderLocation: 10,
+},
+{
+format: 'sint32x4',
+offset: 15452,
+shaderLocation: 12,
+},
+{
+format: 'sint32x4',
+offset: 844,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 20440,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 19056,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x4',
+offset: 15916,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 20964,
+attributes: [
+{
+format: 'unorm8x4',
+offset: 20016,
+shaderLocation: 8,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'src',
+dstFactor: 'dst-alpha'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rg8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-clamp',
+},
+depthBias: 50,
+depthBiasSlopeScale: 70,
+depthBiasClamp: 73,
+},
+}
+);
+let imageBitmap1 = await createImageBitmap(img0);
+let commandEncoder8 = device0.createCommandEncoder(
+{
+label: '\u7d76\ubc14',
+}
+);
+try {
+computePassEncoder1.setPipeline(
+pipeline0
+);
+} catch {}
+try {
+commandEncoder5.copyTextureToTexture(
+{
+  texture: texture4,
+  mipLevel: 4,
+  origin: { x: 0, y: 2, z: 0 },
+  aspect: 'stencil-only',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 1772, y: 22, z: 0 },
+  aspect: 'all',
+},
+{width: 251, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+2040,
+new BigUint64Array(35380),
+15534,
+432
+);
+} catch {}
+let promise2 = device0.createComputePipelineAsync(
+{
+label: '\u0ffa\u06d0\u{1fc81}\ue9aa\u4595\u{1fb68}\u07b8\u0878\ueff1\u{1f947}\u0639',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline2 = device0.createRenderPipeline(
+{
+label: '\u5d61\u0b09\udeff\u{1fb86}\u{1fec2}\u{1fc33}\u0194\u0b4f\u0b26\u{1fe2a}\u01fa',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 27036,
+attributes: [
+{
+format: 'float32',
+offset: 24052,
+shaderLocation: 9,
+},
+{
+format: 'float32x4',
+offset: 5904,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x4',
+offset: 24632,
+shaderLocation: 11,
+},
+{
+format: 'uint16x2',
+offset: 25664,
+shaderLocation: 0,
+},
+{
+format: 'float16x4',
+offset: 20044,
+shaderLocation: 1,
+},
+{
+format: 'sint32x2',
+offset: 15956,
+shaderLocation: 6,
+},
+{
+format: 'sint32x4',
+offset: 18012,
+shaderLocation: 12,
+},
+{
+format: 'float32x4',
+offset: 19580,
+shaderLocation: 3,
+},
+{
+format: 'snorm8x4',
+offset: 16792,
+shaderLocation: 7,
+},
+{
+format: 'uint16x2',
+offset: 11964,
+shaderLocation: 15,
+},
+{
+format: 'sint32x4',
+offset: 12256,
+shaderLocation: 13,
+},
+{
+format: 'snorm8x4',
+offset: 18220,
+shaderLocation: 2,
+},
+{
+format: 'uint16x4',
+offset: 21940,
+shaderLocation: 10,
+},
+{
+format: 'unorm16x2',
+offset: 20692,
+shaderLocation: 5,
+},
+{
+format: 'unorm16x4',
+offset: 52,
+shaderLocation: 4,
+},
+{
+format: 'float32x3',
+offset: 224,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 18088,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 12076,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 29232,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x4',
+offset: 17040,
+shaderLocation: 14,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg32float',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'dst-alpha',
+dstFactor: 'one-minus-src'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'one-minus-src-alpha',
+dstFactor: 'one'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'one',
+dstFactor: 'src'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+let gpuCanvasContext2 = offscreenCanvas1.getContext('webgpu');
+document.body.prepend('\ue562\u5cf0\u{1f969}\u0b2f\u8aa8');
+let bindGroup1 = device0.createBindGroup({
+label: '\ud123\ubc07\u0c61\ubceb\u0071\u9337\u3189\u{1fa4f}',
+layout: bindGroupLayout1,
+entries: [
+
+],
+});
+pseudoSubmit(device0, commandEncoder8);
+let textureView9 = texture7.createView(
+{
+label: '\ude8e\u294c\u987e\u02d0\u2e3b\u070c\u{1ffa4}',
+baseMipLevel: 1,
+arrayLayerCount: 1,
+}
+);
+let computePassEncoder4 = commandEncoder0.beginComputePass();
+let renderBundle6 = renderBundleEncoder2.finish(
+{
+
+}
+);
+try {
+computePassEncoder2.setBindGroup(
+1,
+bindGroup0
+);
+} catch {}
+try {
+commandEncoder7.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+document.body.prepend(img1);
+canvas0.width = 331;
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let textureView10 = texture7.createView(
+{
+label: '\u04e2\u45d4\u1b60\u2289\uf117\u1cfe',
+baseMipLevel: 4,
+baseArrayLayer: 0,
+}
+);
+let renderPassEncoder0 = commandEncoder5.beginRenderPass(
+{
+label: '\u07d7\u{1fb69}\u{1fa8f}\u0fe1\ue528\u41c8\u08c3',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+{
+view: textureView7,
+depthSlice: 11,
+clearValue: {
+r: -10.40,
+g: 386.2,
+b: 493.0,
+a: -115.7,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView7,
+depthSlice: 5,
+clearValue: {
+r: -993.3,
+g: 276.6,
+b: 790.1,
+a: 190.8,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView7,
+depthSlice: 3,
+clearValue: {
+r: 393.0,
+g: -361.0,
+b: 802.1,
+a: -829.7,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView7,
+depthSlice: 2,
+clearValue: {
+r: 258.9,
+g: -327.2,
+b: 713.1,
+a: -596.5,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView7,
+depthSlice: 19,
+clearValue: {
+r: 807.3,
+g: 765.3,
+b: 915.2,
+a: 240.1,
+},
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet3,
+maxDrawCount: 29048,
+}
+);
+try {
+computePassEncoder4.setBindGroup(
+6,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(
+1,
+bindGroup1,
+new Uint32Array(6245),
+526,
+0
+);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(
+72
+);
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+28.49,
+0.3075,
+15.76,
+0.6299,
+0.5560,
+0.6620
+);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(
+49,
+undefined
+);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder7.copyTextureToTexture(
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 192, y: 18, z: 2 },
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 2424, y: 6, z: 69 },
+  aspect: 'all',
+},
+{width: 1536, height: 36, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder4.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let textureView11 = texture2.createView(
+{
+label: '\u0eac\uacd2\u{1f697}\ubdca\u0aa3\u2488\u{1f96e}\u0ab4',
+dimension: '2d-array',
+aspect: 'all',
+}
+);
+let renderPassEncoder1 = commandEncoder7.beginRenderPass(
+{
+label: '\u05f7\uefa2',
+colorAttachments: [
+undefined,
+{
+view: textureView7,
+depthSlice: 8,
+clearValue: {
+r: -406.9,
+g: 452.2,
+b: 720.4,
+a: -862.0,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView7,
+depthSlice: 12,
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView7,
+depthSlice: 14,
+clearValue: {
+r: -251.7,
+g: 813.2,
+b: -247.8,
+a: 351.3,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView7,
+depthSlice: 17,
+clearValue: {
+r: 682.6,
+g: 263.9,
+b: 737.1,
+a: 954.5,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView7,
+depthSlice: 18,
+clearValue: {
+r: 839.9,
+g: 431.2,
+b: -811.7,
+a: 554.2,
+},
+loadOp: 'load',
+storeOp: 'store'
+}
+],
+maxDrawCount: 79280,
+}
+);
+let renderBundle7 = renderBundleEncoder6.finish(
+{
+label: '\u7995\u3ba0\u0d5a\u{1fb7f}'
+}
+);
+try {
+computePassEncoder2.setBindGroup(
+1,
+bindGroup1,
+new Uint32Array(6882),
+1390,
+0
+);
+} catch {}
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+7,
+1,
+12,
+0
+);
+} catch {}
+let promise3 = device0.createRenderPipelineAsync(
+{
+label: '\u0ba7\u88cd\u00f6\ued8b\uc44c\uca56\u0ff4\u58ce\u{1fcc8}',
+layout: 'auto',
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 24764,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 5300,
+shaderLocation: 12,
+},
+{
+format: 'uint32x4',
+offset: 16144,
+shaderLocation: 14,
+},
+{
+format: 'unorm8x2',
+offset: 8576,
+shaderLocation: 2,
+},
+{
+format: 'float32x2',
+offset: 9476,
+shaderLocation: 16,
+},
+{
+format: 'float16x4',
+offset: 14040,
+shaderLocation: 3,
+},
+{
+format: 'float32x2',
+offset: 22216,
+shaderLocation: 4,
+},
+{
+format: 'float32',
+offset: 6664,
+shaderLocation: 1,
+},
+{
+format: 'sint16x4',
+offset: 7716,
+shaderLocation: 13,
+},
+{
+format: 'uint16x2',
+offset: 3888,
+shaderLocation: 15,
+},
+{
+format: 'snorm16x2',
+offset: 22264,
+shaderLocation: 8,
+},
+{
+format: 'uint16x2',
+offset: 328,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 15208,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 3996,
+shaderLocation: 11,
+},
+{
+format: 'unorm16x2',
+offset: 4064,
+shaderLocation: 5,
+},
+{
+format: 'sint32x2',
+offset: 6588,
+shaderLocation: 6,
+},
+{
+format: 'unorm16x4',
+offset: 4564,
+shaderLocation: 9,
+},
+{
+format: 'uint8x2',
+offset: 1840,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 9972,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+attributes: [
+
+],
+},
+{
+arrayStride: 13168,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x4',
+offset: 16556,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x761dde23,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'one-minus-dst-alpha',
+dstFactor: 'one-minus-src-alpha'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'src-alpha',
+dstFactor: 'one-minus-dst'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+try {
+computePassEncoder4.setBindGroup(
+5,
+bindGroup1,
+new Uint32Array(4401),
+3493,
+0
+);
+} catch {}
+try {
+commandEncoder4.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let buffer2 = device0.createBuffer(
+{
+size: 57476,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let renderBundle8 = renderBundleEncoder4.finish(
+{
+label: '\u0a75\u1177'
+}
+);
+let sampler7 = device0.createSampler(
+{
+label: '\u375d\u858c',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 97.648,
+lodMaxClamp: 99.106,
+}
+);
+try {
+renderPassEncoder0.setBindGroup(
+4,
+bindGroup1,
+new Uint32Array(8362),
+2167,
+0
+);
+} catch {}
+document.body.prepend(video0);
+document.body.append('\u8db4\u0fd6\u{1fa90}');
+try {
+adapter0.label = '\u6178\u0fcd';
+} catch {}
+let commandEncoder9 = device0.createCommandEncoder(
+{
+label: '\u7bb5\ud929\u04ca\u{1fcab}\u0ee9\u0d18',
+}
+);
+let querySet6 = device0.createQuerySet(
+{
+label: '\uff15\u0e4e\u21e8\u9852\ue0b7\u0747\u0efe',
+type: 'occlusion',
+count: 847,
+}
+);
+let sampler8 = device0.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 60.316,
+lodMaxClamp: 63.027,
+maxAnisotropy: 7,
+}
+);
+try {
+computePassEncoder2.setPipeline(
+pipeline0
+);
+} catch {}
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 3306, y: 24, z: 46 },
+  aspect: 'all',
+},
+new Float64Array(new ArrayBuffer(56)),
+/* required buffer size: 394 */{
+offset: 394,
+bytesPerRow: 13790,
+},
+{width: 5112, height: 12, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\u0c76\u{1f6b9}\ua2b7\u6036\ubd24');
+let shaderModule1 = device0.createShaderModule(
+{
+label: '\u6246\u0762\ub3d9\u0ed8\u{1ff7d}\u06fd\u0a41\ud37b\u07a9',
+code: `
+
+@compute @workgroup_size(8, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S2 {
+@location(6) f0: vec3<f16>,
+@location(22) f1: i32,
+@location(40) f2: vec3<i32>,
+@location(50) f3: vec4<u32>,
+@location(39) f4: f16,
+@location(31) f5: vec3<f32>,
+@location(43) f6: u32,
+@location(1) f7: vec4<f16>,
+@location(14) f8: vec3<i32>,
+@location(18) f9: vec2<i32>,
+@location(53) f10: vec2<i32>,
+@builtin(sample_index) f11: u32,
+@location(27) f12: vec2<i32>,
+@location(35) f13: vec2<f16>,
+@location(8) f14: vec3<f16>,
+@location(45) f15: vec2<u32>,
+@location(37) f16: vec4<f32>,
+@location(7) f17: u32,
+@location(19) f18: vec4<i32>,
+@location(10) f19: vec3<f16>,
+@location(21) f20: vec2<i32>,
+@builtin(sample_mask) f21: u32,
+@builtin(front_facing) f22: bool,
+@builtin(position) f23: vec4<f32>
+}
+struct FragmentOutput0 {
+@location(7) f0: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(44) a0: i32, @location(36) a1: vec3<i32>, @location(42) a2: vec2<f32>, @location(20) a3: vec4<u32>, @location(9) a4: i32, @location(16) a5: vec4<f16>, a6: S2) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S1 {
+@location(2) f0: u32,
+@location(9) f1: i32,
+@builtin(vertex_index) f2: u32
+}
+struct VertexOutput0 {
+@location(6) f14: vec3<f16>,
+@location(35) f15: vec2<f16>,
+@location(40) f16: vec3<i32>,
+@location(45) f17: vec2<u32>,
+@location(20) f18: vec4<u32>,
+@location(44) f19: i32,
+@location(37) f20: vec4<f32>,
+@location(9) f21: i32,
+@location(21) f22: vec2<i32>,
+@location(42) f23: vec2<f32>,
+@location(36) f24: vec3<i32>,
+@location(14) f25: vec3<i32>,
+@location(7) f26: u32,
+@location(43) f27: u32,
+@location(16) f28: vec4<f16>,
+@location(39) f29: f16,
+@location(53) f30: vec2<i32>,
+@builtin(position) f31: vec4<f32>,
+@location(8) f32: vec3<f16>,
+@location(10) f33: vec3<f16>,
+@location(19) f34: vec4<i32>,
+@location(27) f35: vec2<i32>,
+@location(31) f36: vec3<f32>,
+@location(1) f37: vec4<f16>,
+@location(18) f38: vec2<i32>,
+@location(22) f39: i32,
+@location(50) f40: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec2<f16>, @builtin(instance_index) a1: u32, a2: S1, @location(14) a3: vec2<f16>, @location(12) a4: vec4<f32>, @location(10) a5: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder10 = device0.createCommandEncoder(
+{
+label: '\u08a5\u0902\u0cda\u0ed4',
+}
+);
+let texture8 = device0.createTexture(
+{
+label: '\u{1f8bc}\u{1f8bb}\u62ae\ue8cd\u0eef\ubeb1\uce69\u04f0\u7eb9',
+size: {width: 3430, height: 75, depthOrArrayLayers: 109},
+dimension: '2d',
+format: 'astc-10x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let renderPassEncoder2 = commandEncoder4.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView7,
+depthSlice: 5,
+clearValue: {
+r: -695.8,
+g: 975.9,
+b: -446.4,
+a: -450.6,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView7,
+depthSlice: 14,
+clearValue: {
+r: -298.6,
+g: 875.7,
+b: -609.6,
+a: -260.8,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView7,
+depthSlice: 4,
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView7,
+depthSlice: 20,
+clearValue: {
+r: 764.7,
+g: 941.8,
+b: 781.5,
+a: -299.0,
+},
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet0,
+maxDrawCount: 365248,
+}
+);
+try {
+renderBundleEncoder5.setBindGroup(
+3,
+bindGroup0,
+[]
+);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(
+71,
+undefined,
+3147707092,
+1103665189
+);
+} catch {}
+try {
+commandEncoder10.copyBufferToBuffer(
+buffer0,
+46264,
+buffer1,
+2952,
+796
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let shaderModule2 = device0.createShaderModule(
+{
+label: '\u2f03\u1381\u0ea9\u{1f807}\u0099\u5911\udf27\udefc\u{1fc44}',
+code: `@group(2) @binding(2555)
+var<storage, read_write> i0: array<u32>;
+
+@compute @workgroup_size(7, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S3 {
+@location(27) f0: vec2<f32>,
+@location(2) f1: vec4<i32>,
+@builtin(sample_mask) f2: u32,
+@location(47) f3: u32,
+@builtin(front_facing) f4: bool,
+@location(37) f5: vec4<u32>,
+@location(17) f6: vec2<f32>,
+@location(19) f7: vec3<f32>,
+@location(13) f8: vec4<f32>,
+@location(3) f9: vec3<u32>,
+@location(34) f10: vec2<f16>,
+@location(39) f11: vec3<f32>,
+@location(26) f12: vec3<f16>,
+@location(21) f13: vec4<u32>,
+@location(5) f14: vec3<u32>
+}
+struct FragmentOutput0 {
+@location(1) f0: f32,
+@location(6) f1: vec2<i32>,
+@builtin(sample_mask) f2: u32,
+@location(2) f3: vec4<u32>,
+@location(7) f4: vec2<f32>,
+@location(0) f5: i32
+}
+
+@fragment
+fn fragment0(@location(12) a0: f16, @builtin(position) a1: vec4<f32>, @location(43) a2: vec4<u32>, @location(46) a3: vec2<i32>, a4: S3, @builtin(sample_index) a5: u32, @location(51) a6: vec4<f16>, @location(33) a7: vec3<u32>, @location(9) a8: vec3<f32>, @location(20) a9: f16, @location(41) a10: vec2<u32>, @location(44) a11: vec2<f16>, @location(35) a12: vec4<f16>, @location(1) a13: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(37) f41: vec4<u32>,
+@location(3) f42: vec3<u32>,
+@location(51) f43: vec4<f16>,
+@location(47) f44: u32,
+@location(17) f45: vec2<f32>,
+@location(9) f46: vec3<f32>,
+@location(43) f47: vec4<u32>,
+@location(12) f48: f16,
+@location(20) f49: f16,
+@location(26) f50: vec3<f16>,
+@location(46) f51: vec2<i32>,
+@location(39) f52: vec3<f32>,
+@location(5) f53: vec3<u32>,
+@location(19) f54: vec3<f32>,
+@location(1) f55: u32,
+@location(44) f56: vec2<f16>,
+@location(33) f57: vec3<u32>,
+@location(13) f58: vec4<f32>,
+@location(21) f59: vec4<u32>,
+@location(41) f60: vec2<u32>,
+@location(35) f61: vec4<f16>,
+@location(34) f62: vec2<f16>,
+@builtin(position) f63: vec4<f32>,
+@location(27) f64: vec2<f32>,
+@location(2) f65: vec4<i32>
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let querySet7 = device0.createQuerySet(
+{
+label: '\ubd84\u{1f893}',
+type: 'occlusion',
+count: 36,
+}
+);
+try {
+renderPassEncoder2.setVertexBuffer(
+11,
+undefined,
+1215718460,
+2900071312
+);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(
+4,
+bindGroup1,
+new Uint32Array(6971),
+5236,
+0
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+20348,
+new BigUint64Array(12623),
+4064,
+264
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageBitmap2 = await createImageBitmap(img0);
+let bindGroup2 = device0.createBindGroup({
+layout: bindGroupLayout1,
+entries: [
+
+],
+});
+let querySet8 = device0.createQuerySet(
+{
+label: '\u33ac\u{1ff6b}\u{1f73a}\u2fe8\ufd0b\uf089',
+type: 'occlusion',
+count: 3365,
+}
+);
+let sampler9 = device0.createSampler(
+{
+label: '\u0dff\u0532\u0929\u{1fd28}\u{1fda7}\u993a\u0616\u6c55\uaade\u27ec\u5cf8',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 50.856,
+lodMaxClamp: 80.207,
+}
+);
+try {
+computePassEncoder2.setBindGroup(
+3,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(
+8
+);
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+78.54,
+0.8859,
+7.593,
+0.1118,
+0.5288,
+0.8447
+);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+4,
+bindGroup0
+);
+} catch {}
+let pipeline3 = device0.createComputePipeline(
+{
+layout: pipelineLayout0,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline4 = device0.createRenderPipeline(
+{
+label: '\u0891\u{1f7b1}\u06a3\ufebd\ue75f',
+layout: 'auto',
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 25088,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 4392,
+shaderLocation: 15,
+},
+{
+format: 'snorm8x4',
+offset: 14184,
+shaderLocation: 8,
+},
+{
+format: 'uint32',
+offset: 12776,
+shaderLocation: 0,
+},
+{
+format: 'sint16x4',
+offset: 16156,
+shaderLocation: 6,
+},
+{
+format: 'unorm8x4',
+offset: 1900,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 8048,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x3',
+offset: 7072,
+shaderLocation: 10,
+},
+{
+format: 'unorm8x2',
+offset: 4858,
+shaderLocation: 5,
+},
+{
+format: 'uint16x2',
+offset: 1892,
+shaderLocation: 14,
+},
+{
+format: 'unorm8x2',
+offset: 322,
+shaderLocation: 11,
+},
+{
+format: 'float16x4',
+offset: 6440,
+shaderLocation: 9,
+},
+{
+format: 'float32x4',
+offset: 228,
+shaderLocation: 2,
+},
+{
+format: 'float32x3',
+offset: 1508,
+shaderLocation: 4,
+},
+{
+format: 'sint32x3',
+offset: 64,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x2',
+offset: 470,
+shaderLocation: 1,
+},
+{
+format: 'sint32x2',
+offset: 6280,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 27008,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 11112,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 25724,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 18520,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+unclippedDepth: false,
+},
+multisample: {
+mask: 0xee17dcff,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'src',
+dstFactor: 'constant'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rg8unorm',
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r32float',
+}
+],
+},
+}
+);
+let img2 = await imageWithData(92, 130, '#c84077a9', '#dd0fa58e');
+try {
+window.someLabel = externalTexture1.label;
+} catch {}
+let texture9 = device0.createTexture(
+{
+label: '\u2dc7\u337c\u08e2\ubc3c\u{1f8ea}\u4bde\u0580',
+size: {width: 7048},
+dimension: '1d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView12 = texture9.createView(
+{
+label: '\u0695\u0123\u70a2\u{1fc31}\u1bab\u9624\u0008',
+}
+);
+let renderBundleEncoder7 = device0.createRenderBundleEncoder(
+{
+label: '\u{1f62a}\u{1fed6}\u5c36\u{1fdc2}',
+colorFormats: [
+'rgba8uint',
+'rg32float',
+'rgba8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 281,
+}
+);
+let renderBundle9 = renderBundleEncoder5.finish(
+{
+label: '\ufe60\u07d2'
+}
+);
+try {
+renderPassEncoder0.setVertexBuffer(
+94,
+undefined,
+1237534831,
+2716474131
+);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+commandEncoder10.copyBufferToBuffer(
+buffer0,
+6000,
+buffer1,
+7900,
+224
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+1528,
+new Int16Array(40379),
+23744,
+1044
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture4,
+  mipLevel: 2,
+  origin: { x: 0, y: 7, z: 0 },
+  aspect: 'stencil-only',
+},
+new ArrayBuffer(40),
+/* required buffer size: 144 */{
+offset: 144,
+rowsPerImage: 264,
+},
+{width: 1005, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline5 = device0.createComputePipeline(
+{
+label: '\u01ca\ub612\u{1f9bc}\u{1fee0}\u08c8\u0a42\u{1fd66}\u36c1\u{1f9d7}',
+layout: 'auto',
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let img3 = await imageWithData(199, 279, '#d1645f33', '#129a3976');
+let commandBuffer1 = commandEncoder9.finish(
+{
+label: '\u0c09\u480d\u{1fd74}\ua139\ue8d6\u6381',
+}
+);
+let texture10 = device0.createTexture(
+{
+label: '\u9c40\u008c\u{1fb53}\ua457\u8a54\uaef8\u32da\u005c',
+size: {width: 44, height: 176, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+sampleCount: 1,
+dimension: '2d',
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+try {
+computePassEncoder4.setBindGroup(
+7,
+bindGroup1,
+new Uint32Array(4049),
+3732,
+0
+);
+} catch {}
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+computePassEncoder4.setPipeline(
+pipeline3
+);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant(
+{
+r: -500.6,
+g: 393.2,
+b: -526.3,
+a: -708.0,
+}
+);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+0,
+bindGroup0,
+new Uint32Array(2490),
+346,
+0
+);
+} catch {}
+try {
+commandEncoder6.copyBufferToBuffer(
+buffer1,
+3964,
+buffer2,
+35816,
+4088
+);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+3092,
+new Float32Array(20346),
+16190,
+980
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline6 = device0.createRenderPipeline(
+{
+label: '\u603c\u5c34\ud3c8\u08c7\u0192\u577d\u{1fe5e}',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 21592,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32',
+offset: 16648,
+shaderLocation: 10,
+},
+{
+format: 'float32x2',
+offset: 968,
+shaderLocation: 3,
+},
+{
+format: 'sint32x3',
+offset: 5104,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 22388,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 3360,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 34244,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 15616,
+shaderLocation: 14,
+},
+{
+format: 'float16x2',
+offset: 23076,
+shaderLocation: 12,
+},
+{
+format: 'uint16x2',
+offset: 2688,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'replace',
+depthFailOp: 'replace',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 3896,
+stencilWriteMask: 199,
+depthBias: 78,
+depthBiasSlopeScale: 36,
+depthBiasClamp: 58,
+},
+}
+);
+let shaderModule3 = device0.createShaderModule(
+{
+label: '\u{1f70f}\u3cfa\u3274\u{1fa0f}\u21ab\u{1f637}\u{1fa80}\u2708',
+code: `@group(0) @binding(2555)
+var<storage, read_write> function0: array<u32>;
+
+@compute @workgroup_size(8, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S5 {
+@location(49) f0: f16,
+@location(53) f1: u32,
+@location(44) f2: f16,
+@location(24) f3: vec2<i32>,
+@location(3) f4: vec4<f16>,
+@location(16) f5: vec4<i32>,
+@location(19) f6: vec4<i32>,
+@location(30) f7: vec3<f32>,
+@builtin(sample_index) f8: u32,
+@location(31) f9: vec3<u32>,
+@location(23) f10: vec3<u32>,
+@location(2) f11: vec4<i32>,
+@location(46) f12: vec4<f32>,
+@builtin(front_facing) f13: bool,
+@builtin(sample_mask) f14: u32
+}
+struct FragmentOutput0 {
+@location(7) f0: f32,
+@location(1) f1: vec4<u32>,
+@location(2) f2: vec3<u32>
+}
+
+@fragment
+fn fragment0(@location(15) a0: vec3<i32>, @location(39) a1: vec4<u32>, @location(37) a2: vec4<f32>, @location(11) a3: vec2<f32>, @location(0) a4: vec3<i32>, @location(18) a5: vec4<u32>, @location(10) a6: vec3<f32>, @location(32) a7: vec4<f32>, @location(8) a8: vec3<f32>, a9: S5) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S4 {
+@location(10) f0: vec2<f16>,
+@builtin(instance_index) f1: u32,
+@location(9) f2: vec3<f32>
+}
+struct VertexOutput0 {
+@location(15) f66: vec3<i32>,
+@location(0) f67: vec3<i32>,
+@location(11) f68: vec2<f32>,
+@location(2) f69: vec4<i32>,
+@location(31) f70: vec3<u32>,
+@location(24) f71: vec2<i32>,
+@location(23) f72: vec3<u32>,
+@location(3) f73: vec4<f16>,
+@location(10) f74: vec3<f32>,
+@location(32) f75: vec4<f32>,
+@location(53) f76: u32,
+@location(30) f77: vec3<f32>,
+@location(46) f78: vec4<f32>,
+@location(19) f79: vec4<i32>,
+@location(8) f80: vec3<f32>,
+@location(18) f81: vec4<u32>,
+@location(16) f82: vec4<i32>,
+@location(37) f83: vec4<f32>,
+@location(49) f84: f16,
+@location(39) f85: vec4<u32>,
+@location(44) f86: f16,
+@builtin(position) f87: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec3<u32>, @location(7) a1: vec4<f32>, @location(6) a2: u32, @builtin(vertex_index) a3: u32, @location(13) a4: vec3<i32>, @location(11) a5: vec3<f32>, @location(5) a6: vec2<u32>, @location(8) a7: vec2<f16>, @location(1) a8: vec2<f16>, @location(4) a9: vec3<f16>, a10: S4, @location(0) a11: vec3<i32>, @location(15) a12: i32, @location(2) a13: vec4<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let querySet9 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 1885,
+}
+);
+let renderBundle10 = renderBundleEncoder5.finish(
+{
+label: '\u395c\u3131\u0583\u27c8\u8b1a'
+}
+);
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: -370.3,
+g: -611.5,
+b: 965.5,
+a: 719.0,
+}
+);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(
+1470
+);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+5.850,
+0.7915,
+76.78,
+0.07358,
+0.4570,
+0.9693
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb',
+'bgra8unorm',
+'bgra8unorm',
+'bgra8unorm'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: { x: 25, y: 1, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(48),
+/* required buffer size: 801 */{
+offset: 801,
+bytesPerRow: 179,
+},
+{width: 54, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\u{1fdad}\u701a\u045d\u81ff\u06d2\u0ffc\u507d');
+let imageBitmap3 = await createImageBitmap(imageBitmap2);
+try {
+window.someLabel = device0.label;
+} catch {}
+let buffer3 = device0.createBuffer(
+{
+label: '\u6e4a\u0639\uafbd\u{1feee}\ue079\u352e\u{1fd4e}\u04f8\u09c2\u017d\uab77',
+size: 13247,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let commandEncoder11 = device0.createCommandEncoder(
+{
+label: '\ua7ee\u25ef\u263d\u{1f79c}\u289d\u613f\u080a\ue043',
+}
+);
+let renderBundleEncoder8 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgb10a2uint',
+'rgba32sint'
+],
+sampleCount: 999,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+70.53,
+0.6515,
+4.597,
+0.1188,
+0.8304,
+0.9351
+);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(
+0,
+bindGroup2
+);
+} catch {}
+try {
+commandEncoder10.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let texture11 = device0.createTexture(
+{
+label: '\u{1fba7}\u{1fe25}\u265c\u03a6\u75dd',
+size: [147, 5, 12],
+mipLevelCount: 4,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'depth16unorm'
+],
+}
+);
+let renderBundle11 = renderBundleEncoder2.finish(
+{
+label: '\uc6e5\u978d\u24cf'
+}
+);
+try {
+renderPassEncoder0.setBindGroup(
+2,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+77,
+0,
+7,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(
+2944
+);
+} catch {}
+try {
+commandEncoder6.clearBuffer(
+buffer2
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder10.insertDebugMarker(
+'\ucd1b'
+);
+} catch {}
+canvas1.width = 310;
+let video2 = await videoWithData();
+let renderPassEncoder3 = commandEncoder6.beginRenderPass(
+{
+label: '\u{1f963}\u0b2a\u{1ff61}\u7673\ue032\ub5f8\u{1fd4f}\u06ac',
+colorAttachments: [
+{
+view: textureView7,
+depthSlice: 15,
+clearValue: {
+r: -866.1,
+g: -287.9,
+b: 779.0,
+a: -225.6,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+undefined,
+{
+view: textureView7,
+depthSlice: 24,
+clearValue: {
+r: 182.4,
+g: -230.0,
+b: 29.27,
+a: 475.1,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView7,
+depthSlice: 9,
+clearValue: {
+r: -138.3,
+g: 221.7,
+b: -479.5,
+a: 974.3,
+},
+loadOp: 'load',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet3,
+maxDrawCount: 17232,
+}
+);
+try {
+computePassEncoder4.setPipeline(
+pipeline5
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+3,
+bindGroup2,
+new Uint32Array(1117),
+436,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(
+116
+);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(
+95,
+undefined,
+954595302,
+2549476686
+);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+2,
+bindGroup1
+);
+} catch {}
+try {
+buffer0.destroy();
+} catch {}
+let pipeline7 = await promise3;
+let commandEncoder12 = device0.createCommandEncoder(
+{
+label: '\u{1fbc9}\uae99\u{1fc28}\u6147\u0eec',
+}
+);
+let textureView13 = texture2.createView(
+{
+label: '\u7dbd\uce15\u0d46\u08a4\u0d4d\u0f96\u3728\uf33c\u{1fd97}',
+dimension: '2d-array',
+aspect: 'all',
+baseMipLevel: 3,
+}
+);
+let renderBundleEncoder9 = device0.createRenderBundleEncoder(
+{
+label: '\u8097\ua951\u0019\u035c\u0513\u{1fa0d}\u00db\ue101\u{1fea7}\u3a4c',
+colorFormats: [
+'r8sint',
+'r16sint',
+'rgba16sint',
+'rgba16sint',
+'rgb10a2unorm',
+'rg32float',
+'r8sint',
+'rgba16uint'
+],
+sampleCount: 249,
+depthReadOnly: true,
+}
+);
+try {
+computePassEncoder4.setPipeline(
+pipeline3
+);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+4760,
+new Float32Array(17329),
+13430,
+668
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 2652, y: 66, z: 53 },
+  aspect: 'all',
+},
+new Float64Array(new ArrayBuffer(40)),
+/* required buffer size: 66082858 */{
+offset: 170,
+bytesPerRow: 15764,
+rowsPerImage: 262,
+},
+{width: 5826, height: 0, depthOrArrayLayers: 17}
+);
+} catch {}
+document.body.append('\u09c5\u{1fef1}\u{1fcd0}\u059d\u2890\u0704\u020c\u4c29');
+let videoFrame0 = new VideoFrame(img3, {timestamp: 0});
+let textureView14 = texture8.createView(
+{
+label: '\u0624\u0695\u{1f9f3}\u{1fc76}\u817b\u{1fa7b}\uefdf\u0391',
+baseArrayLayer: 36,
+arrayLayerCount: 38,
+}
+);
+try {
+computePassEncoder4.setPipeline(
+pipeline0
+);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(
+8,
+bindGroup2
+);
+} catch {}
+let pipeline8 = device0.createComputePipeline(
+{
+layout: 'auto',
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend(img0);
+let querySet10 = device0.createQuerySet(
+{
+label: '\u4a06\u194d\ub4ce\u0956',
+type: 'occlusion',
+count: 3349,
+}
+);
+let renderPassEncoder4 = commandEncoder2.beginRenderPass(
+{
+label: '\ud02a\u0587\u{1fbdf}',
+colorAttachments: [
+{
+view: textureView7,
+depthSlice: 5,
+clearValue: {
+r: -191.1,
+g: -867.5,
+b: -847.6,
+a: -404.6,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView7,
+depthSlice: 24,
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView7,
+depthSlice: 9,
+clearValue: {
+r: -190.8,
+g: -116.4,
+b: 45.82,
+a: -231.9,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView7,
+depthSlice: 3,
+clearValue: {
+r: -709.9,
+g: -943.2,
+b: -138.4,
+a: 473.0,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView7,
+depthSlice: 0,
+clearValue: {
+r: -81.69,
+g: 225.0,
+b: -16.04,
+a: -539.7,
+},
+loadOp: 'load',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet1,
+}
+);
+let renderBundle12 = renderBundleEncoder5.finish();
+try {
+renderPassEncoder3.beginOcclusionQuery(
+32
+);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let buffer4 = device0.createBuffer(
+{
+label: '\u0875\u1c6b\u0a68\u0f77\u33bd\u0a69\u1c42\u0f39\u0efe',
+size: 24283,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: false,
+}
+);
+let textureView15 = texture11.createView(
+{
+label: '\u3f30\u09f1\u1e35\u0e0e\ub908\u5a5d\ue2e1\u6038',
+aspect: 'depth-only',
+baseMipLevel: 0,
+baseArrayLayer: 1,
+arrayLayerCount: 1,
+}
+);
+let renderBundleEncoder10 = device0.createRenderBundleEncoder(
+{
+label: '\u0c45\u017e\u787d\u5570\uab4c\u{1f91b}',
+colorFormats: [
+'rg16sint',
+'r16sint',
+'rgba32uint',
+'rg8unorm',
+'r8uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 569,
+depthReadOnly: true,
+}
+);
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+64.51,
+0.8233,
+24.37,
+0.06858,
+0.5570,
+0.7618
+);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+8,
+bindGroup2,
+new Uint32Array(675),
+634,
+0
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder13 = device0.createCommandEncoder(
+{
+label: '\u660e\ue860\u0fd6\u640b',
+}
+);
+let querySet11 = device0.createQuerySet(
+{
+label: '\u87ef\u0864\uefc8\u{1fe9e}\ud487\uec22\u84bc',
+type: 'occlusion',
+count: 4083,
+}
+);
+let computePassEncoder5 = commandEncoder12.beginComputePass(
+{
+label: '\u444f\u00be\udad5\u{1fd13}'
+}
+);
+let sampler10 = device0.createSampler(
+{
+label: '\u5bb6\u{1f677}\ufb8d\u3174',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 40.053,
+maxAnisotropy: 18,
+}
+);
+let img4 = await imageWithData(218, 90, '#871abc92', '#d805c513');
+let texture12 = device0.createTexture(
+{
+label: '\u28b4\uf42d\u9e7d\u0973\u04c8\ud5d9\u{1f992}\u{1fde5}',
+size: {width: 223, height: 1, depthOrArrayLayers: 234},
+mipLevelCount: 3,
+sampleCount: 1,
+dimension: '3d',
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder6 = commandEncoder0.beginComputePass(
+{
+
+}
+);
+let renderPassEncoder5 = commandEncoder10.beginRenderPass(
+{
+label: '\ud925\uf2fd\u{1fcf0}\ud04d',
+colorAttachments: [
+{
+view: textureView7,
+depthSlice: 7,
+clearValue: {
+r: -2.514,
+g: -167.4,
+b: 860.1,
+a: -232.4,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+{
+view: textureView7,
+depthSlice: 1,
+clearValue: {
+r: 201.1,
+g: -608.9,
+b: 553.3,
+a: -56.87,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined,
+{
+view: textureView7,
+depthSlice: 13,
+clearValue: {
+r: 879.5,
+g: 707.4,
+b: 646.5,
+a: -745.0,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined,
+{
+view: textureView7,
+depthSlice: 15,
+clearValue: {
+r: -325.1,
+g: 791.4,
+b: 757.8,
+a: -672.7,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined,
+{
+view: textureView7,
+depthSlice: 9,
+clearValue: {
+r: -825.1,
+g: -740.2,
+b: -234.1,
+a: 866.8,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined
+],
+occlusionQuerySet: querySet0,
+maxDrawCount: 135352,
+}
+);
+try {
+renderPassEncoder4.setBindGroup(
+4,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(
+1812
+);
+} catch {}
+try {
+renderPassEncoder3.setViewport(
+28.42,
+0.1764,
+11.96,
+0.09396,
+0.7432,
+0.9035
+);
+} catch {}
+try {
+texture2.destroy();
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(
+buffer4,
+10344,
+buffer2,
+616,
+12444
+);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 1860, y: 5, z: 7 },
+  aspect: 'all',
+},
+new ArrayBuffer(31212),
+/* required buffer size: 31212 */{
+offset: 956,
+bytesPerRow: 2332,
+rowsPerImage: 255,
+},
+{width: 1420, height: 65, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline9 = await device0.createComputePipelineAsync(
+{
+label: '\u06f5\u{1fa3d}\u0710\u0833\u0488\u0eb0\u08f2\u12a7\ud13c',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let renderBundle13 = renderBundleEncoder3.finish(
+{
+label: '\ua5e7\ua997\u{1f802}\ucc07'
+}
+);
+let sampler11 = device0.createSampler(
+{
+label: '\uedc0\u6e3e\ue4f0\u0641\u8656\uc3ed\u01d5',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 80.412,
+lodMaxClamp: 95.040,
+}
+);
+try {
+renderPassEncoder3.setBindGroup(
+5,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: -381.7,
+g: -379.4,
+b: -539.3,
+a: -61.76,
+}
+);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(
+3,
+bindGroup1
+);
+} catch {}
+let promise4 = device0.createComputePipelineAsync(
+{
+label: '\u{1fd76}\u00f3\u0b27\u{1fa7f}\u0795',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let offscreenCanvas2 = new OffscreenCanvas(602, 20);
+try {
+offscreenCanvas2.getContext('2d');
+} catch {}
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(
+2,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: 583.9,
+g: 747.7,
+b: 250.1,
+a: 468.6,
+}
+);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(
+1866
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(
+buffer1,
+3608,
+buffer2,
+41420,
+3740
+);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder0.clearBuffer(
+buffer2
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+document.body.append('\u{1f74d}\u{1fbe7}');
+let shaderModule4 = device0.createShaderModule(
+{
+label: '\u10c4\uc3d2\u{1f640}',
+code: `@group(2) @binding(1014)
+var<storage, read_write> field0: array<u32>;
+@group(0) @binding(2555)
+var<storage, read_write> function1: array<u32>;
+
+@compute @workgroup_size(8, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: vec2<f32>,
+@location(6) f1: f32,
+@location(0) f2: vec2<f32>,
+@location(2) f3: i32
+}
+
+@fragment
+fn fragment0(@location(0) a0: vec3<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(17) f88: i32,
+@builtin(position) f89: vec4<f32>,
+@location(28) f90: vec3<f16>,
+@location(50) f91: vec3<f16>,
+@location(0) f92: vec3<f32>,
+@location(31) f93: f32,
+@location(37) f94: u32,
+@location(12) f95: f32,
+@location(42) f96: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(16) a0: vec3<f16>, @location(15) a1: vec4<i32>, @location(11) a2: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroupLayout2 = device0.createBindGroupLayout(
+{
+label: '\u0241\u066f\u{1fda1}\u0c4c\u0763\u6107\u56d2\u0250\u4023',
+entries: [
+{
+binding: 1103,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '2d-array' },
+},
+{
+binding: 1856,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+},
+{
+binding: 2306,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '3d' },
+}
+],
+}
+);
+let commandEncoder14 = device0.createCommandEncoder(
+{
+}
+);
+let renderBundleEncoder11 = device0.createRenderBundleEncoder(
+{
+label: '\u0be4\u416c\u023a\ueb36\ud6bb\u026e\u73de\uef7c\ufbdd',
+colorFormats: [
+'rg32float',
+'rgba32uint',
+'r32uint',
+'rgb10a2unorm',
+'rgba8uint',
+'rgba16sint',
+'rg16float'
+],
+sampleCount: 573,
+}
+);
+let renderBundle14 = renderBundleEncoder9.finish(
+{
+label: '\u0b46\u03ef\u{1fd75}\u0c62\ua33f'
+}
+);
+try {
+renderPassEncoder3.beginOcclusionQuery(
+48
+);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(
+1283
+);
+} catch {}
+try {
+commandEncoder0.clearBuffer(
+buffer1,
+7740
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let imageBitmap4 = await createImageBitmap(img4);
+let bindGroupLayout3 = device0.createBindGroupLayout(
+{
+label: '\u5333\u1008\u{1fe1f}\u0e54\u0d3b\ua464',
+entries: [
+
+],
+}
+);
+let querySet12 = device0.createQuerySet(
+{
+label: '\u0074\u{1fb2c}\uf07d\u{1f9ff}\u7a91\u{1f761}',
+type: 'occlusion',
+count: 3162,
+}
+);
+let texture13 = gpuCanvasContext0.getCurrentTexture();
+let renderPassEncoder6 = commandEncoder0.beginRenderPass(
+{
+label: '\u0ac1\ufa95\u0435\u3471',
+colorAttachments: [
+{
+view: textureView7,
+depthSlice: 0,
+clearValue: {
+r: 922.7,
+g: 472.8,
+b: 308.3,
+a: 362.2,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView7,
+depthSlice: 4,
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView7,
+depthSlice: 3,
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined,
+{
+view: textureView7,
+depthSlice: 21,
+clearValue: {
+r: 625.2,
+g: 482.6,
+b: -935.7,
+a: -915.6,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined,
+{
+view: textureView7,
+depthSlice: 18,
+clearValue: {
+r: -101.1,
+g: -843.5,
+b: -320.3,
+a: 728.2,
+},
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+}
+);
+try {
+computePassEncoder1.setPipeline(
+pipeline8
+);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+0,
+1,
+85,
+0
+);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(
+26,
+undefined,
+2076974496,
+1232392802
+);
+} catch {}
+try {
+commandEncoder13.copyTextureToTexture(
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 1691, y: 12, z: 0 },
+  aspect: 'stencil-only',
+},
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'stencil-only',
+},
+{width: 2011, height: 16, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 2058, y: 0, z: 11 },
+  aspect: 'all',
+},
+new ArrayBuffer(12849653),
+/* required buffer size: 12849653 */{
+offset: 173,
+bytesPerRow: 5099,
+rowsPerImage: 56,
+},
+{width: 1896, height: 0, depthOrArrayLayers: 46}
+);
+} catch {}
+let buffer5 = device0.createBuffer(
+{
+label: '\u{1f85a}\u{1f9a3}\u6752\uee08',
+size: 23459,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let renderPassEncoder7 = commandEncoder14.beginRenderPass(
+{
+label: '\u0933\u5129\u09a3\u0395\u79e0\u023b\u{1f61d}\u0d69\u{1f61f}',
+colorAttachments: [
+undefined,
+undefined,
+{
+view: textureView7,
+depthSlice: 21,
+clearValue: {
+r: 357.7,
+g: -318.7,
+b: 670.7,
+a: 999.1,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView7,
+depthSlice: 11,
+clearValue: {
+r: 715.1,
+g: 227.2,
+b: 913.3,
+a: 599.0,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+undefined,
+undefined
+],
+maxDrawCount: 21200,
+}
+);
+try {
+renderPassEncoder5.beginOcclusionQuery(
+80
+);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(
+2533
+);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+computePassEncoder1.pushDebugGroup(
+'\ua1b4'
+);
+} catch {}
+try {
+computePassEncoder1.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'astc-4x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+gc();
+let sampler12 = device0.createSampler(
+{
+label: '\u{1fcc5}\u6b85',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 18.170,
+lodMaxClamp: 43.264,
+}
+);
+try {
+renderPassEncoder3.setBindGroup(
+8,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(
+62,
+0,
+3,
+1
+);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(
+0,
+buffer5,
+5724,
+2530
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture11,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 2 },
+  aspect: 'all',
+},
+new ArrayBuffer(40),
+/* required buffer size: 58778 */{
+offset: 962,
+bytesPerRow: 214,
+rowsPerImage: 270,
+},
+{width: 18, height: 1, depthOrArrayLayers: 2}
+);
+} catch {}
+video2.width = 191;
+let textureView16 = texture5.createView(
+{
+label: '\u0a95\ua39c',
+dimension: '1d',
+}
+);
+try {
+computePassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(
+1,
+1,
+78,
+0
+);
+} catch {}
+document.body.prepend(video1);
+document.body.append('\u07c1\u2c93\u1648\u{1fea2}\u2c94');
+let imageData3 = new ImageData(108, 68);
+let bindGroupLayout4 = device0.createBindGroupLayout(
+{
+label: '\ub23c\u0b6b\u670f\u5ed5\u04c1\u{1fde8}',
+entries: [
+{
+binding: 599,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let bindGroup3 = device0.createBindGroup({
+label: '\u0953\u4e60\u{1f7b7}\u{1fe79}\ub5fe\u07eb',
+layout: bindGroupLayout4,
+entries: [
+{
+binding: 599,
+resource: externalTexture1
+}
+],
+});
+let sampler13 = device0.createSampler(
+{
+label: '\u00ff\u47e7\ua5ef\u930d\u333d\u0f81\u02e2\u{1fa6e}\u7538\u07ac\u0d35',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 83.239,
+}
+);
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(
+80
+);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(
+2,
+buffer5,
+22816
+);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(
+6,
+buffer5,
+12388,
+612
+);
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8sint'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 820, y: 35, z: 19 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(new ArrayBuffer(8)),
+/* required buffer size: 971 */{
+offset: 971,
+bytesPerRow: 2377,
+},
+{width: 1430, height: 40, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline10 = await promise2;
+let pipeline11 = await device0.createRenderPipelineAsync(
+{
+label: '\u94c7\u{1f7a5}\u4307\u0e75\u8db7',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+
+]
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32sint',
+}
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'less-equal',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilWriteMask: 2375,
+depthBias: 72,
+depthBiasSlopeScale: 24,
+},
+}
+);
+let texture14 = device0.createTexture(
+{
+label: '\u29a2\u00fe\u6d71\u029f\u8532\u341c\u{1fd89}',
+size: {width: 150, height: 210, depthOrArrayLayers: 254},
+mipLevelCount: 6,
+dimension: '2d',
+format: 'astc-10x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x6-unorm'
+],
+}
+);
+let renderBundleEncoder12 = device0.createRenderBundleEncoder(
+{
+label: '\ue25d\u0e5f\u038e\uaac4',
+colorFormats: [
+'rg32sint',
+undefined,
+'r8unorm',
+'r16float',
+'rgba32uint',
+'rgba32uint',
+'rgba16uint'
+],
+sampleCount: 335,
+stencilReadOnly: true,
+}
+);
+let sampler14 = device0.createSampler(
+{
+label: '\u8c66\u{1f83b}\u7631\u{1f982}\u433a\u009b\u0c58\u0804',
+addressModeU: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 51.292,
+lodMaxClamp: 80.839,
+maxAnisotropy: 9,
+}
+);
+try {
+renderPassEncoder2.setBindGroup(
+4,
+bindGroup2,
+[]
+);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(
+56
+);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(
+71,
+0,
+14,
+0
+);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(
+70,
+undefined
+);
+} catch {}
+try {
+commandEncoder12.copyTextureToTexture(
+{
+  texture: texture4,
+  mipLevel: 2,
+  origin: { x: 250, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'stencil-only',
+},
+{width: 251, height: 2, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder13.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline12 = device0.createComputePipeline(
+{
+label: '\u074a\u054b\u833a\u8593\u76ef\u0f41\u073a\u0774\u{1fe49}',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend(video0);
+let texture15 = device0.createTexture(
+{
+size: [18, 1, 1784],
+dimension: '3d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16uint',
+'rgba16uint',
+'rgba16uint'
+],
+}
+);
+let texture16 = gpuCanvasContext2.getCurrentTexture();
+try {
+renderPassEncoder3.beginOcclusionQuery(
+72
+);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant(
+{
+r: -14.73,
+g: -471.7,
+b: 692.9,
+a: -897.9,
+}
+);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(
+1,
+bindGroup2
+);
+} catch {}
+try {
+commandEncoder3.copyTextureToBuffer(
+{
+  texture: texture11,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 4 },
+  aspect: 'depth-only',
+},
+{
+/* bytesInLastRow: 36 widthInBlocks: 18 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 19792 */
+offset: 19756,
+bytesPerRow: 256,
+rowsPerImage: 249,
+buffer: buffer5,
+},
+{width: 18, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer3,
+11628,
+new Float32Array(59794),
+30078,
+364
+);
+} catch {}
+document.body.prepend('\u0dfc\u77b6\u0f77\u0ddc\u{1f6cc}\u0daf');
+let img5 = await imageWithData(241, 68, '#a910eb36', '#fcfc2e0b');
+let imageData4 = new ImageData(32, 156);
+let commandEncoder15 = device0.createCommandEncoder(
+{
+label: '\ubcaf\ub5af\u{1ff21}',
+}
+);
+try {
+renderPassEncoder2.setBindGroup(
+3,
+bindGroup3
+);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(
+4,
+bindGroup2
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+document.body.append('\u{1f737}\ufeef\uc8f8\u{1fd63}\u063a\ub6d3');
+try {
+window.someLabel = pipeline0.label;
+} catch {}
+let computePassEncoder7 = commandEncoder12.beginComputePass(
+{
+label: '\u397c\u87ad'
+}
+);
+let renderBundleEncoder13 = device0.createRenderBundleEncoder(
+{
+label: '\u26ae\ub797\u0a43\u{1fdd6}',
+colorFormats: [
+'rg16sint',
+'rgb10a2unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 20,
+}
+);
+let renderBundle15 = renderBundleEncoder10.finish(
+{
+label: '\u0ed3\u0dee\u{1f91d}\u03aa\u{1f935}\u0970\u5c62\u0548\u4c3f'
+}
+);
+try {
+computePassEncoder7.setBindGroup(
+7,
+bindGroup2,
+new Uint32Array(8436),
+5730,
+0
+);
+} catch {}
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(
+4,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(
+68,
+0,
+21,
+1
+);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(
+2125
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+9,
+buffer5,
+4416
+);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(
+8,
+bindGroup3
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video2,
+  origin: { x: 4, y: 12 },
+  flipY: false,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipelineLayout1 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+
+],
+}
+);
+try {
+renderPassEncoder4.setScissorRect(
+30,
+0,
+23,
+0
+);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(
+3,
+buffer5
+);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(
+7,
+bindGroup2,
+new Uint32Array(5285),
+4438,
+0
+);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(
+buffer0,
+34032,
+buffer3,
+13208,
+0
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder15.copyTextureToTexture(
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'stencil-only',
+},
+{width: 4023, height: 33, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer5,
+16144,
+new Int16Array(64811),
+7640,
+1424
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture14,
+  mipLevel: 0,
+  origin: { x: 30, y: 132, z: 97 },
+  aspect: 'all',
+},
+new Float64Array(new ArrayBuffer(80)),
+/* required buffer size: 100701 */{
+offset: 806,
+bytesPerRow: 327,
+rowsPerImage: 147,
+},
+{width: 100, height: 72, depthOrArrayLayers: 3}
+);
+} catch {}
+gc();
+document.body.append('\u09f0\u9a83\u078c\u0cf0\u7782\u336d\u9b59\u5709\u2c65\u0bbb\ue93a');
+let videoFrame1 = new VideoFrame(img0, {timestamp: 0});
+let shaderModule5 = device0.createShaderModule(
+{
+label: '\u8d38\u0660\u0feb\u0ec9\u00d1\uab29\u4e30\u057e\ue66f\u4c4d\u0245',
+code: `
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: vec3<u32>,
+@location(3) f1: u32,
+@location(5) f2: i32,
+@location(7) f3: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_mask) a1: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S6 {
+@location(5) f0: vec3<f32>,
+@location(14) f1: vec4<f32>,
+@location(10) f2: f32,
+@location(6) f3: vec3<f16>,
+@location(7) f4: vec3<f16>,
+@location(12) f5: i32,
+@location(13) f6: vec4<f32>,
+@location(1) f7: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(4) a0: vec2<u32>, @location(0) a1: vec3<u32>, @location(11) a2: f32, @location(15) a3: u32, @location(9) a4: vec3<f32>, a5: S6, @location(3) a6: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+}
+);
+let renderPassEncoder8 = commandEncoder11.beginRenderPass(
+{
+label: '\u6a1e\u{1f697}\uf592\u67ba\udc36\u09b3\u0eda',
+colorAttachments: [
+{
+view: textureView7,
+depthSlice: 8,
+clearValue: {
+r: 801.7,
+g: 439.7,
+b: 759.8,
+a: 469.7,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView7,
+depthSlice: 19,
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView7,
+depthSlice: 16,
+clearValue: {
+r: 929.4,
+g: -750.5,
+b: 256.8,
+a: -778.5,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined
+],
+maxDrawCount: 224360,
+}
+);
+try {
+renderBundleEncoder13.setBindGroup(
+7,
+bindGroup2
+);
+} catch {}
+try {
+commandEncoder13.copyTextureToTexture(
+{
+  texture: texture4,
+  mipLevel: 2,
+  origin: { x: 43, y: 3, z: 0 },
+  aspect: 'stencil-only',
+},
+{
+  texture: texture4,
+  mipLevel: 3,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+{width: 502, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder13.clearBuffer(
+buffer5,
+6472,
+7964
+);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+renderPassEncoder4.insertDebugMarker(
+'\ud192'
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(8),
+/* required buffer size: 387 */{
+offset: 387,
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 17, y: 66 },
+  flipY: true,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise5 = device0.createComputePipelineAsync(
+{
+layout: 'auto',
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+canvas0.width = 1003;
+document.body.append('\u0414\uab08\ufb77\u{1f988}\u09b1\u064a\u09c1\ua597');
+let offscreenCanvas3 = new OffscreenCanvas(467, 508);
+let shaderModule6 = device0.createShaderModule(
+{
+label: '\ua879\u7795\u0308\u042b\u43d3\u0281\uf14a\ua467\u7eec',
+code: `
+
+@compute @workgroup_size(6, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(0) f0: vec4<u32>,
+@location(4) f1: vec3<i32>,
+@location(7) f2: i32,
+@location(1) f3: vec2<i32>,
+@builtin(sample_mask) f4: u32,
+@location(2) f5: vec2<f32>,
+@location(3) f6: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(32) a0: vec3<i32>, @location(21) a1: vec3<i32>, @location(8) a2: vec2<i32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S7 {
+@location(1) f0: vec4<u32>,
+@location(8) f1: i32,
+@builtin(instance_index) f2: u32,
+@location(6) f3: vec2<f32>,
+@location(7) f4: vec4<i32>,
+@location(0) f5: vec4<f16>,
+@location(3) f6: vec2<i32>,
+@location(16) f7: vec3<i32>,
+@builtin(vertex_index) f8: u32,
+@location(12) f9: i32,
+@location(13) f10: i32,
+@location(10) f11: vec4<f32>,
+@location(9) f12: vec3<f16>,
+@location(4) f13: i32,
+@location(5) f14: u32,
+@location(15) f15: vec4<f16>,
+@location(14) f16: vec2<u32>,
+@location(11) f17: vec4<f16>,
+@location(2) f18: vec4<i32>
+}
+struct VertexOutput0 {
+@location(8) f97: vec2<i32>,
+@location(9) f98: vec4<i32>,
+@location(6) f99: f16,
+@builtin(position) f100: vec4<f32>,
+@location(32) f101: vec3<i32>,
+@location(21) f102: vec3<i32>,
+@location(16) f103: i32
+}
+
+@vertex
+fn vertex0(a0: S7) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let buffer6 = device0.createBuffer(
+{
+label: '\ubb4e\u0038',
+size: 20388,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+}
+);
+let texture17 = device0.createTexture(
+{
+label: '\u0df0\u3874',
+size: [6737],
+dimension: '1d',
+format: 'r32sint',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32sint'
+],
+}
+);
+try {
+renderPassEncoder0.setVertexBuffer(
+1,
+buffer6,
+15420,
+1969
+);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(
+6,
+bindGroup2
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let pipeline13 = await device0.createRenderPipelineAsync(
+{
+label: '\uf28d\ub272\u3f0b\u{1f607}\u2ddb\u051e\u{1fb44}\u01d5\u{1f9c1}\u{1f7f7}',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 16068,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x4',
+offset: 7048,
+shaderLocation: 5,
+},
+{
+format: 'unorm16x4',
+offset: 1384,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x4',
+offset: 8796,
+shaderLocation: 9,
+},
+{
+format: 'sint32x2',
+offset: 14332,
+shaderLocation: 12,
+},
+{
+format: 'float16x2',
+offset: 12256,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 25548,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 15380,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 23780,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 10988,
+shaderLocation: 10,
+},
+{
+format: 'sint16x4',
+offset: 2452,
+shaderLocation: 6,
+},
+{
+format: 'uint16x4',
+offset: 4176,
+shaderLocation: 14,
+},
+{
+format: 'float32',
+offset: 17156,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 10604,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 10020,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x2',
+offset: 1784,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x2',
+offset: 8916,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x4',
+offset: 9948,
+shaderLocation: 16,
+},
+{
+format: 'uint8x4',
+offset: 4156,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 12256,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 14904,
+attributes: [
+{
+format: 'snorm16x4',
+offset: 7720,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 3144,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 28912,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x2',
+offset: 23062,
+shaderLocation: 13,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'never',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 2660,
+stencilWriteMask: 3147,
+depthBias: 16,
+depthBiasSlopeScale: 42,
+depthBiasClamp: 19,
+},
+}
+);
+let textureView17 = texture0.createView(
+{
+label: '\ufe5a\u7e05\u004b\ua905',
+dimension: '2d-array',
+}
+);
+let sampler15 = device0.createSampler(
+{
+label: '\u01db\u65e3\u3732\u6909\uc5a0\u0c51\ue8b2',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 73.328,
+lodMaxClamp: 76.165,
+}
+);
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(
+60,
+1,
+1,
+0
+);
+} catch {}
+try {
+renderPassEncoder3.setViewport(
+1.883,
+0.2410,
+12.54,
+0.5613,
+0.08803,
+0.3988
+);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(
+3,
+bindGroup2
+);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(
+6,
+bindGroup0,
+new Uint32Array(2076),
+716,
+0
+);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(
+2,
+buffer6,
+10424,
+9175
+);
+} catch {}
+try {
+commandEncoder12.copyBufferToBuffer(
+buffer1,
+5788,
+buffer3,
+1224,
+1812
+);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let gpuCanvasContext3 = offscreenCanvas3.getContext('webgpu');
+let texture18 = device0.createTexture(
+{
+label: '\u0413\u0665',
+size: {width: 52, height: 56, depthOrArrayLayers: 1},
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'etc2-rgb8unorm-srgb'
+],
+}
+);
+let textureView18 = texture13.createView(
+{
+label: '\u{1fddb}\ua2de\u0857',
+}
+);
+let renderBundleEncoder14 = device0.createRenderBundleEncoder(
+{
+label: '\u29b3\ue886\u01a0\u094d\ucfe0',
+colorFormats: [
+'rg16sint',
+'bgra8unorm-srgb',
+'r8uint',
+'rgba8sint',
+'r16sint'
+],
+sampleCount: 116,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder0.setBindGroup(
+3,
+bindGroup3
+);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(
+buffer6,
+'uint16',
+15222,
+3875
+);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(
+8,
+buffer5,
+22180,
+394
+);
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(
+buffer4,
+21124,
+buffer1,
+2636,
+892
+);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+44988,
+new Float32Array(55830),
+34834,
+1408
+);
+} catch {}
+let texture19 = device0.createTexture(
+{
+label: '\u0d58\u4c56\u9e24\u1fef',
+size: {width: 256, height: 8, depthOrArrayLayers: 139},
+mipLevelCount: 5,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-8x8-unorm',
+'astc-8x8-unorm'
+],
+}
+);
+let textureView19 = texture14.createView(
+{
+label: '\u0a5e\ueae6\uc8fb\udde8\u04b1\u9710\u{1fec8}\u7f4d\u22be',
+dimension: '2d',
+mipLevelCount: 2,
+baseArrayLayer: 191,
+}
+);
+let computePassEncoder8 = commandEncoder12.beginComputePass(
+{
+label: '\u0648\u{1f609}\u6fe8\u65d6'
+}
+);
+let renderBundle16 = renderBundleEncoder12.finish(
+{
+label: '\u9143\u07ea\u0347'
+}
+);
+let sampler16 = device0.createSampler(
+{
+label: '\u{1ffb4}\u9b0e\u5e60\u0502\u{1f66f}',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 46.327,
+lodMaxClamp: 55.457,
+compare: 'always',
+}
+);
+try {
+renderPassEncoder4.beginOcclusionQuery(
+0
+);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(
+6,
+buffer5,
+15420,
+2835
+);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(
+buffer6,
+5328,
+buffer2,
+34732,
+13884
+);
+dissociateBuffer(device0, buffer6);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder3.copyTextureToTexture(
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: { x: 719, y: 4, z: 1 },
+  aspect: 'stencil-only',
+},
+{
+  texture: texture4,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'stencil-only',
+},
+{width: 251, height: 2, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder3.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+15104,
+new Int16Array(62223),
+36136,
+3244
+);
+} catch {}
+document.body.append('\u010d\u0d31\u{1fab0}\u0b99\u{1fa2f}\u{1fa3e}\u0e3e\ud3fb\u655f');
+let computePassEncoder9 = commandEncoder15.beginComputePass(
+{
+label: '\u39f1\uea39\ua642\u01a6\u{1fe61}\u0681\u63f5\u10b3\u{1f6cd}'
+}
+);
+try {
+computePassEncoder8.setPipeline(
+pipeline9
+);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(
+7,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant(
+{
+r: 867.9,
+g: -446.3,
+b: 662.6,
+a: -933.5,
+}
+);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(
+3,
+buffer5,
+17992,
+910
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+document.body.append('\u230b\ue967\u{1fc1c}\u918d\u436f\uefad\u{1fa07}\u0d31\u096b');
+let texture20 = device0.createTexture(
+{
+label: '\ub6b0\u{1fb45}\u{1f6ae}\uc7df\u528e\u0cab\u{1fad8}\u6a4d\ua3c5\u33a7\uef0e',
+size: {width: 1414},
+dimension: '1d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8snorm',
+'rgba8snorm'
+],
+}
+);
+let sampler17 = device0.createSampler(
+{
+label: '\u095c\u{1f653}\u3719',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 65.525,
+lodMaxClamp: 68.091,
+maxAnisotropy: 20,
+}
+);
+try {
+computePassEncoder8.setPipeline(
+pipeline3
+);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+await buffer4.mapAsync(
+GPUMapMode.WRITE,
+3456,
+10024
+);
+} catch {}
+try {
+commandEncoder3.copyBufferToBuffer(
+buffer1,
+3136,
+buffer3,
+4108,
+560
+);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder13.copyTextureToTexture(
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 320, y: 40, z: 7 },
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 1780, y: 20, z: 7 },
+  aspect: 'all',
+},
+{width: 1360, height: 10, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture14,
+  mipLevel: 3,
+  origin: { x: 10, y: 0, z: 55 },
+  aspect: 'all',
+},
+new ArrayBuffer(40),
+/* required buffer size: 1816989 */{
+offset: 613,
+bytesPerRow: 35,
+rowsPerImage: 279,
+},
+{width: 10, height: 18, depthOrArrayLayers: 187}
+);
+} catch {}
+let commandEncoder16 = device0.createCommandEncoder(
+{
+label: '\udd49\u{1f924}\u478d\u0229\u4404\u5071\u{1f741}',
+}
+);
+let renderPassEncoder9 = commandEncoder13.beginRenderPass(
+{
+label: '\u4493\ue1e1\u422d\ua5b7\u0365\u7e79\ua99d',
+colorAttachments: [
+{
+view: textureView7,
+depthSlice: 24,
+clearValue: {
+r: -187.6,
+g: -595.8,
+b: -851.8,
+a: -361.3,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView7,
+depthSlice: 21,
+clearValue: {
+r: 789.1,
+g: 243.7,
+b: 599.1,
+a: -749.9,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView7,
+depthSlice: 3,
+clearValue: {
+r: -714.6,
+g: -528.9,
+b: 806.2,
+a: -386.9,
+},
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+maxDrawCount: 117184,
+}
+);
+try {
+renderPassEncoder6.setBindGroup(
+1,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder8.setViewport(
+7.742,
+0.3303,
+2.569,
+0.4613,
+0.6221,
+0.7436
+);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(
+buffer6,
+'uint32',
+15912,
+3515
+);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(
+5,
+buffer6,
+7800,
+6038
+);
+} catch {}
+let arrayBuffer0 = buffer4.getMappedRange(
+3456,
+2020
+);
+try {
+commandEncoder3.copyTextureToTexture(
+{
+  texture: texture4,
+  mipLevel: 4,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'stencil-only',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 915, y: 23, z: 0 },
+  aspect: 'stencil-only',
+},
+{width: 251, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline14 = await device0.createRenderPipelineAsync(
+{
+label: '\u{1fc37}\u96aa\u8115\ub80d\u6336\u{1f719}',
+layout: 'auto',
+vertex: {
+module: shaderModule6,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 26696,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x4',
+offset: 19508,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 24304,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 22632,
+shaderLocation: 5,
+},
+{
+format: 'uint32x2',
+offset: 4392,
+shaderLocation: 14,
+},
+{
+format: 'uint8x2',
+offset: 23592,
+shaderLocation: 1,
+},
+{
+format: 'sint32x2',
+offset: 4444,
+shaderLocation: 7,
+},
+{
+format: 'sint32x3',
+offset: 4400,
+shaderLocation: 12,
+},
+{
+format: 'float32x4',
+offset: 20856,
+shaderLocation: 15,
+},
+{
+format: 'sint8x4',
+offset: 13220,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x4',
+offset: 8400,
+shaderLocation: 11,
+},
+{
+format: 'sint32x3',
+offset: 18700,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 24000,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 864,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x2',
+offset: 656,
+shaderLocation: 10,
+},
+{
+format: 'unorm8x2',
+offset: 484,
+shaderLocation: 0,
+},
+{
+format: 'float32',
+offset: 128,
+shaderLocation: 6,
+},
+{
+format: 'sint32x2',
+offset: 256,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x2',
+offset: 232,
+shaderLocation: 9,
+},
+{
+format: 'sint32',
+offset: 108,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 4820,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 21200,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 33552,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 4204,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 1400,
+shaderLocation: 8,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x9e869bd0,
+},
+fragment: {
+module: shaderModule6,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rgb10a2uint',
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+},
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'zero',
+dstFactor: 'constant'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'zero',
+dstFactor: 'constant'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL,
+},
+{
+format: 'rg16float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthCompare: 'always',
+stencilFront: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 2608,
+stencilWriteMask: 3964,
+depthBias: 81,
+depthBiasSlopeScale: 78,
+depthBiasClamp: 6,
+},
+}
+);
+document.body.prepend('\u8e7f\u356e\u{1feda}');
+let shaderModule7 = device0.createShaderModule(
+{
+label: '\u0b02\u7334\u{1fcb9}\u{1fbea}',
+code: `@group(2) @binding(1014)
+var<storage, read_write> local0: array<u32>;
+
+@compute @workgroup_size(4, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(2) f0: f32,
+@location(6) f1: vec2<u32>,
+@location(1) f2: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool, @builtin(position) a3: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(6) a0: vec4<i32>, @location(8) a1: u32, @location(10) a2: vec4<f16>, @location(9) a3: vec4<i32>, @location(4) a4: u32, @location(13) a5: vec4<f16>, @location(0) a6: vec4<f32>, @location(14) a7: vec4<u32>, @location(16) a8: vec2<f16>, @location(11) a9: vec2<u32>, @location(2) a10: vec2<f32>, @location(15) a11: vec3<f32>, @location(5) a12: vec2<f32>, @builtin(vertex_index) a13: u32, @location(7) a14: f32, @location(1) a15: vec2<u32>, @location(12) a16: i32, @location(3) a17: vec3<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let buffer7 = device0.createBuffer(
+{
+label: '\u002f\u148e\u030c\u0105\u5460\u{1ffcc}\u{1fc1f}\u6733\ufa22',
+size: 47917,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let computePassEncoder10 = commandEncoder16.beginComputePass(
+{
+
+}
+);
+let renderBundleEncoder15 = device0.createRenderBundleEncoder(
+{
+label: '\u{1f726}\u{1fcdc}\u{1fc03}\u8d73\ubb09\uf542\u7870\ua830\u{1fdcf}\uc796\u5070',
+colorFormats: [
+'rgba8sint'
+],
+sampleCount: 938,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder2.setBindGroup(
+6,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant(
+{
+r: 752.5,
+g: -749.0,
+b: -673.1,
+a: -766.7,
+}
+);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(
+buffer6,
+'uint32'
+);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(
+5,
+buffer5,
+2652
+);
+} catch {}
+try {
+commandEncoder3.copyTextureToBuffer(
+{
+  texture: texture18,
+  mipLevel: 0,
+  origin: { x: 8, y: 48, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 64 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 36432 */
+offset: 36432,
+bytesPerRow: 256,
+buffer: buffer7,
+},
+{width: 32, height: 4, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder3.insertDebugMarker(
+'\u{1ff1a}'
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8uint',
+'rgba32float',
+'rgba16float',
+'rgba16float'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+let querySet13 = device0.createQuerySet(
+{
+label: '\u6031\u67f4',
+type: 'occlusion',
+count: 1915,
+}
+);
+let texture21 = device0.createTexture(
+{
+label: '\u{1fc22}\u04f2\u{1f839}',
+size: [2780, 6, 240],
+mipLevelCount: 10,
+sampleCount: 1,
+format: 'astc-10x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-10x6-unorm-srgb',
+'astc-10x6-unorm-srgb'
+],
+}
+);
+try {
+computePassEncoder10.setPipeline(
+pipeline9
+);
+} catch {}
+try {
+renderPassEncoder9.setViewport(
+3.064,
+0.5772,
+30.13,
+0.1635,
+0.7931,
+0.8000
+);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(
+buffer6,
+'uint16',
+19614
+);
+} catch {}
+try {
+commandEncoder3.copyBufferToBuffer(
+buffer0,
+1560,
+buffer3,
+3508,
+1752
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder3.copyTextureToTexture(
+{
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 1134, y: 0, z: 28 },
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 4302, y: 36, z: 32 },
+  aspect: 'all',
+},
+{width: 2340, height: 6, depthOrArrayLayers: 6}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture18,
+  mipLevel: 0,
+  origin: { x: 8, y: 8, z: 1 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer0),
+/* required buffer size: 798 */{
+offset: 798,
+bytesPerRow: 276,
+},
+{width: 24, height: 20, depthOrArrayLayers: 0}
+);
+} catch {}
+let shaderModule8 = device0.createShaderModule(
+{
+label: '\u6b85\ufb7c\u055b\u0e04\ua07f\u0b80\u{1f8f9}\u4415',
+code: `@group(0) @binding(1014)
+var<storage, read_write> global0: array<u32>;
+@group(2) @binding(1014)
+var<storage, read_write> field1: array<u32>;
+
+@compute @workgroup_size(2, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(1) f0: vec4<i32>,
+@location(5) f1: f32,
+@builtin(sample_mask) f2: u32,
+@location(0) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(7) f104: f32,
+@location(50) f105: vec2<i32>,
+@location(1) f106: vec4<f16>,
+@location(24) f107: vec3<f32>,
+@location(16) f108: vec3<f16>,
+@builtin(position) f109: vec4<f32>,
+@location(14) f110: f32,
+@location(41) f111: vec4<i32>,
+@location(0) f112: vec3<u32>,
+@location(45) f113: vec2<u32>,
+@location(54) f114: vec3<u32>,
+@location(10) f115: f16,
+@location(43) f116: vec2<u32>,
+@location(29) f117: vec4<f16>,
+@location(2) f118: vec4<u32>,
+@location(32) f119: vec3<i32>,
+@location(5) f120: f32,
+@location(37) f121: vec4<f32>,
+@location(6) f122: vec4<i32>,
+@location(3) f123: i32,
+@location(30) f124: f16,
+@location(22) f125: vec3<u32>,
+@location(20) f126: vec4<u32>,
+@location(31) f127: vec2<f32>,
+@location(9) f128: f16,
+@location(34) f129: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec2<i32>, @location(4) a1: i32, @location(6) a2: vec2<u32>, @location(16) a3: vec2<i32>, @builtin(vertex_index) a4: u32, @location(10) a5: vec3<f16>, @location(11) a6: vec4<i32>, @location(9) a7: vec3<f32>, @location(5) a8: vec4<f16>, @location(13) a9: f16) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let textureView20 = texture3.createView(
+{
+baseMipLevel: 1,
+baseArrayLayer: 13,
+arrayLayerCount: 30,
+}
+);
+let computePassEncoder11 = commandEncoder3.beginComputePass();
+let renderBundleEncoder16 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+undefined
+],
+sampleCount: 286,
+stencilReadOnly: false,
+}
+);
+try {
+renderPassEncoder0.setScissorRect(
+73,
+1,
+5,
+0
+);
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(
+2421
+);
+} catch {}
+try {
+renderPassEncoder9.setViewport(
+77.86,
+0.4437,
+6.915,
+0.3438,
+0.3110,
+0.5873
+);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(
+3,
+bindGroup1,
+new Uint32Array(5503),
+4911,
+0
+);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(
+2,
+buffer5,
+7564,
+12535
+);
+} catch {}
+try {
+await buffer7.mapAsync(
+GPUMapMode.READ,
+30616,
+8292
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap4,
+  origin: { x: 176, y: 24 },
+  flipY: false,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\u{1fced}\ub060\u{1f668}\u01f7\u9dc8\u0c86\u3b4d\ubd0f');
+try {
+computePassEncoder8.setBindGroup(
+0,
+bindGroup3
+);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+63.93,
+0.1196,
+9.136,
+0.5419,
+0.8439,
+0.8799
+);
+} catch {}
+let renderBundleEncoder17 = device0.createRenderBundleEncoder(
+{
+label: '\u{1fed0}\u{1f763}',
+colorFormats: [
+'rg8uint',
+'r32sint',
+'rgba32uint',
+'rgb10a2unorm',
+'rgba32uint'
+],
+sampleCount: 28,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder6.setBlendConstant(
+{
+r: 157.6,
+g: 167.1,
+b: -142.9,
+a: 417.3,
+}
+);
+} catch {}
+let promise6 = device0.createComputePipelineAsync(
+{
+label: '\u7f3b\u0c4a\u8df0\u1087\u07ad\u05bd\u0601\uf4e0',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let querySet14 = device0.createQuerySet(
+{
+label: '\u06ef\u930d\ub8b4\u0b41',
+type: 'occlusion',
+count: 1993,
+}
+);
+let sampler18 = device0.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 21.111,
+lodMaxClamp: 34.202,
+}
+);
+try {
+renderPassEncoder4.beginOcclusionQuery(
+16
+);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+25,
+0,
+3,
+0
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer3,
+1580,
+new Float32Array(32520),
+12995,
+588
+);
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video1,
+  origin: { x: 6, y: 2 },
+  flipY: false,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline15 = device0.createRenderPipeline(
+{
+label: '\u04ce\u99d9\u55e7\u2c38\u{1fe7d}\u{1f74d}\uebaa\u68ae\u5181\u1e27',
+layout: 'auto',
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 25428,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 7068,
+shaderLocation: 15,
+},
+{
+format: 'sint32x4',
+offset: 5064,
+shaderLocation: 13,
+},
+{
+format: 'uint32',
+offset: 13820,
+shaderLocation: 5,
+},
+{
+format: 'uint32',
+offset: 11736,
+shaderLocation: 14,
+},
+{
+format: 'snorm16x4',
+offset: 7648,
+shaderLocation: 8,
+},
+{
+format: 'uint32',
+offset: 44,
+shaderLocation: 6,
+},
+{
+format: 'snorm8x4',
+offset: 22992,
+shaderLocation: 4,
+},
+{
+format: 'float32x3',
+offset: 22008,
+shaderLocation: 9,
+},
+{
+format: 'float16x2',
+offset: 3296,
+shaderLocation: 11,
+},
+{
+format: 'snorm8x4',
+offset: 25040,
+shaderLocation: 7,
+},
+{
+format: 'sint32x3',
+offset: 11632,
+shaderLocation: 2,
+},
+{
+format: 'sint32x4',
+offset: 11004,
+shaderLocation: 0,
+},
+{
+format: 'snorm8x2',
+offset: 24470,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 5368,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 2566,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule3,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+failOp: 'invert',
+depthFailOp: 'invert',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'zero',
+depthFailOp: 'decrement-clamp',
+passOp: 'replace',
+},
+stencilReadMask: 3430,
+stencilWriteMask: 2855,
+depthBias: 38,
+depthBiasSlopeScale: 73,
+depthBiasClamp: 11,
+},
+}
+);
+document.body.append('\u0faf\u1809\u4074\ufc7a\u0c9f\u05dc\u{1f8bb}\u9a62\u05c3');
+try {
+renderPassEncoder9.setVertexBuffer(
+2,
+buffer6,
+15428
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture21,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 16 },
+  aspect: 'all',
+},
+new Int8Array(new ArrayBuffer(40)),
+/* required buffer size: 2734009 */{
+offset: 355,
+bytesPerRow: 61,
+rowsPerImage: 231,
+},
+{width: 20, height: 0, depthOrArrayLayers: 195}
+);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(767, 845);
+try {
+renderPassEncoder8.setBindGroup(
+8,
+bindGroup2,
+new Uint32Array(1300),
+951,
+0
+);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(
+9,
+buffer6
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x5-unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer0,
+]);
+} catch {}
+let bindGroup4 = device0.createBindGroup({
+label: '\u0ff8\u2502\u{1fe0f}',
+layout: bindGroupLayout1,
+entries: [
+
+],
+});
+let buffer8 = device0.createBuffer(
+{
+label: '\u2382\uc156',
+size: 56845,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let querySet15 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 581,
+}
+);
+let sampler19 = device0.createSampler(
+{
+label: '\ud560\u3b19\u{1ff1a}\ua7bd\uc77d\u{1f7e5}\u{1fb15}',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMaxClamp: 24.916,
+compare: 'less',
+}
+);
+try {
+renderPassEncoder2.setBindGroup(
+8,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(
+buffer6,
+'uint16',
+7600,
+6690
+);
+} catch {}
+let promise8 = buffer2.mapAsync(
+GPUMapMode.READ
+);
+try {
+device0.queue.writeBuffer(
+buffer5,
+2084,
+new Int16Array(31616),
+14888,
+1752
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Uint8Array(arrayBuffer0),
+/* required buffer size: 257 */{
+offset: 257,
+rowsPerImage: 108,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline16 = device0.createComputePipeline(
+{
+label: '\u031d\u85e4\u0cb0\ue195',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline17 = device0.createRenderPipeline(
+{
+label: '\u09f1\uda69\u0215\u0cc7\u4c8a\u4ed8\u07a8\ub5cf\u50f6\ud7ca\u0460',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule7,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 16436,
+attributes: [
+{
+format: 'sint8x4',
+offset: 224,
+shaderLocation: 6,
+},
+{
+format: 'uint32x2',
+offset: 7084,
+shaderLocation: 14,
+},
+{
+format: 'sint32x2',
+offset: 7280,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x4',
+offset: 7688,
+shaderLocation: 0,
+},
+{
+format: 'float16x2',
+offset: 4612,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x2',
+offset: 15196,
+shaderLocation: 15,
+},
+{
+format: 'float32x4',
+offset: 7800,
+shaderLocation: 7,
+},
+{
+format: 'unorm16x2',
+offset: 16384,
+shaderLocation: 5,
+},
+{
+format: 'float32',
+offset: 4760,
+shaderLocation: 16,
+},
+{
+format: 'unorm8x2',
+offset: 6482,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 28824,
+attributes: [
+{
+format: 'float32x2',
+offset: 23272,
+shaderLocation: 10,
+},
+{
+format: 'uint32x4',
+offset: 21444,
+shaderLocation: 1,
+},
+{
+format: 'uint32x4',
+offset: 9500,
+shaderLocation: 8,
+},
+{
+format: 'float16x4',
+offset: 13332,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 17224,
+attributes: [
+{
+format: 'uint8x4',
+offset: 2472,
+shaderLocation: 4,
+},
+{
+format: 'uint8x2',
+offset: 9566,
+shaderLocation: 11,
+},
+{
+format: 'sint32x2',
+offset: 1020,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+cullMode: 'front',
+},
+multisample: {
+count: 4,
+mask: 0xb11e11d5,
+},
+fragment: {
+module: shaderModule7,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'dst',
+dstFactor: 'zero'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'src-alpha-saturated',
+dstFactor: 'one-minus-dst'
+},
+},
+format: 'r16float',
+},
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilReadMask: 1361,
+stencilWriteMask: 3458,
+depthBias: 46,
+depthBiasSlopeScale: 24,
+depthBiasClamp: 29,
+},
+}
+);
+document.body.append('\u0974\u{1fa8e}\u17f1\u0a4d\ub148');
+let bindGroup5 = device0.createBindGroup({
+label: '\u8dbe\u7b5c\u{1f75a}\u{1fd0c}\u5562\u2680\u0399',
+layout: bindGroupLayout1,
+entries: [
+
+],
+});
+let pipelineLayout2 = device0.createPipelineLayout(
+{
+label: '\u{1fa4f}\u0044\u4e6c\u0712\u567f\u0544\u{1f88e}\u5f4c\ucd32',
+bindGroupLayouts: [
+bindGroupLayout3,
+bindGroupLayout1
+],
+}
+);
+let buffer9 = device0.createBuffer(
+{
+size: 5820,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+mappedAtCreation: false,
+}
+);
+let textureView21 = texture2.createView(
+{
+label: '\u0a53\u3369\u0739\u{1fb98}',
+dimension: '2d',
+baseArrayLayer: 0,
+}
+);
+let renderBundle17 = renderBundleEncoder10.finish(
+{
+label: '\u08b9\u{1f827}\ua98b'
+}
+);
+try {
+renderPassEncoder2.setViewport(
+65.17,
+0.05681,
+23.51,
+0.8232,
+0.5050,
+0.5880
+);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(
+6,
+bindGroup5,
+new Uint32Array(9970),
+9820,
+0
+);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(
+4,
+buffer5,
+2032,
+885
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer5,
+6492,
+new DataView(new ArrayBuffer(62896)),
+58135,
+304
+);
+} catch {}
+let pipeline18 = await device0.createRenderPipelineAsync(
+{
+label: '\ufe60\u{1f765}\u{1f89c}\u063c\u{1f8a7}',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 23728,
+attributes: [
+
+],
+},
+{
+arrayStride: 28144,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 12200,
+shaderLocation: 3,
+},
+{
+format: 'sint32x3',
+offset: 20600,
+shaderLocation: 9,
+},
+{
+format: 'float16x4',
+offset: 19752,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 23968,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 22944,
+shaderLocation: 10,
+},
+{
+format: 'unorm16x2',
+offset: 16648,
+shaderLocation: 12,
+},
+{
+format: 'uint16x2',
+offset: 4628,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'never',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 3744,
+depthBias: 69,
+depthBiasSlopeScale: 1,
+depthBiasClamp: 54,
+},
+}
+);
+document.body.append('\u2c79\uc9e9\u{1fd74}\u9986\u0764');
+try {
+renderPassEncoder4.setScissorRect(
+3,
+0,
+73,
+1
+);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(
+0,
+bindGroup1
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer9,
+2344,
+new BigUint64Array(45322),
+29131,
+228
+);
+} catch {}
+let pipeline19 = device0.createRenderPipeline(
+{
+label: '\u{1fe8e}\u3239\u{1f8a7}',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule4,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 28412,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x2',
+offset: 23924,
+shaderLocation: 15,
+},
+{
+format: 'snorm16x4',
+offset: 18388,
+shaderLocation: 11,
+},
+{
+format: 'float32',
+offset: 26316,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x785ce45d,
+},
+fragment: {
+module: shaderModule4,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32float',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+{
+format: 'r32sint',
+},
+undefined,
+{
+format: 'rg16float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'one-minus-dst-alpha',
+dstFactor: 'one-minus-dst-alpha'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.BLUE,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'less',
+depthFailOp: 'keep',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+},
+stencilReadMask: 696,
+stencilWriteMask: 457,
+depthBias: 46,
+depthBiasClamp: 83,
+},
+}
+);
+let gpuCanvasContext4 = offscreenCanvas4.getContext('webgpu');
+let texture22 = device0.createTexture(
+{
+label: '\ue1d7\uc68b\u6b16',
+size: {width: 8249},
+dimension: '1d',
+format: 'rg32uint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg32uint'
+],
+}
+);
+try {
+renderPassEncoder4.setBindGroup(
+5,
+bindGroup4,
+[]
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'astc-12x10-unorm-srgb',
+'bgra8unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture13,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Uint32Array(new ArrayBuffer(72)),
+/* required buffer size: 736 */{
+offset: 736,
+bytesPerRow: 167,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 1, y: 51 },
+  flipY: true,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+video1.height = 285;
+let renderBundleEncoder18 = device0.createRenderBundleEncoder(
+{
+label: '\u{1fed3}\u{1f626}',
+colorFormats: [
+'rgba16sint',
+'r16float',
+'rg8unorm',
+'rgba8sint',
+'rgba16float',
+'rgba32float',
+'rg8unorm'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 445,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder9.setBindGroup(
+0,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant(
+{
+r: -792.8,
+g: 984.8,
+b: -344.9,
+a: 963.7,
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 427 */{
+offset: 427,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 433, y: 8 },
+  flipY: false,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\uefaa\u{1f835}\u8974\u154e\udc98\u9616\u{1fd9c}');
+let textureView22 = texture12.createView(
+{
+}
+);
+let renderBundle18 = renderBundleEncoder9.finish(
+{
+label: '\u5213\u{1fbda}\u0737\u0ce0\u59f2\u{1fc5c}\u086e\u1cbd\u{1f870}\u0ecd\u{1f9c6}'
+}
+);
+try {
+renderPassEncoder0.setVertexBuffer(
+1,
+buffer8
+);
+} catch {}
+try {
+await promise8;
+} catch {}
+let bindGroup6 = device0.createBindGroup({
+label: '\u9f77\u0865\u9163\ube4e\u562a',
+layout: bindGroupLayout1,
+entries: [
+
+],
+});
+try {
+renderPassEncoder7.setBindGroup(
+0,
+bindGroup6,
+new Uint32Array(1610),
+404,
+0
+);
+} catch {}
+offscreenCanvas0.height = 648;
+try {
+adapter1.label = '\u0d17\u0ae9\u7bc8\ufa0c\u{1fcb6}';
+} catch {}
+try {
+textureView9.label = '\u{1f9f4}\u034f\u4dec\u19e3\u98e1\u3055\u020b\ud754';
+} catch {}
+let commandEncoder17 = device0.createCommandEncoder(
+{
+label: '\ub2c6\u73af\u263f',
+}
+);
+let renderBundleEncoder19 = device0.createRenderBundleEncoder(
+{
+label: '\u49ea\u046d\u8486\u4e80\u0c26\u0e53\u2b9f\u026c\u2b75\u{1f709}',
+colorFormats: [
+'bgra8unorm',
+'rg8uint',
+'rg8unorm',
+undefined,
+'rgb10a2unorm',
+'rg16uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 187,
+depthReadOnly: false,
+}
+);
+try {
+renderPassEncoder9.setBindGroup(
+0,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+63,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(
+buffer6,
+'uint16',
+17680,
+1210
+);
+} catch {}
+try {
+commandEncoder17.copyBufferToBuffer(
+buffer9,
+1292,
+buffer8,
+38460,
+1164
+);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer8);
+} catch {}
+document.body.append('\u9a26\ud97c\u8e0a\u285d\u0978');
+let bindGroupLayout5 = pipeline2.getBindGroupLayout(0);
+let textureView23 = texture15.createView(
+{
+label: '\u0c94\u70f0\u8340\u5f0e\u11c3\udcfd\u7f11',
+}
+);
+let renderPassEncoder10 = commandEncoder17.beginRenderPass(
+{
+label: '\u6377\u{1f6ef}\u797e\ud00a\u06b9\u8579\ue3f7\u5f9a\u94a5\uf786\ud1bd',
+colorAttachments: [
+undefined,
+{
+view: textureView7,
+depthSlice: 4,
+clearValue: {
+r: -69.02,
+g: -87.41,
+b: -855.7,
+a: -778.8,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView7,
+depthSlice: 6,
+clearValue: {
+r: -388.6,
+g: 409.3,
+b: 290.4,
+a: -339.3,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView7,
+depthSlice: 11,
+clearValue: {
+r: 508.4,
+g: -103.4,
+b: 754.9,
+a: -474.6,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView7,
+depthSlice: 20,
+clearValue: {
+r: 661.6,
+g: -709.9,
+b: -469.4,
+a: 207.4,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined
+],
+occlusionQuerySet: querySet1,
+maxDrawCount: 26264,
+}
+);
+let sampler20 = device0.createSampler(
+{
+label: '\udf40\u{1f839}\u8709\u492d\u6e7c\u0df4\u{1f630}',
+addressModeU: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 45.867,
+lodMaxClamp: 92.623,
+maxAnisotropy: 7,
+}
+);
+try {
+computePassEncoder9.setPipeline(
+pipeline3
+);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(
+64
+);
+} catch {}
+try {
+renderPassEncoder7.setViewport(
+56.94,
+0.7882,
+16.31,
+0.1975,
+0.9572,
+0.9990
+);
+} catch {}
+let promise9 = device0.createComputePipelineAsync(
+{
+label: '\u069f\u0bd0\u{1fb0c}\u0385\u00d6\u{1ffac}\u7fee\u2521',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.prepend('\u3b3d\u{1f7e8}\u0463\ueb39\u85b1\u{1fb08}');
+let buffer10 = device0.createBuffer(
+{
+size: 13219,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let renderBundle19 = renderBundleEncoder15.finish(
+{
+
+}
+);
+try {
+renderPassEncoder3.setBlendConstant(
+{
+r: -439.4,
+g: 914.4,
+b: 664.9,
+a: 628.5,
+}
+);
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(
+1135
+);
+} catch {}
+try {
+texture10.destroy();
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer9,
+296,
+new Float32Array(26657),
+12883,
+1272
+);
+} catch {}
+let video3 = await videoWithData();
+let bindGroup7 = device0.createBindGroup({
+layout: bindGroupLayout3,
+entries: [
+
+],
+});
+let textureView24 = texture9.createView(
+{
+label: '\u5990\u{1fe75}\uccd8\u747a\u{1f7aa}\uaa86\u0b7b\u0761\u0655',
+}
+);
+let renderBundleEncoder20 = device0.createRenderBundleEncoder(
+{
+label: '\uaef2\ue38a\u4131\ud678\u{1f7a8}\uffe0',
+colorFormats: [
+'rg32sint',
+'rgba8unorm-srgb'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 976,
+depthReadOnly: true,
+}
+);
+let renderBundle20 = renderBundleEncoder2.finish(
+{
+label: '\u03f2\u349b\u0f56\u08f4\u08b3\u0048\ufadd\u0840'
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+7,
+bindGroup1,
+[]
+);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant(
+{
+r: -146.4,
+g: -0.3806,
+b: -140.4,
+a: -926.6,
+}
+);
+} catch {}
+try {
+renderPassEncoder9.setViewport(
+13.26,
+0.7593,
+29.43,
+0.01407,
+0.8359,
+0.9331
+);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(
+buffer9,
+'uint32',
+988
+);
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+document.body.prepend('\u{1f9f2}\ud899\ua31b\u7423\u007a\u{1fe67}\u000e\u09d0');
+try {
+renderPassEncoder10.setBindGroup(
+0,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(
+1,
+bindGroup4,
+new Uint32Array(1266),
+1226,
+0
+);
+} catch {}
+try {
+renderPassEncoder5.setViewport(
+82.71,
+0.2339,
+1.230,
+0.4038,
+0.9335,
+0.9916
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 196, y: 58 },
+  flipY: true,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline20 = await device0.createComputePipelineAsync(
+{
+layout: pipelineLayout0,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline21 = device0.createRenderPipeline(
+{
+label: '\u1b77\u390b\u63e9\u4b7c\u{1ff96}\u301b',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule4,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 9008,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 600,
+shaderLocation: 16,
+},
+{
+format: 'snorm16x4',
+offset: 7756,
+shaderLocation: 11,
+},
+{
+format: 'sint8x2',
+offset: 1690,
+shaderLocation: 15,
+}
+],
+}
+]
+},
+primitive: {
+cullMode: 'front',
+},
+fragment: {
+module: shaderModule4,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'rg8unorm',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'zero',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilWriteMask: 2311,
+depthBias: 23,
+depthBiasSlopeScale: 98,
+depthBiasClamp: 64,
+},
+}
+);
+try {
+await promise10;
+} catch {}
+canvas1.width = 747;
+let img6 = await imageWithData(173, 237, '#ccd21e49', '#93bf8e6f');
+let commandEncoder18 = device0.createCommandEncoder(
+{
+label: '\u0af6\u{1faab}\u6dda\u{1fd97}\u57a9\ubb75\u{1fd1a}\u0b06',
+}
+);
+let renderPassEncoder11 = commandEncoder18.beginRenderPass(
+{
+label: '\u2faa\u3391\u45a1\u9758',
+colorAttachments: [
+{
+view: textureView7,
+depthSlice: 24,
+clearValue: {
+r: -113.6,
+g: 879.6,
+b: 150.5,
+a: -728.1,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView7,
+depthSlice: 2,
+clearValue: {
+r: 685.0,
+g: 528.4,
+b: -190.8,
+a: -921.0,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined,
+{
+view: textureView7,
+depthSlice: 19,
+clearValue: {
+r: -857.0,
+g: 851.0,
+b: -812.2,
+a: 243.8,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView7,
+depthSlice: 18,
+clearValue: {
+r: 423.7,
+g: -54.27,
+b: 593.6,
+a: 105.0,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView7,
+depthSlice: 21,
+clearValue: {
+r: 678.3,
+g: -18.04,
+b: 685.8,
+a: -966.7,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+undefined,
+undefined
+],
+occlusionQuerySet: querySet15,
+}
+);
+try {
+renderPassEncoder8.setScissorRect(
+88,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(
+0,
+bindGroup5
+);
+} catch {}
+let pipeline22 = device0.createRenderPipeline(
+{
+label: '\u521d\ua7c8',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8sint',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+},
+stencilReadMask: 3208,
+stencilWriteMask: 1539,
+depthBias: 14,
+depthBiasSlopeScale: 96,
+depthBiasClamp: 44,
+},
+}
+);
+canvas1.height = 852;
+let bindGroupLayout6 = device0.createBindGroupLayout(
+{
+label: '\u0dc9\ud169\u0514\u{1fcaf}\ua0a6\u{1f95f}\u11c8',
+entries: [
+{
+binding: 1046,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'read-only-storage', minBindingSize: 528620, hasDynamicOffset: true },
+},
+{
+binding: 1935,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}
+],
+}
+);
+let sampler21 = device0.createSampler(
+{
+label: '\uf4b9\u43ab\u0e5b\u{1fc53}\u27ed\uefd5\ud4ba\ue45f',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 27.932,
+lodMaxClamp: 79.008,
+maxAnisotropy: 4,
+}
+);
+try {
+computePassEncoder11.setBindGroup(
+8,
+bindGroup2,
+new Uint32Array(5217),
+3255,
+0
+);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(
+64
+);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(
+buffer9,
+'uint16',
+2028
+);
+} catch {}
+let pipeline23 = await device0.createComputePipelineAsync(
+{
+label: '\u0030\u29aa\u4073\u{1f78d}\ud353\u9ea2\u73fd\u61b2',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let renderBundle21 = renderBundleEncoder12.finish();
+let sampler22 = device0.createSampler(
+{
+label: '\u0b6f\ub4d3\u3608\u{1fffb}\u{1fd5a}\u0e43\u4cb5\u{1fcdc}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 98.008,
+lodMaxClamp: 98.761,
+maxAnisotropy: 15,
+}
+);
+try {
+computePassEncoder8.setPipeline(
+pipeline12
+);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant(
+{
+r: 437.2,
+g: -634.4,
+b: 1.417,
+a: -948.3,
+}
+);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(
+2,
+buffer8,
+16940,
+24017
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture13,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 753 */{
+offset: 753,
+bytesPerRow: 34,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let texture23 = device0.createTexture(
+{
+label: '\ub473\u020f\u7a05\udf15',
+size: [42, 234, 1],
+mipLevelCount: 6,
+format: 'r8snorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8snorm',
+'r8snorm',
+'r8snorm'
+],
+}
+);
+let renderBundleEncoder21 = device0.createRenderBundleEncoder(
+{
+label: '\u2d55\u1150\ue5c1\u66e1\u049c\uc237\u{1f812}',
+colorFormats: [
+'rgb10a2unorm',
+'r32uint'
+],
+sampleCount: 385,
+}
+);
+try {
+renderPassEncoder3.setBlendConstant(
+{
+r: -589.3,
+g: -603.8,
+b: 398.1,
+a: 969.0,
+}
+);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(
+1,
+buffer8,
+34928,
+3665
+);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(
+3,
+bindGroup2
+);
+} catch {}
+document.body.prepend(img3);
+document.body.append('\u0832\ud38c\ud280\u02e1\u0551\u0d48\u{1fc60}\u5ba8\u{1fbaf}\u058f');
+let querySet16 = device0.createQuerySet(
+{
+label: '\u0564\uc1fa\u0335\u{1f657}\u529a\u{1fc39}\u006b\u{1ffdd}\u9f28',
+type: 'occlusion',
+count: 3059,
+}
+);
+let renderBundle22 = renderBundleEncoder13.finish(
+{
+label: '\u679f\u6dc1'
+}
+);
+try {
+computePassEncoder8.setBindGroup(
+5,
+bindGroup2
+);
+} catch {}
+try {
+computePassEncoder11.setPipeline(
+pipeline3
+);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+1.740,
+0.6954,
+15.18,
+0.1828,
+0.2291,
+0.6438
+);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(
+buffer9,
+'uint32',
+4044,
+1749
+);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(
+2,
+buffer6
+);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(
+3,
+buffer5
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 59, y: 66 },
+  flipY: false,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\u0e83\u{1f87b}\u{1fd06}');
+let bindGroupLayout7 = device0.createBindGroupLayout(
+{
+label: '\u{1ff70}\u6967\ud17c\u{1fc9f}',
+entries: [
+{
+binding: 525,
+visibility: GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 707685, hasDynamicOffset: true },
+},
+{
+binding: 1484,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+try {
+computePassEncoder8.setBindGroup(
+6,
+bindGroup2,
+[]
+);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(
+buffer6,
+'uint16',
+2914,
+3092
+);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(
+3,
+buffer8,
+52752
+);
+} catch {}
+try {
+buffer1.destroy();
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer8,
+54072,
+new DataView(new ArrayBuffer(17684)),
+6661,
+1376
+);
+} catch {}
+let pipeline24 = device0.createRenderPipeline(
+{
+label: '\u7efe\ue693\ucb18\u{1f60d}\u{1fdec}\u8a94',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule7,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 23044,
+attributes: [
+{
+format: 'uint32x2',
+offset: 16596,
+shaderLocation: 8,
+},
+{
+format: 'float16x4',
+offset: 22920,
+shaderLocation: 5,
+},
+{
+format: 'uint32x4',
+offset: 16568,
+shaderLocation: 4,
+},
+{
+format: 'sint32x2',
+offset: 16080,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x4',
+offset: 12512,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 13668,
+attributes: [
+{
+format: 'sint32x2',
+offset: 4176,
+shaderLocation: 6,
+},
+{
+format: 'float32x4',
+offset: 11900,
+shaderLocation: 10,
+},
+{
+format: 'uint16x4',
+offset: 2044,
+shaderLocation: 14,
+},
+{
+format: 'snorm8x2',
+offset: 6930,
+shaderLocation: 3,
+},
+{
+format: 'float32',
+offset: 4584,
+shaderLocation: 0,
+},
+{
+format: 'uint16x2',
+offset: 11488,
+shaderLocation: 1,
+},
+{
+format: 'uint16x2',
+offset: 7936,
+shaderLocation: 11,
+},
+{
+format: 'unorm16x2',
+offset: 9728,
+shaderLocation: 16,
+},
+{
+format: 'snorm16x4',
+offset: 12068,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 12336,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x4',
+offset: 11180,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 17868,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 33904,
+attributes: [
+{
+format: 'unorm8x2',
+offset: 30352,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 6832,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 33644,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 24756,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule7,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'r8unorm',
+writeMask: 0,
+},
+undefined,
+undefined,
+undefined,
+{
+format: 'rg32uint',
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'less',
+failOp: 'replace',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 1758,
+depthBias: 43,
+depthBiasSlopeScale: 48,
+depthBiasClamp: 70,
+},
+}
+);
+try {
+await promise7;
+} catch {}
+document.body.prepend('\u0923\u0453\uc770\ueea8\ubd92\ubc24\u09a4\u37ea\u{1fd76}');
+let pipelineLayout3 = device0.createPipelineLayout(
+{
+label: '\u0abb\u0ce4\u64dc\u097f',
+bindGroupLayouts: [
+bindGroupLayout6,
+bindGroupLayout1,
+bindGroupLayout6,
+bindGroupLayout4,
+bindGroupLayout4,
+bindGroupLayout0,
+bindGroupLayout2
+],
+}
+);
+let querySet17 = device0.createQuerySet(
+{
+label: '\u036f\ud0ed\ub5ba\u09d5\u06b7\u{1f600}\u{1f71a}',
+type: 'occlusion',
+count: 3875,
+}
+);
+let renderBundleEncoder22 = device0.createRenderBundleEncoder(
+{
+label: '\u057e\u384f\u{1fac1}\uc61a\ub29a\u{1fa0f}\u0269\u562d\u5b8e',
+colorFormats: [
+'rgb10a2uint',
+'r32float',
+'rg16float',
+'rgb10a2unorm',
+'r8sint',
+'bgra8unorm-srgb',
+'rg32sint',
+'rgba8uint'
+],
+sampleCount: 682,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder9.setScissorRect(
+34,
+1,
+4,
+0
+);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer1,
+]);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture18,
+  mipLevel: 0,
+  origin: { x: 24, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 213 */{
+offset: 213,
+bytesPerRow: 298,
+},
+{width: 16, height: 12, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 181, y: 53 },
+  flipY: true,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+video0.height = 82;
+let img7 = await imageWithData(153, 147, '#80076fd6', '#b21b72c8');
+let imageData5 = new ImageData(164, 248);
+try {
+computePassEncoder11.setPipeline(
+pipeline5
+);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant(
+{
+r: -18.74,
+g: 450.2,
+b: 483.1,
+a: -173.7,
+}
+);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(
+3,
+0,
+21,
+1
+);
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'bgra8unorm',
+'bgra8unorm'
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+try {
+await promise11;
+} catch {}
+let videoFrame2 = new VideoFrame(video1, {timestamp: 0});
+let texture24 = device0.createTexture(
+{
+label: '\u0502\u{1f609}\uaffb\u559d\udb18\u722a\ua744\uf0fd\u34e5\uec7d\u0bfc',
+size: [6, 17, 158],
+format: 'rgba32sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba32sint'
+],
+}
+);
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant(
+{
+r: 607.9,
+g: -205.8,
+b: 927.0,
+a: 946.5,
+}
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+1,
+buffer8
+);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(
+5,
+bindGroup6
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video2,
+  origin: { x: 1, y: 14 },
+  flipY: false,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let bindGroupLayout8 = device0.createBindGroupLayout(
+{
+entries: [
+{
+binding: 1534,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+},
+{
+binding: 2722,
+visibility: 0,
+sampler: { type: 'filtering' },
+},
+{
+binding: 1658,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+let renderBundleEncoder23 = device0.createRenderBundleEncoder(
+{
+label: '\u078e\u3e74\u0ad6\uf546',
+colorFormats: [
+'r32sint',
+'r32float',
+'rg16uint',
+'rgba16uint',
+'rgba16float',
+'rgba16sint',
+'rg32sint',
+'rg16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 751,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(
+21,
+0,
+64,
+0
+);
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+46.90,
+0.1883,
+16.52,
+0.6720,
+0.02990,
+0.03568
+);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(
+7,
+bindGroup3
+);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(
+7,
+buffer6,
+17052,
+2784
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer9,
+3184,
+new BigUint64Array(63146),
+16699,
+88
+);
+} catch {}
+document.body.prepend('\u08e9\u0d32\u0f7c\uc420\u{1fe0a}\u{1f883}\u{1f71d}\u5157');
+let offscreenCanvas5 = new OffscreenCanvas(903, 269);
+let videoFrame3 = new VideoFrame(videoFrame2, {timestamp: 0});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'r16float',
+'rg8uint',
+'r16uint',
+'r16float',
+undefined,
+'rgba8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 138,
+depthReadOnly: true,
+stencilReadOnly: false,
+}
+);
+try {
+renderPassEncoder9.setBindGroup(
+4,
+bindGroup5
+);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(
+6,
+bindGroup5,
+new Uint32Array(1105),
+121,
+0
+);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(
+8,
+undefined
+);
+} catch {}
+let pipeline25 = device0.createComputePipeline(
+{
+layout: pipelineLayout2,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let renderBundle23 = renderBundleEncoder8.finish(
+{
+
+}
+);
+try {
+renderPassEncoder0.setBindGroup(
+0,
+bindGroup6,
+new Uint32Array(1461),
+146,
+0
+);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(
+56,
+0,
+17,
+0
+);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(
+2,
+bindGroup2,
+new Uint32Array(1838),
+1373,
+0
+);
+} catch {}
+try {
+renderPassEncoder9.pushDebugGroup(
+'\uff73'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer8,
+52648,
+new BigUint64Array(62950),
+23867,
+324
+);
+} catch {}
+let img8 = await imageWithData(263, 194, '#1956791e', '#d32c54ab');
+let bindGroupLayout9 = device0.createBindGroupLayout(
+{
+entries: [
+
+],
+}
+);
+let bindGroup8 = device0.createBindGroup({
+label: '\u083f\u0bb9\ubf33\ufad7\u1432\u{1f917}\u47aa\u0e76\u0748',
+layout: bindGroupLayout9,
+entries: [
+
+],
+});
+let commandEncoder19 = device0.createCommandEncoder(
+{
+label: '\u0551\u{1fbd2}\u726d\uda5b\u{1f9b5}\u0040\u66c9\u4d8a\u{1f906}',
+}
+);
+let querySet18 = device0.createQuerySet(
+{
+label: '\u{1f8aa}\uf6eb',
+type: 'occlusion',
+count: 3257,
+}
+);
+try {
+computePassEncoder8.setBindGroup(
+6,
+bindGroup8,
+new Uint32Array(9755),
+8425,
+0
+);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant(
+{
+r: -943.5,
+g: -472.0,
+b: -412.8,
+a: -821.7,
+}
+);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(
+0,
+bindGroup7
+);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(
+0,
+bindGroup0,
+new Uint32Array(1782),
+1353,
+0
+);
+} catch {}
+try {
+renderPassEncoder9.popDebugGroup();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.prepend('\u{1fefa}\u0be8\u6669\u{1fc9e}');
+let buffer11 = device0.createBuffer(
+{
+label: '\u0163\uab1e\u{1fbd1}\u{1fa1c}\u3fb5\u607b',
+size: 56655,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let renderPassEncoder12 = commandEncoder19.beginRenderPass(
+{
+label: '\u2ed7\u25ad\u04db\uf1e1\u1adf\u0ce7\ucbd1\u{1fed8}\udf74\u0a53',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+{
+view: textureView7,
+depthSlice: 2,
+clearValue: {
+r: 383.4,
+g: 836.9,
+b: -422.4,
+a: -440.0,
+},
+loadOp: 'load',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet12,
+maxDrawCount: 32560,
+}
+);
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant(
+{
+r: 204.4,
+g: -827.4,
+b: 521.5,
+a: 256.5,
+}
+);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(
+13,
+0,
+44,
+1
+);
+} catch {}
+try {
+commandEncoder12.copyTextureToTexture(
+{
+  texture: texture11,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 6 },
+  aspect: 'all',
+},
+{width: 18, height: 1, depthOrArrayLayers: 4}
+);
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float',
+'rgba16float'
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 20, y: 0, z: 221 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 242797 */{
+offset: 472,
+bytesPerRow: 527,
+rowsPerImage: 51,
+},
+{width: 108, height: 1, depthOrArrayLayers: 10}
+);
+} catch {}
+let gpuCanvasContext5 = offscreenCanvas5.getContext('webgpu');
+let offscreenCanvas6 = new OffscreenCanvas(919, 502);
+let textureView25 = texture23.createView(
+{
+dimension: '2d-array',
+baseMipLevel: 3,
+mipLevelCount: 2,
+}
+);
+let computePassEncoder12 = commandEncoder12.beginComputePass(
+{
+label: '\u{1fbb3}\u0131\u9473\ub2cb\u31c9\u84b7\u34c8\ua0ea'
+}
+);
+let renderBundleEncoder25 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'r32float',
+'rgba16float',
+'r16float',
+'rgba8unorm',
+'r16sint',
+undefined,
+'rg16float',
+'rgba32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 775,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+4,
+bindGroup7,
+new Uint32Array(4267),
+3660,
+0
+);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(
+39,
+1,
+30,
+0
+);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(
+15,
+undefined,
+275039853,
+1953371739
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer8,
+4104,
+new Int16Array(63791),
+41424,
+2180
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture9,
+  mipLevel: 0,
+  origin: { x: 53, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint32Array(new ArrayBuffer(56)),
+/* required buffer size: 400 */{
+offset: 400,
+},
+{width: 4171, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline26 = device0.createComputePipeline(
+{
+label: '\u0060\u{1f9a3}',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+gc();
+let renderBundle24 = renderBundleEncoder20.finish(
+{
+label: '\u005a\uacd0\u00eb\u014e\ub45d\u938a'
+}
+);
+try {
+computePassEncoder12.setBindGroup(
+5,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(
+6,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant(
+{
+r: -947.6,
+g: 790.5,
+b: -705.7,
+a: -775.1,
+}
+);
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(
+43,
+1,
+24,
+0
+);
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(
+1365
+);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(
+9,
+buffer8,
+40212
+);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(
+5,
+bindGroup4
+);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(
+1,
+buffer6,
+8952,
+8493
+);
+} catch {}
+let pipeline27 = device0.createComputePipeline(
+{
+label: '\u7315\u6062\ua9df\u1dce',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageBitmap5 = await createImageBitmap(video2);
+let shaderModule9 = device0.createShaderModule(
+{
+label: '\u22d7\u1754\u0fa7\ua592\u0d15\u4ed7\uda4a\ubb1b\u2a02\u{1fc00}',
+code: `@group(2) @binding(1046)
+var<storage, read_write> i1: array<u32>;
+
+@compute @workgroup_size(5, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(5) f0: vec4<f32>,
+@builtin(sample_mask) f1: u32,
+@location(0) f2: vec4<i32>,
+@location(1) f3: i32,
+@location(6) f4: f32,
+@location(7) f5: i32,
+@location(3) f6: f32,
+@builtin(frag_depth) f7: f32,
+@location(4) f8: vec2<i32>,
+@location(2) f9: vec2<f32>
+}
+
+@fragment
+fn fragment0(@location(17) a0: vec4<i32>, @location(30) a1: vec2<i32>, @location(32) a2: vec2<f16>, @location(18) a3: vec3<f32>, @location(3) a4: vec2<f32>, @builtin(sample_mask) a5: u32, @location(6) a6: f16, @location(12) a7: vec2<i32>, @location(37) a8: f32, @location(19) a9: vec3<f32>, @location(25) a10: vec4<f32>, @location(51) a11: vec3<u32>, @location(24) a12: vec2<f16>, @location(36) a13: vec2<f16>, @location(16) a14: vec4<i32>, @location(31) a15: vec4<f16>, @location(10) a16: u32, @location(7) a17: vec4<u32>, @location(14) a18: f32, @location(15) a19: vec2<f16>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(54) f130: vec4<f16>,
+@location(17) f131: vec4<i32>,
+@location(31) f132: vec4<f16>,
+@builtin(position) f133: vec4<f32>,
+@location(23) f134: vec3<i32>,
+@location(25) f135: vec4<f32>,
+@location(12) f136: vec2<i32>,
+@location(24) f137: vec2<f16>,
+@location(14) f138: f32,
+@location(16) f139: vec4<i32>,
+@location(19) f140: vec3<f32>,
+@location(10) f141: u32,
+@location(32) f142: vec2<f16>,
+@location(3) f143: vec2<f32>,
+@location(36) f144: vec2<f16>,
+@location(18) f145: vec3<f32>,
+@location(39) f146: vec4<i32>,
+@location(6) f147: f16,
+@location(51) f148: vec3<u32>,
+@location(37) f149: f32,
+@location(30) f150: vec2<i32>,
+@location(9) f151: vec3<i32>,
+@location(55) f152: vec4<i32>,
+@location(15) f153: vec2<f16>,
+@location(7) f154: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec4<f32>, @location(3) a1: vec4<f16>, @location(0) a2: f16, @location(16) a3: u32, @location(13) a4: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder20 = device0.createCommandEncoder(
+{
+label: '\u26fc\u{1fa71}\ueac9\uf47a\u{1fda6}\u6397\u15dd\ufeb3\u0fff',
+}
+);
+let textureView26 = texture18.createView(
+{
+label: '\u0a9b\u126a\u502a\uf722',
+dimension: '2d-array',
+}
+);
+try {
+computePassEncoder12.setBindGroup(
+0,
+bindGroup8,
+new Uint32Array(1290),
+386,
+0
+);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.setViewport(
+60.04,
+0.8666,
+27.37,
+0.08906,
+0.6044,
+0.8641
+);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(
+3,
+buffer6,
+3360
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 2910, y: 18, z: 19 },
+  aspect: 'all',
+},
+new DataView(arrayBuffer0),
+/* required buffer size: 220725 */{
+offset: 707,
+bytesPerRow: 1966,
+rowsPerImage: 100,
+},
+{width: 672, height: 72, depthOrArrayLayers: 2}
+);
+} catch {}
+let pipeline28 = device0.createRenderPipeline(
+{
+label: '\u53c5\u03ab\u{1f651}\ue5fc\u575c\ud322\u0657',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 836,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32',
+offset: 296,
+shaderLocation: 12,
+},
+{
+format: 'sint32x3',
+offset: 396,
+shaderLocation: 9,
+},
+{
+format: 'float16x2',
+offset: 480,
+shaderLocation: 10,
+},
+{
+format: 'uint32x3',
+offset: 644,
+shaderLocation: 2,
+},
+{
+format: 'snorm8x4',
+offset: 264,
+shaderLocation: 3,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 556,
+shaderLocation: 14,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0xc84d324a,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilWriteMask: 3132,
+depthBias: 30,
+depthBiasSlopeScale: 6,
+},
+}
+);
+video3.height = 22;
+document.body.append('\u{1f7f3}\u716b\ud983\u361a');
+let textureView27 = texture21.createView(
+{
+label: '\ufa9f\u8374',
+dimension: '2d',
+format: 'astc-10x6-unorm-srgb',
+baseMipLevel: 8,
+mipLevelCount: 1,
+baseArrayLayer: 112,
+}
+);
+let renderPassEncoder13 = commandEncoder20.beginRenderPass(
+{
+label: '\u60d5\ube04\u52d7\u{1fcd8}\u9f2f',
+colorAttachments: [
+undefined,
+{
+view: textureView7,
+depthSlice: 18,
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined,
+undefined,
+undefined,
+{
+view: textureView7,
+depthSlice: 3,
+clearValue: {
+r: -965.2,
+g: -543.2,
+b: 458.5,
+a: 952.6,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView7,
+depthSlice: 22,
+clearValue: {
+r: -799.7,
+g: -995.4,
+b: -293.7,
+a: -763.2,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView7,
+depthSlice: 1,
+clearValue: {
+r: -71.01,
+g: 533.9,
+b: 403.5,
+a: -652.1,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView7,
+depthSlice: 21,
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined
+],
+occlusionQuerySet: querySet14,
+maxDrawCount: 165384,
+}
+);
+let renderBundleEncoder26 = device0.createRenderBundleEncoder(
+{
+label: '\u9e19\u{1fbac}\u{1f978}\u065d\u{1f8d2}',
+colorFormats: [
+'rgb10a2unorm',
+'rgba16sint',
+'r8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 411,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant(
+{
+r: 516.7,
+g: -746.0,
+b: -768.2,
+a: 421.6,
+}
+);
+} catch {}
+let pipeline29 = await device0.createComputePipelineAsync(
+{
+label: '\u6036\ubc48\u{1fef2}\u96b0\u1b4b\u18be\u{1fa62}\uc559\u{1fbfc}\u03f3',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline30 = await device0.createRenderPipelineAsync(
+{
+label: '\u54db\u1cda',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule8,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 23488,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 29324,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x3',
+offset: 3308,
+shaderLocation: 7,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 12344,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x4',
+offset: 22468,
+shaderLocation: 13,
+},
+{
+format: 'uint8x2',
+offset: 19092,
+shaderLocation: 6,
+},
+{
+format: 'sint16x4',
+offset: 6548,
+shaderLocation: 16,
+},
+{
+format: 'sint16x2',
+offset: 21988,
+shaderLocation: 4,
+},
+{
+format: 'sint8x2',
+offset: 21072,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x2',
+offset: 15588,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule8,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilReadMask: 1690,
+stencilWriteMask: 339,
+depthBiasSlopeScale: 65,
+},
+}
+);
+let textureView28 = texture10.createView(
+{
+label: '\u06f8\u0e11\u{1f84f}\u99e8\u0586\u0adc\ufc53\u5ccd\u0abd',
+baseMipLevel: 4,
+mipLevelCount: 1,
+baseArrayLayer: 0,
+}
+);
+let renderBundleEncoder27 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg16sint',
+'rgba8unorm-srgb',
+'rgba8uint',
+'r8unorm',
+undefined,
+undefined,
+'rg8sint',
+'rg16sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 80,
+stencilReadOnly: false,
+}
+);
+let renderBundle25 = renderBundleEncoder9.finish(
+{
+label: '\u03f9\ud0eb\u7077\u0ca4\u7fbf\u5ad1\u010e\u{1f8b5}\u3dec'
+}
+);
+try {
+computePassEncoder9.setPipeline(
+pipeline10
+);
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant(
+{
+r: -770.6,
+g: 53.27,
+b: 841.0,
+a: -236.4,
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer5,
+17596,
+new Float32Array(57647),
+49362,
+176
+);
+} catch {}
+let pipeline31 = await device0.createComputePipelineAsync(
+{
+label: '\u060c\u77ac\u0cd3',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+gc();
+document.body.append('\u4c80\uf26b\ufc7c\u{1febf}\u{1f835}\u4a9c\uf061');
+let bindGroupLayout10 = device0.createBindGroupLayout(
+{
+entries: [
+{
+binding: 2525,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+},
+{
+binding: 492,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+}
+],
+}
+);
+let texture25 = device0.createTexture(
+{
+size: [1168, 16, 1],
+mipLevelCount: 5,
+format: 'rgba8uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundleEncoder28 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg8sint',
+'r32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 155,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder3.setScissorRect(
+18,
+0,
+6,
+0
+);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(
+5,
+bindGroup3
+);
+} catch {}
+try {
+texture15.destroy();
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer3,
+11512,
+new Float32Array(55891),
+15994,
+192
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 0, y: 65 },
+  flipY: false,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline32 = device0.createComputePipeline(
+{
+layout: pipelineLayout1,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+video1.height = 110;
+let commandEncoder21 = device0.createCommandEncoder(
+{
+label: '\u{1f643}\u7721\u0fec\ub5d2\u309d\ubc69',
+}
+);
+let texture26 = device0.createTexture(
+{
+label: '\ucc7c\u{1f9f3}\u01f6\u094c\u{1fe49}\u0a5d\u213f\u180f\u{1ff28}\ud451\u5f0e',
+size: {width: 247, height: 33, depthOrArrayLayers: 198},
+mipLevelCount: 8,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float',
+'rgba16float'
+],
+}
+);
+let computePassEncoder13 = commandEncoder21.beginComputePass(
+{
+label: '\u0d61\uabf1\u34aa\u{1f8c2}\u0bf7\ub5d1'
+}
+);
+try {
+computePassEncoder13.setPipeline(
+pipeline25
+);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(
+56
+);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: 849.0,
+g: -860.8,
+b: -73.21,
+a: 415.0,
+}
+);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(
+2302
+);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(
+3,
+buffer5,
+21968,
+1099
+);
+} catch {}
+try {
+texture10.destroy();
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer9,
+1728,
+new BigUint64Array(7530),
+3267,
+68
+);
+} catch {}
+let img9 = await imageWithData(224, 284, '#22c4bd45', '#6b02a0d3');
+let querySet19 = device0.createQuerySet(
+{
+label: '\u0997\ueab8\u0217\u7e7e\u0922\u{1fe9d}\u5c01\uf11c\u09ee\udf57',
+type: 'occlusion',
+count: 2711,
+}
+);
+try {
+renderPassEncoder9.setBindGroup(
+8,
+bindGroup1,
+new Uint32Array(9144),
+1402,
+0
+);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(
+0
+);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(
+24,
+1,
+7,
+0
+);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(
+3013
+);
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+40.76,
+0.6385,
+28.25,
+0.2671,
+0.6772,
+0.8973
+);
+} catch {}
+try {
+await buffer11.mapAsync(
+GPUMapMode.WRITE,
+0,
+33540
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer8,
+49968,
+new Int16Array(52430),
+47006,
+1260
+);
+} catch {}
+document.body.prepend(video3);
+try {
+offscreenCanvas6.getContext('bitmaprenderer');
+} catch {}
+let sampler23 = device0.createSampler(
+{
+label: '\u5e3a\ua221\ue6e5\u0571\u0876',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 10.911,
+lodMaxClamp: 96.080,
+}
+);
+try {
+renderPassEncoder7.setBindGroup(
+1,
+bindGroup2,
+new Uint32Array(1317),
+1177,
+0
+);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(
+264
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 108, y: 53 },
+  flipY: true,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline33 = await device0.createRenderPipelineAsync(
+{
+label: '\u{1fef2}\u0f02\ufe9b\u0205\u395f\u50da\u{1fb80}\u065f',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 12324,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 3500,
+shaderLocation: 12,
+},
+{
+format: 'uint32',
+offset: 380,
+shaderLocation: 0,
+},
+{
+format: 'float16x4',
+offset: 1112,
+shaderLocation: 8,
+},
+{
+format: 'unorm8x4',
+offset: 9284,
+shaderLocation: 5,
+},
+{
+format: 'sint16x4',
+offset: 4236,
+shaderLocation: 6,
+},
+{
+format: 'uint16x2',
+offset: 8464,
+shaderLocation: 14,
+},
+{
+format: 'snorm8x2',
+offset: 3192,
+shaderLocation: 9,
+},
+{
+format: 'uint32x2',
+offset: 7668,
+shaderLocation: 10,
+},
+{
+format: 'unorm8x4',
+offset: 4372,
+shaderLocation: 3,
+},
+{
+format: 'snorm8x4',
+offset: 9468,
+shaderLocation: 16,
+},
+{
+format: 'sint32x3',
+offset: 7232,
+shaderLocation: 13,
+},
+{
+format: 'snorm8x2',
+offset: 2106,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 8816,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x4',
+offset: 23328,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 29256,
+shaderLocation: 4,
+},
+{
+format: 'float16x2',
+offset: 19592,
+shaderLocation: 11,
+},
+{
+format: 'unorm16x2',
+offset: 7824,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+targets: [
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rgba8unorm-srgb',
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'src',
+dstFactor: 'constant'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'one-minus-dst-alpha',
+dstFactor: 'src-alpha-saturated'
+},
+},
+format: 'rg8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'one-minus-src',
+dstFactor: 'one-minus-dst-alpha'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'src-alpha',
+dstFactor: 'zero'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+format: 'rgb10a2uint',
+writeMask: 0,
+},
+undefined
+],
+},
+}
+);
+document.body.prepend(canvas0);
+offscreenCanvas5.width = 636;
+let texture27 = device0.createTexture(
+{
+label: '\u0c61\u{1ff7e}\u8009',
+size: {width: 64, height: 128, depthOrArrayLayers: 179},
+mipLevelCount: 6,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'etc2-rgb8unorm-srgb'
+],
+}
+);
+let renderBundle26 = renderBundleEncoder8.finish(
+{
+label: '\u53e9\u{1fd9e}\u64c8'
+}
+);
+try {
+renderPassEncoder0.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+renderPassEncoder4.setViewport(
+47.12,
+0.01583,
+41.78,
+0.6728,
+0.08102,
+0.6307
+);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(
+buffer9,
+'uint32',
+5748,
+63
+);
+} catch {}
+let promise12 = device0.popErrorScope();
+let pipeline34 = await promise5;
+try {
+await promise12;
+} catch {}
+gc();
+let buffer12 = device0.createBuffer(
+{
+label: '\u1f99\u9b86\u0f7b',
+size: 31400,
+usage: GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+let renderBundleEncoder29 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg32float',
+'bgra8unorm-srgb',
+undefined
+],
+sampleCount: 645,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder7.setBindGroup(
+4,
+bindGroup5,
+[]
+);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+21,
+0,
+14,
+1
+);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(
+5,
+bindGroup8
+);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(
+buffer9,
+'uint16',
+1280,
+3071
+);
+} catch {}
+try {
+texture24.destroy();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img7,
+  origin: { x: 86, y: 127 },
+  flipY: false,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline35 = device0.createComputePipeline(
+{
+label: '\u060a\u545e\u{1f95b}\u0b10\u520b\u09d4',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+},
+}
+);
+let canvas2 = document.createElement('canvas');
+let bindGroupLayout11 = device0.createBindGroupLayout(
+{
+label: '\u{1fb75}\u5b76\u2f3d\u098a\u0835\u0a2b',
+entries: [
+{
+binding: 523,
+visibility: 0,
+sampler: { type: 'filtering' },
+},
+{
+binding: 1544,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'bgra8unorm', access: 'write-only', viewDimension: '1d' },
+},
+{
+binding: 423,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+}
+],
+}
+);
+let bindGroup9 = device0.createBindGroup({
+layout: bindGroupLayout3,
+entries: [
+
+],
+});
+let querySet20 = device0.createQuerySet(
+{
+label: '\u3196\u{1f727}\u1f85\u{1fcbc}\u013a',
+type: 'occlusion',
+count: 15,
+}
+);
+let texture28 = device0.createTexture(
+{
+size: [4720, 255, 1],
+mipLevelCount: 8,
+format: 'astc-5x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-5x5-unorm-srgb',
+'astc-5x5-unorm-srgb'
+],
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture7,
+  mipLevel: 1,
+  origin: { x: 71, y: 0, z: 36 },
+  aspect: 'all',
+},
+new Uint8Array(new ArrayBuffer(16)),
+/* required buffer size: 2562432 */{
+offset: 700,
+bytesPerRow: 1067,
+rowsPerImage: 30,
+},
+{width: 233, height: 1, depthOrArrayLayers: 81}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 445, y: 215 },
+  flipY: false,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+canvas2.getContext('bitmaprenderer');
+} catch {}
+let renderBundle27 = renderBundleEncoder26.finish(
+{
+label: '\u0f1b\u7f2d\u01dd\ubeae\u73ae'
+}
+);
+try {
+renderPassEncoder13.setStencilReference(
+1134
+);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(
+buffer6,
+'uint32'
+);
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+let renderBundleEncoder30 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg8unorm',
+'rg32float',
+'rg16uint',
+'r32float',
+'rgba8unorm',
+'rg16sint',
+'rgba32sint',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 152,
+stencilReadOnly: false,
+}
+);
+try {
+renderPassEncoder12.beginOcclusionQuery(
+48
+);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(
+6,
+undefined,
+339297279,
+3865343512
+);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(
+7,
+buffer8,
+54236,
+680
+);
+} catch {}
+let texture29 = device0.createTexture(
+{
+size: [236, 1, 1688],
+mipLevelCount: 8,
+sampleCount: 1,
+dimension: '3d',
+format: 'rg8sint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+renderPassEncoder2.setBindGroup(
+3,
+bindGroup5
+);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+8,
+buffer6,
+8208,
+1564
+);
+} catch {}
+try {
+await buffer10.mapAsync(
+GPUMapMode.WRITE,
+2496,
+1844
+);
+} catch {}
+let pipeline36 = device0.createComputePipeline(
+{
+label: '\u70a5\udd6f',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let shaderModule10 = device0.createShaderModule(
+{
+label: '\ubf8f\ufab4\u099d\u0797\ud161\u5663\u0d44\u1fff\u099a',
+code: `@group(0) @binding(2555)
+var<storage, read_write> i2: array<u32>;
+
+@compute @workgroup_size(2, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@builtin(frag_depth) f0: f32,
+@location(2) f1: vec3<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S8 {
+@location(13) f0: vec4<i32>,
+@location(9) f1: vec4<f16>,
+@location(3) f2: f16,
+@builtin(instance_index) f3: u32,
+@location(1) f4: vec4<f16>,
+@location(10) f5: vec2<i32>,
+@location(14) f6: f16
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec3<u32>, @location(15) a1: vec3<u32>, a2: S8, @location(2) a3: vec3<f16>, @builtin(vertex_index) a4: u32, @location(0) a5: vec3<u32>, @location(5) a6: vec3<i32>, @location(7) a7: vec2<f32>, @location(12) a8: vec2<f32>, @location(11) a9: i32, @location(4) a10: vec4<f32>, @location(6) a11: f16, @location(16) a12: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder22 = device0.createCommandEncoder(
+{
+label: '\u{1f8f6}\u0ec7\u0cfc\u203d\u42c4\ue1a7\u589a',
+}
+);
+let texture30 = device0.createTexture(
+{
+label: '\u{1f83c}\u{1fb6a}\u810b\u6c66\uf598\u{1fb20}\u0f09\u0464\u{1f9fd}\ue517',
+size: [14, 1, 1317],
+mipLevelCount: 8,
+dimension: '3d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+1,
+bindGroup7
+);
+} catch {}
+try {
+computePassEncoder12.setPipeline(
+pipeline3
+);
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(
+23,
+1,
+59,
+0
+);
+} catch {}
+try {
+commandEncoder22.clearBuffer(
+buffer3,
+288,
+12176
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+gpuCanvasContext3.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb',
+'r32uint'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 10}
+*/
+{
+  source: img3,
+  origin: { x: 6, y: 193 },
+  flipY: false,
+},
+{
+  texture: texture30,
+  mipLevel: 7,
+  origin: { x: 1, y: 0, z: 2 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline37 = await device0.createRenderPipelineAsync(
+{
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule5,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 20,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x3',
+offset: 0,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 10884,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x4',
+offset: 8788,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 5352,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 2476,
+shaderLocation: 6,
+},
+{
+format: 'float16x2',
+offset: 1480,
+shaderLocation: 13,
+},
+{
+format: 'sint32',
+offset: 1196,
+shaderLocation: 12,
+},
+{
+format: 'snorm16x2',
+offset: 2072,
+shaderLocation: 10,
+},
+{
+format: 'unorm8x2',
+offset: 3310,
+shaderLocation: 7,
+},
+{
+format: 'float32x4',
+offset: 3044,
+shaderLocation: 14,
+},
+{
+format: 'uint32x3',
+offset: 1572,
+shaderLocation: 15,
+},
+{
+format: 'uint32x4',
+offset: 3712,
+shaderLocation: 4,
+},
+{
+format: 'snorm16x4',
+offset: 40,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 11236,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 8456,
+shaderLocation: 9,
+},
+{
+format: 'snorm8x2',
+offset: 7198,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 14760,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 6176,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 1672,
+attributes: [
+
+],
+},
+{
+arrayStride: 10700,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 7112,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule5,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'replace',
+passOp: 'invert',
+},
+stencilReadMask: 3326,
+stencilWriteMask: 3571,
+depthBiasSlopeScale: 34,
+depthBiasClamp: 94,
+},
+}
+);
+let buffer13 = device0.createBuffer(
+{
+size: 5928,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let commandEncoder23 = device0.createCommandEncoder(
+{
+label: '\u0892\u021e\u{1fc2a}\u638d\u{1fb4c}\u1cdf\u0214\u{1f821}\u039a\u0087',
+}
+);
+let renderBundle28 = renderBundleEncoder21.finish(
+{
+label: '\u{1f7f4}\u{1f880}\u5ae5\ubd23\u{1f64d}\u{1f934}\u0a49\uc06e'
+}
+);
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(
+2,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(
+72
+);
+} catch {}
+try {
+commandEncoder23.copyBufferToTexture(
+{
+/* bytesInLastRow: 2976 widthInBlocks: 186 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 13856 */
+offset: 13856,
+bytesPerRow: 3072,
+buffer: buffer6,
+},
+{
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 72, y: 0, z: 68 },
+  aspect: 'all',
+},
+{width: 1116, height: 60, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder21.copyTextureToTexture(
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 647, y: 25, z: 0 },
+  aspect: 'stencil-only',
+},
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: { x: 0, y: 8, z: 0 },
+  aspect: 'stencil-only',
+},
+{width: 2011, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+gpuCanvasContext4.configure(
+{
+device: device0,
+format: 'astc-10x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32float',
+'astc-10x8-unorm',
+'astc-10x8-unorm-srgb'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(new ArrayBuffer(40)),
+/* required buffer size: 2823605 */{
+offset: 957,
+bytesPerRow: 463,
+rowsPerImage: 254,
+},
+{width: 50, height: 1, depthOrArrayLayers: 25}
+);
+} catch {}
+try {
+await promise13;
+} catch {}
+let img10 = await imageWithData(169, 212, '#8e1845ec', '#e11284ae');
+let commandEncoder24 = device0.createCommandEncoder();
+let commandBuffer2 = commandEncoder24.finish(
+{
+label: '\u1e58\u6529\u{1fa74}\u{1f978}\u0105',
+}
+);
+let texture31 = device0.createTexture(
+{
+label: '\u6bfb\u8677\u91c5\u0479\u{1f971}',
+size: {width: 3288, height: 192, depthOrArrayLayers: 201},
+mipLevelCount: 2,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-8x8-unorm',
+'astc-8x8-unorm-srgb',
+'astc-8x8-unorm'
+],
+}
+);
+let computePassEncoder14 = commandEncoder23.beginComputePass(
+{
+label: '\u3228\udce0\u{1fb15}\u{1fbea}\u32f0\ue440\u05e5\uf900'
+}
+);
+let renderBundleEncoder31 = device0.createRenderBundleEncoder(
+{
+label: '\u{1fec8}\u{1f7b1}\u656f',
+colorFormats: [
+'rgba16float'
+],
+sampleCount: 651,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler24 = device0.createSampler(
+{
+label: '\ud798\u{1fb42}',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 52.050,
+lodMaxClamp: 71.261,
+maxAnisotropy: 13,
+}
+);
+try {
+renderPassEncoder0.setVertexBuffer(
+5,
+buffer6
+);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(
+1,
+bindGroup2
+);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(
+1,
+buffer8,
+53140,
+3256
+);
+} catch {}
+try {
+commandEncoder22.copyBufferToBuffer(
+buffer10,
+13096,
+buffer1,
+7580,
+52
+);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder21.copyBufferToTexture(
+{
+/* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 14784 */
+offset: 14784,
+buffer: buffer6,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder22.copyTextureToTexture(
+{
+  texture: texture4,
+  mipLevel: 2,
+  origin: { x: 0, y: 6, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 2,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'stencil-only',
+},
+{width: 1005, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder22.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+video3.height = 296;
+document.body.append('\u091a\u5c00');
+try {
+window.someLabel = computePassEncoder13.label;
+} catch {}
+let renderBundle29 = renderBundleEncoder30.finish(
+{
+label: '\u46b4\u032c\u82c0\u9195'
+}
+);
+try {
+computePassEncoder10.setPipeline(
+pipeline27
+);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(
+8,
+bindGroup7
+);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(
+2,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(
+1,
+buffer6,
+6192,
+940
+);
+} catch {}
+document.body.prepend('\u030f\u8eea');
+let commandBuffer3 = commandEncoder21.finish(
+{
+label: '\ub65b\u0267\u8ea7\u052a\u0343\u029a\ufcd1\u0010\ueffc\u4e1c\u{1f89d}',
+}
+);
+pseudoSubmit(device0, commandEncoder23);
+let texture32 = device0.createTexture(
+{
+label: '\u{1fba0}\u{1f753}\u270c\u50f3\u230e\u9020',
+size: [46, 2, 154],
+mipLevelCount: 8,
+dimension: '3d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm'
+],
+}
+);
+try {
+renderPassEncoder12.setBlendConstant(
+{
+r: 685.6,
+g: -811.0,
+b: -954.4,
+a: 891.0,
+}
+);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(
+9,
+1,
+15,
+0
+);
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+48.44,
+0.4736,
+0.6221,
+0.05682,
+0.3089,
+0.9675
+);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(
+2,
+buffer6,
+18380
+);
+} catch {}
+try {
+commandEncoder22.copyBufferToTexture(
+{
+/* bytesInLastRow: 3976 widthInBlocks: 994 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 27312 */
+offset: 23336,
+rowsPerImage: 301,
+buffer: buffer0,
+},
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 106, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 994, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder22.clearBuffer(
+buffer5,
+3648,
+7608
+);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(
+72
+);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+45.12,
+0.8541,
+11.48,
+0.02356,
+0.5874,
+0.6284
+);
+} catch {}
+try {
+commandEncoder22.copyBufferToTexture(
+{
+/* bytesInLastRow: 80 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 39680 */
+offset: 39680,
+bytesPerRow: 256,
+buffer: buffer0,
+},
+{
+  texture: texture18,
+  mipLevel: 0,
+  origin: { x: 0, y: 4, z: 0 },
+  aspect: 'all',
+},
+{width: 40, height: 40, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer3,
+7964,
+new Float32Array(58664),
+17881,
+504
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 7, height: 1, depthOrArrayLayers: 658}
+*/
+{
+  source: imageData2,
+  origin: { x: 64, y: 3 },
+  flipY: false,
+},
+{
+  texture: texture30,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 116 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let commandEncoder25 = device0.createCommandEncoder(
+{
+label: '\ueeef\u4abf\u0d58\uc2b5\u94c7\u{1f858}\u{1fdd0}',
+}
+);
+let commandBuffer4 = commandEncoder25.finish();
+let texture33 = gpuCanvasContext1.getCurrentTexture();
+let renderBundleEncoder32 = device0.createRenderBundleEncoder(
+{
+label: '\u7e6a\u638c\u04db\u96c1\u02d1\u4021',
+colorFormats: [
+'rg11b10ufloat',
+undefined,
+'r16sint',
+'rgba16sint',
+'rg32uint',
+'r8uint',
+'rgba16uint'
+],
+sampleCount: 722,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder9.setPipeline(
+pipeline25
+);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(
+buffer9,
+'uint16',
+3326,
+1588
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+0,
+buffer5,
+17536,
+3643
+);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(
+buffer6,
+'uint32',
+8652,
+10239
+);
+} catch {}
+try {
+commandEncoder22.copyBufferToTexture(
+{
+/* bytesInLastRow: 3708 widthInBlocks: 927 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 28596 */
+offset: 24888,
+buffer: buffer0,
+},
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 165, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 927, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder22.clearBuffer(
+buffer9
+);
+dissociateBuffer(device0, buffer9);
+} catch {}
+let pipeline38 = await device0.createComputePipelineAsync(
+{
+label: '\uffe1\u00e5\u014a\u00b5\u{1feaf}\u8805',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+video1.width = 2;
+let imageBitmap6 = await createImageBitmap(imageBitmap5);
+pseudoSubmit(device0, commandEncoder2);
+let renderBundle30 = renderBundleEncoder29.finish();
+try {
+renderPassEncoder2.setBindGroup(
+2,
+bindGroup8
+);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(
+3,
+bindGroup0,
+new Uint32Array(8229),
+6573,
+0
+);
+} catch {}
+try {
+renderPassEncoder11.end();
+} catch {}
+try {
+renderPassEncoder7.setViewport(
+9.979,
+0.7257,
+41.38,
+0.2739,
+0.8447,
+0.9196
+);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder22.copyTextureToBuffer(
+{
+  texture: texture4,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'stencil-only',
+},
+{
+/* bytesInLastRow: 502 widthInBlocks: 502 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 29788 */
+offset: 29788,
+bytesPerRow: 512,
+buffer: buffer8,
+},
+{width: 502, height: 4, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture12,
+  mipLevel: 1,
+  origin: { x: 29, y: 1, z: 32 },
+  aspect: 'all',
+},
+new Int8Array(new ArrayBuffer(48)),
+/* required buffer size: 411989 */{
+offset: 189,
+bytesPerRow: 116,
+rowsPerImage: 50,
+},
+{width: 4, height: 0, depthOrArrayLayers: 72}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 206, y: 67 },
+  flipY: false,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let img11 = await imageWithData(56, 8, '#2d65e72b', '#f0956207');
+let commandEncoder26 = device0.createCommandEncoder(
+{
+label: '\u05ed\u{1fbdc}\ue4f7\u0f5f\u27b3\u2219\ue7c9\ue820\u9d42\u0f02',
+}
+);
+let textureView29 = texture12.createView(
+{
+label: '\u07db\u{1fad9}\ua8fb\u{1fab5}\u4537\u{1faf7}\ud91c\u{1f7b0}',
+mipLevelCount: 2,
+baseArrayLayer: 0,
+}
+);
+let renderBundle31 = renderBundleEncoder21.finish(
+{
+label: '\u{1fe1c}\u0123\u02d4\ucd81\u{1fde7}\u20b9\u{1fd9a}\u0f5d'
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+6,
+bindGroup9
+);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant(
+{
+r: 524.1,
+g: 382.3,
+b: 513.9,
+a: 682.9,
+}
+);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(
+buffer9,
+'uint32',
+3572
+);
+} catch {}
+try {
+commandEncoder22.copyBufferToBuffer(
+buffer1,
+6124,
+buffer7,
+30960,
+948
+);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let pipeline39 = device0.createComputePipeline(
+{
+label: '\u02c7\u0c3f\u03b8\udffd\u1d08',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let texture34 = device0.createTexture(
+{
+label: '\u0a31\u03d1\u{1f869}\u3652\u096b\u857f\u0e8f\u9fa3\u8df3\u022f\u34f7',
+size: {width: 9852, height: 92, depthOrArrayLayers: 1},
+mipLevelCount: 14,
+format: 'etc2-rgb8a1unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+renderPassEncoder7.setBindGroup(
+3,
+bindGroup6
+);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+6,
+buffer6,
+12884,
+5233
+);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(
+7,
+bindGroup4,
+new Uint32Array(994),
+673,
+0
+);
+} catch {}
+try {
+commandEncoder22.copyBufferToBuffer(
+buffer10,
+8204,
+buffer5,
+14300,
+3908
+);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder26.copyBufferToTexture(
+{
+/* bytesInLastRow: 52 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 23196 */
+offset: 2460,
+bytesPerRow: 256,
+rowsPerImage: 27,
+buffer: buffer0,
+},
+{
+  texture: texture7,
+  mipLevel: 4,
+  origin: { x: 18, y: 1, z: 9 },
+  aspect: 'all',
+},
+{width: 13, height: 0, depthOrArrayLayers: 4}
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder26.clearBuffer(
+buffer7,
+24040,
+20448
+);
+dissociateBuffer(device0, buffer7);
+} catch {}
+let canvas3 = document.createElement('canvas');
+let bindGroup10 = device0.createBindGroup({
+label: '\uc907\u04f4\u{1fd61}\u{1fee2}\u1245\u0f9d\u0734\ubffc',
+layout: bindGroupLayout3,
+entries: [
+
+],
+});
+let renderBundleEncoder33 = device0.createRenderBundleEncoder(
+{
+label: '\ua92e\udecc\u01e8\u0b06\u{1ff3e}\u1048',
+colorFormats: [
+'rgb10a2uint',
+'rg11b10ufloat',
+'rgb10a2unorm',
+'rg8uint',
+undefined,
+'rg16sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 602,
+}
+);
+let sampler25 = device0.createSampler(
+{
+label: '\ud489\u7017\u03c5\uaea2\u{1fd2b}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 77.070,
+maxAnisotropy: 9,
+}
+);
+try {
+computePassEncoder11.setPipeline(
+pipeline31
+);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(
+80
+);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(
+63,
+1,
+13,
+0
+);
+} catch {}
+try {
+querySet12.destroy();
+} catch {}
+try {
+commandEncoder22.copyBufferToBuffer(
+buffer6,
+3740,
+buffer8,
+10184,
+2304
+);
+dissociateBuffer(device0, buffer6);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+gpuCanvasContext5.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture7,
+  mipLevel: 2,
+  origin: { x: 18, y: 0, z: 17 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 2687305 */{
+offset: 49,
+bytesPerRow: 783,
+rowsPerImage: 104,
+},
+{width: 149, height: 0, depthOrArrayLayers: 34}
+);
+} catch {}
+let video4 = await videoWithData();
+try {
+renderPassEncoder4.beginOcclusionQuery(
+72
+);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant(
+{
+r: -452.9,
+g: -321.6,
+b: -232.7,
+a: -398.2,
+}
+);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(
+1070
+);
+} catch {}
+try {
+commandEncoder26.copyTextureToBuffer(
+{
+  texture: texture28,
+  mipLevel: 3,
+  origin: { x: 145, y: 5, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 80 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 20336 */
+offset: 20336,
+rowsPerImage: 234,
+buffer: buffer8,
+},
+{width: 25, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer8);
+} catch {}
+let pipeline40 = await device0.createRenderPipelineAsync(
+{
+label: '\u0185\u68f2\u{1f644}\u{1f840}\u6779\u7f4c\u{1fb95}\u0a7e',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule9,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 18392,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 16196,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 32064,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 24436,
+shaderLocation: 13,
+},
+{
+format: 'uint32x2',
+offset: 23808,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 6496,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 29232,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 29248,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 14956,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 18796,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 6388,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 2986,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule9,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32sint',
+},
+{
+format: 'r8sint',
+writeMask: 0,
+},
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r16float',
+writeMask: 0,
+},
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r16float',
+writeMask: 0,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'less',
+depthFailOp: 'invert',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'invert',
+},
+stencilReadMask: 3976,
+stencilWriteMask: 565,
+depthBias: 19,
+},
+}
+);
+let imageBitmap7 = await createImageBitmap(video4);
+let textureView30 = texture18.createView(
+{
+label: '\u212c\u0984\ue7ae\u9c0a\u64f5\u815c\u{1fd80}\u8d62',
+dimension: '2d-array',
+arrayLayerCount: 1,
+}
+);
+let computePassEncoder15 = commandEncoder26.beginComputePass(
+{
+
+}
+);
+let sampler26 = device0.createSampler(
+{
+label: '\u72fc\u0a34\u{1f7a6}\u{1f945}\ud6bd\uc8d8\u3a4a\u7ae2\u0ab0',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 48.233,
+lodMaxClamp: 74.219,
+maxAnisotropy: 7,
+}
+);
+try {
+renderPassEncoder4.setViewport(
+80.98,
+0.04476,
+3.893,
+0.7313,
+0.4443,
+0.5657
+);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(
+1,
+buffer8,
+8048,
+43781
+);
+} catch {}
+let pipeline41 = device0.createRenderPipeline(
+{
+label: '\udc48\u06e1\ud739\u{1fd69}\u1e9b\u0276\u0635\u0345\u00c7\u{1f6b9}',
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x7372e749,
+},
+}
+);
+document.body.prepend(img7);
+let texture35 = device0.createTexture(
+{
+label: '\uae69\u{1f688}\u0d01\uca34',
+size: [8890, 10, 1],
+mipLevelCount: 13,
+format: 'astc-10x5-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x5-unorm',
+'astc-10x5-unorm-srgb',
+'astc-10x5-unorm-srgb'
+],
+}
+);
+let texture36 = gpuCanvasContext5.getCurrentTexture();
+try {
+renderPassEncoder4.setBindGroup(
+2,
+bindGroup3
+);
+} catch {}
+try {
+renderPassEncoder8.setViewport(
+58.02,
+0.01822,
+10.68,
+0.05249,
+0.8321,
+0.9839
+);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(
+50,
+undefined
+);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(
+8,
+buffer6,
+52,
+15302
+);
+} catch {}
+let texture37 = device0.createTexture(
+{
+size: {width: 7012},
+dimension: '1d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+try {
+computePassEncoder11.setPipeline(
+pipeline38
+);
+} catch {}
+try {
+renderPassEncoder13.setViewport(
+1.674,
+0.01338,
+80.54,
+0.5312,
+0.8190,
+0.8294
+);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(
+9,
+buffer5,
+19968,
+2272
+);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(
+4,
+bindGroup10,
+new Uint32Array(8921),
+4308,
+0
+);
+} catch {}
+let pipeline42 = device0.createComputePipeline(
+{
+label: '\u1214\ufa5b\u9eb9\u4d18\ud626\ua309\u0ab1\u1f4c\u056f\u9a3b\u228f',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let bindGroup11 = device0.createBindGroup({
+label: '\u0e36\ue067\u86ca\u8968\uc7ad\u01d4\u024e\u3f00\u0045',
+layout: bindGroupLayout1,
+entries: [
+
+],
+});
+let commandEncoder27 = device0.createCommandEncoder(
+{
+label: '\u{1fb78}\u7108\u031b',
+}
+);
+let querySet21 = device0.createQuerySet(
+{
+label: '\u{1f767}\ub32a\u5ea8\u01b8\u0a76\u319f\u8e61\u5ae5\u1252\u0f4b',
+type: 'occlusion',
+count: 230,
+}
+);
+let computePassEncoder16 = commandEncoder22.beginComputePass(
+{
+label: '\u{1f984}\u{1fa5d}\u{1f615}\u{1ffd6}\u73a9\u0675\u5669\u06ff'
+}
+);
+let renderBundleEncoder34 = device0.createRenderBundleEncoder(
+{
+label: '\udb44\u394a',
+colorFormats: [
+'rgba16float',
+'rg32sint',
+'r8unorm',
+'rg16float',
+undefined,
+'rgba16sint',
+'rgba8unorm-srgb',
+'r16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 943,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle32 = renderBundleEncoder34.finish(
+{
+label: '\u{1fa37}\u6506\u{1fcf4}\u0751\u0965\u9462\ucce4\u5db9\u7166'
+}
+);
+let sampler27 = device0.createSampler(
+{
+label: '\u4c3b\ue998\u75a2\u0532',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 97.907,
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder7.setScissorRect(
+18,
+0,
+44,
+0
+);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(
+0,
+bindGroup6
+);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(
+8,
+buffer8
+);
+} catch {}
+try {
+commandEncoder27.clearBuffer(
+buffer2,
+26520
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let video5 = await videoWithData();
+let bindGroupLayout12 = pipeline31.getBindGroupLayout(1);
+let computePassEncoder17 = commandEncoder27.beginComputePass();
+try {
+computePassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(
+3,
+bindGroup10,
+[]
+);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(
+25,
+0,
+10,
+1
+);
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+84.98,
+0.5380,
+1.514,
+0.04152,
+0.2952,
+0.9907
+);
+} catch {}
+try {
+commandEncoder22.insertDebugMarker(
+'\u0e5e'
+);
+} catch {}
+let img12 = await imageWithData(10, 49, '#07a2cfe3', '#03187f41');
+try {
+externalTexture1.label = '\u0334\u047e\u7a97\ub825\ufe1f\ua094';
+} catch {}
+let querySet22 = device0.createQuerySet(
+{
+label: '\u0fca\u60bc\uf1f9\u{1f9e0}\u98bd\u{1fe95}',
+type: 'occlusion',
+count: 3508,
+}
+);
+let texture38 = device0.createTexture(
+{
+label: '\u{1f850}\ufc3f\uf046\u{1faf3}\u057b\u10dc\u0a97\u{1f962}',
+size: {width: 48, height: 220, depthOrArrayLayers: 205},
+mipLevelCount: 7,
+dimension: '2d',
+format: 'astc-8x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+renderPassEncoder9.setBindGroup(
+2,
+bindGroup11,
+new Uint32Array(9230),
+3881,
+0
+);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(
+buffer6,
+'uint32',
+9272,
+2944
+);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(
+4,
+buffer5,
+1756
+);
+} catch {}
+let promise14 = buffer3.mapAsync(
+GPUMapMode.READ,
+0,
+5924
+);
+try {
+commandEncoder22.clearBuffer(
+buffer7,
+21472,
+14948
+);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer5,
+16068,
+new Float32Array(51623),
+21887,
+336
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 23, height: 1, depthOrArrayLayers: 77}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 1, y: 0 },
+  flipY: true,
+},
+{
+  texture: texture32,
+  mipLevel: 1,
+  origin: { x: 4, y: 0, z: 52 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 5, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await promise14;
+} catch {}
+let bindGroup12 = device0.createBindGroup({
+layout: bindGroupLayout9,
+entries: [
+
+],
+});
+let commandEncoder28 = device0.createCommandEncoder();
+let texture39 = device0.createTexture(
+{
+label: '\u0d64\u426b\u{1fe06}',
+size: [10, 1365, 1],
+mipLevelCount: 8,
+dimension: '2d',
+format: 'astc-10x5-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x5-unorm-srgb'
+],
+}
+);
+try {
+computePassEncoder11.setBindGroup(
+3,
+bindGroup6,
+new Uint32Array(9031),
+6774,
+0
+);
+} catch {}
+try {
+computePassEncoder12.setPipeline(
+pipeline34
+);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(
+4,
+1,
+40,
+0
+);
+} catch {}
+try {
+commandEncoder28.copyBufferToBuffer(
+buffer4,
+7480,
+buffer8,
+12284,
+13604
+);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder22.copyTextureToBuffer(
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 870, y: 0, z: 73 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 4048 widthInBlocks: 253 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 40720 */
+offset: 40720,
+bytesPerRow: 4096,
+buffer: buffer8,
+},
+{width: 2530, height: 10, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer9,
+1476,
+new DataView(new ArrayBuffer(43065)),
+1445,
+1296
+);
+} catch {}
+let pipeline43 = await promise4;
+let pipeline44 = device0.createRenderPipeline(
+{
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule5,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 25640,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 6204,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x2',
+offset: 558,
+shaderLocation: 10,
+},
+{
+format: 'sint32x4',
+offset: 16580,
+shaderLocation: 1,
+},
+{
+format: 'snorm16x4',
+offset: 16548,
+shaderLocation: 5,
+},
+{
+format: 'sint8x4',
+offset: 7380,
+shaderLocation: 12,
+},
+{
+format: 'float32',
+offset: 11176,
+shaderLocation: 6,
+},
+{
+format: 'uint16x4',
+offset: 14060,
+shaderLocation: 3,
+},
+{
+format: 'snorm8x2',
+offset: 6642,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x4',
+offset: 21212,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x2',
+offset: 6670,
+shaderLocation: 14,
+},
+{
+format: 'unorm8x2',
+offset: 23768,
+shaderLocation: 13,
+},
+{
+format: 'uint8x4',
+offset: 21816,
+shaderLocation: 0,
+},
+{
+format: 'uint32',
+offset: 10720,
+shaderLocation: 15,
+},
+{
+format: 'float32x2',
+offset: 11840,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+}
+);
+try {
+commandEncoder9.label = '\u40fa\u05b0\u{1fcf4}\u{1fbc5}\u{1fc53}\uab3a\u0093';
+} catch {}
+let bindGroupLayout13 = device0.createBindGroupLayout(
+{
+entries: [
+{
+binding: 1809,
+visibility: 0,
+storageTexture: { format: 'rgba8sint', access: 'write-only', viewDimension: '1d' },
+}
+],
+}
+);
+let querySet23 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 106,
+}
+);
+try {
+computePassEncoder11.setBindGroup(
+6,
+bindGroup8,
+new Uint32Array(1987),
+1255,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+46,
+1,
+23,
+0
+);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(
+buffer9,
+'uint32',
+1716
+);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(
+6,
+bindGroup0,
+[]
+);
+} catch {}
+let gpuCanvasContext6 = canvas3.getContext('webgpu');
+let bindGroupLayout14 = device0.createBindGroupLayout(
+{
+label: '\u6466\u9e98\u8d3b\u3635\uf720',
+entries: [
+{
+binding: 2064,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba32float', access: 'read-only', viewDimension: '2d' },
+}
+],
+}
+);
+let texture40 = device0.createTexture(
+{
+label: '\u{1fb30}\u0141\uebeb\u7277\u0635\u2f3d\u690a\u05bb',
+size: [6370],
+dimension: '1d',
+format: 'rg32uint',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundle33 = renderBundleEncoder21.finish(
+{
+label: '\u{1f79b}\u50ed\u{1f619}\u77f5\uba5f'
+}
+);
+let externalTexture2 = device0.importExternalTexture(
+{
+label: '\u0d93\ud9ec\ud92d\u0c81\u{1fb85}\uc0e8\u{1f702}',
+source: videoFrame2,
+}
+);
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+49,
+0,
+20,
+1
+);
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(
+1037
+);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(
+2,
+buffer6,
+18448
+);
+} catch {}
+let pipeline45 = device0.createComputePipeline(
+{
+label: '\u91e0\u9d9c\ua8e1\u098c\u{1f64d}',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule10,
+entryPoint: 'compute0',
+},
+}
+);
+let pipeline46 = device0.createRenderPipeline(
+{
+label: '\u{1f6b5}\u{1fb26}\u{1fb77}',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule6,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 2468,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 988,
+shaderLocation: 10,
+},
+{
+format: 'float16x4',
+offset: 2280,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x4',
+offset: 1728,
+shaderLocation: 6,
+},
+{
+format: 'sint16x2',
+offset: 148,
+shaderLocation: 16,
+},
+{
+format: 'uint32x2',
+offset: 1156,
+shaderLocation: 14,
+},
+{
+format: 'unorm8x4',
+offset: 1848,
+shaderLocation: 9,
+},
+{
+format: 'unorm8x4',
+offset: 1128,
+shaderLocation: 15,
+},
+{
+format: 'sint32x3',
+offset: 684,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 1604,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x4',
+offset: 1532,
+shaderLocation: 2,
+},
+{
+format: 'sint32x4',
+offset: 904,
+shaderLocation: 3,
+},
+{
+format: 'uint32x2',
+offset: 1068,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 17544,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 2356,
+shaderLocation: 13,
+},
+{
+format: 'sint32x2',
+offset: 5112,
+shaderLocation: 12,
+},
+{
+format: 'sint16x4',
+offset: 8744,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 5240,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'sint16x4',
+offset: 13440,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 33976,
+attributes: [
+{
+format: 'uint16x4',
+offset: 6296,
+shaderLocation: 5,
+},
+{
+format: 'float16x2',
+offset: 32760,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+},
+}
+);
+let imageBitmap8 = await createImageBitmap(imageBitmap3);
+let bindGroupLayout15 = pipeline18.getBindGroupLayout(1);
+let texture41 = device0.createTexture(
+{
+label: '\u03fc\u9c83',
+size: [10164, 260, 1],
+mipLevelCount: 8,
+dimension: '2d',
+format: 'astc-12x10-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-12x10-unorm-srgb',
+'astc-12x10-unorm',
+'astc-12x10-unorm-srgb'
+],
+}
+);
+let renderBundle34 = renderBundleEncoder20.finish(
+{
+label: '\u0030\u0d01\u7931'
+}
+);
+try {
+renderPassEncoder13.setBindGroup(
+3,
+bindGroup12,
+new Uint32Array(5128),
+384,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(
+3693
+);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(
+buffer9,
+'uint32'
+);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(
+0,
+bindGroup3,
+new Uint32Array(8250),
+5641,
+0
+);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(
+8,
+buffer6,
+19012,
+1355
+);
+} catch {}
+try {
+commandEncoder22.copyBufferToBuffer(
+buffer13,
+4948,
+buffer8,
+51412,
+352
+);
+dissociateBuffer(device0, buffer13);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder28.copyTextureToTexture(
+{
+  texture: texture32,
+  mipLevel: 7,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture32,
+  mipLevel: 0,
+  origin: { x: 33, y: 0, z: 64 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 7, height: 1, depthOrArrayLayers: 658}
+*/
+{
+  source: canvas1,
+  origin: { x: 207, y: 735 },
+  flipY: true,
+},
+{
+  texture: texture30,
+  mipLevel: 1,
+  origin: { x: 7, y: 0, z: 468 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline47 = device0.createRenderPipeline(
+{
+label: '\u77a9\u0a02\u{1feb5}\u0645\u{1fd2b}\u0bb3\u061b\u174f\u0a19',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule10,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 32100,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 6348,
+shaderLocation: 1,
+},
+{
+format: 'unorm8x4',
+offset: 14980,
+shaderLocation: 14,
+},
+{
+format: 'uint16x4',
+offset: 2092,
+shaderLocation: 8,
+},
+{
+format: 'unorm8x4',
+offset: 27796,
+shaderLocation: 12,
+},
+{
+format: 'snorm16x4',
+offset: 19224,
+shaderLocation: 9,
+},
+{
+format: 'sint16x2',
+offset: 19424,
+shaderLocation: 5,
+},
+{
+format: 'sint8x2',
+offset: 24078,
+shaderLocation: 11,
+},
+{
+format: 'unorm8x2',
+offset: 3980,
+shaderLocation: 16,
+},
+{
+format: 'float16x2',
+offset: 30796,
+shaderLocation: 7,
+},
+{
+format: 'float32x2',
+offset: 9732,
+shaderLocation: 6,
+},
+{
+format: 'uint8x2',
+offset: 27826,
+shaderLocation: 0,
+},
+{
+format: 'float16x2',
+offset: 26640,
+shaderLocation: 4,
+},
+{
+format: 'uint16x2',
+offset: 3792,
+shaderLocation: 15,
+},
+{
+format: 'sint32x4',
+offset: 13920,
+shaderLocation: 10,
+},
+{
+format: 'unorm8x4',
+offset: 10632,
+shaderLocation: 3,
+},
+{
+format: 'float16x4',
+offset: 296,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 32676,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 5916,
+shaderLocation: 13,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0xe72a9543,
+},
+fragment: {
+module: shaderModule10,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'invert',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 550,
+stencilWriteMask: 3965,
+depthBias: 99,
+depthBiasSlopeScale: 1,
+depthBiasClamp: 36,
+},
+}
+);
+let img13 = await imageWithData(119, 9, '#f7dddc09', '#59674816');
+let textureView31 = texture25.createView(
+{
+label: '\udf7d\u1611\u91d7\u0cc6\uff02\u4b84\u{1fc85}',
+baseMipLevel: 3,
+}
+);
+let renderBundleEncoder35 = device0.createRenderBundleEncoder(
+{
+label: '\ube77\ub984\u0a46\u{1fe68}',
+colorFormats: [
+'rgba32sint',
+'rg32float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 605,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder9.setBindGroup(
+6,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+62,
+0,
+17,
+0
+);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(
+buffer6,
+'uint16'
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+6,
+buffer8,
+56160,
+444
+);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(
+6,
+bindGroup7
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer9,
+5552,
+new Int16Array(8152),
+3922,
+60
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img9,
+  origin: { x: 199, y: 77 },
+  flipY: false,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline48 = await device0.createRenderPipelineAsync(
+{
+label: '\u1cfc\u803a\u{1ff56}\u60d6\u0221\u{1f682}\u0dd2',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule8,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1504,
+attributes: [
+{
+format: 'sint8x2',
+offset: 842,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x4',
+offset: 432,
+shaderLocation: 10,
+},
+{
+format: 'snorm16x2',
+offset: 1440,
+shaderLocation: 5,
+},
+{
+format: 'uint32x2',
+offset: 1192,
+shaderLocation: 6,
+},
+{
+format: 'snorm8x4',
+offset: 1276,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 24796,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 6732,
+shaderLocation: 16,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 22356,
+shaderLocation: 13,
+},
+{
+format: 'sint32x3',
+offset: 20796,
+shaderLocation: 4,
+},
+{
+format: 'sint32x2',
+offset: 15888,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule8,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rg16sint',
+writeMask: 0,
+},
+undefined,
+undefined,
+undefined,
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+undefined,
+undefined
+],
+},
+}
+);
+document.body.append('\u0a02\u1b1f\u{1fe52}\uf3b4');
+let bindGroup13 = device0.createBindGroup({
+label: '\u{1fd54}\u0754\u{1f9d6}\u{1fbef}\uca2d\u1696\u{1f8c3}\u1dbb\u1343\u30e2\u0c4a',
+layout: bindGroupLayout1,
+entries: [
+
+],
+});
+pseudoSubmit(device0, commandEncoder14);
+let texture42 = device0.createTexture(
+{
+label: '\u051a\ude28\u0e63',
+size: {width: 108, height: 1, depthOrArrayLayers: 1888},
+mipLevelCount: 3,
+dimension: '3d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+try {
+renderPassEncoder8.setBlendConstant(
+{
+r: -580.7,
+g: 874.0,
+b: -286.1,
+a: 189.6,
+}
+);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(
+82,
+0,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder9.setViewport(
+71.84,
+0.5454,
+11.75,
+0.3505,
+0.3717,
+0.8999
+);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(
+buffer9,
+'uint32'
+);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(
+8,
+buffer5,
+8164,
+11605
+);
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'r32sint',
+'rg8sint'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer8,
+21748,
+new BigUint64Array(17475),
+5482,
+880
+);
+} catch {}
+let imageData6 = new ImageData(172, 156);
+let videoFrame4 = new VideoFrame(imageBitmap8, {timestamp: 0});
+let computePassEncoder18 = commandEncoder26.beginComputePass(
+{
+label: '\u{1fa33}\u{1f7db}\u8225\u0580\u07ad\u009e\u77d2\ube32'
+}
+);
+try {
+computePassEncoder12.dispatchWorkgroups(
+1
+);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(
+4,
+bindGroup13
+);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(
+64
+);
+} catch {}
+try {
+renderPassEncoder8.setViewport(
+28.25,
+0.4385,
+58.90,
+0.02584,
+0.01923,
+0.4039
+);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(
+buffer6,
+'uint16'
+);
+} catch {}
+try {
+commandEncoder22.copyTextureToTexture(
+{
+  texture: texture32,
+  mipLevel: 2,
+  origin: { x: 3, y: 0, z: 22 },
+  aspect: 'all',
+},
+{
+  texture: texture32,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder22.clearBuffer(
+buffer5,
+5400,
+6196
+);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture38,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 90 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 983509 */{
+offset: 949,
+bytesPerRow: 178,
+rowsPerImage: 92,
+},
+{width: 0, height: 5, depthOrArrayLayers: 61}
+);
+} catch {}
+let renderBundle35 = renderBundleEncoder30.finish(
+{
+
+}
+);
+try {
+computePassEncoder9.setPipeline(
+pipeline10
+);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant(
+{
+r: -895.6,
+g: 257.9,
+b: 981.3,
+a: 601.0,
+}
+);
+} catch {}
+try {
+commandEncoder22.copyBufferToBuffer(
+buffer10,
+8716,
+buffer2,
+11940,
+2628
+);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder28.copyBufferToTexture(
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 14944 */
+offset: 14944,
+buffer: buffer6,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer6);
+} catch {}
+document.body.append('\u0588\u{1fb1f}\u0ea3\u0ee4\u{1fd7a}');
+let texture43 = device0.createTexture(
+{
+label: '\u1987\u905d\u9235\u{1f6c3}\u9f53\u0b9e\u2cb7',
+size: {width: 792, height: 204, depthOrArrayLayers: 71},
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb'
+],
+}
+);
+let textureView32 = texture12.createView(
+{
+label: '\u{1fc34}\ue5bf\udfa9\u{1fcf8}\u0f88\uac35\u002b\u1ac6\u0ee6\u6c3e\u0cfd',
+baseMipLevel: 2,
+}
+);
+let sampler28 = device0.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 36.517,
+lodMaxClamp: 42.532,
+compare: 'never',
+maxAnisotropy: 12,
+}
+);
+try {
+renderPassEncoder10.setBlendConstant(
+{
+r: 388.8,
+g: 490.3,
+b: 250.7,
+a: 275.4,
+}
+);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(
+buffer9,
+'uint32',
+3444,
+1372
+);
+} catch {}
+try {
+commandEncoder28.insertDebugMarker(
+'\ucdda'
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 451, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(24),
+/* required buffer size: 2926 */{
+offset: 38,
+},
+{width: 722, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline49 = device0.createComputePipeline(
+{
+label: '\uad3e\u067f\u9d9b\u0cc7\u2103',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule9,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+canvas3.width = 677;
+let commandEncoder29 = device0.createCommandEncoder(
+{
+label: '\u2dc7\u9077\u05d4\u0043\u04fa\u{1fce9}\uec04\u9728\u86c5\u1bec',
+}
+);
+let texture44 = device0.createTexture(
+{
+size: {width: 2794},
+dimension: '1d',
+format: 'r32float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32float',
+'r32float'
+],
+}
+);
+let renderPassEncoder14 = commandEncoder29.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+{
+view: textureView7,
+depthSlice: 9,
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined
+],
+occlusionQuerySet: querySet21,
+maxDrawCount: 292728,
+}
+);
+let renderBundle36 = renderBundleEncoder19.finish(
+{
+label: '\ue90a\u389b\ue4d3'
+}
+);
+try {
+computePassEncoder18.setPipeline(
+pipeline38
+);
+} catch {}
+try {
+renderPassEncoder12.beginOcclusionQuery(
+64
+);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant(
+{
+r: -835.0,
+g: 547.4,
+b: -886.5,
+a: 371.9,
+}
+);
+} catch {}
+try {
+commandEncoder22.copyTextureToBuffer(
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 93, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 1228 widthInBlocks: 307 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 46032 */
+offset: 46032,
+rowsPerImage: 45,
+buffer: buffer8,
+},
+{width: 307, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+renderPassEncoder8.insertDebugMarker(
+'\u203e'
+);
+} catch {}
+let pipeline50 = device0.createRenderPipeline(
+{
+label: '\u85a6\u{1fd08}\u5c4e\u0721',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule6,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 13616,
+attributes: [
+{
+format: 'uint32x3',
+offset: 5380,
+shaderLocation: 1,
+},
+{
+format: 'uint32',
+offset: 7512,
+shaderLocation: 14,
+},
+{
+format: 'float32x3',
+offset: 4920,
+shaderLocation: 15,
+},
+{
+format: 'sint8x2',
+offset: 2112,
+shaderLocation: 12,
+},
+{
+format: 'sint32x3',
+offset: 3268,
+shaderLocation: 7,
+},
+{
+format: 'float16x2',
+offset: 12528,
+shaderLocation: 11,
+},
+{
+format: 'float32x2',
+offset: 4832,
+shaderLocation: 6,
+},
+{
+format: 'uint32',
+offset: 13388,
+shaderLocation: 5,
+},
+{
+format: 'sint32x3',
+offset: 7460,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 27580,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 24812,
+shaderLocation: 10,
+},
+{
+format: 'sint32x2',
+offset: 5404,
+shaderLocation: 3,
+},
+{
+format: 'snorm8x2',
+offset: 22198,
+shaderLocation: 0,
+},
+{
+format: 'float32x2',
+offset: 12324,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 24660,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x4',
+offset: 23528,
+shaderLocation: 13,
+},
+{
+format: 'sint32x4',
+offset: 22844,
+shaderLocation: 2,
+},
+{
+format: 'sint16x2',
+offset: 60,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 13936,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 1984,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 30964,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 34604,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x2',
+offset: 18084,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x1419f109,
+},
+fragment: {
+module: shaderModule6,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rgb10a2uint',
+},
+{
+format: 'r32sint',
+},
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'one-minus-dst',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'one-minus-src-alpha',
+dstFactor: 'one-minus-src-alpha'
+},
+},
+format: 'rg8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'invert',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 4081,
+stencilWriteMask: 3835,
+depthBias: 66,
+depthBiasClamp: 72,
+},
+}
+);
+document.body.append('\u{1fc3e}\u{1ff8e}\u222d\u0684\u15ad\ufbde\u03cf\u{1ffa6}');
+let adapter3 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let commandEncoder30 = device0.createCommandEncoder(
+{
+label: '\u{1fb0b}\ue578\u05e0\u{1fb68}',
+}
+);
+let textureView33 = texture8.createView(
+{
+dimension: '2d',
+baseArrayLayer: 67,
+}
+);
+let renderBundleEncoder36 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 676,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder12.dispatchWorkgroups(
+4
+);
+} catch {}
+try {
+renderPassEncoder9.end();
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant(
+{
+r: -781.8,
+g: 416.1,
+b: 788.6,
+a: -38.33,
+}
+);
+} catch {}
+try {
+renderPassEncoder14.setScissorRect(
+84,
+0,
+5,
+1
+);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(
+5,
+buffer6,
+19232,
+684
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer9,
+5428,
+new Float32Array(24587),
+130,
+68
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 20}
+*/
+{
+  source: video4,
+  origin: { x: 11, y: 13 },
+  flipY: false,
+},
+{
+  texture: texture30,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 2 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let canvas4 = document.createElement('canvas');
+let img14 = await imageWithData(265, 195, '#aa2fc824', '#90300aa4');
+let shaderModule11 = device0.createShaderModule(
+{
+label: '\u{1fe60}\u0715\u9757\u0f14\u{1f65e}\u67f0\uf8e4\ub19a\u36f5',
+code: `@group(5) @binding(2494)
+var<storage, read_write> global1: array<u32>;
+
+@compute @workgroup_size(5, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: vec2<f32>,
+@location(7) f1: vec2<f32>,
+@location(0) f2: vec4<u32>,
+@location(3) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(5) a0: f16, @location(14) a1: vec2<f16>, @location(0) a2: vec2<i32>, @location(11) a3: u32, @location(2) a4: vec4<f32>, @location(8) a5: u32, @location(16) a6: vec4<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+}
+);
+let querySet24 = device0.createQuerySet(
+{
+label: '\u0254\u032f\u6b03\u8689\u{1f8db}\ua4c8\u{1ff08}\u{1f83a}',
+type: 'occlusion',
+count: 1455,
+}
+);
+let texture45 = device0.createTexture(
+{
+label: '\u{1fbcc}\uda0e\u064d\u1ebc\u4b84\u{1f8c8}\uc677',
+size: [142, 97, 1],
+mipLevelCount: 5,
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'depth32float-stencil8'
+],
+}
+);
+let textureView34 = texture42.createView(
+{
+baseMipLevel: 1,
+mipLevelCount: 1,
+}
+);
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(
+buffer9,
+'uint16',
+3278
+);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(
+9,
+buffer8,
+29132,
+19662
+);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(
+1,
+buffer6
+);
+} catch {}
+try {
+commandEncoder22.clearBuffer(
+buffer7,
+10116,
+10460
+);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+computePassEncoder11.insertDebugMarker(
+'\u00c1'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer8,
+47664,
+new DataView(new ArrayBuffer(42638)),
+28085,
+4360
+);
+} catch {}
+let bindGroup14 = device0.createBindGroup({
+label: '\u4454\ud08a',
+layout: bindGroupLayout12,
+entries: [
+
+],
+});
+try {
+computePassEncoder12.dispatchWorkgroupsIndirect(
+buffer9,
+944
+);
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(
+16
+);
+} catch {}
+try {
+await buffer10.mapAsync(
+GPUMapMode.WRITE,
+11224,
+308
+);
+} catch {}
+try {
+commandEncoder28.copyBufferToBuffer(
+buffer1,
+1176,
+buffer8,
+8844,
+2036
+);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder30.copyTextureToTexture(
+{
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 1536, y: 18, z: 30 },
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 1698, y: 18, z: 57 },
+  aspect: 'all',
+},
+{width: 2340, height: 30, depthOrArrayLayers: 0}
+);
+} catch {}
+let commandEncoder31 = device0.createCommandEncoder();
+let textureView35 = texture14.createView(
+{
+baseMipLevel: 5,
+baseArrayLayer: 187,
+arrayLayerCount: 35,
+}
+);
+try {
+computePassEncoder17.setBindGroup(
+5,
+bindGroup7,
+new Uint32Array(3264),
+2626,
+0
+);
+} catch {}
+try {
+computePassEncoder10.end();
+} catch {}
+try {
+computePassEncoder17.setPipeline(
+pipeline27
+);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(
+6,
+bindGroup8,
+[]
+);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant(
+{
+r: -279.5,
+g: -701.7,
+b: 664.5,
+a: 669.1,
+}
+);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(
+buffer9,
+'uint32',
+5432,
+269
+);
+} catch {}
+let img15 = await imageWithData(245, 165, '#b9915927', '#bdaf7921');
+let buffer14 = device0.createBuffer(
+{
+label: '\uebe5\uab48\u0916\u0ae2\u3676\ub0eb\u{1f64f}',
+size: 16251,
+usage: GPUBufferUsage.MAP_READ,
+}
+);
+let commandEncoder32 = device0.createCommandEncoder(
+{
+}
+);
+let computePassEncoder19 = commandEncoder28.beginComputePass(
+{
+
+}
+);
+let renderBundleEncoder37 = device0.createRenderBundleEncoder(
+{
+label: '\uc369\u{1f7cb}\u6ff3\u7161',
+colorFormats: [
+'rgba16sint',
+'r8uint',
+'r8sint',
+undefined,
+'rg32float',
+'rgb10a2uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 56,
+depthReadOnly: true,
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+1,
+bindGroup10
+);
+} catch {}
+try {
+computePassEncoder12.dispatchWorkgroups(
+2,
+1
+);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(
+buffer6,
+'uint32',
+4504,
+5374
+);
+} catch {}
+try {
+commandEncoder31.copyBufferToBuffer(
+buffer11,
+5084,
+buffer9,
+1512,
+404
+);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer9,
+5532,
+new Int16Array(29441),
+4115,
+76
+);
+} catch {}
+let pipeline51 = await device0.createComputePipelineAsync(
+{
+layout: pipelineLayout0,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+},
+}
+);
+let gpuCanvasContext7 = canvas4.getContext('webgpu');
+document.body.append('\u43b7\udf1c\u9dc7\u6cbc\u9097\u981e\u0d76\u{1fdda}');
+let pipelineLayout4 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout11,
+bindGroupLayout0,
+bindGroupLayout2,
+bindGroupLayout10
+],
+}
+);
+let texture46 = device0.createTexture(
+{
+size: {width: 120, height: 120, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-8x8-unorm',
+'astc-8x8-unorm-srgb',
+'astc-8x8-unorm-srgb'
+],
+}
+);
+let texture47 = gpuCanvasContext4.getCurrentTexture();
+let textureView36 = texture19.createView(
+{
+baseMipLevel: 2,
+baseArrayLayer: 50,
+arrayLayerCount: 73,
+}
+);
+try {
+renderPassEncoder3.setBindGroup(
+7,
+bindGroup7,
+new Uint32Array(3895),
+2020,
+0
+);
+} catch {}
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.setViewport(
+3.131,
+0.4721,
+11.08,
+0.2169,
+0.8327,
+0.8710
+);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(
+4,
+bindGroup9
+);
+} catch {}
+let arrayBuffer1 = buffer10.getMappedRange(
+11360,
+76
+);
+try {
+commandEncoder31.clearBuffer(
+buffer2,
+28344,
+2140
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer5,
+12268,
+new DataView(new ArrayBuffer(38068)),
+14802,
+4640
+);
+} catch {}
+let querySet25 = device0.createQuerySet(
+{
+label: '\u07c1\u0c86\u0fa4\u965d\u{1fceb}\u4f10\u0301\u2424\u02ca\u45ff\u4ee9',
+type: 'occlusion',
+count: 2588,
+}
+);
+let sampler29 = device0.createSampler(
+{
+label: '\u{1fd69}\u32a5\u86cd\u0be3',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 64.233,
+maxAnisotropy: 1,
+}
+);
+try {
+computePassEncoder19.setPipeline(
+pipeline32
+);
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+await buffer14.mapAsync(
+GPUMapMode.READ,
+9720,
+1316
+);
+} catch {}
+try {
+commandEncoder32.copyBufferToBuffer(
+buffer9,
+4764,
+buffer5,
+7440,
+172
+);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+renderBundleEncoder31.pushDebugGroup(
+'\u90b4'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer5,
+3060,
+new BigUint64Array(43502),
+6029,
+2088
+);
+} catch {}
+let promise15 = device0.queue.onSubmittedWorkDone();
+try {
+adapter1.label = '\u340f\u04c4\u171f\u03d8\ue6f2\u1817\u0820\uc4fc\u55a6\u{1fb13}';
+} catch {}
+let buffer15 = device0.createBuffer(
+{
+label: '\u4455\u3a1a\ued9e\u{1fa50}',
+size: 24360,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+mappedAtCreation: true,
+}
+);
+let renderBundle37 = renderBundleEncoder12.finish(
+{
+label: '\u{1faa3}\u3d76\ucb55\u2ba5\u0dca\u35e1\ua5a3\u7bdb\u0946\u0347'
+}
+);
+try {
+computePassEncoder19.dispatchWorkgroups(
+5,
+3,
+5
+);
+} catch {}
+try {
+computePassEncoder11.setPipeline(
+pipeline23
+);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(
+1,
+buffer15,
+12700
+);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(
+7,
+bindGroup10
+);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(
+3,
+buffer15
+);
+} catch {}
+try {
+commandEncoder31.clearBuffer(
+buffer15
+);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture31,
+  mipLevel: 1,
+  origin: { x: 8, y: 72, z: 131 },
+  aspect: 'all',
+},
+new DataView(new ArrayBuffer(8)),
+/* required buffer size: 903 */{
+offset: 903,
+bytesPerRow: 3318,
+},
+{width: 1536, height: 24, depthOrArrayLayers: 0}
+);
+} catch {}
+let bindGroup15 = device0.createBindGroup({
+label: '\ufecd\u{1ffd4}\ubf26\u{1fa00}\u02a2\uc98b\u0609\u62da',
+layout: bindGroupLayout15,
+entries: [
+
+],
+});
+let commandEncoder33 = device0.createCommandEncoder(
+{
+label: '\u00fb\u0b52\u286b\u0dab\u01bf\u0b66\u058a\u068c\uf0bb\u{1fc71}\u0901',
+}
+);
+pseudoSubmit(device0, commandEncoder0);
+let textureView37 = texture27.createView(
+{
+label: '\u{1fc93}\u9ea2',
+baseMipLevel: 5,
+baseArrayLayer: 109,
+arrayLayerCount: 55,
+}
+);
+let renderBundle38 = renderBundleEncoder36.finish(
+{
+
+}
+);
+try {
+renderPassEncoder10.beginOcclusionQuery(
+72
+);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(
+buffer9,
+'uint32',
+3544
+);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(
+8,
+bindGroup14
+);
+} catch {}
+let pipeline52 = await device0.createComputePipelineAsync(
+{
+label: '\u245e\u36c9\u0415\u106b',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend(canvas3);
+offscreenCanvas3.width = 688;
+let renderPassEncoder15 = commandEncoder30.beginRenderPass(
+{
+label: '\u96d5\uf422\ub3e9\u{1f9d9}\u{1fdde}\u9c73\u026a\uc219',
+colorAttachments: [
+{
+view: textureView7,
+depthSlice: 12,
+clearValue: {
+r: -176.9,
+g: 729.9,
+b: -9.328,
+a: -583.5,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView7,
+depthSlice: 18,
+clearValue: {
+r: -474.6,
+g: 978.5,
+b: 311.4,
+a: -753.5,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView7,
+depthSlice: 24,
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView7,
+depthSlice: 8,
+clearValue: {
+r: 508.4,
+g: 960.2,
+b: 594.3,
+a: 265.3,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView7,
+depthSlice: 19,
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet3,
+}
+);
+try {
+renderPassEncoder15.beginOcclusionQuery(
+16
+);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(
+2,
+bindGroup0,
+new Uint32Array(6936),
+6710,
+0
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer8,
+34380,
+new Float32Array(15622),
+3100,
+4904
+);
+} catch {}
+try {
+await promise15;
+} catch {}
+offscreenCanvas0.width = 540;
+document.body.prepend('\uae12\u5d77\u{1fd66}\u{1fd80}\u04ea\u3223\u8def\u{1fa8a}\u5149');
+let pipelineLayout5 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout13,
+bindGroupLayout3,
+bindGroupLayout8
+],
+}
+);
+let commandEncoder34 = device0.createCommandEncoder();
+try {
+renderBundleEncoder37.setBindGroup(
+1,
+bindGroup10,
+new Uint32Array(973),
+887,
+0
+);
+} catch {}
+try {
+renderBundleEncoder31.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer3,
+]);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame5 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+let bindGroup16 = device0.createBindGroup({
+label: '\u2dfd\u0917\u58f7\u05cf\u{1fb28}\u0d73\u022d\u0514\u{1fcde}',
+layout: bindGroupLayout3,
+entries: [
+
+],
+});
+let computePassEncoder20 = commandEncoder32.beginComputePass(
+{
+label: '\u03a5\ud7f7\uefbf\u0141\u{1f901}'
+}
+);
+let renderBundle39 = renderBundleEncoder10.finish(
+{
+label: '\u7082\uf479\u0126'
+}
+);
+try {
+computePassEncoder19.dispatchWorkgroups(
+4,
+1,
+2
+);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(
+5,
+bindGroup5
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'stencil-only',
+},
+new ArrayBuffer(34601),
+/* required buffer size: 34601 */{
+offset: 100,
+bytesPerRow: 2166,
+rowsPerImage: 245,
+},
+{width: 2011, height: 16, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 164}
+*/
+{
+  source: offscreenCanvas6,
+  origin: { x: 880, y: 434 },
+  flipY: true,
+},
+{
+  texture: texture30,
+  mipLevel: 3,
+  origin: { x: 0, y: 1, z: 31 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline53 = device0.createComputePipeline(
+{
+label: '\u06ed\u03f7\u130d',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend('\u0a9c\u0bf6\u0abd');
+let bindGroup17 = device0.createBindGroup({
+label: '\uf271\u3039\uadb6\u63af\u01c6',
+layout: bindGroupLayout4,
+entries: [
+{
+binding: 599,
+resource: externalTexture1
+}
+],
+});
+let renderBundleEncoder38 = device0.createRenderBundleEncoder(
+{
+label: '\u0d8d\u{1ff1a}\udb71\u{1fb57}',
+colorFormats: [
+'rg32sint',
+'rg16uint'
+],
+sampleCount: 401,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder15.setBindGroup(
+2,
+bindGroup6
+);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(
+1,
+bindGroup12
+);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer9,
+1400,
+new BigUint64Array(31791),
+21384,
+508
+);
+} catch {}
+let pipeline54 = await device0.createRenderPipelineAsync(
+{
+label: '\u9a03\u8188\u8a21\ube44',
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}
+],
+},
+}
+);
+let commandEncoder35 = device0.createCommandEncoder(
+{
+label: '\uf599\u061b\u009a\u085f\u093d',
+}
+);
+let textureView38 = texture1.createView(
+{
+label: '\u06a4\u780b\u{1fa3a}\u{1fd1f}\u0722\uaf6f\u{1fd60}\u18a4',
+baseMipLevel: 1,
+mipLevelCount: 2,
+}
+);
+try {
+renderBundleEncoder31.setVertexBuffer(
+2,
+buffer8,
+45692,
+2619
+);
+} catch {}
+try {
+commandEncoder31.resolveQuerySet(
+querySet0,
+238,
+61,
+buffer15,
+10240
+);
+} catch {}
+let pipeline55 = device0.createComputePipeline(
+{
+label: '\u{1fbad}\u{1f8f9}\u{1f709}',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule9,
+entryPoint: 'compute0',
+},
+}
+);
+document.body.append('\u{1fc0f}\ufbb6\u0d29\u{1f6fa}\u09b4');
+let videoFrame6 = new VideoFrame(videoFrame3, {timestamp: 0});
+let bindGroupLayout16 = device0.createBindGroupLayout(
+{
+label: '\u4e43\u7f50\u5935\u2d88\u0156\u0913\ub264\u23c1\u4b2a',
+entries: [
+
+],
+}
+);
+let computePassEncoder21 = commandEncoder22.beginComputePass(
+{
+label: '\u1631\u3a3a\u7b3b\u08df\u040a\udac5\u{1fa26}\u8505\u{1ff0c}\ud13c'
+}
+);
+let renderPassEncoder16 = commandEncoder16.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView32,
+depthSlice: 21,
+clearValue: {
+r: -999.8,
+g: 666.6,
+b: -947.6,
+a: -304.2,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView32,
+depthSlice: 8,
+clearValue: {
+r: 541.7,
+g: 37.65,
+b: -441.2,
+a: 924.9,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView32,
+depthSlice: 34,
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet10,
+maxDrawCount: 193960,
+}
+);
+let renderBundle40 = renderBundleEncoder21.finish(
+{
+
+}
+);
+try {
+computePassEncoder17.setPipeline(
+pipeline45
+);
+} catch {}
+try {
+renderPassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(
+8,
+1,
+21,
+0
+);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(
+buffer9,
+'uint32',
+708,
+2891
+);
+} catch {}
+try {
+commandEncoder31.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder35.resolveQuerySet(
+querySet23,
+76,
+11,
+buffer15,
+2048
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer8,
+48100,
+new DataView(new ArrayBuffer(51197)),
+4739,
+4712
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture11,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 6 },
+  aspect: 'depth-only',
+},
+new Float32Array(arrayBuffer1),
+/* required buffer size: 75709 */{
+offset: 745,
+bytesPerRow: 79,
+rowsPerImage: 237,
+},
+{width: 36, height: 1, depthOrArrayLayers: 5}
+);
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(
+601
+);
+} catch {}
+try {
+renderPassEncoder15.setViewport(
+30.22,
+0.6722,
+19.88,
+0.1736,
+0.3095,
+0.3841
+);
+} catch {}
+let arrayBuffer2 = buffer10.getMappedRange(
+11224,
+4
+);
+try {
+gpuCanvasContext6.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm',
+'depth24plus',
+'rgba8unorm-srgb',
+'rg32float'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer8,
+23008,
+new Int16Array(52775),
+32972,
+12960
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer0),
+/* required buffer size: 613 */{
+offset: 613,
+bytesPerRow: 166,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise16 = device0.createRenderPipelineAsync(
+{
+label: '\uae53\ufcd5\uc747\uf936\u56e8\u3eff\u7008',
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule4,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 35088,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32',
+offset: 13844,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 23516,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32',
+offset: 1824,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 21468,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 24744,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 2176,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'none',
+},
+multisample: {
+count: 4,
+mask: 0xcfc8574f,
+},
+fragment: {
+module: shaderModule4,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg32float',
+},
+undefined,
+{
+format: 'r8sint',
+},
+undefined,
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'src',
+dstFactor: 'src'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rg16float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined
+],
+},
+}
+);
+document.body.append('\u{1fbaa}\u02d0\u5e9c\u00aa\uf324\u0bdb\u0195\u69d2\ufcea\u{1fac6}');
+let imageBitmap9 = await createImageBitmap(videoFrame1);
+let imageData7 = new ImageData(144, 156);
+let buffer16 = device0.createBuffer(
+{
+size: 16139,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+}
+);
+let textureView39 = texture42.createView(
+{
+label: '\u0f56\u0856\u{1fbc5}\u0b87\u03cd\u{1f6ca}\u0e48\u27cd\uf855\u922d\u0998',
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+try {
+computePassEncoder11.setPipeline(
+pipeline23
+);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(
+8,
+bindGroup16
+);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder15.setViewport(
+34.73,
+0.9939,
+43.01,
+0.00181,
+0.6045,
+0.6929
+);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(
+buffer6,
+'uint16',
+14890
+);
+} catch {}
+try {
+commandEncoder31.copyBufferToBuffer(
+buffer9,
+540,
+buffer5,
+5448,
+612
+);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture7,
+  mipLevel: 2,
+  origin: { x: 6, y: 0, z: 40 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 447380 */{
+offset: 691,
+bytesPerRow: 939,
+rowsPerImage: 95,
+},
+{width: 166, height: 1, depthOrArrayLayers: 6}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 5, height: 1, depthOrArrayLayers: 19}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 202, y: 0 },
+  flipY: true,
+},
+{
+  texture: texture32,
+  mipLevel: 3,
+  origin: { x: 3, y: 0, z: 7 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\u{1f7b5}\u43d4\u5ca0\u8d73\ubeec\u071f\u03aa\u947c');
+let canvas5 = document.createElement('canvas');
+let commandEncoder36 = device0.createCommandEncoder(
+{
+}
+);
+let textureView40 = texture46.createView(
+{
+label: '\u7201\u{1fed8}\ude36\u907e\ucb2c',
+format: 'astc-8x8-unorm-srgb',
+baseMipLevel: 1,
+mipLevelCount: 3,
+}
+);
+let renderBundle41 = renderBundleEncoder3.finish();
+let sampler30 = device0.createSampler(
+{
+label: '\u{1f813}\u03b7\u9bfa\u{1fa2d}\u9354\u{1fc3a}\u0221\ub72d\u92bd\u{1fb8b}',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 10.185,
+maxAnisotropy: 2,
+}
+);
+try {
+computePassEncoder20.setPipeline(
+pipeline34
+);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant(
+{
+r: 686.1,
+g: 831.9,
+b: -487.3,
+a: 663.1,
+}
+);
+} catch {}
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder33.clearBuffer(
+buffer9
+);
+dissociateBuffer(device0, buffer9);
+} catch {}
+let pipeline56 = await promise9;
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let computePassEncoder22 = commandEncoder36.beginComputePass(
+{
+label: '\u92ab\u2082\uf3df\u309a'
+}
+);
+let sampler31 = device0.createSampler(
+{
+label: '\u{1ffce}\u{1fa50}\uaf42\u5294',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 55.976,
+lodMaxClamp: 73.816,
+maxAnisotropy: 16,
+}
+);
+try {
+computePassEncoder19.dispatchWorkgroups(
+1,
+3
+);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(
+8,
+bindGroup15,
+new Uint32Array(74),
+44,
+0
+);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(
+buffer9,
+'uint32',
+5508,
+231
+);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(
+1,
+buffer15,
+20496
+);
+} catch {}
+try {
+commandEncoder34.copyBufferToBuffer(
+buffer10,
+9028,
+buffer5,
+8644,
+692
+);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer8,
+23556,
+new Float32Array(7160),
+1440,
+2464
+);
+} catch {}
+try {
+window.someLabel = externalTexture2.label;
+} catch {}
+let querySet26 = device0.createQuerySet(
+{
+label: '\u37c9\u0c72\u2ee6\u0a9d\u30e5',
+type: 'occlusion',
+count: 1694,
+}
+);
+let renderBundle42 = renderBundleEncoder28.finish();
+try {
+renderPassEncoder16.setBindGroup(
+0,
+bindGroup9
+);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: 458.2,
+g: -108.7,
+b: 117.4,
+a: -633.3,
+}
+);
+} catch {}
+try {
+renderPassEncoder3.setViewport(
+21.40,
+0.8435,
+0.1390,
+0.1415,
+0.5444,
+0.9299
+);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(
+buffer16,
+'uint16',
+13652
+);
+} catch {}
+try {
+querySet8.destroy();
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer16,
+13812,
+new BigUint64Array(25139),
+17550,
+180
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap6,
+  origin: { x: 6, y: 2 },
+  flipY: false,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\u01cf\u431e\u8ef4\u1656\u3121\u7d9b\u38a9\ud221\u04fb\udb86');
+let img16 = await imageWithData(157, 203, '#2021e391', '#539350bd');
+let commandEncoder37 = device0.createCommandEncoder(
+{
+label: '\uabf3\ud3a7\ufd8b\u39b4\ua77e\u07d2\u0367\u71ff\u1413\ud825\u9e9b',
+}
+);
+let texture48 = device0.createTexture(
+{
+label: '\u0e3c\ue093\u{1feaa}\uffc9\u{1fbc7}\u0fe3\u475f\ufcd8\u{1fc8f}\u6317',
+size: [206, 1, 1684],
+mipLevelCount: 11,
+dimension: '3d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg11b10ufloat'
+],
+}
+);
+try {
+computePassEncoder22.setBindGroup(
+2,
+bindGroup9,
+new Uint32Array(3309),
+88,
+0
+);
+} catch {}
+try {
+computePassEncoder20.dispatchWorkgroups(
+1,
+4
+);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(
+8,
+bindGroup12
+);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(
+0,
+bindGroup6,
+new Uint32Array(2426),
+1242,
+0
+);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(
+8,
+buffer8
+);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+try {
+commandEncoder34.copyBufferToBuffer(
+buffer4,
+14572,
+buffer15,
+22680,
+1320
+);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+commandEncoder35.clearBuffer(
+buffer8,
+17020,
+28236
+);
+dissociateBuffer(device0, buffer8);
+} catch {}
+let adapter4 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let canvas6 = document.createElement('canvas');
+try {
+window.someLabel = textureView4.label;
+} catch {}
+let commandBuffer5 = commandEncoder34.finish();
+let textureView41 = texture23.createView(
+{
+label: '\u{1fa15}\u0bdd',
+baseMipLevel: 2,
+mipLevelCount: 3,
+}
+);
+let renderBundleEncoder39 = device0.createRenderBundleEncoder(
+{
+label: '\u028a\u49f8\u{1fa28}\u646a',
+colorFormats: [
+undefined,
+'rg32float',
+'rgba16sint',
+'r32uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 125,
+depthReadOnly: false,
+}
+);
+let sampler32 = device0.createSampler(
+{
+label: '\u06a6\ub3db',
+addressModeU: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 69.007,
+lodMaxClamp: 76.053,
+}
+);
+try {
+renderPassEncoder12.setVertexBuffer(
+7,
+buffer15,
+18984,
+3548
+);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(
+8,
+buffer8,
+16580,
+10784
+);
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture(
+{
+  texture: texture42,
+  mipLevel: 0,
+  origin: { x: 23, y: 1, z: 1782 },
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: { x: 5, y: 1, z: 0 },
+  aspect: 'all',
+},
+{width: 67, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder35.clearBuffer(
+buffer9
+);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder35.resolveQuerySet(
+querySet2,
+776,
+842,
+buffer15,
+9472
+);
+} catch {}
+let pipeline57 = await promise16;
+let videoFrame7 = new VideoFrame(img1, {timestamp: 0});
+let shaderModule12 = device0.createShaderModule(
+{
+label: '\u0319\uc100\u0e8c\u{1f6d5}',
+code: `@group(2) @binding(1014)
+var<storage, read_write> local1: array<u32>;
+
+@compute @workgroup_size(4, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: vec4<f32>,
+@location(7) f1: vec3<i32>,
+@location(6) f2: vec3<f32>,
+@location(1) f3: vec4<f32>,
+@location(5) f4: vec2<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(sample_mask) a2: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S9 {
+@location(4) f0: u32,
+@location(13) f1: vec3<i32>,
+@location(1) f2: vec2<f16>,
+@location(7) f3: vec3<u32>,
+@location(11) f4: vec3<f16>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(0) a1: u32, @location(3) a2: u32, @location(8) a3: f16, @location(6) a4: vec3<i32>, a5: S9, @location(5) a6: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+}
+);
+let texture49 = device0.createTexture(
+{
+label: '\u33f0\u{1f6f0}\u0b64\u6eae\u0568\u0a65\u06b2\u5512\u66aa',
+size: {width: 228, height: 1, depthOrArrayLayers: 1410},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rg32uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32uint',
+'rg32uint',
+'rg32uint'
+],
+}
+);
+let computePassEncoder23 = commandEncoder31.beginComputePass(
+{
+label: '\ub68a\u02d1\u0848\u{1fd9c}\u056c'
+}
+);
+let sampler33 = device0.createSampler(
+{
+label: '\u77fa\u026b\uc87d\u0a41\u0a92',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+lodMaxClamp: 98.207,
+}
+);
+try {
+renderPassEncoder16.beginOcclusionQuery(
+32
+);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.setViewport(
+53.18,
+0.9095,
+28.00,
+0.04817,
+0.6720,
+0.6742
+);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(
+6,
+buffer6
+);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(
+8,
+buffer8,
+9764,
+44993
+);
+} catch {}
+try {
+commandEncoder35.copyBufferToBuffer(
+buffer4,
+7396,
+buffer8,
+13648,
+12860
+);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer4,
+commandBuffer5,
+commandBuffer2,
+]);
+} catch {}
+let pipeline58 = await device0.createRenderPipelineAsync(
+{
+label: '\u9114\ue964\u{1f9b0}\u0503\u{1f86a}\uebeb',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 34440,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x2',
+offset: 18036,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 34424,
+shaderLocation: 4,
+},
+{
+format: 'sint32',
+offset: 22336,
+shaderLocation: 12,
+},
+{
+format: 'float16x4',
+offset: 34180,
+shaderLocation: 3,
+},
+{
+format: 'uint32',
+offset: 7036,
+shaderLocation: 14,
+},
+{
+format: 'sint16x2',
+offset: 23952,
+shaderLocation: 6,
+},
+{
+format: 'snorm8x2',
+offset: 1318,
+shaderLocation: 8,
+},
+{
+format: 'uint32x3',
+offset: 32248,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 20012,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 13756,
+shaderLocation: 9,
+},
+{
+format: 'float16x2',
+offset: 4324,
+shaderLocation: 16,
+},
+{
+format: 'uint32',
+offset: 1660,
+shaderLocation: 15,
+},
+{
+format: 'uint32x2',
+offset: 404,
+shaderLocation: 10,
+},
+{
+format: 'snorm8x2',
+offset: 19364,
+shaderLocation: 11,
+},
+{
+format: 'unorm16x2',
+offset: 10940,
+shaderLocation: 5,
+},
+{
+format: 'sint16x4',
+offset: 5636,
+shaderLocation: 13,
+},
+{
+format: 'snorm8x4',
+offset: 17888,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 2472,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 10316,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x2',
+offset: 4628,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x4a540fa4,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg32float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+}
+],
+},
+}
+);
+canvas4.height = 643;
+let computePassEncoder24 = commandEncoder37.beginComputePass(
+{
+label: '\u0cc2\u0ff7\u06ca\u{1f9fc}\u0262\u058f\u0a15\uf92d\u68f1\u0fed'
+}
+);
+try {
+computePassEncoder20.dispatchWorkgroupsIndirect(
+buffer1,
+2152
+);
+} catch {}
+try {
+computePassEncoder18.setPipeline(
+pipeline52
+);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(
+buffer6,
+'uint16',
+14924,
+381
+);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(
+2,
+buffer8
+);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(
+6,
+bindGroup16
+);
+} catch {}
+try {
+commandEncoder35.copyBufferToBuffer(
+buffer10,
+204,
+buffer2,
+25284,
+8840
+);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let pipeline59 = await promise6;
+let pipeline60 = await device0.createRenderPipelineAsync(
+{
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 21964,
+shaderLocation: 10,
+},
+{
+format: 'unorm8x4',
+offset: 8304,
+shaderLocation: 14,
+},
+{
+format: 'sint32x4',
+offset: 24668,
+shaderLocation: 9,
+},
+{
+format: 'uint32',
+offset: 14868,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 6844,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 6480,
+shaderLocation: 12,
+},
+{
+format: 'unorm16x2',
+offset: 5880,
+shaderLocation: 3,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'decrement-clamp',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 1302,
+stencilWriteMask: 2405,
+depthBias: 89,
+depthBiasSlopeScale: 65,
+depthBiasClamp: 11,
+},
+}
+);
+gc();
+try {
+canvas5.getContext('webgpu');
+} catch {}
+try {
+querySet22.label = '\u863c\u041a\uf020\u01a1\ue8a0\u2d69\u459c\u{1fb60}';
+} catch {}
+let texture50 = device0.createTexture(
+{
+label: '\u2767\u338f\u{1fa34}\u02fd\u714b',
+size: {width: 75, height: 20, depthOrArrayLayers: 1},
+sampleCount: 1,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+renderPassEncoder8.setVertexBuffer(
+2,
+buffer15,
+12432,
+5916
+);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(
+1,
+bindGroup8,
+new Uint32Array(2337),
+1747,
+0
+);
+} catch {}
+document.body.prepend('\ud9d0\u{1f6aa}\uc4dd\u{1f764}\u{1fbe0}\ufc4c\u8905\uddaa\u{1f6b8}');
+let texture51 = device0.createTexture(
+{
+label: '\u{1f86f}\u89a9',
+size: [5184, 6, 1],
+format: 'astc-8x6-unorm',
+usage: GPUTextureUsage.COPY_DST,
+}
+);
+try {
+computePassEncoder23.setBindGroup(
+6,
+bindGroup7,
+new Uint32Array(8824),
+296,
+0
+);
+} catch {}
+let arrayBuffer3 = buffer11.getMappedRange(
+0,
+15648
+);
+try {
+commandEncoder35.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let gpuCanvasContext8 = canvas6.getContext('webgpu');
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let bindGroup18 = device0.createBindGroup({
+label: '\uc196\ue0b6\u9767\u056e',
+layout: bindGroupLayout15,
+entries: [
+
+],
+});
+let buffer17 = device0.createBuffer(
+{
+label: '\u{1fae6}\u{1f84f}\u07d8\u{1fb4d}\u{1f625}\u9e6f\u{1fe11}\u68bb',
+size: 2900,
+usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let querySet27 = device0.createQuerySet(
+{
+label: '\u0224\uab3b\u3e0c\u8383\u0cbc\u74ab\u0281\u0a87\ub9ac',
+type: 'occlusion',
+count: 91,
+}
+);
+let texture52 = device0.createTexture(
+{
+label: '\ucad5\ub4c9\u252c\u6024\ud099',
+size: [210, 130, 1],
+dimension: '2d',
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x10-unorm-srgb'
+],
+}
+);
+let textureView42 = texture29.createView(
+{
+label: '\u{1f869}\u{1ff28}\u5dbe\u51f1\u0754\ue2cf\uc56c\u0458\u0537',
+baseMipLevel: 3,
+mipLevelCount: 2,
+}
+);
+let renderBundleEncoder40 = device0.createRenderBundleEncoder(
+{
+label: '\u47af\ue2da',
+colorFormats: [
+'rg32uint',
+'rgb10a2uint',
+undefined,
+'rg32float',
+'rgb10a2uint'
+],
+sampleCount: 12,
+depthReadOnly: true,
+}
+);
+try {
+computePassEncoder22.setBindGroup(
+1,
+bindGroup2
+);
+} catch {}
+try {
+computePassEncoder20.dispatchWorkgroupsIndirect(
+buffer1,
+1624
+);
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(
+buffer9,
+'uint16',
+3576
+);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(
+3,
+buffer5,
+21532,
+1794
+);
+} catch {}
+try {
+commandEncoder35.copyBufferToBuffer(
+buffer11,
+31616,
+buffer16,
+364,
+2340
+);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer9,
+4600,
+new Float32Array(47903),
+2017,
+168
+);
+} catch {}
+let pipeline61 = device0.createComputePipeline(
+{
+layout: pipelineLayout0,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+},
+}
+);
+document.body.prepend(video3);
+let videoFrame8 = new VideoFrame(imageBitmap4, {timestamp: 0});
+let bindGroup19 = device0.createBindGroup({
+layout: bindGroupLayout3,
+entries: [
+
+],
+});
+let textureView43 = texture22.createView(
+{
+label: '\u1fa0\u{1fdc8}\u{1f69d}\u63cd',
+}
+);
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: -333.3,
+g: -456.6,
+b: 616.0,
+a: 924.1,
+}
+);
+} catch {}
+try {
+renderBundleEncoder32.setIndexBuffer(
+buffer6,
+'uint16',
+1716,
+13676
+);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(
+3,
+buffer6,
+20384,
+0
+);
+} catch {}
+let imageBitmap10 = await createImageBitmap(offscreenCanvas0);
+let commandEncoder38 = device0.createCommandEncoder(
+{
+label: '\u8bef\u973b\uf594\udd73\ua401\u478c\ub5fb\u5615\u{1fa41}\ue03c',
+}
+);
+let querySet28 = device0.createQuerySet(
+{
+label: '\u{1f91b}\ufec5\uc5a9\u13f2',
+type: 'occlusion',
+count: 3526,
+}
+);
+let renderBundle43 = renderBundleEncoder7.finish(
+{
+label: '\u037c\uaa14\ubc42\u{1fc0d}'
+}
+);
+try {
+computePassEncoder9.setPipeline(
+pipeline20
+);
+} catch {}
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(
+279
+);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(
+buffer9,
+'uint16',
+536,
+2414
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture30,
+  mipLevel: 5,
+  origin: { x: 1, y: 0, z: 14 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 79442 */{
+offset: 748,
+bytesPerRow: 49,
+rowsPerImage: 146,
+},
+{width: 0, height: 0, depthOrArrayLayers: 12}
+);
+} catch {}
+document.body.prepend(video2);
+let bindGroupLayout17 = device0.createBindGroupLayout(
+{
+label: '\u091e\uf3e9\u{1fb49}\uc8ec\udd61',
+entries: [
+{
+binding: 1457,
+visibility: 0,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+},
+{
+binding: 2455,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+},
+{
+binding: 2894,
+visibility: 0,
+buffer: { type: 'read-only-storage', minBindingSize: 65147, hasDynamicOffset: true },
+}
+],
+}
+);
+let renderBundle44 = renderBundleEncoder9.finish(
+{
+label: '\u0e73\ufd7a\udfe6\u194f\u9d62\u{1fbe4}\uda99\u2213\u08cb'
+}
+);
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(
+4,
+buffer17,
+2000,
+174
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture45,
+  mipLevel: 2,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'stencil-only',
+},
+arrayBuffer0,
+/* required buffer size: 725 */{
+offset: 725,
+},
+{width: 35, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline62 = device0.createComputePipeline(
+{
+layout: pipelineLayout1,
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+},
+}
+);
+let canvas7 = document.createElement('canvas');
+let imageData8 = new ImageData(184, 4);
+let texture53 = device0.createTexture(
+{
+label: '\u58e5\u0355\u0209\u5183\u{1f84b}\ufedf\ue04d',
+size: {width: 64, height: 95, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+dimension: '2d',
+format: 'astc-8x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-8x5-unorm'
+],
+}
+);
+try {
+computePassEncoder11.setBindGroup(
+2,
+bindGroup3
+);
+} catch {}
+try {
+renderPassEncoder14.setScissorRect(
+1,
+1,
+52,
+0
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 122, y: 45 },
+  flipY: true,
+},
+{
+  texture: texture32,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+canvas7.getContext('2d');
+} catch {}
+try {
+computePassEncoder18.dispatchWorkgroupsIndirect(
+buffer1,
+4448
+);
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(
+2225
+);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(
+1,
+buffer15,
+19688
+);
+} catch {}
+document.body.prepend('\u{1f935}\u0dec\u{1fee0}\u0168\u{1fbc7}\u{1ff51}\udb0a\udccb');
+let renderPassEncoder17 = commandEncoder12.beginRenderPass(
+{
+label: '\u0f45\u0823',
+colorAttachments: [
+{
+view: textureView39,
+depthSlice: 430,
+clearValue: {
+r: -441.4,
+g: 220.7,
+b: 623.1,
+a: 330.8,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView39,
+depthSlice: 321,
+clearValue: {
+r: -987.2,
+g: 946.0,
+b: 757.7,
+a: -667.0,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+undefined,
+{
+view: textureView39,
+depthSlice: 120,
+clearValue: {
+r: -115.9,
+g: 313.8,
+b: -261.5,
+a: -941.0,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined
+],
+occlusionQuerySet: querySet24,
+}
+);
+let sampler34 = device0.createSampler(
+{
+label: '\u04dd\u077d\u{1fa51}\u9b0f\u{1fee0}\u0328\u{1fbb3}\udbe7\u0d0e',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 95.026,
+lodMaxClamp: 96.951,
+maxAnisotropy: 12,
+}
+);
+try {
+renderPassEncoder17.setStencilReference(
+1157
+);
+} catch {}
+try {
+commandEncoder38.clearBuffer(
+buffer9
+);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+renderBundleEncoder18.pushDebugGroup(
+'\u0ddf'
+);
+} catch {}
+try {
+commandEncoder33.insertDebugMarker(
+'\u{1fa5e}'
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 10, y: 87 },
+  flipY: false,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline63 = device0.createComputePipeline(
+{
+label: '\u2e7b\uac44\u5e49\u{1fbb3}\u039c\u{1fa10}\u0cd2\u{1f897}\u0ba9',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline64 = await device0.createRenderPipelineAsync(
+{
+label: '\uc81d\u99f1',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule6,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 5436,
+attributes: [
+{
+format: 'float32x3',
+offset: 4,
+shaderLocation: 10,
+},
+{
+format: 'uint32x2',
+offset: 2924,
+shaderLocation: 14,
+},
+{
+format: 'sint8x4',
+offset: 3328,
+shaderLocation: 13,
+},
+{
+format: 'sint32x3',
+offset: 2188,
+shaderLocation: 7,
+},
+{
+format: 'sint8x2',
+offset: 4622,
+shaderLocation: 12,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 24,
+shaderLocation: 6,
+},
+{
+format: 'sint32x4',
+offset: 3180,
+shaderLocation: 3,
+},
+{
+format: 'sint16x4',
+offset: 440,
+shaderLocation: 2,
+},
+{
+format: 'uint8x4',
+offset: 1656,
+shaderLocation: 5,
+},
+{
+format: 'float32x4',
+offset: 4056,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 652,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 96,
+shaderLocation: 0,
+},
+{
+format: 'sint32',
+offset: 312,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 8332,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 1944,
+shaderLocation: 1,
+},
+{
+format: 'sint16x2',
+offset: 648,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 29708,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'snorm8x2',
+offset: 34468,
+shaderLocation: 11,
+},
+{
+format: 'sint16x2',
+offset: 15756,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 10476,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 18548,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 13156,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule6,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'rg32sint',
+}
+],
+},
+}
+);
+let pipelineLayout6 = device0.createPipelineLayout(
+{
+label: '\u{1f7bd}\ue5aa\u6974\u{1fb4c}\u2022\uba74\u{1fb22}\u{1fee5}\u6905\u{1fee5}\u6f49',
+bindGroupLayouts: [
+
+],
+}
+);
+let renderBundleEncoder41 = device0.createRenderBundleEncoder(
+{
+label: '\u03c6\u{1f8e6}\uf71a\u{1f859}\u{1f9e9}\u078c\u600a\u039a\u24a7\u0c4f\u0b44',
+colorFormats: [
+'rgba8uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 441,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder11.setPipeline(
+pipeline49
+);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder15.setViewport(
+59.98,
+0.3852,
+21.29,
+0.3430,
+0.9362,
+0.9784
+);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(
+8,
+buffer8,
+14228,
+2853
+);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+commandEncoder35.copyBufferToBuffer(
+buffer13,
+2344,
+buffer7,
+18848,
+2308
+);
+dissociateBuffer(device0, buffer13);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+renderBundleEncoder11.insertDebugMarker(
+'\u{1f947}'
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas1,
+  origin: { x: 590, y: 387 },
+  flipY: false,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend('\u07da\uf3cf\u{1fc31}\ub7e1\u{1f813}\ubb19\uf6de\uf222\u6c28\u5d8b');
+try {
+adapter3.label = '\udeca\ue274\u423c\u2ee0\u{1fcc9}\u4e59\u2ad7\u34c4\u9a97\u3a0e\u25b4';
+} catch {}
+try {
+computePassEncoder21.setPipeline(
+pipeline56
+);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(
+2,
+bindGroup5
+);
+} catch {}
+try {
+commandEncoder33.resolveQuerySet(
+querySet12,
+2547,
+126,
+buffer15,
+23040
+);
+} catch {}
+try {
+computePassEncoder22.insertDebugMarker(
+'\u2d98'
+);
+} catch {}
+let promise17 = device0.createComputePipelineAsync(
+{
+label: '\u2dd8\u1398\ua2db\u3b9e',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline65 = device0.createRenderPipeline(
+{
+layout: pipelineLayout5,
+vertex: {
+module: shaderModule9,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 17528,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x2',
+offset: 10580,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x4',
+offset: 16008,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 18664,
+attributes: [
+{
+format: 'unorm16x2',
+offset: 12540,
+shaderLocation: 3,
+},
+{
+format: 'float32x3',
+offset: 4100,
+shaderLocation: 13,
+},
+{
+format: 'float32',
+offset: 18528,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x6876aef4,
+},
+fragment: {
+module: shaderModule9,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+},
+{
+format: 'rg16float',
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'one-minus-constant',
+dstFactor: 'dst-alpha'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.GREEN,
+},
+{
+format: 'rg8sint',
+},
+{
+format: 'rg11b10ufloat',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.BLUE,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'not-equal',
+depthFailOp: 'increment-clamp',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'zero',
+depthFailOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 3194,
+stencilWriteMask: 3733,
+depthBias: 86,
+depthBiasSlopeScale: 17,
+depthBiasClamp: 25,
+},
+}
+);
+let buffer18 = device0.createBuffer(
+{
+label: '\u0446\u1276\u8dbc\uc110\u9d55\u04ee\uf9f3\u73b6\u7e3f\u63be',
+size: 45468,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let renderBundleEncoder42 = device0.createRenderBundleEncoder(
+{
+label: '\u0922\u0a9d\u537e\u84f5\u8f87\u5a80\u590b',
+colorFormats: [
+'rgba32float',
+undefined,
+'r16sint',
+'rg32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 471,
+stencilReadOnly: true,
+}
+);
+let renderBundle45 = renderBundleEncoder0.finish(
+{
+label: '\u21e5\uf61d\u{1f973}\u364a\u{1fb2a}\ua363\u{1fa24}\u{1fdde}\u{1f87d}\u{1ffa9}'
+}
+);
+try {
+computePassEncoder23.setPipeline(
+pipeline9
+);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+55,
+0,
+20,
+1
+);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(
+8,
+bindGroup2,
+new Uint32Array(3517),
+2338,
+0
+);
+} catch {}
+try {
+commandEncoder33.copyTextureToBuffer(
+{
+  texture: texture18,
+  mipLevel: 0,
+  origin: { x: 40, y: 52, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 11936 */
+offset: 11936,
+rowsPerImage: 63,
+buffer: buffer16,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer16,
+12548,
+new BigUint64Array(42521),
+39611,
+52
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img13,
+  origin: { x: 36, y: 8 },
+  flipY: true,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let video6 = await videoWithData();
+let renderPassEncoder18 = commandEncoder38.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView32,
+depthSlice: 36,
+clearValue: {
+r: -92.16,
+g: -320.4,
+b: 465.3,
+a: -106.3,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView32,
+depthSlice: 17,
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined,
+undefined,
+{
+view: textureView32,
+depthSlice: 44,
+clearValue: {
+r: -666.1,
+g: -465.7,
+b: -128.0,
+a: 284.7,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+{
+view: textureView32,
+depthSlice: 27,
+clearValue: {
+r: -889.6,
+g: 400.9,
+b: 814.4,
+a: 337.1,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView32,
+depthSlice: 54,
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined
+],
+occlusionQuerySet: querySet21,
+maxDrawCount: 35240,
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture32,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 2 },
+  aspect: 'all',
+},
+new ArrayBuffer(482),
+/* required buffer size: 482 */{
+offset: 482,
+rowsPerImage: 125,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let img17 = await imageWithData(271, 183, '#07121f32', '#703f1b36');
+let shaderModule13 = device0.createShaderModule(
+{
+label: '\u01a9\u0591\u6706\u2dc5',
+code: `
+
+@compute @workgroup_size(2, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S10 {
+@location(27) f0: i32,
+@location(14) f1: vec4<f16>,
+@location(29) f2: vec3<u32>,
+@location(0) f3: vec4<u32>,
+@location(15) f4: u32,
+@location(1) f5: vec4<f32>,
+@location(6) f6: vec4<f32>,
+@location(55) f7: f16,
+@location(50) f8: vec3<u32>,
+@location(32) f9: vec4<f16>,
+@location(18) f10: i32,
+@location(33) f11: vec3<i32>,
+@location(24) f12: u32
+}
+struct FragmentOutput0 {
+@builtin(frag_depth) f0: f32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @location(19) a1: vec4<f16>, @location(41) a2: vec4<u32>, a3: S10, @location(11) a4: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(15) f155: u32,
+@location(0) f156: vec4<u32>,
+@location(18) f157: i32,
+@location(47) f158: f32,
+@location(36) f159: i32,
+@location(50) f160: vec3<u32>,
+@location(1) f161: vec4<f32>,
+@location(19) f162: vec4<f16>,
+@location(29) f163: vec3<u32>,
+@location(11) f164: vec4<f32>,
+@builtin(position) f165: vec4<f32>,
+@location(27) f166: i32,
+@location(14) f167: vec4<f16>,
+@location(41) f168: vec4<u32>,
+@location(16) f169: vec3<u32>,
+@location(43) f170: vec2<f32>,
+@location(24) f171: u32,
+@location(4) f172: vec3<u32>,
+@location(35) f173: f16,
+@location(32) f174: vec4<f16>,
+@location(6) f175: vec4<f32>,
+@location(46) f176: vec4<f16>,
+@location(31) f177: vec2<f16>,
+@location(55) f178: f16,
+@location(33) f179: vec3<i32>,
+@location(13) f180: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(0) a0: f16, @location(15) a1: vec4<i32>, @location(10) a2: vec3<f32>, @location(16) a3: vec2<i32>, @location(1) a4: vec4<u32>, @location(2) a5: vec2<f16>, @location(5) a6: vec3<u32>, @location(14) a7: f16, @location(8) a8: vec4<f32>, @location(3) a9: f16, @location(6) a10: u32, @location(12) a11: vec4<f32>, @location(11) a12: vec3<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let renderPassEncoder19 = commandEncoder33.beginRenderPass(
+{
+label: '\u0bdd\u94d7\uca01\u2061\u{1f85d}\ue735\u{1f7b6}\u{1fc90}',
+colorAttachments: [
+undefined,
+{
+view: textureView34,
+depthSlice: 428,
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView34,
+depthSlice: 596,
+clearValue: {
+r: 208.4,
+g: -707.2,
+b: -609.8,
+a: 75.21,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+undefined,
+undefined,
+{
+view: textureView34,
+depthSlice: 900,
+clearValue: {
+r: 390.2,
+g: -461.5,
+b: -338.2,
+a: 376.2,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined
+],
+occlusionQuerySet: querySet12,
+maxDrawCount: 213032,
+}
+);
+let renderBundleEncoder43 = device0.createRenderBundleEncoder(
+{
+label: '\u9a9a\u1d00\u318c\u03c1',
+colorFormats: [
+'r16uint',
+undefined,
+'rg32sint',
+'rgba16float',
+'rgba16sint',
+'r32sint',
+'rgba8sint',
+'rgb10a2unorm'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 702,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder16.setBindGroup(
+2,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(
+0,
+bindGroup17,
+new Uint32Array(7467),
+2550,
+0
+);
+} catch {}
+try {
+renderPassEncoder14.setViewport(
+47.33,
+0.1801,
+15.35,
+0.6123,
+0.5891,
+0.6747
+);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(
+0,
+buffer5
+);
+} catch {}
+try {
+buffer5.destroy();
+} catch {}
+try {
+commandEncoder35.resolveQuerySet(
+querySet9,
+1022,
+444,
+buffer15,
+5888
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap4,
+  origin: { x: 36, y: 21 },
+  flipY: false,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline66 = await promise17;
+pseudoSubmit(device0, commandEncoder4);
+let texture54 = device0.createTexture(
+{
+label: '\ufa6a\u2090\u07cf\uef7c\u1361\u217a\u0371',
+size: [206, 56, 1],
+mipLevelCount: 7,
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'r8snorm',
+'r8snorm',
+'r8snorm'
+],
+}
+);
+let textureView44 = texture36.createView(
+{
+dimension: '2d',
+baseMipLevel: 0,
+baseArrayLayer: 0,
+}
+);
+let renderPassEncoder20 = commandEncoder35.beginRenderPass(
+{
+label: '\ue5e4\u4763\u5ea1\u{1fc8b}\ub990\ua409\u0b75\u0e5e\u8834\uaaa4\u0a7f',
+colorAttachments: [
+{
+view: textureView7,
+depthSlice: 22,
+clearValue: {
+r: -562.5,
+g: 32.63,
+b: 305.4,
+a: -615.4,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined,
+{
+view: textureView7,
+depthSlice: 10,
+clearValue: {
+r: 727.3,
+g: 151.0,
+b: 16.20,
+a: -105.9,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+undefined,
+{
+view: textureView7,
+depthSlice: 2,
+clearValue: {
+r: -486.1,
+g: -754.0,
+b: -102.0,
+a: -260.6,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView7,
+depthSlice: 1,
+clearValue: {
+r: -361.2,
+g: 623.1,
+b: -437.0,
+a: 611.0,
+},
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+maxDrawCount: 104776,
+}
+);
+let renderBundleEncoder44 = device0.createRenderBundleEncoder(
+{
+label: '\u7eaa\u0808\u7ea8\u815f\u{1f9ed}',
+colorFormats: [
+undefined
+],
+sampleCount: 534,
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+0,
+bindGroup11,
+[]
+);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(
+4045
+);
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+16.35,
+0.1705,
+14.97,
+0.3264,
+0.5612,
+0.9092
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer8,
+18736,
+new DataView(new ArrayBuffer(64611)),
+32538,
+13004
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 800, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 963 */{
+offset: 963,
+},
+{width: 1000, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline67 = await device0.createRenderPipelineAsync(
+{
+label: '\ub543\ub5b6\u04c6',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 34696,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 19308,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 16672,
+shaderLocation: 10,
+},
+{
+format: 'uint16x2',
+offset: 17024,
+shaderLocation: 2,
+},
+{
+format: 'snorm8x4',
+offset: 1224,
+shaderLocation: 14,
+},
+{
+format: 'snorm16x2',
+offset: 9404,
+shaderLocation: 3,
+},
+{
+format: 'sint32',
+offset: 4020,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 2372,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 2112,
+shaderLocation: 12,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0x9185df3f,
+},
+}
+);
+gc();
+let commandEncoder39 = device0.createCommandEncoder();
+let querySet29 = device0.createQuerySet(
+{
+label: '\u0700\u{1fb41}\u04f0',
+type: 'occlusion',
+count: 2395,
+}
+);
+let sampler35 = device0.createSampler(
+{
+label: '\u919c\u09ca\uddf0\ucfe9\u811a\u5404\u045d\uc531\u07a2\ub634',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 74.841,
+lodMaxClamp: 77.062,
+}
+);
+try {
+computePassEncoder18.setBindGroup(
+1,
+bindGroup6,
+new Uint32Array(6019),
+289,
+0
+);
+} catch {}
+try {
+renderPassEncoder14.setStencilReference(
+779
+);
+} catch {}
+try {
+commandEncoder39.copyBufferToBuffer(
+buffer15,
+14288,
+buffer1,
+6740,
+32
+);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture26,
+  mipLevel: 6,
+  origin: { x: 1, y: 0, z: 93 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 833651 */{
+offset: 611,
+bytesPerRow: 178,
+rowsPerImage: 120,
+},
+{width: 2, height: 0, depthOrArrayLayers: 40}
+);
+} catch {}
+let pipeline68 = await device0.createRenderPipelineAsync(
+{
+label: '\u{1f912}\u07f5\u0fd8',
+layout: pipelineLayout6,
+vertex: {
+module: shaderModule10,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 17560,
+attributes: [
+{
+format: 'float32x2',
+offset: 11720,
+shaderLocation: 12,
+},
+{
+format: 'uint16x2',
+offset: 15280,
+shaderLocation: 8,
+},
+{
+format: 'float32x2',
+offset: 8792,
+shaderLocation: 9,
+},
+{
+format: 'sint8x4',
+offset: 2448,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x2',
+offset: 14788,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x4',
+offset: 5000,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 22544,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x4',
+offset: 10464,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 25492,
+attributes: [
+{
+format: 'unorm16x4',
+offset: 14260,
+shaderLocation: 3,
+},
+{
+format: 'float32x3',
+offset: 19492,
+shaderLocation: 2,
+},
+{
+format: 'sint16x2',
+offset: 16428,
+shaderLocation: 5,
+},
+{
+format: 'uint32x4',
+offset: 23828,
+shaderLocation: 0,
+},
+{
+format: 'float32x4',
+offset: 48,
+shaderLocation: 14,
+},
+{
+format: 'float16x4',
+offset: 532,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 27788,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 4468,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 27604,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x4',
+offset: 1908,
+shaderLocation: 10,
+},
+{
+format: 'uint16x2',
+offset: 10508,
+shaderLocation: 15,
+},
+{
+format: 'snorm8x4',
+offset: 3640,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+},
+fragment: {
+module: shaderModule10,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'keep',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-wrap',
+},
+stencilWriteMask: 3302,
+depthBias: 84,
+depthBiasSlopeScale: 19,
+depthBiasClamp: 52,
+},
+}
+);
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+document.body.append('\u0c1e\u2cd3\ucbb2\u0bf0\u{1f662}\ub36c\u{1f9f6}\u0e09\u7011\uf057');
+let texture55 = device0.createTexture(
+{
+label: '\ubd51\ub859\u386a\ufec1\u22fe',
+size: [4366, 142, 1],
+mipLevelCount: 10,
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg16sint',
+'rg16sint'
+],
+}
+);
+let textureView45 = texture31.createView(
+{
+label: '\u3360\u0f10\u{1fe4a}\u74b8',
+mipLevelCount: 1,
+baseArrayLayer: 93,
+arrayLayerCount: 58,
+}
+);
+let renderBundleEncoder45 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg16sint',
+'rgba8uint',
+'r32float',
+'r32uint',
+'bgra8unorm',
+'r32sint'
+],
+sampleCount: 47,
+}
+);
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(
+1,
+bindGroup19,
+new Uint32Array(8062),
+2885,
+0
+);
+} catch {}
+try {
+renderPassEncoder20.setScissorRect(
+60,
+0,
+16,
+0
+);
+} catch {}
+try {
+renderPassEncoder17.setStencilReference(
+4037
+);
+} catch {}
+try {
+renderPassEncoder18.setViewport(
+16.86,
+0.1360,
+9.797,
+0.7426,
+0.9206,
+0.9220
+);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(
+7,
+buffer15,
+6100
+);
+} catch {}
+try {
+device0.pushErrorScope(
+'internal'
+);
+} catch {}
+try {
+commandEncoder27.copyTextureToTexture(
+{
+  texture: texture26,
+  mipLevel: 5,
+  origin: { x: 2, y: 1, z: 19 },
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder39.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline69 = device0.createComputePipeline(
+{
+label: '\u0032\u5276\u0dad',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule13,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let bindGroupLayout18 = device0.createBindGroupLayout(
+{
+label: '\u0971\u1e0c\ud350\u1f57\uf53e\u6205\ued9e\uf3e4\ude6d\ua788',
+entries: [
+{
+binding: 962,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 1398,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let commandEncoder40 = device0.createCommandEncoder(
+{
+label: '\u2e59\u2c58\ucd5b\u6b7d',
+}
+);
+let querySet30 = device0.createQuerySet(
+{
+label: '\u24ae\u{1ff04}\u9985\u4229\u0dd9\uf30f\u2b1b\u97f9\u68f4\u2fdc\uaaba',
+type: 'occlusion',
+count: 945,
+}
+);
+try {
+computePassEncoder21.setBindGroup(
+0,
+bindGroup13,
+new Uint32Array(4272),
+1491,
+0
+);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+63,
+0,
+23,
+0
+);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(
+0,
+buffer15,
+6424,
+15391
+);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(
+5,
+bindGroup10
+);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(
+9,
+buffer15,
+17364,
+4059
+);
+} catch {}
+try {
+commandEncoder39.copyBufferToBuffer(
+buffer10,
+9948,
+buffer16,
+11000,
+2376
+);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder39.clearBuffer(
+buffer8,
+22020,
+10592
+);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer16,
+5680,
+new BigUint64Array(59764),
+49642,
+244
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas5,
+  origin: { x: 40, y: 188 },
+  flipY: false,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(
+3,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder12.setViewport(
+60.95,
+0.3958,
+5.888,
+0.3607,
+0.8747,
+0.8902
+);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(
+5,
+buffer6,
+4704,
+12933
+);
+} catch {}
+try {
+commandEncoder39.copyBufferToBuffer(
+buffer9,
+4884,
+buffer15,
+13764,
+156
+);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer15);
+} catch {}
+let pipeline70 = await device0.createComputePipelineAsync(
+{
+label: '\u1dea\u{1f97c}\u0cbf\ubc81\u{1fd39}',
+layout: 'auto',
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let canvas8 = document.createElement('canvas');
+let imageData9 = new ImageData(164, 204);
+let bindGroupLayout19 = device0.createBindGroupLayout(
+{
+label: '\u8005\ufa5b',
+entries: [
+
+],
+}
+);
+let pipelineLayout7 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout10,
+bindGroupLayout7,
+bindGroupLayout14,
+bindGroupLayout2,
+bindGroupLayout12,
+bindGroupLayout2,
+bindGroupLayout11,
+bindGroupLayout8,
+bindGroupLayout7
+],
+}
+);
+let computePassEncoder25 = commandEncoder39.beginComputePass(
+{
+label: '\u{1f85d}\u{1fb6a}\u0ede'
+}
+);
+let renderPassEncoder21 = commandEncoder40.beginRenderPass(
+{
+label: '\u292e\u0bf5\u{1f6b4}\u{1fa1b}\ufaa5\u991d\u8470\ua2cd',
+colorAttachments: [
+{
+view: textureView34,
+depthSlice: 207,
+clearValue: {
+r: 930.2,
+g: 738.0,
+b: -183.2,
+a: -19.86,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined,
+undefined,
+{
+view: textureView34,
+depthSlice: 775,
+clearValue: {
+r: -350.1,
+g: -876.8,
+b: 681.3,
+a: 248.1,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined,
+{
+view: textureView34,
+depthSlice: 725,
+clearValue: {
+r: 663.3,
+g: -372.9,
+b: 641.3,
+a: 63.94,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined,
+{
+view: textureView34,
+depthSlice: 791,
+clearValue: {
+r: 214.0,
+g: -177.1,
+b: 491.7,
+a: -962.5,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined
+],
+occlusionQuerySet: querySet27,
+}
+);
+try {
+commandEncoder27.copyBufferToBuffer(
+buffer18,
+37188,
+buffer15,
+19772,
+152
+);
+dissociateBuffer(device0, buffer18);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+renderBundleEncoder18.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 20}
+*/
+{
+  source: img9,
+  origin: { x: 47, y: 47 },
+  flipY: true,
+},
+{
+  texture: texture30,
+  mipLevel: 6,
+  origin: { x: 1, y: 0, z: 12 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let bindGroupLayout20 = device0.createBindGroupLayout(
+{
+label: '\u084d\u{1f7f9}\u{1fc6d}\u3508\uc7c8\u1084\u{1f7cb}',
+entries: [
+{
+binding: 1802,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+}
+],
+}
+);
+let commandEncoder41 = device0.createCommandEncoder(
+{
+label: '\u340f\u2169\ue36b\u{1ff02}\u0cc4\u0406\uf68b',
+}
+);
+let renderPassEncoder22 = commandEncoder27.beginRenderPass(
+{
+label: '\u8ca9\u{1ff0d}\u16f9',
+colorAttachments: [
+{
+view: textureView39,
+depthSlice: 72,
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined,
+{
+view: textureView39,
+depthSlice: 110,
+clearValue: {
+r: 127.3,
+g: -858.5,
+b: 175.8,
+a: 130.9,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined,
+undefined,
+{
+view: textureView39,
+depthSlice: 112,
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView39,
+depthSlice: 70,
+clearValue: {
+r: 488.0,
+g: 55.95,
+b: 333.2,
+a: 172.4,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView39,
+depthSlice: 202,
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+undefined
+],
+maxDrawCount: 41448,
+}
+);
+try {
+renderBundleEncoder38.setBindGroup(
+5,
+bindGroup14,
+[]
+);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(
+2,
+bindGroup10,
+new Uint32Array(824),
+335,
+0
+);
+} catch {}
+try {
+commandEncoder41.copyTextureToTexture(
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 940, y: 15, z: 51 },
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 1070, y: 10, z: 33 },
+  aspect: 'all',
+},
+{width: 2260, height: 35, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder41.resolveQuerySet(
+querySet21,
+130,
+1,
+buffer15,
+13824
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture13,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Int8Array(arrayBuffer2),
+/* required buffer size: 148 */{
+offset: 148,
+rowsPerImage: 232,
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline71 = device0.createRenderPipeline(
+{
+label: '\u{1f79e}\u0557\u{1f7df}\u34f6\u0a8e',
+layout: pipelineLayout5,
+vertex: {
+module: shaderModule8,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 3780,
+attributes: [
+{
+format: 'sint8x2',
+offset: 2056,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 25556,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x3',
+offset: 3484,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x2',
+offset: 19486,
+shaderLocation: 10,
+},
+{
+format: 'float16x2',
+offset: 2704,
+shaderLocation: 13,
+},
+{
+format: 'sint16x4',
+offset: 2300,
+shaderLocation: 11,
+},
+{
+format: 'float32x2',
+offset: 24876,
+shaderLocation: 5,
+},
+{
+format: 'uint32x4',
+offset: 8212,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 10636,
+attributes: [
+{
+format: 'float16x4',
+offset: 5212,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 7456,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 15596,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 5856,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32',
+offset: 3496,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0xe3f0362c,
+},
+fragment: {
+module: shaderModule8,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'rg8uint',
+},
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+},
+undefined,
+undefined,
+undefined,
+{
+format: 'r32float',
+},
+undefined
+],
+},
+}
+);
+let img18 = await imageWithData(266, 191, '#1630f2ac', '#e3b1ee7a');
+let texture56 = device0.createTexture(
+{
+label: '\u{1f72a}\u3b94\u{1f804}\ucdc4\u5491',
+size: {width: 239, height: 2, depthOrArrayLayers: 44},
+mipLevelCount: 2,
+dimension: '2d',
+format: 'rg16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+}
+);
+let computePassEncoder26 = commandEncoder41.beginComputePass();
+let sampler36 = device0.createSampler(
+{
+label: '\u{1ff61}\ua671\u0072',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 84.909,
+}
+);
+try {
+computePassEncoder22.setBindGroup(
+0,
+bindGroup18,
+new Uint32Array(378),
+326,
+0
+);
+} catch {}
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+8,
+buffer17,
+248,
+2261
+);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(
+1,
+bindGroup4
+);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(
+7,
+buffer15
+);
+} catch {}
+document.body.prepend('\u{1fd22}\ue1db\ubd06\u0707\uc370\u{1f738}\u011a\u{1fec4}\udbed\u9360');
+let videoFrame9 = new VideoFrame(canvas8, {timestamp: 0});
+let buffer19 = device0.createBuffer(
+{
+size: 57748,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT,
+mappedAtCreation: true,
+}
+);
+let textureView46 = texture55.createView(
+{
+label: '\uec9f\u27ed\u6cb9\u4d12\uabca\uebb3\u1122',
+dimension: '2d-array',
+baseMipLevel: 8,
+mipLevelCount: 1,
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+5,
+bindGroup8,
+new Uint32Array(3759),
+495,
+0
+);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(
+5,
+bindGroup16,
+new Uint32Array(8333),
+2377,
+0
+);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant(
+{
+r: 556.2,
+g: 798.4,
+b: -245.4,
+a: -497.3,
+}
+);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(
+8,
+buffer15,
+14296,
+2520
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+computePassEncoder21.insertDebugMarker(
+'\u65d9'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer16,
+13396,
+new BigUint64Array(17526),
+16534,
+116
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture32,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(56),
+/* required buffer size: 31770 */{
+offset: 882,
+bytesPerRow: 132,
+rowsPerImage: 234,
+},
+{width: 1, height: 0, depthOrArrayLayers: 2}
+);
+} catch {}
+let bindGroup20 = device0.createBindGroup({
+label: '\u0d4b\u0ef0\u5ec9\u1f3e\u{1f62b}\u0fa3\ue1f8\u5df2\u68ab',
+layout: bindGroupLayout9,
+entries: [
+
+],
+});
+let buffer20 = device0.createBuffer(
+{
+label: '\ueb72\u0f51\u0320\u1553\ucc1b\u{1fde5}\u67dd',
+size: 44504,
+usage: GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+let texture57 = device0.createTexture(
+{
+label: '\u0edf\u02f0\ub0d5\u4744\u754a',
+size: {width: 152, height: 1, depthOrArrayLayers: 887},
+mipLevelCount: 3,
+dimension: '3d',
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+
+],
+}
+);
+let textureView47 = texture17.createView(
+{
+baseMipLevel: 0,
+}
+);
+try {
+renderPassEncoder22.setBindGroup(
+7,
+bindGroup18,
+new Uint32Array(356),
+306,
+0
+);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(
+7,
+buffer6
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer9,
+5168,
+new Float32Array(63301),
+36682,
+108
+);
+} catch {}
+let pipeline72 = await device0.createRenderPipelineAsync(
+{
+label: '\u1ea5\u034e\u4d81\u14d8\u0a62\u98c4\u49eb\ud0dc\u{1ff58}\u{1f89c}',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 10176,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x3',
+offset: 7192,
+shaderLocation: 2,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 1644,
+shaderLocation: 3,
+},
+{
+format: 'unorm16x2',
+offset: 3696,
+shaderLocation: 14,
+},
+{
+format: 'unorm16x2',
+offset: 3352,
+shaderLocation: 10,
+},
+{
+format: 'snorm8x4',
+offset: 4040,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 10152,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 25216,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 26344,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 22156,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 22344,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 8560,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 12968,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 10584,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'back',
+},
+multisample: {
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'zero',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'replace',
+depthFailOp: 'decrement-clamp',
+},
+stencilReadMask: 3804,
+stencilWriteMask: 2286,
+depthBiasClamp: 33,
+},
+}
+);
+gc();
+document.body.append('\u8daf\u17f0\u050e\u0fe6\u{1f9a8}');
+let bindGroup21 = device0.createBindGroup({
+layout: bindGroupLayout4,
+entries: [
+{
+binding: 599,
+resource: externalTexture1
+}
+],
+});
+let querySet31 = device0.createQuerySet(
+{
+label: '\uc295\u0ff7\u0dd8\u7b08\u8997\u72fd\u0ef4',
+type: 'occlusion',
+count: 131,
+}
+);
+let textureView48 = texture36.createView(
+{
+label: '\u02db\u5be8\u{1fc9e}\u09e5\ua013\u{1fecb}',
+dimension: '2d',
+}
+);
+try {
+computePassEncoder21.setBindGroup(
+0,
+bindGroup17
+);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(
+7,
+bindGroup18,
+[]
+);
+} catch {}
+let pipeline73 = device0.createComputePipeline(
+{
+label: '\u{1ff63}\u0cad\u080f\u078b\ua0d6\ubacd\u{1f71f}\u0364',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let sampler37 = device0.createSampler(
+{
+label: '\u5256\u0a7c\u82cb',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 13.713,
+lodMaxClamp: 52.883,
+maxAnisotropy: 11,
+}
+);
+try {
+renderPassEncoder20.setScissorRect(
+36,
+0,
+37,
+0
+);
+} catch {}
+let pipeline74 = device0.createComputePipeline(
+{
+label: '\u0558\u0bec\uad65\u09c4\u{1fccb}\u7877\u{1fead}\u78d5\u70c4\u{1fbd9}',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule10,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+device0.label = '\u0d49\u{1f98c}\u4840\u000a\ub8ac\u0336\u5a59\u0fba\u8597\uc954\ufe6f';
+} catch {}
+let commandEncoder42 = device0.createCommandEncoder();
+let texture58 = device0.createTexture(
+{
+label: '\uc2af\u03f4\ub5f8\u{1ff14}\u6b17\u0d8e\u0907\u0969',
+size: [236, 120, 1],
+mipLevelCount: 7,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'etc2-rgb8unorm',
+'etc2-rgb8unorm'
+],
+}
+);
+try {
+renderPassEncoder18.setStencilReference(
+947
+);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(
+4,
+buffer5,
+8640,
+964
+);
+} catch {}
+try {
+commandEncoder42.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 10}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 311, y: 203 },
+  flipY: false,
+},
+{
+  texture: texture30,
+  mipLevel: 7,
+  origin: { x: 1, y: 0, z: 3 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+canvas8.getContext('webgpu');
+} catch {}
+let textureView49 = texture30.createView(
+{
+label: '\u{1fbb2}\u0f74\u0d39\u6b35\ubbf9',
+baseMipLevel: 7,
+mipLevelCount: 1,
+}
+);
+try {
+renderPassEncoder12.setBindGroup(
+1,
+bindGroup13
+);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant(
+{
+r: -376.7,
+g: -709.5,
+b: -448.5,
+a: 810.4,
+}
+);
+} catch {}
+try {
+renderPassEncoder22.setScissorRect(
+14,
+1,
+5,
+0
+);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(
+3,
+buffer17
+);
+} catch {}
+try {
+commandEncoder42.copyBufferToBuffer(
+buffer10,
+824,
+buffer7,
+43804,
+1668
+);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer7);
+} catch {}
+document.body.prepend(img17);
+gc();
+try {
+await adapter3.requestAdapterInfo();
+} catch {}
+let bindGroup22 = device0.createBindGroup({
+label: '\u{1fadf}\u{1f99f}\uf8ab\u6bee\u10a4\u998b\ud61e',
+layout: bindGroupLayout12,
+entries: [
+
+],
+});
+let querySet32 = device0.createQuerySet(
+{
+label: '\u0c6b\u4930',
+type: 'occlusion',
+count: 2073,
+}
+);
+let texture59 = device0.createTexture(
+{
+label: '\ub820\u9593\u0ea6',
+size: {width: 8990, height: 6, depthOrArrayLayers: 149},
+format: 'astc-10x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x6-unorm',
+'astc-10x6-unorm'
+],
+}
+);
+try {
+renderPassEncoder8.setBindGroup(
+6,
+bindGroup11
+);
+} catch {}
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+48.88,
+0.2865,
+18.12,
+0.3799,
+0.5893,
+0.5982
+);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(
+8,
+bindGroup16,
+new Uint32Array(7354),
+2827,
+0
+);
+} catch {}
+try {
+commandEncoder42.copyBufferToTexture(
+{
+/* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 20992 */
+offset: 20992,
+buffer: buffer0,
+},
+{
+  texture: texture41,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 12, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder42.copyTextureToBuffer(
+{
+  texture: texture58,
+  mipLevel: 3,
+  origin: { x: 0, y: 8, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 32 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 21672 */
+offset: 21640,
+rowsPerImage: 283,
+buffer: buffer8,
+},
+{width: 16, height: 4, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer8);
+} catch {}
+let commandEncoder43 = device0.createCommandEncoder(
+{
+label: '\u0974\u34aa\u{1fafd}\u3454\uddc9\u{1fab2}\u2ec5\u{1f906}\u0b4f\u01a8',
+}
+);
+let textureView50 = texture9.createView(
+{
+label: '\u2881\u0f20\ub4bc',
+}
+);
+let renderBundleEncoder46 = device0.createRenderBundleEncoder(
+{
+label: '\u5926\u0e7b\uddbd\u61c5\u{1f6f0}\ud46d\u05ee',
+colorFormats: [
+undefined,
+'rgba32uint',
+'r32uint',
+'rgba8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 3,
+}
+);
+let sampler38 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 74.499,
+lodMaxClamp: 82.151,
+}
+);
+try {
+computePassEncoder19.dispatchWorkgroups(
+1,
+4,
+4
+);
+} catch {}
+try {
+computePassEncoder9.setPipeline(
+pipeline73
+);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(
+6,
+buffer6,
+5104,
+11573
+);
+} catch {}
+let pipeline75 = device0.createRenderPipeline(
+{
+label: '\u46c9\u5bf0\u05cc\uc09d\u0555\u017f\u2780\u5db5\ua22d\ucecb\ua846',
+layout: 'auto',
+vertex: {
+module: shaderModule9,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 31188,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 27040,
+shaderLocation: 3,
+},
+{
+format: 'unorm16x2',
+offset: 23952,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 33448,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 29136,
+shaderLocation: 9,
+},
+{
+format: 'float32x4',
+offset: 13656,
+shaderLocation: 0,
+},
+{
+format: 'uint32x2',
+offset: 28524,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule9,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rgba16sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r8sint',
+writeMask: 0,
+},
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'dst',
+dstFactor: 'one-minus-src'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'dst-alpha',
+dstFactor: 'src-alpha'
+},
+},
+format: 'r8unorm',
+},
+{
+format: 'r16float',
+writeMask: GPUColorWrite.ALL,
+},
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALPHA,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'replace',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'always',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'invert',
+},
+stencilReadMask: 1976,
+stencilWriteMask: 145,
+depthBiasSlopeScale: 87,
+depthBiasClamp: 64,
+},
+}
+);
+try {
+textureView37.label = '\u3d67\u9889\u221f\ufc31\u0302\u0124';
+} catch {}
+let bindGroupLayout21 = device0.createBindGroupLayout(
+{
+entries: [
+
+],
+}
+);
+let texture60 = device0.createTexture(
+{
+label: '\u48e4\u2961\u{1f634}',
+size: {width: 240, height: 20, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+sampleCount: 1,
+format: 'astc-10x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: 289.0,
+g: 439.4,
+b: -43.35,
+a: 36.03,
+}
+);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(
+8,
+buffer8
+);
+} catch {}
+try {
+commandEncoder42.copyBufferToBuffer(
+buffer10,
+12924,
+buffer2,
+16824,
+280
+);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer9,
+1940,
+new DataView(new ArrayBuffer(59999)),
+4840,
+3656
+);
+} catch {}
+let pipeline76 = await device0.createComputePipelineAsync(
+{
+label: '\u7227\u0d05\u2bc5\uc47e\u{1fb04}\u053f\u{1faae}\ubbb8\u1acc',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+},
+}
+);
+let pipeline77 = device0.createRenderPipeline(
+{
+label: '\uab86\u0c9d\ubc9c\u318d\u3860\u0afd',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 32916,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 1960,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 1572,
+shaderLocation: 13,
+},
+{
+format: 'snorm8x2',
+offset: 1786,
+shaderLocation: 11,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 372,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x2',
+offset: 1748,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 4092,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x2',
+offset: 2298,
+shaderLocation: 6,
+},
+{
+format: 'uint32x3',
+offset: 48,
+shaderLocation: 14,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 2920,
+shaderLocation: 9,
+},
+{
+format: 'sint32x4',
+offset: 3908,
+shaderLocation: 2,
+},
+{
+format: 'unorm8x2',
+offset: 200,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 9788,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 3884,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 20520,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 1244,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 35020,
+shaderLocation: 15,
+},
+{
+format: 'uint16x2',
+offset: 8284,
+shaderLocation: 5,
+},
+{
+format: 'sint32',
+offset: 32948,
+shaderLocation: 0,
+},
+{
+format: 'float32x2',
+offset: 31992,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule3,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.BLUE,
+},
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+undefined,
+undefined
+],
+},
+}
+);
+document.body.append('\u0233\u{1fce1}');
+let querySet33 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 3478,
+}
+);
+try {
+renderPassEncoder14.setBindGroup(
+1,
+bindGroup17,
+new Uint32Array(8384),
+7660,
+0
+);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+4010
+);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(
+1,
+bindGroup22
+);
+} catch {}
+try {
+computePassEncoder24.insertDebugMarker(
+'\u52aa'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer8,
+31740,
+new DataView(new ArrayBuffer(28259)),
+9189,
+18040
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 2, height: 1, depthOrArrayLayers: 9}
+*/
+{
+  source: videoFrame8,
+  origin: { x: 46, y: 89 },
+  flipY: false,
+},
+{
+  texture: texture32,
+  mipLevel: 4,
+  origin: { x: 1, y: 0, z: 5 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let querySet34 = device0.createQuerySet(
+{
+label: '\u7fb8\u{1fc7f}\u6cc6\u{1f624}\u02b2\udb17\uc541\u{1fe34}\u{1f6f7}',
+type: 'occlusion',
+count: 2197,
+}
+);
+let renderPassEncoder23 = commandEncoder42.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView32,
+depthSlice: 29,
+clearValue: {
+r: 429.1,
+g: 911.2,
+b: 542.5,
+a: 527.8,
+},
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet16,
+maxDrawCount: 19512,
+}
+);
+let renderBundle46 = renderBundleEncoder24.finish();
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(
+66,
+1,
+9,
+0
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder43.clearBuffer(
+buffer5,
+6776,
+4504
+);
+dissociateBuffer(device0, buffer5);
+} catch {}
+let pipeline78 = device0.createRenderPipeline(
+{
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule5,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 8148,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 2800,
+shaderLocation: 6,
+},
+{
+format: 'uint32x4',
+offset: 5144,
+shaderLocation: 0,
+},
+{
+format: 'unorm16x4',
+offset: 3020,
+shaderLocation: 10,
+},
+{
+format: 'unorm16x4',
+offset: 8128,
+shaderLocation: 5,
+},
+{
+format: 'uint32',
+offset: 336,
+shaderLocation: 15,
+},
+{
+format: 'unorm8x2',
+offset: 7558,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x4',
+offset: 1776,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x2',
+offset: 2556,
+shaderLocation: 13,
+},
+{
+format: 'sint16x4',
+offset: 2756,
+shaderLocation: 1,
+},
+{
+format: 'uint32x4',
+offset: 4060,
+shaderLocation: 4,
+},
+{
+format: 'sint32x3',
+offset: 808,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x4',
+offset: 6840,
+shaderLocation: 14,
+},
+{
+format: 'uint8x2',
+offset: 4060,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 1204,
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 18700,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule5,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+},
+{
+format: 'rg16uint',
+}
+],
+},
+}
+);
+let img19 = await imageWithData(63, 123, '#a55d0223', '#8c6c9add');
+let video7 = await videoWithData();
+let renderPassEncoder24 = commandEncoder43.beginRenderPass(
+{
+label: '\u24e2\u08a5\uf8f4\u985f\u{1fc40}',
+colorAttachments: [
+undefined,
+{
+view: textureView34,
+depthSlice: 343,
+clearValue: {
+r: -266.4,
+g: -188.2,
+b: 738.4,
+a: 674.7,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView34,
+depthSlice: 202,
+clearValue: {
+r: 778.2,
+g: -608.2,
+b: 812.0,
+a: -253.9,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined,
+undefined,
+undefined,
+undefined,
+{
+view: textureView34,
+depthSlice: 25,
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet14,
+maxDrawCount: 73808,
+}
+);
+let renderBundleEncoder47 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'r16sint',
+'r32float',
+'rgb10a2unorm',
+'r32float',
+'rgb10a2unorm',
+'rgba8uint',
+undefined,
+undefined
+],
+sampleCount: 591,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder16.setVertexBuffer(
+34,
+undefined,
+2813977968
+);
+} catch {}
+try {
+renderBundleEncoder37.setIndexBuffer(
+buffer16,
+'uint16',
+7816,
+3584
+);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(
+7,
+buffer6,
+16548,
+2440
+);
+} catch {}
+try {
+gpuCanvasContext8.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-4x4-unorm'
+],
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer9,
+2224,
+new Float32Array(15886),
+6079,
+580
+);
+} catch {}
+let img20 = await imageWithData(200, 206, '#41ceacbc', '#3188a25f');
+let imageBitmap11 = await createImageBitmap(img20);
+let bindGroupLayout22 = device0.createBindGroupLayout(
+{
+label: '\u01f1\u02d8\ud7d9\u0cf2\u8afc\udbf1\u7309\ubc37\u0ab6',
+entries: [
+{
+binding: 86,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '3d' },
+},
+{
+binding: 512,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 389007, hasDynamicOffset: false },
+},
+{
+binding: 2887,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+}
+],
+}
+);
+let bindGroup23 = device0.createBindGroup({
+label: '\u328e\u56f5\u00e8\ub939\u50ff\u{1f73e}',
+layout: bindGroupLayout18,
+entries: [
+{
+binding: 962,
+resource: {
+buffer: buffer17,
+offset: 1632,
+}
+},
+{
+binding: 1398,
+resource: sampler38
+}
+],
+});
+let textureView51 = texture30.createView(
+{
+label: '\u7fe6\u085d\ud2e1\udbdb\u{1fd0c}\u{1fa5a}\u3c89\uc8fa',
+baseMipLevel: 4,
+baseArrayLayer: 0,
+}
+);
+let renderBundle47 = renderBundleEncoder29.finish(
+{
+
+}
+);
+try {
+computePassEncoder21.setBindGroup(
+6,
+bindGroup16
+);
+} catch {}
+try {
+computePassEncoder11.dispatchWorkgroups(
+4,
+1,
+5
+);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(
+6,
+bindGroup13,
+new Uint32Array(8667),
+4679,
+0
+);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(
+40,
+1,
+2,
+0
+);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(
+buffer6,
+'uint16',
+12788,
+3017
+);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(
+5,
+bindGroup8,
+new Uint32Array(5426),
+4753,
+0
+);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(
+8,
+buffer5,
+13248,
+9588
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer8,
+7156,
+new Float32Array(26112),
+3467,
+12268
+);
+} catch {}
+let promise18 = device0.createRenderPipelineAsync(
+{
+label: '\u39d7\u0470',
+layout: 'auto',
+vertex: {
+module: shaderModule12,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 25180,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 120,
+shaderLocation: 1,
+},
+{
+format: 'uint32x4',
+offset: 656,
+shaderLocation: 0,
+},
+{
+format: 'float32x2',
+offset: 14644,
+shaderLocation: 5,
+},
+{
+format: 'uint16x2',
+offset: 22064,
+shaderLocation: 3,
+},
+{
+format: 'sint32x4',
+offset: 14768,
+shaderLocation: 13,
+},
+{
+format: 'sint32x3',
+offset: 8976,
+shaderLocation: 6,
+},
+{
+format: 'unorm16x2',
+offset: 20804,
+shaderLocation: 8,
+},
+{
+format: 'uint16x4',
+offset: 12580,
+shaderLocation: 7,
+},
+{
+format: 'uint8x2',
+offset: 9176,
+shaderLocation: 4,
+},
+{
+format: 'snorm16x2',
+offset: 676,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x43ab945d,
+},
+fragment: {
+module: shaderModule12,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'rgba8unorm',
+writeMask: 0,
+},
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater',
+depthFailOp: 'replace',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 2468,
+stencilWriteMask: 3944,
+depthBias: 6,
+depthBiasSlopeScale: 62,
+},
+}
+);
+let shaderModule14 = device0.createShaderModule(
+{
+code: `
+
+@compute @workgroup_size(2, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S12 {
+@location(40) f0: vec3<i32>,
+@location(22) f1: vec3<f32>,
+@location(23) f2: vec3<i32>,
+@location(45) f3: vec3<i32>,
+@location(53) f4: vec4<f16>,
+@location(50) f5: vec3<f32>,
+@location(14) f6: i32,
+@location(43) f7: vec4<f16>,
+@location(44) f8: vec2<i32>,
+@builtin(position) f9: vec4<f32>,
+@location(47) f10: i32,
+@location(49) f11: f16,
+@location(26) f12: vec4<f16>,
+@location(41) f13: vec4<f16>
+}
+struct FragmentOutput0 {
+@location(7) f0: vec4<f32>,
+@location(0) f1: vec3<u32>,
+@location(6) f2: i32,
+@location(3) f3: vec3<i32>,
+@location(1) f4: vec4<i32>,
+@location(2) f5: vec2<u32>,
+@builtin(sample_mask) f6: u32,
+@location(4) f7: vec2<u32>,
+@location(5) f8: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(17) a0: vec2<u32>, @location(8) a1: f32, @location(48) a2: vec3<u32>, @location(55) a3: i32, @location(28) a4: vec2<f16>, @location(42) a5: vec2<f16>, @location(7) a6: vec3<i32>, @location(27) a7: f32, @location(38) a8: vec2<f32>, a9: S12, @location(51) a10: vec4<i32>, @location(15) a11: vec3<f16>, @location(13) a12: vec3<f32>, @location(2) a13: vec2<i32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S11 {
+@location(11) f0: vec2<f16>,
+@location(16) f1: vec2<u32>,
+@location(5) f2: vec3<f32>,
+@location(0) f3: vec3<i32>,
+@location(7) f4: vec4<u32>,
+@location(14) f5: vec3<i32>,
+@location(12) f6: vec4<i32>
+}
+struct VertexOutput0 {
+@location(28) f181: vec2<f16>,
+@location(27) f182: f32,
+@location(7) f183: vec3<i32>,
+@builtin(position) f184: vec4<f32>,
+@location(49) f185: f16,
+@location(22) f186: vec3<f32>,
+@location(14) f187: i32,
+@location(51) f188: vec4<i32>,
+@location(40) f189: vec3<i32>,
+@location(55) f190: i32,
+@location(13) f191: vec3<f32>,
+@location(26) f192: vec4<f16>,
+@location(15) f193: vec3<f16>,
+@location(50) f194: vec3<f32>,
+@location(38) f195: vec2<f32>,
+@location(17) f196: vec2<u32>,
+@location(2) f197: vec2<i32>,
+@location(42) f198: vec2<f16>,
+@location(53) f199: vec4<f16>,
+@location(44) f200: vec2<i32>,
+@location(47) f201: i32,
+@location(8) f202: f32,
+@location(43) f203: vec4<f16>,
+@location(41) f204: vec4<f16>,
+@location(23) f205: vec3<i32>,
+@location(45) f206: vec3<i32>,
+@location(48) f207: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec4<u32>, @location(15) a1: vec2<f32>, @builtin(instance_index) a2: u32, @location(13) a3: vec3<f32>, @builtin(vertex_index) a4: u32, a5: S11, @location(6) a6: vec4<i32>, @location(4) a7: vec4<f16>, @location(3) a8: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroupLayout23 = device0.createBindGroupLayout(
+{
+label: '\u0141\u030b',
+entries: [
+{
+binding: 440,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(
+50,
+1,
+5,
+0
+);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(
+5,
+buffer6,
+3400,
+14144
+);
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(
+7,
+bindGroup12,
+new Uint32Array(3453),
+1077,
+0
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture54,
+  mipLevel: 6,
+  origin: { x: 2, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Int32Array(arrayBuffer0),
+/* required buffer size: 693 */{
+offset: 693,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline79 = device0.createComputePipeline(
+{
+label: '\u00e1\u0e68\ued9f',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let video8 = await videoWithData();
+let imageBitmap12 = await createImageBitmap(imageData3);
+let querySet35 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 3931,
+}
+);
+let texture61 = device0.createTexture(
+{
+label: '\u64e6\u55da\u393f\u7a00\u69e9\u027b\ueabc\u5d60\ucb01\u{1fb08}\u43ee',
+size: [60, 248, 218],
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'eac-rg11snorm'
+],
+}
+);
+let renderBundle48 = renderBundleEncoder47.finish(
+{
+label: '\u062b\u{1f897}\u0f45\uf3a8'
+}
+);
+try {
+renderPassEncoder21.beginOcclusionQuery(
+56
+);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(
+17,
+0,
+34,
+1
+);
+} catch {}
+try {
+renderBundleEncoder38.setIndexBuffer(
+buffer9,
+'uint16',
+2876,
+2444
+);
+} catch {}
+try {
+device0.pushErrorScope(
+'internal'
+);
+} catch {}
+video5.height = 170;
+let canvas9 = document.createElement('canvas');
+let video9 = await videoWithData();
+let commandEncoder44 = device0.createCommandEncoder(
+{
+label: '\u7682\u{1ffd4}\u0545\u0d4a\u0831\u9a2f\uf195\ua8f1',
+}
+);
+let textureView52 = texture1.createView(
+{
+label: '\u0d7a\u0988\u04f7\u{1fcd0}\u0a2d\ub4ba\u67be\u149b\u3072\u61c3',
+mipLevelCount: 3,
+}
+);
+let sampler39 = device0.createSampler(
+{
+label: '\u{1fa09}\uf6f4\uc590\u0114\u26a3\u{1f8bd}\u067d\u16d1\u5e83\u{1fad6}\ua569',
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 49.066,
+lodMaxClamp: 56.875,
+compare: 'less',
+}
+);
+try {
+computePassEncoder25.setPipeline(
+pipeline49
+);
+} catch {}
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder22.setStencilReference(
+2883
+);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(
+buffer9,
+'uint32',
+4936,
+123
+);
+} catch {}
+try {
+renderBundleEncoder39.setVertexBuffer(
+4,
+buffer17,
+1292
+);
+} catch {}
+try {
+commandEncoder44.clearBuffer(
+buffer5,
+13724,
+5704
+);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+computePassEncoder20.insertDebugMarker(
+'\u196b'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer9,
+4808,
+new DataView(new ArrayBuffer(9641)),
+8774,
+244
+);
+} catch {}
+let bindGroupLayout24 = pipeline58.getBindGroupLayout(0);
+let commandEncoder45 = device0.createCommandEncoder(
+{
+label: '\u0dd3\u1258',
+}
+);
+let renderPassEncoder25 = commandEncoder44.beginRenderPass(
+{
+label: '\u05f0\u00f8\u0819\u91b3\u00c5\udf87\u0f77\u09d3\u12b2\u{1ff77}',
+colorAttachments: [
+{
+view: textureView7,
+depthSlice: 5,
+clearValue: {
+r: -332.7,
+g: 353.7,
+b: 602.3,
+a: 754.0,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView7,
+depthSlice: 1,
+clearValue: {
+r: -985.1,
+g: 961.2,
+b: -226.2,
+a: -347.6,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined,
+{
+view: textureView7,
+depthSlice: 17,
+clearValue: {
+r: 123.8,
+g: 447.8,
+b: -734.0,
+a: 931.3,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView7,
+depthSlice: 12,
+clearValue: {
+r: -696.9,
+g: -891.1,
+b: -595.9,
+a: -362.6,
+},
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet31,
+maxDrawCount: 6472,
+}
+);
+let renderBundle49 = renderBundleEncoder42.finish(
+{
+label: '\u{1f877}\ud6b1\u38f5\uc806\ued9e\u083f\u7da4\u1d56'
+}
+);
+try {
+computePassEncoder18.setPipeline(
+pipeline9
+);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(
+0,
+bindGroup14
+);
+} catch {}
+try {
+canvas9.getContext('webgl');
+} catch {}
+pseudoSubmit(device0, commandEncoder40);
+let texture62 = device0.createTexture(
+{
+label: '\ue330\u16a2\uc094\u9069\u2912\u6977\u098d\u2332\u6b13\u0bee\u90d1',
+size: [143, 143, 1],
+sampleCount: 4,
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'bgra8unorm-srgb'
+],
+}
+);
+let renderBundleEncoder48 = device0.createRenderBundleEncoder(
+{
+label: '\u14c2\ub706\uca42\u333e',
+colorFormats: [
+undefined,
+undefined,
+'r32sint',
+'rg32sint',
+'r32uint',
+undefined,
+'rg32sint',
+'r16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 565,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle50 = renderBundleEncoder43.finish();
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.setViewport(
+31.96,
+0.9397,
+45.77,
+0.06015,
+0.5063,
+0.7403
+);
+} catch {}
+try {
+commandEncoder45.copyBufferToBuffer(
+buffer19,
+51412,
+buffer8,
+45680,
+3948
+);
+dissociateBuffer(device0, buffer19);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder45.resolveQuerySet(
+querySet9,
+1490,
+172,
+buffer15,
+20224
+);
+} catch {}
+let textureView53 = texture34.createView(
+{
+label: '\u0a2b\uec04\u0b5b\udd65\u0ae2\ue584\u{1f8e7}',
+baseMipLevel: 12,
+mipLevelCount: 1,
+baseArrayLayer: 0,
+arrayLayerCount: 1,
+}
+);
+let renderBundle51 = renderBundleEncoder48.finish(
+{
+
+}
+);
+try {
+renderPassEncoder15.setBindGroup(
+2,
+bindGroup23,
+new Uint32Array(3786),
+3255,
+0
+);
+} catch {}
+try {
+renderPassEncoder16.beginOcclusionQuery(
+48
+);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder45.copyTextureToTexture(
+{
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 2124, y: 18, z: 56 },
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 576, y: 42, z: 20 },
+  aspect: 'all',
+},
+{width: 2208, height: 12, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+externalTexture2.label = '\uf9c1\u7c1a\u0e16\u{1ff84}\u01f3\u{1f83f}\ubc95';
+} catch {}
+let buffer21 = device0.createBuffer(
+{
+label: '\u273a\u{1fc30}\u3c32\u07dc\ub351\u54cd\u006c\u95ab',
+size: 60167,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let commandEncoder46 = device0.createCommandEncoder(
+{
+label: '\u08be\u0e02\u{1f857}',
+}
+);
+try {
+renderPassEncoder15.setBindGroup(
+1,
+bindGroup9,
+new Uint32Array(7961),
+3201,
+0
+);
+} catch {}
+try {
+renderPassEncoder23.setStencilReference(
+3495
+);
+} catch {}
+try {
+renderPassEncoder22.setViewport(
+13.73,
+0.7222,
+2.173,
+0.00870,
+0.7887,
+0.9936
+);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(
+6,
+bindGroup5,
+new Uint32Array(602),
+375,
+0
+);
+} catch {}
+try {
+commandEncoder46.copyBufferToBuffer(
+buffer18,
+16360,
+buffer19,
+31912,
+3512
+);
+dissociateBuffer(device0, buffer18);
+dissociateBuffer(device0, buffer19);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer16,
+2788,
+new BigUint64Array(49505),
+16382,
+656
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture60,
+  mipLevel: 0,
+  origin: { x: 150, y: 0, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(56),
+/* required buffer size: 941 */{
+offset: 941,
+},
+{width: 40, height: 10, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\uacb4\u77f2\u{1f942}\u6616\u9293\u6edd');
+let img21 = await imageWithData(62, 246, '#496c41f2', '#0f4498e2');
+let video10 = await videoWithData();
+let shaderModule15 = device0.createShaderModule(
+{
+label: '\u2f7d\u{1f705}\ua4bd\u1261',
+code: `@group(0) @binding(1046)
+var<storage, read_write> parameter1: array<u32>;
+@group(6) @binding(1103)
+var<storage, read_write> function2: array<u32>;
+
+@compute @workgroup_size(4, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(0) f0: vec4<u32>,
+@location(1) f1: vec4<u32>,
+@location(5) f2: vec3<f32>,
+@location(6) f3: vec4<u32>,
+@location(2) f4: vec3<i32>,
+@location(4) f5: u32,
+@location(7) f6: i32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S13 {
+@location(5) f0: i32,
+@location(2) f1: vec4<i32>,
+@location(1) f2: vec4<u32>,
+@location(7) f3: f32,
+@location(0) f4: vec3<f16>,
+@location(15) f5: vec3<f16>,
+@location(11) f6: u32,
+@location(10) f7: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(16) a0: i32, @builtin(vertex_index) a1: u32, @location(12) a2: vec2<f16>, @location(4) a3: i32, a4: S13, @location(13) a5: vec3<i32>, @location(6) a6: f32, @location(8) a7: vec2<u32>, @location(9) a8: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+}
+);
+let textureView54 = texture39.createView(
+{
+dimension: '2d-array',
+mipLevelCount: 4,
+}
+);
+try {
+commandEncoder45.clearBuffer(
+buffer8,
+47232,
+2836
+);
+dissociateBuffer(device0, buffer8);
+} catch {}
+let pipeline80 = device0.createRenderPipeline(
+{
+label: '\u00af\u326d\u059b\u{1fb6b}\u03f1\u33d1\u0baf\u0b75\u0533\u2dbe\u{1f8dd}',
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule9,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x4',
+offset: 4604,
+shaderLocation: 9,
+},
+{
+format: 'uint16x2',
+offset: 22184,
+shaderLocation: 16,
+},
+{
+format: 'snorm8x2',
+offset: 21554,
+shaderLocation: 0,
+},
+{
+format: 'float16x4',
+offset: 8952,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 4992,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 1732,
+attributes: [
+
+],
+},
+{
+arrayStride: 10796,
+attributes: [
+
+],
+},
+{
+arrayStride: 6932,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 9028,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x2',
+offset: 6936,
+shaderLocation: 3,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule9,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+failOp: 'decrement-wrap',
+depthFailOp: 'zero',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'replace',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 3401,
+depthBias: 85,
+depthBiasClamp: 8,
+},
+}
+);
+let textureView55 = texture7.createView(
+{
+label: '\u{1fd45}\u0a73\ue749\uaa00\uf342\u1ad0\u{1fb01}',
+baseMipLevel: 3,
+}
+);
+let renderBundleEncoder49 = device0.createRenderBundleEncoder(
+{
+label: '\u0c93\u401d',
+colorFormats: [
+'rgba8unorm-srgb',
+'bgra8unorm',
+'rg16float',
+'r8unorm',
+'rg32sint',
+'r8uint',
+'r8unorm',
+'rgba32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 57,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder0.setBindGroup(
+3,
+bindGroup18
+);
+} catch {}
+try {
+renderPassEncoder17.setViewport(
+1.779,
+0.9476,
+22.57,
+0.00845,
+0.8586,
+0.9285
+);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(
+buffer16,
+'uint32',
+8528,
+4642
+);
+} catch {}
+try {
+gpuCanvasContext8.configure(
+{
+device: device0,
+format: 'astc-5x5-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-5x5-unorm-srgb'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer9,
+524,
+new Float32Array(10955),
+2934,
+764
+);
+} catch {}
+let pipeline81 = device0.createRenderPipeline(
+{
+label: '\u{1fe54}\uc3b1\u{1ff9d}\u1c95\udee5\u37b7\u1115\u73d1\uf0f8\u0f86',
+layout: 'auto',
+vertex: {
+module: shaderModule13,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 17240,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 11428,
+shaderLocation: 11,
+},
+{
+format: 'uint8x4',
+offset: 8480,
+shaderLocation: 6,
+},
+{
+format: 'float32x2',
+offset: 9556,
+shaderLocation: 2,
+},
+{
+format: 'float32x2',
+offset: 15796,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x4',
+offset: 2828,
+shaderLocation: 3,
+},
+{
+format: 'unorm16x4',
+offset: 8008,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 21256,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x4',
+offset: 15888,
+shaderLocation: 5,
+},
+{
+format: 'uint8x2',
+offset: 15332,
+shaderLocation: 1,
+},
+{
+format: 'sint16x4',
+offset: 16976,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x4',
+offset: 14340,
+shaderLocation: 14,
+},
+{
+format: 'snorm8x2',
+offset: 4054,
+shaderLocation: 8,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 104,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 27576,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x2',
+offset: 19378,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x42f600e5,
+},
+fragment: {
+module: shaderModule13,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'never',
+failOp: 'zero',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 1074,
+stencilWriteMask: 1494,
+depthBias: 98,
+depthBiasSlopeScale: 53,
+depthBiasClamp: 2,
+},
+}
+);
+let bindGroupLayout25 = device0.createBindGroupLayout(
+{
+label: '\u0101\u0ae4\u01d2\ue548\u08c9\u7ff8\u{1fde9}\u035a',
+entries: [
+{
+binding: 1151,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+},
+{
+binding: 1071,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+}
+],
+}
+);
+let commandEncoder47 = device0.createCommandEncoder(
+{
+}
+);
+try {
+computePassEncoder20.dispatchWorkgroups(
+1,
+1
+);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder46.copyBufferToBuffer(
+buffer15,
+12496,
+buffer3,
+272,
+3896
+);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer16,
+10932,
+new DataView(new ArrayBuffer(3632)),
+2950,
+300
+);
+} catch {}
+let pipeline82 = device0.createComputePipeline(
+{
+label: '\u8423\u65f0\ubf80\ua43b\u{1f713}\u6913\u{1ffee}\ufc65',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let querySet36 = device0.createQuerySet(
+{
+label: '\u0b8b\uf8a5\u39d3\u0689\u01a2\ufd46',
+type: 'occlusion',
+count: 2368,
+}
+);
+let computePassEncoder27 = commandEncoder46.beginComputePass(
+{
+label: '\u{1ff94}\u2a6c\u{1f94d}\u09ab\u723c\u27e5\u001d\u9af9\u1375\u000e\u{1fea5}'
+}
+);
+let renderPassEncoder26 = commandEncoder47.beginRenderPass(
+{
+label: '\u{1f64b}\u9ed5\u{1fc3f}\u685c\u{1fe4c}\u07d2',
+colorAttachments: [
+{
+view: textureView49,
+depthSlice: 5,
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined,
+{
+view: textureView49,
+depthSlice: 8,
+clearValue: {
+r: 534.3,
+g: 591.1,
+b: 15.02,
+a: 763.6,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView49,
+depthSlice: 4,
+clearValue: {
+r: -534.2,
+g: 232.8,
+b: 2.981,
+a: 763.5,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView49,
+depthSlice: 7,
+clearValue: {
+r: -936.4,
+g: -802.5,
+b: -196.0,
+a: 585.5,
+},
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet34,
+maxDrawCount: 81224,
+}
+);
+let sampler40 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 33.210,
+maxAnisotropy: 5,
+}
+);
+try {
+renderPassEncoder21.setBindGroup(
+2,
+bindGroup12
+);
+} catch {}
+try {
+renderPassEncoder22.setViewport(
+19.14,
+0.7953,
+5.497,
+0.00101,
+0.7925,
+0.8918
+);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(
+buffer9,
+'uint32',
+5356,
+450
+);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(
+5,
+buffer5,
+7204,
+12841
+);
+} catch {}
+document.body.prepend(img20);
+let buffer22 = device0.createBuffer(
+{
+label: '\u4154\u3d96\u{1f993}\u4dcc',
+size: 30633,
+usage: GPUBufferUsage.MAP_READ,
+}
+);
+let commandEncoder48 = device0.createCommandEncoder(
+{
+label: '\u08f5\uebda\udd90\u{1f769}\u009e\u0e38\u{1fb7d}\u{1fc49}\u2e9c\u0790\uf656',
+}
+);
+let textureView56 = texture60.createView(
+{
+dimension: '2d',
+}
+);
+let renderBundle52 = renderBundleEncoder49.finish(
+{
+label: '\uef44\u{1f8c6}\u2786\u9678\u{1fb1c}\u0a19\u{1f6c4}\u0bac\u{1fff5}'
+}
+);
+try {
+computePassEncoder24.end();
+} catch {}
+let pipeline83 = device0.createComputePipeline(
+{
+label: '\ufc60\ue4f7\ued1e\ub31b\u1c4c\u{1f75d}',
+layout: pipelineLayout6,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let videoFrame10 = new VideoFrame(canvas5, {timestamp: 0});
+let computePassEncoder28 = commandEncoder37.beginComputePass(
+{
+label: '\u{1ffda}\u0e7b'
+}
+);
+try {
+computePassEncoder25.dispatchWorkgroups(
+2,
+4
+);
+} catch {}
+try {
+renderPassEncoder13.end();
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(
+70,
+1,
+16,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.setViewport(
+80.90,
+0.2113,
+5.533,
+0.2716,
+0.2499,
+0.8016
+);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(
+5,
+buffer21,
+35936,
+3832
+);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(
+2,
+buffer8,
+56236,
+602
+);
+} catch {}
+try {
+commandEncoder48.copyTextureToTexture(
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 1490, y: 30, z: 18 },
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 1850, y: 0, z: 40 },
+  aspect: 'all',
+},
+{width: 1460, height: 40, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder45.clearBuffer(
+buffer2,
+47664
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture41,
+  mipLevel: 2,
+  origin: { x: 132, y: 0, z: 1 },
+  aspect: 'all',
+},
+new BigUint64Array(arrayBuffer1),
+/* required buffer size: 208 */{
+offset: 208,
+bytesPerRow: 1629,
+rowsPerImage: 281,
+},
+{width: 1008, height: 40, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline84 = device0.createRenderPipeline(
+{
+label: '\udcf5\uba41\u42b9\ub902\u0185\u6b93\u{1f82a}',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule9,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1428,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 28,
+shaderLocation: 13,
+},
+{
+format: 'snorm16x2',
+offset: 700,
+shaderLocation: 9,
+},
+{
+format: 'float32x3',
+offset: 160,
+shaderLocation: 3,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 956,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 9628,
+attributes: [
+
+],
+},
+{
+arrayStride: 17956,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 2408,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule9,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.ALPHA,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'less',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'replace',
+depthFailOp: 'decrement-wrap',
+passOp: 'invert',
+},
+depthBias: 89,
+depthBiasSlopeScale: 63,
+depthBiasClamp: 46,
+},
+}
+);
+document.body.prepend('\ude4c\u4d10\u95b7\u8a79\u6687\u0d5e\ue151\u4010\udd5c\u3ece');
+let querySet37 = device0.createQuerySet(
+{
+label: '\ufec1\u{1f7cd}\u{1fa39}\ueb3c\ubef2',
+type: 'occlusion',
+count: 1605,
+}
+);
+let texture63 = device0.createTexture(
+{
+label: '\uaef0\u471c\u9428\uef4c\u{1f8a7}\u{1f870}\u{1fb16}\u026b\u0cfc',
+size: [192, 1, 187],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'r16sint',
+'r16sint'
+],
+}
+);
+let computePassEncoder29 = commandEncoder45.beginComputePass(
+{
+
+}
+);
+let renderPassEncoder27 = commandEncoder48.beginRenderPass(
+{
+label: '\u{1f664}\ue562\u{1f7e1}\u9352\u154e\u4669\u0984\u61ad\ua30e\u19be',
+colorAttachments: [
+{
+view: textureView34,
+depthSlice: 940,
+clearValue: {
+r: -156.1,
+g: 563.2,
+b: 619.7,
+a: 414.2,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView34,
+depthSlice: 122,
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView34,
+depthSlice: 755,
+clearValue: {
+r: 584.3,
+g: -750.9,
+b: -79.37,
+a: -802.7,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView34,
+depthSlice: 711,
+clearValue: {
+r: -506.8,
+g: 537.9,
+b: 458.4,
+a: 425.4,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView34,
+depthSlice: 549,
+clearValue: {
+r: -901.1,
+g: -948.9,
+b: 825.8,
+a: 842.6,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet36,
+maxDrawCount: 231864,
+}
+);
+let renderBundle53 = renderBundleEncoder32.finish();
+try {
+computePassEncoder19.dispatchWorkgroups(
+4
+);
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder15.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder25.setBlendConstant(
+{
+r: 519.2,
+g: -569.8,
+b: -622.7,
+a: 598.6,
+}
+);
+} catch {}
+try {
+renderPassEncoder14.setScissorRect(
+64,
+0,
+12,
+1
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline85 = device0.createRenderPipeline(
+{
+layout: pipelineLayout7,
+vertex: {
+module: shaderModule5,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 24224,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x4',
+offset: 15404,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 7496,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 6276,
+shaderLocation: 9,
+},
+{
+format: 'float32x2',
+offset: 5848,
+shaderLocation: 13,
+},
+{
+format: 'snorm16x4',
+offset: 300,
+shaderLocation: 5,
+},
+{
+format: 'sint32',
+offset: 3212,
+shaderLocation: 12,
+},
+{
+format: 'uint16x2',
+offset: 1848,
+shaderLocation: 3,
+},
+{
+format: 'uint32x3',
+offset: 1472,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x4',
+offset: 6552,
+shaderLocation: 10,
+},
+{
+format: 'uint32x3',
+offset: 228,
+shaderLocation: 15,
+},
+{
+format: 'float16x2',
+offset: 4864,
+shaderLocation: 7,
+},
+{
+format: 'sint8x2',
+offset: 20,
+shaderLocation: 1,
+},
+{
+format: 'unorm8x4',
+offset: 256,
+shaderLocation: 14,
+},
+{
+format: 'uint16x2',
+offset: 1784,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 18380,
+attributes: [
+{
+format: 'float32x3',
+offset: 1088,
+shaderLocation: 6,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+},
+multisample: {
+mask: 0xaa76b205,
+},
+fragment: {
+module: shaderModule5,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'never',
+failOp: 'replace',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 741,
+stencilWriteMask: 1101,
+depthBias: 50,
+depthBiasSlopeScale: 43,
+depthBiasClamp: 33,
+},
+}
+);
+document.body.prepend(canvas2);
+let bindGroup24 = device0.createBindGroup({
+label: '\u24f6\u942b\u{1fa0c}\u075c',
+layout: bindGroupLayout23,
+entries: [
+{
+binding: 440,
+resource: sampler20
+}
+],
+});
+let commandEncoder49 = device0.createCommandEncoder(
+{
+label: '\u{1f956}\u{1fea6}',
+}
+);
+let querySet38 = device0.createQuerySet(
+{
+label: '\uf4c9\u7c99\u8d78',
+type: 'occlusion',
+count: 3106,
+}
+);
+let texture64 = device0.createTexture(
+{
+label: '\u0e27\u0fdf\u1bcf\u0f8a\u{1fb35}\uc41b\u{1f9b4}',
+size: {width: 220, height: 6, depthOrArrayLayers: 247},
+mipLevelCount: 2,
+format: 'astc-10x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let renderPassEncoder28 = commandEncoder49.beginRenderPass(
+{
+label: '\u{1f885}\uc568\u74bb\u06bb\u{1f65d}\u394c\u8a4a',
+colorAttachments: [
+{
+view: textureView49,
+depthSlice: 7,
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView49,
+depthSlice: 8,
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView49,
+depthSlice: 5,
+clearValue: {
+r: -437.9,
+g: -312.4,
+b: 49.82,
+a: -601.5,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView49,
+depthSlice: 6,
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView49,
+depthSlice: 0,
+clearValue: {
+r: -638.4,
+g: -456.6,
+b: 788.4,
+a: -658.0,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet15,
+maxDrawCount: 410992,
+}
+);
+let renderBundleEncoder50 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg16uint',
+'rgba16uint',
+'bgra8unorm',
+'rg16sint',
+'r16float'
+],
+sampleCount: 978,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder23.setBlendConstant(
+{
+r: -121.8,
+g: -889.6,
+b: 331.2,
+a: -896.3,
+}
+);
+} catch {}
+try {
+renderPassEncoder18.setViewport(
+24.78,
+0.5737,
+14.56,
+0.06048,
+0.6268,
+0.9149
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer8,
+54232,
+new Float32Array(65152),
+33393,
+252
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas5,
+  origin: { x: 391, y: 199 },
+  flipY: true,
+},
+{
+  texture: texture32,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let bindGroup25 = device0.createBindGroup({
+label: '\u84c8\u01ee\u9611\ua839\uc0c0\u5826\u9816\u8545',
+layout: bindGroupLayout23,
+entries: [
+{
+binding: 440,
+resource: sampler8
+}
+],
+});
+try {
+computePassEncoder26.setBindGroup(
+2,
+bindGroup11,
+[]
+);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(
+0,
+bindGroup7
+);
+} catch {}
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder20.setBlendConstant(
+{
+r: -274.7,
+g: 687.9,
+b: 840.3,
+a: -851.8,
+}
+);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(
+buffer6,
+'uint16',
+11246,
+6577
+);
+} catch {}
+document.body.append('\u{1f73f}\u0247\u0197\ufa1c');
+let bindGroup26 = device0.createBindGroup({
+label: '\u0af4\udc3d\u{1fb53}\uebeb\u{1fd14}\u113c\u4260\u{1fd58}',
+layout: bindGroupLayout3,
+entries: [
+
+],
+});
+try {
+computePassEncoder19.setPipeline(
+pipeline45
+);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(
+3,
+bindGroup10
+);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(
+1,
+bindGroup11,
+new Uint32Array(3393),
+110,
+0
+);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(
+8,
+buffer21,
+6328,
+31229
+);
+} catch {}
+let bindGroupLayout26 = device0.createBindGroupLayout(
+{
+entries: [
+{
+binding: 1420,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba32float', access: 'read-only', viewDimension: '2d-array' },
+},
+{
+binding: 2471,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+let textureView57 = texture48.createView(
+{
+label: '\u07a9\uf7fc\u8ad4\u{1f997}\u560c\u240c\u{1ff9b}\u9ed4\u8057',
+aspect: 'all',
+baseMipLevel: 3,
+mipLevelCount: 8,
+}
+);
+let sampler41 = device0.createSampler(
+{
+label: '\u{1fdf6}\u80e0\u050e',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 51.345,
+lodMaxClamp: 97.941,
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+4,
+bindGroup22,
+new Uint32Array(620),
+212,
+0
+);
+} catch {}
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder46.setIndexBuffer(
+buffer16,
+'uint16',
+8644,
+7287
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 678, y: 0, z: 7 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 767410 */{
+offset: 66,
+bytesPerRow: 192,
+rowsPerImage: 95,
+},
+{width: 42, height: 42, depthOrArrayLayers: 43}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img13,
+  origin: { x: 98, y: 4 },
+  flipY: true,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\ud333\u08ce\u0cba\u0026\u05f8\u09f1');
+let commandEncoder50 = device0.createCommandEncoder();
+try {
+computePassEncoder26.setPipeline(
+pipeline63
+);
+} catch {}
+try {
+renderPassEncoder22.end();
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(
+7,
+bindGroup9
+);
+} catch {}
+try {
+commandEncoder50.copyTextureToTexture(
+{
+  texture: texture42,
+  mipLevel: 1,
+  origin: { x: 20, y: 0, z: 287 },
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 2,
+  origin: { x: 9, y: 1, z: 1 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-5x5-unorm',
+'astc-8x8-unorm',
+'depth32float'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer21,
+12440,
+new Float32Array(25168),
+18893,
+4356
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 14, height: 1, depthOrArrayLayers: 1317}
+*/
+{
+  source: imageData0,
+  origin: { x: 13, y: 11 },
+  flipY: false,
+},
+{
+  texture: texture30,
+  mipLevel: 0,
+  origin: { x: 5, y: 0, z: 976 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 4, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\u4c5e\u{1fc30}\u0c0b\u{1f83c}');
+try {
+window.someLabel = renderBundleEncoder34.label;
+} catch {}
+let texture65 = device0.createTexture(
+{
+label: '\u{1fadc}\u0116\ua024\u7c02\uc38c\u{1f93e}\u{1ff56}\u003d\u67f7',
+size: [8575, 120, 227],
+format: 'astc-5x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+}
+);
+let renderBundle54 = renderBundleEncoder13.finish(
+{
+label: '\u{1f9db}\u821b\uf97c\ua44a\u{1fbd6}\u{1f892}\u{1fcf0}\u02cb\u{1f63a}\u{1f76f}\u0325'
+}
+);
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant(
+{
+r: -604.9,
+g: 733.3,
+b: 959.1,
+a: -887.7,
+}
+);
+} catch {}
+try {
+commandEncoder50.copyTextureToBuffer(
+{
+  texture: texture38,
+  mipLevel: 5,
+  origin: { x: 8, y: 5, z: 136 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 1008 */
+offset: 1008,
+bytesPerRow: 0,
+rowsPerImage: 299,
+buffer: buffer16,
+},
+{width: 0, height: 5, depthOrArrayLayers: 13}
+);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder50.resolveQuerySet(
+querySet8,
+894,
+2463,
+buffer15,
+4096
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas7 = new OffscreenCanvas(432, 922);
+let img22 = await imageWithData(102, 184, '#ba3bb45f', '#36b98af2');
+let shaderModule16 = device0.createShaderModule(
+{
+label: '\u75bb\u{1fc1c}\u08eb\u05cb\u0bf3\u43be\ue59a\u57da',
+code: `
+
+@compute @workgroup_size(7, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(0) f0: f32,
+@location(5) f1: vec4<i32>,
+@location(3) f2: vec2<u32>,
+@location(7) f3: vec2<u32>
+}
+
+@fragment
+fn fragment0(@location(23) a0: vec3<f16>, @location(31) a1: f32, @location(21) a2: vec4<f32>, @builtin(sample_index) a3: u32, @location(15) a4: f32, @location(24) a5: vec4<f16>, @location(30) a6: vec3<i32>, @location(50) a7: vec2<f32>, @location(54) a8: vec4<i32>, @location(13) a9: vec2<i32>, @location(49) a10: vec3<u32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(30) f208: vec3<i32>,
+@location(47) f209: vec2<f32>,
+@location(3) f210: vec2<i32>,
+@location(17) f211: vec3<u32>,
+@location(16) f212: vec2<i32>,
+@builtin(position) f213: vec4<f32>,
+@location(11) f214: vec3<f16>,
+@location(45) f215: vec3<i32>,
+@location(12) f216: vec3<f16>,
+@location(34) f217: u32,
+@location(54) f218: vec4<i32>,
+@location(27) f219: vec3<i32>,
+@location(32) f220: i32,
+@location(23) f221: vec3<f16>,
+@location(22) f222: f32,
+@location(50) f223: vec2<f32>,
+@location(9) f224: vec4<i32>,
+@location(21) f225: vec4<f32>,
+@location(25) f226: vec3<f32>,
+@location(49) f227: vec3<u32>,
+@location(15) f228: f32,
+@location(24) f229: vec4<f16>,
+@location(13) f230: vec2<i32>,
+@location(7) f231: vec3<i32>,
+@location(33) f232: vec2<f32>,
+@location(41) f233: vec2<f32>,
+@location(31) f234: f32
+}
+
+@vertex
+fn vertex0(@location(4) a0: vec3<i32>, @location(3) a1: vec4<f32>, @location(15) a2: i32, @location(2) a3: i32, @location(6) a4: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let querySet39 = device0.createQuerySet(
+{
+label: '\u1544\ufefb\u6931\u869d',
+type: 'occlusion',
+count: 1194,
+}
+);
+let renderBundleEncoder51 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+undefined,
+'r8unorm',
+undefined,
+'rg16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 12,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder8.setViewport(
+55.03,
+0.7551,
+2.160,
+0.1619,
+0.7722,
+0.9715
+);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(
+8,
+buffer15,
+14888,
+2402
+);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(
+7,
+bindGroup22
+);
+} catch {}
+let arrayBuffer4 = buffer10.getMappedRange(
+11248,
+104
+);
+try {
+commandEncoder50.clearBuffer(
+buffer19
+);
+dissociateBuffer(device0, buffer19);
+} catch {}
+let video11 = await videoWithData();
+let bindGroup27 = device0.createBindGroup({
+label: '\u1569\ud6ea',
+layout: bindGroupLayout9,
+entries: [
+
+],
+});
+let computePassEncoder30 = commandEncoder50.beginComputePass(
+{
+label: '\u0a20\u{1fd84}\u{1f809}\u0914\ued1e\u82dd\u8445'
+}
+);
+let renderBundle55 = renderBundleEncoder1.finish(
+{
+label: '\u0177\u4162\u0384\ued60\u{1fe5c}\uc9d5\u3da4\u{1f704}\ud0a0\u3a24'
+}
+);
+let sampler42 = device0.createSampler(
+{
+label: '\u6c2a\u0294\u{1feba}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 60.003,
+lodMaxClamp: 77.326,
+}
+);
+try {
+computePassEncoder26.setBindGroup(
+3,
+bindGroup10
+);
+} catch {}
+try {
+renderPassEncoder19.setStencilReference(
+3804
+);
+} catch {}
+try {
+gpuCanvasContext8.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: imageData1,
+  origin: { x: 176, y: 100 },
+  flipY: true,
+},
+{
+  texture: texture32,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let promise19 = adapter3.requestDevice(
+{
+label: '\uacd9\u2856\u0c80\u0dd7\u081c\u{1f781}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 9,
+maxColorAttachmentBytesPerSample: 60,
+maxVertexAttributes: 21,
+maxVertexBufferArrayStride: 34014,
+maxStorageTexturesPerShaderStage: 41,
+maxStorageBuffersPerShaderStage: 21,
+maxDynamicStorageBuffersPerPipelineLayout: 27818,
+maxBindingsPerBindGroup: 3468,
+maxTextureDimension1D: 13250,
+maxTextureDimension2D: 14187,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 93394810,
+maxInterStageShaderVariables: 90,
+maxInterStageShaderComponents: 87,
+},
+}
+);
+let img23 = await imageWithData(95, 28, '#6d44d51e', '#aa25911e');
+let textureView58 = texture30.createView(
+{
+label: '\ua5d3\u08ab\u{1f750}\u802a\u95f9\u0365\ue680',
+baseMipLevel: 7,
+baseArrayLayer: 0,
+}
+);
+try {
+computePassEncoder25.dispatchWorkgroupsIndirect(
+buffer19,
+19468
+);
+} catch {}
+try {
+renderPassEncoder12.beginOcclusionQuery(
+16
+);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant(
+{
+r: -231.6,
+g: -941.8,
+b: 996.4,
+a: 456.7,
+}
+);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(
+buffer16,
+'uint16',
+916,
+12383
+);
+} catch {}
+try {
+gpuCanvasContext3.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let pipeline86 = device0.createComputePipeline(
+{
+label: '\ud232\u0dca\u{1f94a}',
+layout: pipelineLayout6,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline87 = device0.createRenderPipeline(
+{
+label: '\u{1f88c}\ua588\u3e91\u6bfa\u828a\u0a0c\uaf49\u8010',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule7,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1816,
+attributes: [
+
+],
+},
+{
+arrayStride: 17328,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 9912,
+shaderLocation: 4,
+},
+{
+format: 'float16x2',
+offset: 14956,
+shaderLocation: 10,
+},
+{
+format: 'uint16x4',
+offset: 1720,
+shaderLocation: 14,
+},
+{
+format: 'float16x4',
+offset: 10280,
+shaderLocation: 7,
+},
+{
+format: 'sint8x2',
+offset: 11520,
+shaderLocation: 6,
+},
+{
+format: 'sint16x4',
+offset: 7384,
+shaderLocation: 12,
+},
+{
+format: 'uint32x2',
+offset: 5092,
+shaderLocation: 11,
+},
+{
+format: 'unorm16x2',
+offset: 13312,
+shaderLocation: 5,
+},
+{
+format: 'unorm16x4',
+offset: 2548,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x2',
+offset: 14684,
+shaderLocation: 13,
+},
+{
+format: 'snorm16x2',
+offset: 1936,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+
+],
+},
+{
+arrayStride: 24832,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 4184,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x3',
+offset: 1884,
+shaderLocation: 9,
+},
+{
+format: 'uint32',
+offset: 4100,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 1080,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 998,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 31016,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 3456,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x4',
+offset: 19840,
+shaderLocation: 3,
+},
+{
+format: 'uint8x2',
+offset: 5488,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule7,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+let sampler43 = device0.createSampler(
+{
+label: '\u1c6e\ucd21\u{1f77c}\u980d\ub31e\u9eee\u7e25\u562d\ubfb7\u0517',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+lodMinClamp: 2.472,
+lodMaxClamp: 59.625,
+}
+);
+try {
+renderPassEncoder19.end();
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+12.39,
+0.7363,
+25.66,
+0.1839,
+0.7813,
+0.9023
+);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(
+4,
+bindGroup20,
+new Uint32Array(9196),
+6844,
+0
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer21,
+44728,
+new Int16Array(12805),
+9610,
+1704
+);
+} catch {}
+document.body.prepend('\u2c79\u1d4a\u{1f739}\ud5f2');
+let adapter5 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let buffer23 = device0.createBuffer(
+{
+label: '\uba63\ub8bc\u{1f663}\u0808\uf6d7',
+size: 30779,
+usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+mappedAtCreation: false,
+}
+);
+let sampler44 = device0.createSampler(
+{
+label: '\ud8b9\uc3b0\u{1f9da}\u{1fbf1}\u0f67\u{1f6d6}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 75.938,
+lodMaxClamp: 88.032,
+}
+);
+try {
+computePassEncoder26.dispatchWorkgroups(
+2
+);
+} catch {}
+try {
+computePassEncoder22.setPipeline(
+pipeline31
+);
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(
+64
+);
+} catch {}
+try {
+renderPassEncoder18.setViewport(
+44.63,
+0.3427,
+0.09455,
+0.5584,
+0.01022,
+0.8588
+);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(
+7,
+bindGroup18
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture31,
+  mipLevel: 1,
+  origin: { x: 296, y: 16, z: 7 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 77493 */{
+offset: 391,
+bytesPerRow: 758,
+rowsPerImage: 93,
+},
+{width: 272, height: 72, depthOrArrayLayers: 2}
+);
+} catch {}
+let pipeline88 = device0.createRenderPipeline(
+{
+label: '\ua74f\ude1c\u{1ffc5}\uf641',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule8,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 18768,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x3',
+offset: 5188,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x4',
+offset: 5312,
+shaderLocation: 9,
+},
+{
+format: 'sint8x4',
+offset: 10752,
+shaderLocation: 11,
+},
+{
+format: 'sint32',
+offset: 6336,
+shaderLocation: 16,
+},
+{
+format: 'float32x2',
+offset: 14232,
+shaderLocation: 10,
+},
+{
+format: 'unorm8x4',
+offset: 8316,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 19760,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x4',
+offset: 17156,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 34044,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 22972,
+shaderLocation: 5,
+},
+{
+format: 'sint32',
+offset: 32376,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+cullMode: 'back',
+},
+fragment: {
+module: shaderModule8,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 939,
+stencilWriteMask: 1034,
+depthBias: 90,
+depthBiasSlopeScale: 41,
+depthBiasClamp: 70,
+},
+}
+);
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let bindGroup28 = device0.createBindGroup({
+label: '\u0351\u9e4e\u03a4\uca0d\uaede\u8e65\u{1f815}',
+layout: bindGroupLayout16,
+entries: [
+
+],
+});
+let renderBundle56 = renderBundleEncoder6.finish(
+{
+label: '\uc869\u6d74\u088c\u07b6\u{1fe98}\u013b\u6a9a\ub566\u{1fc99}'
+}
+);
+try {
+computePassEncoder22.setBindGroup(
+5,
+bindGroup14,
+new Uint32Array(5661),
+4004,
+0
+);
+} catch {}
+try {
+computePassEncoder21.setPipeline(
+pipeline51
+);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(
+8,
+buffer15
+);
+} catch {}
+let video12 = await videoWithData();
+let bindGroupLayout27 = pipeline82.getBindGroupLayout(0);
+let commandEncoder51 = device0.createCommandEncoder(
+{
+label: '\u1766\u1a9b',
+}
+);
+let textureView59 = texture33.createView(
+{
+dimension: '2d-array',
+baseMipLevel: 0,
+}
+);
+try {
+computePassEncoder26.setBindGroup(
+0,
+bindGroup26,
+new Uint32Array(8445),
+1178,
+0
+);
+} catch {}
+try {
+computePassEncoder19.setPipeline(
+pipeline56
+);
+} catch {}
+try {
+renderPassEncoder17.end();
+} catch {}
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(
+4,
+bindGroup22,
+new Uint32Array(9801),
+1070,
+0
+);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(
+9,
+buffer15,
+11948,
+4016
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture46,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(16),
+/* required buffer size: 267 */{
+offset: 267,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 7, height: 1, depthOrArrayLayers: 658}
+*/
+{
+  source: canvas1,
+  origin: { x: 358, y: 374 },
+  flipY: true,
+},
+{
+  texture: texture30,
+  mipLevel: 1,
+  origin: { x: 3, y: 1, z: 483 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline89 = device0.createRenderPipeline(
+{
+label: '\u{1fd0c}\u4cce\u{1ffaf}',
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule13,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 21980,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 18112,
+shaderLocation: 6,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 19016,
+shaderLocation: 0,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 2792,
+shaderLocation: 2,
+},
+{
+format: 'sint8x4',
+offset: 652,
+shaderLocation: 15,
+},
+{
+format: 'sint8x4',
+offset: 15744,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 20820,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 9574,
+shaderLocation: 8,
+},
+{
+format: 'snorm16x2',
+offset: 10972,
+shaderLocation: 14,
+},
+{
+format: 'uint32x3',
+offset: 12996,
+shaderLocation: 5,
+},
+{
+format: 'float32x3',
+offset: 8052,
+shaderLocation: 12,
+},
+{
+format: 'float16x4',
+offset: 12256,
+shaderLocation: 10,
+},
+{
+format: 'float32x4',
+offset: 11964,
+shaderLocation: 3,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 1564,
+shaderLocation: 11,
+},
+{
+format: 'uint16x4',
+offset: 9888,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule13,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-wrap',
+},
+stencilWriteMask: 1784,
+depthBias: 75,
+depthBiasSlopeScale: 75,
+depthBiasClamp: 3,
+},
+}
+);
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+document.body.append('\u0826\u{1f9cf}\u95d6\u0483\uc096\u0e22');
+let renderBundle57 = renderBundleEncoder39.finish();
+let sampler45 = device0.createSampler(
+{
+label: '\u06e1\u2bf0\ue951\u0870',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 90.837,
+lodMaxClamp: 99.236,
+}
+);
+try {
+computePassEncoder25.dispatchWorkgroups(
+4,
+3,
+4
+);
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(
+1927
+);
+} catch {}
+try {
+commandEncoder51.resolveQuerySet(
+querySet19,
+692,
+656,
+buffer21,
+45824
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture32,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 22 },
+  aspect: 'all',
+},
+new Int16Array(arrayBuffer1),
+/* required buffer size: 77295 */{
+offset: 603,
+bytesPerRow: 154,
+rowsPerImage: 249,
+},
+{width: 5, height: 0, depthOrArrayLayers: 3}
+);
+} catch {}
+let pipeline90 = await device0.createComputePipelineAsync(
+{
+layout: pipelineLayout7,
+compute: {
+module: shaderModule13,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageData10 = new ImageData(208, 68);
+let pipelineLayout8 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout1
+],
+}
+);
+let querySet40 = device0.createQuerySet(
+{
+label: '\u{1f610}\u0473\uea8d',
+type: 'occlusion',
+count: 1251,
+}
+);
+let texture66 = device0.createTexture(
+{
+size: {width: 332, height: 1, depthOrArrayLayers: 141},
+mipLevelCount: 8,
+dimension: '2d',
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+let renderPassEncoder29 = commandEncoder51.beginRenderPass(
+{
+label: '\u0859\ue19d\u0add\u{1f609}\u7eb7\u3e01\u1429\u77b5',
+colorAttachments: [
+undefined,
+{
+view: textureView34,
+depthSlice: 34,
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView34,
+depthSlice: 299,
+clearValue: {
+r: -326.1,
+g: -560.1,
+b: -814.4,
+a: -930.9,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView34,
+depthSlice: 676,
+clearValue: {
+r: -213.2,
+g: 760.6,
+b: 823.9,
+a: 206.9,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined,
+{
+view: textureView34,
+depthSlice: 131,
+clearValue: {
+r: -658.0,
+g: -480.9,
+b: -999.0,
+a: -824.7,
+},
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet0,
+maxDrawCount: 264480,
+}
+);
+let renderBundleEncoder52 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 982,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder21.setBindGroup(
+6,
+bindGroup24,
+new Uint32Array(116),
+56,
+0
+);
+} catch {}
+try {
+renderPassEncoder26.setStencilReference(
+2185
+);
+} catch {}
+try {
+renderPassEncoder12.setViewport(
+30.05,
+0.3426,
+52.97,
+0.4797,
+0.8347,
+0.9092
+);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(
+4,
+buffer15,
+4960,
+15273
+);
+} catch {}
+let pipeline91 = device0.createComputePipeline(
+{
+label: '\u05e2\u{1fb80}\u{1f768}\u88aa\ud51c',
+layout: 'auto',
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline92 = await device0.createRenderPipelineAsync(
+{
+label: '\u{1f828}\u945e\u{1f6f3}\uf5f7\u9092\u53fe\u0347\u{1f988}\u{1fa4d}',
+layout: pipelineLayout8,
+vertex: {
+module: shaderModule11,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 11644,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 4276,
+shaderLocation: 16,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 8564,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x4',
+offset: 7364,
+shaderLocation: 5,
+},
+{
+format: 'uint16x2',
+offset: 1936,
+shaderLocation: 8,
+},
+{
+format: 'sint16x4',
+offset: 8076,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'uint16x4',
+offset: 18284,
+shaderLocation: 11,
+},
+{
+format: 'unorm8x2',
+offset: 31840,
+shaderLocation: 14,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+},
+fragment: {
+module: shaderModule11,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+}
+],
+},
+}
+);
+gc();
+try {
+offscreenCanvas7.getContext('webgpu');
+} catch {}
+let querySet41 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 2685,
+}
+);
+let textureView60 = texture23.createView(
+{
+label: '\u40b0\u0863\ud7a1\u1792\u0adb\u0cab\u1064\u7066',
+dimension: '2d-array',
+format: 'r8snorm',
+baseMipLevel: 4,
+}
+);
+try {
+renderPassEncoder12.setBindGroup(
+4,
+bindGroup3
+);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant(
+{
+r: -671.0,
+g: 160.6,
+b: -327.6,
+a: -81.34,
+}
+);
+} catch {}
+try {
+renderPassEncoder15.setViewport(
+41.18,
+0.4898,
+27.71,
+0.2890,
+0.6281,
+0.7695
+);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(
+0,
+buffer15,
+9896,
+125
+);
+} catch {}
+try {
+device0.destroy();
+} catch {}
+document.body.append('\u3d4c\u0aba\u0517\u0468\u8d4d');
+let canvas10 = document.createElement('canvas');
+let offscreenCanvas8 = new OffscreenCanvas(28, 89);
+try {
+canvas10.getContext('webgl2');
+} catch {}
+let gpuCanvasContext9 = offscreenCanvas8.getContext('webgpu');
+document.body.prepend(img21);
+let device1 = await promise19;
+try {
+adapter4.label = '\u06bc\u{1fbf0}\ub23e\u0a49\u{1fa6e}\u2cf2\u46c8\udcce\u02c1\u5742';
+} catch {}
+try {
+device1.queue.label = '\u{1fa7b}\u{1fa57}\u{1fe65}\u{1ff71}\u{1fe08}';
+} catch {}
+let texture67 = device1.createTexture(
+{
+label: '\u0851\u7d84\u71b3\u056a\u{1fd5c}\u4a4d',
+size: [144, 10, 19],
+mipLevelCount: 5,
+format: 'astc-12x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-12x10-unorm-srgb',
+'astc-12x10-unorm'
+],
+}
+);
+try {
+device1.queue.writeTexture(
+{
+  texture: texture67,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint8Array(arrayBuffer0),
+/* required buffer size: 612255 */{
+offset: 471,
+bytesPerRow: 293,
+rowsPerImage: 116,
+},
+{width: 0, height: 10, depthOrArrayLayers: 19}
+);
+} catch {}
+let imageBitmap13 = await createImageBitmap(img10);
+let sampler46 = device1.createSampler(
+{
+label: '\u{1ffc5}\u055c\u1180\ubf46\uc128\u072e\u9cf3\u0012\u04dd\u{1ff2d}\uf299',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 80.444,
+lodMaxClamp: 95.358,
+maxAnisotropy: 7,
+}
+);
+let externalTexture3 = device1.importExternalTexture(
+{
+label: '\u5c8b\u5bde\ubf37\uaf56',
+source: video11,
+colorSpace: 'srgb',
+}
+);
+try {
+gpuCanvasContext0.configure(
+{
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'stencil8',
+'rg32uint',
+'rgba16float'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let offscreenCanvas9 = new OffscreenCanvas(665, 831);
+let textureView61 = texture67.createView(
+{
+label: '\u{1fb4f}\u7238\u0391\u810c\u{1f656}',
+dimension: '2d-array',
+format: 'astc-12x10-unorm',
+baseMipLevel: 1,
+baseArrayLayer: 15,
+arrayLayerCount: 3,
+}
+);
+gc();
+let offscreenCanvas10 = new OffscreenCanvas(28, 890);
+let textureView62 = texture67.createView(
+{
+label: '\u0902\ua422\u0808\u{1ff18}\u0da8\u5cc5\u824c\uaf49\u57c4\u0eeb\u{1f8b8}',
+baseMipLevel: 3,
+mipLevelCount: 1,
+baseArrayLayer: 3,
+arrayLayerCount: 7,
+}
+);
+let gpuCanvasContext10 = offscreenCanvas10.getContext('webgpu');
+let imageBitmap14 = await createImageBitmap(imageBitmap10);
+let bindGroupLayout28 = device1.createBindGroupLayout(
+{
+entries: [
+{
+binding: 721,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '3d' },
+},
+{
+binding: 2669,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+let querySet42 = device1.createQuerySet(
+{
+type: 'occlusion',
+count: 1209,
+}
+);
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let gpuCanvasContext11 = offscreenCanvas9.getContext('webgpu');
+document.body.append('\u0728\u650a\u0a07\u0f84\u{1fd5d}\u9d46\u{1fc11}\u1601');
+let offscreenCanvas11 = new OffscreenCanvas(938, 949);
+let bindGroupLayout29 = device1.createBindGroupLayout(
+{
+entries: [
+{
+binding: 1731,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '2d' },
+},
+{
+binding: 954,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '2d-array' },
+},
+{
+binding: 2370,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+}
+],
+}
+);
+let renderBundleEncoder53 = device1.createRenderBundleEncoder(
+{
+label: '\u0cf6\ub55a\ua54a\u60b2\ud1d9',
+colorFormats: [
+'rgba8uint',
+'rgba32float',
+'rgba32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 483,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+device1.queue.writeTexture(
+{
+  texture: texture67,
+  mipLevel: 1,
+  origin: { x: 0, y: 10, z: 2 },
+  aspect: 'all',
+},
+new Float32Array(arrayBuffer2),
+/* required buffer size: 54466 */{
+offset: 886,
+bytesPerRow: 228,
+rowsPerImage: 47,
+},
+{width: 36, height: 0, depthOrArrayLayers: 6}
+);
+} catch {}
+let imageBitmap15 = await createImageBitmap(canvas7);
+let renderBundleEncoder54 = device1.createRenderBundleEncoder(
+{
+label: '\u{1f96d}\u4e41\u5de0\u0cef\ub78a',
+colorFormats: [
+'rg8unorm',
+'bgra8unorm',
+'rgba32uint',
+'r32sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 131,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder54.pushDebugGroup(
+'\u05c7'
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture67,
+  mipLevel: 2,
+  origin: { x: 12, y: 0, z: 4 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(new ArrayBuffer(56)),
+/* required buffer size: 54218 */{
+offset: 125,
+bytesPerRow: 19,
+rowsPerImage: 219,
+},
+{width: 12, height: 0, depthOrArrayLayers: 14}
+);
+} catch {}
+try {
+offscreenCanvas11.getContext('webgpu');
+} catch {}
+document.body.prepend('\u0d9a\uf8bd\ud47c\u04b9\u09c5\u{1fb76}\uc87c\u{1f6e9}\uf5b8');
+let video13 = await videoWithData();
+let pipelineLayout9 = device1.createPipelineLayout(
+{
+label: '\u04a2\u9380',
+bindGroupLayouts: [
+bindGroupLayout28,
+bindGroupLayout28,
+bindGroupLayout28,
+bindGroupLayout28,
+bindGroupLayout28,
+bindGroupLayout28
+],
+}
+);
+let textureView63 = texture67.createView(
+{
+label: '\u0342\ud1f2\ueae7\udc4b\udd4b\u70b6',
+dimension: '2d',
+aspect: 'all',
+baseMipLevel: 2,
+baseArrayLayer: 10,
+}
+);
+let sampler47 = device1.createSampler(
+{
+label: '\u{1f8dc}\u3be0\u{1f8f9}\u0e59',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 19.932,
+lodMaxClamp: 64.543,
+compare: 'less-equal',
+maxAnisotropy: 13,
+}
+);
+try {
+renderBundleEncoder54.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device1,
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let sampler48 = device1.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 9.649,
+lodMaxClamp: 90.045,
+compare: 'not-equal',
+}
+);
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend('\u7823\ua566\u5222\u8a31\u{1fae9}\udf7c\ub6f6\u41dc');
+let video14 = await videoWithData();
+let shaderModule17 = device1.createShaderModule(
+{
+label: '\u{1fbb7}\u{1f88d}\u{1f8a8}\ue538\u{1f719}\u0101\ucf24\u3ce8\u5cc7\ua993',
+code: `@group(1) @binding(2669)
+var<storage, read_write> local2: array<u32>;
+@group(3) @binding(2669)
+var<storage, read_write> type0: array<u32>;
+@group(4) @binding(2669)
+var<storage, read_write> i3: array<u32>;
+@group(3) @binding(721)
+var<storage, read_write> local3: array<u32>;
+
+@compute @workgroup_size(1, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S15 {
+@location(76) f0: vec4<f32>,
+@location(24) f1: vec2<f32>,
+@location(5) f2: vec2<i32>,
+@location(37) f3: vec4<f32>,
+@location(83) f4: i32,
+@location(7) f5: vec4<i32>,
+@location(12) f6: vec2<u32>,
+@location(15) f7: f32,
+@location(81) f8: vec4<f16>,
+@location(20) f9: vec3<f32>,
+@location(42) f10: f16,
+@location(80) f11: vec2<f16>,
+@location(45) f12: f32,
+@location(33) f13: vec3<u32>,
+@location(82) f14: u32,
+@location(63) f15: i32,
+@location(75) f16: vec4<f16>
+}
+struct FragmentOutput0 {
+@location(7) f0: vec2<u32>,
+@location(1) f1: vec4<u32>,
+@location(3) f2: u32,
+@location(4) f3: vec3<f32>,
+@location(5) f4: u32,
+@location(0) f5: i32,
+@location(6) f6: vec4<i32>,
+@location(2) f7: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(61) a0: vec4<i32>, @location(71) a1: vec4<f16>, @location(19) a2: f16, @location(79) a3: vec3<i32>, @location(47) a4: u32, a5: S15, @builtin(front_facing) a6: bool, @location(51) a7: i32, @location(16) a8: vec3<f32>, @builtin(sample_mask) a9: u32, @location(65) a10: u32, @location(66) a11: f16, @location(64) a12: vec3<i32>, @location(13) a13: i32, @location(72) a14: i32, @location(73) a15: vec3<u32>, @location(60) a16: vec3<u32>, @location(2) a17: i32, @location(43) a18: u32, @location(18) a19: i32, @location(89) a20: i32, @location(55) a21: vec3<i32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S14 {
+@location(3) f0: vec2<f32>,
+@location(11) f1: vec2<u32>,
+@location(2) f2: vec3<f16>,
+@location(10) f3: vec3<f16>,
+@location(17) f4: vec4<i32>,
+@location(20) f5: vec2<f32>,
+@location(13) f6: vec2<u32>,
+@location(5) f7: vec3<f32>,
+@location(1) f8: vec4<f16>,
+@location(0) f9: u32,
+@location(19) f10: vec3<f16>,
+@location(9) f11: vec2<u32>,
+@location(14) f12: f32,
+@location(4) f13: vec2<u32>,
+@location(6) f14: f32,
+@location(7) f15: vec3<u32>,
+@location(18) f16: vec4<f32>,
+@location(8) f17: vec2<f16>,
+@location(15) f18: vec2<i32>,
+@location(12) f19: vec4<u32>,
+@location(16) f20: vec2<i32>,
+@builtin(instance_index) f21: u32,
+@builtin(vertex_index) f22: u32
+}
+struct VertexOutput0 {
+@location(82) f235: u32,
+@location(2) f236: i32,
+@location(19) f237: f16,
+@location(63) f238: i32,
+@location(66) f239: f16,
+@location(7) f240: vec4<i32>,
+@location(37) f241: vec4<f32>,
+@location(33) f242: vec3<u32>,
+@location(89) f243: i32,
+@location(42) f244: f16,
+@location(55) f245: vec3<i32>,
+@location(24) f246: vec2<f32>,
+@location(64) f247: vec3<i32>,
+@location(75) f248: vec4<f16>,
+@location(47) f249: u32,
+@location(76) f250: vec4<f32>,
+@location(16) f251: vec3<f32>,
+@location(71) f252: vec4<f16>,
+@location(59) f253: u32,
+@location(45) f254: f32,
+@location(80) f255: vec2<f16>,
+@location(36) f256: vec2<f32>,
+@location(15) f257: f32,
+@location(73) f258: vec3<u32>,
+@location(61) f259: vec4<i32>,
+@location(51) f260: i32,
+@location(43) f261: u32,
+@location(83) f262: i32,
+@location(20) f263: vec3<f32>,
+@location(65) f264: u32,
+@location(79) f265: vec3<i32>,
+@location(12) f266: vec2<u32>,
+@location(81) f267: vec4<f16>,
+@location(57) f268: vec4<f16>,
+@location(72) f269: i32,
+@location(18) f270: i32,
+@location(69) f271: vec2<u32>,
+@location(13) f272: i32,
+@location(5) f273: vec2<i32>,
+@location(60) f274: vec3<u32>,
+@builtin(position) f275: vec4<f32>
+}
+
+@vertex
+fn vertex0(a0: S14) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+try {
+renderBundleEncoder53.setVertexBuffer(
+4,
+undefined,
+1571589423,
+797177549
+);
+} catch {}
+let pipeline93 = await device1.createRenderPipelineAsync(
+{
+label: '\u020b\u11de\u03c7\u{1fdaa}\u7988\u265f\u49fe\ub508\u6517\u0db8',
+layout: pipelineLayout9,
+vertex: {
+module: shaderModule17,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 27776,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 24284,
+shaderLocation: 13,
+},
+{
+format: 'unorm8x4',
+offset: 14612,
+shaderLocation: 18,
+},
+{
+format: 'uint32',
+offset: 23520,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x4',
+offset: 1720,
+shaderLocation: 10,
+},
+{
+format: 'snorm16x4',
+offset: 2364,
+shaderLocation: 1,
+},
+{
+format: 'float32x4',
+offset: 22436,
+shaderLocation: 2,
+},
+{
+format: 'snorm8x4',
+offset: 17664,
+shaderLocation: 14,
+},
+{
+format: 'uint32',
+offset: 5664,
+shaderLocation: 4,
+},
+{
+format: 'sint8x4',
+offset: 14784,
+shaderLocation: 16,
+},
+{
+format: 'uint16x4',
+offset: 7444,
+shaderLocation: 11,
+},
+{
+format: 'unorm8x2',
+offset: 20902,
+shaderLocation: 5,
+},
+{
+format: 'unorm16x2',
+offset: 9312,
+shaderLocation: 8,
+},
+{
+format: 'unorm16x2',
+offset: 26468,
+shaderLocation: 3,
+},
+{
+format: 'sint32x4',
+offset: 3528,
+shaderLocation: 17,
+},
+{
+format: 'uint8x4',
+offset: 11256,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x4',
+offset: 20124,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 25600,
+attributes: [
+{
+format: 'uint32x4',
+offset: 10944,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 25408,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x3',
+offset: 12888,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 12204,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 8784,
+shaderLocation: 19,
+},
+{
+format: 'sint8x2',
+offset: 8656,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 8064,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 704,
+attributes: [
+{
+format: 'unorm16x2',
+offset: 316,
+shaderLocation: 20,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: false,
+},
+fragment: {
+module: shaderModule17,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'rgba32uint',
+writeMask: 0,
+},
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'one-minus-src',
+dstFactor: 'one-minus-src-alpha'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthCompare: 'always',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+},
+stencilReadMask: 3362,
+stencilWriteMask: 3308,
+depthBias: 62,
+depthBiasSlopeScale: 0,
+depthBiasClamp: 62,
+},
+}
+);
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let pipeline94 = await device1.createRenderPipelineAsync(
+{
+label: '\u0b10\uf391\u786c\ubb40\ua33e\u023d\u9ef9\u0d64',
+layout: pipelineLayout9,
+vertex: {
+module: shaderModule17,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 19384,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 15684,
+shaderLocation: 13,
+},
+{
+format: 'snorm16x4',
+offset: 18028,
+shaderLocation: 20,
+},
+{
+format: 'uint8x4',
+offset: 1344,
+shaderLocation: 9,
+},
+{
+format: 'uint32',
+offset: 948,
+shaderLocation: 0,
+},
+{
+format: 'uint32',
+offset: 12532,
+shaderLocation: 11,
+},
+{
+format: 'sint32x2',
+offset: 14896,
+shaderLocation: 15,
+},
+{
+format: 'sint8x4',
+offset: 14636,
+shaderLocation: 17,
+},
+{
+format: 'uint8x4',
+offset: 17160,
+shaderLocation: 7,
+},
+{
+format: 'uint8x2',
+offset: 13236,
+shaderLocation: 12,
+},
+{
+format: 'float32x2',
+offset: 5728,
+shaderLocation: 19,
+},
+{
+format: 'snorm8x2',
+offset: 5572,
+shaderLocation: 10,
+},
+{
+format: 'snorm8x2',
+offset: 5176,
+shaderLocation: 2,
+},
+{
+format: 'sint32x3',
+offset: 11608,
+shaderLocation: 16,
+},
+{
+format: 'unorm8x2',
+offset: 2718,
+shaderLocation: 5,
+},
+{
+format: 'snorm16x2',
+offset: 4816,
+shaderLocation: 6,
+},
+{
+format: 'unorm8x4',
+offset: 10880,
+shaderLocation: 1,
+},
+{
+format: 'snorm16x2',
+offset: 15832,
+shaderLocation: 18,
+},
+{
+format: 'unorm16x4',
+offset: 4976,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 21124,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 27892,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32',
+offset: 19640,
+shaderLocation: 3,
+},
+{
+format: 'float32x3',
+offset: 912,
+shaderLocation: 8,
+},
+{
+format: 'uint8x4',
+offset: 13136,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x1a158688,
+},
+fragment: {
+module: shaderModule17,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32sint',
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+format: 'rgb10a2uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'dst',
+dstFactor: 'one-minus-constant'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r16float',
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r8sint',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'zero',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilWriteMask: 2014,
+depthBias: 10,
+depthBiasSlopeScale: 80,
+depthBiasClamp: 65,
+},
+}
+);
+let img24 = await imageWithData(36, 40, '#704fd0bc', '#dc3321c1');
+let bindGroupLayout30 = device1.createBindGroupLayout(
+{
+label: '\u{1fca3}\ufe56',
+entries: [
+{
+binding: 1920,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '2d-array' },
+},
+{
+binding: 453,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 535,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let querySet43 = device1.createQuerySet(
+{
+label: '\u0af0\u39a0\u1bb8\u28f0',
+type: 'occlusion',
+count: 2115,
+}
+);
+let texture68 = device1.createTexture(
+{
+label: '\u{1fd36}\u0ee5\u{1f7bc}',
+size: [90, 70, 8],
+mipLevelCount: 4,
+format: 'astc-10x5-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x5-unorm',
+'astc-10x5-unorm-srgb',
+'astc-10x5-unorm-srgb'
+],
+}
+);
+try {
+renderBundleEncoder54.insertDebugMarker(
+'\u0f26'
+);
+} catch {}
+document.body.prepend('\u06be\ue75c\ua446');
+let video15 = await videoWithData();
+let texture69 = device0.createTexture(
+{
+label: '\u4b52\ua816\u063c\u{1fe7c}\u0f74\u0a6e',
+size: [2813],
+dimension: '1d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16uint',
+'rgba16uint'
+],
+}
+);
+try {
+renderPassEncoder24.beginOcclusionQuery(
+80
+);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(
+buffer9,
+'uint16',
+1776,
+1039
+);
+} catch {}
+document.body.append('\u92fa\u5016\u08ac\u355d\ud044\u189f\u7d99\u0f79\ued5d\u037c');
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+document.body.append('\u{1fb81}\u{1f6f6}\u5e19\u{1f9d0}\u0b28');
+let imageBitmap16 = await createImageBitmap(offscreenCanvas10);
+let textureView64 = texture67.createView(
+{
+label: '\u01e6\ud08b\u2b73\u{1f9c9}\u8781\u{1f664}\u{1f682}\u33a3',
+dimension: '2d',
+baseMipLevel: 1,
+baseArrayLayer: 16,
+}
+);
+document.body.append('\u1cea\u0456');
+let img25 = await imageWithData(39, 191, '#45e07018', '#559881a4');
+let videoFrame11 = new VideoFrame(imageBitmap4, {timestamp: 0});
+let buffer24 = device0.createBuffer(
+{
+label: '\u50cf\u0ec4',
+size: 12088,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let querySet44 = device0.createQuerySet(
+{
+label: '\u4f47\u514b\u4c0e\uf75f\u{1f7d9}\u02bc\u43b1',
+type: 'occlusion',
+count: 1161,
+}
+);
+let renderBundle58 = renderBundleEncoder37.finish(
+{
+label: '\u0345\u6b69\u45ab\uaba2\u0381\u{1fed0}\u{1f71c}\u06fd\u2d07\u0857\uf97f'
+}
+);
+try {
+computePassEncoder20.setPipeline(
+pipeline34
+);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(
+1784
+);
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+56.66,
+0.7147,
+21.22,
+0.1585,
+0.8114,
+0.8904
+);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(
+0,
+buffer21,
+46428,
+10690
+);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(
+3,
+buffer8
+);
+} catch {}
+try {
+renderBundleEncoder25.insertDebugMarker(
+'\u0965'
+);
+} catch {}
+video0.width = 172;
+gc();
+document.body.append('\u975b\u{1f9a5}');
+let shaderModule18 = device1.createShaderModule(
+{
+label: '\uef96\ube42\uc33d\ua93e\u0c1b\uc482\u41a7',
+code: `
+
+@compute @workgroup_size(1, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(0) f0: vec2<i32>,
+@location(1) f1: vec4<i32>,
+@location(7) f2: u32,
+@location(3) f3: vec3<f32>,
+@location(2) f4: vec4<i32>,
+@location(6) f5: i32,
+@location(4) f6: vec2<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(sample_mask) a1: u32, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S16 {
+@location(10) f0: vec2<f16>,
+@location(14) f1: vec3<i32>,
+@location(7) f2: vec3<i32>,
+@location(6) f3: vec4<i32>,
+@location(2) f4: f16,
+@location(1) f5: i32,
+@location(17) f6: f32
+}
+
+@vertex
+fn vertex0(@location(18) a0: vec3<f16>, @location(8) a1: vec4<u32>, @builtin(instance_index) a2: u32, @builtin(vertex_index) a3: u32, @location(5) a4: vec4<u32>, @location(20) a5: i32, a6: S16, @location(11) a7: vec2<u32>, @location(15) a8: vec3<f16>, @location(16) a9: vec2<f16>, @location(4) a10: vec3<f16>, @location(13) a11: vec4<i32>, @location(0) a12: vec2<f16>, @location(19) a13: vec2<u32>, @location(3) a14: vec4<f32>, @location(12) a15: vec3<f16>, @location(9) a16: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+}
+);
+let pipelineLayout10 = device1.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout28,
+bindGroupLayout28,
+bindGroupLayout28,
+bindGroupLayout29,
+bindGroupLayout30,
+bindGroupLayout30,
+bindGroupLayout30,
+bindGroupLayout30
+],
+}
+);
+let texture70 = device1.createTexture(
+{
+size: {width: 10, height: 2, depthOrArrayLayers: 505},
+mipLevelCount: 6,
+sampleCount: 1,
+dimension: '3d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8snorm'
+],
+}
+);
+gc();
+let commandEncoder52 = device1.createCommandEncoder(
+{
+label: '\u1c7d\u07e1\u{1fc4c}\u{1fdd6}\u6b74\u0bdc\u{1ff57}\u0eed\udcde',
+}
+);
+pseudoSubmit(device1, commandEncoder52);
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+offscreenCanvas8.width = 421;
+document.body.append('\u1f9f\ubc0a\u3b65\u40e0\u0888');
+let offscreenCanvas12 = new OffscreenCanvas(305, 797);
+let imageBitmap17 = await createImageBitmap(img16);
+document.body.prepend('\u08bf\uf7eb\u088e\u{1f959}\u{1fab1}\ua1cf\u044a\u0fab');
+let renderBundleEncoder55 = device1.createRenderBundleEncoder(
+{
+label: '\u0574\u{1f92d}\u0344\u52ed\u{1f736}\u30e8',
+colorFormats: [
+'rgb10a2uint',
+'rg32uint',
+'rg16uint',
+'rgba8unorm',
+'bgra8unorm-srgb',
+'rg16float',
+'rg8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 279,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle59 = renderBundleEncoder55.finish();
+document.body.append('\u0974\u2c89');
+let imageBitmap18 = await createImageBitmap(img20);
+let videoFrame12 = new VideoFrame(videoFrame9, {timestamp: 0});
+try {
+adapter3.label = '\ue384\u0433\u0925\u4ea8';
+} catch {}
+canvas4.height = 684;
+document.body.append('\u{1fde1}\uf032\u2813\ua97e\u{1ffe6}\u05ac');
+try {
+offscreenCanvas12.getContext('webgpu');
+} catch {}
+let buffer25 = device1.createBuffer(
+{
+label: '\u{1f768}\u{1fd39}',
+size: 30264,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+mappedAtCreation: true,
+}
+);
+let texture71 = device1.createTexture(
+{
+label: '\u{1fbe1}\u{1fab8}',
+size: [1305, 1, 12],
+mipLevelCount: 10,
+dimension: '3d',
+format: 'r32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32float'
+],
+}
+);
+let renderBundle60 = renderBundleEncoder53.finish(
+{
+label: '\u04a4\u0450\ube49\u4720\u07ff\u04ef\u0875\uc109\u{1f831}'
+}
+);
+let externalTexture4 = device1.importExternalTexture(
+{
+label: '\u080b\u01d3\u3dc3\u{1f9ca}',
+source: videoFrame9,
+colorSpace: 'srgb',
+}
+);
+try {
+buffer25.unmap();
+} catch {}
+let promise20 = device1.popErrorScope();
+try {
+gpuCanvasContext8.configure(
+{
+device: device1,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rg32float'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+document.body.prepend('\u3c9b\u213f\u{1fd86}\u1ad2\u53b0\u{1f759}\u9908\u3649\u5605');
+let shaderModule19 = device0.createShaderModule(
+{
+label: '\uae39\u{1fa22}\ufc63\udac1\uf9bf',
+code: `
+
+@compute @workgroup_size(8, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S18 {
+@builtin(position) f0: vec4<f32>,
+@location(12) f1: i32,
+@location(1) f2: vec2<f32>,
+@builtin(sample_index) f3: u32,
+@location(19) f4: vec3<f32>,
+@builtin(front_facing) f5: bool,
+@location(11) f6: vec4<f16>,
+@builtin(sample_mask) f7: u32,
+@location(52) f8: vec2<f32>,
+@location(6) f9: vec3<f16>,
+@location(0) f10: vec4<f16>,
+@location(40) f11: vec4<i32>,
+@location(42) f12: vec3<f32>,
+@location(18) f13: vec4<u32>,
+@location(32) f14: vec3<f16>,
+@location(28) f15: vec3<f32>,
+@location(49) f16: vec3<i32>,
+@location(36) f17: f32,
+@location(5) f18: vec3<i32>,
+@location(33) f19: f32,
+@location(41) f20: vec4<f16>,
+@location(10) f21: vec3<f16>,
+@location(38) f22: vec2<f32>
+}
+struct FragmentOutput0 {
+@location(2) f0: vec3<i32>,
+@location(6) f1: vec3<i32>,
+@location(4) f2: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(24) a0: u32, a1: S18, @location(17) a2: vec4<u32>, @location(4) a3: vec2<f32>, @location(29) a4: i32, @location(15) a5: vec4<u32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S17 {
+@location(1) f0: vec2<u32>,
+@location(12) f1: vec4<u32>,
+@location(11) f2: u32,
+@location(9) f3: vec4<i32>,
+@location(14) f4: f16,
+@location(0) f5: vec2<f32>,
+@location(4) f6: i32,
+@location(15) f7: vec2<f16>,
+@location(8) f8: u32,
+@location(13) f9: vec2<f16>,
+@location(3) f10: vec3<f16>,
+@builtin(instance_index) f11: u32,
+@location(16) f12: vec3<f32>
+}
+struct VertexOutput0 {
+@location(40) f276: vec4<i32>,
+@location(42) f277: vec3<f32>,
+@location(6) f278: vec3<f16>,
+@location(5) f279: vec3<i32>,
+@location(29) f280: i32,
+@location(0) f281: vec4<f16>,
+@location(52) f282: vec2<f32>,
+@builtin(position) f283: vec4<f32>,
+@location(32) f284: vec3<f16>,
+@location(19) f285: vec3<f32>,
+@location(10) f286: vec3<f16>,
+@location(17) f287: vec4<u32>,
+@location(38) f288: vec2<f32>,
+@location(1) f289: vec2<f32>,
+@location(33) f290: f32,
+@location(11) f291: vec4<f16>,
+@location(15) f292: vec4<u32>,
+@location(41) f293: vec4<f16>,
+@location(12) f294: i32,
+@location(49) f295: vec3<i32>,
+@location(4) f296: vec2<f32>,
+@location(18) f297: vec4<u32>,
+@location(28) f298: vec3<f32>,
+@location(36) f299: f32,
+@location(24) f300: u32
+}
+
+@vertex
+fn vertex0(@location(5) a0: i32, @location(6) a1: vec3<i32>, @location(2) a2: vec2<f32>, @location(7) a3: i32, @builtin(vertex_index) a4: u32, a5: S17, @location(10) a6: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder53 = device0.createCommandEncoder(
+{
+label: '\u{1faaa}\u0866\u899c\u07a9\u0d7c\u9e88\u83e1\u{1f863}',
+}
+);
+let querySet45 = device0.createQuerySet(
+{
+label: '\u{1f710}\u5634\u0f5d',
+type: 'occlusion',
+count: 2660,
+}
+);
+let renderPassEncoder30 = commandEncoder53.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView32,
+depthSlice: 43,
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView32,
+depthSlice: 33,
+clearValue: {
+r: 7.825,
+g: 7.645,
+b: -913.9,
+a: -119.4,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView32,
+depthSlice: 12,
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView32,
+depthSlice: 42,
+clearValue: {
+r: 557.8,
+g: -291.9,
+b: -724.6,
+a: -173.4,
+},
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+maxDrawCount: 490120,
+}
+);
+let renderBundle61 = renderBundleEncoder28.finish(
+{
+
+}
+);
+try {
+renderPassEncoder24.beginOcclusionQuery(
+16
+);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(
+buffer23,
+'uint32',
+28552,
+444
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture4,
+  mipLevel: 2,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'stencil-only',
+},
+new Uint32Array(arrayBuffer3),
+/* required buffer size: 988 */{
+offset: 988,
+rowsPerImage: 187,
+},
+{width: 1005, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+gc();
+let canvas11 = document.createElement('canvas');
+let imageData11 = new ImageData(100, 248);
+document.body.append('\u0355\u3719\u02a3\u0879\u{1f7d5}\u{1f666}');
+let bindGroupLayout31 = pipeline93.getBindGroupLayout(4);
+let commandEncoder54 = device1.createCommandEncoder();
+let commandBuffer6 = commandEncoder54.finish();
+let textureView65 = texture71.createView(
+{
+label: '\ud2a4\u{1f6b0}',
+baseMipLevel: 3,
+mipLevelCount: 2,
+}
+);
+let sampler49 = device1.createSampler(
+{
+label: '\u4e4f\uaebb\u{1fd62}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 94.085,
+}
+);
+document.body.prepend('\u06e6\u{1f6ae}\u3531\u{1ff63}\u9912\u00d0\u{1f970}\u73d2');
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let bindGroupLayout32 = pipeline94.getBindGroupLayout(5);
+let commandEncoder55 = device1.createCommandEncoder(
+{
+label: '\u0c58\u6a4e\u0e6a\u{1ffae}\u709c',
+}
+);
+let commandBuffer7 = commandEncoder55.finish(
+{
+label: '\uba90\u0c48\ub8c2\u32c6\u0d34\u0a6b\u{1ffca}\u2c3d',
+}
+);
+let renderBundleEncoder56 = device1.createRenderBundleEncoder(
+{
+label: '\u{1fba9}\u25e3\ua5bf\u965d\u0368\u4181\u0d2a\ue82f\u0f3c\u{1fcd8}\u{1f65f}',
+colorFormats: [
+'rg32sint',
+'rgba32sint',
+'rg16sint',
+'rgba32sint'
+],
+sampleCount: 877,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder56.setVertexBuffer(
+9,
+buffer25
+);
+} catch {}
+let commandEncoder56 = device0.createCommandEncoder(
+{
+label: '\u336e\u6c7b\ubc6e\u076b\u7899\u7a66\u03d5\u{1faf1}\u09e0\u7980\u7839',
+}
+);
+let computePassEncoder31 = commandEncoder56.beginComputePass(
+{
+
+}
+);
+let sampler50 = device0.createSampler(
+{
+label: '\u{1fe4c}\u1fd1\u01a9',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 54.650,
+lodMaxClamp: 86.529,
+maxAnisotropy: 10,
+}
+);
+try {
+computePassEncoder31.setBindGroup(
+6,
+bindGroup28
+);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(
+80
+);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(
+2315
+);
+} catch {}
+let gpuCanvasContext12 = canvas11.getContext('webgpu');
+video5.width = 188;
+let offscreenCanvas13 = new OffscreenCanvas(774, 391);
+let renderBundle62 = renderBundleEncoder54.finish(
+{
+label: '\u235f\u0093\u0a39\u{1fca9}\u03c5\u0078\u0720\uf1a5\ud080'
+}
+);
+let sampler51 = device1.createSampler(
+{
+label: '\u1355\u0b44\u{1f7c1}\u0504\u0eb1',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 71.491,
+lodMaxClamp: 75.078,
+maxAnisotropy: 11,
+}
+);
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+try {
+await promise20;
+} catch {}
+document.body.append('\u{1f9cb}\u2749\u{1fd13}\u06c2\u{1fba4}\u37ed\u0d4f\u1d43\u867b');
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+offscreenCanvas11.width = 961;
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+document.body.append('\u7dfe\u0a42\ua1ed\u5ac4\u0fac\u937f\ufddb\u09b4');
+canvas9.width = 718;
+try {
+bindGroupLayout5.label = '\uc327\u016f\u{1fb0f}\u055e\u{1f9a9}';
+} catch {}
+let gpuCanvasContext13 = offscreenCanvas13.getContext('webgpu');
+let video16 = await videoWithData();
+let offscreenCanvas14 = new OffscreenCanvas(113, 916);
+let shaderModule20 = device1.createShaderModule(
+{
+label: '\u{1fa8b}\uc924\u558d\u{1fdc2}\u63f6\u{1fc90}\u{1fa2a}',
+code: `@group(3) @binding(2669)
+var<storage, read_write> field2: array<u32>;
+
+@compute @workgroup_size(3, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S20 {
+@location(80) f0: f16,
+@location(39) f1: i32,
+@location(29) f2: u32,
+@location(9) f3: vec2<f32>
+}
+struct FragmentOutput0 {
+@location(1) f0: vec3<u32>,
+@location(5) f1: vec3<f32>,
+@location(0) f2: vec3<f32>,
+@location(4) f3: vec3<u32>,
+@location(3) f4: vec2<f32>,
+@location(7) f5: vec3<i32>,
+@location(2) f6: vec3<u32>,
+@location(6) f7: i32,
+@builtin(sample_mask) f8: u32,
+@builtin(frag_depth) f9: f32
+}
+
+@fragment
+fn fragment0(@location(71) a0: vec4<f32>, @location(15) a1: i32, a2: S20, @location(20) a3: vec3<i32>, @location(45) a4: u32, @location(82) a5: vec4<f16>, @location(11) a6: vec3<u32>, @location(72) a7: vec3<i32>, @location(63) a8: vec2<f16>, @location(3) a9: vec3<i32>, @location(18) a10: vec2<i32>, @location(57) a11: vec3<i32>, @location(21) a12: vec2<f16>, @location(14) a13: vec3<f32>, @location(74) a14: vec2<f16>, @location(84) a15: vec3<u32>, @location(5) a16: vec2<f32>, @location(76) a17: vec2<f32>, @location(65) a18: f16, @location(59) a19: vec2<f16>, @location(26) a20: vec4<i32>, @location(53) a21: vec3<f32>, @location(4) a22: f16, @location(37) a23: vec2<i32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S19 {
+@location(19) f0: vec3<f32>,
+@location(12) f1: vec2<i32>,
+@location(5) f2: vec3<f32>,
+@location(6) f3: vec3<u32>,
+@location(9) f4: vec2<f32>,
+@location(14) f5: vec2<i32>,
+@location(20) f6: vec4<i32>,
+@location(16) f7: vec2<f16>,
+@location(17) f8: vec3<u32>
+}
+struct VertexOutput0 {
+@location(18) f301: vec2<i32>,
+@location(53) f302: vec3<f32>,
+@location(57) f303: vec3<i32>,
+@location(72) f304: vec3<i32>,
+@location(9) f305: vec2<f32>,
+@location(84) f306: vec3<u32>,
+@location(51) f307: vec4<u32>,
+@location(14) f308: vec3<f32>,
+@location(26) f309: vec4<i32>,
+@location(65) f310: f16,
+@location(76) f311: vec2<f32>,
+@location(71) f312: vec4<f32>,
+@location(39) f313: i32,
+@location(82) f314: vec4<f16>,
+@location(6) f315: vec4<f32>,
+@location(45) f316: u32,
+@location(80) f317: f16,
+@location(74) f318: vec2<f16>,
+@location(47) f319: i32,
+@location(32) f320: vec2<u32>,
+@location(20) f321: vec3<i32>,
+@location(33) f322: vec2<i32>,
+@location(37) f323: vec2<i32>,
+@location(66) f324: vec3<f16>,
+@location(88) f325: vec2<f32>,
+@location(15) f326: i32,
+@location(5) f327: vec2<f32>,
+@location(35) f328: vec3<f32>,
+@location(11) f329: vec3<u32>,
+@location(3) f330: vec3<i32>,
+@location(63) f331: vec2<f16>,
+@location(4) f332: f16,
+@location(21) f333: vec2<f16>,
+@location(59) f334: vec2<f16>,
+@location(49) f335: vec4<f16>,
+@location(29) f336: u32,
+@builtin(position) f337: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec3<u32>, @location(3) a1: vec4<f32>, @location(13) a2: vec4<u32>, a3: S19, @location(2) a4: vec2<i32>, @location(0) a5: vec3<f16>, @location(15) a6: vec2<i32>, @location(4) a7: vec3<i32>, @location(1) a8: vec4<f16>, @location(11) a9: vec4<f16>, @location(18) a10: vec4<f32>, @location(7) a11: vec2<u32>, @location(8) a12: vec4<f32>, @builtin(vertex_index) a13: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let pipelineLayout11 = device1.createPipelineLayout(
+{
+label: '\u{1f907}\u{1ffb0}\ue054\u9c27\udf58',
+bindGroupLayouts: [
+bindGroupLayout28,
+bindGroupLayout32,
+bindGroupLayout29,
+bindGroupLayout32
+],
+}
+);
+let texture72 = device1.createTexture(
+{
+label: '\u7880\u{1fd65}\u36a9\u0acf\u{1f7d8}\u8c71',
+size: [5000, 230, 135],
+mipLevelCount: 5,
+format: 'astc-10x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x5-unorm',
+'astc-10x5-unorm',
+'astc-10x5-unorm'
+],
+}
+);
+let pipeline95 = device1.createComputePipeline(
+{
+layout: 'auto',
+compute: {
+module: shaderModule17,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let canvas12 = document.createElement('canvas');
+let video17 = await videoWithData();
+try {
+canvas12.getContext('webgl');
+} catch {}
+let gpuCanvasContext14 = offscreenCanvas14.getContext('webgpu');
+canvas5.height = 542;
+let textureView66 = texture70.createView(
+{
+label: '\u1292\u047b\u{1fb2b}\u01eb\u5ee0\u0d91\u36e5\u{1f79b}\u{1f8ac}\u{1f728}',
+baseMipLevel: 4,
+}
+);
+let renderBundle63 = renderBundleEncoder53.finish(
+{
+label: '\u{1f66f}\uccfc\u9ec4\udc4e'
+}
+);
+try {
+device1.queue.writeTexture(
+{
+  texture: texture70,
+  mipLevel: 2,
+  origin: { x: 0, y: 1, z: 9 },
+  aspect: 'all',
+},
+new DataView(arrayBuffer3),
+/* required buffer size: 2004435 */{
+offset: 815,
+bytesPerRow: 170,
+rowsPerImage: 142,
+},
+{width: 2, height: 0, depthOrArrayLayers: 84}
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let textureView67 = texture53.createView(
+{
+label: '\u72af\u1a57\u02b4\ubeb3\u8694\ue079\u{1fd17}',
+dimension: '2d-array',
+format: 'astc-8x5-unorm',
+}
+);
+let renderBundleEncoder57 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg8unorm',
+'rg8uint',
+'rg16float',
+'rg16sint',
+'rg32uint',
+'r8sint',
+'rgba16sint',
+'bgra8unorm'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 3,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder27.setBindGroup(
+0,
+bindGroup17,
+new Uint32Array(2631),
+816,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(
+2,
+bindGroup27,
+new Uint32Array(2385),
+746,
+0
+);
+} catch {}
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder57.setVertexBuffer(
+31,
+undefined,
+1797620908,
+2008095971
+);
+} catch {}
+let commandEncoder57 = device1.createCommandEncoder(
+{
+label: '\uc52a\u895e\uf239\u09a6\u03b6\u0c8e\u0d8c\u0147',
+}
+);
+let textureView68 = texture67.createView(
+{
+label: '\u6d80\u0030',
+baseMipLevel: 1,
+mipLevelCount: 2,
+baseArrayLayer: 1,
+arrayLayerCount: 6,
+}
+);
+try {
+commandEncoder57.copyTextureToTexture(
+{
+  texture: texture70,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 31 },
+  aspect: 'all',
+},
+{
+  texture: texture70,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 15 },
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 16}
+);
+} catch {}
+try {
+commandEncoder57.clearBuffer(
+buffer25
+);
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+renderBundleEncoder56.insertDebugMarker(
+'\u24b5'
+);
+} catch {}
+try {
+device1.queue.submit([
+commandBuffer6,
+]);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer25,
+17328,
+new BigUint64Array(61136),
+7905,
+1464
+);
+} catch {}
+let device2 = await adapter1.requestDevice(
+{
+label: '\u{1ff7b}\ua22d\u028f\ucc80\u370d\u00c2\u{1ff09}',
+requiredLimits: {
+maxBindGroups: 5,
+maxColorAttachmentBytesPerSample: 44,
+maxVertexAttributes: 27,
+maxVertexBufferArrayStride: 13300,
+maxStorageTexturesPerShaderStage: 8,
+maxStorageBuffersPerShaderStage: 20,
+maxDynamicStorageBuffersPerPipelineLayout: 59455,
+maxBindingsPerBindGroup: 4631,
+maxTextureDimension1D: 16019,
+maxTextureDimension2D: 9813,
+maxVertexBuffers: 10,
+maxUniformBufferBindingSize: 102322238,
+maxInterStageShaderVariables: 20,
+maxInterStageShaderComponents: 82,
+},
+}
+);
+let img26 = await imageWithData(260, 49, '#58e49df2', '#6880f837');
+let shaderModule21 = device1.createShaderModule(
+{
+label: '\u075c\uec9a\u626f\u0be7',
+code: `@group(5) @binding(721)
+var<storage, read_write> parameter2: array<u32>;
+
+@compute @workgroup_size(8, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S22 {
+@location(79) f0: vec4<u32>,
+@location(41) f1: f32,
+@location(11) f2: vec3<u32>,
+@location(81) f3: vec3<f16>,
+@location(85) f4: vec3<u32>,
+@location(55) f5: vec4<f16>,
+@location(4) f6: vec4<f32>,
+@location(50) f7: i32,
+@location(28) f8: vec4<u32>,
+@location(9) f9: vec2<f16>,
+@location(65) f10: f16,
+@location(73) f11: vec3<i32>,
+@location(83) f12: vec2<f32>,
+@location(88) f13: vec2<f16>,
+@location(37) f14: f32,
+@location(77) f15: vec4<f16>,
+@builtin(sample_index) f16: u32,
+@location(44) f17: vec4<f32>,
+@location(62) f18: vec2<f32>,
+@location(8) f19: i32,
+@location(29) f20: vec2<i32>,
+@location(35) f21: vec2<f16>,
+@location(68) f22: vec4<f32>
+}
+struct FragmentOutput0 {
+@location(0) f0: u32,
+@location(7) f1: vec4<i32>,
+@location(6) f2: vec2<i32>,
+@location(2) f3: vec2<f32>,
+@location(1) f4: f32,
+@location(3) f5: i32,
+@builtin(sample_mask) f6: u32,
+@location(5) f7: u32,
+@location(4) f8: vec2<u32>
+}
+
+@fragment
+fn fragment0(@location(22) a0: f32, @builtin(front_facing) a1: bool, @location(32) a2: vec2<f32>, @location(80) a3: vec4<u32>, @location(69) a4: vec3<i32>, @builtin(sample_mask) a5: u32, @location(1) a6: vec3<u32>, @builtin(position) a7: vec4<f32>, @location(45) a8: vec3<i32>, @location(58) a9: vec2<i32>, @location(30) a10: vec2<f16>, a11: S22, @location(20) a12: f32, @location(19) a13: vec2<i32>, @location(7) a14: vec3<u32>, @location(38) a15: vec3<i32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S21 {
+@location(14) f0: f16,
+@location(0) f1: vec4<i32>,
+@location(17) f2: vec2<u32>,
+@location(9) f3: vec2<u32>,
+@location(11) f4: vec4<u32>,
+@builtin(instance_index) f5: u32,
+@location(3) f6: i32,
+@location(16) f7: f16,
+@builtin(vertex_index) f8: u32,
+@location(5) f9: i32
+}
+struct VertexOutput0 {
+@location(68) f338: vec4<f32>,
+@location(38) f339: vec3<i32>,
+@location(4) f340: vec4<f32>,
+@location(69) f341: vec3<i32>,
+@location(19) f342: vec2<i32>,
+@location(30) f343: vec2<f16>,
+@location(88) f344: vec2<f16>,
+@location(50) f345: i32,
+@location(62) f346: vec2<f32>,
+@location(9) f347: vec2<f16>,
+@location(37) f348: f32,
+@location(7) f349: vec3<u32>,
+@location(79) f350: vec4<u32>,
+@location(80) f351: vec4<u32>,
+@location(73) f352: vec3<i32>,
+@location(58) f353: vec2<i32>,
+@location(44) f354: vec4<f32>,
+@location(35) f355: vec2<f16>,
+@location(55) f356: vec4<f16>,
+@location(83) f357: vec2<f32>,
+@location(20) f358: f32,
+@location(41) f359: f32,
+@location(28) f360: vec4<u32>,
+@location(65) f361: f16,
+@location(45) f362: vec3<i32>,
+@location(85) f363: vec3<u32>,
+@location(1) f364: vec3<u32>,
+@location(29) f365: vec2<i32>,
+@location(77) f366: vec4<f16>,
+@location(81) f367: vec3<f16>,
+@location(11) f368: vec3<u32>,
+@builtin(position) f369: vec4<f32>,
+@location(8) f370: i32,
+@location(22) f371: f32,
+@location(32) f372: vec2<f32>
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec4<f16>, @location(20) a1: f16, @location(13) a2: i32, @location(18) a3: vec3<f32>, @location(1) a4: vec3<u32>, @location(10) a5: vec4<f16>, @location(15) a6: vec4<i32>, @location(12) a7: vec3<f32>, @location(4) a8: f32, @location(19) a9: vec2<f16>, @location(7) a10: i32, a11: S21, @location(8) a12: vec2<f16>, @location(6) a13: f32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let textureView69 = texture70.createView(
+{
+label: '\u6e04\u9231\u0d26\u0c62\uf332\u0a62\ub064',
+baseMipLevel: 1,
+}
+);
+let computePassEncoder32 = commandEncoder57.beginComputePass();
+try {
+computePassEncoder32.setPipeline(
+pipeline95
+);
+} catch {}
+try {
+renderBundleEncoder56.setIndexBuffer(
+buffer25,
+'uint32'
+);
+} catch {}
+let buffer26 = device2.createBuffer(
+{
+size: 2245,
+usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let querySet46 = device2.createQuerySet(
+{
+type: 'occlusion',
+count: 1329,
+}
+);
+let adapter6 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let sampler52 = device2.createSampler(
+{
+label: '\u{1f67a}\u097e\u{1fc4d}',
+addressModeU: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMaxClamp: 89.545,
+}
+);
+try {
+device2.pushErrorScope(
+'validation'
+);
+} catch {}
+let adapter7 = await navigator.gpu.requestAdapter(
+{
+powerPreference: 'high-performance',
+}
+);
+let querySet47 = device2.createQuerySet(
+{
+label: '\u09c9\u4d71\u854e\u4a76\ua4f9\u0627\udc3c\u093a\u0822\u0d38',
+type: 'occlusion',
+count: 7,
+}
+);
+let buffer27 = device1.createBuffer(
+{
+size: 30151,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+try {
+device1.queue.writeTexture(
+{
+  texture: texture67,
+  mipLevel: 1,
+  origin: { x: 36, y: 0, z: 5 },
+  aspect: 'all',
+},
+new ArrayBuffer(72),
+/* required buffer size: 22566 */{
+offset: 6,
+bytesPerRow: 80,
+rowsPerImage: 282,
+},
+{width: 24, height: 0, depthOrArrayLayers: 2}
+);
+} catch {}
+let renderBundleEncoder58 = device1.createRenderBundleEncoder(
+{
+label: '\u825a\u0073\u{1fdff}\u0005',
+colorFormats: [
+'rg8sint',
+'rg8uint',
+'r8unorm',
+'rg11b10ufloat',
+'bgra8unorm-srgb'
+],
+sampleCount: 478,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+let renderBundle64 = renderBundleEncoder58.finish(
+{
+label: '\uc994\u942a\ua730\u0093'
+}
+);
+let externalTexture5 = device1.importExternalTexture(
+{
+label: '\u9d8b\ucca3\u4f8b\u95ba\u9e2e\u{1fa68}\ua9be\u0c5c',
+source: video17,
+colorSpace: 'display-p3',
+}
+);
+try {
+buffer27.unmap();
+} catch {}
+let video18 = await videoWithData();
+let commandEncoder58 = device2.createCommandEncoder(
+{
+}
+);
+let computePassEncoder33 = commandEncoder58.beginComputePass();
+let renderBundleEncoder59 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg32float',
+'r8sint',
+'rgba32sint',
+'rg16uint',
+'rgba8sint',
+'rg32uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 610,
+stencilReadOnly: true,
+}
+);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+canvas2.width = 522;
+document.body.append('\u05a4\u765b\uea1e\uba15\uee37\uc197\ub1ac\uc7da\u3d23');
+try {
+computePassEncoder32.setPipeline(
+pipeline95
+);
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(
+9,
+buffer25,
+22092,
+4203
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer25,
+21476,
+new Int16Array(10975),
+2283,
+1240
+);
+} catch {}
+document.body.prepend('\u{1fa4f}\u0119');
+let querySet48 = device2.createQuerySet(
+{
+label: '\uf87a\uc1cf\u0d54\u7d9b\u922e\u0dac',
+type: 'occlusion',
+count: 539,
+}
+);
+let texture73 = device2.createTexture(
+{
+label: '\u{1fe70}\u8cd0\u30d5\u{1f9f6}\u133a\u4c69',
+size: [1774, 1, 38],
+mipLevelCount: 6,
+dimension: '3d',
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'bgra8unorm',
+'bgra8unorm-srgb',
+'bgra8unorm-srgb'
+],
+}
+);
+let textureView70 = texture73.createView(
+{
+label: '\u{1fa91}\ueda3\uc526\u6e70\u{1f703}\u474d\u{1ff9d}\u0fe9',
+baseMipLevel: 4,
+}
+);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let canvas13 = document.createElement('canvas');
+document.body.prepend(img15);
+let videoFrame13 = new VideoFrame(video11, {timestamp: 0});
+let querySet49 = device1.createQuerySet(
+{
+label: '\u{1f842}\u03f1\u16dd\u31a9\u{1f611}',
+type: 'occlusion',
+count: 1025,
+}
+);
+let texture74 = device1.createTexture(
+{
+size: [243, 31, 1],
+mipLevelCount: 8,
+format: 'r8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let sampler53 = device1.createSampler(
+{
+label: '\u{1f9e6}\u{1fc29}\u{1f88f}\uaaf3',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 9.213,
+lodMaxClamp: 47.725,
+compare: 'not-equal',
+maxAnisotropy: 19,
+}
+);
+try {
+device1.queue.submit([
+commandBuffer7,
+]);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let textureView71 = texture73.createView(
+{
+format: 'bgra8unorm',
+mipLevelCount: 5,
+}
+);
+let renderBundleEncoder60 = device2.createRenderBundleEncoder(
+{
+label: '\u693f\ud55f\u013d\u7182\u96c0\u07da\u0caa\u0a81\u012d\ud873\ua640',
+colorFormats: [
+'rgba16float',
+'rgba32sint',
+'r8unorm',
+'rgba32uint'
+],
+sampleCount: 668,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder59.setVertexBuffer(
+3,
+buffer26,
+2224,
+1
+);
+} catch {}
+try {
+canvas13.getContext('bitmaprenderer');
+} catch {}
+let bindGroupLayout33 = device2.createBindGroupLayout(
+{
+label: '\u1c00\u1954\u7f87\u2e9c\u{1fc50}\ubc8a',
+entries: [
+{
+binding: 4246,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'non-filtering' },
+},
+{
+binding: 4421,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '2d-array' },
+},
+{
+binding: 260,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}
+],
+}
+);
+let commandEncoder59 = device2.createCommandEncoder(
+{
+label: '\uc1ad\ue206\u02c1\u0e67',
+}
+);
+let querySet50 = device2.createQuerySet(
+{
+label: '\uad9e\u1792\u{1f8b0}\u2ff8\u00c0\u{1f941}\u0703',
+type: 'occlusion',
+count: 496,
+}
+);
+let commandBuffer8 = commandEncoder59.finish(
+{
+label: '\u0fd8\u00a7\u65c2\u0dff\u0bcb\uaa53\ue041',
+}
+);
+let sampler54 = device2.createSampler(
+{
+label: '\u4b60\u0488\uc112\u{1fcee}\u555b\u10a5\u1b7c\u0bdd\u08a1\u0260',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 52.153,
+maxAnisotropy: 16,
+}
+);
+try {
+await adapter6.requestAdapterInfo();
+} catch {}
+let bindGroupLayout34 = device1.createBindGroupLayout(
+{
+label: '\uf19a\u{1fb2e}\u074f\u0cd0\ufac3\u{1f964}\u4f84\u033c',
+entries: [
+{
+binding: 2940,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '2d' },
+},
+{
+binding: 443,
+visibility: GPUShaderStage.FRAGMENT,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}
+],
+}
+);
+let bindGroupLayout35 = pipeline94.getBindGroupLayout(4);
+let buffer28 = device1.createBuffer(
+{
+label: '\u{1fcab}\u0759\u0c4e\ubf17',
+size: 15142,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let querySet51 = device1.createQuerySet(
+{
+type: 'occlusion',
+count: 760,
+}
+);
+let renderBundleEncoder61 = device1.createRenderBundleEncoder(
+{
+label: '\u{1fe8a}\u{1fe3a}\u5961\u{1fd54}\u6cb7',
+colorFormats: [
+'r8unorm',
+undefined,
+'r16float',
+'r16uint',
+'rg8unorm',
+'rg8uint',
+'rg11b10ufloat'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 242,
+depthReadOnly: true,
+}
+);
+let sampler55 = device1.createSampler(
+{
+label: '\u98bd\u{1f9ed}\u6083',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 72.795,
+lodMaxClamp: 79.844,
+maxAnisotropy: 1,
+}
+);
+let promise21 = buffer27.mapAsync(
+GPUMapMode.READ,
+7168,
+3256
+);
+try {
+computePassEncoder32.insertDebugMarker(
+'\u6110'
+);
+} catch {}
+let img27 = await imageWithData(45, 279, '#b9db6171', '#8b2ae78b');
+let texture75 = device2.createTexture(
+{
+label: '\ua111\u{1f6a9}\u0cff\ufb14\u{1f810}\u0505\u{1fb3f}\uf37a\u67df',
+size: [136, 134, 1],
+mipLevelCount: 5,
+format: 'rgba32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32uint',
+'rgba32uint'
+],
+}
+);
+try {
+renderBundleEncoder59.setVertexBuffer(
+6,
+buffer26,
+1220,
+194
+);
+} catch {}
+let imageBitmap19 = await createImageBitmap(imageBitmap11);
+document.body.append('\u5eb6\u2628\u5e53\u0532\uc295\u0960');
+let buffer29 = device1.createBuffer(
+{
+size: 20237,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+pseudoSubmit(device1, commandEncoder57);
+try {
+gpuCanvasContext14.configure(
+{
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rg8uint',
+'rgba16float'
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let bindGroupLayout36 = device1.createBindGroupLayout(
+{
+label: '\uaeb7\u{1fef4}\u0665\u{1fbdd}\u0149\u87c5',
+entries: [
+
+],
+}
+);
+let commandEncoder60 = device1.createCommandEncoder(
+{
+label: '\u53c9\u0197\u0d11\u528a\u5c90\u26fb\u63e9\u0659\u{1fee3}\u{1f6c3}',
+}
+);
+let querySet52 = device1.createQuerySet(
+{
+label: '\u0786\u{1f83b}',
+type: 'occlusion',
+count: 2266,
+}
+);
+let renderBundle65 = renderBundleEncoder61.finish(
+{
+label: '\u53e0\u504d\u06f1\u1e9d\u0fc1\u77f0\u28c6\uffb1\u0d22\u7df7'
+}
+);
+let pipeline96 = device1.createComputePipeline(
+{
+label: '\u0233\uf38c\u5e1f\u{1f86f}\ue28a\u04db\u0e61\ubcbd\ub301\u4ef2\u69d3',
+layout: 'auto',
+compute: {
+module: shaderModule21,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let texture76 = device2.createTexture(
+{
+label: '\uddab\u{1f6bc}\u05e5\u0014',
+size: [1956, 1, 1718],
+mipLevelCount: 6,
+dimension: '3d',
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'r32sint',
+'r32sint'
+],
+}
+);
+let renderBundleEncoder62 = device2.createRenderBundleEncoder(
+{
+label: '\u0956\u3270\u{1f8ea}',
+colorFormats: [
+'rgba32float',
+'r8unorm',
+'rgba16float',
+'rg16float',
+'rgba8unorm-srgb',
+'r16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 529,
+stencilReadOnly: true,
+}
+);
+let renderBundle66 = renderBundleEncoder59.finish(
+{
+label: '\u{1f6d3}\u8685\u9bf4\u7f1d\u2a22\u063e\u0fbf\uec26\u0b8c\u0c5c\u{1f611}'
+}
+);
+let buffer30 = device2.createBuffer(
+{
+label: '\ua696\ua1f3\u7350\ufac4\u0cd9\ufab9\uc62c\u0fd0\u{1fec5}',
+size: 4915,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let commandEncoder61 = device2.createCommandEncoder(
+{
+label: '\u0998\u496d',
+}
+);
+let querySet53 = device2.createQuerySet(
+{
+label: '\uc23f\u{1f945}\u{1f8b0}\u2782\u0c65\u0261\u8543\u5a83\uff52\ubbc9',
+type: 'occlusion',
+count: 988,
+}
+);
+let texture77 = device2.createTexture(
+{
+label: '\u0d08\u93bf\u{1fa8b}\u72fc\ua75c\u3e58',
+size: [203, 1, 518],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'r8uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'r8uint'
+],
+}
+);
+let renderBundleEncoder63 = device2.createRenderBundleEncoder(
+{
+label: '\u5157\u2011\u{1f834}\u0ca8\u4ae7',
+colorFormats: [
+'r16sint',
+undefined,
+'rg16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 132,
+depthReadOnly: true,
+}
+);
+try {
+commandEncoder61.copyTextureToTexture(
+{
+  texture: texture73,
+  mipLevel: 0,
+  origin: { x: 642, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture73,
+  mipLevel: 3,
+  origin: { x: 149, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 7, height: 1, depthOrArrayLayers: 3}
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer30,
+432,
+new Float32Array(5472),
+2496,
+172
+);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+try {
+device2.label = '\u6f51\u0ffe';
+} catch {}
+let bindGroupLayout37 = device2.createBindGroupLayout(
+{
+label: '\udbf6\u{1f99e}\u1561\u{1fa1f}\u42bb\u5684\u0181\u80dd',
+entries: [
+{
+binding: 918,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+},
+{
+binding: 118,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+},
+{
+binding: 1378,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+let commandEncoder62 = device2.createCommandEncoder(
+{
+label: '\u723a\u012a\ud84f\u58d2\u8c86\ue01e\u9ce4\u0872\u0b9a',
+}
+);
+let textureView72 = texture73.createView(
+{
+label: '\u0c4f\u0be8\u0002\u0bfb\uc4f0\u{1ff5f}\u4fe5\u3c60\u7ebe',
+format: 'bgra8unorm',
+baseMipLevel: 2,
+mipLevelCount: 2,
+}
+);
+let renderBundle67 = renderBundleEncoder62.finish(
+{
+label: '\u81d2\u{1fdfd}\u8cfa\u6ac0\u84c3\u{1f76b}'
+}
+);
+try {
+device2.pushErrorScope(
+'internal'
+);
+} catch {}
+try {
+commandEncoder61.copyTextureToTexture(
+{
+  texture: texture73,
+  mipLevel: 5,
+  origin: { x: 10, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture73,
+  mipLevel: 2,
+  origin: { x: 176, y: 0, z: 5 },
+  aspect: 'all',
+},
+{width: 44, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device2.queue.submit([
+]);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let adapter8 = await navigator.gpu.requestAdapter(
+{
+}
+);
+try {
+renderBundleEncoder56.setVertexBuffer(
+10,
+buffer25
+);
+} catch {}
+try {
+commandEncoder60.copyTextureToTexture(
+{
+  texture: texture72,
+  mipLevel: 0,
+  origin: { x: 2590, y: 140, z: 49 },
+  aspect: 'all',
+},
+{
+  texture: texture72,
+  mipLevel: 0,
+  origin: { x: 2960, y: 170, z: 14 },
+  aspect: 'all',
+},
+{width: 1720, height: 30, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer25,
+19968,
+new DataView(new ArrayBuffer(48172)),
+6456,
+9428
+);
+} catch {}
+let pipeline97 = device1.createComputePipeline(
+{
+label: '\ua203\ua06a\u{1f8f2}\u{1f714}\u2157\u226d\ub93b\u{1f66d}\u01e4\uf34f',
+layout: pipelineLayout10,
+compute: {
+module: shaderModule17,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+video16.width = 181;
+let img28 = await imageWithData(248, 117, '#86559de9', '#c35bea68');
+video12.width = 105;
+let videoFrame14 = new VideoFrame(video7, {timestamp: 0});
+gc();
+let img29 = await imageWithData(125, 23, '#b888eb1f', '#0111e31c');
+try {
+await promise21;
+} catch {}
+let video19 = await videoWithData();
+let commandEncoder63 = device1.createCommandEncoder(
+{
+}
+);
+try {
+renderBundleEncoder56.setIndexBuffer(
+buffer25,
+'uint16',
+926
+);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+try {
+commandEncoder60.copyTextureToTexture(
+{
+  texture: texture68,
+  mipLevel: 0,
+  origin: { x: 0, y: 50, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture72,
+  mipLevel: 4,
+  origin: { x: 10, y: 5, z: 107 },
+  aspect: 'all',
+},
+{width: 70, height: 5, depthOrArrayLayers: 4}
+);
+} catch {}
+let pipeline98 = await device1.createRenderPipelineAsync(
+{
+label: '\u3126\u0652\u{1fb48}\ue5d6\u7e8b\u{1fdf3}\u0ea7\u{1f916}\u02d3',
+layout: pipelineLayout9,
+vertex: {
+module: shaderModule21,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 29088,
+attributes: [
+{
+format: 'sint16x4',
+offset: 15364,
+shaderLocation: 13,
+},
+{
+format: 'float16x4',
+offset: 4096,
+shaderLocation: 6,
+},
+{
+format: 'float32x2',
+offset: 17436,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 25204,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x4',
+offset: 10504,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x4',
+offset: 10504,
+shaderLocation: 2,
+},
+{
+format: 'sint8x2',
+offset: 21006,
+shaderLocation: 5,
+},
+{
+format: 'uint8x4',
+offset: 10948,
+shaderLocation: 9,
+},
+{
+format: 'uint32',
+offset: 15048,
+shaderLocation: 1,
+},
+{
+format: 'unorm16x4',
+offset: 11996,
+shaderLocation: 10,
+},
+{
+format: 'float32x2',
+offset: 16084,
+shaderLocation: 19,
+},
+{
+format: 'sint32x4',
+offset: 6756,
+shaderLocation: 15,
+},
+{
+format: 'snorm16x4',
+offset: 152,
+shaderLocation: 12,
+},
+{
+format: 'float16x2',
+offset: 8304,
+shaderLocation: 8,
+},
+{
+format: 'sint32',
+offset: 1740,
+shaderLocation: 7,
+},
+{
+format: 'uint8x4',
+offset: 16572,
+shaderLocation: 11,
+},
+{
+format: 'uint16x2',
+offset: 18884,
+shaderLocation: 17,
+},
+{
+format: 'unorm8x2',
+offset: 15364,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 27108,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 15216,
+shaderLocation: 20,
+},
+{
+format: 'sint32',
+offset: 2048,
+shaderLocation: 3,
+},
+{
+format: 'sint32',
+offset: 2648,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x4',
+offset: 19512,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule21,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8uint',
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 1174,
+stencilWriteMask: 2747,
+depthBias: 39,
+depthBiasSlopeScale: 71,
+depthBiasClamp: 64,
+},
+}
+);
+canvas9.width = 581;
+document.body.prepend('\u{1fe2b}\u0a32');
+let pipelineLayout12 = device2.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout37,
+bindGroupLayout37
+],
+}
+);
+try {
+renderBundleEncoder63.setVertexBuffer(
+2,
+buffer26,
+1504,
+111
+);
+} catch {}
+try {
+commandEncoder61.clearBuffer(
+buffer30,
+3124,
+44
+);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+device2.queue.submit([
+commandBuffer8,
+]);
+} catch {}
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+document.body.append('\u0dfb\u604c\u605c\u8369\u03f4\u4c72\u89e3\u011c\u{1fa9b}\u{1fc13}\u{1ff3d}');
+let shaderModule22 = device1.createShaderModule(
+{
+label: '\u65dc\u1f2d\uf9ae\ub4d5',
+code: `
+
+@compute @workgroup_size(7, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) {
+
+}
+
+
+
+@vertex
+fn vertex0(@location(17) a0: vec3<u32>, @location(19) a1: vec4<f32>, @location(14) a2: vec3<i32>, @location(20) a3: vec3<u32>, @location(16) a4: vec4<f32>, @location(10) a5: i32, @location(5) a6: f16, @location(3) a7: vec3<f32>, @location(15) a8: vec2<i32>, @builtin(vertex_index) a9: u32, @location(11) a10: f16, @location(0) a11: vec2<i32>, @location(12) a12: vec4<f16>, @location(8) a13: vec2<f16>, @location(13) a14: vec4<u32>, @location(4) a15: f16, @location(7) a16: vec3<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+}
+);
+let texture78 = device1.createTexture(
+{
+label: '\uf00a\ub24d\u3c3a\u{1f997}\u0151\u{1fa8f}\u{1fd2c}\u0c11\u0b1a',
+size: [4330, 230, 253],
+mipLevelCount: 6,
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let computePassEncoder34 = commandEncoder60.beginComputePass(
+{
+label: '\u0daf\u0e56'
+}
+);
+try {
+commandEncoder63.copyTextureToTexture(
+{
+  texture: texture70,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 43 },
+  aspect: 'all',
+},
+{
+  texture: texture70,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 4 },
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 82}
+);
+} catch {}
+try {
+commandEncoder63.resolveQuerySet(
+querySet49,
+532,
+294,
+buffer25,
+18688
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer29,
+6896,
+new DataView(new ArrayBuffer(22445)),
+3248,
+4836
+);
+} catch {}
+let pipeline99 = await device1.createComputePipelineAsync(
+{
+label: '\ub777\u0b5d\u0a29\u{1fb27}\u{1f76e}\u9df6\uab5f\u{1f8a3}\u0ec7\u410b\u08b8',
+layout: pipelineLayout10,
+compute: {
+module: shaderModule21,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+gc();
+let video20 = await videoWithData();
+let pipelineLayout13 = device1.createPipelineLayout(
+{
+bindGroupLayouts: [
+
+],
+}
+);
+let texture79 = device1.createTexture(
+{
+label: '\ua0cf\u0276\u56de\u9c44\uaecd\u2089',
+size: [3452],
+dimension: '1d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8snorm',
+'r8snorm'
+],
+}
+);
+let computePassEncoder35 = commandEncoder63.beginComputePass(
+{
+label: '\u0e54\u{1f8e4}\u{1faef}\u0a48\u82f5\u7d5a'
+}
+);
+let renderBundle68 = renderBundleEncoder58.finish(
+{
+label: '\u042d\u{1f6ce}\u09e5\u63d2\u0e28\u78e8\u04ab'
+}
+);
+try {
+renderBundleEncoder56.setVertexBuffer(
+10,
+buffer25,
+21588,
+4222
+);
+} catch {}
+try {
+buffer25.unmap();
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer29,
+12204,
+new DataView(new ArrayBuffer(18249)),
+1092,
+4848
+);
+} catch {}
+let videoFrame15 = new VideoFrame(img19, {timestamp: 0});
+let sampler56 = device1.createSampler(
+{
+label: '\u1c77\u8d50\uaf86\uba5e\u0a55\u0d43\u0ccb',
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 22.424,
+lodMaxClamp: 57.987,
+}
+);
+try {
+computePassEncoder34.end();
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(
+11,
+buffer28,
+8244,
+2754
+);
+} catch {}
+try {
+commandEncoder60.clearBuffer(
+buffer29,
+19800,
+20
+);
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+commandEncoder60.resolveQuerySet(
+querySet49,
+30,
+137,
+buffer28,
+13056
+);
+} catch {}
+document.body.append('\u62df\u31bc\u{1fc9e}\u0bd2\u{1f777}\ue697\ucee9');
+let querySet54 = device2.createQuerySet(
+{
+label: '\u8543\ud8fb\u2c24\u{1f6e0}',
+type: 'occlusion',
+count: 3036,
+}
+);
+let texture80 = device2.createTexture(
+{
+size: {width: 1384, height: 1, depthOrArrayLayers: 12},
+dimension: '3d',
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder36 = commandEncoder62.beginComputePass(
+{
+
+}
+);
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+offscreenCanvas0.height = 334;
+let imageData12 = new ImageData(60, 192);
+let bindGroupLayout38 = device1.createBindGroupLayout(
+{
+label: '\uebad\u0d9f\u{1fa04}',
+entries: [
+{
+binding: 3324,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '2d' },
+},
+{
+binding: 2413,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '2d' },
+}
+],
+}
+);
+let bindGroup29 = device1.createBindGroup({
+label: '\u{1ffbb}\u{1f674}\ub2eb\u0a8b\u0dee\ubaab\u{1f999}\u{1f670}',
+layout: bindGroupLayout36,
+entries: [
+
+],
+});
+let computePassEncoder37 = commandEncoder60.beginComputePass(
+{
+label: '\u08a6\u1125\u4496\u0039\u0d9e\u06b8\uf7f3\u9237\u{1ffb1}'
+}
+);
+try {
+device1.queue.writeTexture(
+{
+  texture: texture78,
+  mipLevel: 1,
+  origin: { x: 300, y: 80, z: 139 },
+  aspect: 'all',
+},
+arrayBuffer3,
+/* required buffer size: 28474975 */{
+offset: 815,
+bytesPerRow: 2620,
+rowsPerImage: 247,
+},
+{width: 1630, height: 0, depthOrArrayLayers: 45}
+);
+} catch {}
+let texture81 = device2.createTexture(
+{
+label: '\u{1fd71}\u035b\u8e8a\ue36b\u{1f789}\u0841',
+size: [3586, 89, 31],
+mipLevelCount: 7,
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg16float'
+],
+}
+);
+let renderBundleEncoder64 = device2.createRenderBundleEncoder(
+{
+label: '\u4004\u07a8\u1a69\u{1f6be}\u{1ffc5}\ub90c\uaa31\u{1f714}\u0db0\ua1fc\u3638',
+colorFormats: [
+undefined,
+'rgb10a2uint',
+'rg8sint',
+'r16float',
+undefined,
+'rg8unorm',
+'rg16sint',
+'rgb10a2unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 341,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle69 = renderBundleEncoder64.finish(
+{
+label: '\u9f1b\u{1f66b}\u9470\u0cf9\u0196\u{1fef8}\u3216'
+}
+);
+try {
+commandEncoder61.clearBuffer(
+buffer30,
+2820,
+1352
+);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture75,
+  mipLevel: 1,
+  origin: { x: 6, y: 3, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(72),
+/* required buffer size: 989 */{
+offset: 989,
+bytesPerRow: 629,
+rowsPerImage: 270,
+},
+{width: 36, height: 40, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1384, height: 1, depthOrArrayLayers: 12}
+*/
+{
+  source: video19,
+  origin: { x: 0, y: 10 },
+  flipY: true,
+},
+{
+  texture: texture80,
+  mipLevel: 0,
+  origin: { x: 359, y: 0, z: 4 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 16, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+window.someLabel = externalTexture0.label;
+} catch {}
+let video21 = await videoWithData();
+try {
+window.someLabel = shaderModule9.label;
+} catch {}
+let bindGroupLayout39 = pipeline5.getBindGroupLayout(2);
+try {
+renderPassEncoder0.setBindGroup(
+3,
+bindGroup25
+);
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(
+80
+);
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(
+34,
+1,
+3,
+0
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture65,
+  mipLevel: 0,
+  origin: { x: 7615, y: 55, z: 136 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 10822267 */{
+offset: 171,
+bytesPerRow: 2024,
+rowsPerImage: 297,
+},
+{width: 560, height: 5, depthOrArrayLayers: 19}
+);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+computePassEncoder37.setBindGroup(
+8,
+bindGroup29
+);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+let textureView73 = texture77.createView(
+{
+label: '\u5434\u48af\uf002\u05d9',
+aspect: 'all',
+}
+);
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 448, height: 11, depthOrArrayLayers: 31}
+*/
+{
+  source: imageBitmap11,
+  origin: { x: 136, y: 14 },
+  flipY: false,
+},
+{
+  texture: texture81,
+  mipLevel: 3,
+  origin: { x: 232, y: 3, z: 18 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 30, height: 6, depthOrArrayLayers: 1}
+);
+} catch {}
+let offscreenCanvas15 = new OffscreenCanvas(139, 56);
+let buffer31 = device2.createBuffer(
+{
+label: '\ua30d\u{1f7f9}\u{1fab1}\u{1fb0d}\uebdc\u0074\u0031\u8a96\u{1f6ba}\ua117\u{1f92c}',
+size: 37616,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let commandEncoder64 = device2.createCommandEncoder(
+{
+label: '\u04d1\u439d\u{1f908}\u33b5\u01df\u{1f81e}',
+}
+);
+let commandBuffer9 = commandEncoder61.finish(
+{
+label: '\uab8d\u014c\u533b\u{1fcd4}\ub75b\u0a8e\u{1fe68}\ue0e0\u06ef\ua428',
+}
+);
+let textureView74 = texture73.createView(
+{
+label: '\u{1fd61}\uecbe\ub28c\u{1f803}\u5400\u71f9\u642e\u01b9\u496d\u0ff5',
+mipLevelCount: 5,
+arrayLayerCount: 1,
+}
+);
+try {
+buffer26.unmap();
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture80,
+  mipLevel: 0,
+  origin: { x: 162, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer3,
+/* required buffer size: 1537771 */{
+offset: 650,
+bytesPerRow: 743,
+rowsPerImage: 188,
+},
+{width: 597, height: 1, depthOrArrayLayers: 12}
+);
+} catch {}
+let imageData13 = new ImageData(244, 4);
+let texture82 = device1.createTexture(
+{
+label: '\u0594\u0c11\u{1fbe9}\u58e3\uaf5e\u3439\u44f0\u3995\uc691\u{1f96e}',
+size: [196, 124, 1],
+mipLevelCount: 5,
+dimension: '2d',
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'eac-rg11snorm',
+'eac-rg11snorm',
+'eac-rg11snorm'
+],
+}
+);
+let renderBundle70 = renderBundleEncoder58.finish(
+{
+label: '\u0104\ub16f\u0c50'
+}
+);
+let commandEncoder65 = device2.createCommandEncoder(
+{
+label: '\u81f2\ua0a3\u{1ff52}\u7656\ue8a5\u8a4e\u{1fc94}\u{1fbef}',
+}
+);
+try {
+device2.queue.submit([
+commandBuffer9,
+]);
+} catch {}
+let offscreenCanvas16 = new OffscreenCanvas(51, 503);
+let commandEncoder66 = device2.createCommandEncoder();
+let promise22 = buffer30.mapAsync(
+GPUMapMode.READ,
+0,
+2048
+);
+let shaderModule23 = device1.createShaderModule(
+{
+code: `@group(3) @binding(954)
+var<storage, read_write> parameter3: array<u32>;
+@group(6) @binding(535)
+var<storage, read_write> global2: array<u32>;
+@group(7) @binding(1920)
+var<storage, read_write> function3: array<u32>;
+
+@compute @workgroup_size(2, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(5) f0: vec2<u32>,
+@location(0) f1: vec2<f32>,
+@builtin(frag_depth) f2: f32,
+@builtin(sample_mask) f3: u32,
+@location(4) f4: vec4<u32>,
+@location(2) f5: vec2<f32>,
+@location(6) f6: i32,
+@location(1) f7: vec4<f32>,
+@location(3) f8: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_mask) a1: u32, @builtin(sample_index) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S23 {
+@location(16) f0: vec2<f16>,
+@location(7) f1: vec4<u32>,
+@location(13) f2: i32,
+@location(17) f3: u32,
+@location(3) f4: vec3<u32>,
+@location(0) f5: vec2<i32>,
+@location(8) f6: vec2<f32>,
+@location(9) f7: f32,
+@location(10) f8: vec3<f16>,
+@location(19) f9: vec3<u32>,
+@location(11) f10: vec3<i32>,
+@location(2) f11: vec2<i32>,
+@location(5) f12: vec4<f16>,
+@builtin(vertex_index) f13: u32,
+@location(20) f14: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(6) a0: f32, @location(15) a1: vec3<u32>, @location(4) a2: u32, a3: S23, @location(12) a4: vec3<u32>, @location(18) a5: vec2<i32>, @location(14) a6: vec3<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+}
+);
+let texture83 = device1.createTexture(
+{
+label: '\u2b67\u59be\u3040\u8d61\ueaa1\u6eb3\u0473\u{1ffc8}\u2d99\ubabb\u9abf',
+size: [3181],
+dimension: '1d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let renderBundle71 = renderBundleEncoder58.finish(
+{
+label: '\u06ee\ub390\u307e\u{1fd52}\ua60f'
+}
+);
+let offscreenCanvas17 = new OffscreenCanvas(310, 410);
+try {
+computePassEncoder37.end();
+} catch {}
+try {
+commandEncoder60.clearBuffer(
+buffer25
+);
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+commandEncoder60.resolveQuerySet(
+querySet51,
+59,
+174,
+buffer28,
+6912
+);
+} catch {}
+try {
+await promise22;
+} catch {}
+let img30 = await imageWithData(209, 245, '#33c4f7d3', '#d8e242e6');
+try {
+offscreenCanvas15.getContext('bitmaprenderer');
+} catch {}
+let shaderModule24 = device2.createShaderModule(
+{
+label: '\uda55\u6e36\u2636\u00a1\u2b98',
+code: `
+
+@compute @workgroup_size(8, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@location(2) a0: f16, @location(4) a1: vec2<i32>, @location(13) a2: vec3<f16>, @location(3) a3: f16, @location(17) a4: vec2<f32>) -> @builtin(frag_depth) f32 {
+return f32();
+}
+
+struct S24 {
+@location(0) f0: vec3<i32>,
+@location(14) f1: vec3<f32>,
+@location(19) f2: u32,
+@location(15) f3: vec2<f16>,
+@location(20) f4: vec2<f32>,
+@location(6) f5: vec3<f16>,
+@location(4) f6: vec2<u32>,
+@location(11) f7: i32,
+@location(16) f8: vec4<f16>,
+@location(26) f9: vec4<u32>
+}
+struct VertexOutput0 {
+@builtin(position) f373: vec4<f32>,
+@location(2) f374: f16,
+@location(13) f375: vec3<f16>,
+@location(17) f376: vec2<f32>,
+@location(15) f377: f32,
+@location(16) f378: vec3<f32>,
+@location(14) f379: f16,
+@location(10) f380: u32,
+@location(6) f381: vec2<u32>,
+@location(4) f382: vec2<i32>,
+@location(1) f383: vec3<u32>,
+@location(12) f384: u32,
+@location(8) f385: vec4<f32>,
+@location(11) f386: vec4<u32>,
+@location(3) f387: f16,
+@location(9) f388: vec3<i32>,
+@location(5) f389: vec2<u32>,
+@location(0) f390: vec2<f16>,
+@location(18) f391: vec2<u32>,
+@location(7) f392: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec2<i32>, @location(23) a1: i32, @builtin(vertex_index) a2: u32, @location(25) a3: vec3<f16>, a4: S24, @location(10) a5: vec2<u32>, @location(12) a6: vec4<f16>, @location(3) a7: u32, @location(24) a8: vec2<i32>, @location(22) a9: vec2<f16>, @location(1) a10: f16, @location(7) a11: vec4<u32>, @location(13) a12: vec3<i32>, @location(17) a13: vec3<f16>, @location(21) a14: vec2<u32>, @location(18) a15: vec3<u32>, @location(2) a16: f32, @location(9) a17: vec4<u32>, @builtin(instance_index) a18: u32, @location(8) a19: f32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let textureView75 = texture73.createView(
+{
+baseMipLevel: 1,
+mipLevelCount: 3,
+}
+);
+try {
+device2.pushErrorScope(
+'out-of-memory'
+);
+} catch {}
+try {
+buffer30.unmap();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+renderBundleEncoder63.setVertexBuffer(
+5,
+buffer26,
+288,
+1392
+);
+} catch {}
+try {
+commandEncoder66.clearBuffer(
+buffer30,
+1736,
+3108
+);
+dissociateBuffer(device2, buffer30);
+} catch {}
+let pipeline100 = device2.createRenderPipeline(
+{
+label: '\u05f4\uf9da\u6343\u0212\u924b\u3b7f\u075a\uf7c2',
+layout: pipelineLayout12,
+vertex: {
+module: shaderModule24,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 11128,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 10664,
+shaderLocation: 25,
+},
+{
+format: 'snorm8x2',
+offset: 8160,
+shaderLocation: 14,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 8608,
+shaderLocation: 8,
+},
+{
+format: 'sint32',
+offset: 8972,
+shaderLocation: 0,
+},
+{
+format: 'snorm8x2',
+offset: 8622,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x2',
+offset: 1904,
+shaderLocation: 22,
+},
+{
+format: 'uint16x2',
+offset: 10468,
+shaderLocation: 18,
+},
+{
+format: 'float16x2',
+offset: 8052,
+shaderLocation: 6,
+},
+{
+format: 'uint8x4',
+offset: 8388,
+shaderLocation: 7,
+},
+{
+format: 'snorm8x2',
+offset: 1784,
+shaderLocation: 16,
+},
+{
+format: 'uint16x4',
+offset: 10372,
+shaderLocation: 19,
+},
+{
+format: 'snorm8x2',
+offset: 8510,
+shaderLocation: 20,
+},
+{
+format: 'uint8x2',
+offset: 4672,
+shaderLocation: 26,
+},
+{
+format: 'sint8x2',
+offset: 10566,
+shaderLocation: 13,
+},
+{
+format: 'uint32x2',
+offset: 3428,
+shaderLocation: 3,
+},
+{
+format: 'sint32x4',
+offset: 9392,
+shaderLocation: 11,
+},
+{
+format: 'uint8x4',
+offset: 7548,
+shaderLocation: 4,
+},
+{
+format: 'float32x2',
+offset: 8092,
+shaderLocation: 2,
+},
+{
+format: 'sint8x4',
+offset: 6732,
+shaderLocation: 5,
+},
+{
+format: 'uint8x4',
+offset: 5568,
+shaderLocation: 9,
+},
+{
+format: 'uint32x2',
+offset: 396,
+shaderLocation: 10,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 6308,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x2',
+offset: 1074,
+shaderLocation: 1,
+},
+{
+format: 'sint32',
+offset: 1276,
+shaderLocation: 24,
+},
+{
+format: 'sint16x4',
+offset: 116,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 3468,
+attributes: [
+{
+format: 'float16x4',
+offset: 2060,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 11648,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 7520,
+shaderLocation: 21,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'front',
+},
+multisample: {
+count: 4,
+mask: 0xcaaf9925,
+},
+fragment: {
+module: shaderModule24,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+failOp: 'zero',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-wrap',
+},
+depthBias: 69,
+depthBiasSlopeScale: 74,
+depthBiasClamp: 52,
+},
+}
+);
+document.body.append('\u0274\u704b\u{1fd56}\u22c0\ud316\uc194\u{1f75d}');
+let promise23 = navigator.gpu.requestAdapter(
+{
+}
+);
+let querySet55 = device2.createQuerySet(
+{
+label: '\ue05c\u0e2e\u0253\u{1fd45}\uff68\u{1fd66}\uda4f\u8181',
+type: 'occlusion',
+count: 2420,
+}
+);
+let computePassEncoder38 = commandEncoder66.beginComputePass(
+{
+label: '\u070e\u0ffb\u41bc'
+}
+);
+try {
+renderBundleEncoder63.setVertexBuffer(
+8,
+buffer26,
+1036,
+602
+);
+} catch {}
+let arrayBuffer5 = buffer31.getMappedRange(
+29960
+);
+try {
+buffer26.unmap();
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture81,
+  mipLevel: 3,
+  origin: { x: 50, y: 9, z: 27 },
+  aspect: 'all',
+},
+new BigInt64Array(arrayBuffer3),
+/* required buffer size: 163733 */{
+offset: 553,
+bytesPerRow: 616,
+rowsPerImage: 132,
+},
+{width: 139, height: 1, depthOrArrayLayers: 3}
+);
+} catch {}
+pseudoSubmit(device2, commandEncoder66);
+let textureView76 = texture75.createView(
+{
+label: '\u8675\u0890\ue541\ua8a6\u676a',
+baseMipLevel: 4,
+}
+);
+let sampler57 = device2.createSampler(
+{
+label: '\u{1fc1b}\ubc8b\u1eba\u01d3\u09e2\u3d95\u32c7',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'linear',
+lodMinClamp: 37.972,
+lodMaxClamp: 42.738,
+}
+);
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend('\uf0f1\u06fa\uf721\u5436\u0666\u9476\u0be5\u0a8c\u0124\u9f4d\u0130');
+let adapter9 = await promise23;
+let imageData14 = new ImageData(256, 4);
+document.body.append('\u0749\u{1fa1c}\uc7ce\u04df\u0cf1\u05f4\u{1fdc5}\u65fe');
+let videoFrame16 = new VideoFrame(videoFrame15, {timestamp: 0});
+let renderBundleEncoder65 = device2.createRenderBundleEncoder(
+{
+label: '\u679c\ua2b6\u03a1\u{1fdf5}\ub48a\ubb0a',
+colorFormats: [
+'rgb10a2unorm',
+'rg16uint',
+'bgra8unorm-srgb',
+'rgba16float',
+'rgba8unorm-srgb',
+'r8unorm',
+'r8sint',
+'r16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 321,
+stencilReadOnly: true,
+}
+);
+let sampler58 = device2.createSampler(
+{
+label: '\u5c94\u{1f67a}\u0a06\u8079\u0268\u0b79\u04de\u05c5\u{1fcdb}\ue158',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 42.647,
+maxAnisotropy: 2,
+}
+);
+let pipelineLayout14 = device2.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout33
+],
+}
+);
+let promise24 = device2.popErrorScope();
+try {
+commandEncoder65.copyBufferToBuffer(
+buffer31,
+1080,
+buffer30,
+736,
+252
+);
+dissociateBuffer(device2, buffer31);
+dissociateBuffer(device2, buffer30);
+} catch {}
+let pipeline101 = device2.createComputePipeline(
+{
+layout: pipelineLayout12,
+compute: {
+module: shaderModule24,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.append('\u9ab9\u45ef\u78fe\ud4cc\u6cb7\u033c\u59fe\u{1fd60}');
+let commandEncoder67 = device1.createCommandEncoder(
+{
+label: '\u040c\ufa29\u7be5\u8736\u{1fbb8}\u0cbf\uf0f6\uddcf\u1069',
+}
+);
+let renderBundleEncoder66 = device1.createRenderBundleEncoder(
+{
+label: '\u0d32\u{1f926}\u0210\u470b\u1be5\uf3f2',
+colorFormats: [
+'rg8sint',
+'rgb10a2unorm',
+'rgba16sint',
+'rgb10a2unorm',
+'rg16sint',
+'rgba8sint',
+'rg32float'
+],
+sampleCount: 626,
+}
+);
+try {
+computePassEncoder35.setPipeline(
+pipeline99
+);
+} catch {}
+try {
+commandEncoder60.copyBufferToBuffer(
+buffer25,
+15888,
+buffer28,
+4424,
+1544
+);
+dissociateBuffer(device1, buffer25);
+dissociateBuffer(device1, buffer28);
+} catch {}
+let canvas14 = document.createElement('canvas');
+try {
+window.someLabel = externalTexture0.label;
+} catch {}
+document.body.append('\u8330\u6acc\u07ce\u2317');
+let computePassEncoder39 = commandEncoder64.beginComputePass(
+{
+label: '\u{1fc83}\u{1f86e}\uc29f\u0eef\ua54d\u{1fca9}\ue5a4\u{1fb59}\u{1f7f3}'
+}
+);
+try {
+renderBundleEncoder63.setVertexBuffer(
+3,
+buffer26
+);
+} catch {}
+let pipeline102 = await device2.createRenderPipelineAsync(
+{
+label: '\u5912\u032c',
+layout: pipelineLayout14,
+vertex: {
+module: shaderModule24,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 11684,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 9840,
+shaderLocation: 18,
+},
+{
+format: 'sint32x2',
+offset: 9544,
+shaderLocation: 13,
+},
+{
+format: 'sint32x3',
+offset: 10928,
+shaderLocation: 5,
+},
+{
+format: 'unorm16x2',
+offset: 5200,
+shaderLocation: 22,
+},
+{
+format: 'float32',
+offset: 3212,
+shaderLocation: 1,
+},
+{
+format: 'uint16x4',
+offset: 4288,
+shaderLocation: 26,
+},
+{
+format: 'sint16x2',
+offset: 1948,
+shaderLocation: 0,
+},
+{
+format: 'uint32',
+offset: 11640,
+shaderLocation: 3,
+},
+{
+format: 'uint32x4',
+offset: 7612,
+shaderLocation: 10,
+},
+{
+format: 'float32x3',
+offset: 5048,
+shaderLocation: 2,
+},
+{
+format: 'sint8x2',
+offset: 1332,
+shaderLocation: 24,
+},
+{
+format: 'float16x4',
+offset: 1840,
+shaderLocation: 8,
+},
+{
+format: 'uint32x3',
+offset: 7372,
+shaderLocation: 19,
+},
+{
+format: 'float32x4',
+offset: 3100,
+shaderLocation: 20,
+},
+{
+format: 'float32',
+offset: 3260,
+shaderLocation: 25,
+},
+{
+format: 'unorm16x2',
+offset: 2604,
+shaderLocation: 6,
+},
+{
+format: 'float32x4',
+offset: 7328,
+shaderLocation: 14,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 11076,
+shaderLocation: 17,
+},
+{
+format: 'uint32x3',
+offset: 8324,
+shaderLocation: 4,
+},
+{
+format: 'unorm16x4',
+offset: 916,
+shaderLocation: 12,
+},
+{
+format: 'sint8x4',
+offset: 7148,
+shaderLocation: 23,
+},
+{
+format: 'sint32x4',
+offset: 3004,
+shaderLocation: 11,
+},
+{
+format: 'float32',
+offset: 656,
+shaderLocation: 15,
+},
+{
+format: 'uint8x2',
+offset: 6424,
+shaderLocation: 7,
+},
+{
+format: 'uint32',
+offset: 788,
+shaderLocation: 21,
+}
+],
+},
+{
+arrayStride: 13048,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 12124,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x2',
+offset: 7874,
+shaderLocation: 9,
+},
+{
+format: 'snorm8x4',
+offset: 8556,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'front',
+},
+fragment: {
+module: shaderModule24,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'equal',
+depthFailOp: 'keep',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+},
+stencilReadMask: 3951,
+stencilWriteMask: 3019,
+depthBias: 22,
+depthBiasSlopeScale: 24,
+depthBiasClamp: 18,
+},
+}
+);
+let bindGroupLayout40 = device2.createBindGroupLayout(
+{
+entries: [
+{
+binding: 1289,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '2d-array' },
+},
+{
+binding: 752,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+}
+],
+}
+);
+let pipelineLayout15 = device2.createPipelineLayout(
+{
+label: '\ua7b9\uc16f\u70a7\u80f4\u0b7a\ud996\u10f7\ubfba\u7d5a\u6dfe',
+bindGroupLayouts: [
+bindGroupLayout37,
+bindGroupLayout37
+],
+}
+);
+let commandEncoder68 = device2.createCommandEncoder(
+{
+label: '\u0bb5\u9e82\ufb3e\u{1f642}\u{1fc9a}',
+}
+);
+try {
+renderBundleEncoder60.setVertexBuffer(
+5,
+buffer26,
+736,
+262
+);
+} catch {}
+try {
+await promise24;
+} catch {}
+video0.height = 171;
+let canvas15 = document.createElement('canvas');
+document.body.prepend('\ufd7f\u0b53\u2148\u0acc\u089e\u0e53\ucab8\u08d2\uf34c\u4041');
+let imageData15 = new ImageData(56, 72);
+document.body.append('\uf86f\u3f21');
+let bindGroupLayout41 = device2.createBindGroupLayout(
+{
+label: '\u82e0\u9727\u{1f7f6}\u4fbc',
+entries: [
+
+],
+}
+);
+let texture84 = device2.createTexture(
+{
+label: '\u9e19\u012b\u4deb',
+size: {width: 620, height: 1, depthOrArrayLayers: 212},
+mipLevelCount: 1,
+dimension: '3d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundle72 = renderBundleEncoder65.finish();
+try {
+computePassEncoder36.setPipeline(
+pipeline101
+);
+} catch {}
+try {
+commandEncoder68.copyBufferToBuffer(
+buffer31,
+304,
+buffer30,
+504,
+1860
+);
+dissociateBuffer(device2, buffer31);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+gpuCanvasContext9.configure(
+{
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rgba8unorm-srgb',
+'rgba8unorm-srgb',
+'rgba8unorm-srgb',
+'rgb10a2unorm'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1384, height: 1, depthOrArrayLayers: 12}
+*/
+{
+  source: img16,
+  origin: { x: 33, y: 43 },
+  flipY: true,
+},
+{
+  texture: texture80,
+  mipLevel: 0,
+  origin: { x: 274, y: 0, z: 7 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 96, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\ua3ad\u{1faf7}\u030e\ud2ee\u2c27\ud86b\u0d45\u091b\uf602\udfdb');
+let buffer32 = device2.createBuffer(
+{
+size: 41693,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let textureView77 = texture80.createView(
+{
+}
+);
+let renderBundleEncoder67 = device2.createRenderBundleEncoder(
+{
+label: '\u3ff1\u4a77\u0d73\u7ea7\u00a3\u072f',
+colorFormats: [
+'rgba32sint',
+'rgba8unorm',
+'rg32sint',
+'bgra8unorm'
+],
+sampleCount: 314,
+}
+);
+document.body.append('\u5d55\u025a\u73cf\ud15c\uabca\u02f4');
+let commandEncoder69 = device1.createCommandEncoder(
+{
+label: '\ue8fa\u4dbd\u{1f7ea}\u{1fe62}\u{1ff87}\uc3ed\u{1fef5}\u088f\u{1fb95}\u{1fe37}\u0ca8',
+}
+);
+let renderBundleEncoder68 = device1.createRenderBundleEncoder(
+{
+label: '\u{1faff}\u0350\u{1fd8e}\u{1fbbc}',
+colorFormats: [
+'rg11b10ufloat',
+'r32uint',
+'r32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 356,
+stencilReadOnly: true,
+}
+);
+try {
+commandEncoder69.clearBuffer(
+buffer29,
+18908,
+24
+);
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+commandEncoder69.resolveQuerySet(
+querySet49,
+45,
+706,
+buffer25,
+2560
+);
+} catch {}
+let renderBundle73 = renderBundleEncoder53.finish(
+{
+label: '\uf055\u07c7\u{1f7e5}\ueae4\u0795\ud7dd\ub711\u0216\u0733\u1782'
+}
+);
+try {
+renderBundleEncoder68.setBindGroup(
+3,
+bindGroup29,
+new Uint32Array(4019),
+3011,
+0
+);
+} catch {}
+try {
+commandEncoder69.resolveQuerySet(
+querySet43,
+221,
+7,
+buffer28,
+5376
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture74,
+  mipLevel: 0,
+  origin: { x: 19, y: 6, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(64),
+/* required buffer size: 232 */{
+offset: 232,
+bytesPerRow: 182,
+},
+{width: 108, height: 25, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline103 = device1.createComputePipeline(
+{
+label: '\u{1f8d5}\u{1fe54}\u8cc9\u4473',
+layout: pipelineLayout13,
+compute: {
+module: shaderModule18,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let texture85 = device1.createTexture(
+{
+label: '\u4fde\ufa83\uab40',
+size: [197, 1, 163],
+mipLevelCount: 2,
+dimension: '3d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16sint'
+],
+}
+);
+let textureView78 = texture82.createView(
+{
+dimension: '2d-array',
+mipLevelCount: 3,
+}
+);
+let renderBundle74 = renderBundleEncoder58.finish(
+{
+
+}
+);
+try {
+computePassEncoder35.setBindGroup(
+7,
+bindGroup29,
+new Uint32Array(9733),
+5013,
+0
+);
+} catch {}
+try {
+renderBundleEncoder68.setVertexBuffer(
+10,
+buffer28,
+11856,
+3086
+);
+} catch {}
+try {
+commandEncoder69.copyTextureToBuffer(
+{
+  texture: texture82,
+  mipLevel: 1,
+  origin: { x: 28, y: 56, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 144 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 7824 */
+offset: 7824,
+rowsPerImage: 273,
+buffer: buffer27,
+},
+{width: 36, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device1, buffer27);
+} catch {}
+try {
+commandEncoder67.resolveQuerySet(
+querySet51,
+329,
+8,
+buffer28,
+4096
+);
+} catch {}
+try {
+computePassEncoder35.insertDebugMarker(
+'\u0e1d'
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture72,
+  mipLevel: 2,
+  origin: { x: 60, y: 20, z: 122 },
+  aspect: 'all',
+},
+new Uint8Array(new ArrayBuffer(8)),
+/* required buffer size: 868446 */{
+offset: 420,
+bytesPerRow: 1783,
+rowsPerImage: 121,
+},
+{width: 930, height: 15, depthOrArrayLayers: 5}
+);
+} catch {}
+let device3 = await adapter5.requestDevice(
+{
+label: '\u{1fb59}\u0435\ue320\uf917',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 50,
+maxVertexAttributes: 17,
+maxVertexBufferArrayStride: 7334,
+maxStorageTexturesPerShaderStage: 9,
+maxStorageBuffersPerShaderStage: 25,
+maxDynamicStorageBuffersPerPipelineLayout: 29928,
+maxBindingsPerBindGroup: 5332,
+maxTextureDimension1D: 13380,
+maxTextureDimension2D: 12451,
+maxVertexBuffers: 12,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 264005397,
+maxInterStageShaderVariables: 32,
+maxInterStageShaderComponents: 69,
+},
+}
+);
+document.body.prepend('\u344f\u{1fead}\u5529');
+let computePassEncoder40 = commandEncoder68.beginComputePass(
+{
+label: '\u0ce8\u0d58\u07d8\u0219\u9c74\u0b5e\u0571\u9903\u2abe\u626d'
+}
+);
+let renderBundleEncoder69 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba16uint',
+'r32float',
+'r8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 660,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder33.setPipeline(
+pipeline101
+);
+} catch {}
+let device4 = await adapter2.requestDevice(
+{
+label: '\u0c9f\u0cda\u3f21\u0af7\u835a\u8d99\u2901\u037f\u5a1d\u8900',
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 37,
+maxVertexAttributes: 28,
+maxVertexBufferArrayStride: 64343,
+maxStorageTexturesPerShaderStage: 15,
+maxStorageBuffersPerShaderStage: 40,
+maxDynamicStorageBuffersPerPipelineLayout: 34316,
+maxBindingsPerBindGroup: 4585,
+maxTextureArrayLayers: 256,
+maxTextureDimension1D: 10059,
+maxTextureDimension2D: 12999,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 46654273,
+maxInterStageShaderVariables: 121,
+maxInterStageShaderComponents: 105,
+},
+}
+);
+let offscreenCanvas18 = new OffscreenCanvas(940, 487);
+try {
+buffer26.label = '\u{1f9bf}\ud932\ud02d\uff07\u{1f6eb}\u{1f6b7}\u{1fb83}\u{1f90d}';
+} catch {}
+let texture86 = device2.createTexture(
+{
+label: '\u134a\u09f6',
+size: [38, 2, 95],
+mipLevelCount: 2,
+dimension: '3d',
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderPassEncoder31 = commandEncoder65.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+{
+view: textureView77,
+depthSlice: 9,
+clearValue: {
+r: -826.8,
+g: -240.1,
+b: 947.9,
+a: -578.9,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined,
+{
+view: textureView77,
+depthSlice: 1,
+clearValue: {
+r: -952.8,
+g: 179.0,
+b: -21.74,
+a: 230.0,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView77,
+depthSlice: 6,
+clearValue: {
+r: -882.6,
+g: -334.2,
+b: 496.9,
+a: 369.9,
+},
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+maxDrawCount: 49472,
+}
+);
+try {
+renderPassEncoder31.setScissorRect(
+1297,
+1,
+70,
+0
+);
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device2,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rg16float'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture73,
+  mipLevel: 5,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(48),
+/* required buffer size: 634 */{
+offset: 634,
+rowsPerImage: 271,
+},
+{width: 55, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1384, height: 1, depthOrArrayLayers: 12}
+*/
+{
+  source: videoFrame15,
+  origin: { x: 10, y: 79 },
+  flipY: true,
+},
+{
+  texture: texture80,
+  mipLevel: 0,
+  origin: { x: 443, y: 0, z: 2 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 18, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let gpuCanvasContext15 = offscreenCanvas16.getContext('webgpu');
+document.body.append('\u202e\u2b24\u077f\ue082\u{1fc73}\u322c\u6217\u0774\u{1fdad}\u20e3\u013f');
+let bindGroupLayout42 = device4.createBindGroupLayout(
+{
+label: '\ud306\u2d1a\u043b',
+entries: [
+{
+binding: 2218,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+}
+],
+}
+);
+let pipelineLayout16 = device4.createPipelineLayout(
+{
+label: '\u3aa6\u0386\u14f8\ufb2a\u6eab',
+bindGroupLayouts: [
+bindGroupLayout42,
+bindGroupLayout42
+],
+}
+);
+let sampler59 = device4.createSampler(
+{
+label: '\u9c30\uf56c\u5d43',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 71.927,
+lodMaxClamp: 95.604,
+}
+);
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder70 = device1.createCommandEncoder(
+{
+label: '\u7703\u0c1c\u5d84\u2fdd\u03d9\ue304\u0250\u7275',
+}
+);
+let querySet56 = device1.createQuerySet(
+{
+label: '\u088f\u47c9\u82cb\u5430\u9f66\u1e8a\u{1fbf2}\ud136',
+type: 'occlusion',
+count: 2387,
+}
+);
+pseudoSubmit(device1, commandEncoder60);
+let renderBundleEncoder70 = device1.createRenderBundleEncoder(
+{
+label: '\ubbee\ub812\ue4af\u5ce2\u362d\uac83',
+colorFormats: [
+'rg16sint',
+'rgba16sint',
+'rgba16sint',
+'rgba8unorm',
+'r32uint'
+],
+sampleCount: 597,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler60 = device1.createSampler(
+{
+label: '\u{1fa30}\uaf0e\u9726\ua664\u6423\u{1f91c}\u258f\u0701\u0d94\ua0e4',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 72.370,
+lodMaxClamp: 93.635,
+maxAnisotropy: 10,
+}
+);
+try {
+computePassEncoder35.setBindGroup(
+1,
+bindGroup29
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer25,
+9000,
+new DataView(new ArrayBuffer(788))
+);
+} catch {}
+let video22 = await videoWithData();
+let imageBitmap20 = await createImageBitmap(imageData7);
+try {
+adapter2.label = '\u{1fb7d}\ue1f8\u{1f8ff}';
+} catch {}
+let textureView79 = texture73.createView(
+{
+label: '\u155f\ueca3\uf3b3\u8006\u0431\u{1f641}\ue99a\u0ac2\ucfb4\u84f5',
+aspect: 'all',
+baseMipLevel: 1,
+mipLevelCount: 1,
+}
+);
+let renderBundleEncoder71 = device2.createRenderBundleEncoder(
+{
+label: '\u7bd8\uadc3\u0f6f',
+colorFormats: [
+'rg8sint'
+],
+sampleCount: 470,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder31.setBlendConstant(
+{
+r: -950.6,
+g: 583.5,
+b: -518.4,
+a: 590.0,
+}
+);
+} catch {}
+try {
+renderPassEncoder31.setViewport(
+673.0,
+0.4315,
+139.6,
+0.2004,
+0.4490,
+0.6112
+);
+} catch {}
+try {
+await buffer32.mapAsync(
+GPUMapMode.READ,
+9776,
+16656
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer30,
+4612,
+new BigUint64Array(53242),
+3391,
+0
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1384, height: 1, depthOrArrayLayers: 12}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 149, y: 245 },
+  flipY: false,
+},
+{
+  texture: texture80,
+  mipLevel: 0,
+  origin: { x: 181, y: 0, z: 3 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 2, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline104 = await device2.createComputePipelineAsync(
+{
+label: '\u2933\u62dc\u{1fad4}\u0bc2\u42a6\uf26a\ua2c6\u1e18\u03e7',
+layout: pipelineLayout12,
+compute: {
+module: shaderModule24,
+entryPoint: 'compute0',
+},
+}
+);
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+try {
+adapter6.label = '\ua44d\u0597\u{1fd5d}\u{1fcd1}\u{1ff77}\u4b9f\u{1fbb4}\u2564';
+} catch {}
+let bindGroupLayout43 = device1.createBindGroupLayout(
+{
+entries: [
+{
+binding: 910,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '3d' },
+},
+{
+binding: 1271,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+},
+{
+binding: 2208,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+let sampler61 = device1.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 75.806,
+lodMaxClamp: 80.556,
+}
+);
+try {
+computePassEncoder35.end();
+} catch {}
+try {
+renderBundleEncoder68.setBindGroup(
+1,
+bindGroup29
+);
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(
+buffer25,
+8592,
+buffer29,
+9548,
+8744
+);
+dissociateBuffer(device1, buffer25);
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+commandEncoder67.copyTextureToTexture(
+{
+  texture: texture70,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 16 },
+  aspect: 'all',
+},
+{
+  texture: texture70,
+  mipLevel: 0,
+  origin: { x: 7, y: 0, z: 203 },
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 93}
+);
+} catch {}
+let texture87 = device4.createTexture(
+{
+label: '\ua489\u0e3f',
+size: [170, 190, 1],
+mipLevelCount: 8,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'stencil8',
+'stencil8',
+'stencil8'
+],
+}
+);
+let renderBundleEncoder72 = device4.createRenderBundleEncoder(
+{
+label: '\u0656\u{1f964}\u05a9',
+colorFormats: [
+undefined,
+'rgba32uint',
+'rgba16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 235,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let commandEncoder71 = device3.createCommandEncoder(
+{
+}
+);
+let commandBuffer10 = commandEncoder71.finish(
+{
+label: '\ub394\u3603\ud9c0',
+}
+);
+let renderBundleEncoder73 = device3.createRenderBundleEncoder(
+{
+label: '\u7e90\u{1f7c2}\uc42e\u6fb5\uc277',
+colorFormats: [
+'r32uint',
+'rg16sint',
+'rg16uint',
+undefined
+],
+sampleCount: 458,
+stencilReadOnly: false,
+}
+);
+try {
+gpuCanvasContext8.configure(
+{
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8unorm',
+'rgba16uint'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let img31 = await imageWithData(230, 16, '#187a5259', '#21d07e5a');
+let querySet57 = device2.createQuerySet(
+{
+label: '\u{1f8b2}\ue97a\u{1fc24}\u{1feea}\u538a',
+type: 'occlusion',
+count: 2287,
+}
+);
+let texture88 = device2.createTexture(
+{
+label: '\u{1fe5e}\u{1fbb7}\u{1fa3b}\u0e80\u{1fa87}\u088e\u0960\u0bba\u5302\u2acb\u0ddb',
+size: [11286],
+mipLevelCount: 1,
+dimension: '1d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder74 = device2.createRenderBundleEncoder(
+{
+label: '\uaf24\u36a9\u0421',
+colorFormats: [
+'r32uint',
+'rgba16float',
+'rgba8unorm',
+'r32sint',
+'r8unorm',
+'rgba8sint',
+undefined,
+'r32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 127,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder31.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder31.setViewport(
+102.9,
+0.6397,
+933.2,
+0.1246,
+0.9859,
+0.9956
+);
+} catch {}
+try {
+renderBundleEncoder69.setVertexBuffer(
+1,
+buffer26
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture80,
+  mipLevel: 0,
+  origin: { x: 224, y: 0, z: 8 },
+  aspect: 'all',
+},
+new Int8Array(arrayBuffer4),
+/* required buffer size: 154726 */{
+offset: 471,
+bytesPerRow: 583,
+rowsPerImage: 88,
+},
+{width: 343, height: 1, depthOrArrayLayers: 4}
+);
+} catch {}
+let pipeline105 = await device2.createComputePipelineAsync(
+{
+label: '\u67c2\u3c36\uc6b4\uf021\u9efb\uff4e\u00cb',
+layout: pipelineLayout14,
+compute: {
+module: shaderModule24,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageData16 = new ImageData(92, 188);
+let bindGroupLayout44 = device3.createBindGroupLayout(
+{
+label: '\u0249\u6b45\u0dc8\u5f8c\u{1ffc1}\uae37\u0de8\u0866\u283c\ua0ba',
+entries: [
+{
+binding: 4613,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+},
+{
+binding: 2304,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '2d' },
+}
+],
+}
+);
+let renderBundleEncoder75 = device3.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg16sint',
+'rg8sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 615,
+stencilReadOnly: true,
+}
+);
+let renderBundle75 = renderBundleEncoder73.finish(
+{
+label: '\u07f3\u4ff8\uf91c\ua631\uc3e1'
+}
+);
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+window.someLabel = device0.label;
+} catch {}
+document.body.prepend(canvas10);
+document.body.append('\u{1fdca}\u20fa\u32b4\u0733');
+document.body.prepend(canvas4);
+offscreenCanvas9.height = 816;
+let img32 = await imageWithData(289, 209, '#413612f1', '#00867d3b');
+let buffer33 = device3.createBuffer(
+{
+label: '\u5900\u52a6\u9d88',
+size: 24952,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+let texture89 = gpuCanvasContext4.getCurrentTexture();
+let commandEncoder72 = device1.createCommandEncoder(
+{
+label: '\uc537\u9502\u8e02\u00a0\u0431\u{1fdd4}\u0ee7\u62b2\u09c3',
+}
+);
+let texture90 = device1.createTexture(
+{
+label: '\u01e6\u103f',
+size: [46, 124, 1],
+mipLevelCount: 6,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'depth16unorm',
+'depth16unorm',
+'depth16unorm'
+],
+}
+);
+let pipeline106 = device1.createComputePipeline(
+{
+label: '\u573a\u{1fa79}\u04ea\ucf4b\u9062\uec9d\u7771\u1a32',
+layout: pipelineLayout9,
+compute: {
+module: shaderModule18,
+entryPoint: 'compute0',
+},
+}
+);
+let gpuCanvasContext16 = canvas14.getContext('webgpu');
+canvas7.height = 634;
+let buffer34 = device2.createBuffer(
+{
+label: '\u58c7\ua90a\u6f4b\u{1f8f0}\u0f00\uf359\u51a8\u{1f9cf}\u0dba',
+size: 776,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+mappedAtCreation: true,
+}
+);
+let texture91 = device2.createTexture(
+{
+label: '\u{1fd7e}\ud783\u04ae\ubf69\u9e33\u0fff\u6438',
+size: {width: 78, height: 207, depthOrArrayLayers: 240},
+mipLevelCount: 3,
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32float'
+],
+}
+);
+let textureView80 = texture81.createView(
+{
+label: '\u14a7\u55b3\ub773\u4c3d\u9b40',
+dimension: '2d',
+baseMipLevel: 3,
+mipLevelCount: 3,
+baseArrayLayer: 24,
+}
+);
+let renderBundleEncoder76 = device2.createRenderBundleEncoder(
+{
+label: '\udc2b\u{1fc64}\ube7a\u{1ff13}',
+colorFormats: [
+'rg16sint',
+undefined,
+'bgra8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 524,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder31.setBlendConstant(
+{
+r: -282.0,
+g: 104.7,
+b: 277.2,
+a: 141.6,
+}
+);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(
+8,
+buffer26,
+1400,
+21
+);
+} catch {}
+try {
+renderBundleEncoder71.setVertexBuffer(
+5,
+buffer26,
+1920,
+268
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext17 = canvas15.getContext('webgpu');
+document.body.append('\ubdb6\uba24\u7b0b\udf3d\u0870\u322f\ue4f5\ub075');
+let videoFrame17 = new VideoFrame(offscreenCanvas18, {timestamp: 0});
+document.body.append('\u{1fba3}\u0a98\u040b\u{1f747}\u0df8\u068d\u894a\u0305');
+let device5 = await adapter7.requestDevice(
+{
+label: '\u60dc\u0b2b\u{1fcd5}\u8999\u059d\u{1fac5}\u5b6b\u0721\uaf41',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 50,
+maxVertexAttributes: 17,
+maxVertexBufferArrayStride: 43105,
+maxStorageTexturesPerShaderStage: 29,
+maxStorageBuffersPerShaderStage: 40,
+maxDynamicStorageBuffersPerPipelineLayout: 2474,
+maxBindingsPerBindGroup: 4386,
+maxTextureDimension1D: 13483,
+maxTextureDimension2D: 12299,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 178544058,
+maxInterStageShaderVariables: 120,
+maxInterStageShaderComponents: 79,
+},
+}
+);
+let adapter10 = await navigator.gpu.requestAdapter();
+let img33 = await imageWithData(223, 112, '#bc1e536b', '#77dbbeb2');
+let renderBundleEncoder77 = device2.createRenderBundleEncoder(
+{
+label: '\u05c8\u1c88',
+colorFormats: [
+'bgra8unorm-srgb',
+undefined,
+undefined,
+'r32uint',
+undefined
+],
+sampleCount: 836,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder31.setScissorRect(
+605,
+1,
+592,
+0
+);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(
+9,
+buffer26,
+4,
+1897
+);
+} catch {}
+let gpuCanvasContext18 = offscreenCanvas18.getContext('webgpu');
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let canvas16 = document.createElement('canvas');
+let pipelineLayout17 = device3.createPipelineLayout(
+{
+label: '\u9b1b\u{1f659}\u{1ff27}\u4a4b',
+bindGroupLayouts: [
+bindGroupLayout44,
+bindGroupLayout44,
+bindGroupLayout44,
+bindGroupLayout44,
+bindGroupLayout44,
+bindGroupLayout44,
+bindGroupLayout44,
+bindGroupLayout44,
+bindGroupLayout44,
+bindGroupLayout44
+],
+}
+);
+let texture92 = device3.createTexture(
+{
+label: '\u9bab\u07d4',
+size: [83, 9, 30],
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rg32sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32sint',
+'rg32sint',
+'rg32sint'
+],
+}
+);
+let textureView81 = texture89.createView(
+{
+label: '\u{1f9cf}\u7c55\u46a9',
+dimension: '2d-array',
+}
+);
+let renderBundle76 = renderBundleEncoder73.finish(
+{
+label: '\ud95f\u3a8a\u0a20\u{1f9d8}\u7a61\u{1ffc6}'
+}
+);
+try {
+renderBundleEncoder75.setVertexBuffer(
+54,
+undefined,
+2301868860
+);
+} catch {}
+document.body.prepend(canvas0);
+document.body.prepend('\uffa0\ua929\u21d4\ub145\u4370\u7266\u2134\u020f\u9632\u{1f861}\u{1f92b}');
+try {
+window.someLabel = pipeline83.label;
+} catch {}
+try {
+canvas16.getContext('webgl2');
+} catch {}
+let texture93 = device5.createTexture(
+{
+label: '\u0dcd\uc1ec',
+size: [1567, 1, 1290],
+mipLevelCount: 5,
+dimension: '3d',
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'r32sint'
+],
+}
+);
+let sampler62 = device5.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 78.301,
+lodMaxClamp: 89.862,
+compare: 'less-equal',
+}
+);
+try {
+gpuCanvasContext2.configure(
+{
+device: device5,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let renderBundle77 = renderBundleEncoder71.finish(
+{
+label: '\u{1fa3f}\u{1f84c}\u0da4\uad88\u537f'
+}
+);
+try {
+renderPassEncoder31.setScissorRect(
+1040,
+1,
+65,
+0
+);
+} catch {}
+try {
+renderPassEncoder31.setViewport(
+1382.0,
+0.3675,
+0.1943,
+0.00012,
+0.5353,
+0.5489
+);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(
+9,
+buffer26
+);
+} catch {}
+let pipeline107 = device2.createRenderPipeline(
+{
+label: '\ue5a6\u{1f9a4}\u0011\u{1fbce}\u01e4',
+layout: 'auto',
+vertex: {
+module: shaderModule24,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 12564,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 12544,
+shaderLocation: 19,
+},
+{
+format: 'sint32x3',
+offset: 6384,
+shaderLocation: 24,
+},
+{
+format: 'sint32x2',
+offset: 7092,
+shaderLocation: 13,
+},
+{
+format: 'sint16x2',
+offset: 7960,
+shaderLocation: 11,
+},
+{
+format: 'snorm8x2',
+offset: 8824,
+shaderLocation: 25,
+}
+],
+},
+{
+arrayStride: 6976,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 1024,
+shaderLocation: 14,
+},
+{
+format: 'uint8x4',
+offset: 2468,
+shaderLocation: 18,
+},
+{
+format: 'uint32x3',
+offset: 408,
+shaderLocation: 3,
+},
+{
+format: 'float32x2',
+offset: 1548,
+shaderLocation: 20,
+},
+{
+format: 'uint8x4',
+offset: 1220,
+shaderLocation: 4,
+},
+{
+format: 'uint8x2',
+offset: 2574,
+shaderLocation: 7,
+},
+{
+format: 'sint16x4',
+offset: 3596,
+shaderLocation: 23,
+},
+{
+format: 'unorm8x4',
+offset: 2556,
+shaderLocation: 8,
+},
+{
+format: 'uint32',
+offset: 592,
+shaderLocation: 21,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 2676,
+shaderLocation: 15,
+},
+{
+format: 'uint8x4',
+offset: 5912,
+shaderLocation: 10,
+},
+{
+format: 'float16x4',
+offset: 5612,
+shaderLocation: 6,
+},
+{
+format: 'float32x4',
+offset: 4416,
+shaderLocation: 17,
+},
+{
+format: 'float16x4',
+offset: 3432,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 568,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 296,
+shaderLocation: 26,
+},
+{
+format: 'float16x4',
+offset: 300,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x4',
+offset: 272,
+shaderLocation: 1,
+},
+{
+format: 'float32x3',
+offset: 100,
+shaderLocation: 22,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 316,
+shaderLocation: 2,
+},
+{
+format: 'uint32x4',
+offset: 20,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 6788,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x3',
+offset: 3932,
+shaderLocation: 0,
+},
+{
+format: 'sint32x4',
+offset: 1592,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+cullMode: 'front',
+},
+fragment: {
+module: shaderModule24,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'invert',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 349,
+stencilWriteMask: 2030,
+depthBias: 37,
+depthBiasSlopeScale: 37,
+depthBiasClamp: 5,
+},
+}
+);
+let commandEncoder73 = device1.createCommandEncoder(
+{
+label: '\u4a6f\u83f5\u{1fd65}\u3c1c\u29d7\ud240\u{1fc0b}\u8271\u685f',
+}
+);
+let texture94 = device1.createTexture(
+{
+label: '\u5591\u0156\u1900',
+size: [215, 26, 155],
+mipLevelCount: 3,
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rg11b10ufloat',
+'rg11b10ufloat',
+'rg11b10ufloat'
+],
+}
+);
+let sampler63 = device1.createSampler(
+{
+label: '\ue5d1\uf51d\u{1fa5c}\ue1b9\u0dc4',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 17.637,
+maxAnisotropy: 16,
+}
+);
+try {
+gpuCanvasContext17.configure(
+{
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let pipeline108 = device1.createRenderPipeline(
+{
+label: '\ubd2c\u441a\u059f\u1a37\ub96f',
+layout: pipelineLayout13,
+vertex: {
+module: shaderModule17,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 7828,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 2440,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'snorm16x4',
+offset: 4660,
+shaderLocation: 19,
+},
+{
+format: 'float32x2',
+offset: 27144,
+shaderLocation: 20,
+},
+{
+format: 'uint16x4',
+offset: 21092,
+shaderLocation: 4,
+},
+{
+format: 'uint16x4',
+offset: 2688,
+shaderLocation: 13,
+},
+{
+format: 'snorm8x2',
+offset: 17692,
+shaderLocation: 2,
+},
+{
+format: 'uint16x4',
+offset: 748,
+shaderLocation: 12,
+},
+{
+format: 'uint32',
+offset: 11808,
+shaderLocation: 9,
+},
+{
+format: 'float32x3',
+offset: 4672,
+shaderLocation: 6,
+},
+{
+format: 'sint32x3',
+offset: 8068,
+shaderLocation: 17,
+},
+{
+format: 'unorm8x2',
+offset: 3776,
+shaderLocation: 3,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 28688,
+shaderLocation: 14,
+},
+{
+format: 'snorm8x2',
+offset: 3076,
+shaderLocation: 10,
+},
+{
+format: 'uint8x2',
+offset: 9076,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 20064,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x4',
+offset: 10088,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 20288,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x4',
+offset: 17564,
+shaderLocation: 18,
+},
+{
+format: 'float32x2',
+offset: 13356,
+shaderLocation: 1,
+},
+{
+format: 'uint16x2',
+offset: 11160,
+shaderLocation: 7,
+},
+{
+format: 'sint32x2',
+offset: 344,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 16860,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x3',
+offset: 21648,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+multisample: {
+},
+fragment: {
+module: shaderModule17,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'rgb10a2uint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rgba32uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'rg16float',
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+try {
+offscreenCanvas17.getContext('2d');
+} catch {}
+let textureView82 = texture92.createView(
+{
+label: '\u0e81\u770a\u0ad5\u9d62\u{1f6d7}\u{1ffe4}\ufb4c\u03ed\u089c',
+mipLevelCount: 1,
+}
+);
+try {
+buffer33.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8snorm',
+'bgra8unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+document.body.prepend('\uee85\u693c\u{1fc83}\u0c91\u0baa\u{1fdde}\u0beb\ubdb8\u{1ffa8}\ud6a9\uc13d');
+let textureView83 = texture92.createView(
+{
+label: '\u5a9b\u{1f8f3}\u5805\u01f5\ue621\u029a\u19d5',
+mipLevelCount: 2,
+}
+);
+let canvas17 = document.createElement('canvas');
+try {
+window.someLabel = device4.queue.label;
+} catch {}
+document.body.append('\u546f\uc302\u{1fbee}\ud2b1');
+let video23 = await videoWithData();
+let commandEncoder74 = device5.createCommandEncoder(
+{
+label: '\ude26\u0993\u020a\u{1fcaf}\u0a15\u0bb4\u{1fea3}',
+}
+);
+let textureView84 = texture93.createView(
+{
+label: '\u{1fec5}\u787b\u0a97\u3465\u0b29\u0713\u2a32',
+aspect: 'all',
+mipLevelCount: 4,
+}
+);
+let sampler64 = device5.createSampler(
+{
+label: '\u0acd\ub1ab\u5cec\uc1ab',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 59.405,
+compare: 'less-equal',
+maxAnisotropy: 12,
+}
+);
+try {
+commandEncoder74.copyTextureToTexture(
+{
+  texture: texture93,
+  mipLevel: 3,
+  origin: { x: 50, y: 1, z: 9 },
+  aspect: 'all',
+},
+{
+  texture: texture93,
+  mipLevel: 4,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 88, height: 0, depthOrArrayLayers: 29}
+);
+} catch {}
+let imageBitmap21 = await createImageBitmap(img22);
+try {
+canvas17.getContext('webgl');
+} catch {}
+let shaderModule25 = device1.createShaderModule(
+{
+label: '\u0f8c\u{1fb66}\u02bf\u0e4a\u{1f9fa}\u{1ff8c}\u{1fbeb}',
+code: `@group(5) @binding(535)
+var<storage, read_write> type1: array<u32>;
+
+@compute @workgroup_size(3, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@builtin(frag_depth) f0: f32,
+@location(2) f1: vec4<i32>,
+@location(3) f2: vec4<f32>,
+@location(4) f3: vec4<i32>,
+@location(5) f4: f32,
+@location(6) f5: vec2<f32>,
+@location(1) f6: vec3<u32>
+}
+
+@fragment
+fn fragment0(@location(17) a0: vec2<i32>, @location(73) a1: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S25 {
+@location(3) f0: i32,
+@location(20) f1: f32,
+@location(12) f2: vec4<f32>,
+@location(8) f3: vec4<f16>,
+@location(11) f4: vec3<u32>,
+@builtin(instance_index) f5: u32,
+@location(0) f6: i32,
+@location(17) f7: i32,
+@location(10) f8: u32,
+@location(15) f9: u32,
+@builtin(vertex_index) f10: u32,
+@location(1) f11: vec3<f16>,
+@location(13) f12: vec4<i32>,
+@location(2) f13: vec4<f32>,
+@location(18) f14: vec4<u32>,
+@location(14) f15: vec3<f32>,
+@location(6) f16: f32,
+@location(9) f17: vec4<f32>,
+@location(19) f18: vec2<u32>,
+@location(7) f19: i32
+}
+struct VertexOutput0 {
+@location(74) f393: vec4<f16>,
+@location(51) f394: vec3<i32>,
+@builtin(position) f395: vec4<f32>,
+@location(22) f396: vec2<i32>,
+@location(72) f397: vec3<f32>,
+@location(31) f398: f16,
+@location(58) f399: vec2<u32>,
+@location(7) f400: vec4<i32>,
+@location(77) f401: f16,
+@location(12) f402: u32,
+@location(21) f403: vec2<f16>,
+@location(63) f404: vec2<f32>,
+@location(62) f405: vec2<u32>,
+@location(32) f406: vec4<u32>,
+@location(82) f407: f16,
+@location(52) f408: u32,
+@location(41) f409: vec3<f16>,
+@location(46) f410: vec3<i32>,
+@location(0) f411: vec4<f32>,
+@location(64) f412: f16,
+@location(25) f413: vec4<i32>,
+@location(85) f414: vec3<f16>,
+@location(34) f415: f16,
+@location(20) f416: vec4<i32>,
+@location(73) f417: vec4<f32>,
+@location(76) f418: vec4<u32>,
+@location(88) f419: vec3<i32>,
+@location(40) f420: vec2<u32>,
+@location(11) f421: vec3<f16>,
+@location(15) f422: vec4<f16>,
+@location(17) f423: vec2<i32>,
+@location(10) f424: vec4<f16>,
+@location(36) f425: i32,
+@location(78) f426: vec2<f32>,
+@location(27) f427: u32
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec2<u32>, @location(4) a1: vec3<u32>, a2: S25, @location(16) a3: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let buffer35 = device1.createBuffer(
+{
+label: '\ubedc\u0e58',
+size: 7950,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let renderBundle78 = renderBundleEncoder56.finish(
+{
+label: '\u0306\u035b\u{1f6ff}\u1631\u8530\u{1f86a}\u1389\u0414\ub398'
+}
+);
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let promise25 = device1.createComputePipelineAsync(
+{
+layout: pipelineLayout13,
+compute: {
+module: shaderModule21,
+entryPoint: 'compute0',
+},
+}
+);
+let offscreenCanvas19 = new OffscreenCanvas(517, 853);
+let querySet58 = device5.createQuerySet(
+{
+label: '\u2257\u08d0\u0d72\u0d29\u7b2c\u{1f769}\uce14\ubcee',
+type: 'occlusion',
+count: 3942,
+}
+);
+let textureView85 = texture93.createView(
+{
+label: '\u0666\ua5d0\u130f\u0fe3\u001b\u618f\u4669\uec02\ufb2b',
+baseMipLevel: 3,
+mipLevelCount: 1,
+}
+);
+try {
+device3.queue.writeBuffer(
+buffer33,
+16592,
+new BigUint64Array(36283),
+24934,
+8
+);
+} catch {}
+offscreenCanvas17.width = 444;
+let renderBundleEncoder78 = device4.createRenderBundleEncoder(
+{
+label: '\u0ede\u0907\u0138\ua3d3\u937d\ue090\u0b3a\ubd1b\u284a',
+colorFormats: [
+'r16sint',
+'rg16uint',
+'rgba8uint',
+undefined,
+'rgb10a2unorm',
+undefined,
+'rg16float',
+'bgra8unorm'
+],
+sampleCount: 820,
+stencilReadOnly: true,
+}
+);
+let renderBundle79 = renderBundleEncoder78.finish(
+{
+
+}
+);
+let imageBitmap22 = await createImageBitmap(img13);
+let computePassEncoder41 = commandEncoder74.beginComputePass(
+{
+label: '\u099e\u7a06\u{1f903}\u{1fd10}\u{1feeb}\u3a3a\ufe38\u6b31\u1f2a\u02c2'
+}
+);
+let renderBundleEncoder79 = device5.createRenderBundleEncoder(
+{
+label: '\u084d\ueacf\u9e66',
+colorFormats: [
+'rg11b10ufloat',
+'rgba8sint',
+'rgba32sint',
+'r8unorm'
+],
+sampleCount: 969,
+stencilReadOnly: true,
+}
+);
+let gpuCanvasContext19 = offscreenCanvas19.getContext('webgpu');
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+let video24 = await videoWithData();
+let querySet59 = device3.createQuerySet(
+{
+type: 'occlusion',
+count: 3602,
+}
+);
+let video25 = await videoWithData();
+let imageData17 = new ImageData(88, 216);
+let computePassEncoder42 = commandEncoder70.beginComputePass(
+{
+label: '\u1676\ub7e3\ub53b\u3a17\u5e15\u06e8\u5adc\u{1f925}\u79b1'
+}
+);
+let renderBundleEncoder80 = device1.createRenderBundleEncoder(
+{
+label: '\u0fca\ue886\u{1ff0a}\u0ef3\u2c8d',
+colorFormats: [
+'r8sint',
+'rg8unorm',
+'rgba32float',
+'r32uint',
+'bgra8unorm-srgb',
+'rgba32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 260,
+}
+);
+let renderBundle80 = renderBundleEncoder61.finish(
+{
+label: '\u92e2\u1bda\u{1fbf5}\uc91a\u03d0\u1d4d\uab29\u042f\u0c5e\u98a1'
+}
+);
+try {
+commandEncoder72.clearBuffer(
+buffer29,
+1324,
+10068
+);
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+commandEncoder73.resolveQuerySet(
+querySet51,
+674,
+9,
+buffer28,
+12288
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer29,
+4948,
+new Float32Array(60612),
+14505,
+2760
+);
+} catch {}
+let pipeline109 = device1.createRenderPipeline(
+{
+label: '\ucd57\u{1f6f5}\u4ba1\u0982\u0ef4\uf4b9\uaa39\u0e6c\u9677',
+layout: pipelineLayout10,
+vertex: {
+module: shaderModule25,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 5168,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x2',
+offset: 2676,
+shaderLocation: 7,
+},
+{
+format: 'snorm8x2',
+offset: 4760,
+shaderLocation: 9,
+},
+{
+format: 'float16x2',
+offset: 4048,
+shaderLocation: 12,
+},
+{
+format: 'float32x4',
+offset: 4996,
+shaderLocation: 6,
+},
+{
+format: 'uint16x2',
+offset: 1320,
+shaderLocation: 5,
+},
+{
+format: 'float32',
+offset: 3904,
+shaderLocation: 8,
+},
+{
+format: 'sint8x2',
+offset: 1650,
+shaderLocation: 17,
+},
+{
+format: 'uint8x4',
+offset: 792,
+shaderLocation: 16,
+},
+{
+format: 'uint16x4',
+offset: 1224,
+shaderLocation: 10,
+},
+{
+format: 'sint32x2',
+offset: 72,
+shaderLocation: 13,
+},
+{
+format: 'uint8x2',
+offset: 626,
+shaderLocation: 11,
+},
+{
+format: 'sint32',
+offset: 4988,
+shaderLocation: 0,
+},
+{
+format: 'float32x2',
+offset: 3836,
+shaderLocation: 1,
+},
+{
+format: 'uint8x4',
+offset: 116,
+shaderLocation: 15,
+},
+{
+format: 'uint8x4',
+offset: 1248,
+shaderLocation: 19,
+},
+{
+format: 'uint8x4',
+offset: 536,
+shaderLocation: 18,
+},
+{
+format: 'sint8x4',
+offset: 148,
+shaderLocation: 3,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 2112,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x4',
+offset: 4016,
+shaderLocation: 20,
+}
+],
+},
+{
+arrayStride: 23748,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 10220,
+shaderLocation: 14,
+},
+{
+format: 'uint32',
+offset: 20068,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x5d376389,
+},
+fragment: {
+module: shaderModule25,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'rg16uint',
+writeMask: GPUColorWrite.BLUE,
+},
+{
+format: 'rgba8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-wrap',
+},
+stencilWriteMask: 2135,
+depthBiasSlopeScale: 27,
+},
+}
+);
+let buffer36 = device4.createBuffer(
+{
+label: '\u2452\uab17\u025f\u723a\u5cc0\u5d1b\u{1f817}',
+size: 21359,
+usage: GPUBufferUsage.MAP_READ,
+}
+);
+let texture95 = device4.createTexture(
+{
+label: '\u{1f764}\u0b49',
+size: [11790, 6, 1],
+mipLevelCount: 10,
+format: 'astc-6x6-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+gpuCanvasContext7.configure(
+{
+device: device4,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb',
+'bgra8unorm-srgb',
+'rgba8unorm-srgb',
+'rg16sint'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.append('\ub8d1\u1c80');
+let bindGroupLayout45 = device1.createBindGroupLayout(
+{
+entries: [
+{
+binding: 727,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 1010,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 318633, hasDynamicOffset: true },
+},
+{
+binding: 3324,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+}
+],
+}
+);
+let buffer37 = device1.createBuffer(
+{
+label: '\uc0f2\u{1f964}\u5cd3',
+size: 56085,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+try {
+gpuCanvasContext16.configure(
+{
+device: device1,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture74,
+  mipLevel: 2,
+  origin: { x: 12, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer3,
+/* required buffer size: 613 */{
+offset: 431,
+bytesPerRow: 29,
+},
+{width: 8, height: 7, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline110 = device1.createRenderPipeline(
+{
+label: '\u8e74\u204a\uaae9\uc8a7\u50a1',
+layout: 'auto',
+vertex: {
+module: shaderModule21,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 5016,
+attributes: [
+{
+format: 'unorm16x2',
+offset: 812,
+shaderLocation: 20,
+},
+{
+format: 'float32x3',
+offset: 3332,
+shaderLocation: 12,
+},
+{
+format: 'float32x3',
+offset: 88,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 700,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 536,
+shaderLocation: 10,
+},
+{
+format: 'sint32x4',
+offset: 468,
+shaderLocation: 5,
+},
+{
+format: 'snorm16x2',
+offset: 36,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'uint32x3',
+offset: 21308,
+shaderLocation: 1,
+},
+{
+format: 'sint32x3',
+offset: 1472,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 7208,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 7064,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 4668,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 4236,
+shaderLocation: 6,
+},
+{
+format: 'uint32x4',
+offset: 3488,
+shaderLocation: 9,
+},
+{
+format: 'uint8x2',
+offset: 3328,
+shaderLocation: 17,
+},
+{
+format: 'sint32x4',
+offset: 4484,
+shaderLocation: 13,
+},
+{
+format: 'float16x4',
+offset: 464,
+shaderLocation: 14,
+},
+{
+format: 'sint32x3',
+offset: 1676,
+shaderLocation: 7,
+},
+{
+format: 'unorm16x4',
+offset: 2540,
+shaderLocation: 8,
+},
+{
+format: 'sint16x2',
+offset: 736,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x2',
+offset: 1924,
+shaderLocation: 2,
+},
+{
+format: 'uint8x4',
+offset: 3608,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 7976,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x2',
+offset: 4648,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 15832,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 12944,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 9396,
+attributes: [
+
+],
+},
+{
+arrayStride: 12108,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 11332,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x4',
+offset: 7308,
+shaderLocation: 15,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0x1fc44af4,
+},
+fragment: {
+module: shaderModule21,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+},
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'one-minus-dst',
+dstFactor: 'zero'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'invert',
+depthFailOp: 'zero',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'invert',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 1433,
+stencilWriteMask: 3946,
+depthBias: 22,
+depthBiasSlopeScale: 75,
+},
+}
+);
+document.body.prepend(video0);
+let videoFrame18 = new VideoFrame(videoFrame3, {timestamp: 0});
+let textureView86 = texture70.createView(
+{
+dimension: '3d',
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+let computePassEncoder43 = commandEncoder69.beginComputePass();
+let renderBundle81 = renderBundleEncoder66.finish(
+{
+label: '\u0c0f\u081b\u732b\u3c99\uafb8\u1e02\u0603\u9f5c\uaa9e'
+}
+);
+let sampler65 = device1.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 99.871,
+}
+);
+try {
+renderBundleEncoder80.setBindGroup(
+8,
+bindGroup29,
+new Uint32Array(9297),
+2479,
+0
+);
+} catch {}
+try {
+commandEncoder72.copyBufferToBuffer(
+buffer25,
+8900,
+buffer29,
+420,
+16616
+);
+dissociateBuffer(device1, buffer25);
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+commandEncoder72.clearBuffer(
+buffer28,
+3444,
+8140
+);
+dissociateBuffer(device1, buffer28);
+} catch {}
+try {
+commandEncoder67.resolveQuerySet(
+querySet49,
+785,
+144,
+buffer28,
+8448
+);
+} catch {}
+document.body.append('\ub973\u061a\u5f30\ude7f');
+let offscreenCanvas20 = new OffscreenCanvas(117, 483);
+let pipelineLayout18 = device2.createPipelineLayout(
+{
+label: '\u05d2\u47e7\u9173\u{1fa6c}\u{1fabd}\u8dd0\u04da\u2285\ue1c5',
+bindGroupLayouts: [
+bindGroupLayout33,
+bindGroupLayout40,
+bindGroupLayout37
+],
+}
+);
+let buffer38 = device2.createBuffer(
+{
+label: '\u{1ffab}\u0007',
+size: 38482,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+}
+);
+let querySet60 = device2.createQuerySet(
+{
+label: '\u0d02\u0865\u0823\ubbdb\u0b2d\ua1c4\u0c23\u{1f912}\u0374',
+type: 'occlusion',
+count: 3875,
+}
+);
+let renderBundle82 = renderBundleEncoder71.finish(
+{
+label: '\u0f95\u86f9'
+}
+);
+try {
+renderPassEncoder31.setBlendConstant(
+{
+r: -583.3,
+g: -235.7,
+b: -600.1,
+a: 210.9,
+}
+);
+} catch {}
+try {
+renderPassEncoder31.setViewport(
+500.8,
+0.4505,
+99.34,
+0.2906,
+0.4253,
+0.7430
+);
+} catch {}
+try {
+renderBundleEncoder63.setVertexBuffer(
+0,
+buffer26
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture75,
+  mipLevel: 0,
+  origin: { x: 95, y: 48, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 64071 */{
+offset: 345,
+bytesPerRow: 762,
+},
+{width: 30, height: 84, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+offscreenCanvas20.getContext('webgl2');
+} catch {}
+try {
+commandEncoder67.copyBufferToBuffer(
+buffer25,
+5516,
+buffer29,
+4340,
+3892
+);
+dissociateBuffer(device1, buffer25);
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+commandEncoder72.copyTextureToTexture(
+{
+  texture: texture78,
+  mipLevel: 0,
+  origin: { x: 4000, y: 0, z: 92 },
+  aspect: 'all',
+},
+{
+  texture: texture78,
+  mipLevel: 4,
+  origin: { x: 170, y: 10, z: 19 },
+  aspect: 'all',
+},
+{width: 60, height: 10, depthOrArrayLayers: 146}
+);
+} catch {}
+try {
+gpuCanvasContext3.configure(
+{
+device: device1,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb',
+'bgra8unorm',
+'r8unorm',
+'bgra8unorm-srgb'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer28,
+12324,
+new Int16Array(20888),
+10487,
+540
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture72,
+  mipLevel: 2,
+  origin: { x: 850, y: 5, z: 62 },
+  aspect: 'all',
+},
+new DataView(new ArrayBuffer(80)),
+/* required buffer size: 286964 */{
+offset: 516,
+bytesPerRow: 356,
+rowsPerImage: 199,
+},
+{width: 140, height: 45, depthOrArrayLayers: 5}
+);
+} catch {}
+let pipeline111 = device1.createComputePipeline(
+{
+label: '\u00d8\ub3ba\u{1fa98}',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule18,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let texture96 = device1.createTexture(
+{
+label: '\u0f78\uef71\u{1ff8c}\u0be9\u0d8f\u{1ffea}\u0da1\u9fd0\u{1fbc6}\ud501',
+size: {width: 13380, height: 220, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'etc2-rgb8a1unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'etc2-rgb8a1unorm',
+'etc2-rgb8a1unorm-srgb'
+],
+}
+);
+let sampler66 = device1.createSampler(
+{
+label: '\u952d\uad0e\u01fe\u61fe',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMinClamp: 90.027,
+lodMaxClamp: 94.838,
+}
+);
+try {
+renderBundleEncoder80.setVertexBuffer(
+6,
+buffer28,
+5064,
+4213
+);
+} catch {}
+try {
+commandEncoder72.resolveQuerySet(
+querySet51,
+442,
+94,
+buffer25,
+4608
+);
+} catch {}
+try {
+commandEncoder63.insertDebugMarker(
+'\ub844'
+);
+} catch {}
+let pipeline112 = await device1.createComputePipelineAsync(
+{
+label: '\u004c\u0eac\uddb3',
+layout: pipelineLayout9,
+compute: {
+module: shaderModule21,
+entryPoint: 'compute0',
+},
+}
+);
+let texture97 = device1.createTexture(
+{
+label: '\u0662\uda62\ufeb4',
+size: {width: 256, height: 6, depthOrArrayLayers: 155},
+mipLevelCount: 3,
+format: 'astc-8x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let computePassEncoder44 = commandEncoder63.beginComputePass(
+{
+label: '\u515b\u0faa\u{1faf0}\u{1fb00}\ufd95\u{1ff14}\u094c\ud020\u{1f91e}'
+}
+);
+let renderBundle83 = renderBundleEncoder80.finish(
+{
+label: '\u{1fecb}\u0982'
+}
+);
+let sampler67 = device1.createSampler(
+{
+label: '\u1e11\u{1f7f2}\u02f4\u1cdf',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 60.424,
+lodMaxClamp: 61.321,
+maxAnisotropy: 13,
+}
+);
+try {
+renderBundleEncoder68.setVertexBuffer(
+1,
+buffer28
+);
+} catch {}
+try {
+commandEncoder72.resolveQuerySet(
+querySet49,
+615,
+1,
+buffer25,
+5376
+);
+} catch {}
+document.body.append('\u{1ff88}\u2ed0\uedea\u055c');
+let video26 = await videoWithData();
+let textureView87 = texture91.createView(
+{
+label: '\ub156\u7c8b\u0e4c\u09fb\u007a\uea0e\u{1fec6}\u00ed\ue26a',
+dimension: '2d',
+baseMipLevel: 2,
+baseArrayLayer: 222,
+}
+);
+try {
+renderPassEncoder31.setBlendConstant(
+{
+r: -212.0,
+g: 781.0,
+b: 862.2,
+a: 798.1,
+}
+);
+} catch {}
+try {
+renderPassEncoder31.setScissorRect(
+1337,
+1,
+4,
+0
+);
+} catch {}
+try {
+renderPassEncoder31.setViewport(
+774.0,
+0.1195,
+469.0,
+0.4902,
+0.2606,
+0.9753
+);
+} catch {}
+try {
+renderBundleEncoder77.setVertexBuffer(
+2,
+buffer26,
+940,
+1287
+);
+} catch {}
+try {
+renderBundleEncoder69.pushDebugGroup(
+'\udc1b'
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 112, height: 2, depthOrArrayLayers: 31}
+*/
+{
+  source: video16,
+  origin: { x: 13, y: 14 },
+  flipY: true,
+},
+{
+  texture: texture81,
+  mipLevel: 5,
+  origin: { x: 65, y: 0, z: 22 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline113 = device2.createRenderPipeline(
+{
+label: '\u3dce\u0c7d',
+layout: pipelineLayout18,
+vertex: {
+module: shaderModule24,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 732,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x4',
+offset: 108,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x2',
+offset: 376,
+shaderLocation: 8,
+},
+{
+format: 'float32x2',
+offset: 452,
+shaderLocation: 20,
+},
+{
+format: 'uint16x4',
+offset: 564,
+shaderLocation: 3,
+},
+{
+format: 'uint8x4',
+offset: 452,
+shaderLocation: 4,
+},
+{
+format: 'uint16x2',
+offset: 492,
+shaderLocation: 10,
+},
+{
+format: 'uint32',
+offset: 456,
+shaderLocation: 21,
+},
+{
+format: 'sint8x4',
+offset: 40,
+shaderLocation: 24,
+},
+{
+format: 'unorm8x4',
+offset: 440,
+shaderLocation: 14,
+},
+{
+format: 'sint16x2',
+offset: 216,
+shaderLocation: 23,
+},
+{
+format: 'uint8x4',
+offset: 624,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 2364,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 1984,
+shaderLocation: 25,
+},
+{
+format: 'float32x4',
+offset: 244,
+shaderLocation: 2,
+},
+{
+format: 'float16x4',
+offset: 1708,
+shaderLocation: 15,
+},
+{
+format: 'snorm16x2',
+offset: 2316,
+shaderLocation: 12,
+},
+{
+format: 'uint16x2',
+offset: 1396,
+shaderLocation: 26,
+},
+{
+format: 'snorm16x2',
+offset: 2116,
+shaderLocation: 1,
+},
+{
+format: 'uint32x4',
+offset: 76,
+shaderLocation: 19,
+},
+{
+format: 'uint32x2',
+offset: 736,
+shaderLocation: 7,
+},
+{
+format: 'sint8x4',
+offset: 1748,
+shaderLocation: 13,
+},
+{
+format: 'unorm8x4',
+offset: 32,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 11836,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 2496,
+shaderLocation: 16,
+},
+{
+format: 'sint32',
+offset: 11484,
+shaderLocation: 0,
+},
+{
+format: 'sint16x2',
+offset: 11500,
+shaderLocation: 11,
+},
+{
+format: 'snorm8x2',
+offset: 4820,
+shaderLocation: 6,
+},
+{
+format: 'float32x4',
+offset: 10924,
+shaderLocation: 22,
+},
+{
+format: 'sint32x4',
+offset: 5256,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule24,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'zero',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2980,
+stencilWriteMask: 2086,
+depthBias: 55,
+depthBiasSlopeScale: 48,
+},
+}
+);
+document.body.append('\u{1fdee}\u60fa\u0ab6\u7045\u908c\u0fe6\u4a1d\u{1fcda}');
+let imageData18 = new ImageData(216, 92);
+let commandEncoder75 = device2.createCommandEncoder(
+{
+label: '\u8721\u{1fec5}\u29e9\u{1fa76}\u{1f86b}\u0e8b\u0da3\u{1fd15}\u{1fec9}',
+}
+);
+let renderBundleEncoder81 = device2.createRenderBundleEncoder(
+{
+label: '\u4b4e\u6f86',
+colorFormats: [
+undefined,
+'rgb10a2unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 459,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder31.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(
+70,
+undefined
+);
+} catch {}
+try {
+renderBundleEncoder60.setVertexBuffer(
+9,
+buffer26,
+2120,
+95
+);
+} catch {}
+let arrayBuffer6 = buffer32.getMappedRange(
+9776,
+1352
+);
+try {
+commandEncoder75.copyBufferToBuffer(
+buffer34,
+32,
+buffer38,
+5836,
+144
+);
+dissociateBuffer(device2, buffer34);
+dissociateBuffer(device2, buffer38);
+} catch {}
+try {
+renderBundleEncoder69.insertDebugMarker(
+'\u7671'
+);
+} catch {}
+let pipeline114 = device2.createComputePipeline(
+{
+layout: pipelineLayout18,
+compute: {
+module: shaderModule24,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let sampler68 = device3.createSampler(
+{
+label: '\u{1faf1}\u{1fc67}\u15c4\u{1fdba}\u0fca\u4bed\u9b47\u0930',
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 4.294,
+lodMaxClamp: 69.642,
+maxAnisotropy: 12,
+}
+);
+try {
+renderBundleEncoder75.setVertexBuffer(
+80,
+undefined,
+2517022442
+);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer33,
+13428,
+new Float32Array(43150),
+11541,
+1920
+);
+} catch {}
+offscreenCanvas1.width = 930;
+let img34 = await imageWithData(6, 139, '#3e0992bb', '#e3e4fd2f');
+let querySet61 = device3.createQuerySet(
+{
+type: 'occlusion',
+count: 1064,
+}
+);
+let texture98 = device3.createTexture(
+{
+label: '\u4ed1\uc48f\u{1fce4}\uccdb\u0fcd\u{1fb1d}\ud597\u{1f9b9}\u5f4b\u83b1\u{1fa79}',
+size: [240, 80, 118],
+mipLevelCount: 2,
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+}
+);
+try {
+renderPassEncoder31.setBlendConstant(
+{
+r: -796.2,
+g: -462.3,
+b: -57.13,
+a: 981.0,
+}
+);
+} catch {}
+try {
+renderPassEncoder31.setScissorRect(
+1098,
+0,
+55,
+0
+);
+} catch {}
+try {
+commandEncoder75.clearBuffer(
+buffer30,
+612,
+96
+);
+dissociateBuffer(device2, buffer30);
+} catch {}
+let promise26 = device2.createComputePipelineAsync(
+{
+label: '\u9cd9\u{1fe50}\u0360\u03ec\u62a5\u{1f78b}\u979b\ufcbf',
+layout: pipelineLayout14,
+compute: {
+module: shaderModule24,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let texture99 = device3.createTexture(
+{
+label: '\u0fed\u{1f60c}\u0e7f\u{1fa45}\u{1f661}\u{1f994}\u005a\u03ec\uc914\u0236\ue343',
+size: [4340],
+dimension: '1d',
+format: 'rg32uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32uint',
+'rg32uint'
+],
+}
+);
+let renderBundleEncoder82 = device3.createRenderBundleEncoder(
+{
+label: '\ud27c\u0eae\u2c06\u0279\u1662\u8646\u79c6',
+colorFormats: [
+'rg16uint',
+'r8unorm',
+'rg16float',
+'rg8unorm',
+'rg32sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 946,
+stencilReadOnly: true,
+}
+);
+try {
+device3.queue.writeBuffer(
+buffer33,
+20060,
+new Int16Array(24845),
+4566,
+1048
+);
+} catch {}
+let img35 = await imageWithData(279, 100, '#10b68738', '#fda51537');
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+try {
+pipeline107.label = '\u{1f633}\ue37d\u0114\ucdeb\u89b5\u2b2d\u{1f634}\u5186\uaf8b\u0f6d';
+} catch {}
+let commandEncoder76 = device2.createCommandEncoder(
+{
+label: '\u{1fe55}\u0b25\u226c',
+}
+);
+pseudoSubmit(device2, commandEncoder75);
+let textureView88 = texture81.createView(
+{
+label: '\u{1fc73}\ufda2\u0694\u{1f604}\u05a0',
+baseMipLevel: 1,
+mipLevelCount: 3,
+baseArrayLayer: 25,
+arrayLayerCount: 2,
+}
+);
+let computePassEncoder45 = commandEncoder76.beginComputePass(
+{
+label: '\u3f19\u0d79\u1416\u193d\u{1fa2f}\ue0b7\u29b0\u40b9\ua23a'
+}
+);
+try {
+await device2.popErrorScope();
+} catch {}
+try {
+computePassEncoder33.insertDebugMarker(
+'\u0eec'
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture81,
+  mipLevel: 3,
+  origin: { x: 344, y: 4, z: 10 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer2),
+/* required buffer size: 679068 */{
+offset: 733,
+bytesPerRow: 607,
+rowsPerImage: 139,
+},
+{width: 79, height: 6, depthOrArrayLayers: 9}
+);
+} catch {}
+let buffer39 = device5.createBuffer(
+{
+label: '\ud4eb\ud268\uc02b\u{1fb9d}\ue976\ud7cb\u122e',
+size: 59300,
+usage: GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+mappedAtCreation: false,
+}
+);
+let commandEncoder77 = device5.createCommandEncoder(
+{
+label: '\ufde2\u{1fefc}\ue086\u2aa6',
+}
+);
+let textureView89 = texture93.createView(
+{
+label: '\u07e7\u{1fd19}',
+baseMipLevel: 1,
+mipLevelCount: 2,
+}
+);
+let renderBundle84 = renderBundleEncoder79.finish(
+{
+
+}
+);
+try {
+device5.queue.writeTexture(
+{
+  texture: texture93,
+  mipLevel: 2,
+  origin: { x: 352, y: 0, z: 43 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 1631101 */{
+offset: 961,
+bytesPerRow: 156,
+rowsPerImage: 129,
+},
+{width: 24, height: 1, depthOrArrayLayers: 82}
+);
+} catch {}
+try {
+await device5.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append('\u0314\u51d2\u9b19\uae70\u0f26\u{1fabc}\u55a5\u856b\u9f68\ue884');
+let computePassEncoder46 = commandEncoder72.beginComputePass(
+{
+label: '\u09e6\ubeeb\u14ad\u{1f9f8}\u{1fb71}\uf840\u0f53\u0a14'
+}
+);
+let renderBundleEncoder83 = device1.createRenderBundleEncoder(
+{
+label: '\u081e\u2c46\u{1f62c}\u2f21\u0215\ua769\u{1f9fa}',
+colorFormats: [
+'rgba16uint',
+'bgra8unorm-srgb',
+'rg8sint',
+'rgba32float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 260,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder70.setIndexBuffer(
+buffer25,
+'uint16'
+);
+} catch {}
+try {
+commandEncoder73.clearBuffer(
+buffer25
+);
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: { x: 50, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer6,
+/* required buffer size: 13100156 */{
+offset: 188,
+bytesPerRow: 532,
+rowsPerImage: 162,
+},
+{width: 127, height: 0, depthOrArrayLayers: 153}
+);
+} catch {}
+let commandEncoder78 = device2.createCommandEncoder(
+{
+label: '\u{1fd05}\u49ac\u176c\u8a19\u{1fee8}\u{1fa54}\u{1f9dc}\u1900\u0d65',
+}
+);
+try {
+renderPassEncoder31.setIndexBuffer(
+buffer38,
+'uint32',
+24664
+);
+} catch {}
+try {
+commandEncoder78.clearBuffer(
+buffer34,
+724
+);
+dissociateBuffer(device2, buffer34);
+} catch {}
+let pipeline115 = device2.createRenderPipeline(
+{
+label: '\u637b\u49dd',
+layout: pipelineLayout12,
+vertex: {
+module: shaderModule24,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 184,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32',
+offset: 10060,
+shaderLocation: 14,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 9648,
+shaderLocation: 22,
+},
+{
+format: 'uint8x2',
+offset: 3422,
+shaderLocation: 26,
+},
+{
+format: 'snorm8x2',
+offset: 11578,
+shaderLocation: 12,
+},
+{
+format: 'uint32x2',
+offset: 2524,
+shaderLocation: 19,
+},
+{
+format: 'float32x4',
+offset: 9136,
+shaderLocation: 25,
+},
+{
+format: 'uint16x2',
+offset: 12696,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x2',
+offset: 8122,
+shaderLocation: 16,
+},
+{
+format: 'sint32x3',
+offset: 3216,
+shaderLocation: 0,
+},
+{
+format: 'snorm8x2',
+offset: 3550,
+shaderLocation: 6,
+},
+{
+format: 'uint32x4',
+offset: 1380,
+shaderLocation: 21,
+},
+{
+format: 'unorm16x4',
+offset: 9124,
+shaderLocation: 15,
+},
+{
+format: 'float32x3',
+offset: 2628,
+shaderLocation: 17,
+},
+{
+format: 'sint8x2',
+offset: 1954,
+shaderLocation: 13,
+},
+{
+format: 'unorm8x2',
+offset: 7188,
+shaderLocation: 1,
+},
+{
+format: 'uint32x2',
+offset: 13180,
+shaderLocation: 10,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 16,
+shaderLocation: 2,
+},
+{
+format: 'uint32',
+offset: 4552,
+shaderLocation: 3,
+},
+{
+format: 'sint8x2',
+offset: 12280,
+shaderLocation: 11,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 3384,
+shaderLocation: 20,
+},
+{
+format: 'float16x2',
+offset: 7244,
+shaderLocation: 8,
+},
+{
+format: 'uint32x4',
+offset: 9876,
+shaderLocation: 18,
+},
+{
+format: 'sint32x2',
+offset: 10048,
+shaderLocation: 23,
+},
+{
+format: 'sint32',
+offset: 216,
+shaderLocation: 24,
+},
+{
+format: 'uint32x4',
+offset: 6208,
+shaderLocation: 7,
+},
+{
+format: 'uint32',
+offset: 9776,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 8900,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x2',
+offset: 5688,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+frontFace: 'ccw',
+},
+fragment: {
+module: shaderModule24,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'never',
+failOp: 'increment-clamp',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilReadMask: 1820,
+stencilWriteMask: 2086,
+depthBias: 79,
+depthBiasSlopeScale: 80,
+},
+}
+);
+document.body.prepend('\uc692\u1711\u0f0e\u{1ff87}\u6594\uce25\u27c6\u0bc6\ud522\u0216');
+try {
+renderPassEncoder31.setIndexBuffer(
+buffer38,
+'uint16',
+4864,
+28968
+);
+} catch {}
+let pipeline116 = device2.createComputePipeline(
+{
+label: '\ua337\u53a1\u00d0\u0496\ub522\u0e52\u58f6',
+layout: pipelineLayout14,
+compute: {
+module: shaderModule24,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+document.body.prepend('\uf03a\u7e8b\u0f41\u{1fd5f}\ue073\u4073\u8c6e\u0d57\u{1f9f6}\u2461');
+let video27 = await videoWithData();
+let renderBundleEncoder84 = device5.createRenderBundleEncoder(
+{
+label: '\u{1fe7e}\ubae9\u9df0\u3eb4\u2187\u{1fa89}\u15af',
+colorFormats: [
+undefined,
+'rg16float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 808,
+}
+);
+try {
+commandEncoder77.copyTextureToTexture(
+{
+  texture: texture93,
+  mipLevel: 1,
+  origin: { x: 181, y: 0, z: 360 },
+  aspect: 'all',
+},
+{
+  texture: texture93,
+  mipLevel: 4,
+  origin: { x: 1, y: 0, z: 14 },
+  aspect: 'all',
+},
+{width: 95, height: 1, depthOrArrayLayers: 41}
+);
+} catch {}
+try {
+gpuCanvasContext12.configure(
+{
+device: device5,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-4x4-unorm-srgb',
+'rgba8unorm',
+'rgba8unorm-srgb'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let video28 = await videoWithData();
+let imageData19 = new ImageData(200, 16);
+let texture100 = device4.createTexture(
+{
+label: '\u128c\u0a05\u{1f7c0}\u50a8\u0f5a\ued6b',
+size: [16, 8, 233],
+mipLevelCount: 3,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView90 = texture87.createView(
+{
+dimension: '2d',
+aspect: 'stencil-only',
+baseMipLevel: 1,
+}
+);
+let renderBundle85 = renderBundleEncoder78.finish(
+{
+label: '\uf21f\u42e6\u{1f9c4}\u0bc7\uf9fb\u70be\u{1fed6}\u1532\u9ebf'
+}
+);
+try {
+device4.queue.writeTexture(
+{
+  texture: texture100,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(56),
+/* required buffer size: 5620623 */{
+offset: 33,
+bytesPerRow: 270,
+rowsPerImage: 257,
+},
+{width: 0, height: 0, depthOrArrayLayers: 82}
+);
+} catch {}
+let shaderModule26 = device1.createShaderModule(
+{
+code: `
+
+@compute @workgroup_size(2, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(1) f0: vec3<f32>,
+@location(0) f1: f32,
+@location(5) f2: u32,
+@location(6) f3: vec4<u32>,
+@location(3) f4: u32,
+@builtin(frag_depth) f5: f32
+}
+
+@fragment
+fn fragment0(@location(38) a0: vec3<f32>, @location(37) a1: vec2<i32>, @location(74) a2: f32, @location(71) a3: vec2<f16>, @location(83) a4: u32, @location(80) a5: vec3<f32>, @location(79) a6: i32, @location(5) a7: vec3<f16>, @builtin(position) a8: vec4<f32>, @location(32) a9: vec4<f32>, @builtin(sample_index) a10: u32, @location(13) a11: vec4<u32>, @builtin(sample_mask) a12: u32, @location(22) a13: vec4<f16>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S26 {
+@location(12) f0: vec2<f16>,
+@location(2) f1: vec4<f16>,
+@location(8) f2: vec3<f32>,
+@location(0) f3: vec3<u32>,
+@location(15) f4: f32,
+@location(5) f5: vec4<u32>,
+@location(19) f6: i32,
+@location(10) f7: vec2<u32>,
+@location(20) f8: vec3<u32>,
+@location(13) f9: vec2<u32>
+}
+struct VertexOutput0 {
+@location(80) f428: vec3<f32>,
+@location(79) f429: i32,
+@location(71) f430: vec2<f16>,
+@builtin(position) f431: vec4<f32>,
+@location(22) f432: vec4<f16>,
+@location(56) f433: vec2<u32>,
+@location(5) f434: vec3<f16>,
+@location(83) f435: u32,
+@location(13) f436: vec4<u32>,
+@location(37) f437: vec2<i32>,
+@location(14) f438: i32,
+@location(28) f439: vec2<u32>,
+@location(74) f440: f32,
+@location(38) f441: vec3<f32>,
+@location(32) f442: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(7) a0: u32, @location(18) a1: vec2<f32>, @location(3) a2: vec3<f32>, @location(4) a3: vec2<f16>, @location(6) a4: vec2<i32>, @location(14) a5: vec2<i32>, a6: S26, @location(11) a7: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroupLayout46 = device1.createBindGroupLayout(
+{
+label: '\u14ca\u868f\u{1ff7e}\u4897\u06ea',
+entries: [
+{
+binding: 930,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let renderBundle86 = renderBundleEncoder55.finish(
+{
+
+}
+);
+try {
+computePassEncoder46.setPipeline(
+pipeline111
+);
+} catch {}
+try {
+renderBundleEncoder83.setBindGroup(
+1,
+bindGroup29
+);
+} catch {}
+try {
+renderBundleEncoder70.setBindGroup(
+5,
+bindGroup29,
+new Uint32Array(1197),
+1119,
+0
+);
+} catch {}
+try {
+renderBundleEncoder83.setVertexBuffer(
+3,
+buffer25,
+11028,
+6243
+);
+} catch {}
+try {
+gpuCanvasContext17.configure(
+{
+device: device1,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb',
+'astc-10x5-unorm',
+'astc-12x10-unorm',
+'astc-12x10-unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer27,
+22020,
+new BigUint64Array(20759),
+4811,
+576
+);
+} catch {}
+let pipeline117 = await device1.createComputePipelineAsync(
+{
+layout: 'auto',
+compute: {
+module: shaderModule18,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.append('\u111a\u00ae\uf1fe\u{1fc17}\u59b7\u1825');
+let querySet62 = device4.createQuerySet(
+{
+label: '\uf1f2\ud242\ubf10\u9805\u0818\u015b\u01a1\u02b5\ue464\u0157\u0ef0',
+type: 'occlusion',
+count: 178,
+}
+);
+let texture101 = device4.createTexture(
+{
+label: '\u{1fa6f}\u0d21\u3f49\u0b42\uebd8\u{1faf1}\u0228\u069d\u0d33\u9800\u0575',
+size: [1750, 1, 1592],
+mipLevelCount: 10,
+sampleCount: 1,
+dimension: '3d',
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'bgra8unorm',
+'bgra8unorm-srgb'
+],
+}
+);
+let sampler69 = device4.createSampler(
+{
+label: '\u08cc\u107c\u0fa6\u3e23\u2458\u{1fe52}\u{1f603}\u21d1\ua1b9',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 51.028,
+lodMaxClamp: 91.353,
+compare: 'never',
+}
+);
+try {
+device4.queue.writeTexture(
+{
+  texture: texture101,
+  mipLevel: 0,
+  origin: { x: 215, y: 0, z: 1523 },
+  aspect: 'all',
+},
+new BigUint64Array(arrayBuffer6),
+/* required buffer size: 8219881 */{
+offset: 247,
+bytesPerRow: 5355,
+rowsPerImage: 59,
+},
+{width: 1266, height: 1, depthOrArrayLayers: 27}
+);
+} catch {}
+let shaderModule27 = device1.createShaderModule(
+{
+label: '\u49b4\uef28\u0722\u01bd\u8e10',
+code: `@group(2) @binding(721)
+var<storage, read_write> field3: array<u32>;
+
+@compute @workgroup_size(7, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S28 {
+@location(33) f0: vec4<f16>,
+@location(22) f1: vec4<f16>,
+@location(11) f2: vec2<i32>,
+@location(39) f3: vec2<i32>,
+@location(84) f4: i32,
+@location(67) f5: vec2<f16>,
+@location(2) f6: u32,
+@location(23) f7: vec3<f16>,
+@builtin(sample_index) f8: u32,
+@location(40) f9: vec2<f16>,
+@location(81) f10: vec2<f32>,
+@location(72) f11: vec2<u32>,
+@builtin(sample_mask) f12: u32,
+@location(32) f13: vec4<f32>,
+@location(64) f14: i32,
+@location(37) f15: vec3<f32>,
+@location(49) f16: vec2<f32>
+}
+
+@fragment
+fn fragment0(@location(78) a0: vec3<f32>, @location(83) a1: f32, @location(60) a2: i32, @location(85) a3: vec2<u32>, @location(47) a4: vec2<u32>, @location(0) a5: u32, @location(50) a6: vec2<f32>, @builtin(position) a7: vec4<f32>, @location(9) a8: f16, @location(53) a9: vec2<u32>, @builtin(front_facing) a10: bool, @location(52) a11: vec3<u32>, @location(75) a12: vec3<f16>, @location(59) a13: vec3<i32>, @location(8) a14: vec4<i32>, @location(76) a15: u32, @location(3) a16: i32, @location(66) a17: f32, @location(70) a18: vec3<u32>, a19: S28, @location(35) a20: vec4<f32>, @location(79) a21: u32) {
+
+}
+
+struct S27 {
+@location(8) f0: f16,
+@location(13) f1: i32,
+@location(11) f2: f16,
+@location(16) f3: vec4<f16>,
+@location(3) f4: vec4<i32>,
+@location(17) f5: vec2<f32>
+}
+struct VertexOutput0 {
+@location(75) f443: vec3<f16>,
+@location(83) f444: f32,
+@location(59) f445: vec3<i32>,
+@location(32) f446: vec4<f32>,
+@location(0) f447: u32,
+@location(60) f448: i32,
+@location(9) f449: f16,
+@location(53) f450: vec2<u32>,
+@location(85) f451: vec2<u32>,
+@location(84) f452: i32,
+@location(79) f453: u32,
+@location(23) f454: vec3<f16>,
+@location(67) f455: vec2<f16>,
+@location(49) f456: vec2<f32>,
+@location(8) f457: vec4<i32>,
+@location(81) f458: vec2<f32>,
+@location(33) f459: vec4<f16>,
+@location(72) f460: vec2<u32>,
+@location(52) f461: vec3<u32>,
+@location(3) f462: i32,
+@location(22) f463: vec4<f16>,
+@location(35) f464: vec4<f32>,
+@location(66) f465: f32,
+@location(11) f466: vec2<i32>,
+@location(37) f467: vec3<f32>,
+@location(76) f468: u32,
+@location(39) f469: vec2<i32>,
+@location(64) f470: i32,
+@builtin(position) f471: vec4<f32>,
+@location(47) f472: vec2<u32>,
+@location(40) f473: vec2<f16>,
+@location(78) f474: vec3<f32>,
+@location(50) f475: vec2<f32>,
+@location(2) f476: u32,
+@location(70) f477: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec4<u32>, @location(2) a1: f16, a2: S27, @location(10) a3: vec2<i32>, @location(4) a4: vec4<i32>, @location(20) a5: f16, @location(1) a6: vec2<i32>, @location(18) a7: vec3<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let renderBundle87 = renderBundleEncoder80.finish(
+{
+label: '\udcc3\u46b7\ubbad'
+}
+);
+try {
+commandEncoder67.copyBufferToBuffer(
+buffer35,
+372,
+buffer29,
+11444,
+532
+);
+dissociateBuffer(device1, buffer35);
+dissociateBuffer(device1, buffer29);
+} catch {}
+gc();
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let textureView91 = texture80.createView(
+{
+label: '\u020d\uebf8\u304a\u4321\u0276\u{1f725}\u01d7\u060e\u02af\u5f8b\ud639',
+}
+);
+let computePassEncoder47 = commandEncoder78.beginComputePass(
+{
+
+}
+);
+let renderBundleEncoder85 = device2.createRenderBundleEncoder(
+{
+label: '\u97fc\u7157\u83f9\u{1f807}\u0987\ue732',
+colorFormats: [
+'rg32uint',
+'rg8sint',
+'rgba8unorm'
+],
+sampleCount: 758,
+}
+);
+let renderBundle88 = renderBundleEncoder85.finish(
+{
+label: '\u{1fa1a}\u{1f9af}\u{1f9eb}\u{1f8dc}\u1aaa'
+}
+);
+try {
+renderPassEncoder31.setBlendConstant(
+{
+r: 372.5,
+g: 265.5,
+b: -792.7,
+a: -686.8,
+}
+);
+} catch {}
+try {
+renderPassEncoder31.setViewport(
+294.7,
+0.2987,
+354.1,
+0.5298,
+0.9037,
+0.9931
+);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(
+buffer38,
+'uint16'
+);
+} catch {}
+let arrayBuffer7 = buffer32.getMappedRange(
+11288,
+2316
+);
+let bindGroupLayout47 = device4.createBindGroupLayout(
+{
+label: '\u{1fc66}\u4998\u{1f9e1}',
+entries: [
+
+],
+}
+);
+let buffer40 = device4.createBuffer(
+{
+label: '\u01c8\uafa0\u10ee\u61e6\u2a98\ubd87',
+size: 13643,
+usage: GPUBufferUsage.MAP_WRITE,
+}
+);
+let renderBundle89 = renderBundleEncoder78.finish(
+{
+
+}
+);
+let promise27 = buffer40.mapAsync(
+GPUMapMode.WRITE,
+0,
+8032
+);
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let img36 = await imageWithData(44, 143, '#a67e8271', '#1e9d1421');
+let promise28 = adapter1.requestAdapterInfo();
+let querySet63 = device4.createQuerySet(
+{
+label: '\u3fe5\u{1f6db}\u2da3\ud3cc\ufb59\u4b19\u4a70\u02ed\u0379\u{1fbf2}\u{1f6d0}',
+type: 'occlusion',
+count: 2409,
+}
+);
+let texture102 = device4.createTexture(
+{
+size: [109, 5, 26],
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rg32uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rg32uint'
+],
+}
+);
+let textureView92 = texture101.createView(
+{
+label: '\u{1fc3d}\u3eb4\u9263\ud3a9\u0d3e\u{1f77c}\ua800\u1c2e\uf676\u7a2f',
+baseMipLevel: 3,
+mipLevelCount: 5,
+}
+);
+try {
+renderBundleEncoder72.setVertexBuffer(
+82,
+undefined
+);
+} catch {}
+try {
+renderBundleEncoder72.pushDebugGroup(
+'\ud425'
+);
+} catch {}
+let device6 = await adapter9.requestDevice(
+{
+label: '\ua253\u5ff3\u07b0',
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxColorAttachmentBytesPerSample: 57,
+maxVertexAttributes: 23,
+maxVertexBufferArrayStride: 5640,
+maxStorageTexturesPerShaderStage: 21,
+maxStorageBuffersPerShaderStage: 29,
+maxDynamicStorageBuffersPerPipelineLayout: 25019,
+maxBindingsPerBindGroup: 3459,
+maxTextureArrayLayers: 256,
+maxTextureDimension1D: 9782,
+maxTextureDimension2D: 12553,
+maxVertexBuffers: 9,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 246102019,
+maxInterStageShaderVariables: 49,
+maxInterStageShaderComponents: 121,
+},
+}
+);
+let videoFrame19 = new VideoFrame(offscreenCanvas18, {timestamp: 0});
+let pipelineLayout19 = device4.createPipelineLayout(
+{
+label: '\u3da3\u0f71\u639b\u0276\ua593\uac84\ubd5d\uf049',
+bindGroupLayouts: [
+bindGroupLayout47,
+bindGroupLayout47
+],
+}
+);
+let querySet64 = device4.createQuerySet(
+{
+label: '\u{1fcd5}\u{1fc66}\u717b\u88a4\ubee9\ub5ec',
+type: 'occlusion',
+count: 1837,
+}
+);
+let renderBundleEncoder86 = device4.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba16float',
+'bgra8unorm-srgb',
+'rgba32float',
+'r8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 671,
+}
+);
+let sampler70 = device4.createSampler(
+{
+label: '\u02a0\u{1ff15}\u7240\u0025\ue03a\u097b\u{1fce7}\uc387\u219d\u0921\u0119',
+addressModeU: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 60.956,
+lodMaxClamp: 61.568,
+}
+);
+document.body.append('\u24c7\u{1ffaa}\u0b0d');
+let shaderModule28 = device2.createShaderModule(
+{
+code: `
+
+@compute @workgroup_size(2, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: vec4<u32>,
+@location(6) f1: vec2<i32>,
+@location(7) f2: vec2<u32>,
+@location(1) f3: u32,
+@location(5) f4: vec2<i32>,
+@location(0) f5: vec2<u32>,
+@location(3) f6: f32
+}
+
+@fragment
+fn fragment0(@location(16) a0: vec3<f32>, @location(8) a1: vec4<f16>, @location(3) a2: vec4<f32>, @location(19) a3: u32, @location(4) a4: vec2<f32>, @location(9) a5: vec3<f16>, @builtin(position) a6: vec4<f32>, @location(18) a7: vec3<u32>, @builtin(sample_mask) a8: u32, @builtin(front_facing) a9: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S29 {
+@location(0) f0: vec4<i32>,
+@location(17) f1: vec4<f16>,
+@location(25) f2: f32,
+@location(2) f3: vec2<f16>,
+@location(5) f4: vec2<f16>,
+@location(7) f5: vec3<i32>,
+@location(4) f6: u32,
+@location(1) f7: vec3<u32>,
+@location(18) f8: vec2<i32>,
+@location(22) f9: vec3<f16>
+}
+struct VertexOutput0 {
+@location(3) f478: vec4<f32>,
+@location(19) f479: u32,
+@location(18) f480: vec3<u32>,
+@builtin(position) f481: vec4<f32>,
+@location(4) f482: vec2<f32>,
+@location(9) f483: vec3<f16>,
+@location(16) f484: vec3<f32>,
+@location(8) f485: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec2<i32>, @location(26) a1: vec3<f16>, a2: S29, @location(3) a3: u32, @location(23) a4: vec3<f32>, @location(21) a5: vec3<f16>, @location(13) a6: vec4<u32>, @location(10) a7: vec4<f32>, @location(20) a8: f32, @location(19) a9: vec3<f32>, @location(6) a10: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let commandEncoder79 = device2.createCommandEncoder(
+{
+}
+);
+let querySet65 = device2.createQuerySet(
+{
+label: '\u0ebc\uaf4d\u067e\u{1f89a}\uf1c5\u3cb6\u1299\u035c',
+type: 'occlusion',
+count: 3900,
+}
+);
+let renderBundle90 = renderBundleEncoder74.finish(
+{
+
+}
+);
+try {
+renderPassEncoder31.executeBundles([]);
+} catch {}
+try {
+buffer38.destroy();
+} catch {}
+try {
+commandEncoder79.copyBufferToBuffer(
+buffer38,
+35112,
+buffer32,
+39448,
+900
+);
+dissociateBuffer(device2, buffer38);
+dissociateBuffer(device2, buffer32);
+} catch {}
+try {
+commandEncoder79.clearBuffer(
+buffer30,
+2728,
+668
+);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer30,
+3480,
+new DataView(new ArrayBuffer(42932)),
+26959,
+476
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture91,
+  mipLevel: 0,
+  origin: { x: 28, y: 127, z: 89 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 9653524 */{
+offset: 136,
+bytesPerRow: 542,
+rowsPerImage: 362,
+},
+{width: 23, height: 73, depthOrArrayLayers: 50}
+);
+} catch {}
+let renderPassEncoder32 = commandEncoder79.beginRenderPass(
+{
+label: '\u{1f7d2}\u0635',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+{
+view: textureView91,
+depthSlice: 0,
+clearValue: {
+r: -932.5,
+g: 403.7,
+b: -660.3,
+a: -81.05,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined
+],
+occlusionQuerySet: querySet53,
+maxDrawCount: 39344,
+}
+);
+let renderBundle91 = renderBundleEncoder74.finish(
+{
+label: '\u7aba\u0365\ua200\u567e\u0742\u1ad7'
+}
+);
+try {
+renderPassEncoder32.setBlendConstant(
+{
+r: -805.4,
+g: -338.8,
+b: -873.0,
+a: -960.0,
+}
+);
+} catch {}
+try {
+renderPassEncoder31.setScissorRect(
+943,
+0,
+20,
+1
+);
+} catch {}
+try {
+renderPassEncoder32.setStencilReference(
+1926
+);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(
+1,
+buffer26,
+748
+);
+} catch {}
+try {
+renderBundleEncoder60.setVertexBuffer(
+0,
+buffer26,
+372,
+424
+);
+} catch {}
+try {
+device2.pushErrorScope(
+'validation'
+);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture73,
+  mipLevel: 3,
+  origin: { x: 135, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer6,
+/* required buffer size: 373 */{
+offset: 373,
+},
+{width: 55, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await promise28;
+} catch {}
+document.body.append('\u8aeb\u{1fc0c}\u{1f7ba}\u028b\u24bf\u5645\uc192\u0205');
+let sampler71 = device5.createSampler(
+{
+label: '\u08a0\ubd56\u600a\u0d9b\ua4a0\uf2b5\udda3\u212c\u0cd5\u7a4e\ud68b',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 64.621,
+lodMaxClamp: 94.583,
+maxAnisotropy: 1,
+}
+);
+try {
+renderBundleEncoder84.setVertexBuffer(
+4,
+buffer39,
+40856,
+9016
+);
+} catch {}
+try {
+await device5.popErrorScope();
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture93,
+  mipLevel: 1,
+  origin: { x: 419, y: 0, z: 54 },
+  aspect: 'all',
+},
+new Float32Array(arrayBuffer4),
+/* required buffer size: 37528882 */{
+offset: 283,
+bytesPerRow: 787,
+rowsPerImage: 85,
+},
+{width: 126, height: 1, depthOrArrayLayers: 562}
+);
+} catch {}
+try {
+externalTexture3.label = '\u4597\ubca6\u00bf\u0d92\u0f98\u6bf7\uff8b\u3c13\u0a25';
+} catch {}
+let commandBuffer11 = commandEncoder73.finish(
+{
+label: '\u{1fb58}\u09e8\u0195',
+}
+);
+let computePassEncoder48 = commandEncoder67.beginComputePass(
+{
+label: '\u088c\u8b10\uf4d4\ud95a\u0ad1\u{1fe7c}\u{1fed6}\u{1ff50}\uc724\ud530\u0c1f'
+}
+);
+let renderBundle92 = renderBundleEncoder56.finish(
+{
+label: '\u017b\ufdab\uc4e6\u99b4\u{1fb59}\u{1fb1b}\u0880\u3758\u{1f629}\u9da2'
+}
+);
+let sampler72 = device1.createSampler(
+{
+label: '\u06f7\u0017\u1e0d',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 35.437,
+lodMaxClamp: 85.388,
+maxAnisotropy: 18,
+}
+);
+try {
+computePassEncoder46.setPipeline(
+pipeline111
+);
+} catch {}
+try {
+renderBundleEncoder83.setBindGroup(
+2,
+bindGroup29
+);
+} catch {}
+let imageData20 = new ImageData(152, 60);
+let sampler73 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 42.205,
+maxAnisotropy: 4,
+}
+);
+try {
+renderPassEncoder10.setBindGroup(
+4,
+bindGroup4,
+new Uint32Array(5050),
+44,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder30.executeBundles([]);
+} catch {}
+try {
+gpuCanvasContext13.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rg11b10ufloat',
+'rgba8unorm-srgb'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer8,
+21492,
+new Float32Array(31986),
+1200,
+5968
+);
+} catch {}
+document.body.append('\u7410\u{1f9bd}\u3087\u09fe\u255d\u{1fcb0}');
+let device7 = await adapter8.requestDevice(
+{
+label: '\u8d51\u0e8e',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable'
+],
+}
+);
+let img37 = await imageWithData(238, 226, '#d7a5cc79', '#88ce798d');
+let video29 = await videoWithData();
+let renderBundleEncoder87 = device3.createRenderBundleEncoder(
+{
+label: '\u0611\ue2da\u5722\u{1f94d}\ue997\ufbe9\ufef0\u{1fc2d}\u51d7',
+colorFormats: [
+'r16sint',
+'rgba8uint',
+'rgba16float',
+'r32sint',
+'rgb10a2unorm',
+'rg16float',
+'rgb10a2uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 10,
+}
+);
+try {
+gpuCanvasContext4.configure(
+{
+device: device3,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'r16uint',
+'astc-5x5-unorm-srgb',
+'rgba16float'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer33,
+464,
+new DataView(new ArrayBuffer(39724)),
+27416
+);
+} catch {}
+let texture103 = device4.createTexture(
+{
+size: [72, 260, 1],
+mipLevelCount: 8,
+format: 'eac-r11snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'eac-r11snorm',
+'eac-r11snorm',
+'eac-r11snorm'
+],
+}
+);
+let renderBundle93 = renderBundleEncoder86.finish(
+{
+label: '\u02e4\u{1f788}\u{1fda1}\u3dba'
+}
+);
+try {
+await buffer36.mapAsync(
+GPUMapMode.READ,
+10984,
+9980
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture103,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+new BigInt64Array(arrayBuffer4),
+/* required buffer size: 414 */{
+offset: 414,
+rowsPerImage: 220,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\ued7d\u{1fe48}\ua9cd\u0cbc\u505d\u066a\udc57\ud710\u0653\u5cd8\u{1f71d}');
+let texture104 = device3.createTexture(
+{
+label: '\u{1fc39}\u{1f7a0}\u0971\uadef',
+size: {width: 12130, height: 8, depthOrArrayLayers: 1},
+mipLevelCount: 14,
+format: 'astc-10x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder88 = device3.createRenderBundleEncoder(
+{
+label: '\u{1fe57}\u02fb\u9b3a\u012c\u3eac\ufe01\u09d0\uecea\u00ad\u0dc5\u0c40',
+colorFormats: [
+'r16uint',
+'rgba8unorm',
+'rg32uint',
+'r32float',
+'rgb10a2uint',
+'rgba16sint'
+],
+sampleCount: 61,
+depthReadOnly: true,
+}
+);
+let renderBundle94 = renderBundleEncoder82.finish(
+{
+label: '\u094b\u0db0\ud18a\ubcce\ua859\u{1f634}\u7d76\ua38f\u201f\ub2a9\u7eda'
+}
+);
+let sampler74 = device3.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 42.538,
+lodMaxClamp: 71.009,
+}
+);
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+document.body.prepend('\u{1fb52}\udb01\u927f\u3f63\u{1f62f}\ue984\u5f4c\u05f4\u0119\u6c03');
+let commandEncoder80 = device2.createCommandEncoder(
+{
+label: '\u2ab3\ude73\ub872',
+}
+);
+let querySet66 = device2.createQuerySet(
+{
+label: '\u290a\u037a\u4a9d\u0c4a\u0889\u0530\u434d\u09a1\u4812',
+type: 'occlusion',
+count: 1581,
+}
+);
+let renderPassEncoder33 = commandEncoder80.beginRenderPass(
+{
+label: '\u{1f7f3}\ud710\u{1ff85}\u{1f9e2}\u0728',
+colorAttachments: [
+{
+view: textureView76,
+clearValue: {
+r: -184.4,
+g: -886.2,
+b: 961.0,
+a: 619.6,
+},
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet55,
+}
+);
+let renderBundleEncoder89 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+undefined,
+'rg8sint',
+'r16sint',
+'rgba8sint',
+'rgba16uint',
+'r8unorm'
+],
+sampleCount: 98,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder31.end();
+} catch {}
+try {
+renderPassEncoder33.setScissorRect(
+2,
+7,
+5,
+0
+);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(
+buffer38,
+'uint16',
+29494
+);
+} catch {}
+try {
+computePassEncoder45.pushDebugGroup(
+'\u{1fd50}'
+);
+} catch {}
+document.body.prepend('\ubed5\u3ee0\u0204\u0540\u28b6\u1bf0\uf31f\u1dd1');
+let commandEncoder81 = device1.createCommandEncoder(
+{
+label: '\u{1fdc7}\u670b\u22d2\ub574\u5477',
+}
+);
+try {
+computePassEncoder46.end();
+} catch {}
+let promise29 = device1.queue.onSubmittedWorkDone();
+let pipeline118 = await device1.createRenderPipelineAsync(
+{
+label: '\u0a20\u{1f824}',
+layout: pipelineLayout10,
+vertex: {
+module: shaderModule17,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 24648,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x2',
+offset: 18600,
+shaderLocation: 16,
+},
+{
+format: 'float32x4',
+offset: 14104,
+shaderLocation: 6,
+},
+{
+format: 'float16x2',
+offset: 22048,
+shaderLocation: 18,
+},
+{
+format: 'uint16x2',
+offset: 20260,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x2',
+offset: 13340,
+shaderLocation: 20,
+},
+{
+format: 'uint8x4',
+offset: 3752,
+shaderLocation: 7,
+},
+{
+format: 'sint8x4',
+offset: 12332,
+shaderLocation: 17,
+},
+{
+format: 'uint8x2',
+offset: 2808,
+shaderLocation: 11,
+},
+{
+format: 'float16x4',
+offset: 14000,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 6820,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 6796,
+shaderLocation: 12,
+},
+{
+format: 'uint32x3',
+offset: 4908,
+shaderLocation: 13,
+},
+{
+format: 'float32x2',
+offset: 732,
+shaderLocation: 5,
+},
+{
+format: 'unorm16x4',
+offset: 2980,
+shaderLocation: 2,
+},
+{
+format: 'snorm8x4',
+offset: 6272,
+shaderLocation: 10,
+},
+{
+format: 'sint32x3',
+offset: 2800,
+shaderLocation: 15,
+},
+{
+format: 'float32',
+offset: 5920,
+shaderLocation: 1,
+},
+{
+format: 'float32x4',
+offset: 1704,
+shaderLocation: 8,
+},
+{
+format: 'uint32',
+offset: 60,
+shaderLocation: 9,
+},
+{
+format: 'uint32x3',
+offset: 3936,
+shaderLocation: 4,
+},
+{
+format: 'snorm16x4',
+offset: 4484,
+shaderLocation: 14,
+},
+{
+format: 'unorm8x2',
+offset: 4748,
+shaderLocation: 3,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0x8075ba81,
+},
+fragment: {
+module: shaderModule17,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8sint',
+writeMask: 0,
+},
+{
+format: 'rgb10a2uint',
+}
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'invert',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 3029,
+depthBias: 77,
+depthBiasSlopeScale: 43,
+depthBiasClamp: 63,
+},
+}
+);
+document.body.prepend(video23);
+let buffer41 = device6.createBuffer(
+{
+label: '\u0ebc\u{1fd5f}\u8fc5\u6dbe\ucf57\u3dac\u122c\u1351\u4e8a\u{1f983}\uc818',
+size: 36990,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+}
+);
+try {
+gpuCanvasContext10.configure(
+{
+device: device6,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb',
+'rgba8unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+gc();
+document.body.prepend('\u444f\u073f\u0020\ucaab\uccc8\ubdac\u{1fbbd}');
+let offscreenCanvas21 = new OffscreenCanvas(648, 876);
+let video30 = await videoWithData();
+let buffer42 = device6.createBuffer(
+{
+label: '\u7547\uc348\u2dd8\u1e06\u5bb9\u77c3\uee2a\uaec3\u{1fb45}\u55c5',
+size: 16116,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let sampler75 = device6.createSampler(
+{
+label: '\u{1fd67}\u8016\u{1f77e}\u{1fa6f}\u0847',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 82.189,
+lodMaxClamp: 84.405,
+}
+);
+let gpuCanvasContext20 = offscreenCanvas21.getContext('webgpu');
+let imageBitmap23 = await createImageBitmap(img35);
+let querySet67 = device4.createQuerySet(
+{
+label: '\u8d89\u{1f6db}\ua25d\u3bdf\u{1ff82}',
+type: 'occlusion',
+count: 117,
+}
+);
+let textureView93 = texture101.createView(
+{
+label: '\ud218\u{1fe4a}\uceb4\u0af9\u65ba\u923d\u6904',
+format: 'bgra8unorm',
+baseMipLevel: 1,
+mipLevelCount: 5,
+arrayLayerCount: 1,
+}
+);
+try {
+device4.queue.writeTexture(
+{
+  texture: texture101,
+  mipLevel: 8,
+  origin: { x: 3, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 138 */{
+offset: 138,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\u0217\u0a7e\ub0e5\u3cb2');
+let commandEncoder82 = device5.createCommandEncoder();
+let textureView94 = texture93.createView(
+{
+label: '\uf747\u{1f8ab}\u05b0\u7e9c\u{1f9c4}\u491e\u05e9\u09c9\u9da2',
+aspect: 'all',
+baseMipLevel: 4,
+}
+);
+let renderBundle95 = renderBundleEncoder84.finish(
+{
+label: '\ua08c\u008d\u{1fbff}\u{1f7a4}\u0ab1\u{1fec5}\uffac\u9912\u7000\u058c'
+}
+);
+try {
+await device5.queue.onSubmittedWorkDone();
+} catch {}
+try {
+await promise29;
+} catch {}
+document.body.prepend('\ubeb0\u2754\u{1fafa}');
+let commandEncoder83 = device7.createCommandEncoder(
+{
+label: '\u10e3\u43a5\u4f9c\u0f32\u0e88\u191c',
+}
+);
+let sampler76 = device7.createSampler(
+{
+label: '\u4cc0\ued01\u8faa',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 63.899,
+lodMaxClamp: 64.245,
+}
+);
+try {
+gpuCanvasContext10.configure(
+{
+device: device7,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST,
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+await promise27;
+} catch {}
+let buffer43 = device5.createBuffer(
+{
+size: 21367,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let renderBundle96 = renderBundleEncoder79.finish();
+try {
+commandEncoder77.copyTextureToTexture(
+{
+  texture: texture93,
+  mipLevel: 1,
+  origin: { x: 286, y: 0, z: 459 },
+  aspect: 'all',
+},
+{
+  texture: texture93,
+  mipLevel: 2,
+  origin: { x: 112, y: 0, z: 115 },
+  aspect: 'all',
+},
+{width: 3, height: 1, depthOrArrayLayers: 161}
+);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture93,
+  mipLevel: 0,
+  origin: { x: 977, y: 1, z: 138 },
+  aspect: 'all',
+},
+new ArrayBuffer(0),
+/* required buffer size: 61592878 */{
+offset: 388,
+bytesPerRow: 995,
+rowsPerImage: 171,
+},
+{width: 236, height: 0, depthOrArrayLayers: 363}
+);
+} catch {}
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+document.body.prepend('\uf767\ufb27\uc265\u{1fa64}\u7ae1\uff37\u{1f758}\ub1f3');
+let renderBundle97 = renderBundleEncoder56.finish(
+{
+label: '\u9a91\u78d1\u{1fea1}\u{1f92e}\u01a9\ud8a2\u4168'
+}
+);
+try {
+commandEncoder72.copyBufferToBuffer(
+buffer35,
+4204,
+buffer25,
+16316,
+44
+);
+dissociateBuffer(device1, buffer35);
+dissociateBuffer(device1, buffer25);
+} catch {}
+let pipeline119 = device1.createComputePipeline(
+{
+label: '\u0355\u9ff4',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule27,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+device4.queue.writeTexture(
+{
+  texture: texture101,
+  mipLevel: 2,
+  origin: { x: 99, y: 1, z: 112 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 4420835 */{
+offset: 667,
+bytesPerRow: 872,
+rowsPerImage: 37,
+},
+{width: 190, height: 0, depthOrArrayLayers: 138}
+);
+} catch {}
+let promise30 = device6.queue.onSubmittedWorkDone();
+try {
+renderBundleEncoder88.label = '\u{1f879}\u{1ff9d}';
+} catch {}
+let sampler77 = device3.createSampler(
+{
+label: '\u3925\uc9df\u0ced\u05d7\u{1f75b}\u058f\u{1fcf3}\ue9ec\uecf1',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 83.412,
+lodMaxClamp: 86.281,
+}
+);
+try {
+renderBundleEncoder87.pushDebugGroup(
+'\ub9e8'
+);
+} catch {}
+document.body.prepend(canvas2);
+let texture105 = device2.createTexture(
+{
+size: [187, 119, 1],
+mipLevelCount: 3,
+dimension: '2d',
+format: 'rgba8sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+try {
+renderPassEncoder33.end();
+} catch {}
+try {
+renderPassEncoder32.setStencilReference(
+1213
+);
+} catch {}
+try {
+renderBundleEncoder77.setVertexBuffer(
+1,
+buffer26,
+684,
+799
+);
+} catch {}
+let img38 = await imageWithData(8, 125, '#68a1b216', '#94753f83');
+let video31 = await videoWithData();
+try {
+adapter9.label = '\u2b3b\u237e\uaf7e\u69c3\ua01f\u0c7c\u6dcf\u1216\ufc71\u5587\u0447';
+} catch {}
+let bindGroupLayout48 = device6.createBindGroupLayout(
+{
+label: '\u0944\u{1f7eb}\u0191\u3b4d',
+entries: [
+{
+binding: 2994,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+let texture106 = device6.createTexture(
+{
+label: '\u916c\u0d15\ub3a5',
+size: {width: 675, height: 108, depthOrArrayLayers: 63},
+mipLevelCount: 4,
+format: 'astc-5x4-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let textureView95 = texture106.createView(
+{
+label: '\u{1fc3f}\ua0af\ud334',
+dimension: '2d',
+baseMipLevel: 3,
+baseArrayLayer: 59,
+}
+);
+document.body.prepend(canvas8);
+let querySet68 = device1.createQuerySet(
+{
+type: 'occlusion',
+count: 638,
+}
+);
+let textureView96 = texture72.createView(
+{
+label: '\u6374\u516e\u7898\u5e01\u0b8c\u0891\u{1f93d}\ue33a\u1df1',
+dimension: '2d',
+format: 'astc-10x5-unorm',
+baseMipLevel: 4,
+baseArrayLayer: 89,
+}
+);
+try {
+commandEncoder72.clearBuffer(
+buffer28,
+8724,
+932
+);
+dissociateBuffer(device1, buffer28);
+} catch {}
+try {
+device1.queue.submit([
+]);
+} catch {}
+document.body.prepend('\u1613\u47b2\uf58b\u9631\u034a\u{1ff0e}\u0fda\u5fbf');
+let adapter11 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let texture107 = device3.createTexture(
+{
+label: '\u5537\ua265\u{1ff3c}\u9238\u3b60',
+size: [1476, 1, 196],
+mipLevelCount: 10,
+dimension: '3d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg11b10ufloat'
+],
+}
+);
+try {
+device3.queue.writeTexture(
+{
+  texture: texture104,
+  mipLevel: 2,
+  origin: { x: 2020, y: 8, z: 0 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer6),
+/* required buffer size: 575 */{
+offset: 575,
+rowsPerImage: 279,
+},
+{width: 380, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let video32 = await videoWithData();
+let querySet69 = device4.createQuerySet(
+{
+label: '\u6dad\u0521\u0ca5\u{1fc21}\u8d7a\u1842\u6925\u{1ff2a}\u03a1',
+type: 'occlusion',
+count: 1284,
+}
+);
+let renderBundleEncoder90 = device4.createRenderBundleEncoder(
+{
+label: '\u4d3f\uffbf\ub1ca\u0cc5\u{1f757}\ue7e7\u{1febc}',
+colorFormats: [
+'rg11b10ufloat',
+'rgba8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 105,
+stencilReadOnly: true,
+}
+);
+let renderBundle98 = renderBundleEncoder86.finish(
+{
+label: '\u0383\uf78e\u06a3\u3891\u03d1\u{1f8da}\u0d16\ud34c\u55aa'
+}
+);
+let sampler78 = device4.createSampler(
+{
+label: '\u0393\u{1fef5}\u1674\u276e\ud135\u1ffe\ufea1\u8040\u281c\u22fc\u07c8',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 82.455,
+lodMaxClamp: 96.107,
+maxAnisotropy: 12,
+}
+);
+try {
+buffer40.unmap();
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture100,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 28 },
+  aspect: 'all',
+},
+arrayBuffer6,
+/* required buffer size: 3458955 */{
+offset: 705,
+bytesPerRow: 290,
+rowsPerImage: 159,
+},
+{width: 0, height: 8, depthOrArrayLayers: 76}
+);
+} catch {}
+let imageData21 = new ImageData(188, 132);
+let renderBundleEncoder91 = device4.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg32sint',
+'rgba8sint',
+undefined
+],
+sampleCount: 923,
+depthReadOnly: true,
+}
+);
+let sampler79 = device4.createSampler(
+{
+label: '\u76a4\u0e83\u013d\ub73a\u85ee\u{1f60e}\u0c78\u0e12\u071e',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 16.198,
+lodMaxClamp: 45.689,
+compare: 'less',
+}
+);
+document.body.prepend('\u079c\u4a66\u00ae\u040c\u{1f83a}\ufef8');
+let img39 = await imageWithData(211, 39, '#2ef8c2be', '#b71c38d2');
+let querySet70 = device5.createQuerySet(
+{
+label: '\u0ceb\u03ed\u2bf1\u0b97',
+type: 'occlusion',
+count: 3687,
+}
+);
+let texture108 = device5.createTexture(
+{
+label: '\u{1f9c6}\u{1f75d}\u1ed9\u{1f873}\u53b4\uce20\u0f18\u28cc\u30e9\ue038',
+size: {width: 10530, height: 5, depthOrArrayLayers: 180},
+mipLevelCount: 11,
+dimension: '2d',
+format: 'astc-10x5-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-10x5-unorm',
+'astc-10x5-unorm',
+'astc-10x5-unorm'
+],
+}
+);
+let computePassEncoder49 = commandEncoder82.beginComputePass();
+try {
+commandEncoder77.copyTextureToTexture(
+{
+  texture: texture93,
+  mipLevel: 2,
+  origin: { x: 59, y: 0, z: 25 },
+  aspect: 'all',
+},
+{
+  texture: texture93,
+  mipLevel: 3,
+  origin: { x: 5, y: 0, z: 26 },
+  aspect: 'all',
+},
+{width: 172, height: 1, depthOrArrayLayers: 130}
+);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture108,
+  mipLevel: 2,
+  origin: { x: 30, y: 5, z: 65 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 1060195 */{
+offset: 136,
+bytesPerRow: 1059,
+rowsPerImage: 13,
+},
+{width: 490, height: 0, depthOrArrayLayers: 78}
+);
+} catch {}
+let imageBitmap24 = await createImageBitmap(img18);
+let img40 = await imageWithData(271, 298, '#dda324c3', '#bb607fdc');
+let videoFrame20 = new VideoFrame(video26, {timestamp: 0});
+let computePassEncoder50 = commandEncoder81.beginComputePass(
+{
+
+}
+);
+let renderBundle99 = renderBundleEncoder66.finish(
+{
+label: '\u00d2\u61a7'
+}
+);
+let sampler80 = device1.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 3.517,
+lodMaxClamp: 35.216,
+}
+);
+try {
+computePassEncoder44.end();
+} catch {}
+try {
+renderBundleEncoder83.setBindGroup(
+3,
+bindGroup29
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: { x: 10, y: 0, z: 13 },
+  aspect: 'all',
+},
+new Float32Array(arrayBuffer5),
+/* required buffer size: 549257 */{
+offset: 545,
+bytesPerRow: 504,
+rowsPerImage: 8,
+},
+{width: 180, height: 1, depthOrArrayLayers: 137}
+);
+} catch {}
+document.body.prepend('\u0e5e\uf621\uab7f\u8e41\u82ad\ud5b2\u{1feb3}\u{1fb42}\u2bbe\ue942\ua541');
+canvas2.width = 982;
+try {
+window.someLabel = externalTexture2.label;
+} catch {}
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device5,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32float',
+'bgra8unorm',
+'bgra8unorm-srgb',
+'rgba8unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture108,
+  mipLevel: 9,
+  origin: { x: 10, y: 0, z: 59 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(new ArrayBuffer(16)),
+/* required buffer size: 449025 */{
+offset: 577,
+bytesPerRow: 286,
+rowsPerImage: 16,
+},
+{width: 10, height: 0, depthOrArrayLayers: 99}
+);
+} catch {}
+let texture109 = device7.createTexture(
+{
+label: '\u{1f7da}\udee9\u{1f80c}\ua0d1\u9235\u9811\u{1fe67}\u0def\u004c\uc012\ua2df',
+size: [693, 1, 1636],
+mipLevelCount: 5,
+dimension: '3d',
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb'
+],
+}
+);
+let textureView97 = texture109.createView(
+{
+label: '\u{1fc0c}\u476d\ucd25\udc35\u634a\uc1ad\u1d90',
+baseMipLevel: 3,
+mipLevelCount: 1,
+baseArrayLayer: 0,
+}
+);
+try {
+commandEncoder83.copyTextureToTexture(
+{
+  texture: texture109,
+  mipLevel: 0,
+  origin: { x: 388, y: 1, z: 960 },
+  aspect: 'all',
+},
+{
+  texture: texture109,
+  mipLevel: 2,
+  origin: { x: 5, y: 1, z: 39 },
+  aspect: 'all',
+},
+{width: 120, height: 0, depthOrArrayLayers: 368}
+);
+} catch {}
+let texture110 = device4.createTexture(
+{
+label: '\u089e\ud81c\u{1fc3a}\u0a72\ub0f8\u048e\ufef9\u029f',
+size: [110, 168, 1],
+mipLevelCount: 6,
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x8-unorm'
+],
+}
+);
+let renderBundleEncoder92 = device4.createRenderBundleEncoder(
+{
+label: '\u{1f7bd}\u4a7b\u{1f77c}\ubde9\u00ee',
+colorFormats: [
+'rgba16uint',
+'rgba8sint',
+'r32sint',
+'rg32sint',
+'rgba8sint',
+'r8unorm',
+'rg8uint'
+],
+sampleCount: 950,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+document.body.append('\ua2ba\uc40e\u62cf');
+let videoFrame21 = new VideoFrame(canvas12, {timestamp: 0});
+try {
+renderPassEncoder32.beginOcclusionQuery(
+16
+);
+} catch {}
+try {
+renderPassEncoder32.setScissorRect(
+894,
+0,
+78,
+1
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer34,
+88,
+new Float32Array(11876),
+7612,
+76
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 448, height: 11, depthOrArrayLayers: 31}
+*/
+{
+  source: canvas7,
+  origin: { x: 73, y: 314 },
+  flipY: true,
+},
+{
+  texture: texture81,
+  mipLevel: 3,
+  origin: { x: 129, y: 7, z: 22 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 209, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let promise31 = navigator.gpu.requestAdapter(
+{
+}
+);
+try {
+querySet66.label = '\u{1fa16}\uf2e9\u4806\ue81d\u41f3\u0426';
+} catch {}
+let commandEncoder84 = device2.createCommandEncoder(
+{
+label: '\u7dde\u{1fcd6}\u{1fd97}\u2773\u{1fd0b}\ue1bf\u{1f73d}\u{1f7e3}',
+}
+);
+pseudoSubmit(device2, commandEncoder78);
+let sampler81 = device5.createSampler(
+{
+label: '\u8165\u0b7e\ua1d7\u8b69\uca4f\u1b3f\u0d95\u0581\u0cc1',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 18.660,
+lodMaxClamp: 60.887,
+compare: 'greater-equal',
+maxAnisotropy: 1,
+}
+);
+try {
+renderBundleEncoder69.setVertexBuffer(
+6,
+buffer26,
+2216
+);
+} catch {}
+try {
+buffer26.unmap();
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer34,
+348,
+new BigUint64Array(40257),
+29071,
+36
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture80,
+  mipLevel: 0,
+  origin: { x: 242, y: 0, z: 3 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 1854574 */{
+offset: 427,
+bytesPerRow: 1194,
+rowsPerImage: 194,
+},
+{width: 1059, height: 1, depthOrArrayLayers: 9}
+);
+} catch {}
+let offscreenCanvas22 = new OffscreenCanvas(322, 105);
+let videoFrame22 = new VideoFrame(videoFrame18, {timestamp: 0});
+pseudoSubmit(device1, commandEncoder67);
+try {
+computePassEncoder43.setPipeline(
+pipeline111
+);
+} catch {}
+try {
+renderBundleEncoder70.setIndexBuffer(
+buffer25,
+'uint16',
+11292,
+1153
+);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+try {
+commandEncoder72.copyBufferToBuffer(
+buffer25,
+19180,
+buffer29,
+2280,
+700
+);
+dissociateBuffer(device1, buffer25);
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+commandEncoder63.clearBuffer(
+buffer28,
+148,
+7880
+);
+dissociateBuffer(device1, buffer28);
+} catch {}
+let img41 = await imageWithData(160, 48, '#7a759d40', '#e5862363');
+let imageBitmap25 = await createImageBitmap(imageData13);
+let pipelineLayout20 = device6.createPipelineLayout(
+{
+label: '\u{1f60c}\uce36\u16ca',
+bindGroupLayouts: [
+bindGroupLayout48,
+bindGroupLayout48,
+bindGroupLayout48
+],
+}
+);
+let externalTexture6 = device6.importExternalTexture(
+{
+label: '\u{1fdb1}\u0bed\ued5e\u0b6a\u02c5\u{1f774}\u{1f7cc}\u08fc\u0c74\u0a73',
+source: videoFrame7,
+}
+);
+try {
+device6.destroy();
+} catch {}
+let texture111 = device5.createTexture(
+{
+label: '\u5ac3\u0a4c\u0d31\u{1fa5e}\u1244\u{1fec3}',
+size: {width: 5816, height: 4, depthOrArrayLayers: 238},
+mipLevelCount: 8,
+dimension: '2d',
+format: 'astc-4x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+}
+);
+let computePassEncoder51 = commandEncoder77.beginComputePass(
+{
+label: '\u{1ff95}\u03b0\u9dd1'
+}
+);
+let renderBundleEncoder93 = device5.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8unorm-srgb'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 943,
+stencilReadOnly: true,
+}
+);
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+try {
+window.someLabel = externalTexture6.label;
+} catch {}
+offscreenCanvas1.height = 742;
+document.body.append('\ub6d2\u3aa8\ud8bc\u0851\u0749');
+let commandEncoder85 = device5.createCommandEncoder(
+{
+label: '\ua461\u1d13\ubeb1\u0866\u3afb\ubfe4\u868a\u0d91\u0c60\ubdc8',
+}
+);
+try {
+renderBundleEncoder93.setIndexBuffer(
+buffer43,
+'uint32',
+1468,
+4267
+);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture93,
+  mipLevel: 3,
+  origin: { x: 38, y: 0, z: 4 },
+  aspect: 'all',
+},
+new BigInt64Array(arrayBuffer1),
+/* required buffer size: 11790958 */{
+offset: 238,
+bytesPerRow: 356,
+rowsPerImage: 240,
+},
+{width: 16, height: 0, depthOrArrayLayers: 139}
+);
+} catch {}
+try {
+videoFrame18.close();
+} catch {}
+document.body.prepend('\u0e87\u7c96\u0d2e\u80e1\u79dd\u3895\u126b');
+try {
+offscreenCanvas22.getContext('bitmaprenderer');
+} catch {}
+let sampler82 = device7.createSampler(
+{
+label: '\u0ea4\u00d8\u0990\u33e4\u4b65',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+mipmapFilter: 'nearest',
+lodMaxClamp: 28.037,
+maxAnisotropy: 1,
+}
+);
+let offscreenCanvas23 = new OffscreenCanvas(864, 178);
+try {
+offscreenCanvas23.getContext('webgl2');
+} catch {}
+let textureView98 = texture74.createView(
+{
+label: '\u7f43\u476b',
+dimension: '2d-array',
+baseMipLevel: 6,
+}
+);
+let renderBundle100 = renderBundleEncoder55.finish();
+try {
+computePassEncoder42.setBindGroup(
+2,
+bindGroup29
+);
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(
+buffer35,
+3180,
+buffer28,
+3224,
+980
+);
+dissociateBuffer(device1, buffer35);
+dissociateBuffer(device1, buffer28);
+} catch {}
+let pipeline120 = await device1.createRenderPipelineAsync(
+{
+label: '\u07f5\u07a0\uadc1\u9309\u1c18',
+layout: pipelineLayout9,
+vertex: {
+module: shaderModule18,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 7476,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x4',
+offset: 3232,
+shaderLocation: 17,
+},
+{
+format: 'sint32x2',
+offset: 5008,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 31604,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 1856,
+shaderLocation: 3,
+},
+{
+format: 'unorm16x4',
+offset: 28,
+shaderLocation: 16,
+},
+{
+format: 'sint32',
+offset: 1532,
+shaderLocation: 13,
+},
+{
+format: 'float16x2',
+offset: 15212,
+shaderLocation: 9,
+},
+{
+format: 'uint32x4',
+offset: 28116,
+shaderLocation: 5,
+},
+{
+format: 'sint32x4',
+offset: 14284,
+shaderLocation: 7,
+},
+{
+format: 'float16x4',
+offset: 25388,
+shaderLocation: 4,
+},
+{
+format: 'uint32x3',
+offset: 26120,
+shaderLocation: 8,
+},
+{
+format: 'sint8x4',
+offset: 7920,
+shaderLocation: 1,
+},
+{
+format: 'unorm16x2',
+offset: 18668,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x2',
+offset: 30600,
+shaderLocation: 10,
+},
+{
+format: 'float32x2',
+offset: 22408,
+shaderLocation: 0,
+},
+{
+format: 'sint8x2',
+offset: 2494,
+shaderLocation: 20,
+}
+],
+},
+{
+arrayStride: 11428,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 17988,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32',
+offset: 2784,
+shaderLocation: 12,
+},
+{
+format: 'snorm16x4',
+offset: 17408,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x2',
+offset: 4564,
+shaderLocation: 2,
+},
+{
+format: 'uint32x3',
+offset: 11672,
+shaderLocation: 11,
+},
+{
+format: 'uint8x4',
+offset: 16168,
+shaderLocation: 19,
+},
+{
+format: 'sint8x4',
+offset: 15840,
+shaderLocation: 14,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0xd06fae03,
+},
+fragment: {
+module: shaderModule18,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'rg8sint',
+},
+{
+format: 'r16sint',
+},
+{
+format: 'rgba8sint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'constant',
+dstFactor: 'one-minus-dst'
+},
+},
+format: 'r16float',
+writeMask: 0,
+},
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+undefined,
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+failOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'always',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 2746,
+stencilWriteMask: 1292,
+depthBias: 89,
+},
+}
+);
+let canvas18 = document.createElement('canvas');
+let computePassEncoder52 = commandEncoder63.beginComputePass(
+{
+label: '\u0169\u00f0\u026d\uf45a\u50a8'
+}
+);
+let renderBundleEncoder94 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba32uint',
+'rgba32float',
+'bgra8unorm',
+undefined,
+'bgra8unorm',
+'r32float'
+],
+sampleCount: 255,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder68.setBindGroup(
+4,
+bindGroup29,
+new Uint32Array(8916),
+5722,
+0
+);
+} catch {}
+try {
+commandEncoder72.copyBufferToBuffer(
+buffer35,
+1124,
+buffer29,
+3036,
+2632
+);
+dissociateBuffer(device1, buffer35);
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+commandEncoder72.clearBuffer(
+buffer27,
+3024,
+18964
+);
+dissociateBuffer(device1, buffer27);
+} catch {}
+offscreenCanvas17.width = 811;
+document.body.prepend('\u071a\u03ab\u07a6');
+let canvas19 = document.createElement('canvas');
+let querySet71 = device5.createQuerySet(
+{
+label: '\ud18b\u2ad0\u0d2c',
+type: 'occlusion',
+count: 1208,
+}
+);
+try {
+commandEncoder85.pushDebugGroup(
+'\u0d8d'
+);
+} catch {}
+try {
+gpuCanvasContext11.configure(
+{
+device: device5,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg16sint'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+gc();
+document.body.append('\u4c69\u{1fd91}\u63e8');
+let imageData22 = new ImageData(52, 140);
+let texture112 = device1.createTexture(
+{
+label: '\u90c0\uddf2\u010b\u75eb\u{1f90a}\u0e92\u9567\u550a\u38d2\u0df6',
+size: [10768, 8, 209],
+mipLevelCount: 12,
+sampleCount: 1,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundleEncoder95 = device1.createRenderBundleEncoder(
+{
+label: '\ub6d4\u80df\u01c5\u059b\u0258\u0cea',
+colorFormats: [
+'r32sint',
+'rg8unorm',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 369,
+}
+);
+try {
+renderBundleEncoder83.setIndexBuffer(
+buffer25,
+'uint16',
+8192,
+4662
+);
+} catch {}
+try {
+renderBundleEncoder68.setVertexBuffer(
+10,
+buffer28,
+12692,
+1893
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer28,
+4684,
+new DataView(new ArrayBuffer(60610)),
+17781,
+8276
+);
+} catch {}
+let pipeline121 = await promise25;
+document.body.prepend('\ua8f2\u0139\u882e\u5759\uc959\u03c2\u{1f698}\u{1fe09}\uec0c\u01ad\u5b09');
+let img42 = await imageWithData(17, 96, '#c37227cf', '#d530317b');
+let commandEncoder86 = device1.createCommandEncoder(
+{
+label: '\u45ca\uf367\u0d2b\u0e02',
+}
+);
+try {
+renderBundleEncoder70.setIndexBuffer(
+buffer25,
+'uint32',
+16288,
+7333
+);
+} catch {}
+try {
+commandEncoder72.copyBufferToBuffer(
+buffer25,
+2472,
+buffer27,
+16580,
+12620
+);
+dissociateBuffer(device1, buffer25);
+dissociateBuffer(device1, buffer27);
+} catch {}
+try {
+device1.destroy();
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let offscreenCanvas24 = new OffscreenCanvas(584, 613);
+try {
+adapter3.label = '\u54e6\uc6c6\u0b8a\u{1fc5b}\ud8ab\u8273\u024c';
+} catch {}
+let renderBundle101 = renderBundleEncoder84.finish(
+{
+label: '\u78b4\u{1fe7f}\u3b33\ue500\u33f9\u{1f9e4}\uc554\u016c\u6fdf'
+}
+);
+try {
+gpuCanvasContext15.configure(
+{
+device: device5,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16sint'
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+await promise30;
+} catch {}
+gc();
+let imageBitmap26 = await createImageBitmap(imageBitmap6);
+try {
+offscreenCanvas24.getContext('webgpu');
+} catch {}
+let textureView99 = texture75.createView(
+{
+label: '\u0ce7\u7fd4',
+dimension: '2d-array',
+baseMipLevel: 3,
+}
+);
+let computePassEncoder53 = commandEncoder84.beginComputePass(
+{
+label: '\u0230\ua69d\u2642\u{1f701}\u2ddf\uc8a2'
+}
+);
+let renderBundleEncoder96 = device2.createRenderBundleEncoder(
+{
+label: '\u0da4\u0a2e\u927c\u7d84\u0f0a\u{1ff79}\u71d7\u5b35',
+colorFormats: [
+'bgra8unorm-srgb',
+'rgba16float',
+'rg8unorm',
+'r32float',
+'r16sint',
+undefined,
+'rg16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 678,
+}
+);
+let sampler83 = device2.createSampler(
+{
+label: '\u4fb4\u676d\u7383\u0ab3\u8f5a\u9741\u{1fd94}',
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 0.373,
+lodMaxClamp: 76.318,
+compare: 'equal',
+}
+);
+try {
+renderPassEncoder32.setIndexBuffer(
+buffer38,
+'uint16'
+);
+} catch {}
+try {
+renderBundleEncoder69.setIndexBuffer(
+buffer38,
+'uint16',
+22640
+);
+} catch {}
+try {
+computePassEncoder45.popDebugGroup();
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer34,
+524,
+new BigUint64Array(842),
+411,
+0
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 448, height: 11, depthOrArrayLayers: 31}
+*/
+{
+  source: imageBitmap26,
+  origin: { x: 9, y: 5 },
+  flipY: false,
+},
+{
+  texture: texture81,
+  mipLevel: 3,
+  origin: { x: 281, y: 2, z: 3 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 7, height: 9, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline122 = await device2.createRenderPipelineAsync(
+{
+label: '\u{1febf}\u8e83\u0de6\uc531\u5c8a\u{1faef}',
+layout: pipelineLayout14,
+vertex: {
+module: shaderModule24,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 12000,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 9352,
+shaderLocation: 20,
+},
+{
+format: 'float32',
+offset: 2264,
+shaderLocation: 25,
+},
+{
+format: 'uint32x4',
+offset: 8448,
+shaderLocation: 7,
+},
+{
+format: 'sint8x2',
+offset: 2772,
+shaderLocation: 5,
+},
+{
+format: 'snorm8x2',
+offset: 9562,
+shaderLocation: 2,
+},
+{
+format: 'sint16x2',
+offset: 9068,
+shaderLocation: 0,
+},
+{
+format: 'uint16x4',
+offset: 9788,
+shaderLocation: 19,
+},
+{
+format: 'sint32x3',
+offset: 1268,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 12324,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 4980,
+shaderLocation: 18,
+},
+{
+format: 'float32x3',
+offset: 10492,
+shaderLocation: 8,
+},
+{
+format: 'uint8x2',
+offset: 986,
+shaderLocation: 10,
+},
+{
+format: 'float16x2',
+offset: 5560,
+shaderLocation: 17,
+},
+{
+format: 'uint16x2',
+offset: 9572,
+shaderLocation: 9,
+},
+{
+format: 'uint8x2',
+offset: 3968,
+shaderLocation: 4,
+},
+{
+format: 'snorm16x4',
+offset: 9024,
+shaderLocation: 6,
+},
+{
+format: 'uint32x4',
+offset: 1192,
+shaderLocation: 21,
+},
+{
+format: 'float32x2',
+offset: 10204,
+shaderLocation: 12,
+},
+{
+format: 'unorm16x4',
+offset: 12100,
+shaderLocation: 15,
+},
+{
+format: 'sint8x2',
+offset: 6578,
+shaderLocation: 11,
+},
+{
+format: 'float16x2',
+offset: 196,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 9104,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x2',
+offset: 982,
+shaderLocation: 13,
+},
+{
+format: 'snorm8x2',
+offset: 5776,
+shaderLocation: 14,
+},
+{
+format: 'uint16x2',
+offset: 5020,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 3512,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 324,
+attributes: [
+
+],
+},
+{
+arrayStride: 6764,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 372,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 108,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x4',
+offset: 40,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 7944,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 13000,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 4820,
+shaderLocation: 26,
+},
+{
+format: 'sint32x4',
+offset: 4724,
+shaderLocation: 24,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule24,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'never',
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'less-equal',
+passOp: 'invert',
+},
+stencilReadMask: 1729,
+stencilWriteMask: 377,
+depthBias: 47,
+depthBiasSlopeScale: 21,
+depthBiasClamp: 53,
+},
+}
+);
+try {
+canvas18.getContext('webgpu');
+} catch {}
+let bindGroup30 = device4.createBindGroup({
+label: '\u{1f84a}\ue01e',
+layout: bindGroupLayout47,
+entries: [
+
+],
+});
+let sampler84 = device4.createSampler(
+{
+label: '\udd8b\u{1fac5}\ub069\uecb9\uf1cf\u0a57\u0782\u8b80',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 73.887,
+lodMaxClamp: 84.428,
+}
+);
+try {
+renderBundleEncoder72.setBindGroup(
+8,
+bindGroup30
+);
+} catch {}
+try {
+gpuCanvasContext14.configure(
+{
+device: device4,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-12x10-unorm-srgb',
+'bgra8unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+document.body.prepend('\ucc1c\u0dfb\u2963\u5763\u0795\uc0fb\u9ca3\ufc12\u{1f70d}');
+let imageData23 = new ImageData(52, 232);
+try {
+canvas19.getContext('bitmaprenderer');
+} catch {}
+let bindGroupLayout49 = device2.createBindGroupLayout(
+{
+label: '\uaa27\u{1f6f4}\ucb7c\u{1f67f}\u04b2\u7ba8\u{1f6bd}\uc45d\u{1fc5b}\ud223',
+entries: [
+{
+binding: 2364,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '2d' },
+}
+],
+}
+);
+let texture113 = device2.createTexture(
+{
+label: '\u05f0\ubc96\u053f\u59ba\u{1fcde}\u0fd3\u{1fbcd}\u143b\ue73c',
+size: {width: 253, height: 231, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+sampleCount: 1,
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+try {
+renderPassEncoder32.setScissorRect(
+1132,
+0,
+96,
+0
+);
+} catch {}
+try {
+renderPassEncoder32.setViewport(
+817.3,
+0.2852,
+127.7,
+0.4270,
+0.2038,
+0.6183
+);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(
+9,
+buffer26,
+1172,
+561
+);
+} catch {}
+try {
+renderPassEncoder32.pushDebugGroup(
+'\u08cb'
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer30,
+2728,
+new Int16Array(47343),
+38609,
+740
+);
+} catch {}
+video17.height = 155;
+canvas8.height = 332;
+let imageData24 = new ImageData(48, 112);
+let commandEncoder87 = device7.createCommandEncoder(
+{
+label: '\uf6f0\u{1f74f}\u0c2f\u98d3\u1658\u{1fcd9}\u{1fad9}\u{1fe86}\u741f',
+}
+);
+let texture114 = gpuCanvasContext1.getCurrentTexture();
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+document.body.prepend('\u0e2b\u0f17\u02ac\ud8e6\u5707\u1c7e\u43f8\u{1f760}\uea3c\u{1fc66}');
+let renderBundleEncoder97 = device7.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg16uint',
+'rgba16float',
+'rg8sint',
+undefined,
+'r16float',
+'r16uint',
+'rg8unorm',
+'r8sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 640,
+depthReadOnly: false,
+}
+);
+let sampler85 = device7.createSampler(
+{
+label: '\ub6ba\u0cf0\u{1f961}\u094e',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 5.699,
+lodMaxClamp: 36.175,
+compare: 'greater',
+maxAnisotropy: 4,
+}
+);
+try {
+renderBundleEncoder97.setVertexBuffer(
+54,
+undefined,
+3725338067,
+53605792
+);
+} catch {}
+try {
+device7.queue.copyExternalImageToTexture(
+/*
+{width: 173, height: 1, depthOrArrayLayers: 409}
+*/
+{
+  source: img10,
+  origin: { x: 20, y: 96 },
+  flipY: true,
+},
+{
+  texture: texture109,
+  mipLevel: 2,
+  origin: { x: 84, y: 0, z: 52 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 69, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\u0091\u{1fa36}\u4b68\u91f5\u5516\ucac7\u{1f6d9}\u378f\u8511\u0bc3\u23d2');
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+offscreenCanvas14.height = 637;
+let texture115 = device4.createTexture(
+{
+label: '\ucf53\ub90f\ua68e\u6c12\u9441\u44d4\u{1faf7}',
+size: {width: 2851},
+dimension: '1d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+renderBundleEncoder92.setBindGroup(
+2,
+bindGroup30,
+[]
+);
+} catch {}
+try {
+renderBundleEncoder72.setVertexBuffer(
+53,
+undefined,
+2137844963,
+2151680712
+);
+} catch {}
+let commandEncoder88 = device7.createCommandEncoder(
+{
+label: '\ude3a\u9339\u{1faab}\u9f01\u9c79\u5fd4\ued21\u{1fe3d}\ud730\uba94\udd3d',
+}
+);
+let renderBundleEncoder98 = device7.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba16float',
+'rgb10a2unorm',
+'r8uint',
+'r8sint',
+'r32uint',
+'rg32uint'
+],
+sampleCount: 607,
+stencilReadOnly: true,
+}
+);
+try {
+commandEncoder88.copyTextureToTexture(
+{
+  texture: texture109,
+  mipLevel: 2,
+  origin: { x: 9, y: 0, z: 336 },
+  aspect: 'all',
+},
+{
+  texture: texture109,
+  mipLevel: 3,
+  origin: { x: 18, y: 0, z: 178 },
+  aspect: 'all',
+},
+{width: 64, height: 1, depthOrArrayLayers: 20}
+);
+} catch {}
+try {
+commandEncoder88.insertDebugMarker(
+'\u{1fd11}'
+);
+} catch {}
+pseudoSubmit(device5, commandEncoder85);
+let textureView100 = texture111.createView(
+{
+label: '\ud8ed\u87fa\u42d7\ufab6',
+dimension: '2d',
+format: 'astc-4x4-unorm-srgb',
+baseMipLevel: 5,
+mipLevelCount: 1,
+baseArrayLayer: 180,
+}
+);
+let renderBundleEncoder99 = device5.createRenderBundleEncoder(
+{
+label: '\u{1f9ac}\u3cac\u{1fa84}\u653c\uaa90\u0ac9',
+colorFormats: [
+'rgb10a2unorm',
+'r8sint',
+'r32float',
+undefined,
+undefined
+],
+sampleCount: 119,
+stencilReadOnly: true,
+}
+);
+let externalTexture7 = device5.importExternalTexture(
+{
+label: '\u0bed\ud065\u{1fea9}',
+source: video30,
+colorSpace: 'srgb',
+}
+);
+let imageData25 = new ImageData(176, 156);
+document.body.prepend(img26);
+let canvas20 = document.createElement('canvas');
+let imageData26 = new ImageData(196, 196);
+let gpuCanvasContext21 = canvas20.getContext('webgpu');
+gc();
+try {
+window.someLabel = sampler77.label;
+} catch {}
+let renderBundle102 = renderBundleEncoder75.finish(
+{
+label: '\ub29b\u{1fb28}\u{1faa0}'
+}
+);
+let sampler86 = device3.createSampler(
+{
+label: '\u980e\u{1f72a}\u{1f9e5}\u0891\ufbf2\u{1f9b4}\ua06b\ueb0e',
+addressModeU: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 29.203,
+lodMaxClamp: 42.596,
+}
+);
+try {
+device3.queue.writeTexture(
+{
+  texture: texture107,
+  mipLevel: 9,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 405 */{
+offset: 405,
+},
+{width: 2, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let promise32 = device3.queue.onSubmittedWorkDone();
+let offscreenCanvas25 = new OffscreenCanvas(103, 413);
+let texture116 = device5.createTexture(
+{
+label: '\u94bd\ub8e7\u34c4\u{1fc13}\u{1f710}\ubf79\u0826\u{1fd02}\u{1ff37}\u{1fdfc}\u0002',
+size: [3830, 72, 1],
+mipLevelCount: 12,
+format: 'rgba32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder100 = device5.createRenderBundleEncoder(
+{
+label: '\u0d0d\u748f\u9c81\u9b04',
+colorFormats: [
+'bgra8unorm',
+'bgra8unorm-srgb',
+'rgba16uint',
+'r16sint',
+'rgba32uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 644,
+depthReadOnly: true,
+}
+);
+let bindGroup31 = device4.createBindGroup({
+layout: bindGroupLayout47,
+entries: [
+
+],
+});
+let commandEncoder89 = device4.createCommandEncoder(
+{
+label: '\udebe\u12c8\uee11\uc1c1\u5fa0\u56ba\u0011\ubaed\u1536\ued34',
+}
+);
+try {
+await buffer40.mapAsync(
+GPUMapMode.WRITE,
+0,
+4764
+);
+} catch {}
+gc();
+let offscreenCanvas26 = new OffscreenCanvas(1023, 115);
+try {
+adapter2.label = '\u{1f76f}\u538c\u0281\u0ca5\u0abe';
+} catch {}
+let renderBundle103 = renderBundleEncoder99.finish(
+{
+
+}
+);
+let adapter12 = await navigator.gpu.requestAdapter();
+try {
+offscreenCanvas26.getContext('bitmaprenderer');
+} catch {}
+let shaderModule29 = device3.createShaderModule(
+{
+label: '\u06c5\u99ea\u0f63\u{1f757}\ub03d\uc40c\u0433\u9ee9\u029f',
+code: `@group(3) @binding(2304)
+var<storage, read_write> local4: array<u32>;
+
+@compute @workgroup_size(8, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: vec4<f32>,
+@location(0) f1: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(6) a0: vec4<f32>, @builtin(sample_mask) a1: u32, @location(12) a2: f16, @builtin(position) a3: vec4<f32>, @location(22) a4: vec4<f32>, @location(19) a5: vec4<i32>, @location(30) a6: vec4<f32>, @location(27) a7: u32, @location(25) a8: f32, @location(20) a9: f16, @location(13) a10: vec2<i32>, @location(24) a11: vec2<u32>, @location(26) a12: vec3<i32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S30 {
+@location(4) f0: i32,
+@location(1) f1: i32
+}
+struct VertexOutput0 {
+@location(24) f486: vec2<u32>,
+@location(30) f487: vec4<f32>,
+@location(26) f488: vec3<i32>,
+@location(0) f489: vec2<f32>,
+@location(13) f490: vec2<i32>,
+@location(7) f491: vec2<u32>,
+@location(25) f492: f32,
+@location(12) f493: f16,
+@location(29) f494: f16,
+@location(15) f495: vec2<f16>,
+@location(22) f496: vec4<f32>,
+@location(31) f497: vec3<u32>,
+@location(3) f498: vec2<f16>,
+@location(28) f499: vec4<u32>,
+@location(27) f500: u32,
+@location(19) f501: vec4<i32>,
+@location(6) f502: vec4<f32>,
+@location(1) f503: vec3<i32>,
+@location(20) f504: f16,
+@builtin(position) f505: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec2<f32>, @location(3) a1: vec2<f16>, @location(0) a2: vec4<i32>, @location(6) a3: vec2<i32>, @location(16) a4: vec4<f32>, @builtin(vertex_index) a5: u32, @location(8) a6: vec3<f16>, @location(2) a7: vec3<i32>, @location(10) a8: vec2<f32>, @location(5) a9: vec4<u32>, @builtin(instance_index) a10: u32, a11: S30, @location(7) a12: u32, @location(9) a13: u32, @location(13) a14: f16, @location(14) a15: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let querySet72 = device3.createQuerySet(
+{
+label: '\uc613\u0a29\ua894',
+type: 'occlusion',
+count: 3753,
+}
+);
+let renderBundle104 = renderBundleEncoder82.finish(
+{
+label: '\u{1fe79}\u13dc'
+}
+);
+let gpuCanvasContext22 = offscreenCanvas25.getContext('webgpu');
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+canvas1.height = 857;
+let renderBundle105 = renderBundleEncoder99.finish();
+let video33 = await videoWithData();
+try {
+window.someLabel = device1.label;
+} catch {}
+let videoFrame23 = new VideoFrame(img32, {timestamp: 0});
+let commandEncoder90 = device7.createCommandEncoder(
+{
+label: '\u5a7b\ub89a\u0956\u{1fa9d}',
+}
+);
+let commandBuffer12 = commandEncoder87.finish();
+pseudoSubmit(device7, commandEncoder83);
+let texture117 = gpuCanvasContext14.getCurrentTexture();
+let textureView101 = texture109.createView(
+{
+label: '\ue2e0\u{1fa17}',
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+try {
+device7.queue.writeTexture(
+{
+  texture: texture117,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 912 */{
+offset: 912,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let video34 = await videoWithData();
+try {
+renderBundleEncoder100.setVertexBuffer(
+1,
+buffer43,
+18172,
+149
+);
+} catch {}
+gc();
+document.body.append('\ue49c\uc13f\uff21\u{1f85c}\u9e07\u007d\u6705\u6a16\u764e\ud834\u513c');
+let canvas21 = document.createElement('canvas');
+let commandBuffer13 = commandEncoder88.finish(
+{
+}
+);
+let renderBundleEncoder101 = device7.createRenderBundleEncoder(
+{
+label: '\u{1fcc1}\u00f7\u0fb3\u07bf\u{1fe50}\u53aa\u{1fcc4}',
+colorFormats: [
+'rgb10a2unorm',
+'rg16uint',
+'bgra8unorm-srgb'
+],
+sampleCount: 19,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+commandEncoder90.copyTextureToTexture(
+{
+  texture: texture109,
+  mipLevel: 3,
+  origin: { x: 41, y: 0, z: 38 },
+  aspect: 'all',
+},
+{
+  texture: texture117,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let imageData27 = new ImageData(152, 256);
+let shaderModule30 = device3.createShaderModule(
+{
+label: '\u4f98\u{1f686}\ub11f\u8d53\u0cdd\u0098\u0808\u{1fead}\u9e4a',
+code: `@group(8) @binding(2304)
+var<storage, read_write> field4: array<u32>;
+
+@compute @workgroup_size(4, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S32 {
+@location(1) f0: i32,
+@builtin(position) f1: vec4<f32>,
+@location(14) f2: f32,
+@builtin(sample_mask) f3: u32,
+@location(28) f4: vec3<i32>,
+@location(2) f5: u32,
+@location(0) f6: vec4<f16>
+}
+struct FragmentOutput0 {
+@location(5) f0: vec2<f32>,
+@location(2) f1: vec2<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @location(12) a1: f16, @location(29) a2: vec2<i32>, @location(11) a3: f16, @builtin(front_facing) a4: bool, @location(20) a5: vec2<f16>, a6: S32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S31 {
+@location(15) f0: vec3<u32>,
+@location(3) f1: f32,
+@location(12) f2: vec2<f16>,
+@location(9) f3: vec3<f32>,
+@builtin(instance_index) f4: u32,
+@location(8) f5: vec2<i32>,
+@location(2) f6: vec4<i32>
+}
+struct VertexOutput0 {
+@location(25) f506: vec4<f32>,
+@location(29) f507: vec2<i32>,
+@location(31) f508: vec4<u32>,
+@location(14) f509: f32,
+@location(9) f510: f32,
+@location(11) f511: f16,
+@location(1) f512: i32,
+@location(26) f513: vec2<f16>,
+@location(20) f514: vec2<f16>,
+@location(0) f515: vec4<f16>,
+@location(28) f516: vec3<i32>,
+@location(4) f517: f16,
+@location(15) f518: vec3<i32>,
+@builtin(position) f519: vec4<f32>,
+@location(17) f520: vec4<f16>,
+@location(19) f521: vec4<u32>,
+@location(12) f522: f16,
+@location(2) f523: u32,
+@location(3) f524: vec3<f32>
+}
+
+@vertex
+fn vertex0(a0: S31, @location(1) a1: vec2<i32>, @location(13) a2: u32, @location(10) a3: vec4<f16>, @location(11) a4: vec3<i32>, @location(14) a5: vec2<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let commandEncoder91 = device3.createCommandEncoder();
+let textureView102 = texture99.createView(
+{
+label: '\u{1fe67}\udda3\u{1f88b}\u674c\ub000\u025a\ua383',
+dimension: '1d',
+}
+);
+let computePassEncoder54 = commandEncoder91.beginComputePass(
+{
+label: '\ue302\u0c99\u5f60'
+}
+);
+try {
+device3.queue.writeBuffer(
+buffer33,
+22704,
+new DataView(new ArrayBuffer(10819)),
+3149,
+276
+);
+} catch {}
+let pipeline123 = device3.createComputePipeline(
+{
+layout: 'auto',
+compute: {
+module: shaderModule30,
+entryPoint: 'compute0',
+},
+}
+);
+let offscreenCanvas27 = new OffscreenCanvas(253, 192);
+let commandEncoder92 = device4.createCommandEncoder(
+{
+label: '\u02c0\u{1f7ea}\uf131',
+}
+);
+let computePassEncoder55 = commandEncoder89.beginComputePass(
+{
+label: '\u4065\u165b\ua6c6\u76f6\ud2db'
+}
+);
+let renderBundle106 = renderBundleEncoder86.finish(
+{
+label: '\u1a66\u83bf\u0836\ubc8e\u0eee\u37d7\u{1feeb}\u{1fbe5}'
+}
+);
+try {
+computePassEncoder55.setBindGroup(
+1,
+bindGroup30,
+new Uint32Array(4201),
+2519,
+0
+);
+} catch {}
+try {
+computePassEncoder55.end();
+} catch {}
+try {
+commandEncoder92.copyTextureToTexture(
+{
+  texture: texture103,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture103,
+  mipLevel: 4,
+  origin: { x: 0, y: 16, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+try {
+offscreenCanvas27.getContext('bitmaprenderer');
+} catch {}
+try {
+renderBundleEncoder72.setBindGroup(
+8,
+bindGroup31,
+new Uint32Array(3732),
+2067,
+0
+);
+} catch {}
+try {
+await promise32;
+} catch {}
+let bindGroup32 = device2.createBindGroup({
+label: '\u052a\u09c8\u08db\u07f9\ua854\u31e9\u05e1\uf5f0\u{1ff79}\ubc93',
+layout: bindGroupLayout41,
+entries: [
+
+],
+});
+let textureView103 = texture84.createView(
+{
+label: '\u0230\ufd8f\uac5b\u0b1f\u00c8\u26d0\u{1f72b}',
+arrayLayerCount: 1,
+}
+);
+try {
+renderPassEncoder32.setStencilReference(
+3923
+);
+} catch {}
+try {
+renderBundleEncoder67.setBindGroup(
+1,
+bindGroup32
+);
+} catch {}
+try {
+buffer30.unmap();
+} catch {}
+try {
+await buffer30.mapAsync(
+GPUMapMode.READ,
+0,
+2940
+);
+} catch {}
+let pipeline124 = await device2.createRenderPipelineAsync(
+{
+layout: pipelineLayout18,
+vertex: {
+module: shaderModule24,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 10192,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 1352,
+shaderLocation: 19,
+},
+{
+format: 'uint32x3',
+offset: 10140,
+shaderLocation: 10,
+},
+{
+format: 'float16x4',
+offset: 9988,
+shaderLocation: 6,
+},
+{
+format: 'uint16x2',
+offset: 7692,
+shaderLocation: 3,
+},
+{
+format: 'sint16x4',
+offset: 6100,
+shaderLocation: 11,
+},
+{
+format: 'uint32x4',
+offset: 3700,
+shaderLocation: 7,
+},
+{
+format: 'uint8x4',
+offset: 220,
+shaderLocation: 21,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 4064,
+shaderLocation: 22,
+},
+{
+format: 'uint8x4',
+offset: 5132,
+shaderLocation: 9,
+},
+{
+format: 'snorm8x4',
+offset: 3772,
+shaderLocation: 1,
+},
+{
+format: 'snorm8x4',
+offset: 6340,
+shaderLocation: 20,
+},
+{
+format: 'float32x2',
+offset: 5012,
+shaderLocation: 17,
+},
+{
+format: 'unorm8x2',
+offset: 9794,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 8864,
+shaderLocation: 12,
+},
+{
+format: 'uint8x2',
+offset: 9924,
+shaderLocation: 4,
+},
+{
+format: 'sint8x2',
+offset: 9090,
+shaderLocation: 23,
+},
+{
+format: 'float32x3',
+offset: 5200,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 1816,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 9260,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x4',
+offset: 2600,
+shaderLocation: 15,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 4800,
+shaderLocation: 16,
+},
+{
+format: 'uint8x4',
+offset: 8336,
+shaderLocation: 26,
+},
+{
+format: 'unorm16x4',
+offset: 1580,
+shaderLocation: 25,
+},
+{
+format: 'uint16x2',
+offset: 3164,
+shaderLocation: 18,
+},
+{
+format: 'sint8x4',
+offset: 7832,
+shaderLocation: 5,
+},
+{
+format: 'sint16x4',
+offset: 7996,
+shaderLocation: 0,
+},
+{
+format: 'sint32',
+offset: 816,
+shaderLocation: 13,
+},
+{
+format: 'snorm8x2',
+offset: 4438,
+shaderLocation: 8,
+},
+{
+format: 'sint8x4',
+offset: 1844,
+shaderLocation: 24,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule24,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'always',
+failOp: 'invert',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'invert',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 2084,
+stencilWriteMask: 969,
+depthBias: 50,
+depthBiasClamp: 85,
+},
+}
+);
+let gpuCanvasContext23 = canvas21.getContext('webgpu');
+let textureView104 = texture107.createView(
+{
+label: '\u3718\u1bf9\u{1f8e3}\u{1f794}\ud711\ubc69',
+aspect: 'all',
+baseMipLevel: 3,
+mipLevelCount: 2,
+}
+);
+try {
+device3.queue.submit([
+commandBuffer10,
+]);
+} catch {}
+let video35 = await videoWithData();
+let renderBundle107 = renderBundleEncoder100.finish(
+{
+label: '\uc312\u6907'
+}
+);
+let sampler87 = device5.createSampler(
+{
+label: '\u{1fb9e}\udc3f\u{1fa95}\u0f1a\u0d71',
+addressModeU: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 46.239,
+lodMaxClamp: 83.763,
+compare: 'equal',
+}
+);
+try {
+gpuCanvasContext13.configure(
+{
+device: device5,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'astc-10x8-unorm',
+'bgra8unorm',
+'astc-5x4-unorm',
+'bgra8unorm'
+],
+}
+);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture116,
+  mipLevel: 0,
+  origin: { x: 2300, y: 52, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer6,
+/* required buffer size: 890 */{
+offset: 890,
+bytesPerRow: 8545,
+},
+{width: 525, height: 4, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.prepend('\u6611\u1696');
+let adapter13 = await promise31;
+let imageData28 = new ImageData(220, 144);
+let bindGroupLayout50 = device7.createBindGroupLayout(
+{
+entries: [
+{
+binding: 335,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let commandEncoder93 = device7.createCommandEncoder(
+{
+label: '\u0f55\u3b89\u{1f9f6}',
+}
+);
+let textureView105 = texture117.createView(
+{
+format: 'astc-12x10-unorm-srgb',
+mipLevelCount: 1,
+}
+);
+try {
+device7.queue.copyExternalImageToTexture(
+/*
+{width: 693, height: 1, depthOrArrayLayers: 1636}
+*/
+{
+  source: imageBitmap8,
+  origin: { x: 151, y: 8 },
+  flipY: false,
+},
+{
+  texture: texture109,
+  mipLevel: 0,
+  origin: { x: 561, y: 0, z: 435 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 77, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+gc();
+document.body.append('\ub15f\u{1fb89}\u7091\u0e92\u5ef4\u0848\u{1ff7f}\u3c91\u5bd2\u8a69');
+let bindGroup33 = device4.createBindGroup({
+layout: bindGroupLayout47,
+entries: [
+
+],
+});
+pseudoSubmit(device4, commandEncoder92);
+let textureView106 = texture100.createView(
+{
+label: '\u0b33\u{1ff39}\u5487\u8c57\u0bc0\u{1f868}\uf85e\uace9\u57aa\ubd11\u0e2e',
+dimension: '2d',
+baseMipLevel: 1,
+mipLevelCount: 2,
+baseArrayLayer: 43,
+}
+);
+let sampler88 = device4.createSampler(
+{
+label: '\u0830\ua2ac\u{1fbc3}\u{1fa1b}\u4509\ua831',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMaxClamp: 7.911,
+}
+);
+try {
+renderBundleEncoder90.setBindGroup(
+4,
+bindGroup30,
+new Uint32Array(1569),
+1074,
+0
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture100,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 18 },
+  aspect: 'all',
+},
+new ArrayBuffer(8),
+/* required buffer size: 8529867 */{
+offset: 577,
+bytesPerRow: 154,
+rowsPerImage: 265,
+},
+{width: 0, height: 0, depthOrArrayLayers: 210}
+);
+} catch {}
+let textureView107 = texture82.createView(
+{
+label: '\u0d82\u0dcd\u0727\u{1ff03}\ud750\u02b1\u5c05\u04aa\ud102\u0c6c\u0523',
+baseMipLevel: 4,
+}
+);
+try {
+renderBundleEncoder83.setBindGroup(
+0,
+bindGroup29
+);
+} catch {}
+try {
+commandEncoder86.copyBufferToBuffer(
+buffer37,
+35972,
+buffer27,
+27036,
+2188
+);
+dissociateBuffer(device1, buffer37);
+dissociateBuffer(device1, buffer27);
+} catch {}
+try {
+commandEncoder86.resolveQuerySet(
+querySet42,
+27,
+237,
+buffer28,
+9472
+);
+} catch {}
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let videoFrame24 = new VideoFrame(canvas13, {timestamp: 0});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+document.body.prepend('\u417a\ua2b7\u082c\udd8c\u58b2\uf15f\u714e');
+let bindGroupLayout51 = device2.createBindGroupLayout(
+{
+label: '\u858e\u0b6e',
+entries: [
+
+],
+}
+);
+let renderBundleEncoder102 = device2.createRenderBundleEncoder(
+{
+label: '\ufcdc\u{1f700}\u1568\u062b',
+colorFormats: [
+'rg32sint',
+'rg32uint',
+'rgba8sint',
+'bgra8unorm',
+'rgba32float'
+],
+sampleCount: 917,
+}
+);
+try {
+renderPassEncoder32.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(
+43,
+undefined,
+1385475890,
+749084950
+);
+} catch {}
+try {
+renderBundleEncoder63.setBindGroup(
+1,
+bindGroup32
+);
+} catch {}
+try {
+renderBundleEncoder89.setVertexBuffer(
+8,
+buffer26,
+1056
+);
+} catch {}
+let pipeline125 = await promise26;
+let videoFrame25 = new VideoFrame(video23, {timestamp: 0});
+try {
+computePassEncoder54.setPipeline(
+pipeline123
+);
+} catch {}
+try {
+querySet61.destroy();
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer33,
+14188,
+new BigUint64Array(8353),
+4002,
+588
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture107,
+  mipLevel: 1,
+  origin: { x: 63, y: 1, z: 7 },
+  aspect: 'all',
+},
+arrayBuffer6,
+/* required buffer size: 25404460 */{
+offset: 60,
+bytesPerRow: 2954,
+rowsPerImage: 172,
+},
+{width: 670, height: 0, depthOrArrayLayers: 51}
+);
+} catch {}
+try {
+renderPassEncoder32.beginOcclusionQuery(
+80
+);
+} catch {}
+try {
+renderPassEncoder32.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder32.setBlendConstant(
+{
+r: -506.0,
+g: -965.9,
+b: -995.1,
+a: -826.2,
+}
+);
+} catch {}
+try {
+await device2.popErrorScope();
+} catch {}
+let adapter14 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let canvas22 = document.createElement('canvas');
+pseudoSubmit(device3, commandEncoder91);
+try {
+renderBundleEncoder87.setVertexBuffer(
+4,
+undefined,
+629089581,
+2003628266
+);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer33,
+21696,
+new BigUint64Array(48420),
+21589,
+32
+);
+} catch {}
+document.body.prepend('\u0b72\ub1a3\u0673\u{1f9d6}\u{1fe1e}\u{1fc92}\u0885\u0a9d\u{1fd81}');
+try {
+window.someLabel = renderPassEncoder33.label;
+} catch {}
+let commandEncoder94 = device2.createCommandEncoder();
+let sampler89 = device2.createSampler(
+{
+label: '\u0bca\u04fe\u01b0\u{1f9cb}\u1c2c\u{1fe71}\u063b\u6c74',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 50.334,
+lodMaxClamp: 82.577,
+maxAnisotropy: 17,
+}
+);
+try {
+computePassEncoder36.setPipeline(
+pipeline105
+);
+} catch {}
+try {
+renderPassEncoder32.beginOcclusionQuery(
+40
+);
+} catch {}
+try {
+renderPassEncoder32.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder63.setVertexBuffer(
+39,
+undefined,
+2986079777,
+155696626
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline126 = device2.createComputePipeline(
+{
+label: '\udec3\u0a10\u02d9\u6e48\u4f6b\u926c\u8b0d\u0363',
+layout: pipelineLayout14,
+compute: {
+module: shaderModule24,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+canvas22.getContext('webgl');
+} catch {}
+let textureView108 = texture85.createView(
+{
+label: '\u058a\u73a0\u{1fbb4}\u06c6\u70f0\ub46d\u6405\u00f3\u4a92\u3505\u{1fdfe}',
+baseMipLevel: 1,
+}
+);
+try {
+commandEncoder86.copyBufferToBuffer(
+buffer37,
+30324,
+buffer27,
+12808,
+9232
+);
+dissociateBuffer(device1, buffer37);
+dissociateBuffer(device1, buffer27);
+} catch {}
+document.body.prepend(video29);
+try {
+window.someLabel = commandEncoder87.label;
+} catch {}
+let texture118 = device7.createTexture(
+{
+label: '\u5784\u7bd8\ubfa8\u{1f637}',
+size: {width: 27, height: 18, depthOrArrayLayers: 41},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8unorm',
+'rg8unorm'
+],
+}
+);
+let renderPassEncoder34 = commandEncoder93.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView101,
+depthSlice: 201,
+clearValue: {
+r: 86.45,
+g: 514.4,
+b: 236.8,
+a: -743.1,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+undefined
+],
+maxDrawCount: 90968,
+}
+);
+let adapter15 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let textureView109 = texture108.createView(
+{
+label: '\u9dcc\u0372\u8ee7\u0251\u0a83\ud0a1\u638c\u0600\u7de9\u{1f97a}',
+baseMipLevel: 8,
+mipLevelCount: 2,
+baseArrayLayer: 29,
+arrayLayerCount: 46,
+}
+);
+let renderBundleEncoder103 = device5.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg8sint',
+'r16float'
+],
+sampleCount: 645,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle108 = renderBundleEncoder99.finish();
+document.body.prepend(canvas1);
+let canvas23 = document.createElement('canvas');
+try {
+canvas23.getContext('webgl');
+} catch {}
+let textureView110 = texture88.createView(
+{
+label: '\u1f1c\u0d41\uf0cf\u08ad\u03d1\u0c15\uab3f',
+dimension: '1d',
+aspect: 'all',
+mipLevelCount: 1,
+arrayLayerCount: 1,
+}
+);
+let sampler90 = device2.createSampler(
+{
+label: '\u7b5e\u6716\uda86\u{1f862}\u49b9\u5781\u0268\u{1f9cb}\uc0a4',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 14.729,
+lodMaxClamp: 36.342,
+}
+);
+try {
+renderPassEncoder32.setBlendConstant(
+{
+r: -683.7,
+g: -748.2,
+b: 978.9,
+a: -826.5,
+}
+);
+} catch {}
+try {
+renderBundleEncoder81.setBindGroup(
+0,
+bindGroup32
+);
+} catch {}
+try {
+renderBundleEncoder76.setIndexBuffer(
+buffer38,
+'uint32'
+);
+} catch {}
+try {
+renderBundleEncoder69.setVertexBuffer(
+5,
+buffer26,
+1948,
+168
+);
+} catch {}
+let promise33 = device2.queue.onSubmittedWorkDone();
+document.body.prepend('\u0a22\u3cc5\u1ac0\ufba3\u7d44\u8afc\u0f5a');
+let textureView111 = texture118.createView(
+{
+label: '\uceb6\u5c7b\ue6f0',
+baseMipLevel: 1,
+mipLevelCount: 1,
+baseArrayLayer: 0,
+}
+);
+try {
+renderPassEncoder34.setBlendConstant(
+{
+r: 767.6,
+g: 542.2,
+b: 897.1,
+a: 756.6,
+}
+);
+} catch {}
+try {
+renderBundleEncoder101.insertDebugMarker(
+'\u{1fd59}'
+);
+} catch {}
+let promise34 = device7.queue.onSubmittedWorkDone();
+let img43 = await imageWithData(267, 255, '#ad36d806', '#e49cc96c');
+try {
+adapter12.label = '\u{1f635}\u2497';
+} catch {}
+let commandEncoder95 = device2.createCommandEncoder(
+{
+label: '\u{1fb61}\udfef\ucfbe\u{1f7ac}\u8e9a',
+}
+);
+let texture119 = device2.createTexture(
+{
+label: '\uda1f\u0cd7',
+size: {width: 254, height: 1, depthOrArrayLayers: 43},
+mipLevelCount: 2,
+sampleCount: 1,
+format: 'rgba16sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16sint',
+'rgba16sint'
+],
+}
+);
+let renderPassEncoder35 = commandEncoder94.beginRenderPass(
+{
+label: '\udb0c\u{1fd34}\ua1bc\u1537\ud3cd\u9996',
+colorAttachments: [
+{
+view: textureView77,
+depthSlice: 11,
+loadOp: 'load',
+storeOp: 'store'
+}
+],
+maxDrawCount: 100176,
+}
+);
+let renderBundle109 = renderBundleEncoder89.finish(
+{
+
+}
+);
+try {
+computePassEncoder33.setBindGroup(
+3,
+bindGroup32
+);
+} catch {}
+try {
+computePassEncoder40.setBindGroup(
+4,
+bindGroup32,
+new Uint32Array(5162),
+3237,
+0
+);
+} catch {}
+try {
+computePassEncoder53.setPipeline(
+pipeline126
+);
+} catch {}
+try {
+renderPassEncoder32.beginOcclusionQuery(
+72
+);
+} catch {}
+try {
+renderPassEncoder32.setBlendConstant(
+{
+r: 76.20,
+g: -556.5,
+b: 545.7,
+a: 312.6,
+}
+);
+} catch {}
+try {
+commandEncoder95.clearBuffer(
+buffer34
+);
+dissociateBuffer(device2, buffer34);
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb'
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1384, height: 1, depthOrArrayLayers: 12}
+*/
+{
+  source: video13,
+  origin: { x: 3, y: 0 },
+  flipY: false,
+},
+{
+  texture: texture80,
+  mipLevel: 0,
+  origin: { x: 1072, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 11, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline127 = await device2.createComputePipelineAsync(
+{
+layout: 'auto',
+compute: {
+module: shaderModule28,
+entryPoint: 'compute0',
+},
+}
+);
+document.body.prepend('\u{1fba9}\u4865\u{1f682}\u5985\u{1fa0f}\ub3cf\u4590\u3a78\ua680\u5e89\u0697');
+let texture120 = device3.createTexture(
+{
+label: '\u1fd3\u0680',
+size: [120, 120, 1],
+mipLevelCount: 5,
+format: 'eac-r11snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'eac-r11snorm'
+],
+}
+);
+let textureView112 = texture107.createView(
+{
+label: '\ucf4e\u198f\ue9b4\u7343\u6bf1',
+mipLevelCount: 6,
+}
+);
+let renderBundle110 = renderBundleEncoder82.finish(
+{
+label: '\u49ce\uce31\u8901\u0b4b\u835d\ua3d7\u{1fa8a}\u0620\u{1fe6f}\ub7b7\u06f5'
+}
+);
+try {
+gpuCanvasContext6.configure(
+{
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'astc-10x5-unorm',
+'bgra8unorm',
+'bgra8unorm',
+'r8uint'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer33,
+11704,
+new BigUint64Array(63933),
+45790,
+1648
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture104,
+  mipLevel: 12,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Int16Array(arrayBuffer6),
+/* required buffer size: 143 */{
+offset: 143,
+},
+{width: 0, height: 8, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline128 = await device3.createComputePipelineAsync(
+{
+label: '\u4f0d\ue780\u982c',
+layout: pipelineLayout17,
+compute: {
+module: shaderModule29,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline129 = device3.createRenderPipeline(
+{
+layout: pipelineLayout17,
+vertex: {
+module: shaderModule30,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 1324,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 1104,
+shaderLocation: 12,
+},
+{
+format: 'sint16x4',
+offset: 312,
+shaderLocation: 2,
+},
+{
+format: 'float32x2',
+offset: 60,
+shaderLocation: 3,
+},
+{
+format: 'uint16x2',
+offset: 272,
+shaderLocation: 15,
+},
+{
+format: 'unorm8x4',
+offset: 1108,
+shaderLocation: 9,
+},
+{
+format: 'float16x4',
+offset: 1308,
+shaderLocation: 10,
+},
+{
+format: 'uint16x2',
+offset: 0,
+shaderLocation: 13,
+},
+{
+format: 'sint16x4',
+offset: 408,
+shaderLocation: 11,
+},
+{
+format: 'sint32',
+offset: 832,
+shaderLocation: 8,
+},
+{
+format: 'sint32',
+offset: 472,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 4576,
+attributes: [
+{
+format: 'float32x4',
+offset: 180,
+shaderLocation: 14,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+},
+fragment: {
+module: shaderModule30,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+undefined,
+{
+format: 'rg8uint',
+},
+undefined
+],
+},
+depthStencil: {
+format: 'stencil8',
+stencilFront: {
+compare: 'never',
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+passOp: 'keep',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+},
+stencilReadMask: 3791,
+stencilWriteMask: 3986,
+depthBiasClamp: 64,
+},
+}
+);
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+let promise35 = navigator.gpu.requestAdapter(
+{
+}
+);
+let video36 = await videoWithData();
+let imageBitmap27 = await createImageBitmap(img14);
+let promise36 = adapter10.requestAdapterInfo();
+let commandEncoder96 = device2.createCommandEncoder(
+{
+label: '\ufc22\u2fd6\u100e\u{1fe24}',
+}
+);
+try {
+renderPassEncoder32.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder35.setScissorRect(
+1171,
+0,
+57,
+1
+);
+} catch {}
+let arrayBuffer8 = buffer32.getMappedRange(
+11240,
+16
+);
+try {
+buffer34.unmap();
+} catch {}
+try {
+commandEncoder95.resolveQuerySet(
+querySet46,
+308,
+66,
+buffer34,
+0
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1384, height: 1, depthOrArrayLayers: 12}
+*/
+{
+  source: offscreenCanvas13,
+  origin: { x: 41, y: 203 },
+  flipY: false,
+},
+{
+  texture: texture80,
+  mipLevel: 0,
+  origin: { x: 47, y: 0, z: 9 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 566, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline130 = await device2.createComputePipelineAsync(
+{
+label: '\u0051\ua413\u0d1f\ue188\u960b\u950e\u7968\u7941',
+layout: pipelineLayout12,
+compute: {
+module: shaderModule24,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let buffer44 = device2.createBuffer(
+{
+label: '\u0e4e\u01b4\u{1f73b}',
+size: 15449,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let querySet73 = device2.createQuerySet(
+{
+label: '\u044a\u7076\u6c0a',
+type: 'occlusion',
+count: 3997,
+}
+);
+try {
+renderPassEncoder35.setBindGroup(
+0,
+bindGroup32
+);
+} catch {}
+try {
+renderPassEncoder35.setScissorRect(
+1320,
+1,
+49,
+0
+);
+} catch {}
+try {
+renderPassEncoder32.setViewport(
+865.7,
+0.7964,
+68.29,
+0.1208,
+0.6837,
+0.9467
+);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(
+6,
+buffer26,
+2200
+);
+} catch {}
+try {
+renderBundleEncoder96.pushDebugGroup(
+'\u{1f6cf}'
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1384, height: 1, depthOrArrayLayers: 12}
+*/
+{
+  source: imageData5,
+  origin: { x: 27, y: 124 },
+  flipY: false,
+},
+{
+  texture: texture80,
+  mipLevel: 0,
+  origin: { x: 412, y: 0, z: 3 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 100, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let video37 = await videoWithData();
+let texture121 = gpuCanvasContext17.getCurrentTexture();
+let renderBundle111 = renderBundleEncoder98.finish();
+try {
+renderPassEncoder34.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder34.setScissorRect(
+45,
+0,
+123,
+1
+);
+} catch {}
+try {
+renderPassEncoder34.setViewport(
+16.59,
+0.5781,
+133.1,
+0.3297,
+0.9556,
+0.9602
+);
+} catch {}
+try {
+texture109.destroy();
+} catch {}
+try {
+renderPassEncoder34.pushDebugGroup(
+'\u00da'
+);
+} catch {}
+try {
+renderPassEncoder34.popDebugGroup();
+} catch {}
+try {
+await promise33;
+} catch {}
+let buffer45 = device4.createBuffer(
+{
+size: 63420,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+mappedAtCreation: true,
+}
+);
+let textureView113 = texture95.createView(
+{
+label: '\ub75a\u{1f844}\u{1faa2}\u2e18\u2104\u620e\u04cc\u{1f67d}\u094f\uddf9',
+baseMipLevel: 9,
+}
+);
+let renderBundle112 = renderBundleEncoder91.finish(
+{
+
+}
+);
+try {
+renderBundleEncoder90.setBindGroup(
+7,
+bindGroup33
+);
+} catch {}
+let promise37 = device4.popErrorScope();
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundleEncoder104 = device6.createRenderBundleEncoder(
+{
+label: '\u0f67\u{1f8b4}\u09dd\u055c\u1945\u{1fdfe}\u0d2a\u0869\u553c',
+colorFormats: [
+'r8uint',
+'r8uint',
+'r16float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 961,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder104.setVertexBuffer(
+4,
+buffer41
+);
+} catch {}
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+canvas16.width = 967;
+let adapter16 = await navigator.gpu.requestAdapter(
+{
+powerPreference: 'high-performance',
+}
+);
+let bindGroupLayout52 = device5.createBindGroupLayout(
+{
+label: '\u0035\u{1fd0f}\u4329\u0fbf\u1c70\u008b\u{1fa63}\u40f5\u5b1f\u{1f700}',
+entries: [
+{
+binding: 2299,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+let pipelineLayout21 = device5.createPipelineLayout(
+{
+label: '\u0eb7\u{1fbaa}\u5cd9\ue367\u898f\u3f99\u59d9\u0f41\u087c',
+bindGroupLayouts: [
+bindGroupLayout52
+],
+}
+);
+let texture122 = device5.createTexture(
+{
+size: {width: 10214, height: 2, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16float',
+'r16float'
+],
+}
+);
+let renderBundleEncoder105 = device5.createRenderBundleEncoder(
+{
+label: '\u0e3e\u015a\ua96e\u2a7e\u9062',
+colorFormats: [
+'r32float',
+'rg8sint',
+'rg16sint',
+'rgba32uint',
+'rg32float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 83,
+stencilReadOnly: true,
+}
+);
+try {
+await device5.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder97 = device4.createCommandEncoder(
+{
+}
+);
+document.body.append('\u{1f9a2}\u02a3');
+let canvas24 = document.createElement('canvas');
+let img44 = await imageWithData(294, 16, '#1c75ca65', '#92a0907e');
+let commandEncoder98 = device5.createCommandEncoder(
+{
+label: '\u98b5\uf0c3\u023e\ue5f7\ub479\u309b\u{1fae7}\u970f\uc44a\uf372\u{1fbfe}',
+}
+);
+let renderBundle113 = renderBundleEncoder103.finish(
+{
+label: '\ue897\u0c41\u1078\u02e3\u57d0'
+}
+);
+let sampler91 = device5.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 28.755,
+lodMaxClamp: 56.888,
+}
+);
+try {
+renderBundleEncoder105.setVertexBuffer(
+7,
+buffer39,
+20984,
+13936
+);
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(
+/*
+{width: 5107, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img12,
+  origin: { x: 5, y: 35 },
+  flipY: true,
+},
+{
+  texture: texture122,
+  mipLevel: 1,
+  origin: { x: 455, y: 1, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 3, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\u0f3d\ubc40\u9bc1\u{1fafe}\u6220\u31d3\u004d\u{1f7eb}\u9de7');
+let canvas25 = document.createElement('canvas');
+try {
+device3.queue.label = '\u0484\u0436';
+} catch {}
+let shaderModule31 = device3.createShaderModule(
+{
+code: `@group(6) @binding(4613)
+var<storage, read_write> local5: array<u32>;
+
+@compute @workgroup_size(1, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: u32,
+@builtin(sample_mask) f1: u32,
+@location(0) f2: vec3<i32>,
+@location(3) f3: vec4<f32>,
+@location(7) f4: vec2<f32>,
+@location(1) f5: vec3<i32>,
+@location(6) f6: vec4<u32>,
+@builtin(frag_depth) f7: f32,
+@location(2) f8: vec2<f32>,
+@location(5) f9: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(24) a0: vec3<f16>, @location(8) a1: f32, @location(13) a2: vec2<u32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S33 {
+@location(11) f0: vec2<f32>,
+@location(6) f1: vec2<i32>,
+@location(4) f2: vec2<f16>,
+@location(9) f3: vec3<i32>,
+@builtin(instance_index) f4: u32,
+@location(3) f5: vec3<f16>,
+@location(16) f6: vec3<f16>,
+@location(2) f7: i32
+}
+struct VertexOutput0 {
+@location(24) f525: vec3<f16>,
+@location(13) f526: vec2<u32>,
+@location(14) f527: vec3<u32>,
+@location(8) f528: f32,
+@builtin(position) f529: vec4<f32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(14) a1: vec3<f32>, a2: S33, @location(10) a3: vec4<f32>, @location(0) a4: vec2<f32>, @location(13) a5: vec2<u32>, @location(15) a6: vec3<u32>, @location(1) a7: vec3<i32>, @location(12) a8: vec3<f16>, @location(7) a9: vec4<f16>, @location(5) a10: vec2<i32>, @location(8) a11: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+try {
+device3.queue.writeBuffer(
+buffer33,
+7764,
+new Int16Array(59324),
+23784,
+4468
+);
+} catch {}
+try {
+renderPassEncoder34.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder101.setVertexBuffer(
+3,
+undefined,
+2658640843,
+474745338
+);
+} catch {}
+try {
+renderPassEncoder34.insertDebugMarker(
+'\u34d8'
+);
+} catch {}
+try {
+device7.queue.submit([
+commandBuffer13,
+]);
+} catch {}
+try {
+device7.queue.writeTexture(
+{
+  texture: texture121,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer2),
+/* required buffer size: 203 */{
+offset: 199,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let gpuCanvasContext24 = canvas24.getContext('webgpu');
+let renderPassEncoder36 = commandEncoder96.beginRenderPass(
+{
+label: '\u51f2\u{1fa7d}\u0043\u{1fe8e}\u070c\ufff3\u3b1f\u0644\u9a4a\u8365',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+{
+view: textureView76,
+clearValue: {
+r: 997.9,
+g: -492.1,
+b: 985.0,
+a: -266.6,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined,
+undefined
+],
+occlusionQuerySet: querySet55,
+maxDrawCount: 272,
+}
+);
+let sampler92 = device2.createSampler(
+{
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 96.433,
+lodMaxClamp: 99.896,
+}
+);
+try {
+renderPassEncoder35.setIndexBuffer(
+buffer38,
+'uint32',
+15248,
+18595
+);
+} catch {}
+try {
+buffer44.unmap();
+} catch {}
+try {
+commandEncoder95.copyTextureToTexture(
+{
+  texture: texture73,
+  mipLevel: 4,
+  origin: { x: 55, y: 0, z: 2 },
+  aspect: 'all',
+},
+{
+  texture: texture73,
+  mipLevel: 5,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+{width: 45, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 224, height: 5, depthOrArrayLayers: 31}
+*/
+{
+  source: offscreenCanvas10,
+  origin: { x: 3, y: 229 },
+  flipY: true,
+},
+{
+  texture: texture81,
+  mipLevel: 4,
+  origin: { x: 27, y: 3, z: 29 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 22, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline131 = device2.createComputePipeline(
+{
+label: '\u{1f9fb}\uc63e\u225a',
+layout: 'auto',
+compute: {
+module: shaderModule28,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let commandEncoder99 = device5.createCommandEncoder(
+{
+label: '\u{1f775}\u643c\u{1f773}\u1f96\u{1fb10}\u865d\u526a\u01a1\u2233\ud85f',
+}
+);
+let computePassEncoder56 = commandEncoder99.beginComputePass(
+{
+label: '\uc9c4\u6c32\u0977\u{1fd78}\ubca0\u089f\ubc14\u6226\u3354\ub889\u0474'
+}
+);
+try {
+querySet70.destroy();
+} catch {}
+try {
+commandEncoder98.copyTextureToTexture(
+{
+  texture: texture116,
+  mipLevel: 0,
+  origin: { x: 3258, y: 5, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture116,
+  mipLevel: 0,
+  origin: { x: 1602, y: 38, z: 1 },
+  aspect: 'all',
+},
+{width: 59, height: 29, depthOrArrayLayers: 0}
+);
+} catch {}
+let shaderModule32 = device5.createShaderModule(
+{
+label: '\u{1f997}\u28f2\ue9c9\u{1f6a9}\ucf8d\u{1fd89}\u{1f6b1}\u{1fb9c}',
+code: `
+
+@compute @workgroup_size(7, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(1) f0: vec3<u32>,
+@location(2) f1: vec3<i32>,
+@location(3) f2: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(92) a0: vec4<u32>, @location(51) a1: vec3<f16>, @location(72) a2: u32, @location(11) a3: vec4<u32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S34 {
+@location(1) f0: vec2<f32>,
+@location(14) f1: vec3<u32>,
+@builtin(instance_index) f2: u32,
+@location(3) f3: vec2<f16>,
+@builtin(vertex_index) f4: u32,
+@location(7) f5: vec4<f32>,
+@location(11) f6: vec2<f16>,
+@location(10) f7: vec2<f32>,
+@location(16) f8: vec2<u32>
+}
+struct VertexOutput0 {
+@location(1) f530: vec4<i32>,
+@location(48) f531: vec2<u32>,
+@location(72) f532: u32,
+@location(23) f533: vec3<u32>,
+@location(119) f534: vec4<f16>,
+@location(12) f535: vec2<f32>,
+@location(43) f536: vec3<i32>,
+@location(11) f537: vec4<u32>,
+@location(75) f538: vec4<f32>,
+@location(69) f539: vec3<u32>,
+@location(105) f540: vec3<f32>,
+@location(98) f541: vec2<f16>,
+@location(30) f542: i32,
+@location(45) f543: i32,
+@location(82) f544: f16,
+@location(51) f545: vec3<f16>,
+@location(107) f546: vec3<f32>,
+@location(57) f547: vec4<u32>,
+@location(31) f548: f16,
+@location(55) f549: vec3<i32>,
+@location(54) f550: vec2<u32>,
+@location(9) f551: vec2<f16>,
+@location(63) f552: vec3<f16>,
+@location(33) f553: vec4<f16>,
+@location(83) f554: vec3<f16>,
+@location(92) f555: vec4<u32>,
+@location(8) f556: vec4<f32>,
+@builtin(position) f557: vec4<f32>,
+@location(74) f558: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec3<f16>, @location(0) a1: f32, @location(8) a2: vec4<f16>, a3: S34, @location(5) a4: vec4<f16>, @location(2) a5: vec4<f16>, @location(13) a6: vec2<u32>, @location(4) a7: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroup34 = device5.createBindGroup({
+label: '\uf0e3\u0f3f\u009c\u0fe1\uef2a\u050b\ubbe8\ud978',
+layout: bindGroupLayout52,
+entries: [
+{
+binding: 2299,
+resource: sampler87
+}
+],
+});
+let querySet74 = device5.createQuerySet(
+{
+label: '\ueaac\ub482\u09f0\uaa24',
+type: 'occlusion',
+count: 2364,
+}
+);
+let computePassEncoder57 = commandEncoder98.beginComputePass(
+{
+label: '\u38ce\u0c06'
+}
+);
+try {
+computePassEncoder56.setBindGroup(
+7,
+bindGroup34
+);
+} catch {}
+try {
+renderBundleEncoder105.setVertexBuffer(
+8,
+buffer39,
+42848,
+8439
+);
+} catch {}
+try {
+gpuCanvasContext15.configure(
+{
+device: device5,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'astc-10x6-unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(
+/*
+{width: 1276, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 50, y: 55 },
+  flipY: true,
+},
+{
+  texture: texture122,
+  mipLevel: 3,
+  origin: { x: 1045, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 227, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\ub27d\ud3a9\u0605\uc7fc');
+let bindGroupLayout53 = device3.createBindGroupLayout(
+{
+label: '\u0d42\u{1fc26}\u0326',
+entries: [
+
+],
+}
+);
+let texture123 = device3.createTexture(
+{
+size: {width: 7953},
+dimension: '1d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16sint',
+'r16sint'
+],
+}
+);
+let textureView114 = texture104.createView(
+{
+label: '\u{1fed1}\u{1fe3d}\u7114\ua191\u9cb8\u{1fa70}\u252d\u40ac',
+dimension: '2d-array',
+baseMipLevel: 2,
+mipLevelCount: 11,
+}
+);
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+document.body.append('\u0a9b\u77a1\u0d5e\ubc5f\ub971\ue780\u02f4\u99dc');
+let imageBitmap28 = await createImageBitmap(imageBitmap12);
+let texture124 = gpuCanvasContext3.getCurrentTexture();
+try {
+renderPassEncoder36.beginOcclusionQuery(
+8
+);
+} catch {}
+try {
+renderPassEncoder32.setBlendConstant(
+{
+r: 140.4,
+g: 824.1,
+b: 691.9,
+a: 54.57,
+}
+);
+} catch {}
+try {
+renderPassEncoder35.setScissorRect(
+558,
+1,
+762,
+0
+);
+} catch {}
+try {
+renderPassEncoder36.setViewport(
+1.633,
+7.628,
+5.607,
+0.2314,
+0.9189,
+0.9403
+);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(
+buffer38,
+'uint32',
+12748,
+11342
+);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+try {
+gpuCanvasContext13.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float',
+'rgba8unorm-srgb',
+'rgba16float',
+'rg8uint'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1384, height: 1, depthOrArrayLayers: 12}
+*/
+{
+  source: canvas3,
+  origin: { x: 436, y: 99 },
+  flipY: true,
+},
+{
+  texture: texture80,
+  mipLevel: 0,
+  origin: { x: 578, y: 0, z: 8 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 195, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+gc();
+document.body.prepend('\u095d\u1a70\u98df\u64a0\u3a19\u01ec');
+let videoFrame26 = new VideoFrame(img21, {timestamp: 0});
+let textureView115 = texture80.createView(
+{
+label: '\u{1fcac}\u{1f787}\u7e98',
+format: 'r8unorm',
+}
+);
+let sampler93 = device2.createSampler(
+{
+label: '\u{1fec5}\u1773\uf73a\u984d\ucaa2\u7fc4\u{1f611}\u{1ff15}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 43.354,
+lodMaxClamp: 74.682,
+}
+);
+try {
+renderPassEncoder36.setIndexBuffer(
+buffer38,
+'uint16',
+31928,
+4431
+);
+} catch {}
+try {
+renderBundleEncoder69.setBindGroup(
+0,
+bindGroup32
+);
+} catch {}
+try {
+commandEncoder95.copyBufferToBuffer(
+buffer38,
+15996,
+buffer32,
+12104,
+4340
+);
+dissociateBuffer(device2, buffer38);
+dissociateBuffer(device2, buffer32);
+} catch {}
+try {
+commandEncoder95.clearBuffer(
+buffer38,
+14560,
+14916
+);
+dissociateBuffer(device2, buffer38);
+} catch {}
+try {
+renderPassEncoder32.popDebugGroup();
+} catch {}
+let promise38 = device2.queue.onSubmittedWorkDone();
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1384, height: 1, depthOrArrayLayers: 12}
+*/
+{
+  source: img9,
+  origin: { x: 16, y: 186 },
+  flipY: true,
+},
+{
+  texture: texture80,
+  mipLevel: 0,
+  origin: { x: 418, y: 0, z: 2 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 208, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline132 = device2.createRenderPipeline(
+{
+label: '\u0624\u98c0\u3278\u{1fb2d}\uc2e3\u{1fb85}\u2367\u0cc6\u084c\u0cc7',
+layout: pipelineLayout18,
+vertex: {
+module: shaderModule28,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 12616,
+attributes: [
+{
+format: 'sint32x3',
+offset: 7572,
+shaderLocation: 6,
+},
+{
+format: 'snorm8x4',
+offset: 8448,
+shaderLocation: 5,
+},
+{
+format: 'snorm8x2',
+offset: 7964,
+shaderLocation: 10,
+},
+{
+format: 'unorm16x4',
+offset: 8468,
+shaderLocation: 26,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 12016,
+shaderLocation: 23,
+},
+{
+format: 'sint16x2',
+offset: 6660,
+shaderLocation: 15,
+},
+{
+format: 'unorm8x2',
+offset: 10012,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 10672,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x2',
+offset: 4044,
+shaderLocation: 22,
+},
+{
+format: 'unorm8x2',
+offset: 3278,
+shaderLocation: 25,
+},
+{
+format: 'uint32x3',
+offset: 4928,
+shaderLocation: 3,
+},
+{
+format: 'uint32x2',
+offset: 2932,
+shaderLocation: 4,
+},
+{
+format: 'snorm16x2',
+offset: 3012,
+shaderLocation: 20,
+},
+{
+format: 'uint32x2',
+offset: 2772,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 1208,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 712,
+shaderLocation: 19,
+},
+{
+format: 'sint8x2',
+offset: 938,
+shaderLocation: 18,
+},
+{
+format: 'sint32x4',
+offset: 80,
+shaderLocation: 0,
+},
+{
+format: 'sint32x4',
+offset: 628,
+shaderLocation: 7,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 796,
+shaderLocation: 17,
+},
+{
+format: 'uint8x4',
+offset: 592,
+shaderLocation: 1,
+},
+{
+format: 'float16x2',
+offset: 808,
+shaderLocation: 21,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+frontFace: 'cw',
+cullMode: 'back',
+},
+multisample: {
+count: 4,
+mask: 0x8c69aeb6,
+},
+fragment: {
+module: shaderModule28,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.BLUE,
+},
+{
+format: 'r32uint',
+},
+undefined,
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 826,
+stencilWriteMask: 1853,
+depthBiasSlopeScale: 47,
+depthBiasClamp: 99,
+},
+}
+);
+let offscreenCanvas28 = new OffscreenCanvas(720, 27);
+let buffer46 = device5.createBuffer(
+{
+label: '\u034f\u0429\u5258\u5877\uec01\u0295\u955f\ue12f\u07b9',
+size: 20961,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: false,
+}
+);
+let commandEncoder100 = device5.createCommandEncoder(
+{
+label: '\u0a29\ua0dc\ud245\u0722',
+}
+);
+let querySet75 = device5.createQuerySet(
+{
+label: '\u098a\u58ae\u0cb4\u7537\u{1f7f0}\ud7a3\u477b\udb16\u110f',
+type: 'occlusion',
+count: 3719,
+}
+);
+let texture125 = gpuCanvasContext9.getCurrentTexture();
+let renderBundle114 = renderBundleEncoder79.finish(
+{
+label: '\u0ba2\u02c6\u08de\u09be\ud1b8'
+}
+);
+let sampler94 = device5.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 66.036,
+lodMaxClamp: 69.832,
+}
+);
+try {
+computePassEncoder51.setBindGroup(
+8,
+bindGroup34,
+new Uint32Array(1137),
+97,
+0
+);
+} catch {}
+try {
+computePassEncoder41.end();
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+let imageBitmap29 = await createImageBitmap(img7);
+try {
+canvas25.getContext('webgpu');
+} catch {}
+let bindGroup35 = device4.createBindGroup({
+layout: bindGroupLayout47,
+entries: [
+
+],
+});
+let texture126 = device4.createTexture(
+{
+size: [255, 1, 1277],
+mipLevelCount: 10,
+dimension: '3d',
+format: 'rgba8sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8sint',
+'rgba8sint',
+'rgba8sint'
+],
+}
+);
+try {
+renderBundleEncoder92.setBindGroup(
+9,
+bindGroup30,
+[]
+);
+} catch {}
+try {
+renderBundleEncoder72.popDebugGroup();
+} catch {}
+document.body.append('\u{1fd4a}\u272f\u3fc2\u0bd8\u0174');
+let video38 = await videoWithData();
+try {
+adapter4.label = '\ua133\u0505\u{1fcc8}\u0510\u0bba';
+} catch {}
+try {
+offscreenCanvas28.getContext('webgl');
+} catch {}
+let commandEncoder101 = device3.createCommandEncoder(
+{
+label: '\u{1fc91}\u{1f977}\ua835\ub3f5\uf472\u5352\uff2a\uf551\u6ca5\uf734',
+}
+);
+let computePassEncoder58 = commandEncoder101.beginComputePass(
+{
+label: '\u24a0\u{1f7a8}\u{1f876}\u9b54\u1f52\u06ab\u{1f8e2}\u0f5f\ua746\u{1fa49}'
+}
+);
+try {
+renderBundleEncoder88.setVertexBuffer(
+78,
+undefined,
+2698336130,
+1221230320
+);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer33,
+11828,
+new Float32Array(62310),
+18792,
+2168
+);
+} catch {}
+document.body.append('\u{1fb24}\u1b79\u{1f8c0}\u0624\u92c7\u{1f757}\u03b4\u0f5f\u742b\uc084\u039a');
+let bindGroupLayout54 = device7.createBindGroupLayout(
+{
+label: '\u{1ffac}\u36af\u07d5\ub811\ub054\u0cb9\u00bc\u941c\u5d68',
+entries: [
+
+],
+}
+);
+let bindGroup36 = device7.createBindGroup({
+layout: bindGroupLayout54,
+entries: [
+
+],
+});
+let renderBundleEncoder106 = device7.createRenderBundleEncoder(
+{
+label: '\u{1fca8}\u04a4\u1c46\ufe93\ubd6c',
+colorFormats: [
+'r8uint',
+'rgba32float'
+],
+sampleCount: 97,
+}
+);
+let sampler95 = device7.createSampler(
+{
+label: '\u8b09\uba30\u8391\u0851\u07bc\u{1faca}\u72e8\u{1f788}\ucd2d\u988a',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 71.786,
+lodMaxClamp: 97.864,
+}
+);
+try {
+renderPassEncoder34.setBlendConstant(
+{
+r: 355.7,
+g: 0.5213,
+b: -700.3,
+a: 847.6,
+}
+);
+} catch {}
+try {
+renderPassEncoder34.setScissorRect(
+5,
+0,
+44,
+1
+);
+} catch {}
+try {
+renderPassEncoder34.setStencilReference(
+1895
+);
+} catch {}
+try {
+renderPassEncoder34.setViewport(
+159.4,
+0.3169,
+2.354,
+0.5090,
+0.9449,
+0.9558
+);
+} catch {}
+let canvas26 = document.createElement('canvas');
+let commandEncoder102 = device5.createCommandEncoder(
+{
+label: '\u0a25\u{1fc71}\ufe14\u2f3d\u4cd3\uc71d\uceb5',
+}
+);
+try {
+commandEncoder100.copyTextureToTexture(
+{
+  texture: texture93,
+  mipLevel: 0,
+  origin: { x: 460, y: 0, z: 1064 },
+  aspect: 'all',
+},
+{
+  texture: texture93,
+  mipLevel: 1,
+  origin: { x: 158, y: 0, z: 74 },
+  aspect: 'all',
+},
+{width: 342, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await promise36;
+} catch {}
+let commandEncoder103 = device3.createCommandEncoder(
+{
+label: '\u{1ffb3}\ud7e1\u09fd\u{1f60b}\u0e2a\udbcb\ue55a\u3f31\u{1fa09}',
+}
+);
+let sampler96 = device3.createSampler(
+{
+label: '\u0e6e\u{1fbc1}\u1fd8\u{1ff59}\u{1ffd6}',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 82.053,
+lodMaxClamp: 83.984,
+maxAnisotropy: 4,
+}
+);
+try {
+computePassEncoder58.end();
+} catch {}
+try {
+commandEncoder103.copyTextureToBuffer(
+{
+  texture: texture107,
+  mipLevel: 6,
+  origin: { x: 11, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 18784 */
+offset: 18784,
+bytesPerRow: 512,
+buffer: buffer33,
+},
+{width: 4, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device3, buffer33);
+} catch {}
+try {
+commandEncoder103.clearBuffer(
+buffer33,
+3248
+);
+dissociateBuffer(device3, buffer33);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+await promise34;
+} catch {}
+document.body.prepend(img24);
+let img45 = await imageWithData(208, 10, '#927f895e', '#21b094c3');
+let bindGroupLayout55 = device5.createBindGroupLayout(
+{
+label: '\u329b\u{1fdb7}',
+entries: [
+{
+binding: 2785,
+visibility: 0,
+sampler: { type: 'filtering' },
+},
+{
+binding: 3637,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+}
+],
+}
+);
+let querySet76 = device5.createQuerySet(
+{
+label: '\u16b9\ue177\u8296\ub0d8\u2be9\ua905\ube26\u7ac9\u0732',
+type: 'occlusion',
+count: 2784,
+}
+);
+let texture127 = device5.createTexture(
+{
+label: '\u03e0\u0e8f',
+size: {width: 158, height: 1, depthOrArrayLayers: 949},
+mipLevelCount: 9,
+dimension: '3d',
+format: 'r8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let textureView116 = texture122.createView(
+{
+dimension: '2d-array',
+}
+);
+let renderBundle115 = renderBundleEncoder105.finish(
+{
+label: '\u085c\u{1f8c5}\u64d5\u{1f792}\u0460\uae8f\u03b8\u11e3\uc125'
+}
+);
+try {
+commandEncoder74.copyTextureToTexture(
+{
+  texture: texture116,
+  mipLevel: 10,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture116,
+  mipLevel: 1,
+  origin: { x: 91, y: 15, z: 1 },
+  aspect: 'all',
+},
+{width: 3, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline133 = await device5.createRenderPipelineAsync(
+{
+label: '\u8304\u466d\u1f71',
+layout: pipelineLayout21,
+vertex: {
+module: shaderModule32,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 19500,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 10746,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x2',
+offset: 17680,
+shaderLocation: 8,
+},
+{
+format: 'snorm16x4',
+offset: 10920,
+shaderLocation: 0,
+},
+{
+format: 'float32x4',
+offset: 7652,
+shaderLocation: 9,
+},
+{
+format: 'float32x4',
+offset: 14380,
+shaderLocation: 10,
+},
+{
+format: 'float32x3',
+offset: 16964,
+shaderLocation: 11,
+},
+{
+format: 'uint16x4',
+offset: 9008,
+shaderLocation: 16,
+},
+{
+format: 'float16x2',
+offset: 18940,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x4',
+offset: 7996,
+shaderLocation: 2,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 9892,
+shaderLocation: 1,
+},
+{
+format: 'snorm16x2',
+offset: 11548,
+shaderLocation: 5,
+},
+{
+format: 'uint8x4',
+offset: 0,
+shaderLocation: 13,
+},
+{
+format: 'uint32',
+offset: 4044,
+shaderLocation: 4,
+},
+{
+format: 'uint32x3',
+offset: 10144,
+shaderLocation: 14,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule32,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.RED,
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 2421,
+stencilWriteMask: 791,
+depthBias: 3,
+},
+}
+);
+let bindGroup37 = device2.createBindGroup({
+label: '\u42ef\u{1fa2e}\u{1f60c}\ua4bf',
+layout: bindGroupLayout41,
+entries: [
+
+],
+});
+let buffer47 = device2.createBuffer(
+{
+size: 23392,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+let commandEncoder104 = device2.createCommandEncoder(
+{
+label: '\uc676\u9d5d',
+}
+);
+let textureView117 = texture105.createView(
+{
+format: 'rgba8sint',
+baseMipLevel: 1,
+}
+);
+let sampler97 = device2.createSampler(
+{
+label: '\u9883\u635e',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMaxClamp: 98.865,
+compare: 'equal',
+}
+);
+try {
+renderPassEncoder36.setStencilReference(
+2021
+);
+} catch {}
+try {
+renderBundleEncoder67.setVertexBuffer(
+9,
+buffer26
+);
+} catch {}
+try {
+commandEncoder104.resolveQuerySet(
+querySet60,
+662,
+63,
+buffer34,
+0
+);
+} catch {}
+try {
+renderBundleEncoder67.insertDebugMarker(
+'\u5060'
+);
+} catch {}
+try {
+gpuCanvasContext23.configure(
+{
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer34,
+684,
+new BigUint64Array(3668),
+100,
+0
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture124,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new BigInt64Array(arrayBuffer4),
+/* required buffer size: 990 */{
+offset: 990,
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder89.copyTextureToTexture(
+{
+  texture: texture110,
+  mipLevel: 1,
+  origin: { x: 10, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture110,
+  mipLevel: 1,
+  origin: { x: 0, y: 16, z: 1 },
+  aspect: 'all',
+},
+{width: 40, height: 64, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext17.configure(
+{
+device: device4,
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+document.body.append('\u{1fab8}\ua8cc\u2d9b\u{1fde1}\ud6b9\u6285\u047d\u{1f954}\u{1fd79}\u{1ff8d}\u{1f7df}');
+let commandEncoder105 = device7.createCommandEncoder();
+let querySet77 = device7.createQuerySet(
+{
+type: 'occlusion',
+count: 703,
+}
+);
+let renderBundle116 = renderBundleEncoder101.finish(
+{
+
+}
+);
+let sampler98 = device7.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+lodMaxClamp: 95.251,
+maxAnisotropy: 1,
+}
+);
+try {
+gpuCanvasContext1.configure(
+{
+device: device7,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm',
+'astc-10x8-unorm-srgb',
+'bgra8unorm-srgb',
+'astc-6x6-unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let imageData29 = new ImageData(160, 248);
+document.body.append('\ub69a\u{1ff52}');
+let imageBitmap30 = await createImageBitmap(videoFrame20);
+let querySet78 = device3.createQuerySet(
+{
+label: '\ub69c\u27f7\u2df0\u{1f851}\u0f88\u066a\u0f5a\uc3a2\u91a8\u1fd7',
+type: 'occlusion',
+count: 862,
+}
+);
+let renderBundle117 = renderBundleEncoder75.finish(
+{
+label: '\u4b30\u74cc\uab93\u033f'
+}
+);
+try {
+gpuCanvasContext1.configure(
+{
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+document.body.prepend('\u{1fe36}\u0448');
+let imageBitmap31 = await createImageBitmap(video8);
+document.body.prepend('\u0cfb\udecc\u{1f771}\u076c\u5f2c\ua5a4\u31a2\u{1f6ea}\u089f');
+let imageBitmap32 = await createImageBitmap(imageData29);
+try {
+adapter2.label = '\u05e1\ub05f\u9895\u04cb\u{1fdfc}\u0ffc\u{1feec}\u0bda\u7dbd\u4c98\u0c19';
+} catch {}
+try {
+canvas26.getContext('bitmaprenderer');
+} catch {}
+let querySet79 = device5.createQuerySet(
+{
+type: 'occlusion',
+count: 1366,
+}
+);
+let renderBundle118 = renderBundleEncoder84.finish(
+{
+label: '\u24a2\ud1e9\u{1fbf5}\ud35d\u{1fe6d}\u{1fad5}'
+}
+);
+let offscreenCanvas29 = new OffscreenCanvas(822, 480);
+let pipelineLayout22 = device7.createPipelineLayout(
+{
+label: '\u4871\u{1ff8c}\u14ad\u244b\u1f16\uef1f\u5261\ucd50\ub0e0\u0e80',
+bindGroupLayouts: [
+bindGroupLayout50,
+bindGroupLayout54,
+bindGroupLayout54,
+bindGroupLayout50
+],
+}
+);
+let commandEncoder106 = device7.createCommandEncoder(
+{
+}
+);
+let texture128 = device7.createTexture(
+{
+label: '\u0a84\u0c10\ua817\u{1fcbe}\u{1f763}\u{1fb69}\u5f45',
+size: {width: 5490, height: 228, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'astc-10x6-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder107 = device7.createRenderBundleEncoder(
+{
+label: '\ua4b9\uf445\u09c6\u{1fd75}\uab19\ub1f0\uf30f',
+colorFormats: [
+'r16float',
+'rgba8sint',
+'rgba32sint',
+'r8uint',
+'rg16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 928,
+}
+);
+try {
+renderPassEncoder34.setScissorRect(
+117,
+1,
+41,
+0
+);
+} catch {}
+try {
+commandEncoder90.copyTextureToTexture(
+{
+  texture: texture109,
+  mipLevel: 0,
+  origin: { x: 189, y: 1, z: 1161 },
+  aspect: 'all',
+},
+{
+  texture: texture109,
+  mipLevel: 3,
+  origin: { x: 14, y: 0, z: 39 },
+  aspect: 'all',
+},
+{width: 71, height: 0, depthOrArrayLayers: 97}
+);
+} catch {}
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+let videoFrame27 = new VideoFrame(img26, {timestamp: 0});
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let offscreenCanvas30 = new OffscreenCanvas(316, 714);
+let shaderModule33 = device2.createShaderModule(
+{
+label: '\u{1f892}\u308a\u01ce\u13bc\u3258\u9865\u7b05\u{1ff92}\u0b6f',
+code: `@group(0) @binding(4246)
+var<storage, read_write> local6: array<u32>;
+
+@compute @workgroup_size(5, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(7) f0: vec4<i32>,
+@location(4) f1: vec2<f32>,
+@location(6) f2: vec4<u32>,
+@location(5) f3: vec3<f32>,
+@builtin(sample_mask) f4: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(sample_mask) a1: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S35 {
+@location(8) f0: f16,
+@builtin(instance_index) f1: u32,
+@location(11) f2: vec3<f16>,
+@location(14) f3: vec3<u32>,
+@location(5) f4: u32,
+@builtin(vertex_index) f5: u32,
+@location(1) f6: vec2<f32>,
+@location(20) f7: f32,
+@location(24) f8: vec2<i32>,
+@location(6) f9: f16,
+@location(26) f10: vec4<f32>,
+@location(18) f11: vec2<f16>,
+@location(22) f12: i32,
+@location(17) f13: vec2<i32>,
+@location(21) f14: vec3<i32>,
+@location(9) f15: i32
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec2<f16>, @location(15) a1: vec3<i32>, a2: S35, @location(7) a3: vec2<f16>, @location(0) a4: vec2<f32>, @location(4) a5: vec4<f32>, @location(13) a6: vec2<f16>, @location(12) a7: vec4<f16>, @location(3) a8: vec4<f32>, @location(19) a9: vec4<i32>, @location(16) a10: vec2<f16>, @location(2) a11: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder107 = device2.createCommandEncoder();
+let querySet80 = device2.createQuerySet(
+{
+label: '\udec8\u{1fafa}\ud970\u08a9\u0e2e\u0263\u07c3\u0062\u5d16\u970b',
+type: 'occlusion',
+count: 1052,
+}
+);
+let renderPassEncoder37 = commandEncoder104.beginRenderPass(
+{
+label: '\u0da4\u{1fc02}\u88ab\u{1f878}\u{1fa63}\u3612\u{1fa16}',
+colorAttachments: [
+{
+view: textureView77,
+depthSlice: 10,
+clearValue: {
+r: 982.3,
+g: 207.7,
+b: -386.2,
+a: 654.4,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined,
+{
+view: textureView77,
+depthSlice: 5,
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+maxDrawCount: 19120,
+}
+);
+try {
+renderPassEncoder37.setScissorRect(
+8,
+0,
+870,
+1
+);
+} catch {}
+let arrayBuffer9 = buffer47.getMappedRange(
+2216,
+18668
+);
+try {
+commandEncoder95.resolveQuerySet(
+querySet46,
+769,
+8,
+buffer34,
+256
+);
+} catch {}
+let pipeline134 = await device2.createRenderPipelineAsync(
+{
+label: '\u0012\u0b9b\u47b3\ubf4d\u{1f6bf}\u{1ff1f}\u1dee\u0ea1\ue052\ub709',
+layout: pipelineLayout18,
+vertex: {
+module: shaderModule24,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 8212,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32',
+offset: 6256,
+shaderLocation: 12,
+},
+{
+format: 'uint32x3',
+offset: 1448,
+shaderLocation: 26,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 5156,
+shaderLocation: 8,
+},
+{
+format: 'uint8x2',
+offset: 1994,
+shaderLocation: 4,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 5504,
+shaderLocation: 6,
+},
+{
+format: 'sint32x2',
+offset: 2296,
+shaderLocation: 23,
+},
+{
+format: 'sint32x4',
+offset: 2472,
+shaderLocation: 11,
+},
+{
+format: 'uint8x2',
+offset: 7672,
+shaderLocation: 18,
+},
+{
+format: 'uint32x4',
+offset: 4960,
+shaderLocation: 10,
+},
+{
+format: 'unorm8x2',
+offset: 3304,
+shaderLocation: 22,
+},
+{
+format: 'float16x4',
+offset: 6148,
+shaderLocation: 20,
+},
+{
+format: 'uint8x2',
+offset: 7292,
+shaderLocation: 7,
+},
+{
+format: 'uint32',
+offset: 256,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x4',
+offset: 7224,
+shaderLocation: 16,
+},
+{
+format: 'uint8x4',
+offset: 3892,
+shaderLocation: 21,
+},
+{
+format: 'sint8x4',
+offset: 7240,
+shaderLocation: 0,
+},
+{
+format: 'sint32x2',
+offset: 7928,
+shaderLocation: 5,
+},
+{
+format: 'snorm16x2',
+offset: 2100,
+shaderLocation: 14,
+},
+{
+format: 'unorm16x4',
+offset: 1796,
+shaderLocation: 25,
+}
+],
+},
+{
+arrayStride: 5764,
+attributes: [
+{
+format: 'float32x3',
+offset: 1912,
+shaderLocation: 1,
+},
+{
+format: 'sint16x4',
+offset: 236,
+shaderLocation: 13,
+},
+{
+format: 'uint32x3',
+offset: 5240,
+shaderLocation: 3,
+},
+{
+format: 'float32',
+offset: 736,
+shaderLocation: 15,
+},
+{
+format: 'sint32x3',
+offset: 4884,
+shaderLocation: 24,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 7844,
+shaderLocation: 17,
+},
+{
+format: 'float32x4',
+offset: 2424,
+shaderLocation: 2,
+},
+{
+format: 'uint32x3',
+offset: 12684,
+shaderLocation: 19,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+cullMode: 'front',
+},
+multisample: {
+count: 4,
+},
+fragment: {
+module: shaderModule24,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'invert',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'invert',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 3681,
+depthBias: 44,
+depthBiasSlopeScale: 93,
+depthBiasClamp: 81,
+},
+}
+);
+let gpuCanvasContext25 = offscreenCanvas29.getContext('webgpu');
+try {
+await promise37;
+} catch {}
+document.body.append('\u0f30\u{1f95a}\u15f3\u757f\u0e16\u47ab');
+let promise39 = adapter15.requestDevice(
+{
+label: '\u9afd\u7b64\u2f5b\ucbc6\u7973\ub49a',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 7,
+maxColorAttachmentBytesPerSample: 57,
+maxVertexAttributes: 28,
+maxVertexBufferArrayStride: 59556,
+maxStorageTexturesPerShaderStage: 36,
+maxStorageBuffersPerShaderStage: 26,
+maxDynamicStorageBuffersPerPipelineLayout: 8753,
+maxBindingsPerBindGroup: 3953,
+maxTextureArrayLayers: 256,
+maxTextureDimension1D: 13790,
+maxTextureDimension2D: 9382,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 66020138,
+maxInterStageShaderVariables: 82,
+maxInterStageShaderComponents: 120,
+},
+}
+);
+let commandEncoder108 = device5.createCommandEncoder(
+{
+}
+);
+let texture129 = device5.createTexture(
+{
+size: {width: 58, height: 2, depthOrArrayLayers: 149},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16sint',
+'rgba16sint',
+'rgba16sint'
+],
+}
+);
+let renderBundle119 = renderBundleEncoder99.finish(
+{
+label: '\ub49c\ub131\u03ae\ub51c\u07de\u{1f74d}\u2383'
+}
+);
+try {
+renderBundleEncoder93.setVertexBuffer(
+5,
+buffer43,
+8536,
+11371
+);
+} catch {}
+try {
+commandEncoder108.copyTextureToTexture(
+{
+  texture: texture116,
+  mipLevel: 3,
+  origin: { x: 327, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture116,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 26, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let video39 = await videoWithData();
+try {
+await adapter3.requestAdapterInfo();
+} catch {}
+document.body.append('\u394a\uac2d');
+try {
+adapter12.label = '\u{1fc44}\u09b4\ue553\u1a08\u0daf\u{1f630}';
+} catch {}
+try {
+offscreenCanvas30.getContext('webgl2');
+} catch {}
+offscreenCanvas1.height = 646;
+document.body.append('\u00be\u0719\u72ed\u8615\ue3b5');
+let imageData30 = new ImageData(64, 200);
+try {
+await promise38;
+} catch {}
+let bindGroupLayout56 = device3.createBindGroupLayout(
+{
+label: '\u4338\u0ef1\u3872',
+entries: [
+
+],
+}
+);
+let bindGroupLayout57 = pipeline129.getBindGroupLayout(6);
+let computePassEncoder59 = commandEncoder103.beginComputePass(
+{
+label: '\udca7\u801a\u{1fd7f}\u0f90\u0b8c\u9ea1'
+}
+);
+let renderPassEncoder38 = commandEncoder101.beginRenderPass(
+{
+label: '\u0501\u04e0\ub7a5\u05d5\u57dc',
+colorAttachments: [
+undefined,
+undefined,
+{
+view: textureView82,
+depthSlice: 10,
+clearValue: {
+r: 104.1,
+g: 378.9,
+b: 262.8,
+a: 552.1,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined,
+{
+view: textureView82,
+depthSlice: 2,
+clearValue: {
+r: -792.9,
+g: 552.3,
+b: 918.2,
+a: 642.5,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView82,
+depthSlice: 23,
+clearValue: {
+r: -259.3,
+g: -211.0,
+b: 679.0,
+a: 502.5,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined
+],
+occlusionQuerySet: querySet61,
+maxDrawCount: 394888,
+}
+);
+let externalTexture8 = device3.importExternalTexture(
+{
+label: '\u0661\u{1f947}\u028f\ue2dd',
+source: videoFrame12,
+colorSpace: 'display-p3',
+}
+);
+try {
+renderPassEncoder38.setStencilReference(
+2716
+);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(
+85,
+undefined,
+181703285
+);
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+document.body.append('\ue9b7\u02af\u{1ff12}\u{1ff4c}\u4f8e\u0cf4\ue062\uf090\u{1ff1f}\u{1fbbb}');
+let img46 = await imageWithData(29, 36, '#d52853eb', '#7db9c3f5');
+let shaderModule34 = device7.createShaderModule(
+{
+label: '\uf6c6\u{1fb60}\u224b',
+code: `
+
+@compute @workgroup_size(5, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(2) f0: u32,
+@location(4) f1: i32,
+@location(5) f2: vec2<i32>,
+@location(0) f3: vec3<f32>,
+@location(6) f4: i32,
+@location(3) f5: i32,
+@location(1) f6: vec3<i32>,
+@location(7) f7: u32,
+@builtin(frag_depth) f8: f32
+}
+
+@fragment
+fn fragment0(@location(1) a0: vec4<u32>, @location(6) a1: i32, @builtin(front_facing) a2: bool, @location(5) a3: i32, @location(15) a4: vec4<i32>, @location(2) a5: vec3<f16>, @location(8) a6: vec4<f32>, @builtin(position) a7: vec4<f32>, @builtin(sample_mask) a8: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S36 {
+@location(8) f0: f32,
+@location(2) f1: vec2<u32>,
+@builtin(instance_index) f2: u32,
+@location(0) f3: vec2<u32>,
+@location(3) f4: i32,
+@builtin(vertex_index) f5: u32,
+@location(13) f6: vec2<f32>,
+@location(9) f7: vec2<u32>,
+@location(14) f8: vec4<f16>,
+@location(11) f9: vec2<f16>
+}
+struct VertexOutput0 {
+@location(15) f559: vec4<i32>,
+@location(5) f560: i32,
+@location(8) f561: vec4<f32>,
+@location(1) f562: vec4<u32>,
+@location(2) f563: vec3<f16>,
+@location(6) f564: i32,
+@builtin(position) f565: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec4<f16>, a1: S36, @location(6) a2: vec2<i32>, @location(4) a3: vec3<i32>, @location(7) a4: u32, @location(5) a5: vec4<u32>, @location(1) a6: vec3<f16>, @location(10) a7: vec4<f32>, @location(12) a8: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+}
+);
+let renderBundleEncoder108 = device7.createRenderBundleEncoder(
+{
+label: '\u67f7\u09c5\u0b16\ue2d4\ud4bb\u{1f9ba}\ueb8d\ua9ee\u00ff\u3ed7',
+colorFormats: [
+'rg8uint',
+'rgb10a2uint',
+'r8unorm',
+'rgba32float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 781,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder34.executeBundles([]);
+} catch {}
+let promise40 = device7.createRenderPipelineAsync(
+{
+label: '\u051a\u756f\u0feb\u077a\u0aed\u0291\u4975',
+layout: pipelineLayout22,
+vertex: {
+module: shaderModule34,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 56,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 4,
+shaderLocation: 3,
+},
+{
+format: 'snorm8x4',
+offset: 52,
+shaderLocation: 14,
+},
+{
+format: 'uint32x3',
+offset: 36,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x2',
+offset: 12,
+shaderLocation: 11,
+},
+{
+format: 'uint32x2',
+offset: 0,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x4',
+offset: 20,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x4',
+offset: 32,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 684,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 828,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 676,
+shaderLocation: 10,
+},
+{
+format: 'snorm16x4',
+offset: 268,
+shaderLocation: 15,
+},
+{
+format: 'sint32',
+offset: 748,
+shaderLocation: 4,
+},
+{
+format: 'float32x4',
+offset: 316,
+shaderLocation: 13,
+},
+{
+format: 'uint32x3',
+offset: 144,
+shaderLocation: 0,
+},
+{
+format: 'uint32x2',
+offset: 356,
+shaderLocation: 2,
+},
+{
+format: 'sint8x4',
+offset: 200,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 1516,
+attributes: [
+{
+format: 'float32x2',
+offset: 940,
+shaderLocation: 1,
+},
+{
+format: 'uint32x3',
+offset: 992,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+unclippedDepth: false,
+},
+multisample: {
+count: 4,
+mask: 0xf2614aa9,
+},
+fragment: {
+module: shaderModule34,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'equal',
+failOp: 'replace',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'invert',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 1451,
+stencilWriteMask: 3184,
+depthBias: 100,
+depthBiasSlopeScale: 14,
+depthBiasClamp: 25,
+},
+}
+);
+document.body.append('\ub0e9\u0601\u0907\u00e2\ue11d\u2bac\ucbfc\u22de');
+let offscreenCanvas31 = new OffscreenCanvas(258, 744);
+let renderBundle120 = renderBundleEncoder73.finish(
+{
+
+}
+);
+try {
+computePassEncoder59.setPipeline(
+pipeline123
+);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(
+53,
+undefined
+);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer33,
+11944,
+new Float32Array(3443),
+3432
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture104,
+  mipLevel: 3,
+  origin: { x: 300, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Int16Array(arrayBuffer5),
+/* required buffer size: 462 */{
+offset: 462,
+bytesPerRow: 539,
+},
+{width: 170, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let gpuCanvasContext26 = offscreenCanvas31.getContext('webgpu');
+let textureView118 = texture123.createView(
+{
+label: '\u0f62\u93c6\u0b02\uca44\u0643\u{1f783}\u2522',
+}
+);
+let renderBundle121 = renderBundleEncoder82.finish(
+{
+
+}
+);
+try {
+computePassEncoder54.pushDebugGroup(
+'\u99ca'
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture107,
+  mipLevel: 2,
+  origin: { x: 57, y: 0, z: 5 },
+  aspect: 'all',
+},
+new ArrayBuffer(64),
+/* required buffer size: 10778349 */{
+offset: 97,
+bytesPerRow: 1259,
+rowsPerImage: 214,
+},
+{width: 303, height: 1, depthOrArrayLayers: 41}
+);
+} catch {}
+let renderPassEncoder39 = commandEncoder107.beginRenderPass(
+{
+label: '\u4963\u0257\u{1f7a0}\u{1f6d9}\u4ac3\u33db\u{1fd07}\u0c10\u{1f6d9}\u0a27\uc701',
+colorAttachments: [
+{
+view: textureView103,
+depthSlice: 99,
+clearValue: {
+r: -774.3,
+g: -983.9,
+b: -552.3,
+a: -579.2,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView103,
+depthSlice: 93,
+clearValue: {
+r: 568.7,
+g: 832.6,
+b: -280.0,
+a: 359.5,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView103,
+depthSlice: 73,
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet80,
+}
+);
+let renderBundleEncoder109 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+undefined,
+'rg8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 67,
+stencilReadOnly: true,
+}
+);
+let renderBundle122 = renderBundleEncoder71.finish();
+let sampler99 = device2.createSampler(
+{
+label: '\u3c4b\u07be\u0c27\u2434\u70da\ua063\u20b9\u46ec\u{1f80d}\ue883\ucec4',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 22.314,
+compare: 'less-equal',
+maxAnisotropy: 9,
+}
+);
+try {
+renderPassEncoder36.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder39.setBlendConstant(
+{
+r: -739.9,
+g: -945.3,
+b: -770.5,
+a: -632.0,
+}
+);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(
+buffer38,
+'uint16'
+);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(
+0,
+buffer26,
+1992,
+176
+);
+} catch {}
+try {
+renderBundleEncoder77.setVertexBuffer(
+22,
+undefined,
+210196946,
+3404458158
+);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+commandEncoder95.resolveQuerySet(
+querySet60,
+3833,
+41,
+buffer34,
+0
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture124,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer5,
+/* required buffer size: 890 */{
+offset: 886,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let canvas27 = document.createElement('canvas');
+let imageData31 = new ImageData(4, 12);
+document.body.append('\u{1fabc}\u66f3\u7978\u91f9\ufc95\u74b9');
+gc();
+let renderBundleEncoder110 = device2.createRenderBundleEncoder(
+{
+label: '\u004d\u0855\u{1fa4b}\u{1fd0c}\u0ab9\u0b54\u67d7\u0dd1\udc99\u08f3\u7b8a',
+colorFormats: [
+'rgba8unorm',
+'rg32uint',
+'rgb10a2uint',
+'rg8sint',
+undefined,
+'r16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 522,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder40.setPipeline(
+pipeline114
+);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(
+2,
+bindGroup37
+);
+} catch {}
+try {
+renderPassEncoder32.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder39.setViewport(
+266.2,
+0.1164,
+123.2,
+0.8420,
+0.5183,
+0.6702
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 112, height: 2, depthOrArrayLayers: 31}
+*/
+{
+  source: img35,
+  origin: { x: 69, y: 40 },
+  flipY: false,
+},
+{
+  texture: texture81,
+  mipLevel: 5,
+  origin: { x: 31, y: 1, z: 3 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 5, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let texture130 = device4.createTexture(
+{
+label: '\ua7dd\uc0a3\uf798\u0b04\u05c7\u990f\u{1ff3f}',
+size: {width: 136, height: 136, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'eac-rg11unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'eac-rg11unorm',
+'eac-rg11unorm'
+],
+}
+);
+let sampler100 = device4.createSampler(
+{
+label: '\u0bd9\uecf1\u8e92\ua419\u7ed3\u0e33\u{1f688}',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 33.867,
+lodMaxClamp: 36.391,
+maxAnisotropy: 1,
+}
+);
+try {
+buffer40.unmap();
+} catch {}
+try {
+commandEncoder97.copyTextureToTexture(
+{
+  texture: texture130,
+  mipLevel: 0,
+  origin: { x: 60, y: 8, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture130,
+  mipLevel: 1,
+  origin: { x: 4, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 16, height: 64, depthOrArrayLayers: 0}
+);
+} catch {}
+let promise41 = device4.queue.onSubmittedWorkDone();
+let pipeline135 = device5.createComputePipeline(
+{
+label: '\u{1fbe7}\u0739\u6ae5\u9466\u088b\ua8aa\u5bb2\u{1fe82}\u{1fa0b}',
+layout: pipelineLayout21,
+compute: {
+module: shaderModule32,
+entryPoint: 'compute0',
+},
+}
+);
+let pipeline136 = device5.createRenderPipeline(
+{
+label: '\u88be\u015a',
+layout: pipelineLayout21,
+vertex: {
+module: shaderModule32,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 38028,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 11560,
+shaderLocation: 10,
+},
+{
+format: 'float16x4',
+offset: 664,
+shaderLocation: 3,
+},
+{
+format: 'snorm16x2',
+offset: 35232,
+shaderLocation: 0,
+},
+{
+format: 'float32x3',
+offset: 17544,
+shaderLocation: 5,
+},
+{
+format: 'snorm16x4',
+offset: 37424,
+shaderLocation: 9,
+},
+{
+format: 'uint8x2',
+offset: 9686,
+shaderLocation: 14,
+},
+{
+format: 'snorm8x4',
+offset: 14028,
+shaderLocation: 1,
+},
+{
+format: 'snorm16x2',
+offset: 11176,
+shaderLocation: 2,
+},
+{
+format: 'uint32x4',
+offset: 1780,
+shaderLocation: 13,
+},
+{
+format: 'uint16x2',
+offset: 18296,
+shaderLocation: 4,
+},
+{
+format: 'snorm16x2',
+offset: 28548,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 14972,
+attributes: [
+
+],
+},
+{
+arrayStride: 3448,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x4',
+offset: 1052,
+shaderLocation: 8,
+},
+{
+format: 'unorm16x2',
+offset: 2416,
+shaderLocation: 11,
+},
+{
+format: 'uint32x2',
+offset: 3420,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'back',
+},
+fragment: {
+module: shaderModule32,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'rg16sint',
+writeMask: 0,
+},
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'one-minus-constant',
+dstFactor: 'one-minus-dst-alpha'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}
+],
+},
+}
+);
+video30.width = 178;
+try {
+renderPassEncoder38.setBlendConstant(
+{
+r: 887.6,
+g: 648.5,
+b: -463.8,
+a: -345.7,
+}
+);
+} catch {}
+try {
+renderPassEncoder38.setStencilReference(
+3129
+);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer33,
+2308,
+new Float32Array(48446),
+32068,
+804
+);
+} catch {}
+let gpuCanvasContext27 = canvas27.getContext('webgpu');
+let imageBitmap33 = await createImageBitmap(video33);
+let pipelineLayout23 = device7.createPipelineLayout(
+{
+label: '\ue97d\u39e1\u076f\ue723\u7f49\u2e1c\u72cf\u6689\u71f7',
+bindGroupLayouts: [
+bindGroupLayout54,
+bindGroupLayout54,
+bindGroupLayout54,
+bindGroupLayout54
+],
+}
+);
+let querySet81 = device7.createQuerySet(
+{
+label: '\u33a4\u0480\uaeb0\u0b93\u{1f93e}\uc97d\u01ef\u03cd\u{1fe09}\u04bc\u7308',
+type: 'occlusion',
+count: 954,
+}
+);
+let renderBundleEncoder111 = device7.createRenderBundleEncoder(
+{
+label: '\u0d0d\u0aad\u04c4\u{1fb5a}\u{1fefd}\u8e83\u0eca\ue73f',
+colorFormats: [
+'bgra8unorm-srgb',
+'rg8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 156,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder111.setBindGroup(
+1,
+bindGroup36
+);
+} catch {}
+try {
+renderBundleEncoder108.setVertexBuffer(
+3,
+undefined
+);
+} catch {}
+try {
+commandEncoder105.copyTextureToTexture(
+{
+  texture: texture109,
+  mipLevel: 2,
+  origin: { x: 141, y: 0, z: 225 },
+  aspect: 'all',
+},
+{
+  texture: texture121,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend(img14);
+let querySet82 = device2.createQuerySet(
+{
+label: '\ub823\uafba\uf7a1\u7a71\ue1ed\ufcad\ueba1',
+type: 'occlusion',
+count: 853,
+}
+);
+let texture131 = device2.createTexture(
+{
+label: '\u2040\u552c\u{1f83b}\ua163\u0ab8\u{1ffc3}',
+size: [15471],
+sampleCount: 1,
+dimension: '1d',
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+}
+);
+let renderBundle123 = renderBundleEncoder74.finish(
+{
+label: '\u{1f8a9}\u5fca\u901e\ua855\udbd8\ub81a\ud8be\u0c54\u8b88\u0acd'
+}
+);
+try {
+computePassEncoder40.setBindGroup(
+1,
+bindGroup37
+);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(
+0,
+bindGroup32,
+new Uint32Array(4202),
+2388,
+0
+);
+} catch {}
+try {
+renderPassEncoder36.beginOcclusionQuery(
+0
+);
+} catch {}
+try {
+renderPassEncoder35.setViewport(
+530.8,
+0.7520,
+334.1,
+0.1414,
+0.1339,
+0.4788
+);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(
+buffer38,
+'uint16'
+);
+} catch {}
+try {
+commandEncoder95.copyBufferToBuffer(
+buffer38,
+33728,
+buffer44,
+5448,
+188
+);
+dissociateBuffer(device2, buffer38);
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+commandEncoder95.copyBufferToTexture(
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 21232 */
+offset: 21232,
+bytesPerRow: 0,
+buffer: buffer38,
+},
+{
+  texture: texture75,
+  mipLevel: 4,
+  origin: { x: 3, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 0, height: 8, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device2, buffer38);
+} catch {}
+try {
+commandEncoder95.resolveQuerySet(
+querySet82,
+441,
+90,
+buffer34,
+0
+);
+} catch {}
+let pipeline137 = await device2.createComputePipelineAsync(
+{
+label: '\u{1fd7e}\u5238\ufdc3\u8ed3\u0a3e\u{1f861}\u{1f624}\u3d88\ub3b5\u{1f7fe}\u{1f83a}',
+layout: pipelineLayout12,
+compute: {
+module: shaderModule28,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline138 = device2.createRenderPipeline(
+{
+label: '\u9edc\u080c\u2c8e',
+layout: pipelineLayout15,
+vertex: {
+module: shaderModule28,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 8468,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 2528,
+shaderLocation: 13,
+},
+{
+format: 'uint8x4',
+offset: 7900,
+shaderLocation: 1,
+},
+{
+format: 'snorm16x2',
+offset: 6832,
+shaderLocation: 20,
+}
+],
+},
+{
+arrayStride: 6580,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 5628,
+shaderLocation: 19,
+},
+{
+format: 'snorm8x2',
+offset: 1722,
+shaderLocation: 17,
+},
+{
+format: 'sint8x4',
+offset: 2268,
+shaderLocation: 0,
+},
+{
+format: 'unorm16x4',
+offset: 4480,
+shaderLocation: 23,
+},
+{
+format: 'snorm8x2',
+offset: 6274,
+shaderLocation: 5,
+},
+{
+format: 'sint32x2',
+offset: 3168,
+shaderLocation: 15,
+},
+{
+format: 'snorm8x4',
+offset: 5780,
+shaderLocation: 22,
+},
+{
+format: 'uint8x4',
+offset: 3912,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 4152,
+attributes: [
+{
+format: 'snorm16x2',
+offset: 3536,
+shaderLocation: 10,
+},
+{
+format: 'uint32',
+offset: 1872,
+shaderLocation: 3,
+},
+{
+format: 'sint8x4',
+offset: 832,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 7600,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 3088,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 2042,
+shaderLocation: 21,
+}
+],
+},
+{
+arrayStride: 5820,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 2576,
+shaderLocation: 25,
+},
+{
+format: 'sint8x4',
+offset: 5736,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 6004,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x2',
+offset: 5148,
+shaderLocation: 6,
+},
+{
+format: 'float32',
+offset: 5312,
+shaderLocation: 26,
+}
+],
+},
+{
+arrayStride: 1696,
+attributes: [
+
+],
+},
+{
+arrayStride: 11288,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 4680,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule28,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+{
+format: 'r16float',
+writeMask: GPUColorWrite.GREEN,
+}
+],
+},
+}
+);
+try {
+await promise41;
+} catch {}
+let shaderModule35 = device4.createShaderModule(
+{
+label: '\u0450\u0e77',
+code: `
+
+@compute @workgroup_size(3, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S38 {
+@location(93) f0: i32,
+@location(70) f1: vec2<f16>,
+@location(12) f2: u32,
+@location(47) f3: f16,
+@location(101) f4: vec4<f32>,
+@location(110) f5: vec2<f32>,
+@location(109) f6: vec4<f32>,
+@location(99) f7: vec4<i32>,
+@location(108) f8: vec4<f32>,
+@location(79) f9: vec3<i32>,
+@builtin(sample_mask) f10: u32,
+@location(111) f11: u32,
+@location(77) f12: vec2<u32>
+}
+struct FragmentOutput0 {
+@location(7) f0: vec4<u32>,
+@builtin(sample_mask) f1: u32,
+@location(1) f2: vec2<f32>,
+@location(0) f3: u32,
+@location(2) f4: u32,
+@location(3) f5: vec2<i32>,
+@location(4) f6: f32,
+@location(6) f7: f32
+}
+
+@fragment
+fn fragment0(a0: S38, @location(57) a1: vec2<i32>, @builtin(position) a2: vec4<f32>, @location(112) a3: vec2<u32>, @location(52) a4: vec2<u32>, @location(103) a5: vec4<u32>, @location(18) a6: vec4<i32>, @builtin(sample_index) a7: u32, @builtin(front_facing) a8: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S37 {
+@location(22) f0: vec3<f32>,
+@location(26) f1: vec4<u32>,
+@location(14) f2: vec2<f16>,
+@location(8) f3: vec4<i32>,
+@location(12) f4: vec4<f32>,
+@location(24) f5: f16
+}
+struct VertexOutput0 {
+@location(12) f566: u32,
+@location(112) f567: vec2<u32>,
+@location(108) f568: vec4<f32>,
+@location(18) f569: vec4<i32>,
+@location(70) f570: vec2<f16>,
+@location(57) f571: vec2<i32>,
+@location(47) f572: f16,
+@location(79) f573: vec3<i32>,
+@location(101) f574: vec4<f32>,
+@location(109) f575: vec4<f32>,
+@location(111) f576: u32,
+@location(103) f577: vec4<u32>,
+@location(52) f578: vec2<u32>,
+@location(110) f579: vec2<f32>,
+@builtin(position) f580: vec4<f32>,
+@location(77) f581: vec2<u32>,
+@location(99) f582: vec4<i32>,
+@location(93) f583: i32
+}
+
+@vertex
+fn vertex0(@location(0) a0: i32, @location(20) a1: vec3<u32>, @location(23) a2: vec4<f32>, @location(25) a3: vec4<f32>, @location(18) a4: vec4<f32>, @location(4) a5: vec4<u32>, @location(5) a6: vec2<f16>, @location(13) a7: vec3<f16>, @location(2) a8: vec3<f32>, @location(15) a9: vec4<u32>, @location(3) a10: vec4<i32>, @location(1) a11: vec4<f16>, @location(9) a12: vec4<u32>, a13: S37, @location(17) a14: f16, @location(19) a15: vec2<u32>, @location(11) a16: vec2<u32>, @location(27) a17: vec4<f32>, @location(21) a18: vec2<f32>, @location(6) a19: vec4<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroup38 = device4.createBindGroup({
+label: '\u05d5\u09f2\uf998\u0b57\u0828\u6961\u2ac2\u6426\u735b\u{1fdc0}\u5242',
+layout: bindGroupLayout47,
+entries: [
+
+],
+});
+let querySet83 = device4.createQuerySet(
+{
+type: 'occlusion',
+count: 3260,
+}
+);
+let texture132 = device4.createTexture(
+{
+label: '\u4d96\u4fb0\u0f73\u9201',
+size: {width: 2615},
+dimension: '1d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+renderBundleEncoder72.setBindGroup(
+1,
+bindGroup30,
+new Uint32Array(3265),
+1848,
+0
+);
+} catch {}
+try {
+renderBundleEncoder90.setVertexBuffer(
+1,
+buffer45,
+32568,
+25341
+);
+} catch {}
+try {
+buffer36.unmap();
+} catch {}
+try {
+commandEncoder89.clearBuffer(
+buffer45
+);
+dissociateBuffer(device4, buffer45);
+} catch {}
+let promise42 = device4.createComputePipelineAsync(
+{
+label: '\uf119\u{1feeb}\u0a39\u{1fd50}\u2805\u091d\u240e\u{1fc0c}',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule35,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let canvas28 = document.createElement('canvas');
+let texture133 = gpuCanvasContext9.getCurrentTexture();
+let textureView119 = texture128.createView(
+{
+label: '\u83cf\u07e5\u021b\u2807\u0a43\u247a\u00ba',
+aspect: 'all',
+baseMipLevel: 1,
+}
+);
+try {
+renderPassEncoder34.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder34.setBlendConstant(
+{
+r: 788.5,
+g: 41.06,
+b: 638.4,
+a: -317.8,
+}
+);
+} catch {}
+try {
+commandEncoder90.pushDebugGroup(
+'\u71f2'
+);
+} catch {}
+let pipeline139 = await device7.createComputePipelineAsync(
+{
+label: '\u3ae4\ud151\u0dd9\uffd4\u1719\u0ef4\uc0e5\u107a\uc24f\u0eec\u2bbd',
+layout: pipelineLayout22,
+compute: {
+module: shaderModule34,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend('\u93c4\u058f\u{1f9b3}\u0a7a\ua35d\ub0eb\u{1fad5}\u1888\ub09f\u06d7');
+let img47 = await imageWithData(83, 78, '#53c9a2bb', '#c5b5f03c');
+let imageBitmap34 = await createImageBitmap(img40);
+try {
+canvas28.getContext('2d');
+} catch {}
+let querySet84 = device4.createQuerySet(
+{
+type: 'occlusion',
+count: 2269,
+}
+);
+let computePassEncoder60 = commandEncoder97.beginComputePass(
+{
+
+}
+);
+try {
+renderBundleEncoder72.setIndexBuffer(
+buffer45,
+'uint32',
+6316,
+34901
+);
+} catch {}
+let arrayBuffer10 = buffer45.getMappedRange(
+47928,
+14516
+);
+document.body.prepend('\u{1fe4e}\ub644\u{1faba}\u07fc\u07fe\u94b3\uc5a3\ub75c');
+let offscreenCanvas32 = new OffscreenCanvas(445, 645);
+let img48 = await imageWithData(22, 242, '#9534740a', '#ee8fe5b8');
+let video40 = await videoWithData();
+let imageBitmap35 = await createImageBitmap(imageBitmap32);
+try {
+computePassEncoder59.setPipeline(
+pipeline128
+);
+} catch {}
+try {
+renderPassEncoder38.setBlendConstant(
+{
+r: -687.4,
+g: -852.3,
+b: 545.7,
+a: -926.9,
+}
+);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(
+65,
+undefined,
+619484134,
+1795522362
+);
+} catch {}
+try {
+renderBundleEncoder87.popDebugGroup();
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture98,
+  mipLevel: 0,
+  origin: { x: 20, y: 20, z: 49 },
+  aspect: 'all',
+},
+arrayBuffer8,
+/* required buffer size: 312843 */{
+offset: 151,
+bytesPerRow: 341,
+rowsPerImage: 304,
+},
+{width: 210, height: 50, depthOrArrayLayers: 4}
+);
+} catch {}
+document.body.prepend(video4);
+let video41 = await videoWithData();
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let commandEncoder109 = device2.createCommandEncoder();
+let sampler101 = device2.createSampler(
+{
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 60.058,
+lodMaxClamp: 89.056,
+maxAnisotropy: 16,
+}
+);
+try {
+computePassEncoder40.setBindGroup(
+4,
+bindGroup37,
+new Uint32Array(1948),
+999,
+0
+);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(
+4,
+buffer26,
+564,
+1616
+);
+} catch {}
+try {
+await buffer44.mapAsync(
+GPUMapMode.READ,
+6640,
+3632
+);
+} catch {}
+try {
+commandEncoder109.copyBufferToBuffer(
+buffer31,
+28936,
+buffer34,
+500,
+184
+);
+dissociateBuffer(device2, buffer31);
+dissociateBuffer(device2, buffer34);
+} catch {}
+try {
+commandEncoder109.clearBuffer(
+buffer38,
+35948,
+1084
+);
+dissociateBuffer(device2, buffer38);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1384, height: 1, depthOrArrayLayers: 12}
+*/
+{
+  source: video32,
+  origin: { x: 4, y: 4 },
+  flipY: false,
+},
+{
+  texture: texture80,
+  mipLevel: 0,
+  origin: { x: 101, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 6, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend(canvas12);
+let video42 = await videoWithData();
+let commandEncoder110 = device4.createCommandEncoder(
+{
+label: '\u0c01\uc931\u394b\uc2a0',
+}
+);
+let renderBundle124 = renderBundleEncoder78.finish();
+let sampler102 = device4.createSampler(
+{
+label: '\u0c23\u{1fd40}\u424d\u{1fac6}\u02a0\u15ab\uf9dc',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'linear',
+lodMinClamp: 44.455,
+lodMaxClamp: 74.877,
+}
+);
+let externalTexture9 = device4.importExternalTexture(
+{
+label: '\u9b0d\ue5d0\u0cb2\ubb6c\u6c30\u49b8\ua44c\u14c2\ude4d\u9956\u1015',
+source: videoFrame14,
+}
+);
+try {
+renderBundleEncoder92.setBindGroup(
+7,
+bindGroup35
+);
+} catch {}
+try {
+commandEncoder110.clearBuffer(
+buffer45
+);
+dissociateBuffer(device4, buffer45);
+} catch {}
+let promise43 = device4.createComputePipelineAsync(
+{
+label: '\u0d7a\u{1f6dd}\ud463\u67ff\u87de\u9379\u011c\uba31',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule35,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let shaderModule36 = device3.createShaderModule(
+{
+code: `
+
+@compute @workgroup_size(5, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(2) f0: f32
+}
+
+@fragment
+fn fragment0(@location(11) a0: vec3<f32>, @location(12) a1: vec2<f32>, @location(27) a2: vec2<u32>, @location(28) a3: vec2<u32>, @location(9) a4: vec3<i32>, @location(16) a5: f32, @location(13) a6: vec4<f16>, @location(2) a7: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(5) f584: vec3<i32>,
+@location(25) f585: vec2<u32>,
+@location(28) f586: vec2<u32>,
+@location(31) f587: vec2<f32>,
+@location(14) f588: u32,
+@location(11) f589: vec3<f32>,
+@location(30) f590: vec4<u32>,
+@location(24) f591: vec2<i32>,
+@builtin(position) f592: vec4<f32>,
+@location(15) f593: vec4<i32>,
+@location(22) f594: vec4<i32>,
+@location(27) f595: vec2<u32>,
+@location(12) f596: vec2<f32>,
+@location(3) f597: i32,
+@location(10) f598: vec4<i32>,
+@location(9) f599: vec3<i32>,
+@location(16) f600: f32,
+@location(17) f601: vec2<i32>,
+@location(0) f602: f16,
+@location(29) f603: f32,
+@location(2) f604: vec4<f32>,
+@location(21) f605: vec2<i32>,
+@location(7) f606: u32,
+@location(13) f607: vec4<f16>,
+@location(23) f608: vec3<f32>,
+@location(18) f609: vec4<f32>,
+@location(19) f610: vec4<i32>,
+@location(4) f611: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec4<f16>, @location(13) a1: vec4<f32>, @location(10) a2: vec2<i32>, @location(6) a3: vec4<u32>, @location(14) a4: vec4<f16>, @location(16) a5: vec4<f32>, @location(2) a6: vec3<f16>, @location(15) a7: f32, @builtin(instance_index) a8: u32, @location(8) a9: i32, @location(1) a10: vec3<u32>, @builtin(vertex_index) a11: u32, @location(5) a12: vec3<f16>, @location(9) a13: vec4<u32>, @location(12) a14: vec3<f32>, @location(4) a15: vec4<f32>, @location(0) a16: vec2<i32>, @location(7) a17: vec2<i32>, @location(3) a18: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let pipelineLayout24 = device3.createPipelineLayout(
+{
+label: '\ue262\u09db\u0dd2\u55be\ua049\u7427\u{1f6b2}\u{1fb65}\u{1fe59}\u767d\u{1fb9e}',
+bindGroupLayouts: [
+bindGroupLayout57,
+bindGroupLayout53,
+bindGroupLayout44
+],
+}
+);
+try {
+renderPassEncoder38.setBlendConstant(
+{
+r: -92.85,
+g: -604.1,
+b: -780.4,
+a: 969.4,
+}
+);
+} catch {}
+try {
+renderPassEncoder38.setStencilReference(
+3612
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture107,
+  mipLevel: 7,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(arrayBuffer0),
+/* required buffer size: 724 */{
+offset: 720,
+rowsPerImage: 7,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise44 = device3.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext24.unconfigure();
+} catch {}
+let bindGroup39 = device0.createBindGroup({
+label: '\u00fc\u{1f6d1}\u{1fa78}\u33d5\u8527\u{1fea0}\u24eb\ufd26\u91e3',
+layout: bindGroupLayout19,
+entries: [
+
+],
+});
+try {
+computePassEncoder21.setBindGroup(
+5,
+bindGroup10,
+new Uint32Array(3526),
+2645,
+0
+);
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(
+40
+);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(
+75,
+0,
+10,
+1
+);
+} catch {}
+let pipeline140 = device0.createRenderPipeline(
+{
+label: '\u553c\ua989\u1f2b\u4ccc\ua262\u2a14\u{1fc04}\u7b9b\u{1f79a}\u9dd7',
+layout: 'auto',
+vertex: {
+module: shaderModule6,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 12252,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x4',
+offset: 11908,
+shaderLocation: 4,
+},
+{
+format: 'uint16x4',
+offset: 1176,
+shaderLocation: 14,
+},
+{
+format: 'snorm8x4',
+offset: 7960,
+shaderLocation: 9,
+},
+{
+format: 'sint32x2',
+offset: 5356,
+shaderLocation: 13,
+},
+{
+format: 'sint32',
+offset: 10324,
+shaderLocation: 7,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 444,
+shaderLocation: 15,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 5668,
+shaderLocation: 10,
+},
+{
+format: 'sint8x4',
+offset: 3068,
+shaderLocation: 16,
+},
+{
+format: 'float16x2',
+offset: 1340,
+shaderLocation: 6,
+},
+{
+format: 'uint16x2',
+offset: 9308,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 11920,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x2',
+offset: 5524,
+shaderLocation: 12,
+},
+{
+format: 'sint8x2',
+offset: 956,
+shaderLocation: 2,
+},
+{
+format: 'unorm8x4',
+offset: 10764,
+shaderLocation: 0,
+},
+{
+format: 'sint8x4',
+offset: 10104,
+shaderLocation: 3,
+},
+{
+format: 'uint8x4',
+offset: 3888,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 29916,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 1072,
+attributes: [
+
+],
+},
+{
+arrayStride: 15728,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x2',
+offset: 144,
+shaderLocation: 11,
+},
+{
+format: 'sint16x2',
+offset: 8120,
+shaderLocation: 8,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule6,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.BLUE,
+},
+{
+format: 'rg16float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rg11b10ufloat',
+writeMask: 0,
+},
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'less',
+failOp: 'invert',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+},
+stencilReadMask: 1794,
+stencilWriteMask: 2129,
+depthBias: 99,
+depthBiasSlopeScale: 89,
+},
+}
+);
+try {
+renderPassEncoder38.setScissorRect(
+7,
+6,
+20,
+1
+);
+} catch {}
+try {
+renderBundleEncoder88.setVertexBuffer(
+62,
+undefined
+);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer33,
+17672,
+new Float32Array(42479),
+31454,
+616
+);
+} catch {}
+let pipeline141 = await device3.createComputePipelineAsync(
+{
+label: '\ubb88\u{1f910}\u071f\uda8c\u0eca\u6de2\u{1ff21}\u0884\u0ee5\u4a8d',
+layout: pipelineLayout17,
+compute: {
+module: shaderModule29,
+entryPoint: 'compute0',
+},
+}
+);
+let shaderModule37 = device4.createShaderModule(
+{
+code: `
+
+@compute @workgroup_size(1, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S40 {
+@location(75) f0: vec2<i32>,
+@builtin(front_facing) f1: bool,
+@location(80) f2: vec2<i32>,
+@location(67) f3: vec2<f32>,
+@location(61) f4: i32,
+@builtin(sample_mask) f5: u32,
+@location(10) f6: vec3<u32>,
+@location(109) f7: vec4<f16>,
+@builtin(sample_index) f8: u32,
+@location(90) f9: u32,
+@location(4) f10: vec3<f16>,
+@location(45) f11: vec2<u32>,
+@location(9) f12: vec3<u32>,
+@location(110) f13: vec3<f32>,
+@location(53) f14: vec4<f32>,
+@location(32) f15: f16,
+@location(101) f16: u32,
+@location(25) f17: vec3<u32>,
+@location(93) f18: vec3<f16>,
+@location(17) f19: vec3<i32>,
+@builtin(position) f20: vec4<f32>,
+@location(114) f21: vec4<f16>,
+@location(106) f22: u32,
+@location(13) f23: vec3<f32>,
+@location(44) f24: f32,
+@location(103) f25: vec3<u32>,
+@location(11) f26: vec3<f32>,
+@location(116) f27: vec4<i32>,
+@location(118) f28: vec2<u32>,
+@location(56) f29: vec4<f32>,
+@location(102) f30: vec4<i32>,
+@location(64) f31: vec3<u32>,
+@location(97) f32: vec4<i32>,
+@location(0) f33: vec2<f32>,
+@location(42) f34: vec3<f16>,
+@location(2) f35: f32,
+@location(86) f36: f32,
+@location(46) f37: vec4<u32>
+}
+struct FragmentOutput0 {
+@location(2) f0: vec2<f32>,
+@location(7) f1: vec2<i32>,
+@location(5) f2: vec3<f32>,
+@builtin(frag_depth) f3: f32,
+@location(1) f4: i32,
+@builtin(sample_mask) f5: u32,
+@location(4) f6: u32,
+@location(3) f7: u32,
+@location(0) f8: vec3<i32>
+}
+
+@fragment
+fn fragment0(a0: S40, @location(95) a1: vec3<f32>, @location(20) a2: vec2<f16>, @location(39) a3: vec4<f16>, @location(29) a4: u32, @location(52) a5: i32, @location(71) a6: u32, @location(63) a7: f32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S39 {
+@location(24) f0: vec2<f16>,
+@location(20) f1: vec4<i32>,
+@location(26) f2: u32,
+@location(3) f3: vec3<u32>,
+@location(11) f4: vec3<f16>,
+@location(8) f5: f16,
+@location(18) f6: vec4<f16>,
+@location(25) f7: vec2<u32>,
+@location(1) f8: vec3<f32>,
+@location(4) f9: u32,
+@location(27) f10: vec2<i32>,
+@location(15) f11: vec4<i32>,
+@location(22) f12: vec4<i32>,
+@location(16) f13: vec3<u32>,
+@builtin(instance_index) f14: u32,
+@location(7) f15: vec2<f32>,
+@location(13) f16: vec2<f32>,
+@location(23) f17: vec2<f16>,
+@location(6) f18: i32,
+@location(10) f19: vec4<i32>,
+@location(0) f20: vec4<f32>,
+@location(19) f21: vec2<f32>,
+@location(2) f22: vec4<f32>,
+@location(9) f23: f32,
+@location(17) f24: vec3<f16>,
+@location(14) f25: vec3<f32>
+}
+struct VertexOutput0 {
+@location(86) f612: f32,
+@location(11) f613: vec3<f32>,
+@location(71) f614: u32,
+@location(32) f615: f16,
+@location(110) f616: vec3<f32>,
+@location(80) f617: vec2<i32>,
+@location(39) f618: vec4<f16>,
+@location(114) f619: vec4<f16>,
+@location(52) f620: i32,
+@location(116) f621: vec4<i32>,
+@location(0) f622: vec2<f32>,
+@location(4) f623: vec3<f16>,
+@location(103) f624: vec3<u32>,
+@builtin(position) f625: vec4<f32>,
+@location(45) f626: vec2<u32>,
+@location(102) f627: vec4<i32>,
+@location(93) f628: vec3<f16>,
+@location(109) f629: vec4<f16>,
+@location(67) f630: vec2<f32>,
+@location(17) f631: vec3<i32>,
+@location(20) f632: vec2<f16>,
+@location(64) f633: vec3<u32>,
+@location(106) f634: u32,
+@location(2) f635: f32,
+@location(10) f636: vec3<u32>,
+@location(63) f637: f32,
+@location(25) f638: vec3<u32>,
+@location(13) f639: vec3<f32>,
+@location(101) f640: u32,
+@location(95) f641: vec3<f32>,
+@location(90) f642: u32,
+@location(9) f643: vec3<u32>,
+@location(42) f644: vec3<f16>,
+@location(75) f645: vec2<i32>,
+@location(61) f646: i32,
+@location(53) f647: vec4<f32>,
+@location(56) f648: vec4<f32>,
+@location(46) f649: vec4<u32>,
+@location(118) f650: vec2<u32>,
+@location(97) f651: vec4<i32>,
+@location(44) f652: f32,
+@location(29) f653: u32
+}
+
+@vertex
+fn vertex0(@location(21) a0: vec2<i32>, a1: S39, @location(12) a2: vec3<f16>, @location(5) a3: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+}
+);
+let commandEncoder111 = device4.createCommandEncoder(
+{
+label: '\u77ef\u190f\u{1f66a}\uaa95',
+}
+);
+let computePassEncoder61 = commandEncoder110.beginComputePass(
+{
+label: '\u090d\u0cb4\u0d12\ubba6\u0be3\u0d1f\u88ae\u01a1'
+}
+);
+try {
+renderBundleEncoder92.setBindGroup(
+2,
+bindGroup31,
+new Uint32Array(9696),
+2539,
+0
+);
+} catch {}
+try {
+commandEncoder111.copyTextureToTexture(
+{
+  texture: texture103,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture103,
+  mipLevel: 5,
+  origin: { x: 0, y: 8, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline142 = await device4.createRenderPipelineAsync(
+{
+label: '\ube50\u0bea',
+layout: pipelineLayout16,
+vertex: {
+module: shaderModule37,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 36604,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 32900,
+shaderLocation: 3,
+},
+{
+format: 'float32x3',
+offset: 20988,
+shaderLocation: 8,
+},
+{
+format: 'sint32x2',
+offset: 27628,
+shaderLocation: 15,
+},
+{
+format: 'uint8x4',
+offset: 7428,
+shaderLocation: 4,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 30920,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 53136,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 3056,
+shaderLocation: 23,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 55940,
+shaderLocation: 7,
+},
+{
+format: 'uint32x2',
+offset: 47700,
+shaderLocation: 25,
+},
+{
+format: 'sint32x2',
+offset: 4696,
+shaderLocation: 6,
+},
+{
+format: 'snorm8x4',
+offset: 63176,
+shaderLocation: 1,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 59344,
+shaderLocation: 13,
+},
+{
+format: 'sint8x2',
+offset: 28152,
+shaderLocation: 27,
+},
+{
+format: 'snorm16x4',
+offset: 18224,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x4',
+offset: 51572,
+shaderLocation: 14,
+},
+{
+format: 'unorm16x2',
+offset: 6452,
+shaderLocation: 12,
+},
+{
+format: 'sint32x2',
+offset: 21920,
+shaderLocation: 22,
+},
+{
+format: 'unorm16x4',
+offset: 31768,
+shaderLocation: 11,
+},
+{
+format: 'uint32x2',
+offset: 31360,
+shaderLocation: 16,
+},
+{
+format: 'float32x2',
+offset: 58600,
+shaderLocation: 24,
+},
+{
+format: 'sint8x4',
+offset: 1160,
+shaderLocation: 10,
+},
+{
+format: 'sint16x2',
+offset: 16832,
+shaderLocation: 20,
+},
+{
+format: 'unorm8x4',
+offset: 7084,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 48728,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 22136,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x2',
+offset: 17744,
+shaderLocation: 19,
+},
+{
+format: 'uint32x4',
+offset: 7212,
+shaderLocation: 26,
+}
+],
+},
+{
+arrayStride: 38932,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 5048,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 1404,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 27596,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 8904,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 5604,
+shaderLocation: 9,
+},
+{
+format: 'float16x4',
+offset: 3288,
+shaderLocation: 17,
+},
+{
+format: 'sint32',
+offset: 1136,
+shaderLocation: 21,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'none',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule37,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r16sint',
+},
+{
+format: 'r8unorm',
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.GREEN,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.RED,
+},
+{
+format: 'r32float',
+},
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'never',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+depthBias: 23,
+depthBiasSlopeScale: 55,
+},
+}
+);
+try {
+await promise44;
+} catch {}
+let offscreenCanvas33 = new OffscreenCanvas(625, 225);
+try {
+pipeline138.label = '\ud0c7\u{1fc19}\u{1f9cd}\u3184';
+} catch {}
+let commandEncoder112 = device2.createCommandEncoder(
+{
+label: '\u{1fa2b}\u{1f613}\u0280\ud75a\uac96',
+}
+);
+let querySet85 = device2.createQuerySet(
+{
+label: '\u{1fd3d}\u{1f934}\u0140\ua8bb\uea01',
+type: 'occlusion',
+count: 2060,
+}
+);
+let renderBundle125 = renderBundleEncoder102.finish(
+{
+label: '\uf920\u0698\u02dc'
+}
+);
+let sampler103 = device2.createSampler(
+{
+label: '\u742b\u0a7d\u031a\u95e2\u1547\u01ef\u023b\u041e\ue62c\u{1feaf}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 20.895,
+lodMaxClamp: 34.214,
+compare: 'always',
+maxAnisotropy: 1,
+}
+);
+try {
+computePassEncoder39.setBindGroup(
+0,
+bindGroup37
+);
+} catch {}
+try {
+renderPassEncoder32.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder32.setScissorRect(
+221,
+0,
+369,
+0
+);
+} catch {}
+try {
+renderBundleEncoder77.setBindGroup(
+2,
+bindGroup37,
+new Uint32Array(7149),
+1578,
+0
+);
+} catch {}
+try {
+commandEncoder109.copyTextureToBuffer(
+{
+  texture: texture105,
+  mipLevel: 0,
+  origin: { x: 25, y: 18, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 624 widthInBlocks: 156 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 24136 */
+offset: 24136,
+bytesPerRow: 768,
+buffer: buffer38,
+},
+{width: 156, height: 46, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device2, buffer38);
+} catch {}
+try {
+commandEncoder95.clearBuffer(
+buffer38,
+7212,
+27632
+);
+dissociateBuffer(device2, buffer38);
+} catch {}
+let pipeline143 = device2.createRenderPipeline(
+{
+label: '\u1bd2\u768f\ub6ee\u016b\u20ed',
+layout: pipelineLayout14,
+vertex: {
+module: shaderModule28,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 3444,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 876,
+shaderLocation: 15,
+},
+{
+format: 'snorm16x4',
+offset: 2616,
+shaderLocation: 26,
+},
+{
+format: 'snorm16x4',
+offset: 2408,
+shaderLocation: 10,
+},
+{
+format: 'unorm16x2',
+offset: 2156,
+shaderLocation: 23,
+},
+{
+format: 'unorm16x2',
+offset: 2120,
+shaderLocation: 5,
+},
+{
+format: 'snorm16x2',
+offset: 236,
+shaderLocation: 20,
+},
+{
+format: 'sint16x2',
+offset: 252,
+shaderLocation: 18,
+},
+{
+format: 'snorm16x2',
+offset: 2420,
+shaderLocation: 21,
+},
+{
+format: 'uint8x2',
+offset: 2830,
+shaderLocation: 3,
+},
+{
+format: 'sint16x4',
+offset: 2396,
+shaderLocation: 6,
+},
+{
+format: 'unorm8x4',
+offset: 1220,
+shaderLocation: 22,
+},
+{
+format: 'unorm16x2',
+offset: 3304,
+shaderLocation: 17,
+},
+{
+format: 'uint32',
+offset: 3220,
+shaderLocation: 1,
+},
+{
+format: 'uint8x2',
+offset: 100,
+shaderLocation: 13,
+},
+{
+format: 'sint32',
+offset: 1380,
+shaderLocation: 0,
+},
+{
+format: 'uint32x4',
+offset: 1236,
+shaderLocation: 4,
+},
+{
+format: 'float32x2',
+offset: 2308,
+shaderLocation: 19,
+},
+{
+format: 'sint8x2',
+offset: 2580,
+shaderLocation: 7,
+},
+{
+format: 'float16x4',
+offset: 2544,
+shaderLocation: 2,
+},
+{
+format: 'float16x2',
+offset: 2028,
+shaderLocation: 25,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+cullMode: 'back',
+unclippedDepth: false,
+},
+fragment: {
+module: shaderModule28,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.GREEN,
+},
+undefined,
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+format: 'rgb10a2uint',
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthCompare: 'always',
+stencilFront: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'invert',
+passOp: 'replace',
+},
+stencilReadMask: 425,
+stencilWriteMask: 1093,
+depthBias: 96,
+depthBiasSlopeScale: 20,
+depthBiasClamp: 36,
+},
+}
+);
+let gpuCanvasContext28 = offscreenCanvas33.getContext('webgpu');
+try {
+gpuCanvasContext26.unconfigure();
+} catch {}
+let buffer48 = device2.createBuffer(
+{
+label: '\u2d9f\u9856',
+size: 14805,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+}
+);
+let renderBundle126 = renderBundleEncoder65.finish(
+{
+label: '\u7655\u{1fc23}\u02f4\u064c\ueb11\u0be9\u6fd0\ub96b'
+}
+);
+try {
+computePassEncoder36.setBindGroup(
+0,
+bindGroup37
+);
+} catch {}
+try {
+computePassEncoder33.setBindGroup(
+4,
+bindGroup32,
+new Uint32Array(2345),
+2083,
+0
+);
+} catch {}
+try {
+computePassEncoder45.setPipeline(
+pipeline101
+);
+} catch {}
+try {
+renderPassEncoder39.beginOcclusionQuery(
+56
+);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(
+1,
+buffer26,
+224,
+844
+);
+} catch {}
+try {
+commandEncoder95.copyBufferToTexture(
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 27372 */
+offset: 27372,
+bytesPerRow: 256,
+buffer: buffer38,
+},
+{
+  texture: texture124,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device2, buffer38);
+} catch {}
+try {
+commandEncoder95.resolveQuerySet(
+querySet54,
+665,
+1265,
+buffer48,
+512
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture131,
+  mipLevel: 0,
+  origin: { x: 3889, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint8Array(new ArrayBuffer(80)),
+/* required buffer size: 7123 */{
+offset: 847,
+},
+{width: 6276, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend(canvas14);
+let img49 = await imageWithData(257, 102, '#df233953', '#fb8b1486');
+let video43 = await videoWithData();
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let bindGroupLayout58 = device5.createBindGroupLayout(
+{
+label: '\u1037\u118b\u8e6c\u{1fc42}\u0356\u5977',
+entries: [
+
+],
+}
+);
+let textureView120 = texture108.createView(
+{
+label: '\ua232\u93f4\u3c47\ubbaa\u039c\u013c\u8947',
+baseMipLevel: 0,
+mipLevelCount: 1,
+baseArrayLayer: 40,
+arrayLayerCount: 98,
+}
+);
+let computePassEncoder62 = commandEncoder74.beginComputePass(
+{
+label: '\u80bc\ue127\u1ff6'
+}
+);
+let renderBundleEncoder112 = device5.createRenderBundleEncoder(
+{
+label: '\u0d89\u96d8\u6082\ufafd\ua091\u1a02\ucca1\u{1f62e}\u0a20',
+colorFormats: [
+'rgb10a2unorm',
+'rg16uint',
+'rg8unorm',
+'r32uint',
+'rgba32uint',
+'r8sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 785,
+depthReadOnly: true,
+stencilReadOnly: false,
+}
+);
+try {
+computePassEncoder51.setBindGroup(
+7,
+bindGroup34
+);
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+try {
+commandEncoder102.copyTextureToTexture(
+{
+  texture: texture93,
+  mipLevel: 2,
+  origin: { x: 4, y: 0, z: 3 },
+  aspect: 'all',
+},
+{
+  texture: texture93,
+  mipLevel: 0,
+  origin: { x: 1074, y: 0, z: 247 },
+  aspect: 'all',
+},
+{width: 378, height: 1, depthOrArrayLayers: 211}
+);
+} catch {}
+try {
+renderBundleEncoder112.insertDebugMarker(
+'\u02c1'
+);
+} catch {}
+let device8 = await adapter11.requestDevice(
+{
+label: '\u0a22\u1acb',
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'indirect-first-instance',
+'shader-f16',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxVertexAttributes: 26,
+maxVertexBufferArrayStride: 34966,
+maxStorageTexturesPerShaderStage: 31,
+maxStorageBuffersPerShaderStage: 21,
+maxDynamicStorageBuffersPerPipelineLayout: 55156,
+maxBindingsPerBindGroup: 3323,
+maxTextureDimension1D: 10442,
+maxTextureDimension2D: 9376,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 14985377,
+maxInterStageShaderVariables: 54,
+maxInterStageShaderComponents: 111,
+},
+}
+);
+let gpuCanvasContext29 = offscreenCanvas32.getContext('webgpu');
+document.body.prepend('\u05a7\u0e8e\uedee\u{1f82a}\u41bf\u0b7b\u{1f641}');
+let querySet86 = device7.createQuerySet(
+{
+label: '\u{1fd79}\u0038\ud5a8\u0a87\u{1faf7}\u8efe\u7f0a\u2ed7\u{1fae7}',
+type: 'occlusion',
+count: 2360,
+}
+);
+let textureView121 = texture109.createView(
+{
+}
+);
+try {
+gpuCanvasContext7.configure(
+{
+device: device7,
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8uint',
+'rgba32sint',
+'r32sint'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let bindGroup40 = device7.createBindGroup({
+label: '\uea1b\u851c\u6469',
+layout: bindGroupLayout54,
+entries: [
+
+],
+});
+let texture134 = device7.createTexture(
+{
+label: '\u{1f774}\u4989\u5c13\u787e\u5554',
+size: [3430, 8, 176],
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-10x8-unorm',
+'astc-10x8-unorm'
+],
+}
+);
+try {
+renderPassEncoder34.setViewport(
+84.22,
+0.8316,
+10.18,
+0.1489,
+0.3515,
+0.7626
+);
+} catch {}
+let promise45 = device7.popErrorScope();
+try {
+commandEncoder90.popDebugGroup();
+} catch {}
+try {
+device7.queue.copyExternalImageToTexture(
+/*
+{width: 43, height: 1, depthOrArrayLayers: 102}
+*/
+{
+  source: video10,
+  origin: { x: 6, y: 5 },
+  flipY: true,
+},
+{
+  texture: texture109,
+  mipLevel: 4,
+  origin: { x: 19, y: 0, z: 30 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let texture135 = device3.createTexture(
+{
+label: '\u9a8b\u{1faee}\u0c69\u74d8',
+size: {width: 4328, height: 24, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+
+],
+}
+);
+let sampler104 = device3.createSampler(
+{
+label: '\u9321\u7778\ud01d\u70b6\uad20\u62da\u{1ffb2}',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 72.305,
+lodMaxClamp: 76.929,
+maxAnisotropy: 4,
+}
+);
+try {
+renderPassEncoder38.beginOcclusionQuery(
+48
+);
+} catch {}
+try {
+renderPassEncoder38.setViewport(
+22.02,
+8.273,
+56.48,
+0.2870,
+0.7295,
+0.7675
+);
+} catch {}
+let video44 = await videoWithData();
+canvas17.width = 140;
+let video45 = await videoWithData();
+let videoFrame28 = new VideoFrame(img12, {timestamp: 0});
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+document.body.append('\u{1fdd5}\u00cc\u3486\ua9d0\u6b46\uc409');
+let adapter17 = await navigator.gpu.requestAdapter(
+{
+powerPreference: 'high-performance',
+}
+);
+let imageBitmap36 = await createImageBitmap(img31);
+let commandEncoder113 = device7.createCommandEncoder(
+{
+label: '\u0fbb\u044b\ua807\uec40\u{1fd13}\ub915\ub1ea\u0d3c',
+}
+);
+let texture136 = device7.createTexture(
+{
+label: '\u{1f92e}\u0a08\u013c\u025a\u0b19\u0235\u26cd\u099e\u0636\u0500\u{1fa56}',
+size: {width: 5089},
+dimension: '1d',
+format: 'rg32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32float',
+'rg32float',
+'rg32float'
+],
+}
+);
+try {
+renderPassEncoder34.setBlendConstant(
+{
+r: 170.6,
+g: -298.2,
+b: -944.1,
+a: 345.2,
+}
+);
+} catch {}
+try {
+commandEncoder106.copyTextureToTexture(
+{
+  texture: texture109,
+  mipLevel: 4,
+  origin: { x: 13, y: 0, z: 8 },
+  aspect: 'all',
+},
+{
+  texture: texture117,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await device7.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append('\u3190\u2f64\uaa76\u{1fa77}\u014a\u{1f6de}\uc2f2');
+let shaderModule38 = device7.createShaderModule(
+{
+label: '\u0197\u7375\u371d\u0db0\u575a\ua630',
+code: `
+
+@compute @workgroup_size(2, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S41 {
+@builtin(position) f0: vec4<f32>,
+@builtin(sample_mask) f1: u32
+}
+struct FragmentOutput0 {
+@location(6) f0: i32,
+@location(0) f1: u32,
+@location(2) f2: i32,
+@builtin(sample_mask) f3: u32,
+@location(7) f4: vec4<f32>,
+@location(3) f5: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, a1: S41, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(0) a0: vec4<f32>, @location(5) a1: f16, @location(7) a2: vec3<f32>, @location(13) a3: vec3<f32>, @location(2) a4: vec3<f32>, @location(1) a5: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroupLayout59 = device7.createBindGroupLayout(
+{
+entries: [
+{
+binding: 120,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+}
+],
+}
+);
+let sampler105 = device7.createSampler(
+{
+label: '\u2563\u0b8a\udffc\u44c6\u2ea7\u{1fbc5}\u1e51\u0765\u0d58',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 93.826,
+lodMaxClamp: 94.408,
+maxAnisotropy: 12,
+}
+);
+try {
+renderPassEncoder34.setBindGroup(
+3,
+bindGroup40
+);
+} catch {}
+try {
+renderPassEncoder34.setStencilReference(
+1324
+);
+} catch {}
+try {
+renderBundleEncoder107.setBindGroup(
+1,
+bindGroup36
+);
+} catch {}
+try {
+gpuCanvasContext13.configure(
+{
+device: device7,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm',
+'astc-6x6-unorm-srgb',
+'rgba8unorm-srgb',
+'rgba8unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let pipeline144 = device7.createRenderPipeline(
+{
+layout: pipelineLayout22,
+vertex: {
+module: shaderModule34,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 700,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 548,
+shaderLocation: 7,
+},
+{
+format: 'float32x3',
+offset: 204,
+shaderLocation: 14,
+},
+{
+format: 'sint32',
+offset: 100,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 424,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 256,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x2',
+offset: 150,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 1220,
+shaderLocation: 2,
+},
+{
+format: 'sint16x2',
+offset: 640,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x4',
+offset: 640,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 1320,
+attributes: [
+{
+format: 'sint32x2',
+offset: 200,
+shaderLocation: 6,
+},
+{
+format: 'float32x2',
+offset: 680,
+shaderLocation: 11,
+},
+{
+format: 'uint8x4',
+offset: 464,
+shaderLocation: 5,
+},
+{
+format: 'uint32x2',
+offset: 56,
+shaderLocation: 0,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 252,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 780,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 520,
+shaderLocation: 1,
+},
+{
+format: 'snorm8x4',
+offset: 136,
+shaderLocation: 13,
+},
+{
+format: 'uint16x4',
+offset: 676,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+primitive: {
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0xb1a2d1b3,
+},
+fragment: {
+module: shaderModule34,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'one',
+dstFactor: 'one-minus-dst'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'zero',
+dstFactor: 'src-alpha'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 1184,
+stencilWriteMask: 3273,
+depthBias: 18,
+depthBiasSlopeScale: 58,
+depthBiasClamp: 77,
+},
+}
+);
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let renderBundle127 = renderBundleEncoder111.finish(
+{
+label: '\u92b2\ue877\u{1fb27}\u0ab2\u0bd9'
+}
+);
+try {
+renderPassEncoder34.setBindGroup(
+3,
+bindGroup40,
+new Uint32Array(4924),
+4247,
+0
+);
+} catch {}
+try {
+renderPassEncoder34.setScissorRect(
+81,
+1,
+53,
+0
+);
+} catch {}
+try {
+renderBundleEncoder107.insertDebugMarker(
+'\u008c'
+);
+} catch {}
+try {
+gpuCanvasContext24.configure(
+{
+device: device7,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device7.queue.writeTexture(
+{
+  texture: texture133,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer3,
+/* required buffer size: 338 */{
+offset: 338,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await device7.queue.onSubmittedWorkDone();
+} catch {}
+  log('the end')
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -37,6 +37,7 @@
 - (instancetype)init NS_UNAVAILABLE;
 @property (nonatomic) id<MTLTexture> texture;
 @property (nonatomic) MTLClearColor clearColor;
+@property (nonatomic) NSUInteger depthPlane;
 @end
 
 struct WGPUCommandEncoderImpl {

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -416,7 +416,7 @@ void CommandEncoder::runClearEncoder(NSMutableDictionary<NSNumber*, TextureAndCl
             mtlAttachment.texture = t;
             mtlAttachment.level = 0;
             mtlAttachment.slice = 0;
-            mtlAttachment.depthPlane = 0;
+            mtlAttachment.depthPlane = textureAndClearColor.depthPlane;
         }
         clearRenderCommandEncoder = [m_commandBuffer renderCommandEncoderWithDescriptor:clearDescriptor];
     }

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -112,18 +112,16 @@ RenderPassEncoder::RenderPassEncoder(id<MTLRenderCommandEncoder> renderCommandEn
         if (!textureToClear)
             continue;
         TextureAndClearColor *textureWithClearColor = [[TextureAndClearColor alloc] initWithTexture:textureToClear];
-        bool storeOpDiscardAndLoadOpLoad = false;
         if (attachment.storeOp != WGPUStoreOp_Discard) {
             auto& c = attachment.clearValue;
             textureWithClearColor.clearColor = MTLClearColorMake(c.r, c.g, c.b, c.a);
         } else if (attachment.loadOp == WGPULoadOp_Load) {
-            storeOpDiscardAndLoadOpLoad = true;
             textureWithClearColor.clearColor = MTLClearColorMake(0, 0, 0, 0);
             [m_attachmentsToClear setObject:textureWithClearColor forKey:@(i)];
         }
 
-        if (attachment.loadOp == WGPULoadOp_Clear || storeOpDiscardAndLoadOpLoad)
-            [m_allColorAttachments setObject:textureWithClearColor forKey:@(i)];
+        textureWithClearColor.depthPlane = attachment.depthSlice.value_or(0);
+        [m_allColorAttachments setObject:textureWithClearColor forKey:@(i)];
     }
 
     if (const auto* attachment = descriptor.depthStencilAttachment) {


### PR DESCRIPTION
#### 31db0f6ee6a433c221719a930aab848e4bd871bd
<pre>
[WebGPU] runClearEncoder may clear wrong depth slice for 3D textures
<a href="https://bugs.webkit.org/show_bug.cgi?id=273017">https://bugs.webkit.org/show_bug.cgi?id=273017</a>
&lt;radar://126621270&gt;

Reviewed by Tadeu Zagallo.

When running the clear encoder for a render pass which draws no geometry,
we must use all the existing render targets otherwise the PSO won&apos;t match.

Also we weren&apos;t setting the depth slice so overlap on 3D textures was possible,
which is not allowed.

* LayoutTests/fast/webgpu/fuzz-273017-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-273017.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/CommandEncoder.h:
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::runClearEncoder):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::m_maxDrawCount):

Canonical link: <a href="https://commits.webkit.org/277855@main">https://commits.webkit.org/277855@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5da850100867d5ba346d60e7e5b56924c64931e5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48800 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28011 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51771 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51486 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44866 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33954 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25541 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39892 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49382 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/25660 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20991 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23121 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6855 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53397 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23850 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20120 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47193 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/25114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42290 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46136 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10740 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25921 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/24834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->