### PR TITLE
Create clear entry points for color parsing to allow uniformly passing options/tracking nesting

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-relative-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-relative-color-expected.txt
@@ -279,7 +279,10 @@ FAIL Property color value 'color-mix(in srgb, rgb(from rebeccapurple none g b), 
 Actual:   color(srgb 0.2 0.2 0.6)
 Expected: color(srgb 0.4 0.2 0.6).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 0.2
-FAIL Property color value 'rgb(from color-mix(in srgb, red, red) r g b / alpha)' assert_true: 'rgb(from color-mix(in srgb, red, red) r g b / alpha)' is a supported value for color. expected true got false
+FAIL Property color value 'rgb(from color-mix(in srgb, red, red) r g b / alpha)' Colors do not match.
+Actual:   rgb(255, 0, 0)
+Expected: color(srgb 1 0 0).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL Property color value 'hsl(from rebeccapurple h s l)' Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
@@ -497,7 +500,10 @@ Actual:   rgba(153, 102, 102, 0.5)
 Expected: color(srgb 0.6 0.4 0.4 / 0.5).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 PASS Property color value 'color-mix(in hsl, hsl(from rebeccapurple none s l), rebeccapurple)'
-FAIL Property color value 'hsl(from color-mix(in srgb, red, red) h s l / alpha)' assert_true: 'hsl(from color-mix(in srgb, red, red) h s l / alpha)' is a supported value for color. expected true got false
+FAIL Property color value 'hsl(from color-mix(in srgb, red, red) h s l / alpha)' Colors do not match.
+Actual:   rgb(255, 0, 0)
+Expected: color(srgb 1 0 0).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL Property color value 'hwb(from rebeccapurple h w b)' Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
@@ -715,7 +721,10 @@ Actual:   rgba(128, 51, 51, 0.5)
 Expected: color(srgb 0.5 0.2 0.2 / 0.5).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
 PASS Property color value 'color-mix(in hwb, hwb(from rebeccapurple none w b), rebeccapurple)'
-FAIL Property color value 'hwb(from color-mix(in srgb, red, red) h w b / alpha)' assert_true: 'hwb(from color-mix(in srgb, red, red) h w b / alpha)' is a supported value for color. expected true got false
+FAIL Property color value 'hwb(from color-mix(in srgb, red, red) h w b / alpha)' Colors do not match.
+Actual:   rgb(255, 0, 0)
+Expected: color(srgb 1 0 0).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 PASS Property color value 'lab(from lab(25 20 50) l a b)'
 PASS Property color value 'lab(from lab(25 20 50) l a b / alpha)'
 PASS Property color value 'lab(from lab(25 20 50 / 40%) l a b / alpha)'
@@ -768,7 +777,7 @@ PASS Property color value 'lab(from lab(none none none / none) l a b / alpha)'
 PASS Property color value 'lab(from lab(25 none 50) l a b)'
 PASS Property color value 'lab(from lab(25 20 50 / none) l a b / alpha)'
 PASS Property color value 'color-mix(in lab, lab(from lab(25 20 50) none a b), lab(25 20 50))'
-FAIL Property color value 'lab(from color-mix(in lab, lab(25 20 50), lab(25 20 50)) l a b / alpha)' assert_true: 'lab(from color-mix(in lab, lab(25 20 50), lab(25 20 50)) l a b / alpha)' is a supported value for color. expected true got false
+PASS Property color value 'lab(from color-mix(in lab, lab(25 20 50), lab(25 20 50)) l a b / alpha)'
 PASS Property color value 'oklab(from oklab(0.25 0.2 0.5) l a b)'
 PASS Property color value 'oklab(from oklab(0.25 0.2 0.5) l a b / alpha)'
 PASS Property color value 'oklab(from oklab(0.25 0.2 0.5 / 40%) l a b / alpha)'
@@ -821,7 +830,7 @@ PASS Property color value 'oklab(from oklab(none none none / none) l a b / alpha
 PASS Property color value 'oklab(from oklab(0.25 none 0.5) l a b)'
 PASS Property color value 'oklab(from oklab(0.25 0.2 0.5 / none) l a b / alpha)'
 PASS Property color value 'color-mix(in oklab, oklab(from oklab(0.25 0.2 0.5) none a b), oklab(0.25 0.2 0.5))'
-FAIL Property color value 'oklab(from color-mix(in oklab, oklab(0.25 0.2 0.5), oklab(0.25 0.2 0.5)) l a b / alpha)' assert_true: 'oklab(from color-mix(in oklab, oklab(0.25 0.2 0.5), oklab(0.25 0.2 0.5)) l a b / alpha)' is a supported value for color. expected true got false
+PASS Property color value 'oklab(from color-mix(in oklab, oklab(0.25 0.2 0.5), oklab(0.25 0.2 0.5)) l a b / alpha)'
 PASS Property color value 'lch(from lch(0.7 45 30) l c h)'
 PASS Property color value 'lch(from lch(0.7 45 30) l c h / alpha)'
 PASS Property color value 'lch(from lch(0.7 45 30 / 40%) l c h / alpha)'
@@ -878,7 +887,7 @@ PASS Property color value 'lch(from lch(none none none / none) l c h / alpha)'
 PASS Property color value 'lch(from lch(0.7 none 30) l c h)'
 PASS Property color value 'lch(from lch(0.7 45 30 / none) l c h / alpha)'
 PASS Property color value 'color-mix(in lch, lch(from lch(0.7 45 30) l c none), lch(0.7 45 30))'
-FAIL Property color value 'lch(from color-mix(in lch, lch(70 45 30), lch(70 45 30)) l c h / alpha)' assert_true: 'lch(from color-mix(in lch, lch(70 45 30), lch(70 45 30)) l c h / alpha)' is a supported value for color. expected true got false
+PASS Property color value 'lch(from color-mix(in lch, lch(70 45 30), lch(70 45 30)) l c h / alpha)'
 PASS Property color value 'oklch(from oklch(0.7 0.45 30) l c h)'
 PASS Property color value 'oklch(from oklch(0.7 0.45 30) l c h / alpha)'
 PASS Property color value 'oklch(from oklch(0.7 0.45 30 / 40%) l c h / alpha)'
@@ -935,7 +944,7 @@ PASS Property color value 'oklch(from oklch(none none none / none) l c h / alpha
 PASS Property color value 'oklch(from oklch(0.7 none 30) l c h)'
 PASS Property color value 'oklch(from oklch(0.7 0.45 30 / none) l c h / alpha)'
 PASS Property color value 'color-mix(in oklch, oklch(from oklch(0.7 0.45 30) l c none), oklch(0.7 0.45 30))'
-FAIL Property color value 'oklch(from color-mix(in oklch, oklch(0.7 0.45 30), oklch(0.7 0.45 30)) l c h / alpha)' assert_true: 'oklch(from color-mix(in oklch, oklch(0.7 0.45 30), oklch(0.7 0.45 30)) l c h / alpha)' is a supported value for color. expected true got false
+PASS Property color value 'oklch(from color-mix(in oklch, oklch(0.7 0.45 30), oklch(0.7 0.45 30)) l c h / alpha)'
 PASS Property color value 'color(from color(srgb 0.7 0.5 0.3) srgb r g b)'
 PASS Property color value 'color(from color(srgb 0.7 0.5 0.3) srgb r g b / alpha)'
 FAIL Property color value 'color(from color(srgb 0.7 0.5 0.3 / 40%) srgb r g b)' Colors do not match.
@@ -1017,7 +1026,7 @@ PASS Property color value 'color(from color(srgb none none none) srgb r g b)'
 PASS Property color value 'color(from color(srgb none none none / none) srgb r g b / alpha)'
 PASS Property color value 'color(from color(srgb 0.7 none 0.3) srgb r g b)'
 PASS Property color value 'color(from color(srgb 0.7 0.5 0.3 / none) srgb r g b / alpha)'
-FAIL Property color value 'color(from color-mix(in xyz, color(srgb 0.7 0.5 0.3), color(srgb 0.7 0.5 0.3)) srgb r g b / alpha)' assert_true: 'color(from color-mix(in xyz, color(srgb 0.7 0.5 0.3), color(srgb 0.7 0.5 0.3)) srgb r g b / alpha)' is a supported value for color. expected true got false
+PASS Property color value 'color(from color-mix(in xyz, color(srgb 0.7 0.5 0.3), color(srgb 0.7 0.5 0.3)) srgb r g b / alpha)'
 PASS Property color value 'color(from color(srgb-linear 0.7 0.5 0.3) srgb-linear r g b)'
 PASS Property color value 'color(from color(srgb-linear 0.7 0.5 0.3) srgb-linear r g b / alpha)'
 FAIL Property color value 'color(from color(srgb-linear 0.7 0.5 0.3 / 40%) srgb-linear r g b)' Colors do not match.
@@ -1099,7 +1108,7 @@ PASS Property color value 'color(from color(srgb-linear none none none) srgb-lin
 PASS Property color value 'color(from color(srgb-linear none none none / none) srgb-linear r g b / alpha)'
 PASS Property color value 'color(from color(srgb-linear 0.7 none 0.3) srgb-linear r g b)'
 PASS Property color value 'color(from color(srgb-linear 0.7 0.5 0.3 / none) srgb-linear r g b / alpha)'
-FAIL Property color value 'color(from color-mix(in xyz, color(srgb-linear 0.7 0.5 0.3), color(srgb-linear 0.7 0.5 0.3)) srgb-linear r g b / alpha)' assert_true: 'color(from color-mix(in xyz, color(srgb-linear 0.7 0.5 0.3), color(srgb-linear 0.7 0.5 0.3)) srgb-linear r g b / alpha)' is a supported value for color. expected true got false
+PASS Property color value 'color(from color-mix(in xyz, color(srgb-linear 0.7 0.5 0.3), color(srgb-linear 0.7 0.5 0.3)) srgb-linear r g b / alpha)'
 PASS Property color value 'color(from color(a98-rgb 0.7 0.5 0.3) a98-rgb r g b)'
 PASS Property color value 'color(from color(a98-rgb 0.7 0.5 0.3) a98-rgb r g b / alpha)'
 FAIL Property color value 'color(from color(a98-rgb 0.7 0.5 0.3 / 40%) a98-rgb r g b)' Colors do not match.
@@ -1181,7 +1190,10 @@ PASS Property color value 'color(from color(a98-rgb none none none) a98-rgb r g 
 PASS Property color value 'color(from color(a98-rgb none none none / none) a98-rgb r g b / alpha)'
 PASS Property color value 'color(from color(a98-rgb 0.7 none 0.3) a98-rgb r g b)'
 PASS Property color value 'color(from color(a98-rgb 0.7 0.5 0.3 / none) a98-rgb r g b / alpha)'
-FAIL Property color value 'color(from color-mix(in xyz, color(a98-rgb 0.7 0.5 0.3), color(a98-rgb 0.7 0.5 0.3)) a98-rgb r g b / alpha)' assert_true: 'color(from color-mix(in xyz, color(a98-rgb 0.7 0.5 0.3), color(a98-rgb 0.7 0.5 0.3)) a98-rgb r g b / alpha)' is a supported value for color. expected true got false
+FAIL Property color value 'color(from color-mix(in xyz, color(a98-rgb 0.7 0.5 0.3), color(a98-rgb 0.7 0.5 0.3)) a98-rgb r g b / alpha)' Colors do not match.
+Actual:   color(a98-rgb 0.724466 0.511409 0.324083)
+Expected: color(a98-rgb 0.7 0.5 0.3).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.7 +/- 0.01, expected 0.7 but got 0.724466
 PASS Property color value 'color(from color(rec2020 0.7 0.5 0.3) rec2020 r g b)'
 PASS Property color value 'color(from color(rec2020 0.7 0.5 0.3) rec2020 r g b / alpha)'
 FAIL Property color value 'color(from color(rec2020 0.7 0.5 0.3 / 40%) rec2020 r g b)' Colors do not match.
@@ -1263,7 +1275,7 @@ PASS Property color value 'color(from color(rec2020 none none none) rec2020 r g 
 PASS Property color value 'color(from color(rec2020 none none none / none) rec2020 r g b / alpha)'
 PASS Property color value 'color(from color(rec2020 0.7 none 0.3) rec2020 r g b)'
 PASS Property color value 'color(from color(rec2020 0.7 0.5 0.3 / none) rec2020 r g b / alpha)'
-FAIL Property color value 'color(from color-mix(in xyz, color(rec2020 0.7 0.5 0.3), color(rec2020 0.7 0.5 0.3)) rec2020 r g b / alpha)' assert_true: 'color(from color-mix(in xyz, color(rec2020 0.7 0.5 0.3), color(rec2020 0.7 0.5 0.3)) rec2020 r g b / alpha)' is a supported value for color. expected true got false
+PASS Property color value 'color(from color-mix(in xyz, color(rec2020 0.7 0.5 0.3), color(rec2020 0.7 0.5 0.3)) rec2020 r g b / alpha)'
 PASS Property color value 'color(from color(prophoto-rgb 0.7 0.5 0.3) prophoto-rgb r g b)'
 PASS Property color value 'color(from color(prophoto-rgb 0.7 0.5 0.3) prophoto-rgb r g b / alpha)'
 FAIL Property color value 'color(from color(prophoto-rgb 0.7 0.5 0.3 / 40%) prophoto-rgb r g b)' Colors do not match.
@@ -1345,7 +1357,7 @@ PASS Property color value 'color(from color(prophoto-rgb none none none) prophot
 PASS Property color value 'color(from color(prophoto-rgb none none none / none) prophoto-rgb r g b / alpha)'
 PASS Property color value 'color(from color(prophoto-rgb 0.7 none 0.3) prophoto-rgb r g b)'
 PASS Property color value 'color(from color(prophoto-rgb 0.7 0.5 0.3 / none) prophoto-rgb r g b / alpha)'
-FAIL Property color value 'color(from color-mix(in xyz, color(prophoto-rgb 0.7 0.5 0.3), color(prophoto-rgb 0.7 0.5 0.3)) prophoto-rgb r g b / alpha)' assert_true: 'color(from color-mix(in xyz, color(prophoto-rgb 0.7 0.5 0.3), color(prophoto-rgb 0.7 0.5 0.3)) prophoto-rgb r g b / alpha)' is a supported value for color. expected true got false
+PASS Property color value 'color(from color-mix(in xyz, color(prophoto-rgb 0.7 0.5 0.3), color(prophoto-rgb 0.7 0.5 0.3)) prophoto-rgb r g b / alpha)'
 PASS Property color value 'color(from color(display-p3 0.7 0.5 0.3) display-p3 r g b)'
 PASS Property color value 'color(from color(display-p3 0.7 0.5 0.3) display-p3 r g b / alpha)'
 FAIL Property color value 'color(from color(display-p3 0.7 0.5 0.3 / 40%) display-p3 r g b)' Colors do not match.
@@ -1427,7 +1439,7 @@ PASS Property color value 'color(from color(display-p3 none none none) display-p
 PASS Property color value 'color(from color(display-p3 none none none / none) display-p3 r g b / alpha)'
 PASS Property color value 'color(from color(display-p3 0.7 none 0.3) display-p3 r g b)'
 PASS Property color value 'color(from color(display-p3 0.7 0.5 0.3 / none) display-p3 r g b / alpha)'
-FAIL Property color value 'color(from color-mix(in xyz, color(display-p3 0.7 0.5 0.3), color(display-p3 0.7 0.5 0.3)) display-p3 r g b / alpha)' assert_true: 'color(from color-mix(in xyz, color(display-p3 0.7 0.5 0.3), color(display-p3 0.7 0.5 0.3)) display-p3 r g b / alpha)' is a supported value for color. expected true got false
+PASS Property color value 'color(from color-mix(in xyz, color(display-p3 0.7 0.5 0.3), color(display-p3 0.7 0.5 0.3)) display-p3 r g b / alpha)'
 PASS Property color value 'color(from color(xyz 7 -20.5 100) xyz x y z)'
 PASS Property color value 'color(from color(xyz 7 -20.5 100) xyz x y z / alpha)'
 FAIL Property color value 'color(from color(xyz 7 -20.5 100 / 40%) xyz x y z)' Colors do not match.
@@ -1479,7 +1491,7 @@ PASS Property color value 'color(from color(xyz none none none) xyz x y z)'
 PASS Property color value 'color(from color(xyz none none none / none) xyz x y z / alpha)'
 PASS Property color value 'color(from color(xyz 7 none 100) xyz x y z)'
 PASS Property color value 'color(from color(xyz 7 -20.5 100 / none) xyz x y z / alpha)'
-FAIL Property color value 'color(from color-mix(in xyz, color(xyz 0.7 0.5 0.3), color(xyz 0.7 0.5 0.3)) xyz x y z / alpha)' assert_true: 'color(from color-mix(in xyz, color(xyz 0.7 0.5 0.3), color(xyz 0.7 0.5 0.3)) xyz x y z / alpha)' is a supported value for color. expected true got false
+PASS Property color value 'color(from color-mix(in xyz, color(xyz 0.7 0.5 0.3), color(xyz 0.7 0.5 0.3)) xyz x y z / alpha)'
 PASS Property color value 'color(from color(xyz-d50 7 -20.5 100) xyz-d50 x y z)'
 PASS Property color value 'color(from color(xyz-d50 7 -20.5 100) xyz-d50 x y z / alpha)'
 FAIL Property color value 'color(from color(xyz-d50 7 -20.5 100 / 40%) xyz-d50 x y z)' Colors do not match.
@@ -1531,7 +1543,7 @@ PASS Property color value 'color(from color(xyz-d50 none none none) xyz-d50 x y 
 PASS Property color value 'color(from color(xyz-d50 none none none / none) xyz-d50 x y z / alpha)'
 PASS Property color value 'color(from color(xyz-d50 7 none 100) xyz-d50 x y z)'
 PASS Property color value 'color(from color(xyz-d50 7 -20.5 100 / none) xyz-d50 x y z / alpha)'
-FAIL Property color value 'color(from color-mix(in xyz, color(xyz-d50 0.7 0.5 0.3), color(xyz-d50 0.7 0.5 0.3)) xyz-d50 x y z / alpha)' assert_true: 'color(from color-mix(in xyz, color(xyz-d50 0.7 0.5 0.3), color(xyz-d50 0.7 0.5 0.3)) xyz-d50 x y z / alpha)' is a supported value for color. expected true got false
+PASS Property color value 'color(from color-mix(in xyz, color(xyz-d50 0.7 0.5 0.3), color(xyz-d50 0.7 0.5 0.3)) xyz-d50 x y z / alpha)'
 PASS Property color value 'color(from color(xyz-d65 7 -20.5 100) xyz-d65 x y z)'
 PASS Property color value 'color(from color(xyz-d65 7 -20.5 100) xyz-d65 x y z / alpha)'
 FAIL Property color value 'color(from color(xyz-d65 7 -20.5 100 / 40%) xyz-d65 x y z)' Colors do not match.
@@ -1583,7 +1595,7 @@ PASS Property color value 'color(from color(xyz-d65 none none none) xyz-d65 x y 
 PASS Property color value 'color(from color(xyz-d65 none none none / none) xyz-d65 x y z / alpha)'
 PASS Property color value 'color(from color(xyz-d65 7 none 100) xyz-d65 x y z)'
 PASS Property color value 'color(from color(xyz-d65 7 -20.5 100 / none) xyz-d65 x y z / alpha)'
-FAIL Property color value 'color(from color-mix(in xyz, color(xyz-d65 0.7 0.5 0.3), color(xyz-d65 0.7 0.5 0.3)) xyz-d65 x y z / alpha)' assert_true: 'color(from color-mix(in xyz, color(xyz-d65 0.7 0.5 0.3), color(xyz-d65 0.7 0.5 0.3)) xyz-d65 x y z / alpha)' is a supported value for color. expected true got false
+PASS Property color value 'color(from color-mix(in xyz, color(xyz-d65 0.7 0.5 0.3), color(xyz-d65 0.7 0.5 0.3)) xyz-d65 x y z / alpha)'
 PASS Property color value 'color(from color(srgb-linear 0.25 0.5 0.75) srgb r g b)'
 PASS Property color value 'color(from color(srgb 0.25 0.5 0.75) srgb-linear r g b)'
 PASS Property color value 'color(from color(display-p3 0.25 0.5 0.75) srgb r g b)'

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color-expected.txt
@@ -272,7 +272,10 @@ Actual:   rgba(51, 102, 153, 0)
 Expected: color(srgb 0.2 0.4 0.6 / 0).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from currentColor r g b)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['color'] = "rgb(from color-mix(in srgb, red, red) r g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgb(from color-mix(in srgb, red, red) r g b / alpha)" should set the property value Colors do not match.
+Actual:   rgb(255, 0, 0)
+Expected: color(srgb 1 0 0).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL e.style['color'] = "rgba(from rebeccapurple r g b)" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['color'] = "rgba(from rebeccapurple r g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) r g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
@@ -556,7 +559,10 @@ Actual:   rgba(153, 102, 102, 0.5)
 Expected: color(srgb 0.6 0.4 0.4 / 0.5).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hsl(from currentColor h s l)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['color'] = "hsl(from color-mix(in srgb, red, red) h s l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsl(from color-mix(in srgb, red, red) h s l / alpha)" should set the property value Colors do not match.
+Actual:   rgb(255, 0, 0)
+Expected: color(srgb 1 0 0).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL e.style['color'] = "hsla(from rebeccapurple h s l)" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['color'] = "hsla(from rebeccapurple h s l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['color'] = "hsla(from rgb(20%, 40%, 60%, 80%) h s l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
@@ -825,7 +831,10 @@ Actual:   rgba(128, 51, 51, 0.5)
 Expected: color(srgb 0.5 0.2 0.2 / 0.5).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
 FAIL e.style['color'] = "hwb(from currentColor h w b)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['color'] = "hwb(from color-mix(in srgb, red, red) h w b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hwb(from color-mix(in srgb, red, red) h w b / alpha)" should set the property value Colors do not match.
+Actual:   rgb(255, 0, 0)
+Expected: color(srgb 1 0 0).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 PASS e.style['color'] = "lab(from lab(25 20 50) l a b)" should set the property value
 PASS e.style['color'] = "lab(from lab(25 20 50) l a b / alpha)" should set the property value
 PASS e.style['color'] = "lab(from lab(25 20 50 / 40%) l a b / alpha)" should set the property value
@@ -876,7 +885,7 @@ PASS e.style['color'] = "lab(from lab(none none none / none) l a b / alpha)" sho
 PASS e.style['color'] = "lab(from lab(25 none 50) l a b)" should set the property value
 PASS e.style['color'] = "lab(from lab(25 20 50 / none) l a b / alpha)" should set the property value
 FAIL e.style['color'] = "lab(from currentColor l a b)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['color'] = "lab(from color-mix(in lab, lab(25 20 50), lab(25 20 50)) l a b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['color'] = "lab(from color-mix(in lab, lab(25 20 50), lab(25 20 50)) l a b / alpha)" should set the property value
 PASS e.style['color'] = "oklab(from oklab(0.25 0.2 0.5) l a b)" should set the property value
 PASS e.style['color'] = "oklab(from oklab(0.25 0.2 0.5) l a b / alpha)" should set the property value
 PASS e.style['color'] = "oklab(from oklab(0.25 0.2 0.5 / 40%) l a b / alpha)" should set the property value
@@ -927,7 +936,7 @@ PASS e.style['color'] = "oklab(from oklab(none none none / none) l a b / alpha)"
 PASS e.style['color'] = "oklab(from oklab(0.25 none 0.5) l a b)" should set the property value
 PASS e.style['color'] = "oklab(from oklab(0.25 0.2 0.5 / none) l a b / alpha)" should set the property value
 FAIL e.style['color'] = "oklab(from currentColor l a b)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['color'] = "oklab(from color-mix(in oklab, oklab(0.25 0.2 0.5), oklab(0.25 0.2 0.5)) l a b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['color'] = "oklab(from color-mix(in oklab, oklab(0.25 0.2 0.5), oklab(0.25 0.2 0.5)) l a b / alpha)" should set the property value
 PASS e.style['color'] = "lch(from lch(0.7 45 30) l c h)" should set the property value
 PASS e.style['color'] = "lch(from lch(0.7 45 30) l c h / alpha)" should set the property value
 PASS e.style['color'] = "lch(from lch(0.7 45 30 / 40%) l c h / alpha)" should set the property value
@@ -983,7 +992,7 @@ PASS e.style['color'] = "lch(from lch(none none none / none) l c h / alpha)" sho
 PASS e.style['color'] = "lch(from lch(0.7 none 30) l c h)" should set the property value
 PASS e.style['color'] = "lch(from lch(0.7 45 30 / none) l c h / alpha)" should set the property value
 FAIL e.style['color'] = "lch(from currentColor) l c h)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['color'] = "lch(from color-mix(in lch, lch(70 45 30), lch(70 45 30)) l c h / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['color'] = "lch(from color-mix(in lch, lch(70 45 30), lch(70 45 30)) l c h / alpha)" should set the property value
 PASS e.style['color'] = "oklch(from oklch(0.7 0.45 30) l c h)" should set the property value
 PASS e.style['color'] = "oklch(from oklch(0.7 0.45 30) l c h / alpha)" should set the property value
 PASS e.style['color'] = "oklch(from oklch(0.7 0.45 30 / 40%) l c h / alpha)" should set the property value
@@ -1038,7 +1047,7 @@ PASS e.style['color'] = "oklch(from oklch(none none none) l c h)" should set the
 PASS e.style['color'] = "oklch(from oklch(none none none / none) l c h / alpha)" should set the property value
 PASS e.style['color'] = "oklch(from oklch(0.7 none 30) l c h)" should set the property value
 PASS e.style['color'] = "oklch(from oklch(0.7 0.45 30 / none) l c h / alpha)" should set the property value
-FAIL e.style['color'] = "oklch(from color-mix(in oklch, oklch(0.7 0.45 30), oklch(0.7 0.45 30)) l c h / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['color'] = "oklch(from color-mix(in oklch, oklch(0.7 0.45 30), oklch(0.7 0.45 30)) l c h / alpha)" should set the property value
 FAIL e.style['color'] = "oklch(from currentColor l c h)" should set the property value assert_not_equals: property should be set got disallowed value ""
 PASS e.style['color'] = "color(from color(srgb 0.7 0.5 0.3) srgb r g b)" should set the property value
 PASS e.style['color'] = "color(from color(srgb 0.7 0.5 0.3) srgb r g b / alpha)" should set the property value
@@ -1118,7 +1127,7 @@ PASS e.style['color'] = "color(from color(srgb none none none / none) srgb r g b
 PASS e.style['color'] = "color(from color(srgb 0.7 none 0.3) srgb r g b)" should set the property value
 PASS e.style['color'] = "color(from color(srgb 0.7 0.5 0.3 / none) srgb r g b / alpha)" should set the property value
 FAIL e.style['color'] = "color(from currentColor srgb r g b)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['color'] = "color(from color-mix(in xyz, color(srgb 0.7 0.5 0.3), color(srgb 0.7 0.5 0.3)) srgb r g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['color'] = "color(from color-mix(in xyz, color(srgb 0.7 0.5 0.3), color(srgb 0.7 0.5 0.3)) srgb r g b / alpha)" should set the property value
 PASS e.style['color'] = "color(from color(srgb-linear 0.7 0.5 0.3) srgb-linear r g b)" should set the property value
 PASS e.style['color'] = "color(from color(srgb-linear 0.7 0.5 0.3) srgb-linear r g b / alpha)" should set the property value
 FAIL e.style['color'] = "color(from color(srgb-linear 0.7 0.5 0.3 / 40%) srgb-linear r g b)" should set the property value Colors do not match.
@@ -1197,7 +1206,7 @@ PASS e.style['color'] = "color(from color(srgb-linear none none none / none) srg
 PASS e.style['color'] = "color(from color(srgb-linear 0.7 none 0.3) srgb-linear r g b)" should set the property value
 PASS e.style['color'] = "color(from color(srgb-linear 0.7 0.5 0.3 / none) srgb-linear r g b / alpha)" should set the property value
 FAIL e.style['color'] = "color(from currentColor srgb-linear r g b)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['color'] = "color(from color-mix(in xyz, color(srgb-linear 0.7 0.5 0.3), color(srgb-linear 0.7 0.5 0.3)) srgb-linear r g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['color'] = "color(from color-mix(in xyz, color(srgb-linear 0.7 0.5 0.3), color(srgb-linear 0.7 0.5 0.3)) srgb-linear r g b / alpha)" should set the property value
 PASS e.style['color'] = "color(from color(a98-rgb 0.7 0.5 0.3) a98-rgb r g b)" should set the property value
 PASS e.style['color'] = "color(from color(a98-rgb 0.7 0.5 0.3) a98-rgb r g b / alpha)" should set the property value
 FAIL e.style['color'] = "color(from color(a98-rgb 0.7 0.5 0.3 / 40%) a98-rgb r g b)" should set the property value Colors do not match.
@@ -1276,7 +1285,10 @@ PASS e.style['color'] = "color(from color(a98-rgb none none none / none) a98-rgb
 PASS e.style['color'] = "color(from color(a98-rgb 0.7 none 0.3) a98-rgb r g b)" should set the property value
 PASS e.style['color'] = "color(from color(a98-rgb 0.7 0.5 0.3 / none) a98-rgb r g b / alpha)" should set the property value
 FAIL e.style['color'] = "color(from currentColor a98-rgb r g b)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['color'] = "color(from color-mix(in xyz, color(a98-rgb 0.7 0.5 0.3), color(a98-rgb 0.7 0.5 0.3)) a98-rgb r g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "color(from color-mix(in xyz, color(a98-rgb 0.7 0.5 0.3), color(a98-rgb 0.7 0.5 0.3)) a98-rgb r g b / alpha)" should set the property value Colors do not match.
+Actual:   color(a98-rgb 0.724466 0.511409 0.324083)
+Expected: color(a98-rgb 0.7 0.5 0.3).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.7 +/- 0.01, expected 0.7 but got 0.724466
 PASS e.style['color'] = "color(from color(rec2020 0.7 0.5 0.3) rec2020 r g b)" should set the property value
 PASS e.style['color'] = "color(from color(rec2020 0.7 0.5 0.3) rec2020 r g b / alpha)" should set the property value
 FAIL e.style['color'] = "color(from color(rec2020 0.7 0.5 0.3 / 40%) rec2020 r g b)" should set the property value Colors do not match.
@@ -1355,7 +1367,7 @@ PASS e.style['color'] = "color(from color(rec2020 none none none / none) rec2020
 PASS e.style['color'] = "color(from color(rec2020 0.7 none 0.3) rec2020 r g b)" should set the property value
 PASS e.style['color'] = "color(from color(rec2020 0.7 0.5 0.3 / none) rec2020 r g b / alpha)" should set the property value
 FAIL e.style['color'] = "color(from currentColor rec2020 r g b)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['color'] = "color(from color-mix(in xyz, color(rec2020 0.7 0.5 0.3), color(rec2020 0.7 0.5 0.3)) rec2020 r g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['color'] = "color(from color-mix(in xyz, color(rec2020 0.7 0.5 0.3), color(rec2020 0.7 0.5 0.3)) rec2020 r g b / alpha)" should set the property value
 PASS e.style['color'] = "color(from color(prophoto-rgb 0.7 0.5 0.3) prophoto-rgb r g b)" should set the property value
 PASS e.style['color'] = "color(from color(prophoto-rgb 0.7 0.5 0.3) prophoto-rgb r g b / alpha)" should set the property value
 FAIL e.style['color'] = "color(from color(prophoto-rgb 0.7 0.5 0.3 / 40%) prophoto-rgb r g b)" should set the property value Colors do not match.
@@ -1434,7 +1446,7 @@ PASS e.style['color'] = "color(from color(prophoto-rgb none none none / none) pr
 PASS e.style['color'] = "color(from color(prophoto-rgb 0.7 none 0.3) prophoto-rgb r g b)" should set the property value
 PASS e.style['color'] = "color(from color(prophoto-rgb 0.7 0.5 0.3 / none) prophoto-rgb r g b / alpha)" should set the property value
 FAIL e.style['color'] = "color(from currentColor prophoto-rgb r g b)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['color'] = "color(from color-mix(in xyz, color(prophoto-rgb 0.7 0.5 0.3), color(prophoto-rgb 0.7 0.5 0.3)) prophoto-rgb r g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['color'] = "color(from color-mix(in xyz, color(prophoto-rgb 0.7 0.5 0.3), color(prophoto-rgb 0.7 0.5 0.3)) prophoto-rgb r g b / alpha)" should set the property value
 PASS e.style['color'] = "color(from color(display-p3 0.7 0.5 0.3) display-p3 r g b)" should set the property value
 PASS e.style['color'] = "color(from color(display-p3 0.7 0.5 0.3) display-p3 r g b / alpha)" should set the property value
 FAIL e.style['color'] = "color(from color(display-p3 0.7 0.5 0.3 / 40%) display-p3 r g b)" should set the property value Colors do not match.
@@ -1513,7 +1525,7 @@ PASS e.style['color'] = "color(from color(display-p3 none none none / none) disp
 PASS e.style['color'] = "color(from color(display-p3 0.7 none 0.3) display-p3 r g b)" should set the property value
 PASS e.style['color'] = "color(from color(display-p3 0.7 0.5 0.3 / none) display-p3 r g b / alpha)" should set the property value
 FAIL e.style['color'] = "color(from currentColor display-p3 r g b)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['color'] = "color(from color-mix(in xyz, color(display-p3 0.7 0.5 0.3), color(display-p3 0.7 0.5 0.3)) display-p3 r g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['color'] = "color(from color-mix(in xyz, color(display-p3 0.7 0.5 0.3), color(display-p3 0.7 0.5 0.3)) display-p3 r g b / alpha)" should set the property value
 PASS e.style['color'] = "color(from color(xyz 7 -20.5 100) xyz x y z)" should set the property value
 PASS e.style['color'] = "color(from color(xyz 7 -20.5 100) xyz x y z / alpha)" should set the property value
 FAIL e.style['color'] = "color(from color(xyz 7 -20.5 100 / 40%) xyz x y z)" should set the property value Colors do not match.
@@ -1562,7 +1574,7 @@ PASS e.style['color'] = "color(from color(xyz none none none / none) xyz x y z /
 PASS e.style['color'] = "color(from color(xyz 7 none 100) xyz x y z)" should set the property value
 PASS e.style['color'] = "color(from color(xyz 7 -20.5 100 / none) xyz x y z / alpha)" should set the property value
 FAIL e.style['color'] = "color(from currentColor xyz x y z)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['color'] = "color(from color-mix(in xyz, color(xyz 0.7 0.5 0.3), color(xyz 0.7 0.5 0.3)) xyz x y z / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['color'] = "color(from color-mix(in xyz, color(xyz 0.7 0.5 0.3), color(xyz 0.7 0.5 0.3)) xyz x y z / alpha)" should set the property value
 PASS e.style['color'] = "color(from color(xyz-d50 7 -20.5 100) xyz-d50 x y z)" should set the property value
 PASS e.style['color'] = "color(from color(xyz-d50 7 -20.5 100) xyz-d50 x y z / alpha)" should set the property value
 FAIL e.style['color'] = "color(from color(xyz-d50 7 -20.5 100 / 40%) xyz-d50 x y z)" should set the property value Colors do not match.
@@ -1611,7 +1623,7 @@ PASS e.style['color'] = "color(from color(xyz-d50 none none none / none) xyz-d50
 PASS e.style['color'] = "color(from color(xyz-d50 7 none 100) xyz-d50 x y z)" should set the property value
 PASS e.style['color'] = "color(from color(xyz-d50 7 -20.5 100 / none) xyz-d50 x y z / alpha)" should set the property value
 FAIL e.style['color'] = "color(from currentColor xyz-d50 x y z)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['color'] = "color(from color-mix(in xyz, color(xyz-d50 0.7 0.5 0.3), color(xyz-d50 0.7 0.5 0.3)) xyz-d50 x y z / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['color'] = "color(from color-mix(in xyz, color(xyz-d50 0.7 0.5 0.3), color(xyz-d50 0.7 0.5 0.3)) xyz-d50 x y z / alpha)" should set the property value
 PASS e.style['color'] = "color(from color(xyz-d65 7 -20.5 100) xyz-d65 x y z)" should set the property value
 PASS e.style['color'] = "color(from color(xyz-d65 7 -20.5 100) xyz-d65 x y z / alpha)" should set the property value
 FAIL e.style['color'] = "color(from color(xyz-d65 7 -20.5 100 / 40%) xyz-d65 x y z)" should set the property value Colors do not match.
@@ -1660,7 +1672,7 @@ PASS e.style['color'] = "color(from color(xyz-d65 none none none / none) xyz-d65
 PASS e.style['color'] = "color(from color(xyz-d65 7 none 100) xyz-d65 x y z)" should set the property value
 PASS e.style['color'] = "color(from color(xyz-d65 7 -20.5 100 / none) xyz-d65 x y z / alpha)" should set the property value
 FAIL e.style['color'] = "color(from currentColor xyz-d65 x y z)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['color'] = "color(from color-mix(in xyz, color(xyz-d65 0.7 0.5 0.3), color(xyz-d65 0.7 0.5 0.3)) xyz-d65 x y z / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['color'] = "color(from color-mix(in xyz, color(xyz-d65 0.7 0.5 0.3), color(xyz-d65 0.7 0.5 0.3)) xyz-d65 x y z / alpha)" should set the property value
 PASS e.style['color'] = "rgb(from var(--bg-color) r g b / 80%)" should set the property value
 PASS e.style['color'] = "lch(from var(--color) calc(l / 2) c h)" should set the property value
 PASS e.style['color'] = "rgb(from var(--color) calc(r * .3 + g * .59 + b * .11) calc(r * .3 + g * .59 + b * .11) calc(r * .3 + g * .59 + b * .11))" should set the property value

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.fillStyle.toStringFunctionCallback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.fillStyle.toStringFunctionCallback-expected.txt
@@ -3,5 +3,5 @@
 Passing a function in to ctx.fillStyle or ctx.strokeStyle with a toString callback works as specified
 
 
-FAIL Passing a function in to ctx.fillStyle or ctx.strokeStyle with a toString callback works as specified assert_equals: ctx.fillStyle === "#008000" (got #800000[string], expected #008000[string]) expected "#008000" but got "#800000"
+PASS Passing a function in to ctx.fillStyle or ctx.strokeStyle with a toString callback works as specified
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.fillStyle.toStringFunctionCallback.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.fillStyle.toStringFunctionCallback.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Passing a function in to ctx.fillStyle or ctx.strokeStyle with a toString callback works as specified assert_equals: ctx.fillStyle === "#008000" (got #800000[string], expected #008000[string]) expected "#008000" but got "#800000"
+PASS Passing a function in to ctx.fillStyle or ctx.strokeStyle with a toString callback works as specified
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "StyleColor.h"
+#include <optional>
 #include <wtf/OptionSet.h>
 #include <wtf/RefPtr.h>
 
@@ -39,14 +40,23 @@ struct CSSParserContext;
 
 namespace CSSPropertyParserHelpers {
 
-// MARK: <color>
-Color consumeColorWorkerSafe(CSSParserTokenRange&, const CSSParserContext&);
-RefPtr<CSSPrimitiveValue> consumeColor(CSSParserTokenRange&, const CSSParserContext&, bool acceptQuirkyColors = false, OptionSet<StyleColor::CSSColorType> = { StyleColor::CSSColorType::Absolute, StyleColor::CSSColorType::Current, StyleColor::CSSColorType::System });
+// Options to augment color parsing.
+struct CSSColorParsingOptions {
+    bool acceptQuirkyColors = false;
+    OptionSet<StyleColor::CSSColorType> allowedColorTypes = { StyleColor::CSSColorType::Absolute, StyleColor::CSSColorType::Current, StyleColor::CSSColorType::System };
+};
 
-
-// MARK: <color-interpolation-method>
+// MARK: <color-interpolation-method> (raw)
 std::optional<ColorInterpolationMethod> consumeColorInterpolationMethod(CSSParserTokenRange&);
 
-}
-}
+// MARK: <color> (raw)
+Color consumeColorRaw(CSSParserTokenRange&, const CSSParserContext&, const CSSColorParsingOptions&);
+Color parseColorRawWorkerSafe(const String&, const CSSParserContext&, const CSSColorParsingOptions&);
+Color parseColorRaw(const String&, const CSSParserContext&, const CSSColorParsingOptions&);
 
+// MARK: <color> (CSSPrimitiveValue)
+RefPtr<CSSPrimitiveValue> consumeColor(CSSParserTokenRange&, const CSSParserContext&, const CSSColorParsingOptions&);
+RefPtr<CSSPrimitiveValue> consumeColor(CSSParserTokenRange&, const CSSParserContext&, bool acceptQuirkyColors = false, OptionSet<StyleColor::CSSColorType> = { StyleColor::CSSColorType::Absolute, StyleColor::CSSColorType::Current, StyleColor::CSSColorType::System });
+
+}
+}

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Number.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Number.cpp
@@ -32,7 +32,7 @@ namespace CSSPropertyParserHelpers {
 
 // MARK: Number (Raw)
 
-static std::optional<NumberRaw> validatedNumberRaw(double value, ValueRange valueRange)
+std::optional<NumberRaw> validatedNumberRaw(double value, ValueRange valueRange)
 {
     if (valueRange == ValueRange::NonNegative && value < 0)
         return std::nullopt;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Number.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Number.h
@@ -41,6 +41,8 @@ namespace CSSPropertyParserHelpers {
 
 // MARK: Number (Raw)
 
+std::optional<NumberRaw> validatedNumberRaw(double, ValueRange);
+
 struct NumberRawKnownTokenTypeFunctionConsumer {
     static constexpr CSSParserTokenType tokenType = FunctionToken;
     static std::optional<NumberRaw> consume(CSSParserTokenRange&, const CSSCalcSymbolTable&, ValueRange, CSSParserMode, UnitlessQuirk, UnitlessZeroQuirk);

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Percent.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Percent.cpp
@@ -32,7 +32,7 @@ namespace CSSPropertyParserHelpers {
 
 // MARK: Percent (raw)
 
-static std::optional<PercentRaw> validatedPercentRaw(double value, ValueRange valueRange)
+std::optional<PercentRaw> validatedPercentRaw(double value, ValueRange valueRange)
 {
     if (valueRange == ValueRange::NonNegative && value < 0)
         return std::nullopt;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Percent.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Percent.h
@@ -43,6 +43,8 @@ namespace CSSPropertyParserHelpers {
 
 // MARK: Percent (raw)
 
+std::optional<PercentRaw> validatedPercentRaw(double, ValueRange);
+
 struct PercentRawKnownTokenTypeFunctionConsumer {
     static constexpr CSSParserTokenType tokenType = FunctionToken;
     static std::optional<PercentRaw> consume(CSSParserTokenRange&, const CSSCalcSymbolTable&, ValueRange, CSSParserMode, UnitlessQuirk, UnitlessZeroQuirk);

--- a/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
@@ -41,7 +41,6 @@
 #include "CSSParserTokenRange.h"
 #include "CSSPropertyParser.h"
 #include "CSSPropertyParserConsumer+Angle.h"
-#include "CSSPropertyParserConsumer+Color.h"
 #include "CSSPropertyParserConsumer+Ident.h"
 #include "CSSPropertyParserConsumer+Integer.h"
 #include "CSSPropertyParserConsumer+List.h"
@@ -76,18 +75,6 @@ std::optional<CSSPropertyParserHelpers::FontRaw> CSSPropertyParserWorkerSafe::pa
     range.consumeWhitespace();
 
     return CSSPropertyParserHelpers::consumeFontRaw(range, mode);
-}
-
-Color CSSPropertyParserWorkerSafe::parseColor(const String& string)
-{
-    if (auto color = CSSParserFastPaths::parseSimpleColor(string))
-        return *color;
-
-    CSSTokenizer tokenizer(string);
-    CSSParserTokenRange range(tokenizer.tokenRange());
-    range.consumeWhitespace();
-
-    return CSSPropertyParserHelpers::consumeColorWorkerSafe(range, CSSParserContext(HTMLStandardMode));
 }
 
 static CSSParserMode parserMode(ScriptExecutionContext& context)

--- a/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.h
@@ -37,12 +37,10 @@ class CSSPrimitiveValue;
 class CSSValue;
 class CSSValueList;
 class CSSValuePool;
-class Color;
 class ScriptExecutionContext;
 
 class CSSPropertyParserWorkerSafe {
 public:
-    static Color parseColor(const String&);
     static std::optional<CSSPropertyParserHelpers::FontRaw> parseFont(const String&, CSSParserMode = HTMLStandardMode);
 
     static RefPtr<CSSValueList> parseFontFaceSrc(const String&, const CSSParserContext&);

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -51,6 +51,8 @@ class ScriptExecutionContext;
 class SecurityOrigin;
 class WebCoreOpaqueRoot;
 
+struct CSSParserContext;
+
 enum class ShouldApplyPostProcessingToDirtyRect : bool { No, Yes };
 
 class CanvasDisplayBufferObserver : public CanMakeWeakPtr<CanvasDisplayBufferObserver> {
@@ -96,6 +98,8 @@ public:
     ScriptExecutionContext* scriptExecutionContext() const { return canvasBaseScriptExecutionContext();  }
 
     virtual CanvasRenderingContext* renderingContext() const = 0;
+
+    virtual const CSSParserContext& cssParserContext() const = 0;
 
     void addObserver(CanvasObserver&);
     void removeObserver(CanvasObserver&);

--- a/Source/WebCore/html/CustomPaintCanvas.cpp
+++ b/Source/WebCore/html/CustomPaintCanvas.cpp
@@ -27,6 +27,7 @@
 #include "CustomPaintCanvas.h"
 
 #include "BitmapImage.h"
+#include "CSSParserContext.h"
 #include "CanvasRenderingContext.h"
 #include "DisplayListDrawingContext.h"
 #include "DisplayListRecorder.h"
@@ -129,6 +130,14 @@ void CustomPaintCanvas::replayDisplayListImpl(GraphicsContext& target) const
         replayer.replay(FloatRect { { }, size() });
         displayList.clear();
     }
+}
+
+const CSSParserContext& CustomPaintCanvas::cssParserContext() const
+{
+    // FIXME: Rather than using a default CSSParserContext, there should be one exposed via ScriptExecutionContext.
+    if (!m_cssParserContext)
+        m_cssParserContext = WTF::makeUnique<CSSParserContext>(HTMLStandardMode);
+    return *m_cssParserContext;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/CustomPaintCanvas.h
+++ b/Source/WebCore/html/CustomPaintCanvas.h
@@ -72,6 +72,8 @@ public:
     void queueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) final { };
     void dispatchEvent(Event&) final { }
 
+    const CSSParserContext& cssParserContext() const final;
+
     using RefCounted::ref;
     using RefCounted::deref;
 
@@ -86,6 +88,8 @@ private:
     std::unique_ptr<CanvasRenderingContext> m_context;
     mutable std::unique_ptr<DisplayList::DrawingContext> m_recordingContext;
     mutable RefPtr<Image> m_copiedImage;
+
+    mutable std::unique_ptr<CSSParserContext> m_cssParserContext;
 };
 
 }

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -31,6 +31,7 @@
 #include "BitmapImage.h"
 #include "Blob.h"
 #include "BlobCallback.h"
+#include "CSSParserContext.h"
 #include "CanvasGradient.h"
 #include "CanvasPattern.h"
 #include "CanvasRenderingContext2D.h"
@@ -1012,6 +1013,13 @@ void HTMLCanvasElement::queueTaskKeepingObjectAlive(TaskSource source, Function<
 void HTMLCanvasElement::dispatchEvent(Event& event)
 {
     Node::dispatchEvent(event);
+}
+
+const CSSParserContext& HTMLCanvasElement::cssParserContext() const
+{
+    if (!m_cssParserContext)
+        m_cssParserContext = WTF::makeUnique<CSSParserContext>(document());
+    return *m_cssParserContext;
 }
 
 WebCoreOpaqueRoot root(HTMLCanvasElement* canvas)

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -28,7 +28,6 @@
 #pragma once
 
 #include "ActiveDOMObject.h"
-#include "CSSParserContext.h"
 #include "CanvasBase.h"
 #include "Document.h"
 #include "FloatRect.h"
@@ -118,6 +117,8 @@ public:
     ExceptionOr<Ref<MediaStream>> captureStream(std::optional<double>&& frameRequestRate);
 #endif
 
+    const CSSParserContext& cssParserContext() const final;
+
     Image* copiedImage() const final;
     void clearCopiedImage() const final;
     RefPtr<ImageData> getImageData();
@@ -138,8 +139,6 @@ public:
 
     void queueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) final;
     void dispatchEvent(Event&) final;
-
-    CSSParserContext& cssParserContext();
 
     using HTMLElement::ref;
     using HTMLElement::deref;
@@ -186,7 +185,7 @@ private:
 
     std::unique_ptr<CanvasRenderingContext> m_context;
     mutable RefPtr<Image> m_copiedImage; // FIXME: This is temporary for platforms that have to copy the image buffer to render (and for CSSCanvasValue).
-    std::unique_ptr<CSSParserContext> m_cssParserContext;
+    mutable std::unique_ptr<CSSParserContext> m_cssParserContext;
     bool m_ignoreReset { false };
     // m_hasCreatedImageBuffer means we tried to malloc the buffer. We didn't necessarily get it.
     mutable bool m_hasCreatedImageBuffer { false };
@@ -196,13 +195,6 @@ private:
 #endif
     bool m_isSnapshotting { false };
 };
-
-inline CSSParserContext& HTMLCanvasElement::cssParserContext()
-{
-    if (!m_cssParserContext)
-        m_cssParserContext = WTF::makeUnique<CSSParserContext>(document());
-    return *m_cssParserContext;
-}
 
 WebCoreOpaqueRoot root(HTMLCanvasElement*);
 

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(OFFSCREEN_CANVAS)
 
 #include "BitmapImage.h"
+#include "CSSParserContext.h"
 #include "CSSValuePool.h"
 #include "CanvasRenderingContext.h"
 #include "Chrome.h"
@@ -574,6 +575,14 @@ void OffscreenCanvas::queueTaskKeepingObjectAlive(TaskSource source, Function<vo
 void OffscreenCanvas::dispatchEvent(Event& event)
 {
     EventDispatcher::dispatchEvent({ this }, event);
+}
+
+const CSSParserContext& OffscreenCanvas::cssParserContext() const
+{
+    // FIXME: Rather than using a default CSSParserContext, there should be one exposed via ScriptExecutionContext.
+    if (!m_cssParserContext)
+        m_cssParserContext = WTF::makeUnique<CSSParserContext>(HTMLStandardMode);
+    return *m_cssParserContext;
 }
 
 }

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -135,6 +135,8 @@ public:
 
     CanvasRenderingContext* renderingContext() const final { return m_context.get(); }
 
+    const CSSParserContext& cssParserContext() const final;
+
     ExceptionOr<std::optional<OffscreenRenderingContext>> getContext(JSC::JSGlobalObject&, RenderingContextType, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments);
     ExceptionOr<RefPtr<ImageBitmap>> transferToImageBitmap();
     void convertToBlob(ImageEncodeOptions&&, Ref<DeferredPromise>&&);
@@ -191,6 +193,8 @@ private:
     mutable bool m_hasCreatedImageBuffer { false };
     bool m_detached { false };
     bool m_hasScheduledCommit { false };
+
+    mutable std::unique_ptr<CSSParserContext> m_cssParserContext;
 };
 
 }


### PR DESCRIPTION
#### 3d1a81f05a45ba46e924c411cfe06f510109054b
<pre>
Create clear entry points for color parsing to allow uniformly passing options/tracking nesting
<a href="https://bugs.webkit.org/show_bug.cgi?id=273019">https://bugs.webkit.org/show_bug.cgi?id=273019</a>

Reviewed by Darin Adler.

In preparation for additional changes to color parsing, this change
creates a consistent interface for the color parsing/consuming functions,
extracting out the color specific options into a new CSSColorParsingOptions
struct and utilizing the clear entry points to track nesting levels.
(For an example of nesting, parsing `color-mix()` is itself a color,
but as part of its parse, it recursively requires an additional &apos;origin&apos;
color to be parsed).

The nesting level will be useful in the near future to allow changes
in parsing when not at the top level.

* LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-relative-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color-expected.txt:
    In clarify the recursion, I fixed a bug where we were unnecessarily
    restrictive and were preventing nested `color-mix()` from working.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp:
(WebCore::CSSPropertyParserHelpers::ColorParserState::ColorParserState):
    Mutable state used only in the cpp file to track options and nesting level.

(WebCore::CSSPropertyParserHelpers::ColorParserStateNester::ColorParserStateNester):
(WebCore::CSSPropertyParserHelpers::ColorParserStateNester::~ColorParserStateNester):
    Helper to increment/decrement nesting level using RAII.

(WebCore::CSSPropertyParserHelpers::consumeOriginColorRaw):
(WebCore::CSSPropertyParserHelpers::parseRelativeRGBParametersRaw):
(WebCore::CSSPropertyParserHelpers::parseRGBParametersRaw):
(WebCore::CSSPropertyParserHelpers::parseRelativeHSLParametersRaw):
(WebCore::CSSPropertyParserHelpers::parseNonRelativeHSLParametersRaw):
(WebCore::CSSPropertyParserHelpers::parseHSLParametersRaw):
(WebCore::CSSPropertyParserHelpers::parseRelativeHWBParametersRaw):
(WebCore::CSSPropertyParserHelpers::parseNonRelativeHWBParametersRaw):
(WebCore::CSSPropertyParserHelpers::parseHWBParametersRaw):
(WebCore::CSSPropertyParserHelpers::parseRelativeLabParametersRaw):
(WebCore::CSSPropertyParserHelpers::parseLabParametersRaw):
(WebCore::CSSPropertyParserHelpers::parseRelativeLCHParametersRaw):
(WebCore::CSSPropertyParserHelpers::parseNonRelativeLCHParametersRaw):
(WebCore::CSSPropertyParserHelpers::parseLCHParametersRaw):
(WebCore::CSSPropertyParserHelpers::parseRelativeColorFunctionParameters):
(WebCore::CSSPropertyParserHelpers::parseColorFunctionParametersRaw):
(WebCore::CSSPropertyParserHelpers::parseColorContrastFunctionParametersRaw):
(WebCore::CSSPropertyParserHelpers::consumeColorMixComponentRaw):
(WebCore::CSSPropertyParserHelpers::consumeColorMixComponent):
(WebCore::CSSPropertyParserHelpers::parseColorMixFunctionParametersRaw):
(WebCore::CSSPropertyParserHelpers::parseColorMixFunctionParameters):
(WebCore::CSSPropertyParserHelpers::parseLightDarkFunctionParameters):
(WebCore::CSSPropertyParserHelpers::parseHexColor):
(WebCore::CSSPropertyParserHelpers::parseColorFunctionRaw):
(WebCore::CSSPropertyParserHelpers::parseColorFunction):
(WebCore::CSSPropertyParserHelpers::consumeColor):
(WebCore::CSSPropertyParserHelpers::consumeColorRaw):
(WebCore::CSSPropertyParserHelpers::parseColorRawWorkerSafe):
(WebCore::CSSPropertyParserHelpers::parseColorRaw):
    Pass ColorParserState down the stack.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Number.cpp:
(WebCore::CSSPropertyParserHelpers::validatedNumberRaw):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Number.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Percent.cpp:
(WebCore::CSSPropertyParserHelpers::validatedPercentRaw):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Percent.h:
    Add validate function forward declarations into the headers. This
    was only compiling due to the unified build happening to group
    things just right.

* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp:
(WebCore::CSSPropertyParserWorkerSafe::parseColor): Deleted.
* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.h:
    Move to CSSPropertyParserConsumer+Color.h.

* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/CustomPaintCanvas.h:
(WebCore::CustomPaintCanvas::cssParserContext const):
* Source/WebCore/html/HTMLCanvasElement.h:
(WebCore::HTMLCanvasElement::cssParserContext const):
(WebCore::HTMLCanvasElement::cssParserContext): Deleted.
* Source/WebCore/html/OffscreenCanvas.h:
(WebCore::OffscreenCanvas::cssParserContext const):
    Since a CSSParserContext is needed for all canvases, move the
    existing HTMLCanvasElement function to be a virtual function
    on CanvasBase and implement for OffscreenCanvas and CustomPaintCanvas.

* Source/WebCore/html/canvas/CanvasStyle.cpp:
(WebCore::parseColor):
(WebCore::currentColor):
    Call the new CSSPropertyParserConsumer+Color.h parse functions. In
    a subsequent change, these will need to pass additional options for
    overriding hsl()/hsla() parsing behavior.

Canonical link: <a href="https://commits.webkit.org/277783@main">https://commits.webkit.org/277783@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f1ac463650ac4583e0737e2137b9a37d7857184

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48557 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51244 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44622 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50862 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25295 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39704 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25437 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41891 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20801 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22914 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43064 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6613 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44852 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53151 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23603 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19905 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46996 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24869 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42097 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45919 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10707 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25673 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24591 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->