### PR TITLE
[WebGPU] setPipelineState fails when X32_Stencil8 attachment is used in a Stencil8 pipeline

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2092,6 +2092,8 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-272911.html [ Pass Failure ]
 [ Debug ] fast/webgpu/fuzz-273017.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-273017.html [ Pass Failure ]
+[ Debug ] fast/webgpu/fuzz-273021.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-273021.html [ Pass Failure ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/fuzz-273021-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-273021-expected.txt
@@ -1,0 +1,675 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 982x5202
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x5202
+  RenderBlock {HTML} at (0,0) size 785x5202 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x5186
+      RenderText {#text} at (32,137) size 26x17
+        text run at (32,137) width 26: "\x{C1AA}\x{C94}"
+      RenderText {#text} at (57,137) size 87x17
+        text run at (57,137) width 87: "\x{4F78}\x{D83F}\x{DE8B}\x{D83F}\x{DDDC}\x{9E7}\x{C52}\x{63A9}\x{77E1}"
+      RenderText {#text} at (443,137) size 62x17
+        text run at (443,137) width 62: "\x{910F}\x{742A}\x{B92}\x{D83D}\x{DE81}"
+      RenderText {#text} at (504,137) size 65x17
+        text run at (504,137) width 65: "\x{D75}\x{BE26}\x{D83E}\x{DED9}\x{2ABB}"
+      RenderText {#text} at (568,137) size 98x17
+        text run at (568,137) width 98: "\x{A76}\x{44CD}\x{DF6}\x{4F0}\x{1C62}\x{FD8}\x{235A}\x{173E}\x{D83F}\x{DED7}"
+      RenderText {#text} at (665,137) size 72x17
+        text run at (665,137) width 72: "\x{D83E}\x{DD5B}\x{200B}\x{D83D}\x{DFEA}\x{1A46}\x{AB6F}\x{D83F}\x{DF12}"
+      RenderText {#text} at (300,296) size 63x17
+        text run at (300,296) width 15: "\x{34E5}"
+        text run at (315,296) width 11 RTL: "\x{85D}"
+        text run at (325,296) width 38: "\x{F632}\x{B956}\x{FFC}"
+      RenderText {#text} at (362,296) size 123x17
+        text run at (362,296) width 123: "\x{4E06}\x{CECA}\x{D83F}\x{DED1}\x{E430}\x{96AB}\x{85DD}\x{575E}\x{1D9}\x{879E}"
+      RenderText {#text} at (484,296) size 79x17
+        text run at (484,296) width 79: "\x{D83E}\x{DCE2}\x{AD5}\x{8870}\x{20C7}\x{B348}\x{AD31}"
+      RenderText {#text} at (562,296) size 45x17
+        text run at (562,296) width 35: "\x{C6E8}\x{D83E}\x{DC2A}\x{A026}"
+        text run at (596,296) width 11 RTL: "\x{7DA}"
+      RenderText {#text} at (606,296) size 82x17
+        text run at (606,296) width 16: "\x{3FBE}"
+        text run at (621,296) width 10 RTL: "\x{72F}\x{82B}"
+        text run at (630,296) width 58: "\x{91B1}\x{1F7}\x{D83F}\x{DC56}\x{ED0}\x{77B4}"
+      RenderText {#text} at (600,454) size 70x17
+        text run at (600,454) width 70: "\x{9AA}\x{4946}\x{4B32}\x{D83E}\x{DCA5}\x{908}\x{D83F}\x{DF1A}"
+      RenderImage {IMG} at (284,592) size 21x165
+      RenderText {#text} at (305,744) size 80x17
+        text run at (305,744) width 80: "\x{3091}\x{9AD}\x{ABA2}\x{CFD}\x{D83D}\x{DF95}\x{B13}\x{4B0E}"
+      RenderText {#text} at (384,744) size 154x17
+        text run at (384,744) width 63: "\x{C22}\x{4C66}\x{A99C}\x{D83E}\x{DEB0}"
+        text run at (446,744) width 15 RTL: "\x{6FA}"
+        text run at (460,744) width 78: "\x{F675}\x{5712}\x{E343}\x{A88A}\x{4B4}\x{608C}"
+      RenderText {#text} at (553,744) size 36x17
+        text run at (553,744) width 36: "\x{55A7}\x{D83F}\x{DF2E}\x{2DD8}"
+      RenderText {#text} at (588,744) size 107x17
+        text run at (588,744) width 60: "\x{D83E}\x{DC95}\x{16CF}\x{C63A}\x{82D}\x{A2F8}\x{D83D}\x{DFD8}"
+        text run at (647,744) width 12 RTL: "\x{86B}"
+        text run at (658,744) width 37: "\x{A737}\x{D83F}\x{DF22}\x{D83F}\x{DFBF}"
+      RenderText {#text} at (0,744) size 762x181
+        text run at (694,744) width 68: "\x{1401}\x{CD2}\x{B6E4}\x{8940}\x{AF27}"
+        text run at (0,908) width 57: "\x{CAE4}\x{90}\x{8DB9}\x{1EC8}\x{FF00}"
+      RenderText {#text} at (72,908) size 37x17
+        text run at (72,908) width 27: "\x{B66D}\x{592}\x{D83F}\x{DEDD}"
+        text run at (98,908) width 11 RTL: "\x{64A}"
+      RenderText {#text} at (457,908) size 94x17
+        text run at (457,908) width 94: "\x{5D93}\x{D7F}\x{5957}\x{D83E}\x{DE78}\x{51B}\x{E8D}\x{D7C}"
+      RenderText {#text} at (550,908) size 120x17
+        text run at (550,908) width 120: "\x{7195}\x{556F}\x{D83E}\x{DCAE}\x{ED7}\x{D83F}\x{DC74}\x{D83F}\x{DC9A}\x{D83F}\x{DF3F}\x{D83E}\x{DE67}\x{C08D}\x{2E51}"
+      RenderText {#text} at (0,908) size 755x175
+        text run at (669,908) width 86: "\x{D83E}\x{DF48}\x{25CA}\x{5554}\x{4281}\x{D83F}\x{DF60}\x{E4EE}\x{434E}"
+        text run at (0,1066) width 20 RTL: "\x{FD79}"
+        text run at (19,1066) width 26: "\x{CAA}\x{C890}"
+      RenderText {#text} at (44,1066) size 42x17
+        text run at (44,1066) width 42: "\x{C93}\x{D83D}\x{DE93}\x{995}"
+      RenderText {#text} at (385,1066) size 99x17
+        text run at (385,1066) width 99: "\x{140}\x{30B}\x{D83F}\x{DD8B}\x{E03E}\x{D83E}\x{DF2B}\x{75AD}\x{D83E}\x{DCE1}\x{E7C2}\x{CF21}\x{420}"
+      RenderText {#text} at (483,1066) size 22x17
+        text run at (483,1066) width 22: "\x{D83E}\x{DF49}\x{6}"
+      RenderText {#text} at (504,1066) size 108x17
+        text run at (504,1066) width 108: "\x{C24}\x{4EF}\x{D83F}\x{DED8}\x{30C9}\x{6D71}\x{40B1}\x{D83E}\x{DEF4}\x{F888}"
+      RenderText {#text} at (611,1066) size 115x17
+        text run at (611,1066) width 115: "\x{6EDD}\x{D83E}\x{DD93}\x{929}\x{6982}\x{C1A}\x{E97}\x{4E1}\x{2813}\x{3ED}\x{585}"
+      RenderText {#text} at (0,1066) size 751x42
+        text run at (725,1066) width 26: "\x{EFCC}\x{4DA1}"
+        text run at (0,1091) width 44: "\x{13B}\x{D83E}\x{DC1C}\x{55D6}\x{A35}"
+      RenderText {#text} at (0,1501) size 86x17
+        text run at (0,1501) width 8: "\x{663}"
+        text run at (7,1501) width 79: "\x{73A6}\x{D83D}\x{DF18}\x{F3F}\x{B3C}\x{38BB}\x{B45}\x{823}\x{D83F}\x{DC95}"
+      RenderText {#text} at (85,1501) size 63x17
+        text run at (85,1501) width 63: "\x{4592}\x{21E7}\x{8DB}\x{B90B}\x{499}"
+      RenderText {#text} at (147,1501) size 107x17
+        text run at (147,1501) width 22: "\x{D83F}\x{DD08}\x{D840}"
+        text run at (168,1501) width 15 RTL: "\x{8BE}"
+        text run at (182,1501) width 72: "\x{6A31}\x{407}\x{975}\x{D83F}\x{DFC9}\x{8716}\x{D83F}\x{DE6D}"
+      RenderText {#text} at (253,1501) size 32x17
+        text run at (253,1501) width 32: "\x{2D8F}\x{F772}"
+      RenderText {#text} at (284,1501) size 11x17
+        text run at (284,1501) width 11: "\x{517}\x{343}"
+      RenderText {#text} at (294,1501) size 42x17
+        text run at (294,1501) width 42: "\x{DDBE}\x{5A81}\x{8744}"
+      RenderText {#text} at (335,1501) size 29x17
+        text run at (335,1501) width 29: "\x{A2C5}\x{B79D}\x{B9}"
+      RenderText {#text} at (363,1501) size 72x17
+        text run at (363,1501) width 72: "\x{B3A7}\x{E810}\x{AFF5}\x{B583}\x{46FD}"
+      RenderText {#text} at (434,1501) size 81x17
+        text run at (434,1501) width 81: "\x{1A23}\x{991C}\x{FD7}\x{D83F}\x{DEE9}\x{D83E}\x{DC87}\x{BEF1}\x{D83E}\x{DF30}"
+      RenderText {#text} at (514,1501) size 72x17
+        text run at (514,1501) width 72: "\x{BC91}\x{AD3}\x{D4C}\x{95A}\x{C81E}\x{90A}"
+      RenderText {#text} at (585,1501) size 108x17
+        text run at (585,1501) width 37: "\x{648D}\x{D83E}\x{DCFE}\x{EED5}"
+        text run at (621,1501) width 9 RTL: "\x{7D6}"
+        text run at (629,1501) width 64: "\x{FE45}\x{1A75}\x{EBF6}\x{5997}\x{1B95}\x{C3C}"
+      RenderText {#text} at (213,2180) size 110x17
+        text run at (213,2180) width 15: "\x{730E}"
+        text run at (228,2180) width 22 RTL: "\x{893}\x{63B}"
+        text run at (249,2180) width 74: "\x{37B0}\x{D83D}\x{DF13}\x{7144}\x{A748}\x{D83D}\x{DEA3}\x{654}"
+      RenderHTMLCanvas {CANVAS} at (322,1523) size 301x670
+      RenderText {#text} at (622,2180) size 53x17
+        text run at (622,2180) width 23: "\x{EAD5}\x{D5A}"
+        text run at (644,2180) width 24 RTL: "\x{8B8}\x{FBA}"
+        text run at (667,2180) width 8: "\x{FF}"
+      RenderText {#text} at (674,2180) size 46x17
+        text run at (674,2180) width 46: "\x{4E04}\x{4715}\x{2ED7}"
+      RenderText {#text} at (0,2180) size 739x45
+        text run at (719,2180) width 20: "\x{EDB}\x{A016}"
+        text run at (0,2208) width 51: "\x{4EE}\x{D83D}\x{DF66}\x{E14F}\x{25B}\x{F27C}"
+      RenderText {#text} at (50,2208) size 123x17
+        text run at (50,2208) width 12 RTL: "\x{88F}"
+        text run at (61,2208) width 66: "\x{56DE}\x{75E3}\x{8FF1}\x{D83E}\x{DDF9}"
+        text run at (126,2208) width 11 RTL: "\x{803}"
+        text run at (136,2208) width 37: "\x{185E}\x{4350}\x{295}\x{D83D}\x{DF2A}"
+      RenderText {#text} at (172,2208) size 70x17
+        text run at (172,2208) width 51: "\x{2AF}\x{34CD}\x{725A}\x{D83D}\x{DE76}"
+        text run at (222,2208) width 20 RTL: "\x{FD02}"
+      RenderText {#text} at (241,2208) size 126x17
+        text run at (241,2208) width 38: "\x{D665}\x{9AD8}\x{296}"
+        text run at (278,2208) width 12 RTL: "\x{FB37}"
+        text run at (289,2208) width 67: "\x{BEE8}\x{D83F}\x{DE77}\x{D359}\x{9A67}\x{D83F}\x{DE37}"
+        text run at (355,2208) width 12 RTL: "\x{5FC}"
+      RenderText {#text} at (366,2208) size 57x17
+        text run at (366,2208) width 57: "\x{A5ED}\x{C406}\x{162E}\x{9661}"
+      RenderText {#text} at (422,2208) size 64x17
+        text run at (422,2208) width 64: "\x{FFE}\x{3ACD}\x{4A37}\x{EEAE}\x{D83E}\x{DC79}"
+      RenderText {#text} at (485,2208) size 124x17
+        text run at (485,2208) width 124: "\x{A1}\x{55C}\x{F41D}\x{AA95}\x{3A64}\x{F68F}\x{D83D}\x{DF3B}\x{DA00}\x{855B}\x{C24D}\x{447D}"
+      RenderText {#text} at (608,2208) size 122x17
+        text run at (608,2208) width 122: "\x{F315}\x{41E}\x{DD54}\x{D83E}\x{DDE2}\x{D83D}\x{DEE9}\x{5B24}\x{BBB7}\x{A8A2}\x{24F}"
+      RenderText {#text} at (0,2208) size 760x224
+        text run at (729,2208) width 31: "\x{9C9D}\x{BB35}"
+        text run at (0,2415) width 52: "\x{431F}\x{D83E}\x{DFBF}\x{9FE}\x{4545}"
+      RenderText {#text} at (51,2415) size 138x17
+        text run at (51,2415) width 71: "\x{B606}\x{C420}\x{C27D}\x{308}\x{886E}\x{563}"
+        text run at (121,2415) width 14 RTL: "\x{77D}"
+        text run at (134,2415) width 55: "\x{3948}\x{5EF4}\x{A28E}\x{BAB6}"
+      RenderText {#text} at (204,2415) size 114x17
+        text run at (204,2415) width 114: "\x{CFC9}\x{AB02}\x{BFB0}\x{D83F}\x{DE32}\x{3CC0}\x{8AD8}\x{2711}\x{4D25}"
+      RenderText {#text} at (317,2415) size 104x17
+        text run at (317,2415) width 104: "\x{19EE}\x{9E44}\x{E64A}\x{D83E}\x{DC17}\x{D83E}\x{DE59}\x{62A1}\x{1F7}\x{7F8F}"
+      RenderText {#text} at (420,2415) size 46x17
+        text run at (420,2415) width 46: "\x{2458}\x{D83E}\x{DDEF}\x{27C8}"
+      RenderText {#text} at (465,2415) size 28x17
+        text run at (465,2415) width 28: "\x{C985}\x{1645}"
+      RenderImage {IMG} at (492,2227) size 182x201
+      RenderText {#text} at (673,2415) size 61x17
+        text run at (673,2415) width 61: "\x{D83F}\x{DE63}\x{D83D}\x{DEC6}\x{3355}\x{D83E}\x{DF0E}\x{17A6}"
+      RenderText {#text} at (290,2554) size 67x17
+        text run at (290,2554) width 67: "\x{89}\x{4AC3}\x{9A87}\x{E4F1}\x{8154}"
+      RenderText {#text} at (356,2554) size 120x17
+        text run at (356,2554) width 72: "\x{D83E}\x{DE82}\x{1D98}\x{629D}\x{AE61}\x{7BCB}"
+        text run at (427,2554) width 14 RTL: "\x{852}"
+        text run at (440,2554) width 36: "\x{B2BB}\x{28EC}\x{29B1}"
+      RenderText {#text} at (475,2554) size 51x17
+        text run at (475,2554) width 51: "\x{D83D}\x{DF4E}\x{D83F}\x{DC12}\x{634B}\x{6008}"
+      RenderText {#text} at (525,2554) size 118x17
+        text run at (525,2554) width 118: "\x{278}\x{4C70}\x{905}\x{D83E}\x{DD64}\x{D83E}\x{DED5}\x{A441}\x{D83F}\x{DE86}\x{D83E}\x{DFDA}\x{D83F}\x{DFAB}"
+      RenderText {#text} at (0,2554) size 767x175
+        text run at (642,2554) width 71: "\x{2F6C}\x{9192}\x{586B}\x{291}\x{4D45}"
+        text run at (712,2554) width 25 RTL: "\x{FD21}"
+        text run at (736,2554) width 31: "\x{CF1C}\x{8A0B}"
+        text run at (0,2712) width 11: "\x{E4C8}"
+      RenderImage {IMG} at (10,2573) size 295x152
+      RenderText {#text} at (304,2712) size 88x17
+        text run at (304,2712) width 40: "\x{A78E}\x{63A3}\x{C4AF}"
+        text run at (343,2712) width 10 RTL: "\x{843}"
+        text run at (352,2712) width 40: "\x{30B2}\x{AE1B}\x{A810}"
+      RenderText {#text} at (391,2712) size 26x17
+        text run at (391,2712) width 26: "\x{D83D}\x{DEED}\x{98D1}"
+      RenderText {#text} at (416,2712) size 103x17
+        text run at (416,2712) width 103: "\x{C934}\x{C655}\x{1CA}\x{ACA}\x{D83E}\x{DC1C}'\x{D83E}\x{DD9D}\x{D83F}\x{DC62}"
+      RenderText {#text} at (518,2712) size 81x17
+        text run at (518,2712) width 27: "\x{BCE}\x{3CEB}"
+        text run at (544,2712) width 9 RTL: "\x{5E8}"
+        text run at (552,2712) width 47: "\x{397B}\x{F98}\x{A58}\x{2104}"
+      RenderImage {IMG} at (300,2765) size 26x233
+      RenderText {#text} at (626,2985) size 70x17
+        text run at (626,2985) width 55: "\x{D83D}\x{DEF7}\x{83C5}\x{D83E}\x{DDE1}"
+        text run at (681,2985) width 15 RTL: "\x{5D4}\x{846}"
+      RenderText {#text} at (0,2985) size 756x252
+        text run at (695,2985) width 61: "\x{D8E}\x{9EB9}\x{9FD5}\x{D83F}\x{DE5F}"
+        text run at (0,3220) width 53: "\x{88DA}\x{655}\x{D83F}\x{DF38}\x{B757}\x{3D8}\x{FE2A}"
+      RenderText {#text} at (52,3220) size 48x17
+        text run at (52,3220) width 48: "\x{2602}\x{5A15}\x{1797}\x{A38}"
+      RenderText {#text} at (99,3220) size 52x17
+        text run at (99,3220) width 52: "\x{DA07}\x{547E}\x{D83D}\x{DF3C}\x{8CAF}"
+      RenderImage {IMG} at (150,3004) size 247x229
+      RenderText {#text} at (396,3220) size 47x17
+        text run at (396,3220) width 47: "\x{D83F}\x{DC3E}\x{262}\x{3E0D}\x{E7E9}"
+      RenderText {#text} at (442,3220) size 103x17
+        text run at (442,3220) width 27: "\x{D851}\x{5F41}"
+        text run at (468,3220) width 20 RTL: "\x{837}"
+        text run at (487,3220) width 58: "\x{B48}\x{D83E}\x{DCB0}\x{BDCB}\x{B8EC}"
+      RenderText {#text} at (544,3220) size 46x17
+        text run at (544,3220) width 46: "\x{7A6}\x{90EE}\x{548D}\x{B538}"
+      RenderText {#text} at (589,3220) size 60x17
+        text run at (589,3220) width 8: "\x{31F}"
+        text run at (596,3220) width 8 RTL: "\x{676}"
+        text run at (603,3220) width 46: "\x{7053}\x{2F9B}\x{305}\x{657A}"
+      RenderText {#text} at (648,3220) size 105x17
+        text run at (648,3220) width 63: "\x{A6B}\x{AA0}\x{4013}\x{8F6E}\x{A9D1}\x{6DB}"
+        text run at (710,3220) width 6 RTL: "\x{FE97}"
+        text run at (715,3220) width 38: "\x{7754}\x{2FAF}\x{D83D}\x{DF4C}"
+      RenderText {#text} at (0,3220) size 764x47
+        text run at (752,3220) width 12: "\x{2EF8}"
+        text run at (0,3250) width 15: "\x{37A9}"
+      RenderText {#text} at (0,3421) size 56x17
+        text run at (0,3421) width 56: "\x{D83F}\x{DC0D}\x{67DC}\x{6EA3}\x{3A79}"
+      RenderText {#text} at (55,3421) size 67x17
+        text run at (55,3421) width 67: "\x{1}\x{CA89}\x{7852}\x{BDBC}\x{BED}"
+      RenderText {#text} at (0,3834) size 55x17
+        text run at (0,3834) width 55: "\x{3EA}\x{5659}\x{B224}\x{5A3A}"
+      RenderImage {IMG} at (54,3788) size 47x59
+      RenderText {#text} at (100,3834) size 93x17
+        text run at (100,3834) width 93: "\x{7D65}\x{4D20}\x{898}\x{D83F}\x{DE70}\x{B767}\x{90C}\x{4CCF}"
+      RenderText {#text} at (527,3834) size 122x17
+        text run at (527,3834) width 122: "\x{8AA4}\x{A3E}\x{B9F}\x{1F10}\x{E49}\x{D83F}\x{DF44}\x{B78}\x{CE88}\x{19F5}\x{D83D}\x{DEC0}"
+      RenderText {#text} at (648,3834) size 93x17
+        text run at (648,3834) width 67: "\x{DAB}\x{B758}\x{E82}\x{339}\x{D754}\x{98B}"
+        text run at (714,3834) width 12 RTL: "\x{895}"
+        text run at (725,3834) width 16: "\x{B544}"
+      RenderText {#text} at (0,3973) size 117x17
+        text run at (0,3973) width 117: "\x{5DE9}\x{BAC7}\x{615A}\x{443}\x{D83E}\x{DC0B}\x{5AE9}\x{FB8}\x{3E2D}\x{45A8}"
+      RenderImage {IMG} at (116,3920) size 156x66
+      RenderText {#text} at (271,3973) size 111x17
+        text run at (271,3973) width 111: "\x{4456}\x{763D}\x{6858}\x{3197}\x{7B4A}\x{A6C5}\x{13D1}\x{AE2C}"
+      RenderText {#text} at (381,3973) size 82x17
+        text run at (381,3973) width 82: "\x{4907}\x{B652}\x{D83E}\x{DE43}\x{CBD5}\x{C520}\x{459}"
+      RenderImage {IMG} at (462,3859) size 288x127
+      RenderText {#text} at (0,4001) size 120x17
+        text run at (0,4001) width 120: "\x{D83F}\x{DDA7}\x{363}\x{D83E}\x{DC47}\x{5E75}\x{D83F}\x{DE23}\x{1AE}\x{A8E5}\x{D83F}\x{DEF3}\x{48DF}\x{5107}"
+      RenderText {#text} at (119,4001) size 27x17
+        text run at (119,4001) width 27: "\x{E95D}\x{BA46}"
+      RenderText {#text} at (145,4001) size 110x17
+        text run at (145,4001) width 99: "\x{6D9B}\x{D83D}\x{DE24}\x{8BA2}\x{6CE6}\x{E9B}\x{D83E}\x{DFA8}\x{1361}\x{22DE}"
+        text run at (243,4001) width 12 RTL: "\x{621}\x{709}"
+      RenderText {#text} at (254,4001) size 35x17
+        text run at (254,4001) width 35: "\x{D83F}\x{DD69}\x{5660}\x{A0E6}"
+      RenderText {#text} at (288,4001) size 84x17
+        text run at (288,4001) width 84: "\x{6B8D}\x{CD3F}{\x{BA63}\x{D83F}\x{DC58}\x{D83E}\x{DE79}"
+      RenderText {#text} at (371,4001) size 79x17
+        text run at (371,4001) width 79: "\x{6BB9}\x{D83F}\x{DEA4}\x{2C97}\x{2972}\x{1BF}\x{DE85}\x{CFE7}"
+      RenderText {#text} at (449,4001) size 67x17
+        text run at (449,4001) width 67: "\x{EF1}\x{B007}\x{3F51}\x{261D}\x{D83F}\x{DC63}"
+      RenderText {#text} at (515,4001) size 76x17
+        text run at (515,4001) width 44: "\x{98B8}\x{29B}\x{9DD}\x{D83E}\x{DF77}"
+        text run at (558,4001) width 12 RTL: "\x{812}"
+        text run at (569,4001) width 22: "\x{970}\x{4E6C}"
+      RenderText {#text} at (590,4001) size 140x17
+        text run at (590,4001) width 140: "\x{D83D}\x{DFE5}\x{D83E}\x{DC26}\x{61CA}\x{D83E}\x{DE1C}\x{D83E}\x{DC4B}\x{8674}\x{3056}\x{1992}\x{37B8}\x{8F24}"
+      RenderImage {IMG} at (0,4272) size 76x41
+      RenderText {#text} at (76,4300) size 26x17
+        text run at (76,4300) width 26: "\x{E444}\x{8A50}"
+      RenderText {#text} at (101,4300) size 123x17
+        text run at (101,4300) width 123: "\x{6E4}\x{312}\x{D83E}\x{DDBF}\x{D3EF}\x{2A01}\x{8F1B}\x{24D5}\x{D83F}\x{DD89}\x{CE5}\x{4551}"
+      RenderImage {IMG} at (223,4251) size 56x62
+      RenderText {#text} at (278,4300) size 31x17
+        text run at (278,4300) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (308,4300) size 81x17
+        text run at (308,4300) width 81: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (388,4300) size 69x17
+        text run at (388,4300) width 7 RTL: "\x{692}"
+        text run at (394,4300) width 63: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (0,4363) size 298x170
+      RenderText {#text} at (298,4520) size 103x17
+        text run at (298,4520) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (438,4520) size 100x17
+        text run at (438,4520) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (537,4520) size 117x17
+        text run at (537,4520) width 32: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (568,4520) width 10 RTL: "\x{79B}"
+        text run at (577,4520) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (0,4540) size 292x253
+      RenderText {#text} at (292,4780) size 103x17
+        text run at (292,4780) width 103: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (394,4780) size 105x17
+        text run at (394,4780) width 105: "\x{10D}\x{BA96}\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (498,4780) size 102x17
+        text run at (498,4780) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (599,4780) size 116x17
+        text run at (599,4780) width 116: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (0,4811) size 34x17
+        text run at (0,4811) width 34: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (33,4811) size 120x17
+        text run at (33,4811) width 26: "\x{24BF}\x{B00}"
+        text run at (58,4811) width 12 RTL: "\x{5FF}"
+        text run at (69,4811) width 14: "\x{2FA}\x{B13}"
+        text run at (82,4811) width 11 RTL: "\x{8BC}"
+        text run at (92,4811) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (152,4811) size 88x17
+        text run at (152,4811) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (239,4811) size 88x17
+        text run at (239,4811) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (326,4811) size 22x17
+        text run at (326,4811) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (347,4811) size 111x17
+        text run at (347,4811) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (457,4811) size 79x17
+        text run at (457,4811) width 79: "\x{ECB8}\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (535,4811) size 85x17
+        text run at (535,4811) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+      RenderText {#text} at (619,4811) size 100x17
+        text run at (619,4811) width 80: "\x{D83F}\x{DD83}\x{D83F}\x{DD58}\x{6EE2}\x{47A3}\x{10B}\x{2CC7}\x{BC62}"
+        text run at (698,4811) width 10 RTL: "\x{67F}"
+        text run at (707,4811) width 12: "\x{D83F}\x{DC12}"
+      RenderText {#text} at (0,4811) size 752x45
+        text run at (718,4811) width 34: "\x{F24}\x{A756}\x{4864}"
+        text run at (0,4839) width 116: "\x{D83D}\x{DF2C}\x{D83E}\x{DD04}\x{D83D}\x{DFF9}\x{D83E}\x{DD6D}\x{D83D}\x{DF33}\x{9AA9}\x{FF4C}\x{D83E}\x{DEAD}"
+      RenderText {#text} at (115,4839) size 52x17
+        text run at (115,4839) width 27: "\x{84E2}\x{D83E}\x{DCB2}"
+        text run at (141,4839) width 11 RTL: "\x{793}"
+        text run at (151,4839) width 16: "\x{812B}"
+      RenderText {#text} at (166,4839) size 119x17
+        text run at (166,4839) width 119: "\x{CD98}\x{D83E}\x{DEF8}\x{D83E}\x{DDA7}\x{AF08}\x{4EB8}\x{1243}\x{B2E}\x{FF7}"
+      RenderText {#text} at (284,4839) size 96x17
+        text run at (284,4839) width 96: "\x{1E56}\x{DB7F}\x{3BE0}\x{9F86}\x{4C4D}\x{D83F}\x{DCB1}\x{D83E}\x{DD9F}"
+      RenderText {#text} at (379,4839) size 60x17
+        text run at (379,4839) width 16: "\x{AC6C}"
+        text run at (394,4839) width 15 RTL: "\x{84C}"
+        text run at (408,4839) width 31: "\x{3CFB}\x{C01}"
+      RenderText {#text} at (438,4839) size 84x17
+        text run at (438,4839) width 84: "\x{C96F}\x{CFE}\x{D83E}\x{DD4C}\x{2EB1}\x{BFB}\x{D83F}\x{DFDA}"
+      RenderText {#text} at (521,4839) size 74x17
+        text run at (521,4839) width 74: "\x{966}\x{D83D}\x{DE44}\x{F51D}\x{D83E}\x{DF45}\x{F91}\x{2772}\x{D83F}\x{DF3B}"
+      RenderText {#text} at (594,4839) size 89x17
+        text run at (594,4839) width 67: "\x{94A5}\x{8A96}\x{6D75}\x{D83F}\x{DC81}\x{180}"
+        text run at (660,4839) width 12 RTL: "\x{6A6}"
+        text run at (671,4839) width 12: "\x{D83F}\x{DC37}"
+      RenderText {#text} at (682,4839) size 78x17
+        text run at (682,4839) width 58: "\x{EA1}\x{FB1}\x{A34}\x{5543}\x{D83F}\x{DF64}"
+        text run at (739,4839) width 13 RTL: "\x{801}"
+        text run at (751,4839) width 9: "\x{2EE1}"
+      RenderText {#text} at (0,4865) size 34x17
+        text run at (0,4865) width 34: "\x{1498}\x{D83F}\x{DE40}\x{D83E}\x{DC29}"
+      RenderText {#text} at (33,4865) size 23x17
+        text run at (33,4865) width 23: "\x{3040}\x{D83E}\x{DE44}"
+      RenderText {#text} at (55,4865) size 74x17
+        text run at (55,4865) width 74: "\x{D83F}\x{DF07}\x{DE60}\x{958}\x{D83F}\x{DD30}\x{4AC5}\x{3F37}"
+      RenderText {#text} at (128,4865) size 133x17
+        text run at (128,4865) width 133: "\x{7F0}\x{9CF}\x{C47A}\x{D74}\x{161C}\x{1F13}\x{97BB}\x{4FF7}\x{3AEF}\x{D83E}\x{DC98}\x{DDA}"
+      RenderText {#text} at (260,4865) size 111x17
+        text run at (260,4865) width 111: "\x{E60A}\x{5E72}\x{FAFC}\x{A318}\x{960}\x{9825}\x{265E}\x{6633}\x{6C91}"
+      RenderText {#text} at (370,4865) size 109x17
+        text run at (370,4865) width 61: "\x{739A}\x{2679}\x{24C2}\x{4019}"
+        text run at (430,4865) width 12 RTL: "\x{5C9}"
+        text run at (441,4865) width 38: "\x{CEE6}\x{D83E}\x{DF11}\x{A44}"
+      RenderText {#text} at (478,4865) size 32x17
+        text run at (478,4865) width 32: "\x{A89}\x{D83E}\x{DE59}\x{D83E}\x{DE6F}"
+      RenderText {#text} at (509,4865) size 83x17
+        text run at (509,4865) width 68: "\x{C1D6}\x{DC6A}\x{6930}\x{9921}\x{432}\x{ED}"
+        text run at (576,4865) width 5 RTL: "\x{701}"
+        text run at (580,4865) width 12: "\x{C84}"
+      RenderText {#text} at (591,4865) size 98x17
+        text run at (591,4865) width 98: "\x{D83D}\x{DE53}\x{D83F}\x{DC79}\x{C460}\x{BEF2}\x{4C04}\x{156}\x{372}\x{47A}"
+      RenderText {#text} at (688,4865) size 23x17
+        text run at (688,4865) width 23: "\x{D83E}\x{DC7C}\x{D83F}\x{DC5B}"
+      RenderText {#text} at (0,4865) size 756x43
+        text run at (710,4865) width 46: "\x{37FE}\x{9416}\x{9668}"
+        text run at (0,4891) width 54: "\x{E6B0}\x{F1F}\x{E27B}\x{B1B}\x{6F8B}"
+      RenderText {#text} at (53,4891) size 89x17
+        text run at (53,4891) width 89: "\x{533}\x{D83F}\x{DDD9}\x{C481}\x{C5EC}\x{A889}\x{49D9}\x{D83F}\x{DEBB}"
+      RenderText {#text} at (141,4891) size 120x17
+        text run at (141,4891) width 16: "\x{589C}"
+        text run at (156,4891) width 12 RTL: "\x{5CC}"
+        text run at (167,4891) width 49: "\x{1FF}\x{8296}\x{D83F}\x{DD87}\x{C9CD}"
+        text run at (215,4891) width 11 RTL: "\x{5E1}"
+        text run at (225,4891) width 12: "\x{EB97}"
+        text run at (236,4891) width 14 RTL: "\x{8B6}"
+        text run at (249,4891) width 12: "\x{D83E}\x{DE33}"
+      RenderText {#text} at (260,4891) size 70x17
+        text run at (260,4891) width 70: "\x{29E}\x{3AD8}\x{911F}\x{4170}\x{89AC}"
+      RenderText {#text} at (329,4891) size 127x17
+        text run at (329,4891) width 127: "\x{DAE}\x{D83E}\x{DFD0}\x{D676}\x{7A82}\x{D83F}\x{DC92}\x{D33}\x{99C8}\x{D83E}\x{DD52}\x{8FDE}\x{140}"
+      RenderText {#text} at (455,4891) size 145x17
+        text run at (455,4891) width 128: "\x{D83E}\x{DCB1}\x{D83E}\x{DCB7}\x{D83F}\x{DDE3}\x{B97C}\x{C855}\x{CD5B}\x{CF1}\x{C54C}\x{4043}\x{1535}"
+        text run at (587,4891) width 13 RTL: "\x{83D}"
+      RenderText {#text} at (582,4891) size 84x17
+        text run at (582,4891) width 6 RTL: "\x{5D5}"
+        text run at (599,4891) width 67: "\x{5E92}\x{1E8A}\x{9A39}\x{D29}\x{D83F}\x{DEBA}"
+      RenderText {#text} at (665,4891) size 31x17
+        text run at (665,4891) width 31: "\x{47B5}\x{8C8D}"
+      RenderText {#text} at (0,4891) size 764x45
+        text run at (695,4891) width 69: "\x{275C}\x{145}\x{C5C7}\x{F654}\x{DAD7}\x{BDD7}"
+        text run at (0,4919) width 19: "n\x{F047}"
+      RenderText {#text} at (18,4919) size 120x17
+        text run at (18,4919) width 28: "\x{ABB4}\x{AACB}\x{A19}"
+        text run at (45,4919) width 15 RTL: "\x{717}"
+        text run at (59,4919) width 79: "\x{E620}\x{D83E}\x{DC2C}\x{D83D}\x{DE54}\x{2C3}\x{BD07}\x{536}\x{4AFF}"
+      RenderText {#text} at (137,4919) size 63x17
+        text run at (137,4919) width 32: "\x{D83E}\x{DDCC}\x{D83E}\x{DC21}"
+        text run at (168,4919) width 17 RTL: "\x{6BE}\x{769}"
+        text run at (184,4919) width 16: "\x{41BE}"
+      RenderText {#text} at (199,4919) size 41x17
+        text run at (199,4919) width 15 RTL: "\x{808}"
+        text run at (213,4919) width 27: "\x{D83E}\x{DE4B}\x{4961}"
+      RenderText {#text} at (239,4919) size 48x17
+        text run at (239,4919) width 48: "\x{2CE9}\x{E5A6}\x{7C86}\x{10}"
+      RenderText {#text} at (286,4919) size 140x17
+        text run at (286,4919) width 140: "\x{D83F}\x{DE92}\x{E10B}\x{E644}\x{346D}\x{DD9}\x{EC1}\x{1D39}\x{BAE0}\x{CCC}\x{D0A}\x{272D}"
+      RenderText {#text} at (425,4919) size 144x17
+        text run at (425,4919) width 144: "\x{8E33}\x{F5F6}\x{D83E}\x{DD52}\x{542C}\x{AE0C}\x{33F}\x{B49F}\x{D83E}\x{DCA8}\x{DA4}\x{D83F}\x{DC82}\x{6138}"
+      RenderText {#text} at (568,4919) size 102x17
+        text run at (568,4919) width 33: "\x{D83F}\x{DF2D}\x{F4A7}\x{E7C6}"
+        text run at (600,4919) width 10 RTL: "\x{639}"
+        text run at (609,4919) width 27: "\x{FDD}\x{8C02}"
+        text run at (635,4919) width 5 RTL: "\x{627}"
+        text run at (639,4919) width 31: "\x{64C5}\x{3878}"
+      RenderText {#text} at (0,4919) size 768x44
+        text run at (669,4919) width 99: "\x{911D}\x{B0A}\x{D83E}\x{DF5D}\x{530D}\x{D6F0}\x{302}\x{9DF7}\x{D18}"
+        text run at (0,4946) width 15: "\x{B088}\x{EC9}"
+      RenderText {#text} at (14,4946) size 27x17
+        text run at (14,4946) width 12: "\x{D83F}\x{DDBE}"
+        text run at (35,4946) width 6 RTL: "\x{6C0}"
+      RenderText {#text} at (25,4946) size 76x17
+        text run at (25,4946) width 11 RTL: "\x{6D1}"
+        text run at (40,4946) width 61: "\x{B7EC}\x{DC39}\x{73EF}\x{1F90}\x{D83E}\x{DFE6}"
+      RenderText {#text} at (100,4946) size 132x17
+        text run at (100,4946) width 111: "\x{326D}\x{F53}\x{D83E}\x{DCAB}\x{482}\x{D83E}\x{DFFE}\x{B32F}\x{D83F}\x{DD03}\x{5C3E}\x{3D9C}"
+        text run at (210,4946) width 22 RTL: "\x{FCFC}"
+      RenderText {#text} at (231,4946) size 102x17
+        text run at (231,4946) width 77: "\x{8950}\x{4E2A}\x{EDC}\x{D83E}\x{DCD7}\x{D83F}\x{DD84}\x{44E}"
+        text run at (307,4946) width 11 RTL: "\x{848}"
+        text run at (317,4946) width 16: "\x{AF80}"
+      RenderText {#text} at (332,4946) size 129x17
+        text run at (332,4946) width 129: "\x{54D7}\x{E79C}\x{8C16}\x{63C6}\x{F54D}\x{8CEB}\x{8E6}\x{D83E}\x{DD1E}\x{F5BB}\x{AD09}"
+      RenderText {#text} at (460,4946) size 95x17
+        text run at (460,4946) width 95: "\x{D07B}\x{D83D}\x{DEBF}\x{C5}\x{D83E}\x{DCF7}\x{F8}\x{4AC9}\x{6E8E}"
+      RenderText {#text} at (554,4946) size 112x17
+        text run at (554,4946) width 112: "\x{C7FE}\x{AE4D}\x{4827}\x{BA55}\x{62AD}\x{FBA}\x{6065}\x{4EFC}"
+      RenderText {#text} at (0,4946) size 755x45
+        text run at (665,4946) width 90: "\x{10C6}\x{4BF}\x{BBE4}\x{D3B}\x{A0A}\x{B8E}\x{1487}\x{D83F}\x{DC7C}"
+        text run at (0,4974) width 32: "\x{23D}\x{1AA}\x{8F3F}"
+      RenderText {#text} at (31,4974) size 36x17
+        text run at (31,4974) width 36: "\x{328}\x{E96}\x{D83F}\x{DF71}\x{F10F}"
+      RenderText {#text} at (66,4974) size 88x17
+        text run at (66,4974) width 88: "\x{614A}\x{C870}\x{E997}\x{D83F}\x{DE46}\x{2D8B}\x{B80}\x{EFC4}"
+      RenderText {#text} at (153,4974) size 140x17
+        text run at (153,4974) width 140: "\x{496B}\x{D83F}\x{DE84}\x{D3D8}\x{D83D}\x{DF44}\x{1244}\x{D83E}\x{DD7C}\x{3C8A}\x{D73F}\x{E6DF}\x{D83F}\x{DD5E}"
+      RenderText {#text} at (292,4974) size 11x17
+        text run at (292,4974) width 11: "\x{2995}\x{F7D}"
+      RenderText {#text} at (302,4974) size 60x17
+        text run at (302,4974) width 60: "\x{515D}\x{DEA}k\x{D83F}\x{DDE9}\x{D099}"
+      RenderText {#text} at (361,4974) size 83x17
+        text run at (361,4974) width 83: "\x{4936}\x{A04}\x{D83D}\x{DE68}\x{7F8E}\x{5145}\x{3B80}"
+      RenderText {#text} at (443,4974) size 42x17
+        text run at (443,4974) width 42: "\x{B92B}\x{B663}\x{D83F}\x{DF52}"
+      RenderText {#text} at (484,4974) size 32x17
+        text run at (484,4974) width 32: "\x{D83F}\x{DD45}\x{4C8}\x{1500}"
+      RenderText {#text} at (515,4974) size 103x17
+        text run at (515,4974) width 11 RTL: "\x{649}"
+        text run at (525,4974) width 93: "Y\x{E2}\x{D83D}\x{DFCF}\x{BE7}\x{E856}\x{D83D}\x{DF5D}\x{96CF}\x{76BA}"
+      RenderText {#text} at (617,4974) size 71x17
+        text run at (617,4974) width 71: "\x{3190}\x{B978}\x{898}\x{AD2C}\x{CF05}"
+      RenderText {#text} at (687,4974) size 49x17
+        text run at (687,4974) width 49: "\x{D83F}\x{DC2C}\x{DDE0}\x{2E3F}\x{3B9A}"
+      RenderText {#text} at (0,5002) size 78x17
+        text run at (0,5002) width 31: "\x{D83E}\x{DE42}\x{A6E}\x{D9FC}"
+        text run at (30,5002) width 18 RTL: "\x{FC17}"
+        text run at (47,5002) width 31: "\x{24A9}\x{5434}"
+      RenderText {#text} at (77,5002) size 138x17
+        text run at (77,5002) width 138: "\x{8EB0}\x{D83F}\x{DCBB}\x{8B92}\x{4961}\x{D83F}\x{DE5F}\x{815F}\x{1496}\x{75DF}\x{F135}\x{D83E}\x{DCAE}\x{AB94}"
+      RenderText {#text} at (214,5002) size 119x17
+        text run at (214,5002) width 119: "\x{7}\x{F4E}\x{E9C5}\x{D83E}\x{DD16}\x{FF4}\x{C8B2}\x{8885}\x{1181}\x{D83F}\x{DDD6}"
+      RenderText {#text} at (332,5002) size 138x17
+        text run at (332,5002) width 138: "\x{F40D}\x{D83E}\x{DE7B}\x{D83F}\x{DE68}\x{481}\x{1242}\x{BA41}\x{8A50}\x{D83F}\x{DD54}\x{2F2A}\x{D83D}\x{DE49}"
+      RenderText {#text} at (469,5002) size 137x17
+        text run at (469,5002) width 137: "\x{884F}\x{146B}\x{D9C5}\x{D83E}\x{DF3C}\x{40EA}\x{BCD5}\x{5E1B}\x{A59}\x{D83E}\x{DCDD}\x{D83F}\x{DDF0}\x{7C60}"
+      RenderText {#text} at (605,5002) size 119x17
+        text run at (605,5002) width 119: "\x{5BB}\x{D83D}\x{DF58}\x{994}\x{D6F}\x{D83F}\x{DCBF}\x{1E35}\x{DD08}\x{90FE}\x{16AD}\x{B0D1}\x{5E87}"
+      RenderText {#text} at (0,5002) size 758x45
+        text run at (723,5002) width 35: "\x{78F9}\x{D83F}\x{DC10}\x{A0E3}"
+        text run at (0,5030) width 15: "\x{5AFC}"
+      RenderText {#text} at (15,5030) size 130x17
+        text run at (15,5030) width 130: "\x{5084}\x{BECB}\x{6B64}\x{D83E}\x{DC65}\x{D72B}\x{7CD8}\x{D83F}\x{DC17}\x{9C6}\x{D83F}\x{DEF6}\x{7A6}"
+      RenderText {#text} at (144,5030) size 67x17
+        text run at (144,5030) width 67: "\x{21AA}\x{C3A9}\x{32C1}\x{1E22}\x{D00}"
+      RenderText {#text} at (210,5030) size 111x17
+        text run at (210,5030) width 10 RTL: "\x{682}"
+        text run at (219,5030) width 102: "\x{78A3}\x{E49}\x{B61}\x{C2}\x{E55}\x{555}\x{3F5}\x{A4E9}\x{34EC}\x{D83E}\x{DE4D}"
+      RenderText {#text} at (320,5030) size 96x17
+        text run at (320,5030) width 42: "\x{5699}\x{8FFA}\x{F786}"
+        text run at (361,5030) width 9 RTL: "\x{685}"
+        text run at (369,5030) width 47: "\x{1D3F}\x{DB6B}\x{BF05}\x{4083}"
+      RenderText {#text} at (415,5030) size 35x17
+        text run at (415,5030) width 31: "\x{7F14}\x{9D87}"
+        text run at (445,5030) width 5 RTL: "\x{627}"
+      RenderText {#text} at (449,5030) size 53x17
+        text run at (449,5030) width 53: "\x{D83F}\x{DD01}\x{4ED3}\x{60F4}\x{2C4D}"
+      RenderText {#text} at (501,5030) size 52x17
+        text run at (501,5030) width 52: "\x{D404}\x{ADEF}\x{558}\x{D83F}\x{DC9A}"
+      RenderText {#text} at (552,5030) size 73x17
+        text run at (552,5030) width 12: "\x{D83E}\x{DF0D}"
+        text run at (563,5030) width 12 RTL: "\x{5EA}"
+        text run at (574,5030) width 51: "\x{1211}\x{EE55}\x{1C8A}\x{D83F}\x{DEAD}"
+      RenderText {#text} at (0,5030) size 744x42
+        text run at (624,5030) width 120: "\x{D83E}\x{DE97}\x{AFC9}\x{D83F}\x{DC32}\x{D83F}\x{DD2F}\x{20A}\x{F3F1}\x{D83E}\x{DD8F}\x{2E70}\x{3838}"
+        text run at (0,5055) width 11: "\x{D83E}\x{DF9C}"
+      RenderText {#text} at (10,5055) size 121x17
+        text run at (10,5055) width 121: "\x{D83E}\x{DC74}\x{D83D}\x{DF80}\x{FAE}\x{EA64}\x{525}\x{D83F}\x{DF92}\x{D83E}\x{DE4A}\x{4F6}\x{D83F}\x{DE5D}\x{D83E}\x{DF5C}\x{88DC}"
+      RenderText {#text} at (130,5055) size 38x17
+        text run at (130,5055) width 38: "\x{6B58}\x{CF96}\x{168B}"
+      RenderText {#text} at (167,5055) size 108x17
+        text run at (167,5055) width 50: "\x{B850}\x{D83D}\x{DF15}\x{850E}\x{C90}"
+        text run at (216,5055) width 8 RTL: "\x{6C1}"
+        text run at (223,5055) width 52: "\x{D83F}\x{DF5B}\x{6949}\x{4E7E}\x{9BA}"
+      RenderText {#text} at (274,5055) size 110x17
+        text run at (274,5055) width 12: "\x{D83E}\x{DC0E}"
+        text run at (285,5055) width 10 RTL: "\x{7D5}"
+        text run at (294,5055) width 90: "\x{3ADE}\x{D83D}\x{DFBF}\x{55B}\x{D83E}\x{DFD0}\x{F3C9}\x{AFC}\x{D83F}\x{DEA7}\x{FD5}\x{B6C}"
+      RenderText {#text} at (383,5055) size 57x17
+        text run at (383,5055) width 57: "\x{945}\x{5DA4}\x{D83E}\x{DDEE}\x{53A}"
+      RenderText {#text} at (439,5055) size 107x17
+        text run at (439,5055) width 107: "\x{81F7}\x{48AB}\x{2610}\x{6F92}\x{D83E}\x{DC73}\x{8881}\x{45F}\x{F920}"
+      RenderText {#text} at (545,5055) size 128x17
+        text run at (545,5055) width 128: "\x{E4B}\x{DD7}\x{736}\x{F5A}\x{7373}\x{532}\x{D83E}\x{DC9E}\x{D83E}\x{DE64}\x{274A}\x{CBF1}\x{6AA5}"
+      RenderText {#text} at (0,5055) size 751x45
+        text run at (672,5055) width 79: "\x{DEDD}\x{DC4D}\x{D83F}\x{DEBA}\x{D83F}\x{DE46}\x{F56F}\x{141D}\x{BA38}"
+        text run at (0,5083) width 48: "\x{E100}\x{E5A4}\x{E4D8}\x{6679}"
+      RenderText {#text} at (47,5083) size 51x17
+        text run at (47,5083) width 51: "\x{8AC3}\x{5294}\x{E15}\x{F006}"
+      RenderText {#text} at (97,5083) size 123x17
+        text run at (97,5083) width 123: "\x{F769}\x{D83E}\x{DCA1}\x{D83E}\x{DDF9}\x{25AE}\x{72E5}\x{D83E}\x{DCCF}\x{4A8C}\x{D1F0}\x{D83E}\x{DC81}\x{1C7A}"
+      RenderText {#text} at (219,5083) size 118x17
+        text run at (219,5083) width 22: "\x{D83F}\x{DEF5}\x{F8EC}"
+        text run at (240,5083) width 11 RTL: "\x{6D0}"
+        text run at (250,5083) width 16: "\x{487A}"
+        text run at (265,5083) width 7 RTL: "\x{693}"
+        text run at (271,5083) width 66: "\x{F3C}\x{9485}\x{673D}\x{D83E}\x{DCAB}\x{81DF}"
+      RenderText {#text} at (336,5083) size 130x17
+        text run at (336,5083) width 109: "\x{4A16}\x{82C6}\x{643C}\x{D83D}\x{DEB5}\x{135B}\x{DB59}\x{D83F}\x{DF91}\x{EA82}"
+        text run at (444,5083) width 11 RTL: "\x{752}"
+        text run at (454,5083) width 12: "\x{D83E}\x{DC78}"
+      RenderText {#text} at (465,5083) size 22x17
+        text run at (465,5083) width 22: "\x{94EA}\x{227}"
+      RenderText {#text} at (486,5083) size 124x17
+        text run at (486,5083) width 66: "\x{BA4}\x{1557}\x{E7B2}\x{E3DF}\x{D83D}\x{DE1A}"
+        text run at (551,5083) width 18 RTL: "\x{FCFA}"
+        text run at (568,5083) width 42: "\x{82F5}\x{A7BB}\x{C572}"
+      RenderText {#text} at (609,5083) size 105x17
+        text run at (609,5083) width 105: "\x{EDFC}\x{EFEA}\x{99D}\x{BD3D}\x{A907}\x{CBD}\x{D83F}\x{DF12}\x{918}\x{53F}\x{F1}"
+      RenderText {#text} at (713,5083) size 30x17
+        text run at (713,5083) width 23: "\x{AF5}\x{DCE}"
+        text run at (735,5083) width 8 RTL: "\x{84B}"
+      RenderText {#text} at (0,5083) size 758x45
+        text run at (742,5083) width 16: "\x{D83D}\x{DF05}"
+        text run at (0,5111) width 102: "\x{6B6B}\x{A57}\x{D83F}\x{DE71}\x{A8A}\x{FAB9}\x{2E87}\x{E26D}\x{9DC0}"
+      RenderText {#text} at (101,5111) size 127x17
+        text run at (101,5111) width 127: "\x{C1F9}\x{D83F}\x{DE33}\x{F143}\x{815B}\x{D83E}\x{DCFB}\x{AE3E}\x{4D6}\x{246}\x{D83D}\x{DF03}\x{B53D}"
+      RenderText {#text} at (227,5111) size 128x17
+        text run at (227,5111) width 128: "\x{D83E}\x{DCCB}\x{A4F7}\x{3F2}\x{4A5}\x{F49}\x{6D02}\x{2BE1}\x{1DAF}\x{D83E}\x{DE79}\x{3F1D}\x{B2D}"
+      RenderText {#text} at (354,5111) size 44x17
+        text run at (354,5111) width 44: "\x{E6FD}\x{D83E}\x{DCEA}\x{C86}\x{D83D}\x{DFB6}"
+      RenderText {#text} at (397,5111) size 94x17
+        text run at (397,5111) width 94: "\x{8550}\x{315}\x{D83F}\x{DEBE}\x{9D59}\x{A8E0}\x{D29}\x{DD57}\x{3736}"
+      RenderText {#text} at (490,5111) size 40x17
+        text run at (490,5111) width 40: "\x{978}\x{16F}\x{A1C}\x{9FCF}"
+      RenderText {#text} at (529,5111) size 121x17
+        text run at (529,5111) width 121: "\x{445}\x{C7E}\x{49B4}\x{F256}\x{9EB}\x{E2B3}\x{7D5D}\x{D83D}\x{DF3A}\x{D83F}\x{DDB5}\x{F993}"
+      RenderText {#text} at (649,5111) size 90x17
+        text run at (649,5111) width 90: "\x{203}\x{799B}\x{D83F}\x{DF95}\x{6834}\x{4A6E}\x{D83F}\x{DEEA}\x{634E}"
+      RenderText {#text} at (0,5111) size 754x45
+        text run at (738,5111) width 16: "\x{B821}"
+        text run at (0,5139) width 48: "\x{A615}\x{1D6}\x{4E7}\x{E06C}q"
+      RenderText {#text} at (47,5139) size 57x17
+        text run at (47,5139) width 57: "\x{D83E}\x{DEC0}\x{FAA}\x{D83D}\x{DED3}\x{474A}"
+      RenderText {#text} at (103,5139) size 117x17
+        text run at (103,5139) width 117: "\x{F198}\x{27BB}\x{5D7A}\x{AA7}\x{AF9C}\x{1EE4}\x{23C2}\x{35DA}\x{E551}"
+      RenderText {#text} at (219,5139) size 27x17
+        text run at (219,5139) width 27: "\x{5A8F}\x{D67}"
+      RenderText {#text} at (245,5139) size 25x17
+        text run at (245,5139) width 25: "\x{422F}\x{F34}"
+      RenderText {#text} at (269,5139) size 113x17
+        text run at (269,5139) width 113: "\x{4E0B}\x{AD32}\x{9EF}\x{92F2}\x{6147}\x{A0D8}\x{D83E}\x{DDCE}\x{D63F}"
+      RenderText {#text} at (381,5139) size 97x17
+        text run at (381,5139) width 16: "\x{D83E}\x{DF77}\x{2D42}"
+        text run at (396,5139) width 15 RTL: "\x{FC9D}"
+        text run at (410,5139) width 68: "\x{56AB}\x{38D3}\x{32E0}\x{1EF}\x{D6B}"
+      RenderText {#text} at (477,5139) size 20x17
+        text run at (477,5139) width 20: "\x{10}\x{E8A}"
+      RenderText {#text} at (496,5139) size 122x17
+        text run at (496,5139) width 23: "\x{D83E}\x{DC7F}\x{E324}"
+        text run at (518,5139) width 12 RTL: "\x{88A}"
+        text run at (529,5139) width 89: "\x{F2E}\x{9192}\x{B089}\x{E52B}\x{D83E}\x{DE89}\x{D83D}\x{DFBF}\x{8FA8}"
+      RenderText {#text} at (617,5139) size 77x17
+        text run at (617,5139) width 77: "\x{BAB5}\x{D028}\x{E7E}\x{D83F}\x{DC2F}\x{E14}\x{38B9}"
+      RenderText {#text} at (693,5139) size 50x17
+        text run at (693,5139) width 50: "\x{34E}\x{A22F}\x{24F}\x{D83E}\x{DC0E}\x{7F63}"
+      RenderText {#text} at (0,5139) size 758x42
+        text run at (742,5139) width 16: "\x{725E}"
+        text run at (0,5164) width 52: "\x{3512}\x{89F2}\x{E971}\x{F91}"
+        text run at (51,5164) width 10 RTL: "\x{5E4}"
+      RenderText {#text} at (60,5164) size 46x17
+        text run at (60,5164) width 46: "\x{F2C1}\x{570}\x{178}\x{91C7}"
+layer at (8,142) size 16x16
+  RenderVideo {VIDEO} at (0,134) size 16x16
+layer at (24,142) size 16x16
+  RenderVideo {VIDEO} at (16,134) size 16x16
+layer at (151,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (143,0) size 300x150
+layer at (8,167) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,159) size 300x150
+layer at (8,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,317) size 300x150
+layer at (308,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,317) size 300x150
+layer at (8,481) size 284x284
+  RenderVideo {VIDEO} at (0,473) size 284x284
+layer at (546,749) size 16x16
+  RenderVideo {VIDEO} at (537,741) size 17x16
+layer at (65,913) size 16x16
+  RenderVideo {VIDEO} at (56,905) size 17x16
+layer at (116,779) size 349x150
+  RenderHTMLCanvas {CANVAS} at (108,771) size 350x150
+layer at (93,937) size 300x150
+  RenderHTMLCanvas {CANVAS} at (85,929) size 301x150
+layer at (8,1120) size 885x385
+  RenderHTMLCanvas {CANVAS} at (0,1112) size 885x385
+layer at (8,1988) size 213x213
+  RenderVideo {VIDEO} at (0,1980) size 213x213
+layer at (196,2420) size 16x16
+  RenderVideo {VIDEO} at (188,2412) size 17x16
+layer at (8,2448) size 290x127
+  RenderHTMLCanvas {CANVAS} at (0,2440) size 290x127
+layer at (8,2856) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,2848) size 300x150
+layer at (334,2739) size 300x267
+  RenderHTMLCanvas {CANVAS} at (326,2731) size 300x267
+layer at (8,3276) size 974x150
+  RenderHTMLCanvas {CANVAS} at (0,3268) size 974x150
+layer at (8,3447) size 905x349
+  RenderHTMLCanvas {CANVAS} at (0,3439) size 905x349
+layer at (200,3832) size 335x23
+  RenderHTMLCanvas {CANVAS} at (192,3824) size 336x23
+layer at (748,3839) size 16x16
+  RenderVideo {VIDEO} at (740,3831) size 17x16
+layer at (465,4030) size 291x291
+  RenderVideo {VIDEO} at (456,4022) size 292x291
+layer at (408,4328) size 38x213
+  RenderVideo {VIDEO} at (400,4320) size 39x213

--- a/LayoutTests/fast/webgpu/fuzz-273021.html
+++ b/LayoutTests/fast/webgpu/fuzz-273021.html
@@ -1,0 +1,27519 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUCommandEncoder} commandEncoder
+ */
+function pseudoSubmit(device, commandEncoder) {
+  device.pushErrorScope('validation');
+  commandEncoder.clearBuffer(device.createBuffer({size: 0, usage: 0}), 0, 0);
+  device.popErrorScope().then(() => {});
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let device0 = await adapter0.requestDevice(
+{
+label: '\u7a96\u983f\u{1f8c1}\u{1fc94}\udd8b\u1555\u641a\u{1fd80}\u01be\u0ffc\u1f04',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 9,
+maxColorAttachmentBytesPerSample: 47,
+maxVertexAttributes: 25,
+maxVertexBufferArrayStride: 59287,
+maxStorageTexturesPerShaderStage: 11,
+maxStorageBuffersPerShaderStage: 35,
+maxDynamicStorageBuffersPerPipelineLayout: 10207,
+maxBindingsPerBindGroup: 8560,
+maxTextureDimension1D: 11399,
+maxTextureDimension2D: 9125,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 146870324,
+maxInterStageShaderVariables: 40,
+maxInterStageShaderComponents: 88,
+},
+}
+);
+document.body.append('\ue5ec\u48b4\u0d13\u19a2\u930b');
+let buffer0 = device0.createBuffer(
+{
+size: 31163,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let commandEncoder0 = device0.createCommandEncoder(
+{
+label: '\u1633\ube9d\u{1f90c}\u0f0e',
+}
+);
+let img0 = await imageWithData(189, 24, '#4edc94b4', '#f81f6cd7');
+let querySet0 = device0.createQuerySet(
+{
+label: '\ud2a8\udf17\u{1ffcb}\udd22\u0cf5\uafc5\u0fb2\uda02',
+type: 'occlusion',
+count: 3254,
+}
+);
+let texture0 = device0.createTexture(
+{
+label: '\u6684\u083b',
+size: [1177, 1, 35],
+mipLevelCount: 7,
+sampleCount: 1,
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+let renderBundleEncoder0 = device0.createRenderBundleEncoder(
+{
+label: '\u0486\u0284',
+colorFormats: [
+'rg32float',
+'rg32sint',
+'rg32uint',
+'bgra8unorm'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 718,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler0 = device0.createSampler(
+{
+label: '\u{1fc46}\u{1f8e0}\u616f\u02d3\u{1fa11}\u2696\u0ecf\u1672\u{1fa6e}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 16.702,
+lodMaxClamp: 72.519,
+maxAnisotropy: 3,
+}
+);
+try {
+renderBundleEncoder0.setVertexBuffer(
+22,
+undefined
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout0 = device0.createBindGroupLayout(
+{
+label: '\u{1f90e}\ud6f4\u{1fcf5}\u{1fef4}\u{1f988}\u{1f960}\u{1f7d3}\uc868',
+entries: [
+{
+binding: 5645,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+},
+{
+binding: 8053,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let buffer1 = device0.createBuffer(
+{
+label: '\u106b\u{1f94a}\u39c1\u{1fe38}\u077f\u{1fc0b}\u{1fd6a}\u2067\u{1fec4}\u9815\u3eaa',
+size: 25352,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+mappedAtCreation: true,
+}
+);
+pseudoSubmit(device0, commandEncoder0);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 4,
+  origin: { x: 29, y: 0, z: 22 },
+  aspect: 'all',
+},
+new ArrayBuffer(8),
+/* required buffer size: 1222234 */{
+offset: 970,
+bytesPerRow: 557,
+rowsPerImage: 274,
+},
+{width: 20, height: 1, depthOrArrayLayers: 9}
+);
+} catch {}
+let pipelineLayout0 = device0.createPipelineLayout(
+{
+label: '\u0e2a\u755b\u0cf6\u0182\uf3ea\u{1fe4a}\ud6fb\u614c',
+bindGroupLayouts: [
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0
+],
+}
+);
+let commandEncoder1 = device0.createCommandEncoder(
+{
+label: '\u{1f9d7}\u{1f7d2}\uf1de\u0886\u0ef6\ud9c0\u{1fc0c}',
+}
+);
+let textureView0 = texture0.createView(
+{
+dimension: '2d',
+mipLevelCount: 4,
+baseArrayLayer: 18,
+}
+);
+try {
+renderBundleEncoder0.setVertexBuffer(
+16,
+undefined,
+1345073326
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 399, y: 0, z: 29 },
+  aspect: 'all',
+},
+new Int32Array(new ArrayBuffer(56)),
+/* required buffer size: 698966 */{
+offset: 827,
+bytesPerRow: 5967,
+rowsPerImage: 39,
+},
+{width: 364, height: 0, depthOrArrayLayers: 4}
+);
+} catch {}
+let shaderModule0 = device0.createShaderModule(
+{
+label: '\u4251\u6626\u0b82',
+code: `
+
+@compute @workgroup_size(3, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(7) f0: vec3<f32>,
+@location(3) f1: u32,
+@location(1) f2: f32,
+@location(0) f3: f32,
+@location(6) f4: i32,
+@location(4) f5: vec3<u32>,
+@location(5) f6: vec3<u32>,
+@location(2) f7: vec3<f32>,
+@builtin(sample_mask) f8: u32
+}
+
+@fragment
+fn fragment0(@location(4) a0: i32, @builtin(sample_mask) a1: u32, @builtin(sample_index) a2: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S0 {
+@location(13) f0: i32,
+@location(2) f1: vec2<f16>,
+@location(14) f2: vec3<f16>,
+@location(16) f3: vec4<u32>,
+@location(15) f4: f16
+}
+struct VertexOutput0 {
+@location(20) f0: vec4<i32>,
+@location(24) f1: vec4<f32>,
+@location(1) f2: vec2<i32>,
+@location(13) f3: f16,
+@location(28) f4: vec2<u32>,
+@location(18) f5: vec2<f16>,
+@location(0) f6: f32,
+@location(25) f7: vec3<i32>,
+@location(38) f8: vec3<f16>,
+@location(22) f9: vec3<f32>,
+@location(7) f10: vec2<i32>,
+@location(32) f11: u32,
+@location(6) f12: vec2<i32>,
+@location(3) f13: vec2<f16>,
+@location(35) f14: vec3<f32>,
+@location(37) f15: vec2<u32>,
+@builtin(position) f16: vec4<f32>,
+@location(5) f17: vec4<f32>,
+@location(16) f18: vec2<f16>,
+@location(17) f19: vec2<i32>,
+@location(12) f20: vec4<f32>,
+@location(36) f21: vec3<u32>,
+@location(23) f22: i32,
+@location(27) f23: vec2<f16>,
+@location(9) f24: vec3<u32>,
+@location(4) f25: i32,
+@location(15) f26: vec2<u32>,
+@location(21) f27: vec3<u32>,
+@location(30) f28: vec3<i32>,
+@location(19) f29: vec4<u32>,
+@location(8) f30: vec2<f32>,
+@location(34) f31: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(1) a0: vec2<i32>, @location(22) a1: vec2<u32>, @location(12) a2: vec3<f32>, @location(8) a3: vec2<u32>, @location(10) a4: vec4<i32>, a5: S0, @location(23) a6: f32, @location(7) a7: vec3<f32>, @location(17) a8: vec3<i32>, @location(18) a9: i32, @location(20) a10: vec3<f32>, @location(0) a11: vec4<f16>, @location(21) a12: vec3<f32>, @location(4) a13: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let renderBundleEncoder1 = device0.createRenderBundleEncoder(
+{
+label: '\u0c7a\u1878\u{1f753}\u{1fbce}\u{1fd2f}\u1f39\u0712\u{1f97e}\u08f5',
+colorFormats: [
+'rgba32float',
+'rg32sint'
+],
+sampleCount: 247,
+depthReadOnly: true,
+}
+);
+try {
+commandEncoder1.copyBufferToBuffer(
+buffer0,
+20400,
+buffer1,
+24752,
+268
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 5,
+  origin: { x: 1, y: 0, z: 16 },
+  aspect: 'all',
+},
+new ArrayBuffer(638211),
+/* required buffer size: 638211 */{
+offset: 717,
+bytesPerRow: 743,
+rowsPerImage: 286,
+},
+{width: 35, height: 0, depthOrArrayLayers: 4}
+);
+} catch {}
+let promise0 = device0.createRenderPipelineAsync(
+{
+label: '\u4d13\u58bd\u{1fca5}\u54b7\u1f70\u8191\u{1fa5b}',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 49852,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 22420,
+shaderLocation: 14,
+},
+{
+format: 'sint32x2',
+offset: 44520,
+shaderLocation: 18,
+},
+{
+format: 'uint32x3',
+offset: 39728,
+shaderLocation: 22,
+},
+{
+format: 'uint16x4',
+offset: 36720,
+shaderLocation: 8,
+},
+{
+format: 'sint16x2',
+offset: 35220,
+shaderLocation: 17,
+},
+{
+format: 'float32x2',
+offset: 49628,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x4',
+offset: 13020,
+shaderLocation: 21,
+},
+{
+format: 'float32x4',
+offset: 17164,
+shaderLocation: 4,
+},
+{
+format: 'float32',
+offset: 3216,
+shaderLocation: 15,
+},
+{
+format: 'sint8x4',
+offset: 32776,
+shaderLocation: 10,
+},
+{
+format: 'float32x3',
+offset: 43524,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x2',
+offset: 2976,
+shaderLocation: 12,
+},
+{
+format: 'unorm16x2',
+offset: 39280,
+shaderLocation: 2,
+},
+{
+format: 'sint32x2',
+offset: 34620,
+shaderLocation: 13,
+},
+{
+format: 'snorm8x4',
+offset: 35940,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 46136,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 7640,
+shaderLocation: 20,
+},
+{
+format: 'uint16x2',
+offset: 30272,
+shaderLocation: 16,
+},
+{
+format: 'sint16x4',
+offset: 29044,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'one-minus-src',
+dstFactor: 'dst'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'one-minus-dst-alpha',
+dstFactor: 'dst'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'src-alpha-saturated',
+dstFactor: 'constant'
+},
+},
+format: 'r8unorm',
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.GREEN,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}
+],
+},
+}
+);
+let textureView1 = texture0.createView(
+{
+label: '\u8862\u0878\ud203\u0170\ucf32\u0f42\ud371\u3d1f',
+baseMipLevel: 3,
+baseArrayLayer: 1,
+arrayLayerCount: 30,
+}
+);
+let arrayBuffer0 = buffer1.getMappedRange(
+8312
+);
+try {
+commandEncoder1.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder1.resolveQuerySet(
+querySet0,
+2902,
+56,
+buffer1,
+21504
+);
+} catch {}
+let imageBitmap0 = await createImageBitmap(img0);
+try {
+adapter0.label = '\u24e0\u7a4e\ub6a6\u0345\u0fad';
+} catch {}
+let buffer2 = device0.createBuffer(
+{
+label: '\u0895\u0f25\u{1f8b9}\u9c11\u0cc0\u0147\u{1f865}\u79e2',
+size: 45946,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: false,
+}
+);
+let renderBundle0 = renderBundleEncoder0.finish(
+{
+label: '\u6199\u{1ffbc}'
+}
+);
+try {
+renderBundleEncoder1.setIndexBuffer(
+buffer1,
+'uint32',
+7096,
+11744
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(423, 758);
+let texture1 = device0.createTexture(
+{
+label: '\u{1fc37}\u3a84',
+size: {width: 4799},
+dimension: '1d',
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder0 = commandEncoder1.beginComputePass(
+{
+label: '\u86de\u9139\u{1f9b9}\u1b59\u{1f896}\u02d7\u{1f632}\u0ffe\u969b\u{1fe31}\u7b2f'
+}
+);
+let renderBundle1 = renderBundleEncoder0.finish(
+{
+
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 2,
+  origin: { x: 113, y: 0, z: 12 },
+  aspect: 'all',
+},
+new DataView(new ArrayBuffer(56)),
+/* required buffer size: 1154172 */{
+offset: 716,
+bytesPerRow: 364,
+rowsPerImage: 288,
+},
+{width: 19, height: 1, depthOrArrayLayers: 12}
+);
+} catch {}
+let pipeline0 = device0.createRenderPipeline(
+{
+label: '\u06f1\u35c8\u{1f8c5}\u{1fc0e}\u{1f644}\u07d1\u{1fdca}',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 12280,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 11682,
+shaderLocation: 20,
+},
+{
+format: 'sint8x2',
+offset: 4296,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 37520,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x3',
+offset: 7892,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x4',
+offset: 2452,
+shaderLocation: 14,
+},
+{
+format: 'sint16x4',
+offset: 29280,
+shaderLocation: 1,
+},
+{
+format: 'float32x3',
+offset: 35412,
+shaderLocation: 23,
+},
+{
+format: 'unorm16x4',
+offset: 30232,
+shaderLocation: 0,
+},
+{
+format: 'unorm16x2',
+offset: 24880,
+shaderLocation: 21,
+},
+{
+format: 'uint32x3',
+offset: 324,
+shaderLocation: 8,
+},
+{
+format: 'sint16x2',
+offset: 18628,
+shaderLocation: 17,
+},
+{
+format: 'float32x4',
+offset: 35244,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x4',
+offset: 772,
+shaderLocation: 2,
+},
+{
+format: 'uint32x3',
+offset: 22016,
+shaderLocation: 22,
+},
+{
+format: 'unorm16x4',
+offset: 912,
+shaderLocation: 15,
+},
+{
+format: 'sint32',
+offset: 32840,
+shaderLocation: 13,
+},
+{
+format: 'sint32x2',
+offset: 6264,
+shaderLocation: 10,
+},
+{
+format: 'snorm16x4',
+offset: 18324,
+shaderLocation: 12,
+},
+{
+format: 'float32x2',
+offset: 27676,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0xae291664,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'src-alpha-saturated',
+dstFactor: 'dst'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'greater-equal',
+depthFailOp: 'increment-wrap',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 47,
+depthBias: 31,
+},
+}
+);
+document.body.append('\uade0\u{1fb0e}\u7bdb\u0a35\ufe32\u8f9b\u9b3d\u{1ffe5}\u2e5d\u4e2a\u0d22');
+let commandEncoder2 = device0.createCommandEncoder();
+let textureView2 = texture1.createView(
+{
+label: '\u05a2\u515e\u02cc\u{1f756}\u0a3c\u0805\u6208',
+}
+);
+let sampler1 = device0.createSampler(
+{
+label: '\udf49\u6e71\u{1fe55}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 75.834,
+lodMaxClamp: 88.133,
+compare: 'always',
+maxAnisotropy: 12,
+}
+);
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(
+93,
+undefined,
+2129971308,
+58019792
+);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder2.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(
+querySet0,
+2726,
+20,
+buffer1,
+5376
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 6,
+  origin: { x: 4, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 1242844 */{
+offset: 764,
+bytesPerRow: 392,
+rowsPerImage: 96,
+},
+{width: 14, height: 1, depthOrArrayLayers: 34}
+);
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+let pipeline1 = await device0.createComputePipelineAsync(
+{
+label: '\u6f52\u469c\u5171\u0015\u0886\u8abc\u087c\u5095\u0886\udb72\u{1f814}',
+layout: 'auto',
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let textureView3 = texture1.createView(
+{
+label: '\uea92\u08ba\u8019',
+mipLevelCount: 1,
+}
+);
+try {
+commandEncoder1.copyBufferToBuffer(
+buffer0,
+2212,
+buffer1,
+10916,
+12220
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 2,
+  origin: { x: 8, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 11869887 */{
+offset: 27,
+bytesPerRow: 4731,
+rowsPerImage: 76,
+},
+{width: 282, height: 1, depthOrArrayLayers: 34}
+);
+} catch {}
+let promise2 = device0.createRenderPipelineAsync(
+{
+label: '\u036f\u{1fa07}\u894a\u6199\ufc1b\u{1ff88}',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 24852,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 1604,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x4',
+offset: 8472,
+shaderLocation: 14,
+},
+{
+format: 'snorm8x2',
+offset: 6652,
+shaderLocation: 21,
+},
+{
+format: 'snorm16x4',
+offset: 5276,
+shaderLocation: 4,
+},
+{
+format: 'sint32x3',
+offset: 23020,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 52152,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x4',
+offset: 31420,
+shaderLocation: 1,
+},
+{
+format: 'unorm8x4',
+offset: 19452,
+shaderLocation: 2,
+},
+{
+format: 'uint8x2',
+offset: 46808,
+shaderLocation: 22,
+},
+{
+format: 'float16x4',
+offset: 43900,
+shaderLocation: 20,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x2',
+offset: 28380,
+shaderLocation: 18,
+},
+{
+format: 'snorm16x4',
+offset: 35416,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 16040,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 15828,
+shaderLocation: 23,
+},
+{
+format: 'sint32x2',
+offset: 3772,
+shaderLocation: 13,
+},
+{
+format: 'float16x4',
+offset: 10780,
+shaderLocation: 0,
+},
+{
+format: 'uint32x2',
+offset: 2496,
+shaderLocation: 8,
+},
+{
+format: 'uint8x2',
+offset: 13366,
+shaderLocation: 16,
+},
+{
+format: 'sint32',
+offset: 13856,
+shaderLocation: 10,
+},
+{
+format: 'float16x2',
+offset: 5212,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+},
+multisample: {
+count: 1,
+mask: 0x9b6d266d,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+targets: [
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'one-minus-constant',
+dstFactor: 'dst-alpha'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'one-minus-constant',
+dstFactor: 'one-minus-src-alpha'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'src-alpha',
+dstFactor: 'src-alpha'
+},
+},
+format: 'r8unorm',
+writeMask: 0,
+},
+{
+format: 'r16float',
+writeMask: 0,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.BLUE,
+},
+{
+format: 'rg16uint',
+},
+{
+format: 'rg8uint',
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'greater',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilReadMask: 722,
+stencilWriteMask: 480,
+depthBias: 93,
+depthBiasSlopeScale: 60,
+depthBiasClamp: 58,
+},
+}
+);
+document.body.append('\u05ad\uef97');
+let texture2 = device0.createTexture(
+{
+label: '\u0f83\u0f93\u0114\ub85e',
+size: {width: 4992, height: 3, depthOrArrayLayers: 1},
+mipLevelCount: 10,
+sampleCount: 1,
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let textureView4 = texture0.createView(
+{
+label: '\u{1f88a}\ud666\ub94d\u{1f872}\u1f61\u9b13\u0525\ua0ea\u{1feb1}',
+dimension: '2d',
+baseMipLevel: 4,
+mipLevelCount: 1,
+baseArrayLayer: 30,
+arrayLayerCount: 1,
+}
+);
+let renderBundleEncoder2 = device0.createRenderBundleEncoder(
+{
+label: '\u21b9\u3c4c\u859c\u0136\uef9d\u0d95\u0743\u0ad2\u{1fdcb}',
+colorFormats: [
+'r16sint',
+'rg32uint',
+'rg32uint',
+'rg16sint',
+undefined,
+'rg16float',
+'rgba16uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 389,
+stencilReadOnly: true,
+}
+);
+try {
+await promise1;
+} catch {}
+let videoFrame0 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+try {
+commandEncoder1.copyTextureToTexture(
+{
+  texture: texture2,
+  mipLevel: 3,
+  origin: { x: 229, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 5,
+  origin: { x: 34, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 88, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let commandEncoder3 = device0.createCommandEncoder();
+let textureView5 = texture2.createView(
+{
+label: '\ue862\u10a8\ufc0e\u0e62\ufbf2\u{1f7ec}\u3353\ud84b\u{1f909}',
+baseMipLevel: 2,
+mipLevelCount: 5,
+}
+);
+let renderBundleEncoder3 = device0.createRenderBundleEncoder(
+{
+label: '\u9c6b\u4a73\u0343\u078a\u031c\u025f\uce5b\uccf2\u0ff0\u036b\ua9e7',
+colorFormats: [
+'rgba16uint',
+'rg8uint',
+'r32float',
+'r16sint',
+undefined,
+undefined,
+'rg16uint',
+'r32uint'
+],
+sampleCount: 762,
+stencilReadOnly: true,
+}
+);
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 156, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 22, y: 20 },
+  flipY: true,
+},
+{
+  texture: texture2,
+  mipLevel: 5,
+  origin: { x: 36, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 109, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let bindGroupLayout1 = device0.createBindGroupLayout(
+{
+label: '\udbfa\u{1f6d2}\u0ee6\u{1ffe0}\ucf6c\u0841\u098f',
+entries: [
+{
+binding: 482,
+visibility: GPUShaderStage.FRAGMENT,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+},
+{
+binding: 6583,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'comparison' },
+},
+{
+binding: 523,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+try {
+renderBundleEncoder2.setIndexBuffer(
+buffer1,
+'uint32',
+14304,
+6133
+);
+} catch {}
+let promise3 = buffer2.mapAsync(
+GPUMapMode.WRITE,
+31720,
+11444
+);
+try {
+commandEncoder2.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder1.resolveQuerySet(
+querySet0,
+1249,
+902,
+buffer1,
+14848
+);
+} catch {}
+let img1 = await imageWithData(276, 77, '#97ade604', '#2178271b');
+try {
+offscreenCanvas0.getContext('webgpu');
+} catch {}
+let computePassEncoder1 = commandEncoder3.beginComputePass(
+{
+label: '\u3460\u0d40\uf4dd\ud932\u3307\u0735\u0fea\u9b7e\ucb53\uf627'
+}
+);
+let renderBundle2 = renderBundleEncoder3.finish(
+{
+label: '\u{1fd59}\u3bac\u6011\u0241\uc9d3\u0d94\u{1f81d}\u{1f9de}\u{1fd51}\u08d6\u9214'
+}
+);
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder2.copyBufferToBuffer(
+buffer0,
+5304,
+buffer1,
+11304,
+7664
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.insertDebugMarker(
+'\u0a73'
+);
+} catch {}
+let pipeline2 = device0.createComputePipeline(
+{
+label: '\u3faa\u3437\ufd88\u{1f792}',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let commandEncoder4 = device0.createCommandEncoder(
+{
+label: '\u4fa4\u7d82\u95b2\u6c51\u{1fb9b}\u{1fe1f}\u04d7\u09e1\u7d17',
+}
+);
+try {
+renderBundleEncoder2.setVertexBuffer(
+11,
+undefined
+);
+} catch {}
+try {
+commandEncoder1.clearBuffer(
+buffer1,
+6668,
+11176
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let canvas0 = document.createElement('canvas');
+let commandEncoder5 = device0.createCommandEncoder(
+{
+label: '\ue03e\ue45e\uc422\u6eb5\u{1fc8b}',
+}
+);
+let sampler2 = device0.createSampler(
+{
+label: '\u0823\u3414\ue3d5\u{1f933}\uc679\udb52\u0473\u06ab\u06bd\uae07',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 86.829,
+maxAnisotropy: 18,
+}
+);
+try {
+commandEncoder4.resolveQuerySet(
+querySet0,
+1679,
+227,
+buffer1,
+3840
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1248, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 25, y: 14 },
+  flipY: false,
+},
+{
+  texture: texture2,
+  mipLevel: 2,
+  origin: { x: 852, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 152, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let canvas1 = document.createElement('canvas');
+let bindGroupLayout2 = device0.createBindGroupLayout(
+{
+label: '\u{1f668}\u03cf\u{1fbee}',
+entries: [
+{
+binding: 3405,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 203894, hasDynamicOffset: false },
+},
+{
+binding: 7520,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+},
+{
+binding: 7250,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rg32sint', access: 'write-only', viewDimension: '1d' },
+}
+],
+}
+);
+let texture3 = device0.createTexture(
+{
+label: '\uff9d\u{1f71b}\uc43b',
+size: [226, 1, 105],
+mipLevelCount: 8,
+dimension: '3d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb10a2uint'
+],
+}
+);
+try {
+commandEncoder4.copyBufferToBuffer(
+buffer0,
+14348,
+buffer1,
+22844,
+160
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+try {
+canvas0.getContext('webgl2');
+} catch {}
+let texture4 = device0.createTexture(
+{
+label: '\u617c\u70ed\u0f4d\u{1fa6f}',
+size: {width: 198, height: 1, depthOrArrayLayers: 237},
+mipLevelCount: 2,
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16float',
+'r16float'
+],
+}
+);
+let textureView6 = texture4.createView(
+{
+label: '\uc307\u0a08\ua047\u7916\u72d3\u9f0e\u{1f88b}',
+dimension: '2d-array',
+baseArrayLayer: 98,
+arrayLayerCount: 102,
+}
+);
+try {
+computePassEncoder1.setPipeline(
+pipeline2
+);
+} catch {}
+try {
+commandEncoder1.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext0 = canvas1.getContext('webgpu');
+let shaderModule1 = device0.createShaderModule(
+{
+label: '\u0ccc\ue9a6\u6e69\u91db\u{1fe00}\u{1f9f2}\u{1f8f7}\u7890\u8ebd\u0db6\u{1f7c6}',
+code: `@group(6) @binding(5645)
+var<storage, read_write> function0: array<u32>;
+
+@compute @workgroup_size(1, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(3) f0: f32,
+@location(2) f1: vec3<f32>,
+@location(5) f2: vec3<f32>,
+@location(1) f3: vec2<i32>,
+@location(6) f4: vec4<f32>,
+@location(4) f5: vec2<f32>,
+@location(0) f6: vec2<i32>,
+@location(7) f7: vec2<f32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(front_facing) a1: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@builtin(position) f32: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(21) a0: vec4<f32>, @location(24) a1: vec3<u32>, @location(13) a2: vec4<f32>, @location(7) a3: u32, @location(3) a4: vec4<f32>, @location(4) a5: f32, @location(10) a6: vec3<i32>, @location(2) a7: vec4<u32>, @location(18) a8: vec4<f16>, @location(1) a9: vec4<f32>, @location(14) a10: vec4<f16>, @location(15) a11: f32, @location(0) a12: vec2<i32>, @location(8) a13: vec4<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let textureView7 = texture3.createView(
+{
+label: '\u15dd\u0963\u0d32\u{1fad7}',
+baseMipLevel: 7,
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 87, y: 0, z: 71 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 2314546 */{
+offset: 140,
+bytesPerRow: 164,
+rowsPerImage: 168,
+},
+{width: 19, height: 1, depthOrArrayLayers: 85}
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let commandEncoder6 = device0.createCommandEncoder(
+{
+}
+);
+let computePassEncoder2 = commandEncoder6.beginComputePass(
+{
+
+}
+);
+try {
+computePassEncoder2.setPipeline(
+pipeline1
+);
+} catch {}
+try {
+commandEncoder1.resolveQuerySet(
+querySet0,
+408,
+1051,
+buffer1,
+12544
+);
+} catch {}
+let video0 = await videoWithData();
+let texture5 = device0.createTexture(
+{
+label: '\u1cb4\u0f77\u812f\u6990\u0c59\u0715\u34dc\u0d9f',
+size: {width: 232, height: 1, depthOrArrayLayers: 219},
+mipLevelCount: 8,
+dimension: '3d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg16float'
+],
+}
+);
+let textureView8 = texture5.createView(
+{
+label: '\u914d\u0fb1\u033f\uaf85\u{1f8a1}\u{1f9bb}',
+format: 'rg16float',
+baseMipLevel: 1,
+mipLevelCount: 5,
+baseArrayLayer: 0,
+}
+);
+try {
+commandEncoder2.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 78, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 37, y: 23 },
+  flipY: false,
+},
+{
+  texture: texture2,
+  mipLevel: 6,
+  origin: { x: 57, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 11, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline3 = await promise2;
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture6 = device0.createTexture(
+{
+label: '\ua47f\u0885\u024f\u58e3',
+size: [135, 1, 122],
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let computePassEncoder3 = commandEncoder4.beginComputePass(
+{
+label: '\u212a\u0ec9\u{1fc9f}\u{1fcc6}\u2593\u0bed\u6967\u78df'
+}
+);
+try {
+computePassEncoder2.setPipeline(
+pipeline2
+);
+} catch {}
+try {
+renderBundleEncoder1.setIndexBuffer(
+buffer1,
+'uint32',
+9800,
+3777
+);
+} catch {}
+try {
+commandEncoder5.copyBufferToBuffer(
+buffer0,
+11364,
+buffer1,
+14060,
+9660
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.copyTextureToTexture(
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 62, y: 1, z: 158 },
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: { x: 2, y: 1, z: 83 },
+  aspect: 'all',
+},
+{width: 92, height: 0, depthOrArrayLayers: 59}
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'depth32float',
+'rgba16float',
+'depth16unorm',
+'rg8snorm'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture5,
+  mipLevel: 3,
+  origin: { x: 4, y: 0, z: 6 },
+  aspect: 'all',
+},
+new Int8Array(arrayBuffer0),
+/* required buffer size: 12932 */{
+offset: 7,
+bytesPerRow: 225,
+rowsPerImage: 3,
+},
+{width: 25, height: 1, depthOrArrayLayers: 20}
+);
+} catch {}
+let pipeline4 = device0.createComputePipeline(
+{
+label: '\ufa02\u0f76\u0a5c\u03f7\u685a\u48b5\u{1fbb0}\u2a31\u97a3\ub30b\u0f10',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+await promise4;
+} catch {}
+document.body.prepend('\u03f7\u5b82\u3033\u08fa\uf5ba\ufa51\u{1f718}\ub506\ufbf1\u3222');
+let shaderModule2 = device0.createShaderModule(
+{
+label: '\ub404\u{1f78d}\uc089\u0735\ue6c3\u{1fda5}\u0238\u084e\ue2e3\u703b',
+code: `@group(4) @binding(8053)
+var<storage, read_write> type0: array<u32>;
+
+@compute @workgroup_size(8, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: u32,
+@location(7) f1: vec4<f32>,
+@location(5) f2: vec2<i32>,
+@builtin(sample_mask) f3: u32
+}
+
+@fragment
+fn fragment0(@location(33) a0: vec2<f16>, @location(19) a1: vec4<f16>, @location(20) a2: vec3<i32>, @location(4) a3: vec2<u32>, @location(39) a4: i32, @location(14) a5: f32, @location(17) a6: f16, @location(10) a7: vec3<f32>, @location(26) a8: f16, @location(27) a9: vec4<u32>, @location(15) a10: vec3<f16>, @location(16) a11: vec2<f16>, @location(12) a12: vec2<u32>, @builtin(sample_index) a13: u32, @location(32) a14: vec2<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(21) f33: vec3<f16>,
+@location(23) f34: vec3<f32>,
+@location(10) f35: vec3<f32>,
+@location(11) f36: vec2<u32>,
+@location(29) f37: vec4<f32>,
+@location(25) f38: u32,
+@builtin(position) f39: vec4<f32>,
+@location(18) f40: vec4<u32>,
+@location(5) f41: vec3<u32>,
+@location(32) f42: vec2<f32>,
+@location(19) f43: vec4<f16>,
+@location(2) f44: vec3<i32>,
+@location(4) f45: vec2<u32>,
+@location(30) f46: vec3<u32>,
+@location(16) f47: vec2<f16>,
+@location(33) f48: vec2<f16>,
+@location(28) f49: vec2<f16>,
+@location(20) f50: vec3<i32>,
+@location(36) f51: vec2<f16>,
+@location(8) f52: vec4<f16>,
+@location(26) f53: f16,
+@location(22) f54: vec2<i32>,
+@location(24) f55: vec2<f16>,
+@location(39) f56: i32,
+@location(1) f57: vec3<f32>,
+@location(31) f58: vec2<u32>,
+@location(38) f59: u32,
+@location(27) f60: vec4<u32>,
+@location(13) f61: vec3<f32>,
+@location(9) f62: vec3<i32>,
+@location(15) f63: vec3<f16>,
+@location(17) f64: f16,
+@location(14) f65: f32,
+@location(0) f66: vec2<f16>,
+@location(37) f67: u32,
+@location(34) f68: vec2<u32>,
+@location(12) f69: vec2<u32>
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+}
+);
+let querySet1 = device0.createQuerySet(
+{
+label: '\u8b9c\u{1fd17}\u0b0c\u8942\u091e\u{1faec}\u94e6\u6617\u2d49\u570f\u0cc2',
+type: 'occlusion',
+count: 2043,
+}
+);
+let texture7 = device0.createTexture(
+{
+size: [231, 1, 1379],
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8uint'
+],
+}
+);
+let texture8 = gpuCanvasContext0.getCurrentTexture();
+try {
+renderBundleEncoder2.setVertexBuffer(
+44,
+undefined,
+2889269022,
+1016925159
+);
+} catch {}
+try {
+commandEncoder2.copyTextureToTexture(
+{
+  texture: texture2,
+  mipLevel: 2,
+  origin: { x: 760, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 4,
+  origin: { x: 162, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 90, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder5.resolveQuerySet(
+querySet1,
+1807,
+26,
+buffer1,
+7168
+);
+} catch {}
+let pipeline5 = await device0.createComputePipelineAsync(
+{
+layout: pipelineLayout0,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.append('\u0246\ua0db\u0a2c\u07c8');
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 4,
+  origin: { x: 66, y: 0, z: 14 },
+  aspect: 'all',
+},
+new BigUint64Array(arrayBuffer0),
+/* required buffer size: 640 */{
+offset: 640,
+bytesPerRow: 365,
+},
+{width: 5, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline6 = device0.createRenderPipeline(
+{
+label: '\u0be7\u{1f742}\u0944\u04b4\u{1fb24}\u74c3',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 53708,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 11484,
+shaderLocation: 10,
+},
+{
+format: 'sint32',
+offset: 51608,
+shaderLocation: 18,
+},
+{
+format: 'uint16x4',
+offset: 30328,
+shaderLocation: 22,
+},
+{
+format: 'snorm16x4',
+offset: 5032,
+shaderLocation: 15,
+},
+{
+format: 'sint8x2',
+offset: 51124,
+shaderLocation: 1,
+},
+{
+format: 'snorm8x2',
+offset: 29906,
+shaderLocation: 14,
+},
+{
+format: 'snorm8x4',
+offset: 11108,
+shaderLocation: 12,
+},
+{
+format: 'unorm16x4',
+offset: 13832,
+shaderLocation: 21,
+},
+{
+format: 'sint16x2',
+offset: 18248,
+shaderLocation: 17,
+},
+{
+format: 'sint32x4',
+offset: 29704,
+shaderLocation: 13,
+},
+{
+format: 'snorm8x2',
+offset: 1192,
+shaderLocation: 0,
+},
+{
+format: 'unorm16x4',
+offset: 7876,
+shaderLocation: 23,
+},
+{
+format: 'float32x3',
+offset: 33096,
+shaderLocation: 7,
+},
+{
+format: 'uint16x2',
+offset: 50028,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 37392,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 15984,
+attributes: [
+{
+format: 'unorm8x4',
+offset: 904,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 7428,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32',
+offset: 5436,
+shaderLocation: 20,
+},
+{
+format: 'uint8x4',
+offset: 4992,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x4',
+offset: 48216,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0x8230f1cd,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r32float',
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r16uint',
+},
+{
+format: 'rg32uint',
+},
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+format: 'r32sint',
+}
+],
+},
+}
+);
+let pipelineLayout1 = device0.createPipelineLayout(
+{
+label: '\u8a95\uef70',
+bindGroupLayouts: [
+bindGroupLayout1,
+bindGroupLayout0,
+bindGroupLayout2
+],
+}
+);
+let texture9 = device0.createTexture(
+{
+label: '\u5ceb\u97e3\u{1f731}\u{1f87b}\u5ef6\u{1f96a}\u1821',
+size: [5092],
+mipLevelCount: 1,
+dimension: '1d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16sint',
+'rgba16sint',
+'rgba16sint'
+],
+}
+);
+let textureView9 = texture5.createView(
+{
+dimension: '3d',
+baseMipLevel: 7,
+mipLevelCount: 1,
+}
+);
+let computePassEncoder4 = commandEncoder1.beginComputePass(
+{
+label: '\u{1f9d2}\u{1fbc1}\uf5bf\ue0af\u8b35\u60fb'
+}
+);
+let computePassEncoder5 = commandEncoder5.beginComputePass();
+let canvas2 = document.createElement('canvas');
+let commandEncoder7 = device0.createCommandEncoder(
+{
+label: '\u0e3e\u029a\ua7f9\u0540\uca0f\u05fe\u82a5',
+}
+);
+let texture10 = device0.createTexture(
+{
+size: [985, 1, 421],
+mipLevelCount: 9,
+sampleCount: 1,
+dimension: '3d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8unorm'
+],
+}
+);
+let renderBundle3 = renderBundleEncoder2.finish(
+{
+label: '\uc19c\u9903\u9ecd\u5ce8\u{1ff24}\u5ee9\u02ff\u2ef0\u0102\u0185'
+}
+);
+try {
+computePassEncoder5.pushDebugGroup(
+'\uaf8b'
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 3,
+  origin: { x: 22, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer0),
+/* required buffer size: 1752674 */{
+offset: 458,
+bytesPerRow: 2114,
+rowsPerImage: 46,
+},
+{width: 114, height: 1, depthOrArrayLayers: 19}
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline7 = await device0.createRenderPipelineAsync(
+{
+label: '\uc66e\ueff0\u04b4\u4401',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 5296,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32',
+offset: 4552,
+shaderLocation: 17,
+},
+{
+format: 'float16x2',
+offset: 4776,
+shaderLocation: 21,
+},
+{
+format: 'unorm8x4',
+offset: 3828,
+shaderLocation: 14,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 3636,
+shaderLocation: 23,
+},
+{
+format: 'float32x4',
+offset: 3720,
+shaderLocation: 12,
+},
+{
+format: 'float32x3',
+offset: 3136,
+shaderLocation: 20,
+},
+{
+format: 'snorm16x2',
+offset: 1272,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 53112,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 10452,
+shaderLocation: 10,
+},
+{
+format: 'sint32x3',
+offset: 16616,
+shaderLocation: 13,
+},
+{
+format: 'uint32x3',
+offset: 8224,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 15156,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 10112,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 31536,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x2',
+offset: 76,
+shaderLocation: 18,
+},
+{
+format: 'uint32x2',
+offset: 25744,
+shaderLocation: 8,
+},
+{
+format: 'sint16x4',
+offset: 16360,
+shaderLocation: 1,
+},
+{
+format: 'snorm16x4',
+offset: 27248,
+shaderLocation: 15,
+},
+{
+format: 'unorm8x4',
+offset: 14580,
+shaderLocation: 0,
+},
+{
+format: 'float32',
+offset: 1796,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x2',
+offset: 13618,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x9eb8fa60,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'src',
+dstFactor: 'one-minus-constant'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rg16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+format: 'r16uint',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+failOp: 'keep',
+passOp: 'replace',
+},
+stencilReadMask: 25,
+stencilWriteMask: 4085,
+depthBiasSlopeScale: 26,
+depthBiasClamp: 80,
+},
+}
+);
+let sampler3 = device0.createSampler(
+{
+label: '\u44cb\u0666\u{1f7ae}\uda72\uba18\u{1fd8f}\ucdea\uc51e',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 64.945,
+lodMaxClamp: 96.411,
+}
+);
+try {
+renderBundleEncoder1.setVertexBuffer(
+81,
+undefined,
+2923224440,
+7634745
+);
+} catch {}
+try {
+commandEncoder2.clearBuffer(
+buffer1,
+22360
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(
+querySet1,
+146,
+1673,
+buffer1,
+6912
+);
+} catch {}
+let gpuCanvasContext1 = canvas2.getContext('webgpu');
+document.body.prepend('\u8a17\u0dcb\ube67');
+let texture11 = device0.createTexture(
+{
+label: '\u7929\u0e73\u07e0',
+size: [25, 3, 203],
+mipLevelCount: 5,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'depth24plus-stencil8',
+'depth24plus-stencil8'
+],
+}
+);
+let computePassEncoder6 = commandEncoder2.beginComputePass(
+{
+label: '\u1a56\u05a8\u{1ff7a}\u0380\u0fd0\u03c5\u6105\u061f\u0088\ue9d6'
+}
+);
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder7.copyTextureToTexture(
+{
+  texture: texture11,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 11 },
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 1,
+  origin: { x: 4, y: 0, z: 18 },
+  aspect: 'all',
+},
+{width: 6, height: 1, depthOrArrayLayers: 163}
+);
+} catch {}
+try {
+commandEncoder7.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 144, y: 0, z: 29 },
+  aspect: 'all',
+},
+new BigInt64Array(arrayBuffer0),
+/* required buffer size: 5264847 */{
+offset: 119,
+bytesPerRow: 16051,
+rowsPerImage: 164,
+},
+{width: 1002, height: 0, depthOrArrayLayers: 3}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 624, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 20, y: 11 },
+  flipY: true,
+},
+{
+  texture: texture2,
+  mipLevel: 3,
+  origin: { x: 425, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 157, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline8 = device0.createRenderPipeline(
+{
+label: '\u0916\u{1feb3}\u9b3e\u1e6f\u4e3c\uf2db\u7df9',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 11280,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 2808,
+shaderLocation: 10,
+},
+{
+format: 'uint32',
+offset: 9312,
+shaderLocation: 24,
+},
+{
+format: 'float16x2',
+offset: 1016,
+shaderLocation: 21,
+},
+{
+format: 'uint32x2',
+offset: 9144,
+shaderLocation: 2,
+},
+{
+format: 'unorm8x2',
+offset: 3844,
+shaderLocation: 14,
+},
+{
+format: 'unorm16x2',
+offset: 5536,
+shaderLocation: 4,
+},
+{
+format: 'snorm16x4',
+offset: 4988,
+shaderLocation: 3,
+},
+{
+format: 'uint16x2',
+offset: 6376,
+shaderLocation: 7,
+},
+{
+format: 'snorm8x2',
+offset: 5540,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 33132,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x2',
+offset: 1364,
+shaderLocation: 1,
+},
+{
+format: 'sint32x2',
+offset: 22580,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 54360,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 8052,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x4',
+offset: 6528,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 32088,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 29828,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 21532,
+shaderLocation: 15,
+},
+{
+format: 'sint32x3',
+offset: 3084,
+shaderLocation: 8,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+multisample: {
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.ALL,
+}
+],
+},
+}
+);
+let texture12 = device0.createTexture(
+{
+size: [152, 216, 22],
+mipLevelCount: 5,
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba32float'
+],
+}
+);
+let renderBundle4 = renderBundleEncoder1.finish();
+try {
+computePassEncoder5.setPipeline(
+pipeline4
+);
+} catch {}
+let pipeline9 = await promise0;
+let querySet2 = device0.createQuerySet(
+{
+label: '\u756f\u{1f6a5}\u0ba8\u389c\u02c1\u{1f702}\u0fc9\u{1f69a}\u8290',
+type: 'occlusion',
+count: 3410,
+}
+);
+let renderBundle5 = renderBundleEncoder3.finish(
+{
+label: '\u{1f80d}\u6014\u{1fd5d}\u7e8a\u{1fd64}\u{1fcda}\u9c18\u8da7\ue64a\u{1fbeb}\u0d17'
+}
+);
+let promise5 = device0.createRenderPipelineAsync(
+{
+label: '\u6660\u{1ffc3}\u0396\u0245\u{1f6d6}\u048c',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 31932,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 19888,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 37700,
+shaderLocation: 24,
+},
+{
+format: 'sint32x2',
+offset: 31244,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x2',
+offset: 21872,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x2',
+offset: 49540,
+shaderLocation: 4,
+},
+{
+format: 'sint8x2',
+offset: 4466,
+shaderLocation: 8,
+},
+{
+format: 'float16x4',
+offset: 52960,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 52968,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 38636,
+shaderLocation: 14,
+},
+{
+format: 'sint32x4',
+offset: 17156,
+shaderLocation: 10,
+},
+{
+format: 'unorm8x4',
+offset: 29356,
+shaderLocation: 13,
+},
+{
+format: 'uint8x2',
+offset: 2812,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 40484,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 54520,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 29840,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32',
+offset: 19124,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 27828,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 15440,
+shaderLocation: 1,
+},
+{
+format: 'snorm8x2',
+offset: 23992,
+shaderLocation: 21,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+frontFace: 'cw',
+cullMode: 'front',
+},
+multisample: {
+count: 4,
+mask: 0xf6fc5b68,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'dst',
+dstFactor: 'one-minus-src'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'src-alpha-saturated',
+dstFactor: 'zero'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'src-alpha',
+dstFactor: 'src-alpha'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rg16float',
+writeMask: GPUColorWrite.ALL,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'constant',
+dstFactor: 'dst-alpha'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'one-minus-constant',
+dstFactor: 'constant'
+},
+},
+format: 'rg11b10ufloat',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+let bindGroupLayout3 = device0.createBindGroupLayout(
+{
+label: '\u1326\u{1fdfa}\u{1fef2}\u0b5e\udc2e\u{1f6f0}',
+entries: [
+
+],
+}
+);
+let renderBundleEncoder4 = device0.createRenderBundleEncoder(
+{
+label: '\u77fb\ufe51\u{1f684}',
+colorFormats: [
+'rg32sint',
+'bgra8unorm-srgb'
+],
+sampleCount: 254,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder4.insertDebugMarker(
+'\u0167'
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb',
+'rgba16uint'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let img2 = await imageWithData(252, 121, '#5e967853', '#de15bed4');
+let texture13 = device0.createTexture(
+{
+label: '\u1fdb\u{1f6a1}\ub58c\u{1f611}\u04bb\u0d89\u{1fe98}\u0b9f',
+size: {width: 194, height: 35, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_DST,
+}
+);
+try {
+commandEncoder7.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 152, height: 216, depthOrArrayLayers: 22}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 59, y: 569 },
+  flipY: true,
+},
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 77, y: 100, z: 9 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 66, height: 102, depthOrArrayLayers: 1}
+);
+} catch {}
+let textureView10 = texture4.createView(
+{
+label: '\u{1f716}\u3730\u8771\u05d7\u04aa',
+mipLevelCount: 1,
+baseArrayLayer: 126,
+arrayLayerCount: 43,
+}
+);
+try {
+computePassEncoder3.setPipeline(
+pipeline1
+);
+} catch {}
+try {
+commandEncoder7.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+computePassEncoder5.pushDebugGroup(
+'\u0ded'
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture5,
+  mipLevel: 2,
+  origin: { x: 1, y: 0, z: 3 },
+  aspect: 'all',
+},
+new BigInt64Array(arrayBuffer0),
+/* required buffer size: 732823 */{
+offset: 503,
+bytesPerRow: 246,
+rowsPerImage: 124,
+},
+{width: 56, height: 1, depthOrArrayLayers: 25}
+);
+} catch {}
+document.body.append('\u6a5a\u0f78\u{1fdd7}\u058c');
+let adapter1 = await navigator.gpu.requestAdapter();
+let imageBitmap1 = await createImageBitmap(img2);
+let commandEncoder8 = device0.createCommandEncoder(
+{
+}
+);
+let sampler4 = device0.createSampler(
+{
+label: '\u25f7\u068d\u0ffd\u02c6\u6f88\u0579',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 2.455,
+lodMaxClamp: 54.358,
+}
+);
+try {
+commandEncoder8.copyTextureToTexture(
+{
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 4, y: 38, z: 6 },
+  aspect: 'all',
+},
+{
+  texture: texture0,
+  mipLevel: 3,
+  origin: { x: 46, y: 0, z: 26 },
+  aspect: 'all',
+},
+{width: 34, height: 0, depthOrArrayLayers: 6}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 38, height: 54, depthOrArrayLayers: 22}
+*/
+{
+  source: video0,
+  origin: { x: 1, y: 1 },
+  flipY: false,
+},
+{
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 21, y: 40, z: 15 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 10, height: 7, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline10 = await device0.createRenderPipelineAsync(
+{
+label: '\u23cd\ub5fe\u5c83\u6f2d\ub6b8\u6209\u87a3\uc982\u01a5\u{1fe6e}\ucd1a',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 10696,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 1074,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x2',
+offset: 1642,
+shaderLocation: 13,
+},
+{
+format: 'uint16x2',
+offset: 7500,
+shaderLocation: 24,
+},
+{
+format: 'uint8x4',
+offset: 8664,
+shaderLocation: 2,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 2584,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x2',
+offset: 3494,
+shaderLocation: 18,
+},
+{
+format: 'sint32x2',
+offset: 8248,
+shaderLocation: 10,
+},
+{
+format: 'float16x2',
+offset: 1204,
+shaderLocation: 1,
+},
+{
+format: 'unorm8x2',
+offset: 9186,
+shaderLocation: 14,
+},
+{
+format: 'sint32',
+offset: 3808,
+shaderLocation: 8,
+},
+{
+format: 'sint8x4',
+offset: 1744,
+shaderLocation: 0,
+},
+{
+format: 'unorm8x2',
+offset: 9408,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 7020,
+attributes: [
+{
+format: 'unorm8x2',
+offset: 3238,
+shaderLocation: 21,
+},
+{
+format: 'uint16x2',
+offset: 28,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: false,
+},
+multisample: {
+count: 4,
+mask: 0xfe1f3ba2,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg8sint',
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'one-minus-dst',
+dstFactor: 'constant'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rg11b10ufloat',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}
+],
+},
+}
+);
+let bindGroupLayout4 = device0.createBindGroupLayout(
+{
+label: '\ua22d\u03e1\u0275\u020f',
+entries: [
+{
+binding: 1830,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 8496,
+visibility: 0,
+texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+}
+],
+}
+);
+try {
+computePassEncoder2.setPipeline(
+pipeline4
+);
+} catch {}
+try {
+commandEncoder8.copyBufferToBuffer(
+buffer2,
+30796,
+buffer1,
+3356,
+12448
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder8.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder7.resolveQuerySet(
+querySet2,
+3084,
+278,
+buffer1,
+8448
+);
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(367, 461);
+let texture14 = device0.createTexture(
+{
+label: '\u2fd8\ud867\u257a\uf336\u30b9\u3d98\u{1ff47}\udefb\u0890\u{1f6b2}\u330d',
+size: [216, 78, 1],
+mipLevelCount: 5,
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg16float'
+],
+}
+);
+let renderBundleEncoder5 = device0.createRenderBundleEncoder(
+{
+label: '\uf688\u8489',
+colorFormats: [
+'rgba16uint',
+'r16float',
+'rgba32float',
+'rgba32uint',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 899,
+}
+);
+let pipeline11 = device0.createComputePipeline(
+{
+label: '\u8124\u0fbb\uf544\ua194\u{1fbf6}',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let imageData0 = new ImageData(96, 12);
+let texture15 = device0.createTexture(
+{
+size: [1144, 1, 1798],
+mipLevelCount: 11,
+dimension: '3d',
+format: 'r8uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8uint',
+'r8uint',
+'r8uint'
+],
+}
+);
+let renderBundleEncoder6 = device0.createRenderBundleEncoder(
+{
+label: '\ubda6\u9a27\u0c03\u9900\u03da',
+colorFormats: [
+'r8sint',
+'rg11b10ufloat',
+'rgba16sint',
+'rgba32float',
+'rg11b10ufloat'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 794,
+depthReadOnly: true,
+}
+);
+let sampler5 = device0.createSampler(
+{
+label: '\u2cf4\u0a59\u0d5f\u6927\u79f8',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 87.251,
+lodMaxClamp: 94.762,
+}
+);
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+await promise3;
+} catch {}
+try {
+offscreenCanvas1.getContext('2d');
+} catch {}
+let bindGroup0 = device0.createBindGroup({
+label: '\u{1ffd0}\u7488\u0b89',
+layout: bindGroupLayout3,
+entries: [
+
+],
+});
+let pipelineLayout2 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout4,
+bindGroupLayout0
+],
+}
+);
+let commandEncoder9 = device0.createCommandEncoder(
+{
+}
+);
+let texture16 = device0.createTexture(
+{
+label: '\u053a\u{1faa3}\u1820\u9c03\u4966\u0460',
+size: [7919],
+dimension: '1d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+}
+);
+let textureView11 = texture10.createView(
+{
+label: '\u{1fadc}\u14e3\u{1f7eb}\u0eff\u0b72\u5804\u0898\u0e9b\u0257',
+mipLevelCount: 1,
+}
+);
+let renderBundleEncoder7 = device0.createRenderBundleEncoder(
+{
+label: '\u{1ffb7}\u5e42\ue45e\u01b1',
+colorFormats: [
+'r8unorm',
+'rgba8unorm-srgb',
+'rgba8unorm-srgb',
+'r32float',
+'rgba8uint',
+'rg8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 85,
+depthReadOnly: true,
+}
+);
+let renderBundle6 = renderBundleEncoder0.finish();
+let sampler6 = device0.createSampler(
+{
+label: '\u07ca\u{1fc4a}\u{1f79a}\u60a6\u0187\u40d9\u{1fd91}\ue681\u0fba',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 63.761,
+lodMaxClamp: 67.494,
+}
+);
+try {
+renderBundleEncoder4.setIndexBuffer(
+buffer1,
+'uint32',
+12516,
+7209
+);
+} catch {}
+try {
+commandEncoder8.copyTextureToTexture(
+{
+  texture: texture11,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 7 },
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 2,
+  origin: { x: 1, y: 0, z: 16 },
+  aspect: 'all',
+},
+{width: 3, height: 1, depthOrArrayLayers: 169}
+);
+} catch {}
+try {
+commandEncoder8.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture11,
+  mipLevel: 3,
+  origin: { x: 0, y: 1, z: 108 },
+  aspect: 'stencil-only',
+},
+new Uint16Array(arrayBuffer0),
+/* required buffer size: 584 */{
+offset: 584,
+bytesPerRow: 181,
+rowsPerImage: 8,
+},
+{width: 3, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend('\ua77e\u{1fef9}\u{1fa83}\u0af7\uf8c9\u2068\u5785\ub0b8\u0f8f\uca78\u02a3');
+let commandEncoder10 = device0.createCommandEncoder(
+{
+label: '\u180c\u{1ff0a}\u0653\u76fd',
+}
+);
+let querySet3 = device0.createQuerySet(
+{
+label: '\u{1fa47}\uc32b\u{1fc18}\u0b87\ub0cc\u02c2\ud401\u3c53\ued3d\u645c\u400e',
+type: 'occlusion',
+count: 3096,
+}
+);
+let textureView12 = texture11.createView(
+{
+label: '\ua4e6\u044e\u{1f7c4}\u0551',
+dimension: '2d',
+aspect: 'stencil-only',
+baseMipLevel: 1,
+mipLevelCount: 1,
+baseArrayLayer: 51,
+}
+);
+let sampler7 = device0.createSampler(
+{
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMaxClamp: 45.820,
+}
+);
+try {
+computePassEncoder3.setPipeline(
+pipeline2
+);
+} catch {}
+try {
+commandEncoder7.resolveQuerySet(
+querySet0,
+2844,
+314,
+buffer1,
+3584
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 18, y: 12, z: 10 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 262703 */{
+offset: 90,
+bytesPerRow: 327,
+rowsPerImage: 259,
+},
+{width: 2, height: 27, depthOrArrayLayers: 4}
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend('\u0d99\u3b28\u3a7b\u058f\u3088\u9d51\u536e\u0a77\u02c6');
+let img3 = await imageWithData(180, 249, '#fc8463b8', '#c2b282c9');
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+try {
+adapter0.label = '\u09c9\u{1f89c}\u797a';
+} catch {}
+let renderPassEncoder0 = commandEncoder8.beginRenderPass(
+{
+label: '\u038e\u{1f98c}\u0cbe\u4784\u0f8e\u{1fef1}\ub531\u048e\u343b\u0013\u191b',
+colorAttachments: [
+
+],
+depthStencilAttachment: {
+view: textureView12,
+depthClearValue: -4.089978836096881,
+depthReadOnly: true,
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet2,
+}
+);
+let renderBundleEncoder8 = device0.createRenderBundleEncoder(
+{
+label: '\u021b\u{1fff4}\u1ace\u6fe7\u766c\u{1f7d7}\u597a\u0a4d\ude3d\u0ea3',
+colorFormats: [
+'r8unorm',
+'rg8uint',
+'rgba16sint',
+'r32sint'
+],
+sampleCount: 157,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder0.setScissorRect(
+8,
+0,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(
+2646
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture9,
+  mipLevel: 0,
+  origin: { x: 812, y: 0, z: 0 },
+  aspect: 'all',
+},
+new BigUint64Array(new ArrayBuffer(32)),
+/* required buffer size: 892 */{
+offset: 892,
+bytesPerRow: 20695,
+},
+{width: 2573, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let texture17 = device0.createTexture(
+{
+label: '\u0b6c\ud418\u0630\u8e09\u3a6f\u7b32\u01b8\u032e\ub4a1\u0aa4',
+size: [179, 1, 80],
+mipLevelCount: 5,
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let textureView13 = texture3.createView(
+{
+label: '\udfef\u{1f714}\ud850\u3f3b\u036a\u{1fc45}\u00a4\uf996\ud063\u8403',
+baseMipLevel: 4,
+}
+);
+let renderBundleEncoder9 = device0.createRenderBundleEncoder(
+{
+label: '\u0842\u4896\u015f\u072e\u0759\u81dd',
+colorFormats: [
+undefined,
+'rg8uint'
+],
+sampleCount: 377,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder0.beginOcclusionQuery(
+80
+);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant(
+{
+r: 287.0,
+g: -463.9,
+b: 202.8,
+a: -200.5,
+}
+);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(
+9,
+undefined,
+4223854026,
+69583569
+);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+renderBundleEncoder5.insertDebugMarker(
+'\u{1fe77}'
+);
+} catch {}
+document.body.append('\u8d90\u4543\u7c58\u0c4c\ub4f0\u6fa1\u058d\u1e92\u08da\u094d');
+let videoFrame1 = new VideoFrame(videoFrame0, {timestamp: 0});
+let renderBundle7 = renderBundleEncoder9.finish(
+{
+label: '\u21b2\u0c43\u{1fa0d}'
+}
+);
+try {
+renderPassEncoder0.setBindGroup(
+4,
+bindGroup0,
+new Uint32Array(3590),
+3413,
+0
+);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(
+96,
+undefined,
+1007893235,
+191296214
+);
+} catch {}
+try {
+commandEncoder10.copyTextureToTexture(
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 17, y: 211, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 972, y: 0, z: 24 },
+  aspect: 'all',
+},
+{width: 127, height: 1, depthOrArrayLayers: 3}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture14,
+  mipLevel: 2,
+  origin: { x: 5, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 79 */{
+offset: 79,
+bytesPerRow: 313,
+},
+{width: 32, height: 19, depthOrArrayLayers: 0}
+);
+} catch {}
+let texture18 = device0.createTexture(
+{
+size: [8586, 92, 255],
+mipLevelCount: 3,
+dimension: '2d',
+format: 'r16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16float',
+'r16float',
+'r16float'
+],
+}
+);
+let sampler8 = device0.createSampler(
+{
+label: '\u0a9c\u{1f768}\u{1f714}\ucde7\uc78b\u0c49\u0162\u15a9\ue4df',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 21.881,
+lodMaxClamp: 42.501,
+compare: 'greater',
+}
+);
+try {
+computePassEncoder4.setBindGroup(
+4,
+bindGroup0,
+new Uint32Array(6837),
+6729,
+0
+);
+} catch {}
+try {
+computePassEncoder3.setPipeline(
+pipeline11
+);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+1.684,
+0.2037,
+9.357,
+0.5083,
+0.6976,
+0.8736
+);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(
+73,
+undefined,
+240923236
+);
+} catch {}
+let pipeline12 = device0.createComputePipeline(
+{
+layout: pipelineLayout2,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let img4 = await imageWithData(171, 256, '#4e6519a0', '#874452f7');
+let shaderModule3 = device0.createShaderModule(
+{
+label: '\ude19\u{1f6db}\u{1fb88}\u2bcd\u02f4',
+code: `@group(5) @binding(8053)
+var<storage, read_write> i0: array<u32>;
+@group(4) @binding(8053)
+var<storage, read_write> type1: array<u32>;
+
+@compute @workgroup_size(4, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S2 {
+@builtin(position) f0: vec4<f32>,
+@builtin(sample_index) f1: u32
+}
+struct FragmentOutput0 {
+@location(0) f0: vec2<i32>,
+@location(2) f1: vec4<f32>,
+@location(5) f2: vec3<f32>,
+@location(7) f3: vec3<i32>,
+@builtin(frag_depth) f4: f32,
+@location(4) f5: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, a1: S2, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S1 {
+@location(3) f0: vec3<f32>,
+@location(16) f1: f32,
+@location(19) f2: vec4<u32>,
+@location(23) f3: vec2<f16>,
+@location(21) f4: vec2<i32>,
+@location(20) f5: vec4<i32>,
+@location(17) f6: i32,
+@location(12) f7: i32,
+@location(2) f8: vec4<u32>,
+@location(4) f9: vec2<f16>,
+@location(6) f10: u32,
+@location(1) f11: vec3<i32>,
+@location(22) f12: vec2<i32>,
+@location(11) f13: vec2<i32>,
+@location(13) f14: vec2<f32>,
+@location(24) f15: vec3<f16>,
+@location(0) f16: vec2<f32>
+}
+
+@vertex
+fn vertex0(@location(18) a0: vec2<f16>, @location(8) a1: vec3<i32>, @location(7) a2: vec2<u32>, @builtin(instance_index) a3: u32, @location(9) a4: vec4<f16>, a5: S1, @location(14) a6: u32, @location(5) a7: u32, @location(15) a8: vec4<f32>, @location(10) a9: vec2<i32>, @builtin(vertex_index) a10: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder11 = device0.createCommandEncoder(
+{
+}
+);
+let textureView14 = texture3.createView(
+{
+baseMipLevel: 6,
+}
+);
+let renderPassEncoder1 = commandEncoder10.beginRenderPass(
+{
+label: '\u{1f9bb}\u0d2b\u0fdb',
+colorAttachments: [
+
+],
+depthStencilAttachment: {
+view: textureView12,
+depthClearValue: -2.1219429721902046,
+stencilClearValue: 3104,
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet1,
+maxDrawCount: 63912,
+}
+);
+let renderBundleEncoder10 = device0.createRenderBundleEncoder(
+{
+label: '\ua65c\u7ead\udbcf\u7284\u0fb4\u{1fadd}\u2cef',
+colorFormats: [
+undefined,
+'rg16sint',
+'r16float',
+'r32float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 961,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder1.setBlendConstant(
+{
+r: -870.5,
+g: -596.9,
+b: 448.7,
+a: 452.4,
+}
+);
+} catch {}
+try {
+commandEncoder11.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+let texture19 = gpuCanvasContext0.getCurrentTexture();
+let textureView15 = texture0.createView(
+{
+label: '\uf61c\u0182\u0ac6\u{1ff0d}\u{1fa07}\u0cce\ueea0\uce51\u767f\u{1fe4e}\u20c8',
+baseMipLevel: 5,
+baseArrayLayer: 20,
+arrayLayerCount: 10,
+}
+);
+let computePassEncoder7 = commandEncoder7.beginComputePass();
+let sampler9 = device0.createSampler(
+{
+label: '\u61dd\u6ee1\u854f\u{1fd58}\u03e6\u{1fd83}\uaa89\u0073\u09d9\uf470',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMaxClamp: 62.837,
+}
+);
+try {
+renderPassEncoder1.setBlendConstant(
+{
+r: 764.4,
+g: -14.91,
+b: 979.5,
+a: 449.7,
+}
+);
+} catch {}
+try {
+renderPassEncoder1.setViewport(
+2.395,
+0.1054,
+1.409,
+0.3517,
+0.5148,
+0.9018
+);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(
+60,
+undefined,
+961687375
+);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder11.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+computePassEncoder5.popDebugGroup();
+} catch {}
+let pipeline13 = device0.createComputePipeline(
+{
+label: '\u4b55\u041e\uc391\u0143\u0f61\uf76f',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline14 = await device0.createRenderPipelineAsync(
+{
+label: '\u5239\u012e\u0d84\u47c8\u8adb\u3a6e\ub4b4\u0db3\u02f4\u01fa\u0dab',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x4',
+offset: 2240,
+shaderLocation: 14,
+},
+{
+format: 'float32x4',
+offset: 24372,
+shaderLocation: 1,
+},
+{
+format: 'snorm16x2',
+offset: 15096,
+shaderLocation: 21,
+},
+{
+format: 'unorm16x2',
+offset: 29604,
+shaderLocation: 18,
+},
+{
+format: 'uint32',
+offset: 52968,
+shaderLocation: 7,
+},
+{
+format: 'float32x4',
+offset: 31948,
+shaderLocation: 3,
+},
+{
+format: 'sint32',
+offset: 13456,
+shaderLocation: 8,
+},
+{
+format: 'unorm8x2',
+offset: 32076,
+shaderLocation: 13,
+},
+{
+format: 'uint32x3',
+offset: 52488,
+shaderLocation: 2,
+},
+{
+format: 'unorm8x4',
+offset: 4552,
+shaderLocation: 15,
+},
+{
+format: 'sint32x4',
+offset: 59008,
+shaderLocation: 0,
+},
+{
+format: 'sint16x4',
+offset: 47660,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 34112,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 25052,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x3',
+offset: 23968,
+shaderLocation: 24,
+},
+{
+format: 'float32',
+offset: 16684,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x272a9b8d,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg32sint',
+writeMask: 0,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'never',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'replace',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilReadMask: 3,
+stencilWriteMask: 3785,
+depthBiasSlopeScale: 34,
+},
+}
+);
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.append('\u04f1\u6f45');
+let textureView16 = texture6.createView(
+{
+label: '\uce72\u{1fc1b}\u{1ffbb}\u75e2\u{1f98e}\uec86\uaf76\u7ad0\u{1fec6}\u0c7c',
+format: 'rg16sint',
+baseMipLevel: 0,
+mipLevelCount: 1,
+}
+);
+let computePassEncoder8 = commandEncoder11.beginComputePass();
+let renderPassEncoder2 = commandEncoder9.beginRenderPass(
+{
+label: '\u41ae\u0d6c\u01c5\u{1f6d8}\u5207\u6678\u29d2\u7b70\u05f6',
+colorAttachments: [
+undefined
+],
+depthStencilAttachment: {
+view: textureView12,
+stencilClearValue: 64851,
+stencilLoadOp: 'clear',
+stencilStoreOp: 'store',
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet2,
+maxDrawCount: 11216,
+}
+);
+let renderBundleEncoder11 = device0.createRenderBundleEncoder(
+{
+label: '\u0d0b\u31e8\ub6e0\u{1fa4a}\u03e0\u02d7\uf0b9\u0971\u15a8\u{1ff98}',
+colorFormats: [
+'bgra8unorm-srgb',
+'rg8unorm',
+'rgb10a2unorm',
+'rg32float',
+'rg16uint',
+'rgba16float',
+'rg16sint'
+],
+sampleCount: 577,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder0.setBindGroup(
+3,
+bindGroup0,
+new Uint32Array(4732),
+3997,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant(
+{
+r: 298.4,
+g: 474.6,
+b: 594.6,
+a: 968.9,
+}
+);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+3.906,
+0.1947,
+5.833,
+0.1495,
+0.7807,
+0.9221
+);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(
+buffer1,
+'uint32',
+18820,
+5674
+);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+5,
+bindGroup0
+);
+} catch {}
+try {
+computePassEncoder5.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 19, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 173, y: 49 },
+  flipY: true,
+},
+{
+  texture: texture2,
+  mipLevel: 8,
+  origin: { x: 7, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 6, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline15 = device0.createComputePipeline(
+{
+label: '\u00e2\u2637\uf3b8\u033d\u2ac3',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let video1 = await videoWithData();
+let commandEncoder12 = device0.createCommandEncoder(
+{
+label: '\u811d\u0811\u{1f889}\u0b50\u0b38\u{1fbfd}\uad82\u6da9\u{1fd3a}\u087d\u8998',
+}
+);
+let computePassEncoder9 = commandEncoder12.beginComputePass(
+{
+label: '\u5558\ub8bf'
+}
+);
+let renderBundleEncoder12 = device0.createRenderBundleEncoder(
+{
+label: '\ub490\u{1f886}\u{1f939}\u{1fe55}\u0230\u35e4\u09b2\u{1f83e}\u{1fab4}\u3ccf\u{1fb5b}',
+colorFormats: [
+'r16sint',
+'rg8uint',
+'bgra8unorm',
+'rgba32sint',
+'rgb10a2uint',
+'r16float'
+],
+sampleCount: 169,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder2.setViewport(
+1.026,
+0.1627,
+4.358,
+0.3787,
+0.6663,
+0.7206
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1248, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 181, y: 326 },
+  flipY: false,
+},
+{
+  texture: texture2,
+  mipLevel: 2,
+  origin: { x: 218, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 194, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await promise6;
+} catch {}
+document.body.prepend(img0);
+pseudoSubmit(device0, commandEncoder8);
+try {
+renderPassEncoder0.setScissorRect(
+1,
+1,
+11,
+0
+);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(
+5,
+bindGroup0
+);
+} catch {}
+let shaderModule4 = device0.createShaderModule(
+{
+label: '\u4503\u1798\u21da\u{1fa4d}\u{1f6fd}\uff3c\u{1f99b}\u{1fe90}',
+code: `
+
+@compute @workgroup_size(2, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: vec4<i32>,
+@location(7) f1: i32,
+@location(3) f2: vec2<i32>,
+@location(5) f3: i32,
+@location(0) f4: vec2<u32>,
+@location(1) f5: vec3<f32>,
+@location(6) f6: vec4<u32>,
+@location(2) f7: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S3 {
+@location(19) f0: vec3<f16>,
+@location(13) f1: vec4<f32>,
+@location(23) f2: vec3<f32>,
+@location(3) f3: f16,
+@location(4) f4: f16,
+@location(11) f5: vec4<f32>,
+@location(22) f6: u32,
+@location(5) f7: vec4<f16>,
+@location(21) f8: vec3<f16>,
+@location(1) f9: vec4<f32>
+}
+
+@vertex
+fn vertex0(a0: S3, @location(7) a1: vec2<f16>, @location(15) a2: vec3<f16>, @location(18) a3: vec2<f16>, @location(17) a4: vec3<f16>, @location(20) a5: vec3<u32>, @location(2) a6: vec2<f16>, @location(8) a7: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture20 = device0.createTexture(
+{
+label: '\u8773\ub7ea\uafb9',
+size: [828, 1, 129],
+mipLevelCount: 1,
+sampleCount: 1,
+dimension: '3d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: -657.0,
+g: 294.9,
+b: 633.5,
+a: -370.3,
+}
+);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(
+buffer1,
+'uint16'
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let querySet4 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 2745,
+}
+);
+let texture21 = device0.createTexture(
+{
+size: [39, 199, 1],
+mipLevelCount: 6,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'depth24plus'
+],
+}
+);
+let sampler10 = device0.createSampler(
+{
+label: '\u0b06\u0060\u2300\u09a0\u090d\ue773\u6b76\u{1f7b9}\u0c36\u0288',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 21.594,
+lodMaxClamp: 72.856,
+}
+);
+try {
+computePassEncoder4.setPipeline(
+pipeline11
+);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant(
+{
+r: -577.3,
+g: -788.7,
+b: 201.3,
+a: -372.6,
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture13,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new DataView(arrayBuffer0),
+/* required buffer size: 796 */{
+offset: 796,
+bytesPerRow: 171,
+},
+{width: 11, height: 4, depthOrArrayLayers: 0}
+);
+} catch {}
+canvas2.height = 679;
+pseudoSubmit(device0, commandEncoder3);
+let sampler11 = device0.createSampler(
+{
+label: '\u69aa\u1da0\u994a\u{1f8b7}\u053b\uf525',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 40.715,
+lodMaxClamp: 62.680,
+maxAnisotropy: 17,
+}
+);
+try {
+renderPassEncoder2.setScissorRect(
+4,
+1,
+4,
+0
+);
+} catch {}
+let pipeline16 = device0.createComputePipeline(
+{
+label: '\u2f86\u{1fc06}\ubdef\u0370\ucb37\u062a',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let video2 = await videoWithData();
+let textureView17 = texture8.createView(
+{
+label: '\u0a49\uccd6\ueb91\u5c7a\u0a76\u033c\uead7\ucc7c\u04fd',
+format: 'depth32float',
+}
+);
+try {
+renderPassEncoder1.setIndexBuffer(
+buffer1,
+'uint32'
+);
+} catch {}
+let pipeline17 = device0.createComputePipeline(
+{
+label: '\u{1f8c7}\u6fd0',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+computePassEncoder2.setBindGroup(
+0,
+bindGroup0
+);
+} catch {}
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(
+3,
+bindGroup0
+);
+} catch {}
+try {
+commandEncoder2.copyBufferToBuffer(
+buffer2,
+9660,
+buffer1,
+4408,
+1072
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(
+querySet0,
+352,
+319,
+buffer1,
+5376
+);
+} catch {}
+let pipeline18 = await device0.createComputePipelineAsync(
+{
+label: '\u04e3\u0e91',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let texture22 = device0.createTexture(
+{
+label: '\ufa00\u{1ff76}',
+size: {width: 127, height: 201, depthOrArrayLayers: 43},
+mipLevelCount: 2,
+format: 'rg32float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let textureView18 = texture11.createView(
+{
+label: '\u{1fa89}\u{1fa4c}\u0ef5\ua782\u07cc\u8430\u{1f608}',
+dimension: '2d',
+aspect: 'stencil-only',
+baseMipLevel: 2,
+mipLevelCount: 2,
+baseArrayLayer: 169,
+}
+);
+let sampler12 = device0.createSampler(
+{
+label: '\u{1ff0d}\u2993\u{1fdef}\ucda2\u03d2\u3167\ue495\u2c0d\u0db5',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 17.000,
+lodMaxClamp: 21.132,
+}
+);
+try {
+renderPassEncoder2.setBindGroup(
+5,
+bindGroup0,
+new Uint32Array(2604),
+2564,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(
+2043
+);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+8.681,
+0.1472,
+0.2119,
+0.5194,
+0.7355,
+0.8257
+);
+} catch {}
+try {
+querySet4.destroy();
+} catch {}
+try {
+commandEncoder2.copyBufferToBuffer(
+buffer0,
+26636,
+buffer1,
+24524,
+212
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture5,
+  mipLevel: 4,
+  origin: { x: 11, y: 0, z: 2 },
+  aspect: 'all',
+},
+new Int32Array(arrayBuffer0),
+/* required buffer size: 111108 */{
+offset: 930,
+bytesPerRow: 122,
+rowsPerImage: 301,
+},
+{width: 3, height: 1, depthOrArrayLayers: 4}
+);
+} catch {}
+let pipeline19 = device0.createRenderPipeline(
+{
+layout: 'auto',
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'invert',
+depthFailOp: 'replace',
+passOp: 'zero',
+},
+stencilReadMask: 3467,
+stencilWriteMask: 2529,
+depthBiasSlopeScale: 61,
+depthBiasClamp: 87,
+},
+}
+);
+document.body.prepend('\u{1f98b}\u5673\u6acd\ua02e\uf916\u{1fa91}\u3b62\u2f51\u8a32\ua9c2\u{1fa20}');
+let commandEncoder13 = device0.createCommandEncoder(
+{
+label: '\u{1f884}\u86b3\u0fb0\ube37\uca77\u{1fc5a}\u0068\u{1f666}\u{1fcb1}',
+}
+);
+let texture23 = device0.createTexture(
+{
+label: '\uedeb\u2b40\u0a67\u4cba\uc271\u803a\ud7a1\ud3c8\udba6',
+size: [782, 1, 1372],
+dimension: '3d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rg32sint',
+'rg32sint',
+'rg32sint'
+],
+}
+);
+let textureView19 = texture7.createView(
+{
+label: '\u3706\u14cd\uca09',
+aspect: 'all',
+format: 'rgba8uint',
+baseMipLevel: 1,
+mipLevelCount: 3,
+}
+);
+try {
+renderPassEncoder2.setStencilReference(
+643
+);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer1,
+'uint32'
+);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(
+3,
+bindGroup0
+);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(
+buffer0,
+6752,
+buffer1,
+23320,
+1792
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture11,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 121 },
+  aspect: 'stencil-only',
+},
+new BigInt64Array(arrayBuffer0),
+/* required buffer size: 2759494 */{
+offset: 94,
+bytesPerRow: 140,
+rowsPerImage: 270,
+},
+{width: 1, height: 0, depthOrArrayLayers: 74}
+);
+} catch {}
+let querySet5 = device0.createQuerySet(
+{
+label: '\u6581\u0471\u0f08\u4f40\u05e1\u6fb7\u02dd\uaaa6',
+type: 'occlusion',
+count: 3724,
+}
+);
+let renderBundle8 = renderBundleEncoder8.finish(
+{
+label: '\u3334\u4dfd'
+}
+);
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+1,
+bindGroup0,
+new Uint32Array(6481),
+819,
+0
+);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(
+buffer1,
+'uint32',
+2100,
+4671
+);
+} catch {}
+try {
+commandEncoder6.copyBufferToTexture(
+{
+/* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 17232 */
+offset: 17232,
+buffer: buffer0,
+},
+{
+  texture: texture14,
+  mipLevel: 2,
+  origin: { x: 29, y: 7, z: 0 },
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(365),
+/* required buffer size: 365 */{
+offset: 365,
+rowsPerImage: 158,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+let renderBundleEncoder13 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg16float',
+'rgba32uint',
+'r8sint',
+'bgra8unorm-srgb'
+],
+sampleCount: 532,
+}
+);
+try {
+computePassEncoder8.setBindGroup(
+7,
+bindGroup0,
+new Uint32Array(5957),
+3862,
+0
+);
+} catch {}
+try {
+computePassEncoder9.setPipeline(
+pipeline4
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+8,
+bindGroup0,
+new Uint32Array(5348),
+121,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(
+2682
+);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(
+buffer1,
+'uint16',
+19520,
+4771
+);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(
+74,
+undefined,
+643326932,
+237792538
+);
+} catch {}
+let promise8 = buffer0.mapAsync(
+GPUMapMode.WRITE,
+312,
+24588
+);
+try {
+commandEncoder2.copyTextureToBuffer(
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 4383, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 1636 widthInBlocks: 409 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 4360 */
+offset: 2724,
+buffer: buffer1,
+},
+{width: 409, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(
+querySet3,
+2300,
+689,
+buffer1,
+8960
+);
+} catch {}
+let buffer3 = device0.createBuffer(
+{
+label: '\u7bce\u6857\u4c3a\u0112\u58ab',
+size: 7914,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let texture24 = device0.createTexture(
+{
+label: '\u620c\ufaf4\ue44c\u{1ff56}\u8095\u03fb\u{1f7a7}',
+size: {width: 10003},
+dimension: '1d',
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float',
+'rgba16float'
+],
+}
+);
+let textureView20 = texture16.createView(
+{
+label: '\uf95e\ua092\u086d\ua591\u058f\u6f25',
+}
+);
+let renderPassEncoder3 = commandEncoder2.beginRenderPass(
+{
+label: '\u2740\u2bda\u8dd6\u021e\u082e',
+colorAttachments: [
+undefined
+],
+depthStencilAttachment: {
+view: textureView12,
+depthReadOnly: false,
+stencilClearValue: 55540,
+stencilLoadOp: 'clear',
+stencilStoreOp: 'discard',
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet0,
+maxDrawCount: 46080,
+}
+);
+try {
+computePassEncoder8.setBindGroup(
+6,
+bindGroup0,
+new Uint32Array(9954),
+497,
+0
+);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(
+1,
+bindGroup0
+);
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(
+querySet4,
+2190,
+336,
+buffer1,
+10496
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+22076,
+new Float32Array(5375),
+3365,
+124
+);
+} catch {}
+document.body.prepend(video1);
+offscreenCanvas1.width = 102;
+let texture25 = device0.createTexture(
+{
+label: '\u{1ff61}\u{1fd21}',
+size: {width: 16, height: 119, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8uint'
+],
+}
+);
+let renderBundleEncoder14 = device0.createRenderBundleEncoder(
+{
+label: '\u{1fadf}\u7aad\u0656\u73a2\u955d\u9132\u{1f9e4}\u03f8\u1afd',
+colorFormats: [
+undefined,
+'rg8uint',
+'r32uint',
+'r8unorm',
+'r32float',
+'rg16uint',
+'rg16sint'
+],
+sampleCount: 394,
+stencilReadOnly: true,
+}
+);
+let renderBundle9 = renderBundleEncoder14.finish();
+try {
+renderPassEncoder3.setBindGroup(
+7,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+9.911,
+0.4671,
+0.06452,
+0.3655,
+0.06401,
+0.3304
+);
+} catch {}
+try {
+commandEncoder6.resolveQuerySet(
+querySet3,
+715,
+1445,
+buffer1,
+1280
+);
+} catch {}
+let pipeline20 = device0.createComputePipeline(
+{
+label: '\u01b4\u07cb\u0184\u01f0\ua68b\u{1fdb6}\u{1ff4e}\u0f55\u{1fbe0}',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+},
+}
+);
+let sampler13 = device0.createSampler(
+{
+label: '\u{1f86d}\ueb7f\u0c05\uad5b\u8a78\u3da6\u{1ff4f}\u{1fb0a}\u0e20\u0f4d',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 38.005,
+compare: 'always',
+}
+);
+try {
+renderPassEncoder2.setVertexBuffer(
+25,
+undefined,
+3205227247,
+830649337
+);
+} catch {}
+try {
+commandEncoder13.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder6.resolveQuerySet(
+querySet3,
+1096,
+1335,
+buffer1,
+0
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture12,
+  mipLevel: 3,
+  origin: { x: 0, y: 3, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(64),
+/* required buffer size: 350914 */{
+offset: 432,
+bytesPerRow: 230,
+rowsPerImage: 100,
+},
+{width: 12, height: 24, depthOrArrayLayers: 16}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 152, height: 216, depthOrArrayLayers: 22}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 149, y: 1 },
+  flipY: false,
+},
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 76, y: 53, z: 5 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 21, depthOrArrayLayers: 0}
+);
+} catch {}
+gc();
+document.body.prepend('\u9817\ud953');
+let shaderModule5 = device0.createShaderModule(
+{
+label: '\u0e72\u660f\ud194\u6403\u0e21',
+code: `
+
+@compute @workgroup_size(3, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: vec4<u32>,
+@location(1) f1: vec3<u32>,
+@location(6) f2: vec3<u32>,
+@location(0) f3: vec3<f32>,
+@location(2) f4: u32,
+@location(5) f5: vec3<f32>,
+@location(7) f6: vec3<i32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S4 {
+@location(24) f0: vec4<f16>,
+@location(8) f1: vec3<i32>,
+@location(15) f2: vec4<i32>,
+@location(14) f3: vec4<i32>,
+@location(0) f4: vec2<f32>,
+@location(19) f5: vec4<u32>,
+@location(22) f6: vec2<f16>,
+@location(23) f7: i32,
+@location(3) f8: vec3<i32>,
+@builtin(vertex_index) f9: u32,
+@location(18) f10: vec2<f32>,
+@location(16) f11: vec2<f16>,
+@location(21) f12: vec2<u32>,
+@location(4) f13: vec2<f16>,
+@location(11) f14: vec4<f16>,
+@location(6) f15: vec2<f16>,
+@location(20) f16: i32,
+@location(17) f17: vec2<f32>,
+@location(10) f18: vec2<f16>,
+@location(1) f19: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(13) a0: vec3<u32>, @location(2) a1: vec2<i32>, @location(12) a2: vec4<u32>, @location(7) a3: f16, @location(5) a4: vec4<u32>, @location(9) a5: i32, @builtin(instance_index) a6: u32, a7: S4) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroup1 = device0.createBindGroup({
+layout: bindGroupLayout3,
+entries: [
+
+],
+});
+let querySet6 = device0.createQuerySet(
+{
+label: '\u031c\u{1fea9}\u014e\u985b\ubc6d\u{1fb00}\ua52c\u{1f7ba}',
+type: 'occlusion',
+count: 4047,
+}
+);
+let renderBundleEncoder15 = device0.createRenderBundleEncoder(
+{
+label: '\u492d\uf1bb\u05e7',
+colorFormats: [
+'rgba16uint',
+'r32float',
+'rgba32uint',
+'rgb10a2unorm',
+'rgba8uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 808,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder3.beginOcclusionQuery(
+72
+);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer3,
+6808,
+new Int16Array(54114),
+24920,
+372
+);
+} catch {}
+let commandEncoder14 = device0.createCommandEncoder(
+{
+label: '\u4557\u{1ffd0}\u0fde',
+}
+);
+let texture26 = device0.createTexture(
+{
+label: '\u1573\u0ea0\ucd70\u{1fed1}\u0b84\u7f53',
+size: {width: 1703, height: 1, depthOrArrayLayers: 218},
+sampleCount: 1,
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb9e5ufloat',
+'rgb9e5ufloat'
+],
+}
+);
+let textureView21 = texture10.createView(
+{
+label: '\u5e90\u0c59\u235c\u0503\udb5b\u{1f95c}\u31ce\u3648\u{1f7ca}',
+aspect: 'all',
+baseMipLevel: 4,
+}
+);
+try {
+renderPassEncoder3.setViewport(
+11.01,
+0.4744,
+0.4072,
+0.3065,
+0.5801,
+0.9759
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture11,
+  mipLevel: 3,
+  origin: { x: 0, y: 1, z: 24 },
+  aspect: 'stencil-only',
+},
+new ArrayBuffer(578603),
+/* required buffer size: 578603 */{
+offset: 875,
+bytesPerRow: 102,
+rowsPerImage: 96,
+},
+{width: 3, height: 0, depthOrArrayLayers: 60}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 39, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 39, y: 279 },
+  flipY: false,
+},
+{
+  texture: texture2,
+  mipLevel: 7,
+  origin: { x: 34, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 3, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let buffer4 = device0.createBuffer(
+{
+label: '\u9894\ub43d\u02f1\u9293\uadd4\uaee3\u5f91\u44ea\ud646',
+size: 59025,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: false,
+}
+);
+let renderBundle10 = renderBundleEncoder0.finish(
+{
+label: '\u1555\ua2d7\u91f0\u{1f9f0}\uc3eb\u02ea'
+}
+);
+try {
+computePassEncoder3.setBindGroup(
+0,
+bindGroup1,
+new Uint32Array(4286),
+3825,
+0
+);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(
+1843
+);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(
+buffer1,
+'uint32',
+14680
+);
+} catch {}
+let promise9 = device0.createRenderPipelineAsync(
+{
+label: '\udb05\ucf76\u9904\u5e80\uff5b',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule5,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 5452,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x2',
+offset: 37540,
+shaderLocation: 10,
+},
+{
+format: 'snorm8x2',
+offset: 6934,
+shaderLocation: 6,
+},
+{
+format: 'sint8x2',
+offset: 9670,
+shaderLocation: 23,
+},
+{
+format: 'float16x4',
+offset: 22608,
+shaderLocation: 24,
+},
+{
+format: 'sint32x4',
+offset: 4380,
+shaderLocation: 3,
+},
+{
+format: 'uint8x4',
+offset: 18336,
+shaderLocation: 19,
+},
+{
+format: 'uint16x2',
+offset: 26768,
+shaderLocation: 12,
+},
+{
+format: 'float32',
+offset: 3884,
+shaderLocation: 17,
+},
+{
+format: 'sint32x2',
+offset: 50992,
+shaderLocation: 15,
+},
+{
+format: 'sint32x3',
+offset: 28280,
+shaderLocation: 14,
+},
+{
+format: 'uint32x3',
+offset: 52604,
+shaderLocation: 13,
+},
+{
+format: 'float32',
+offset: 33116,
+shaderLocation: 18,
+},
+{
+format: 'sint32',
+offset: 22028,
+shaderLocation: 20,
+},
+{
+format: 'float16x4',
+offset: 34204,
+shaderLocation: 22,
+},
+{
+format: 'float32',
+offset: 56812,
+shaderLocation: 16,
+},
+{
+format: 'sint32',
+offset: 58284,
+shaderLocation: 8,
+},
+{
+format: 'unorm8x4',
+offset: 6860,
+shaderLocation: 0,
+},
+{
+format: 'snorm8x2',
+offset: 53984,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 28100,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 22828,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 12880,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x3',
+offset: 1316,
+shaderLocation: 9,
+},
+{
+format: 'float16x4',
+offset: 2884,
+shaderLocation: 4,
+},
+{
+format: 'sint32x2',
+offset: 1180,
+shaderLocation: 2,
+},
+{
+format: 'uint32x3',
+offset: 11664,
+shaderLocation: 21,
+},
+{
+format: 'uint32x3',
+offset: 3572,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+multisample: {
+mask: 0xf7e33623,
+},
+fragment: {
+module: shaderModule5,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.ALL,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'dst-alpha',
+dstFactor: 'src'
+},
+},
+format: 'r8unorm',
+writeMask: 0,
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}
+],
+},
+}
+);
+gc();
+let querySet7 = device0.createQuerySet(
+{
+label: '\ua705\u{1fbc5}\uf895\u{1f6b2}\u8ca9',
+type: 'occlusion',
+count: 611,
+}
+);
+let renderPassEncoder4 = commandEncoder6.beginRenderPass(
+{
+label: '\ud2dd\ud7da\u7418\u02bd\u{1faa7}\u2a3c\ucb68\u35ae',
+colorAttachments: [
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView12,
+stencilLoadOp: 'load',
+stencilStoreOp: 'discard',
+},
+occlusionQuerySet: querySet2,
+maxDrawCount: 39960,
+}
+);
+let renderBundle11 = renderBundleEncoder0.finish(
+{
+label: '\u{1fe06}\ua606'
+}
+);
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+11,
+1,
+1,
+0
+);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(
+buffer1,
+'uint32',
+9652,
+9082
+);
+} catch {}
+try {
+commandEncoder14.copyTextureToTexture(
+{
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 5, y: 20, z: 17 },
+  aspect: 'all',
+},
+{
+  texture: texture12,
+  mipLevel: 1,
+  origin: { x: 40, y: 3, z: 12 },
+  aspect: 'all',
+},
+{width: 33, height: 15, depthOrArrayLayers: 3}
+);
+} catch {}
+try {
+commandEncoder14.resolveQuerySet(
+querySet3,
+1710,
+898,
+buffer1,
+4608
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture9,
+  mipLevel: 0,
+  origin: { x: 603, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 25439 */{
+offset: 879,
+},
+{width: 3070, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 624, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 54, y: 7 },
+  flipY: false,
+},
+{
+  texture: texture2,
+  mipLevel: 3,
+  origin: { x: 106, y: 1, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 187, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let promise10 = device0.createComputePipelineAsync(
+{
+label: '\u44b9\ud0e3\u0237\u{1fa0d}\u0fef\uce6d\u0d10\u{1f620}\u25db\u0ec4\u9015',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.append('\u{1f67c}\u0e8d\u4e4d\u236d\u16c1\u{1fb1d}\u17fb\u0f97\ued31');
+let textureView22 = texture21.createView(
+{
+label: '\u04bd\u37c2\u{1f77b}\u0757\ubc05\u03d5\u5237\u8180',
+dimension: '2d-array',
+baseMipLevel: 3,
+}
+);
+let renderPassEncoder5 = commandEncoder13.beginRenderPass(
+{
+label: '\u1ec9\u{1fa87}\ude3b\u7cdf',
+colorAttachments: [
+undefined
+],
+depthStencilAttachment: {
+view: textureView12,
+stencilLoadOp: 'clear',
+stencilStoreOp: 'discard',
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet2,
+}
+);
+let renderBundle12 = renderBundleEncoder9.finish(
+{
+
+}
+);
+let sampler14 = device0.createSampler(
+{
+label: '\uc87f\u3199\u2c19\u08f3\u2f8f\u0727\u83a8\u7e31\u{1f618}\u769c\u8d47',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMinClamp: 54.298,
+lodMaxClamp: 59.979,
+}
+);
+try {
+computePassEncoder7.setBindGroup(
+8,
+bindGroup0,
+new Uint32Array(6347),
+4620,
+0
+);
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant(
+{
+r: -540.8,
+g: 378.7,
+b: 303.4,
+a: 353.9,
+}
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+50,
+undefined,
+667319022,
+459222807
+);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(
+5,
+bindGroup0,
+new Uint32Array(2996),
+2506,
+0
+);
+} catch {}
+try {
+commandEncoder14.copyTextureToTexture(
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 77, y: 80, z: 7 },
+  aspect: 'all',
+},
+{
+  texture: texture0,
+  mipLevel: 1,
+  origin: { x: 372, y: 0, z: 3 },
+  aspect: 'all',
+},
+{width: 30, height: 0, depthOrArrayLayers: 15}
+);
+} catch {}
+let pipeline21 = await device0.createComputePipelineAsync(
+{
+label: '\ue15a\ucbb4\u43c2\u{1fb1d}\u6808\ue2d2\u8a52\u0a75\u0ade\uac74',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let querySet8 = device0.createQuerySet(
+{
+label: '\u95a3\u0c95\u4289',
+type: 'occlusion',
+count: 1770,
+}
+);
+let computePassEncoder10 = commandEncoder14.beginComputePass(
+{
+label: '\u{1fc9f}\u{1fe37}\u{1fb45}\u0f29\u0513\u{1f9e1}\u0946\u0f7e\u2f5c\u{1feeb}\ue3f9'
+}
+);
+try {
+computePassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder5.setStencilReference(
+3998
+);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(
+89,
+undefined,
+1677072954,
+370451686
+);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(
+82,
+undefined,
+827919397,
+857967204
+);
+} catch {}
+try {
+commandEncoder5.resolveQuerySet(
+querySet7,
+602,
+2,
+buffer1,
+24576
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer3,
+2628,
+new Int16Array(49811),
+10799,
+404
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 191, y: 0, z: 33 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 206303 */{
+offset: 512,
+bytesPerRow: 331,
+rowsPerImage: 9,
+},
+{width: 30, height: 1, depthOrArrayLayers: 70}
+);
+} catch {}
+let imageBitmap2 = await createImageBitmap(video0);
+let shaderModule6 = device0.createShaderModule(
+{
+label: '\ua482\u79b3\u0295\ude36\u83d8',
+code: `
+
+@compute @workgroup_size(4, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: f32,
+@location(6) f1: vec3<i32>,
+@location(2) f2: vec3<u32>,
+@location(7) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(27) a0: u32, @location(38) a1: vec2<f32>, @location(4) a2: vec4<f32>, @location(29) a3: i32, @location(21) a4: vec2<u32>, @location(0) a5: i32, @location(13) a6: u32, @location(2) a7: vec4<i32>, @location(5) a8: i32, @location(25) a9: vec2<f16>, @location(26) a10: vec2<i32>, @location(28) a11: i32, @builtin(front_facing) a12: bool, @builtin(sample_index) a13: u32, @location(9) a14: vec4<i32>, @location(17) a15: vec3<u32>, @builtin(position) a16: vec4<f32>, @location(16) a17: f32, @location(7) a18: vec4<f32>, @builtin(sample_mask) a19: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S5 {
+@location(18) f0: f32,
+@location(20) f1: vec2<f32>,
+@location(15) f2: vec3<i32>,
+@location(8) f3: vec3<f16>,
+@location(14) f4: vec2<f16>,
+@location(10) f5: vec3<i32>,
+@location(1) f6: vec3<i32>,
+@location(9) f7: vec2<f16>,
+@location(2) f8: vec2<i32>,
+@builtin(instance_index) f9: u32
+}
+struct VertexOutput0 {
+@location(5) f70: i32,
+@location(29) f71: i32,
+@location(17) f72: vec3<u32>,
+@location(32) f73: vec3<u32>,
+@builtin(position) f74: vec4<f32>,
+@location(39) f75: vec4<i32>,
+@location(8) f76: i32,
+@location(36) f77: vec2<u32>,
+@location(2) f78: vec4<i32>,
+@location(21) f79: vec2<u32>,
+@location(33) f80: u32,
+@location(20) f81: vec4<u32>,
+@location(38) f82: vec2<f32>,
+@location(14) f83: vec2<u32>,
+@location(24) f84: vec3<f16>,
+@location(9) f85: vec4<i32>,
+@location(18) f86: vec3<f32>,
+@location(6) f87: f16,
+@location(16) f88: f32,
+@location(11) f89: f32,
+@location(10) f90: u32,
+@location(27) f91: u32,
+@location(35) f92: vec4<i32>,
+@location(28) f93: i32,
+@location(12) f94: vec3<i32>,
+@location(30) f95: vec2<f16>,
+@location(3) f96: f16,
+@location(0) f97: i32,
+@location(7) f98: vec4<f32>,
+@location(15) f99: vec2<i32>,
+@location(26) f100: vec2<i32>,
+@location(22) f101: f16,
+@location(25) f102: vec2<f16>,
+@location(31) f103: vec3<f16>,
+@location(34) f104: vec4<f16>,
+@location(19) f105: vec3<f32>,
+@location(13) f106: u32,
+@location(4) f107: vec4<f32>,
+@location(23) f108: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec4<u32>, @location(11) a1: vec3<i32>, @location(24) a2: vec3<f16>, @location(19) a3: u32, @location(13) a4: f16, a5: S5, @builtin(vertex_index) a6: u32, @location(22) a7: vec3<f32>, @location(0) a8: vec3<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder15 = device0.createCommandEncoder();
+let renderPassEncoder6 = commandEncoder15.beginRenderPass(
+{
+label: '\u01cc\u{1f884}\u9b6b\u3546\u{1fa48}\u2b7e\u0330',
+colorAttachments: [
+
+],
+depthStencilAttachment: {
+view: textureView12,
+depthClearValue: 8.120314994649561,
+stencilClearValue: 22634,
+stencilLoadOp: 'clear',
+stencilStoreOp: 'store',
+},
+occlusionQuerySet: querySet1,
+maxDrawCount: 10232,
+}
+);
+try {
+renderPassEncoder4.beginOcclusionQuery(
+8
+);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+1,
+0,
+4,
+1
+);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(
+8,
+bindGroup0,
+new Uint32Array(5823),
+3125,
+0
+);
+} catch {}
+try {
+commandEncoder5.copyBufferToTexture(
+{
+/* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 56504 */
+offset: 56504,
+buffer: buffer4,
+},
+{
+  texture: texture13,
+  mipLevel: 3,
+  origin: { x: 1, y: 3, z: 0 },
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder5.resolveQuerySet(
+querySet5,
+1196,
+1433,
+buffer1,
+8448
+);
+} catch {}
+let querySet9 = device0.createQuerySet(
+{
+label: '\u03ab\ue628\u00c7\u{1f87b}',
+type: 'occlusion',
+count: 2727,
+}
+);
+try {
+computePassEncoder4.setBindGroup(
+4,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(
+8,
+1,
+3,
+0
+);
+} catch {}
+try {
+renderPassEncoder5.setStencilReference(
+2154
+);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(
+buffer1,
+'uint32',
+4348,
+3392
+);
+} catch {}
+try {
+commandEncoder5.copyBufferToBuffer(
+buffer2,
+11344,
+buffer3,
+7868,
+32
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+let img5 = await imageWithData(296, 224, '#ff4ef338', '#f6a48ac1');
+let texture27 = device0.createTexture(
+{
+label: '\ue4b1\u{1fc05}\u6c12\u1ed7\u{1fab5}\u02b7\u0f24\u{1f60f}\u30a7\ud6fb\u{1ff43}',
+size: [1983, 1, 29],
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8unorm'
+],
+}
+);
+let renderBundleEncoder16 = device0.createRenderBundleEncoder(
+{
+label: '\u1f7a\u35d4\uf0ab\ub8af\uab18\u8b9c\u455a\u0b9b\u5dfa',
+colorFormats: [
+'r8uint',
+'rgba8unorm-srgb',
+'rg32float',
+'r32sint',
+undefined,
+'rgba8uint'
+],
+sampleCount: 299,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder2.setBindGroup(
+5,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([]);
+} catch {}
+try {
+commandEncoder5.copyBufferToBuffer(
+buffer0,
+24488,
+buffer1,
+19632,
+2940
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder5.resolveQuerySet(
+querySet8,
+1413,
+201,
+buffer1,
+16384
+);
+} catch {}
+let pipeline22 = await device0.createComputePipelineAsync(
+{
+label: '\u07da\uf0f3\u0f1f\u{1fc64}\u0853',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+gc();
+let textureView23 = texture9.createView(
+{
+label: '\ueb78\u0764',
+}
+);
+try {
+renderPassEncoder6.setScissorRect(
+8,
+0,
+2,
+1
+);
+} catch {}
+try {
+renderPassEncoder5.setViewport(
+8.725,
+0.1500,
+1.144,
+0.4098,
+0.2574,
+0.5463
+);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(
+6,
+bindGroup1,
+new Uint32Array(8266),
+4266,
+0
+);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(
+61,
+undefined,
+1451698574,
+2391547470
+);
+} catch {}
+try {
+commandEncoder5.copyBufferToBuffer(
+buffer4,
+50768,
+buffer1,
+15732,
+2108
+);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder5.resolveQuerySet(
+querySet6,
+1875,
+1404,
+buffer1,
+2816
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+9632,
+new DataView(new ArrayBuffer(7100))
+);
+} catch {}
+let pipeline23 = await promise9;
+document.body.append('\uea02\udd9d\ud1f4\uc18e\u{1fb37}\uedcc\u0a94\ub7ea\u{1ff45}\u0994');
+let img6 = await imageWithData(72, 287, '#6e221b61', '#cd28b4fc');
+let videoFrame2 = new VideoFrame(img5, {timestamp: 0});
+let texture28 = device0.createTexture(
+{
+label: '\ua2bc\u9728',
+size: [1494],
+dimension: '1d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8uint',
+'rgba8uint',
+'rgba8uint'
+],
+}
+);
+let renderPassEncoder7 = commandEncoder5.beginRenderPass(
+{
+label: '\u{1f61c}\u4aa2\u7fad',
+colorAttachments: [
+undefined
+],
+depthStencilAttachment: {
+view: textureView12,
+stencilClearValue: 28018,
+stencilLoadOp: 'load',
+stencilStoreOp: 'discard',
+},
+occlusionQuerySet: querySet5,
+}
+);
+let renderBundle13 = renderBundleEncoder12.finish(
+{
+
+}
+);
+try {
+renderPassEncoder6.setScissorRect(
+3,
+1,
+3,
+0
+);
+} catch {}
+try {
+renderPassEncoder5.setViewport(
+10.98,
+0.5881,
+0.9429,
+0.2263,
+0.6438,
+0.9769
+);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(
+37,
+undefined,
+1050032220,
+1381551466
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 39, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 286, y: 99 },
+  flipY: false,
+},
+{
+  texture: texture2,
+  mipLevel: 7,
+  origin: { x: 7, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 17, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let bindGroup2 = device0.createBindGroup({
+label: '\u{1f7ea}\u6ab1\u{1ff67}\u{1f974}\u{1fe99}\u053e\u607c\u{1f8b2}\u{1fa22}',
+layout: bindGroupLayout3,
+entries: [
+
+],
+});
+let commandEncoder16 = device0.createCommandEncoder(
+{
+}
+);
+let renderPassEncoder8 = commandEncoder16.beginRenderPass(
+{
+colorAttachments: [
+undefined
+],
+depthStencilAttachment: {
+view: textureView12,
+depthClearValue: 5.833512441643974,
+stencilClearValue: 975,
+stencilLoadOp: 'load',
+stencilStoreOp: 'store',
+},
+occlusionQuerySet: querySet3,
+maxDrawCount: 25200,
+}
+);
+try {
+computePassEncoder9.setPipeline(
+pipeline18
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(
+buffer2,
+12160
+);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(
+57,
+undefined
+);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(
+8,
+bindGroup1
+);
+} catch {}
+let pipeline24 = await device0.createRenderPipelineAsync(
+{
+label: '\u0336\u{1fd0f}\u8d71\u{1ff0e}\u34de',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+
+]
+},
+primitive: {
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 3757,
+depthBias: 61,
+depthBiasSlopeScale: 55,
+depthBiasClamp: 50,
+},
+}
+);
+let bindGroupLayout5 = pipeline23.getBindGroupLayout(3);
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer1,
+'uint32'
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 429, y: 1, z: 8 },
+  aspect: 'all',
+},
+new BigInt64Array(arrayBuffer0),
+/* required buffer size: 22597160 */{
+offset: 806,
+bytesPerRow: 2094,
+rowsPerImage: 109,
+},
+{width: 252, height: 0, depthOrArrayLayers: 100}
+);
+} catch {}
+let pipeline25 = device0.createComputePipeline(
+{
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+}
+);
+let pipeline26 = device0.createRenderPipeline(
+{
+label: '\u8817\u5fb6\u{1f8d5}\u{1f8dc}\u{1f9fc}\u569b\uf447\u{1fa0f}\u6e87\uaa92',
+layout: 'auto',
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 52796,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x2',
+offset: 46198,
+shaderLocation: 17,
+},
+{
+format: 'sint16x2',
+offset: 13228,
+shaderLocation: 8,
+},
+{
+format: 'sint16x4',
+offset: 2840,
+shaderLocation: 12,
+},
+{
+format: 'sint32x4',
+offset: 13004,
+shaderLocation: 20,
+},
+{
+format: 'snorm16x4',
+offset: 30124,
+shaderLocation: 24,
+},
+{
+format: 'unorm8x4',
+offset: 23156,
+shaderLocation: 16,
+},
+{
+format: 'float32x3',
+offset: 11016,
+shaderLocation: 0,
+},
+{
+format: 'float32x4',
+offset: 6256,
+shaderLocation: 23,
+},
+{
+format: 'snorm8x2',
+offset: 49468,
+shaderLocation: 13,
+},
+{
+format: 'uint16x2',
+offset: 39096,
+shaderLocation: 14,
+},
+{
+format: 'sint8x2',
+offset: 5116,
+shaderLocation: 1,
+},
+{
+format: 'float32x3',
+offset: 45004,
+shaderLocation: 15,
+},
+{
+format: 'uint32',
+offset: 48884,
+shaderLocation: 7,
+},
+{
+format: 'uint32x2',
+offset: 41080,
+shaderLocation: 2,
+},
+{
+format: 'sint32x2',
+offset: 31984,
+shaderLocation: 10,
+},
+{
+format: 'sint8x2',
+offset: 6004,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 24964,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 4180,
+shaderLocation: 11,
+},
+{
+format: 'uint32x2',
+offset: 2572,
+shaderLocation: 6,
+},
+{
+format: 'float32x4',
+offset: 3060,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 40924,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32',
+offset: 2268,
+shaderLocation: 21,
+},
+{
+format: 'unorm16x2',
+offset: 8652,
+shaderLocation: 18,
+},
+{
+format: 'uint32x4',
+offset: 6184,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 732,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 208,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 47376,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32',
+offset: 37336,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 49052,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 18628,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'none',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x98e76ceb,
+},
+fragment: {
+module: shaderModule3,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.BLUE,
+},
+undefined,
+{
+format: 'rgb10a2unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+undefined,
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'one-minus-src',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'one-minus-src-alpha',
+dstFactor: 'dst'
+},
+},
+format: 'rg16float',
+writeMask: GPUColorWrite.BLUE,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rg11b10ufloat',
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'not-equal',
+},
+stencilReadMask: 179,
+stencilWriteMask: 262,
+depthBiasClamp: 99,
+},
+}
+);
+let texture29 = device0.createTexture(
+{
+label: '\uca5d\u1dae\ufcd1\u6f32\u0ccf\u5440\ub304\u0c76',
+size: [1045, 1, 1420],
+mipLevelCount: 8,
+dimension: '3d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'r8uint'
+],
+}
+);
+let textureView24 = texture29.createView(
+{
+label: '\u036f\u{1fc51}\u07a6\ud614\u010f\uc71e\u0f96\ucce3\uaaf7\u{1f759}',
+baseMipLevel: 3,
+mipLevelCount: 2,
+arrayLayerCount: 1,
+}
+);
+let renderBundle14 = renderBundleEncoder1.finish(
+{
+label: '\u{1f98b}\u{1f86d}\u2c52\u5053\u76d3\uce72\u04fa\u3ae7\u024e\ufa30\u626f'
+}
+);
+let sampler15 = device0.createSampler(
+{
+label: '\ue6d0\u1ea3\u0188\udf91',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 62.616,
+lodMaxClamp: 70.883,
+}
+);
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant(
+{
+r: -102.7,
+g: 209.0,
+b: -222.9,
+a: 865.9,
+}
+);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+3.024,
+0.3755,
+7.037,
+0.2494,
+0.9208,
+0.9384
+);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline19);
+} catch {}
+try {
+commandEncoder1.copyTextureToTexture(
+{
+  texture: texture29,
+  mipLevel: 4,
+  origin: { x: 50, y: 0, z: 18 },
+  aspect: 'all',
+},
+{
+  texture: texture25,
+  mipLevel: 0,
+  origin: { x: 5, y: 113, z: 0 },
+  aspect: 'all',
+},
+{width: 10, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder1.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline27 = device0.createRenderPipeline(
+{
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 14568,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 7532,
+shaderLocation: 15,
+},
+{
+format: 'float32x4',
+offset: 7940,
+shaderLocation: 23,
+},
+{
+format: 'snorm16x2',
+offset: 4148,
+shaderLocation: 14,
+},
+{
+format: 'uint8x2',
+offset: 12794,
+shaderLocation: 22,
+},
+{
+format: 'sint16x2',
+offset: 9604,
+shaderLocation: 17,
+},
+{
+format: 'float16x2',
+offset: 12564,
+shaderLocation: 20,
+},
+{
+format: 'float32x4',
+offset: 12964,
+shaderLocation: 0,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 13956,
+shaderLocation: 12,
+},
+{
+format: 'sint32',
+offset: 10232,
+shaderLocation: 10,
+},
+{
+format: 'sint32x2',
+offset: 7776,
+shaderLocation: 13,
+},
+{
+format: 'sint32x3',
+offset: 4996,
+shaderLocation: 1,
+},
+{
+format: 'float32x3',
+offset: 12836,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x4',
+offset: 1920,
+shaderLocation: 7,
+},
+{
+format: 'uint32x3',
+offset: 1220,
+shaderLocation: 16,
+},
+{
+format: 'float16x4',
+offset: 9136,
+shaderLocation: 21,
+},
+{
+format: 'sint32x4',
+offset: 1920,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x2',
+offset: 772,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 35640,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 45312,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 35664,
+shaderLocation: 8,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0x77e54593,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r16float',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'one',
+dstFactor: 'constant'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'replace',
+depthFailOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-clamp',
+},
+stencilReadMask: 4010,
+stencilWriteMask: 1975,
+depthBias: 16,
+depthBiasSlopeScale: 6,
+depthBiasClamp: 69,
+},
+}
+);
+let commandEncoder17 = device0.createCommandEncoder();
+try {
+computePassEncoder10.setBindGroup(
+3,
+bindGroup2,
+new Uint32Array(5224),
+3919,
+0
+);
+} catch {}
+try {
+computePassEncoder10.setPipeline(
+pipeline16
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(
+buffer3,
+13736
+);
+} catch {}
+let querySet10 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 3846,
+}
+);
+let texture30 = device0.createTexture(
+{
+label: '\u1b06\u7b6f',
+size: [216, 1, 1747],
+dimension: '3d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+try {
+renderPassEncoder4.setBindGroup(
+4,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(
+0,
+bindGroup2,
+new Uint32Array(8168),
+1187,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(
+72
+);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant(
+{
+r: -371.9,
+g: -624.6,
+b: -278.6,
+a: 128.5,
+}
+);
+} catch {}
+try {
+renderPassEncoder6.draw(
+48,
+80,
+80
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndexed(
+16,
+80,
+40,
+496,
+56
+);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(
+buffer1,
+'uint32',
+1228,
+6058
+);
+} catch {}
+try {
+commandEncoder17.copyTextureToTexture(
+{
+  texture: texture23,
+  mipLevel: 0,
+  origin: { x: 387, y: 0, z: 715 },
+  aspect: 'all',
+},
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 253, y: 1, z: 37 },
+  aspect: 'all',
+},
+{width: 336, height: 0, depthOrArrayLayers: 92}
+);
+} catch {}
+try {
+commandEncoder1.resolveQuerySet(
+querySet2,
+66,
+705,
+buffer1,
+11520
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 8 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer0),
+/* required buffer size: 964946 */{
+offset: 521,
+bytesPerRow: 167,
+rowsPerImage: 275,
+},
+{width: 10, height: 0, depthOrArrayLayers: 22}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 9, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 67, y: 4 },
+  flipY: true,
+},
+{
+  texture: texture2,
+  mipLevel: 9,
+  origin: { x: 3, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 6, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+gc();
+try {
+textureView9.label = '\uc92f\u0d43\u6afc\u02e0\u{1f788}\ub39e\u87fc';
+} catch {}
+let querySet11 = device0.createQuerySet(
+{
+label: '\ua2cb\u00d6\ub368\ua1e7\u69f2\uc1c9\u03af\u49fc\u{1fd26}',
+type: 'occlusion',
+count: 1689,
+}
+);
+let sampler16 = device0.createSampler(
+{
+label: '\u0386\ufdda\ucde1\u3a93\ube75',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 99.654,
+lodMaxClamp: 99.733,
+compare: 'not-equal',
+}
+);
+try {
+renderPassEncoder8.setStencilReference(
+3577
+);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(
+8,
+bindGroup0,
+new Uint32Array(4909),
+2155,
+0
+);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(
+buffer1,
+'uint32',
+15328,
+3421
+);
+} catch {}
+try {
+commandEncoder17.clearBuffer(
+buffer3,
+2108,
+5412
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder17.resolveQuerySet(
+querySet6,
+1403,
+564,
+buffer1,
+8704
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer3,
+3844,
+new BigUint64Array(14368),
+7967,
+176
+);
+} catch {}
+document.body.prepend('\ubec7\u1196\u0570\u0c3a\u4081\u17cd\u9322');
+let offscreenCanvas2 = new OffscreenCanvas(958, 1000);
+let textureView25 = texture24.createView(
+{
+arrayLayerCount: 1,
+}
+);
+let renderBundleEncoder17 = device0.createRenderBundleEncoder(
+{
+label: '\u{1f9f4}\u7eac\u6d19',
+colorFormats: [
+'r32float',
+'rgba16float',
+'rg16float',
+'bgra8unorm-srgb',
+'rg8sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 763,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder8.setBindGroup(
+2,
+bindGroup1,
+new Uint32Array(9540),
+4377,
+0
+);
+} catch {}
+try {
+commandEncoder1.resolveQuerySet(
+querySet0,
+106,
+1381,
+buffer1,
+12544
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 22, y: 0, z: 0 },
+  aspect: 'all',
+},
+new BigUint64Array(arrayBuffer0),
+/* required buffer size: 645 */{
+offset: 645,
+bytesPerRow: 28684,
+},
+{width: 7151, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let gpuCanvasContext2 = offscreenCanvas2.getContext('webgpu');
+let canvas3 = document.createElement('canvas');
+let buffer5 = device0.createBuffer(
+{
+label: '\ueda5\u0a92\u{1f9ea}\ub4ad\u{1ff8a}\u046e\u{1f64b}',
+size: 13740,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+let commandBuffer0 = commandEncoder17.finish(
+{
+}
+);
+let texture31 = device0.createTexture(
+{
+label: '\u42fb\ufea7\ub3a4\u{1fffc}\u1b1e\u07ae\u6d06\u{1fc66}\u0fe3\u0432',
+size: [11057],
+dimension: '1d',
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb',
+'bgra8unorm',
+'bgra8unorm-srgb'
+],
+}
+);
+let computePassEncoder11 = commandEncoder1.beginComputePass(
+{
+
+}
+);
+try {
+renderPassEncoder2.setBindGroup(
+5,
+bindGroup2,
+new Uint32Array(5992),
+5150,
+0
+);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(
+64
+);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.draw(
+8
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(
+buffer0,
+99520
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(
+buffer1,
+832
+);
+} catch {}
+try {
+querySet8.destroy();
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(
+56
+);
+} catch {}
+try {
+renderPassEncoder6.draw(
+64,
+56,
+32
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(
+buffer2,
+327776
+);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(
+1,
+bindGroup2,
+new Uint32Array(9044),
+6461,
+0
+);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(
+buffer1,
+'uint16',
+4246,
+11701
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 5,
+  origin: { x: 11, y: 0, z: 5 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 802961 */{
+offset: 657,
+bytesPerRow: 160,
+rowsPerImage: 218,
+},
+{width: 4, height: 1, depthOrArrayLayers: 24}
+);
+} catch {}
+document.body.prepend('\u7956\u094d\u{1f89e}\u0db2\u{1fcfc}\u{1f628}\u18e9\u{1f840}');
+let renderBundleEncoder18 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg11b10ufloat',
+'rgba32float',
+undefined,
+'rgba32uint',
+'rg16sint'
+],
+sampleCount: 593,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder8.setPipeline(
+pipeline4
+);
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant(
+{
+r: -132.5,
+g: -106.9,
+b: -560.6,
+a: -24.30,
+}
+);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+3,
+0,
+3,
+0
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer0,
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer3,
+1312,
+new Float32Array(15823),
+13216,
+776
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let videoFrame3 = new VideoFrame(videoFrame0, {timestamp: 0});
+try {
+window.someLabel = pipeline14.label;
+} catch {}
+let renderBundle15 = renderBundleEncoder9.finish(
+{
+label: '\u{1f6d2}\u2e43\u{1f9e0}\u000e\u{1fdc9}\u0534\u531f'
+}
+);
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: 58.54,
+g: 235.4,
+b: -297.7,
+a: -124.6,
+}
+);
+} catch {}
+let promise11 = buffer2.mapAsync(
+GPUMapMode.WRITE,
+0,
+27184
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 6,
+  origin: { x: 8, y: 0, z: 3 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(new ArrayBuffer(56)),
+/* required buffer size: 293048 */{
+offset: 8,
+bytesPerRow: 296,
+rowsPerImage: 33,
+},
+{width: 10, height: 0, depthOrArrayLayers: 31}
+);
+} catch {}
+let promise12 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 38, height: 54, depthOrArrayLayers: 22}
+*/
+{
+  source: img3,
+  origin: { x: 146, y: 51 },
+  flipY: false,
+},
+{
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 5, y: 28, z: 9 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 28, height: 14, depthOrArrayLayers: 1}
+);
+} catch {}
+let querySet12 = device0.createQuerySet(
+{
+label: '\u0b4f\u0a9d\ub4e0\u0c06\u092d\u{1ffe9}\u7f83\u1ae9',
+type: 'occlusion',
+count: 2524,
+}
+);
+pseudoSubmit(device0, commandEncoder16);
+let texture32 = device0.createTexture(
+{
+label: '\u29db\u0669\ub3ab\u7ca0\u3fe7\u0a26\u4ba0\u{1fcc6}',
+size: [120, 1, 261],
+dimension: '3d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgba16uint',
+'rgba16uint'
+],
+}
+);
+let renderBundle16 = renderBundleEncoder18.finish();
+let sampler17 = device0.createSampler(
+{
+label: '\u0962\u01fe\u057a\ufaf6\u0b9f\u03ea\ue60e\u016d\u{1fee2}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 31.056,
+lodMaxClamp: 91.017,
+}
+);
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(
+32
+);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.setViewport(
+8.122,
+0.5979,
+1.608,
+0.1411,
+0.4145,
+0.8636
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndexed(
+8,
+72,
+48
+);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(
+buffer1,
+'uint16',
+21634,
+830
+);
+} catch {}
+try {
+commandEncoder7.copyBufferToBuffer(
+buffer4,
+54696,
+buffer3,
+5996,
+140
+);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 156, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 113, y: 9 },
+  flipY: false,
+},
+{
+  texture: texture2,
+  mipLevel: 5,
+  origin: { x: 3, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 91, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend('\u7b72\uc273\u7dd4\u5177\u0522\ud8f2\u0a1c\u2f0f');
+let texture33 = device0.createTexture(
+{
+label: '\ud762\ubb54\u083e\ud7b5\u81ac\ud121\u0c30\u2b36',
+size: [3213, 245, 97],
+mipLevelCount: 10,
+dimension: '2d',
+format: 'depth16unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth16unorm'
+],
+}
+);
+let renderBundle17 = renderBundleEncoder14.finish();
+let sampler18 = device0.createSampler(
+{
+label: '\u{1fa25}\u{1f7a5}\u092d\u0877\u622c\u0fe8\u0f2e\uf068\ua1ae\u0f0f',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 56.140,
+lodMaxClamp: 72.242,
+maxAnisotropy: 7,
+}
+);
+try {
+renderPassEncoder6.setBindGroup(
+7,
+bindGroup0,
+new Uint32Array(3945),
+3249,
+0
+);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(
+56
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndexed(
+0
+);
+} catch {}
+let arrayBuffer1 = buffer5.getMappedRange(
+2400,
+3884
+);
+try {
+commandEncoder7.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder7.resolveQuerySet(
+querySet10,
+2927,
+181,
+buffer1,
+15104
+);
+} catch {}
+let renderPassEncoder9 = commandEncoder7.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView12,
+depthClearValue: -8.752514383061422,
+stencilLoadOp: 'load',
+stencilStoreOp: 'discard',
+},
+occlusionQuerySet: querySet8,
+maxDrawCount: 9320,
+}
+);
+try {
+renderPassEncoder2.setBindGroup(
+2,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(
+buffer1,
+'uint16',
+21442,
+409
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 776 */{
+offset: 776,
+rowsPerImage: 204,
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+let pipeline28 = await promise10;
+document.body.prepend('\u08a6\u650a\u8746\u46f8\ue4bd\ud4ad\ub978\uea75');
+let offscreenCanvas3 = new OffscreenCanvas(860, 329);
+let texture34 = device0.createTexture(
+{
+label: '\u0259\u052b\u{1fdb4}\u52e3\u47d3',
+size: {width: 494, height: 1, depthOrArrayLayers: 553},
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16float'
+],
+}
+);
+let textureView26 = texture16.createView(
+{
+label: '\u0d0b\u0d60\ud042',
+aspect: 'all',
+}
+);
+let sampler19 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 7.406,
+}
+);
+try {
+computePassEncoder8.setBindGroup(
+5,
+bindGroup2
+);
+} catch {}
+try {
+computePassEncoder8.setPipeline(
+pipeline2
+);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+8,
+0,
+1,
+0
+);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(
+2880
+);
+} catch {}
+try {
+renderPassEncoder6.draw(
+16,
+72,
+24,
+24
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(
+buffer3,
+55112
+);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(
+62,
+undefined
+);
+} catch {}
+let renderBundle18 = renderBundleEncoder10.finish(
+{
+label: '\u8462\u{1f6a4}\u1380\u0622\u7bb1\u749c'
+}
+);
+let sampler20 = device0.createSampler(
+{
+label: '\u0c53\uaa49\u{1fba5}\u7f22\u{1fab3}\u0a90\udd7d',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 30.374,
+lodMaxClamp: 68.266,
+}
+);
+try {
+computePassEncoder11.setPipeline(
+pipeline2
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+5,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder9.end();
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(
+48
+);
+} catch {}
+try {
+renderPassEncoder6.draw(
+40,
+64,
+0
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndexed(
+80,
+32,
+24
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(
+buffer4,
+22248
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(
+buffer2,
+141416
+);
+} catch {}
+let pipeline29 = device0.createRenderPipeline(
+{
+label: '\uecda\u0275\u{1fae6}\u2126\u{1fb33}\u25f1\u0751\u{1f913}',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule4,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 45464,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 29004,
+shaderLocation: 8,
+},
+{
+format: 'float32x3',
+offset: 6628,
+shaderLocation: 1,
+},
+{
+format: 'unorm16x2',
+offset: 12336,
+shaderLocation: 23,
+},
+{
+format: 'unorm16x4',
+offset: 33816,
+shaderLocation: 19,
+},
+{
+format: 'snorm16x4',
+offset: 2372,
+shaderLocation: 2,
+},
+{
+format: 'uint32x2',
+offset: 30564,
+shaderLocation: 20,
+},
+{
+format: 'unorm8x2',
+offset: 31800,
+shaderLocation: 4,
+},
+{
+format: 'float16x4',
+offset: 38524,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x2',
+offset: 18100,
+shaderLocation: 21,
+},
+{
+format: 'unorm8x2',
+offset: 29126,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x2',
+offset: 39280,
+shaderLocation: 13,
+},
+{
+format: 'float32x2',
+offset: 27652,
+shaderLocation: 5,
+},
+{
+format: 'float32x4',
+offset: 30492,
+shaderLocation: 11,
+},
+{
+format: 'uint16x2',
+offset: 12008,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 45472,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 22758,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 51240,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 39716,
+shaderLocation: 15,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 4488,
+shaderLocation: 3,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'back',
+},
+fragment: {
+module: shaderModule4,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'constant',
+dstFactor: 'dst'
+},
+},
+format: 'r8unorm',
+writeMask: 0,
+},
+{
+format: 'bgra8unorm-srgb',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'r16sint',
+writeMask: 0,
+},
+{
+format: 'rgba16sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'keep',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 2959,
+stencilWriteMask: 2057,
+depthBias: 48,
+depthBiasSlopeScale: 31,
+depthBiasClamp: 93,
+},
+}
+);
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+let texture35 = gpuCanvasContext1.getCurrentTexture();
+let textureView27 = texture14.createView(
+{
+label: '\uc8ae\u387e\u7cb1\uae8f\u{1fa24}',
+dimension: '2d-array',
+baseMipLevel: 3,
+}
+);
+let renderBundleEncoder19 = device0.createRenderBundleEncoder(
+{
+label: '\u0850\u{1fcb4}\u0f78\uc135\uea75\u8ed9\u41d6\u0d6f\uca96',
+colorFormats: [
+'rgba16float',
+undefined,
+undefined,
+'r16float',
+undefined,
+'rgba8unorm-srgb',
+'rg16uint'
+],
+sampleCount: 498,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder6.setBindGroup(
+4,
+bindGroup0,
+new Uint32Array(8725),
+2125,
+0
+);
+} catch {}
+try {
+renderPassEncoder6.draw(
+24,
+40,
+32
+);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline19);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer3,
+4656,
+new DataView(new ArrayBuffer(48283)),
+25290,
+1904
+);
+} catch {}
+document.body.append('\u0e0f\u8b6d\u{1f7a6}\u84eb\u1da9\u{1fb43}\uf6e0\u493e\u87f5');
+let offscreenCanvas4 = new OffscreenCanvas(540, 459);
+let imageData1 = new ImageData(4, 12);
+let bindGroup3 = device0.createBindGroup({
+label: '\u0969\u0309\uc6b6\u02fc\ueb5a\u05fb\u018b\u0395',
+layout: bindGroupLayout3,
+entries: [
+
+],
+});
+let texture36 = device0.createTexture(
+{
+label: '\u03d3\u53a9\u{1ff0d}\u{1fece}\u{1f6af}',
+size: [5140, 1, 99],
+mipLevelCount: 5,
+format: 'stencil8',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'stencil8'
+],
+}
+);
+try {
+renderPassEncoder2.setViewport(
+5.178,
+0.01376,
+0.4974,
+0.03841,
+0.3153,
+0.8812
+);
+} catch {}
+try {
+renderPassEncoder6.draw(
+0,
+24,
+72,
+48
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(
+buffer0,
+162704
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+15,
+undefined,
+4062478189,
+177232896
+);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(
+86,
+undefined,
+511883039,
+1942267196
+);
+} catch {}
+try {
+renderBundleEncoder15.pushDebugGroup(
+'\u23c3'
+);
+} catch {}
+let pipeline30 = await device0.createComputePipelineAsync(
+{
+label: '\uf4a4\u07e0',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipelineLayout3 = device0.createPipelineLayout(
+{
+label: '\u1676\udc14\u{1fd9d}\u0606\u8427\u{1f6fc}\u0cfb\u045e\u03cc\u{1fd26}',
+bindGroupLayouts: [
+bindGroupLayout3,
+bindGroupLayout1,
+bindGroupLayout3,
+bindGroupLayout1,
+bindGroupLayout3
+],
+}
+);
+let commandEncoder18 = device0.createCommandEncoder(
+{
+label: '\u{1fe24}\u{1f77e}\ub4e4\ua4fe\u6c97',
+}
+);
+try {
+computePassEncoder3.setPipeline(
+pipeline22
+);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(
+6,
+bindGroup3,
+[]
+);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+10,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(
+buffer1,
+'uint16',
+3348,
+10054
+);
+} catch {}
+try {
+commandEncoder18.copyBufferToBuffer(
+buffer0,
+8724,
+buffer1,
+10836,
+11756
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder18.copyBufferToTexture(
+{
+/* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 8496 */
+offset: 8488,
+bytesPerRow: 512,
+buffer: buffer4,
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder18.clearBuffer(
+buffer3,
+4572,
+1100
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture31,
+  mipLevel: 0,
+  origin: { x: 1489, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 140 */{
+offset: 140,
+},
+{width: 3060, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 38, height: 54, depthOrArrayLayers: 22}
+*/
+{
+  source: img4,
+  origin: { x: 74, y: 129 },
+  flipY: false,
+},
+{
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 12, y: 15, z: 7 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 18, height: 23, depthOrArrayLayers: 0}
+);
+} catch {}
+let commandEncoder19 = device0.createCommandEncoder();
+let computePassEncoder12 = commandEncoder19.beginComputePass(
+{
+label: '\ud516\u0f49'
+}
+);
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder8.setViewport(
+5.933,
+0.01352,
+5.575,
+0.1892,
+0.4056,
+0.7430
+);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(
+60,
+undefined,
+1548308683,
+1537289225
+);
+} catch {}
+try {
+commandEncoder18.copyBufferToBuffer(
+buffer4,
+49968,
+buffer3,
+804,
+3720
+);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer3,
+5256,
+new Float32Array(38108),
+4512,
+472
+);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder(
+{
+label: '\ua9f5\u266e\u{1fc65}\u{1fb63}\u{1ff29}\uf1e5\u37bf',
+}
+);
+let querySet13 = device0.createQuerySet(
+{
+label: '\u0df2\u0362\u3345\u2ee4\u0039\u0853\u0700',
+type: 'occlusion',
+count: 661,
+}
+);
+try {
+renderPassEncoder2.setBindGroup(
+4,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(
+7,
+1,
+2,
+0
+);
+} catch {}
+try {
+renderPassEncoder6.draw(
+80,
+80,
+0,
+32
+);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(
+3,
+bindGroup3
+);
+} catch {}
+try {
+commandEncoder20.copyTextureToTexture(
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: { x: 24, y: 1, z: 276 },
+  aspect: 'all',
+},
+{
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 642, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 74, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder18.clearBuffer(
+buffer1,
+16736
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder18.resolveQuerySet(
+querySet13,
+490,
+17,
+buffer1,
+18944
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 3,
+  origin: { x: 8, y: 1, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 25 */{
+offset: 25,
+},
+{width: 309, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 76, height: 108, depthOrArrayLayers: 22}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 229, y: 13 },
+  flipY: true,
+},
+{
+  texture: texture12,
+  mipLevel: 1,
+  origin: { x: 29, y: 52, z: 5 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 34, height: 47, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend(video1);
+let shaderModule7 = device0.createShaderModule(
+{
+label: '\u029e\u4bfe\u33dc\u043a\uf447\uf508\u6e16',
+code: `
+
+@compute @workgroup_size(6, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S7 {
+@location(2) f0: vec3<f16>,
+@location(24) f1: vec4<f16>,
+@location(38) f2: f32,
+@builtin(sample_index) f3: u32,
+@location(0) f4: f32,
+@location(32) f5: vec4<i32>,
+@location(19) f6: vec3<u32>,
+@builtin(position) f7: vec4<f32>,
+@location(28) f8: vec4<f32>,
+@location(16) f9: vec4<f32>,
+@location(12) f10: vec2<i32>,
+@location(20) f11: vec4<f16>,
+@location(11) f12: f16,
+@location(17) f13: vec3<f16>,
+@location(25) f14: vec3<i32>,
+@location(6) f15: vec3<f16>,
+@location(33) f16: vec3<i32>,
+@location(30) f17: vec4<f16>,
+@location(9) f18: f16,
+@location(34) f19: vec3<f16>,
+@location(21) f20: vec3<f32>,
+@location(3) f21: f16
+}
+struct FragmentOutput0 {
+@location(7) f0: vec4<i32>,
+@location(1) f1: vec2<f32>,
+@location(6) f2: vec3<f32>,
+@location(4) f3: vec3<f32>,
+@location(5) f4: f32,
+@location(2) f5: u32,
+@location(3) f6: vec3<f32>,
+@location(0) f7: i32,
+@builtin(sample_mask) f8: u32
+}
+
+@fragment
+fn fragment0(@location(15) a0: vec3<i32>, @location(26) a1: vec2<f32>, @location(36) a2: i32, @builtin(sample_mask) a3: u32, @location(37) a4: vec4<f32>, a5: S7, @builtin(front_facing) a6: bool, @location(14) a7: vec4<f32>, @location(8) a8: vec4<i32>, @location(10) a9: vec4<u32>, @location(7) a10: vec2<f16>, @location(29) a11: vec2<u32>, @location(22) a12: i32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S6 {
+@location(2) f0: f32,
+@location(19) f1: vec3<f16>,
+@location(11) f2: vec4<f16>,
+@location(14) f3: f32,
+@builtin(vertex_index) f4: u32,
+@location(23) f5: i32,
+@location(9) f6: i32,
+@builtin(instance_index) f7: u32,
+@location(13) f8: vec2<u32>,
+@location(20) f9: vec4<f16>,
+@location(22) f10: vec2<u32>,
+@location(5) f11: i32,
+@location(17) f12: vec3<i32>,
+@location(16) f13: f16,
+@location(18) f14: vec3<f16>,
+@location(1) f15: vec3<u32>,
+@location(0) f16: vec4<f32>,
+@location(12) f17: vec4<u32>,
+@location(4) f18: vec2<i32>,
+@location(6) f19: vec3<i32>
+}
+struct VertexOutput0 {
+@builtin(position) f109: vec4<f32>,
+@location(37) f110: vec4<f32>,
+@location(25) f111: vec3<i32>,
+@location(8) f112: vec4<i32>,
+@location(11) f113: f16,
+@location(26) f114: vec2<f32>,
+@location(33) f115: vec3<i32>,
+@location(7) f116: vec2<f16>,
+@location(2) f117: vec3<f16>,
+@location(16) f118: vec4<f32>,
+@location(19) f119: vec3<u32>,
+@location(29) f120: vec2<u32>,
+@location(6) f121: vec3<f16>,
+@location(10) f122: vec4<u32>,
+@location(20) f123: vec4<f16>,
+@location(14) f124: vec4<f32>,
+@location(36) f125: i32,
+@location(38) f126: f32,
+@location(3) f127: f16,
+@location(0) f128: f32,
+@location(22) f129: i32,
+@location(15) f130: vec3<i32>,
+@location(12) f131: vec2<i32>,
+@location(17) f132: vec3<f16>,
+@location(30) f133: vec4<f16>,
+@location(21) f134: vec3<f32>,
+@location(24) f135: vec4<f16>,
+@location(32) f136: vec4<i32>,
+@location(34) f137: vec3<f16>,
+@location(9) f138: f16,
+@location(13) f139: vec4<f32>,
+@location(28) f140: vec4<f32>
+}
+
+@vertex
+fn vertex0(a0: S6, @location(8) a1: vec3<f16>, @location(15) a2: vec2<f32>, @location(3) a3: i32, @location(21) a4: f16, @location(24) a5: vec3<f32>, @location(7) a6: vec3<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroupLayout6 = pipeline21.getBindGroupLayout(2);
+let commandBuffer1 = commandEncoder18.finish(
+{
+label: '\u6601\u0e8e\ud14c\u0b39\u06ba\u28a8',
+}
+);
+let textureView28 = texture7.createView(
+{
+label: '\u0093\u1362',
+dimension: '3d',
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+let sampler21 = device0.createSampler(
+{
+label: '\u22d6\u0041\udf01\u{1fb6a}\u3668\u6f24\uf289\u026e\u38a8\u0373\u0f82',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+lodMinClamp: 37.873,
+lodMaxClamp: 50.535,
+}
+);
+try {
+computePassEncoder9.setPipeline(
+pipeline15
+);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(
+2,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(
+1803
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(
+buffer3,
+56960
+);
+} catch {}
+try {
+commandEncoder20.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+13156,
+new Float32Array(8667),
+5048,
+752
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 8,
+  origin: { x: 11, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(56),
+/* required buffer size: 614 */{
+offset: 602,
+},
+{width: 3, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline31 = await device0.createRenderPipelineAsync(
+{
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule6,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 33320,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 1576,
+shaderLocation: 5,
+},
+{
+format: 'sint32x3',
+offset: 31856,
+shaderLocation: 15,
+},
+{
+format: 'sint32x2',
+offset: 27672,
+shaderLocation: 2,
+},
+{
+format: 'sint32',
+offset: 30916,
+shaderLocation: 10,
+},
+{
+format: 'uint32',
+offset: 30100,
+shaderLocation: 19,
+},
+{
+format: 'snorm16x2',
+offset: 30264,
+shaderLocation: 13,
+},
+{
+format: 'unorm16x4',
+offset: 6364,
+shaderLocation: 22,
+},
+{
+format: 'snorm8x2',
+offset: 10912,
+shaderLocation: 8,
+},
+{
+format: 'sint32x4',
+offset: 4484,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 23076,
+shaderLocation: 24,
+}
+],
+},
+{
+arrayStride: 22692,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x4',
+offset: 9524,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x4',
+offset: 21276,
+shaderLocation: 14,
+},
+{
+format: 'snorm16x2',
+offset: 7072,
+shaderLocation: 20,
+},
+{
+format: 'sint32x4',
+offset: 3832,
+shaderLocation: 11,
+},
+{
+format: 'sint32x2',
+offset: 3116,
+shaderLocation: 0,
+},
+{
+format: 'unorm16x4',
+offset: 3856,
+shaderLocation: 18,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule6,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+undefined,
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.RED,
+},
+undefined
+],
+},
+}
+);
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+document.body.prepend('\u0d0d\uf47c');
+let offscreenCanvas5 = new OffscreenCanvas(681, 622);
+pseudoSubmit(device0, commandEncoder1);
+let texture37 = device0.createTexture(
+{
+label: '\u7727\udbfa\ud7a7',
+size: [204, 1, 163],
+mipLevelCount: 7,
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb10a2uint',
+'rgb10a2uint',
+'rgb10a2uint'
+],
+}
+);
+let renderBundle19 = renderBundleEncoder8.finish(
+{
+label: '\u{1ff32}\ucf72\uae33\ue951\u{1f632}\u0e20\u994f\u0597\u081e\u{1fcac}\u{1f933}'
+}
+);
+let sampler22 = device0.createSampler(
+{
+label: '\uea54\u04fc\u0dcd\uf41f\u{1fcdb}',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 40.208,
+lodMaxClamp: 97.550,
+}
+);
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder4.setViewport(
+11.23,
+0.7973,
+0.3847,
+0.09207,
+0.4052,
+0.5121
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(
+buffer5,
+3072
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+await buffer4.mapAsync(
+GPUMapMode.WRITE,
+0,
+23296
+);
+} catch {}
+try {
+commandEncoder20.copyBufferToBuffer(
+buffer0,
+20684,
+buffer1,
+4160,
+1968
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder20.copyTextureToTexture(
+{
+  texture: texture29,
+  mipLevel: 1,
+  origin: { x: 396, y: 0, z: 518 },
+  aspect: 'all',
+},
+{
+  texture: texture25,
+  mipLevel: 1,
+  origin: { x: 1, y: 55, z: 0 },
+  aspect: 'all',
+},
+{width: 4, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let commandEncoder21 = device0.createCommandEncoder(
+{
+label: '\u0f54\u0ceb\u8dd8\u7785\u0878\u0f5a',
+}
+);
+let renderPassEncoder10 = commandEncoder21.beginRenderPass(
+{
+label: '\u0c1b\u06ea',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView12,
+depthReadOnly: true,
+stencilClearValue: 14639,
+stencilLoadOp: 'load',
+stencilStoreOp: 'store',
+},
+occlusionQuerySet: querySet12,
+maxDrawCount: 7720,
+}
+);
+try {
+computePassEncoder3.setPipeline(
+pipeline11
+);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(
+1,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(
+72
+);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant(
+{
+r: 144.9,
+g: 925.0,
+b: 487.4,
+a: -241.5,
+}
+);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(
+3398
+);
+} catch {}
+try {
+renderPassEncoder6.draw(
+48,
+72,
+64,
+72
+);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(
+7,
+bindGroup2,
+[]
+);
+} catch {}
+try {
+commandEncoder20.copyBufferToBuffer(
+buffer0,
+29332,
+buffer3,
+1928,
+4
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder20.copyTextureToTexture(
+{
+  texture: texture23,
+  mipLevel: 0,
+  origin: { x: 132, y: 0, z: 797 },
+  aspect: 'all',
+},
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 63, y: 1, z: 6 },
+  aspect: 'all',
+},
+{width: 629, height: 0, depthOrArrayLayers: 81}
+);
+} catch {}
+try {
+commandEncoder20.insertDebugMarker(
+'\u6fab'
+);
+} catch {}
+document.body.prepend(video2);
+let bindGroupLayout7 = pipeline27.getBindGroupLayout(1);
+let commandEncoder22 = device0.createCommandEncoder(
+{
+label: '\ue710\ua424\u{1f9cd}\u36e0\uc1db\udd14\ue104\u04bd\u13c0',
+}
+);
+try {
+renderPassEncoder4.setIndexBuffer(
+buffer1,
+'uint32',
+17472,
+7245
+);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(
+5,
+bindGroup3,
+new Uint32Array(923),
+642,
+0
+);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(
+buffer1,
+'uint32',
+9724,
+4033
+);
+} catch {}
+try {
+renderPassEncoder4.insertDebugMarker(
+'\u576c'
+);
+} catch {}
+let pipeline32 = device0.createComputePipeline(
+{
+layout: pipelineLayout2,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipelineLayout4 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout1,
+bindGroupLayout1,
+bindGroupLayout1,
+bindGroupLayout1,
+bindGroupLayout2,
+bindGroupLayout3
+],
+}
+);
+let textureView29 = texture30.createView(
+{
+}
+);
+let computePassEncoder13 = commandEncoder22.beginComputePass(
+{
+label: '\u05e5\ubb50\ua27a'
+}
+);
+let renderBundle20 = renderBundleEncoder0.finish(
+{
+label: '\u{1ff12}\u6a3e\u0355\u0cd1'
+}
+);
+try {
+renderPassEncoder6.drawIndirect(
+buffer5,
+57096
+);
+} catch {}
+try {
+commandEncoder20.copyBufferToTexture(
+{
+/* bytesInLastRow: 76 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 22608 */
+offset: 22608,
+bytesPerRow: 256,
+buffer: buffer0,
+},
+{
+  texture: texture13,
+  mipLevel: 3,
+  origin: { x: 5, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 19, height: 4, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder20.copyTextureToBuffer(
+{
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 1235, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 156 widthInBlocks: 39 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 11704 */
+offset: 11704,
+buffer: buffer1,
+},
+{width: 39, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 92, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Float32Array(arrayBuffer1),
+/* required buffer size: 4403593 */{
+offset: 91,
+bytesPerRow: 5959,
+rowsPerImage: 6,
+},
+{width: 720, height: 1, depthOrArrayLayers: 124}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 152, height: 216, depthOrArrayLayers: 22}
+*/
+{
+  source: canvas0,
+  origin: { x: 210, y: 5 },
+  flipY: true,
+},
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 16, y: 11, z: 2 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 87, height: 141, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\u0fe7\u05e8\u90d7');
+let renderPassEncoder11 = commandEncoder20.beginRenderPass(
+{
+label: '\u5fbe\ud8db\u0d05\u{1f62e}\u{1f631}\u647c\u0acf\u075a\u1520',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView12,
+depthReadOnly: false,
+stencilReadOnly: true,
+},
+maxDrawCount: 469272,
+}
+);
+try {
+renderPassEncoder8.beginOcclusionQuery(
+40
+);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(
+1576
+);
+} catch {}
+try {
+renderPassEncoder6.draw(
+0
+);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(
+59,
+undefined,
+2385919275,
+193648541
+);
+} catch {}
+let textureView30 = texture0.createView(
+{
+label: '\uf54e\udc81\ub66a\uff7b\u57c3\u{1fcb2}\ud531\ufbce\u72d8\u0c7e',
+baseMipLevel: 3,
+baseArrayLayer: 20,
+arrayLayerCount: 14,
+}
+);
+let renderBundleEncoder20 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'bgra8unorm-srgb',
+undefined,
+'rg8unorm',
+'rgb10a2unorm'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 952,
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+6,
+bindGroup2,
+new Uint32Array(5345),
+1269,
+0
+);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant(
+{
+r: -246.0,
+g: 212.8,
+b: 537.5,
+a: -380.0,
+}
+);
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+11.80,
+0.3266,
+0.1515,
+0.4203,
+0.08072,
+0.9549
+);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(
+buffer1,
+'uint32',
+16192,
+7650
+);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(
+32,
+undefined
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 19, height: 27, depthOrArrayLayers: 22}
+*/
+{
+  source: imageData0,
+  origin: { x: 78, y: 0 },
+  flipY: true,
+},
+{
+  texture: texture12,
+  mipLevel: 3,
+  origin: { x: 7, y: 5, z: 11 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 12, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+offscreenCanvas3.width = 168;
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+2694
+);
+} catch {}
+try {
+renderPassEncoder6.draw(
+8,
+0,
+32
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(
+buffer2,
+683432
+);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+5,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(
+44,
+undefined,
+4079835363,
+205906857
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer3,
+352,
+new BigUint64Array(46128),
+11344,
+236
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture11,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 10 },
+  aspect: 'stencil-only',
+},
+arrayBuffer1,
+/* required buffer size: 915465 */{
+offset: 225,
+bytesPerRow: 290,
+rowsPerImage: 263,
+},
+{width: 3, height: 0, depthOrArrayLayers: 13}
+);
+} catch {}
+let promise14 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext3 = offscreenCanvas4.getContext('webgpu');
+let commandEncoder23 = device0.createCommandEncoder();
+let textureView31 = texture27.createView(
+{
+baseMipLevel: 3,
+}
+);
+let renderBundle21 = renderBundleEncoder13.finish();
+let sampler23 = device0.createSampler(
+{
+label: '\u{1f85b}\u3511\ua454\ub328\u35bd\u0093\ud361\uca1a',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 90.872,
+lodMaxClamp: 99.341,
+compare: 'always',
+maxAnisotropy: 1,
+}
+);
+try {
+commandEncoder23.resolveQuerySet(
+querySet4,
+355,
+2009,
+buffer1,
+7936
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm',
+'bgra8unorm-srgb'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+let gpuCanvasContext4 = offscreenCanvas3.getContext('webgpu');
+let imageBitmap3 = await createImageBitmap(canvas1);
+let commandEncoder24 = device0.createCommandEncoder(
+{
+}
+);
+let commandBuffer2 = commandEncoder23.finish(
+{
+label: '\ud30c\uadeb\u5e93\u01cc\u2c1c\u{1fa4d}\uf0c8\u1458\ua8ea\u{1fb3a}\ud0f8',
+}
+);
+let texture38 = device0.createTexture(
+{
+size: {width: 6443, height: 1, depthOrArrayLayers: 176},
+mipLevelCount: 4,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth24plus-stencil8',
+'depth24plus-stencil8',
+'depth24plus-stencil8'
+],
+}
+);
+let renderBundleEncoder21 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'r16uint',
+'rg16uint',
+undefined,
+'rg32sint',
+undefined
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 750,
+stencilReadOnly: true,
+}
+);
+let sampler24 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 43.031,
+compare: 'equal',
+}
+);
+try {
+computePassEncoder13.setPipeline(
+pipeline30
+);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(
+32
+);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+1079
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndexed(
+64
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(
+buffer2,
+80048
+);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(
+4,
+bindGroup1
+);
+} catch {}
+try {
+commandEncoder24.copyTextureToTexture(
+{
+  texture: texture29,
+  mipLevel: 3,
+  origin: { x: 75, y: 1, z: 150 },
+  aspect: 'all',
+},
+{
+  texture: texture25,
+  mipLevel: 0,
+  origin: { x: 3, y: 50, z: 0 },
+  aspect: 'all',
+},
+{width: 12, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder24.resolveQuerySet(
+querySet1,
+1529,
+316,
+buffer1,
+6656
+);
+} catch {}
+try {
+renderBundleEncoder15.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 2496, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 12, y: 680 },
+  flipY: false,
+},
+{
+  texture: texture2,
+  mipLevel: 1,
+  origin: { x: 540, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 388, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise15 = device0.createRenderPipelineAsync(
+{
+label: '\ubc62\u{1ff39}\u{1f9df}\u02c2\u{1f85a}\u{1ffd5}',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule6,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 42864,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 46232,
+attributes: [
+{
+format: 'snorm8x4',
+offset: 14596,
+shaderLocation: 20,
+},
+{
+format: 'snorm16x4',
+offset: 10708,
+shaderLocation: 14,
+},
+{
+format: 'snorm16x4',
+offset: 21152,
+shaderLocation: 9,
+},
+{
+format: 'float32',
+offset: 20100,
+shaderLocation: 24,
+},
+{
+format: 'unorm16x2',
+offset: 6500,
+shaderLocation: 13,
+},
+{
+format: 'sint32x3',
+offset: 40176,
+shaderLocation: 11,
+},
+{
+format: 'uint32x4',
+offset: 27172,
+shaderLocation: 19,
+},
+{
+format: 'sint8x4',
+offset: 42452,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 14888,
+attributes: [
+{
+format: 'sint32',
+offset: 11732,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 2620,
+attributes: [
+{
+format: 'float32',
+offset: 1256,
+shaderLocation: 8,
+},
+{
+format: 'snorm16x2',
+offset: 96,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 31968,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x2',
+offset: 7212,
+shaderLocation: 2,
+},
+{
+format: 'uint16x2',
+offset: 17768,
+shaderLocation: 5,
+},
+{
+format: 'sint32x3',
+offset: 8460,
+shaderLocation: 10,
+},
+{
+format: 'sint8x4',
+offset: 3484,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 54320,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 12400,
+shaderLocation: 18,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule6,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+{
+format: 'r16uint',
+},
+undefined,
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}
+],
+},
+}
+);
+document.body.prepend(canvas0);
+document.body.append('\u0402\u{1fece}\u5855\u99c7');
+let imageData2 = new ImageData(88, 212);
+let bindGroupLayout8 = device0.createBindGroupLayout(
+{
+label: '\u0fff\u{1ffdb}\uaa5e',
+entries: [
+{
+binding: 1608,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'read-only-storage', minBindingSize: 679720, hasDynamicOffset: true },
+}
+],
+}
+);
+pseudoSubmit(device0, commandEncoder19);
+try {
+computePassEncoder13.setBindGroup(
+6,
+bindGroup1,
+new Uint32Array(5491),
+3568,
+0
+);
+} catch {}
+try {
+computePassEncoder13.setPipeline(
+pipeline30
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndexed(
+80,
+40,
+48,
+-320,
+24
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(
+buffer4,
+29064
+);
+} catch {}
+try {
+commandEncoder24.copyTextureToTexture(
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 4 },
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 34, y: 1, z: 122 },
+  aspect: 'all',
+},
+{width: 130, height: 0, depthOrArrayLayers: 113}
+);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+offscreenCanvas4.width = 806;
+let shaderModule8 = device0.createShaderModule(
+{
+label: '\u05f0\u7ec7\ucef8\u045e\uaf92\u{1fae9}\u4824\u{1fecd}\u5ad0',
+code: `@group(1) @binding(8053)
+var<storage, read_write> type2: array<u32>;
+
+@compute @workgroup_size(1, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S9 {
+@location(21) f0: vec2<f16>,
+@location(11) f1: vec3<u32>,
+@location(13) f2: i32,
+@location(15) f3: vec4<u32>,
+@location(37) f4: vec2<f16>,
+@builtin(sample_mask) f5: u32,
+@location(5) f6: vec4<f32>,
+@location(2) f7: vec4<u32>,
+@location(24) f8: vec4<i32>,
+@location(38) f9: u32,
+@location(17) f10: f16,
+@location(20) f11: vec3<u32>,
+@location(29) f12: vec3<i32>,
+@location(28) f13: vec2<f16>,
+@builtin(front_facing) f14: bool,
+@location(27) f15: vec2<f16>,
+@builtin(position) f16: vec4<f32>,
+@location(39) f17: f32,
+@location(1) f18: vec3<f16>
+}
+struct FragmentOutput0 {
+@location(2) f0: vec2<f32>,
+@location(7) f1: vec2<i32>,
+@location(4) f2: f32,
+@location(3) f3: vec4<f32>,
+@location(6) f4: vec4<u32>,
+@location(5) f5: vec3<i32>,
+@location(1) f6: u32
+}
+
+@fragment
+fn fragment0(a0: S9, @location(33) a1: vec4<u32>, @location(10) a2: i32, @builtin(sample_index) a3: u32, @location(30) a4: vec4<f32>, @location(19) a5: vec4<u32>, @location(0) a6: vec2<f32>, @location(34) a7: vec2<f16>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S8 {
+@location(0) f0: vec2<f32>,
+@location(1) f1: vec3<f32>,
+@location(19) f2: vec3<f32>,
+@location(17) f3: u32,
+@location(22) f4: vec3<f16>,
+@location(6) f5: vec4<f16>,
+@location(9) f6: vec2<i32>,
+@location(21) f7: u32,
+@location(3) f8: vec3<u32>,
+@location(16) f9: vec2<i32>,
+@location(2) f10: vec4<u32>
+}
+struct VertexOutput0 {
+@location(17) f141: f16,
+@location(15) f142: vec4<u32>,
+@location(30) f143: vec4<f32>,
+@location(2) f144: vec4<u32>,
+@location(20) f145: vec3<u32>,
+@location(38) f146: u32,
+@location(21) f147: vec2<f16>,
+@location(0) f148: vec2<f32>,
+@location(33) f149: vec4<u32>,
+@location(27) f150: vec2<f16>,
+@location(34) f151: vec2<f16>,
+@location(29) f152: vec3<i32>,
+@location(39) f153: f32,
+@location(5) f154: vec4<f32>,
+@location(19) f155: vec4<u32>,
+@location(10) f156: i32,
+@location(1) f157: vec3<f16>,
+@location(13) f158: i32,
+@builtin(position) f159: vec4<f32>,
+@location(11) f160: vec3<u32>,
+@location(37) f161: vec2<f16>,
+@location(24) f162: vec4<i32>,
+@location(28) f163: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(4) a0: vec3<f32>, @location(23) a1: vec4<u32>, @location(11) a2: vec3<f32>, @builtin(instance_index) a3: u32, a4: S8, @location(24) a5: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let renderPassEncoder12 = commandEncoder24.beginRenderPass(
+{
+colorAttachments: [
+
+],
+depthStencilAttachment: {
+view: textureView12,
+stencilClearValue: 9713,
+stencilLoadOp: 'clear',
+stencilStoreOp: 'discard',
+},
+occlusionQuerySet: querySet10,
+maxDrawCount: 571720,
+}
+);
+let sampler25 = device0.createSampler(
+{
+label: '\u1c5c\u00e7\uc365\u335c\u02d1\u0542\uca16\u{1fd52}\u1898\u0a00\u2bfb',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+lodMinClamp: 51.819,
+lodMaxClamp: 59.713,
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder12.setBindGroup(
+5,
+bindGroup2,
+new Uint32Array(9514),
+6810,
+0
+);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(
+buffer3,
+291504
+);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(
+buffer1,
+'uint16',
+22034,
+1443
+);
+} catch {}
+try {
+renderPassEncoder12.pushDebugGroup(
+'\u0a46'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer3,
+5860,
+new BigUint64Array(28854),
+19693,
+248
+);
+} catch {}
+let offscreenCanvas6 = new OffscreenCanvas(162, 461);
+let commandEncoder25 = device0.createCommandEncoder();
+let textureView32 = texture14.createView(
+{
+label: '\u8a8b\u23a7\ub091\u0574\udbd0\u4e4d\u77c9\u8d33\u01e3\u{1fbae}\u0be8',
+dimension: '2d-array',
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+let renderBundle22 = renderBundleEncoder20.finish(
+{
+label: '\u7f0b\u8e3b\u7e85\uea38\ubd7d\u0bca\ubadc\u{1fc87}\ue8c6\u58e4'
+}
+);
+try {
+computePassEncoder3.setBindGroup(
+8,
+bindGroup2,
+new Uint32Array(5916),
+3937,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant(
+{
+r: -221.3,
+g: -659.5,
+b: 767.9,
+a: 350.9,
+}
+);
+} catch {}
+try {
+renderPassEncoder6.draw(
+48,
+80,
+56,
+56
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(
+buffer5,
+5136
+);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(
+0,
+bindGroup2
+);
+} catch {}
+try {
+commandEncoder25.clearBuffer(
+buffer3,
+4848,
+1084
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer3,
+2244,
+new DataView(new ArrayBuffer(23738)),
+16634,
+200
+);
+} catch {}
+let pipeline33 = device0.createComputePipeline(
+{
+label: '\u{1fe61}\u531f\u054c\u63b6\u0175\u325d\u{1fc07}\u0bf5\u08cb\u0ca6',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+},
+}
+);
+let video3 = await videoWithData();
+try {
+canvas3.getContext('2d');
+} catch {}
+let textureView33 = texture3.createView(
+{
+baseMipLevel: 5,
+mipLevelCount: 1,
+baseArrayLayer: 0,
+}
+);
+let renderBundle23 = renderBundleEncoder10.finish(
+{
+label: '\ufd3c\u{1f89d}\u036b\u9606\u1050\ua094\uc2e4'
+}
+);
+try {
+computePassEncoder13.setBindGroup(
+8,
+bindGroup0,
+new Uint32Array(627),
+430,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(
+4,
+1,
+8,
+0
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndexed(
+16,
+64
+);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(
+buffer1,
+'uint32',
+12368,
+4400
+);
+} catch {}
+try {
+gpuCanvasContext3.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+let pipeline34 = device0.createComputePipeline(
+{
+label: '\u{1ff78}\u226a\udeb0\u11f2\u864e\u3bfa\u5154\u0b14',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let computePassEncoder14 = commandEncoder25.beginComputePass(
+{
+label: '\u6fc0\u{1f822}\u{1ff53}\u0ac5\u0abe\u55f4\u0d5a\ud8ad\ud59b\uc05e\u00bd'
+}
+);
+try {
+renderPassEncoder10.setScissorRect(
+0,
+1,
+5,
+0
+);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(
+6,
+bindGroup3
+);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(
+buffer1,
+'uint32'
+);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(
+62,
+undefined,
+2964409556,
+60021216
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+8120,
+new Int16Array(53488),
+35181,
+1712
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let img7 = await imageWithData(233, 271, '#fd78c133', '#682053c0');
+let video4 = await videoWithData();
+try {
+adapter0.label = '\ud177\ubd82';
+} catch {}
+try {
+offscreenCanvas5.getContext('webgl');
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(
+0,
+bindGroup1,
+new Uint32Array(3658),
+2925,
+0
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndexed(
+0,
+48,
+56,
+184,
+8
+);
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder(
+{
+label: '\ued01\ua22a',
+}
+);
+let renderBundleEncoder22 = device0.createRenderBundleEncoder(
+{
+label: '\u0979\u017d\u4d4a\ub8eb\u{1fd7a}\ub65e\ub1ea',
+colorFormats: [
+'rgba8uint',
+'r32sint'
+],
+sampleCount: 592,
+stencilReadOnly: true,
+}
+);
+let sampler26 = device0.createSampler(
+{
+label: '\u{1feab}\u9399\u0b41\u0f53',
+addressModeU: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 30.422,
+lodMaxClamp: 83.296,
+}
+);
+try {
+renderPassEncoder12.beginOcclusionQuery(
+72
+);
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant(
+{
+r: 4.824,
+g: 371.7,
+b: 696.0,
+a: -493.9,
+}
+);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(
+9,
+0,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder6.draw(
+64,
+32,
+32,
+48
+);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(
+buffer1,
+'uint32',
+8852,
+3368
+);
+} catch {}
+try {
+gpuCanvasContext3.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth16unorm',
+'rg32float'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 76, height: 108, depthOrArrayLayers: 22}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 253, y: 633 },
+  flipY: false,
+},
+{
+  texture: texture12,
+  mipLevel: 1,
+  origin: { x: 8, y: 15, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 46, height: 51, depthOrArrayLayers: 1}
+);
+} catch {}
+let bindGroupLayout9 = device0.createBindGroupLayout(
+{
+label: '\u0736\u27dc\u039f\u{1f8df}\u{1fb85}\u3650\uf2ef\u{1f76b}\u086b\u{1fafa}\u7626',
+entries: [
+{
+binding: 4899,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+let querySet14 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 3876,
+}
+);
+let texture39 = device0.createTexture(
+{
+size: [43, 2, 187],
+mipLevelCount: 6,
+dimension: '3d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+let renderBundle24 = renderBundleEncoder12.finish(
+{
+label: '\u0823\u0a25\uecd1\u0515\u{1fc4a}\ue609\u140a\u3b8e'
+}
+);
+try {
+renderPassEncoder12.setBindGroup(
+3,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(
+3,
+bindGroup0,
+new Uint32Array(9731),
+3604,
+0
+);
+} catch {}
+try {
+renderPassEncoder6.draw(
+64,
+80,
+24,
+56
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndexed(
+72,
+0,
+32,
+112
+);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(
+buffer1,
+'uint32',
+15984,
+4849
+);
+} catch {}
+try {
+device0.pushErrorScope(
+'out-of-memory'
+);
+} catch {}
+try {
+commandEncoder26.clearBuffer(
+buffer3,
+6896,
+296
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer1,
+commandBuffer2,
+]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 5}
+*/
+{
+  source: img2,
+  origin: { x: 92, y: 54 },
+  flipY: false,
+},
+{
+  texture: texture39,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let gpuCanvasContext5 = offscreenCanvas6.getContext('webgpu');
+document.body.append('\ua6e6\u04a1\u{1fdcb}\u{1f77c}\u93ae\u9d41\u58ca\u465c\u3a67\u7ff6');
+let device1 = await adapter1.requestDevice(
+{
+label: '\ufd3a\u{1fdd7}\u058c\u{1fca7}\u1301\u2786',
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable'
+],
+}
+);
+let renderBundle25 = renderBundleEncoder15.finish();
+try {
+computePassEncoder14.setBindGroup(
+3,
+bindGroup1,
+new Uint32Array(9406),
+3831,
+0
+);
+} catch {}
+try {
+renderPassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+5.469,
+0.2968,
+0.2854,
+0.2977,
+0.3761,
+0.6026
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(
+buffer3,
+23744
+);
+} catch {}
+let promise16 = buffer3.mapAsync(
+GPUMapMode.READ,
+0,
+6520
+);
+document.body.append('\u525f\u{1fe84}\u0ed7\u2f70');
+let imageBitmap4 = await createImageBitmap(imageData0);
+let shaderModule9 = device0.createShaderModule(
+{
+label: '\u00da\u0164\ubd40\u06bf\ua897\u72a9\u08b7\u024d\u01e2',
+code: `
+
+@compute @workgroup_size(7, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(2) f0: vec2<f32>,
+@location(7) f1: vec4<i32>,
+@location(0) f2: vec4<u32>,
+@location(1) f3: i32,
+@builtin(sample_mask) f4: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S10 {
+@builtin(vertex_index) f0: u32,
+@location(2) f1: vec2<i32>,
+@location(17) f2: vec2<u32>,
+@location(18) f3: vec3<f32>,
+@location(3) f4: u32,
+@location(13) f5: f32,
+@location(23) f6: vec4<u32>,
+@location(14) f7: vec3<i32>,
+@location(15) f8: vec2<i32>,
+@location(19) f9: vec2<f16>,
+@location(4) f10: vec4<f16>,
+@location(8) f11: vec4<f32>,
+@location(7) f12: vec2<i32>,
+@location(1) f13: u32,
+@builtin(instance_index) f14: u32,
+@location(16) f15: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(20) a0: vec4<f32>, @location(11) a1: i32, @location(5) a2: vec4<f16>, @location(6) a3: vec2<u32>, @location(10) a4: vec4<u32>, @location(22) a5: f16, @location(24) a6: f16, a7: S10) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let computePassEncoder15 = commandEncoder26.beginComputePass(
+{
+label: '\u5036\ud73c\u02ad\u456f\uf0fc\u{1f625}\ud5d5\ubf2d\u{1f6d7}\u0f16\u{1fc7b}'
+}
+);
+try {
+renderPassEncoder8.setIndexBuffer(
+buffer1,
+'uint16',
+15232,
+7002
+);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline24);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(
+buffer1,
+'uint32'
+);
+} catch {}
+let arrayBuffer2 = buffer5.getMappedRange(
+0,
+428
+);
+try {
+device0.queue.writeBuffer(
+buffer1,
+12320,
+new DataView(new ArrayBuffer(5569)),
+1767,
+2824
+);
+} catch {}
+let pipeline35 = await device0.createRenderPipelineAsync(
+{
+label: '\uac35\u05ba\u2b8a\ucece\u0b16\u9720\ue7f9\u{1ffe1}\uda22\ud383',
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule9,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 47516,
+attributes: [
+{
+format: 'uint32x3',
+offset: 41440,
+shaderLocation: 23,
+},
+{
+format: 'float16x4',
+offset: 38832,
+shaderLocation: 19,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 22640,
+shaderLocation: 22,
+},
+{
+format: 'snorm16x2',
+offset: 32920,
+shaderLocation: 4,
+},
+{
+format: 'uint8x4',
+offset: 12880,
+shaderLocation: 3,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 16376,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x4',
+offset: 20792,
+shaderLocation: 8,
+},
+{
+format: 'unorm16x2',
+offset: 18776,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 29512,
+attributes: [
+{
+format: 'sint16x2',
+offset: 5792,
+shaderLocation: 7,
+},
+{
+format: 'sint8x4',
+offset: 3456,
+shaderLocation: 15,
+},
+{
+format: 'unorm8x2',
+offset: 12298,
+shaderLocation: 5,
+},
+{
+format: 'uint8x4',
+offset: 17988,
+shaderLocation: 1,
+},
+{
+format: 'unorm8x4',
+offset: 7864,
+shaderLocation: 20,
+},
+{
+format: 'sint8x4',
+offset: 23256,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x4',
+offset: 5900,
+shaderLocation: 18,
+},
+{
+format: 'sint16x2',
+offset: 17296,
+shaderLocation: 11,
+},
+{
+format: 'float32',
+offset: 19300,
+shaderLocation: 24,
+},
+{
+format: 'uint32x4',
+offset: 26356,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 27772,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 2044,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 46496,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 55196,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 18808,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 56,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 53236,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x3',
+offset: 15120,
+shaderLocation: 6,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'none',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0xe9bb7a33,
+},
+fragment: {
+module: shaderModule9,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16uint',
+writeMask: 0,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rg32float',
+writeMask: GPUColorWrite.ALPHA,
+},
+undefined,
+undefined,
+undefined
+],
+},
+}
+);
+try {
+await promise13;
+} catch {}
+video3.height = 275;
+let querySet15 = device1.createQuerySet(
+{
+label: '\u0da6\u034b\u{1f650}\u0477\u7331\u025b\u948c',
+type: 'occlusion',
+count: 2213,
+}
+);
+let renderBundleEncoder23 = device1.createRenderBundleEncoder(
+{
+label: '\u5ce0\u0793\ub501\u64cd\u7153\u{1fe9e}\uafe1\u3ab4\u1f17\u41fd\u074b',
+colorFormats: [
+'rgba32float'
+],
+sampleCount: 557,
+}
+);
+let bindGroup4 = device0.createBindGroup({
+layout: bindGroupLayout3,
+entries: [
+
+],
+});
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(
+9,
+1,
+3,
+0
+);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(
+buffer1,
+'uint16',
+524
+);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+79,
+undefined,
+3228372472,
+1052360598
+);
+} catch {}
+try {
+buffer3.destroy();
+} catch {}
+try {
+renderBundleEncoder7.pushDebugGroup(
+'\u003b'
+);
+} catch {}
+let pipeline36 = await device0.createComputePipelineAsync(
+{
+layout: pipelineLayout3,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+canvas1.height = 863;
+document.body.prepend('\uffe4\u0303\u06e7\u0af7\u0c0c\u0743\u{1feff}\u3520\u182b');
+let querySet16 = device0.createQuerySet(
+{
+label: '\u837a\u055f\u{1fc5c}\u4598\u{1fcc5}\u099f\u{1ff37}',
+type: 'occlusion',
+count: 184,
+}
+);
+try {
+computePassEncoder14.setPipeline(
+pipeline30
+);
+} catch {}
+try {
+renderPassEncoder8.setViewport(
+9.199,
+0.8278,
+0.2957,
+0.04332,
+0.6487,
+0.8030
+);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+15440,
+new Float32Array(8087),
+5465,
+1064
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 3,
+  origin: { x: 50, y: 0, z: 9 },
+  aspect: 'all',
+},
+new ArrayBuffer(1743742),
+/* required buffer size: 1743742 */{
+offset: 46,
+bytesPerRow: 1320,
+rowsPerImage: 165,
+},
+{width: 81, height: 1, depthOrArrayLayers: 9}
+);
+} catch {}
+let pipeline37 = await device0.createComputePipelineAsync(
+{
+label: '\u2d10\u024d\u{1fea8}\u{1f6fc}\u{1f7d9}\u0dd3\u9fd4',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+},
+}
+);
+try {
+renderPassEncoder6.setScissorRect(
+12,
+0,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndexed(
+56
+);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+try {
+await promise8;
+} catch {}
+document.body.prepend('\u{1f7ea}\u0fdc\u{1fe97}\u{1f6bb}\u0ac7\u{1f6ae}\u225b\u1de5');
+let img8 = await imageWithData(236, 76, '#7b7a2370', '#46ba6955');
+document.body.append('\u9f68\u{1fbce}\ub90e\u{1ffae}');
+let canvas4 = document.createElement('canvas');
+let texture40 = device1.createTexture(
+{
+size: {width: 5987},
+dimension: '1d',
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'r32sint',
+'r32sint',
+'r32sint'
+],
+}
+);
+let textureView34 = texture40.createView(
+{
+label: '\u{1f631}\ue825',
+baseMipLevel: 0,
+mipLevelCount: 1,
+}
+);
+let renderBundleEncoder24 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+'bgra8unorm',
+'bgra8unorm',
+undefined,
+'r16sint'
+],
+sampleCount: 681,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+document.body.prepend(video2);
+gc();
+let bindGroupLayout10 = device0.createBindGroupLayout(
+{
+label: '\u8150\u{1f706}\u241a\u853d\u92a8\u5010\u04cb\u21cd\u3875\u0850',
+entries: [
+{
+binding: 1625,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+},
+{
+binding: 4266,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}
+],
+}
+);
+let textureView35 = texture0.createView(
+{
+label: '\u488e\ufac0',
+baseMipLevel: 4,
+mipLevelCount: 1,
+baseArrayLayer: 18,
+arrayLayerCount: 9,
+}
+);
+try {
+renderPassEncoder6.draw(
+24,
+24,
+24
+);
+} catch {}
+try {
+querySet1.destroy();
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture39,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 2 },
+  aspect: 'all',
+},
+new Float32Array(arrayBuffer0),
+/* required buffer size: 209403 */{
+offset: 17,
+bytesPerRow: 76,
+rowsPerImage: 145,
+},
+{width: 3, height: 1, depthOrArrayLayers: 20}
+);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+await promise7;
+} catch {}
+document.body.prepend('\u{1f72c}\u48d4\u032f\u0159\u{1ffce}');
+let offscreenCanvas7 = new OffscreenCanvas(637, 260);
+let video5 = await videoWithData();
+let sampler27 = device1.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 22.994,
+lodMaxClamp: 93.804,
+maxAnisotropy: 11,
+}
+);
+try {
+renderBundleEncoder24.setVertexBuffer(
+21,
+undefined,
+2106169507,
+1087599450
+);
+} catch {}
+let promise17 = device1.queue.onSubmittedWorkDone();
+let querySet17 = device0.createQuerySet(
+{
+label: '\u{1f7dc}\u0fa9\u11d0\u{1fb56}\u{1f85f}\u0de4\u7a80\u{1faed}\u138b\u5bda',
+type: 'occlusion',
+count: 1485,
+}
+);
+let renderBundle26 = renderBundleEncoder0.finish(
+{
+label: '\u029c\u0818\u04ce'
+}
+);
+try {
+renderPassEncoder11.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant(
+{
+r: -76.47,
+g: -444.3,
+b: -540.8,
+a: -427.6,
+}
+);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(
+2,
+1,
+10,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+2212
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+15808,
+new Int16Array(51795),
+50322,
+604
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture38,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 3 },
+  aspect: 'stencil-only',
+},
+arrayBuffer1,
+/* required buffer size: 26170134 */{
+offset: 389,
+bytesPerRow: 989,
+rowsPerImage: 252,
+},
+{width: 805, height: 1, depthOrArrayLayers: 106}
+);
+} catch {}
+try {
+adapter1.label = '\uef83\uf46f\u46fd\u0e1f\u{1fca7}\u0fbc';
+} catch {}
+let commandEncoder27 = device1.createCommandEncoder(
+{
+label: '\u5449\u{1f9c0}\u0efd\u31bc\ue3c5\u{1f9b4}\u0988\u{1fada}',
+}
+);
+let renderBundle27 = renderBundleEncoder23.finish(
+{
+
+}
+);
+document.body.append('\u761b\u7f9b');
+let offscreenCanvas8 = new OffscreenCanvas(840, 1011);
+let video6 = await videoWithData();
+try {
+canvas4.getContext('2d');
+} catch {}
+let commandEncoder28 = device0.createCommandEncoder(
+{
+label: '\u0680\u5afa\u4df7',
+}
+);
+let querySet18 = device0.createQuerySet(
+{
+label: '\u001f\u0e34\uf357\u{1fce0}\u019e\u424f\u09c8\u078a\u53b4\u00b4',
+type: 'occlusion',
+count: 2139,
+}
+);
+try {
+renderPassEncoder4.setBindGroup(
+6,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(
+48
+);
+} catch {}
+try {
+renderPassEncoder6.setViewport(
+6.820,
+0.1535,
+4.944,
+0.1475,
+0.7593,
+0.8078
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndexed(
+0,
+24,
+16,
+520,
+32
+);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+41,
+undefined,
+2403550034
+);
+} catch {}
+try {
+commandEncoder28.resolveQuerySet(
+querySet14,
+2740,
+875,
+buffer1,
+15104
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline38 = device0.createComputePipeline(
+{
+layout: pipelineLayout2,
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let video7 = await videoWithData();
+let textureView36 = texture40.createView(
+{
+}
+);
+try {
+device1.queue.writeTexture(
+{
+  texture: texture40,
+  mipLevel: 0,
+  origin: { x: 2260, y: 1, z: 0 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(arrayBuffer2),
+/* required buffer size: 971 */{
+offset: 971,
+rowsPerImage: 252,
+},
+{width: 969, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(
+buffer5,
+86376
+);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(
+60,
+undefined
+);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(
+buffer1,
+'uint32',
+3852
+);
+} catch {}
+try {
+renderBundleEncoder7.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+15576,
+new BigUint64Array(54989),
+21994,
+360
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 4, y: 12, z: 16 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 814 */{
+offset: 814,
+bytesPerRow: 664,
+},
+{width: 32, height: 35, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline39 = device0.createRenderPipeline(
+{
+label: '\u{1ff2b}\ua62a\u{1fca1}\u9001\u0043',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+
+]
+},
+primitive: {
+topology: 'line-strip',
+frontFace: 'cw',
+cullMode: 'none',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+{
+format: 'r32sint',
+writeMask: 0,
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'zero',
+dstFactor: 'one-minus-dst-alpha'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'one-minus-dst-alpha',
+dstFactor: 'one-minus-src'
+},
+},
+format: 'rgba8unorm-srgb',
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'invert',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'invert',
+},
+stencilReadMask: 676,
+depthBias: 8,
+depthBiasClamp: 10,
+},
+}
+);
+try {
+await promise17;
+} catch {}
+let canvas5 = document.createElement('canvas');
+let textureView37 = texture40.createView(
+{
+arrayLayerCount: 1,
+}
+);
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.append('\ub996\ua030\u088a\u748d\u{1fd79}\u07c7');
+let bindGroupLayout11 = device1.createBindGroupLayout(
+{
+label: '\u472d\ub36a',
+entries: [
+{
+binding: 165,
+visibility: 0,
+texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+}
+],
+}
+);
+pseudoSubmit(device1, commandEncoder27);
+let sampler28 = device1.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 39.523,
+lodMaxClamp: 81.579,
+maxAnisotropy: 9,
+}
+);
+try {
+device1.queue.writeTexture(
+{
+  texture: texture40,
+  mipLevel: 0,
+  origin: { x: 962, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 639 */{
+offset: 639,
+},
+{width: 596, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend(img3);
+let offscreenCanvas9 = new OffscreenCanvas(883, 1006);
+let renderBundle28 = renderBundleEncoder10.finish(
+{
+label: '\u{1f6e4}\ue9d6\u0854\u{1f91a}\u{1fe54}\ua188\u1d32\u0baf'
+}
+);
+try {
+renderPassEncoder4.setBindGroup(
+8,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant(
+{
+r: 200.0,
+g: 150.8,
+b: -391.8,
+a: 162.8,
+}
+);
+} catch {}
+try {
+renderPassEncoder6.draw(
+64
+);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(
+0,
+bindGroup2
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder28.copyTextureToTexture(
+{
+  texture: texture23,
+  mipLevel: 0,
+  origin: { x: 87, y: 0, z: 338 },
+  aspect: 'all',
+},
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 61, y: 0, z: 22 },
+  aspect: 'all',
+},
+{width: 625, height: 1, depthOrArrayLayers: 95}
+);
+} catch {}
+let pipelineLayout5 = device1.createPipelineLayout(
+{
+label: '\u77d5\ufc41',
+bindGroupLayouts: [
+bindGroupLayout11
+],
+}
+);
+let renderBundleEncoder25 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8unorm',
+undefined,
+undefined,
+'rg32float',
+'rgba8uint',
+'rgba16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 614,
+depthReadOnly: true,
+}
+);
+let sampler29 = device1.createSampler(
+{
+label: '\u{1ff38}\u0a21\u3d58\u021f',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 19.379,
+lodMaxClamp: 85.907,
+compare: 'not-equal',
+}
+);
+document.body.prepend(img4);
+let pipelineLayout6 = device0.createPipelineLayout(
+{
+label: '\ucacc\u0311\u86c0\ua392\u6912\uf8e5\u{1fd75}\u07ed\u52e3\u0c7f',
+bindGroupLayouts: [
+bindGroupLayout3,
+bindGroupLayout5,
+bindGroupLayout10,
+bindGroupLayout9,
+bindGroupLayout2,
+bindGroupLayout10,
+bindGroupLayout1
+],
+}
+);
+let commandBuffer3 = commandEncoder28.finish(
+{
+}
+);
+let texture41 = device0.createTexture(
+{
+label: '\u{1fec2}\u0322\u{1fabe}\uc122\u0709\u981d\u03dc\u015b\u{1f744}\ued8a',
+size: {width: 3559},
+dimension: '1d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+let renderBundleEncoder26 = device0.createRenderBundleEncoder(
+{
+label: '\u7bb1\u0bae\u{1f925}\u8f83\u02f3',
+colorFormats: [
+'rg8sint',
+'bgra8unorm',
+'r16uint',
+'r32float',
+'r8sint',
+'rgba16float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 544,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder10.setStencilReference(
+611
+);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(
+1,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder12.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer3,
+]);
+} catch {}
+let pipeline40 = device0.createComputePipeline(
+{
+layout: pipelineLayout3,
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let querySet19 = device1.createQuerySet(
+{
+label: '\u3740\u0543\u{1f84c}\u{1ffa8}\u{1f716}\u0310\u87bf\u20ba\u{1fc16}\u0a51',
+type: 'occlusion',
+count: 1272,
+}
+);
+let renderBundle29 = renderBundleEncoder25.finish();
+try {
+querySet19.label = '\u09dc\u3aae\u092a\u0d91\u0096\u50b5';
+} catch {}
+let renderBundle30 = renderBundleEncoder23.finish(
+{
+label: '\u64f7\u5119\u0e5f\u52d8\u0d12\ua2a4\u0158\u{1f8bd}\u051c'
+}
+);
+try {
+renderBundleEncoder24.setVertexBuffer(
+48,
+undefined,
+1075437278,
+2940022559
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let textureView38 = texture12.createView(
+{
+mipLevelCount: 4,
+baseArrayLayer: 16,
+}
+);
+let renderBundleEncoder27 = device0.createRenderBundleEncoder(
+{
+label: '\u{1ffdb}\u029a\u4e21\u{1f950}\u0689',
+colorFormats: [
+'rg16uint',
+'r32sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 298,
+}
+);
+let sampler30 = device0.createSampler(
+{
+addressModeW: 'clamp-to-edge',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 42.013,
+lodMaxClamp: 91.617,
+}
+);
+try {
+computePassEncoder3.setBindGroup(
+7,
+bindGroup1,
+new Uint32Array(3169),
+669,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline19);
+} catch {}
+let pipeline41 = device0.createComputePipeline(
+{
+label: '\u025f\u{1fc05}\u55cd\u{1f714}\u{1fb93}',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+}
+);
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+document.body.append('\u411b\uec99\u20b2\uf1e8\u8a9e');
+let buffer6 = device0.createBuffer(
+{
+label: '\u5693\u{1f631}\u{1ff21}\u3188\u16bb',
+size: 22542,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let sampler31 = device0.createSampler(
+{
+label: '\u3ce9\u81f0\u64b8\u60d6\u09cd\u0b74\u03ee\u1201\u05a0\ua7a0\ud12f',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 83.549,
+}
+);
+try {
+renderPassEncoder10.beginOcclusionQuery(
+40
+);
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(
+5,
+0,
+0,
+1
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(
+64,
+48,
+8,
+344,
+8
+);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(
+4,
+buffer6,
+12228,
+5506
+);
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext6 = offscreenCanvas9.getContext('webgpu');
+try {
+await promise16;
+} catch {}
+try {
+offscreenCanvas7.getContext('bitmaprenderer');
+} catch {}
+pseudoSubmit(device0, commandEncoder2);
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(
+2735
+);
+} catch {}
+try {
+renderPassEncoder8.setViewport(
+8.118,
+0.03524,
+1.347,
+0.2188,
+0.8696,
+0.8965
+);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(
+buffer6,
+'uint32',
+10420,
+5826
+);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(
+3,
+buffer6,
+10376,
+4980
+);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(
+3,
+buffer6
+);
+} catch {}
+try {
+renderPassEncoder12.pushDebugGroup(
+'\u0cb4'
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture9,
+  mipLevel: 0,
+  origin: { x: 3241, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Float32Array(arrayBuffer2),
+/* required buffer size: 32 */{
+offset: 32,
+},
+{width: 824, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let querySet20 = device0.createQuerySet(
+{
+label: '\uaf71\u3020\udb0a\u8b41\u{1fc3d}\u00ec\u6054\uc768',
+type: 'occlusion',
+count: 3872,
+}
+);
+let texture42 = device0.createTexture(
+{
+label: '\ubf62\u00bf\u0bce',
+size: {width: 8549},
+dimension: '1d',
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder16 = commandEncoder26.beginComputePass(
+{
+label: '\u6cd1\u8a8b\ueee4\u98d9\u0f54\u046b'
+}
+);
+let renderBundle31 = renderBundleEncoder26.finish(
+{
+label: '\u4abb\u{1fd94}\uc940\u05b3\u04eb'
+}
+);
+try {
+computePassEncoder8.setBindGroup(
+6,
+bindGroup0,
+new Uint32Array(4227),
+1835,
+0
+);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(
+2668
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(
+buffer4,
+353448
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(
+buffer6,
+26360
+);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(
+1,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(
+8,
+buffer6
+);
+} catch {}
+try {
+renderPassEncoder12.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 21, height: 1, depthOrArrayLayers: 93}
+*/
+{
+  source: imageData2,
+  origin: { x: 0, y: 61 },
+  flipY: true,
+},
+{
+  texture: texture39,
+  mipLevel: 1,
+  origin: { x: 3, y: 0, z: 11 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 17, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let gpuCanvasContext7 = offscreenCanvas8.getContext('webgpu');
+gc();
+document.body.append('\u0c50\u2e37\u7f1b\uca2a\u{1ff30}\u0bec\u4f1a\u{1f621}\u{1f66b}\uc2d1');
+let pipelineLayout7 = device1.createPipelineLayout(
+{
+label: '\u374b\u08e5\u0d2c\u4e8e\u{1f63d}\ued4a\u3789\u0dd3\u14d2',
+bindGroupLayouts: [
+bindGroupLayout11,
+bindGroupLayout11,
+bindGroupLayout11,
+bindGroupLayout11
+],
+}
+);
+let textureView39 = texture40.createView(
+{
+label: '\u0552\u0ae1\uc9a3\u0ae5\u2503\u54f7\u0cef',
+baseMipLevel: 0,
+}
+);
+document.body.append('\u09dd\u0338\u319c\uc124\u4876\u4720\u{1f836}\u7f54\u6c6c');
+let bindGroupLayout12 = device1.createBindGroupLayout(
+{
+label: '\u{1f6ee}\u{1ff98}\u{1f643}\u{1f8d6}\u{1f90e}\ub83f\ufcc8\u7df5\uc73a',
+entries: [
+{
+binding: 588,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '3d' },
+}
+],
+}
+);
+try {
+renderBundleEncoder24.pushDebugGroup(
+'\u{1f893}'
+);
+} catch {}
+let gpuCanvasContext8 = canvas5.getContext('webgpu');
+try {
+await promise11;
+} catch {}
+let commandEncoder29 = device1.createCommandEncoder(
+{
+label: '\u{1fd0b}\ua6af\ubcf9\u8b3b\u633e\u2f76\u05b9',
+}
+);
+let texture43 = device1.createTexture(
+{
+label: '\u{1f7e7}\u93fb\u0afd\ub505\u228f',
+size: {width: 1699},
+dimension: '1d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+device0.queue.label = '\ue0e0\u1828\ud342\u089d\u9fa3\u0d04\u{1f7d3}\u0b1d';
+} catch {}
+let commandEncoder30 = device0.createCommandEncoder();
+let texture44 = device0.createTexture(
+{
+label: '\u0823\u7fb1\u0bb9\u{1fff0}',
+size: {width: 256, height: 160, depthOrArrayLayers: 103},
+format: 'stencil8',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'stencil8'
+],
+}
+);
+try {
+renderPassEncoder4.setBlendConstant(
+{
+r: 539.7,
+g: 789.9,
+b: 884.9,
+a: 439.7,
+}
+);
+} catch {}
+try {
+renderPassEncoder6.setViewport(
+10.06,
+0.9374,
+0.06808,
+0.00226,
+0.2628,
+0.9372
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer4,
+127104
+);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(
+buffer1,
+'uint32',
+15296,
+2479
+);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture25,
+  mipLevel: 1,
+  origin: { x: 1, y: 15, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 3771 */{
+offset: 959,
+bytesPerRow: 255,
+},
+{width: 7, height: 12, depthOrArrayLayers: 1}
+);
+} catch {}
+let canvas6 = document.createElement('canvas');
+let bindGroupLayout13 = device0.createBindGroupLayout(
+{
+label: '\u380e\u4f1b\u0119\uedeb\u{1f963}\u7826',
+entries: [
+{
+binding: 3843,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+},
+{
+binding: 8305,
+visibility: 0,
+externalTexture: {},
+}
+],
+}
+);
+let computePassEncoder17 = commandEncoder30.beginComputePass(
+{
+label: '\u1cb1\u30fa\u4f57\u{1f7fa}\u{1fb29}\u2abb\u4abc\u0736\u{1ff68}'
+}
+);
+try {
+renderPassEncoder6.setStencilReference(
+3797
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(
+buffer1,
+880
+);
+} catch {}
+let arrayBuffer3 = buffer4.getMappedRange(
+4064,
+3440
+);
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 2, height: 1, depthOrArrayLayers: 11}
+*/
+{
+  source: img1,
+  origin: { x: 28, y: 32 },
+  flipY: false,
+},
+{
+  texture: texture39,
+  mipLevel: 4,
+  origin: { x: 0, y: 1, z: 8 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline42 = await device0.createComputePipelineAsync(
+{
+layout: pipelineLayout1,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+},
+}
+);
+let pipelineLayout8 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout8,
+bindGroupLayout10,
+bindGroupLayout1,
+bindGroupLayout10,
+bindGroupLayout8
+],
+}
+);
+let sampler32 = device0.createSampler(
+{
+label: '\ua10e\u0a20\u{1f6ea}\u0a9e\u12f8\u{1ff08}\u0833\u{1f8c1}\uf51b',
+addressModeU: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 97.824,
+compare: 'greater-equal',
+maxAnisotropy: 4,
+}
+);
+try {
+computePassEncoder8.setBindGroup(
+7,
+bindGroup1
+);
+} catch {}
+try {
+computePassEncoder14.setBindGroup(
+6,
+bindGroup2,
+new Uint32Array(7378),
+5624,
+0
+);
+} catch {}
+try {
+computePassEncoder3.setPipeline(
+pipeline32
+);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(
+7,
+bindGroup0
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture5,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 2 },
+  aspect: 'all',
+},
+new ArrayBuffer(80),
+/* required buffer size: 527 */{
+offset: 523,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise19 = device0.createRenderPipelineAsync(
+{
+label: '\u0eb1\u{1f6bd}\u{1f8ab}\u{1fe78}\u232d\uc089\u0b87\uc812\u039d\u1ac4',
+layout: 'auto',
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 53016,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 10400,
+shaderLocation: 4,
+},
+{
+format: 'sint32',
+offset: 9704,
+shaderLocation: 20,
+},
+{
+format: 'sint32x3',
+offset: 7208,
+shaderLocation: 8,
+},
+{
+format: 'float32x3',
+offset: 4180,
+shaderLocation: 16,
+},
+{
+format: 'sint16x2',
+offset: 2748,
+shaderLocation: 12,
+},
+{
+format: 'uint32x4',
+offset: 6068,
+shaderLocation: 19,
+},
+{
+format: 'sint32x2',
+offset: 30968,
+shaderLocation: 21,
+},
+{
+format: 'sint16x2',
+offset: 30724,
+shaderLocation: 1,
+},
+{
+format: 'float32',
+offset: 35108,
+shaderLocation: 0,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 28220,
+shaderLocation: 18,
+},
+{
+format: 'snorm16x2',
+offset: 38080,
+shaderLocation: 24,
+},
+{
+format: 'uint32x4',
+offset: 32628,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x2',
+offset: 44386,
+shaderLocation: 13,
+},
+{
+format: 'uint16x4',
+offset: 38888,
+shaderLocation: 6,
+},
+{
+format: 'sint32',
+offset: 4320,
+shaderLocation: 11,
+},
+{
+format: 'unorm16x4',
+offset: 41824,
+shaderLocation: 23,
+},
+{
+format: 'sint32x3',
+offset: 51528,
+shaderLocation: 10,
+},
+{
+format: 'uint32x3',
+offset: 24440,
+shaderLocation: 5,
+},
+{
+format: 'uint8x4',
+offset: 21532,
+shaderLocation: 14,
+},
+{
+format: 'float32x3',
+offset: 26876,
+shaderLocation: 15,
+},
+{
+format: 'snorm16x4',
+offset: 41272,
+shaderLocation: 3,
+},
+{
+format: 'sint8x4',
+offset: 17136,
+shaderLocation: 22,
+},
+{
+format: 'sint32x2',
+offset: 36144,
+shaderLocation: 17,
+},
+{
+format: 'unorm8x2',
+offset: 52678,
+shaderLocation: 9,
+},
+{
+format: 'uint16x4',
+offset: 10992,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x1d1ece2f,
+},
+fragment: {
+module: shaderModule3,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+undefined,
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'one-minus-constant',
+dstFactor: 'one-minus-dst-alpha'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'one-minus-dst-alpha',
+dstFactor: 'one-minus-dst'
+},
+},
+format: 'r16float',
+writeMask: 0,
+},
+undefined,
+{
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'rg32float',
+},
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'greater',
+failOp: 'invert',
+depthFailOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-clamp',
+passOp: 'invert',
+},
+stencilReadMask: 2979,
+stencilWriteMask: 1008,
+depthBias: 2,
+depthBiasClamp: 47,
+},
+}
+);
+let renderBundleEncoder28 = device0.createRenderBundleEncoder(
+{
+label: '\u8cc6\u{1f78a}\u02ed\ud847\u02a7\uc929\ua326\u{1feb4}',
+colorFormats: [
+'rg32float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 537,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder6.drawIndexed(
+32
+);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+5,
+buffer6,
+10340,
+4263
+);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(
+buffer6,
+'uint16'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+14264,
+new Int16Array(5256)
+);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let img9 = await imageWithData(158, 110, '#0598ef9a', '#e33edf03');
+let video8 = await videoWithData();
+let imageBitmap5 = await createImageBitmap(video0);
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(
+11,
+0,
+1,
+1
+);
+} catch {}
+try {
+renderPassEncoder12.setViewport(
+2.682,
+0.3483,
+4.689,
+0.1100,
+0.9326,
+0.9801
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(
+buffer2,
+5208
+);
+} catch {}
+try {
+device0.pushErrorScope(
+'validation'
+);
+} catch {}
+try {
+buffer3.destroy();
+} catch {}
+let promise20 = device0.createRenderPipelineAsync(
+{
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule5,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 36772,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 18888,
+shaderLocation: 7,
+},
+{
+format: 'snorm8x4',
+offset: 23548,
+shaderLocation: 18,
+},
+{
+format: 'uint32x2',
+offset: 12032,
+shaderLocation: 12,
+},
+{
+format: 'uint32x3',
+offset: 22768,
+shaderLocation: 13,
+},
+{
+format: 'snorm16x2',
+offset: 188,
+shaderLocation: 1,
+},
+{
+format: 'unorm8x4',
+offset: 3068,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 1584,
+attributes: [
+{
+format: 'float32x3',
+offset: 784,
+shaderLocation: 11,
+},
+{
+format: 'uint16x2',
+offset: 320,
+shaderLocation: 19,
+},
+{
+format: 'unorm16x4',
+offset: 1148,
+shaderLocation: 17,
+},
+{
+format: 'sint32x4',
+offset: 1480,
+shaderLocation: 3,
+},
+{
+format: 'sint8x4',
+offset: 1324,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 15784,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x4',
+offset: 3788,
+shaderLocation: 14,
+},
+{
+format: 'sint8x2',
+offset: 4956,
+shaderLocation: 23,
+},
+{
+format: 'sint32',
+offset: 4840,
+shaderLocation: 9,
+},
+{
+format: 'uint16x4',
+offset: 1408,
+shaderLocation: 21,
+},
+{
+format: 'sint8x2',
+offset: 12194,
+shaderLocation: 20,
+},
+{
+format: 'unorm16x4',
+offset: 14596,
+shaderLocation: 10,
+},
+{
+format: 'unorm8x2',
+offset: 1404,
+shaderLocation: 22,
+},
+{
+format: 'sint16x2',
+offset: 13692,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x2',
+offset: 8056,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 44160,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 6244,
+shaderLocation: 0,
+},
+{
+format: 'float32x2',
+offset: 42320,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 44548,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 58316,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x4',
+offset: 8572,
+shaderLocation: 15,
+},
+{
+format: 'float32x2',
+offset: 43648,
+shaderLocation: 24,
+}
+],
+},
+{
+arrayStride: 47440,
+attributes: [
+{
+format: 'uint32',
+offset: 24436,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0xce61f90e,
+},
+fragment: {
+module: shaderModule5,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'zero',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+failOp: 'increment-wrap',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 3183,
+stencilWriteMask: 4010,
+depthBias: 89,
+depthBiasSlopeScale: 22,
+depthBiasClamp: 95,
+},
+}
+);
+let pipelineLayout9 = device0.createPipelineLayout(
+{
+label: '\u02aa\u3b72\ub3fd\u02e4\ub3bd\ud55e\u09c4',
+bindGroupLayouts: [
+
+],
+}
+);
+let texture45 = device0.createTexture(
+{
+label: '\u0a5e\uee5c',
+size: [636, 1, 28],
+mipLevelCount: 10,
+dimension: '3d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rgba8unorm',
+'rgba8unorm',
+'rgba8unorm-srgb'
+],
+}
+);
+try {
+computePassEncoder8.setBindGroup(
+3,
+bindGroup1,
+new Uint32Array(4732),
+3649,
+0
+);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(
+4,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline24);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+2748,
+new DataView(new ArrayBuffer(49811)),
+26053,
+1460
+);
+} catch {}
+let promise21 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 156, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas3,
+  origin: { x: 158, y: 101 },
+  flipY: true,
+},
+{
+  texture: texture2,
+  mipLevel: 5,
+  origin: { x: 97, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 39, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline43 = await device0.createComputePipelineAsync(
+{
+layout: pipelineLayout6,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let texture46 = device0.createTexture(
+{
+label: '\u{1fbcf}\u{1f8cd}\ua82e\ue3df\u0962\u00ee',
+size: {width: 3003, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 9,
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'r32sint',
+'r32sint',
+'r32sint'
+],
+}
+);
+let renderBundleEncoder29 = device0.createRenderBundleEncoder(
+{
+label: '\uf521\u9dee\u{1fcd4}\ub27a\u116d\u0e0e\ue51c\ub7bc',
+colorFormats: [
+'rgba8unorm-srgb',
+'rgba32sint'
+],
+sampleCount: 130,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant(
+{
+r: 851.8,
+g: -705.5,
+b: -320.9,
+a: 919.4,
+}
+);
+} catch {}
+let promise22 = device0.popErrorScope();
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append('\u473b\ucef9');
+let renderBundleEncoder30 = device0.createRenderBundleEncoder(
+{
+label: '\uf6da\u08da\u{1fcd0}\u{1fd22}\u0037\u57d8\u9d5f\u074c\uafad\u{1f6fb}',
+colorFormats: [
+'bgra8unorm',
+'rg8sint',
+'rgba32float',
+'rg16sint'
+],
+sampleCount: 273,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline24);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext5.configure(
+{
+device: device0,
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth32float',
+'rg16sint',
+'bgra8unorm',
+'rg16sint'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture11,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 16 },
+  aspect: 'stencil-only',
+},
+arrayBuffer1,
+/* required buffer size: 2949966 */{
+offset: 310,
+bytesPerRow: 155,
+rowsPerImage: 110,
+},
+{width: 6, height: 1, depthOrArrayLayers: 174}
+);
+} catch {}
+let pipeline44 = await device0.createComputePipelineAsync(
+{
+label: '\u1394\u0fef\u0bab\u39eb\u{1fb78}\uf7a9\ue502\uc330\u054b\u{1fe7b}',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+},
+}
+);
+document.body.prepend('\u{1fb14}\ued56\u065d\u9812\u0e18\u{1fe79}');
+let commandEncoder31 = device0.createCommandEncoder(
+{
+}
+);
+let commandBuffer4 = commandEncoder31.finish(
+{
+label: '\u{1f9b4}\u{1fdbd}\u{1fd33}\u2cc7\u2757\ued5c\u0bb4',
+}
+);
+let texture47 = device0.createTexture(
+{
+label: '\u0ccd\u14d8',
+size: [10, 1, 1992],
+mipLevelCount: 9,
+dimension: '3d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+renderPassEncoder10.setBindGroup(
+5,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.setViewport(
+8.226,
+0.8442,
+1.069,
+0.1405,
+0.5167,
+0.5838
+);
+} catch {}
+try {
+renderPassEncoder6.draw(
+40,
+48,
+72,
+72
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(
+buffer5,
+45320
+);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(
+1,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(
+7,
+bindGroup4,
+new Uint32Array(3271),
+381,
+0
+);
+} catch {}
+let arrayBuffer4 = buffer4.getMappedRange(
+2440,
+688
+);
+document.body.prepend(canvas1);
+let bindGroupLayout14 = device0.createBindGroupLayout(
+{
+label: '\uea26\u5a0b\uca85\ue4f9\u05d6\u{1f6dd}\ub373\u24b2\u3e9b\u391e\u9c4c',
+entries: [
+{
+binding: 345,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+}
+],
+}
+);
+let querySet21 = device0.createQuerySet(
+{
+label: '\u{1f6f6}\u{1f7df}\ue350\ueff6\ua6aa\uec87\u{1fc65}\ucb60\u0759\u32df',
+type: 'occlusion',
+count: 3275,
+}
+);
+let texture48 = device0.createTexture(
+{
+label: '\ue0ac\u7752\u9970\uf401\u406a\uc7c9\u0bd0\u1b19\u02cc\u{1fc5a}',
+size: {width: 21, height: 5, depthOrArrayLayers: 138},
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8snorm'
+],
+}
+);
+try {
+computePassEncoder10.setBindGroup(
+6,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(
+4,
+1,
+5,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+1425
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndexed(
+32,
+8,
+40,
+-592,
+8
+);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(
+8,
+buffer6,
+17592,
+2538
+);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(
+8,
+bindGroup2,
+[]
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture41,
+  mipLevel: 0,
+  origin: { x: 156, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(24),
+/* required buffer size: 19226 */{
+offset: 322,
+},
+{width: 2363, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let imageBitmap6 = await createImageBitmap(imageBitmap5);
+try {
+computePassEncoder8.setPipeline(
+pipeline37
+);
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(
+8,
+0,
+1,
+0
+);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let commandEncoder32 = device0.createCommandEncoder();
+pseudoSubmit(device0, commandEncoder10);
+let texture49 = device0.createTexture(
+{
+label: '\u0f1e\u0209\u4714\uc22d\u{1fa8d}\u5dba\u045a\u0780',
+size: {width: 10298},
+dimension: '1d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg16float',
+'rg16float'
+],
+}
+);
+let textureView40 = texture41.createView(
+{
+format: 'rg32sint',
+}
+);
+let sampler33 = device0.createSampler(
+{
+label: '\u{1fa2a}\u0f73',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 79.547,
+lodMaxClamp: 98.870,
+maxAnisotropy: 5,
+}
+);
+try {
+renderPassEncoder12.drawIndirect(
+buffer2,
+98000
+);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(
+buffer6,
+'uint16'
+);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline24);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(
+buffer6,
+'uint32',
+14432,
+1842
+);
+} catch {}
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder32.copyBufferToBuffer(
+buffer6,
+10168,
+buffer5,
+9100,
+568
+);
+dissociateBuffer(device0, buffer6);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder32.resolveQuerySet(
+querySet18,
+2127,
+6,
+buffer1,
+17408
+);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer4,
+]);
+} catch {}
+let promise23 = device0.queue.onSubmittedWorkDone();
+let commandEncoder33 = device0.createCommandEncoder(
+{
+label: '\u1f4a\u1f40',
+}
+);
+pseudoSubmit(device0, commandEncoder12);
+let textureView41 = texture29.createView(
+{
+label: '\u0cdf\u{1fb60}\u0cee\ub14e',
+format: 'r8uint',
+baseMipLevel: 1,
+mipLevelCount: 2,
+baseArrayLayer: 0,
+}
+);
+let renderBundleEncoder31 = device0.createRenderBundleEncoder(
+{
+label: '\ub141\u{1fa21}\u0f8c\ud8b8\u022e',
+colorFormats: [
+undefined,
+'rg11b10ufloat',
+'rgba32uint',
+undefined
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 348,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder4.setIndexBuffer(
+buffer1,
+'uint16',
+18178,
+3032
+);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(
+8,
+buffer6,
+864,
+6197
+);
+} catch {}
+let promise24 = buffer0.mapAsync(
+GPUMapMode.WRITE,
+3696,
+5500
+);
+try {
+commandEncoder33.resolveQuerySet(
+querySet8,
+515,
+504,
+buffer1,
+0
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+18096,
+new BigUint64Array(4)
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 10, height: 1, depthOrArrayLayers: 46}
+*/
+{
+  source: video1,
+  origin: { x: 6, y: 14 },
+  flipY: true,
+},
+{
+  texture: texture39,
+  mipLevel: 2,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 8, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+canvas6.getContext('2d');
+} catch {}
+let commandEncoder34 = device1.createCommandEncoder();
+let textureView42 = texture43.createView(
+{
+label: '\u3609\ub390',
+format: 'bgra8unorm',
+baseArrayLayer: 0,
+}
+);
+let sampler34 = device1.createSampler(
+{
+label: '\ub7f6\u{1fdc9}\ud1a3\u0e11\u{1f9e1}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 83.046,
+lodMaxClamp: 93.089,
+maxAnisotropy: 1,
+}
+);
+gc();
+document.body.append('\u8c96\u9af3\ueb14\u019c\u7c6d');
+let computePassEncoder18 = commandEncoder32.beginComputePass(
+{
+
+}
+);
+try {
+renderPassEncoder10.setBindGroup(
+8,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(
+24,
+8
+);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(
+buffer6,
+'uint32'
+);
+} catch {}
+try {
+commandEncoder33.resolveQuerySet(
+querySet10,
+3459,
+187,
+buffer1,
+17920
+);
+} catch {}
+try {
+gpuCanvasContext3.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let imageBitmap7 = await createImageBitmap(img8);
+let commandBuffer5 = commandEncoder33.finish(
+{
+label: '\u{1f96b}\u0eb2\u{1fac0}\uaf3b\u0d16\ud70b\uc622\u787d\u7737\u{1f856}\u8afe',
+}
+);
+pseudoSubmit(device0, commandEncoder13);
+try {
+renderPassEncoder6.setBindGroup(
+3,
+bindGroup1,
+[]
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(
+buffer1,
+242672
+);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(
+buffer6,
+'uint32',
+7080,
+7345
+);
+} catch {}
+let promise25 = device0.popErrorScope();
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+offscreenCanvas9.height = 770;
+let renderBundle32 = renderBundleEncoder27.finish(
+{
+label: '\u0b9d\u01fb\u0cbc\u{1ff3c}\uf69b\u3d44\u2460'
+}
+);
+try {
+renderPassEncoder11.setStencilReference(
+1640
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(
+16,
+48
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer2,
+65000
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+2,
+buffer6,
+5380,
+5713
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 78, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video4,
+  origin: { x: 0, y: 12 },
+  flipY: false,
+},
+{
+  texture: texture2,
+  mipLevel: 6,
+  origin: { x: 55, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 7, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline45 = await device0.createComputePipelineAsync(
+{
+label: '\uc75c\uc52f\u{1fca7}\u099a\ubc54\u8ed5',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline46 = await device0.createRenderPipelineAsync(
+{
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule6,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x2',
+offset: 696,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 49112,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 26020,
+shaderLocation: 11,
+},
+{
+format: 'uint16x2',
+offset: 20120,
+shaderLocation: 19,
+},
+{
+format: 'sint32',
+offset: 4172,
+shaderLocation: 2,
+},
+{
+format: 'sint16x2',
+offset: 22356,
+shaderLocation: 10,
+},
+{
+format: 'snorm16x2',
+offset: 1880,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 3156,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 2392,
+shaderLocation: 15,
+},
+{
+format: 'sint8x4',
+offset: 2568,
+shaderLocation: 0,
+},
+{
+format: 'float32x2',
+offset: 996,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x4',
+offset: 2592,
+shaderLocation: 20,
+},
+{
+format: 'float16x2',
+offset: 2184,
+shaderLocation: 14,
+},
+{
+format: 'snorm16x2',
+offset: 1764,
+shaderLocation: 18,
+},
+{
+format: 'snorm8x4',
+offset: 1816,
+shaderLocation: 24,
+}
+],
+},
+{
+arrayStride: 24020,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 15236,
+shaderLocation: 8,
+},
+{
+format: 'uint32x2',
+offset: 16432,
+shaderLocation: 5,
+},
+{
+format: 'snorm8x2',
+offset: 9908,
+shaderLocation: 13,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x7ca9489b,
+},
+fragment: {
+module: shaderModule6,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+{
+format: 'r16uint',
+writeMask: 0,
+}
+],
+},
+}
+);
+let img10 = await imageWithData(33, 264, '#d45a93aa', '#b2be45fa');
+let shaderModule10 = device1.createShaderModule(
+{
+label: '\u0da3\u05ac\u0e55\u{1ff15}\u0eba',
+code: `
+
+@compute @workgroup_size(5, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: vec2<i32>,
+@location(2) f1: vec2<i32>,
+@location(3) f2: f32,
+@location(7) f3: i32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_mask) a1: u32, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(4) a0: vec4<f32>, @location(1) a1: vec2<f32>, @location(13) a2: f16, @location(8) a3: vec2<i32>, @location(2) a4: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+}
+);
+let pipelineLayout10 = device1.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout11,
+bindGroupLayout12,
+bindGroupLayout11,
+bindGroupLayout12
+],
+}
+);
+let textureView43 = texture40.createView(
+{
+label: '\u7d07\uce7e\u{1fb15}\udc99\u9c2b\u{1fecb}',
+}
+);
+let renderBundleEncoder32 = device1.createRenderBundleEncoder(
+{
+label: '\uc085\u{1fc94}\u6ded\u0d09\ua13b\ue68e\ub248',
+colorFormats: [
+'rg16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 99,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle33 = renderBundleEncoder23.finish();
+try {
+renderBundleEncoder24.setVertexBuffer(
+71,
+undefined,
+1830158220,
+2361829841
+);
+} catch {}
+let pipeline47 = device1.createComputePipeline(
+{
+label: '\u28e1\u8ab9',
+layout: pipelineLayout7,
+compute: {
+module: shaderModule10,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageData3 = new ImageData(136, 36);
+let videoFrame4 = new VideoFrame(imageBitmap1, {timestamp: 0});
+let commandEncoder35 = device1.createCommandEncoder();
+let texture50 = device1.createTexture(
+{
+size: [4060, 208, 10],
+mipLevelCount: 4,
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let computePassEncoder19 = commandEncoder29.beginComputePass(
+{
+label: '\u8ab7\u{1fb22}\u592a\u8883\u05c1\u{1f89a}\u041f\u2d66\ubc47'
+}
+);
+let renderBundle34 = renderBundleEncoder23.finish(
+{
+label: '\u0f4b\u{1faaf}'
+}
+);
+try {
+computePassEncoder19.setPipeline(
+pipeline47
+);
+} catch {}
+try {
+renderBundleEncoder24.popDebugGroup();
+} catch {}
+let canvas7 = document.createElement('canvas');
+let textureView44 = texture43.createView(
+{
+label: '\u0db4\u3a4f',
+mipLevelCount: 1,
+}
+);
+let sampler35 = device1.createSampler(
+{
+label: '\u{1fafd}\u82cf\u6aaf\u{1f7d5}\u8edf',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 62.475,
+lodMaxClamp: 96.467,
+compare: 'less',
+}
+);
+try {
+computePassEncoder19.end();
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture40,
+  mipLevel: 0,
+  origin: { x: 3715, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint8Array(arrayBuffer0),
+/* required buffer size: 483 */{
+offset: 483,
+},
+{width: 1754, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+gc();
+document.body.prepend('\u{1fba0}\u05c3\u{1f8cb}\u640c\u0e7c\u{1fdcb}\u{1fd41}\u9b5d');
+let buffer7 = device0.createBuffer(
+{
+label: '\uc14a\u{1f9ad}\ueb54\u0579\u03b5\ub4c4\u4114\u03e6\u{1fcb4}\ued76',
+size: 29940,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let querySet22 = device0.createQuerySet(
+{
+label: '\u48f0\u08df\u1881\u0820\u15f7\u07b9\u0f79\udfa1\u{1fb54}\u172f',
+type: 'occlusion',
+count: 2371,
+}
+);
+try {
+computePassEncoder14.setPipeline(
+pipeline21
+);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant(
+{
+r: -432.4,
+g: -763.4,
+b: 852.1,
+a: -601.3,
+}
+);
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(
+5,
+0,
+6,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(
+buffer6,
+'uint16',
+22246,
+139
+);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(
+buffer6,
+'uint16',
+19942,
+2546
+);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(
+4,
+buffer6,
+5164,
+2119
+);
+} catch {}
+let adapter2 = await navigator.gpu.requestAdapter(
+{
+powerPreference: 'high-performance',
+}
+);
+let imageData4 = new ImageData(4, 248);
+try {
+renderPassEncoder11.setIndexBuffer(
+buffer1,
+'uint32',
+20608,
+3594
+);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(
+1,
+buffer6
+);
+} catch {}
+try {
+gpuCanvasContext4.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 154 */{
+offset: 154,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+gc();
+document.body.append('\u{1fe18}\u{1ffdf}');
+let promise26 = adapter2.requestDevice(
+{
+label: '\u698d\u01de\u8926\u0718\u{1febf}\ufe4b\u{1fe6b}\u144f\uc7c2',
+}
+);
+let renderBundle35 = renderBundleEncoder28.finish(
+{
+label: '\ud4c9\u6de5\u{1fa6d}\u{1f8f8}\u071c\u26d2\ubd71'
+}
+);
+try {
+renderPassEncoder11.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant(
+{
+r: 270.3,
+g: -364.5,
+b: 745.7,
+a: -149.0,
+}
+);
+} catch {}
+try {
+gpuCanvasContext3.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth16unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+document.body.prepend('\uee8c\uf218\u{1f7c5}\u0d67\u0eba');
+let buffer8 = device1.createBuffer(
+{
+label: '\u0289\u0c69\ueca3\u{1fd52}\u{1f6ab}\uad25\u{1faff}\uee63\uaaf9',
+size: 2071,
+usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+}
+);
+let commandEncoder36 = device1.createCommandEncoder(
+{
+label: '\u{1f79d}\u08c0\ud0be\u031f\u7d6e',
+}
+);
+gc();
+document.body.prepend('\u8998\u1fbe\u0873\u9412\uc95a');
+let querySet23 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 3096,
+}
+);
+let texture51 = device0.createTexture(
+{
+size: [4223],
+dimension: '1d',
+format: 'rgba8sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8sint',
+'rgba8sint'
+],
+}
+);
+try {
+computePassEncoder16.setPipeline(
+pipeline13
+);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(
+5,
+buffer6,
+1752,
+17031
+);
+} catch {}
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+17940,
+new Int16Array(6896),
+4701,
+1096
+);
+} catch {}
+let commandEncoder37 = device0.createCommandEncoder(
+{
+label: '\u282e\u0320\ua585\ud73f\u029a\u{1fa88}\ufa7c\u7291\u{1f8fb}\u08e8',
+}
+);
+try {
+computePassEncoder14.setPipeline(
+pipeline2
+);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(
+56
+);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.draw(
+56,
+56,
+16,
+40
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndexed(
+24,
+8
+);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(
+0,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(
+buffer1,
+'uint16'
+);
+} catch {}
+try {
+commandEncoder37.copyBufferToBuffer(
+buffer4,
+47416,
+buffer1,
+24140,
+584
+);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let texture52 = device1.createTexture(
+{
+label: '\u013e\u{1f861}\uafa8',
+size: [234, 17, 1],
+mipLevelCount: 6,
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView45 = texture52.createView(
+{
+label: '\u{1ffd3}\u836a\u5c1c\u{1fc67}',
+baseMipLevel: 3,
+mipLevelCount: 1,
+}
+);
+let computePassEncoder20 = commandEncoder36.beginComputePass(
+{
+
+}
+);
+let renderBundleEncoder33 = device1.createRenderBundleEncoder(
+{
+label: '\u0f9c\u429a\u{1f996}\u{1fc4e}',
+colorFormats: [
+'rg32sint',
+'rgba16uint',
+undefined,
+'rgba8uint'
+],
+sampleCount: 644,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle36 = renderBundleEncoder33.finish(
+{
+label: '\u1dd5\u5558\u{1fdee}\u{1fc20}\u05a2\u157a'
+}
+);
+let sampler36 = device1.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 29.381,
+lodMaxClamp: 35.390,
+}
+);
+try {
+gpuCanvasContext8.configure(
+{
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16float',
+'astc-10x6-unorm',
+'r8snorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let gpuCanvasContext9 = canvas7.getContext('webgpu');
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+await promise25;
+} catch {}
+let adapter3 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let shaderModule11 = device1.createShaderModule(
+{
+label: '\ubc94\uc3e6\u7035\u{1fd93}',
+code: `@group(0) @binding(165)
+var<storage, read_write> parameter0: array<u32>;
+
+@compute @workgroup_size(6, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(1) f0: vec4<i32>,
+@location(3) f1: vec4<u32>,
+@location(6) f2: vec4<f32>,
+@location(2) f3: vec3<i32>,
+@location(4) f4: vec2<u32>,
+@builtin(frag_depth) f5: f32,
+@location(5) f6: vec2<u32>,
+@location(0) f7: vec3<f32>,
+@location(7) f8: i32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S11 {
+@location(15) f0: vec3<f32>,
+@location(8) f1: vec2<u32>,
+@location(1) f2: vec3<u32>,
+@location(12) f3: vec3<f16>,
+@builtin(vertex_index) f4: u32
+}
+
+@vertex
+fn vertex0(a0: S11, @location(11) a1: f16, @location(6) a2: f32, @location(13) a3: i32, @location(7) a4: vec3<i32>, @location(2) a5: vec4<f16>, @location(10) a6: f16, @location(9) a7: vec3<u32>, @location(14) a8: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+}
+);
+let querySet24 = device1.createQuerySet(
+{
+label: '\u0b20\u5ebe\u4ca1\ub500\u343c\ud678',
+type: 'occlusion',
+count: 389,
+}
+);
+let renderBundle37 = renderBundleEncoder25.finish();
+try {
+computePassEncoder20.setPipeline(
+pipeline47
+);
+} catch {}
+try {
+commandEncoder34.resolveQuerySet(
+querySet24,
+95,
+233,
+buffer8,
+0
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture43,
+  mipLevel: 0,
+  origin: { x: 378, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(2855),
+/* required buffer size: 2855 */{
+offset: 347,
+rowsPerImage: 262,
+},
+{width: 627, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\u7a2c\u938c\u06ae\u6639');
+let computePassEncoder21 = commandEncoder37.beginComputePass(
+{
+label: '\uf0d3\u{1f656}\u4819\u6299\u{1fadb}\u6852\ufe45\uf0b9\u5022\u{1f69d}\u0a19'
+}
+);
+let renderBundle38 = renderBundleEncoder27.finish(
+{
+label: '\u{1f8cf}\u02c4\u528e\u0d81\u{1fa44}\u0b5a\u6d6e\u8d25\u0007'
+}
+);
+try {
+renderPassEncoder12.setBindGroup(
+6,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder11.end();
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(
+56
+);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(
+11,
+0,
+0,
+1
+);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(
+8,
+buffer6,
+2888,
+11072
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture25,
+  mipLevel: 1,
+  origin: { x: 3, y: 8, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 127 */{
+offset: 127,
+bytesPerRow: 33,
+},
+{width: 1, height: 35, depthOrArrayLayers: 0}
+);
+} catch {}
+let querySet25 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 1935,
+}
+);
+let texture53 = device0.createTexture(
+{
+size: {width: 1183, height: 76, depthOrArrayLayers: 218},
+mipLevelCount: 4,
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rg11b10ufloat',
+'rg11b10ufloat',
+'rg11b10ufloat'
+],
+}
+);
+try {
+renderPassEncoder6.setBindGroup(
+5,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder10.draw(
+40,
+32,
+24,
+32
+);
+} catch {}
+try {
+renderPassEncoder6.drawIndexed(
+40,
+16,
+64,
+800,
+16
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(
+buffer1,
+252248
+);
+} catch {}
+let adapter4 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let textureView46 = texture50.createView(
+{
+label: '\u{1fdd2}\u0500\u{1f8c6}\u{1f8eb}\u{1fa15}\u2caa\u10f0\u{1ffa6}',
+dimension: '2d',
+baseMipLevel: 1,
+mipLevelCount: 1,
+baseArrayLayer: 9,
+}
+);
+let computePassEncoder22 = commandEncoder29.beginComputePass(
+{
+label: '\u1028\ubc1d\u{1ff6b}\u0937\u027f'
+}
+);
+let renderPassEncoder13 = commandEncoder34.beginRenderPass(
+{
+label: '\udf58\u{1f9fd}\u0eea\u6e43\u0e33\u0ccf\u{1fb67}\u063f',
+colorAttachments: [
+{
+view: textureView45,
+clearValue: {
+r: 4.910,
+g: 844.1,
+b: -699.4,
+a: -67.26,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined
+],
+occlusionQuerySet: querySet19,
+maxDrawCount: 78784,
+}
+);
+let sampler37 = device1.createSampler(
+{
+label: '\u{1f617}\u903a\u{1fbac}\uf65e\u24ba\u67f0\u8131',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 36.158,
+lodMaxClamp: 77.863,
+maxAnisotropy: 14,
+}
+);
+try {
+renderPassEncoder13.end();
+} catch {}
+try {
+commandEncoder35.resolveQuerySet(
+querySet19,
+147,
+140,
+buffer8,
+512
+);
+} catch {}
+let promise27 = device1.createComputePipelineAsync(
+{
+label: '\ub038\u{1fc06}\u3fdb\u04e4\u0e2b\ubb20\u0990\u02c9',
+layout: 'auto',
+compute: {
+module: shaderModule10,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let offscreenCanvas10 = new OffscreenCanvas(510, 520);
+let buffer9 = device1.createBuffer(
+{
+size: 44119,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+}
+);
+let computePassEncoder23 = commandEncoder35.beginComputePass();
+try {
+device1.pushErrorScope(
+'out-of-memory'
+);
+} catch {}
+document.body.prepend('\u{1f7ad}\u0380');
+let texture54 = device0.createTexture(
+{
+label: '\u0f6e\u162d\u{1fa2c}\ud829\ub786\u477d',
+size: {width: 244, height: 1, depthOrArrayLayers: 805},
+mipLevelCount: 10,
+dimension: '3d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb'
+],
+}
+);
+let textureView47 = texture51.createView(
+{
+label: '\u0ac5\u8846\u{1fcb4}\u47c6\u{1ff20}\u01b1',
+aspect: 'all',
+}
+);
+let renderBundleEncoder34 = device0.createRenderBundleEncoder(
+{
+label: '\u42a3\u{1fe3e}\u{1fb53}\u1bcd\u{1ff76}',
+colorFormats: [
+'r32float',
+'r16uint',
+'rgb10a2unorm',
+'r32sint',
+'rgba32sint',
+'r16float'
+],
+sampleCount: 95,
+}
+);
+let sampler38 = device0.createSampler(
+{
+label: '\u294a\u0bb0\u061d\u0fda',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 87.915,
+lodMaxClamp: 99.274,
+maxAnisotropy: 16,
+}
+);
+try {
+computePassEncoder17.setBindGroup(
+6,
+bindGroup3
+);
+} catch {}
+try {
+computePassEncoder18.setPipeline(
+pipeline42
+);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.drawIndexed(
+8
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer5,
+78968
+);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline19);
+} catch {}
+try {
+querySet12.destroy();
+} catch {}
+let renderBundle39 = renderBundleEncoder18.finish();
+let externalTexture0 = device0.importExternalTexture(
+{
+label: '\uf901\u{1faa1}\u0bd0\ub7d0\u014f\u31c0\u945f\u2106',
+source: videoFrame1,
+colorSpace: 'display-p3',
+}
+);
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(
+buffer1,
+'uint16',
+2180,
+18256
+);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(
+3,
+buffer6,
+10824,
+9055
+);
+} catch {}
+let renderBundle40 = renderBundleEncoder2.finish();
+try {
+computePassEncoder3.setPipeline(
+pipeline41
+);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(
+3,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(
+56
+);
+} catch {}
+try {
+renderPassEncoder10.draw(
+0,
+64,
+64
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(
+72,
+64,
+16,
+752,
+80
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(
+buffer5,
+153568
+);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(
+4,
+buffer6,
+6380
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img1);
+let bindGroupLayout15 = device1.createBindGroupLayout(
+{
+entries: [
+{
+binding: 97,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rg32uint', access: 'write-only', viewDimension: '2d' },
+},
+{
+binding: 421,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+},
+{
+binding: 972,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let texture55 = device1.createTexture(
+{
+size: {width: 3192, height: 48, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'astc-12x12-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-12x12-unorm',
+'astc-12x12-unorm-srgb'
+],
+}
+);
+let sampler39 = device1.createSampler(
+{
+label: '\u0f35\u41a6\ub651\u{1fe6d}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMaxClamp: 50.167,
+}
+);
+let querySet26 = device1.createQuerySet(
+{
+label: '\u393e\u{1fb10}\u5d79\u{1ffc4}\u6dbd\u0855\u{1f68b}',
+type: 'occlusion',
+count: 2037,
+}
+);
+try {
+computePassEncoder22.end();
+} catch {}
+try {
+commandEncoder29.copyTextureToTexture(
+{
+  texture: texture52,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture52,
+  mipLevel: 3,
+  origin: { x: 11, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 15, height: 2, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder29.clearBuffer(
+buffer9,
+22432,
+2252
+);
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+commandEncoder29.resolveQuerySet(
+querySet15,
+1270,
+226,
+buffer8,
+0
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout16 = pipeline47.getBindGroupLayout(3);
+let querySet27 = device1.createQuerySet(
+{
+label: '\u{1fd42}\u09db\ua3e7\u{1fa94}\u2cd5\u{1f6e5}\u{1f997}',
+type: 'occlusion',
+count: 311,
+}
+);
+let computePassEncoder24 = commandEncoder29.beginComputePass(
+{
+label: '\u{1fd5b}\u0928\u1b00\ud242\u099d\uf298\u38f9\u9bbf\u{1fb67}'
+}
+);
+let renderBundleEncoder35 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg32uint',
+'rg32float',
+'rgba32uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 510,
+depthReadOnly: true,
+}
+);
+try {
+await promise21;
+} catch {}
+let promise28 = adapter4.requestDevice(
+{
+label: '\u{1fdf6}\ubc9a\u02fd\u6359',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxBindGroups: 9,
+maxColorAttachmentBytesPerSample: 62,
+maxVertexAttributes: 21,
+maxVertexBufferArrayStride: 48250,
+maxStorageTexturesPerShaderStage: 33,
+maxStorageBuffersPerShaderStage: 13,
+maxDynamicStorageBuffersPerPipelineLayout: 34410,
+maxBindingsPerBindGroup: 1425,
+maxTextureDimension1D: 11537,
+maxTextureDimension2D: 9477,
+maxVertexBuffers: 12,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 15607066,
+maxInterStageShaderVariables: 53,
+maxInterStageShaderComponents: 121,
+},
+}
+);
+let videoFrame5 = new VideoFrame(offscreenCanvas4, {timestamp: 0});
+let texture56 = device0.createTexture(
+{
+size: [84, 1, 240],
+mipLevelCount: 4,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth32float',
+'depth32float'
+],
+}
+);
+let textureView48 = texture33.createView(
+{
+label: '\u0263\ud9f7\u0f73\u{1fca0}\u0806\u0522',
+aspect: 'depth-only',
+baseMipLevel: 5,
+mipLevelCount: 3,
+baseArrayLayer: 84,
+arrayLayerCount: 7,
+}
+);
+try {
+renderPassEncoder6.setBindGroup(
+7,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setViewport(
+7.811,
+0.3431,
+3.223,
+0.05814,
+0.5836,
+0.6426
+);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(
+1,
+buffer6,
+16520,
+1499
+);
+} catch {}
+let bindGroupLayout17 = device1.createBindGroupLayout(
+{
+label: '\u23d2\u{1fdd8}\u9958\u36ab\u46b5\u0198\u00b8\u09f4\u0bfd',
+entries: [
+{
+binding: 273,
+visibility: GPUShaderStage.FRAGMENT,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 410,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+}
+],
+}
+);
+let querySet28 = device1.createQuerySet(
+{
+label: '\u087b\u0666\ue338\ub502\u2a9e\u3b60\u0021\udcfc\u04b9\u{1f939}\u{1fbf3}',
+type: 'occlusion',
+count: 1861,
+}
+);
+let textureView49 = texture43.createView(
+{
+label: '\u7cad\u0c8e\u{1f74c}\u{1fbf8}\u45bc',
+format: 'bgra8unorm',
+arrayLayerCount: 1,
+}
+);
+let pipeline48 = await promise27;
+let buffer10 = device1.createBuffer(
+{
+size: 44664,
+usage: GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let commandEncoder38 = device1.createCommandEncoder();
+let textureView50 = texture40.createView(
+{
+label: '\u0314\u{1fc2e}\u0773\ubafd\u{1fa44}',
+baseArrayLayer: 0,
+}
+);
+let renderPassEncoder14 = commandEncoder38.beginRenderPass(
+{
+label: '\u42f9\u610c\uc8a8\u06e2\u0dde\u{1fef8}\u3d6b\u0188',
+colorAttachments: [
+{
+view: textureView45,
+clearValue: {
+r: 245.1,
+g: -644.7,
+b: 848.0,
+a: -580.4,
+},
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+maxDrawCount: 223320,
+}
+);
+try {
+computePassEncoder20.setPipeline(
+pipeline47
+);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([]);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer9,
+36096,
+new Int16Array(12517),
+4127,
+3216
+);
+} catch {}
+let promise29 = device1.createComputePipelineAsync(
+{
+layout: pipelineLayout5,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+device1.destroy();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let img11 = await imageWithData(131, 198, '#ed8b0a3a', '#f73b6859');
+let bindGroupLayout18 = device0.createBindGroupLayout(
+{
+label: '\u556d\u2751\u2107\u0b7a',
+entries: [
+{
+binding: 2814,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+}
+],
+}
+);
+let querySet29 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 784,
+}
+);
+try {
+renderPassEncoder8.setBindGroup(
+1,
+bindGroup0,
+[]
+);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(
+6,
+buffer6
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+2708,
+new Int16Array(2534),
+601,
+1264
+);
+} catch {}
+let gpuCanvasContext10 = offscreenCanvas10.getContext('webgpu');
+let buffer11 = device0.createBuffer(
+{
+size: 47780,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+let commandEncoder39 = device0.createCommandEncoder();
+let textureView51 = texture21.createView(
+{
+label: '\u38eb\ufc26\u90b0',
+aspect: 'depth-only',
+mipLevelCount: 1,
+}
+);
+try {
+computePassEncoder3.setBindGroup(
+2,
+bindGroup4,
+new Uint32Array(1455),
+1135,
+0
+);
+} catch {}
+try {
+computePassEncoder18.setPipeline(
+pipeline18
+);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(
+40
+);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(
+2857
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer2,
+138744
+);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(
+6,
+bindGroup1,
+new Uint32Array(318),
+200,
+0
+);
+} catch {}
+try {
+commandEncoder39.copyTextureToBuffer(
+{
+  texture: texture42,
+  mipLevel: 0,
+  origin: { x: 456, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 21496 widthInBlocks: 5374 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 23184 */
+offset: 23184,
+buffer: buffer1,
+},
+{width: 5374, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder39.clearBuffer(
+buffer3,
+7700,
+56
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder39.resolveQuerySet(
+querySet2,
+1677,
+568,
+buffer1,
+7680
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let computePassEncoder25 = commandEncoder39.beginComputePass();
+let renderBundleEncoder36 = device0.createRenderBundleEncoder(
+{
+label: '\u09f3\u7f06\u{1ffeb}\ucd90\u6c71\u0206\u{1f687}\u4df2\u{1fca0}\u084b',
+colorFormats: [
+'rgba32uint',
+'rg8uint',
+'r8unorm',
+'bgra8unorm',
+'r32float',
+'bgra8unorm-srgb'
+],
+sampleCount: 952,
+}
+);
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(
+72
+);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.draw(
+72,
+16,
+24
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+0,
+buffer6,
+5384,
+16797
+);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+let pipeline49 = device0.createComputePipeline(
+{
+label: '\u0ce3\u5773\u052c\ub39c\u0c3b\ud073\u8d98\u7453',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let pipelineLayout11 = device0.createPipelineLayout(
+{
+label: '\u0c06\u{1fe31}\ue838\u0358\u5bce\ue168\ufa83\u088e\uadbe\uc672',
+bindGroupLayouts: [
+
+],
+}
+);
+let texture57 = device0.createTexture(
+{
+label: '\u047d\u8ffc\u560e\u{1fdd3}',
+size: [3, 3, 25],
+mipLevelCount: 2,
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'bgra8unorm-srgb',
+'bgra8unorm-srgb',
+'bgra8unorm-srgb'
+],
+}
+);
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(
+8,
+1,
+2,
+0
+);
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(
+1637
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(
+24,
+8
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(
+buffer1,
+311184
+);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(
+9,
+buffer6,
+15912,
+5259
+);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(
+buffer6,
+'uint16',
+16594,
+1096
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture47,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 951 },
+  aspect: 'all',
+},
+new Float32Array(new ArrayBuffer(48)),
+/* required buffer size: 10874237 */{
+offset: 833,
+bytesPerRow: 163,
+rowsPerImage: 204,
+},
+{width: 3, height: 0, depthOrArrayLayers: 328}
+);
+} catch {}
+let pipeline50 = device0.createRenderPipeline(
+{
+label: '\u2543\u{1fca2}\uc83a\u{1f94f}\u9a52\u8441',
+layout: 'auto',
+vertex: {
+module: shaderModule9,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 38988,
+attributes: [
+{
+format: 'uint32x3',
+offset: 19228,
+shaderLocation: 6,
+},
+{
+format: 'float16x2',
+offset: 25016,
+shaderLocation: 4,
+},
+{
+format: 'float16x4',
+offset: 10008,
+shaderLocation: 16,
+},
+{
+format: 'sint16x2',
+offset: 10828,
+shaderLocation: 7,
+},
+{
+format: 'sint32',
+offset: 10304,
+shaderLocation: 11,
+},
+{
+format: 'uint32x3',
+offset: 22248,
+shaderLocation: 1,
+},
+{
+format: 'uint32x3',
+offset: 16688,
+shaderLocation: 23,
+},
+{
+format: 'unorm16x4',
+offset: 38972,
+shaderLocation: 13,
+},
+{
+format: 'uint16x4',
+offset: 36052,
+shaderLocation: 10,
+},
+{
+format: 'sint8x2',
+offset: 36008,
+shaderLocation: 15,
+},
+{
+format: 'float32x3',
+offset: 10604,
+shaderLocation: 5,
+},
+{
+format: 'uint8x2',
+offset: 38916,
+shaderLocation: 17,
+},
+{
+format: 'snorm8x2',
+offset: 10620,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x4',
+offset: 9036,
+shaderLocation: 20,
+},
+{
+format: 'float32',
+offset: 2412,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 47680,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 18240,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 3996,
+shaderLocation: 3,
+},
+{
+format: 'sint16x2',
+offset: 15004,
+shaderLocation: 2,
+},
+{
+format: 'snorm8x4',
+offset: 6152,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 12792,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 544,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x4',
+offset: 288,
+shaderLocation: 24,
+},
+{
+format: 'sint16x2',
+offset: 108,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 59136,
+attributes: [
+{
+format: 'snorm16x4',
+offset: 58932,
+shaderLocation: 19,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x28f89a4e,
+},
+fragment: {
+module: shaderModule9,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rgb10a2uint',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+}
+],
+},
+}
+);
+document.body.prepend('\u852d\u0490\u{1f853}\u234a\u{1fae4}\u0524');
+let adapter5 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let texture58 = device0.createTexture(
+{
+label: '\u{1f952}\uba52\u6444\ue86b\uad83\u0751\u{1ff81}',
+size: {width: 4046, height: 255, depthOrArrayLayers: 178},
+mipLevelCount: 9,
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32sint',
+'r32sint'
+],
+}
+);
+let renderBundle41 = renderBundleEncoder4.finish(
+{
+label: '\u04f6\u0afd\u0dc1\u68cb\u09d0\u{1f93b}\u{1ffc5}\u0479'
+}
+);
+try {
+renderPassEncoder10.setStencilReference(
+646
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(
+buffer7,
+14944
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(
+buffer11,
+470760
+);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(
+6,
+buffer6,
+3096,
+10099
+);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(
+6,
+bindGroup4
+);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+7,
+bindGroup4,
+new Uint32Array(7598),
+7150,
+0
+);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(
+1,
+buffer6,
+15484,
+6872
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture57,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 1 },
+  aspect: 'all',
+},
+new Float64Array(new ArrayBuffer(80)),
+/* required buffer size: 489746 */{
+offset: 513,
+bytesPerRow: 275,
+rowsPerImage: 127,
+},
+{width: 2, height: 2, depthOrArrayLayers: 15}
+);
+} catch {}
+let buffer12 = device0.createBuffer(
+{
+label: '\u{1fa42}\ucb85\u09f0\u2861\u3e47\u088a',
+size: 23658,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+}
+);
+let querySet30 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 672,
+}
+);
+let texture59 = device0.createTexture(
+{
+label: '\u5d25\ua6f1\u{1f661}\u18e1\u44d3\uecab\u0824\u7dee',
+size: [196, 105, 58],
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb10a2uint',
+'rgb10a2uint',
+'rgb10a2uint'
+],
+}
+);
+let renderBundleEncoder37 = device0.createRenderBundleEncoder(
+{
+label: '\u{1fbb1}\u0b4a\ua40a',
+colorFormats: [
+'rg11b10ufloat',
+'rgba8uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 700,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder21.setBindGroup(
+7,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(
+6,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(
+2866
+);
+} catch {}
+try {
+renderPassEncoder12.draw(
+80,
+32
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(
+56,
+64,
+32,
+-16,
+80
+);
+} catch {}
+try {
+await buffer7.mapAsync(
+GPUMapMode.WRITE,
+7376
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer12,
+9848,
+new Int16Array(37749),
+5228,
+5392
+);
+} catch {}
+let canvas8 = document.createElement('canvas');
+let img12 = await imageWithData(239, 35, '#30f47a58', '#57583cb6');
+let video9 = await videoWithData();
+document.body.append('\u0397\u{1f6b8}\uf385\u723d');
+let video10 = await videoWithData();
+let videoFrame6 = new VideoFrame(img10, {timestamp: 0});
+try {
+canvas8.getContext('bitmaprenderer');
+} catch {}
+let bindGroupLayout19 = device0.createBindGroupLayout(
+{
+label: '\u0ec2\ucae9\u0bd5\u1db1\u3d55\u165e\u0ad2\ueffa',
+entries: [
+{
+binding: 3773,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}
+],
+}
+);
+let textureView52 = texture15.createView(
+{
+baseMipLevel: 5,
+mipLevelCount: 2,
+}
+);
+try {
+renderPassEncoder10.setBindGroup(
+1,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant(
+{
+r: -817.0,
+g: -625.6,
+b: 398.0,
+a: 248.0,
+}
+);
+} catch {}
+try {
+renderPassEncoder10.draw(
+16
+);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+await promise18;
+} catch {}
+let commandEncoder40 = device0.createCommandEncoder(
+{
+label: '\u97e4\u81df\u0a15\u9a20',
+}
+);
+let renderBundle42 = renderBundleEncoder31.finish(
+{
+
+}
+);
+try {
+renderPassEncoder4.setBindGroup(
+2,
+bindGroup3,
+new Uint32Array(4417),
+2867,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.beginOcclusionQuery(
+40
+);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(
+5,
+buffer12,
+4804,
+10378
+);
+} catch {}
+try {
+commandEncoder40.clearBuffer(
+buffer12,
+556,
+9928
+);
+dissociateBuffer(device0, buffer12);
+} catch {}
+let imageBitmap8 = await createImageBitmap(img9);
+let commandEncoder41 = device0.createCommandEncoder(
+{
+}
+);
+let computePassEncoder26 = commandEncoder40.beginComputePass(
+{
+label: '\u07f7\u1f54\u0f8f\u{1fc3a}\u0bdd\u9edb'
+}
+);
+let renderBundle43 = renderBundleEncoder14.finish(
+{
+label: '\u218e\u{1fb4b}\u1540\u{1f6db}'
+}
+);
+try {
+renderPassEncoder4.setBindGroup(
+0,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(
+0,
+0,
+10,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer4,
+88448
+);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(
+2,
+bindGroup4,
+new Uint32Array(4113),
+2077,
+0
+);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(
+0,
+buffer12,
+2420,
+14482
+);
+} catch {}
+try {
+commandEncoder41.copyBufferToBuffer(
+buffer12,
+8776,
+buffer3,
+5088,
+1352
+);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+7828,
+new DataView(new ArrayBuffer(6619)),
+3691
+);
+} catch {}
+let promise30 = device0.createComputePipelineAsync(
+{
+label: '\ud7b3\uf400\ua8b9\u{1fa23}\ub1d8\u{1fec5}\u1649',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline51 = device0.createRenderPipeline(
+{
+layout: pipelineLayout6,
+vertex: {
+module: shaderModule5,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 53892,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 45536,
+shaderLocation: 9,
+},
+{
+format: 'unorm8x4',
+offset: 16332,
+shaderLocation: 22,
+},
+{
+format: 'snorm8x4',
+offset: 44792,
+shaderLocation: 18,
+},
+{
+format: 'sint16x4',
+offset: 40948,
+shaderLocation: 20,
+},
+{
+format: 'float32x4',
+offset: 41824,
+shaderLocation: 4,
+},
+{
+format: 'uint32x3',
+offset: 31144,
+shaderLocation: 5,
+},
+{
+format: 'uint32x2',
+offset: 40420,
+shaderLocation: 21,
+},
+{
+format: 'unorm16x2',
+offset: 24988,
+shaderLocation: 17,
+},
+{
+format: 'uint16x2',
+offset: 43988,
+shaderLocation: 19,
+},
+{
+format: 'float32x4',
+offset: 48196,
+shaderLocation: 24,
+},
+{
+format: 'snorm16x4',
+offset: 7216,
+shaderLocation: 6,
+},
+{
+format: 'float32x4',
+offset: 10204,
+shaderLocation: 1,
+},
+{
+format: 'sint8x2',
+offset: 41536,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 19152,
+shaderLocation: 0,
+},
+{
+format: 'float32x2',
+offset: 12132,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 57156,
+attributes: [
+{
+format: 'unorm8x4',
+offset: 18556,
+shaderLocation: 10,
+},
+{
+format: 'sint32',
+offset: 23444,
+shaderLocation: 23,
+},
+{
+format: 'sint32x4',
+offset: 11844,
+shaderLocation: 8,
+},
+{
+format: 'sint8x4',
+offset: 1972,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 38632,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x4',
+offset: 7552,
+shaderLocation: 11,
+},
+{
+format: 'sint32x2',
+offset: 32496,
+shaderLocation: 15,
+},
+{
+format: 'uint8x2',
+offset: 15898,
+shaderLocation: 12,
+},
+{
+format: 'uint32x3',
+offset: 13424,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 14556,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 4204,
+shaderLocation: 7,
+},
+{
+format: 'sint32x4',
+offset: 2768,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x297777dc,
+},
+fragment: {
+module: shaderModule5,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r16uint',
+writeMask: 0,
+}
+],
+},
+}
+);
+try {
+await promise23;
+} catch {}
+document.body.append('\u{1fded}\ub7c5\u{1fbe7}\u{1f868}');
+let querySet31 = device0.createQuerySet(
+{
+label: '\u0464\u0a86\u0895\u3a68',
+type: 'occlusion',
+count: 2741,
+}
+);
+let computePassEncoder27 = commandEncoder41.beginComputePass(
+{
+label: '\ue4a5\uaddd\u{1ffeb}\u07c5\uaf98\u0d34\u1d62\u41c9\u1fbd'
+}
+);
+try {
+renderPassEncoder4.setBindGroup(
+5,
+bindGroup1,
+new Uint32Array(7560),
+3199,
+0
+);
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(
+7,
+1,
+4,
+0
+);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(
+2103
+);
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+9.944,
+0.2963,
+0.1951,
+0.2655,
+0.6944,
+0.9648
+);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline24);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+let promise31 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(canvas2);
+let imageData5 = new ImageData(192, 80);
+try {
+await promise12;
+} catch {}
+let canvas9 = document.createElement('canvas');
+try {
+window.someLabel = buffer9.label;
+} catch {}
+let gpuCanvasContext11 = canvas9.getContext('webgpu');
+try {
+await promise31;
+} catch {}
+let offscreenCanvas11 = new OffscreenCanvas(397, 274);
+pseudoSubmit(device0, commandEncoder4);
+let sampler40 = device0.createSampler(
+{
+label: '\u{1fc54}\u7929\u528c\u{1fcb4}\u0502\ua175\u{1feb0}\u01be\u0fa3\u002d\uaa8f',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 75.972,
+lodMaxClamp: 94.150,
+}
+);
+try {
+computePassEncoder10.setBindGroup(
+8,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(
+1,
+0,
+1,
+1
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 76, height: 108, depthOrArrayLayers: 22}
+*/
+{
+  source: imageBitmap7,
+  origin: { x: 81, y: 48 },
+  flipY: false,
+},
+{
+  texture: texture12,
+  mipLevel: 1,
+  origin: { x: 20, y: 40, z: 14 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 52, height: 16, depthOrArrayLayers: 1}
+);
+} catch {}
+let gpuCanvasContext12 = offscreenCanvas11.getContext('webgpu');
+let renderBundleEncoder38 = device0.createRenderBundleEncoder(
+{
+label: '\ud4e5\uba1e\ub4ee\u0d9a\u{1f6fb}\u0c51\ub17c\u{1f657}\u0eb0\u{1fc98}',
+colorFormats: [
+'rgba32sint',
+'r8sint',
+'rg32sint',
+'r16float'
+],
+sampleCount: 993,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder12.setViewport(
+9.119,
+0.4627,
+2.174,
+0.5278,
+0.2430,
+0.6221
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer4,
+285760
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer6,
+10568
+);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(
+2,
+buffer6,
+16588,
+1772
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture39,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 100 },
+  aspect: 'all',
+},
+new ArrayBuffer(32),
+/* required buffer size: 731045 */{
+offset: 619,
+bytesPerRow: 260,
+rowsPerImage: 117,
+},
+{width: 43, height: 2, depthOrArrayLayers: 25}
+);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let video11 = await videoWithData();
+video1.width = 223;
+document.body.append('\u1df4\u{1fee3}\ue6c5\u17f8');
+let device2 = await adapter5.requestDevice(
+{
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+}
+);
+let commandEncoder42 = device2.createCommandEncoder(
+{
+label: '\u{1f6bd}\u0bc7\u{1fbf7}\u8001\u{1fbd9}',
+}
+);
+document.body.prepend('\uf899\uf2a3\u{1febb}\u040c\u{1fa49}\u0815\ua0bb\uab58');
+let bindGroup5 = device0.createBindGroup({
+label: '\u0dd4\uac67\u4325\u{1fbb8}\u06fc\u{1f641}\u01c7',
+layout: bindGroupLayout3,
+entries: [
+
+],
+});
+try {
+computePassEncoder18.setPipeline(
+pipeline25
+);
+} catch {}
+try {
+renderPassEncoder10.draw(
+56
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(
+56,
+16,
+64,
+-328,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline24);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer5,
+]);
+} catch {}
+let pipeline52 = await device0.createRenderPipelineAsync(
+{
+label: '\u090f\u01b9\u7e1e\u{1f812}\u3f09\uc683\ud49f',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 6312,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 4102,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 57984,
+shaderLocation: 13,
+},
+{
+format: 'uint8x4',
+offset: 2984,
+shaderLocation: 7,
+},
+{
+format: 'sint32x4',
+offset: 30252,
+shaderLocation: 8,
+},
+{
+format: 'snorm16x4',
+offset: 48116,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x2',
+offset: 32362,
+shaderLocation: 0,
+},
+{
+format: 'sint16x2',
+offset: 57820,
+shaderLocation: 20,
+},
+{
+format: 'float32x4',
+offset: 35060,
+shaderLocation: 23,
+},
+{
+format: 'sint32x2',
+offset: 2716,
+shaderLocation: 11,
+},
+{
+format: 'sint8x4',
+offset: 41508,
+shaderLocation: 1,
+},
+{
+format: 'uint32x3',
+offset: 32564,
+shaderLocation: 2,
+},
+{
+format: 'sint8x2',
+offset: 4796,
+shaderLocation: 12,
+},
+{
+format: 'uint32x4',
+offset: 11724,
+shaderLocation: 14,
+},
+{
+format: 'sint32',
+offset: 36756,
+shaderLocation: 17,
+},
+{
+format: 'sint8x2',
+offset: 10226,
+shaderLocation: 10,
+},
+{
+format: 'uint32',
+offset: 44004,
+shaderLocation: 19,
+},
+{
+format: 'unorm16x2',
+offset: 21396,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'sint8x2',
+offset: 19730,
+shaderLocation: 22,
+},
+{
+format: 'uint8x4',
+offset: 49508,
+shaderLocation: 5,
+},
+{
+format: 'float32x2',
+offset: 41252,
+shaderLocation: 3,
+},
+{
+format: 'uint16x2',
+offset: 56344,
+shaderLocation: 6,
+},
+{
+format: 'float32',
+offset: 15880,
+shaderLocation: 9,
+},
+{
+format: 'sint16x4',
+offset: 40472,
+shaderLocation: 21,
+},
+{
+format: 'snorm8x2',
+offset: 33754,
+shaderLocation: 24,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 22844,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 14880,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule3,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+passOp: 'replace',
+},
+stencilReadMask: 2422,
+stencilWriteMask: 3009,
+depthBiasSlopeScale: 80,
+depthBiasClamp: 28,
+},
+}
+);
+gc();
+document.body.append('\ue406\u05a6\u{1feb7}\u436b\u{1fe81}\u0389\u8403\u6dc4\u0372');
+document.body.prepend('\u51d3\ud91e\u0fab\u5953\u9e16\u0347\ue870\u0546\u{1fe7a}\u0819');
+try {
+computePassEncoder17.setBindGroup(
+1,
+bindGroup0,
+new Uint32Array(117),
+18,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant(
+{
+r: 122.3,
+g: -773.6,
+b: -239.6,
+a: -768.6,
+}
+);
+} catch {}
+try {
+renderPassEncoder8.setViewport(
+0.4742,
+0.8402,
+4.356,
+0.04258,
+0.8629,
+0.9645
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(
+16,
+72,
+32
+);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(
+2,
+buffer12,
+13916,
+6170
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture59,
+  mipLevel: 0,
+  origin: { x: 106, y: 1, z: 3 },
+  aspect: 'all',
+},
+new ArrayBuffer(8),
+/* required buffer size: 323710 */{
+offset: 852,
+bytesPerRow: 129,
+rowsPerImage: 343,
+},
+{width: 25, height: 102, depthOrArrayLayers: 8}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 38, height: 54, depthOrArrayLayers: 22}
+*/
+{
+  source: imageBitmap6,
+  origin: { x: 2, y: 14 },
+  flipY: true,
+},
+{
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 24, y: 17, z: 19 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 9, height: 2, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline53 = await device0.createRenderPipelineAsync(
+{
+label: '\u33ea\u{1f73b}\u503b',
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule6,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 34836,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 31432,
+shaderLocation: 10,
+},
+{
+format: 'snorm8x2',
+offset: 9856,
+shaderLocation: 9,
+},
+{
+format: 'uint32x2',
+offset: 8368,
+shaderLocation: 19,
+},
+{
+format: 'unorm8x2',
+offset: 27144,
+shaderLocation: 8,
+},
+{
+format: 'sint32',
+offset: 9792,
+shaderLocation: 0,
+},
+{
+format: 'unorm8x4',
+offset: 25240,
+shaderLocation: 14,
+},
+{
+format: 'sint8x4',
+offset: 19368,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 52752,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 29960,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 1808,
+shaderLocation: 1,
+},
+{
+format: 'sint32x3',
+offset: 9520,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x2',
+offset: 17012,
+shaderLocation: 24,
+},
+{
+format: 'uint32',
+offset: 23532,
+shaderLocation: 5,
+},
+{
+format: 'unorm16x4',
+offset: 27752,
+shaderLocation: 22,
+},
+{
+format: 'float32',
+offset: 8444,
+shaderLocation: 18,
+},
+{
+format: 'sint32x3',
+offset: 26268,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x4',
+offset: 7400,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 32888,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 24140,
+shaderLocation: 20,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x4cf71bba,
+},
+depthStencil: {
+format: 'stencil8',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'invert',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'invert',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 2572,
+depthBiasSlopeScale: 30,
+depthBiasClamp: 57,
+},
+}
+);
+let img13 = await imageWithData(141, 122, '#f8d0fddf', '#43995ecd');
+let texture60 = device0.createTexture(
+{
+label: '\u072a\u0d3c\uca12\ud4b0\u{1f766}\u{1fe85}\u6d99\u{1fd34}\u9359',
+size: [6160],
+sampleCount: 1,
+dimension: '1d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8uint',
+'rgba8uint',
+'rgba8uint'
+],
+}
+);
+let sampler41 = device0.createSampler(
+{
+label: '\u623e\u{1f8ea}\u781e\u1585\u053f\ufdfc',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 99.407,
+}
+);
+try {
+computePassEncoder13.setBindGroup(
+0,
+bindGroup2,
+new Uint32Array(9934),
+8797,
+0
+);
+} catch {}
+try {
+renderPassEncoder8.setViewport(
+4.837,
+0.5137,
+6.928,
+0.1699,
+0.9237,
+0.9645
+);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(
+buffer6,
+'uint32',
+15528,
+5315
+);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+0,
+buffer6,
+16168
+);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(
+2,
+bindGroup5
+);
+} catch {}
+try {
+renderPassEncoder10.insertDebugMarker(
+'\u{1fd13}'
+);
+} catch {}
+let pipeline54 = await promise19;
+document.body.prepend('\u{1fe58}\u04b1\ud39d\u{1fa0c}\u0ce3\u528d\u26bc\u9216\u943c\u0f2b\udb16');
+let bindGroupLayout20 = device0.createBindGroupLayout(
+{
+label: '\u0a68\u09a9\u0e98\u{1f831}\ude4b\u065c\u0661\u0465\u0c71\u1990',
+entries: [
+{
+binding: 1926,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+},
+{
+binding: 5244,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'filtering' },
+},
+{
+binding: 5335,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+let textureView53 = texture10.createView(
+{
+aspect: 'all',
+baseMipLevel: 7,
+baseArrayLayer: 0,
+}
+);
+let renderBundleEncoder39 = device0.createRenderBundleEncoder(
+{
+label: '\ud715\u{1fd50}\ubdcf\u6e96',
+colorFormats: [
+undefined,
+undefined,
+'rg16uint',
+'bgra8unorm-srgb',
+'bgra8unorm-srgb',
+'rg8uint',
+'rgba8sint',
+'rg32uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 705,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder4.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant(
+{
+r: 526.1,
+g: -952.2,
+b: 938.5,
+a: -600.1,
+}
+);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(
+2,
+bindGroup3
+);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(
+7,
+bindGroup3,
+new Uint32Array(7713),
+2572,
+0
+);
+} catch {}
+try {
+texture39.destroy();
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let bindGroupLayout21 = device0.createBindGroupLayout(
+{
+entries: [
+{
+binding: 6931,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '3d' },
+}
+],
+}
+);
+let textureView54 = texture24.createView(
+{
+label: '\u16e3\u7558\u2c17\ubd48',
+}
+);
+try {
+renderPassEncoder8.setBindGroup(
+8,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(
+2,
+bindGroup0,
+new Uint32Array(2689),
+1275,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(
+3998
+);
+} catch {}
+try {
+renderPassEncoder12.draw(
+56,
+32,
+24,
+40
+);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(
+7,
+bindGroup4
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture31,
+  mipLevel: 0,
+  origin: { x: 3619, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 24 */{
+offset: 24,
+},
+{width: 4974, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline55 = device0.createComputePipeline(
+{
+layout: pipelineLayout9,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+await promise24;
+} catch {}
+let bindGroupLayout22 = device2.createBindGroupLayout(
+{
+entries: [
+{
+binding: 896,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 351,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '1d' },
+}
+],
+}
+);
+let commandEncoder43 = device2.createCommandEncoder();
+let texture61 = device2.createTexture(
+{
+label: '\u27f2\u45e1\u095e\u60e5\u05e2\u0900\u0d03\u0040\ud428',
+size: {width: 210, height: 1, depthOrArrayLayers: 1884},
+dimension: '3d',
+format: 'rgba8sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder40 = device2.createRenderBundleEncoder(
+{
+label: '\u4525\uecff\ueed0\u243e',
+colorFormats: [
+'rgb10a2unorm'
+],
+sampleCount: 357,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder40.setVertexBuffer(
+48,
+undefined,
+1828285585,
+623566204
+);
+} catch {}
+let renderBundleEncoder41 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'bgra8unorm',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 449,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder16.setPipeline(
+pipeline45
+);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let bindGroupLayout23 = device0.createBindGroupLayout(
+{
+entries: [
+{
+binding: 6904,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}
+],
+}
+);
+let querySet32 = device0.createQuerySet(
+{
+label: '\u{1fc75}\u9820',
+type: 'occlusion',
+count: 2922,
+}
+);
+let renderBundleEncoder42 = device0.createRenderBundleEncoder(
+{
+label: '\u248b\u44a0\u{1f848}',
+colorFormats: [
+'bgra8unorm-srgb',
+'rg16uint',
+'r32sint',
+'r16uint',
+'rg8uint'
+],
+sampleCount: 120,
+depthReadOnly: true,
+}
+);
+let sampler42 = device0.createSampler(
+{
+label: '\u6f59\u832c',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 29.799,
+maxAnisotropy: 16,
+}
+);
+try {
+computePassEncoder8.setPipeline(
+pipeline45
+);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(
+64
+);
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(
+buffer1,
+'uint16',
+6680,
+11960
+);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(
+0,
+bindGroup3,
+new Uint32Array(231),
+6,
+0
+);
+} catch {}
+gc();
+document.body.append('\u{1f647}\u0c45\u0bc3\ud1f9\u0a89\udae7\u{1feb4}');
+let bindGroupLayout24 = device0.createBindGroupLayout(
+{
+entries: [
+{
+binding: 3710,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+}
+],
+}
+);
+let querySet33 = device0.createQuerySet(
+{
+label: '\u34ff\uaa54\u0ed0\u{1f7fe}\u5d52\u33f6\u02c5\u0881\u6c3a\u{1f76b}\u0d47',
+type: 'occlusion',
+count: 2968,
+}
+);
+try {
+renderPassEncoder10.beginOcclusionQuery(
+64
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer12,
+27856
+);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(
+6,
+buffer12,
+3300,
+3070
+);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(
+2,
+buffer12,
+18992,
+3692
+);
+} catch {}
+let pipeline56 = device0.createComputePipeline(
+{
+label: '\ua087\u0c32\u0a3b\u7aec\u{1f71c}\ued47\u{1f82d}\uc605\u{1fe53}\u14f5',
+layout: 'auto',
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+},
+}
+);
+let adapter6 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let bindGroupLayout25 = device2.createBindGroupLayout(
+{
+label: '\u{1fd13}\u08db\u{1f6d9}\u091b\ub74d\u64e0\u{1feb3}\u581a\u67d5',
+entries: [
+{
+binding: 677,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let querySet34 = device2.createQuerySet(
+{
+label: '\uadbb\u09d5\ue540',
+type: 'occlusion',
+count: 366,
+}
+);
+let renderBundle44 = renderBundleEncoder40.finish(
+{
+label: '\u5b2f\u9614\u428d\u043b\u{1fb0a}\u0361\uecb9\u9952'
+}
+);
+let offscreenCanvas12 = new OffscreenCanvas(724, 1015);
+let bindGroup6 = device0.createBindGroup({
+label: '\uc413\u{1fe9f}\uafe6\u0e62\u{1ffff}\u230c\u23af\ud8cf\u{1fcda}\u{1f8df}',
+layout: bindGroupLayout3,
+entries: [
+
+],
+});
+let commandEncoder44 = device0.createCommandEncoder(
+{
+}
+);
+let textureView55 = texture60.createView(
+{
+}
+);
+let renderPassEncoder15 = commandEncoder44.beginRenderPass(
+{
+label: '\u1e84\u{1f79a}\u0469\u{1f810}\u0a74',
+colorAttachments: [
+
+],
+depthStencilAttachment: {
+view: textureView12,
+stencilClearValue: 33762,
+stencilLoadOp: 'load',
+stencilStoreOp: 'discard',
+},
+occlusionQuerySet: querySet13,
+maxDrawCount: 79864,
+}
+);
+try {
+renderPassEncoder15.setBindGroup(
+5,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(
+8
+);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(
+buffer2,
+337280
+);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(
+3,
+buffer6
+);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+1,
+bindGroup5
+);
+} catch {}
+let pipeline57 = await promise20;
+let pipelineLayout12 = device2.createPipelineLayout(
+{
+label: '\u7fa2\u08fc\u06e0\u{1fab9}\uf68f\u3f3f\u0ed9\u{1f75e}\u0487\ud728\u0bb8',
+bindGroupLayouts: [
+
+],
+}
+);
+let gpuCanvasContext13 = offscreenCanvas12.getContext('webgpu');
+let bindGroup7 = device0.createBindGroup({
+layout: bindGroupLayout7,
+entries: [
+{
+binding: 5645,
+resource: {
+buffer: buffer12,
+offset: 21120,
+size: 1004,
+}
+},
+{
+binding: 8053,
+resource: externalTexture0
+}
+],
+});
+try {
+renderPassEncoder15.setBindGroup(
+6,
+bindGroup6
+);
+} catch {}
+try {
+renderPassEncoder12.beginOcclusionQuery(
+16
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let pipeline58 = await promise5;
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+document.body.prepend('\u{1fec8}\u{1fcb9}\u43d2\u9cb1\ua2ae\u{1fea4}\u05c7\ue2b4\uf2b8\u1174');
+let commandEncoder45 = device0.createCommandEncoder(
+{
+label: '\u5fd6\u127d\u0538\u0a69\u{1fb47}\u3064\ub206',
+}
+);
+try {
+renderPassEncoder10.beginOcclusionQuery(
+56
+);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+1157
+);
+} catch {}
+try {
+renderBundleEncoder39.setBindGroup(
+3,
+bindGroup4
+);
+} catch {}
+let imageData6 = new ImageData(72, 132);
+video2.height = 51;
+canvas5.height = 58;
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+try {
+await promise22;
+} catch {}
+let textureView56 = texture21.createView(
+{
+label: '\u0b70\u{1fc1d}\u4e71',
+aspect: 'depth-only',
+baseMipLevel: 2,
+mipLevelCount: 3,
+}
+);
+try {
+computePassEncoder27.setBindGroup(
+4,
+bindGroup1,
+new Uint32Array(2220),
+426,
+0
+);
+} catch {}
+try {
+computePassEncoder10.setPipeline(
+pipeline32
+);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(
+3,
+bindGroup5,
+new Uint32Array(5296),
+2204,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline53);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(
+15,
+undefined,
+720834436,
+2729396198
+);
+} catch {}
+try {
+commandEncoder45.copyBufferToBuffer(
+buffer0,
+1124,
+buffer3,
+5868,
+520
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+5696,
+new Float32Array(31549),
+4282,
+3032
+);
+} catch {}
+try {
+await promise14;
+} catch {}
+document.body.prepend('\u{1fe85}\u{1fd63}\u7f40\u{1f981}\u7c9b\u{1f6c9}\u{1fac2}\u26d1');
+try {
+window.someLabel = device2.label;
+} catch {}
+document.body.append('\u344a\u{1fe9c}\u59a4\u0979\u0e84\u{1f92e}\u0d8b');
+let buffer13 = device0.createBuffer(
+{
+label: '\uff91\u021f\u0e31\uef46',
+size: 54904,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let commandEncoder46 = device0.createCommandEncoder(
+{
+label: '\u0b8b\u040b',
+}
+);
+let textureView57 = texture5.createView(
+{
+label: '\u{1fed1}\u{1f8f8}',
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+let renderPassEncoder16 = commandEncoder46.beginRenderPass(
+{
+label: '\u{1fa20}\u0499\u8176\u1fdb\u0364\u09f6\u1435',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView51,
+depthReadOnly: true,
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet30,
+maxDrawCount: 93728,
+}
+);
+let renderBundle45 = renderBundleEncoder22.finish(
+{
+label: '\uafdb\u{1fd11}\ua84b\u{1f613}\uc861\u{1fd60}'
+}
+);
+let sampler43 = device0.createSampler(
+{
+label: '\u32ca\uf52c',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 15.557,
+lodMaxClamp: 39.244,
+compare: 'equal',
+}
+);
+try {
+renderPassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder8.setViewport(
+11.88,
+0.9180,
+0.01229,
+0.04367,
+0.1010,
+0.9442
+);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(
+32,
+16,
+72,
+656,
+80
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer1,
+38520
+);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(
+3,
+buffer6,
+2244,
+3655
+);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(
+1,
+bindGroup6,
+[]
+);
+} catch {}
+try {
+renderPassEncoder15.insertDebugMarker(
+'\u{1f7eb}'
+);
+} catch {}
+let promise32 = device0.createComputePipelineAsync(
+{
+label: '\ub8a5\u0e9e\u{1fc65}\u7fc5',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+document.body.prepend('\u4e21\u{1f684}\u{1ff6a}\u9f70');
+let pipelineLayout13 = device2.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout25,
+bindGroupLayout22,
+bindGroupLayout25,
+bindGroupLayout22
+],
+}
+);
+let querySet35 = device2.createQuerySet(
+{
+label: '\u67df\u07fc\u0863\u7f32\u{1fc14}\u01bf\u{1ff66}',
+type: 'occlusion',
+count: 3160,
+}
+);
+let texture62 = device2.createTexture(
+{
+label: '\u{1fece}\ue2f5\uf0f9\u8f67\u91da\u5b72\u35d0',
+size: [155, 140, 1],
+mipLevelCount: 8,
+format: 'astc-5x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-5x4-unorm-srgb',
+'astc-5x4-unorm-srgb',
+'astc-5x4-unorm'
+],
+}
+);
+let computePassEncoder28 = commandEncoder42.beginComputePass(
+{
+
+}
+);
+let shaderModule12 = device0.createShaderModule(
+{
+label: '\u05ce\u08aa\u720b',
+code: `@group(2) @binding(7520)
+var<storage, read_write> i1: array<u32>;
+
+@compute @workgroup_size(7, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: i32,
+@location(1) f1: u32,
+@location(2) f2: vec3<i32>,
+@location(7) f3: f32,
+@location(3) f4: vec4<f32>,
+@location(6) f5: vec2<f32>,
+@location(5) f6: f32
+}
+
+@fragment
+fn fragment0(@location(25) a0: vec2<f16>, @location(31) a1: vec2<f32>, @location(16) a2: vec2<u32>, @location(11) a3: vec4<u32>, @location(3) a4: vec2<f16>, @location(12) a5: vec2<f32>, @location(6) a6: vec3<u32>, @location(23) a7: vec4<f16>, @location(21) a8: vec2<u32>, @location(33) a9: vec3<u32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@builtin(position) f164: vec4<f32>,
+@location(3) f165: vec2<f16>,
+@location(6) f166: vec3<u32>,
+@location(11) f167: vec4<u32>,
+@location(25) f168: vec2<f16>,
+@location(29) f169: vec2<f16>,
+@location(33) f170: vec3<u32>,
+@location(16) f171: vec2<u32>,
+@location(26) f172: vec4<i32>,
+@location(21) f173: vec2<u32>,
+@location(31) f174: vec2<f32>,
+@location(23) f175: vec4<f16>,
+@location(12) f176: vec2<f32>
+}
+
+@vertex
+fn vertex0(@location(24) a0: vec4<f32>, @location(10) a1: vec2<f16>, @location(3) a2: vec2<f32>, @location(7) a3: f16, @location(13) a4: f16, @builtin(vertex_index) a5: u32, @location(18) a6: vec3<i32>, @location(16) a7: vec4<u32>, @location(6) a8: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let computePassEncoder29 = commandEncoder45.beginComputePass(
+{
+
+}
+);
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(
+12,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+10.07,
+0.5153,
+1.017,
+0.4816,
+0.8353,
+0.9143
+);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(
+45,
+undefined
+);
+} catch {}
+try {
+device0.pushErrorScope(
+'internal'
+);
+} catch {}
+let pipelineLayout14 = device2.createPipelineLayout(
+{
+label: '\u0aae\u{1fb8c}\u85ac\ue13f\u01a7\ua070',
+bindGroupLayouts: [
+bindGroupLayout22
+],
+}
+);
+let querySet36 = device2.createQuerySet(
+{
+label: '\u818f\u{1ff8d}\u070c\u9d86\ua048\u{1ff69}',
+type: 'occlusion',
+count: 2005,
+}
+);
+let texture63 = device2.createTexture(
+{
+size: {width: 170, height: 50, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+dimension: '2d',
+format: 'astc-10x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-10x5-unorm-srgb',
+'astc-10x5-unorm'
+],
+}
+);
+let renderBundleEncoder43 = device2.createRenderBundleEncoder(
+{
+label: '\uc7b3\u0f36\u0976\u0e2f\u917e\u15cc\u9a05\u105b',
+colorFormats: [
+'rgba32sint',
+'rg8unorm',
+'r32float',
+'rg8unorm',
+'rg16float'
+],
+sampleCount: 476,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder43.setVertexBuffer(
+33,
+undefined,
+2758192364,
+896260021
+);
+} catch {}
+try {
+device0.label = '\u8fe4\uf069\u0c07\u9e0a\u0771\ua5c3\uf29b\u09bf';
+} catch {}
+let commandEncoder47 = device0.createCommandEncoder(
+{
+label: '\u42b3\u{1f8fb}\u0743\uf7c5\u870d\u{1fd04}\u{1fa54}\u5cb3',
+}
+);
+let renderPassEncoder17 = commandEncoder47.beginRenderPass(
+{
+label: '\u{1fb66}\u39d8\u6542\u03e8\u268f\u{1fa22}\u2099',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView51,
+depthClearValue: 0.2580429625879488,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+depthReadOnly: false,
+},
+maxDrawCount: 311056,
+}
+);
+let renderBundle46 = renderBundleEncoder21.finish(
+{
+
+}
+);
+try {
+computePassEncoder17.setBindGroup(
+1,
+bindGroup3
+);
+} catch {}
+try {
+computePassEncoder18.setBindGroup(
+6,
+bindGroup7,
+new Uint32Array(8258),
+3899,
+1
+);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(
+8,
+bindGroup6
+);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(
+7,
+bindGroup0,
+new Uint32Array(4921),
+4678,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.beginOcclusionQuery(
+32
+);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+82,
+undefined,
+3547315814,
+105364962
+);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let adapter7 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let videoFrame7 = new VideoFrame(offscreenCanvas11, {timestamp: 0});
+document.body.prepend('\u148e\u760f\ub991\u0fb9\u74c8\ue484\u04f1\ub3d6\u{1f76a}\uc209');
+document.body.append('\u1e81\u02fa\ubeee\u{1fed4}\u7be3\u0f89\u{1fda8}');
+let buffer14 = device2.createBuffer(
+{
+label: '\u0cb3\ueac2\u{1fa5d}',
+size: 45877,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let querySet37 = device2.createQuerySet(
+{
+label: '\u{1ffc4}\u2866\u41d6\u{1fc73}\u{1fb43}',
+type: 'occlusion',
+count: 1759,
+}
+);
+let texture64 = device2.createTexture(
+{
+label: '\u0656\u{1fb59}\u{1fca2}\u02a6\ua8d7\u499e\u5211\u04a9\ue25b',
+size: [2752, 6, 193],
+mipLevelCount: 9,
+format: 'astc-8x6-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-8x6-unorm-srgb',
+'astc-8x6-unorm-srgb'
+],
+}
+);
+let renderBundleEncoder44 = device2.createRenderBundleEncoder(
+{
+label: '\uc676\u376f\u{1fbb5}\u0340\u0da3\u{1ff49}',
+colorFormats: [
+'rg8uint',
+'rgba8unorm-srgb',
+'rgba32uint'
+],
+sampleCount: 934,
+depthReadOnly: true,
+}
+);
+try {
+commandEncoder43.copyBufferToTexture(
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 43936 */
+offset: 43936,
+buffer: buffer14,
+},
+{
+  texture: texture62,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device2, buffer14);
+} catch {}
+let video12 = await videoWithData();
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let commandEncoder48 = device0.createCommandEncoder(
+{
+label: '\uc13a\u0f65\u26a0\ub4d4',
+}
+);
+let sampler44 = device0.createSampler(
+{
+label: '\u{1fec7}\u{1f7c4}\u9bd5\u0055\u2e8e\u0730\u1add\u0702\u{1fa6d}',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 7.924,
+lodMaxClamp: 63.890,
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder12.setScissorRect(
+12,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder15.draw(
+40
+);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(
+buffer1,
+'uint32'
+);
+} catch {}
+let arrayBuffer5 = buffer5.getMappedRange(
+1512,
+112
+);
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 152, height: 216, depthOrArrayLayers: 22}
+*/
+{
+  source: video12,
+  origin: { x: 4, y: 11 },
+  flipY: true,
+},
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 125, y: 92, z: 19 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 0, height: 2, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipelineLayout15 = device2.createPipelineLayout(
+{
+label: '\u63f2\u6a7a\u1771\ub7fb\ufebe\ud01d\u{1fdf9}\u19df\u0e62\u0123',
+bindGroupLayouts: [
+bindGroupLayout25
+],
+}
+);
+let textureView58 = texture62.createView(
+{
+label: '\u410a\uf0cb\u042a',
+dimension: '2d-array',
+baseMipLevel: 1,
+mipLevelCount: 4,
+}
+);
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+let texture65 = device2.createTexture(
+{
+label: '\u0509\uca4f\u0dfe\u{1f763}\u9a34',
+size: [7570, 10, 110],
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-10x10-unorm-srgb',
+'astc-10x10-unorm-srgb'
+],
+}
+);
+let computePassEncoder30 = commandEncoder43.beginComputePass(
+{
+label: '\u94bf\ufdc4'
+}
+);
+let sampler45 = device2.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 50.615,
+maxAnisotropy: 19,
+}
+);
+try {
+device2.pushErrorScope(
+'internal'
+);
+} catch {}
+let texture66 = device2.createTexture(
+{
+label: '\u0668\u89a8\ubc3f\ub7d9\u059f\u{1fb78}',
+size: {width: 3532},
+dimension: '1d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgba8snorm'
+],
+}
+);
+let renderBundleEncoder45 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg16sint',
+undefined,
+'r32sint',
+'rg32uint',
+'r16uint',
+'r16uint',
+'bgra8unorm',
+'rg8uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 40,
+}
+);
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+document.body.append('\ua971\u058d\u0d91\u0e0d\u0f13\ua5a2\u49af');
+let img14 = await imageWithData(48, 6, '#43cc8f4d', '#1f286901');
+try {
+adapter2.label = '\u{1fd5a}\u042d\u85e3\u{1fe09}\uacd5\u08e1\u0c09\u0100\uc5fe';
+} catch {}
+let offscreenCanvas13 = new OffscreenCanvas(870, 523);
+let videoFrame8 = new VideoFrame(img11, {timestamp: 0});
+try {
+await adapter2.requestAdapterInfo();
+} catch {}
+let texture67 = device2.createTexture(
+{
+size: [7564, 108, 173],
+mipLevelCount: 8,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'etc2-rgb8unorm',
+'etc2-rgb8unorm-srgb',
+'etc2-rgb8unorm-srgb'
+],
+}
+);
+try {
+device2.queue.writeTexture(
+{
+  texture: texture64,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 57 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer1),
+/* required buffer size: 636 */{
+offset: 476,
+},
+{width: 80, height: 6, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let sampler46 = device2.createSampler(
+{
+label: '\u{1f81e}\ud8b0\u09df\u0249\u{1ff5d}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+lodMaxClamp: 99.552,
+maxAnisotropy: 1,
+}
+);
+let canvas10 = document.createElement('canvas');
+let renderPassEncoder18 = commandEncoder48.beginRenderPass(
+{
+label: '\u114f\u21cd',
+colorAttachments: [
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView51,
+depthLoadOp: 'load',
+depthStoreOp: 'discard',
+depthReadOnly: false,
+stencilClearValue: 1106,
+},
+occlusionQuerySet: querySet25,
+}
+);
+try {
+computePassEncoder21.setBindGroup(
+5,
+bindGroup2,
+new Uint32Array(9895),
+1255,
+0
+);
+} catch {}
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder15.setStencilReference(
+1757
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(
+48,
+64,
+8,
+296,
+24
+);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(
+buffer1,
+'uint32',
+1104,
+23597
+);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+6,
+bindGroup3,
+new Uint32Array(3189),
+874,
+0
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer12,
+6816,
+new BigUint64Array(25870),
+25244,
+560
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture57,
+  mipLevel: 0,
+  origin: { x: 3, y: 2, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(72),
+/* required buffer size: 64457 */{
+offset: 889,
+bytesPerRow: 232,
+rowsPerImage: 137,
+},
+{width: 0, height: 0, depthOrArrayLayers: 3}
+);
+} catch {}
+let pipeline59 = device0.createComputePipeline(
+{
+label: '\ue4b3\u{1fc07}\u{1f753}\u4511\u09bc\u1a00\u022d\u{1fcb2}\ufb85\u0a50',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline60 = device0.createRenderPipeline(
+{
+label: '\u9bb8\uda7b\u6a7a\ud627\u0147\u{1f9a9}\u496a\ue299\ubafa\u{1fde8}',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 48408,
+attributes: [
+
+],
+},
+{
+arrayStride: 26896,
+attributes: [
+{
+format: 'unorm8x2',
+offset: 12574,
+shaderLocation: 0,
+},
+{
+format: 'unorm16x4',
+offset: 22488,
+shaderLocation: 9,
+},
+{
+format: 'snorm8x2',
+offset: 1804,
+shaderLocation: 3,
+},
+{
+format: 'sint32',
+offset: 1224,
+shaderLocation: 1,
+},
+{
+format: 'uint8x4',
+offset: 1384,
+shaderLocation: 7,
+},
+{
+format: 'float32x3',
+offset: 23700,
+shaderLocation: 4,
+},
+{
+format: 'uint8x2',
+offset: 3832,
+shaderLocation: 5,
+},
+{
+format: 'uint32x4',
+offset: 188,
+shaderLocation: 19,
+},
+{
+format: 'sint32x2',
+offset: 15272,
+shaderLocation: 17,
+},
+{
+format: 'sint8x4',
+offset: 9488,
+shaderLocation: 8,
+},
+{
+format: 'float32x3',
+offset: 25496,
+shaderLocation: 13,
+},
+{
+format: 'unorm16x2',
+offset: 19572,
+shaderLocation: 18,
+},
+{
+format: 'sint32',
+offset: 11972,
+shaderLocation: 12,
+},
+{
+format: 'sint32',
+offset: 2080,
+shaderLocation: 21,
+},
+{
+format: 'float32x4',
+offset: 24272,
+shaderLocation: 24,
+},
+{
+format: 'uint16x4',
+offset: 14876,
+shaderLocation: 14,
+},
+{
+format: 'sint8x4',
+offset: 25796,
+shaderLocation: 10,
+},
+{
+format: 'sint16x2',
+offset: 21068,
+shaderLocation: 11,
+},
+{
+format: 'snorm8x4',
+offset: 9104,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 34728,
+attributes: [
+{
+format: 'uint8x4',
+offset: 20640,
+shaderLocation: 6,
+},
+{
+format: 'float32x2',
+offset: 28352,
+shaderLocation: 16,
+},
+{
+format: 'snorm8x2',
+offset: 1592,
+shaderLocation: 23,
+},
+{
+format: 'sint32x2',
+offset: 18528,
+shaderLocation: 22,
+},
+{
+format: 'sint8x4',
+offset: 18868,
+shaderLocation: 20,
+}
+],
+},
+{
+arrayStride: 1472,
+attributes: [
+{
+format: 'uint32x3',
+offset: 996,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+multisample: {
+},
+fragment: {
+module: shaderModule3,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+{
+format: 'rgba32float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 7,
+stencilWriteMask: 1029,
+depthBias: 91,
+depthBiasSlopeScale: 0,
+depthBiasClamp: 13,
+},
+}
+);
+document.body.prepend('\ud13a\ud190\u0226');
+let textureView59 = texture63.createView(
+{
+label: '\u0ed7\u06ed\u00be\u4796\u0fa6\u1bd3\u042d',
+dimension: '2d-array',
+baseMipLevel: 4,
+mipLevelCount: 2,
+}
+);
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let texture68 = device2.createTexture(
+{
+label: '\u0ee1\u0f33\u465d\u2629\uf442\u5a22\u{1fe92}\ua64a\u0268',
+size: {width: 7080, height: 105, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-8x5-unorm',
+'astc-8x5-unorm-srgb',
+'astc-8x5-unorm'
+],
+}
+);
+let renderBundle47 = renderBundleEncoder43.finish(
+{
+label: '\u0efb\u7361\ua497\ue2b4\uf7c4\u7a8d\u00c1\uab61'
+}
+);
+let canvas11 = document.createElement('canvas');
+let shaderModule13 = device0.createShaderModule(
+{
+label: '\ud417\u7d00\u0ac6\u{1f959}\ua2a4\u{1f642}\u4783\u7d09\udd63\ue6c9',
+code: `@group(2) @binding(8053)
+var<storage, read_write> field0: array<u32>;
+@group(5) @binding(8053)
+var<storage, read_write> global0: array<u32>;
+@group(0) @binding(8053)
+var<storage, read_write> function1: array<u32>;
+
+@compute @workgroup_size(7, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(1) f0: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(front_facing) a1: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S12 {
+@location(9) f0: vec3<i32>,
+@location(24) f1: f16,
+@location(12) f2: vec4<f16>,
+@location(8) f3: vec3<u32>,
+@location(23) f4: i32,
+@location(14) f5: vec2<i32>,
+@location(0) f6: vec4<i32>,
+@location(13) f7: vec3<f32>,
+@location(18) f8: vec4<i32>,
+@location(11) f9: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(22) a0: vec3<f16>, @location(5) a1: vec3<f16>, @builtin(instance_index) a2: u32, @location(19) a3: vec2<f16>, @location(1) a4: vec3<f16>, @location(20) a5: vec3<i32>, @location(15) a6: vec2<u32>, @location(6) a7: i32, a8: S12, @location(4) a9: vec2<f32>, @location(10) a10: vec2<i32>, @location(16) a11: vec4<u32>, @location(3) a12: vec2<f32>, @location(2) a13: vec3<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+}
+);
+let commandEncoder49 = device0.createCommandEncoder();
+let querySet38 = device0.createQuerySet(
+{
+label: '\uf7b3\ud43c\u{1fb9a}\u4047\u0bfd\u0e14\u{1fcc2}\u{1f7e1}\u5549',
+type: 'occlusion',
+count: 256,
+}
+);
+let texture69 = device0.createTexture(
+{
+label: '\uc62c\uaf31\u0dc0\u70ea\u{1f831}\u{1ff99}',
+size: {width: 55, height: 200, depthOrArrayLayers: 116},
+mipLevelCount: 6,
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let textureView60 = texture39.createView(
+{
+label: '\u{1fa69}\u03d8',
+aspect: 'all',
+format: 'r16float',
+baseMipLevel: 2,
+}
+);
+let renderBundleEncoder46 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg16float',
+'rgba16uint',
+'bgra8unorm',
+'r16uint',
+undefined,
+'rg32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 943,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(
+1990
+);
+} catch {}
+try {
+renderPassEncoder18.setViewport(
+18.83,
+143.2,
+15.10,
+47.19,
+0.3479,
+0.4195
+);
+} catch {}
+try {
+renderPassEncoder12.draw(
+48,
+72,
+48,
+40
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer11,
+103008
+);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(
+buffer1,
+'uint16'
+);
+} catch {}
+try {
+await buffer13.mapAsync(
+GPUMapMode.WRITE,
+18000
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+22584,
+new Float32Array(20500),
+4617,
+560
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture45,
+  mipLevel: 1,
+  origin: { x: 40, y: 1, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(8),
+/* required buffer size: 316202 */{
+offset: 104,
+bytesPerRow: 1033,
+rowsPerImage: 34,
+},
+{width: 213, height: 0, depthOrArrayLayers: 10}
+);
+} catch {}
+let renderPassEncoder19 = commandEncoder49.beginRenderPass(
+{
+label: '\u0f0e\u1725\ue3f5\u0b76\u8e91\u{1f737}\u{1ffe4}\uaff2\u0c66\u0d9b\u49cd',
+colorAttachments: [
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView12,
+depthClearValue: -4.3908371765133,
+depthReadOnly: true,
+stencilClearValue: 21514,
+stencilLoadOp: 'load',
+stencilStoreOp: 'store',
+},
+occlusionQuerySet: querySet17,
+maxDrawCount: 252312,
+}
+);
+try {
+renderPassEncoder12.draw(
+80,
+8,
+56,
+80
+);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(
+buffer1,
+'uint16'
+);
+} catch {}
+try {
+device0.pushErrorScope(
+'internal'
+);
+} catch {}
+let img15 = await imageWithData(57, 104, '#873bc5c7', '#db3f3d8c');
+let buffer15 = device2.createBuffer(
+{
+label: '\u{1ff99}\u{1fffb}\u96d9\ua66f\ud866\u6834\uddcd\u283f',
+size: 16102,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+try {
+device2.queue.writeTexture(
+{
+  texture: texture66,
+  mipLevel: 0,
+  origin: { x: 2820, y: 1, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 590 */{
+offset: 590,
+bytesPerRow: 774,
+rowsPerImage: 231,
+},
+{width: 157, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let img16 = await imageWithData(121, 65, '#aa276fdb', '#2479bc46');
+let shaderModule14 = device0.createShaderModule(
+{
+label: '\u3ef1\ua872\u004b\u2087',
+code: `@group(1) @binding(8053)
+var<storage, read_write> function2: array<u32>;
+@group(0) @binding(482)
+var<storage, read_write> field1: array<u32>;
+
+@compute @workgroup_size(5, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@location(11) a0: vec3<f32>, @location(38) a1: vec3<u32>) {
+
+}
+
+struct S13 {
+@location(22) f0: vec3<i32>,
+@location(19) f1: i32,
+@location(9) f2: vec2<u32>,
+@location(13) f3: vec4<f32>,
+@builtin(instance_index) f4: u32,
+@location(3) f5: vec3<f32>,
+@location(6) f6: u32,
+@location(24) f7: vec2<f16>,
+@location(16) f8: vec4<u32>,
+@builtin(vertex_index) f9: u32,
+@location(7) f10: i32,
+@location(15) f11: f32,
+@location(2) f12: vec3<f16>,
+@location(18) f13: f16,
+@location(12) f14: vec4<f16>
+}
+struct VertexOutput0 {
+@location(12) f177: vec2<f16>,
+@location(9) f178: u32,
+@location(11) f179: vec3<f32>,
+@builtin(position) f180: vec4<f32>,
+@location(38) f181: vec3<u32>,
+@location(1) f182: vec3<f16>
+}
+
+@vertex
+fn vertex0(a0: S13, @location(17) a1: vec4<f32>, @location(21) a2: vec2<f16>, @location(23) a3: vec4<u32>, @location(8) a4: f16, @location(14) a5: vec3<f32>, @location(4) a6: vec4<f32>, @location(20) a7: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+}
+);
+let querySet39 = device0.createQuerySet(
+{
+label: '\u09d8\uc379',
+type: 'occlusion',
+count: 1964,
+}
+);
+let texture70 = device0.createTexture(
+{
+label: '\ub84f\u0b9f\u0bf9\uce4b\u0543\ue044\u8a4f\u0499\u{1fc0e}\ub69e\u6685',
+size: {width: 84, height: 84, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+sampleCount: 1,
+dimension: '2d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8uint'
+],
+}
+);
+let renderBundleEncoder47 = device0.createRenderBundleEncoder(
+{
+label: '\uacc4\u003f\u0c04\ub8c7\u0fd3\u0d58\u9128\u01ee\uab8b\u3b33',
+colorFormats: [
+'rg16float',
+'rg32uint',
+'rgba8unorm',
+'bgra8unorm',
+'rgba8unorm',
+undefined,
+'rg32sint'
+],
+sampleCount: 984,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder4.setBlendConstant(
+{
+r: 620.2,
+g: -515.3,
+b: 966.1,
+a: -414.7,
+}
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer5,
+40568
+);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(
+7,
+buffer6
+);
+} catch {}
+let pipeline61 = device0.createRenderPipeline(
+{
+label: '\u0e58\ua478\ub517\u62ce\u09b3\ubbe4\u836f',
+layout: pipelineLayout6,
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 43500,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32',
+offset: 32848,
+shaderLocation: 17,
+},
+{
+format: 'unorm16x2',
+offset: 8924,
+shaderLocation: 4,
+},
+{
+format: 'float32',
+offset: 10620,
+shaderLocation: 24,
+},
+{
+format: 'sint32x3',
+offset: 2592,
+shaderLocation: 22,
+},
+{
+format: 'float16x4',
+offset: 40248,
+shaderLocation: 13,
+},
+{
+format: 'sint8x4',
+offset: 28552,
+shaderLocation: 8,
+},
+{
+format: 'snorm16x2',
+offset: 34676,
+shaderLocation: 0,
+},
+{
+format: 'sint32',
+offset: 25936,
+shaderLocation: 21,
+},
+{
+format: 'sint32',
+offset: 14696,
+shaderLocation: 11,
+},
+{
+format: 'uint16x4',
+offset: 14112,
+shaderLocation: 7,
+},
+{
+format: 'sint8x4',
+offset: 11920,
+shaderLocation: 1,
+},
+{
+format: 'uint32',
+offset: 14692,
+shaderLocation: 14,
+},
+{
+format: 'sint8x4',
+offset: 13316,
+shaderLocation: 10,
+},
+{
+format: 'float32x4',
+offset: 19844,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x4',
+offset: 13940,
+shaderLocation: 9,
+},
+{
+format: 'sint32x4',
+offset: 36764,
+shaderLocation: 20,
+},
+{
+format: 'snorm16x4',
+offset: 16516,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x2',
+offset: 25662,
+shaderLocation: 3,
+},
+{
+format: 'uint32x4',
+offset: 18252,
+shaderLocation: 6,
+},
+{
+format: 'sint32',
+offset: 13536,
+shaderLocation: 12,
+},
+{
+format: 'uint32x4',
+offset: 41520,
+shaderLocation: 5,
+},
+{
+format: 'uint16x2',
+offset: 3416,
+shaderLocation: 19,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 14944,
+shaderLocation: 15,
+},
+{
+format: 'uint32x4',
+offset: 21624,
+shaderLocation: 2,
+},
+{
+format: 'float32x2',
+offset: 7472,
+shaderLocation: 23,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule3,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'keep',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'replace',
+depthFailOp: 'zero',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 118,
+stencilWriteMask: 1797,
+depthBiasSlopeScale: 86,
+depthBiasClamp: 18,
+},
+}
+);
+let gpuCanvasContext14 = offscreenCanvas13.getContext('webgpu');
+document.body.prepend(video9);
+let textureView61 = texture34.createView(
+{
+label: '\uaf4f\u0b9a\u347c\u5fd1\u{1f9a9}\u09d1\u{1f640}\u0f55',
+baseMipLevel: 4,
+mipLevelCount: 1,
+}
+);
+try {
+computePassEncoder27.setPipeline(
+pipeline15
+);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(
+0,
+bindGroup0,
+[]
+);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant(
+{
+r: -841.5,
+g: 751.1,
+b: 257.6,
+a: 556.6,
+}
+);
+} catch {}
+try {
+renderPassEncoder17.setScissorRect(
+24,
+186,
+0,
+12
+);
+} catch {}
+try {
+renderPassEncoder10.draw(
+56
+);
+} catch {}
+try {
+renderBundleEncoder38.setIndexBuffer(
+buffer6,
+'uint16',
+11136,
+6719
+);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(
+2,
+buffer6
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+1260,
+new DataView(new ArrayBuffer(51876)),
+28508
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 19, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 206, y: 807 },
+  flipY: true,
+},
+{
+  texture: texture2,
+  mipLevel: 8,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 2, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline62 = device0.createComputePipeline(
+{
+label: '\u03f2\u017a\u{1f76f}\u7b5c\u084d\u7c67\u{1f9e0}\u9ae8',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageBitmap9 = await createImageBitmap(offscreenCanvas3);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+document.body.prepend('\u16d6\uebfa\u5aa7\ufade\u6d8b\u0275\u9726\u075c\u5cd7');
+let imageBitmap10 = await createImageBitmap(offscreenCanvas4);
+let querySet40 = device2.createQuerySet(
+{
+type: 'occlusion',
+count: 3859,
+}
+);
+let texture71 = device2.createTexture(
+{
+size: [124, 228, 26],
+mipLevelCount: 3,
+format: 'rgba8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgba8sint'
+],
+}
+);
+let bindGroupLayout26 = device0.createBindGroupLayout(
+{
+entries: [
+{
+binding: 1646,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+},
+{
+binding: 1533,
+visibility: 0,
+sampler: { type: 'comparison' },
+},
+{
+binding: 1977,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '3d' },
+}
+],
+}
+);
+let commandEncoder50 = device0.createCommandEncoder(
+{
+label: '\u9b9e\uf3c2\u{1fc98}\u3cba\ub15f\ue60a\udf20',
+}
+);
+pseudoSubmit(device0, commandEncoder37);
+let texture72 = device0.createTexture(
+{
+label: '\u0a14\u9e0e\u{1f719}\u0627\u{1f715}\u1fb2\ud1d3\uca6a\ueecf\u80fd',
+size: {width: 9524},
+dimension: '1d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let renderPassEncoder20 = commandEncoder50.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView51,
+depthClearValue: -9.316798241654986,
+depthReadOnly: true,
+stencilClearValue: 35008,
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet17,
+maxDrawCount: 283264,
+}
+);
+let renderBundle48 = renderBundleEncoder3.finish(
+{
+label: '\ubec1\ucacb\u{1fb37}\u{1fc64}\u9e2c\u0245\u0608'
+}
+);
+try {
+renderPassEncoder18.setBindGroup(
+1,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant(
+{
+r: -64.67,
+g: -695.3,
+b: 368.8,
+a: -393.1,
+}
+);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(
+8,
+bindGroup2
+);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(
+1,
+buffer12,
+12028,
+8724
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture14,
+  mipLevel: 4,
+  origin: { x: 5, y: 1, z: 0 },
+  aspect: 'all',
+},
+new Int8Array(arrayBuffer1),
+/* required buffer size: 504 */{
+offset: 504,
+bytesPerRow: 48,
+},
+{width: 1, height: 3, depthOrArrayLayers: 0}
+);
+} catch {}
+let imageBitmap11 = await createImageBitmap(video0);
+let shaderModule15 = device2.createShaderModule(
+{
+label: '\uf7ef\u{1f96f}\u0b15\u0ea5\u614b\uf033\u021b\u{1f9ed}\u536c\u07cf',
+code: `
+
+@compute @workgroup_size(8, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(5) f0: f32,
+@location(1) f1: i32,
+@location(3) f2: i32,
+@location(4) f3: vec4<u32>,
+@location(2) f4: vec4<u32>,
+@location(0) f5: vec2<u32>,
+@location(6) f6: vec2<f32>,
+@location(7) f7: vec3<i32>,
+@builtin(sample_mask) f8: u32,
+@builtin(frag_depth) f9: f32
+}
+
+@fragment
+fn fragment0(@location(7) a0: u32, @location(1) a1: vec2<f16>, @location(12) a2: vec2<i32>, @builtin(position) a3: vec4<f32>, @location(15) a4: vec2<u32>, @builtin(front_facing) a5: bool, @location(3) a6: vec4<i32>, @location(11) a7: vec4<u32>, @location(13) a8: vec4<i32>, @location(4) a9: vec3<f32>, @location(6) a10: vec2<i32>, @location(0) a11: vec3<u32>, @location(8) a12: vec3<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S14 {
+@location(14) f0: vec4<u32>,
+@location(10) f1: i32,
+@location(9) f2: vec3<u32>,
+@location(4) f3: vec3<i32>,
+@location(6) f4: f16
+}
+struct VertexOutput0 {
+@location(13) f183: vec4<i32>,
+@location(1) f184: vec2<f16>,
+@location(4) f185: vec3<f32>,
+@location(0) f186: vec3<u32>,
+@location(7) f187: u32,
+@location(14) f188: vec2<i32>,
+@location(2) f189: vec3<f32>,
+@location(10) f190: vec3<f16>,
+@location(11) f191: vec4<u32>,
+@location(3) f192: vec4<i32>,
+@location(12) f193: vec2<i32>,
+@location(15) f194: vec2<u32>,
+@builtin(position) f195: vec4<f32>,
+@location(6) f196: vec2<i32>,
+@location(8) f197: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec2<u32>, @location(12) a1: vec4<f16>, @location(13) a2: f32, @location(2) a3: f32, @location(1) a4: vec4<f16>, @location(5) a5: u32, @location(11) a6: vec2<f16>, @location(0) a7: vec2<u32>, @location(15) a8: vec4<f16>, @location(3) a9: i32, @location(8) a10: vec4<u32>, a11: S14, @builtin(instance_index) a12: u32, @builtin(vertex_index) a13: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture73 = device2.createTexture(
+{
+size: [204, 4, 86],
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'eac-rg11snorm'
+],
+}
+);
+try {
+renderBundleEncoder44.setVertexBuffer(
+4,
+buffer15,
+1360,
+11843
+);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let device3 = await adapter3.requestDevice(
+{
+label: '\u3a3d\u{1ff0c}\u{1f903}\u04e1\u{1fef2}\u076d\u5152\u0dd9',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+}
+);
+let img17 = await imageWithData(289, 3, '#e1ee358d', '#5c65f651');
+let buffer16 = device2.createBuffer(
+{
+label: '\ubf42\u0ab9',
+size: 30876,
+usage: GPUBufferUsage.MAP_READ,
+}
+);
+let querySet41 = device2.createQuerySet(
+{
+type: 'occlusion',
+count: 1735,
+}
+);
+let renderBundleEncoder48 = device2.createRenderBundleEncoder(
+{
+label: '\u4b23\u03b4\u0608\u{1f62f}\u01dd\u09f5\uf91c',
+colorFormats: [
+'r16sint',
+undefined,
+'rg32float',
+undefined,
+'bgra8unorm-srgb',
+'rg8sint',
+'rgba16float'
+],
+sampleCount: 742,
+depthReadOnly: true,
+}
+);
+try {
+computePassEncoder30.end();
+} catch {}
+try {
+texture64.destroy();
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline63 = await device2.createComputePipelineAsync(
+{
+label: '\u{1f765}\u24e5\u{1fd85}\u{1f6b3}\u08ef\u9719\u1a69\u713a\u03ad',
+layout: pipelineLayout13,
+compute: {
+module: shaderModule15,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline64 = device2.createRenderPipeline(
+{
+label: '\udad4\u4c91\u8f17',
+layout: pipelineLayout14,
+vertex: {
+module: shaderModule15,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1740,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 1104,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 324,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 192,
+shaderLocation: 5,
+},
+{
+format: 'snorm8x2',
+offset: 130,
+shaderLocation: 2,
+},
+{
+format: 'sint8x2',
+offset: 320,
+shaderLocation: 4,
+},
+{
+format: 'float32x4',
+offset: 300,
+shaderLocation: 13,
+},
+{
+format: 'float16x2',
+offset: 64,
+shaderLocation: 12,
+},
+{
+format: 'uint8x2',
+offset: 70,
+shaderLocation: 0,
+},
+{
+format: 'unorm16x4',
+offset: 104,
+shaderLocation: 11,
+},
+{
+format: 'uint8x2',
+offset: 292,
+shaderLocation: 14,
+},
+{
+format: 'uint32x2',
+offset: 92,
+shaderLocation: 8,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 292,
+shaderLocation: 1,
+},
+{
+format: 'sint16x4',
+offset: 228,
+shaderLocation: 10,
+},
+{
+format: 'snorm8x2',
+offset: 12,
+shaderLocation: 6,
+},
+{
+format: 'uint8x4',
+offset: 36,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 288,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32',
+offset: 188,
+shaderLocation: 7,
+},
+{
+format: 'snorm8x2',
+offset: 26,
+shaderLocation: 15,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule15,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'zero',
+depthFailOp: 'replace',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 4024,
+depthBias: 90,
+depthBiasClamp: 12,
+},
+}
+);
+document.body.prepend(img3);
+document.body.append('\u{1fa44}\u0128\ufe90\u2bfd\u91bb\u0cce\u012f\u6365\uc385\u0994');
+let img18 = await imageWithData(102, 160, '#ef2cf24e', '#78c684e1');
+let bindGroupLayout27 = device0.createBindGroupLayout(
+{
+label: '\ufd2d\u0e8b',
+entries: [
+{
+binding: 3154,
+visibility: GPUShaderStage.FRAGMENT,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 3923,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+},
+{
+binding: 5151,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+try {
+computePassEncoder14.setBindGroup(
+3,
+bindGroup2
+);
+} catch {}
+try {
+computePassEncoder18.setBindGroup(
+1,
+bindGroup1,
+new Uint32Array(2683),
+1025,
+0
+);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(
+40
+);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(
+buffer1,
+'uint32',
+6808,
+2800
+);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(
+5,
+buffer12,
+3368,
+9327
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+15384,
+new Int16Array(38151),
+13202,
+1560
+);
+} catch {}
+let promise33 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 21, height: 1, depthOrArrayLayers: 93}
+*/
+{
+  source: canvas6,
+  origin: { x: 10, y: 33 },
+  flipY: false,
+},
+{
+  texture: texture39,
+  mipLevel: 1,
+  origin: { x: 14, y: 0, z: 89 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 4, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline65 = await device0.createComputePipelineAsync(
+{
+label: '\uefb8\u23ed\u02e5\u8b9d',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline66 = device0.createRenderPipeline(
+{
+label: '\u5782\u0746\u958b\u{1fd1e}\u8ed2\ube7a',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule4,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 32284,
+attributes: [
+{
+format: 'snorm8x2',
+offset: 1256,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x2',
+offset: 24252,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x4',
+offset: 6948,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x2',
+offset: 20012,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x4',
+offset: 31088,
+shaderLocation: 17,
+},
+{
+format: 'uint32x2',
+offset: 24576,
+shaderLocation: 22,
+},
+{
+format: 'float32',
+offset: 652,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 47576,
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 17312,
+shaderLocation: 4,
+},
+{
+format: 'float16x4',
+offset: 55412,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 55004,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 5588,
+shaderLocation: 23,
+},
+{
+format: 'uint8x4',
+offset: 32772,
+shaderLocation: 20,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x4',
+offset: 33980,
+shaderLocation: 15,
+},
+{
+format: 'snorm16x4',
+offset: 34364,
+shaderLocation: 19,
+},
+{
+format: 'float32',
+offset: 35892,
+shaderLocation: 21,
+}
+],
+},
+{
+arrayStride: 41568,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 22784,
+shaderLocation: 1,
+},
+{
+format: 'snorm8x4',
+offset: 3140,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 44476,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'none',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+},
+fragment: {
+module: shaderModule4,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r16uint',
+},
+{
+format: 'rg16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.RED,
+},
+{
+format: 'rg8sint',
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+},
+{
+format: 'r8sint',
+}
+],
+},
+}
+);
+let gpuCanvasContext15 = canvas11.getContext('webgpu');
+let video13 = await videoWithData();
+let querySet42 = device0.createQuerySet(
+{
+label: '\uf04e\u3b81\u67d2\u04e6\u0e97\u0e3f',
+type: 'occlusion',
+count: 2473,
+}
+);
+let textureView62 = texture56.createView(
+{
+label: '\u900b\ueebd',
+baseMipLevel: 2,
+mipLevelCount: 1,
+baseArrayLayer: 192,
+arrayLayerCount: 37,
+}
+);
+try {
+renderPassEncoder4.setBindGroup(
+3,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(
+1,
+bindGroup6,
+new Uint32Array(9424),
+7041,
+0
+);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder15.draw(
+56,
+16,
+0,
+24
+);
+} catch {}
+let bindGroupLayout28 = device0.createBindGroupLayout(
+{
+label: '\u2446\u8224\u1f52\u4082\u{1fc77}\u{1fc7c}\u{1f896}\u01c0\u0f5c\u0ab4\u19e8',
+entries: [
+
+],
+}
+);
+let pipelineLayout16 = device0.createPipelineLayout(
+{
+label: '\udc1f\ub137',
+bindGroupLayouts: [
+bindGroupLayout14,
+bindGroupLayout4
+],
+}
+);
+let texture74 = device0.createTexture(
+{
+label: '\ue7c9\u02df\u{1f8e2}\u4d34',
+size: {width: 703, height: 1, depthOrArrayLayers: 473},
+mipLevelCount: 10,
+dimension: '3d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb',
+'rgba8unorm'
+],
+}
+);
+let textureView63 = texture30.createView(
+{
+label: '\u0c30\uca5c\uec45\u034c\u{1fddd}\u183f\u5150\u1ab8\u5cf7\u2ffd',
+mipLevelCount: 1,
+}
+);
+try {
+computePassEncoder10.setPipeline(
+pipeline4
+);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(
+64
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(
+48,
+40,
+48
+);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(
+buffer6,
+'uint16',
+998,
+17157
+);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline19);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+},
+new BigInt64Array(arrayBuffer5),
+/* required buffer size: 4606 */{
+offset: 98,
+bytesPerRow: 4647,
+rowsPerImage: 193,
+},
+{width: 1127, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\udc3e\u04e7\u2daf\u31b0\u0334\ufeab\u5ffe');
+let offscreenCanvas14 = new OffscreenCanvas(295, 791);
+try {
+canvas10.getContext('2d');
+} catch {}
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+document.body.prepend('\u65ff\u{1fd1a}\u{1fff3}\u6009\uc03d\u075e\u07a6\u6d06\ufa3e');
+let querySet43 = device0.createQuerySet(
+{
+label: '\u3671\u9571\u{1f6b6}\u{1fb4b}\u{1fecc}\u1f55',
+type: 'occlusion',
+count: 2181,
+}
+);
+let textureView64 = texture26.createView(
+{
+dimension: '2d',
+baseArrayLayer: 210,
+arrayLayerCount: 1,
+}
+);
+let externalTexture1 = device0.importExternalTexture(
+{
+label: '\uce57\u0c52\u0534\u{1fc50}\u0583\uf93a\ufa73\u783b\u20e4\ua299',
+source: video10,
+colorSpace: 'srgb',
+}
+);
+try {
+renderPassEncoder18.setBindGroup(
+4,
+bindGroup6
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(
+buffer7,
+82616
+);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(
+3,
+buffer6,
+7136,
+13815
+);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(
+5,
+bindGroup4
+);
+} catch {}
+try {
+gpuCanvasContext11.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+let pipeline67 = await promise32;
+try {
+await promise33;
+} catch {}
+let imageBitmap12 = await createImageBitmap(img18);
+let buffer17 = device2.createBuffer(
+{
+label: '\u306d\ub12a',
+size: 16711,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let commandBuffer6 = commandEncoder43.finish(
+{
+}
+);
+try {
+computePassEncoder28.setPipeline(
+pipeline63
+);
+} catch {}
+document.body.append('\ufad4\u330e');
+let bindGroup8 = device0.createBindGroup({
+label: '\u59b1\u03a2\u{1fe6f}\ubf8d\u5735\u0c69\u45cd\u06db\u{1fb4e}\u01d8',
+layout: bindGroupLayout3,
+entries: [
+
+],
+});
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(
+buffer13,
+1600
+);
+} catch {}
+try {
+gpuCanvasContext13.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'bgra8unorm-srgb',
+'depth24plus-stencil8',
+'bgra8unorm-srgb'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture45,
+  mipLevel: 2,
+  origin: { x: 13, y: 0, z: 6 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer2),
+/* required buffer size: 1083 */{
+offset: 947,
+rowsPerImage: 291,
+},
+{width: 34, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline68 = device0.createRenderPipeline(
+{
+label: '\u0b4f\ubd69',
+layout: 'auto',
+vertex: {
+module: shaderModule12,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 15352,
+attributes: [
+{
+format: 'snorm16x2',
+offset: 7396,
+shaderLocation: 6,
+},
+{
+format: 'snorm8x4',
+offset: 13824,
+shaderLocation: 10,
+},
+{
+format: 'sint16x2',
+offset: 4512,
+shaderLocation: 18,
+},
+{
+format: 'uint16x4',
+offset: 1196,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 37512,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 26224,
+shaderLocation: 13,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 15552,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 10928,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 5564,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x2',
+offset: 8176,
+shaderLocation: 24,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+},
+multisample: {
+mask: 0xc7788f4f,
+},
+fragment: {
+module: shaderModule12,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'keep',
+depthFailOp: 'replace',
+passOp: 'zero',
+},
+stencilReadMask: 322,
+stencilWriteMask: 890,
+depthBias: 99,
+depthBiasSlopeScale: 49,
+},
+}
+);
+let querySet44 = device2.createQuerySet(
+{
+label: '\u0064\u1bfe\ucf8d\ub3f4\u054e',
+type: 'occlusion',
+count: 1804,
+}
+);
+let textureView65 = texture71.createView(
+{
+label: '\u0903\u4b05\u3eb3\ufb3b\uaba2\u0ab4\u0268\ufa33\u06e5\u05f0\u75b6',
+dimension: '2d',
+baseArrayLayer: 19,
+}
+);
+try {
+device2.pushErrorScope(
+'out-of-memory'
+);
+} catch {}
+try {
+gpuCanvasContext13.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let img19 = await imageWithData(19, 231, '#d338a587', '#0235cf81');
+let imageData7 = new ImageData(152, 80);
+let commandEncoder51 = device0.createCommandEncoder();
+let renderPassEncoder21 = commandEncoder51.beginRenderPass(
+{
+label: '\u0d57\u4aab',
+colorAttachments: [
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView51,
+depthClearValue: -7.343850847460196,
+depthReadOnly: true,
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet20,
+maxDrawCount: 344312,
+}
+);
+try {
+computePassEncoder13.setPipeline(
+pipeline36
+);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder15.setViewport(
+7.533,
+0.2721,
+1.736,
+0.4426,
+0.4287,
+0.7706
+);
+} catch {}
+try {
+renderPassEncoder15.draw(
+24,
+40,
+40,
+40
+);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+1,
+buffer6
+);
+} catch {}
+let pipeline69 = await promise30;
+try {
+offscreenCanvas14.getContext('2d');
+} catch {}
+let pipelineLayout17 = device2.createPipelineLayout(
+{
+label: '\u{1f953}\u8821\u5e4b',
+bindGroupLayouts: [
+bindGroupLayout22,
+bindGroupLayout25
+],
+}
+);
+let querySet45 = device2.createQuerySet(
+{
+label: '\u0890\u287a\u06f4',
+type: 'occlusion',
+count: 1472,
+}
+);
+try {
+device2.queue.writeBuffer(
+buffer17,
+8524,
+new BigUint64Array(15333),
+13480,
+92
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture71,
+  mipLevel: 0,
+  origin: { x: 12, y: 16, z: 4 },
+  aspect: 'all',
+},
+arrayBuffer3,
+/* required buffer size: 2548109 */{
+offset: 633,
+bytesPerRow: 616,
+rowsPerImage: 255,
+},
+{width: 79, height: 56, depthOrArrayLayers: 17}
+);
+} catch {}
+let pipeline70 = await device2.createComputePipelineAsync(
+{
+label: '\uf72f\u99da\u030a\u084c\u1fbf\u0fc6\u{1fb4c}\ua9e5',
+layout: pipelineLayout17,
+compute: {
+module: shaderModule15,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend('\u7f0a\u094f\u1286\u91fc\u0579\u{1fdd1}');
+let renderBundleEncoder49 = device3.createRenderBundleEncoder(
+{
+label: '\u608d\uc101\u8e64\u7ed4\ufbc3\u3c6f\u2515\u7a8f\uf0b2\u0524',
+colorFormats: [
+'rg32sint',
+'rgba8uint',
+'rgba8sint',
+'rg8sint',
+undefined
+],
+sampleCount: 736,
+stencilReadOnly: true,
+}
+);
+try {
+device2.queue.label = '\u3081\u{1f806}\ue393';
+} catch {}
+let renderBundle49 = renderBundleEncoder43.finish();
+try {
+renderBundleEncoder44.setVertexBuffer(
+6,
+buffer15,
+5212,
+7692
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer17,
+4868,
+new Float32Array(28214),
+11459,
+144
+);
+} catch {}
+document.body.prepend('\ubb96\u{1fa48}\u0cbe\u{1fcac}\uc481\u0877');
+let imageData8 = new ImageData(88, 88);
+let bindGroup9 = device0.createBindGroup({
+label: '\u{1ffe0}\u2dc5\uc473\u6150\u{1fbb2}\u08c8',
+layout: bindGroupLayout27,
+entries: [
+{
+binding: 3154,
+resource: {
+buffer: buffer1,
+offset: 12480,
+}
+},
+{
+binding: 5151,
+resource: externalTexture0
+},
+{
+binding: 3923,
+resource: sampler26
+}
+],
+});
+let textureView66 = texture70.createView(
+{
+label: '\u756e\u028d\u2976\u0c1d\u8940',
+}
+);
+let renderBundle50 = renderBundleEncoder46.finish(
+{
+label: '\u5953\u0e27\u0a75\u{1fac1}\u{1feac}\u0a72'
+}
+);
+try {
+computePassEncoder13.setBindGroup(
+6,
+bindGroup0,
+new Uint32Array(4502),
+3276,
+0
+);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(
+2,
+bindGroup3
+);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant(
+{
+r: -506.5,
+g: -68.12,
+b: -491.3,
+a: 115.1,
+}
+);
+} catch {}
+try {
+renderPassEncoder15.draw(
+48,
+72
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(
+40,
+0
+);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(
+buffer6,
+'uint32',
+14824,
+3707
+);
+} catch {}
+let promise34 = device0.popErrorScope();
+let img20 = await imageWithData(272, 41, '#fc65947f', '#14d096ca');
+let shaderModule16 = device0.createShaderModule(
+{
+label: '\u5012\u50ec',
+code: `@group(0) @binding(1608)
+var<storage, read_write> local0: array<u32>;
+
+@compute @workgroup_size(8, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S16 {
+@location(5) f0: vec2<f16>,
+@location(16) f1: vec3<u32>,
+@location(7) f2: f32,
+@location(26) f3: f16,
+@location(39) f4: vec2<f32>,
+@location(11) f5: vec2<f32>,
+@location(19) f6: vec3<f32>,
+@location(4) f7: vec2<f32>,
+@location(28) f8: u32,
+@location(6) f9: u32,
+@location(31) f10: vec2<f32>,
+@location(20) f11: vec4<f32>,
+@location(0) f12: vec2<f16>,
+@location(1) f13: vec4<f16>,
+@location(17) f14: vec4<f16>,
+@location(38) f15: u32,
+@location(22) f16: vec4<u32>,
+@location(12) f17: u32,
+@location(10) f18: vec4<u32>,
+@location(36) f19: vec4<f32>,
+@location(13) f20: vec3<f16>,
+@location(29) f21: vec4<i32>
+}
+struct FragmentOutput0 {
+@location(3) f0: vec3<f32>,
+@location(6) f1: vec4<i32>,
+@location(4) f2: vec4<f32>,
+@location(5) f3: vec2<i32>,
+@location(7) f4: vec3<i32>,
+@location(1) f5: vec3<f32>,
+@location(0) f6: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(32) a0: vec3<u32>, a1: S16, @location(2) a2: vec3<i32>, @location(27) a3: vec2<f16>, @location(34) a4: vec4<f32>, @location(37) a5: i32, @location(9) a6: vec2<f32>, @location(33) a7: vec3<u32>, @location(14) a8: vec4<u32>, @location(18) a9: vec2<f32>, @location(21) a10: f32, @builtin(sample_index) a11: u32, @location(25) a12: vec2<i32>, @location(23) a13: vec3<f16>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S15 {
+@location(21) f0: i32
+}
+struct VertexOutput0 {
+@location(23) f198: vec3<f16>,
+@location(8) f199: vec2<f32>,
+@location(4) f200: vec2<f32>,
+@location(1) f201: vec4<f16>,
+@location(33) f202: vec3<u32>,
+@location(2) f203: vec3<i32>,
+@location(6) f204: u32,
+@location(34) f205: vec4<f32>,
+@location(5) f206: vec2<f16>,
+@builtin(position) f207: vec4<f32>,
+@location(28) f208: u32,
+@location(17) f209: vec4<f16>,
+@location(29) f210: vec4<i32>,
+@location(37) f211: i32,
+@location(19) f212: vec3<f32>,
+@location(25) f213: vec2<i32>,
+@location(26) f214: f16,
+@location(31) f215: vec2<f32>,
+@location(21) f216: f32,
+@location(32) f217: vec3<u32>,
+@location(18) f218: vec2<f32>,
+@location(27) f219: vec2<f16>,
+@location(9) f220: vec2<f32>,
+@location(0) f221: vec2<f16>,
+@location(39) f222: vec2<f32>,
+@location(22) f223: vec4<u32>,
+@location(13) f224: vec3<f16>,
+@location(16) f225: vec3<u32>,
+@location(20) f226: vec4<f32>,
+@location(11) f227: vec2<f32>,
+@location(36) f228: vec4<f32>,
+@location(12) f229: u32,
+@location(38) f230: u32,
+@location(14) f231: vec4<u32>,
+@location(7) f232: f32,
+@location(10) f233: vec4<u32>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(19) a1: vec3<f32>, @builtin(vertex_index) a2: u32, @location(2) a3: vec4<f16>, @location(11) a4: vec2<f32>, @location(4) a5: vec4<u32>, @location(9) a6: vec4<f16>, @location(8) a7: vec4<i32>, @location(5) a8: vec4<f32>, @location(6) a9: vec3<f16>, @location(1) a10: vec4<f32>, @location(23) a11: vec2<f32>, @location(10) a12: f32, @location(18) a13: vec3<f32>, a14: S15, @location(15) a15: vec2<i32>, @location(13) a16: vec2<u32>, @location(20) a17: f32, @location(14) a18: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder52 = device0.createCommandEncoder(
+{
+label: '\u0dc1\u48ae\ub0ab\u9ddb\u873a\uc5c4',
+}
+);
+let texture75 = device0.createTexture(
+{
+label: '\u2dbd\u020d\u{1f8d8}\u0b25\u0268\u1f45\u4276\u{1ffba}\u{1f6bc}',
+size: [207, 1, 227],
+mipLevelCount: 6,
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8uint',
+'r8uint'
+],
+}
+);
+try {
+renderPassEncoder18.beginOcclusionQuery(
+48
+);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant(
+{
+r: 328.7,
+g: 777.7,
+b: -717.4,
+a: -501.4,
+}
+);
+} catch {}
+try {
+renderPassEncoder19.setStencilReference(
+624
+);
+} catch {}
+try {
+renderPassEncoder4.setViewport(
+10.62,
+0.6584,
+0.5488,
+0.2333,
+0.2082,
+0.7874
+);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(
+5,
+buffer6,
+512
+);
+} catch {}
+try {
+commandEncoder52.resolveQuerySet(
+querySet16,
+111,
+1,
+buffer1,
+10496
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 6, depthOrArrayLayers: 116}
+*/
+{
+  source: canvas0,
+  origin: { x: 130, y: 24 },
+  flipY: true,
+},
+{
+  texture: texture69,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 47 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 4, depthOrArrayLayers: 1}
+);
+} catch {}
+let video14 = await videoWithData();
+let commandEncoder53 = device3.createCommandEncoder();
+let renderBundleEncoder50 = device3.createRenderBundleEncoder(
+{
+label: '\u{1fa89}\u{1fa3d}\uab5a\u0c0a\u46d9\u209a\u53da\u0e35\u05a5\u4783\u47c6',
+colorFormats: [
+undefined,
+'rg11b10ufloat',
+'rgba32sint',
+'rg8unorm',
+'r8unorm',
+'r8sint'
+],
+sampleCount: 491,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+let imageBitmap13 = await createImageBitmap(canvas0);
+let videoFrame9 = new VideoFrame(offscreenCanvas9, {timestamp: 0});
+let computePassEncoder31 = commandEncoder53.beginComputePass(
+{
+label: '\u{1f630}\ucf11\u063e\u3130\u{1f815}\u9cce'
+}
+);
+try {
+computePassEncoder31.end();
+} catch {}
+try {
+await promise34;
+} catch {}
+let imageBitmap14 = await createImageBitmap(video9);
+let computePassEncoder32 = commandEncoder52.beginComputePass(
+{
+
+}
+);
+let renderBundle51 = renderBundleEncoder26.finish(
+{
+label: '\u0ff6\u1887'
+}
+);
+try {
+computePassEncoder29.setPipeline(
+pipeline15
+);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(
+64,
+24,
+48,
+-80,
+80
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(
+buffer12,
+310968
+);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(
+8,
+buffer12,
+15156,
+6247
+);
+} catch {}
+let computePassEncoder33 = commandEncoder53.beginComputePass(
+{
+label: '\u59c8\u05d6\u{1f925}\u0f6e\u{1fbc6}\u{1f893}\u051a\u0a1e\u7e02'
+}
+);
+let renderBundleEncoder51 = device3.createRenderBundleEncoder(
+{
+label: '\u{1f8c7}\u8790\u0782\u0837\u0ad4\u545d\ufcc4\u530d',
+colorFormats: [
+'rg16float',
+'r16sint',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 577,
+stencilReadOnly: false,
+}
+);
+let sampler47 = device3.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 70.527,
+lodMaxClamp: 74.200,
+}
+);
+let imageData9 = new ImageData(92, 172);
+let texture76 = device0.createTexture(
+{
+label: '\u691a\ueb9e\u008f\u68de\u0533\u6329\u{1f95a}\ud56b\u{1f6ac}\udb98',
+size: {width: 2092, height: 1, depthOrArrayLayers: 207},
+mipLevelCount: 3,
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+let renderBundle52 = renderBundleEncoder12.finish(
+{
+label: '\u04c1\u{1f7d5}\u519a\u{1f6fb}\ue5be'
+}
+);
+let sampler48 = device0.createSampler(
+{
+label: '\u{1f9eb}\u09fe\u0035\u0cd3',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 60.145,
+lodMaxClamp: 74.394,
+maxAnisotropy: 16,
+}
+);
+try {
+computePassEncoder16.end();
+} catch {}
+try {
+computePassEncoder8.setPipeline(
+pipeline33
+);
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(
+8
+);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(
+buffer6,
+'uint32',
+17704,
+1211
+);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+6,
+buffer12,
+23060,
+135
+);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(
+0,
+buffer6,
+9284
+);
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(
+buffer13,
+14084,
+buffer12,
+1732,
+19604
+);
+dissociateBuffer(device0, buffer13);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder26.clearBuffer(
+buffer3,
+3852,
+2352
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture75,
+  mipLevel: 0,
+  origin: { x: 16, y: 1, z: 39 },
+  aspect: 'all',
+},
+new Uint8Array(new ArrayBuffer(72)),
+/* required buffer size: 3643558 */{
+offset: 118,
+bytesPerRow: 323,
+rowsPerImage: 240,
+},
+{width: 171, height: 0, depthOrArrayLayers: 48}
+);
+} catch {}
+let pipeline71 = await device0.createComputePipelineAsync(
+{
+label: '\ub165\ueab2\u40ba\u0f4e\u{1f683}\u05fd',
+layout: pipelineLayout8,
+compute: {
+module: shaderModule16,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let commandEncoder54 = device3.createCommandEncoder();
+let computePassEncoder34 = commandEncoder54.beginComputePass();
+let renderBundle53 = renderBundleEncoder49.finish(
+{
+label: '\ua065\uabca\u0e54\u{1fbd5}\u{1f8af}\ue525\u60a9\u0c0b\u0e2a'
+}
+);
+let sampler49 = device3.createSampler(
+{
+label: '\u1e14\u{1fdf4}\ub8c4\u0a3f\u{1fbd5}\u9522',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 1.065,
+lodMaxClamp: 12.959,
+maxAnisotropy: 8,
+}
+);
+let promise35 = device3.queue.onSubmittedWorkDone();
+document.body.append('\u0149\u{1fbae}\u029a\u08cb\u05a6\u0997\u{1fe45}');
+document.body.append('\u02e8\ubcbe\u8b42\u{1fe88}\uc722\u42b4\u0dd8\u4a5a');
+let bindGroupLayout29 = device0.createBindGroupLayout(
+{
+label: '\u{1f908}\ub058',
+entries: [
+{
+binding: 2320,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+}
+],
+}
+);
+let texture77 = device0.createTexture(
+{
+size: {width: 2672, height: 152, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+try {
+computePassEncoder26.setPipeline(
+pipeline16
+);
+} catch {}
+try {
+renderPassEncoder15.setBlendConstant(
+{
+r: 996.8,
+g: -339.2,
+b: 744.3,
+a: 405.5,
+}
+);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(
+8,
+24,
+32,
+552,
+8
+);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(
+buffer4,
+1608
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+10040,
+new Int16Array(34921),
+1780,
+1712
+);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+try {
+window.someLabel = textureView43.label;
+} catch {}
+let imageBitmap15 = await createImageBitmap(imageData1);
+let renderPassEncoder22 = commandEncoder26.beginRenderPass(
+{
+label: '\u8263\u0247\u38e6\u5c33\u905b\u0990',
+colorAttachments: [
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView51,
+depthClearValue: -2.445623025070038,
+depthReadOnly: true,
+stencilClearValue: 17717,
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet14,
+maxDrawCount: 18216,
+}
+);
+let renderBundle54 = renderBundleEncoder1.finish(
+{
+
+}
+);
+try {
+renderPassEncoder10.drawIndexed(
+24,
+0
+);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(
+buffer11,
+410616
+);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(
+buffer12,
+473712
+);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(
+9,
+buffer6,
+17144,
+1618
+);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(
+0,
+bindGroup1,
+new Uint32Array(1243),
+201,
+0
+);
+} catch {}
+let img21 = await imageWithData(183, 234, '#5af5e6c7', '#0274d83c');
+let shaderModule17 = device2.createShaderModule(
+{
+label: '\u{1fdbc}\u{1fd39}\u0dd2',
+code: `@group(0) @binding(896)
+var<storage, read_write> i2: array<u32>;
+
+@compute @workgroup_size(4, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: vec3<i32>,
+@location(4) f1: vec2<f32>,
+@location(7) f2: vec2<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(14) a0: f32, @location(13) a1: vec3<i32>, @location(5) a2: vec4<i32>, @location(3) a3: vec3<u32>, @location(1) a4: vec2<f16>, @location(15) a5: vec2<f16>, @location(6) a6: vec2<f32>, @location(10) a7: vec2<i32>, @location(8) a8: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder55 = device2.createCommandEncoder(
+{
+label: '\u0e96\u0189\u08d4\u{1fb2b}\ufc5d\u47d5\uc679',
+}
+);
+let texture78 = device2.createTexture(
+{
+size: {width: 180, height: 1, depthOrArrayLayers: 308},
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rgba32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba32uint',
+'rgba32uint'
+],
+}
+);
+let computePassEncoder35 = commandEncoder55.beginComputePass(
+{
+label: '\u6064\u06e2\ubf10\ud156\u{1fa1a}\u8e30\ud699\uc285\ua305\u0027\ue93a'
+}
+);
+try {
+renderBundleEncoder44.setVertexBuffer(
+7,
+buffer15,
+4844
+);
+} catch {}
+try {
+buffer14.destroy();
+} catch {}
+let pipeline72 = await device2.createRenderPipelineAsync(
+{
+label: '\u010d\u5fd3',
+layout: pipelineLayout15,
+vertex: {
+module: shaderModule17,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1428,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 580,
+shaderLocation: 14,
+},
+{
+format: 'sint8x4',
+offset: 1352,
+shaderLocation: 5,
+},
+{
+format: 'sint32x3',
+offset: 1284,
+shaderLocation: 10,
+},
+{
+format: 'uint8x2',
+offset: 422,
+shaderLocation: 8,
+},
+{
+format: 'sint32x3',
+offset: 296,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 972,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 272,
+shaderLocation: 1,
+},
+{
+format: 'uint8x2',
+offset: 712,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 300,
+attributes: [
+{
+format: 'unorm8x2',
+offset: 180,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 1144,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 2004,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 1948,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 1252,
+shaderLocation: 15,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule17,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'zero',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 1125,
+stencilWriteMask: 988,
+depthBias: 85,
+depthBiasSlopeScale: 65,
+},
+}
+);
+document.body.prepend('\u{1fffb}\u0f8a\uba68\ue1e6\u20a0\u9c84\u04ca\u{1f7eb}');
+let querySet46 = device2.createQuerySet(
+{
+label: '\ue136\u6e94\u{1fb7e}\u{1ff8a}\u7693',
+type: 'occlusion',
+count: 1766,
+}
+);
+let externalTexture2 = device2.importExternalTexture(
+{
+label: '\uf912\u0b59\u9e47\u1ca7\u{1f6ca}\u02c0\u{1fbcd}\u7200\u039c\u11a7\u{1ff14}',
+source: videoFrame4,
+colorSpace: 'display-p3',
+}
+);
+try {
+gpuCanvasContext5.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb',
+'rgba16float'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let pipeline73 = device2.createComputePipeline(
+{
+layout: pipelineLayout17,
+compute: {
+module: shaderModule17,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let commandEncoder56 = device3.createCommandEncoder();
+document.body.append('\udc0c\u8cdc\uc5d1\u520f\ub58d\ua7ce\ue105\u61c4\u{1ff45}');
+let bindGroupLayout30 = device3.createBindGroupLayout(
+{
+label: '\u95f6\u{1f8b8}\uf679\u03b2',
+entries: [
+{
+binding: 62,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+}
+],
+}
+);
+let computePassEncoder36 = commandEncoder56.beginComputePass(
+{
+label: '\u{1f8e4}\u{1fb34}\ud39e\u0a42\u009e\u93d0\u0926\u{1f644}\u0bc1\u0817'
+}
+);
+let renderBundle55 = renderBundleEncoder50.finish(
+{
+label: '\u{1f8a2}\u44a1\ud375\u7cbd\u6d80\u1530\u59e4\u{1feeb}\uc445'
+}
+);
+let sampler50 = device3.createSampler(
+{
+label: '\ub616\u0636\u70b9\u5e0a\u0ac0\u0ca5\u9952\u0972\u2ae4',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 78.319,
+maxAnisotropy: 9,
+}
+);
+try {
+renderBundleEncoder51.setVertexBuffer(
+45,
+undefined,
+1099756660,
+2589758062
+);
+} catch {}
+let promise36 = device3.popErrorScope();
+try {
+await promise35;
+} catch {}
+let offscreenCanvas15 = new OffscreenCanvas(735, 1017);
+let imageData10 = new ImageData(20, 160);
+let videoFrame10 = new VideoFrame(img10, {timestamp: 0});
+let commandEncoder57 = device0.createCommandEncoder(
+{
+label: '\ubeff\u7ee5\u6dc0\u01bb\u0ea1\u{1ff3c}\u{1f9ee}\u7d6b',
+}
+);
+let querySet47 = device0.createQuerySet(
+{
+label: '\u0208\u3963\u0985\u9d5b',
+type: 'occlusion',
+count: 3302,
+}
+);
+let texture79 = device0.createTexture(
+{
+label: '\u{1fb4d}\ubd34\u057d\u5036\u695e\u81c0\u{1faea}\u{1fc70}\u0a2f\u{1fc5a}\u0ae6',
+size: [152, 1, 1057],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'r32uint',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundleEncoder52 = device0.createRenderBundleEncoder(
+{
+label: '\u30ea\u4b48\u0027\u85a5\ucbfb\u03ad\u01ca\u7fb9',
+colorFormats: [
+'rgba16float',
+'rg32sint',
+'rgb10a2uint',
+undefined,
+'rg8uint',
+'rgba16float',
+'r16uint',
+'rg32uint'
+],
+sampleCount: 918,
+}
+);
+try {
+computePassEncoder26.setBindGroup(
+3,
+bindGroup8,
+new Uint32Array(4617),
+743,
+0
+);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(
+2830
+);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(
+buffer6,
+'uint16',
+14860,
+2931
+);
+} catch {}
+try {
+commandEncoder57.copyBufferToBuffer(
+buffer0,
+22364,
+buffer11,
+43556,
+368
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder57.resolveQuerySet(
+querySet18,
+729,
+313,
+buffer1,
+15104
+);
+} catch {}
+gc();
+let videoFrame11 = new VideoFrame(offscreenCanvas14, {timestamp: 0});
+let commandBuffer7 = commandEncoder57.finish(
+{
+label: '\u036c\u6996\u2b33\u89c3\ua8b4',
+}
+);
+let texture80 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder14.setPipeline(
+pipeline49
+);
+} catch {}
+try {
+renderPassEncoder12.draw(
+56
+);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(
+8,
+buffer6,
+10564
+);
+} catch {}
+try {
+offscreenCanvas15.getContext('webgl');
+} catch {}
+gc();
+let textureView67 = texture72.createView(
+{
+label: '\u1eae\u{1f87d}\u443b',
+baseArrayLayer: 0,
+}
+);
+let renderBundleEncoder53 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg8uint',
+'rgba8sint',
+'r8unorm',
+'r32sint',
+'rg8sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 514,
+}
+);
+let renderBundle56 = renderBundleEncoder20.finish(
+{
+
+}
+);
+try {
+computePassEncoder32.setPipeline(
+pipeline62
+);
+} catch {}
+try {
+renderPassEncoder15.draw(
+0
+);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(
+5,
+bindGroup3
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+document.body.append('\u0571\u864c\u{1f918}\uf329\u0eb0\u0211\u0da1\u0a58\u{1f9a4}\u{1fda0}');
+try {
+adapter1.label = '\u0748\uac8d\u07ce\u5f95\u0d17\u{1fb08}\u0c87\u024f\u03d3';
+} catch {}
+let adapter8 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let bindGroupLayout31 = device2.createBindGroupLayout(
+{
+label: '\uf66d\udfd0\u1439\u1401',
+entries: [
+{
+binding: 15,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+},
+{
+binding: 584,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+},
+{
+binding: 559,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+}
+],
+}
+);
+try {
+device2.queue.writeBuffer(
+buffer17,
+10348,
+new Int16Array(22354),
+11699,
+96
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture71,
+  mipLevel: 0,
+  origin: { x: 35, y: 95, z: 12 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 1695549 */{
+offset: 49,
+bytesPerRow: 416,
+rowsPerImage: 333,
+},
+{width: 75, height: 80, depthOrArrayLayers: 13}
+);
+} catch {}
+let adapter9 = await navigator.gpu.requestAdapter();
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+offscreenCanvas2.width = 599;
+gc();
+let commandEncoder58 = device2.createCommandEncoder(
+{
+label: '\u{1ffd2}\u{1fd24}\u7eb2\u050a\uab91\u4dcf',
+}
+);
+let querySet48 = device2.createQuerySet(
+{
+type: 'occlusion',
+count: 1724,
+}
+);
+let texture81 = device2.createTexture(
+{
+label: '\u5273\ubb21\u43a4\u{1f720}',
+size: {width: 5050, height: 144, depthOrArrayLayers: 184},
+mipLevelCount: 3,
+format: 'astc-10x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-10x8-unorm-srgb',
+'astc-10x8-unorm',
+'astc-10x8-unorm'
+],
+}
+);
+try {
+renderBundleEncoder45.setVertexBuffer(
+1,
+buffer15,
+8128,
+317
+);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+commandEncoder58.clearBuffer(
+buffer17,
+3856,
+8968
+);
+dissociateBuffer(device2, buffer17);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture71,
+  mipLevel: 0,
+  origin: { x: 37, y: 105, z: 5 },
+  aspect: 'all',
+},
+new Uint32Array(arrayBuffer5),
+/* required buffer size: 446452 */{
+offset: 835,
+bytesPerRow: 253,
+rowsPerImage: 242,
+},
+{width: 21, height: 68, depthOrArrayLayers: 8}
+);
+} catch {}
+let renderBundleEncoder54 = device0.createRenderBundleEncoder(
+{
+label: '\u7bf9\u0189\u2ff6\udb40\u0565\uc692\uf864\u942a\u2753\u7599',
+colorFormats: [
+'rgba8unorm',
+'r8unorm',
+'r8uint',
+'rgba8unorm-srgb',
+'rgba16float',
+'rgba32sint',
+'rg8unorm'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 854,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(
+64,
+48
+);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(
+0,
+buffer6
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 25, depthOrArrayLayers: 116}
+*/
+{
+  source: imageBitmap5,
+  origin: { x: 2, y: 10 },
+  flipY: true,
+},
+{
+  texture: texture69,
+  mipLevel: 3,
+  origin: { x: 3, y: 12, z: 99 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 2, height: 4, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline74 = await device0.createRenderPipelineAsync(
+{
+layout: pipelineLayout6,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 17268,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32',
+offset: 15024,
+shaderLocation: 16,
+},
+{
+format: 'snorm8x4',
+offset: 7820,
+shaderLocation: 21,
+},
+{
+format: 'unorm16x2',
+offset: 14992,
+shaderLocation: 20,
+}
+],
+},
+{
+arrayStride: 21512,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 3760,
+shaderLocation: 15,
+},
+{
+format: 'float32',
+offset: 11784,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x4',
+offset: 14164,
+shaderLocation: 0,
+},
+{
+format: 'snorm8x2',
+offset: 6798,
+shaderLocation: 7,
+},
+{
+format: 'sint32x3',
+offset: 7884,
+shaderLocation: 1,
+},
+{
+format: 'float16x4',
+offset: 14996,
+shaderLocation: 4,
+},
+{
+format: 'uint32x4',
+offset: 16912,
+shaderLocation: 22,
+},
+{
+format: 'uint32x3',
+offset: 3164,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x4',
+offset: 10256,
+shaderLocation: 23,
+},
+{
+format: 'sint8x2',
+offset: 1902,
+shaderLocation: 10,
+},
+{
+format: 'sint32x4',
+offset: 19424,
+shaderLocation: 13,
+},
+{
+format: 'float32x4',
+offset: 18168,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 1308,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 660,
+shaderLocation: 18,
+},
+{
+format: 'sint32x3',
+offset: 320,
+shaderLocation: 17,
+},
+{
+format: 'snorm8x2',
+offset: 660,
+shaderLocation: 14,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'replace',
+depthFailOp: 'replace',
+passOp: 'zero',
+},
+stencilReadMask: 3779,
+depthBiasSlopeScale: 73,
+depthBiasClamp: 84,
+},
+}
+);
+document.body.prepend('\ua43b\ud28e');
+let video15 = await videoWithData();
+let pipelineLayout18 = device3.createPipelineLayout(
+{
+label: '\u0416\u{1fb69}\u{1f948}',
+bindGroupLayouts: [
+bindGroupLayout30,
+bindGroupLayout30
+],
+}
+);
+let querySet49 = device3.createQuerySet(
+{
+label: '\u0e69\u3b36\u0329\u{1fe9b}\u{1f988}',
+type: 'occlusion',
+count: 3075,
+}
+);
+let externalTexture3 = device3.importExternalTexture(
+{
+label: '\u9f5b\u8a65\u{1fabe}\ud907\uefee\u664b\u27c4\u{1ff6a}\u85a2\u32f6\u1d32',
+source: videoFrame6,
+colorSpace: 'display-p3',
+}
+);
+try {
+gpuCanvasContext9.configure(
+{
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-8x6-unorm-srgb'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let promise37 = device3.queue.onSubmittedWorkDone();
+document.body.append('\u0424\u501b\ua376\u{1f86e}\u3305\u0c80\u039a\u9d5a');
+let commandEncoder59 = device2.createCommandEncoder(
+{
+label: '\ub457\u6f4d',
+}
+);
+try {
+computePassEncoder28.end();
+} catch {}
+try {
+computePassEncoder35.setPipeline(
+pipeline73
+);
+} catch {}
+let video16 = await videoWithData();
+let img22 = await imageWithData(186, 83, '#63926674', '#e238dab2');
+let imageBitmap16 = await createImageBitmap(videoFrame6);
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+let querySet50 = device1.createQuerySet(
+{
+label: '\u0412\u4211\u{1fc0d}\u6f25',
+type: 'occlusion',
+count: 854,
+}
+);
+let textureView68 = texture55.createView(
+{
+label: '\u{1f61d}\u2a4a\u5801\u3364\u07e1\u039e\ud28e\u7c34\u{1ffdc}',
+format: 'astc-12x12-unorm',
+mipLevelCount: 1,
+}
+);
+let renderBundleEncoder55 = device1.createRenderBundleEncoder(
+{
+label: '\u0fb5\u0baa\u{1faf2}\u{1f99d}\u7b7e\u0785\u70ad\u0aba',
+colorFormats: [
+'rgba32uint',
+'r32float',
+'rgb10a2unorm',
+'rg16uint'
+],
+sampleCount: 503,
+}
+);
+try {
+computePassEncoder23.setPipeline(
+pipeline48
+);
+} catch {}
+try {
+renderPassEncoder14.setViewport(
+15.87,
+1.629,
+2.979,
+0.03515,
+0.4577,
+0.9651
+);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(
+4,
+undefined,
+2301222159,
+106451637
+);
+} catch {}
+try {
+await promise36;
+} catch {}
+let renderBundleEncoder56 = device3.createRenderBundleEncoder(
+{
+label: '\u080e\ua2b4\uc598\u43a2\u{1ffed}\ua22c\u1478',
+colorFormats: [
+'rg32uint',
+'r32sint',
+'rg8uint',
+'r8uint',
+'r8unorm'
+],
+sampleCount: 472,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let buffer18 = device3.createBuffer(
+{
+label: '\u0dbb\u3a60\u959d\u{1fd5f}\u91bf\u0d12\u9934\ubc43\u3cc9',
+size: 10395,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let texture82 = device3.createTexture(
+{
+size: [81, 11, 1],
+mipLevelCount: 3,
+format: 'rgba16uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+let textureView69 = texture82.createView(
+{
+label: '\u6768\u01d9\u04f2\u1a37\u096d\u00bf\u2879\u0d82\u00db',
+dimension: '2d-array',
+mipLevelCount: 2,
+}
+);
+try {
+gpuCanvasContext14.configure(
+{
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'astc-12x10-unorm',
+'bgra8unorm-srgb'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+await promise37;
+} catch {}
+document.body.append('\u{1ff76}\u9b21');
+document.body.prepend('\u0cd2\u0ba5\ud685\u3353\u4300\u3c40\u2b79\uc3da\u19a3');
+let commandBuffer8 = commandEncoder42.finish(
+{
+label: '\u0e99\ub053\u13ea\u74f2\u2188',
+}
+);
+let renderBundle57 = renderBundleEncoder43.finish(
+{
+label: '\uca00\u4168\u4b1c\u89de\u0a09\u5b89\u{1f776}\u001e\ua57f'
+}
+);
+try {
+commandEncoder58.copyTextureToTexture(
+{
+  texture: texture78,
+  mipLevel: 0,
+  origin: { x: 25, y: 0, z: 272 },
+  aspect: 'all',
+},
+{
+  texture: texture78,
+  mipLevel: 5,
+  origin: { x: 5, y: 0, z: 3 },
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 4}
+);
+} catch {}
+try {
+commandEncoder59.clearBuffer(
+buffer17,
+10908,
+5428
+);
+dissociateBuffer(device2, buffer17);
+} catch {}
+gc();
+let videoFrame12 = new VideoFrame(video15, {timestamp: 0});
+gc();
+document.body.append('\u03b7\u{1f7db}\u04b1\uf87a\u8927\u{1fa68}\u8005\u4056\u853d\u79e4\u00a1');
+let shaderModule18 = device2.createShaderModule(
+{
+code: `
+
+@compute @workgroup_size(4, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> @builtin(frag_depth) f32 {
+return f32();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(9) a1: u32, @location(1) a2: vec3<f32>, @location(7) a3: vec2<u32>, @builtin(vertex_index) a4: u32, @location(6) a5: vec4<u32>, @location(3) a6: i32, @location(5) a7: vec4<f32>, @location(8) a8: vec2<f16>, @location(10) a9: i32, @location(14) a10: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+}
+);
+let textureView70 = texture67.createView(
+{
+label: '\u9717\ucfcd\u08bd\u7fe8\u5d36',
+dimension: '2d',
+baseMipLevel: 0,
+mipLevelCount: 3,
+baseArrayLayer: 135,
+}
+);
+let renderBundleEncoder57 = device2.createRenderBundleEncoder(
+{
+label: '\uc3a9\u0e40',
+colorFormats: [
+'rgba8unorm',
+'rg32uint',
+'rg8uint',
+'r8unorm',
+'rgb10a2uint',
+'r32float',
+undefined
+],
+sampleCount: 58,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle58 = renderBundleEncoder57.finish(
+{
+label: '\u4aa8\ub3a6\u{1f9ff}'
+}
+);
+try {
+computePassEncoder35.setPipeline(
+pipeline63
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture78,
+  mipLevel: 5,
+  origin: { x: 2, y: 0, z: 2 },
+  aspect: 'all',
+},
+new Int16Array(arrayBuffer0),
+/* required buffer size: 10595 */{
+offset: 156,
+bytesPerRow: 143,
+rowsPerImage: 73,
+},
+{width: 2, height: 0, depthOrArrayLayers: 2}
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let imageBitmap17 = await createImageBitmap(canvas3);
+let bindGroup10 = device0.createBindGroup({
+layout: bindGroupLayout0,
+entries: [
+{
+binding: 8053,
+resource: externalTexture1
+},
+{
+binding: 5645,
+resource: {
+buffer: buffer12,
+offset: 23360,
+size: 72,
+}
+}
+],
+});
+let pipelineLayout19 = device0.createPipelineLayout(
+{
+label: '\u5bf8\u0d62\u{1f6fb}',
+bindGroupLayouts: [
+bindGroupLayout29,
+bindGroupLayout21
+],
+}
+);
+let texture83 = device0.createTexture(
+{
+label: '\u{1f620}\u072a\uecdf\u147e\uf656\uf8e8\u031e\ucf3b\u9e16\u{1fbd6}',
+size: {width: 10582},
+dimension: '1d',
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg16sint',
+'rg16sint'
+],
+}
+);
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(
+buffer12,
+16352
+);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(
+4,
+buffer6,
+19632,
+972
+);
+} catch {}
+try {
+renderBundleEncoder42.setIndexBuffer(
+buffer1,
+'uint32'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer12,
+720,
+new DataView(new ArrayBuffer(9698)),
+2000,
+1996
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture45,
+  mipLevel: 4,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer3,
+/* required buffer size: 935 */{
+offset: 823,
+},
+{width: 28, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise38 = device0.createRenderPipelineAsync(
+{
+label: '\u{1fc37}\u02ec\u4c56\u{1fa60}\u0cfc\u0fc2\u0bd9',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 22204,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32',
+offset: 14568,
+shaderLocation: 24,
+},
+{
+format: 'uint32x4',
+offset: 7776,
+shaderLocation: 7,
+},
+{
+format: 'float32x4',
+offset: 16768,
+shaderLocation: 1,
+},
+{
+format: 'float16x2',
+offset: 4056,
+shaderLocation: 13,
+},
+{
+format: 'sint32x3',
+offset: 11516,
+shaderLocation: 8,
+},
+{
+format: 'unorm8x2',
+offset: 11176,
+shaderLocation: 21,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 12412,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x4',
+offset: 5584,
+shaderLocation: 15,
+},
+{
+format: 'unorm8x2',
+offset: 10626,
+shaderLocation: 18,
+},
+{
+format: 'sint32x3',
+offset: 1812,
+shaderLocation: 0,
+},
+{
+format: 'float32x3',
+offset: 11888,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 27560,
+attributes: [
+{
+format: 'sint32x3',
+offset: 23888,
+shaderLocation: 10,
+},
+{
+format: 'unorm8x4',
+offset: 10576,
+shaderLocation: 14,
+},
+{
+format: 'uint8x2',
+offset: 3520,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'src',
+dstFactor: 'one'
+},
+},
+format: 'r16float',
+writeMask: 0,
+}
+],
+},
+}
+);
+let textureView71 = texture71.createView(
+{
+dimension: '2d',
+baseMipLevel: 2,
+}
+);
+let renderPassEncoder23 = commandEncoder59.beginRenderPass(
+{
+label: '\u{1f607}\u{1f9f0}\ub159\u9965\u03e8',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+{
+view: textureView71,
+clearValue: {
+r: -724.5,
+g: 569.0,
+b: -237.6,
+a: 247.6,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined
+],
+occlusionQuerySet: querySet35,
+maxDrawCount: 205504,
+}
+);
+let renderBundleEncoder58 = device2.createRenderBundleEncoder(
+{
+label: '\ub054\u{1fbe5}\u07ec\u91ce\u{1fbc1}\u3536\u{1f7c4}\u0f71\u0113\u698c',
+colorFormats: [
+'r32uint',
+undefined
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 506,
+stencilReadOnly: true,
+}
+);
+try {
+commandEncoder58.clearBuffer(
+buffer17,
+6924,
+5004
+);
+dissociateBuffer(device2, buffer17);
+} catch {}
+try {
+gpuCanvasContext7.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16float',
+'rgba16float',
+'astc-8x5-unorm',
+'astc-10x5-unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer17,
+5220,
+new DataView(new ArrayBuffer(41237)),
+14226,
+7140
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture73,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 38 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 1210095 */{
+offset: 935,
+bytesPerRow: 817,
+rowsPerImage: 185,
+},
+{width: 192, height: 0, depthOrArrayLayers: 9}
+);
+} catch {}
+document.body.append('\u9388\u{1fac7}');
+let querySet51 = device0.createQuerySet(
+{
+label: '\u{1fcb8}\uec69\ubba2\ud665\u8e54',
+type: 'occlusion',
+count: 559,
+}
+);
+let textureView72 = texture33.createView(
+{
+label: '\u6f66\u043a\uf4ee\u0729\u{1fdb1}\u7506\u01aa\u0434\u0acd',
+dimension: '2d',
+baseMipLevel: 3,
+mipLevelCount: 4,
+baseArrayLayer: 67,
+arrayLayerCount: 1,
+}
+);
+try {
+computePassEncoder17.setPipeline(
+pipeline34
+);
+} catch {}
+try {
+renderPassEncoder21.beginOcclusionQuery(
+32
+);
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant(
+{
+r: -58.15,
+g: -416.5,
+b: -204.7,
+a: 730.4,
+}
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(
+buffer0,
+218240
+);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(
+buffer1,
+'uint32',
+16472
+);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(
+8,
+buffer12,
+21636,
+649
+);
+} catch {}
+let offscreenCanvas16 = new OffscreenCanvas(936, 731);
+let texture84 = device0.createTexture(
+{
+label: '\u{1f967}\u{1f9d6}\uc17b\u28f3',
+size: [2334],
+dimension: '1d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8unorm',
+'rg8unorm',
+'rg8unorm'
+],
+}
+);
+try {
+renderPassEncoder10.beginOcclusionQuery(
+64
+);
+} catch {}
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant(
+{
+r: -119.1,
+g: -372.4,
+b: 813.6,
+a: 747.5,
+}
+);
+} catch {}
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+let querySet52 = device0.createQuerySet(
+{
+label: '\u2752\u0eca\u0e40\u6c21\u84bc\ua698\u1c53\u{1fbe0}\u0224',
+type: 'occlusion',
+count: 2759,
+}
+);
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder22.setViewport(
+0.5984,
+46.08,
+15.21,
+38.69,
+0.5127,
+0.5226
+);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(
+buffer6,
+'uint32'
+);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(
+4,
+bindGroup1
+);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(
+8,
+bindGroup0,
+new Uint32Array(3697),
+1200,
+0
+);
+} catch {}
+try {
+gpuCanvasContext11.configure(
+{
+device: device0,
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_DST,
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+10752,
+new Float32Array(42563),
+8753,
+1336
+);
+} catch {}
+let pipeline75 = device0.createComputePipeline(
+{
+layout: pipelineLayout16,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline76 = device0.createRenderPipeline(
+{
+label: '\u{1f72a}\u8a20\ud998\u886f\u{1f806}\u08ab\u72d4\u231b\uc26d\u0107',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 16408,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x2',
+offset: 11400,
+shaderLocation: 10,
+},
+{
+format: 'sint8x4',
+offset: 12488,
+shaderLocation: 17,
+},
+{
+format: 'snorm16x4',
+offset: 11688,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x4',
+offset: 9460,
+shaderLocation: 20,
+},
+{
+format: 'unorm16x2',
+offset: 11000,
+shaderLocation: 12,
+},
+{
+format: 'float16x2',
+offset: 900,
+shaderLocation: 2,
+},
+{
+format: 'unorm8x4',
+offset: 9804,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x4',
+offset: 14792,
+shaderLocation: 0,
+},
+{
+format: 'sint8x2',
+offset: 11358,
+shaderLocation: 13,
+},
+{
+format: 'uint16x4',
+offset: 5228,
+shaderLocation: 16,
+},
+{
+format: 'float16x4',
+offset: 1848,
+shaderLocation: 21,
+},
+{
+format: 'sint16x4',
+offset: 14496,
+shaderLocation: 18,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 13420,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x2',
+offset: 10108,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 53920,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 30924,
+shaderLocation: 8,
+},
+{
+format: 'float16x4',
+offset: 36668,
+shaderLocation: 14,
+},
+{
+format: 'sint16x4',
+offset: 27984,
+shaderLocation: 1,
+},
+{
+format: 'uint32x4',
+offset: 27704,
+shaderLocation: 22,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0x1aacc50b,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'one-minus-src',
+dstFactor: 'one-minus-constant'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'dst-alpha',
+dstFactor: 'src-alpha-saturated'
+},
+},
+format: 'r16float',
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'src-alpha',
+dstFactor: 'src-alpha-saturated'
+},
+},
+format: 'rg11b10ufloat',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}
+],
+},
+}
+);
+let video17 = await videoWithData();
+let renderBundleEncoder59 = device3.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba32sint',
+'rg11b10ufloat',
+'rgb10a2unorm',
+undefined
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 956,
+stencilReadOnly: true,
+}
+);
+try {
+gpuCanvasContext5.configure(
+{
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let img23 = await imageWithData(11, 254, '#69baa31d', '#06ad551a');
+let sampler51 = device3.createSampler(
+{
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 53.217,
+}
+);
+try {
+device3.pushErrorScope(
+'out-of-memory'
+);
+} catch {}
+try {
+await device3.popErrorScope();
+} catch {}
+try {
+renderBundleEncoder51.insertDebugMarker(
+'\u{1fe56}'
+);
+} catch {}
+try {
+device3.destroy();
+} catch {}
+canvas7.height = 613;
+let videoFrame13 = videoFrame3.clone();
+let textureView73 = texture82.createView(
+{
+label: '\u01ac\udf8b\u898b\u0bd8\u0b1e\u{1fee6}\u0194\u{1f623}\u88bd\uaf3e\u9e95',
+baseMipLevel: 1,
+baseArrayLayer: 0,
+}
+);
+let renderBundle59 = renderBundleEncoder59.finish(
+{
+label: '\u05a4\u0bbb\u{1fed1}\u1bbe'
+}
+);
+try {
+renderBundleEncoder51.setIndexBuffer(
+buffer18,
+'uint32',
+8476
+);
+} catch {}
+let promise39 = device3.popErrorScope();
+let promise40 = device3.queue.onSubmittedWorkDone();
+document.body.append('\u053a\u51c6');
+let offscreenCanvas17 = new OffscreenCanvas(1013, 649);
+let videoFrame14 = new VideoFrame(canvas1, {timestamp: 0});
+try {
+offscreenCanvas16.getContext('webgl2');
+} catch {}
+let buffer19 = device2.createBuffer(
+{
+label: '\ufeab\u0388\u8ee7\u{1f999}\ubb00\u0835\u9193',
+size: 46321,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let commandEncoder60 = device2.createCommandEncoder(
+{
+label: '\u57f7\u654e\u0375\ucf1f\ud466\ucb06\uebf5\u1284\uff7c',
+}
+);
+let textureView74 = texture71.createView(
+{
+label: '\u2dbb\ubeb6\ua2d1\u0d22\u0438\u3611\uccb4\u2a2d',
+dimension: '2d',
+format: 'rgba8sint',
+baseMipLevel: 2,
+baseArrayLayer: 19,
+}
+);
+let renderBundleEncoder60 = device2.createRenderBundleEncoder(
+{
+label: '\uc594\u0e3d\u{1fba2}\u{1ff72}\ufd4f\u{1f6e5}\ua4ab\u1b41\u0cd7\u1ee7',
+colorFormats: [
+'rgb10a2unorm',
+'rgb10a2unorm',
+'rgba32sint',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 402,
+stencilReadOnly: true,
+}
+);
+try {
+device2.pushErrorScope(
+'internal'
+);
+} catch {}
+try {
+await device2.popErrorScope();
+} catch {}
+try {
+commandEncoder58.clearBuffer(
+buffer19,
+38700,
+6640
+);
+dissociateBuffer(device2, buffer19);
+} catch {}
+try {
+renderPassEncoder23.insertDebugMarker(
+'\u7f4f'
+);
+} catch {}
+let pipeline77 = device2.createComputePipeline(
+{
+label: '\uf646\u0696\uc5dc\u04de\u0bd2\u0ac7\ue1bb',
+layout: pipelineLayout17,
+compute: {
+module: shaderModule15,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline78 = await device2.createRenderPipelineAsync(
+{
+label: '\u07bb\u9144\u1236\u3d6f\u0d6e\u5999\u1cc8\ud486\u{1fac6}\u7fd6',
+layout: pipelineLayout15,
+vertex: {
+module: shaderModule15,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 108,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 48,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 276,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 88,
+shaderLocation: 8,
+},
+{
+format: 'uint16x2',
+offset: 28,
+shaderLocation: 5,
+},
+{
+format: 'sint32',
+offset: 88,
+shaderLocation: 4,
+},
+{
+format: 'sint16x2',
+offset: 20,
+shaderLocation: 10,
+},
+{
+format: 'unorm16x2',
+offset: 0,
+shaderLocation: 12,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 156,
+shaderLocation: 2,
+},
+{
+format: 'uint32x2',
+offset: 100,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x2',
+offset: 144,
+shaderLocation: 11,
+},
+{
+format: 'uint32x2',
+offset: 8,
+shaderLocation: 14,
+},
+{
+format: 'sint32x3',
+offset: 240,
+shaderLocation: 3,
+},
+{
+format: 'uint32x4',
+offset: 260,
+shaderLocation: 0,
+},
+{
+format: 'unorm16x4',
+offset: 104,
+shaderLocation: 13,
+},
+{
+format: 'float16x4',
+offset: 156,
+shaderLocation: 15,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 92,
+shaderLocation: 6,
+},
+{
+format: 'uint16x2',
+offset: 28,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+frontFace: 'ccw',
+cullMode: 'none',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x54db1967,
+},
+fragment: {
+module: shaderModule15,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.GREEN,
+},
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'src-alpha',
+dstFactor: 'dst-alpha'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 2068,
+stencilWriteMask: 2553,
+depthBias: 87,
+depthBiasSlopeScale: 33,
+depthBiasClamp: 83,
+},
+}
+);
+gc();
+try {
+offscreenCanvas17.getContext('2d');
+} catch {}
+let adapter10 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let offscreenCanvas18 = new OffscreenCanvas(493, 897);
+document.body.append('\u0f99\u06b7\u{1f6e3}\u0ad2');
+try {
+window.someLabel = computePassEncoder23.label;
+} catch {}
+document.body.prepend(canvas0);
+let shaderModule19 = device0.createShaderModule(
+{
+label: '\u51cc\u{1fa98}\u4d3a\u{1fc28}',
+code: `@group(1) @binding(5645)
+var<storage, read_write> function3: array<u32>;
+
+@compute @workgroup_size(6, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(2) f0: vec3<f32>,
+@location(6) f1: vec2<u32>,
+@location(3) f2: vec4<f32>,
+@location(7) f3: u32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(36) f234: vec4<i32>,
+@location(9) f235: f16,
+@location(1) f236: i32,
+@location(13) f237: vec2<u32>,
+@location(37) f238: u32,
+@builtin(position) f239: vec4<f32>,
+@location(33) f240: vec3<f16>,
+@location(5) f241: vec2<f32>,
+@location(0) f242: vec4<f32>,
+@location(27) f243: vec2<i32>,
+@location(31) f244: u32,
+@location(35) f245: vec4<f16>,
+@location(20) f246: vec3<f32>,
+@location(19) f247: vec2<f32>,
+@location(30) f248: f16,
+@location(32) f249: vec4<f32>,
+@location(38) f250: vec3<f32>,
+@location(7) f251: vec3<i32>,
+@location(2) f252: f16
+}
+
+@vertex
+fn vertex0(@location(20) a0: vec3<f32>, @location(6) a1: f32, @location(19) a2: vec2<i32>, @location(0) a3: i32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+try {
+computePassEncoder25.setPipeline(
+pipeline5
+);
+} catch {}
+try {
+renderPassEncoder12.draw(
+0,
+48,
+24,
+16
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer11,
+323424
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture12,
+  mipLevel: 1,
+  origin: { x: 6, y: 6, z: 6 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 202151 */{
+offset: 534,
+bytesPerRow: 961,
+rowsPerImage: 134,
+},
+{width: 48, height: 76, depthOrArrayLayers: 2}
+);
+} catch {}
+let commandEncoder61 = device2.createCommandEncoder(
+{
+label: '\u0f5d\u{1fb76}\u99ff\u{1fce1}\u{1fada}\u4465\u4ee5\u6ea3\u0443\u18b5\u{1fdcf}',
+}
+);
+let commandBuffer9 = commandEncoder61.finish();
+let textureView75 = texture73.createView(
+{
+label: '\u0931\u331f',
+aspect: 'all',
+baseArrayLayer: 69,
+arrayLayerCount: 11,
+}
+);
+let renderBundleEncoder61 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg32sint',
+'r16float',
+'r8uint'
+],
+sampleCount: 582,
+stencilReadOnly: true,
+}
+);
+let renderBundle60 = renderBundleEncoder57.finish(
+{
+label: '\u{1fea7}\uf5c3\u0458\u5ed8\u0b91\u03aa\u{1fc0d}\u29b8\u09ad'
+}
+);
+try {
+renderPassEncoder23.setStencilReference(
+2544
+);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(
+7,
+buffer15,
+11476,
+355
+);
+} catch {}
+try {
+renderBundleEncoder60.setVertexBuffer(
+3,
+buffer15,
+4936
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer17,
+5364,
+new BigUint64Array(6531),
+2864,
+252
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline79 = device2.createRenderPipeline(
+{
+layout: pipelineLayout14,
+vertex: {
+module: shaderModule17,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1168,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 564,
+shaderLocation: 3,
+},
+{
+format: 'unorm16x4',
+offset: 912,
+shaderLocation: 6,
+},
+{
+format: 'unorm16x4',
+offset: 480,
+shaderLocation: 15,
+},
+{
+format: 'sint8x4',
+offset: 420,
+shaderLocation: 5,
+},
+{
+format: 'float32x4',
+offset: 192,
+shaderLocation: 14,
+},
+{
+format: 'sint32x3',
+offset: 952,
+shaderLocation: 13,
+},
+{
+format: 'sint16x4',
+offset: 724,
+shaderLocation: 10,
+},
+{
+format: 'uint32x4',
+offset: 424,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 1208,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 1712,
+attributes: [
+
+],
+},
+{
+arrayStride: 188,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 484,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 8,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+},
+multisample: {
+count: 1,
+mask: 0x938f2847,
+},
+fragment: {
+module: shaderModule17,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'zero',
+dstFactor: 'dst'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'one-minus-dst',
+dstFactor: 'one-minus-dst'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+undefined,
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'dst',
+dstFactor: 'dst'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.GREEN,
+}
+],
+},
+}
+);
+document.body.append('\u0bf5\u{1f937}\u8541\u291c\u0456\u4b8d\u0d3a');
+let canvas12 = document.createElement('canvas');
+try {
+renderPassEncoder23.setBlendConstant(
+{
+r: 67.93,
+g: -810.3,
+b: 336.4,
+a: -372.8,
+}
+);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(
+0,
+buffer15,
+11908,
+3024
+);
+} catch {}
+let pipeline80 = device2.createComputePipeline(
+{
+layout: pipelineLayout13,
+compute: {
+module: shaderModule17,
+entryPoint: 'compute0',
+},
+}
+);
+try {
+window.someLabel = device1.label;
+} catch {}
+try {
+textureView43.label = '\u5c9d\u9a75\ua857\u082b\u{1f89f}';
+} catch {}
+document.body.prepend(canvas12);
+let bindGroupLayout32 = device0.createBindGroupLayout(
+{
+label: '\u{1fab9}\ufd6b\u0eaf\u7db0\u0269',
+entries: [
+{
+binding: 1738,
+visibility: 0,
+storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '3d' },
+},
+{
+binding: 6773,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let commandEncoder62 = device0.createCommandEncoder(
+{
+}
+);
+try {
+renderPassEncoder12.setVertexBuffer(
+9,
+buffer6,
+3404,
+16292
+);
+} catch {}
+try {
+device0.pushErrorScope(
+'out-of-memory'
+);
+} catch {}
+try {
+commandEncoder62.copyBufferToBuffer(
+buffer12,
+18672,
+buffer11,
+1328,
+2420
+);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder62.copyTextureToTexture(
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 91, y: 1, z: 197 },
+  aspect: 'all',
+},
+{
+  texture: texture39,
+  mipLevel: 1,
+  origin: { x: 10, y: 1, z: 54 },
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 35}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer12,
+8836,
+new Float32Array(64788),
+7208,
+3444
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture38,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 83 },
+  aspect: 'stencil-only',
+},
+new DataView(arrayBuffer5),
+/* required buffer size: 20984938 */{
+offset: 855,
+bytesPerRow: 3334,
+rowsPerImage: 217,
+},
+{width: 3221, height: 1, depthOrArrayLayers: 30}
+);
+} catch {}
+let bindGroup11 = device0.createBindGroup({
+label: '\ueced\u0676\u98f2\u01c7\u{1f95d}\u07a0\u040f\uca61\udde5',
+layout: bindGroupLayout5,
+entries: [
+{
+binding: 5645,
+resource: {
+buffer: buffer12,
+offset: 6336,
+size: 6640,
+}
+},
+{
+binding: 8053,
+resource: externalTexture1
+}
+],
+});
+let texture85 = device0.createTexture(
+{
+label: '\u4ec5\u6dfa\u8a65\u{1fdb1}\u1fd8\u7523\u7355\u{1fe22}\u0450\uc252',
+size: {width: 3426},
+dimension: '1d',
+format: 'rgba32float',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let texture86 = gpuCanvasContext5.getCurrentTexture();
+try {
+renderPassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder18.executeBundles([]);
+} catch {}
+let arrayBuffer6 = buffer5.getMappedRange(
+6288,
+96
+);
+try {
+buffer3.unmap();
+} catch {}
+try {
+computePassEncoder25.insertDebugMarker(
+'\u0372'
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture75,
+  mipLevel: 1,
+  origin: { x: 2, y: 0, z: 27 },
+  aspect: 'all',
+},
+new ArrayBuffer(40),
+/* required buffer size: 5762567 */{
+offset: 557,
+bytesPerRow: 174,
+rowsPerImage: 185,
+},
+{width: 55, height: 0, depthOrArrayLayers: 180}
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline81 = device0.createComputePipeline(
+{
+label: '\u{1f7d9}\udd2e\u1fc5',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule19,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend('\u6397\u2b3e\u1b72\uecc8\u033d\u0d66\u{1ffd3}\uebb3\u5428');
+document.body.prepend('\u{1feb6}\u732f\u5369\ucfb7\u653a');
+let renderBundleEncoder62 = device0.createRenderBundleEncoder(
+{
+label: '\u159a\u5669\u6334\ubeed\ua62e\u4447\u0167',
+colorFormats: [
+'r16float',
+'rgba32float',
+'rgba16uint',
+'rg16float',
+'r16sint',
+'rgba8sint',
+'r32uint'
+],
+sampleCount: 259,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder20.setIndexBuffer(
+buffer6,
+'uint16',
+19638,
+709
+);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(
+5,
+buffer12,
+11180,
+2165
+);
+} catch {}
+try {
+commandEncoder62.clearBuffer(
+buffer3,
+20,
+4536
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder62.resolveQuerySet(
+querySet47,
+950,
+1822,
+buffer1,
+768
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 21, height: 1, depthOrArrayLayers: 93}
+*/
+{
+  source: offscreenCanvas9,
+  origin: { x: 627, y: 349 },
+  flipY: true,
+},
+{
+  texture: texture39,
+  mipLevel: 1,
+  origin: { x: 6, y: 1, z: 70 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 13, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await promise40;
+} catch {}
+let computePassEncoder37 = commandEncoder60.beginComputePass(
+{
+label: '\u515d\ua362\u0469\u0e9f\u00b4\u1c23\u60e3\u{1ff7d}'
+}
+);
+let renderPassEncoder24 = commandEncoder58.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView71,
+clearValue: {
+r: -415.1,
+g: -726.1,
+b: 544.8,
+a: -518.6,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined,
+{
+view: textureView74,
+clearValue: {
+r: -107.9,
+g: 701.9,
+b: -813.8,
+a: 969.0,
+},
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet40,
+maxDrawCount: 151008,
+}
+);
+let renderBundleEncoder63 = device2.createRenderBundleEncoder(
+{
+label: '\u{1fec9}\u6c40\u{1f9b6}\u01e6\u{1f8fe}\u{1fbca}\u{1fd6d}\uf06b\u0516\u0820\u5a31',
+colorFormats: [
+'bgra8unorm-srgb',
+'r32sint',
+'r8unorm',
+'rg16sint',
+undefined,
+'r32uint',
+undefined,
+'rg32uint'
+],
+sampleCount: 504,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder23.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder48.insertDebugMarker(
+'\u648b'
+);
+} catch {}
+try {
+gpuCanvasContext6.configure(
+{
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+let canvas13 = document.createElement('canvas');
+try {
+offscreenCanvas18.getContext('2d');
+} catch {}
+let gpuCanvasContext16 = canvas12.getContext('webgpu');
+let offscreenCanvas19 = new OffscreenCanvas(384, 399);
+let commandEncoder63 = device2.createCommandEncoder(
+{
+label: '\u8be4\u61a9\u6e59\uf08d\ubd48\uef84\u128f\u0487\u1af0\uddda',
+}
+);
+let texture87 = device2.createTexture(
+{
+size: {width: 204, height: 72, depthOrArrayLayers: 216},
+mipLevelCount: 3,
+format: 'astc-12x12-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-12x12-unorm',
+'astc-12x12-unorm',
+'astc-12x12-unorm-srgb'
+],
+}
+);
+let sampler52 = device2.createSampler(
+{
+label: '\u5b7b\u{1fdaf}\uc5ee\u03e2\ua21c\u06e2\u{1fb8f}\u2429\u5038',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 12.863,
+lodMaxClamp: 74.352,
+compare: 'not-equal',
+}
+);
+try {
+renderPassEncoder24.setScissorRect(
+0,
+57,
+17,
+0
+);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(
+3,
+buffer15,
+724
+);
+} catch {}
+try {
+renderBundleEncoder60.setVertexBuffer(
+7,
+buffer15,
+9068,
+4727
+);
+} catch {}
+try {
+await buffer19.mapAsync(
+GPUMapMode.READ,
+0,
+40212
+);
+} catch {}
+let pipeline82 = await device2.createComputePipelineAsync(
+{
+label: '\u617b\u79eb\u{1f62d}',
+layout: pipelineLayout17,
+compute: {
+module: shaderModule15,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+await promise39;
+} catch {}
+canvas3.width = 683;
+gc();
+document.body.append('\u0c60\u{1f7ed}\u{1fba8}\u{1fbe1}\u7f5c\u0a3c\u2cce\u0124\u00f7');
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let img24 = await imageWithData(31, 65, '#8bbdb34b', '#7721eb3f');
+let video18 = await videoWithData();
+let imageData11 = new ImageData(140, 104);
+let shaderModule20 = device2.createShaderModule(
+{
+label: '\u{1fd64}\u289f\ufc88\ue0b7\u126d\u05d5\u9da6\u0da3',
+code: `
+
+@compute @workgroup_size(5, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@location(3) a0: vec4<f32>, @location(0) a1: vec3<f32>, @location(8) a2: i32, @location(11) a3: f16, @location(13) a4: vec2<f16>) {
+
+}
+
+struct S17 {
+@builtin(vertex_index) f0: u32,
+@location(15) f1: vec2<f32>,
+@location(6) f2: vec2<f16>
+}
+struct VertexOutput0 {
+@location(11) f253: f16,
+@location(13) f254: vec2<f16>,
+@location(0) f255: vec3<f32>,
+@location(3) f256: vec4<f32>,
+@builtin(position) f257: vec4<f32>,
+@location(8) f258: i32
+}
+
+@vertex
+fn vertex0(@location(0) a0: f16, @location(1) a1: vec4<f16>, @location(13) a2: vec2<i32>, @location(2) a3: vec3<u32>, @location(5) a4: vec4<f32>, @location(3) a5: vec3<u32>, @location(9) a6: vec4<f32>, @location(7) a7: vec2<u32>, @builtin(instance_index) a8: u32, @location(14) a9: u32, @location(10) a10: vec2<f16>, @location(4) a11: vec4<u32>, a12: S17, @location(11) a13: vec2<i32>, @location(12) a14: vec2<u32>, @location(8) a15: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+}
+);
+let bindGroup12 = device2.createBindGroup({
+label: '\u{1ffbd}\ua9d3\uaf89\u{1ff4b}\u{1fde6}\u0e63\u369b\ub176\u5a06\ud8c9\u77da',
+layout: bindGroupLayout25,
+entries: [
+{
+binding: 677,
+resource: externalTexture2
+}
+],
+});
+let querySet53 = device2.createQuerySet(
+{
+label: '\u03e6\u5118\u84bf',
+type: 'occlusion',
+count: 1532,
+}
+);
+let texture88 = device2.createTexture(
+{
+label: '\u{1fbe0}\uabc5\u2ddd\ucb6f\u{1f694}\u5107\u{1f78b}\u0808\u7975',
+size: [4721],
+dimension: '1d',
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float',
+'rgba16float',
+'rgba16float'
+],
+}
+);
+let computePassEncoder38 = commandEncoder63.beginComputePass();
+let renderBundleEncoder64 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8unorm',
+'rgba16sint',
+'rgba32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 724,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder23.setBindGroup(
+0,
+bindGroup12
+);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(
+3,
+bindGroup12,
+new Uint32Array(4078),
+2685,
+0
+);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder24.setBlendConstant(
+{
+r: 536.8,
+g: -660.0,
+b: 443.7,
+a: -88.17,
+}
+);
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(
+23,
+22,
+3,
+12
+);
+} catch {}
+try {
+renderPassEncoder23.setStencilReference(
+3464
+);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(
+0,
+bindGroup12,
+[]
+);
+} catch {}
+try {
+renderBundleEncoder61.setVertexBuffer(
+6,
+buffer15,
+12448,
+3017
+);
+} catch {}
+try {
+gpuCanvasContext8.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rg16uint',
+'rgba16float',
+'astc-6x5-unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+document.body.prepend(canvas7);
+let imageData12 = new ImageData(96, 52);
+let renderBundleEncoder65 = device2.createRenderBundleEncoder(
+{
+label: '\u0acf\u8dc6\u79c7\u04af',
+colorFormats: [
+'rgba8uint',
+'rgba32uint',
+undefined,
+'rg8sint'
+],
+sampleCount: 579,
+depthReadOnly: true,
+}
+);
+let renderBundle61 = renderBundleEncoder63.finish(
+{
+label: '\u0ae1\u07c3\u{1f7b3}\u5a13\u0b17\ud0f8\u09ad'
+}
+);
+try {
+renderPassEncoder24.setViewport(
+5.765,
+34.22,
+16.35,
+17.38,
+0.7034,
+0.9445
+);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+let gpuCanvasContext17 = offscreenCanvas19.getContext('webgpu');
+let commandEncoder64 = device0.createCommandEncoder(
+{
+label: '\u0bb5\u7231\u7dbf',
+}
+);
+pseudoSubmit(device0, commandEncoder46);
+let computePassEncoder39 = commandEncoder64.beginComputePass(
+{
+label: '\u{1f6c8}\u{1fe98}\ube87\u{1f98e}'
+}
+);
+try {
+renderPassEncoder8.setBindGroup(
+1,
+bindGroup8,
+new Uint32Array(2258),
+2142,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(
+0,
+bindGroup0,
+new Uint32Array(3152),
+782,
+0
+);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(
+0,
+buffer6,
+13868,
+8306
+);
+} catch {}
+let arrayBuffer7 = buffer13.getMappedRange(
+18000,
+2152
+);
+try {
+buffer4.destroy();
+} catch {}
+try {
+commandEncoder62.copyBufferToTexture(
+{
+/* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 25432 */
+offset: 25432,
+bytesPerRow: 512,
+buffer: buffer4,
+},
+{
+  texture: texture13,
+  mipLevel: 1,
+  origin: { x: 46, y: 3, z: 1 },
+  aspect: 'all',
+},
+{width: 10, height: 2, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder62.clearBuffer(
+buffer12,
+3744,
+3828
+);
+dissociateBuffer(device0, buffer12);
+} catch {}
+let videoFrame15 = new VideoFrame(img15, {timestamp: 0});
+try {
+canvas13.getContext('bitmaprenderer');
+} catch {}
+canvas8.height = 548;
+let video19 = await videoWithData();
+try {
+adapter7.label = '\uc4b9\ua588\u0053\ue90c\uf54c';
+} catch {}
+try {
+renderBundle53.label = '\u61b7\ub775\u{1fac6}\u3f27\ua981';
+} catch {}
+document.body.prepend('\u07cc\u0681');
+let imageBitmap18 = await createImageBitmap(img1);
+try {
+computePassEncoder38.insertDebugMarker(
+'\u052b'
+);
+} catch {}
+try {
+gpuCanvasContext8.configure(
+{
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb',
+'rgba8unorm-srgb'
+],
+}
+);
+} catch {}
+video17.height = 54;
+offscreenCanvas1.width = 650;
+document.body.append('\u09a4\u5994\u3194\u{1f702}\u26d4\u238e\u{1f6a4}\u708b\u{1f872}\u0632');
+let offscreenCanvas20 = new OffscreenCanvas(915, 52);
+try {
+offscreenCanvas20.getContext('webgl');
+} catch {}
+let querySet54 = device2.createQuerySet(
+{
+label: '\uc3ca\ufca0\u079a\u0d06\u274f\u{1fd66}\u025b\u{1fb26}',
+type: 'occlusion',
+count: 2464,
+}
+);
+let sampler53 = device2.createSampler(
+{
+label: '\ubeeb\u1b5f\u0f7a\u{1fc0e}\u0aaf\u678e',
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 49.359,
+lodMaxClamp: 61.430,
+maxAnisotropy: 20,
+}
+);
+try {
+renderBundleEncoder58.setBindGroup(
+0,
+bindGroup12
+);
+} catch {}
+try {
+renderPassEncoder24.insertDebugMarker(
+'\uc19c'
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer17,
+9308,
+new BigUint64Array(4178),
+3363,
+28
+);
+} catch {}
+let pipeline83 = await device2.createRenderPipelineAsync(
+{
+label: '\u350c\u{1fc1a}\u072f\udf2d\u0e21\ufbbe\u033b\u2dd6\u7a3a\u9e5b',
+layout: 'auto',
+vertex: {
+module: shaderModule15,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 1364,
+shaderLocation: 5,
+},
+{
+format: 'sint16x2',
+offset: 1236,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 620,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 600,
+shaderLocation: 10,
+},
+{
+format: 'snorm16x4',
+offset: 448,
+shaderLocation: 15,
+},
+{
+format: 'uint32',
+offset: 124,
+shaderLocation: 8,
+},
+{
+format: 'uint16x2',
+offset: 384,
+shaderLocation: 7,
+},
+{
+format: 'snorm8x4',
+offset: 324,
+shaderLocation: 6,
+},
+{
+format: 'unorm8x2',
+offset: 184,
+shaderLocation: 2,
+},
+{
+format: 'uint32',
+offset: 420,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x4',
+offset: 536,
+shaderLocation: 12,
+},
+{
+format: 'uint8x4',
+offset: 460,
+shaderLocation: 0,
+},
+{
+format: 'float32x3',
+offset: 48,
+shaderLocation: 1,
+},
+{
+format: 'uint32',
+offset: 44,
+shaderLocation: 14,
+},
+{
+format: 'sint8x4',
+offset: 332,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 1388,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 176,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 1848,
+attributes: [
+{
+format: 'snorm8x2',
+offset: 1538,
+shaderLocation: 13,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule15,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg8uint',
+writeMask: 0,
+},
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'rg16uint',
+},
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 1539,
+depthBiasClamp: 15,
+},
+}
+);
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let device4 = await promise26;
+document.body.append('\u9e10\u05ed\u592f\u9cac\u0d0e\u{1f65f}');
+let bindGroupLayout33 = device4.createBindGroupLayout(
+{
+label: '\u6b9f\uceec',
+entries: [
+{
+binding: 971,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'non-filtering' },
+}
+],
+}
+);
+let querySet55 = device4.createQuerySet(
+{
+type: 'occlusion',
+count: 4000,
+}
+);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+document.body.prepend('\u3219\u0c22\u01a2\u{1f7d2}\u95a9\u780d\u7a60\ude54\u7ed4\uc728\u0542');
+let bindGroupLayout34 = device0.createBindGroupLayout(
+{
+entries: [
+{
+binding: 5589,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+let commandEncoder65 = device0.createCommandEncoder(
+{
+}
+);
+try {
+computePassEncoder32.setPipeline(
+pipeline28
+);
+} catch {}
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder22.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder20.setViewport(
+8.951,
+159.3,
+25.30,
+2.063,
+0.3531,
+0.8590
+);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(
+28,
+undefined,
+2419354957,
+475852193
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture77,
+  mipLevel: 0,
+  origin: { x: 10, y: 114, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(40),
+/* required buffer size: 42984 */{
+offset: 660,
+bytesPerRow: 5304,
+},
+{width: 2598, height: 8, depthOrArrayLayers: 1}
+);
+} catch {}
+offscreenCanvas18.height = 934;
+let imageBitmap19 = await createImageBitmap(imageBitmap5);
+let buffer20 = device4.createBuffer(
+{
+label: '\u{1f849}\u71ab\u505a\u03e0\u18f8\u{1fd1a}',
+size: 52705,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+mappedAtCreation: false,
+}
+);
+try {
+buffer20.unmap();
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+offscreenCanvas13.height = 650;
+let shaderModule21 = device0.createShaderModule(
+{
+label: '\u{1fd60}\u05a9\u41b4\u78bb',
+code: `@group(3) @binding(4899)
+var<storage, read_write> global1: array<u32>;
+@group(1) @binding(8053)
+var<storage, read_write> local1: array<u32>;
+
+@compute @workgroup_size(6, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S18 {
+@builtin(front_facing) f0: bool,
+@builtin(sample_index) f1: u32
+}
+struct FragmentOutput0 {
+@location(0) f0: i32,
+@location(3) f1: vec3<u32>,
+@location(6) f2: vec2<u32>,
+@location(5) f3: i32,
+@location(1) f4: vec2<u32>,
+@location(2) f5: vec3<f32>,
+@location(7) f6: vec3<u32>,
+@location(4) f7: vec3<u32>
+}
+
+@fragment
+fn fragment0(a0: S18, @builtin(position) a1: vec4<f32>, @builtin(sample_mask) a2: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(21) a1: f32, @location(4) a2: vec4<f16>, @builtin(instance_index) a3: u32, @location(20) a4: vec2<f32>, @location(18) a5: vec4<f16>, @location(17) a6: f16, @location(10) a7: vec3<f32>, @location(11) a8: vec3<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroup13 = device0.createBindGroup({
+label: '\u{1f925}\uc425\u05cd\ud4ca',
+layout: bindGroupLayout23,
+entries: [
+{
+binding: 6904,
+resource: externalTexture1
+}
+],
+});
+let texture89 = device0.createTexture(
+{
+label: '\u0cde\u6ced\u0a21\u08a6\u{1fa8f}\u{1ff8b}\u0253\u0186\u5e87',
+size: [55, 196, 174],
+mipLevelCount: 4,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'bgra8unorm',
+'bgra8unorm'
+],
+}
+);
+let textureView76 = texture35.createView(
+{
+label: '\ua077\u522e\u03b1\uf42f\u6f31\u1bf5\u95cd',
+dimension: '2d-array',
+}
+);
+try {
+computePassEncoder27.end();
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(
+3,
+1,
+1,
+0
+);
+} catch {}
+try {
+commandEncoder41.copyBufferToBuffer(
+buffer13,
+13216,
+buffer3,
+2984,
+2080
+);
+dissociateBuffer(device0, buffer13);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+12068,
+new DataView(new ArrayBuffer(34752)),
+16787,
+4744
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 19, height: 27, depthOrArrayLayers: 22}
+*/
+{
+  source: video19,
+  origin: { x: 0, y: 2 },
+  flipY: true,
+},
+{
+  texture: texture12,
+  mipLevel: 3,
+  origin: { x: 5, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 13, height: 11, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline84 = device0.createComputePipeline(
+{
+label: '\u{1fee9}\u8f19\u0783\u{1f625}\u{1f6ea}\u04a7\u0247\uc729\u401d\u{1ff4e}',
+layout: 'auto',
+compute: {
+module: shaderModule21,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+gc();
+document.body.prepend('\u7751\u{1f7dd}\ua035\ufc64\u05ba\u{1fc21}\u041e\u96f0\u09a3\u8c53');
+document.body.append('\u76f1\u061a\u1e3a\u0032\u59cb');
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+document.body.prepend('\u7773\ue0ed\u6679\ud896\u0402\u0b82\u1898\u{1fd84}\uadec\u5830');
+let canvas14 = document.createElement('canvas');
+let texture90 = device2.createTexture(
+{
+label: '\uae19\u0fa0\u75cb\u9653\u0407\u0cdb\u46c4',
+size: {width: 160, height: 24, depthOrArrayLayers: 216},
+mipLevelCount: 2,
+format: 'astc-4x4-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-4x4-unorm',
+'astc-4x4-unorm-srgb'
+],
+}
+);
+try {
+renderPassEncoder23.setScissorRect(
+25,
+33,
+1,
+19
+);
+} catch {}
+try {
+renderPassEncoder24.setViewport(
+16.92,
+53.25,
+1.917,
+2.455,
+0.9681,
+0.9704
+);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(
+6,
+buffer15,
+6708,
+8730
+);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(
+2,
+bindGroup12,
+new Uint32Array(2932),
+2295,
+0
+);
+} catch {}
+try {
+gpuCanvasContext9.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgba16float',
+'rgba16float',
+'rgba16float',
+'eac-rg11snorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device2.queue.submit([
+commandBuffer6,
+commandBuffer9,
+]);
+} catch {}
+let shaderModule22 = device0.createShaderModule(
+{
+code: `@group(0) @binding(1830)
+var<storage, read_write> global2: array<u32>;
+
+@compute @workgroup_size(6, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: f32,
+@location(4) f1: f32,
+@location(5) f2: i32,
+@location(3) f3: vec4<f32>,
+@location(7) f4: u32,
+@location(0) f5: vec4<f32>,
+@location(2) f6: vec4<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(10) a0: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let renderPassEncoder25 = commandEncoder65.beginRenderPass(
+{
+label: '\u64d3\u{1f626}\ud20a\u02cc\u{1fdee}\u0bd9\u3a85',
+colorAttachments: [
+undefined
+],
+depthStencilAttachment: {
+view: textureView12,
+depthClearValue: -7.067856907529038,
+stencilClearValue: 17238,
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet42,
+}
+);
+try {
+renderPassEncoder21.end();
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(
+32
+);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(
+0,
+80,
+8
+);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(
+4,
+buffer12,
+1248
+);
+} catch {}
+try {
+commandEncoder41.copyTextureToTexture(
+{
+  texture: texture19,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture45,
+  mipLevel: 4,
+  origin: { x: 18, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder62.resolveQuerySet(
+querySet9,
+150,
+1356,
+buffer1,
+1280
+);
+} catch {}
+try {
+renderBundleEncoder17.insertDebugMarker(
+'\u0849'
+);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer7,
+]);
+} catch {}
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+document.body.append('\u15a7\u023b\u046a');
+let video20 = await videoWithData();
+let videoFrame16 = new VideoFrame(canvas2, {timestamp: 0});
+try {
+canvas14.getContext('webgpu');
+} catch {}
+let videoFrame17 = new VideoFrame(video2, {timestamp: 0});
+document.body.append('\u{1fd49}\u799c\u{1fc08}\u67d3\u{1ff27}\u04fa\u8e8e\uac38\u{1fd04}\u89d9\u994c');
+let promise41 = adapter2.requestAdapterInfo();
+let promise42 = device4.queue.onSubmittedWorkDone();
+let pipelineLayout20 = device2.createPipelineLayout(
+{
+label: '\u0b74\ud707\u9c35',
+bindGroupLayouts: [
+bindGroupLayout31,
+bindGroupLayout25
+],
+}
+);
+let externalTexture4 = device2.importExternalTexture(
+{
+label: '\uf1f2\u02de\u2a45\u{1fed2}\u{1fac3}\u409c\ua40c\u{1fcdc}\u6441',
+source: video9,
+colorSpace: 'display-p3',
+}
+);
+try {
+renderPassEncoder24.setBindGroup(
+2,
+bindGroup12,
+new Uint32Array(4637),
+1112,
+0
+);
+} catch {}
+try {
+renderPassEncoder24.setScissorRect(
+17,
+17,
+9,
+1
+);
+} catch {}
+try {
+renderPassEncoder23.setViewport(
+29.39,
+34.12,
+0.7949,
+19.35,
+0.4596,
+0.5944
+);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(
+22,
+undefined
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture62,
+  mipLevel: 0,
+  origin: { x: 80, y: 44, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 1095 */{
+offset: 145,
+bytesPerRow: 82,
+},
+{width: 15, height: 48, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await promise41;
+} catch {}
+let video21 = await videoWithData();
+try {
+renderPassEncoder23.setBindGroup(
+2,
+bindGroup12,
+[]
+);
+} catch {}
+try {
+renderPassEncoder24.setBlendConstant(
+{
+r: -133.3,
+g: -599.9,
+b: 307.0,
+a: 419.5,
+}
+);
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(
+6,
+31,
+4,
+14
+);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(
+3,
+buffer15,
+7620,
+1476
+);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture65,
+  mipLevel: 0,
+  origin: { x: 1620, y: 0, z: 11 },
+  aspect: 'all',
+},
+new Int16Array(arrayBuffer7),
+/* required buffer size: 995 */{
+offset: 995,
+},
+{width: 2540, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline85 = device2.createComputePipeline(
+{
+label: '\u9dff\u6772\u3191\u{1f9da}',
+layout: 'auto',
+compute: {
+module: shaderModule20,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let promise43 = device2.createRenderPipelineAsync(
+{
+label: '\u76a9\u09ce\u07ce\uaf55\ua61b\ua21c\ufedd',
+layout: pipelineLayout13,
+vertex: {
+module: shaderModule18,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 680,
+attributes: [
+{
+format: 'snorm16x2',
+offset: 92,
+shaderLocation: 14,
+},
+{
+format: 'uint8x4',
+offset: 360,
+shaderLocation: 7,
+},
+{
+format: 'float32x3',
+offset: 408,
+shaderLocation: 8,
+},
+{
+format: 'float16x2',
+offset: 108,
+shaderLocation: 1,
+},
+{
+format: 'sint8x2',
+offset: 220,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 1448,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 948,
+shaderLocation: 6,
+},
+{
+format: 'sint8x4',
+offset: 364,
+shaderLocation: 10,
+},
+{
+format: 'uint32x4',
+offset: 208,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 756,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'front',
+},
+multisample: {
+count: 4,
+mask: 0xfa610a04,
+},
+fragment: {
+module: shaderModule18,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'keep',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 3370,
+stencilWriteMask: 3750,
+depthBias: 68,
+},
+}
+);
+try {
+textureView13.label = '\u0f41\u0e8a\ub16c\u3865\ua243\u0332\u00d6\u085d\u0f34\u4f81';
+} catch {}
+let commandEncoder66 = device0.createCommandEncoder(
+{
+}
+);
+let querySet56 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 3564,
+}
+);
+let textureView77 = texture41.createView(
+{
+label: '\u{1fe21}\u9bdd\u{1fc1d}\u4440\u0f70\u6021',
+}
+);
+let renderPassEncoder26 = commandEncoder66.beginRenderPass(
+{
+label: '\u0c88\u0b14\u162c\u{1f80d}\ua233\u4193\u0054\ud436\u09fc\ue8ab',
+colorAttachments: [
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView12,
+depthClearValue: -5.264349048090107,
+depthReadOnly: false,
+stencilLoadOp: 'load',
+stencilStoreOp: 'discard',
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet10,
+maxDrawCount: 211336,
+}
+);
+try {
+await device0.popErrorScope();
+} catch {}
+let promise44 = device0.queue.onSubmittedWorkDone();
+let promise45 = device0.createRenderPipelineAsync(
+{
+label: '\u947b\ud77d\uc7f7\u{1f978}',
+layout: pipelineLayout11,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 39600,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 17708,
+shaderLocation: 2,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 12612,
+shaderLocation: 0,
+},
+{
+format: 'uint8x2',
+offset: 37144,
+shaderLocation: 16,
+},
+{
+format: 'sint32',
+offset: 6520,
+shaderLocation: 1,
+},
+{
+format: 'sint32x3',
+offset: 26292,
+shaderLocation: 17,
+},
+{
+format: 'float32x3',
+offset: 24840,
+shaderLocation: 21,
+},
+{
+format: 'snorm8x2',
+offset: 34000,
+shaderLocation: 20,
+},
+{
+format: 'sint32x4',
+offset: 13324,
+shaderLocation: 10,
+},
+{
+format: 'sint16x4',
+offset: 18020,
+shaderLocation: 13,
+},
+{
+format: 'float32x2',
+offset: 30188,
+shaderLocation: 14,
+},
+{
+format: 'float32x2',
+offset: 5532,
+shaderLocation: 15,
+},
+{
+format: 'uint16x2',
+offset: 31908,
+shaderLocation: 22,
+},
+{
+format: 'uint32',
+offset: 38476,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 50580,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 28140,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x2',
+offset: 20156,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x2',
+offset: 23996,
+shaderLocation: 12,
+},
+{
+format: 'unorm8x4',
+offset: 8,
+shaderLocation: 7,
+},
+{
+format: 'sint8x4',
+offset: 15088,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 35064,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 10130,
+shaderLocation: 23,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16float',
+writeMask: GPUColorWrite.BLUE,
+},
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'constant',
+dstFactor: 'dst-alpha'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'one',
+dstFactor: 'src-alpha-saturated'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+format: 'r8unorm',
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'src',
+dstFactor: 'dst-alpha'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'src-alpha',
+dstFactor: 'one-minus-dst'
+},
+},
+format: 'rg11b10ufloat',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'replace',
+depthFailOp: 'invert',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 3852,
+stencilWriteMask: 873,
+depthBiasSlopeScale: 77,
+depthBiasClamp: 32,
+},
+}
+);
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let texture91 = gpuCanvasContext13.getCurrentTexture();
+let sampler54 = device2.createSampler(
+{
+label: '\u9302\u63ed\ucb30\u0666\u01b4\u{1fd22}\u46fa',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 12.600,
+lodMaxClamp: 33.457,
+}
+);
+try {
+computePassEncoder35.setPipeline(
+pipeline85
+);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(
+3,
+buffer15,
+5940,
+1424
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let promise46 = device2.createComputePipelineAsync(
+{
+label: '\u367b\u2443\ue01a\ua470\u6651\u7f98',
+layout: pipelineLayout13,
+compute: {
+module: shaderModule20,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline86 = await device2.createRenderPipelineAsync(
+{
+label: '\ue6a1\u0c3b\u95b4\u7768\u0c67\u0350\u05c6\u421f\u5b89\ubfd7',
+layout: pipelineLayout14,
+vertex: {
+module: shaderModule15,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 1436,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x2',
+offset: 256,
+shaderLocation: 10,
+},
+{
+format: 'float32x4',
+offset: 284,
+shaderLocation: 1,
+},
+{
+format: 'uint32x2',
+offset: 900,
+shaderLocation: 9,
+},
+{
+format: 'unorm8x2',
+offset: 704,
+shaderLocation: 13,
+},
+{
+format: 'float32x3',
+offset: 132,
+shaderLocation: 12,
+},
+{
+format: 'float32x3',
+offset: 1268,
+shaderLocation: 15,
+},
+{
+format: 'uint32x3',
+offset: 1112,
+shaderLocation: 14,
+},
+{
+format: 'uint32x2',
+offset: 552,
+shaderLocation: 0,
+},
+{
+format: 'unorm8x2',
+offset: 1352,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x2',
+offset: 728,
+shaderLocation: 6,
+},
+{
+format: 'uint32x3',
+offset: 1324,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 1704,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x4',
+offset: 344,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x3',
+offset: 740,
+shaderLocation: 3,
+},
+{
+format: 'sint32x3',
+offset: 796,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 372,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32',
+offset: 136,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+
+],
+},
+{
+arrayStride: 1672,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 1384,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'front',
+},
+fragment: {
+module: shaderModule15,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r16sint',
+},
+{
+format: 'rgb10a2uint',
+writeMask: 0,
+},
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+},
+{
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'keep',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilWriteMask: 1343,
+depthBias: 9,
+depthBiasSlopeScale: 48,
+depthBiasClamp: 53,
+},
+}
+);
+let querySet57 = device2.createQuerySet(
+{
+label: '\ucf5e\u0d1e\u5b94\u082e\u7670',
+type: 'occlusion',
+count: 3147,
+}
+);
+pseudoSubmit(device2, commandEncoder63);
+let textureView78 = texture62.createView(
+{
+label: '\u92e0\u0272\u{1fdef}\u0291\u091d',
+format: 'astc-5x4-unorm',
+baseMipLevel: 1,
+mipLevelCount: 3,
+}
+);
+let sampler55 = device2.createSampler(
+{
+label: '\u0044\u0110\u{1facf}\u141b\u069b\u0c2a\u8a9b',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 27.470,
+maxAnisotropy: 13,
+}
+);
+try {
+renderPassEncoder24.setVertexBuffer(
+7,
+buffer15
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture68,
+  mipLevel: 1,
+  origin: { x: 864, y: 20, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer5,
+/* required buffer size: 254 */{
+offset: 254,
+bytesPerRow: 3765,
+},
+{width: 1800, height: 10, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let videoFrame18 = new VideoFrame(canvas8, {timestamp: 0});
+let shaderModule23 = device0.createShaderModule(
+{
+label: '\u67b1\u{1f85c}\u05c1\ue920\u99e0\u03db\u0a4f\u{1fcdf}\u2f78\u11c9',
+code: `
+
+@compute @workgroup_size(5, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(5) f0: vec2<i32>,
+@location(1) f1: f32,
+@location(6) f2: vec2<u32>,
+@location(2) f3: f32
+}
+
+@fragment
+fn fragment0(@location(0) a0: vec2<u32>, @location(15) a1: vec3<f16>, @location(21) a2: vec2<f32>, @location(19) a3: vec3<i32>, @location(10) a4: vec3<f16>, @location(6) a5: vec2<i32>, @location(32) a6: vec2<f32>, @builtin(sample_index) a7: u32, @location(37) a8: u32, @location(9) a9: i32, @location(5) a10: f16, @location(24) a11: vec4<i32>, @location(26) a12: vec4<f16>, @location(33) a13: vec3<f16>, @location(23) a14: f16, @location(25) a15: vec4<u32>, @location(18) a16: vec2<f32>, @location(36) a17: vec2<u32>, @location(29) a18: vec4<u32>, @location(4) a19: vec4<i32>, @location(12) a20: vec2<f16>, @location(22) a21: i32, @location(38) a22: f16, @location(39) a23: vec2<i32>, @location(3) a24: vec2<u32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(32) f259: vec2<f32>,
+@location(17) f260: vec3<i32>,
+@location(4) f261: vec4<i32>,
+@location(5) f262: f16,
+@location(3) f263: vec2<u32>,
+@location(24) f264: vec4<i32>,
+@location(25) f265: vec4<u32>,
+@location(13) f266: vec4<i32>,
+@location(28) f267: vec2<i32>,
+@location(2) f268: f32,
+@location(21) f269: vec2<f32>,
+@location(14) f270: vec3<u32>,
+@builtin(position) f271: vec4<f32>,
+@location(30) f272: vec2<f32>,
+@location(36) f273: vec2<u32>,
+@location(33) f274: vec3<f16>,
+@location(6) f275: vec2<i32>,
+@location(15) f276: vec3<f16>,
+@location(34) f277: f32,
+@location(38) f278: f16,
+@location(22) f279: i32,
+@location(12) f280: vec2<f16>,
+@location(9) f281: i32,
+@location(7) f282: f32,
+@location(0) f283: vec2<u32>,
+@location(16) f284: u32,
+@location(37) f285: u32,
+@location(26) f286: vec4<f16>,
+@location(39) f287: vec2<i32>,
+@location(19) f288: vec3<i32>,
+@location(29) f289: vec4<u32>,
+@location(23) f290: f16,
+@location(18) f291: vec2<f32>,
+@location(10) f292: vec3<f16>,
+@location(35) f293: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(17) a0: vec2<u32>, @location(22) a1: u32, @location(3) a2: vec4<f16>, @location(11) a3: f16, @location(23) a4: f32, @location(12) a5: vec3<i32>, @builtin(instance_index) a6: u32, @location(18) a7: vec3<u32>, @location(9) a8: vec3<u32>, @location(14) a9: vec4<i32>, @location(10) a10: vec3<i32>, @location(13) a11: i32, @location(8) a12: vec4<i32>, @location(19) a13: vec2<i32>, @location(5) a14: vec3<u32>, @location(24) a15: f32, @location(20) a16: vec3<f16>, @location(6) a17: vec4<f32>, @location(1) a18: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let textureView79 = texture35.createView(
+{
+mipLevelCount: 1,
+}
+);
+let renderBundle62 = renderBundleEncoder20.finish(
+{
+label: '\u583a\u06c5\u{1f901}\u433e'
+}
+);
+let sampler56 = device0.createSampler(
+{
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 32.510,
+lodMaxClamp: 46.550,
+maxAnisotropy: 11,
+}
+);
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+2276
+);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+4,
+buffer12,
+22440,
+181
+);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+8,
+bindGroup3
+);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(
+6,
+bindGroup0,
+new Uint32Array(7481),
+1700,
+0
+);
+} catch {}
+try {
+commandEncoder41.copyTextureToBuffer(
+{
+  texture: texture86,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 24220 */
+offset: 24220,
+buffer: buffer1,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder62.resolveQuerySet(
+querySet0,
+594,
+902,
+buffer1,
+4352
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+18900,
+new Int16Array(32042),
+18841,
+2152
+);
+} catch {}
+let promise47 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 5}
+*/
+{
+  source: imageData10,
+  origin: { x: 7, y: 20 },
+  flipY: false,
+},
+{
+  texture: texture39,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+canvas2.height = 1023;
+let buffer21 = device2.createBuffer(
+{
+label: '\u46c7\u2be1',
+size: 64244,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let textureView80 = texture65.createView(
+{
+label: '\u0bcf\u0b8f\u0869\u084c\u{1f60c}\u{1f910}\u{1fd51}\u0be9\u06f3',
+format: 'astc-10x10-unorm-srgb',
+baseArrayLayer: 28,
+arrayLayerCount: 30,
+}
+);
+try {
+renderPassEncoder23.setBindGroup(
+3,
+bindGroup12
+);
+} catch {}
+try {
+renderPassEncoder23.setBlendConstant(
+{
+r: -81.76,
+g: 702.1,
+b: -415.7,
+a: -276.1,
+}
+);
+} catch {}
+document.body.prepend('\u{1f75e}\u0485\u{1f9ad}\u26ce\u{1fcac}\udf55\u4669\u0a56\u{1f66a}\ucc22\ue5b7');
+try {
+await promise47;
+} catch {}
+let device5 = await adapter7.requestDevice(
+{
+label: '\u1cc3\u0671\u{1fbcb}\u81cf\u0541\u4573\uc3df\u6dd2\u005d\u0112\u{1fd42}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+}
+);
+let renderBundle63 = renderBundleEncoder42.finish(
+{
+label: '\ubec2\u{1fb8f}\uba63\u0377\uda87\u{1fea3}\u{1f6ce}\u{1f748}\u{1f857}\udb22\u4d21'
+}
+);
+try {
+renderPassEncoder4.setStencilReference(
+2057
+);
+} catch {}
+try {
+renderPassEncoder12.draw(
+72,
+64
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer2,
+92192
+);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(
+3,
+buffer12,
+3928,
+9767
+);
+} catch {}
+try {
+commandEncoder41.clearBuffer(
+buffer3,
+1668,
+2260
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+computePassEncoder26.insertDebugMarker(
+'\ua176'
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageBitmap20 = await createImageBitmap(imageBitmap7);
+let commandEncoder67 = device4.createCommandEncoder();
+document.body.prepend('\ucf32\u00ef\ub4ea\u22e4\u0215\u5405\ua9c7\u08e6\ub9b8\uc461\u38ce');
+try {
+adapter2.label = '\uffee\ue392\u4aed\u3787\u0fec\u{1f9a7}\u0d28\u9e16\u601e\uc414';
+} catch {}
+let buffer22 = device0.createBuffer(
+{
+label: '\u27a3\ubd90',
+size: 9376,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let renderPassEncoder27 = commandEncoder62.beginRenderPass(
+{
+colorAttachments: [
+
+],
+depthStencilAttachment: {
+view: textureView51,
+depthLoadOp: 'load',
+depthStoreOp: 'store',
+stencilClearValue: 16471,
+},
+occlusionQuerySet: querySet2,
+maxDrawCount: 67864,
+}
+);
+let renderBundle64 = renderBundleEncoder15.finish();
+try {
+renderPassEncoder18.setViewport(
+13.55,
+17.36,
+12.01,
+82.91,
+0.6812,
+0.7227
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(
+buffer12,
+60200
+);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(
+6,
+buffer6,
+15432,
+789
+);
+} catch {}
+try {
+commandEncoder41.copyTextureToBuffer(
+{
+  texture: texture19,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 12568 */
+offset: 12568,
+rowsPerImage: 233,
+buffer: buffer12,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder41.resolveQuerySet(
+querySet30,
+455,
+152,
+buffer1,
+4096
+);
+} catch {}
+let imageBitmap21 = await createImageBitmap(imageData4);
+try {
+renderBundle49.label = '\u5c3c\u1d65\ucaf6';
+} catch {}
+let querySet58 = device2.createQuerySet(
+{
+label: '\ud687\uce5b\u{1fef2}',
+type: 'occlusion',
+count: 2839,
+}
+);
+let texture92 = device2.createTexture(
+{
+label: '\u{1f9b8}\u06ff',
+size: {width: 4417, height: 1, depthOrArrayLayers: 102},
+mipLevelCount: 10,
+dimension: '2d',
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView81 = texture90.createView(
+{
+label: '\u964f\u{1f801}\ua637\u068f\u0473\u0d45\u0505',
+dimension: '2d',
+format: 'astc-4x4-unorm-srgb',
+baseMipLevel: 1,
+baseArrayLayer: 119,
+}
+);
+let renderBundleEncoder66 = device2.createRenderBundleEncoder(
+{
+label: '\udd09\ub264\u{1f8b0}\ue51f\u0fb1\u{1fd90}\u4645\u09c9\u1128\u0d81',
+colorFormats: [
+'rg11b10ufloat',
+'bgra8unorm-srgb',
+'rgba32uint',
+undefined
+],
+sampleCount: 133,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+let renderBundle65 = renderBundleEncoder61.finish(
+{
+label: '\u0c8c\u5e45\u430f\u{1fd48}\u{1f9a3}'
+}
+);
+let sampler57 = device2.createSampler(
+{
+label: '\u{1fa52}\u6a4c\u04f4\u{1f9c6}\u266f\u{1f7eb}\ucaae\u8625\u040e\u662a\u0bb3',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 70.429,
+lodMaxClamp: 98.711,
+maxAnisotropy: 16,
+}
+);
+try {
+renderPassEncoder24.setViewport(
+17.24,
+20.92,
+4.627,
+32.02,
+0.3277,
+0.4259
+);
+} catch {}
+try {
+renderBundleEncoder64.setVertexBuffer(
+2,
+buffer15,
+8392,
+4444
+);
+} catch {}
+try {
+device2.queue.submit([
+commandBuffer8,
+]);
+} catch {}
+document.body.prepend(img1);
+let imageBitmap22 = await createImageBitmap(imageBitmap21);
+let querySet59 = device5.createQuerySet(
+{
+label: '\u035a\u50f9\u0951',
+type: 'occlusion',
+count: 825,
+}
+);
+canvas5.height = 496;
+try {
+device2.queue.label = '\u9715\uccab\ue0f4\u{1ffbf}';
+} catch {}
+let shaderModule24 = device2.createShaderModule(
+{
+label: '\u8553\u{1ff0b}\u0143\udd7a\uce80',
+code: `
+
+@compute @workgroup_size(2, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@location(10) a0: vec4<u32>, @location(14) a1: vec3<u32>) -> @location(6) vec4<i32> {
+return vec4<i32>();
+}
+
+struct S19 {
+@location(2) f0: vec2<f16>,
+@location(8) f1: vec4<f32>,
+@location(15) f2: f32,
+@builtin(vertex_index) f3: u32
+}
+struct VertexOutput0 {
+@location(14) f294: vec3<u32>,
+@builtin(position) f295: vec4<f32>,
+@location(4) f296: f32,
+@location(10) f297: vec4<u32>,
+@location(1) f298: f16,
+@location(8) f299: vec3<f32>,
+@location(15) f300: f16,
+@location(7) f301: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec4<i32>, @location(13) a1: i32, @location(14) a2: vec3<f32>, @location(12) a3: vec2<f16>, @location(0) a4: vec3<i32>, @location(7) a5: vec2<f16>, a6: S19, @location(11) a7: vec2<i32>, @location(10) a8: i32, @location(4) a9: vec2<f32>, @location(5) a10: u32, @location(1) a11: f32, @location(6) a12: vec2<f16>, @location(9) a13: vec4<i32>, @builtin(instance_index) a14: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+}
+);
+let querySet60 = device2.createQuerySet(
+{
+label: '\u{1faa0}\u0137\u07c9\u{1fe6c}\ub81e\u3330\u{1f7cc}\u4aa4\u0ce1\u07a5\u04bf',
+type: 'occlusion',
+count: 3993,
+}
+);
+let texture93 = device2.createTexture(
+{
+label: '\u0caa\ubab6\u09f6\u070a',
+size: {width: 5014},
+dimension: '1d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm',
+'rgba8unorm'
+],
+}
+);
+let textureView82 = texture64.createView(
+{
+label: '\u{1fe5a}\uad47\ud232\u07a2\u0fe9\u3106',
+format: 'astc-8x6-unorm-srgb',
+baseMipLevel: 1,
+mipLevelCount: 5,
+baseArrayLayer: 102,
+arrayLayerCount: 54,
+}
+);
+let sampler58 = device2.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+lodMinClamp: 79.706,
+lodMaxClamp: 87.481,
+}
+);
+try {
+computePassEncoder37.setBindGroup(
+3,
+bindGroup12,
+new Uint32Array(8180),
+6472,
+0
+);
+} catch {}
+try {
+computePassEncoder37.setPipeline(
+pipeline80
+);
+} catch {}
+try {
+renderPassEncoder23.setStencilReference(
+2429
+);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(
+5,
+buffer15,
+11240
+);
+} catch {}
+try {
+renderBundleEncoder66.setVertexBuffer(
+3,
+buffer15,
+2240,
+7235
+);
+} catch {}
+try {
+device2.pushErrorScope(
+'validation'
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture78,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 23 },
+  aspect: 'all',
+},
+arrayBuffer5,
+/* required buffer size: 2488778 */{
+offset: 390,
+bytesPerRow: 491,
+rowsPerImage: 181,
+},
+{width: 18, height: 0, depthOrArrayLayers: 29}
+);
+} catch {}
+let pipeline87 = device2.createComputePipeline(
+{
+layout: 'auto',
+compute: {
+module: shaderModule17,
+entryPoint: 'compute0',
+},
+}
+);
+document.body.append('\u{1fb4c}\u9e63\u6e66\u{1f644}\u{1fe83}');
+let querySet61 = device5.createQuerySet(
+{
+label: '\u038e\u0eed\uc796\u7011',
+type: 'occlusion',
+count: 467,
+}
+);
+let renderBundleEncoder67 = device5.createRenderBundleEncoder(
+{
+label: '\u9d41\u04ea\ud2fe',
+colorFormats: [
+'rgba16float',
+'r16uint',
+'bgra8unorm-srgb',
+'rgba8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 895,
+}
+);
+document.body.prepend(video3);
+let img25 = await imageWithData(195, 240, '#efc873de', '#339d725f');
+let pipelineLayout21 = device4.createPipelineLayout(
+{
+label: '\u{1f9b6}\u08c6\u3ef5\u{1f701}\uf04c\u0aa2\u01c8\u0ba0\u0e0e',
+bindGroupLayouts: [
+bindGroupLayout33
+],
+}
+);
+let querySet62 = device4.createQuerySet(
+{
+label: '\u{1fd14}\u1547\u8f89\u29ef\u9982\u0554\uf59f\u{1f844}\u0edd',
+type: 'occlusion',
+count: 2448,
+}
+);
+let texture94 = device4.createTexture(
+{
+label: '\u89a3\u6187',
+size: [145, 1, 220],
+mipLevelCount: 6,
+dimension: '3d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder40 = commandEncoder67.beginComputePass(
+{
+label: '\u{1fa0f}\u5fbe\u6b34\u0bbf\u0e5c\u0c13\ued2f\u44e6\u093d'
+}
+);
+try {
+device4.queue.writeTexture(
+{
+  texture: texture94,
+  mipLevel: 2,
+  origin: { x: 25, y: 0, z: 36 },
+  aspect: 'all',
+},
+new BigUint64Array(arrayBuffer5),
+/* required buffer size: 53852 */{
+offset: 460,
+bytesPerRow: 108,
+rowsPerImage: 247,
+},
+{width: 10, height: 1, depthOrArrayLayers: 3}
+);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let offscreenCanvas21 = new OffscreenCanvas(647, 182);
+let bindGroupLayout35 = device0.createBindGroupLayout(
+{
+label: '\u67c3\uf070\u{1feea}\u{1f9fc}\u98b7\ua59b\uccc5\u0925',
+entries: [
+{
+binding: 618,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let bindGroup14 = device0.createBindGroup({
+label: '\u{1f98b}\u01cc\uf74d\uc3d6',
+layout: bindGroupLayout1,
+entries: [
+{
+binding: 482,
+resource: {
+buffer: buffer12,
+offset: 4608,
+size: 472,
+}
+},
+{
+binding: 6583,
+resource: sampler8
+},
+{
+binding: 523,
+resource: {
+buffer: buffer1,
+offset: 11840,
+size: 4136,
+}
+}
+],
+});
+try {
+computePassEncoder14.setBindGroup(
+3,
+bindGroup10,
+[19072]
+);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(
+3,
+bindGroup6
+);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.draw(
+56,
+0,
+48,
+64
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(
+56,
+48,
+32,
+-744,
+16
+);
+} catch {}
+try {
+commandEncoder41.copyTextureToBuffer(
+{
+  texture: texture84,
+  mipLevel: 0,
+  origin: { x: 744, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 1768 widthInBlocks: 884 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 19936 */
+offset: 18168,
+bytesPerRow: 1792,
+rowsPerImage: 48,
+buffer: buffer1,
+},
+{width: 884, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder41.resolveQuerySet(
+querySet10,
+1723,
+985,
+buffer1,
+7936
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture13,
+  mipLevel: 3,
+  origin: { x: 5, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer7,
+/* required buffer size: 906 */{
+offset: 573,
+bytesPerRow: 297,
+},
+{width: 9, height: 2, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise48 = device0.createComputePipelineAsync(
+{
+label: '\uab46\u82b0\u4995\u09a2\u0209\ue645',
+layout: pipelineLayout6,
+compute: {
+module: shaderModule21,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+gc();
+document.body.append('\u{1fa10}\uc632\u048b\u1a17\u09a1\u{1f88e}\u3b12\u4f44\u{1f7af}\u3fe5');
+try {
+window.someLabel = texture55.label;
+} catch {}
+let videoFrame19 = new VideoFrame(imageBitmap14, {timestamp: 0});
+let sampler59 = device4.createSampler(
+{
+label: '\uaaa4\uccfa\u{1f773}\u6737',
+addressModeV: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 43.433,
+lodMaxClamp: 92.269,
+}
+);
+try {
+computePassEncoder40.end();
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer20,
+11128,
+new BigUint64Array(32651),
+17140,
+2108
+);
+} catch {}
+try {
+await promise42;
+} catch {}
+let canvas15 = document.createElement('canvas');
+try {
+externalTexture2.label = '\u09f8\ue040\u66bc';
+} catch {}
+let commandEncoder68 = device2.createCommandEncoder();
+let computePassEncoder41 = commandEncoder68.beginComputePass(
+{
+label: '\u636a\u{1f6cf}\uffed\uc675\u0667\u0f13\u{1f868}\u0ee1\u3f03'
+}
+);
+let renderBundle66 = renderBundleEncoder64.finish(
+{
+
+}
+);
+try {
+computePassEncoder41.setBindGroup(
+3,
+bindGroup12
+);
+} catch {}
+try {
+computePassEncoder41.setPipeline(
+pipeline87
+);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(
+6,
+buffer15
+);
+} catch {}
+let gpuCanvasContext18 = offscreenCanvas21.getContext('webgpu');
+try {
+adapter5.label = '\u{1fd5f}\u{1f7d2}\ub781\u4548';
+} catch {}
+document.body.prepend('\u4257\u3af2\u0921\uc351');
+let offscreenCanvas22 = new OffscreenCanvas(146, 753);
+let shaderModule25 = device4.createShaderModule(
+{
+label: '\u5e86\u{1fc5d}\u768c\u7392\ube10',
+code: `
+
+@compute @workgroup_size(6, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S21 {
+@location(14) f0: vec3<u32>,
+@location(1) f1: vec4<u32>,
+@builtin(position) f2: vec4<f32>,
+@location(8) f3: u32,
+@location(11) f4: vec4<f32>,
+@location(5) f5: vec2<f16>,
+@location(12) f6: vec3<f16>,
+@location(9) f7: vec4<u32>,
+@location(3) f8: vec4<f16>,
+@location(7) f9: vec3<u32>,
+@builtin(sample_index) f10: u32,
+@location(13) f11: vec3<u32>,
+@location(10) f12: vec2<f32>,
+@location(4) f13: f32,
+@builtin(front_facing) f14: bool,
+@location(15) f15: f16,
+@builtin(sample_mask) f16: u32,
+@location(0) f17: vec3<u32>
+}
+struct FragmentOutput0 {
+@location(0) f0: i32,
+@location(3) f1: vec2<u32>,
+@location(5) f2: u32,
+@location(6) f3: vec4<u32>,
+@location(1) f4: f32,
+@location(2) f5: vec3<f32>,
+@location(7) f6: vec2<u32>
+}
+
+@fragment
+fn fragment0(a0: S21, @location(2) a1: vec3<u32>, @location(6) a2: vec2<f16>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S20 {
+@location(6) f0: u32,
+@location(2) f1: vec4<f32>
+}
+struct VertexOutput0 {
+@builtin(position) f302: vec4<f32>,
+@location(15) f303: f16,
+@location(6) f304: vec2<f16>,
+@location(5) f305: vec2<f16>,
+@location(10) f306: vec2<f32>,
+@location(0) f307: vec3<u32>,
+@location(13) f308: vec3<u32>,
+@location(4) f309: f32,
+@location(7) f310: vec3<u32>,
+@location(12) f311: vec3<f16>,
+@location(9) f312: vec4<u32>,
+@location(3) f313: vec4<f16>,
+@location(11) f314: vec4<f32>,
+@location(8) f315: u32,
+@location(2) f316: vec3<u32>,
+@location(14) f317: vec3<u32>,
+@location(1) f318: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: f32, @builtin(vertex_index) a1: u32, @location(8) a2: vec3<f32>, @location(13) a3: vec3<f32>, @location(1) a4: vec3<u32>, @location(10) a5: i32, @location(3) a6: i32, @location(4) a7: vec3<f32>, @location(12) a8: vec3<f32>, a9: S20, @location(7) a10: vec4<f16>, @location(15) a11: f32, @location(9) a12: vec3<u32>, @location(14) a13: vec3<u32>, @location(5) a14: vec4<i32>, @location(0) a15: vec3<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroupLayout36 = device4.createBindGroupLayout(
+{
+label: '\u9a39\u0ccf\ud0d7\u0aba\u0d4a\u5ba9\u099c\u5d7f\ua52d',
+entries: [
+{
+binding: 238,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+},
+{
+binding: 601,
+visibility: 0,
+sampler: { type: 'non-filtering' },
+}
+],
+}
+);
+let commandEncoder69 = device4.createCommandEncoder(
+{
+}
+);
+let texture95 = device4.createTexture(
+{
+label: '\ucd8f\ua389\ubc97\u4b7c\u2380',
+size: {width: 7747, height: 2, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'rg8uint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg8uint',
+'rg8uint'
+],
+}
+);
+let computePassEncoder42 = commandEncoder67.beginComputePass(
+{
+label: '\u0b25\u889f\ue3fe'
+}
+);
+try {
+device4.queue.writeBuffer(
+buffer20,
+956,
+new Float32Array(1640),
+1618,
+16
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture94,
+  mipLevel: 1,
+  origin: { x: 19, y: 1, z: 10 },
+  aspect: 'all',
+},
+arrayBuffer7,
+/* required buffer size: 567373 */{
+offset: 561,
+bytesPerRow: 202,
+rowsPerImage: 46,
+},
+{width: 31, height: 0, depthOrArrayLayers: 62}
+);
+} catch {}
+try {
+offscreenCanvas22.getContext('webgl');
+} catch {}
+let querySet63 = device4.createQuerySet(
+{
+label: '\u04ed\u003f\u0cdb\uc8b2\u8ee9\ue7ef\u01ce\ude7c\u6f6b\u27bb',
+type: 'occlusion',
+count: 319,
+}
+);
+let computePassEncoder43 = commandEncoder69.beginComputePass(
+{
+label: '\u052b\u7259\u0038\u7b7d\u8940\u{1fd67}\u9b4c\u237f\uf2d6'
+}
+);
+try {
+buffer20.destroy();
+} catch {}
+let pipeline88 = await device4.createComputePipelineAsync(
+{
+label: '\uf011\ucef2',
+layout: pipelineLayout21,
+compute: {
+module: shaderModule25,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+gc();
+let device6 = await promise28;
+let imageBitmap23 = await createImageBitmap(videoFrame10);
+document.body.prepend('\u0e54\uc278\u7856');
+let bindGroup15 = device2.createBindGroup({
+label: '\uc6be\udbee\u2853\ub0b3\u0370\uff6d\u041b\u{1ff95}\u9e5a\u0b7c',
+layout: bindGroupLayout25,
+entries: [
+{
+binding: 677,
+resource: externalTexture4
+}
+],
+});
+let renderBundle67 = renderBundleEncoder64.finish(
+{
+label: '\u8de2\u065d\u2533\u0295'
+}
+);
+try {
+computePassEncoder37.setBindGroup(
+0,
+bindGroup12,
+[]
+);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(
+5,
+buffer15,
+2828,
+6866
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend('\u{1ffdf}\u6ea4\u9a37\u06ae');
+try {
+adapter6.label = '\u5021\u59ce\ud947\u{1fe06}\u05f3';
+} catch {}
+let bindGroupLayout37 = device2.createBindGroupLayout(
+{
+label: '\u{1fd91}\u{1f648}\u4c00\u{1fd10}\u{1f6d3}\u{1f67a}',
+entries: [
+{
+binding: 365,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let querySet64 = device2.createQuerySet(
+{
+label: '\u63aa\u12e4\u30d6\u8787\u{1fb4f}\ud99c\ub1af\ua481\u{1f631}\u229f',
+type: 'occlusion',
+count: 1550,
+}
+);
+try {
+renderPassEncoder24.beginOcclusionQuery(
+16
+);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder23.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder23.setViewport(
+25.26,
+51.23,
+0.4605,
+2.609,
+0.9008,
+0.9523
+);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(
+0,
+buffer15,
+4008,
+10273
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.prepend(canvas2);
+let buffer23 = device2.createBuffer(
+{
+size: 54388,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let renderBundleEncoder68 = device2.createRenderBundleEncoder(
+{
+label: '\uf1d3\u7546\u025b\u4f85\u01cd',
+colorFormats: [
+'rg8unorm'
+],
+sampleCount: 920,
+depthReadOnly: true,
+stencilReadOnly: false,
+}
+);
+let renderBundle68 = renderBundleEncoder44.finish(
+{
+label: '\u012a\u9637\ue227\u{1ffec}\u{1f771}'
+}
+);
+try {
+renderPassEncoder24.beginOcclusionQuery(
+72
+);
+} catch {}
+try {
+gpuCanvasContext6.configure(
+{
+device: device2,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'r16float',
+'astc-8x8-unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+video9.height = 139;
+document.body.prepend('\u9373\ua2af\uf77e\u03b4\u9ea5\ue042\u{1ffde}\u9759');
+try {
+canvas15.getContext('webgpu');
+} catch {}
+let bindGroupLayout38 = device4.createBindGroupLayout(
+{
+label: '\u03a4\u{1f9ea}\ub08c\uc067\u{1f805}\ubf88\uda6b\ua7ad\u0382',
+entries: [
+{
+binding: 362,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+},
+{
+binding: 86,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}
+],
+}
+);
+let renderBundleEncoder69 = device4.createRenderBundleEncoder(
+{
+label: '\u9fd0\uf6b2\u018f\u{1fdf9}\u5198\u9048',
+colorFormats: [
+'r8unorm',
+'r32float',
+'rg32float',
+'r32float',
+'r32uint',
+'r32float'
+],
+sampleCount: 256,
+}
+);
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+let pipelineLayout22 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+
+],
+}
+);
+try {
+computePassEncoder14.setPipeline(
+pipeline55
+);
+} catch {}
+try {
+renderPassEncoder20.setBlendConstant(
+{
+r: -129.7,
+g: 665.8,
+b: -77.19,
+a: 550.4,
+}
+);
+} catch {}
+try {
+renderPassEncoder4.setViewport(
+8.916,
+0.2474,
+1.668,
+0.6734,
+0.09535,
+0.2325
+);
+} catch {}
+let arrayBuffer8 = buffer2.getMappedRange(
+3424,
+22652
+);
+try {
+commandEncoder41.resolveQuerySet(
+querySet29,
+274,
+353,
+buffer1,
+13312
+);
+} catch {}
+let pipeline89 = device0.createComputePipeline(
+{
+layout: pipelineLayout6,
+compute: {
+module: shaderModule16,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+offscreenCanvas9.width = 548;
+let pipelineLayout23 = device2.createPipelineLayout(
+{
+bindGroupLayouts: [
+
+],
+}
+);
+let texture96 = device2.createTexture(
+{
+label: '\u04f5\uf65e\u7396\u061a',
+size: [628, 1, 1614],
+mipLevelCount: 2,
+dimension: '3d',
+format: 'r8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8unorm',
+'r8unorm',
+'r8unorm'
+],
+}
+);
+let renderBundleEncoder70 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+undefined,
+undefined,
+'rgb10a2unorm',
+'rg8unorm',
+'rg32float',
+'r32sint'
+],
+sampleCount: 720,
+}
+);
+let externalTexture5 = device2.importExternalTexture(
+{
+source: videoFrame14,
+colorSpace: 'srgb',
+}
+);
+try {
+renderBundleEncoder58.setBindGroup(
+0,
+bindGroup12
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture78,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 7 },
+  aspect: 'all',
+},
+new ArrayBuffer(302),
+/* required buffer size: 302 */{
+offset: 302,
+},
+{width: 10, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundleEncoder71 = device6.createRenderBundleEncoder(
+{
+colorFormats: [
+'r32float',
+'rgba16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 872,
+depthReadOnly: true,
+stencilReadOnly: false,
+}
+);
+let video22 = await videoWithData();
+let texture97 = device4.createTexture(
+{
+size: [133, 150, 226],
+mipLevelCount: 2,
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rg16float',
+'rg16float',
+'rg16float'
+],
+}
+);
+let buffer24 = device5.createBuffer(
+{
+label: '\u092c\ua60e\u70ef\u43a4\u2e8e\u9f3c\uab45\ud6b6\u56f5',
+size: 65364,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+mappedAtCreation: true,
+}
+);
+let texture98 = device5.createTexture(
+{
+label: '\u0bb4\u0e16',
+size: [97, 113, 201],
+mipLevelCount: 6,
+sampleCount: 1,
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'r16sint',
+'r16sint',
+'r16sint'
+],
+}
+);
+let textureView83 = texture98.createView(
+{
+dimension: '2d',
+baseMipLevel: 1,
+mipLevelCount: 2,
+baseArrayLayer: 65,
+}
+);
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+let querySet65 = device6.createQuerySet(
+{
+label: '\u{1f900}\uac8a',
+type: 'occlusion',
+count: 884,
+}
+);
+try {
+await promise44;
+} catch {}
+let videoFrame20 = new VideoFrame(canvas1, {timestamp: 0});
+let buffer25 = device2.createBuffer(
+{
+size: 27137,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+}
+);
+let commandEncoder70 = device2.createCommandEncoder(
+{
+label: '\u98f4\u9816\u0e1b\ucbe3\uc5ac\u476d\udd11\u9d8a',
+}
+);
+let texture99 = gpuCanvasContext0.getCurrentTexture();
+let textureView84 = texture71.createView(
+{
+label: '\u0b7c\u{1fcbd}',
+dimension: '2d',
+mipLevelCount: 1,
+baseArrayLayer: 21,
+}
+);
+let renderPassEncoder28 = commandEncoder70.beginRenderPass(
+{
+label: '\uad8c\u{1f74b}\u6e4d\uece1\u7031\u1c96\u4569\u{1fbae}\u66de\u7935\u0dc2',
+colorAttachments: [
+{
+view: textureView84,
+clearValue: {
+r: -788.8,
+g: -353.8,
+b: -404.0,
+a: 83.84,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined,
+undefined
+],
+occlusionQuerySet: querySet45,
+maxDrawCount: 197936,
+}
+);
+try {
+renderPassEncoder28.setScissorRect(
+102,
+196,
+1,
+3
+);
+} catch {}
+try {
+renderPassEncoder23.setViewport(
+1.411,
+11.62,
+19.88,
+1.799,
+0.4330,
+0.9682
+);
+} catch {}
+try {
+renderBundleEncoder65.setBindGroup(
+0,
+bindGroup12
+);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(
+2,
+bindGroup15,
+new Uint32Array(9630),
+3321,
+0
+);
+} catch {}
+let pipeline90 = device2.createComputePipeline(
+{
+label: '\u0ff0\u{1f9fe}\u{1fb70}',
+layout: pipelineLayout14,
+compute: {
+module: shaderModule17,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let promise49 = device2.createRenderPipelineAsync(
+{
+label: '\u0029\u0307\u3ac2\u242f\u0660\u5c51\u915e\ua32d\u{1f82d}',
+layout: pipelineLayout15,
+vertex: {
+module: shaderModule18,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1188,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 124,
+shaderLocation: 9,
+},
+{
+format: 'unorm8x2',
+offset: 72,
+shaderLocation: 5,
+},
+{
+format: 'sint16x4',
+offset: 1084,
+shaderLocation: 3,
+},
+{
+format: 'unorm16x2',
+offset: 140,
+shaderLocation: 8,
+},
+{
+format: 'float32x2',
+offset: 252,
+shaderLocation: 14,
+},
+{
+format: 'sint16x2',
+offset: 260,
+shaderLocation: 10,
+},
+{
+format: 'uint32x4',
+offset: 764,
+shaderLocation: 7,
+},
+{
+format: 'float32x3',
+offset: 352,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 572,
+attributes: [
+
+],
+},
+{
+arrayStride: 1436,
+attributes: [
+
+],
+},
+{
+arrayStride: 1740,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 1008,
+shaderLocation: 6,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule18,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'invert',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 1875,
+stencilWriteMask: 3262,
+depthBias: 18,
+depthBiasSlopeScale: 41,
+depthBiasClamp: 44,
+},
+}
+);
+let buffer26 = device2.createBuffer(
+{
+label: '\u4802\u0b98\ue06a\ub727\uc1be\u15c5\u90e5\ua6e7',
+size: 55508,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let querySet66 = device2.createQuerySet(
+{
+label: '\u7da6\u4e45\u52e3\udc3c\u{1fa79}\u1de4\u5d40\u0f5a\u05e7\u10b3\u0a72',
+type: 'occlusion',
+count: 3673,
+}
+);
+let renderBundleEncoder72 = device2.createRenderBundleEncoder(
+{
+label: '\u94c8\u042b',
+colorFormats: [
+'rgba8sint',
+'rg32uint',
+'rgba32float',
+'r32float'
+],
+sampleCount: 435,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler60 = device2.createSampler(
+{
+label: '\u0235\u0b26\udca0\u0d9b\u0d6f\u{1fab0}\u04d3\ue591',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 64.743,
+lodMaxClamp: 83.916,
+}
+);
+try {
+renderPassEncoder23.setBindGroup(
+2,
+bindGroup12
+);
+} catch {}
+try {
+renderPassEncoder28.setViewport(
+32.99,
+133.0,
+0.09729,
+43.99,
+0.4055,
+0.8881
+);
+} catch {}
+try {
+computePassEncoder41.insertDebugMarker(
+'\u{1f899}'
+);
+} catch {}
+let pipeline91 = device2.createRenderPipeline(
+{
+layout: pipelineLayout15,
+vertex: {
+module: shaderModule20,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1872,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 1484,
+shaderLocation: 13,
+},
+{
+format: 'snorm16x4',
+offset: 1816,
+shaderLocation: 0,
+},
+{
+format: 'uint8x2',
+offset: 1202,
+shaderLocation: 4,
+},
+{
+format: 'float32',
+offset: 536,
+shaderLocation: 15,
+},
+{
+format: 'sint32',
+offset: 1796,
+shaderLocation: 8,
+},
+{
+format: 'uint8x4',
+offset: 1600,
+shaderLocation: 7,
+},
+{
+format: 'float32x2',
+offset: 1588,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 2016,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 1568,
+shaderLocation: 14,
+},
+{
+format: 'sint8x4',
+offset: 1952,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 416,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 148,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 944,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x2',
+offset: 396,
+shaderLocation: 10,
+},
+{
+format: 'uint8x4',
+offset: 76,
+shaderLocation: 2,
+},
+{
+format: 'float32',
+offset: 112,
+shaderLocation: 5,
+},
+{
+format: 'uint32x3',
+offset: 464,
+shaderLocation: 12,
+},
+{
+format: 'uint32',
+offset: 580,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 1136,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x2',
+offset: 416,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0xff5539ce,
+},
+fragment: {
+module: shaderModule20,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'never',
+depthFailOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 3252,
+stencilWriteMask: 3934,
+depthBias: 66,
+depthBiasSlopeScale: 24,
+depthBiasClamp: 72,
+},
+}
+);
+let promise50 = navigator.gpu.requestAdapter(
+{
+}
+);
+let querySet67 = device4.createQuerySet(
+{
+label: '\u{1f70f}\u{1fe5c}\u6e7e\ua45a\u064e\u0f18\u2650\u4374',
+type: 'occlusion',
+count: 3989,
+}
+);
+let renderBundle69 = renderBundleEncoder69.finish(
+{
+label: '\u0a3f\uf0bd\ub666\ufc32\u{1fa0a}\u{1f602}\ub1f5\u0031\udc59\u{1fe00}\u09c2'
+}
+);
+try {
+computePassEncoder43.end();
+} catch {}
+let imageData13 = new ImageData(144, 256);
+let bindGroupLayout39 = device0.createBindGroupLayout(
+{
+label: '\u0e5c\u08e5\u{1ff71}\u009b',
+entries: [
+{
+binding: 501,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '3d' },
+},
+{
+binding: 546,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+},
+{
+binding: 4381,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '3d' },
+}
+],
+}
+);
+let bindGroup16 = device0.createBindGroup({
+label: '\u0d57\ua009',
+layout: bindGroupLayout7,
+entries: [
+{
+binding: 8053,
+resource: externalTexture0
+},
+{
+binding: 5645,
+resource: {
+buffer: buffer12,
+offset: 23424,
+size: 36,
+}
+}
+],
+});
+let buffer27 = device0.createBuffer(
+{
+label: '\ue426\u2808\u{1fc6c}\u{1f8d9}\u{1f6c1}\u{1fd4a}\u{1f985}\u0880',
+size: 52704,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+let texture100 = device0.createTexture(
+{
+label: '\uc528\u54a0\u{1fe05}\u96b0',
+size: [1082, 1, 787],
+mipLevelCount: 5,
+dimension: '3d',
+format: 'r16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'r16float',
+'r16float'
+],
+}
+);
+let renderBundle70 = renderBundleEncoder38.finish(
+{
+label: '\u8513\u4c0d\udfb4\u7f57\u{1f84f}\u{1f89d}\u2eaa\u06c4\u{1fea3}\u{1fd02}'
+}
+);
+try {
+computePassEncoder14.dispatchWorkgroups(
+1,
+3,
+5
+);
+} catch {}
+try {
+renderPassEncoder26.setBlendConstant(
+{
+r: -348.5,
+g: 416.0,
+b: 817.5,
+a: -675.3,
+}
+);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(
+5,
+bindGroup4
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder41.copyBufferToBuffer(
+buffer12,
+13900,
+buffer1,
+22296,
+1616
+);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline92 = device0.createComputePipeline(
+{
+label: '\u028e\u4f84\u0426\u9ea5\u{1fb89}\uc3ed',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let promise51 = navigator.gpu.requestAdapter(
+{
+}
+);
+let texture101 = device2.createTexture(
+{
+label: '\u{1f77c}\u130e\u{1ff6d}\u0db0\u0128',
+size: [7370],
+dimension: '1d',
+format: 'rg16uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg16uint',
+'rg16uint'
+],
+}
+);
+try {
+renderPassEncoder28.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder65.setBindGroup(
+1,
+bindGroup12,
+new Uint32Array(6470),
+851,
+0
+);
+} catch {}
+let promise52 = device2.createComputePipelineAsync(
+{
+label: '\u3f77\u0d15\ua6de\u06ee\u{1f953}\u0805\u0df3\u{1fd3e}',
+layout: pipelineLayout14,
+compute: {
+module: shaderModule17,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipelineLayout24 = device4.createPipelineLayout(
+{
+label: '\u0399\u0b6a\u0744\u0407\u{1f64c}\u8658\u2f57',
+bindGroupLayouts: [
+
+],
+}
+);
+let computePassEncoder44 = commandEncoder69.beginComputePass(
+{
+
+}
+);
+let renderBundleEncoder73 = device4.createRenderBundleEncoder(
+{
+label: '\u{1fbf0}\u04bf\u{1f60a}\u2721',
+colorFormats: [
+'rgba32uint',
+'r16float',
+'r16uint',
+'rg16uint',
+'rgba8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 169,
+stencilReadOnly: true,
+}
+);
+try {
+device4.destroy();
+} catch {}
+let adapter11 = await navigator.gpu.requestAdapter(
+{
+powerPreference: 'high-performance',
+}
+);
+let img26 = await imageWithData(283, 121, '#a986cc5c', '#fbd0fd46');
+let adapter12 = await promise51;
+let texture102 = device6.createTexture(
+{
+label: '\u0216\u058b\u{1f884}',
+size: {width: 107, height: 1, depthOrArrayLayers: 186},
+mipLevelCount: 8,
+dimension: '3d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16float',
+'r16float'
+],
+}
+);
+let textureView85 = texture102.createView(
+{
+label: '\udd0c\u09bb\u6294\ua735\u6893\u056f\u{1f7c6}',
+baseMipLevel: 2,
+mipLevelCount: 3,
+}
+);
+let sampler61 = device6.createSampler(
+{
+label: '\u1d02\ub04a\u0bf8\uca9b\u12bc\u84fb\u009f\u{1f6d3}\u8eb5',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 87.281,
+lodMaxClamp: 97.426,
+maxAnisotropy: 14,
+}
+);
+document.body.append('\u8d98\ued76');
+let querySet68 = device3.createQuerySet(
+{
+label: '\u{1fae3}\u82b9\u{1fe52}\u6089\u{1f9a8}\u0435\u800c\u8a39\u{1f74b}\ucbf1\u6a7c',
+type: 'occlusion',
+count: 2693,
+}
+);
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+document.body.prepend('\u089b\u051f\u0a1a');
+let texture103 = device5.createTexture(
+{
+label: '\u{1f998}\u016c\u07d6\u{1fb76}\u04ab\u0e8d\u39e5\uec34\uc424\u0a9f\uf993',
+size: {width: 31, height: 1, depthOrArrayLayers: 202},
+dimension: '3d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16sint',
+'r16sint'
+],
+}
+);
+let textureView86 = texture103.createView(
+{
+label: '\u9574\ude82\u{1fd93}\uca70\u9eb8\u07c1',
+}
+);
+let sampler62 = device5.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 24.186,
+lodMaxClamp: 97.169,
+compare: 'always',
+}
+);
+document.body.append('\u{1f74c}\u7c5a\u0be5\ufe78\u4fee\u0f81\u0ab1\u{1f92e}');
+let texture104 = device5.createTexture(
+{
+label: '\u68d5\ua8d3\u954a\ucae6\u0f18\ueda7\u02e1\u{1f853}',
+size: {width: 111, height: 172, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+sampleCount: 1,
+format: 'depth32float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+try {
+await device5.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+pseudoSubmit(device2, commandEncoder58);
+let renderBundle71 = renderBundleEncoder43.finish(
+{
+label: '\ub804\ub92d\u0e2c\u0893\u0478\u09ac\uf7f9\ud212\u{1f8a2}\u69b0'
+}
+);
+try {
+renderPassEncoder24.setBindGroup(
+0,
+bindGroup15,
+new Uint32Array(5087),
+4125,
+0
+);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture99,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer5,
+/* required buffer size: 285 */{
+offset: 285,
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline93 = await promise52;
+let promise53 = device2.createRenderPipelineAsync(
+{
+label: '\u3764\u8f7f\u0990\u6494\u1bf9\u03dc\u{1ff1f}\u7e62\u72e0\ue3f3\uca29',
+layout: pipelineLayout13,
+vertex: {
+module: shaderModule20,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 1096,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 56,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x4',
+offset: 256,
+shaderLocation: 10,
+},
+{
+format: 'uint32x4',
+offset: 688,
+shaderLocation: 14,
+},
+{
+format: 'float32x2',
+offset: 608,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 856,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x2',
+offset: 100,
+shaderLocation: 7,
+},
+{
+format: 'snorm8x4',
+offset: 68,
+shaderLocation: 15,
+},
+{
+format: 'float32x4',
+offset: 312,
+shaderLocation: 6,
+},
+{
+format: 'uint32x4',
+offset: 272,
+shaderLocation: 4,
+},
+{
+format: 'sint32x2',
+offset: 192,
+shaderLocation: 13,
+},
+{
+format: 'float32x2',
+offset: 520,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x2',
+offset: 112,
+shaderLocation: 5,
+},
+{
+format: 'sint16x4',
+offset: 296,
+shaderLocation: 11,
+},
+{
+format: 'uint16x2',
+offset: 736,
+shaderLocation: 3,
+},
+{
+format: 'sint8x2',
+offset: 428,
+shaderLocation: 8,
+},
+{
+format: 'float32x3',
+offset: 712,
+shaderLocation: 1,
+},
+{
+format: 'uint32',
+offset: 696,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule20,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'less',
+failOp: 'decrement-clamp',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 3284,
+stencilWriteMask: 1276,
+depthBias: 51,
+depthBiasSlopeScale: 52,
+depthBiasClamp: 89,
+},
+}
+);
+let video23 = await videoWithData();
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+offscreenCanvas20.width = 352;
+let img27 = await imageWithData(169, 21, '#bf018fa1', '#550a84ce');
+let bindGroup17 = device0.createBindGroup({
+label: '\u2b41\ue790\u9982\u{1fdc7}\u675b\uff32\u{1fe95}\u772d\u0700',
+layout: bindGroupLayout7,
+entries: [
+{
+binding: 5645,
+resource: {
+buffer: buffer12,
+offset: 960,
+size: 7096,
+}
+},
+{
+binding: 8053,
+resource: externalTexture0
+}
+],
+});
+let buffer28 = device0.createBuffer(
+{
+label: '\uc901\u086f\u04c3\u{1fce4}\u1fb1\u{1f9c2}\u06a2\u5854\ue5d0\udd64',
+size: 32308,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+}
+);
+try {
+renderPassEncoder22.beginOcclusionQuery(
+72
+);
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(
+1468
+);
+} catch {}
+try {
+await buffer22.mapAsync(
+GPUMapMode.READ
+);
+} catch {}
+try {
+commandEncoder41.copyBufferToBuffer(
+buffer4,
+35956,
+buffer11,
+12104,
+1240
+);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder41.copyTextureToTexture(
+{
+  texture: texture6,
+  mipLevel: 2,
+  origin: { x: 6, y: 0, z: 30 },
+  aspect: 'all',
+},
+{
+  texture: texture83,
+  mipLevel: 0,
+  origin: { x: 5620, y: 1, z: 1 },
+  aspect: 'all',
+},
+{width: 23, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+document.body.prepend('\ua7ad\u0c99\u09ca');
+let texture105 = device6.createTexture(
+{
+size: {width: 124, height: 4, depthOrArrayLayers: 160},
+mipLevelCount: 2,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'etc2-rgb8unorm'
+],
+}
+);
+let sampler63 = device6.createSampler(
+{
+label: '\u089b\u0e23\u{1fcb6}\uca47\uf528\u001d',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMaxClamp: 94.249,
+}
+);
+try {
+renderBundleEncoder71.setVertexBuffer(
+97,
+undefined,
+1920281616,
+1232365212
+);
+} catch {}
+try {
+device6.addEventListener('uncapturederror', e => { log('device6.uncapturederror'); log(e); e.label = device6.label; });
+} catch {}
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+let videoFrame21 = new VideoFrame(imageBitmap20, {timestamp: 0});
+let bindGroupLayout40 = device5.createBindGroupLayout(
+{
+label: '\uf5ae\u3c34\u01eb\u{1f6b4}\u0c89\u5e9d\u1567\u1eb5',
+entries: [
+{
+binding: 777,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+},
+{
+binding: 778,
+visibility: 0,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let texture106 = device5.createTexture(
+{
+label: '\u{1f66b}\uadac\u{1fc1e}\u70d2\ueb00\u8217\u0b82\ube24\u0405',
+size: {width: 7050, height: 30, depthOrArrayLayers: 196},
+mipLevelCount: 9,
+format: 'astc-10x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+renderBundleEncoder67.setVertexBuffer(
+5,
+buffer24,
+5264,
+39072
+);
+} catch {}
+document.body.prepend('\u0cab\ub06c\ue3a9\u{1fafc}\u00a8\uf22e');
+let video24 = await videoWithData();
+  log('the end')
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -1257,6 +1257,9 @@ void CommandEncoder::clearTextureIfNeeded(Texture& texture, NSUInteger mipLevel,
     if (destinationTexture.dimension() == WGPUTextureDimension_3D)
         slice = 0;
 
+    if (slice >= mtlTexture.arrayLength)
+        return;
+
     [blitCommandEncoder
         copyFromBuffer:temporaryBuffer
         sourceOffset:0

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -1699,6 +1699,8 @@ bool RenderPipeline::colorDepthStencilTargetsMatch(const WGPURenderPassDescripto
         auto& texture = *depthStencilView.get();
         if (texture.format() != m_descriptor.depthStencil->format)
             return false;
+        if (texture.texture().pixelFormat == MTLPixelFormatX32_Stencil8 && m_descriptor.depthStencil->format == WGPUTextureFormat_Stencil8)
+            return false;
         if (texture.sampleCount() != m_descriptor.multisample.count)
             return false;
     } else if (m_descriptor.depthStencil->format != WGPUTextureFormat_Undefined)


### PR DESCRIPTION
#### b2b40994e9d80dd379273b97f5e33c99fa8c0e0d
<pre>
[WebGPU] setPipelineState fails when X32_Stencil8 attachment is used in a Stencil8 pipeline
<a href="https://bugs.webkit.org/show_bug.cgi?id=273021">https://bugs.webkit.org/show_bug.cgi?id=273021</a>
&lt;radar://126621251&gt;

Reviewed by Tadeu Zagallo.

Calling setPipelineState with a Stencil8 format will fail so check
if we have such a mismatch before passing the validation check.

* LayoutTests/TestExpectations:
* LayoutTests/fast/webgpu/fuzz-273021-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-273021.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::clearTextureIfNeeded):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::colorDepthStencilTargetsMatch const):

Canonical link: <a href="https://commits.webkit.org/277856@main">https://commits.webkit.org/277856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/333846c5bc9bf228b1e4e7168127a214b6db6157

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48810 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51496 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44876 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25551 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39899 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49392 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25670 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21000 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23131 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6865 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53407 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23861 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47201 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/25124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42293 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46146 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10744 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25931 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/24844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->