### PR TITLE
[WebGPU] CommandEncoder::copyTexturToTexture fails metal validation in some cases

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2094,6 +2094,8 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-273017.html [ Pass Failure ]
 [ Debug ] fast/webgpu/fuzz-273021.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-273021.html [ Pass Failure ]
+[ Debug ] fast/webgpu/fuzz-273023.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-273023.html [ Pass Failure ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/fuzz-273023-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-273023-expected.txt
@@ -1,0 +1,675 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 982x5202
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x5202
+  RenderBlock {HTML} at (0,0) size 785x5202 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x5186
+      RenderText {#text} at (32,137) size 26x17
+        text run at (32,137) width 26: "\x{C1AA}\x{C94}"
+      RenderText {#text} at (57,137) size 87x17
+        text run at (57,137) width 87: "\x{4F78}\x{D83F}\x{DE8B}\x{D83F}\x{DDDC}\x{9E7}\x{C52}\x{63A9}\x{77E1}"
+      RenderText {#text} at (443,137) size 62x17
+        text run at (443,137) width 62: "\x{910F}\x{742A}\x{B92}\x{D83D}\x{DE81}"
+      RenderText {#text} at (504,137) size 65x17
+        text run at (504,137) width 65: "\x{D75}\x{BE26}\x{D83E}\x{DED9}\x{2ABB}"
+      RenderText {#text} at (568,137) size 98x17
+        text run at (568,137) width 98: "\x{A76}\x{44CD}\x{DF6}\x{4F0}\x{1C62}\x{FD8}\x{235A}\x{173E}\x{D83F}\x{DED7}"
+      RenderText {#text} at (665,137) size 72x17
+        text run at (665,137) width 72: "\x{D83E}\x{DD5B}\x{200B}\x{D83D}\x{DFEA}\x{1A46}\x{AB6F}\x{D83F}\x{DF12}"
+      RenderText {#text} at (300,296) size 63x17
+        text run at (300,296) width 15: "\x{34E5}"
+        text run at (315,296) width 11 RTL: "\x{85D}"
+        text run at (325,296) width 38: "\x{F632}\x{B956}\x{FFC}"
+      RenderText {#text} at (362,296) size 123x17
+        text run at (362,296) width 123: "\x{4E06}\x{CECA}\x{D83F}\x{DED1}\x{E430}\x{96AB}\x{85DD}\x{575E}\x{1D9}\x{879E}"
+      RenderText {#text} at (484,296) size 79x17
+        text run at (484,296) width 79: "\x{D83E}\x{DCE2}\x{AD5}\x{8870}\x{20C7}\x{B348}\x{AD31}"
+      RenderText {#text} at (562,296) size 45x17
+        text run at (562,296) width 35: "\x{C6E8}\x{D83E}\x{DC2A}\x{A026}"
+        text run at (596,296) width 11 RTL: "\x{7DA}"
+      RenderText {#text} at (606,296) size 82x17
+        text run at (606,296) width 16: "\x{3FBE}"
+        text run at (621,296) width 10 RTL: "\x{72F}\x{82B}"
+        text run at (630,296) width 58: "\x{91B1}\x{1F7}\x{D83F}\x{DC56}\x{ED0}\x{77B4}"
+      RenderText {#text} at (600,454) size 70x17
+        text run at (600,454) width 70: "\x{9AA}\x{4946}\x{4B32}\x{D83E}\x{DCA5}\x{908}\x{D83F}\x{DF1A}"
+      RenderImage {IMG} at (284,592) size 21x165
+      RenderText {#text} at (305,744) size 80x17
+        text run at (305,744) width 80: "\x{3091}\x{9AD}\x{ABA2}\x{CFD}\x{D83D}\x{DF95}\x{B13}\x{4B0E}"
+      RenderText {#text} at (384,744) size 154x17
+        text run at (384,744) width 63: "\x{C22}\x{4C66}\x{A99C}\x{D83E}\x{DEB0}"
+        text run at (446,744) width 15 RTL: "\x{6FA}"
+        text run at (460,744) width 78: "\x{F675}\x{5712}\x{E343}\x{A88A}\x{4B4}\x{608C}"
+      RenderText {#text} at (553,744) size 36x17
+        text run at (553,744) width 36: "\x{55A7}\x{D83F}\x{DF2E}\x{2DD8}"
+      RenderText {#text} at (588,744) size 107x17
+        text run at (588,744) width 60: "\x{D83E}\x{DC95}\x{16CF}\x{C63A}\x{82D}\x{A2F8}\x{D83D}\x{DFD8}"
+        text run at (647,744) width 12 RTL: "\x{86B}"
+        text run at (658,744) width 37: "\x{A737}\x{D83F}\x{DF22}\x{D83F}\x{DFBF}"
+      RenderText {#text} at (0,744) size 762x181
+        text run at (694,744) width 68: "\x{1401}\x{CD2}\x{B6E4}\x{8940}\x{AF27}"
+        text run at (0,908) width 57: "\x{CAE4}\x{90}\x{8DB9}\x{1EC8}\x{FF00}"
+      RenderText {#text} at (72,908) size 37x17
+        text run at (72,908) width 27: "\x{B66D}\x{592}\x{D83F}\x{DEDD}"
+        text run at (98,908) width 11 RTL: "\x{64A}"
+      RenderText {#text} at (457,908) size 94x17
+        text run at (457,908) width 94: "\x{5D93}\x{D7F}\x{5957}\x{D83E}\x{DE78}\x{51B}\x{E8D}\x{D7C}"
+      RenderText {#text} at (550,908) size 120x17
+        text run at (550,908) width 120: "\x{7195}\x{556F}\x{D83E}\x{DCAE}\x{ED7}\x{D83F}\x{DC74}\x{D83F}\x{DC9A}\x{D83F}\x{DF3F}\x{D83E}\x{DE67}\x{C08D}\x{2E51}"
+      RenderText {#text} at (0,908) size 755x175
+        text run at (669,908) width 86: "\x{D83E}\x{DF48}\x{25CA}\x{5554}\x{4281}\x{D83F}\x{DF60}\x{E4EE}\x{434E}"
+        text run at (0,1066) width 20 RTL: "\x{FD79}"
+        text run at (19,1066) width 26: "\x{CAA}\x{C890}"
+      RenderText {#text} at (44,1066) size 42x17
+        text run at (44,1066) width 42: "\x{C93}\x{D83D}\x{DE93}\x{995}"
+      RenderText {#text} at (385,1066) size 99x17
+        text run at (385,1066) width 99: "\x{140}\x{30B}\x{D83F}\x{DD8B}\x{E03E}\x{D83E}\x{DF2B}\x{75AD}\x{D83E}\x{DCE1}\x{E7C2}\x{CF21}\x{420}"
+      RenderText {#text} at (483,1066) size 22x17
+        text run at (483,1066) width 22: "\x{D83E}\x{DF49}\x{6}"
+      RenderText {#text} at (504,1066) size 108x17
+        text run at (504,1066) width 108: "\x{C24}\x{4EF}\x{D83F}\x{DED8}\x{30C9}\x{6D71}\x{40B1}\x{D83E}\x{DEF4}\x{F888}"
+      RenderText {#text} at (611,1066) size 115x17
+        text run at (611,1066) width 115: "\x{6EDD}\x{D83E}\x{DD93}\x{929}\x{6982}\x{C1A}\x{E97}\x{4E1}\x{2813}\x{3ED}\x{585}"
+      RenderText {#text} at (0,1066) size 751x42
+        text run at (725,1066) width 26: "\x{EFCC}\x{4DA1}"
+        text run at (0,1091) width 44: "\x{13B}\x{D83E}\x{DC1C}\x{55D6}\x{A35}"
+      RenderText {#text} at (0,1501) size 86x17
+        text run at (0,1501) width 8: "\x{663}"
+        text run at (7,1501) width 79: "\x{73A6}\x{D83D}\x{DF18}\x{F3F}\x{B3C}\x{38BB}\x{B45}\x{823}\x{D83F}\x{DC95}"
+      RenderText {#text} at (85,1501) size 63x17
+        text run at (85,1501) width 63: "\x{4592}\x{21E7}\x{8DB}\x{B90B}\x{499}"
+      RenderText {#text} at (147,1501) size 107x17
+        text run at (147,1501) width 22: "\x{D83F}\x{DD08}\x{D840}"
+        text run at (168,1501) width 15 RTL: "\x{8BE}"
+        text run at (182,1501) width 72: "\x{6A31}\x{407}\x{975}\x{D83F}\x{DFC9}\x{8716}\x{D83F}\x{DE6D}"
+      RenderText {#text} at (253,1501) size 32x17
+        text run at (253,1501) width 32: "\x{2D8F}\x{F772}"
+      RenderText {#text} at (284,1501) size 11x17
+        text run at (284,1501) width 11: "\x{517}\x{343}"
+      RenderText {#text} at (294,1501) size 42x17
+        text run at (294,1501) width 42: "\x{DDBE}\x{5A81}\x{8744}"
+      RenderText {#text} at (335,1501) size 29x17
+        text run at (335,1501) width 29: "\x{A2C5}\x{B79D}\x{B9}"
+      RenderText {#text} at (363,1501) size 72x17
+        text run at (363,1501) width 72: "\x{B3A7}\x{E810}\x{AFF5}\x{B583}\x{46FD}"
+      RenderText {#text} at (434,1501) size 81x17
+        text run at (434,1501) width 81: "\x{1A23}\x{991C}\x{FD7}\x{D83F}\x{DEE9}\x{D83E}\x{DC87}\x{BEF1}\x{D83E}\x{DF30}"
+      RenderText {#text} at (514,1501) size 72x17
+        text run at (514,1501) width 72: "\x{BC91}\x{AD3}\x{D4C}\x{95A}\x{C81E}\x{90A}"
+      RenderText {#text} at (585,1501) size 108x17
+        text run at (585,1501) width 37: "\x{648D}\x{D83E}\x{DCFE}\x{EED5}"
+        text run at (621,1501) width 9 RTL: "\x{7D6}"
+        text run at (629,1501) width 64: "\x{FE45}\x{1A75}\x{EBF6}\x{5997}\x{1B95}\x{C3C}"
+      RenderText {#text} at (213,2180) size 110x17
+        text run at (213,2180) width 15: "\x{730E}"
+        text run at (228,2180) width 22 RTL: "\x{893}\x{63B}"
+        text run at (249,2180) width 74: "\x{37B0}\x{D83D}\x{DF13}\x{7144}\x{A748}\x{D83D}\x{DEA3}\x{654}"
+      RenderHTMLCanvas {CANVAS} at (322,1523) size 301x670
+      RenderText {#text} at (622,2180) size 53x17
+        text run at (622,2180) width 23: "\x{EAD5}\x{D5A}"
+        text run at (644,2180) width 24 RTL: "\x{8B8}\x{FBA}"
+        text run at (667,2180) width 8: "\x{FF}"
+      RenderText {#text} at (674,2180) size 46x17
+        text run at (674,2180) width 46: "\x{4E04}\x{4715}\x{2ED7}"
+      RenderText {#text} at (0,2180) size 739x45
+        text run at (719,2180) width 20: "\x{EDB}\x{A016}"
+        text run at (0,2208) width 51: "\x{4EE}\x{D83D}\x{DF66}\x{E14F}\x{25B}\x{F27C}"
+      RenderText {#text} at (50,2208) size 123x17
+        text run at (50,2208) width 12 RTL: "\x{88F}"
+        text run at (61,2208) width 66: "\x{56DE}\x{75E3}\x{8FF1}\x{D83E}\x{DDF9}"
+        text run at (126,2208) width 11 RTL: "\x{803}"
+        text run at (136,2208) width 37: "\x{185E}\x{4350}\x{295}\x{D83D}\x{DF2A}"
+      RenderText {#text} at (172,2208) size 70x17
+        text run at (172,2208) width 51: "\x{2AF}\x{34CD}\x{725A}\x{D83D}\x{DE76}"
+        text run at (222,2208) width 20 RTL: "\x{FD02}"
+      RenderText {#text} at (241,2208) size 126x17
+        text run at (241,2208) width 38: "\x{D665}\x{9AD8}\x{296}"
+        text run at (278,2208) width 12 RTL: "\x{FB37}"
+        text run at (289,2208) width 67: "\x{BEE8}\x{D83F}\x{DE77}\x{D359}\x{9A67}\x{D83F}\x{DE37}"
+        text run at (355,2208) width 12 RTL: "\x{5FC}"
+      RenderText {#text} at (366,2208) size 57x17
+        text run at (366,2208) width 57: "\x{A5ED}\x{C406}\x{162E}\x{9661}"
+      RenderText {#text} at (422,2208) size 64x17
+        text run at (422,2208) width 64: "\x{FFE}\x{3ACD}\x{4A37}\x{EEAE}\x{D83E}\x{DC79}"
+      RenderText {#text} at (485,2208) size 124x17
+        text run at (485,2208) width 124: "\x{A1}\x{55C}\x{F41D}\x{AA95}\x{3A64}\x{F68F}\x{D83D}\x{DF3B}\x{DA00}\x{855B}\x{C24D}\x{447D}"
+      RenderText {#text} at (608,2208) size 122x17
+        text run at (608,2208) width 122: "\x{F315}\x{41E}\x{DD54}\x{D83E}\x{DDE2}\x{D83D}\x{DEE9}\x{5B24}\x{BBB7}\x{A8A2}\x{24F}"
+      RenderText {#text} at (0,2208) size 760x224
+        text run at (729,2208) width 31: "\x{9C9D}\x{BB35}"
+        text run at (0,2415) width 52: "\x{431F}\x{D83E}\x{DFBF}\x{9FE}\x{4545}"
+      RenderText {#text} at (51,2415) size 138x17
+        text run at (51,2415) width 71: "\x{B606}\x{C420}\x{C27D}\x{308}\x{886E}\x{563}"
+        text run at (121,2415) width 14 RTL: "\x{77D}"
+        text run at (134,2415) width 55: "\x{3948}\x{5EF4}\x{A28E}\x{BAB6}"
+      RenderText {#text} at (204,2415) size 114x17
+        text run at (204,2415) width 114: "\x{CFC9}\x{AB02}\x{BFB0}\x{D83F}\x{DE32}\x{3CC0}\x{8AD8}\x{2711}\x{4D25}"
+      RenderText {#text} at (317,2415) size 104x17
+        text run at (317,2415) width 104: "\x{19EE}\x{9E44}\x{E64A}\x{D83E}\x{DC17}\x{D83E}\x{DE59}\x{62A1}\x{1F7}\x{7F8F}"
+      RenderText {#text} at (420,2415) size 46x17
+        text run at (420,2415) width 46: "\x{2458}\x{D83E}\x{DDEF}\x{27C8}"
+      RenderText {#text} at (465,2415) size 28x17
+        text run at (465,2415) width 28: "\x{C985}\x{1645}"
+      RenderImage {IMG} at (492,2227) size 182x201
+      RenderText {#text} at (673,2415) size 61x17
+        text run at (673,2415) width 61: "\x{D83F}\x{DE63}\x{D83D}\x{DEC6}\x{3355}\x{D83E}\x{DF0E}\x{17A6}"
+      RenderText {#text} at (290,2554) size 67x17
+        text run at (290,2554) width 67: "\x{89}\x{4AC3}\x{9A87}\x{E4F1}\x{8154}"
+      RenderText {#text} at (356,2554) size 120x17
+        text run at (356,2554) width 72: "\x{D83E}\x{DE82}\x{1D98}\x{629D}\x{AE61}\x{7BCB}"
+        text run at (427,2554) width 14 RTL: "\x{852}"
+        text run at (440,2554) width 36: "\x{B2BB}\x{28EC}\x{29B1}"
+      RenderText {#text} at (475,2554) size 51x17
+        text run at (475,2554) width 51: "\x{D83D}\x{DF4E}\x{D83F}\x{DC12}\x{634B}\x{6008}"
+      RenderText {#text} at (525,2554) size 118x17
+        text run at (525,2554) width 118: "\x{278}\x{4C70}\x{905}\x{D83E}\x{DD64}\x{D83E}\x{DED5}\x{A441}\x{D83F}\x{DE86}\x{D83E}\x{DFDA}\x{D83F}\x{DFAB}"
+      RenderText {#text} at (0,2554) size 767x175
+        text run at (642,2554) width 71: "\x{2F6C}\x{9192}\x{586B}\x{291}\x{4D45}"
+        text run at (712,2554) width 25 RTL: "\x{FD21}"
+        text run at (736,2554) width 31: "\x{CF1C}\x{8A0B}"
+        text run at (0,2712) width 11: "\x{E4C8}"
+      RenderImage {IMG} at (10,2573) size 295x152
+      RenderText {#text} at (304,2712) size 88x17
+        text run at (304,2712) width 40: "\x{A78E}\x{63A3}\x{C4AF}"
+        text run at (343,2712) width 10 RTL: "\x{843}"
+        text run at (352,2712) width 40: "\x{30B2}\x{AE1B}\x{A810}"
+      RenderText {#text} at (391,2712) size 26x17
+        text run at (391,2712) width 26: "\x{D83D}\x{DEED}\x{98D1}"
+      RenderText {#text} at (416,2712) size 103x17
+        text run at (416,2712) width 103: "\x{C934}\x{C655}\x{1CA}\x{ACA}\x{D83E}\x{DC1C}'\x{D83E}\x{DD9D}\x{D83F}\x{DC62}"
+      RenderText {#text} at (518,2712) size 81x17
+        text run at (518,2712) width 27: "\x{BCE}\x{3CEB}"
+        text run at (544,2712) width 9 RTL: "\x{5E8}"
+        text run at (552,2712) width 47: "\x{397B}\x{F98}\x{A58}\x{2104}"
+      RenderImage {IMG} at (300,2765) size 26x233
+      RenderText {#text} at (626,2985) size 70x17
+        text run at (626,2985) width 55: "\x{D83D}\x{DEF7}\x{83C5}\x{D83E}\x{DDE1}"
+        text run at (681,2985) width 15 RTL: "\x{5D4}\x{846}"
+      RenderText {#text} at (0,2985) size 756x252
+        text run at (695,2985) width 61: "\x{D8E}\x{9EB9}\x{9FD5}\x{D83F}\x{DE5F}"
+        text run at (0,3220) width 53: "\x{88DA}\x{655}\x{D83F}\x{DF38}\x{B757}\x{3D8}\x{FE2A}"
+      RenderText {#text} at (52,3220) size 48x17
+        text run at (52,3220) width 48: "\x{2602}\x{5A15}\x{1797}\x{A38}"
+      RenderText {#text} at (99,3220) size 52x17
+        text run at (99,3220) width 52: "\x{DA07}\x{547E}\x{D83D}\x{DF3C}\x{8CAF}"
+      RenderImage {IMG} at (150,3004) size 247x229
+      RenderText {#text} at (396,3220) size 47x17
+        text run at (396,3220) width 47: "\x{D83F}\x{DC3E}\x{262}\x{3E0D}\x{E7E9}"
+      RenderText {#text} at (442,3220) size 103x17
+        text run at (442,3220) width 27: "\x{D851}\x{5F41}"
+        text run at (468,3220) width 20 RTL: "\x{837}"
+        text run at (487,3220) width 58: "\x{B48}\x{D83E}\x{DCB0}\x{BDCB}\x{B8EC}"
+      RenderText {#text} at (544,3220) size 46x17
+        text run at (544,3220) width 46: "\x{7A6}\x{90EE}\x{548D}\x{B538}"
+      RenderText {#text} at (589,3220) size 60x17
+        text run at (589,3220) width 8: "\x{31F}"
+        text run at (596,3220) width 8 RTL: "\x{676}"
+        text run at (603,3220) width 46: "\x{7053}\x{2F9B}\x{305}\x{657A}"
+      RenderText {#text} at (648,3220) size 105x17
+        text run at (648,3220) width 63: "\x{A6B}\x{AA0}\x{4013}\x{8F6E}\x{A9D1}\x{6DB}"
+        text run at (710,3220) width 6 RTL: "\x{FE97}"
+        text run at (715,3220) width 38: "\x{7754}\x{2FAF}\x{D83D}\x{DF4C}"
+      RenderText {#text} at (0,3220) size 764x47
+        text run at (752,3220) width 12: "\x{2EF8}"
+        text run at (0,3250) width 15: "\x{37A9}"
+      RenderText {#text} at (0,3421) size 56x17
+        text run at (0,3421) width 56: "\x{D83F}\x{DC0D}\x{67DC}\x{6EA3}\x{3A79}"
+      RenderText {#text} at (55,3421) size 67x17
+        text run at (55,3421) width 67: "\x{1}\x{CA89}\x{7852}\x{BDBC}\x{BED}"
+      RenderText {#text} at (0,3834) size 55x17
+        text run at (0,3834) width 55: "\x{3EA}\x{5659}\x{B224}\x{5A3A}"
+      RenderImage {IMG} at (54,3788) size 47x59
+      RenderText {#text} at (100,3834) size 93x17
+        text run at (100,3834) width 93: "\x{7D65}\x{4D20}\x{898}\x{D83F}\x{DE70}\x{B767}\x{90C}\x{4CCF}"
+      RenderText {#text} at (527,3834) size 122x17
+        text run at (527,3834) width 122: "\x{8AA4}\x{A3E}\x{B9F}\x{1F10}\x{E49}\x{D83F}\x{DF44}\x{B78}\x{CE88}\x{19F5}\x{D83D}\x{DEC0}"
+      RenderText {#text} at (648,3834) size 93x17
+        text run at (648,3834) width 67: "\x{DAB}\x{B758}\x{E82}\x{339}\x{D754}\x{98B}"
+        text run at (714,3834) width 12 RTL: "\x{895}"
+        text run at (725,3834) width 16: "\x{B544}"
+      RenderText {#text} at (0,3973) size 117x17
+        text run at (0,3973) width 117: "\x{5DE9}\x{BAC7}\x{615A}\x{443}\x{D83E}\x{DC0B}\x{5AE9}\x{FB8}\x{3E2D}\x{45A8}"
+      RenderImage {IMG} at (116,3920) size 156x66
+      RenderText {#text} at (271,3973) size 111x17
+        text run at (271,3973) width 111: "\x{4456}\x{763D}\x{6858}\x{3197}\x{7B4A}\x{A6C5}\x{13D1}\x{AE2C}"
+      RenderText {#text} at (381,3973) size 82x17
+        text run at (381,3973) width 82: "\x{4907}\x{B652}\x{D83E}\x{DE43}\x{CBD5}\x{C520}\x{459}"
+      RenderImage {IMG} at (462,3859) size 288x127
+      RenderText {#text} at (0,4001) size 120x17
+        text run at (0,4001) width 120: "\x{D83F}\x{DDA7}\x{363}\x{D83E}\x{DC47}\x{5E75}\x{D83F}\x{DE23}\x{1AE}\x{A8E5}\x{D83F}\x{DEF3}\x{48DF}\x{5107}"
+      RenderText {#text} at (119,4001) size 27x17
+        text run at (119,4001) width 27: "\x{E95D}\x{BA46}"
+      RenderText {#text} at (145,4001) size 110x17
+        text run at (145,4001) width 99: "\x{6D9B}\x{D83D}\x{DE24}\x{8BA2}\x{6CE6}\x{E9B}\x{D83E}\x{DFA8}\x{1361}\x{22DE}"
+        text run at (243,4001) width 12 RTL: "\x{621}\x{709}"
+      RenderText {#text} at (254,4001) size 35x17
+        text run at (254,4001) width 35: "\x{D83F}\x{DD69}\x{5660}\x{A0E6}"
+      RenderText {#text} at (288,4001) size 84x17
+        text run at (288,4001) width 84: "\x{6B8D}\x{CD3F}{\x{BA63}\x{D83F}\x{DC58}\x{D83E}\x{DE79}"
+      RenderText {#text} at (371,4001) size 79x17
+        text run at (371,4001) width 79: "\x{6BB9}\x{D83F}\x{DEA4}\x{2C97}\x{2972}\x{1BF}\x{DE85}\x{CFE7}"
+      RenderText {#text} at (449,4001) size 67x17
+        text run at (449,4001) width 67: "\x{EF1}\x{B007}\x{3F51}\x{261D}\x{D83F}\x{DC63}"
+      RenderText {#text} at (515,4001) size 76x17
+        text run at (515,4001) width 44: "\x{98B8}\x{29B}\x{9DD}\x{D83E}\x{DF77}"
+        text run at (558,4001) width 12 RTL: "\x{812}"
+        text run at (569,4001) width 22: "\x{970}\x{4E6C}"
+      RenderText {#text} at (590,4001) size 140x17
+        text run at (590,4001) width 140: "\x{D83D}\x{DFE5}\x{D83E}\x{DC26}\x{61CA}\x{D83E}\x{DE1C}\x{D83E}\x{DC4B}\x{8674}\x{3056}\x{1992}\x{37B8}\x{8F24}"
+      RenderImage {IMG} at (0,4272) size 76x41
+      RenderText {#text} at (76,4300) size 26x17
+        text run at (76,4300) width 26: "\x{E444}\x{8A50}"
+      RenderText {#text} at (101,4300) size 123x17
+        text run at (101,4300) width 123: "\x{6E4}\x{312}\x{D83E}\x{DDBF}\x{D3EF}\x{2A01}\x{8F1B}\x{24D5}\x{D83F}\x{DD89}\x{CE5}\x{4551}"
+      RenderImage {IMG} at (223,4251) size 56x62
+      RenderText {#text} at (278,4300) size 31x17
+        text run at (278,4300) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (308,4300) size 81x17
+        text run at (308,4300) width 81: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (388,4300) size 69x17
+        text run at (388,4300) width 7 RTL: "\x{692}"
+        text run at (394,4300) width 63: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (0,4363) size 298x170
+      RenderText {#text} at (298,4520) size 103x17
+        text run at (298,4520) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (438,4520) size 100x17
+        text run at (438,4520) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (537,4520) size 117x17
+        text run at (537,4520) width 32: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (568,4520) width 10 RTL: "\x{79B}"
+        text run at (577,4520) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (0,4540) size 292x253
+      RenderText {#text} at (292,4780) size 103x17
+        text run at (292,4780) width 103: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (394,4780) size 105x17
+        text run at (394,4780) width 105: "\x{10D}\x{BA96}\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (498,4780) size 102x17
+        text run at (498,4780) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (599,4780) size 116x17
+        text run at (599,4780) width 116: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (0,4811) size 34x17
+        text run at (0,4811) width 34: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (33,4811) size 120x17
+        text run at (33,4811) width 26: "\x{24BF}\x{B00}"
+        text run at (58,4811) width 12 RTL: "\x{5FF}"
+        text run at (69,4811) width 14: "\x{2FA}\x{B13}"
+        text run at (82,4811) width 11 RTL: "\x{8BC}"
+        text run at (92,4811) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (152,4811) size 88x17
+        text run at (152,4811) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (239,4811) size 88x17
+        text run at (239,4811) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (326,4811) size 22x17
+        text run at (326,4811) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (347,4811) size 111x17
+        text run at (347,4811) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (457,4811) size 79x17
+        text run at (457,4811) width 79: "\x{ECB8}\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (535,4811) size 85x17
+        text run at (535,4811) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+      RenderText {#text} at (619,4811) size 100x17
+        text run at (619,4811) width 80: "\x{D83F}\x{DD83}\x{D83F}\x{DD58}\x{6EE2}\x{47A3}\x{10B}\x{2CC7}\x{BC62}"
+        text run at (698,4811) width 10 RTL: "\x{67F}"
+        text run at (707,4811) width 12: "\x{D83F}\x{DC12}"
+      RenderText {#text} at (0,4811) size 752x45
+        text run at (718,4811) width 34: "\x{F24}\x{A756}\x{4864}"
+        text run at (0,4839) width 116: "\x{D83D}\x{DF2C}\x{D83E}\x{DD04}\x{D83D}\x{DFF9}\x{D83E}\x{DD6D}\x{D83D}\x{DF33}\x{9AA9}\x{FF4C}\x{D83E}\x{DEAD}"
+      RenderText {#text} at (115,4839) size 52x17
+        text run at (115,4839) width 27: "\x{84E2}\x{D83E}\x{DCB2}"
+        text run at (141,4839) width 11 RTL: "\x{793}"
+        text run at (151,4839) width 16: "\x{812B}"
+      RenderText {#text} at (166,4839) size 119x17
+        text run at (166,4839) width 119: "\x{CD98}\x{D83E}\x{DEF8}\x{D83E}\x{DDA7}\x{AF08}\x{4EB8}\x{1243}\x{B2E}\x{FF7}"
+      RenderText {#text} at (284,4839) size 96x17
+        text run at (284,4839) width 96: "\x{1E56}\x{DB7F}\x{3BE0}\x{9F86}\x{4C4D}\x{D83F}\x{DCB1}\x{D83E}\x{DD9F}"
+      RenderText {#text} at (379,4839) size 60x17
+        text run at (379,4839) width 16: "\x{AC6C}"
+        text run at (394,4839) width 15 RTL: "\x{84C}"
+        text run at (408,4839) width 31: "\x{3CFB}\x{C01}"
+      RenderText {#text} at (438,4839) size 84x17
+        text run at (438,4839) width 84: "\x{C96F}\x{CFE}\x{D83E}\x{DD4C}\x{2EB1}\x{BFB}\x{D83F}\x{DFDA}"
+      RenderText {#text} at (521,4839) size 74x17
+        text run at (521,4839) width 74: "\x{966}\x{D83D}\x{DE44}\x{F51D}\x{D83E}\x{DF45}\x{F91}\x{2772}\x{D83F}\x{DF3B}"
+      RenderText {#text} at (594,4839) size 89x17
+        text run at (594,4839) width 67: "\x{94A5}\x{8A96}\x{6D75}\x{D83F}\x{DC81}\x{180}"
+        text run at (660,4839) width 12 RTL: "\x{6A6}"
+        text run at (671,4839) width 12: "\x{D83F}\x{DC37}"
+      RenderText {#text} at (682,4839) size 78x17
+        text run at (682,4839) width 58: "\x{EA1}\x{FB1}\x{A34}\x{5543}\x{D83F}\x{DF64}"
+        text run at (739,4839) width 13 RTL: "\x{801}"
+        text run at (751,4839) width 9: "\x{2EE1}"
+      RenderText {#text} at (0,4865) size 34x17
+        text run at (0,4865) width 34: "\x{1498}\x{D83F}\x{DE40}\x{D83E}\x{DC29}"
+      RenderText {#text} at (33,4865) size 23x17
+        text run at (33,4865) width 23: "\x{3040}\x{D83E}\x{DE44}"
+      RenderText {#text} at (55,4865) size 74x17
+        text run at (55,4865) width 74: "\x{D83F}\x{DF07}\x{DE60}\x{958}\x{D83F}\x{DD30}\x{4AC5}\x{3F37}"
+      RenderText {#text} at (128,4865) size 133x17
+        text run at (128,4865) width 133: "\x{7F0}\x{9CF}\x{C47A}\x{D74}\x{161C}\x{1F13}\x{97BB}\x{4FF7}\x{3AEF}\x{D83E}\x{DC98}\x{DDA}"
+      RenderText {#text} at (260,4865) size 111x17
+        text run at (260,4865) width 111: "\x{E60A}\x{5E72}\x{FAFC}\x{A318}\x{960}\x{9825}\x{265E}\x{6633}\x{6C91}"
+      RenderText {#text} at (370,4865) size 109x17
+        text run at (370,4865) width 61: "\x{739A}\x{2679}\x{24C2}\x{4019}"
+        text run at (430,4865) width 12 RTL: "\x{5C9}"
+        text run at (441,4865) width 38: "\x{CEE6}\x{D83E}\x{DF11}\x{A44}"
+      RenderText {#text} at (478,4865) size 32x17
+        text run at (478,4865) width 32: "\x{A89}\x{D83E}\x{DE59}\x{D83E}\x{DE6F}"
+      RenderText {#text} at (509,4865) size 83x17
+        text run at (509,4865) width 68: "\x{C1D6}\x{DC6A}\x{6930}\x{9921}\x{432}\x{ED}"
+        text run at (576,4865) width 5 RTL: "\x{701}"
+        text run at (580,4865) width 12: "\x{C84}"
+      RenderText {#text} at (591,4865) size 98x17
+        text run at (591,4865) width 98: "\x{D83D}\x{DE53}\x{D83F}\x{DC79}\x{C460}\x{BEF2}\x{4C04}\x{156}\x{372}\x{47A}"
+      RenderText {#text} at (688,4865) size 23x17
+        text run at (688,4865) width 23: "\x{D83E}\x{DC7C}\x{D83F}\x{DC5B}"
+      RenderText {#text} at (0,4865) size 756x43
+        text run at (710,4865) width 46: "\x{37FE}\x{9416}\x{9668}"
+        text run at (0,4891) width 54: "\x{E6B0}\x{F1F}\x{E27B}\x{B1B}\x{6F8B}"
+      RenderText {#text} at (53,4891) size 89x17
+        text run at (53,4891) width 89: "\x{533}\x{D83F}\x{DDD9}\x{C481}\x{C5EC}\x{A889}\x{49D9}\x{D83F}\x{DEBB}"
+      RenderText {#text} at (141,4891) size 120x17
+        text run at (141,4891) width 16: "\x{589C}"
+        text run at (156,4891) width 12 RTL: "\x{5CC}"
+        text run at (167,4891) width 49: "\x{1FF}\x{8296}\x{D83F}\x{DD87}\x{C9CD}"
+        text run at (215,4891) width 11 RTL: "\x{5E1}"
+        text run at (225,4891) width 12: "\x{EB97}"
+        text run at (236,4891) width 14 RTL: "\x{8B6}"
+        text run at (249,4891) width 12: "\x{D83E}\x{DE33}"
+      RenderText {#text} at (260,4891) size 70x17
+        text run at (260,4891) width 70: "\x{29E}\x{3AD8}\x{911F}\x{4170}\x{89AC}"
+      RenderText {#text} at (329,4891) size 127x17
+        text run at (329,4891) width 127: "\x{DAE}\x{D83E}\x{DFD0}\x{D676}\x{7A82}\x{D83F}\x{DC92}\x{D33}\x{99C8}\x{D83E}\x{DD52}\x{8FDE}\x{140}"
+      RenderText {#text} at (455,4891) size 145x17
+        text run at (455,4891) width 128: "\x{D83E}\x{DCB1}\x{D83E}\x{DCB7}\x{D83F}\x{DDE3}\x{B97C}\x{C855}\x{CD5B}\x{CF1}\x{C54C}\x{4043}\x{1535}"
+        text run at (587,4891) width 13 RTL: "\x{83D}"
+      RenderText {#text} at (582,4891) size 84x17
+        text run at (582,4891) width 6 RTL: "\x{5D5}"
+        text run at (599,4891) width 67: "\x{5E92}\x{1E8A}\x{9A39}\x{D29}\x{D83F}\x{DEBA}"
+      RenderText {#text} at (665,4891) size 31x17
+        text run at (665,4891) width 31: "\x{47B5}\x{8C8D}"
+      RenderText {#text} at (0,4891) size 764x45
+        text run at (695,4891) width 69: "\x{275C}\x{145}\x{C5C7}\x{F654}\x{DAD7}\x{BDD7}"
+        text run at (0,4919) width 19: "n\x{F047}"
+      RenderText {#text} at (18,4919) size 120x17
+        text run at (18,4919) width 28: "\x{ABB4}\x{AACB}\x{A19}"
+        text run at (45,4919) width 15 RTL: "\x{717}"
+        text run at (59,4919) width 79: "\x{E620}\x{D83E}\x{DC2C}\x{D83D}\x{DE54}\x{2C3}\x{BD07}\x{536}\x{4AFF}"
+      RenderText {#text} at (137,4919) size 63x17
+        text run at (137,4919) width 32: "\x{D83E}\x{DDCC}\x{D83E}\x{DC21}"
+        text run at (168,4919) width 17 RTL: "\x{6BE}\x{769}"
+        text run at (184,4919) width 16: "\x{41BE}"
+      RenderText {#text} at (199,4919) size 41x17
+        text run at (199,4919) width 15 RTL: "\x{808}"
+        text run at (213,4919) width 27: "\x{D83E}\x{DE4B}\x{4961}"
+      RenderText {#text} at (239,4919) size 48x17
+        text run at (239,4919) width 48: "\x{2CE9}\x{E5A6}\x{7C86}\x{10}"
+      RenderText {#text} at (286,4919) size 140x17
+        text run at (286,4919) width 140: "\x{D83F}\x{DE92}\x{E10B}\x{E644}\x{346D}\x{DD9}\x{EC1}\x{1D39}\x{BAE0}\x{CCC}\x{D0A}\x{272D}"
+      RenderText {#text} at (425,4919) size 144x17
+        text run at (425,4919) width 144: "\x{8E33}\x{F5F6}\x{D83E}\x{DD52}\x{542C}\x{AE0C}\x{33F}\x{B49F}\x{D83E}\x{DCA8}\x{DA4}\x{D83F}\x{DC82}\x{6138}"
+      RenderText {#text} at (568,4919) size 102x17
+        text run at (568,4919) width 33: "\x{D83F}\x{DF2D}\x{F4A7}\x{E7C6}"
+        text run at (600,4919) width 10 RTL: "\x{639}"
+        text run at (609,4919) width 27: "\x{FDD}\x{8C02}"
+        text run at (635,4919) width 5 RTL: "\x{627}"
+        text run at (639,4919) width 31: "\x{64C5}\x{3878}"
+      RenderText {#text} at (0,4919) size 768x44
+        text run at (669,4919) width 99: "\x{911D}\x{B0A}\x{D83E}\x{DF5D}\x{530D}\x{D6F0}\x{302}\x{9DF7}\x{D18}"
+        text run at (0,4946) width 15: "\x{B088}\x{EC9}"
+      RenderText {#text} at (14,4946) size 27x17
+        text run at (14,4946) width 12: "\x{D83F}\x{DDBE}"
+        text run at (35,4946) width 6 RTL: "\x{6C0}"
+      RenderText {#text} at (25,4946) size 76x17
+        text run at (25,4946) width 11 RTL: "\x{6D1}"
+        text run at (40,4946) width 61: "\x{B7EC}\x{DC39}\x{73EF}\x{1F90}\x{D83E}\x{DFE6}"
+      RenderText {#text} at (100,4946) size 132x17
+        text run at (100,4946) width 111: "\x{326D}\x{F53}\x{D83E}\x{DCAB}\x{482}\x{D83E}\x{DFFE}\x{B32F}\x{D83F}\x{DD03}\x{5C3E}\x{3D9C}"
+        text run at (210,4946) width 22 RTL: "\x{FCFC}"
+      RenderText {#text} at (231,4946) size 102x17
+        text run at (231,4946) width 77: "\x{8950}\x{4E2A}\x{EDC}\x{D83E}\x{DCD7}\x{D83F}\x{DD84}\x{44E}"
+        text run at (307,4946) width 11 RTL: "\x{848}"
+        text run at (317,4946) width 16: "\x{AF80}"
+      RenderText {#text} at (332,4946) size 129x17
+        text run at (332,4946) width 129: "\x{54D7}\x{E79C}\x{8C16}\x{63C6}\x{F54D}\x{8CEB}\x{8E6}\x{D83E}\x{DD1E}\x{F5BB}\x{AD09}"
+      RenderText {#text} at (460,4946) size 95x17
+        text run at (460,4946) width 95: "\x{D07B}\x{D83D}\x{DEBF}\x{C5}\x{D83E}\x{DCF7}\x{F8}\x{4AC9}\x{6E8E}"
+      RenderText {#text} at (554,4946) size 112x17
+        text run at (554,4946) width 112: "\x{C7FE}\x{AE4D}\x{4827}\x{BA55}\x{62AD}\x{FBA}\x{6065}\x{4EFC}"
+      RenderText {#text} at (0,4946) size 755x45
+        text run at (665,4946) width 90: "\x{10C6}\x{4BF}\x{BBE4}\x{D3B}\x{A0A}\x{B8E}\x{1487}\x{D83F}\x{DC7C}"
+        text run at (0,4974) width 32: "\x{23D}\x{1AA}\x{8F3F}"
+      RenderText {#text} at (31,4974) size 36x17
+        text run at (31,4974) width 36: "\x{328}\x{E96}\x{D83F}\x{DF71}\x{F10F}"
+      RenderText {#text} at (66,4974) size 88x17
+        text run at (66,4974) width 88: "\x{614A}\x{C870}\x{E997}\x{D83F}\x{DE46}\x{2D8B}\x{B80}\x{EFC4}"
+      RenderText {#text} at (153,4974) size 140x17
+        text run at (153,4974) width 140: "\x{496B}\x{D83F}\x{DE84}\x{D3D8}\x{D83D}\x{DF44}\x{1244}\x{D83E}\x{DD7C}\x{3C8A}\x{D73F}\x{E6DF}\x{D83F}\x{DD5E}"
+      RenderText {#text} at (292,4974) size 11x17
+        text run at (292,4974) width 11: "\x{2995}\x{F7D}"
+      RenderText {#text} at (302,4974) size 60x17
+        text run at (302,4974) width 60: "\x{515D}\x{DEA}k\x{D83F}\x{DDE9}\x{D099}"
+      RenderText {#text} at (361,4974) size 83x17
+        text run at (361,4974) width 83: "\x{4936}\x{A04}\x{D83D}\x{DE68}\x{7F8E}\x{5145}\x{3B80}"
+      RenderText {#text} at (443,4974) size 42x17
+        text run at (443,4974) width 42: "\x{B92B}\x{B663}\x{D83F}\x{DF52}"
+      RenderText {#text} at (484,4974) size 32x17
+        text run at (484,4974) width 32: "\x{D83F}\x{DD45}\x{4C8}\x{1500}"
+      RenderText {#text} at (515,4974) size 103x17
+        text run at (515,4974) width 11 RTL: "\x{649}"
+        text run at (525,4974) width 93: "Y\x{E2}\x{D83D}\x{DFCF}\x{BE7}\x{E856}\x{D83D}\x{DF5D}\x{96CF}\x{76BA}"
+      RenderText {#text} at (617,4974) size 71x17
+        text run at (617,4974) width 71: "\x{3190}\x{B978}\x{898}\x{AD2C}\x{CF05}"
+      RenderText {#text} at (687,4974) size 49x17
+        text run at (687,4974) width 49: "\x{D83F}\x{DC2C}\x{DDE0}\x{2E3F}\x{3B9A}"
+      RenderText {#text} at (0,5002) size 78x17
+        text run at (0,5002) width 31: "\x{D83E}\x{DE42}\x{A6E}\x{D9FC}"
+        text run at (30,5002) width 18 RTL: "\x{FC17}"
+        text run at (47,5002) width 31: "\x{24A9}\x{5434}"
+      RenderText {#text} at (77,5002) size 138x17
+        text run at (77,5002) width 138: "\x{8EB0}\x{D83F}\x{DCBB}\x{8B92}\x{4961}\x{D83F}\x{DE5F}\x{815F}\x{1496}\x{75DF}\x{F135}\x{D83E}\x{DCAE}\x{AB94}"
+      RenderText {#text} at (214,5002) size 119x17
+        text run at (214,5002) width 119: "\x{7}\x{F4E}\x{E9C5}\x{D83E}\x{DD16}\x{FF4}\x{C8B2}\x{8885}\x{1181}\x{D83F}\x{DDD6}"
+      RenderText {#text} at (332,5002) size 138x17
+        text run at (332,5002) width 138: "\x{F40D}\x{D83E}\x{DE7B}\x{D83F}\x{DE68}\x{481}\x{1242}\x{BA41}\x{8A50}\x{D83F}\x{DD54}\x{2F2A}\x{D83D}\x{DE49}"
+      RenderText {#text} at (469,5002) size 137x17
+        text run at (469,5002) width 137: "\x{884F}\x{146B}\x{D9C5}\x{D83E}\x{DF3C}\x{40EA}\x{BCD5}\x{5E1B}\x{A59}\x{D83E}\x{DCDD}\x{D83F}\x{DDF0}\x{7C60}"
+      RenderText {#text} at (605,5002) size 119x17
+        text run at (605,5002) width 119: "\x{5BB}\x{D83D}\x{DF58}\x{994}\x{D6F}\x{D83F}\x{DCBF}\x{1E35}\x{DD08}\x{90FE}\x{16AD}\x{B0D1}\x{5E87}"
+      RenderText {#text} at (0,5002) size 758x45
+        text run at (723,5002) width 35: "\x{78F9}\x{D83F}\x{DC10}\x{A0E3}"
+        text run at (0,5030) width 15: "\x{5AFC}"
+      RenderText {#text} at (15,5030) size 130x17
+        text run at (15,5030) width 130: "\x{5084}\x{BECB}\x{6B64}\x{D83E}\x{DC65}\x{D72B}\x{7CD8}\x{D83F}\x{DC17}\x{9C6}\x{D83F}\x{DEF6}\x{7A6}"
+      RenderText {#text} at (144,5030) size 67x17
+        text run at (144,5030) width 67: "\x{21AA}\x{C3A9}\x{32C1}\x{1E22}\x{D00}"
+      RenderText {#text} at (210,5030) size 111x17
+        text run at (210,5030) width 10 RTL: "\x{682}"
+        text run at (219,5030) width 102: "\x{78A3}\x{E49}\x{B61}\x{C2}\x{E55}\x{555}\x{3F5}\x{A4E9}\x{34EC}\x{D83E}\x{DE4D}"
+      RenderText {#text} at (320,5030) size 96x17
+        text run at (320,5030) width 42: "\x{5699}\x{8FFA}\x{F786}"
+        text run at (361,5030) width 9 RTL: "\x{685}"
+        text run at (369,5030) width 47: "\x{1D3F}\x{DB6B}\x{BF05}\x{4083}"
+      RenderText {#text} at (415,5030) size 35x17
+        text run at (415,5030) width 31: "\x{7F14}\x{9D87}"
+        text run at (445,5030) width 5 RTL: "\x{627}"
+      RenderText {#text} at (449,5030) size 53x17
+        text run at (449,5030) width 53: "\x{D83F}\x{DD01}\x{4ED3}\x{60F4}\x{2C4D}"
+      RenderText {#text} at (501,5030) size 52x17
+        text run at (501,5030) width 52: "\x{D404}\x{ADEF}\x{558}\x{D83F}\x{DC9A}"
+      RenderText {#text} at (552,5030) size 73x17
+        text run at (552,5030) width 12: "\x{D83E}\x{DF0D}"
+        text run at (563,5030) width 12 RTL: "\x{5EA}"
+        text run at (574,5030) width 51: "\x{1211}\x{EE55}\x{1C8A}\x{D83F}\x{DEAD}"
+      RenderText {#text} at (0,5030) size 744x42
+        text run at (624,5030) width 120: "\x{D83E}\x{DE97}\x{AFC9}\x{D83F}\x{DC32}\x{D83F}\x{DD2F}\x{20A}\x{F3F1}\x{D83E}\x{DD8F}\x{2E70}\x{3838}"
+        text run at (0,5055) width 11: "\x{D83E}\x{DF9C}"
+      RenderText {#text} at (10,5055) size 121x17
+        text run at (10,5055) width 121: "\x{D83E}\x{DC74}\x{D83D}\x{DF80}\x{FAE}\x{EA64}\x{525}\x{D83F}\x{DF92}\x{D83E}\x{DE4A}\x{4F6}\x{D83F}\x{DE5D}\x{D83E}\x{DF5C}\x{88DC}"
+      RenderText {#text} at (130,5055) size 38x17
+        text run at (130,5055) width 38: "\x{6B58}\x{CF96}\x{168B}"
+      RenderText {#text} at (167,5055) size 108x17
+        text run at (167,5055) width 50: "\x{B850}\x{D83D}\x{DF15}\x{850E}\x{C90}"
+        text run at (216,5055) width 8 RTL: "\x{6C1}"
+        text run at (223,5055) width 52: "\x{D83F}\x{DF5B}\x{6949}\x{4E7E}\x{9BA}"
+      RenderText {#text} at (274,5055) size 110x17
+        text run at (274,5055) width 12: "\x{D83E}\x{DC0E}"
+        text run at (285,5055) width 10 RTL: "\x{7D5}"
+        text run at (294,5055) width 90: "\x{3ADE}\x{D83D}\x{DFBF}\x{55B}\x{D83E}\x{DFD0}\x{F3C9}\x{AFC}\x{D83F}\x{DEA7}\x{FD5}\x{B6C}"
+      RenderText {#text} at (383,5055) size 57x17
+        text run at (383,5055) width 57: "\x{945}\x{5DA4}\x{D83E}\x{DDEE}\x{53A}"
+      RenderText {#text} at (439,5055) size 107x17
+        text run at (439,5055) width 107: "\x{81F7}\x{48AB}\x{2610}\x{6F92}\x{D83E}\x{DC73}\x{8881}\x{45F}\x{F920}"
+      RenderText {#text} at (545,5055) size 128x17
+        text run at (545,5055) width 128: "\x{E4B}\x{DD7}\x{736}\x{F5A}\x{7373}\x{532}\x{D83E}\x{DC9E}\x{D83E}\x{DE64}\x{274A}\x{CBF1}\x{6AA5}"
+      RenderText {#text} at (0,5055) size 751x45
+        text run at (672,5055) width 79: "\x{DEDD}\x{DC4D}\x{D83F}\x{DEBA}\x{D83F}\x{DE46}\x{F56F}\x{141D}\x{BA38}"
+        text run at (0,5083) width 48: "\x{E100}\x{E5A4}\x{E4D8}\x{6679}"
+      RenderText {#text} at (47,5083) size 51x17
+        text run at (47,5083) width 51: "\x{8AC3}\x{5294}\x{E15}\x{F006}"
+      RenderText {#text} at (97,5083) size 123x17
+        text run at (97,5083) width 123: "\x{F769}\x{D83E}\x{DCA1}\x{D83E}\x{DDF9}\x{25AE}\x{72E5}\x{D83E}\x{DCCF}\x{4A8C}\x{D1F0}\x{D83E}\x{DC81}\x{1C7A}"
+      RenderText {#text} at (219,5083) size 118x17
+        text run at (219,5083) width 22: "\x{D83F}\x{DEF5}\x{F8EC}"
+        text run at (240,5083) width 11 RTL: "\x{6D0}"
+        text run at (250,5083) width 16: "\x{487A}"
+        text run at (265,5083) width 7 RTL: "\x{693}"
+        text run at (271,5083) width 66: "\x{F3C}\x{9485}\x{673D}\x{D83E}\x{DCAB}\x{81DF}"
+      RenderText {#text} at (336,5083) size 130x17
+        text run at (336,5083) width 109: "\x{4A16}\x{82C6}\x{643C}\x{D83D}\x{DEB5}\x{135B}\x{DB59}\x{D83F}\x{DF91}\x{EA82}"
+        text run at (444,5083) width 11 RTL: "\x{752}"
+        text run at (454,5083) width 12: "\x{D83E}\x{DC78}"
+      RenderText {#text} at (465,5083) size 22x17
+        text run at (465,5083) width 22: "\x{94EA}\x{227}"
+      RenderText {#text} at (486,5083) size 124x17
+        text run at (486,5083) width 66: "\x{BA4}\x{1557}\x{E7B2}\x{E3DF}\x{D83D}\x{DE1A}"
+        text run at (551,5083) width 18 RTL: "\x{FCFA}"
+        text run at (568,5083) width 42: "\x{82F5}\x{A7BB}\x{C572}"
+      RenderText {#text} at (609,5083) size 105x17
+        text run at (609,5083) width 105: "\x{EDFC}\x{EFEA}\x{99D}\x{BD3D}\x{A907}\x{CBD}\x{D83F}\x{DF12}\x{918}\x{53F}\x{F1}"
+      RenderText {#text} at (713,5083) size 30x17
+        text run at (713,5083) width 23: "\x{AF5}\x{DCE}"
+        text run at (735,5083) width 8 RTL: "\x{84B}"
+      RenderText {#text} at (0,5083) size 758x45
+        text run at (742,5083) width 16: "\x{D83D}\x{DF05}"
+        text run at (0,5111) width 102: "\x{6B6B}\x{A57}\x{D83F}\x{DE71}\x{A8A}\x{FAB9}\x{2E87}\x{E26D}\x{9DC0}"
+      RenderText {#text} at (101,5111) size 127x17
+        text run at (101,5111) width 127: "\x{C1F9}\x{D83F}\x{DE33}\x{F143}\x{815B}\x{D83E}\x{DCFB}\x{AE3E}\x{4D6}\x{246}\x{D83D}\x{DF03}\x{B53D}"
+      RenderText {#text} at (227,5111) size 128x17
+        text run at (227,5111) width 128: "\x{D83E}\x{DCCB}\x{A4F7}\x{3F2}\x{4A5}\x{F49}\x{6D02}\x{2BE1}\x{1DAF}\x{D83E}\x{DE79}\x{3F1D}\x{B2D}"
+      RenderText {#text} at (354,5111) size 44x17
+        text run at (354,5111) width 44: "\x{E6FD}\x{D83E}\x{DCEA}\x{C86}\x{D83D}\x{DFB6}"
+      RenderText {#text} at (397,5111) size 94x17
+        text run at (397,5111) width 94: "\x{8550}\x{315}\x{D83F}\x{DEBE}\x{9D59}\x{A8E0}\x{D29}\x{DD57}\x{3736}"
+      RenderText {#text} at (490,5111) size 40x17
+        text run at (490,5111) width 40: "\x{978}\x{16F}\x{A1C}\x{9FCF}"
+      RenderText {#text} at (529,5111) size 121x17
+        text run at (529,5111) width 121: "\x{445}\x{C7E}\x{49B4}\x{F256}\x{9EB}\x{E2B3}\x{7D5D}\x{D83D}\x{DF3A}\x{D83F}\x{DDB5}\x{F993}"
+      RenderText {#text} at (649,5111) size 90x17
+        text run at (649,5111) width 90: "\x{203}\x{799B}\x{D83F}\x{DF95}\x{6834}\x{4A6E}\x{D83F}\x{DEEA}\x{634E}"
+      RenderText {#text} at (0,5111) size 754x45
+        text run at (738,5111) width 16: "\x{B821}"
+        text run at (0,5139) width 48: "\x{A615}\x{1D6}\x{4E7}\x{E06C}q"
+      RenderText {#text} at (47,5139) size 57x17
+        text run at (47,5139) width 57: "\x{D83E}\x{DEC0}\x{FAA}\x{D83D}\x{DED3}\x{474A}"
+      RenderText {#text} at (103,5139) size 117x17
+        text run at (103,5139) width 117: "\x{F198}\x{27BB}\x{5D7A}\x{AA7}\x{AF9C}\x{1EE4}\x{23C2}\x{35DA}\x{E551}"
+      RenderText {#text} at (219,5139) size 27x17
+        text run at (219,5139) width 27: "\x{5A8F}\x{D67}"
+      RenderText {#text} at (245,5139) size 25x17
+        text run at (245,5139) width 25: "\x{422F}\x{F34}"
+      RenderText {#text} at (269,5139) size 113x17
+        text run at (269,5139) width 113: "\x{4E0B}\x{AD32}\x{9EF}\x{92F2}\x{6147}\x{A0D8}\x{D83E}\x{DDCE}\x{D63F}"
+      RenderText {#text} at (381,5139) size 97x17
+        text run at (381,5139) width 16: "\x{D83E}\x{DF77}\x{2D42}"
+        text run at (396,5139) width 15 RTL: "\x{FC9D}"
+        text run at (410,5139) width 68: "\x{56AB}\x{38D3}\x{32E0}\x{1EF}\x{D6B}"
+      RenderText {#text} at (477,5139) size 20x17
+        text run at (477,5139) width 20: "\x{10}\x{E8A}"
+      RenderText {#text} at (496,5139) size 122x17
+        text run at (496,5139) width 23: "\x{D83E}\x{DC7F}\x{E324}"
+        text run at (518,5139) width 12 RTL: "\x{88A}"
+        text run at (529,5139) width 89: "\x{F2E}\x{9192}\x{B089}\x{E52B}\x{D83E}\x{DE89}\x{D83D}\x{DFBF}\x{8FA8}"
+      RenderText {#text} at (617,5139) size 77x17
+        text run at (617,5139) width 77: "\x{BAB5}\x{D028}\x{E7E}\x{D83F}\x{DC2F}\x{E14}\x{38B9}"
+      RenderText {#text} at (693,5139) size 50x17
+        text run at (693,5139) width 50: "\x{34E}\x{A22F}\x{24F}\x{D83E}\x{DC0E}\x{7F63}"
+      RenderText {#text} at (0,5139) size 758x42
+        text run at (742,5139) width 16: "\x{725E}"
+        text run at (0,5164) width 52: "\x{3512}\x{89F2}\x{E971}\x{F91}"
+        text run at (51,5164) width 10 RTL: "\x{5E4}"
+      RenderText {#text} at (60,5164) size 46x17
+        text run at (60,5164) width 46: "\x{F2C1}\x{570}\x{178}\x{91C7}"
+layer at (8,142) size 16x16
+  RenderVideo {VIDEO} at (0,134) size 16x16
+layer at (24,142) size 16x16
+  RenderVideo {VIDEO} at (16,134) size 16x16
+layer at (151,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (143,0) size 300x150
+layer at (8,167) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,159) size 300x150
+layer at (8,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,317) size 300x150
+layer at (308,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,317) size 300x150
+layer at (8,481) size 284x284
+  RenderVideo {VIDEO} at (0,473) size 284x284
+layer at (546,749) size 16x16
+  RenderVideo {VIDEO} at (537,741) size 17x16
+layer at (65,913) size 16x16
+  RenderVideo {VIDEO} at (56,905) size 17x16
+layer at (116,779) size 349x150
+  RenderHTMLCanvas {CANVAS} at (108,771) size 350x150
+layer at (93,937) size 300x150
+  RenderHTMLCanvas {CANVAS} at (85,929) size 301x150
+layer at (8,1120) size 885x385
+  RenderHTMLCanvas {CANVAS} at (0,1112) size 885x385
+layer at (8,1988) size 213x213
+  RenderVideo {VIDEO} at (0,1980) size 213x213
+layer at (196,2420) size 16x16
+  RenderVideo {VIDEO} at (188,2412) size 17x16
+layer at (8,2448) size 290x127
+  RenderHTMLCanvas {CANVAS} at (0,2440) size 290x127
+layer at (8,2856) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,2848) size 300x150
+layer at (334,2739) size 300x267
+  RenderHTMLCanvas {CANVAS} at (326,2731) size 300x267
+layer at (8,3276) size 974x150
+  RenderHTMLCanvas {CANVAS} at (0,3268) size 974x150
+layer at (8,3447) size 905x349
+  RenderHTMLCanvas {CANVAS} at (0,3439) size 905x349
+layer at (200,3832) size 335x23
+  RenderHTMLCanvas {CANVAS} at (192,3824) size 336x23
+layer at (748,3839) size 16x16
+  RenderVideo {VIDEO} at (740,3831) size 17x16
+layer at (465,4030) size 291x291
+  RenderVideo {VIDEO} at (456,4022) size 292x291
+layer at (408,4328) size 38x213
+  RenderVideo {VIDEO} at (400,4320) size 39x213

--- a/LayoutTests/fast/webgpu/fuzz-273023.html
+++ b/LayoutTests/fast/webgpu/fuzz-273023.html
@@ -1,0 +1,45621 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUCommandEncoder} commandEncoder
+ */
+function pseudoSubmit(device, commandEncoder) {
+  device.pushErrorScope('validation');
+  commandEncoder.clearBuffer(device.createBuffer({size: 0, usage: 0}), 0, 0);
+  device.popErrorScope().then(() => {});
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let promise0 = navigator.gpu.requestAdapter(
+{
+powerPreference: 'low-power',
+}
+);
+let adapter0 = await promise0;
+let device0 = await adapter0.requestDevice(
+{
+label: '\u078f\ub29b\u0e18\ub31d\u03c9',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 9,
+maxColorAttachmentBytesPerSample: 44,
+maxVertexAttributes: 17,
+maxVertexBufferArrayStride: 60568,
+maxStorageTexturesPerShaderStage: 24,
+maxStorageBuffersPerShaderStage: 28,
+maxDynamicStorageBuffersPerPipelineLayout: 6561,
+maxBindingsPerBindGroup: 3279,
+maxTextureDimension1D: 8675,
+maxTextureDimension2D: 10706,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 47805724,
+maxInterStageShaderVariables: 60,
+maxInterStageShaderComponents: 87,
+},
+}
+);
+let commandEncoder0 = device0.createCommandEncoder(
+{
+label: '\u0460\u0c9d\u9a2a',
+}
+);
+let sampler0 = device0.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 89.287,
+lodMaxClamp: 99.001,
+maxAnisotropy: 3,
+}
+);
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+let commandBuffer0 = commandEncoder0.finish(
+{
+}
+);
+let texture0 = device0.createTexture(
+{
+label: '\u{1fc18}\u0931\u{1f889}\u0c1a\u156a\u878d\ufaee\u48c5\u0f32',
+size: [114, 2, 24],
+mipLevelCount: 5,
+sampleCount: 1,
+dimension: '3d',
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+try {
+device0.pushErrorScope(
+'out-of-memory'
+);
+} catch {}
+gc();
+let querySet0 = device0.createQuerySet(
+{
+label: '\u51a4\u0154\u0230\u0182\u96cf\u698d\u{1fc1f}\u05c7\u099e\u{1fab0}',
+type: 'occlusion',
+count: 187,
+}
+);
+let texture1 = device0.createTexture(
+{
+label: '\u{1fb1f}\u20a5\u10e2\u04c0\ua011\u0769',
+size: {width: 13, height: 217, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+sampleCount: 1,
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rg16sint'
+],
+}
+);
+let sampler1 = device0.createSampler(
+{
+label: '\ude56\u01d7',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 54.567,
+lodMaxClamp: 85.986,
+maxAnisotropy: 11,
+}
+);
+document.body.prepend('\u{1fd07}\ue522');
+let querySet1 = device0.createQuerySet(
+{
+label: '\u{1f83f}\u2f55\u{1f858}',
+type: 'occlusion',
+count: 3554,
+}
+);
+let textureView0 = texture0.createView(
+{
+label: '\u{1fa7a}\u{1f8fd}\u496c\u966a\u{1fc02}\u20f1\ue301\u{1fe98}\u19b6\ud3ef\u091b',
+dimension: '3d',
+baseMipLevel: 2,
+}
+);
+try {
+await device0.popErrorScope();
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+let commandEncoder1 = device0.createCommandEncoder(
+{
+}
+);
+let texture2 = device0.createTexture(
+{
+label: '\uacbe\ubeec',
+size: [516, 1, 118],
+mipLevelCount: 3,
+sampleCount: 1,
+format: 'r32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32float'
+],
+}
+);
+let computePassEncoder0 = commandEncoder1.beginComputePass();
+let renderBundleEncoder0 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 791,
+depthReadOnly: false,
+}
+);
+let renderBundle0 = renderBundleEncoder0.finish();
+let commandEncoder2 = device0.createCommandEncoder(
+{
+label: '\u0401\u0177\u{1f8be}\u{1fc36}\ub60e\u0c96\u14bc\u0fac\u1c50',
+}
+);
+let querySet2 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 3244,
+}
+);
+try {
+computePassEncoder0.end();
+} catch {}
+document.body.prepend('\ue739\u{1f96d}\u{1ff09}\u{1f7c2}\u{1fb18}\u78b9\u{1fb03}\u73a7');
+let computePassEncoder1 = commandEncoder2.beginComputePass(
+{
+label: '\u626e\uac2f\u30de\u7a21\ufa6f\u220a\uc827\u{1f81b}'
+}
+);
+let renderBundle1 = renderBundleEncoder0.finish(
+{
+label: '\ua0c2\u0067\ud3f7\u5194\u5b8e\u{1fdda}\u{1fe1f}\u{1fe75}\u{1f944}\u{1ffc5}\u6ebf'
+}
+);
+let sampler2 = device0.createSampler(
+{
+label: '\u{1f77b}\u{1fe35}\u01d4\ue9f8\u0354',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 32.032,
+lodMaxClamp: 42.001,
+}
+);
+gc();
+document.body.append('\u06f8\u1230\u0fdf\u2931\u06c3');
+let offscreenCanvas0 = new OffscreenCanvas(1005, 932);
+let texture3 = device0.createTexture(
+{
+label: '\u0df2\u{1fa03}\u{1fbe7}\u{1f72b}\u1788\uf641\uf9b7\ua0cf\u1f51\ueeda',
+size: {width: 207, height: 14, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgba16uint',
+'rgba16uint',
+'rgba16uint'
+],
+}
+);
+let computePassEncoder2 = commandEncoder1.beginComputePass(
+{
+
+}
+);
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.prepend('\u36c2\u2b31\u{1f8d0}\u{1fcc1}\u6ec1\u8940\u0771');
+let offscreenCanvas1 = new OffscreenCanvas(264, 277);
+let video0 = await videoWithData();
+let querySet3 = device0.createQuerySet(
+{
+label: '\u{1fd18}\u064c\u0af2\u{1fd13}\ua3ca\u05e4',
+type: 'occlusion',
+count: 905,
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture3,
+  mipLevel: 5,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+new Uint32Array(new ArrayBuffer(80)),
+/* required buffer size: 613 */{
+offset: 613,
+rowsPerImage: 86,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder3 = device0.createCommandEncoder(
+{
+}
+);
+let texture4 = device0.createTexture(
+{
+label: '\uab60\u00b0\u{1fa79}',
+size: [215, 1, 89],
+mipLevelCount: 8,
+dimension: '3d',
+format: 'rgba32sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgba32sint',
+'rgba32sint',
+'rgba32sint'
+],
+}
+);
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba32sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8uint',
+'rgba32sint'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+document.body.prepend(video0);
+try {
+offscreenCanvas1.getContext('webgl');
+} catch {}
+let buffer0 = device0.createBuffer(
+{
+label: '\u{1fa56}\ufc1a\u25f5\ua2b0\u{1ff77}\u{1f839}\u4b06\u04ad\uddf5',
+size: 28023,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let commandEncoder4 = device0.createCommandEncoder();
+try {
+computePassEncoder1.pushDebugGroup(
+'\ua2d0'
+);
+} catch {}
+try {
+computePassEncoder1.insertDebugMarker(
+'\u5e5d'
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 2, y: 24, z: 1 },
+  aspect: 'all',
+},
+new Float32Array(new ArrayBuffer(40)),
+/* required buffer size: 883 */{
+offset: 883,
+bytesPerRow: 302,
+rowsPerImage: 378,
+},
+{width: 10, height: 164, depthOrArrayLayers: 0}
+);
+} catch {}
+let canvas0 = document.createElement('canvas');
+let imageData0 = new ImageData(96, 136);
+let bindGroupLayout0 = device0.createBindGroupLayout(
+{
+label: '\u{1fc25}\u{1f609}\u66ee\u{1f841}\u0420\uda28\u0dba\u7aa9',
+entries: [
+
+],
+}
+);
+let bindGroup0 = device0.createBindGroup({
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let querySet4 = device0.createQuerySet(
+{
+label: '\uf1f4\u0747\u{1f688}\ua995\u{1f952}\u0231\u105f\u5641',
+type: 'occlusion',
+count: 258,
+}
+);
+let texture5 = device0.createTexture(
+{
+label: '\u{1fbeb}\ued01\uf5f4\u{1fa2a}\u7b3d\ud64e\u6ecb\u0d12\ud305',
+size: {width: 7544},
+dimension: '1d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView1 = texture5.createView(
+{
+label: '\u0e5b\u0ed9\u{1f8d4}\ud8b7\u04d0\u237a\u2781\u4da3\ud61e\u{1f701}\u0242',
+dimension: '1d',
+aspect: 'all',
+}
+);
+let computePassEncoder3 = commandEncoder4.beginComputePass();
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(video0);
+document.body.prepend('\ub15b\u0f5f\u03df\u01bf');
+try {
+canvas0.getContext('2d');
+} catch {}
+let commandBuffer1 = commandEncoder3.finish();
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+video0.width = 267;
+let pipelineLayout0 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0
+],
+}
+);
+let renderBundleEncoder1 = device0.createRenderBundleEncoder(
+{
+label: '\u728d\uca3a\ubf8d\u1e6e\u5a28',
+colorFormats: [
+'rgba32uint',
+undefined,
+'rgba32float',
+'rg8sint',
+'rg8uint',
+'r16uint'
+],
+sampleCount: 324,
+depthReadOnly: true,
+}
+);
+try {
+await buffer0.mapAsync(
+GPUMapMode.WRITE,
+1328,
+17048
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame0 = new VideoFrame(video0, {timestamp: 0});
+let bindGroupLayout1 = device0.createBindGroupLayout(
+{
+label: '\u67c1\u0e3a\u{1f992}\u62f6\u32e8\u60f2\u3dc8',
+entries: [
+{
+binding: 1864,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '1d' },
+},
+{
+binding: 336,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+},
+{
+binding: 2063,
+visibility: GPUShaderStage.FRAGMENT,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}
+],
+}
+);
+let querySet5 = device0.createQuerySet(
+{
+label: '\u359a\u0d15\u0bfa\u857c\u{1f903}\u013a',
+type: 'occlusion',
+count: 3368,
+}
+);
+try {
+computePassEncoder1.setBindGroup(
+7,
+bindGroup0,
+new Uint32Array(2805),
+1835,
+0
+);
+} catch {}
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let textureView2 = texture5.createView(
+{
+label: '\u{1fae7}\uc29f\u05cf\u{1fff8}\u{1fbce}\u{1febe}\u0859\u029d\u{1fa8e}\u15a4',
+}
+);
+try {
+renderBundleEncoder1.setBindGroup(
+0,
+bindGroup0,
+new Uint32Array(3792),
+3048,
+0
+);
+} catch {}
+let arrayBuffer0 = buffer0.getMappedRange(
+7072,
+9240
+);
+document.body.prepend('\ucdd2\u3287');
+let commandEncoder5 = device0.createCommandEncoder(
+{
+label: '\u08b6\uad52\u5f3b\u9c7a\u8787\uad53',
+}
+);
+let sampler3 = device0.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 54.423,
+lodMaxClamp: 65.094,
+maxAnisotropy: 13,
+}
+);
+try {
+renderBundleEncoder1.insertDebugMarker(
+'\u0e89'
+);
+} catch {}
+document.body.append('\u{1fa12}\u13a1\u{1f63d}\u9412\u0019\u{1f66d}\ua60e');
+try {
+adapter0.label = '\u232d\u{1ff79}\u089f\u0032\u{1fbb9}\u031a\ud62d';
+} catch {}
+let querySet6 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 727,
+}
+);
+let renderBundleEncoder2 = device0.createRenderBundleEncoder(
+{
+label: '\u09fc\ub058\u060e\u1fb0\ub899\u0599\u8a71',
+colorFormats: [
+'rgba8unorm-srgb',
+'rg16uint',
+'rg32sint',
+'r32sint',
+'rg16sint',
+undefined
+],
+sampleCount: 284,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder2.setBindGroup(
+6,
+bindGroup0,
+[]
+);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(
+47,
+undefined,
+2522010244,
+503595043
+);
+} catch {}
+try {
+commandEncoder5.copyTextureToTexture(
+{
+  texture: texture2,
+  mipLevel: 1,
+  origin: { x: 2, y: 0, z: 70 },
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: { x: 222, y: 0, z: 35 },
+  aspect: 'all',
+},
+{width: 173, height: 1, depthOrArrayLayers: 37}
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8sint',
+'bgra8unorm-srgb'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+commandEncoder5.copyTextureToTexture(
+{
+  texture: texture3,
+  mipLevel: 3,
+  origin: { x: 10, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 4,
+  origin: { x: 5, y: 1, z: 0 },
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(716, 871);
+let renderBundle2 = renderBundleEncoder2.finish(
+{
+
+}
+);
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup1 = device0.createBindGroup({
+label: '\u6ccd\ub37a\u0deb\ue4f6\u0597\u021f\u24ad',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let commandEncoder6 = device0.createCommandEncoder(
+{
+label: '\u00c4\u1daf',
+}
+);
+let querySet7 = device0.createQuerySet(
+{
+label: '\ubd88\u52f4\u2f06\u{1fe45}\ud8ed',
+type: 'occlusion',
+count: 1684,
+}
+);
+let computePassEncoder4 = commandEncoder6.beginComputePass(
+{
+label: '\u0731\u{1fd26}\udd24\u985c\u080a'
+}
+);
+try {
+computePassEncoder2.setBindGroup(
+5,
+bindGroup0,
+new Uint32Array(3366),
+3132,
+0
+);
+} catch {}
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+commandEncoder1.insertDebugMarker(
+'\u0540'
+);
+} catch {}
+try {
+pipelineLayout0.label = '\uff67\ue6f8\u6c9b\u69a1\u080c\u{1f8d1}\u6bfe\u{1fd80}\u68fb';
+} catch {}
+let bindGroup2 = device0.createBindGroup({
+label: '\u51ec\udea0\u0783\u{1f8ac}',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+try {
+renderBundleEncoder1.setBindGroup(
+7,
+bindGroup1,
+new Uint32Array(357),
+265,
+0
+);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(
+54,
+undefined,
+490564852,
+3014305936
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let buffer1 = device0.createBuffer(
+{
+label: '\u3432\u8467\u0391\u056b\u0d80\u202e\u6169\u1019',
+size: 5734,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+}
+);
+let texture6 = device0.createTexture(
+{
+label: '\u8fcc\u{1fc56}\u049f\u0de6\u{1f9d5}\u8d94\ueff3\u{1fc9d}\u005b\u0f12\u{1f809}',
+size: [2260],
+dimension: '1d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb10a2uint',
+'rgb10a2uint'
+],
+}
+);
+let computePassEncoder5 = commandEncoder1.beginComputePass(
+{
+label: '\u2577\uf810'
+}
+);
+try {
+renderBundleEncoder1.setVertexBuffer(
+92,
+undefined,
+400742938
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 1, y: 6, z: 0 },
+  aspect: 'all',
+},
+new Uint32Array(arrayBuffer0),
+/* required buffer size: 7100 */{
+offset: 764,
+bytesPerRow: 1322,
+},
+{width: 131, height: 5, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+await promise1;
+} catch {}
+let imageBitmap0 = await createImageBitmap(offscreenCanvas1);
+let bindGroup3 = device0.createBindGroup({
+label: '\ucb8f\u{1f6f3}\u780c\u{1fafc}\u3307\u{1f7db}\u5158\uf970\u0908\u9f5b\u53b9',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let commandEncoder7 = device0.createCommandEncoder(
+{
+label: '\u5803\uad5a\u01d0',
+}
+);
+try {
+computePassEncoder4.setBindGroup(
+4,
+bindGroup0
+);
+} catch {}
+let arrayBuffer1 = buffer0.getMappedRange(
+16312,
+1360
+);
+try {
+commandEncoder5.copyBufferToBuffer(
+buffer0,
+10392,
+buffer1,
+604,
+1024
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let canvas1 = document.createElement('canvas');
+let buffer2 = device0.createBuffer(
+{
+size: 30885,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+}
+);
+let renderBundle3 = renderBundleEncoder2.finish(
+{
+label: '\ue62d\u08c3\uc7fd'
+}
+);
+try {
+computePassEncoder4.insertDebugMarker(
+'\u935c'
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder(
+{
+label: '\u346c\u0672\u688e\u1237\u142d\u02b5\u138d\ufc02\u6b6e',
+}
+);
+pseudoSubmit(device0, commandEncoder8);
+let computePassEncoder6 = commandEncoder5.beginComputePass(
+{
+
+}
+);
+let sampler4 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 67.736,
+lodMaxClamp: 74.609,
+}
+);
+try {
+renderBundleEncoder1.setIndexBuffer(
+buffer2,
+'uint16',
+8502,
+15982
+);
+} catch {}
+let commandBuffer2 = commandEncoder7.finish(
+{
+label: '\u{1fd87}\u00a4\u{1fbdf}',
+}
+);
+try {
+computePassEncoder1.setBindGroup(
+2,
+bindGroup3,
+new Uint32Array(2224),
+1743,
+0
+);
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(
+3,
+bindGroup2
+);
+} catch {}
+let buffer3 = device0.createBuffer(
+{
+label: '\u{1f71d}\u{1fdcf}\u6d1b\uf452\u0c34\u3445\u9faa\u0bfb',
+size: 57004,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM,
+}
+);
+let commandEncoder9 = device0.createCommandEncoder(
+{
+label: '\u024b\u0165\u3635',
+}
+);
+let textureView3 = texture1.createView(
+{
+label: '\ud7c5\ud4bc\u8e97\u0e13\u0c23\ud01a\u0a59\u06dd\u595a',
+baseMipLevel: 2,
+}
+);
+try {
+commandEncoder9.copyBufferToTexture(
+{
+/* bytesInLastRow: 8324 widthInBlocks: 2081 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 46456 */
+offset: 38132,
+rowsPerImage: 58,
+buffer: buffer3,
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 118, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 2081, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let commandEncoder10 = device0.createCommandEncoder(
+{
+label: '\ufaba\ucb20\u{1fac2}\u02e8\u0e9c\u88a0\u7d60\u1d82\u{1feeb}\u1c20\u{1f894}',
+}
+);
+let computePassEncoder7 = commandEncoder10.beginComputePass(
+{
+label: '\u{1f632}\u0ddf'
+}
+);
+try {
+computePassEncoder1.popDebugGroup();
+} catch {}
+let commandEncoder11 = device0.createCommandEncoder(
+{
+label: '\u5164\ue29d\u620b\u{1fd9c}',
+}
+);
+let textureView4 = texture1.createView(
+{
+label: '\u093c\u22cd\ub007\u0d6a\u{1f6cd}',
+baseMipLevel: 2,
+}
+);
+let renderBundleEncoder3 = device0.createRenderBundleEncoder(
+{
+label: '\u0088\ub7b2\u0ca8\ue5ba\u0406\u{1f899}\u04b0\u002d\u0168\u038c\u6e82',
+colorFormats: [
+'r16sint',
+'r32float',
+'rgba8unorm-srgb',
+'r8unorm'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 695,
+}
+);
+try {
+commandEncoder9.copyTextureToTexture(
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: { x: 84, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 1,
+  origin: { x: 9, y: 0, z: 10 },
+  aspect: 'all',
+},
+{width: 160, height: 1, depthOrArrayLayers: 101}
+);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+let texture7 = device0.createTexture(
+{
+label: '\u0a9a\u873e\u0883\u0d75',
+size: [189, 3, 17],
+mipLevelCount: 8,
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32sint',
+'r32sint'
+],
+}
+);
+let renderBundleEncoder4 = device0.createRenderBundleEncoder(
+{
+label: '\u{1f9b4}\ua789\u9664\u7ef9\u016b\u{1fa17}\udcfd\u{1f885}\u{1fa57}\u{1f9e2}',
+colorFormats: [
+'rgb10a2unorm',
+'r8unorm',
+'r16uint'
+],
+sampleCount: 236,
+depthReadOnly: true,
+}
+);
+let sampler5 = device0.createSampler(
+{
+label: '\u0e0e\ua78b\u0621\u{1fd76}',
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 5.613,
+}
+);
+try {
+commandEncoder9.copyTextureToTexture(
+{
+  texture: texture3,
+  mipLevel: 2,
+  origin: { x: 3, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 39, y: 2, z: 0 },
+  aspect: 'all',
+},
+{width: 47, height: 2, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+computePassEncoder4.insertDebugMarker(
+'\u249b'
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: { x: 552, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(28478),
+/* required buffer size: 28478 */{
+offset: 302,
+},
+{width: 3522, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let buffer4 = device0.createBuffer(
+{
+label: '\ucccc\ue398\ub32a\uc5b7\u0852\u0275\u0ad7\ud432\u{1fee2}\u{1f792}\ufca1',
+size: 53126,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+}
+);
+let textureView5 = texture6.createView(
+{
+label: '\u{1fdcd}\u0687\u54ae\u04d1\u0bea\u7e11\u1f68\u{1fc3d}\ua0e0',
+}
+);
+try {
+renderBundleEncoder3.setBindGroup(
+2,
+bindGroup1,
+new Uint32Array(6796),
+3386,
+0
+);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder9.copyTextureToTexture(
+{
+  texture: texture2,
+  mipLevel: 2,
+  origin: { x: 7, y: 1, z: 10 },
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 1,
+  origin: { x: 44, y: 1, z: 12 },
+  aspect: 'all',
+},
+{width: 121, height: 0, depthOrArrayLayers: 104}
+);
+} catch {}
+try {
+commandEncoder11.resolveQuerySet(
+querySet1,
+1091,
+1675,
+buffer4,
+12800
+);
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(908, 309);
+let bindGroup4 = device0.createBindGroup({
+label: '\uc362\u{1face}\u{1fa66}\u109c\u{1f756}\ub218\ud8d8\u7aca\ua6d4\u{1fd02}',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+try {
+renderBundleEncoder3.setVertexBuffer(
+10,
+buffer4,
+6068,
+16207
+);
+} catch {}
+let promise2 = device0.popErrorScope();
+try {
+commandEncoder9.copyBufferToBuffer(
+buffer3,
+7040,
+buffer4,
+15404,
+32280
+);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(
+querySet1,
+275,
+2252,
+buffer4,
+8448
+);
+} catch {}
+gc();
+let canvas2 = document.createElement('canvas');
+let img0 = await imageWithData(237, 142, '#92fb107b', '#470a0383');
+let bindGroup5 = device0.createBindGroup({
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let commandEncoder12 = device0.createCommandEncoder(
+{
+label: '\u7da4\u3645\uee74\u{1faa0}\u{1f62b}\u0bfb\u3c94',
+}
+);
+let textureView6 = texture7.createView(
+{
+label: '\u9679\uf9f8\ucb58\ub178\u{1fdd1}\u{1f6a5}',
+baseMipLevel: 5,
+baseArrayLayer: 8,
+arrayLayerCount: 3,
+}
+);
+try {
+renderBundleEncoder4.setBindGroup(
+6,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(
+8,
+buffer4,
+9320,
+32757
+);
+} catch {}
+try {
+commandEncoder9.copyTextureToTexture(
+{
+  texture: texture7,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 1,
+  origin: { x: 35, y: 0, z: 7 },
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 10}
+);
+} catch {}
+try {
+await promise2;
+} catch {}
+let texture8 = device0.createTexture(
+{
+label: '\u568c\u62dc\u054c\u09d5\u{1fac5}\u{1f650}\u{1fd27}\u1aee',
+size: [256, 1, 1103],
+dimension: '3d',
+format: 'r32float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'r32float',
+'r32float'
+],
+}
+);
+try {
+computePassEncoder4.setBindGroup(
+1,
+bindGroup2
+);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(
+8,
+bindGroup1,
+new Uint32Array(9278),
+7908,
+0
+);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+0,
+bindGroup0,
+new Uint32Array(7141),
+2716,
+0
+);
+} catch {}
+try {
+commandEncoder12.copyBufferToBuffer(
+buffer3,
+2632,
+buffer2,
+9212,
+960
+);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder11.resolveQuerySet(
+querySet6,
+38,
+293,
+buffer4,
+3072
+);
+} catch {}
+document.body.append('\u0e3b\u0d97\u{1fe36}\ud713\u{1ff69}');
+try {
+adapter0.label = '\u{1f7af}\u{1fef4}\u9d99';
+} catch {}
+try {
+sampler4.label = '\u1ee0\u{1f8e9}\uffd1\u0e9a\u0055\u4901\u50fc\u6704\u0bca';
+} catch {}
+let bindGroup6 = device0.createBindGroup({
+label: '\u8648\u0294\u0a47\uf9fc\u{1fa74}',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let querySet8 = device0.createQuerySet(
+{
+label: '\u02bf\u0dd0\ue842\ud223\u7b5c',
+type: 'occlusion',
+count: 1979,
+}
+);
+try {
+computePassEncoder4.setBindGroup(
+4,
+bindGroup2,
+[]
+);
+} catch {}
+try {
+commandEncoder11.clearBuffer(
+buffer2,
+24468,
+4888
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let gpuCanvasContext1 = offscreenCanvas2.getContext('webgpu');
+let img1 = await imageWithData(298, 75, '#233b8d3b', '#0cd6ae9c');
+let videoFrame1 = new VideoFrame(canvas2, {timestamp: 0});
+let buffer5 = device0.createBuffer(
+{
+label: '\u9d2d\u{1fbe6}\u81c6\u0744\ud27e\u05a7\u0693\u03bf\u1dbd',
+size: 16008,
+usage: GPUBufferUsage.MAP_READ,
+}
+);
+let texture9 = device0.createTexture(
+{
+size: [1874, 1, 470],
+mipLevelCount: 10,
+dimension: '3d',
+format: 'rg16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+}
+);
+let textureView7 = texture7.createView(
+{
+label: '\u3005\u278b\u16a6\u{1fbf6}\u057c\u{1f6cd}\u8e36\u03f2\u{1fd82}\u0d4c',
+baseMipLevel: 1,
+mipLevelCount: 5,
+baseArrayLayer: 5,
+arrayLayerCount: 10,
+}
+);
+let sampler6 = device0.createSampler(
+{
+label: '\u9062\ufc68',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 51.533,
+lodMaxClamp: 91.390,
+}
+);
+try {
+renderBundleEncoder4.setVertexBuffer(
+5,
+buffer4,
+51040,
+1616
+);
+} catch {}
+try {
+buffer5.destroy();
+} catch {}
+try {
+commandEncoder11.copyBufferToBuffer(
+buffer0,
+9952,
+buffer1,
+1192,
+4080
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+24280,
+new Int16Array(16549),
+6941,
+2380
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 48, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Int8Array(new ArrayBuffer(8)),
+/* required buffer size: 220 */{
+offset: 220,
+},
+{width: 470, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let imageData1 = new ImageData(188, 128);
+let commandEncoder13 = device0.createCommandEncoder(
+{
+label: '\u0c5f\u5674',
+}
+);
+let querySet9 = device0.createQuerySet(
+{
+label: '\u0e69\ue6c0',
+type: 'occlusion',
+count: 2059,
+}
+);
+pseudoSubmit(device0, commandEncoder1);
+let textureView8 = texture3.createView(
+{
+label: '\u3dbc\u044c\udfcd\u{1f678}\u05a7\ue7f1',
+dimension: '2d-array',
+baseMipLevel: 3,
+baseArrayLayer: 0,
+}
+);
+let renderBundleEncoder5 = device0.createRenderBundleEncoder(
+{
+label: '\u04b4\ud69d\u0f07\ua9b1',
+colorFormats: [
+'rg16sint',
+'rg11b10ufloat',
+'rgba8uint',
+'rg32uint',
+'r16float',
+'rgba32uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 220,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder3.setBindGroup(
+1,
+bindGroup5
+);
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(
+buffer1,
+52,
+buffer4,
+46120,
+2276
+);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(
+querySet0,
+55,
+53,
+buffer4,
+22784
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture1,
+  mipLevel: 2,
+  origin: { x: 1, y: 21, z: 0 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer0),
+/* required buffer size: 3775 */{
+offset: 391,
+bytesPerRow: 130,
+rowsPerImage: 272,
+},
+{width: 1, height: 27, depthOrArrayLayers: 1}
+);
+} catch {}
+let gpuCanvasContext2 = canvas1.getContext('webgpu');
+gc();
+document.body.prepend('\u051b\uc62b\u0563\u{1ffba}\u{1ff13}\uf49a\u{1f939}\u2187\uca03');
+try {
+offscreenCanvas3.getContext('webgl2');
+} catch {}
+let buffer6 = device0.createBuffer(
+{
+label: '\u{1fe52}\u5186\u{1fb8c}\u{1fbfc}\ucb43\u010e\u0834\u0663',
+size: 10148,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+mappedAtCreation: true,
+}
+);
+let texture10 = device0.createTexture(
+{
+label: '\u9617\u9d40\u5824\u51fe\u16ab',
+size: {width: 943, height: 1, depthOrArrayLayers: 1276},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb',
+'rgba8unorm',
+'rgba8unorm'
+],
+}
+);
+let computePassEncoder8 = commandEncoder9.beginComputePass(
+{
+label: '\u{1fbad}\u5d02\u6887\u9f5c\u41bd\u2b93\u{1fff5}\u03be\u0f8d'
+}
+);
+try {
+renderBundleEncoder1.setBindGroup(
+6,
+bindGroup6
+);
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(
+buffer0,
+24396,
+buffer4,
+48600,
+744
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer4);
+} catch {}
+document.body.prepend(img1);
+document.body.prepend('\udd8d\u{1fdd7}\u855e\u{1f63e}\u0b21\u4e4c\u07ff');
+let videoFrame2 = new VideoFrame(canvas2, {timestamp: 0});
+let textureView9 = texture10.createView(
+{
+format: 'rgba8unorm-srgb',
+baseMipLevel: 3,
+mipLevelCount: 1,
+}
+);
+let sampler7 = device0.createSampler(
+{
+label: '\u057f\u0fbd\u4133\ub7fd\u9792\u0619\u02ff',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 93.791,
+lodMaxClamp: 94.088,
+}
+);
+try {
+computePassEncoder6.setBindGroup(
+8,
+bindGroup3,
+new Uint32Array(7633),
+2647,
+0
+);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(
+8,
+bindGroup0
+);
+} catch {}
+try {
+commandEncoder13.insertDebugMarker(
+'\u9a6e'
+);
+} catch {}
+let querySet10 = device0.createQuerySet(
+{
+label: '\udd8a\u1789\u{1fca5}\u54c8\u{1f69f}',
+type: 'occlusion',
+count: 515,
+}
+);
+let texture11 = gpuCanvasContext0.getCurrentTexture();
+try {
+commandEncoder13.resolveQuerySet(
+querySet8,
+1331,
+118,
+buffer4,
+26624
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 471, height: 1, depthOrArrayLayers: 638}
+*/
+{
+  source: canvas1,
+  origin: { x: 232, y: 113 },
+  flipY: false,
+},
+{
+  texture: texture10,
+  mipLevel: 1,
+  origin: { x: 76, y: 0, z: 356 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 68, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let gpuCanvasContext3 = canvas2.getContext('webgpu');
+try {
+sampler4.label = '\u02d6\u9e9f\uf1ce\uca13\u5deb\u71e4';
+} catch {}
+let bindGroup7 = device0.createBindGroup({
+label: '\u4f0d\u07ee\u7718\u5ebd\u{1f829}',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let commandEncoder14 = device0.createCommandEncoder(
+{
+label: '\uf51a\u973b\ua6ae\u083e\udb95\u29e8\uccbe\u504d\u{1fab7}\uf08c\u0420',
+}
+);
+let querySet11 = device0.createQuerySet(
+{
+label: '\u0ae0\u2641\u{1fa4a}\u383c\u04c3\u{1fb71}',
+type: 'occlusion',
+count: 3403,
+}
+);
+let textureView10 = texture7.createView(
+{
+baseMipLevel: 5,
+mipLevelCount: 1,
+baseArrayLayer: 13,
+arrayLayerCount: 2,
+}
+);
+try {
+renderBundleEncoder3.setBindGroup(
+5,
+bindGroup2
+);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(
+2,
+buffer4,
+17476,
+11891
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture1,
+  mipLevel: 1,
+  origin: { x: 2, y: 18, z: 0 },
+  aspect: 'all',
+},
+new Uint8Array(arrayBuffer0),
+/* required buffer size: 19639 */{
+offset: 166,
+bytesPerRow: 229,
+},
+{width: 2, height: 86, depthOrArrayLayers: 1}
+);
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(824, 717);
+let texture12 = device0.createTexture(
+{
+label: '\u8b2d\u071e\u8dca\u52d1\u92a9\uf80a\u{1f852}\u4025\u{1ff3f}\u6028',
+size: {width: 16, height: 16, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb9e5ufloat',
+'rgb9e5ufloat'
+],
+}
+);
+let renderPassEncoder0 = commandEncoder14.beginRenderPass(
+{
+label: '\u6e3c\u9ca1\u27eb',
+colorAttachments: [
+{
+view: textureView9,
+depthSlice: 42,
+clearValue: {
+r: -45.42,
+g: -384.6,
+b: -94.04,
+a: 973.6,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView9,
+depthSlice: 132,
+clearValue: {
+r: 210.5,
+g: 247.7,
+b: -51.17,
+a: -643.4,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView9,
+depthSlice: 85,
+clearValue: {
+r: -502.3,
+g: 321.4,
+b: 707.7,
+a: -474.3,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView9,
+depthSlice: 121,
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView9,
+depthSlice: 79,
+clearValue: {
+r: 437.6,
+g: 371.6,
+b: -129.2,
+a: -625.8,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined
+],
+occlusionQuerySet: querySet1,
+maxDrawCount: 152552,
+}
+);
+try {
+renderBundleEncoder5.setBindGroup(
+2,
+bindGroup5,
+new Uint32Array(7806),
+5909,
+0
+);
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(
+buffer2,
+6980,
+buffer1,
+4916,
+780
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder13.copyTextureToTexture(
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 0, y: 102, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 1, y: 23, z: 1 },
+  aspect: 'all',
+},
+{width: 6, height: 106, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+renderPassEncoder0.insertDebugMarker(
+'\u09ba'
+);
+} catch {}
+let imageBitmap1 = await createImageBitmap(img1);
+let bindGroup8 = device0.createBindGroup({
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let buffer7 = device0.createBuffer(
+{
+label: '\u060c\u{1ff2f}\u{1fbb4}\u{1f70c}\u07f7\u{1f936}\u2303\u2e93\u{1f660}',
+size: 13132,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE,
+mappedAtCreation: true,
+}
+);
+let renderBundleEncoder6 = device0.createRenderBundleEncoder(
+{
+label: '\u3758\u{1fa8c}',
+colorFormats: [
+'rg8unorm',
+'rg16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 26,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder0.beginOcclusionQuery(
+16
+);
+} catch {}
+try {
+commandEncoder11.resolveQuerySet(
+querySet11,
+2430,
+972,
+buffer4,
+15872
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 943, height: 1, depthOrArrayLayers: 1276}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 149, y: 67 },
+  flipY: true,
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: { x: 300, y: 0, z: 211 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 9, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let bindGroup9 = device0.createBindGroup({
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let querySet12 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 2206,
+}
+);
+let textureView11 = texture4.createView(
+{
+label: '\u0e5a\u{1f91e}\u04d3\u8495\u03a9\u{1f78e}',
+baseMipLevel: 3,
+mipLevelCount: 3,
+baseArrayLayer: 0,
+}
+);
+let sampler8 = device0.createSampler(
+{
+label: '\u0255\u0eaa\u5e1c\u0cd1\u{1f6de}\u873e\u8d91\ued9a\u{1f952}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 56.632,
+lodMaxClamp: 93.271,
+maxAnisotropy: 14,
+}
+);
+try {
+renderPassEncoder0.setBindGroup(
+2,
+bindGroup8
+);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(
+96,
+1,
+8,
+0
+);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(
+237
+);
+} catch {}
+try {
+commandEncoder11.clearBuffer(
+buffer6,
+1196,
+8200
+);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 58, height: 1, depthOrArrayLayers: 79}
+*/
+{
+  source: imageData1,
+  origin: { x: 89, y: 7 },
+  flipY: true,
+},
+{
+  texture: texture10,
+  mipLevel: 4,
+  origin: { x: 2, y: 0, z: 13 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 54, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+gc();
+let texture13 = device0.createTexture(
+{
+label: '\u52ce\ud5dc\u01bc\u09b0\ua43a\u0406\u{1ff38}\u6610',
+size: {width: 2470},
+dimension: '1d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8snorm'
+],
+}
+);
+let textureView12 = texture7.createView(
+{
+label: '\u99bb\u{1f9eb}\u0b57\u7275\u234e\u7836\u{1fe27}\u{1fbac}',
+dimension: '2d',
+baseMipLevel: 7,
+baseArrayLayer: 14,
+}
+);
+let renderBundle4 = renderBundleEncoder0.finish(
+{
+label: '\u568a\u3280\u73ba\u0fef\u8ebb\ub9d3\u047c\u0bed'
+}
+);
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant(
+{
+r: 371.0,
+g: -872.4,
+b: -559.4,
+a: 440.2,
+}
+);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(
+2125
+);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(
+2,
+bindGroup6
+);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(
+6,
+bindGroup9,
+new Uint32Array(15),
+7,
+0
+);
+} catch {}
+let arrayBuffer2 = buffer6.getMappedRange(
+0,
+7916
+);
+try {
+buffer7.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+1544,
+new Int16Array(63110),
+38362,
+552
+);
+} catch {}
+gc();
+let sampler9 = device0.createSampler(
+{
+label: '\u0941\u5044\uede6\u{1f6d7}\u41fc\u83d0\u0c35',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 81.377,
+lodMaxClamp: 88.229,
+}
+);
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(
+306
+);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(
+0,
+bindGroup4
+);
+} catch {}
+try {
+commandEncoder11.resolveQuerySet(
+querySet7,
+1563,
+116,
+buffer6,
+3328
+);
+} catch {}
+let bindGroup10 = device0.createBindGroup({
+label: '\u86b8\u0246\u{1f972}\u7303\uaff0\u0a23\ud566\u0aca\u{1f6cb}\u{1f6d8}',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let querySet13 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 869,
+}
+);
+let textureView13 = texture8.createView(
+{
+label: '\u255c\uef9b\u0f38\uca21\u07bc\u5381\u{1ff63}\uba3f\ua95b',
+}
+);
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(
+2225
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+11052,
+new BigUint64Array(41373),
+3604,
+168
+);
+} catch {}
+let video1 = await videoWithData();
+let imageData2 = new ImageData(176, 136);
+let buffer8 = device0.createBuffer(
+{
+size: 2448,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let renderBundle5 = renderBundleEncoder1.finish();
+try {
+computePassEncoder3.setBindGroup(
+8,
+bindGroup6,
+new Uint32Array(1428),
+137,
+0
+);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(
+3,
+bindGroup8
+);
+} catch {}
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(
+6,
+bindGroup1
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 58, height: 1, depthOrArrayLayers: 79}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 616, y: 532 },
+  flipY: false,
+},
+{
+  texture: texture10,
+  mipLevel: 4,
+  origin: { x: 31, y: 0, z: 72 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 2, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let bindGroupLayout2 = device0.createBindGroupLayout(
+{
+entries: [
+{
+binding: 2081,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}
+],
+}
+);
+let textureView14 = texture4.createView(
+{
+label: '\u0bdb\u223e\u9b04\u1a0d\ub716',
+dimension: '3d',
+aspect: 'all',
+baseMipLevel: 1,
+mipLevelCount: 6,
+arrayLayerCount: 1,
+}
+);
+let computePassEncoder9 = commandEncoder13.beginComputePass(
+{
+label: '\u{1fd5a}\u9096\u5aa9\u272b\u{1fcd2}\u8172\uc004\u{1ffeb}'
+}
+);
+let renderPassEncoder1 = commandEncoder12.beginRenderPass(
+{
+label: '\u{1f7a4}\u1f79\u6fee\u4ef1\u{1f649}',
+colorAttachments: [
+{
+view: textureView9,
+depthSlice: 132,
+clearValue: {
+r: -894.7,
+g: -969.5,
+b: -171.9,
+a: -612.2,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined,
+{
+view: textureView9,
+depthSlice: 122,
+clearValue: {
+r: 541.8,
+g: 255.4,
+b: 97.27,
+a: -195.3,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined,
+{
+view: textureView9,
+depthSlice: 126,
+clearValue: {
+r: 650.1,
+g: 333.7,
+b: 331.4,
+a: 875.2,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView9,
+depthSlice: 34,
+clearValue: {
+r: -648.8,
+g: -906.1,
+b: -40.29,
+a: -362.6,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView9,
+depthSlice: 87,
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined
+],
+maxDrawCount: 281528,
+}
+);
+try {
+renderPassEncoder1.setViewport(
+41.61,
+0.7368,
+44.11,
+0.05678,
+0.5293,
+0.9573
+);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(
+buffer2,
+'uint32',
+1548,
+2734
+);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(
+buffer1,
+'uint32'
+);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(
+0,
+buffer4,
+27708,
+12662
+);
+} catch {}
+try {
+commandEncoder11.copyTextureToBuffer(
+{
+  texture: texture0,
+  mipLevel: 2,
+  origin: { x: 11, y: 0, z: 2 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 24 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 25124 */
+offset: 3108,
+bytesPerRow: 512,
+rowsPerImage: 43,
+buffer: buffer2,
+},
+{width: 12, height: 0, depthOrArrayLayers: 2}
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder11.resolveQuerySet(
+querySet10,
+169,
+67,
+buffer4,
+6656
+);
+} catch {}
+document.body.append('\u248e\u12c4\ud4fb\udda9\u090a\u2e91\u{1fbce}');
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder15 = device0.createCommandEncoder(
+{
+label: '\u3082\u38f0\ufd1c\u41f1\ua324\u0848\u{1f993}',
+}
+);
+let renderPassEncoder2 = commandEncoder15.beginRenderPass(
+{
+label: '\u3784\u839a\u{1fb1b}',
+colorAttachments: [
+{
+view: textureView3,
+clearValue: {
+r: 151.8,
+g: 895.4,
+b: -903.2,
+a: -759.8,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+occlusionQuerySet: querySet11,
+maxDrawCount: 436048,
+}
+);
+let renderBundleEncoder7 = device0.createRenderBundleEncoder(
+{
+label: '\u1b82\u078b\u9a0c\ue4b2',
+colorFormats: [
+'r32float',
+'r16sint',
+'r32sint',
+'rgba16uint',
+'rg8uint',
+'rg32sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 757,
+}
+);
+let renderBundle6 = renderBundleEncoder4.finish();
+try {
+renderBundleEncoder6.setVertexBuffer(
+11,
+buffer6,
+4536,
+476
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder11.copyBufferToTexture(
+{
+/* bytesInLastRow: 408 widthInBlocks: 51 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 7976 */
+offset: 7976,
+bytesPerRow: 768,
+buffer: buffer7,
+},
+{
+  texture: texture3,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 51, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 117, height: 1, depthOrArrayLayers: 159}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 145, y: 7 },
+  flipY: true,
+},
+{
+  texture: texture10,
+  mipLevel: 3,
+  origin: { x: 9, y: 0, z: 131 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 106, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let renderBundle7 = renderBundleEncoder1.finish();
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: 116.6,
+g: -895.9,
+b: -784.5,
+a: -146.8,
+}
+);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+2,
+46,
+1,
+1
+);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+4,
+buffer2,
+16504
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+9,
+buffer6,
+9188
+);
+} catch {}
+let arrayBuffer3 = buffer6.getMappedRange(
+9560,
+208
+);
+try {
+commandEncoder11.copyBufferToBuffer(
+buffer7,
+4812,
+buffer4,
+29128,
+6120
+);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm',
+'rg16sint'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 943, height: 1, depthOrArrayLayers: 1276}
+*/
+{
+  source: imageData2,
+  origin: { x: 0, y: 31 },
+  flipY: true,
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: { x: 647, y: 0, z: 334 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 176, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let renderBundleEncoder8 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg11b10ufloat',
+'rg8unorm',
+'rg11b10ufloat',
+'rgba8unorm-srgb',
+'rg16float',
+'r16uint',
+'rg11b10ufloat'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 884,
+}
+);
+try {
+computePassEncoder8.setBindGroup(
+0,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+8,
+bindGroup6
+);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(
+8
+);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(
+buffer1,
+'uint32'
+);
+} catch {}
+try {
+commandEncoder11.resolveQuerySet(
+querySet13,
+400,
+390,
+buffer4,
+34560
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+3196,
+new Float32Array(59080),
+42610,
+396
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 471, height: 1, depthOrArrayLayers: 638}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 295, y: 739 },
+  flipY: false,
+},
+{
+  texture: texture10,
+  mipLevel: 1,
+  origin: { x: 39, y: 0, z: 257 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 333, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+pseudoSubmit(device0, commandEncoder15);
+let renderBundle8 = renderBundleEncoder1.finish(
+{
+label: '\u28a5\u7640\uf6c3\u039f\u4620\u07bb'
+}
+);
+try {
+renderPassEncoder2.setScissorRect(
+1,
+37,
+2,
+13
+);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(
+3893
+);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+0.1652,
+15.52,
+0.1699,
+30.97,
+0.07512,
+0.3116
+);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+1,
+bindGroup9
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder11.copyTextureToTexture(
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: { x: 126, y: 1, z: 7 },
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: { x: 44, y: 0, z: 74 },
+  aspect: 'all',
+},
+{width: 363, height: 0, depthOrArrayLayers: 38}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+4896,
+new DataView(new ArrayBuffer(26859)),
+23840,
+572
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture10,
+  mipLevel: 2,
+  origin: { x: 173, y: 1, z: 246 },
+  aspect: 'all',
+},
+new Float64Array(new ArrayBuffer(24)),
+/* required buffer size: 3569216 */{
+offset: 644,
+bytesPerRow: 343,
+rowsPerImage: 289,
+},
+{width: 54, height: 0, depthOrArrayLayers: 37}
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+0,
+bindGroup1
+);
+} catch {}
+try {
+commandEncoder11.copyTextureToTexture(
+{
+  texture: texture3,
+  mipLevel: 4,
+  origin: { x: 5, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 3,
+  origin: { x: 14, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 6, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder11.clearBuffer(
+buffer2,
+29924,
+280
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+2412,
+new Int16Array(42552),
+9773,
+576
+);
+} catch {}
+let querySet14 = device0.createQuerySet(
+{
+label: '\ud187\u{1f6b8}\u64ed\uacac\u4586\u{1fa1e}\u0d71\u0aab',
+type: 'occlusion',
+count: 2857,
+}
+);
+let texture14 = device0.createTexture(
+{
+size: {width: 8, height: 16, depthOrArrayLayers: 87},
+mipLevelCount: 2,
+sampleCount: 1,
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb9e5ufloat',
+'rgb9e5ufloat',
+'rgb9e5ufloat'
+],
+}
+);
+let renderBundleEncoder9 = device0.createRenderBundleEncoder(
+{
+label: '\uf3ac\u{1f925}',
+colorFormats: [
+'r8unorm',
+'rgba16sint',
+'rg32uint'
+],
+sampleCount: 748,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+7,
+bindGroup3,
+[]
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+3,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: 623.5,
+g: 104.5,
+b: 995.3,
+a: 427.9,
+}
+);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(
+buffer1,
+'uint16',
+5434,
+4
+);
+} catch {}
+try {
+commandEncoder11.copyTextureToBuffer(
+{
+  texture: texture9,
+  mipLevel: 9,
+  origin: { x: 2, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 24084 */
+offset: 24084,
+buffer: buffer4,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer4,
+30928,
+new BigUint64Array(53310),
+15239,
+2364
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 836, y: 1, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(923),
+/* required buffer size: 923 */{
+offset: 923,
+bytesPerRow: 109,
+},
+{width: 14, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let querySet15 = device0.createQuerySet(
+{
+label: '\u5058\ud328',
+type: 'occlusion',
+count: 2652,
+}
+);
+let textureView15 = texture11.createView(
+{
+label: '\u04a9\u{1f74b}\u54d4\u7672\u1598\u{1fb9c}\u0d3e\u657a\u0ceb\u1de9',
+}
+);
+let computePassEncoder10 = commandEncoder11.beginComputePass(
+{
+label: '\u{1f63f}\u99b5'
+}
+);
+let renderBundleEncoder10 = device0.createRenderBundleEncoder(
+{
+label: '\u0531\u3fb5\u{1ff41}\u060e\ubaf7',
+colorFormats: [
+'rgba8unorm'
+],
+sampleCount: 15,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler10 = device0.createSampler(
+{
+label: '\u7e51\ufc31\ubc19\ufe62\uf465\u0e99\u0760\u0356',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 18.807,
+lodMaxClamp: 55.889,
+compare: 'greater',
+}
+);
+try {
+renderPassEncoder1.setBlendConstant(
+{
+r: 902.9,
+g: -243.8,
+b: -358.8,
+a: 356.9,
+}
+);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+1,
+buffer6
+);
+} catch {}
+document.body.append('\u02e5\uf153\u0912\u7e31\u14ba');
+try {
+adapter0.label = '\u0cfa\u{1f649}\u{1ff23}\ufae8\u2d58\u3f45\u6cb5\u{1fdcb}\u26e2\u0afe';
+} catch {}
+let buffer9 = device0.createBuffer(
+{
+label: '\ud26f\u00fd\u{1f866}\u{1ff6d}\u{1ff20}\ubcc4\u5890\u430c\u0d84\u0744',
+size: 51050,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+}
+);
+let sampler11 = device0.createSampler(
+{
+label: '\u9dab\ue23c\ubd18\uc400\u3bc1\u0ba5\u8d70\u7bbf\u{1ffbe}\u17e0\u{1fa7f}',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 49.062,
+lodMaxClamp: 49.311,
+}
+);
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: -923.5,
+g: 745.7,
+b: -192.8,
+a: -383.0,
+}
+);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(
+1601
+);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(
+buffer4,
+'uint16',
+28986
+);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(
+4,
+buffer2,
+3900
+);
+} catch {}
+let renderBundleEncoder11 = device0.createRenderBundleEncoder(
+{
+label: '\u20bf\u{1fe67}',
+colorFormats: [
+'r16float',
+'rgba32float',
+'r8unorm',
+'rg8uint',
+'rg8sint',
+'rgba16float',
+'bgra8unorm-srgb'
+],
+sampleCount: 446,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(
+buffer1,
+'uint32',
+3904
+);
+} catch {}
+let renderBundleEncoder12 = device0.createRenderBundleEncoder(
+{
+label: '\u3d97\u7bc6\uc515',
+colorFormats: [
+'r16float',
+'r16float',
+'rg11b10ufloat',
+undefined,
+'rg32float',
+'r8unorm',
+'r8sint'
+],
+sampleCount: 631,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder1.setScissorRect(
+115,
+1,
+2,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer9,
+'uint16',
+35242
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+5,
+buffer9,
+46756,
+861
+);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(
+3,
+buffer4,
+37832,
+5575
+);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer2,
+]);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture3,
+  mipLevel: 5,
+  origin: { x: 5, y: 0, z: 0 },
+  aspect: 'all',
+},
+new DataView(arrayBuffer3),
+/* required buffer size: 442 */{
+offset: 442,
+rowsPerImage: 5,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 471, height: 1, depthOrArrayLayers: 638}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 70, y: 205 },
+  flipY: true,
+},
+{
+  texture: texture10,
+  mipLevel: 1,
+  origin: { x: 259, y: 1, z: 332 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 3, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let bindGroup11 = device0.createBindGroup({
+label: '\u{1fab2}\ub45f\u0012',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+try {
+computePassEncoder8.setBindGroup(
+2,
+bindGroup8,
+new Uint32Array(6374),
+4193,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+107,
+0,
+2,
+1
+);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(
+7,
+bindGroup11,
+new Uint32Array(3521),
+268,
+0
+);
+} catch {}
+try {
+texture4.destroy();
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer9,
+22900,
+new BigUint64Array(32435),
+17625,
+2280
+);
+} catch {}
+video0.height = 206;
+let texture15 = gpuCanvasContext0.getCurrentTexture();
+try {
+renderPassEncoder1.setBindGroup(
+6,
+bindGroup8
+);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer1,
+commandBuffer0,
+]);
+} catch {}
+document.body.prepend('\u806d\u0cd2\u8866\u0268\u{1ffad}\u0b2c\u182f\ua5b5');
+let textureView16 = texture9.createView(
+{
+label: '\ucf73\u6201\ua6fb\u57ff\u0a28\u9955\u4084\u{1f92d}\u2fd5\ub0a8\u2933',
+baseMipLevel: 8,
+}
+);
+let renderBundle9 = renderBundleEncoder7.finish(
+{
+label: '\u0348\u027e\u0cbb\u979f\u0418\ud506\u{1fbc5}\u00df\u{1fe2d}\u{1fac7}\uf372'
+}
+);
+try {
+computePassEncoder6.setBindGroup(
+1,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+8,
+buffer2,
+13740,
+8945
+);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(
+buffer2,
+'uint16',
+21322,
+6371
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture10,
+  mipLevel: 3,
+  origin: { x: 25, y: 1, z: 54 },
+  aspect: 'all',
+},
+new BigInt64Array(arrayBuffer0),
+/* required buffer size: 2873115 */{
+offset: 531,
+bytesPerRow: 372,
+rowsPerImage: 297,
+},
+{width: 72, height: 0, depthOrArrayLayers: 27}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 235, height: 1, depthOrArrayLayers: 319}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 3, y: 0 },
+  flipY: true,
+},
+{
+  texture: texture10,
+  mipLevel: 2,
+  origin: { x: 39, y: 0, z: 143 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 12, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let video2 = await videoWithData();
+let bindGroupLayout3 = device0.createBindGroupLayout(
+{
+label: '\u{1f74c}\u135d\u24b6\u17fa\u0d44\ufd68\u0424\u{1fb51}',
+entries: [
+{
+binding: 1592,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let querySet16 = device0.createQuerySet(
+{
+label: '\u032d\u{1fd18}\u0293\u6942\u0042\u2220\u{1fea7}\ue0d6',
+type: 'occlusion',
+count: 362,
+}
+);
+let sampler12 = device0.createSampler(
+{
+label: '\u03c3\u6d2d\u{1fca4}\u8ef4\u{1fbd0}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMaxClamp: 96.509,
+}
+);
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: -153.4,
+g: -249.6,
+b: -81.86,
+a: -35.35,
+}
+);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+3,
+buffer9,
+13424,
+31007
+);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 471, height: 1, depthOrArrayLayers: 638}
+*/
+{
+  source: imageData2,
+  origin: { x: 29, y: 8 },
+  flipY: false,
+},
+{
+  texture: texture10,
+  mipLevel: 1,
+  origin: { x: 337, y: 0, z: 41 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 133, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend('\ub57e\u1ae2\uf1c4\u011f');
+pseudoSubmit(device0, commandEncoder2);
+try {
+renderPassEncoder1.setBindGroup(
+3,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+76,
+1,
+22,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+2.683,
+12.51,
+0.1371,
+26.73,
+0.5005,
+0.8654
+);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(
+buffer2,
+'uint32',
+19632,
+7537
+);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(
+95,
+undefined,
+457092245,
+244614844
+);
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let textureView17 = texture15.createView(
+{
+label: '\u6ee8\ua15f\u0512\u{1fe7f}\u43ec\u{1fe6c}\u1146\u{1f68b}',
+format: 'rg16sint',
+}
+);
+let sampler13 = device0.createSampler(
+{
+label: '\u{1fe04}\u{1faf5}\u4520\u2b09',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 10.635,
+lodMaxClamp: 92.904,
+maxAnisotropy: 14,
+}
+);
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: 719.6,
+g: 494.4,
+b: 526.6,
+a: -703.1,
+}
+);
+} catch {}
+let arrayBuffer4 = buffer6.getMappedRange(
+9768,
+96
+);
+let offscreenCanvas5 = new OffscreenCanvas(692, 414);
+let renderBundle10 = renderBundleEncoder9.finish();
+try {
+renderPassEncoder1.setBlendConstant(
+{
+r: 290.8,
+g: 111.6,
+b: 555.0,
+a: 293.5,
+}
+);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+91,
+1,
+1,
+0
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 943, height: 1, depthOrArrayLayers: 1276}
+*/
+{
+  source: offscreenCanvas3,
+  origin: { x: 379, y: 120 },
+  flipY: true,
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: { x: 433, y: 0, z: 917 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 265, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let bindGroupLayout4 = device0.createBindGroupLayout(
+{
+label: '\u06c6\u28aa\u0c02',
+entries: [
+{
+binding: 3073,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 294,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+}
+],
+}
+);
+let querySet17 = device0.createQuerySet(
+{
+label: '\uafda\u8bb3\u{1f9e2}\u2f32\u{1fa88}\ue198\u159a',
+type: 'occlusion',
+count: 1496,
+}
+);
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: -480.4,
+g: -393.9,
+b: 456.7,
+a: 438.7,
+}
+);
+} catch {}
+let imageBitmap2 = await createImageBitmap(videoFrame2);
+let texture16 = device0.createTexture(
+{
+label: '\u095e\u160b\u1a63\u{1fa47}\u78fb\u6f3b\u7e6d\u0797',
+size: {width: 6101, height: 2, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let sampler14 = device0.createSampler(
+{
+label: '\u0103\ufbc3\ufc06\ud25e',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+lodMinClamp: 70.629,
+lodMaxClamp: 99.767,
+}
+);
+try {
+renderBundleEncoder8.setBindGroup(
+4,
+bindGroup1,
+new Uint32Array(6695),
+3375,
+0
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 58, height: 1, depthOrArrayLayers: 79}
+*/
+{
+  source: imageData1,
+  origin: { x: 118, y: 101 },
+  flipY: false,
+},
+{
+  texture: texture10,
+  mipLevel: 4,
+  origin: { x: 26, y: 0, z: 56 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 28, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let canvas3 = document.createElement('canvas');
+let imageData3 = new ImageData(252, 204);
+let texture17 = device0.createTexture(
+{
+size: {width: 1354, height: 1, depthOrArrayLayers: 1089},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rg32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32uint',
+'rg32uint',
+'rg32uint'
+],
+}
+);
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: -953.2,
+g: 297.8,
+b: 960.8,
+a: -135.7,
+}
+);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+5,
+buffer6,
+1716,
+5057
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture7,
+  mipLevel: 6,
+  origin: { x: 2, y: 0, z: 13 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 8289 */{
+offset: 957,
+bytesPerRow: 282,
+rowsPerImage: 26,
+},
+{width: 0, height: 1, depthOrArrayLayers: 2}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 471, height: 1, depthOrArrayLayers: 638}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 216, y: 42 },
+  flipY: true,
+},
+{
+  texture: texture10,
+  mipLevel: 1,
+  origin: { x: 27, y: 0, z: 83 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 5, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+document.body.append('\u{1fb92}\u{1f85f}\u{1fa91}\u{1ffb2}\u{1f94f}\u{1f7c8}\u0ed3');
+let bindGroupLayout5 = device0.createBindGroupLayout(
+{
+label: '\u{1fa71}\u05bb\uee19\ue0cb\u7677',
+entries: [
+{
+binding: 2976,
+visibility: GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+let commandEncoder16 = device0.createCommandEncoder(
+{
+}
+);
+let textureView18 = texture1.createView(
+{
+label: '\u6f76\u0f07\u58b9\u6009\u0dea\u{1fb6a}\ua4f7',
+mipLevelCount: 3,
+}
+);
+let renderPassEncoder3 = commandEncoder16.beginRenderPass(
+{
+label: '\u2ada\u0927\u0197\ue771\u{1fc0e}\u0ba6\ud437',
+colorAttachments: [
+undefined,
+{
+view: textureView4,
+clearValue: {
+r: -43.61,
+g: 466.5,
+b: -821.2,
+a: 256.5,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined
+],
+occlusionQuerySet: querySet9,
+maxDrawCount: 30536,
+}
+);
+try {
+renderBundleEncoder10.setBindGroup(
+6,
+bindGroup5
+);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(
+8,
+buffer9,
+7920,
+21194
+);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+document.body.append('\u0cc1\u{1ff19}\ue091\u5a5e\u0e99\uf262\ua1d0');
+let querySet18 = device0.createQuerySet(
+{
+label: '\u0a50\u0d50\u1701\uece6\u2bbe\u{1fe5d}\uf787\u894e',
+type: 'occlusion',
+count: 1645,
+}
+);
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(
+1
+);
+} catch {}
+try {
+renderPassEncoder3.setViewport(
+0.4370,
+20.46,
+2.079,
+9.072,
+0.9079,
+0.9198
+);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+7,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(
+buffer4,
+'uint32',
+30480,
+15281
+);
+} catch {}
+try {
+computePassEncoder8.insertDebugMarker(
+'\uce80'
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture10,
+  mipLevel: 4,
+  origin: { x: 30, y: 0, z: 10 },
+  aspect: 'all',
+},
+arrayBuffer3,
+/* required buffer size: 6804338 */{
+offset: 398,
+bytesPerRow: 366,
+rowsPerImage: 286,
+},
+{width: 22, height: 0, depthOrArrayLayers: 66}
+);
+} catch {}
+document.body.append('\u05d8\u8283\u{1f866}\u0c98\u06b7\u9d3c\u{1f672}\u{1fb95}\u020c');
+let renderBundleEncoder13 = device0.createRenderBundleEncoder(
+{
+label: '\u0265\u{1fb0f}\u{1fdc7}\u{1ff0e}\u{1ffa1}\u3866',
+colorFormats: [
+'rgba16sint',
+'rgba8unorm',
+undefined,
+'r8sint',
+'r16float',
+'rg8sint',
+'r16uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 777,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle11 = renderBundleEncoder13.finish(
+{
+label: '\u3f26\u{1fc2a}\u0868\u0a6b'
+}
+);
+try {
+renderPassEncoder2.setViewport(
+2.002,
+37.98,
+0.9365,
+11.69,
+0.9369,
+0.9820
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+6,
+buffer2,
+15336,
+6769
+);
+} catch {}
+document.body.append('\ueb64\uddf3\u2bd5\u47c3\u{1fb72}\u6287\u{1ff3e}\u{1f9e7}\u{1fede}');
+let sampler15 = device0.createSampler(
+{
+label: '\u8ca6\u{1fc7c}\u61a9\u{1fbde}\u{1fab1}\uf5cb\u6bba\u96e1\uaa26',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 17.946,
+lodMaxClamp: 35.642,
+compare: 'equal',
+maxAnisotropy: 14,
+}
+);
+try {
+renderPassEncoder3.setViewport(
+2.740,
+51.38,
+0.2218,
+1.044,
+0.3034,
+0.4292
+);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(
+3,
+bindGroup6
+);
+} catch {}
+let gpuCanvasContext4 = offscreenCanvas4.getContext('webgpu');
+let offscreenCanvas6 = new OffscreenCanvas(537, 548);
+let querySet19 = device0.createQuerySet(
+{
+label: '\u407c\ua1d4',
+type: 'occlusion',
+count: 1666,
+}
+);
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(
+32
+);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(
+1863
+);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+commandEncoder9.copyBufferToBuffer(
+buffer2,
+12024,
+buffer4,
+25916,
+7580
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder9.clearBuffer(
+buffer6,
+8420
+);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(
+querySet19,
+1091,
+550,
+buffer6,
+1792
+);
+} catch {}
+let imageBitmap3 = await createImageBitmap(imageData0);
+let texture18 = device0.createTexture(
+{
+label: '\ufc6b\udeed\u48e6',
+size: {width: 1791, height: 1, depthOrArrayLayers: 18},
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb'
+],
+}
+);
+try {
+computePassEncoder3.setBindGroup(
+2,
+bindGroup7
+);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(
+0
+);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(
+4,
+bindGroup3,
+new Uint32Array(2374),
+1940,
+0
+);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let querySet20 = device0.createQuerySet(
+{
+label: '\u1d61\u0767\ud887\ucdeb\u0753',
+type: 'occlusion',
+count: 335,
+}
+);
+let textureView19 = texture5.createView(
+{
+mipLevelCount: 1,
+}
+);
+let computePassEncoder11 = commandEncoder9.beginComputePass();
+let renderBundleEncoder14 = device0.createRenderBundleEncoder(
+{
+label: '\u0085\u{1ff52}\u{1fecf}\u080b\u0fb4\ua01d\u3163\u053b\ue8cb\u0cd5\u075c',
+colorFormats: [
+'rgba32float',
+'rgba16uint',
+'rgba8uint'
+],
+sampleCount: 411,
+}
+);
+try {
+renderBundleEncoder5.setVertexBuffer(
+82,
+undefined,
+1888693311
+);
+} catch {}
+let renderBundle12 = renderBundleEncoder11.finish(
+{
+label: '\u74ec\udf98'
+}
+);
+try {
+renderPassEncoder2.beginOcclusionQuery(
+8
+);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+1.775,
+34.37,
+0.9667,
+8.219,
+0.2526,
+0.3263
+);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(
+7,
+buffer6,
+2568,
+5789
+);
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+let pipelineLayout1 = device0.createPipelineLayout(
+{
+label: '\u{1fa97}\uf9f8\u2db5\u8b35',
+bindGroupLayouts: [
+bindGroupLayout3,
+bindGroupLayout1,
+bindGroupLayout4,
+bindGroupLayout5,
+bindGroupLayout2,
+bindGroupLayout3,
+bindGroupLayout5,
+bindGroupLayout1
+],
+}
+);
+let querySet21 = device0.createQuerySet(
+{
+label: '\u0613\uddf1\u873f\u0ddf',
+type: 'occlusion',
+count: 1797,
+}
+);
+let textureView20 = texture12.createView(
+{
+label: '\ub28f\u04f7\u1840\uea4c\u{1fcfb}\u8db9\u02d7\u4525\u7984',
+baseMipLevel: 4,
+}
+);
+try {
+renderPassEncoder3.setBlendConstant(
+{
+r: -517.4,
+g: -842.0,
+b: 627.4,
+a: 348.9,
+}
+);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(
+3532
+);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(
+buffer9,
+'uint32',
+25200
+);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(
+4,
+buffer9
+);
+} catch {}
+document.body.append('\u7a9d\u{1fc51}\u0922');
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let bindGroup12 = device0.createBindGroup({
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let commandEncoder17 = device0.createCommandEncoder(
+{
+label: '\u0fab\u6aa5\u7aa2',
+}
+);
+let textureView21 = texture12.createView(
+{
+label: '\u{1fe61}\u7693\u{1f974}',
+dimension: '2d-array',
+baseMipLevel: 4,
+arrayLayerCount: 1,
+}
+);
+try {
+renderPassEncoder1.setIndexBuffer(
+buffer9,
+'uint16',
+34276,
+12454
+);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+5,
+buffer4,
+34356,
+4953
+);
+} catch {}
+try {
+commandEncoder17.resolveQuerySet(
+querySet10,
+31,
+63,
+buffer9,
+11008
+);
+} catch {}
+try {
+await promise3;
+} catch {}
+let bindGroupLayout6 = device0.createBindGroupLayout(
+{
+label: '\ua5a6\ub5a5\u08f5\u0dbe\u0665',
+entries: [
+{
+binding: 1950,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '3d' },
+},
+{
+binding: 2678,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+},
+{
+binding: 3088,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '1d' },
+}
+],
+}
+);
+let computePassEncoder12 = commandEncoder17.beginComputePass(
+{
+label: '\ue7e5\uf43d\u8c52'
+}
+);
+try {
+computePassEncoder6.setBindGroup(
+7,
+bindGroup10,
+new Uint32Array(7362),
+1007,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+1.803,
+29.37,
+1.128,
+22.89,
+0.4833,
+0.7068
+);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(
+buffer4,
+'uint32',
+16608
+);
+} catch {}
+let video3 = await videoWithData();
+let querySet22 = device0.createQuerySet(
+{
+label: '\u{1f8f8}\u6dab\u43a9\u46e7\u24bf\u6530',
+type: 'occlusion',
+count: 107,
+}
+);
+let texture19 = device0.createTexture(
+{
+label: '\u04e4\u0c8e\uc8ec\u0364\ua496\ue41f\u071c\u{1f689}\uce47',
+size: [4, 4, 206],
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16sint',
+'rgba16sint',
+'rgba16sint'
+],
+}
+);
+let sampler16 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 79.080,
+lodMaxClamp: 95.732,
+maxAnisotropy: 12,
+}
+);
+try {
+renderPassEncoder3.setBindGroup(
+1,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant(
+{
+r: -900.5,
+g: 125.8,
+b: 11.68,
+a: -990.0,
+}
+);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+0,
+47,
+1,
+4
+);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(
+1,
+buffer2,
+26120
+);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(
+buffer9,
+'uint32',
+9896,
+20347
+);
+} catch {}
+try {
+texture11.destroy();
+} catch {}
+let pipelineLayout2 = device0.createPipelineLayout(
+{
+label: '\u0bd4\ub280\ud800\u{1f7f6}\u9a0d\u050c\u003e\u96cd',
+bindGroupLayouts: [
+bindGroupLayout2,
+bindGroupLayout5,
+bindGroupLayout4,
+bindGroupLayout0,
+bindGroupLayout6,
+bindGroupLayout1,
+bindGroupLayout3,
+bindGroupLayout0,
+bindGroupLayout0
+],
+}
+);
+let querySet23 = device0.createQuerySet(
+{
+label: '\ubcae\u0859\u0b97\u0373\u8408\u0a88\u4583\ufcd4\u0578\u08bd',
+type: 'occlusion',
+count: 1388,
+}
+);
+let texture20 = device0.createTexture(
+{
+label: '\u1031\uc8c6\u4ba4\u5708\u05b1\u06ce',
+size: {width: 1096, height: 1, depthOrArrayLayers: 234},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8unorm',
+'rgba8unorm-srgb',
+'rgba8unorm-srgb'
+],
+}
+);
+let sampler17 = device0.createSampler(
+{
+label: '\u0225\u{1ffa4}\u{1fdaa}\u{1f749}\u0b67\u2644\u938f',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 59.723,
+lodMaxClamp: 66.170,
+}
+);
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(
+buffer9,
+'uint16',
+22726,
+7133
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+2,
+buffer4,
+6468,
+33184
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 235, height: 1, depthOrArrayLayers: 319}
+*/
+{
+  source: img0,
+  origin: { x: 15, y: 44 },
+  flipY: false,
+},
+{
+  texture: texture10,
+  mipLevel: 2,
+  origin: { x: 45, y: 1, z: 247 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 190, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let renderBundle13 = renderBundleEncoder13.finish(
+{
+label: '\udb04\u0a8c\u6759\u04c1\u5d63\u0161\u{1f750}\u620c'
+}
+);
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant(
+{
+r: 116.6,
+g: -453.0,
+b: -855.7,
+a: -372.4,
+}
+);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+10,
+0,
+97,
+1
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+0,
+buffer2,
+1848
+);
+} catch {}
+try {
+computePassEncoder5.pushDebugGroup(
+'\u1de6'
+);
+} catch {}
+let canvas4 = document.createElement('canvas');
+try {
+computePassEncoder10.setBindGroup(
+1,
+bindGroup0,
+new Uint32Array(364),
+2,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+2.977,
+13.73,
+0.00018,
+36.51,
+0.7771,
+0.9569
+);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(
+buffer1,
+'uint16',
+3534,
+1111
+);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(
+8,
+buffer2,
+1020,
+9204
+);
+} catch {}
+document.body.prepend('\u{1ffb8}\u09d1\u0606\u{1f78b}');
+let img2 = await imageWithData(280, 273, '#5ae14c95', '#9ec35fd3');
+let bindGroupLayout7 = device0.createBindGroupLayout(
+{
+label: '\u0b24\u09b1\u005a\u09a2',
+entries: [
+{
+binding: 509,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '3d' },
+}
+],
+}
+);
+let commandEncoder18 = device0.createCommandEncoder(
+{
+}
+);
+try {
+commandEncoder18.resolveQuerySet(
+querySet10,
+468,
+25,
+buffer9,
+21248
+);
+} catch {}
+try {
+computePassEncoder5.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 943, height: 1, depthOrArrayLayers: 1276}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 100, y: 164 },
+  flipY: true,
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: { x: 50, y: 0, z: 205 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 862, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+try {
+computePassEncoder3.setBindGroup(
+0,
+bindGroup3
+);
+} catch {}
+try {
+renderPassEncoder1.setViewport(
+94.19,
+0.3090,
+14.28,
+0.5583,
+0.2588,
+0.4489
+);
+} catch {}
+gc();
+document.body.append('\u{1fce4}\u0c4f');
+let canvas5 = document.createElement('canvas');
+let querySet24 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 545,
+}
+);
+let renderPassEncoder4 = commandEncoder18.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+{
+view: textureView3,
+clearValue: {
+r: -549.0,
+g: 862.5,
+b: -496.8,
+a: 924.4,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined
+],
+occlusionQuerySet: querySet18,
+maxDrawCount: 411688,
+}
+);
+let renderBundleEncoder15 = device0.createRenderBundleEncoder(
+{
+label: '\uf39f\u{1fc07}\u{1fd9b}\ub698\ub6e0\u3f44\u0156',
+colorFormats: [
+'r16uint',
+'rgba32sint',
+'rg16sint',
+'rg32float',
+'rg16uint',
+undefined
+],
+sampleCount: 175,
+}
+);
+try {
+computePassEncoder11.setBindGroup(
+4,
+bindGroup5
+);
+} catch {}
+try {
+renderPassEncoder3.setViewport(
+0.6188,
+49.76,
+0.04526,
+4.086,
+0.2741,
+0.5186
+);
+} catch {}
+let promise4 = device0.popErrorScope();
+try {
+renderBundleEncoder6.insertDebugMarker(
+'\u5669'
+);
+} catch {}
+let canvas6 = document.createElement('canvas');
+let textureView22 = texture2.createView(
+{
+baseMipLevel: 1,
+mipLevelCount: 2,
+baseArrayLayer: 70,
+arrayLayerCount: 18,
+}
+);
+let renderBundle14 = renderBundleEncoder0.finish(
+{
+label: '\u5370\ufa5c\u05f2\u00d0'
+}
+);
+let sampler18 = device0.createSampler(
+{
+label: '\u02bd\uc626\u00de\u{1fa21}\u8325\u{1f778}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 14.628,
+lodMaxClamp: 55.460,
+compare: 'always',
+maxAnisotropy: 4,
+}
+);
+try {
+renderPassEncoder2.setViewport(
+0.8572,
+42.39,
+0.7975,
+10.50,
+0.1483,
+0.4912
+);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(
+buffer1,
+'uint16'
+);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+2,
+buffer4
+);
+} catch {}
+let promise5 = device0.popErrorScope();
+try {
+device0.queue.writeTexture(
+{
+  texture: texture9,
+  mipLevel: 8,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(763),
+/* required buffer size: 763 */{
+offset: 763,
+},
+{width: 2, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext5 = offscreenCanvas5.getContext('webgpu');
+let shaderModule0 = device0.createShaderModule(
+{
+label: '\u115e\u0a04\u{1f725}\u0858\u6738\u{1f727}\u0033\u325e\u72ba',
+code: `@group(1) @binding(2976)
+var<storage, read_write> parameter0: array<u32>;
+@group(2) @binding(294)
+var<storage, read_write> type0: array<u32>;
+
+@compute @workgroup_size(2, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S1 {
+@location(25) f0: vec3<i32>,
+@location(6) f1: vec2<f16>,
+@location(33) f2: vec3<i32>,
+@location(46) f3: vec4<i32>,
+@location(18) f4: vec2<u32>,
+@location(53) f5: i32,
+@location(51) f6: vec3<f16>,
+@location(41) f7: vec4<f16>,
+@location(34) f8: vec2<u32>,
+@builtin(sample_mask) f9: u32,
+@location(49) f10: vec4<i32>,
+@location(12) f11: u32,
+@location(54) f12: i32,
+@location(55) f13: vec2<f32>,
+@location(15) f14: vec3<f32>,
+@location(35) f15: vec3<i32>,
+@location(19) f16: f16,
+@location(5) f17: vec2<i32>,
+@location(10) f18: u32,
+@location(23) f19: vec4<f16>,
+@builtin(sample_index) f20: u32,
+@location(14) f21: vec2<u32>,
+@location(30) f22: vec4<f16>,
+@builtin(position) f23: vec4<f32>,
+@location(42) f24: vec3<i32>,
+@location(50) f25: vec2<f16>,
+@location(7) f26: vec4<f32>,
+@location(43) f27: vec2<f16>,
+@location(0) f28: vec3<f16>,
+@location(59) f29: vec4<f16>,
+@location(56) f30: u32,
+@location(20) f31: u32,
+@location(45) f32: vec3<f16>,
+@location(28) f33: u32,
+@location(4) f34: vec4<u32>,
+@location(13) f35: vec2<u32>,
+@location(58) f36: f16,
+@builtin(front_facing) f37: bool
+}
+
+@fragment
+fn fragment0(@location(27) a0: vec3<f16>, a1: S1) -> @location(4) vec3<i32> {
+return vec3<i32>();
+}
+
+struct S0 {
+@location(6) f0: vec2<u32>,
+@location(10) f1: f16
+}
+struct VertexOutput0 {
+@location(5) f0: vec2<i32>,
+@location(53) f1: i32,
+@location(19) f2: f16,
+@location(28) f3: u32,
+@location(51) f4: vec3<f16>,
+@location(49) f5: vec4<i32>,
+@location(42) f6: vec3<i32>,
+@location(45) f7: vec3<f16>,
+@location(20) f8: u32,
+@location(56) f9: u32,
+@location(55) f10: vec2<f32>,
+@location(15) f11: vec3<f32>,
+@location(4) f12: vec4<u32>,
+@location(41) f13: vec4<f16>,
+@location(12) f14: u32,
+@location(35) f15: vec3<i32>,
+@location(27) f16: vec3<f16>,
+@location(46) f17: vec4<i32>,
+@location(14) f18: vec2<u32>,
+@location(59) f19: vec4<f16>,
+@location(0) f20: vec3<f16>,
+@location(10) f21: u32,
+@location(34) f22: vec2<u32>,
+@location(50) f23: vec2<f16>,
+@location(23) f24: vec4<f16>,
+@location(7) f25: vec4<f32>,
+@location(18) f26: vec2<u32>,
+@location(13) f27: vec2<u32>,
+@location(25) f28: vec3<i32>,
+@location(33) f29: vec3<i32>,
+@location(30) f30: vec4<f16>,
+@builtin(position) f31: vec4<f32>,
+@location(6) f32: vec2<f16>,
+@location(58) f33: f16,
+@location(54) f34: i32,
+@location(43) f35: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec4<u32>, @location(1) a1: vec2<i32>, @location(0) a2: vec3<f16>, @builtin(vertex_index) a3: u32, a4: S0, @location(3) a5: vec2<i32>, @builtin(instance_index) a6: u32, @location(8) a7: vec4<f16>, @location(5) a8: f16, @location(9) a9: vec2<f32>, @location(11) a10: vec4<f32>, @location(15) a11: f32, @location(7) a12: vec2<u32>, @location(13) a13: vec2<f16>, @location(4) a14: f16, @location(12) a15: vec4<f16>, @location(14) a16: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let commandEncoder19 = device0.createCommandEncoder();
+let texture21 = device0.createTexture(
+{
+label: '\u52b7\ue735\ua7eb\u{1fea7}\u20ae\u06ce\u{1ff3b}\u{1f7c7}\u53e1',
+size: [1928, 1, 245],
+mipLevelCount: 11,
+dimension: '3d',
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder13 = commandEncoder19.beginComputePass(
+{
+label: '\ufe7d\u0ea9\u347b\u942f'
+}
+);
+try {
+renderPassEncoder1.setIndexBuffer(
+buffer2,
+'uint32',
+8192,
+22209
+);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(
+buffer1,
+'uint32',
+908,
+3337
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise7 = device0.createComputePipelineAsync(
+{
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline0 = device0.createRenderPipeline(
+{
+label: '\u{1f7b5}\u4170\uf4e9\u0b7a\u{1fcd1}\u2374\uc1c8',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 30768,
+attributes: [
+{
+format: 'unorm8x4',
+offset: 10824,
+shaderLocation: 12,
+},
+{
+format: 'unorm8x2',
+offset: 1366,
+shaderLocation: 15,
+},
+{
+format: 'float16x4',
+offset: 200,
+shaderLocation: 9,
+},
+{
+format: 'snorm8x4',
+offset: 22600,
+shaderLocation: 4,
+},
+{
+format: 'uint32',
+offset: 8428,
+shaderLocation: 14,
+},
+{
+format: 'float32x2',
+offset: 2116,
+shaderLocation: 13,
+},
+{
+format: 'float16x4',
+offset: 988,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 55148,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 43048,
+shaderLocation: 8,
+},
+{
+format: 'sint8x4',
+offset: 41324,
+shaderLocation: 3,
+},
+{
+format: 'float16x2',
+offset: 33556,
+shaderLocation: 0,
+},
+{
+format: 'uint8x2',
+offset: 14668,
+shaderLocation: 7,
+},
+{
+format: 'uint16x4',
+offset: 7052,
+shaderLocation: 2,
+},
+{
+format: 'uint32x3',
+offset: 4432,
+shaderLocation: 6,
+},
+{
+format: 'float32',
+offset: 15680,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 28540,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 2040,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 41536,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 19562,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'invert',
+depthFailOp: 'increment-wrap',
+passOp: 'invert',
+},
+stencilBack: {
+failOp: 'increment-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilReadMask: 796,
+stencilWriteMask: 1748,
+depthBias: 94,
+depthBiasSlopeScale: 92,
+depthBiasClamp: 4,
+},
+}
+);
+try {
+computePassEncoder7.setBindGroup(
+0,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(
+56
+);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+2.514,
+39.41,
+0.02543,
+12.29,
+0.6392,
+0.9417
+);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(
+buffer9,
+'uint32',
+30776,
+9530
+);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(
+9,
+buffer6
+);
+} catch {}
+try {
+querySet2.destroy();
+} catch {}
+try {
+computePassEncoder3.insertDebugMarker(
+'\u{1fba5}'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer4,
+10844,
+new DataView(new ArrayBuffer(64151)),
+32283,
+3780
+);
+} catch {}
+let pipeline1 = await device0.createComputePipelineAsync(
+{
+label: '\ua201\u0d38\u3c81\u2ca9\u7296\u{1f614}\u111b\u1da5\u317a\u{1f7c0}',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+}
+);
+try {
+await promise5;
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder(
+{
+}
+);
+let querySet25 = device0.createQuerySet(
+{
+label: '\ufba5\u070e\uc832\uf627\u{1fd61}\u0f43',
+type: 'occlusion',
+count: 2943,
+}
+);
+let texture22 = device0.createTexture(
+{
+label: '\uf495\u03ba\u4f73\u0f8d\uef4b\u{1f752}\u532c\u9c03\u6b5d\u39f2',
+size: {width: 5277},
+dimension: '1d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_DST,
+}
+);
+let renderBundleEncoder16 = device0.createRenderBundleEncoder(
+{
+label: '\u{1f854}\u0e78\u{1ff3c}\u0394',
+colorFormats: [
+'rg16sint',
+'r8sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 106,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: -536.4,
+g: -311.3,
+b: -435.5,
+a: 466.0,
+}
+);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+0,
+36,
+3,
+2
+);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+2,
+bindGroup12
+);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(
+1,
+buffer2
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline2 = device0.createComputePipeline(
+{
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let gpuCanvasContext6 = canvas3.getContext('webgpu');
+document.body.prepend('\u0ec3\u75f5\u011d');
+let canvas7 = document.createElement('canvas');
+let offscreenCanvas7 = new OffscreenCanvas(286, 855);
+let buffer10 = device0.createBuffer(
+{
+label: '\u0690\u8837\u548e\u644d\u7971\u008e',
+size: 36406,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+}
+);
+let querySet26 = device0.createQuerySet(
+{
+label: '\u{1fc2c}\ud709\u0a57\u0fc3\u3abb\u8c6b',
+type: 'occlusion',
+count: 2581,
+}
+);
+let textureView23 = texture2.createView(
+{
+label: '\u0b21\ua62e',
+mipLevelCount: 1,
+baseArrayLayer: 25,
+arrayLayerCount: 39,
+}
+);
+let renderPassEncoder5 = commandEncoder20.beginRenderPass(
+{
+label: '\u0ad1\u9c66\u{1ff94}',
+colorAttachments: [
+undefined,
+undefined,
+{
+view: textureView13,
+depthSlice: 124,
+clearValue: {
+r: 276.4,
+g: 838.0,
+b: 82.25,
+a: 96.23,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView13,
+depthSlice: 437,
+clearValue: {
+r: -677.5,
+g: 498.8,
+b: -770.4,
+a: -980.3,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView13,
+depthSlice: 140,
+clearValue: {
+r: 706.3,
+g: 447.4,
+b: 805.9,
+a: 367.5,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet1,
+}
+);
+let renderBundleEncoder17 = device0.createRenderBundleEncoder(
+{
+label: '\u0e9b\u0315\u{1f9fa}\u5b37',
+colorFormats: [
+'rgba8uint',
+'rg32float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 792,
+depthReadOnly: true,
+}
+);
+let renderBundle15 = renderBundleEncoder12.finish(
+{
+
+}
+);
+try {
+computePassEncoder11.setBindGroup(
+3,
+bindGroup7
+);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+8,
+bindGroup5
+);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(
+5,
+buffer4,
+784,
+1775
+);
+} catch {}
+let renderBundle16 = renderBundleEncoder1.finish();
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(
+8,
+bindGroup6
+);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(
+5,
+bindGroup9
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture9,
+  mipLevel: 9,
+  origin: { x: 2, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint32Array(new ArrayBuffer(16)),
+/* required buffer size: 107 */{
+offset: 103,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend('\u{1fd18}\u8719\u480c\u8d26\u3042\u5a47\u3b44\u{1fab9}\u35a0');
+let bindGroup13 = device0.createBindGroup({
+label: '\u005c\u036e\u0d5b\u{1f90e}',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let renderPassEncoder6 = commandEncoder17.beginRenderPass(
+{
+label: '\u0122\u{1f955}\u4363\u8fbf\u7711\u{1f679}\u9000\u2445',
+colorAttachments: [
+{
+view: textureView3,
+clearValue: {
+r: -289.9,
+g: 661.2,
+b: -315.1,
+a: 328.2,
+},
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+maxDrawCount: 108848,
+}
+);
+try {
+renderPassEncoder4.setBindGroup(
+0,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+0,
+42,
+0,
+11
+);
+} catch {}
+try {
+renderPassEncoder5.setViewport(
+220.5,
+0.9780,
+25.55,
+0.02002,
+0.3998,
+0.9198
+);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(
+7,
+buffer2,
+7092,
+6055
+);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+4,
+bindGroup9
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 471, height: 1, depthOrArrayLayers: 638}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 7 },
+  flipY: true,
+},
+{
+  texture: texture10,
+  mipLevel: 1,
+  origin: { x: 424, y: 0, z: 554 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 16, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+await promise6;
+} catch {}
+let bindGroupLayout8 = device0.createBindGroupLayout(
+{
+label: '\u0e1f\u0ee7\u{1f8a7}\u{1fb10}\u7dd6\u743e\u{1fa5f}',
+entries: [
+{
+binding: 306,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(
+buffer2,
+'uint32',
+16244,
+4875
+);
+} catch {}
+let videoFrame3 = new VideoFrame(canvas1, {timestamp: 0});
+let pipelineLayout3 = device0.createPipelineLayout(
+{
+label: '\uaf64\u0db3\ub16f\uf228\u30ae\u{1f9f3}\ue14f\u{1fd98}\ub1a3\u074c',
+bindGroupLayouts: [
+bindGroupLayout3
+],
+}
+);
+pseudoSubmit(device0, commandEncoder18);
+let renderBundle17 = renderBundleEncoder9.finish(
+{
+
+}
+);
+let sampler19 = device0.createSampler(
+{
+label: '\u4da5\u0dcb\u{1f7bd}\u93bd\u7850\u{1ff97}\u544a\u644a',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 45.902,
+lodMaxClamp: 47.319,
+}
+);
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+98,
+undefined,
+48886279,
+2804207064
+);
+} catch {}
+try {
+device0.label = '\u{1fa3a}\uf453\u0791\u0494';
+} catch {}
+let buffer11 = device0.createBuffer(
+{
+label: '\u3d64\u0407\u57ea\u0878\uf8e3\u437a\uaf09\u79b6',
+size: 42129,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+}
+);
+let commandEncoder21 = device0.createCommandEncoder(
+{
+}
+);
+let textureView24 = texture7.createView(
+{
+label: '\uafa0\u4f7f\u0160\u93c6',
+dimension: '2d',
+baseMipLevel: 2,
+mipLevelCount: 1,
+baseArrayLayer: 9,
+}
+);
+let renderPassEncoder7 = commandEncoder21.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView9,
+depthSlice: 25,
+clearValue: {
+r: 822.9,
+g: 252.3,
+b: -328.2,
+a: -37.04,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+undefined,
+undefined,
+undefined,
+{
+view: textureView9,
+depthSlice: 82,
+clearValue: {
+r: -890.0,
+g: -442.5,
+b: 207.7,
+a: 796.7,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined
+],
+occlusionQuerySet: querySet15,
+maxDrawCount: 8304,
+}
+);
+let sampler20 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 64.943,
+lodMaxClamp: 93.558,
+}
+);
+try {
+computePassEncoder4.setPipeline(
+pipeline2
+);
+} catch {}
+try {
+renderPassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder5.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant(
+{
+r: -187.8,
+g: -270.8,
+b: 156.4,
+a: 4.109,
+}
+);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+3,
+bindGroup0
+);
+} catch {}
+try {
+texture11.destroy();
+} catch {}
+let arrayBuffer5 = buffer6.getMappedRange(
+7920,
+484
+);
+try {
+computePassEncoder11.insertDebugMarker(
+'\u{1fddf}'
+);
+} catch {}
+try {
+gpuCanvasContext6.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg8unorm',
+'bgra8unorm-srgb',
+'rgba8uint'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer11,
+24740,
+new Float32Array(22928),
+826,
+2424
+);
+} catch {}
+let videoFrame4 = new VideoFrame(video2, {timestamp: 0});
+let renderBundle18 = renderBundleEncoder6.finish(
+{
+label: '\u0732\u99ab\u{1fb80}\u0c5e\u7caf\u0670\u{1fb1d}\u{1f6dd}\u8607\u6359'
+}
+);
+try {
+renderPassEncoder5.setIndexBuffer(
+buffer1,
+'uint16',
+490
+);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(
+7,
+buffer9,
+27308,
+19229
+);
+} catch {}
+let pipeline3 = device0.createRenderPipeline(
+{
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 14720,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x3',
+offset: 5584,
+shaderLocation: 1,
+},
+{
+format: 'unorm8x2',
+offset: 14462,
+shaderLocation: 13,
+},
+{
+format: 'uint32x2',
+offset: 13356,
+shaderLocation: 2,
+},
+{
+format: 'uint8x2',
+offset: 11486,
+shaderLocation: 14,
+},
+{
+format: 'unorm8x4',
+offset: 12404,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x2',
+offset: 11784,
+shaderLocation: 10,
+},
+{
+format: 'snorm16x2',
+offset: 4520,
+shaderLocation: 8,
+},
+{
+format: 'sint32',
+offset: 2556,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 9892,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 1296,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 50712,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x4',
+offset: 8500,
+shaderLocation: 0,
+},
+{
+format: 'uint32x2',
+offset: 18764,
+shaderLocation: 7,
+},
+{
+format: 'float32x2',
+offset: 53612,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 47540,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32',
+offset: 41724,
+shaderLocation: 9,
+},
+{
+format: 'uint32x2',
+offset: 39024,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 25292,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 20992,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.RED,
+},
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-clamp',
+passOp: 'replace',
+},
+stencilReadMask: 3594,
+stencilWriteMask: 580,
+depthBias: 89,
+depthBiasSlopeScale: 22,
+},
+}
+);
+let texture23 = gpuCanvasContext6.getCurrentTexture();
+let sampler21 = device0.createSampler(
+{
+label: '\udc37\u0c52\u0438\u{1fad0}\ud0ed\u40d1',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 75.788,
+}
+);
+try {
+renderPassEncoder2.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(
+74,
+undefined,
+477686781,
+2498727931
+);
+} catch {}
+let promise8 = buffer8.mapAsync(
+GPUMapMode.WRITE,
+1616
+);
+let commandEncoder22 = device0.createCommandEncoder(
+{
+label: '\u{1fbed}\uc964\u13b5\uc964\u9dd8\u42e7\udf8d\u{1fb92}\uc0ea',
+}
+);
+let computePassEncoder14 = commandEncoder22.beginComputePass(
+{
+label: '\u04c8\u{1f60a}\u026c\u2dd5\uea1c\ud4f0\u07cd\u6fd4\udfc0'
+}
+);
+let renderBundleEncoder18 = device0.createRenderBundleEncoder(
+{
+label: '\u0522\u082e\u95b1\uf825\u2b39',
+colorFormats: [
+'rgba8sint'
+],
+sampleCount: 984,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setViewport(
+2.490,
+7.588,
+0.09671,
+16.05,
+0.8969,
+0.9607
+);
+} catch {}
+let bindGroupLayout9 = device0.createBindGroupLayout(
+{
+label: '\u{1fd64}\u284b\u0f85\u5425\u388c\u{1fd47}\u0934\u942d\u0ea5',
+entries: [
+
+],
+}
+);
+try {
+computePassEncoder10.setPipeline(
+pipeline1
+);
+} catch {}
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(
+8
+);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant(
+{
+r: -372.8,
+g: -256.3,
+b: -663.6,
+a: 769.2,
+}
+);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(
+218
+);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(
+8,
+buffer4
+);
+} catch {}
+let img3 = await imageWithData(177, 174, '#e01809b9', '#04e09b33');
+let videoFrame5 = new VideoFrame(imageBitmap1, {timestamp: 0});
+let commandEncoder23 = device0.createCommandEncoder(
+{
+label: '\u8049\ub625\uda8b\uf475\ud1ec\u0723\ud844\u{1f63d}',
+}
+);
+let querySet27 = device0.createQuerySet(
+{
+label: '\u0d6b\u0b6d',
+type: 'occlusion',
+count: 1528,
+}
+);
+let texture24 = device0.createTexture(
+{
+label: '\u{1ffca}\ue3f6\uf09f\u2aef\u8209\u0be7\u572c\u00d9',
+size: [202, 83, 1],
+mipLevelCount: 3,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'depth24plus',
+'depth24plus'
+],
+}
+);
+let renderPassEncoder8 = commandEncoder23.beginRenderPass(
+{
+label: '\u6eaa\u4788',
+colorAttachments: [
+{
+view: textureView12,
+clearValue: {
+r: -706.9,
+g: -826.7,
+b: 424.4,
+a: 353.3,
+},
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet3,
+maxDrawCount: 418144,
+}
+);
+try {
+renderPassEncoder8.setBindGroup(
+5,
+bindGroup12
+);
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant(
+{
+r: 401.7,
+g: 980.6,
+b: 158.5,
+a: 196.6,
+}
+);
+} catch {}
+try {
+renderPassEncoder6.setViewport(
+0.5433,
+53.01,
+0.3884,
+0.2112,
+0.6060,
+0.8627
+);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(
+4,
+buffer6,
+5200,
+4754
+);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(
+9,
+buffer6,
+1876,
+7841
+);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8unorm',
+'rgba8unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+gc();
+document.body.append('\u57a4\u3c7d\u066a\ub8eb\u0df6');
+let querySet28 = device0.createQuerySet(
+{
+label: '\u02b0\u{1ff91}\u022b\uf217\u{1fc99}\u592b\u0168\ucc73\ua59c\u{1ff8e}\u07b2',
+type: 'occlusion',
+count: 889,
+}
+);
+let renderBundleEncoder19 = device0.createRenderBundleEncoder(
+{
+label: '\u99ee\u0ab6\u18e4\u1108\u{1f8f0}\u{1fb86}',
+colorFormats: [
+'rgba8unorm-srgb',
+'rg32float',
+'r8sint',
+'rgba8unorm-srgb',
+'rg32sint',
+'rg8unorm',
+'r8unorm'
+],
+sampleCount: 745,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder1.setBindGroup(
+8,
+bindGroup12
+);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+3,
+20,
+0,
+8
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+9,
+buffer2,
+11380,
+10028
+);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(
+3,
+buffer4,
+52624
+);
+} catch {}
+let pipeline4 = device0.createComputePipeline(
+{
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+}
+);
+document.body.prepend(canvas3);
+let img4 = await imageWithData(96, 75, '#7c512152', '#41dad843');
+let texture25 = device0.createTexture(
+{
+label: '\u{1f614}\u{1fc7e}\u{1fedd}\ucbeb\u0347\u0520\u{1fcb8}\u{1ff44}',
+size: [42, 218, 1],
+mipLevelCount: 4,
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8sint'
+],
+}
+);
+let renderBundleEncoder20 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba16uint'
+],
+sampleCount: 780,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+0,
+24,
+3,
+8
+);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(
+2,
+buffer2,
+6788,
+7051
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture7,
+  mipLevel: 3,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 43038 */{
+offset: 918,
+bytesPerRow: 130,
+rowsPerImage: 54,
+},
+{width: 17, height: 0, depthOrArrayLayers: 7}
+);
+} catch {}
+let renderBundle19 = renderBundleEncoder17.finish(
+{
+label: '\u052d\u18a6\u98e8\u{1fc6f}\ua016\ubd9e\u0afd\u0fca\u85dd\ub5c2\u0233'
+}
+);
+let sampler22 = device0.createSampler(
+{
+label: '\u{1fd5c}\u0546\u03b6\u68ba\u0294',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 98.655,
+compare: 'not-equal',
+maxAnisotropy: 4,
+}
+);
+try {
+computePassEncoder3.setBindGroup(
+1,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(
+1,
+27,
+2,
+20
+);
+} catch {}
+try {
+renderPassEncoder1.setViewport(
+54.45,
+0.4109,
+51.56,
+0.1862,
+0.7479,
+0.8918
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 117, height: 1, depthOrArrayLayers: 159}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 250, y: 15 },
+  flipY: true,
+},
+{
+  texture: texture10,
+  mipLevel: 3,
+  origin: { x: 74, y: 0, z: 95 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 19, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await promise8;
+} catch {}
+try {
+adapter0.label = '\u0d07\ubd43\uc470\u0ceb\uec06\u{1ff50}';
+} catch {}
+let textureView25 = texture12.createView(
+{
+label: '\u052a\u0633',
+baseMipLevel: 2,
+}
+);
+try {
+renderPassEncoder8.setBindGroup(
+7,
+bindGroup10,
+new Uint32Array(1091),
+603,
+0
+);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+2,
+35,
+1,
+11
+);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(
+1,
+buffer6,
+7760,
+1615
+);
+} catch {}
+let arrayBuffer6 = buffer6.getMappedRange(
+8408,
+860
+);
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 117, height: 1, depthOrArrayLayers: 159}
+*/
+{
+  source: video2,
+  origin: { x: 6, y: 15 },
+  flipY: false,
+},
+{
+  texture: texture10,
+  mipLevel: 3,
+  origin: { x: 20, y: 0, z: 138 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 6, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+renderPassEncoder6.setViewport(
+0.2592,
+37.58,
+0.6014,
+0.2555,
+0.9002,
+0.9663
+);
+} catch {}
+let pipeline5 = device0.createRenderPipeline(
+{
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 53268,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x4',
+offset: 38336,
+shaderLocation: 3,
+},
+{
+format: 'uint16x2',
+offset: 29832,
+shaderLocation: 14,
+},
+{
+format: 'snorm16x4',
+offset: 1996,
+shaderLocation: 5,
+},
+{
+format: 'float32x2',
+offset: 34236,
+shaderLocation: 10,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 1536,
+shaderLocation: 8,
+},
+{
+format: 'uint32x4',
+offset: 37944,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x4',
+offset: 29724,
+shaderLocation: 11,
+},
+{
+format: 'uint32',
+offset: 21792,
+shaderLocation: 2,
+},
+{
+format: 'uint32x3',
+offset: 38196,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 3644,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 932,
+shaderLocation: 13,
+},
+{
+format: 'snorm8x4',
+offset: 932,
+shaderLocation: 15,
+},
+{
+format: 'float32x2',
+offset: 2724,
+shaderLocation: 12,
+},
+{
+format: 'snorm16x4',
+offset: 3364,
+shaderLocation: 4,
+},
+{
+format: 'float16x4',
+offset: 2600,
+shaderLocation: 9,
+},
+{
+format: 'float32x3',
+offset: 760,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 58872,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 59864,
+attributes: [
+{
+format: 'sint16x2',
+offset: 46152,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined
+],
+},
+}
+);
+document.body.prepend('\u31a1\u{1fc07}\u0efa');
+try {
+renderPassEncoder4.beginOcclusionQuery(
+16
+);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(
+10,
+buffer2,
+28840,
+957
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+5608,
+new Float32Array(7775),
+5388,
+16
+);
+} catch {}
+document.body.prepend('\u4c5d\u{1f924}\u97ba\u0ca4');
+let adapter1 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let bindGroup14 = device0.createBindGroup({
+label: '\u0ccf\ub3b7\ub794\u00f1\u9bde\u9f5e\u79fb\u088a',
+layout: bindGroupLayout5,
+entries: [
+{
+binding: 2976,
+resource: {
+buffer: buffer6,
+offset: 9344,
+}
+}
+],
+});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder(
+{
+label: '\u0fc5\ucade\u6cea\ube36\u{1f691}\u510d\u{1fc82}\u0877\u6018',
+colorFormats: [
+undefined,
+'r32uint',
+'bgra8unorm',
+'rg8sint',
+'rgba8unorm',
+'r16sint',
+'r8uint',
+'rgba8unorm-srgb'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 551,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder8.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(
+buffer9,
+'uint16',
+30158,
+7059
+);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(
+2,
+bindGroup8
+);
+} catch {}
+gc();
+try {
+window.someLabel = textureView19.label;
+} catch {}
+let textureView26 = texture9.createView(
+{
+label: '\u0361\uf305\u7348\u36e6\u6dc6\u1c9f\u{1ff11}\u{1ffa5}',
+baseMipLevel: 4,
+mipLevelCount: 5,
+}
+);
+try {
+renderPassEncoder1.setScissorRect(
+103,
+1,
+9,
+0
+);
+} catch {}
+let arrayBuffer7 = buffer8.getMappedRange(
+1616,
+40
+);
+try {
+renderPassEncoder8.pushDebugGroup(
+'\u1eb7'
+);
+} catch {}
+let pipeline6 = await promise7;
+let promise9 = device0.createRenderPipelineAsync(
+{
+label: '\ueb26\u0d25\u0894\u{1f8bb}\ua6e4',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x2',
+offset: 31292,
+shaderLocation: 8,
+},
+{
+format: 'float32x2',
+offset: 24852,
+shaderLocation: 9,
+},
+{
+format: 'snorm8x2',
+offset: 46668,
+shaderLocation: 12,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 41272,
+shaderLocation: 10,
+},
+{
+format: 'uint32x2',
+offset: 9196,
+shaderLocation: 2,
+},
+{
+format: 'snorm8x4',
+offset: 21180,
+shaderLocation: 5,
+},
+{
+format: 'float16x4',
+offset: 52348,
+shaderLocation: 13,
+},
+{
+format: 'float32',
+offset: 22476,
+shaderLocation: 0,
+},
+{
+format: 'uint32',
+offset: 59312,
+shaderLocation: 7,
+},
+{
+format: 'uint32',
+offset: 13744,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 1084,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32',
+offset: 216,
+shaderLocation: 11,
+},
+{
+format: 'uint32x3',
+offset: 156,
+shaderLocation: 14,
+},
+{
+format: 'sint32',
+offset: 988,
+shaderLocation: 1,
+},
+{
+format: 'snorm8x4',
+offset: 104,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 24996,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 16896,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 49464,
+attributes: [
+
+],
+},
+{
+arrayStride: 24504,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 51128,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 5460,
+shaderLocation: 15,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x8831b08c,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8sint',
+},
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilReadMask: 2950,
+stencilWriteMask: 3829,
+depthBiasSlopeScale: 93,
+depthBiasClamp: 42,
+},
+}
+);
+document.body.prepend('\ucdeb\u237d\ue8e2\u09bd\u{1f8cc}\ue11c\u073a\u974b\udae4\u{1f678}');
+let texture26 = device0.createTexture(
+{
+label: '\u{1f6ea}\u04e0\u{1f890}\u7d64\u50ab',
+size: {width: 1414, height: 1, depthOrArrayLayers: 1981},
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16uint',
+'rgba16uint',
+'rgba16uint'
+],
+}
+);
+let renderBundleEncoder22 = device0.createRenderBundleEncoder(
+{
+label: '\ud198\u3080\u01c9',
+colorFormats: [
+undefined,
+'bgra8unorm-srgb',
+'r32uint',
+'bgra8unorm',
+'rgba32sint',
+'rgba16sint'
+],
+sampleCount: 356,
+}
+);
+let sampler23 = device0.createSampler(
+{
+label: '\ud878\u0bcc\ufcdb\ua123\u0ea3\u1b6b\u047c\u{1ff26}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 74.100,
+maxAnisotropy: 19,
+}
+);
+try {
+renderPassEncoder6.setBlendConstant(
+{
+r: 403.2,
+g: 908.8,
+b: 243.9,
+a: -822.5,
+}
+);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(
+8,
+buffer6,
+1616,
+1929
+);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(
+4,
+bindGroup2
+);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(
+5,
+buffer6,
+3064
+);
+} catch {}
+let pipeline7 = await device0.createRenderPipelineAsync(
+{
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 14056,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 3800,
+shaderLocation: 13,
+},
+{
+format: 'uint32x3',
+offset: 8636,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 22032,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 8404,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 6672,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 4984,
+shaderLocation: 1,
+},
+{
+format: 'unorm8x2',
+offset: 4778,
+shaderLocation: 8,
+},
+{
+format: 'float32',
+offset: 156,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 8180,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 7996,
+shaderLocation: 5,
+},
+{
+format: 'float32',
+offset: 5684,
+shaderLocation: 12,
+},
+{
+format: 'uint8x4',
+offset: 2328,
+shaderLocation: 7,
+},
+{
+format: 'uint32x2',
+offset: 4744,
+shaderLocation: 6,
+},
+{
+format: 'float32',
+offset: 3228,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x2',
+offset: 1612,
+shaderLocation: 0,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 4132,
+shaderLocation: 11,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 7484,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 6920,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 12940,
+attributes: [
+{
+format: 'unorm8x2',
+offset: 12370,
+shaderLocation: 10,
+},
+{
+format: 'uint32x3',
+offset: 11712,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'replace',
+depthFailOp: 'zero',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2704,
+depthBiasSlopeScale: 85,
+depthBiasClamp: 86,
+},
+}
+);
+let imageBitmap4 = await createImageBitmap(imageBitmap2);
+let buffer12 = device0.createBuffer(
+{
+label: '\ua6e7\u017d\u3f6a\u{1fe0f}\u{1f85b}\u0f16',
+size: 53097,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+}
+);
+let texture27 = gpuCanvasContext6.getCurrentTexture();
+let textureView27 = texture8.createView(
+{
+label: '\u{1f78f}\u{1ff0c}\u9c6f\u{1fb79}',
+format: 'r32float',
+mipLevelCount: 1,
+}
+);
+try {
+computePassEncoder13.setPipeline(
+pipeline4
+);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+gpuCanvasContext3.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgba16float'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer9,
+51036,
+new DataView(new ArrayBuffer(29331)),
+26522,
+0
+);
+} catch {}
+try {
+window.someLabel = renderBundleEncoder11.label;
+} catch {}
+let commandEncoder24 = device0.createCommandEncoder();
+let textureView28 = texture25.createView(
+{
+label: '\u{1f613}\uaf8b\u{1ffcd}\u{1fa1c}\u95e9\u55b9\u03f8\u0f54\u6741',
+dimension: '2d-array',
+baseMipLevel: 3,
+mipLevelCount: 1,
+arrayLayerCount: 1,
+}
+);
+let renderPassEncoder9 = commandEncoder24.beginRenderPass(
+{
+label: '\u35cf\u5232\u8677\u094a\u03ec\u{1fd76}',
+colorAttachments: [
+{
+view: textureView27,
+depthSlice: 836,
+clearValue: {
+r: -76.00,
+g: 440.0,
+b: 825.1,
+a: 147.1,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined,
+undefined,
+{
+view: textureView13,
+depthSlice: 537,
+clearValue: {
+r: -256.5,
+g: -824.8,
+b: -873.5,
+a: 175.3,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined
+],
+}
+);
+try {
+renderPassEncoder8.setBlendConstant(
+{
+r: -116.3,
+g: 779.8,
+b: 453.3,
+a: 530.5,
+}
+);
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(
+1228
+);
+} catch {}
+try {
+renderPassEncoder4.setViewport(
+1.163,
+25.42,
+0.3903,
+4.079,
+0.7389,
+0.8667
+);
+} catch {}
+try {
+renderPassEncoder8.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext4.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgb10a2uint',
+'r8unorm',
+'rgba8snorm'
+],
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture26,
+  mipLevel: 5,
+  origin: { x: 12, y: 0, z: 18 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer6),
+/* required buffer size: 804155 */{
+offset: 898,
+bytesPerRow: 415,
+rowsPerImage: 215,
+},
+{width: 29, height: 1, depthOrArrayLayers: 10}
+);
+} catch {}
+let pipeline8 = device0.createComputePipeline(
+{
+label: '\u2104\u0f01\u2068\u67aa\u{1ffba}',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageData4 = new ImageData(168, 76);
+let renderBundleEncoder23 = device0.createRenderBundleEncoder(
+{
+label: '\u08ff\u{1f656}\ud915\u73b7',
+colorFormats: [
+'rgba16uint',
+'rg11b10ufloat',
+'rgba16sint',
+'rg32float',
+undefined,
+'rgb10a2unorm',
+'rgba8uint'
+],
+sampleCount: 198,
+depthReadOnly: true,
+stencilReadOnly: false,
+}
+);
+let renderBundle20 = renderBundleEncoder5.finish(
+{
+
+}
+);
+try {
+computePassEncoder13.setBindGroup(
+6,
+bindGroup8,
+new Uint32Array(3435),
+1796,
+0
+);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(
+2,
+bindGroup13,
+new Uint32Array(5352),
+1566,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(
+80
+);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(
+255,
+0,
+0,
+1
+);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(
+buffer12,
+'uint32',
+47216,
+1621
+);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(
+8,
+buffer6,
+3976
+);
+} catch {}
+try {
+gpuCanvasContext4.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'r32uint',
+'bgra8unorm-srgb'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+document.body.prepend('\u7e20\u058d\u{1faa6}\uef05');
+let bindGroup15 = device0.createBindGroup({
+label: '\u{1fefd}\u0f49\ueee8\u{1fa92}',
+layout: bindGroupLayout5,
+entries: [
+{
+binding: 2976,
+resource: {
+buffer: buffer11,
+offset: 14464,
+size: 8316,
+}
+}
+],
+});
+let texture28 = device0.createTexture(
+{
+size: [650, 1, 1075],
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundleEncoder24 = device0.createRenderBundleEncoder(
+{
+label: '\uf54f\u{1feb0}\u83d5\u708a\u2231',
+colorFormats: [
+undefined,
+'rgba32float',
+'rgba32float',
+'rg11b10ufloat',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 228,
+depthReadOnly: false,
+}
+);
+let sampler24 = device0.createSampler(
+{
+label: '\u079f\u9526\u7f68\u7e44',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 84.272,
+lodMaxClamp: 89.135,
+compare: 'greater-equal',
+}
+);
+try {
+computePassEncoder7.setPipeline(
+pipeline1
+);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(
+2863
+);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(
+1,
+buffer11,
+4284,
+26934
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 117, height: 1, depthOrArrayLayers: 159}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 492, y: 375 },
+  flipY: false,
+},
+{
+  texture: texture10,
+  mipLevel: 3,
+  origin: { x: 7, y: 0, z: 19 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 89, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await promise4;
+} catch {}
+let shaderModule1 = device0.createShaderModule(
+{
+label: '\u0d96\u03d6',
+code: `@group(3) @binding(2976)
+var<storage, read_write> i0: array<u32>;
+
+@compute @workgroup_size(7, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S3 {
+@builtin(front_facing) f0: bool,
+@builtin(sample_mask) f1: u32
+}
+struct FragmentOutput0 {
+@location(0) f0: vec2<i32>,
+@location(1) f1: vec4<f32>,
+@location(7) f2: vec3<f32>,
+@builtin(frag_depth) f3: f32,
+@location(2) f4: f32,
+@location(3) f5: vec2<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, a1: S3) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S2 {
+@location(11) f0: vec2<f32>,
+@location(3) f1: i32,
+@builtin(instance_index) f2: u32,
+@location(8) f3: vec2<u32>,
+@location(5) f4: vec2<u32>,
+@location(9) f5: vec2<u32>,
+@location(15) f6: i32,
+@location(1) f7: u32,
+@location(14) f8: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(13) a0: vec4<i32>, @builtin(vertex_index) a1: u32, a2: S2, @location(0) a3: vec2<f32>, @location(10) a4: f32, @location(16) a5: vec4<i32>, @location(7) a6: vec2<u32>, @location(4) a7: vec4<u32>, @location(12) a8: vec4<u32>, @location(6) a9: u32, @location(2) a10: vec3<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder25 = device0.createCommandEncoder(
+{
+label: '\ufb93\u{1f779}\u665c\u01c5\u{1fac4}\u2622',
+}
+);
+let texture29 = device0.createTexture(
+{
+label: '\u{1fbf9}\ucf2a\u0d9f\ub40a\u5250\u0648\u0a4b\u0cf2\u{1f9c5}\u03a1\u2230',
+size: [2039, 1, 58],
+mipLevelCount: 11,
+dimension: '2d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView29 = texture11.createView(
+{
+label: '\u1109\u0a4a\ua8ba\udf04\uffdc\u0b30\u0ee1',
+dimension: '2d-array',
+}
+);
+let renderBundleEncoder25 = device0.createRenderBundleEncoder(
+{
+label: '\u7cc3\u0072\u0f11\u0b03\ud714\u0179\u5268\u02ed',
+colorFormats: [
+'r8sint',
+'rgba8unorm-srgb',
+'rgba8uint',
+'rg16sint',
+'rgba16uint',
+'r32sint',
+'rg16uint'
+],
+sampleCount: 184,
+}
+);
+let sampler25 = device0.createSampler(
+{
+addressModeU: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 29.297,
+lodMaxClamp: 99.409,
+maxAnisotropy: 17,
+}
+);
+try {
+computePassEncoder7.setBindGroup(
+2,
+bindGroup12,
+new Uint32Array(3493),
+2737,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: 432.5,
+g: -623.9,
+b: 816.1,
+a: 249.4,
+}
+);
+} catch {}
+let buffer13 = device0.createBuffer(
+{
+size: 25936,
+usage: GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+let renderBundleEncoder26 = device0.createRenderBundleEncoder(
+{
+label: '\uc0f9\u{1f637}\u0115\ue781',
+colorFormats: [
+'rgba8unorm',
+'rg8uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 676,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder2.setScissorRect(
+1,
+31,
+2,
+23
+);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(
+2,
+buffer6,
+10136,
+2
+);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+2,
+bindGroup3,
+new Uint32Array(4329),
+539,
+0
+);
+} catch {}
+try {
+commandEncoder25.copyTextureToTexture(
+{
+  texture: texture23,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture27,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer10,
+24424,
+new DataView(new ArrayBuffer(50427)),
+15342,
+1380
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 235, height: 1, depthOrArrayLayers: 319}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 1, y: 11 },
+  flipY: true,
+},
+{
+  texture: texture10,
+  mipLevel: 2,
+  origin: { x: 145, y: 0, z: 29 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 15, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend('\u{1fd51}\u{1f7d9}\udff9\u0a29\uc1ed\u0064\u6d37\u{1f9d5}\u{1f845}\u0e31');
+let texture30 = device0.createTexture(
+{
+label: '\u865d\u21c6\u{1faf1}\u06c0\u49f4',
+size: {width: 4744},
+sampleCount: 1,
+dimension: '1d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundleEncoder27 = device0.createRenderBundleEncoder(
+{
+label: '\u42b1\udad9\u4c83\u5338',
+colorFormats: [
+'r16uint',
+'rgba16sint',
+'r32sint',
+'rgba32float',
+'rgba8unorm-srgb'
+],
+sampleCount: 243,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder8.setBindGroup(
+2,
+bindGroup7
+);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(
+buffer9,
+'uint32',
+2240
+);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+4,
+buffer9,
+37876
+);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(
+1,
+bindGroup8,
+new Uint32Array(8745),
+7269,
+0
+);
+} catch {}
+try {
+commandEncoder25.clearBuffer(
+buffer10,
+32428,
+2440
+);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder25.resolveQuerySet(
+querySet12,
+2127,
+39,
+buffer10,
+35584
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 943, height: 1, depthOrArrayLayers: 1276}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 706, y: 237 },
+  flipY: false,
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: { x: 260, y: 1, z: 220 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 258, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\u1659\u2528\uabe4\u{1f7c4}\u{1f64f}\u7ce7\u0b03\u4af2\ucb0e\u0120');
+let renderPassEncoder10 = commandEncoder25.beginRenderPass(
+{
+label: '\u46aa\u0242\u{1f9d1}\uab9f\u{1fa0b}\u8348',
+colorAttachments: [
+{
+view: textureView12,
+clearValue: {
+r: 328.7,
+g: 351.1,
+b: 622.7,
+a: -349.2,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet8,
+maxDrawCount: 137144,
+}
+);
+let renderBundle21 = renderBundleEncoder21.finish(
+{
+label: '\u{1feaf}\u4cf0\uafaa\ub572\u676d\u0aa2\u702f\u{1f9e3}'
+}
+);
+try {
+renderPassEncoder6.setScissorRect(
+1,
+25,
+0,
+2
+);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(
+4,
+bindGroup7,
+[]
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 235, height: 1, depthOrArrayLayers: 319}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 363, y: 360 },
+  flipY: false,
+},
+{
+  texture: texture10,
+  mipLevel: 2,
+  origin: { x: 14, y: 0, z: 284 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 156, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+offscreenCanvas6.getContext('webgl');
+} catch {}
+let textureView30 = texture13.createView(
+{
+label: '\u0969\u44f6\u4b0e',
+}
+);
+try {
+renderPassEncoder8.setBindGroup(
+6,
+bindGroup9
+);
+} catch {}
+try {
+renderPassEncoder3.setViewport(
+1.129,
+29.87,
+0.4573,
+20.46,
+0.6128,
+0.8041
+);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(
+7,
+bindGroup13
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+2312,
+new BigUint64Array(44475),
+3710,
+304
+);
+} catch {}
+document.body.prepend('\ubaaf\uff2b');
+let sampler26 = device0.createSampler(
+{
+label: '\ue729\u9585\u{1fb7d}\u5e3a',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 84.032,
+lodMaxClamp: 88.219,
+}
+);
+try {
+renderPassEncoder4.setBindGroup(
+3,
+bindGroup14,
+new Uint32Array(916),
+560,
+0
+);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant(
+{
+r: 819.9,
+g: -108.9,
+b: 677.1,
+a: 11.26,
+}
+);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(
+10,
+buffer9
+);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(
+8,
+bindGroup2
+);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(
+buffer1,
+'uint16',
+1082,
+4269
+);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(
+5,
+undefined,
+2907347561,
+644570293
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture28,
+  mipLevel: 1,
+  origin: { x: 3, y: 0, z: 243 },
+  aspect: 'all',
+},
+new DataView(arrayBuffer4),
+/* required buffer size: 131812 */{
+offset: 240,
+bytesPerRow: 618,
+rowsPerImage: 1,
+},
+{width: 139, height: 1, depthOrArrayLayers: 213}
+);
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder();
+let renderPassEncoder11 = commandEncoder26.beginRenderPass(
+{
+label: '\u0c0d\u42ab\uaa7a\u{1ff2e}\u{1fa71}\u{1f7a6}',
+colorAttachments: [
+undefined,
+{
+view: textureView24,
+clearValue: {
+r: 187.7,
+g: 820.0,
+b: 379.2,
+a: 465.5,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined,
+undefined,
+undefined,
+undefined
+],
+maxDrawCount: 352248,
+}
+);
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(
+1,
+30,
+2,
+1
+);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(
+0,
+bindGroup7,
+new Uint32Array(242),
+226,
+0
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg16float',
+'rgba8unorm',
+'rgba8unorm',
+'rgba8unorm-srgb'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let pipeline9 = await device0.createComputePipelineAsync(
+{
+label: '\uf466\u0937\udbea',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let textureView31 = texture26.createView(
+{
+label: '\ue70a\u6c7c\u0842\u0c77\uc8e3\u{1f924}',
+baseMipLevel: 5,
+}
+);
+let sampler27 = device0.createSampler(
+{
+label: '\u06ed\u0d9a\u0276\u0420\u1b93\u{1fbdd}\u{1f7b5}',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMaxClamp: 96.847,
+compare: 'less',
+}
+);
+try {
+computePassEncoder7.setPipeline(
+pipeline4
+);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(
+3,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(
+48
+);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(
+buffer9,
+'uint16',
+2252,
+2742
+);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+4,
+buffer11,
+16360,
+6921
+);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(
+5,
+buffer9,
+19756,
+29509
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+await buffer0.mapAsync(
+GPUMapMode.WRITE,
+18240,
+4128
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer4,
+45400,
+new DataView(new ArrayBuffer(15848)),
+5292,
+884
+);
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+let pipeline10 = device0.createRenderPipeline(
+{
+label: '\u037a\u1f9c\u0951\u094e\u{1fc4e}\u{1fad1}\uae34\u04cb\ud64b\u857b\uc119',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 24912,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 20592,
+shaderLocation: 9,
+},
+{
+format: 'uint16x4',
+offset: 8556,
+shaderLocation: 6,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 12852,
+shaderLocation: 15,
+},
+{
+format: 'float32x2',
+offset: 16256,
+shaderLocation: 13,
+},
+{
+format: 'float32x2',
+offset: 1668,
+shaderLocation: 4,
+},
+{
+format: 'snorm16x2',
+offset: 24376,
+shaderLocation: 11,
+},
+{
+format: 'float16x2',
+offset: 17808,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 10236,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 2072,
+shaderLocation: 2,
+},
+{
+format: 'uint16x2',
+offset: 7364,
+shaderLocation: 7,
+},
+{
+format: 'sint32',
+offset: 7356,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 14292,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 9756,
+shaderLocation: 5,
+},
+{
+format: 'float16x4',
+offset: 4100,
+shaderLocation: 10,
+},
+{
+format: 'float32',
+offset: 2764,
+shaderLocation: 8,
+},
+{
+format: 'uint32x2',
+offset: 4092,
+shaderLocation: 14,
+},
+{
+format: 'sint32x4',
+offset: 3724,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 55892,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 59344,
+attributes: [
+{
+format: 'snorm8x2',
+offset: 1974,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'none',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALL,
+},
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 1869,
+depthBiasClamp: 77,
+},
+}
+);
+try {
+window.someLabel = bindGroup8.label;
+} catch {}
+let bindGroupLayout10 = device0.createBindGroupLayout(
+{
+label: '\u{1fe5c}\u{1f816}',
+entries: [
+{
+binding: 3140,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+}
+],
+}
+);
+let commandEncoder27 = device0.createCommandEncoder(
+{
+label: '\u04e9\u{1fc43}\uedcb',
+}
+);
+let querySet29 = device0.createQuerySet(
+{
+label: '\u0b24\uc3e2\uac49\ud053',
+type: 'occlusion',
+count: 964,
+}
+);
+let computePassEncoder15 = commandEncoder27.beginComputePass(
+{
+label: '\u3c4c\ua88c\u{1f7a0}\u908b\u71d8'
+}
+);
+try {
+renderPassEncoder9.setViewport(
+69.81,
+0.4587,
+172.6,
+0.2503,
+0.2949,
+0.4002
+);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(
+4,
+bindGroup12
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 943, height: 1, depthOrArrayLayers: 1276}
+*/
+{
+  source: imageData2,
+  origin: { x: 33, y: 26 },
+  flipY: true,
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: { x: 200, y: 0, z: 1023 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 68, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await promise10;
+} catch {}
+let imageData5 = new ImageData(236, 44);
+let pipelineLayout4 = device0.createPipelineLayout(
+{
+label: '\u2d8a\u6a89\ubce0\u6c33\u{1f6d3}\u{1fc7a}\ue86d\u02bd\u5608',
+bindGroupLayouts: [
+bindGroupLayout2,
+bindGroupLayout2,
+bindGroupLayout4,
+bindGroupLayout6,
+bindGroupLayout0,
+bindGroupLayout5,
+bindGroupLayout6,
+bindGroupLayout9
+],
+}
+);
+let querySet30 = device0.createQuerySet(
+{
+label: '\u2124\uc900\u{1f8fb}\u{1f6a9}\uc58d\u8bb5\u001a\u0917\ue0a0\uadb7',
+type: 'occlusion',
+count: 333,
+}
+);
+let sampler28 = device0.createSampler(
+{
+label: '\uae52\u0ec6\uc15f',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 98.354,
+lodMaxClamp: 99.296,
+}
+);
+try {
+renderPassEncoder1.setBindGroup(
+4,
+bindGroup15
+);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(
+4,
+buffer6,
+8412,
+854
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture18,
+  mipLevel: 2,
+  origin: { x: 216, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(140962),
+/* required buffer size: 140962 */{
+offset: 628,
+bytesPerRow: 803,
+rowsPerImage: 58,
+},
+{width: 153, height: 1, depthOrArrayLayers: 4}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 58, height: 1, depthOrArrayLayers: 79}
+*/
+{
+  source: imageData4,
+  origin: { x: 6, y: 10 },
+  flipY: true,
+},
+{
+  texture: texture10,
+  mipLevel: 4,
+  origin: { x: 13, y: 0, z: 55 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 31, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline11 = device0.createRenderPipeline(
+{
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1020,
+attributes: [
+{
+format: 'uint16x2',
+offset: 360,
+shaderLocation: 2,
+},
+{
+format: 'uint16x4',
+offset: 20,
+shaderLocation: 4,
+},
+{
+format: 'uint16x4',
+offset: 968,
+shaderLocation: 9,
+},
+{
+format: 'sint16x2',
+offset: 208,
+shaderLocation: 16,
+},
+{
+format: 'float16x2',
+offset: 524,
+shaderLocation: 11,
+},
+{
+format: 'float16x4',
+offset: 968,
+shaderLocation: 14,
+},
+{
+format: 'uint32x4',
+offset: 464,
+shaderLocation: 5,
+},
+{
+format: 'unorm8x2',
+offset: 764,
+shaderLocation: 0,
+},
+{
+format: 'uint32x4',
+offset: 368,
+shaderLocation: 12,
+},
+{
+format: 'sint32x2',
+offset: 916,
+shaderLocation: 3,
+},
+{
+format: 'uint32x3',
+offset: 364,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 32532,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 7120,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 58192,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x4',
+offset: 33104,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 9616,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x4',
+offset: 8852,
+shaderLocation: 7,
+},
+{
+format: 'sint32',
+offset: 5512,
+shaderLocation: 13,
+},
+{
+format: 'uint32x2',
+offset: 260,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 4596,
+shaderLocation: 15,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'rgba16float',
+writeMask: 0,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'one-minus-src-alpha',
+dstFactor: 'dst'
+},
+},
+format: 'r8unorm',
+writeMask: 0,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'less',
+failOp: 'replace',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'invert',
+},
+stencilWriteMask: 575,
+depthBias: 85,
+depthBiasSlopeScale: 70,
+depthBiasClamp: 29,
+},
+}
+);
+document.body.append('\u821e\ueaf9\u036c');
+let bindGroup16 = device0.createBindGroup({
+label: '\u190c\u484c',
+layout: bindGroupLayout9,
+entries: [
+
+],
+});
+let textureView32 = texture8.createView(
+{
+label: '\u037c\u39bf\uaa7b\u{1f659}\u080b\ud848\u0b52\u46ca\ub7e7\u03b1\u0853',
+arrayLayerCount: 1,
+}
+);
+try {
+computePassEncoder11.setPipeline(
+pipeline2
+);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(
+1,
+1,
+0,
+0
+);
+} catch {}
+let videoFrame6 = new VideoFrame(offscreenCanvas3, {timestamp: 0});
+let bindGroupLayout11 = device0.createBindGroupLayout(
+{
+entries: [
+{
+binding: 374,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 695,
+visibility: 0,
+buffer: { type: 'storage', minBindingSize: 99283, hasDynamicOffset: false },
+}
+],
+}
+);
+let commandEncoder28 = device0.createCommandEncoder(
+{
+label: '\u02c4\uac5d\u{1fc0d}',
+}
+);
+let renderBundleEncoder28 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'r8sint',
+undefined,
+undefined,
+'rg11b10ufloat',
+'r16float',
+'rg32sint',
+'rg8uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 717,
+depthReadOnly: true,
+}
+);
+let sampler29 = device0.createSampler(
+{
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+lodMinClamp: 73.043,
+lodMaxClamp: 90.813,
+}
+);
+try {
+renderPassEncoder10.beginOcclusionQuery(
+64
+);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant(
+{
+r: 676.2,
+g: 188.3,
+b: -497.1,
+a: 384.7,
+}
+);
+} catch {}
+try {
+commandEncoder28.copyBufferToTexture(
+{
+/* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 29660 */
+offset: 29656,
+buffer: buffer12,
+},
+{
+  texture: texture9,
+  mipLevel: 9,
+  origin: { x: 2, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder28.clearBuffer(
+buffer2,
+18992,
+9916
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+renderBundleEncoder22.insertDebugMarker(
+'\uc3f3'
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: { x: 6478, y: 1, z: 0 },
+  aspect: 'all',
+},
+new Int16Array(arrayBuffer3),
+/* required buffer size: 280 */{
+offset: 280,
+},
+{width: 862, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+offscreenCanvas5.height = 171;
+try {
+window.someLabel = device0.label;
+} catch {}
+let texture31 = device0.createTexture(
+{
+size: [734, 1, 157],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rg8unorm',
+'rg8unorm',
+'rg8unorm'
+],
+}
+);
+let sampler30 = device0.createSampler(
+{
+label: '\ua4a7\u80ef\uf920\u95e3\u{1f723}\ua2fa\u0ab0\ud70e\ud0ca\u0d8b\u5190',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 71.440,
+lodMaxClamp: 95.642,
+}
+);
+try {
+computePassEncoder11.setBindGroup(
+0,
+bindGroup11,
+new Uint32Array(6391),
+3999,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(
+0
+);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(
+1618
+);
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+0.06557,
+0.5450,
+0.1955,
+0.2187,
+0.9358,
+0.9991
+);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(
+buffer2,
+'uint16'
+);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(
+4,
+bindGroup8,
+new Uint32Array(825),
+214,
+0
+);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(
+6,
+buffer4
+);
+} catch {}
+try {
+commandEncoder28.copyTextureToTexture(
+{
+  texture: texture9,
+  mipLevel: 5,
+  origin: { x: 33, y: 1, z: 3 },
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 8,
+  origin: { x: 5, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder28.resolveQuerySet(
+querySet22,
+78,
+17,
+buffer6,
+5376
+);
+} catch {}
+let pipeline12 = await device0.createComputePipelineAsync(
+{
+label: '\u18e5\u5535\ub656\u{1f98d}\ud9bd\uda2e\u70e7\u{1f61c}\u8591\uab66\u71ab',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+document.body.prepend(canvas5);
+let video4 = await videoWithData();
+try {
+window.someLabel = querySet17.label;
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(
+8,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder11.end();
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(
+2,
+buffer4,
+12364,
+12865
+);
+} catch {}
+try {
+commandEncoder28.copyBufferToTexture(
+{
+/* bytesInLastRow: 7004 widthInBlocks: 1751 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 49696 */
+offset: 49696,
+bytesPerRow: 7168,
+buffer: buffer3,
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 61, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 1751, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder28.copyTextureToBuffer(
+{
+  texture: texture3,
+  mipLevel: 4,
+  origin: { x: 5, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 16 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 31416 */
+offset: 31416,
+buffer: buffer11,
+},
+{width: 2, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder28.clearBuffer(
+buffer9,
+16932,
+29484
+);
+dissociateBuffer(device0, buffer9);
+} catch {}
+document.body.append('\ua7d1\u5111\u887e\u09a6\u8cb8\u7945\u0f49');
+let imageData6 = new ImageData(120, 120);
+let buffer14 = device0.createBuffer(
+{
+label: '\u8ff0\u60e5\u0f42\u{1fca4}\u{1fa0b}',
+size: 41184,
+usage: GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let renderPassEncoder12 = commandEncoder28.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView12,
+clearValue: {
+r: -17.42,
+g: -360.6,
+b: -328.0,
+a: -866.7,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet8,
+maxDrawCount: 114096,
+}
+);
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant(
+{
+r: 364.5,
+g: 6.986,
+b: 776.6,
+a: 188.0,
+}
+);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(
+5,
+bindGroup11
+);
+} catch {}
+try {
+canvas4.getContext('webgpu');
+} catch {}
+let querySet31 = device0.createQuerySet(
+{
+label: '\u04b1\u{1fb0d}\u{1fb87}\u{1f7d1}\ucc52\u8ba6\u8d90\u0699\u0e81\ueaa2',
+type: 'occlusion',
+count: 43,
+}
+);
+let texture32 = device0.createTexture(
+{
+label: '\ud8d5\uedd2\ua7ce\u0b38\u9f0a',
+size: [4700],
+dimension: '1d',
+format: 'r32float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32float',
+'r32float',
+'r32float'
+],
+}
+);
+let renderBundleEncoder29 = device0.createRenderBundleEncoder(
+{
+label: '\u{1f9bd}\u2679',
+colorFormats: [
+'rg32uint',
+'rgba32uint',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 4,
+}
+);
+try {
+computePassEncoder15.setBindGroup(
+3,
+bindGroup4,
+new Uint32Array(6205),
+773,
+0
+);
+} catch {}
+try {
+computePassEncoder15.setPipeline(
+pipeline1
+);
+} catch {}
+try {
+renderPassEncoder12.beginOcclusionQuery(
+32
+);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(
+8,
+buffer6
+);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(
+11,
+buffer9,
+44060,
+4756
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer10,
+23940,
+new BigUint64Array(50122),
+28691,
+1488
+);
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout7,
+bindGroupLayout0,
+bindGroupLayout8,
+bindGroupLayout7,
+bindGroupLayout4
+],
+}
+);
+let renderBundle22 = renderBundleEncoder13.finish(
+{
+label: '\u0843\u7c81\u3de2\udae4'
+}
+);
+let sampler31 = device0.createSampler(
+{
+label: '\u061a\u6b6f\u00f6',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 54.523,
+lodMaxClamp: 79.961,
+compare: 'not-equal',
+}
+);
+let pipeline13 = await promise9;
+let promise11 = adapter1.requestDevice(
+{
+label: '\u6848\u0a8d\u{1fa99}\u07ac\u7c93\u8a13\u{1f96d}\u{1fbce}\u9304',
+}
+);
+let videoFrame7 = new VideoFrame(img0, {timestamp: 0});
+let texture33 = device0.createTexture(
+{
+size: {width: 6767},
+mipLevelCount: 1,
+dimension: '1d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+computePassEncoder13.setBindGroup(
+1,
+bindGroup16
+);
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(
+1952
+);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(
+1,
+bindGroup8
+);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(
+0,
+buffer4
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture9,
+  mipLevel: 8,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+new Int32Array(new ArrayBuffer(80)),
+/* required buffer size: 135 */{
+offset: 135,
+},
+{width: 4, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise12 = device0.queue.onSubmittedWorkDone();
+let imageData7 = new ImageData(156, 188);
+let videoFrame8 = new VideoFrame(offscreenCanvas3, {timestamp: 0});
+let shaderModule2 = device0.createShaderModule(
+{
+label: '\u00ad\u{1ff9e}\u8d9b\u{1fd23}\u0094',
+code: `@group(3) @binding(2678)
+var<storage, read_write> function0: array<u32>;
+
+@compute @workgroup_size(6, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S5 {
+@location(29) f0: vec2<f16>,
+@location(37) f1: i32,
+@location(12) f2: u32,
+@builtin(position) f3: vec4<f32>,
+@location(56) f4: vec2<f32>,
+@location(40) f5: f16,
+@location(45) f6: vec2<f32>,
+@location(1) f7: vec2<i32>
+}
+struct FragmentOutput0 {
+@location(6) f0: vec3<i32>,
+@location(2) f1: vec3<i32>,
+@location(3) f2: vec2<i32>,
+@location(5) f3: u32,
+@builtin(frag_depth) f4: f32,
+@location(4) f5: vec2<i32>,
+@location(0) f6: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(58) a0: vec2<f16>, a1: S5, @location(4) a2: vec3<u32>, @location(57) a3: u32, @location(19) a4: vec3<u32>, @location(6) a5: vec2<f16>, @builtin(sample_index) a6: u32, @location(52) a7: i32, @location(24) a8: vec2<i32>, @builtin(front_facing) a9: bool, @location(51) a10: f16, @location(26) a11: vec2<f32>, @location(53) a12: vec2<f32>, @location(16) a13: f32, @location(18) a14: vec2<i32>, @location(2) a15: vec2<i32>, @location(20) a16: f16, @builtin(sample_mask) a17: u32, @location(38) a18: vec3<f32>, @location(32) a19: vec3<u32>, @location(5) a20: vec4<i32>, @location(59) a21: f32, @location(22) a22: i32, @location(9) a23: vec2<u32>, @location(21) a24: i32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S4 {
+@location(8) f0: vec3<u32>,
+@location(6) f1: vec4<f32>,
+@location(12) f2: vec2<f32>,
+@location(9) f3: vec2<f32>,
+@location(2) f4: vec4<u32>,
+@location(13) f5: vec3<f16>,
+@location(4) f6: i32
+}
+struct VertexOutput0 {
+@location(18) f36: vec2<i32>,
+@location(28) f37: f16,
+@location(40) f38: f16,
+@location(32) f39: vec3<u32>,
+@location(51) f40: f16,
+@location(4) f41: vec3<u32>,
+@location(19) f42: vec3<u32>,
+@location(6) f43: vec2<f16>,
+@location(12) f44: u32,
+@location(9) f45: vec2<u32>,
+@location(39) f46: vec2<f32>,
+@location(53) f47: vec2<f32>,
+@location(37) f48: i32,
+@location(22) f49: i32,
+@location(47) f50: u32,
+@location(45) f51: vec2<f32>,
+@location(48) f52: vec2<u32>,
+@location(38) f53: vec3<f32>,
+@location(16) f54: f32,
+@location(24) f55: vec2<i32>,
+@location(52) f56: i32,
+@location(54) f57: vec2<u32>,
+@location(44) f58: vec2<u32>,
+@location(58) f59: vec2<f16>,
+@location(59) f60: f32,
+@builtin(position) f61: vec4<f32>,
+@location(56) f62: vec2<f32>,
+@location(20) f63: f16,
+@location(29) f64: vec2<f16>,
+@location(17) f65: vec3<f16>,
+@location(26) f66: vec2<f32>,
+@location(2) f67: vec2<i32>,
+@location(21) f68: i32,
+@location(5) f69: vec4<i32>,
+@location(1) f70: vec2<i32>,
+@location(57) f71: u32,
+@location(10) f72: i32
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec3<f16>, a1: S4, @location(5) a2: vec3<f32>, @location(1) a3: vec2<u32>, @location(0) a4: f32, @location(10) a5: vec2<f32>, @location(14) a6: vec2<f32>, @location(7) a7: vec4<u32>, @location(16) a8: vec3<u32>, @location(15) a9: vec4<i32>, @location(11) a10: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroupLayout12 = device0.createBindGroupLayout(
+{
+label: '\u04a2\u{1fc53}\u0bc7',
+entries: [
+
+],
+}
+);
+let pipelineLayout6 = device0.createPipelineLayout(
+{
+label: '\ud3c3\u6a0a\u1bdb\u099a\u0dde\u066c\ub27a',
+bindGroupLayouts: [
+bindGroupLayout8,
+bindGroupLayout1,
+bindGroupLayout3,
+bindGroupLayout1,
+bindGroupLayout11,
+bindGroupLayout4
+],
+}
+);
+let querySet32 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 3939,
+}
+);
+let renderBundle23 = renderBundleEncoder12.finish(
+{
+label: '\u07d4\u0b70\u7fdf'
+}
+);
+try {
+computePassEncoder7.setPipeline(
+pipeline4
+);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(
+80
+);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setViewport(
+1.279,
+20.83,
+0.3835,
+26.89,
+0.3193,
+0.4976
+);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(
+2,
+bindGroup9,
+new Uint32Array(7983),
+7861,
+0
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture26,
+  mipLevel: 1,
+  origin: { x: 49, y: 0, z: 458 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 23098797 */{
+offset: 189,
+bytesPerRow: 914,
+rowsPerImage: 72,
+},
+{width: 88, height: 0, depthOrArrayLayers: 352}
+);
+} catch {}
+try {
+offscreenCanvas7.getContext('2d');
+} catch {}
+let pipelineLayout7 = device0.createPipelineLayout(
+{
+label: '\u{1fc7e}\u{1f774}\ua1b2\u46a3\ue7c5',
+bindGroupLayouts: [
+bindGroupLayout10,
+bindGroupLayout11,
+bindGroupLayout2,
+bindGroupLayout5,
+bindGroupLayout4,
+bindGroupLayout3,
+bindGroupLayout2,
+bindGroupLayout4,
+bindGroupLayout8
+],
+}
+);
+let commandEncoder29 = device0.createCommandEncoder(
+{
+}
+);
+let textureView33 = texture31.createView(
+{
+label: '\ue39b\u{1fe17}\u{1fe6a}',
+baseMipLevel: 1,
+mipLevelCount: 2,
+}
+);
+let renderBundle24 = renderBundleEncoder29.finish();
+try {
+computePassEncoder14.setBindGroup(
+2,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(
+0,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(
+6,
+bindGroup4,
+new Uint32Array(5080),
+1516,
+0
+);
+} catch {}
+try {
+commandEncoder29.clearBuffer(
+buffer9,
+1724,
+16192
+);
+dissociateBuffer(device0, buffer9);
+} catch {}
+let texture34 = device0.createTexture(
+{
+label: '\ueb47\u{1f6a5}\u2a5e\u0f0d\u{1fe45}\u4c57\u{1f97e}\u00c4\uc68f\u4ea4\u7a84',
+size: {width: 236, height: 1, depthOrArrayLayers: 64},
+mipLevelCount: 6,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'depth24plus-stencil8'
+],
+}
+);
+try {
+renderPassEncoder6.setScissorRect(
+2,
+15,
+0,
+9
+);
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(
+787
+);
+} catch {}
+try {
+commandEncoder29.copyBufferToBuffer(
+buffer0,
+14808,
+buffer1,
+4556,
+1064
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder29.copyTextureToTexture(
+{
+  texture: texture10,
+  mipLevel: 1,
+  origin: { x: 363, y: 0, z: 366 },
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 4 },
+  aspect: 'all',
+},
+{width: 28, height: 1, depthOrArrayLayers: 18}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+25172,
+new BigUint64Array(8312),
+231,
+356
+);
+} catch {}
+let bindGroupLayout13 = device0.createBindGroupLayout(
+{
+label: '\uf0f5\u{1fee7}\u4243\u{1f94b}\u849a\u09b7\u0748',
+entries: [
+
+],
+}
+);
+let bindGroup17 = device0.createBindGroup({
+label: '\u90cd\ue6cc',
+layout: bindGroupLayout13,
+entries: [
+
+],
+});
+let commandEncoder30 = device0.createCommandEncoder(
+{
+label: '\uc3a9\u12d0\ue1e5\u118b\u8910\u0fa7\u8cf6\u{1f81b}',
+}
+);
+let renderBundleEncoder30 = device0.createRenderBundleEncoder(
+{
+label: '\ua14b\uf9a1\u{1f9bf}',
+colorFormats: [
+'bgra8unorm',
+'rg16uint',
+'rgba16uint',
+'rgba16float',
+'r16float',
+'rg8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 211,
+stencilReadOnly: true,
+}
+);
+let sampler32 = device0.createSampler(
+{
+label: '\u{1f7fd}\ub1e3\u0a74\u{1fd90}\u6c3d\u07a1\u6d52\ue859\u{1fc38}',
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 88.987,
+}
+);
+try {
+renderPassEncoder10.setBindGroup(
+5,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(
+2717
+);
+} catch {}
+try {
+renderPassEncoder6.setViewport(
+0.3236,
+29.47,
+0.2521,
+19.35,
+0.2152,
+0.8228
+);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(
+11,
+buffer11,
+29460,
+5638
+);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(
+0,
+buffer9,
+41256,
+7021
+);
+} catch {}
+try {
+commandEncoder30.clearBuffer(
+buffer4,
+3992,
+23128
+);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder30.resolveQuerySet(
+querySet2,
+1048,
+919,
+buffer10,
+8704
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 943, height: 1, depthOrArrayLayers: 1276}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 20, y: 11 },
+  flipY: true,
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: { x: 675, y: 1, z: 20 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 255, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let bindGroupLayout14 = device0.createBindGroupLayout(
+{
+label: '\u5935\u0835',
+entries: [
+{
+binding: 3177,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 1689,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba32sint', access: 'write-only', viewDimension: '1d' },
+},
+{
+binding: 2092,
+visibility: GPUShaderStage.FRAGMENT,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+let querySet33 = device0.createQuerySet(
+{
+label: '\ub03a\u521c\u{1fa27}\u4d63\u52aa\u0930',
+type: 'occlusion',
+count: 1712,
+}
+);
+let textureView34 = texture16.createView(
+{
+label: '\uad5b\uf474\u0a29\u607b\u3fc5\u0a0a\ufac7',
+dimension: '2d-array',
+baseMipLevel: 1,
+mipLevelCount: 1,
+}
+);
+let computePassEncoder16 = commandEncoder29.beginComputePass(
+{
+label: '\u00b0\u6143'
+}
+);
+let renderPassEncoder13 = commandEncoder30.beginRenderPass(
+{
+label: '\u0696\u0489',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthClearValue: 1.5573065535798847,
+depthLoadOp: 'load',
+depthStoreOp: 'discard',
+},
+maxDrawCount: 104080,
+}
+);
+let sampler33 = device0.createSampler(
+{
+label: '\u4c25\ue839\u72da\u67f5\ua784\u5b02\u09cc\u052f\u{1f67c}\u3a17',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 42.344,
+lodMaxClamp: 84.243,
+compare: 'not-equal',
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder4.setBindGroup(
+8,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(
+519,
+0,
+1629,
+0
+);
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(
+814
+);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer4,
+'uint32'
+);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(
+4,
+buffer4,
+42488
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 183, height: 1, depthOrArrayLayers: 39}
+*/
+{
+  source: canvas3,
+  origin: { x: 9, y: 105 },
+  flipY: false,
+},
+{
+  texture: texture31,
+  mipLevel: 2,
+  origin: { x: 14, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 167, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+canvas7.width = 699;
+try {
+canvas5.getContext('webgpu');
+} catch {}
+let bindGroupLayout15 = device0.createBindGroupLayout(
+{
+label: '\u8568\u31af\u049c\uac24\u40c9',
+entries: [
+
+],
+}
+);
+let renderBundleEncoder31 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg32float',
+'rg32uint',
+'rgb10a2unorm',
+'rgba8uint',
+'rgba32sint'
+],
+sampleCount: 414,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder10.beginOcclusionQuery(
+32
+);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(
+0,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(
+buffer11,
+'uint16',
+26756,
+8690
+);
+} catch {}
+try {
+querySet18.destroy();
+} catch {}
+try {
+await promise12;
+} catch {}
+document.body.prepend('\ufaae\u6296\u0c0a\u03ca\u9aca\u6110');
+let promise13 = adapter1.requestAdapterInfo();
+let commandEncoder31 = device0.createCommandEncoder(
+{
+}
+);
+let texture35 = device0.createTexture(
+{
+size: [845, 1, 222],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let textureView35 = texture17.createView(
+{
+dimension: '3d',
+}
+);
+try {
+computePassEncoder6.setBindGroup(
+8,
+bindGroup5,
+new Uint32Array(5967),
+259,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer1,
+'uint16',
+2698
+);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(
+2,
+bindGroup7
+);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(
+7,
+buffer4
+);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let texture36 = device0.createTexture(
+{
+label: '\u8a7c\uc08a\u2a49\u{1f803}\u9b7c\u2616\u{1fe78}\u075d\u1c96\u07a3\u5d87',
+size: [397, 1, 250],
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let renderPassEncoder14 = commandEncoder31.beginRenderPass(
+{
+label: '\u05b5\u2591\u3dde\u415c\ub707\u{1f977}',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthClearValue: 9.463485046868815,
+depthReadOnly: true,
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet29,
+}
+);
+let renderBundleEncoder32 = device0.createRenderBundleEncoder(
+{
+label: '\u4253\u5113\u9940\u{1ff2f}\u04fd\u939f',
+colorFormats: [
+'rg8sint',
+'rgba32sint',
+'rgba8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 521,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder3.setBindGroup(
+3,
+bindGroup17
+);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(
+2,
+bindGroup7
+);
+} catch {}
+let arrayBuffer8 = buffer8.getMappedRange(
+1656,
+4
+);
+let pipeline14 = device0.createComputePipeline(
+{
+label: '\uf1bd\u1664\ub3bf',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let video5 = await videoWithData();
+try {
+canvas7.getContext('webgl2');
+} catch {}
+let texture37 = device0.createTexture(
+{
+label: '\u{1f861}\u{1f74d}\u00a8\udda5\u3ae7\u0bcf\u0292\u082a\u{1ff46}\u0de0\u0901',
+size: {width: 10160, height: 43, depthOrArrayLayers: 41},
+mipLevelCount: 6,
+format: 'r16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16float',
+'r16float'
+],
+}
+);
+let sampler34 = device0.createSampler(
+{
+label: '\u0e76\u{1f81a}\uaef5\u{1fb56}\ue06f\uc80a\u0a9d',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 69.739,
+lodMaxClamp: 88.917,
+compare: 'never',
+maxAnisotropy: 12,
+}
+);
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(
+32,
+1,
+28,
+0
+);
+} catch {}
+try {
+commandEncoder10.resolveQuerySet(
+querySet26,
+412,
+1481,
+buffer4,
+1024
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 183, height: 1, depthOrArrayLayers: 39}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 5, y: 3 },
+  flipY: false,
+},
+{
+  texture: texture31,
+  mipLevel: 2,
+  origin: { x: 172, y: 0, z: 18 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 11, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let texture38 = device0.createTexture(
+{
+label: '\u070f\u0c5a',
+size: [5034],
+mipLevelCount: 1,
+dimension: '1d',
+format: 'rgba32uint',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+computePassEncoder16.setBindGroup(
+4,
+bindGroup8,
+new Uint32Array(6701),
+2769,
+0
+);
+} catch {}
+try {
+computePassEncoder15.setPipeline(
+pipeline8
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+0,
+bindGroup6
+);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(
+0
+);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(
+3,
+buffer6,
+3228,
+2739
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder10.clearBuffer(
+buffer7
+);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+20152,
+new DataView(new ArrayBuffer(52609)),
+31482,
+7060
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 471, height: 1, depthOrArrayLayers: 638}
+*/
+{
+  source: video4,
+  origin: { x: 8, y: 5 },
+  flipY: true,
+},
+{
+  texture: texture10,
+  mipLevel: 1,
+  origin: { x: 7, y: 1, z: 18 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 4, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await promise13;
+} catch {}
+try {
+adapter1.label = '\u03b1\u7079\ufaed\u{1fc1b}\ucb77\u476c\u2e07\uf58c\u{1f7f7}';
+} catch {}
+let bindGroup18 = device0.createBindGroup({
+layout: bindGroupLayout13,
+entries: [
+
+],
+});
+let querySet34 = device0.createQuerySet(
+{
+label: '\uc527\u6adf\uf19a\u7382\u02a6\u85ce',
+type: 'occlusion',
+count: 2469,
+}
+);
+let texture39 = device0.createTexture(
+{
+label: '\u8fef\ucbac\uaaf2\u5f04\u6331\u0006\u0057\u1a11\uefb6',
+size: [11, 1, 89],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'r8snorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8snorm',
+'r8snorm',
+'r8snorm'
+],
+}
+);
+let renderPassEncoder15 = commandEncoder10.beginRenderPass(
+{
+label: '\u0bdd\u4680\u0273\u0447',
+colorAttachments: [
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthLoadOp: 'load',
+depthStoreOp: 'discard',
+stencilClearValue: 38241,
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet22,
+}
+);
+let renderBundle25 = renderBundleEncoder5.finish();
+try {
+computePassEncoder4.setBindGroup(
+2,
+bindGroup15,
+new Uint32Array(9589),
+8462,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+7,
+bindGroup10
+);
+} catch {}
+try {
+renderPassEncoder15.setStencilReference(
+982
+);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(
+buffer9,
+'uint16',
+37028,
+9543
+);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(
+5,
+buffer11,
+29568,
+10325
+);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(
+3,
+bindGroup8
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture17,
+  mipLevel: 0,
+  origin: { x: 701, y: 1, z: 580 },
+  aspect: 'all',
+},
+new BigInt64Array(arrayBuffer1),
+/* required buffer size: 8265256 */{
+offset: 232,
+bytesPerRow: 4783,
+rowsPerImage: 64,
+},
+{width: 576, height: 0, depthOrArrayLayers: 28}
+);
+} catch {}
+document.body.append('\u5b85\u09e6\ucd6e\u7297\u51b5\u{1f7a4}\u04f1\u0bd2\u1201\u0a7b\u3bb7');
+let imageBitmap5 = await createImageBitmap(canvas4);
+let textureView36 = texture21.createView(
+{
+label: '\ub149\u9279',
+baseMipLevel: 2,
+mipLevelCount: 3,
+}
+);
+let sampler35 = device0.createSampler(
+{
+label: '\u8d31\u02f5\ufc00\u75a4\ud326\ue30a\u0426',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 75.997,
+}
+);
+try {
+renderPassEncoder14.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setViewport(
+51.04,
+0.3112,
+34.98,
+0.1139,
+0.9706,
+0.9732
+);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(
+buffer2,
+'uint32',
+3604,
+26321
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture13,
+  mipLevel: 0,
+  origin: { x: 201, y: 1, z: 0 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(new ArrayBuffer(80)),
+/* required buffer size: 495 */{
+offset: 495,
+bytesPerRow: 5798,
+},
+{width: 1434, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 471, height: 1, depthOrArrayLayers: 638}
+*/
+{
+  source: img0,
+  origin: { x: 177, y: 10 },
+  flipY: false,
+},
+{
+  texture: texture10,
+  mipLevel: 1,
+  origin: { x: 397, y: 0, z: 268 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 19, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let canvas8 = document.createElement('canvas');
+let videoFrame9 = new VideoFrame(videoFrame1, {timestamp: 0});
+let commandEncoder32 = device0.createCommandEncoder();
+let querySet35 = device0.createQuerySet(
+{
+label: '\uad85\u0d7a\u000f\u3b80\u{1fa40}\u{1fd43}\u{1f697}\u{1fb26}',
+type: 'occlusion',
+count: 1027,
+}
+);
+let texture40 = device0.createTexture(
+{
+label: '\ub8e4\u8908\ufeee',
+size: [1429, 1, 16],
+mipLevelCount: 8,
+dimension: '3d',
+format: 'rgba8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderPassEncoder16 = commandEncoder32.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthClearValue: 0.2927843938440299,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+stencilClearValue: 4372,
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet31,
+maxDrawCount: 400680,
+}
+);
+try {
+computePassEncoder3.setBindGroup(
+4,
+bindGroup14,
+new Uint32Array(4328),
+2175,
+0
+);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(
+7,
+bindGroup14,
+new Uint32Array(5437),
+563,
+0
+);
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant(
+{
+r: 290.5,
+g: -256.7,
+b: 284.0,
+a: 576.3,
+}
+);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+1314
+);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+4,
+buffer9,
+9064,
+4038
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+14600,
+new BigUint64Array(16680),
+12874,
+908
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 734, height: 1, depthOrArrayLayers: 157}
+*/
+{
+  source: video3,
+  origin: { x: 3, y: 11 },
+  flipY: false,
+},
+{
+  texture: texture31,
+  mipLevel: 0,
+  origin: { x: 419, y: 0, z: 56 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 12, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\uff86\u9747\u0447\u{1fb41}');
+let shaderModule3 = device0.createShaderModule(
+{
+label: '\ubc93\u09d3\u0bcf\ue70b\u0a32\ua77b\ubd79\ue260\u0193',
+code: `@group(6) @binding(3088)
+var<storage, read_write> field0: array<u32>;
+@group(0) @binding(2081)
+var<storage, read_write> global0: array<u32>;
+@group(2) @binding(294)
+var<storage, read_write> parameter1: array<u32>;
+
+@compute @workgroup_size(5, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S6 {
+@location(20) f0: vec4<f32>,
+@location(6) f1: vec2<f16>,
+@location(45) f2: f32,
+@location(17) f3: vec2<f16>
+}
+struct FragmentOutput0 {
+@location(5) f0: vec4<f32>,
+@location(4) f1: f32,
+@location(6) f2: i32,
+@location(3) f3: vec4<u32>,
+@location(2) f4: u32
+}
+
+@fragment
+fn fragment0(@location(52) a0: vec4<f32>, @location(25) a1: vec4<i32>, @location(15) a2: u32, @location(5) a3: vec3<u32>, a4: S6, @location(24) a5: f16, @location(39) a6: vec2<i32>, @location(47) a7: vec2<i32>, @builtin(sample_mask) a8: u32, @location(11) a9: vec2<i32>, @location(56) a10: vec3<i32>, @location(8) a11: f32, @location(3) a12: u32, @builtin(sample_index) a13: u32, @location(44) a14: vec4<f16>, @builtin(position) a15: vec4<f32>, @builtin(front_facing) a16: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(17) f73: vec2<f16>,
+@builtin(position) f74: vec4<f32>,
+@location(44) f75: vec4<f16>,
+@location(39) f76: vec2<i32>,
+@location(20) f77: vec4<f32>,
+@location(5) f78: vec3<u32>,
+@location(47) f79: vec2<i32>,
+@location(11) f80: vec2<i32>,
+@location(25) f81: vec4<i32>,
+@location(8) f82: f32,
+@location(45) f83: f32,
+@location(3) f84: u32,
+@location(24) f85: f16,
+@location(6) f86: vec2<f16>,
+@location(15) f87: u32,
+@location(52) f88: vec4<f32>,
+@location(56) f89: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(1) a0: vec3<f16>, @location(11) a1: i32, @location(9) a2: vec3<i32>, @location(8) a3: vec2<f16>, @builtin(instance_index) a4: u32, @location(7) a5: vec3<f16>, @location(15) a6: vec4<f32>, @location(12) a7: vec3<f32>, @location(10) a8: f32, @location(14) a9: vec4<f32>, @location(16) a10: f32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroupLayout16 = device0.createBindGroupLayout(
+{
+label: '\ue16f\ub410\u1238\u0fa8\u{1fea5}\u0da8',
+entries: [
+{
+binding: 2489,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '1d' },
+},
+{
+binding: 1723,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+let bindGroupLayout17 = pipeline6.getBindGroupLayout(4);
+let querySet36 = device0.createQuerySet(
+{
+label: '\u0ed9\ud05f\ue52f',
+type: 'occlusion',
+count: 4032,
+}
+);
+let textureView37 = texture21.createView(
+{
+label: '\uc185\u0965\ue70a',
+format: 'rg16sint',
+mipLevelCount: 7,
+}
+);
+try {
+renderPassEncoder13.setBindGroup(
+7,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.setViewport(
+0.4151,
+0.4773,
+0.1009,
+0.4534,
+0.4160,
+0.7338
+);
+} catch {}
+let bindGroupLayout18 = device0.createBindGroupLayout(
+{
+label: '\u5d97\u00a0\u067a\u0421\u057d',
+entries: [
+{
+binding: 397,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 2965,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 3233,
+visibility: 0,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let bindGroup19 = device0.createBindGroup({
+label: '\u8b35\uf1f5\u{1fb2f}',
+layout: bindGroupLayout8,
+entries: [
+{
+binding: 306,
+resource: sampler33
+}
+],
+});
+let renderBundleEncoder33 = device0.createRenderBundleEncoder(
+{
+label: '\u9e2a\ucf39\u5b83',
+colorFormats: [
+'r16float'
+],
+sampleCount: 132,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder3.setPipeline(
+pipeline9
+);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(
+7,
+bindGroup8
+);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant(
+{
+r: 345.5,
+g: 37.26,
+b: 232.9,
+a: -892.4,
+}
+);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+let promise14 = device0.queue.onSubmittedWorkDone();
+let pipeline15 = device0.createRenderPipeline(
+{
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 53048,
+shaderLocation: 3,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 55468,
+shaderLocation: 13,
+},
+{
+format: 'uint32x2',
+offset: 37076,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x4',
+offset: 34244,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x2',
+offset: 60148,
+shaderLocation: 5,
+},
+{
+format: 'float32x4',
+offset: 16960,
+shaderLocation: 14,
+},
+{
+format: 'float32x4',
+offset: 59044,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 17404,
+attributes: [
+{
+format: 'float16x2',
+offset: 7024,
+shaderLocation: 9,
+},
+{
+format: 'uint32',
+offset: 10832,
+shaderLocation: 8,
+},
+{
+format: 'uint16x2',
+offset: 276,
+shaderLocation: 16,
+},
+{
+format: 'float32',
+offset: 12540,
+shaderLocation: 6,
+},
+{
+format: 'uint16x4',
+offset: 15812,
+shaderLocation: 2,
+},
+{
+format: 'sint32x2',
+offset: 6384,
+shaderLocation: 4,
+},
+{
+format: 'sint32x4',
+offset: 9588,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 33372,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 31852,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 57732,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 55400,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 38190,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 29804,
+attributes: [
+{
+format: 'uint32x4',
+offset: 22660,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less',
+failOp: 'invert',
+depthFailOp: 'decrement-clamp',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'not-equal',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilWriteMask: 2393,
+depthBiasClamp: 58,
+},
+}
+);
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+gc();
+let texture41 = device0.createTexture(
+{
+label: '\u0d7b\u237d\u73f0\u23fd',
+size: {width: 5462, height: 1, depthOrArrayLayers: 52},
+mipLevelCount: 5,
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+}
+);
+let sampler36 = device0.createSampler(
+{
+label: '\u{1f9dc}\u{1fd13}\u{1f6a6}\u9455\uc55f\ub2ff',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 64.676,
+maxAnisotropy: 19,
+}
+);
+try {
+renderPassEncoder15.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+115,
+0,
+2,
+0
+);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(
+buffer2,
+'uint32',
+12848
+);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(
+7,
+bindGroup11
+);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(
+5,
+bindGroup17,
+new Uint32Array(6675),
+6500,
+0
+);
+} catch {}
+try {
+await buffer8.mapAsync(
+GPUMapMode.WRITE,
+2328,
+68
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let adapter2 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let promise15 = adapter2.requestAdapterInfo();
+let buffer15 = device0.createBuffer(
+{
+label: '\u969e\ud492\u4ce5\u0828',
+size: 41770,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let renderBundleEncoder34 = device0.createRenderBundleEncoder(
+{
+label: '\u9896\u020c\ud958\u1461\u65b9\u0d82\uccd0',
+colorFormats: [
+'r16uint',
+undefined,
+'rgba32sint',
+'r16float',
+'rgba16uint',
+'rgba8sint'
+],
+sampleCount: 893,
+}
+);
+let renderBundle26 = renderBundleEncoder21.finish();
+try {
+renderPassEncoder16.beginOcclusionQuery(
+80
+);
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(
+1417,
+1,
+1593,
+0
+);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+11,
+buffer11,
+39172
+);
+} catch {}
+try {
+renderPassEncoder16.insertDebugMarker(
+'\u{1feed}'
+);
+} catch {}
+document.body.prepend('\ucba8\u{1f62d}\u011d');
+let img5 = await imageWithData(16, 108, '#d972d29b', '#f43a89bb');
+try {
+renderBundleEncoder26.setBindGroup(
+7,
+bindGroup12
+);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(
+5,
+bindGroup19,
+new Uint32Array(658),
+517,
+0
+);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(
+8,
+buffer6
+);
+} catch {}
+try {
+await promise14;
+} catch {}
+document.body.prepend('\u{1f64a}\u1504\u0d0f\u{1f691}\u006c\udfd9\u82b8\u{1ff17}\u0618');
+let imageBitmap6 = await createImageBitmap(offscreenCanvas5);
+try {
+renderPassEncoder14.beginOcclusionQuery(
+48
+);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(
+7,
+bindGroup19,
+new Uint32Array(1823),
+662,
+0
+);
+} catch {}
+let commandEncoder33 = device0.createCommandEncoder(
+{
+}
+);
+let texture42 = device0.createTexture(
+{
+label: '\u6f68\u5768\u8745\ua9ee\u0d6e\u075e\u{1fd8d}\u{1ffbb}\u{1fb58}\uc3fa\u362e',
+size: [8356],
+dimension: '1d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'r8uint'
+],
+}
+);
+let textureView38 = texture12.createView(
+{
+label: '\u251f\ufc76\u{1fc6b}',
+baseMipLevel: 4,
+}
+);
+let renderPassEncoder17 = commandEncoder33.beginRenderPass(
+{
+label: '\u{1fd01}\u073d',
+colorAttachments: [
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthClearValue: -4.6503063201369255,
+depthReadOnly: true,
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet20,
+maxDrawCount: 400248,
+}
+);
+let renderBundleEncoder35 = device0.createRenderBundleEncoder(
+{
+label: '\u0405\u0d1d\u0b49\u3c77\ua0d9\uda44',
+colorFormats: [
+'rgba8unorm-srgb',
+'r32uint',
+'rgba32sint',
+undefined,
+'rgba16float',
+'rgb10a2unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 551,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle27 = renderBundleEncoder30.finish(
+{
+label: '\u0638\u0154\u0b45'
+}
+);
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(
+2896,
+0,
+50,
+1
+);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(
+661
+);
+} catch {}
+try {
+renderPassEncoder17.setViewport(
+1124.3,
+0.1123,
+1304.5,
+0.3353,
+0.7259,
+0.7901
+);
+} catch {}
+try {
+gpuCanvasContext3.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture9,
+  mipLevel: 0,
+  origin: { x: 388, y: 0, z: 232 },
+  aspect: 'all',
+},
+new Int32Array(arrayBuffer2),
+/* required buffer size: 40152772 */{
+offset: 792,
+bytesPerRow: 3682,
+rowsPerImage: 116,
+},
+{width: 863, height: 1, depthOrArrayLayers: 95}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 943, height: 1, depthOrArrayLayers: 1276}
+*/
+{
+  source: img2,
+  origin: { x: 53, y: 165 },
+  flipY: true,
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: { x: 106, y: 0, z: 516 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 224, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend('\u3131\ud1be\u{1fab0}');
+let texture43 = device0.createTexture(
+{
+label: '\u97db\u929b\u4208\u0997\u967b',
+size: {width: 5284},
+dimension: '1d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb',
+'bgra8unorm',
+'bgra8unorm'
+],
+}
+);
+try {
+renderPassEncoder14.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant(
+{
+r: -110.9,
+g: -64.97,
+b: 294.3,
+a: 395.1,
+}
+);
+} catch {}
+try {
+renderPassEncoder4.setViewport(
+1.227,
+39.13,
+0.7827,
+14.81,
+0.7357,
+0.7791
+);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(
+4,
+bindGroup11,
+new Uint32Array(5527),
+465,
+0
+);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(
+buffer15,
+'uint16',
+33970,
+2796
+);
+} catch {}
+let gpuCanvasContext7 = canvas8.getContext('webgpu');
+try {
+computePassEncoder14.setBindGroup(
+7,
+bindGroup13
+);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(
+7,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder16.beginOcclusionQuery(
+56
+);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(
+2,
+18,
+1,
+0
+);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(
+buffer15,
+'uint32',
+4048,
+13420
+);
+} catch {}
+let commandEncoder34 = device0.createCommandEncoder(
+{
+label: '\ub9ea\u{1f64f}\u{1fd11}\u03f8\u7f55\u{1f751}\uc0a9\u943d\u{1f87d}\u0a7e',
+}
+);
+let texture44 = device0.createTexture(
+{
+label: '\u{1f951}\u0289\u060f\u7749\u0483\ua991\u039e\u{1f9ee}\u0213',
+size: [20, 148, 93],
+mipLevelCount: 8,
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg11b10ufloat',
+'rg11b10ufloat',
+'rg11b10ufloat'
+],
+}
+);
+let renderBundle28 = renderBundleEncoder12.finish(
+{
+
+}
+);
+try {
+renderPassEncoder10.setBindGroup(
+0,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant(
+{
+r: -102.6,
+g: 685.0,
+b: 500.2,
+a: -279.1,
+}
+);
+} catch {}
+try {
+renderPassEncoder13.setViewport(
+78.85,
+0.5874,
+2651.6,
+0.3957,
+0.2410,
+0.6391
+);
+} catch {}
+try {
+commandEncoder34.clearBuffer(
+buffer10,
+20848,
+3648
+);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder34.resolveQuerySet(
+querySet36,
+2474,
+802,
+buffer9,
+13568
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture40,
+  mipLevel: 7,
+  origin: { x: 2, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Int8Array(new ArrayBuffer(16)),
+/* required buffer size: 195 */{
+offset: 195,
+},
+{width: 9, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let gpuCanvasContext8 = canvas6.getContext('webgpu');
+try {
+await promise15;
+} catch {}
+let adapter3 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let shaderModule4 = device0.createShaderModule(
+{
+code: `@group(0) @binding(1592)
+var<storage, read_write> field1: array<u32>;
+
+@compute @workgroup_size(3, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(2) f0: u32,
+@builtin(frag_depth) f1: f32,
+@location(0) f2: i32,
+@location(4) f3: i32,
+@location(1) f4: u32,
+@location(5) f5: vec2<f32>,
+@location(7) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S7 {
+@location(4) f0: u32,
+@location(16) f1: vec2<u32>,
+@location(8) f2: vec2<f16>,
+@location(1) f3: vec3<f32>,
+@location(0) f4: vec2<i32>,
+@location(7) f5: f16
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec2<f32>, @location(6) a1: vec2<u32>, @location(2) a2: vec2<u32>, a3: S7, @location(15) a4: i32, @location(13) a5: vec3<f32>, @location(14) a6: vec4<i32>, @location(12) a7: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder35 = device0.createCommandEncoder(
+{
+label: '\u07a7\u0d7d\uecba\u{1f8b9}\u0b03\u{1f9b1}',
+}
+);
+let commandBuffer3 = commandEncoder35.finish(
+{
+}
+);
+let textureView39 = texture12.createView(
+{
+label: '\ub4e0\ufbaf\u9a9e\u{1faa5}\u9519\u4cd3\ud02a\u8ad4\u{1f7f1}\u6d4a',
+dimension: '2d-array',
+aspect: 'all',
+baseMipLevel: 3,
+mipLevelCount: 1,
+}
+);
+try {
+await device0.popErrorScope();
+} catch {}
+let pipeline16 = device0.createComputePipeline(
+{
+label: '\u6657\u0fe7\u{1ff4a}\ue425\u{1fb6b}\u{1f901}\u358f\u0228',
+layout: 'auto',
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+},
+}
+);
+let bindGroupLayout19 = device0.createBindGroupLayout(
+{
+entries: [
+{
+binding: 1946,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '1d' },
+}
+],
+}
+);
+let commandEncoder36 = device0.createCommandEncoder();
+let texture45 = device0.createTexture(
+{
+label: '\u{1fc4f}\u05c9',
+size: [4602],
+dimension: '1d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8sint',
+'rg8sint'
+],
+}
+);
+let renderBundle29 = renderBundleEncoder7.finish();
+try {
+computePassEncoder6.setBindGroup(
+0,
+bindGroup10
+);
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant(
+{
+r: 390.4,
+g: -613.8,
+b: -207.1,
+a: 229.0,
+}
+);
+} catch {}
+try {
+commandEncoder34.copyTextureToBuffer(
+{
+  texture: texture7,
+  mipLevel: 7,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 30948 */
+offset: 30948,
+bytesPerRow: 0,
+rowsPerImage: 73,
+buffer: buffer11,
+},
+{width: 0, height: 0, depthOrArrayLayers: 5}
+);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder34.clearBuffer(
+buffer11,
+37364,
+4660
+);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+canvas4.height = 123;
+let video6 = await videoWithData();
+let querySet37 = device0.createQuerySet(
+{
+label: '\u0f9d\u{1fb52}\u{1fc2d}\ua62e',
+type: 'occlusion',
+count: 458,
+}
+);
+let textureView40 = texture9.createView(
+{
+baseMipLevel: 8,
+}
+);
+let computePassEncoder17 = commandEncoder34.beginComputePass();
+let renderBundleEncoder36 = device0.createRenderBundleEncoder(
+{
+label: '\u09a6\u614a\u{1f7fb}\u{1fc15}\u73af\u{1f76f}\u{1fe16}',
+colorFormats: [
+'rgba8unorm-srgb',
+'rgba8unorm-srgb'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 433,
+}
+);
+let sampler37 = device0.createSampler(
+{
+label: '\u0c98\u{1fc6d}\u3e4a\u{1fee1}\u0076',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 65.019,
+lodMaxClamp: 93.489,
+compare: 'not-equal',
+maxAnisotropy: 2,
+}
+);
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.setViewport(
+0.6480,
+0.4459,
+0.2065,
+0.3680,
+0.9454,
+0.9456
+);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline15);
+} catch {}
+document.body.append('\u48d5\u11f2\u{1f641}');
+let imageBitmap7 = await createImageBitmap(videoFrame7);
+let querySet38 = device0.createQuerySet(
+{
+label: '\u{1f834}\u{1f9f3}\u8179\ua63d\u4531\ue961\u{1f922}\uef52',
+type: 'occlusion',
+count: 1303,
+}
+);
+let textureView41 = texture36.createView(
+{
+label: '\u066f\u7ab7\uef1c\u0545\u059c\u03c0\uc876\u{1f78d}\u124a\udd5d\ub385',
+dimension: '3d',
+baseMipLevel: 2,
+}
+);
+let renderPassEncoder18 = commandEncoder36.beginRenderPass(
+{
+label: '\u0bc3\u{1f7f0}\u{1f808}\u045a\u119a\u046f\ufa67\u{1f905}\u62b0',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthClearValue: -4.062735801997728,
+depthLoadOp: 'load',
+depthStoreOp: 'discard',
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet38,
+maxDrawCount: 13160,
+}
+);
+try {
+computePassEncoder3.setPipeline(
+pipeline14
+);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(
+7,
+bindGroup5,
+new Uint32Array(8373),
+539,
+0
+);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(
+3,
+bindGroup0
+);
+} catch {}
+let arrayBuffer9 = buffer14.getMappedRange(
+0,
+11064
+);
+let renderBundle30 = renderBundleEncoder27.finish();
+try {
+renderPassEncoder9.setStencilReference(
+2321
+);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(
+9,
+buffer4,
+9420
+);
+} catch {}
+let pipeline17 = await device0.createRenderPipelineAsync(
+{
+label: '\ud664\ub938\u0f35\u7bbc\u0c17\u0e3f\u5287',
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 59904,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 43844,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x2',
+offset: 51870,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 38100,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32',
+offset: 6112,
+shaderLocation: 5,
+},
+{
+format: 'sint32x3',
+offset: 23616,
+shaderLocation: 1,
+},
+{
+format: 'uint32',
+offset: 33732,
+shaderLocation: 6,
+},
+{
+format: 'float32x4',
+offset: 8760,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x2',
+offset: 31180,
+shaderLocation: 12,
+},
+{
+format: 'uint16x2',
+offset: 25452,
+shaderLocation: 2,
+},
+{
+format: 'sint8x2',
+offset: 20010,
+shaderLocation: 3,
+},
+{
+format: 'float32x4',
+offset: 9108,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 52560,
+attributes: [
+{
+format: 'float16x2',
+offset: 31272,
+shaderLocation: 9,
+},
+{
+format: 'float16x4',
+offset: 23240,
+shaderLocation: 4,
+},
+{
+format: 'uint8x2',
+offset: 46264,
+shaderLocation: 14,
+},
+{
+format: 'float16x4',
+offset: 44040,
+shaderLocation: 0,
+},
+{
+format: 'float16x2',
+offset: 34124,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 37392,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 5312,
+shaderLocation: 8,
+}
+],
+}
+]
+},
+multisample: {
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16sint',
+},
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+}
+);
+document.body.prepend('\u{1f6f5}\u{1f7ac}\u62fb\u05ac\u0294\ueb3a\u51ec\ud195\u0a32\u{1f98a}');
+let renderBundleEncoder37 = device0.createRenderBundleEncoder(
+{
+label: '\u5eea\u096c',
+colorFormats: [
+'r32sint',
+'rgb10a2unorm'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 977,
+stencilReadOnly: true,
+}
+);
+let sampler38 = device0.createSampler(
+{
+label: '\uc25d\u53c8\u{1fe1f}\u{1fe75}\ubfa0\u06f1\u61aa\u8813\u5af5\u2657',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 92.045,
+}
+);
+try {
+computePassEncoder16.setPipeline(
+pipeline14
+);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+0.7762,
+41.68,
+1.568,
+7.080,
+0.9791,
+0.9889
+);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(
+buffer1,
+80360
+);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline15);
+} catch {}
+let renderBundle31 = renderBundleEncoder18.finish(
+{
+
+}
+);
+try {
+renderPassEncoder15.setBindGroup(
+1,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(
+64
+);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant(
+{
+r: 425.3,
+g: 279.7,
+b: 456.9,
+a: -515.3,
+}
+);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(
+buffer3,
+37256
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+6160,
+new DataView(new ArrayBuffer(13555)),
+13099,
+84
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 943, height: 1, depthOrArrayLayers: 1276}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 3, y: 14 },
+  flipY: false,
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: { x: 691, y: 0, z: 188 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 4, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let imageData8 = new ImageData(192, 232);
+let bindGroupLayout20 = pipeline12.getBindGroupLayout(5);
+let textureView42 = texture18.createView(
+{
+label: '\u0a4b\u4981\u0660\u0740\u08ef\u{1fbae}\u0614\u58ca\u2f42\u06ff',
+baseMipLevel: 2,
+}
+);
+let sampler39 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 58.057,
+lodMaxClamp: 88.088,
+}
+);
+try {
+renderPassEncoder18.beginOcclusionQuery(
+64
+);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(
+1102
+);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(
+buffer6,
+395896
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 734, height: 1, depthOrArrayLayers: 157}
+*/
+{
+  source: canvas3,
+  origin: { x: 23, y: 86 },
+  flipY: false,
+},
+{
+  texture: texture31,
+  mipLevel: 0,
+  origin: { x: 202, y: 1, z: 68 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 275, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline18 = device0.createRenderPipeline(
+{
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 30292,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x2',
+offset: 28304,
+shaderLocation: 2,
+},
+{
+format: 'sint32x2',
+offset: 23956,
+shaderLocation: 3,
+},
+{
+format: 'uint32x2',
+offset: 18564,
+shaderLocation: 6,
+},
+{
+format: 'sint16x4',
+offset: 23528,
+shaderLocation: 13,
+},
+{
+format: 'snorm16x2',
+offset: 18072,
+shaderLocation: 14,
+},
+{
+format: 'sint8x4',
+offset: 28296,
+shaderLocation: 15,
+},
+{
+format: 'float16x2',
+offset: 25880,
+shaderLocation: 11,
+},
+{
+format: 'uint32',
+offset: 10740,
+shaderLocation: 7,
+},
+{
+format: 'uint8x2',
+offset: 10866,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 1368,
+attributes: [
+{
+format: 'unorm8x2',
+offset: 1038,
+shaderLocation: 0,
+},
+{
+format: 'uint8x4',
+offset: 1212,
+shaderLocation: 1,
+},
+{
+format: 'uint8x2',
+offset: 942,
+shaderLocation: 8,
+},
+{
+format: 'uint8x2',
+offset: 858,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 50824,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 19960,
+shaderLocation: 9,
+},
+{
+format: 'uint16x2',
+offset: 49364,
+shaderLocation: 4,
+},
+{
+format: 'float16x2',
+offset: 16472,
+shaderLocation: 10,
+},
+{
+format: 'sint8x4',
+offset: 41868,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'always',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 974,
+depthBias: 39,
+depthBiasSlopeScale: 23,
+depthBiasClamp: 11,
+},
+}
+);
+gc();
+document.body.append('\u0e85\u01a2\u6f23\u{1fd34}\ue47f\u0e46\u{1fbad}\u013e\u{1fb3f}\uc59a\u0d8e');
+let imageBitmap8 = await createImageBitmap(img3);
+try {
+device0.label = '\u2991\u{1ffa5}\ucc06\u58a1\ufda3\u3fa8';
+} catch {}
+let textureView43 = texture13.createView(
+{
+aspect: 'all',
+baseArrayLayer: 0,
+}
+);
+try {
+computePassEncoder4.setBindGroup(
+0,
+bindGroup8
+);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer6,
+7680
+);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(
+buffer15,
+'uint32',
+34560,
+1411
+);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(
+6,
+buffer9
+);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(
+buffer4,
+'uint16',
+38542,
+10231
+);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(
+1,
+buffer4,
+2680,
+24104
+);
+} catch {}
+let arrayBuffer10 = buffer0.getMappedRange(
+18240,
+3128
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture9,
+  mipLevel: 4,
+  origin: { x: 52, y: 0, z: 15 },
+  aspect: 'all',
+},
+arrayBuffer3,
+/* required buffer size: 529318 */{
+offset: 320,
+bytesPerRow: 289,
+rowsPerImage: 183,
+},
+{width: 32, height: 1, depthOrArrayLayers: 11}
+);
+} catch {}
+let offscreenCanvas8 = new OffscreenCanvas(487, 503);
+let texture46 = device0.createTexture(
+{
+label: '\u{1fcf2}\ufaa6\u{1f8ad}\u{1fb75}\u0994\ud23e\u4670',
+size: [442, 1, 1005],
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgba8snorm',
+'rgba8snorm'
+],
+}
+);
+try {
+renderPassEncoder10.beginOcclusionQuery(
+64
+);
+} catch {}
+try {
+renderPassEncoder13.setStencilReference(
+3499
+);
+} catch {}
+try {
+renderPassEncoder10.draw(
+40,
+40,
+56,
+8
+);
+} catch {}
+let arrayBuffer11 = buffer13.getMappedRange(
+23368
+);
+let pipeline19 = device0.createRenderPipeline(
+{
+label: '\u0cdb\ub987',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 19524,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 11676,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 9928,
+shaderLocation: 10,
+},
+{
+format: 'snorm8x4',
+offset: 1268,
+shaderLocation: 11,
+},
+{
+format: 'sint32x4',
+offset: 8680,
+shaderLocation: 15,
+},
+{
+format: 'sint16x2',
+offset: 8956,
+shaderLocation: 3,
+},
+{
+format: 'sint32x3',
+offset: 9980,
+shaderLocation: 13,
+},
+{
+format: 'uint8x2',
+offset: 7456,
+shaderLocation: 1,
+},
+{
+format: 'uint16x4',
+offset: 3000,
+shaderLocation: 12,
+},
+{
+format: 'uint8x2',
+offset: 9316,
+shaderLocation: 6,
+},
+{
+format: 'uint32x3',
+offset: 4204,
+shaderLocation: 5,
+},
+{
+format: 'unorm16x2',
+offset: 8316,
+shaderLocation: 14,
+},
+{
+format: 'uint8x2',
+offset: 9176,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x4',
+offset: 4796,
+shaderLocation: 0,
+},
+{
+format: 'uint32x2',
+offset: 1748,
+shaderLocation: 4,
+},
+{
+format: 'uint32x2',
+offset: 5792,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 45248,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 456,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x3',
+offset: 10656,
+shaderLocation: 16,
+},
+{
+format: 'uint8x4',
+offset: 35980,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+passOp: 'invert',
+},
+stencilReadMask: 153,
+stencilWriteMask: 3265,
+depthBiasSlopeScale: 38,
+depthBiasClamp: 39,
+},
+}
+);
+let videoFrame10 = new VideoFrame(videoFrame9, {timestamp: 0});
+try {
+offscreenCanvas8.getContext('2d');
+} catch {}
+let querySet39 = device0.createQuerySet(
+{
+label: '\u06ee\u1ac0\ua9ec\u{1f68e}\u03a6\u0a02\uf0d9\u0113\u079a\u{1fcd4}\u2deb',
+type: 'occlusion',
+count: 2851,
+}
+);
+let sampler40 = device0.createSampler(
+{
+label: '\u{1ff0b}\u82fd\u8699\u055c\uff7d\ub644\uafb1',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 57.196,
+lodMaxClamp: 75.086,
+maxAnisotropy: 11,
+}
+);
+try {
+computePassEncoder15.setBindGroup(
+2,
+bindGroup15,
+new Uint32Array(9109),
+3496,
+0
+);
+} catch {}
+try {
+computePassEncoder17.setPipeline(
+pipeline1
+);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+85,
+1,
+24,
+0
+);
+} catch {}
+try {
+renderPassEncoder8.draw(
+32,
+8,
+80,
+8
+);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder15.pushDebugGroup(
+'\u0e27'
+);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer3,
+]);
+} catch {}
+let pipeline20 = device0.createComputePipeline(
+{
+layout: pipelineLayout1,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+},
+}
+);
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.append('\u3d6b\u368a\u8b1f\u7abb\u0c79\ue9e9\u0dfd\uf560\uba1e\u{1fd21}\u25b4');
+let bindGroup20 = device0.createBindGroup({
+label: '\u0512\u{1f812}\u{1f8ce}\u765e\u08db\u{1f70f}\ue494',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let textureView44 = texture27.createView(
+{
+label: '\u{1f728}\u04a4\ub407\u0c1c\u0cb7\u0547\u{1fee2}\u00d3\uab01\u0666\uc269',
+dimension: '2d-array',
+format: 'rgba8uint',
+}
+);
+let renderBundleEncoder38 = device0.createRenderBundleEncoder(
+{
+label: '\u7a07\u{1ffc8}\u0ef2\u0154',
+colorFormats: [
+'rg8uint',
+'rg16float',
+'r32uint',
+'r16float',
+'rgba8uint',
+'rg8unorm',
+'rgba8uint'
+],
+sampleCount: 540,
+stencilReadOnly: true,
+}
+);
+let sampler41 = device0.createSampler(
+{
+label: '\u{1ffd9}\u0a71\u{1f87d}\u8de5\u0e47\u7243\u{1fded}',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 8.958,
+lodMaxClamp: 81.974,
+}
+);
+try {
+computePassEncoder17.setBindGroup(
+5,
+bindGroup10
+);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(
+6,
+bindGroup5
+);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(
+64
+);
+} catch {}
+try {
+renderPassEncoder15.setBlendConstant(
+{
+r: -9.667,
+g: 80.91,
+b: -238.8,
+a: 187.9,
+}
+);
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(
+101,
+1,
+2753,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.draw(
+80
+);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(
+9,
+buffer9,
+29132,
+12585
+);
+} catch {}
+gc();
+try {
+renderPassEncoder16.setBindGroup(
+7,
+bindGroup5
+);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant(
+{
+r: -336.8,
+g: 271.9,
+b: -891.6,
+a: -629.6,
+}
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer12,
+58064
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 2,
+  origin: { x: 21, y: 0, z: 64 },
+  aspect: 'all',
+},
+new Float64Array(new ArrayBuffer(80)),
+/* required buffer size: 2583455 */{
+offset: 95,
+bytesPerRow: 598,
+rowsPerImage: 270,
+},
+{width: 103, height: 0, depthOrArrayLayers: 17}
+);
+} catch {}
+let canvas9 = document.createElement('canvas');
+let bindGroup21 = device0.createBindGroup({
+label: '\ua3ab\ufbe8\u8684\ue870\ueacd\u0b2e\u0644\ua3e8\uf64d',
+layout: bindGroupLayout8,
+entries: [
+{
+binding: 306,
+resource: sampler27
+}
+],
+});
+let texture47 = device0.createTexture(
+{
+label: '\ud5d6\u17ff\u765d\u{1fa32}\ued04',
+size: {width: 1532, height: 1, depthOrArrayLayers: 1339},
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+renderPassEncoder8.setViewport(
+0.3962,
+0.2779,
+0.4938,
+0.6342,
+0.1723,
+0.2345
+);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer15,
+'uint32',
+28504,
+11863
+);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(
+0,
+bindGroup0,
+new Uint32Array(1748),
+874,
+0
+);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(
+buffer12,
+'uint32',
+29280
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 367, height: 1, depthOrArrayLayers: 78}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 11 },
+  flipY: false,
+},
+{
+  texture: texture31,
+  mipLevel: 1,
+  origin: { x: 117, y: 1, z: 28 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 6, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend(video2);
+let bindGroup22 = device0.createBindGroup({
+label: '\u7bba\ubc75\u6367\udc19\u059c\u3dbf\u026d\u70fd\u5d6d\u84d0',
+layout: bindGroupLayout8,
+entries: [
+{
+binding: 306,
+resource: sampler33
+}
+],
+});
+let renderBundleEncoder39 = device0.createRenderBundleEncoder(
+{
+label: '\u0ef2\u{1fefb}\u0db9\u0f2e\u0d74',
+colorFormats: [
+'rg32float',
+'bgra8unorm',
+'r16sint',
+'r16uint',
+'rgba8sint'
+],
+sampleCount: 904,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler42 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 3.177,
+lodMaxClamp: 88.584,
+compare: 'less-equal',
+maxAnisotropy: 11,
+}
+);
+try {
+computePassEncoder4.setPipeline(
+pipeline14
+);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(
+8,
+bindGroup20,
+new Uint32Array(8145),
+3620,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant(
+{
+r: 847.7,
+g: 573.1,
+b: -672.8,
+a: -765.6,
+}
+);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+1004
+);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(
+buffer9,
+'uint32',
+18752,
+31544
+);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(
+4,
+buffer2,
+25288,
+74
+);
+} catch {}
+try {
+device0.pushErrorScope(
+'out-of-memory'
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 766, height: 1, depthOrArrayLayers: 669}
+*/
+{
+  source: offscreenCanvas6,
+  origin: { x: 331, y: 428 },
+  flipY: true,
+},
+{
+  texture: texture47,
+  mipLevel: 1,
+  origin: { x: 2, y: 0, z: 305 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 199, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline21 = device0.createRenderPipeline(
+{
+layout: pipelineLayout7,
+vertex: {
+module: shaderModule4,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 30368,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x3',
+offset: 9688,
+shaderLocation: 6,
+},
+{
+format: 'sint8x2',
+offset: 3022,
+shaderLocation: 0,
+},
+{
+format: 'sint32',
+offset: 3924,
+shaderLocation: 14,
+},
+{
+format: 'snorm16x2',
+offset: 148,
+shaderLocation: 1,
+},
+{
+format: 'sint8x4',
+offset: 23312,
+shaderLocation: 15,
+},
+{
+format: 'float32x2',
+offset: 23412,
+shaderLocation: 5,
+},
+{
+format: 'snorm8x4',
+offset: 24624,
+shaderLocation: 7,
+},
+{
+format: 'uint32x4',
+offset: 28416,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 41384,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 1764,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 1240,
+shaderLocation: 12,
+},
+{
+format: 'uint32x3',
+offset: 412,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 60004,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 46364,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 15868,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 22816,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 1124,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0xab8a075f,
+},
+fragment: {
+module: shaderModule4,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.GREEN,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.GREEN,
+},
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 489,
+stencilWriteMask: 1317,
+depthBias: 41,
+depthBiasSlopeScale: 10,
+depthBiasClamp: 11,
+},
+}
+);
+try {
+adapter0.label = '\u7686\u3a06\u{1fc4f}\uc785\u{1fedb}\u0b45\u{1fb8c}\u02f9\u6106\ubb2a';
+} catch {}
+let bindGroup23 = device0.createBindGroup({
+label: '\u2dc2\u{1fa76}\u1d6b\u07e8\ue55a\u486f\u728c',
+layout: bindGroupLayout17,
+entries: [
+
+],
+});
+let commandEncoder37 = device0.createCommandEncoder(
+{
+label: '\u0222\u0b67\u0156\u67db',
+}
+);
+let sampler43 = device0.createSampler(
+{
+addressModeV: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 68.233,
+lodMaxClamp: 90.161,
+}
+);
+try {
+computePassEncoder10.setPipeline(
+pipeline8
+);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(
+4,
+bindGroup6
+);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.draw(
+32,
+24,
+32,
+0
+);
+} catch {}
+try {
+commandEncoder37.copyBufferToBuffer(
+buffer12,
+15472,
+buffer9,
+45844,
+1912
+);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1532, height: 1, depthOrArrayLayers: 1339}
+*/
+{
+  source: img2,
+  origin: { x: 7, y: 10 },
+  flipY: true,
+},
+{
+  texture: texture47,
+  mipLevel: 0,
+  origin: { x: 985, y: 0, z: 472 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 197, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline22 = await device0.createRenderPipelineAsync(
+{
+label: '\u35af\u{1fe60}\u01ef\u0342\u0076\ued80\uc677\u675b\u2184\u064d\uc3b2',
+layout: pipelineLayout5,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 32020,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x4',
+offset: 25192,
+shaderLocation: 13,
+},
+{
+format: 'uint8x4',
+offset: 6096,
+shaderLocation: 5,
+},
+{
+format: 'sint32x4',
+offset: 16740,
+shaderLocation: 16,
+},
+{
+format: 'uint16x4',
+offset: 9632,
+shaderLocation: 4,
+},
+{
+format: 'float32x4',
+offset: 1248,
+shaderLocation: 11,
+},
+{
+format: 'uint32x4',
+offset: 15384,
+shaderLocation: 1,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 20816,
+shaderLocation: 14,
+},
+{
+format: 'uint16x2',
+offset: 19420,
+shaderLocation: 12,
+},
+{
+format: 'uint32',
+offset: 28916,
+shaderLocation: 8,
+},
+{
+format: 'uint32x2',
+offset: 18088,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x4',
+offset: 15936,
+shaderLocation: 10,
+},
+{
+format: 'uint8x4',
+offset: 13716,
+shaderLocation: 6,
+},
+{
+format: 'sint16x4',
+offset: 4748,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 11408,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 4756,
+shaderLocation: 9,
+},
+{
+format: 'float16x4',
+offset: 9572,
+shaderLocation: 0,
+},
+{
+format: 'sint32x4',
+offset: 6712,
+shaderLocation: 3,
+},
+{
+format: 'uint16x2',
+offset: 5528,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r8unorm',
+writeMask: 0,
+},
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'src',
+dstFactor: 'src'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'one',
+dstFactor: 'src-alpha'
+},
+},
+format: 'r8unorm',
+writeMask: 0,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+undefined,
+{
+format: 'rg8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'replace',
+depthFailOp: 'decrement-clamp',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2764,
+stencilWriteMask: 3833,
+depthBias: 90,
+depthBiasSlopeScale: 1,
+depthBiasClamp: 74,
+},
+}
+);
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let querySet40 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 2925,
+}
+);
+try {
+renderPassEncoder14.setScissorRect(
+2207,
+0,
+98,
+1
+);
+} catch {}
+try {
+commandEncoder37.copyBufferToBuffer(
+buffer12,
+33228,
+buffer10,
+20848,
+1996
+);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder37.clearBuffer(
+buffer2,
+8136,
+20260
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32uint',
+'bgra8unorm-srgb'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture28,
+  mipLevel: 1,
+  origin: { x: 33, y: 1, z: 238 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 15374694 */{
+offset: 764,
+bytesPerRow: 827,
+rowsPerImage: 143,
+},
+{width: 206, height: 0, depthOrArrayLayers: 131}
+);
+} catch {}
+let pipeline23 = device0.createComputePipeline(
+{
+label: '\ue39b\u9f7f\u0d51\u0a45',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+},
+}
+);
+let pipeline24 = await device0.createRenderPipelineAsync(
+{
+label: '\ud220\u2908\u{1f78b}\u0dc6\u464e\u0cd3\u2c71\u{1fef7}\u{1fa5c}',
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'unorm8x4',
+offset: 27304,
+shaderLocation: 15,
+},
+{
+format: 'sint16x4',
+offset: 39140,
+shaderLocation: 9,
+},
+{
+format: 'float32x2',
+offset: 53412,
+shaderLocation: 14,
+},
+{
+format: 'float16x2',
+offset: 37832,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 13896,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 7932,
+shaderLocation: 10,
+},
+{
+format: 'float16x2',
+offset: 3664,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 54112,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 17512,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 160,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 28,
+shaderLocation: 16,
+},
+{
+format: 'sint16x4',
+offset: 132,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 55816,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 37664,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule3,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+undefined,
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'rgba16uint',
+},
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'one-minus-dst-alpha',
+dstFactor: 'src'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'one-minus-dst',
+dstFactor: 'one-minus-src-alpha'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'one-minus-src',
+dstFactor: 'zero'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALL,
+},
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'less',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 1906,
+stencilWriteMask: 275,
+depthBiasSlopeScale: 87,
+},
+}
+);
+let imageData9 = new ImageData(32, 180);
+let querySet41 = device0.createQuerySet(
+{
+label: '\u0958\u{1fe73}\u{1fef4}\u049d\u0c1b\u86a6',
+type: 'occlusion',
+count: 3074,
+}
+);
+let computePassEncoder18 = commandEncoder37.beginComputePass(
+{
+
+}
+);
+try {
+computePassEncoder6.setBindGroup(
+5,
+bindGroup19
+);
+} catch {}
+try {
+computePassEncoder3.setPipeline(
+pipeline2
+);
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder17.setStencilReference(
+2534
+);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(
+buffer1,
+'uint32',
+1140,
+1826
+);
+} catch {}
+try {
+renderPassEncoder15.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+22112,
+new Int16Array(50014),
+8742,
+2668
+);
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let offscreenCanvas9 = new OffscreenCanvas(658, 934);
+let buffer16 = device0.createBuffer(
+{
+label: '\u{1f818}\uc05c\u01a1\u089b\u{1ff50}\u1080\u6f3f\u03ef\u8594\u08aa',
+size: 55278,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+}
+);
+try {
+computePassEncoder18.setPipeline(
+pipeline20
+);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(
+72,
+24,
+72,
+-696,
+24
+);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(
+3,
+buffer11
+);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(
+0,
+buffer4,
+18408,
+30163
+);
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 766, height: 1, depthOrArrayLayers: 669}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 226, y: 321 },
+  flipY: false,
+},
+{
+  texture: texture47,
+  mipLevel: 1,
+  origin: { x: 39, y: 0, z: 295 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 478, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await promise16;
+} catch {}
+let querySet42 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 330,
+}
+);
+let renderBundle32 = renderBundleEncoder33.finish(
+{
+label: '\u{1f84f}\u0c36\u{1f9d9}\ua90d\udbfd\u{1ff1f}\u044b\ub3ee\u0ee2\u8e13'
+}
+);
+try {
+computePassEncoder13.setBindGroup(
+5,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: 985.5,
+g: -895.0,
+b: -438.3,
+a: -609.5,
+}
+);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(
+2,
+39,
+1,
+5
+);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(
+buffer15,
+'uint16'
+);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(
+67,
+undefined,
+2262485192
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 367, height: 1, depthOrArrayLayers: 78}
+*/
+{
+  source: canvas2,
+  origin: { x: 11, y: 90 },
+  flipY: false,
+},
+{
+  texture: texture31,
+  mipLevel: 1,
+  origin: { x: 24, y: 1, z: 61 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 4, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\u6f0c\u745f\u9a5a\u{1f847}\u{1fb48}\u{1fc1e}');
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(
+6,
+bindGroup12
+);
+} catch {}
+let textureView45 = texture38.createView(
+{
+label: '\ub6fb\u6c83\u{1fc92}\u{1fcb4}\u{1fcb6}\u0305\u151f\u{1f915}\u{1f695}',
+baseMipLevel: 0,
+arrayLayerCount: 1,
+}
+);
+let renderBundleEncoder40 = device0.createRenderBundleEncoder(
+{
+label: '\u98ca\udb17\u03a4\u{1feab}\u29e4\ub034\u1ef0\u8a90\u813e\u0900',
+colorFormats: [
+'r8uint',
+undefined,
+undefined,
+'rgba16float'
+],
+sampleCount: 302,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler44 = device0.createSampler(
+{
+label: '\u3c3a\u3789\u5b06',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMaxClamp: 47.267,
+}
+);
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant(
+{
+r: 778.0,
+g: 718.5,
+b: -555.2,
+a: -350.4,
+}
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(
+buffer8,
+85200
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer13,
+340728
+);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(
+44,
+undefined,
+2439066992,
+537341674
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture31,
+  mipLevel: 3,
+  origin: { x: 30, y: 1, z: 11 },
+  aspect: 'all',
+},
+new Float32Array(arrayBuffer10),
+/* required buffer size: 503 */{
+offset: 503,
+rowsPerImage: 45,
+},
+{width: 16, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline25 = await device0.createComputePipelineAsync(
+{
+label: '\u0c31\u984c\u{1fdaa}\u6c21',
+layout: pipelineLayout6,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+offscreenCanvas6.height = 923;
+let shaderModule5 = device0.createShaderModule(
+{
+label: '\u065c\u03c3\u{1f6c6}\u{1f73d}',
+code: `@group(1) @binding(2081)
+var<storage, read_write> global1: array<u32>;
+@group(5) @binding(2976)
+var<storage, read_write> parameter2: array<u32>;
+
+@compute @workgroup_size(7, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(0) f0: i32,
+@location(2) f1: vec2<i32>,
+@location(5) f2: i32,
+@location(4) f3: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(54) a0: vec3<i32>, @location(2) a1: f32, @location(34) a2: vec4<u32>, @builtin(position) a3: vec4<f32>, @location(53) a4: vec4<u32>, @location(29) a5: vec4<f16>, @location(52) a6: vec2<i32>, @location(20) a7: i32, @location(16) a8: vec4<u32>, @location(57) a9: vec4<f16>, @location(59) a10: vec2<u32>, @location(19) a11: f16, @location(10) a12: vec4<i32>, @builtin(sample_mask) a13: u32, @location(32) a14: vec2<f32>, @builtin(front_facing) a15: bool, @location(25) a16: vec4<u32>, @location(6) a17: vec4<i32>, @location(18) a18: vec3<f32>, @location(5) a19: vec2<f16>, @builtin(sample_index) a20: u32, @location(49) a21: u32, @location(45) a22: vec3<i32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(19) f90: f16,
+@location(23) f91: vec2<f16>,
+@location(57) f92: vec4<f16>,
+@location(26) f93: vec3<i32>,
+@location(35) f94: vec4<u32>,
+@location(49) f95: u32,
+@location(25) f96: vec4<u32>,
+@location(43) f97: u32,
+@location(18) f98: vec3<f32>,
+@location(30) f99: vec2<i32>,
+@location(32) f100: vec2<f32>,
+@location(54) f101: vec3<i32>,
+@location(52) f102: vec2<i32>,
+@location(45) f103: vec3<i32>,
+@location(5) f104: vec2<f16>,
+@location(53) f105: vec4<u32>,
+@location(36) f106: vec2<f32>,
+@location(44) f107: f16,
+@location(15) f108: vec3<f32>,
+@location(6) f109: vec4<i32>,
+@location(2) f110: f32,
+@location(51) f111: vec3<f32>,
+@location(50) f112: vec4<f32>,
+@location(41) f113: vec2<f16>,
+@location(38) f114: f16,
+@location(34) f115: vec4<u32>,
+@location(16) f116: vec4<u32>,
+@location(29) f117: vec4<f16>,
+@location(17) f118: f16,
+@location(59) f119: vec2<u32>,
+@location(21) f120: f32,
+@location(0) f121: vec3<f16>,
+@location(20) f122: i32,
+@builtin(position) f123: vec4<f32>,
+@location(10) f124: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec2<f16>, @location(7) a1: f32, @location(15) a2: u32, @location(1) a3: vec4<f32>, @location(2) a4: vec2<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let textureView46 = texture21.createView(
+{
+label: '\u0d39\u77e0\u{1fbeb}\u55c0\u{1ff41}\u3cbf\u0fe5\u177a\u0c76\u8649\u0515',
+dimension: '3d',
+format: 'rg16sint',
+baseMipLevel: 1,
+mipLevelCount: 1,
+}
+);
+try {
+computePassEncoder13.setBindGroup(
+8,
+bindGroup21
+);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.draw(
+80,
+56,
+0,
+32
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer0,
+17288
+);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(
+buffer12,
+246080
+);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(
+buffer2,
+'uint16',
+30640,
+147
+);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(
+4,
+buffer11,
+27080,
+12706
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 367, height: 1, depthOrArrayLayers: 78}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 166, y: 141 },
+  flipY: false,
+},
+{
+  texture: texture31,
+  mipLevel: 1,
+  origin: { x: 291, y: 0, z: 38 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 10, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let adapter4 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let img6 = await imageWithData(16, 196, '#7eb4c458', '#4af46308');
+try {
+await adapter2.requestAdapterInfo();
+} catch {}
+let shaderModule6 = device0.createShaderModule(
+{
+code: `@group(5) @binding(3073)
+var<storage, read_write> function1: array<u32>;
+@group(3) @binding(1864)
+var<storage, read_write> local0: array<u32>;
+
+@compute @workgroup_size(8, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(5) f0: vec4<u32>,
+@location(4) f1: f32,
+@location(7) f2: vec2<f32>,
+@location(1) f3: vec3<f32>,
+@location(6) f4: vec3<i32>,
+@location(0) f5: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S8 {
+@location(0) f0: f32,
+@location(8) f1: vec3<f32>,
+@location(7) f2: vec4<u32>,
+@builtin(instance_index) f3: u32,
+@location(6) f4: f32,
+@location(16) f5: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec3<f32>, @location(2) a1: u32, @location(10) a2: vec2<f32>, @location(13) a3: vec2<u32>, a4: S8) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+3,
+bindGroup22,
+new Uint32Array(8277),
+419,
+0
+);
+} catch {}
+try {
+computePassEncoder3.setPipeline(
+pipeline12
+);
+} catch {}
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant(
+{
+r: 58.01,
+g: 631.2,
+b: -700.0,
+a: 823.8,
+}
+);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(
+2574
+);
+} catch {}
+try {
+renderPassEncoder10.draw(
+16
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(
+buffer0,
+80496
+);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(
+7,
+buffer9,
+33384
+);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(
+3,
+bindGroup0
+);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let promise17 = navigator.gpu.requestAdapter(
+{
+}
+);
+let img7 = await imageWithData(258, 50, '#3b98ffc6', '#40d7740b');
+let imageData10 = new ImageData(124, 176);
+let commandEncoder38 = device0.createCommandEncoder(
+{
+}
+);
+let computePassEncoder19 = commandEncoder38.beginComputePass(
+{
+label: '\u080d\u0437\uad58\u0376\u{1fc24}'
+}
+);
+try {
+renderPassEncoder16.setBlendConstant(
+{
+r: -378.9,
+g: -426.3,
+b: -895.8,
+a: 821.8,
+}
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(
+64,
+40,
+72,
+480,
+16
+);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(
+buffer2,
+'uint32'
+);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(
+65,
+undefined,
+2128066866,
+1953899865
+);
+} catch {}
+gc();
+let texture48 = device0.createTexture(
+{
+size: {width: 246, height: 1, depthOrArrayLayers: 63},
+mipLevelCount: 1,
+dimension: '3d',
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32uint',
+'r32uint',
+'r32uint'
+],
+}
+);
+let renderBundle33 = renderBundleEncoder23.finish(
+{
+label: '\ua9f2\u5229\uc09e\u0957\u81c8\u0bcf'
+}
+);
+let sampler45 = device0.createSampler(
+{
+label: '\u07d4\u{1f9ca}\u{1f7f5}\u{1f779}\ua831',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'linear',
+lodMaxClamp: 59.250,
+}
+);
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(
+buffer15,
+'uint32',
+12736,
+26682
+);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+3,
+buffer15,
+36440,
+3030
+);
+} catch {}
+let arrayBuffer12 = buffer0.getMappedRange(
+21368,
+196
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture48,
+  mipLevel: 0,
+  origin: { x: 225, y: 0, z: 52 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(new ArrayBuffer(64)),
+/* required buffer size: 218167 */{
+offset: 235,
+bytesPerRow: 143,
+rowsPerImage: 254,
+},
+{width: 15, height: 0, depthOrArrayLayers: 7}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 235, height: 1, depthOrArrayLayers: 319}
+*/
+{
+  source: video2,
+  origin: { x: 2, y: 15 },
+  flipY: true,
+},
+{
+  texture: texture10,
+  mipLevel: 2,
+  origin: { x: 29, y: 0, z: 175 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 13, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline26 = device0.createComputePipeline(
+{
+label: '\ub6ca\u088a\u18f9\ubf40\u069d\uc192\u6397\uae95\u3e3e\u{1fdd9}',
+layout: pipelineLayout6,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let querySet43 = device0.createQuerySet(
+{
+label: '\u{1f84b}\u{1f779}\u{1f9cc}\u9c0a\u0652\u8514',
+type: 'occlusion',
+count: 647,
+}
+);
+let sampler46 = device0.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 4.588,
+}
+);
+try {
+computePassEncoder17.setPipeline(
+pipeline8
+);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer6,
+1304
+);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(
+buffer15,
+'uint16',
+4724,
+19749
+);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(
+1,
+buffer9
+);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+4,
+bindGroup12
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext8.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer11,
+5296,
+new Int16Array(25323),
+722,
+17960
+);
+} catch {}
+let pipeline27 = await device0.createRenderPipelineAsync(
+{
+label: '\u450b\u{1fd03}\u71d7\udedb\u5869\u0fb3\u02fa\u658a\ud0ae\u8e71\ue0ef',
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule5,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 60108,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 5440,
+shaderLocation: 15,
+},
+{
+format: 'unorm8x2',
+offset: 15480,
+shaderLocation: 1,
+},
+{
+format: 'snorm8x4',
+offset: 51364,
+shaderLocation: 5,
+},
+{
+format: 'uint8x4',
+offset: 53964,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x4',
+offset: 38604,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+},
+fragment: {
+module: shaderModule5,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+undefined,
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}
+],
+},
+}
+);
+try {
+offscreenCanvas9.getContext('2d');
+} catch {}
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(
+40
+);
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(
+246
+);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(
+buffer9,
+'uint32',
+31900,
+7582
+);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(
+buffer12,
+'uint16',
+51846,
+242
+);
+} catch {}
+try {
+commandEncoder4.copyBufferToBuffer(
+buffer8,
+848,
+buffer6,
+4380,
+1428
+);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+5552,
+new DataView(new ArrayBuffer(9885)),
+1326,
+100
+);
+} catch {}
+let pipeline28 = device0.createComputePipeline(
+{
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend('\u37b7\uecbd\u1e05\uc7e7\u00ce\u0180\u7413');
+let sampler47 = device0.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMaxClamp: 94.525,
+}
+);
+try {
+computePassEncoder13.setBindGroup(
+4,
+bindGroup10
+);
+} catch {}
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder18.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder14.setViewport(
+2469.8,
+0.7037,
+455.3,
+0.1777,
+0.4281,
+0.8754
+);
+} catch {}
+try {
+renderPassEncoder12.draw(
+24,
+80,
+24,
+24
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(
+56
+);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(
+0,
+buffer15,
+17932,
+16937
+);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(
+0,
+bindGroup5,
+new Uint32Array(1564),
+1303,
+0
+);
+} catch {}
+try {
+commandEncoder27.copyBufferToBuffer(
+buffer16,
+49208,
+buffer2,
+28404,
+1520
+);
+dissociateBuffer(device0, buffer16);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder4.clearBuffer(
+buffer1,
+2920,
+2024
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let bindGroup24 = device0.createBindGroup({
+label: '\u{1fda7}\u070b\u6c58\ud61f\u0378\u0dc2\u{1fbc1}\u0a80\u1b9f\u9eb6\u56c7',
+layout: bindGroupLayout5,
+entries: [
+{
+binding: 2976,
+resource: {
+buffer: buffer7,
+offset: 3968,
+}
+}
+],
+});
+let commandEncoder39 = device0.createCommandEncoder(
+{
+label: '\u{1f6de}\u{1fe40}\u{1faa3}',
+}
+);
+try {
+computePassEncoder11.setBindGroup(
+8,
+bindGroup10
+);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(
+0
+);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(
+2,
+bindGroup16
+);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(
+5,
+buffer11,
+852,
+10123
+);
+} catch {}
+try {
+commandEncoder4.copyBufferToBuffer(
+buffer0,
+10088,
+buffer2,
+11520,
+3828
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder39.resolveQuerySet(
+querySet7,
+49,
+380,
+buffer15,
+11264
+);
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 766, height: 1, depthOrArrayLayers: 669}
+*/
+{
+  source: imageData1,
+  origin: { x: 25, y: 123 },
+  flipY: false,
+},
+{
+  texture: texture47,
+  mipLevel: 1,
+  origin: { x: 448, y: 0, z: 161 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 81, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let gpuCanvasContext9 = canvas9.getContext('webgpu');
+document.body.prepend(img5);
+let querySet44 = device0.createQuerySet(
+{
+label: '\u08b6\u{1fa41}\u{1fc1b}\u05d6\uc97b\u0a9d\u3ea6',
+type: 'occlusion',
+count: 1225,
+}
+);
+try {
+renderPassEncoder16.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder8.draw(
+32
+);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(
+7,
+buffer4
+);
+} catch {}
+try {
+commandEncoder39.copyTextureToBuffer(
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'depth-only',
+},
+{
+/* bytesInLastRow: 12202 widthInBlocks: 6101 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 52684 */
+offset: 52684,
+bytesPerRow: 12544,
+rowsPerImage: 137,
+buffer: buffer4,
+},
+{width: 6101, height: 2, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder4.clearBuffer(
+buffer6
+);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder4.resolveQuerySet(
+querySet29,
+296,
+644,
+buffer15,
+18944
+);
+} catch {}
+try {
+gpuCanvasContext5.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8snorm',
+'bgra8unorm',
+'rg32sint'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let imageBitmap9 = await createImageBitmap(img7);
+let videoFrame11 = new VideoFrame(img2, {timestamp: 0});
+let bindGroup25 = device0.createBindGroup({
+label: '\u{1fa39}\u0ae1\u1a78\u{1f9da}\u0612',
+layout: bindGroupLayout5,
+entries: [
+{
+binding: 2976,
+resource: {
+buffer: buffer9,
+offset: 24192,
+size: 16816,
+}
+}
+],
+});
+let querySet45 = device0.createQuerySet(
+{
+label: '\u0a7e\u100b\u5fdc\u1894\u{1f6ba}\u{1f98a}\u6d3d',
+type: 'occlusion',
+count: 3009,
+}
+);
+let commandBuffer4 = commandEncoder4.finish();
+let renderBundle34 = renderBundleEncoder28.finish(
+{
+label: '\uc228\ub6d8\u0847\u08cd\u66fe\u0679\u5aa5\u355e\u624d\u8bd4\u27b3'
+}
+);
+try {
+computePassEncoder10.setPipeline(
+pipeline25
+);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(
+5,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder3.setViewport(
+1.296,
+31.06,
+1.407,
+10.09,
+0.9665,
+0.9808
+);
+} catch {}
+try {
+renderPassEncoder12.draw(
+72,
+24
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(
+64,
+40,
+8,
+-800,
+8
+);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(
+6,
+bindGroup12
+);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(
+0,
+buffer11,
+28736
+);
+} catch {}
+try {
+commandEncoder27.copyBufferToBuffer(
+buffer12,
+52944,
+buffer6,
+7100,
+120
+);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder27.clearBuffer(
+buffer1,
+348,
+1760
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+renderBundleEncoder36.pushDebugGroup(
+'\u278a'
+);
+} catch {}
+document.body.append('\ude18\u0b4f');
+let querySet46 = device0.createQuerySet(
+{
+label: '\ub0cf\u{1fb36}\uf422\u8b02\u3e8a\u0a39\ub1e8\ubb4f\u{1fdca}\u0f8d\uf563',
+type: 'occlusion',
+count: 3485,
+}
+);
+let textureView47 = texture31.createView(
+{
+label: '\u{1fb32}\u3510\u4778\u0ed3\uc28f\u3ba1\ua5d8\u9c51\u1b85\u{1f755}\u09be',
+baseMipLevel: 3,
+}
+);
+let renderPassEncoder19 = commandEncoder27.beginRenderPass(
+{
+label: '\u{1fa6a}\u45bb\u81ae\u7a59\u{1f7a0}',
+colorAttachments: [
+
+],
+depthStencilAttachment: {
+view: textureView34,
+depthClearValue: 0.2231747768028145,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+},
+maxDrawCount: 154856,
+}
+);
+let renderBundleEncoder41 = device0.createRenderBundleEncoder(
+{
+label: '\udae3\uc731\u0085\u{1fc56}\u07a5',
+colorFormats: [
+'rgba8sint',
+'rg16float',
+'rgba8unorm',
+'rg8unorm',
+undefined
+],
+sampleCount: 51,
+depthReadOnly: true,
+}
+);
+let sampler48 = device0.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 25.363,
+}
+);
+try {
+computePassEncoder11.setPipeline(
+pipeline20
+);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(
+0
+);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant(
+{
+r: -323.0,
+g: -774.1,
+b: 971.0,
+a: -181.4,
+}
+);
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(
+2271
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(
+24
+);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(
+5,
+bindGroup15,
+new Uint32Array(6293),
+4174,
+0
+);
+} catch {}
+try {
+renderBundleEncoder38.setVertexBuffer(
+4,
+buffer4,
+4076,
+38303
+);
+} catch {}
+try {
+commandEncoder39.copyTextureToTexture(
+{
+  texture: texture1,
+  mipLevel: 1,
+  origin: { x: 1, y: 61, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 2,
+  origin: { x: 1, y: 13, z: 0 },
+  aspect: 'all',
+},
+{width: 2, height: 22, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 58, height: 1, depthOrArrayLayers: 79}
+*/
+{
+  source: imageData8,
+  origin: { x: 131, y: 127 },
+  flipY: false,
+},
+{
+  texture: texture10,
+  mipLevel: 4,
+  origin: { x: 2, y: 0, z: 13 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 55, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+adapter2.label = '\uf695\u8195\u0d04\u0e9a\u919e\u{1fe39}\u0db6';
+} catch {}
+let shaderModule7 = device0.createShaderModule(
+{
+label: '\u0da1\u28ad\udc35\u0852\u0879\u98d3',
+code: `@group(1) @binding(1864)
+var<storage, read_write> local1: array<u32>;
+
+@compute @workgroup_size(8, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S10 {
+@location(12) f0: vec4<i32>,
+@location(52) f1: vec2<f32>,
+@location(47) f2: vec3<f16>
+}
+struct FragmentOutput0 {
+@location(6) f0: vec3<f32>,
+@location(7) f1: u32,
+@location(3) f2: u32,
+@location(2) f3: u32,
+@location(4) f4: vec4<f32>,
+@location(0) f5: u32,
+@location(5) f6: i32,
+@location(1) f7: vec2<f32>,
+@builtin(frag_depth) f8: f32,
+@builtin(sample_mask) f9: u32
+}
+
+@fragment
+fn fragment0(@location(41) a0: i32, @location(30) a1: vec4<i32>, @location(24) a2: vec2<i32>, @builtin(front_facing) a3: bool, @location(28) a4: i32, a5: S10, @builtin(sample_index) a6: u32, @location(20) a7: vec3<i32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S9 {
+@location(8) f0: vec2<i32>,
+@location(14) f1: vec2<i32>,
+@location(9) f2: vec3<f32>,
+@location(16) f3: vec2<u32>,
+@location(0) f4: f32,
+@location(6) f5: vec4<i32>,
+@location(7) f6: vec4<i32>,
+@location(11) f7: f16
+}
+struct VertexOutput0 {
+@location(20) f125: vec3<i32>,
+@location(28) f126: i32,
+@builtin(position) f127: vec4<f32>,
+@location(24) f128: vec2<i32>,
+@location(52) f129: vec2<f32>,
+@location(49) f130: vec4<f32>,
+@location(12) f131: vec4<i32>,
+@location(41) f132: i32,
+@location(30) f133: vec4<i32>,
+@location(47) f134: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec2<i32>, @location(10) a1: vec3<f16>, @location(1) a2: u32, a3: S9, @location(12) a4: vec4<u32>, @location(5) a5: i32, @location(15) a6: f32, @location(13) a7: vec3<f32>, @location(4) a8: vec3<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let commandEncoder40 = device0.createCommandEncoder(
+{
+label: '\uc7cd\u350d\u0b6a\ua039\ufd17\u{1f93e}\ucc65\ub6d4\u7173\u0348',
+}
+);
+let querySet47 = device0.createQuerySet(
+{
+label: '\u2dd0\u0f54\u0fd1\u{1f614}\u9105\u03ca\u4e55\u0a5a\uc386\u33b3\u{1ff9d}',
+type: 'occlusion',
+count: 4094,
+}
+);
+let renderBundleEncoder42 = device0.createRenderBundleEncoder(
+{
+label: '\u{1fbc2}\u0aa4\u0dc2\u0606\u0316\uffa5\u65b5\u{1fccb}',
+colorFormats: [
+'r32uint',
+'r16sint',
+'r8uint',
+undefined,
+'bgra8unorm',
+undefined,
+'rg8uint',
+'rgba16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 998,
+}
+);
+try {
+renderPassEncoder17.setBlendConstant(
+{
+r: 309.2,
+g: 195.5,
+b: 451.2,
+a: 778.7,
+}
+);
+} catch {}
+try {
+renderPassEncoder15.setScissorRect(
+2138,
+1,
+98,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.draw(
+56,
+0,
+56,
+32
+);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(
+buffer11,
+'uint32',
+15940
+);
+} catch {}
+try {
+commandEncoder39.copyBufferToBuffer(
+buffer2,
+7468,
+buffer4,
+5636,
+3280
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder40.resolveQuerySet(
+querySet13,
+420,
+67,
+buffer4,
+15616
+);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer4,
+]);
+} catch {}
+document.body.prepend('\u093d\u9da0\u5e17\u055c\udf0b');
+let bindGroupLayout21 = device0.createBindGroupLayout(
+{
+label: '\u47be\u329a\ua7a4\u57f8\u{1fe77}\ub6cc\u0030\u0a91\u41a9\u06b0\u263c',
+entries: [
+{
+binding: 997,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 1503,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '1d' },
+}
+],
+}
+);
+let renderPassEncoder20 = commandEncoder39.beginRenderPass(
+{
+label: '\u{1ff9d}\u0497\u{1ffaf}\u{1f701}\u{1fb14}\u0522\uae6f',
+colorAttachments: [
+
+],
+depthStencilAttachment: {
+view: textureView34,
+depthLoadOp: 'load',
+depthStoreOp: 'store',
+depthReadOnly: false,
+},
+occlusionQuerySet: querySet33,
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+6,
+bindGroup19,
+new Uint32Array(9038),
+6873,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(
+buffer2,
+'uint32',
+11244,
+11914
+);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(
+2,
+buffer4,
+30828,
+2183
+);
+} catch {}
+try {
+texture11.destroy();
+} catch {}
+try {
+commandEncoder40.resolveQuerySet(
+querySet24,
+257,
+281,
+buffer6,
+3072
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer9,
+1940,
+new BigUint64Array(43642),
+19171,
+3948
+);
+} catch {}
+let buffer17 = device0.createBuffer(
+{
+size: 61720,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+let computePassEncoder20 = commandEncoder40.beginComputePass(
+{
+label: '\u298f\u0620\u0255\u29c3\u8c0f\udac0'
+}
+);
+let renderBundle35 = renderBundleEncoder29.finish(
+{
+label: '\u31a6\u{1ff85}\u0481\uee1e\u08c3'
+}
+);
+try {
+computePassEncoder16.setBindGroup(
+0,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(
+8,
+buffer6,
+4744,
+2773
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 943, height: 1, depthOrArrayLayers: 1276}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 90, y: 308 },
+  flipY: false,
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: { x: 152, y: 1, z: 653 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 772, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline29 = await device0.createComputePipelineAsync(
+{
+label: '\ue75e\u8121\ud66c\u0ef0\u3446\u08d4\ua27c\ue9fb\uce46\u70ef\ua1b1',
+layout: 'auto',
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+gc();
+let promise19 = adapter3.requestDevice(
+{
+label: '\u0994\uca9f\u99ba\u{1fffe}\u67f9\u{1fa06}\u{1faec}\u50d3\u{1fa5b}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 9,
+maxColorAttachmentBytesPerSample: 39,
+maxVertexAttributes: 28,
+maxVertexBufferArrayStride: 11858,
+maxStorageTexturesPerShaderStage: 44,
+maxStorageBuffersPerShaderStage: 32,
+maxDynamicStorageBuffersPerPipelineLayout: 62756,
+maxBindingsPerBindGroup: 8934,
+maxTextureDimension1D: 15872,
+maxTextureDimension2D: 16139,
+maxVertexBuffers: 9,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 228345625,
+maxInterStageShaderVariables: 94,
+maxInterStageShaderComponents: 99,
+},
+}
+);
+let renderBundle36 = renderBundleEncoder37.finish(
+{
+
+}
+);
+try {
+computePassEncoder10.setBindGroup(
+4,
+bindGroup1,
+new Uint32Array(3956),
+3072,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder14.setViewport(
+1687.8,
+0.1438,
+1360.2,
+0.6796,
+0.08026,
+0.1659
+);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(
+3,
+buffer15,
+7060
+);
+} catch {}
+let pipeline30 = await device0.createComputePipelineAsync(
+{
+label: '\ufb46\u495d\u{1fe4f}\u5ef2',
+layout: pipelineLayout7,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let offscreenCanvas10 = new OffscreenCanvas(854, 636);
+try {
+offscreenCanvas10.getContext('webgpu');
+} catch {}
+let texture49 = device0.createTexture(
+{
+label: '\u03bd\u{1fcdc}\u9d4a\uffff\u{1fe18}\u{1fefc}\u0ebe\u04bd',
+size: {width: 155, height: 131, depthOrArrayLayers: 226},
+mipLevelCount: 7,
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+let textureView48 = texture37.createView(
+{
+dimension: '2d',
+baseMipLevel: 3,
+mipLevelCount: 1,
+}
+);
+try {
+renderPassEncoder14.setBindGroup(
+4,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+4384,
+new Float32Array(53483),
+9471,
+672
+);
+} catch {}
+let pipeline31 = await device0.createComputePipelineAsync(
+{
+label: '\u{1f636}\u0bf4\ub9f8\u8946\uf86c\u0587\u6de7\u{1fa98}',
+layout: pipelineLayout7,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+},
+}
+);
+document.body.append('\u94b3\u0591\u380c\u{1f704}\u0192');
+let bindGroupLayout22 = device0.createBindGroupLayout(
+{
+label: '\u0f0d\u080f\u0c8f\u291e\u{1fdac}\u0480\ube9e\ua079\u{1fffd}\uf261\u{1f79a}',
+entries: [
+
+],
+}
+);
+let bindGroup26 = device0.createBindGroup({
+layout: bindGroupLayout8,
+entries: [
+{
+binding: 306,
+resource: sampler24
+}
+],
+});
+let renderBundle37 = renderBundleEncoder31.finish(
+{
+label: '\u{1fa9b}\u{1fda0}'
+}
+);
+try {
+renderPassEncoder2.beginOcclusionQuery(
+0
+);
+} catch {}
+try {
+renderPassEncoder20.setStencilReference(
+1624
+);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(
+buffer15,
+'uint16',
+16994
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+1,
+buffer11
+);
+} catch {}
+try {
+buffer10.destroy();
+} catch {}
+try {
+renderBundleEncoder36.popDebugGroup();
+} catch {}
+document.body.append('\u{1fc31}\u9a69\u{1fc76}\u0d83\uaf4e\u0cba');
+let texture50 = device0.createTexture(
+{
+label: '\uc0d5\u0cf8\u0eec\u{1fc5e}\u{1fbd9}\u42ed\u{1fe18}\u09a1\u0a03\ud1c7',
+size: [2402],
+dimension: '1d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgba16sint',
+'rgba16sint'
+],
+}
+);
+let textureView49 = texture49.createView(
+{
+label: '\u2a1d\uefaa\u0dce\u0c22\u{1fadf}\u81ad\u7ee6\u0420',
+dimension: '2d',
+baseMipLevel: 2,
+mipLevelCount: 3,
+baseArrayLayer: 5,
+}
+);
+let renderBundleEncoder43 = device0.createRenderBundleEncoder(
+{
+label: '\u0cff\u{1fcc5}\u{1fee3}\u0966',
+colorFormats: [
+'r8sint',
+'r16float',
+'r8uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 898,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder20.setStencilReference(
+1886
+);
+} catch {}
+try {
+renderPassEncoder10.draw(
+56,
+40,
+64,
+8
+);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(
+72
+);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(
+0,
+bindGroup17,
+[]
+);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(
+3,
+buffer2,
+16892,
+3045
+);
+} catch {}
+let pipeline32 = await device0.createRenderPipelineAsync(
+{
+label: '\u0c66\u{1fb5a}\u5cba\u09d5\u781e\u39a5\u5796\ub44e\u0598',
+layout: 'auto',
+vertex: {
+module: shaderModule4,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 14092,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x4',
+offset: 10848,
+shaderLocation: 14,
+},
+{
+format: 'sint32x2',
+offset: 8856,
+shaderLocation: 0,
+},
+{
+format: 'snorm8x2',
+offset: 3156,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 32340,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x4',
+offset: 11108,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 17472,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 920,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x2',
+offset: 9372,
+shaderLocation: 8,
+},
+{
+format: 'float32x2',
+offset: 6512,
+shaderLocation: 13,
+},
+{
+format: 'uint8x2',
+offset: 4042,
+shaderLocation: 4,
+},
+{
+format: 'uint32',
+offset: 5672,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x2',
+offset: 13876,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 48796,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 30172,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 48440,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x4',
+offset: 33336,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 9632,
+attributes: [
+
+],
+},
+{
+arrayStride: 56564,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32',
+offset: 32168,
+shaderLocation: 12,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x7432233a,
+},
+fragment: {
+module: shaderModule4,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r16uint',
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+undefined,
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+},
+{
+format: 'rg32float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'zero',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 1995,
+stencilWriteMask: 780,
+depthBias: 50,
+depthBiasSlopeScale: 65,
+depthBiasClamp: 19,
+},
+}
+);
+let video7 = await videoWithData();
+let renderBundleEncoder44 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8unorm-srgb',
+'rgba32sint',
+'r16float',
+'rg32sint'
+],
+sampleCount: 187,
+depthReadOnly: true,
+}
+);
+let renderBundle38 = renderBundleEncoder4.finish(
+{
+label: '\ucb08\u08fb\u0bdf\u{1fc6e}\u07a4\u0fee'
+}
+);
+try {
+computePassEncoder16.setBindGroup(
+3,
+bindGroup5,
+new Uint32Array(8182),
+3166,
+0
+);
+} catch {}
+try {
+computePassEncoder10.setPipeline(
+pipeline9
+);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(
+12,
+1,
+103,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(
+buffer5,
+60840
+);
+} catch {}
+try {
+renderBundleEncoder3.insertDebugMarker(
+'\u{1f7f1}'
+);
+} catch {}
+let pipeline33 = device0.createComputePipeline(
+{
+label: '\u{1fe9f}\u{1fe84}\u{1f8cb}\uec3a\u{1f833}\u6678\ue27f\u{1f7d6}\ufe6a\u2eb0\u{1fe75}',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+},
+}
+);
+document.body.append('\u6482\uaf06');
+let textureView50 = texture19.createView(
+{
+label: '\u07b6\ubb52\u{1fa36}',
+dimension: 'cube-array',
+baseArrayLayer: 123,
+arrayLayerCount: 36,
+}
+);
+let sampler49 = device0.createSampler(
+{
+label: '\udb32\u5c07\u0fcc\u9f1d\u510a\u9d4f\u0e41',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 49.963,
+lodMaxClamp: 96.812,
+}
+);
+try {
+renderPassEncoder14.setBlendConstant(
+{
+r: 494.0,
+g: -980.0,
+b: -0.4451,
+a: -291.2,
+}
+);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(
+buffer13,
+20472
+);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(
+3,
+buffer15,
+38736,
+1694
+);
+} catch {}
+try {
+renderBundleEncoder35.insertDebugMarker(
+'\u{1f826}'
+);
+} catch {}
+try {
+await promise18;
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(
+0,
+bindGroup6
+);
+} catch {}
+try {
+renderPassEncoder8.draw(
+0,
+64,
+48
+);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(
+2,
+bindGroup9,
+new Uint32Array(5196),
+2624,
+0
+);
+} catch {}
+try {
+renderBundleEncoder32.setIndexBuffer(
+buffer1,
+'uint16',
+3796
+);
+} catch {}
+let pipeline34 = await device0.createComputePipelineAsync(
+{
+label: '\u0437\u5e9a\ufbf1\u00d1\ud15e\u9085\u7da2\ucfd3\u755e\u9abd\u{1faa2}',
+layout: pipelineLayout7,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline35 = device0.createRenderPipeline(
+{
+label: '\uc7b4\u09e3\u5f10\u{1f8a7}\u9854',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 49268,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32',
+offset: 23016,
+shaderLocation: 1,
+},
+{
+format: 'sint8x4',
+offset: 44004,
+shaderLocation: 15,
+},
+{
+format: 'float32x3',
+offset: 14460,
+shaderLocation: 0,
+},
+{
+format: 'snorm8x4',
+offset: 17800,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'sint8x2',
+offset: 17346,
+shaderLocation: 11,
+},
+{
+format: 'float32x2',
+offset: 18624,
+shaderLocation: 10,
+},
+{
+format: 'uint32x3',
+offset: 43484,
+shaderLocation: 16,
+},
+{
+format: 'uint32x2',
+offset: 26120,
+shaderLocation: 2,
+},
+{
+format: 'snorm8x2',
+offset: 25264,
+shaderLocation: 3,
+},
+{
+format: 'snorm8x4',
+offset: 2852,
+shaderLocation: 12,
+},
+{
+format: 'sint32x4',
+offset: 12312,
+shaderLocation: 4,
+},
+{
+format: 'uint32x4',
+offset: 37296,
+shaderLocation: 7,
+},
+{
+format: 'snorm8x2',
+offset: 59696,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 38068,
+attributes: [
+
+],
+},
+{
+arrayStride: 58836,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32',
+offset: 17992,
+shaderLocation: 5,
+},
+{
+format: 'float16x4',
+offset: 5816,
+shaderLocation: 6,
+},
+{
+format: 'unorm8x4',
+offset: 48416,
+shaderLocation: 9,
+},
+{
+format: 'uint8x2',
+offset: 21700,
+shaderLocation: 8,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x730002f6,
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALPHA,
+},
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'greater',
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilBack: {
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 88,
+depthBiasSlopeScale: 83,
+depthBiasClamp: 25,
+},
+}
+);
+let renderBundleEncoder45 = device0.createRenderBundleEncoder(
+{
+label: '\u02e8\uf786\uf7f6\u87f8\u{1f81d}\ued5a\u0a7c\u9e92\u5927\u5915\u0fc4',
+colorFormats: [
+'rgba32float',
+'rgba8unorm',
+'bgra8unorm',
+'rg8unorm',
+'r32float',
+'rg8uint',
+'r16sint'
+],
+sampleCount: 321,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(
+6,
+bindGroup17
+);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder15.setScissorRect(
+2065,
+1,
+609,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer9,
+14672
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 183, height: 1, depthOrArrayLayers: 39}
+*/
+{
+  source: imageBitmap4,
+  origin: { x: 64, y: 125 },
+  flipY: false,
+},
+{
+  texture: texture31,
+  mipLevel: 2,
+  origin: { x: 11, y: 0, z: 17 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 164, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let offscreenCanvas11 = new OffscreenCanvas(902, 666);
+let shaderModule8 = device0.createShaderModule(
+{
+code: `
+
+@compute @workgroup_size(1, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(0) f0: vec2<u32>,
+@location(6) f1: i32,
+@location(4) f2: vec2<f32>,
+@location(5) f3: vec3<f32>,
+@location(1) f4: vec4<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S11 {
+@location(12) f0: vec2<f16>,
+@location(14) f1: f16,
+@location(1) f2: f16,
+@location(2) f3: vec2<i32>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(10) a1: vec3<u32>, @location(6) a2: vec4<f16>, @location(4) a3: vec2<u32>, @builtin(vertex_index) a4: u32, @location(9) a5: vec2<f16>, @location(15) a6: vec4<f32>, @location(11) a7: vec4<f32>, @location(0) a8: f16, @location(7) a9: f32, @location(16) a10: vec3<u32>, @location(8) a11: vec3<i32>, @location(5) a12: vec4<f16>, @location(3) a13: vec3<f16>, @location(13) a14: vec4<i32>, a15: S11) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let computePassEncoder21 = commandEncoder6.beginComputePass(
+{
+label: '\u{1fff0}\u089f\u5faf'
+}
+);
+try {
+computePassEncoder19.setBindGroup(
+3,
+bindGroup20,
+new Uint32Array(3787),
+508,
+0
+);
+} catch {}
+try {
+computePassEncoder19.setPipeline(
+pipeline1
+);
+} catch {}
+try {
+renderPassEncoder17.beginOcclusionQuery(
+80
+);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant(
+{
+r: 893.5,
+g: 320.0,
+b: -644.9,
+a: 299.5,
+}
+);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+111
+);
+} catch {}
+try {
+renderPassEncoder8.draw(
+72,
+40,
+40,
+32
+);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(
+7,
+buffer15,
+17992,
+786
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer9,
+48568,
+new DataView(new ArrayBuffer(46659)),
+46045,
+76
+);
+} catch {}
+let bindGroupLayout23 = device0.createBindGroupLayout(
+{
+label: '\u4e8c\u07b7',
+entries: [
+{
+binding: 1144,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+},
+{
+binding: 16,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+}
+],
+}
+);
+let commandEncoder41 = device0.createCommandEncoder(
+{
+label: '\u9e89\u1844\u0e08\u07c0\ub206',
+}
+);
+let textureView51 = texture9.createView(
+{
+format: 'rg16uint',
+baseMipLevel: 9,
+}
+);
+let renderPassEncoder21 = commandEncoder41.beginRenderPass(
+{
+label: '\u7aa7\u2f3e\u1989\u04a0\u{1fcb3}\ucb6c\u{1f850}',
+colorAttachments: [
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthClearValue: 0.6849042179676352,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet44,
+maxDrawCount: 85256,
+}
+);
+try {
+renderPassEncoder9.setBindGroup(
+6,
+bindGroup18,
+new Uint32Array(6969),
+6462,
+0
+);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder20.setBlendConstant(
+{
+r: 437.4,
+g: -848.4,
+b: -996.8,
+a: -946.5,
+}
+);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+2,
+8,
+0,
+20
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(
+40,
+56,
+80,
+408,
+8
+);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(
+buffer4,
+'uint16',
+41368,
+8421
+);
+} catch {}
+let pipeline36 = device0.createComputePipeline(
+{
+layout: pipelineLayout7,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend(canvas8);
+try {
+await adapter2.requestAdapterInfo();
+} catch {}
+try {
+offscreenCanvas11.getContext('webgpu');
+} catch {}
+let texture51 = device0.createTexture(
+{
+label: '\u{1febf}\u{1fe88}\u0b9a\u0016\u0607\ue103\udd85\u672d\ueac1\ua06e',
+size: [5015],
+dimension: '1d',
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'r32uint',
+'r32uint'
+],
+}
+);
+let renderBundle39 = renderBundleEncoder8.finish(
+{
+label: '\u{1fe0d}\u{1ffc7}'
+}
+);
+try {
+renderPassEncoder8.draw(
+56,
+72,
+16,
+72
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(
+56,
+64,
+80
+);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer1,
+'uint16',
+2044,
+2913
+);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(
+0,
+buffer2,
+1068,
+8350
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 383, height: 1, depthOrArrayLayers: 334}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 5, y: 13 },
+  flipY: true,
+},
+{
+  texture: texture47,
+  mipLevel: 2,
+  origin: { x: 126, y: 0, z: 223 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline37 = await device0.createComputePipelineAsync(
+{
+label: '\u5c60\u{1f922}\u6101\u{1fdcd}\u0104\u0a16\u0e21',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline38 = await device0.createRenderPipelineAsync(
+{
+label: '\u686c\u9dd2\u{1fdb7}\u{1ffbc}\u80f2\u31b3',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule7,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 616,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32',
+offset: 104,
+shaderLocation: 4,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 340,
+shaderLocation: 11,
+},
+{
+format: 'sint32',
+offset: 132,
+shaderLocation: 14,
+},
+{
+format: 'float16x2',
+offset: 436,
+shaderLocation: 13,
+},
+{
+format: 'sint32x4',
+offset: 596,
+shaderLocation: 6,
+},
+{
+format: 'uint32',
+offset: 436,
+shaderLocation: 16,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 448,
+shaderLocation: 9,
+},
+{
+format: 'uint16x2',
+offset: 376,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 37760,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x2',
+offset: 6042,
+shaderLocation: 8,
+},
+{
+format: 'sint16x2',
+offset: 14116,
+shaderLocation: 2,
+},
+{
+format: 'uint32x3',
+offset: 14444,
+shaderLocation: 1,
+},
+{
+format: 'unorm8x2',
+offset: 14226,
+shaderLocation: 15,
+},
+{
+format: 'float32x4',
+offset: 5528,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 21732,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 17580,
+shaderLocation: 0,
+},
+{
+format: 'sint8x4',
+offset: 19296,
+shaderLocation: 5,
+},
+{
+format: 'sint32x2',
+offset: 14224,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x79684c0a,
+},
+fragment: {
+module: shaderModule7,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.BLUE,
+},
+{
+format: 'rg16float',
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+},
+{
+format: 'r8uint',
+writeMask: 0,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'zero',
+passOp: 'invert',
+},
+depthBias: 90,
+depthBiasSlopeScale: 61,
+depthBiasClamp: 75,
+},
+}
+);
+try {
+computePassEncoder19.setPipeline(
+pipeline25
+);
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant(
+{
+r: -727.0,
+g: -357.9,
+b: -401.8,
+a: 941.4,
+}
+);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(
+0,
+80,
+48,
+-576,
+32
+);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(
+1,
+buffer11,
+21648,
+2876
+);
+} catch {}
+let arrayBuffer13 = buffer14.getMappedRange(
+13320,
+9236
+);
+try {
+device0.queue.writeBuffer(
+buffer9,
+33580,
+new Float32Array(59393),
+48746,
+892
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture19,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 9 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 448877 */{
+offset: 715,
+bytesPerRow: 54,
+rowsPerImage: 244,
+},
+{width: 2, height: 4, depthOrArrayLayers: 35}
+);
+} catch {}
+let pipeline39 = device0.createComputePipeline(
+{
+layout: pipelineLayout1,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let texture52 = device0.createTexture(
+{
+label: '\u0013\u9439\u82ea\uc673\u96ff\u991d\u{1ff22}\u02c5\ud0c1',
+size: {width: 2315},
+dimension: '1d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16uint',
+'rgba16uint'
+],
+}
+);
+let textureView52 = texture17.createView(
+{
+label: '\u{1fd03}\ubcdb\ue1a4',
+dimension: '3d',
+}
+);
+try {
+renderPassEncoder9.setBlendConstant(
+{
+r: -26.18,
+g: -840.4,
+b: 459.3,
+a: 908.7,
+}
+);
+} catch {}
+try {
+await device0.popErrorScope();
+} catch {}
+let pipeline40 = device0.createComputePipeline(
+{
+label: '\ufea6\u118a\u0fa4',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+}
+);
+gc();
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+let texture53 = device0.createTexture(
+{
+label: '\u5d47\u4ecd\u{1f6c7}\u{1feee}\u2443\u{1f77e}\u{1f7ac}\u134e\u0486',
+size: [151, 151, 1],
+mipLevelCount: 3,
+dimension: '2d',
+format: 'rg32float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let textureView53 = texture36.createView(
+{
+label: '\u640d\uaa71\u0972\u{1fbae}\u0648\u399a\u03c5\u0ea3\u{1f72b}',
+format: 'rg8sint',
+mipLevelCount: 2,
+}
+);
+let sampler50 = device0.createSampler(
+{
+label: '\u950e\u{1fe27}\uf155\u{1faf1}\u0f1a\u23fb\u2dd6\u0196',
+addressModeU: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 38.588,
+lodMaxClamp: 90.379,
+compare: 'not-equal',
+maxAnisotropy: 8,
+}
+);
+try {
+renderPassEncoder12.beginOcclusionQuery(
+48
+);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(
+buffer12,
+'uint16',
+31902
+);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(
+10,
+buffer11,
+24772
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(video0);
+offscreenCanvas3.width = 1022;
+gc();
+document.body.prepend('\uc30b\u6e86\u0c35\u02ca\ue9f5\ua0c5\u011f\u{1ffe3}\u2b0e\u58ca');
+let renderBundleEncoder46 = device0.createRenderBundleEncoder(
+{
+label: '\u{1fd5f}\u{1fe16}\u{1f800}\u{1f655}\u76ef\u{1f8d7}\u068e\ua92f\u1c73\ub091',
+colorFormats: [
+'rg16sint'
+],
+sampleCount: 980,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder14.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(
+buffer13,
+105072
+);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline15);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+4612,
+new Float32Array(64911),
+26898,
+160
+);
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+document.body.append('\u0f28\u2694\uac5c\u9845\u6220\u2b39\u7f11\u2a7f\u{1f9b1}\u1337');
+let offscreenCanvas12 = new OffscreenCanvas(919, 100);
+let video8 = await videoWithData();
+let buffer18 = device0.createBuffer(
+{
+size: 63880,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let querySet48 = device0.createQuerySet(
+{
+label: '\u0c0d\u00cd\u0cf7\u69b8\u6c45\ue65b\u215a\ubb2e\u2f47',
+type: 'occlusion',
+count: 1631,
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+4,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(
+2,
+bindGroup22,
+new Uint32Array(5774),
+4278,
+0
+);
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant(
+{
+r: 804.0,
+g: 851.1,
+b: 690.9,
+a: 448.5,
+}
+);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(
+3,
+buffer11,
+1936,
+1369
+);
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(
+1,
+buffer15
+);
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32sint',
+'rgba8unorm',
+'rgba8unorm-srgb',
+'rgba8unorm'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture21,
+  mipLevel: 6,
+  origin: { x: 7, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 62771 */{
+offset: 231,
+bytesPerRow: 252,
+rowsPerImage: 248,
+},
+{width: 11, height: 1, depthOrArrayLayers: 2}
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline41 = await device0.createComputePipelineAsync(
+{
+layout: pipelineLayout2,
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+},
+}
+);
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.draw(
+32,
+80
+);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(
+buffer15,
+'uint16',
+2442,
+7737
+);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(
+4,
+buffer6,
+6640,
+157
+);
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+let sampler51 = device0.createSampler(
+{
+label: '\u6ed8\u0920\u86d0\ubb66\u388e\u{1fa72}\u02fa\u{1fd8b}\u{1f847}',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 17.782,
+lodMaxClamp: 34.321,
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+7,
+bindGroup19,
+new Uint32Array(3329),
+184,
+0
+);
+} catch {}
+try {
+renderPassEncoder20.beginOcclusionQuery(
+56
+);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(
+1,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(
+3189
+);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(
+0,
+bindGroup16,
+new Uint32Array(4231),
+2317,
+0
+);
+} catch {}
+let promise20 = device0.createComputePipelineAsync(
+{
+label: '\u6341\u718c\u7919\u07ec\u179b\u{1f66c}\u0547\u6362\u052a',
+layout: pipelineLayout6,
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+},
+}
+);
+let promise21 = device0.createRenderPipelineAsync(
+{
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule8,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 54280,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 42716,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 27924,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 5696,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x4',
+offset: 22864,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x2',
+offset: 3204,
+shaderLocation: 14,
+},
+{
+format: 'unorm16x4',
+offset: 928,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x2',
+offset: 15284,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 37512,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x2',
+offset: 32944,
+shaderLocation: 9,
+},
+{
+format: 'uint16x2',
+offset: 15288,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 38552,
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 39676,
+shaderLocation: 12,
+},
+{
+format: 'unorm8x2',
+offset: 40568,
+shaderLocation: 7,
+},
+{
+format: 'sint32x3',
+offset: 14176,
+shaderLocation: 2,
+},
+{
+format: 'unorm8x4',
+offset: 18104,
+shaderLocation: 6,
+},
+{
+format: 'sint32x2',
+offset: 58480,
+shaderLocation: 8,
+},
+{
+format: 'unorm8x4',
+offset: 51052,
+shaderLocation: 11,
+},
+{
+format: 'uint16x4',
+offset: 42616,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x4',
+offset: 33020,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 15744,
+attributes: [
+
+],
+},
+{
+arrayStride: 19200,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 53888,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 34676,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 24324,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x3',
+offset: 7424,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule8,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-wrap',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 36,
+depthBias: 7,
+depthBiasSlopeScale: 29,
+depthBiasClamp: 20,
+},
+}
+);
+let renderBundleEncoder47 = device0.createRenderBundleEncoder(
+{
+label: '\u{1fc16}\u{1f7be}\uda3d\u7457\u9c5a\u0007\u0b41',
+colorFormats: [
+'rg32sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 453,
+depthReadOnly: true,
+}
+);
+let renderBundle40 = renderBundleEncoder2.finish(
+{
+label: '\u50b4\u25e9\u4442\u09f6\u7fcf\uc951\u06ca\u0369\u017a\u{1f719}\ue070'
+}
+);
+try {
+renderPassEncoder17.beginOcclusionQuery(
+72
+);
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant(
+{
+r: 590.4,
+g: 308.6,
+b: 915.4,
+a: 796.7,
+}
+);
+} catch {}
+try {
+renderPassEncoder12.draw(
+32
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(
+56,
+8,
+80,
+-136,
+8
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer12,
+77264
+);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(
+11,
+buffer15
+);
+} catch {}
+let pipeline42 = device0.createComputePipeline(
+{
+label: '\u02fe\u8e7e\u0a19\u{1fd37}\u469d\ue439\u887c\u{1f7cc}\u{1ff84}',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+pseudoSubmit(device0, commandEncoder39);
+let textureView54 = texture3.createView(
+{
+label: '\u{1f8e1}\uc8a2',
+aspect: 'all',
+baseMipLevel: 3,
+}
+);
+let renderBundleEncoder48 = device0.createRenderBundleEncoder(
+{
+label: '\u2acc\u6b27\u09b0\u31c4\u278f\u9e71',
+colorFormats: [
+'rg8uint',
+'rg11b10ufloat',
+'r16uint',
+undefined,
+'rg16sint',
+'rg32uint',
+'rgba16uint'
+],
+sampleCount: 307,
+}
+);
+try {
+renderPassEncoder14.setBindGroup(
+3,
+bindGroup10
+);
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(
+218
+);
+} catch {}
+try {
+renderPassEncoder12.setViewport(
+0.8633,
+0.7460,
+0.01675,
+0.2136,
+0.7186,
+0.9825
+);
+} catch {}
+try {
+renderPassEncoder8.draw(
+24,
+56,
+8,
+24
+);
+} catch {}
+let adapter5 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let bindGroupLayout24 = device0.createBindGroupLayout(
+{
+label: '\u0d55\u{1feb6}\u0cef\ub0b6\ue2ed\u3da1\u0227\u27d7\u41b4',
+entries: [
+{
+binding: 999,
+visibility: 0,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let querySet49 = device0.createQuerySet(
+{
+label: '\uf3c6\ud879\ub94b\u0f95\u91b1\u733c\u581b\u0d79\u4623\ua0c4\u{1fa5a}',
+type: 'occlusion',
+count: 3093,
+}
+);
+let textureView55 = texture0.createView(
+{
+baseMipLevel: 3,
+}
+);
+let sampler52 = device0.createSampler(
+{
+label: '\u1a55\u513a\u68f2\u{1fcfb}\u08a6',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 54.079,
+lodMaxClamp: 97.888,
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder15.setBindGroup(
+6,
+bindGroup8,
+new Uint32Array(6182),
+1080,
+0
+);
+} catch {}
+try {
+renderPassEncoder17.setViewport(
+1207.0,
+0.7026,
+1451.7,
+0.2766,
+0.9627,
+0.9659
+);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer1,
+'uint16',
+3258,
+2009
+);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(
+9,
+buffer4
+);
+} catch {}
+let pipeline43 = await device0.createComputePipelineAsync(
+{
+label: '\u04ae\u6cb4\u4e80\u4da6',
+layout: pipelineLayout7,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+video5.width = 272;
+pseudoSubmit(device0, commandEncoder33);
+let renderBundle41 = renderBundleEncoder20.finish(
+{
+label: '\u{1ff0a}\u6667\u{1f7e2}\udc99\u032b\ue857\u04cd\u0a60\u05a1\u{1fcd0}'
+}
+);
+let sampler53 = device0.createSampler(
+{
+label: '\u02af\u{1fe1d}\u0d47\u8586',
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 46.892,
+lodMaxClamp: 52.699,
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder14.beginOcclusionQuery(
+48
+);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+1695
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(
+buffer1,
+40984
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture41,
+  mipLevel: 2,
+  origin: { x: 330, y: 1, z: 27 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 15932798 */{
+offset: 123,
+bytesPerRow: 3025,
+rowsPerImage: 229,
+},
+{width: 743, height: 0, depthOrArrayLayers: 24}
+);
+} catch {}
+pseudoSubmit(device0, commandEncoder16);
+let texture54 = device0.createTexture(
+{
+label: '\u06c5\u{1fc5e}\ub8cc\u{1fa27}\u936f\u777d\u{1facb}\u49fa',
+size: [217, 153, 1],
+mipLevelCount: 7,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'stencil8',
+'stencil8',
+'stencil8'
+],
+}
+);
+let renderBundle42 = renderBundleEncoder15.finish(
+{
+label: '\ub4ef\u87b0\uf6be\ude7c\u0db6'
+}
+);
+try {
+renderPassEncoder21.setBindGroup(
+0,
+bindGroup26
+);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(
+1716
+);
+} catch {}
+try {
+renderPassEncoder17.setViewport(
+1807.5,
+0.5007,
+197.1,
+0.1564,
+0.3667,
+0.9080
+);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(
+buffer12,
+'uint32',
+48552,
+1076
+);
+} catch {}
+let arrayBuffer14 = buffer18.getMappedRange(
+53216
+);
+let gpuCanvasContext10 = offscreenCanvas12.getContext('webgpu');
+document.body.prepend(img0);
+let video9 = await videoWithData();
+try {
+await adapter2.requestAdapterInfo();
+} catch {}
+let shaderModule9 = device0.createShaderModule(
+{
+code: `@group(4) @binding(2081)
+var<storage, read_write> local2: array<u32>;
+
+@compute @workgroup_size(8, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(5) f0: vec4<i32>,
+@location(2) f1: f32,
+@location(6) f2: f32,
+@builtin(sample_mask) f3: u32,
+@location(7) f4: vec2<f32>,
+@location(4) f5: vec2<u32>,
+@location(3) f6: vec3<u32>,
+@builtin(frag_depth) f7: f32
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_index) a1: u32, @builtin(sample_mask) a2: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(1) a0: vec4<u32>, @builtin(vertex_index) a1: u32, @location(8) a2: vec4<u32>, @location(12) a3: vec2<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder42 = device0.createCommandEncoder(
+{
+}
+);
+let sampler54 = device0.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 91.416,
+maxAnisotropy: 12,
+}
+);
+try {
+renderPassEncoder9.setBindGroup(
+5,
+bindGroup9
+);
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant(
+{
+r: -506.3,
+g: 88.52,
+b: 821.0,
+a: 500.8,
+}
+);
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(
+1010
+);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(
+buffer17,
+267968
+);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline15);
+} catch {}
+try {
+device0.pushErrorScope(
+'validation'
+);
+} catch {}
+try {
+commandEncoder42.clearBuffer(
+buffer4,
+15608,
+36164
+);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let buffer19 = device0.createBuffer(
+{
+label: '\u4e75\u09af\uc775\u0e2f\u0056\u99af',
+size: 23048,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+mappedAtCreation: true,
+}
+);
+let commandEncoder43 = device0.createCommandEncoder(
+{
+}
+);
+let renderBundle43 = renderBundleEncoder7.finish(
+{
+label: '\u{1fc55}\u7aed'
+}
+);
+let sampler55 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 19.351,
+}
+);
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+0.09272,
+5.199,
+1.000,
+10.73,
+0.3268,
+0.4531
+);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(
+4,
+buffer4,
+9440,
+18212
+);
+} catch {}
+try {
+commandEncoder43.resolveQuerySet(
+querySet17,
+307,
+981,
+buffer16,
+23808
+);
+} catch {}
+let pipeline44 = await promise20;
+let adapter6 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let commandEncoder44 = device0.createCommandEncoder(
+{
+label: '\u{1fda4}\u24b9\u{1f6fc}\u741e',
+}
+);
+let texture55 = device0.createTexture(
+{
+size: {width: 7784},
+dimension: '1d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8snorm'
+],
+}
+);
+let sampler56 = device0.createSampler(
+{
+label: '\u{1fd99}\ub69c\u{1ffcf}\u0661\uac1e\u{1ff63}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 96.874,
+lodMaxClamp: 97.372,
+}
+);
+try {
+computePassEncoder16.setBindGroup(
+5,
+bindGroup7,
+new Uint32Array(9451),
+9124,
+0
+);
+} catch {}
+try {
+renderPassEncoder8.setViewport(
+0.5211,
+0.3241,
+0.3621,
+0.1723,
+0.03408,
+0.1990
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(
+buffer11,
+94776
+);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(
+buffer15,
+'uint16',
+3544,
+22741
+);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(
+1,
+bindGroup9
+);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(
+1,
+buffer11,
+5020,
+15846
+);
+} catch {}
+try {
+device0.pushErrorScope(
+'out-of-memory'
+);
+} catch {}
+try {
+commandEncoder44.clearBuffer(
+buffer17
+);
+dissociateBuffer(device0, buffer17);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageData11 = new ImageData(208, 48);
+let texture56 = device0.createTexture(
+{
+label: '\u01cc\uc376\u0483\ua6fd',
+size: {width: 102, height: 5, depthOrArrayLayers: 28},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'r32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32float',
+'r32float'
+],
+}
+);
+try {
+computePassEncoder13.setPipeline(
+pipeline20
+);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant(
+{
+r: 438.0,
+g: -406.1,
+b: 815.1,
+a: 803.4,
+}
+);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(
+0,
+64
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(
+buffer8,
+308744
+);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(
+buffer9,
+'uint16',
+49622,
+1380
+);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+0,
+buffer11,
+5696
+);
+} catch {}
+try {
+commandEncoder42.copyBufferToBuffer(
+buffer2,
+15040,
+buffer11,
+8688,
+12472
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+gpuCanvasContext5.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer11,
+34052,
+new Float32Array(21580),
+14103,
+1868
+);
+} catch {}
+let imageBitmap10 = await createImageBitmap(imageData6);
+let commandEncoder45 = device0.createCommandEncoder(
+{
+label: '\u{1fce3}\u63be',
+}
+);
+try {
+renderPassEncoder20.setBindGroup(
+1,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder8.end();
+} catch {}
+try {
+renderPassEncoder12.beginOcclusionQuery(
+32
+);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(
+2,
+buffer11,
+25548,
+5028
+);
+} catch {}
+try {
+device0.pushErrorScope(
+'out-of-memory'
+);
+} catch {}
+try {
+commandEncoder45.insertDebugMarker(
+'\ud145'
+);
+} catch {}
+let bindGroup27 = device0.createBindGroup({
+label: '\u0fdc\u13c1\u75a7\u783d\ucebe\u7ba4\ud5c1\u7855\u2f77\u5ff4',
+layout: bindGroupLayout12,
+entries: [
+
+],
+});
+let renderBundle44 = renderBundleEncoder9.finish(
+{
+
+}
+);
+try {
+computePassEncoder18.setBindGroup(
+4,
+bindGroup26,
+new Uint32Array(3838),
+968,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+0.02397,
+0.7527,
+0.7333,
+0.1996,
+0.09741,
+0.3239
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(
+buffer4,
+79296
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+7,
+buffer9,
+32860,
+9711
+);
+} catch {}
+try {
+renderBundleEncoder47.setVertexBuffer(
+0,
+buffer15,
+31576
+);
+} catch {}
+try {
+commandEncoder44.copyBufferToBuffer(
+buffer16,
+38984,
+buffer17,
+19836,
+504
+);
+dissociateBuffer(device0, buffer16);
+dissociateBuffer(device0, buffer17);
+} catch {}
+let promise22 = adapter4.requestDevice(
+{
+label: '\u04ea\uc557\u8dfd\u049b\u51d5\u401b\uc25d\u0c80\ua9ad',
+}
+);
+let querySet50 = device0.createQuerySet(
+{
+label: '\u172c\u{1fd48}\u{1f91e}\u78a6\u0267',
+type: 'occlusion',
+count: 707,
+}
+);
+let renderBundleEncoder49 = device0.createRenderBundleEncoder(
+{
+label: '\u445f\ud737\u8ce0\u0b0e\u054d\u{1fcc8}\u0e19',
+colorFormats: [
+'rg16uint',
+'rgba8unorm',
+undefined,
+'rg16float',
+'rgba16sint',
+'rgba8unorm'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 85,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder16.setBindGroup(
+7,
+bindGroup26
+);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(
+56,
+8,
+32,
+464,
+40
+);
+} catch {}
+try {
+renderBundleEncoder32.setIndexBuffer(
+buffer1,
+'uint16',
+2308,
+1435
+);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(
+5,
+buffer2
+);
+} catch {}
+try {
+commandEncoder44.copyBufferToBuffer(
+buffer16,
+30432,
+buffer7,
+2824,
+3216
+);
+dissociateBuffer(device0, buffer16);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder43.clearBuffer(
+buffer19
+);
+dissociateBuffer(device0, buffer19);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer4,
+17516,
+new Float32Array(36221),
+27358,
+6756
+);
+} catch {}
+let pipeline45 = device0.createComputePipeline(
+{
+label: '\u5566\u0740\u0e48\u0085\u6cd4\u{1f9ae}\u2891\u8d74\uc098\u444c',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend('\u08c0\u25b3\uc0a5\u0a76\u{1ff30}\u0331\u3ac9\u3862\u6bee');
+let video10 = await videoWithData();
+let bindGroupLayout25 = device0.createBindGroupLayout(
+{
+label: '\u{1f740}\u237b',
+entries: [
+
+],
+}
+);
+let renderBundle45 = renderBundleEncoder14.finish();
+try {
+computePassEncoder20.setPipeline(
+pipeline39
+);
+} catch {}
+try {
+renderPassEncoder21.setViewport(
+566.8,
+0.5995,
+332.2,
+0.05534,
+0.8526,
+0.8776
+);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(
+3,
+bindGroup20
+);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+commandEncoder45.copyBufferToTexture(
+{
+/* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 6464 */
+offset: 6464,
+bytesPerRow: 512,
+rowsPerImage: 182,
+buffer: buffer16,
+},
+{
+  texture: texture11,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder42.resolveQuerySet(
+querySet49,
+621,
+1662,
+buffer19,
+6144
+);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let querySet51 = device0.createQuerySet(
+{
+label: '\u0437\u89b9\u9bee\u{1f69a}',
+type: 'occlusion',
+count: 3948,
+}
+);
+let renderBundleEncoder50 = device0.createRenderBundleEncoder(
+{
+label: '\u7748\u6cdf\uac4d\u0e7c\u{1fc1a}\u554e',
+colorFormats: [
+'rg16sint',
+'bgra8unorm',
+'rgba32uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 623,
+}
+);
+try {
+computePassEncoder10.setBindGroup(
+1,
+bindGroup24,
+new Uint32Array(8242),
+1124,
+0
+);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(
+5,
+buffer9,
+41552
+);
+} catch {}
+try {
+commandEncoder42.copyBufferToBuffer(
+buffer1,
+340,
+buffer11,
+19148,
+0
+);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder43.copyTextureToTexture(
+{
+  texture: texture48,
+  mipLevel: 0,
+  origin: { x: 95, y: 1, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 4205, y: 1, z: 0 },
+  aspect: 'all',
+},
+{width: 115, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let video11 = await videoWithData();
+let commandEncoder46 = device0.createCommandEncoder(
+{
+label: '\u2982\uda03\u{1f713}\u{1f939}\u8e3a',
+}
+);
+let renderPassEncoder22 = commandEncoder42.beginRenderPass(
+{
+colorAttachments: [
+
+],
+depthStencilAttachment: {
+view: textureView34,
+depthClearValue: -1.5838176702770852,
+depthReadOnly: true,
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet49,
+}
+);
+let sampler57 = device0.createSampler(
+{
+label: '\u{1fa0b}\u6cfd',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+lodMinClamp: 63.873,
+lodMaxClamp: 74.965,
+}
+);
+try {
+renderPassEncoder2.setBindGroup(
+6,
+bindGroup1,
+new Uint32Array(3327),
+502,
+0
+);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant(
+{
+r: 833.7,
+g: 924.6,
+b: 898.2,
+a: 388.7,
+}
+);
+} catch {}
+try {
+renderPassEncoder6.setViewport(
+1.650,
+16.64,
+0.1074,
+16.90,
+0.9237,
+0.9465
+);
+} catch {}
+try {
+renderPassEncoder12.draw(
+16,
+56,
+32,
+40
+);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(
+6,
+bindGroup14
+);
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(
+5,
+buffer2,
+3564
+);
+} catch {}
+try {
+commandEncoder46.copyBufferToBuffer(
+buffer12,
+24264,
+buffer10,
+24804,
+8456
+);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture47,
+  mipLevel: 1,
+  origin: { x: 215, y: 0, z: 139 },
+  aspect: 'all',
+},
+new DataView(new ArrayBuffer(40)),
+/* required buffer size: 130375390 */{
+offset: 962,
+bytesPerRow: 4995,
+rowsPerImage: 174,
+},
+{width: 308, height: 1, depthOrArrayLayers: 151}
+);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let querySet52 = device0.createQuerySet(
+{
+label: '\u04bf\u{1fe94}\u4ecc\u05a2\u{1f7bd}\u92d0\u{1f63f}\uef01\u{1fbd2}\u{1f8b2}\u{1fa93}',
+type: 'occlusion',
+count: 2704,
+}
+);
+pseudoSubmit(device0, commandEncoder19);
+let sampler58 = device0.createSampler(
+{
+label: '\ua942\ufbb7\u0d34\u{1f855}\u0d65\u0906\u22d9\u6e7a\u0965\u0e84',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+lodMinClamp: 93.544,
+lodMaxClamp: 97.524,
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder22.setBindGroup(
+0,
+bindGroup16
+);
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+0.2080,
+0.01384,
+0.3599,
+0.05473,
+0.2330,
+0.6172
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer7,
+44528
+);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(
+69,
+undefined,
+3855217523
+);
+} catch {}
+try {
+renderBundleEncoder41.setIndexBuffer(
+buffer4,
+'uint16',
+36986,
+14232
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder46.copyBufferToTexture(
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 55180 */
+offset: 55180,
+buffer: buffer3,
+},
+{
+  texture: texture27,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder46.resolveQuerySet(
+querySet17,
+861,
+257,
+buffer10,
+17664
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer11,
+4628,
+new Float32Array(59137),
+22966,
+1616
+);
+} catch {}
+let img8 = await imageWithData(243, 225, '#c01f55d6', '#7d7276ac');
+let bindGroupLayout26 = device0.createBindGroupLayout(
+{
+entries: [
+{
+binding: 938,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 2178,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+},
+{
+binding: 3157,
+visibility: 0,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+let renderPassEncoder23 = commandEncoder44.beginRenderPass(
+{
+label: '\ueae8\u209c\u0e5e\u{1faa8}\u0525\u29b3\u15c7\uba73\u83a4',
+colorAttachments: [
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthReadOnly: true,
+stencilClearValue: 62177,
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet43,
+maxDrawCount: 21192,
+}
+);
+try {
+renderPassEncoder20.setBindGroup(
+3,
+bindGroup26
+);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(
+buffer1,
+'uint16',
+1728,
+1872
+);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(
+6,
+bindGroup5
+);
+} catch {}
+try {
+commandEncoder43.copyBufferToBuffer(
+buffer7,
+4588,
+buffer10,
+17824,
+8188
+);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder45.copyTextureToTexture(
+{
+  texture: texture2,
+  mipLevel: 1,
+  origin: { x: 82, y: 0, z: 41 },
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 1,
+  origin: { x: 5, y: 0, z: 2 },
+  aspect: 'all',
+},
+{width: 74, height: 1, depthOrArrayLayers: 25}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 383, height: 1, depthOrArrayLayers: 334}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 465, y: 309 },
+  flipY: false,
+},
+{
+  texture: texture47,
+  mipLevel: 2,
+  origin: { x: 52, y: 0, z: 278 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 177, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise23 = device0.createRenderPipelineAsync(
+{
+label: '\uc039\ucf6d\uc27b\u4e00\u{1f871}',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 53964,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 46480,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 21056,
+shaderLocation: 0,
+},
+{
+format: 'uint16x2',
+offset: 44260,
+shaderLocation: 9,
+},
+{
+format: 'uint32x3',
+offset: 19396,
+shaderLocation: 1,
+},
+{
+format: 'uint8x2',
+offset: 35546,
+shaderLocation: 6,
+},
+{
+format: 'uint8x2',
+offset: 10872,
+shaderLocation: 8,
+},
+{
+format: 'sint16x2',
+offset: 1988,
+shaderLocation: 3,
+},
+{
+format: 'sint16x4',
+offset: 2296,
+shaderLocation: 13,
+},
+{
+format: 'uint8x4',
+offset: 252,
+shaderLocation: 4,
+},
+{
+format: 'uint8x2',
+offset: 2326,
+shaderLocation: 12,
+},
+{
+format: 'uint32x2',
+offset: 38608,
+shaderLocation: 2,
+},
+{
+format: 'float32x4',
+offset: 1832,
+shaderLocation: 10,
+},
+{
+format: 'snorm8x4',
+offset: 19956,
+shaderLocation: 14,
+},
+{
+format: 'uint32x4',
+offset: 26332,
+shaderLocation: 5,
+},
+{
+format: 'uint32x2',
+offset: 30064,
+shaderLocation: 7,
+},
+{
+format: 'sint32x4',
+offset: 168,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 42992,
+attributes: [
+{
+format: 'sint8x2',
+offset: 16916,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 24824,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 4208,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x5870752a,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'constant',
+dstFactor: 'src'
+},
+},
+format: 'bgra8unorm',
+writeMask: GPUColorWrite.BLUE,
+},
+{
+format: 'r16float',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+},
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 2152,
+stencilWriteMask: 3746,
+depthBias: 21,
+depthBiasSlopeScale: 13,
+depthBiasClamp: 56,
+},
+}
+);
+document.body.prepend(img2);
+document.body.append('\u3266\u3e92\ua9f3\u0cd4');
+let commandEncoder47 = device0.createCommandEncoder(
+{
+label: '\u0313\u96c3\udedb\u{1fc5e}',
+}
+);
+let renderPassEncoder24 = commandEncoder47.beginRenderPass(
+{
+label: '\ua803\u{1fbdb}\u806c\uf3fd',
+colorAttachments: [
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthClearValue: 0.7281269738396953,
+depthLoadOp: 'clear',
+depthStoreOp: 'discard',
+stencilClearValue: 2783,
+},
+occlusionQuerySet: querySet12,
+maxDrawCount: 8416,
+}
+);
+let renderBundleEncoder51 = device0.createRenderBundleEncoder(
+{
+label: '\u3de4\u8145\u6b10\uaeb8\u8788\u618c\ua1e4\u0f58\u6990',
+colorFormats: [
+'rg8sint',
+'rg11b10ufloat',
+'rg16uint',
+'rgba16float',
+'rg32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 867,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder24.beginOcclusionQuery(
+40
+);
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(
+2492
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer10,
+80352
+);
+} catch {}
+let arrayBuffer15 = buffer17.getMappedRange();
+try {
+commandEncoder45.copyTextureToTexture(
+{
+  texture: texture1,
+  mipLevel: 2,
+  origin: { x: 2, y: 16, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture21,
+  mipLevel: 10,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\uef9c\ua69b\uc592\u0f07\u9773\u{1f99c}\uee6e\u7614\u{1f8af}\u0c6e\u{1fe99}');
+let canvas10 = document.createElement('canvas');
+let bindGroupLayout27 = device0.createBindGroupLayout(
+{
+label: '\u{1fcd8}\u{1feb8}\u00aa\u9931\ua3c2\u071d',
+entries: [
+{
+binding: 664,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '3d' },
+},
+{
+binding: 278,
+visibility: 0,
+storageTexture: { format: 'rgba8sint', access: 'write-only', viewDimension: '1d' },
+},
+{
+binding: 1104,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}
+],
+}
+);
+let renderBundleEncoder52 = device0.createRenderBundleEncoder(
+{
+label: '\u079f\u5199\ub5b0\u067b',
+colorFormats: [
+'rg16uint',
+'r8sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 556,
+depthReadOnly: true,
+}
+);
+try {
+computePassEncoder17.setBindGroup(
+5,
+bindGroup20
+);
+} catch {}
+try {
+renderPassEncoder23.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(
+48
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer3,
+162952
+);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(
+6,
+buffer15,
+38152,
+3503
+);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(
+2,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(
+6,
+buffer9,
+41472
+);
+} catch {}
+try {
+commandEncoder43.copyTextureToBuffer(
+{
+  texture: texture24,
+  mipLevel: 1,
+  origin: { x: 0, y: 33, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 404 widthInBlocks: 101 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 40476 */
+offset: 40072,
+bytesPerRow: 512,
+buffer: buffer11,
+},
+{width: 101, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+gpuCanvasContext5.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgba32uint',
+'bgra8unorm',
+'bgra8unorm-srgb',
+'rgba32sint'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let pipeline46 = await device0.createComputePipelineAsync(
+{
+label: '\u02c2\u55f5\u2d75\u1acb\u{1ff34}\ue3d0\u{1fd87}',
+layout: pipelineLayout6,
+compute: {
+module: shaderModule9,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let offscreenCanvas13 = new OffscreenCanvas(428, 390);
+let bindGroup28 = device0.createBindGroup({
+label: '\u{1ff6e}\u081f\u3ece\uecd9\u021c\ud813\uc8df\u0ec0\ucbc2\u01d8',
+layout: bindGroupLayout15,
+entries: [
+
+],
+});
+let textureView56 = texture38.createView(
+{
+label: '\u6883\u0bcf\u{1f820}\ucfbe',
+}
+);
+let renderPassEncoder25 = commandEncoder43.beginRenderPass(
+{
+label: '\u9f53\u0794\u{1f84c}\u404d\u{1fee0}\u3897\u{1ff7f}\u{1f6be}\u7563',
+colorAttachments: [
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthClearValue: 3.6546076924742703,
+depthLoadOp: 'load',
+depthStoreOp: 'store',
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet38,
+maxDrawCount: 132216,
+}
+);
+let renderBundle46 = renderBundleEncoder31.finish(
+{
+label: '\ua5f7\u85fa\u110b\u016a\u2607\u0d7e\u{1facc}\udd75\u{1f855}\u5682'
+}
+);
+try {
+renderPassEncoder21.beginOcclusionQuery(
+64
+);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder24.setScissorRect(
+1496,
+0,
+794,
+1
+);
+} catch {}
+try {
+renderPassEncoder19.setViewport(
+1297.5,
+0.1895,
+584.5,
+0.1556,
+0.1507,
+0.4120
+);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(
+1,
+buffer6,
+204,
+5500
+);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(
+8,
+buffer4,
+12168,
+25627
+);
+} catch {}
+let arrayBuffer16 = buffer19.getMappedRange();
+try {
+commandEncoder46.copyTextureToBuffer(
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 27, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 6012 widthInBlocks: 1503 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 25316 */
+offset: 25316,
+bytesPerRow: 6144,
+buffer: buffer4,
+},
+{width: 1503, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 235, height: 1, depthOrArrayLayers: 319}
+*/
+{
+  source: offscreenCanvas7,
+  origin: { x: 27, y: 695 },
+  flipY: true,
+},
+{
+  texture: texture10,
+  mipLevel: 2,
+  origin: { x: 115, y: 0, z: 250 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 92, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let bindGroup29 = device0.createBindGroup({
+label: '\u3ea0\u3739\u0a8d\u0e0a\u8e32\u3df5\ucde6\u{1fc0e}\u90de',
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let pipelineLayout8 = device0.createPipelineLayout(
+{
+label: '\u06c5\u077a',
+bindGroupLayouts: [
+bindGroupLayout5,
+bindGroupLayout25,
+bindGroupLayout22,
+bindGroupLayout3,
+bindGroupLayout13
+],
+}
+);
+let buffer20 = device0.createBuffer(
+{
+label: '\u{1f79a}\u{1f85f}\u0ae2\u0c0c\uc58c\u0a5f\u5cdd\u{1fe6f}\u{1f850}\u{1f6b8}',
+size: 53749,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let texture57 = device0.createTexture(
+{
+label: '\u758c\u6385\u3301\u2fa2\u9a88\u0dd9\u5616\ue2ae',
+size: [976],
+mipLevelCount: 1,
+dimension: '1d',
+format: 'rg32float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView57 = texture4.createView(
+{
+label: '\u0cc8\u0bdb\uf6a5\u10fe',
+baseMipLevel: 4,
+mipLevelCount: 1,
+}
+);
+let renderPassEncoder26 = commandEncoder45.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthLoadOp: 'load',
+depthStoreOp: 'discard',
+depthReadOnly: false,
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet4,
+maxDrawCount: 26480,
+}
+);
+try {
+renderPassEncoder10.drawIndirect(
+buffer17,
+33624
+);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer1,
+'uint16',
+3294,
+577
+);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(
+1,
+buffer19,
+11252,
+3296
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+gc();
+document.body.append('\u9765\u{1f913}\u3528\u0a00\u6de0\ub901\uc230\u7a4e');
+let textureView58 = texture15.createView(
+{
+label: '\u0f5d\u{1ff2a}\ue375\ua239',
+dimension: '2d-array',
+format: 'rg16sint',
+}
+);
+try {
+computePassEncoder14.setBindGroup(
+1,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder22.beginOcclusionQuery(
+32
+);
+} catch {}
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(
+4,
+buffer6,
+4816,
+4610
+);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(
+7,
+bindGroup19
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer4,
+45368,
+new Float32Array(26057),
+157,
+1072
+);
+} catch {}
+let commandEncoder48 = device0.createCommandEncoder(
+{
+label: '\u0b50\u988d\uc824\u{1fe84}\ud7a4\ude56\u34dd\ue34e\u00ac',
+}
+);
+let renderBundle47 = renderBundleEncoder6.finish(
+{
+
+}
+);
+try {
+renderPassEncoder13.setBindGroup(
+8,
+bindGroup7,
+new Uint32Array(5904),
+5109,
+0
+);
+} catch {}
+try {
+renderPassEncoder20.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder26.setStencilReference(
+2696
+);
+} catch {}
+try {
+renderPassEncoder10.draw(
+16
+);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(
+5,
+buffer4,
+12012
+);
+} catch {}
+try {
+renderBundleEncoder38.setIndexBuffer(
+buffer1,
+'uint16',
+3860,
+42
+);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+try {
+await buffer20.mapAsync(
+GPUMapMode.WRITE,
+0,
+26572
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+176,
+new Int16Array(38532),
+34715,
+3184
+);
+} catch {}
+let gpuCanvasContext11 = canvas10.getContext('webgpu');
+let imageBitmap11 = await createImageBitmap(canvas8);
+let commandEncoder49 = device0.createCommandEncoder(
+{
+label: '\u0c38\u0672\u{1ff20}\u0a46\u{1fdea}\uf44d\ud5e8\u218b\uebdf',
+}
+);
+let renderPassEncoder27 = commandEncoder46.beginRenderPass(
+{
+label: '\u11d8\u0a32\u{1ffdd}\ua91d\u16fd\u75bc\u{1fa05}',
+colorAttachments: [
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthClearValue: 0.9742521255576299,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+depthReadOnly: false,
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet6,
+maxDrawCount: 79712,
+}
+);
+try {
+computePassEncoder16.setBindGroup(
+7,
+bindGroup27
+);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant(
+{
+r: -789.7,
+g: -49.44,
+b: 514.0,
+a: -495.5,
+}
+);
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(
+2049
+);
+} catch {}
+try {
+renderPassEncoder24.setViewport(
+223.0,
+0.8043,
+1891.4,
+0.1449,
+0.3306,
+0.3791
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(
+24,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(
+9,
+buffer19,
+14468,
+4709
+);
+} catch {}
+try {
+computePassEncoder18.insertDebugMarker(
+'\u0839'
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture42,
+  mipLevel: 0,
+  origin: { x: 246, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint8Array(arrayBuffer5),
+/* required buffer size: 596 */{
+offset: 596,
+},
+{width: 7039, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline47 = device0.createRenderPipeline(
+{
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule6,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 41164,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 39332,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 57876,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 10644,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 160,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 18664,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 17776,
+shaderLocation: 0,
+},
+{
+format: 'uint32x4',
+offset: 6804,
+shaderLocation: 7,
+},
+{
+format: 'uint32x4',
+offset: 3928,
+shaderLocation: 16,
+},
+{
+format: 'unorm8x2',
+offset: 17748,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 24956,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 42604,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 4792,
+shaderLocation: 10,
+},
+{
+format: 'uint32',
+offset: 11992,
+shaderLocation: 13,
+},
+{
+format: 'unorm8x2',
+offset: 22756,
+shaderLocation: 8,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x79800160,
+},
+fragment: {
+module: shaderModule6,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rg16float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'equal',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilBack: {
+failOp: 'invert',
+depthFailOp: 'invert',
+passOp: 'zero',
+},
+stencilReadMask: 1910,
+depthBias: 65,
+depthBiasSlopeScale: 36,
+depthBiasClamp: 97,
+},
+}
+);
+document.body.prepend('\uc64c\u{1ff88}\u0e1d\u0082\u00e5\u7960\u0ab4');
+let texture58 = device0.createTexture(
+{
+label: '\ubb8f\u0a71\u44e6',
+size: {width: 248, height: 1, depthOrArrayLayers: 185},
+mipLevelCount: 6,
+sampleCount: 1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView59 = texture50.createView(
+{
+label: '\u76b5\u{1f730}\u28e2\u4633\u1515\u3353',
+}
+);
+let renderPassEncoder28 = commandEncoder49.beginRenderPass(
+{
+label: '\u0e8d\u88e7\u0f2d\u1cf7\uc100\u{1ff64}\u4f47',
+colorAttachments: [
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthClearValue: 8.7020164292293,
+depthReadOnly: true,
+stencilClearValue: 24983,
+},
+occlusionQuerySet: querySet41,
+maxDrawCount: 100320,
+}
+);
+let sampler59 = device0.createSampler(
+{
+label: '\ub9f6\u004d\u0c5b\u30ec\u0c38\u{1fa92}\u{1f6c6}\ub378\u{1f641}',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 48.466,
+lodMaxClamp: 82.116,
+compare: 'greater',
+}
+);
+try {
+computePassEncoder19.setPipeline(
+pipeline12
+);
+} catch {}
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(
+1,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(
+buffer0,
+53008
+);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(
+10,
+buffer2,
+6084,
+7414
+);
+} catch {}
+try {
+commandEncoder48.copyTextureToTexture(
+{
+  texture: texture11,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let promise24 = device0.createRenderPipelineAsync(
+{
+label: '\uafb2\u947e\u{1fd3b}',
+layout: pipelineLayout6,
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x2',
+offset: 42872,
+shaderLocation: 15,
+},
+{
+format: 'float16x2',
+offset: 51592,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 55804,
+attributes: [
+{
+format: 'sint32',
+offset: 7972,
+shaderLocation: 9,
+},
+{
+format: 'float32x3',
+offset: 18452,
+shaderLocation: 7,
+},
+{
+format: 'unorm16x4',
+offset: 13220,
+shaderLocation: 8,
+},
+{
+format: 'unorm16x4',
+offset: 13556,
+shaderLocation: 14,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 26608,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 24192,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 50632,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 39348,
+shaderLocation: 1,
+},
+{
+format: 'sint16x2',
+offset: 26688,
+shaderLocation: 11,
+},
+{
+format: 'unorm8x2',
+offset: 41808,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule3,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.GREEN,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'dst-alpha',
+dstFactor: 'one-minus-dst'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r16float',
+},
+{
+format: 'rgb10a2unorm',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.GREEN,
+},
+undefined
+],
+},
+}
+);
+document.body.prepend('\u5f9f\u18a6\u{1f602}\u{1ff65}\u24bf\u04d8');
+let video12 = await videoWithData();
+let buffer21 = device0.createBuffer(
+{
+label: '\u43d1\u{1fc25}\ue955\ub7d6',
+size: 55473,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+mappedAtCreation: false,
+}
+);
+let commandEncoder50 = device0.createCommandEncoder(
+{
+label: '\u{1fa8d}\u7442\u0ca7\u{1fe64}\u{1fde7}\u{1fb2e}\u9bc1\u80ee\u2a40\u{1f9ce}\udba0',
+}
+);
+let renderBundleEncoder53 = device0.createRenderBundleEncoder(
+{
+label: '\u05a8\u0e40\ub803\u1251\u0375\u{1fa5c}\u3d3c',
+colorFormats: [
+'rgba32float',
+'rg8uint',
+'r16uint',
+'rgba16uint',
+'r32float',
+undefined,
+'r8uint'
+],
+sampleCount: 35,
+}
+);
+let renderBundle48 = renderBundleEncoder38.finish();
+let sampler60 = device0.createSampler(
+{
+label: '\u{1f9c2}\u0795\u{1fde6}\u08b2\ufc20',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 55.464,
+lodMaxClamp: 76.603,
+maxAnisotropy: 3,
+}
+);
+try {
+renderPassEncoder13.setScissorRect(
+2019,
+0,
+567,
+1
+);
+} catch {}
+try {
+commandEncoder48.copyBufferToBuffer(
+buffer15,
+38176,
+buffer11,
+8504,
+2812
+);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder48.resolveQuerySet(
+querySet48,
+1432,
+94,
+buffer19,
+18688
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+4776,
+new Float32Array(25660),
+5925,
+1100
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture58,
+  mipLevel: 3,
+  origin: { x: 4, y: 0, z: 34 },
+  aspect: 'all',
+},
+arrayBuffer8,
+/* required buffer size: 284891 */{
+offset: 764,
+bytesPerRow: 13,
+rowsPerImage: 155,
+},
+{width: 3, height: 1, depthOrArrayLayers: 142}
+);
+} catch {}
+document.body.prepend(video10);
+document.body.prepend('\u0d2a\u{1fc34}\u893c');
+let bindGroupLayout28 = device0.createBindGroupLayout(
+{
+label: '\u58a5\uda45\u{1f8d2}\u7176\u05de\u0cc4\ue8e7\u{1f691}\u{1fc98}\u8c72\u869c',
+entries: [
+{
+binding: 1279,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}
+],
+}
+);
+let texture59 = device0.createTexture(
+{
+label: '\u0613\ue887\ud0b7\uf5db\u0e6f\uccbe',
+size: {width: 534, height: 1, depthOrArrayLayers: 396},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+}
+);
+let textureView60 = texture26.createView(
+{
+label: '\u982c\u{1f6fd}\u7f8b\u0a4a\u{1f973}\u{1ff56}',
+dimension: '3d',
+format: 'rgba16uint',
+mipLevelCount: 4,
+}
+);
+let renderBundleEncoder54 = device0.createRenderBundleEncoder(
+{
+label: '\ud1fd\u4274\u{1f99d}\u{1fdc6}\u{1fcab}\u9b3d\ub5a0\u0946\u{1fcca}\u0de0\u0888',
+colorFormats: [
+'r32sint',
+'rg16uint',
+'rg16uint',
+'rgba16uint',
+'rgba16uint',
+'rgba8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 483,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder28.setBlendConstant(
+{
+r: 273.4,
+g: 248.4,
+b: -985.7,
+a: 426.5,
+}
+);
+} catch {}
+try {
+renderPassEncoder22.setViewport(
+730.9,
+0.8216,
+1897.4,
+0.1161,
+0.6926,
+0.8425
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(
+80,
+0,
+16,
+-120,
+64
+);
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(
+buffer12,
+'uint32',
+35772,
+3605
+);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(
+7,
+buffer9
+);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+try {
+commandEncoder48.resolveQuerySet(
+querySet47,
+2363,
+216,
+buffer4,
+47104
+);
+} catch {}
+let promise25 = device0.createRenderPipelineAsync(
+{
+label: '\u0c33\ue169',
+layout: pipelineLayout7,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 24996,
+attributes: [
+{
+format: 'uint32x2',
+offset: 16080,
+shaderLocation: 6,
+},
+{
+format: 'float16x4',
+offset: 23352,
+shaderLocation: 13,
+},
+{
+format: 'uint8x4',
+offset: 18956,
+shaderLocation: 14,
+},
+{
+format: 'float32x4',
+offset: 17776,
+shaderLocation: 15,
+},
+{
+format: 'float32x4',
+offset: 11888,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x2',
+offset: 20946,
+shaderLocation: 8,
+},
+{
+format: 'uint16x4',
+offset: 11256,
+shaderLocation: 7,
+},
+{
+format: 'float32',
+offset: 5612,
+shaderLocation: 10,
+},
+{
+format: 'float16x2',
+offset: 17072,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 33168,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x2',
+offset: 7840,
+shaderLocation: 12,
+},
+{
+format: 'sint32x3',
+offset: 24868,
+shaderLocation: 3,
+},
+{
+format: 'snorm16x2',
+offset: 16912,
+shaderLocation: 11,
+},
+{
+format: 'sint32x2',
+offset: 20956,
+shaderLocation: 1,
+},
+{
+format: 'unorm8x4',
+offset: 2624,
+shaderLocation: 9,
+},
+{
+format: 'uint8x2',
+offset: 29706,
+shaderLocation: 2,
+},
+{
+format: 'float32x3',
+offset: 28828,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'none',
+},
+multisample: {
+count: 4,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16sint',
+writeMask: 0,
+},
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+}
+);
+let sampler61 = device0.createSampler(
+{
+label: '\u{1f98a}\u8a31\u{1fd42}\u{1f935}\u4a27\u058f\u0535',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 30.086,
+lodMaxClamp: 71.766,
+maxAnisotropy: 13,
+}
+);
+try {
+renderPassEncoder12.draw(
+8,
+72,
+8,
+16
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(
+buffer11,
+5008
+);
+} catch {}
+try {
+commandEncoder48.clearBuffer(
+buffer2,
+4604,
+18432
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+gpuCanvasContext8.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth16unorm',
+'rgba32sint',
+'rgba8unorm-srgb'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+let offscreenCanvas14 = new OffscreenCanvas(844, 772);
+let pipelineLayout9 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout19,
+bindGroupLayout10,
+bindGroupLayout15,
+bindGroupLayout24,
+bindGroupLayout9
+],
+}
+);
+let buffer22 = device0.createBuffer(
+{
+label: '\ub4ba\u29c4',
+size: 57680,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+mappedAtCreation: true,
+}
+);
+let renderBundle49 = renderBundleEncoder41.finish(
+{
+label: '\ub394\u{1fd0e}\u1149\u{1f927}\u4d78\uf6b2\u0185\ue362'
+}
+);
+let sampler62 = device0.createSampler(
+{
+label: '\u0020\u{1f9ae}\udea1',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 54.016,
+maxAnisotropy: 6,
+}
+);
+try {
+renderPassEncoder17.setBindGroup(
+7,
+bindGroup17,
+[]
+);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant(
+{
+r: -841.2,
+g: 366.9,
+b: 286.2,
+a: 574.1,
+}
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(
+buffer2,
+13472
+);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(
+9,
+buffer11,
+4880,
+2898
+);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(
+2,
+buffer4,
+21620,
+19062
+);
+} catch {}
+try {
+commandEncoder50.clearBuffer(
+buffer17
+);
+dissociateBuffer(device0, buffer17);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer11,
+15716,
+new DataView(new ArrayBuffer(46776)),
+18908,
+22620
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture31,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 4 },
+  aspect: 'all',
+},
+arrayBuffer3,
+/* required buffer size: 100626 */{
+offset: 762,
+bytesPerRow: 219,
+rowsPerImage: 76,
+},
+{width: 65, height: 0, depthOrArrayLayers: 7}
+);
+} catch {}
+let canvas11 = document.createElement('canvas');
+let imageBitmap12 = await createImageBitmap(offscreenCanvas0);
+let texture60 = device0.createTexture(
+{
+label: '\u5bcd\u0f6d\u0521\u{1fbcf}\u04e9\u60cd\ue579\udf9b\u2072\u0434\u7280',
+size: [119, 13, 1],
+mipLevelCount: 3,
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder22 = commandEncoder48.beginComputePass(
+{
+label: '\u8cbf\ue130\u6c9b\u2f19\u0fdc\u{1fe91}'
+}
+);
+try {
+renderPassEncoder26.beginOcclusionQuery(
+80
+);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(
+buffer15,
+'uint32'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+8404,
+new DataView(new ArrayBuffer(21134)),
+16188,
+216
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture18,
+  mipLevel: 1,
+  origin: { x: 97, y: 0, z: 5 },
+  aspect: 'all',
+},
+new ArrayBuffer(64),
+/* required buffer size: 19526 */{
+offset: 116,
+bytesPerRow: 1294,
+rowsPerImage: 15,
+},
+{width: 278, height: 0, depthOrArrayLayers: 2}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 183, height: 1, depthOrArrayLayers: 39}
+*/
+{
+  source: imageBitmap6,
+  origin: { x: 454, y: 12 },
+  flipY: false,
+},
+{
+  texture: texture31,
+  mipLevel: 2,
+  origin: { x: 82, y: 0, z: 24 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 91, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let canvas12 = document.createElement('canvas');
+let texture61 = device0.createTexture(
+{
+label: '\u230b\u{1f9b3}\ud0f1',
+size: {width: 5880},
+dimension: '1d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView61 = texture25.createView(
+{
+label: '\u{1ff5b}\u62fd',
+format: 'rg8sint',
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+let renderPassEncoder29 = commandEncoder50.beginRenderPass(
+{
+label: '\u0d7e\u{1fe65}\u04c2\ua926\ub7c0\u0d92\u09bb\u0c3c\u0315\ua500\u9922',
+colorAttachments: [
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthClearValue: 0.35914392023636443,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+depthReadOnly: false,
+stencilClearValue: 20643,
+},
+occlusionQuerySet: querySet39,
+maxDrawCount: 374048,
+}
+);
+let sampler63 = device0.createSampler(
+{
+label: '\u{1fb6b}\u05ed',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 59.133,
+lodMaxClamp: 74.248,
+compare: 'less-equal',
+maxAnisotropy: 6,
+}
+);
+try {
+renderPassEncoder10.setBindGroup(
+5,
+bindGroup24
+);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([]);
+} catch {}
+document.body.prepend(video6);
+document.body.append('\u020b\u{1fb03}\uec6d\u88ff\u{1f9dd}\u{1f861}\u{1f80e}\u5421\ub0d4\u0df3');
+let querySet53 = device0.createQuerySet(
+{
+label: '\u3649\u0a98',
+type: 'occlusion',
+count: 428,
+}
+);
+try {
+renderPassEncoder22.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant(
+{
+r: 853.4,
+g: 515.7,
+b: -716.1,
+a: -807.8,
+}
+);
+} catch {}
+try {
+renderPassEncoder17.setStencilReference(
+1669
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer16,
+312440
+);
+} catch {}
+try {
+adapter4.label = '\u0e54\u13b1\u1f0e';
+} catch {}
+try {
+offscreenCanvas13.getContext('webgl2');
+} catch {}
+let buffer23 = device0.createBuffer(
+{
+size: 8715,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+}
+);
+pseudoSubmit(device0, commandEncoder50);
+let texture62 = gpuCanvasContext4.getCurrentTexture();
+try {
+computePassEncoder9.setBindGroup(
+5,
+bindGroup21,
+[]
+);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(
+2,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder15.setBlendConstant(
+{
+r: 515.7,
+g: -611.0,
+b: -375.0,
+a: -83.24,
+}
+);
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(
+83,
+1,
+164,
+0
+);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(
+buffer2,
+'uint32',
+520,
+5201
+);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(
+buffer11,
+'uint32',
+17512,
+2273
+);
+} catch {}
+try {
+renderBundleEncoder40.insertDebugMarker(
+'\u{1fe33}'
+);
+} catch {}
+try {
+device0.label = '\u{1fbc5}\uffea\u006b\ubd25\u02b6\u7270\ue631\u00dc\u8029\udda3\u64a0';
+} catch {}
+let bindGroupLayout29 = device0.createBindGroupLayout(
+{
+label: '\uef75\u2e6b\u087a\u0f31\u5e43\u0f12\u{1fd72}\u{1fb1d}\u{1f7fe}\u{1f6be}',
+entries: [
+{
+binding: 1953,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+}
+],
+}
+);
+let buffer24 = device0.createBuffer(
+{
+label: '\u4a0b\u{1ff38}\u{1f9c2}\u0ab5\u{1f881}\u4359',
+size: 36199,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let texture63 = device0.createTexture(
+{
+label: '\u08c3\u72b3',
+size: {width: 12, height: 198, depthOrArrayLayers: 1},
+sampleCount: 4,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'depth24plus-stencil8',
+'depth24plus-stencil8',
+'depth24plus-stencil8'
+],
+}
+);
+let textureView62 = texture59.createView(
+{
+label: '\u0674\u{1fec4}\uf015\u7f20\u0af5\uae70\u916b',
+mipLevelCount: 2,
+}
+);
+try {
+renderPassEncoder20.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(
+buffer8,
+169088
+);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(
+1,
+bindGroup27
+);
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(
+buffer11,
+'uint16',
+23680,
+17725
+);
+} catch {}
+try {
+await buffer24.mapAsync(
+GPUMapMode.WRITE,
+0,
+35860
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 14, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint32Array(arrayBuffer10),
+/* required buffer size: 859 */{
+offset: 859,
+bytesPerRow: 3632,
+},
+{width: 1788, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+offscreenCanvas0.height = 954;
+let querySet54 = device0.createQuerySet(
+{
+label: '\ub0ba\u0f96\ub347\u{1f826}',
+type: 'occlusion',
+count: 3765,
+}
+);
+let texture64 = device0.createTexture(
+{
+label: '\u{1f75c}\u6756\ue180\u0a37',
+size: {width: 1484},
+dimension: '1d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+computePassEncoder20.setBindGroup(
+7,
+bindGroup6,
+new Uint32Array(9475),
+7576,
+0
+);
+} catch {}
+try {
+computePassEncoder20.setPipeline(
+pipeline34
+);
+} catch {}
+try {
+renderPassEncoder16.beginOcclusionQuery(
+32
+);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(
+1,
+buffer19,
+16636,
+556
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+2404,
+new Float32Array(39560),
+31913,
+752
+);
+} catch {}
+offscreenCanvas3.width = 258;
+let img9 = await imageWithData(69, 76, '#0e3f8ddb', '#27e74c21');
+let imageBitmap13 = await createImageBitmap(imageBitmap11);
+let bindGroupLayout30 = device0.createBindGroupLayout(
+{
+entries: [
+
+],
+}
+);
+let querySet55 = device0.createQuerySet(
+{
+label: '\ud9f2\u3885\u4803\u8912\u6a26\u237c\u7890',
+type: 'occlusion',
+count: 1009,
+}
+);
+let sampler64 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 57.268,
+lodMaxClamp: 82.401,
+maxAnisotropy: 2,
+}
+);
+try {
+renderPassEncoder16.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant(
+{
+r: -267.8,
+g: 335.4,
+b: 128.9,
+a: 27.62,
+}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 367, height: 1, depthOrArrayLayers: 78}
+*/
+{
+  source: imageBitmap4,
+  origin: { x: 93, y: 24 },
+  flipY: false,
+},
+{
+  texture: texture31,
+  mipLevel: 1,
+  origin: { x: 68, y: 0, z: 13 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 142, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipelineLayout10 = device0.createPipelineLayout(
+{
+label: '\u1555\ua2b9\ufea2\u202d\u1c54\ud3db\ua3a4\ub6ca',
+bindGroupLayouts: [
+bindGroupLayout17,
+bindGroupLayout17,
+bindGroupLayout9,
+bindGroupLayout29,
+bindGroupLayout1
+],
+}
+);
+let commandEncoder51 = device0.createCommandEncoder(
+{
+}
+);
+let texture65 = device0.createTexture(
+{
+label: '\u{1ff82}\u07db\u6420\u{1fe57}\u8bbc\u6497\u0b10',
+size: [27, 1, 634],
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8unorm',
+'rg8unorm'
+],
+}
+);
+let textureView63 = texture27.createView(
+{
+label: '\u06d1\u03d8\ua144\u0fd3\u0b30\u{1f61c}\u0efd\u0552\ue3f5',
+format: 'bgra8unorm-srgb',
+baseArrayLayer: 0,
+}
+);
+let renderPassEncoder30 = commandEncoder51.beginRenderPass(
+{
+label: '\u{1fdd0}\u3ed0\u{1f804}\u{1fe34}\u{1f873}\uee12\u0458\u626c\u0ec1\u1e66\u20e6',
+colorAttachments: [
+
+],
+depthStencilAttachment: {
+view: textureView34,
+depthClearValue: 0.19944538627678265,
+depthLoadOp: 'clear',
+depthStoreOp: 'discard',
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet8,
+maxDrawCount: 11344,
+}
+);
+let renderBundleEncoder55 = device0.createRenderBundleEncoder(
+{
+label: '\u0d62\u86db\ua9ed',
+colorFormats: [
+undefined,
+undefined,
+'rg8unorm'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 513,
+}
+);
+let sampler65 = device0.createSampler(
+{
+label: '\u3c0f\ucae6\u612c\u3ddd',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+mipmapFilter: 'linear',
+lodMinClamp: 92.946,
+lodMaxClamp: 94.523,
+compare: 'less-equal',
+maxAnisotropy: 1,
+}
+);
+try {
+computePassEncoder22.setBindGroup(
+5,
+bindGroup20,
+new Uint32Array(4346),
+121,
+0
+);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(
+0,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder18.setScissorRect(
+3036,
+1,
+3,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.draw(
+72
+);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(
+buffer1,
+'uint16',
+5558,
+63
+);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(
+9,
+buffer19
+);
+} catch {}
+try {
+offscreenCanvas14.getContext('webgl');
+} catch {}
+let commandEncoder52 = device0.createCommandEncoder(
+{
+label: '\u04ff\u02dc\u68dc\uda86\u05f0\u09ea\u9da3\ufc6c\ua574\u{1feef}',
+}
+);
+let textureView64 = texture46.createView(
+{
+baseMipLevel: 6,
+}
+);
+let renderBundleEncoder56 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'r16float',
+'rgba8unorm',
+undefined,
+'rg32float',
+undefined,
+'rgba8unorm-srgb',
+'rg8uint',
+'rgba8unorm-srgb'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 124,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder23.setBindGroup(
+4,
+bindGroup15,
+new Uint32Array(1274),
+1069,
+0
+);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(
+916,
+0,
+594,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(
+buffer2,
+126736
+);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(
+buffer12,
+'uint32'
+);
+} catch {}
+let arrayBuffer17 = buffer19.getMappedRange(
+23048,
+0
+);
+try {
+commandEncoder52.resolveQuerySet(
+querySet19,
+1605,
+44,
+buffer23,
+0
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture60,
+  mipLevel: 1,
+  origin: { x: 4, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Uint8Array(arrayBuffer6),
+/* required buffer size: 704 */{
+offset: 704,
+bytesPerRow: 285,
+},
+{width: 39, height: 6, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+document.body.append('\u39db\u0765\u5e3f\u258b');
+let offscreenCanvas15 = new OffscreenCanvas(911, 319);
+let querySet56 = device0.createQuerySet(
+{
+label: '\ub79a\u11ca\uef0b\u{1fb39}',
+type: 'occlusion',
+count: 3674,
+}
+);
+let texture66 = device0.createTexture(
+{
+label: '\uab74\u0f82',
+size: {width: 1444, height: 1, depthOrArrayLayers: 1017},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'bgra8unorm',
+'bgra8unorm'
+],
+}
+);
+let renderBundleEncoder57 = device0.createRenderBundleEncoder(
+{
+label: '\u8506\u9c65\u985f',
+colorFormats: [
+'rg11b10ufloat',
+'rgb10a2uint',
+'rgba16uint',
+'rg16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 452,
+depthReadOnly: true,
+}
+);
+try {
+computePassEncoder21.end();
+} catch {}
+try {
+renderPassEncoder12.draw(
+8,
+16,
+72,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer6,
+22312
+);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(
+11,
+buffer2
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 389, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Float32Array(arrayBuffer12),
+/* required buffer size: 515 */{
+offset: 515,
+bytesPerRow: 12972,
+},
+{width: 3177, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\u09d4\u4cfa\ua53d\ue966\u0670\u0a75\uc5d7\u0ec8\u{1f9ab}\u0959');
+let offscreenCanvas16 = new OffscreenCanvas(674, 204);
+try {
+offscreenCanvas15.getContext('webgl');
+} catch {}
+let bindGroup30 = device0.createBindGroup({
+layout: bindGroupLayout30,
+entries: [
+
+],
+});
+let commandEncoder53 = device0.createCommandEncoder();
+let texture67 = device0.createTexture(
+{
+label: '\u6797\ua08d\u3f03\u3470\u8332\u0f68',
+size: [133, 120, 17],
+mipLevelCount: 2,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+try {
+computePassEncoder22.setBindGroup(
+8,
+bindGroup9
+);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(
+40
+);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant(
+{
+r: 620.7,
+g: 298.2,
+b: -322.5,
+a: -210.6,
+}
+);
+} catch {}
+try {
+renderPassEncoder16.setViewport(
+2877.8,
+0.5435,
+97.97,
+0.1598,
+0.8881,
+0.9671
+);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(
+4,
+buffer2,
+2092,
+1104
+);
+} catch {}
+try {
+renderBundleEncoder43.setIndexBuffer(
+buffer11,
+'uint32',
+16156,
+11692
+);
+} catch {}
+try {
+commandEncoder53.copyBufferToTexture(
+{
+/* bytesInLastRow: 6256 widthInBlocks: 782 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 13424 */
+offset: 13424,
+buffer: buffer12,
+},
+{
+  texture: texture50,
+  mipLevel: 0,
+  origin: { x: 599, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 782, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer12);
+} catch {}
+let buffer25 = device0.createBuffer(
+{
+label: '\u0bc1\u{1f7fb}\u99c0\u0970\u01f0\u897a',
+size: 1501,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let texture68 = device0.createTexture(
+{
+label: '\ue352\u0178\ua0a1\u7cea',
+size: [3543],
+dimension: '1d',
+format: 'rg32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32float',
+'rg32float'
+],
+}
+);
+let renderBundle50 = renderBundleEncoder14.finish(
+{
+label: '\u631b\u8e45\u0e55\u593a'
+}
+);
+let sampler66 = device0.createSampler(
+{
+label: '\ua504\u2102\u{1fb17}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 23.914,
+lodMaxClamp: 77.351,
+maxAnisotropy: 19,
+}
+);
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer13,
+58976
+);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(
+8,
+buffer4,
+28432,
+19191
+);
+} catch {}
+try {
+renderBundleEncoder53.setIndexBuffer(
+buffer4,
+'uint32',
+38992,
+6593
+);
+} catch {}
+try {
+commandEncoder52.copyTextureToBuffer(
+{
+  texture: texture16,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'depth-only',
+},
+{
+/* bytesInLastRow: 3050 widthInBlocks: 1525 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 37896 */
+offset: 37896,
+buffer: buffer11,
+},
+{width: 1525, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 383, height: 1, depthOrArrayLayers: 334}
+*/
+{
+  source: video11,
+  origin: { x: 10, y: 12 },
+  flipY: true,
+},
+{
+  texture: texture47,
+  mipLevel: 2,
+  origin: { x: 317, y: 1, z: 319 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 5, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let offscreenCanvas17 = new OffscreenCanvas(398, 333);
+let img10 = await imageWithData(18, 183, '#2ccae506', '#f7e20e49');
+try {
+window.someLabel = pipelineLayout0.label;
+} catch {}
+let textureView65 = texture42.createView(
+{
+label: '\ue7f1\u016b\u{1f784}\u0cb0\u36ec\u{1ff53}\ubd32',
+}
+);
+let renderBundleEncoder58 = device0.createRenderBundleEncoder(
+{
+label: '\u058d\u9c1f',
+colorFormats: [
+'rgba32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 614,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder26.setBindGroup(
+4,
+bindGroup24,
+[]
+);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant(
+{
+r: -396.9,
+g: -928.8,
+b: -552.2,
+a: -973.7,
+}
+);
+} catch {}
+try {
+renderPassEncoder22.setViewport(
+1128.2,
+0.2465,
+1354.0,
+0.6960,
+0.1689,
+0.2923
+);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(
+buffer15,
+'uint16'
+);
+} catch {}
+try {
+commandEncoder53.copyTextureToTexture(
+{
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 0, y: 2, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 49, y: 9, z: 0 },
+  aspect: 'all',
+},
+{width: 99, height: 5, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline48 = device0.createComputePipeline(
+{
+label: '\u080f\u77de\u0404\u3a1d\u195a\u1e23\u0b2c\u{1fee9}\u{1f7a7}',
+layout: pipelineLayout8,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend('\u9dd3\u0b84\u0dd5\u252b\u0792\u624c');
+try {
+offscreenCanvas17.getContext('webgl2');
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(
+5,
+bindGroup23
+);
+} catch {}
+try {
+renderPassEncoder30.setBlendConstant(
+{
+r: 436.6,
+g: 249.7,
+b: -548.8,
+a: -814.6,
+}
+);
+} catch {}
+try {
+commandEncoder53.copyBufferToTexture(
+{
+/* bytesInLastRow: 4 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 28040 */
+offset: 27780,
+bytesPerRow: 256,
+buffer: buffer3,
+},
+{
+  texture: texture25,
+  mipLevel: 3,
+  origin: { x: 3, y: 7, z: 0 },
+  aspect: 'all',
+},
+{width: 2, height: 2, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder53.resolveQuerySet(
+querySet15,
+226,
+1159,
+buffer16,
+20480
+);
+} catch {}
+document.body.append('\uf7fc\u9d00\u0636\u5b03\u{1f70a}\u4e3d\u7ece');
+let canvas13 = document.createElement('canvas');
+try {
+canvas11.getContext('webgpu');
+} catch {}
+let querySet57 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 880,
+}
+);
+let texture69 = device0.createTexture(
+{
+label: '\u2a2f\u{1f961}\u6cdd\ub8b9\ufc43\u{1f75d}\u9a4e\u6455\u0fd4',
+size: [6617, 206, 109],
+mipLevelCount: 3,
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8unorm'
+],
+}
+);
+let textureView66 = texture18.createView(
+{
+dimension: '3d',
+format: 'rgba8unorm-srgb',
+baseMipLevel: 1,
+}
+);
+let renderPassEncoder31 = commandEncoder53.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthClearValue: 0.8042192820236458,
+depthLoadOp: 'clear',
+depthStoreOp: 'discard',
+depthReadOnly: false,
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet19,
+maxDrawCount: 72920,
+}
+);
+let renderBundle51 = renderBundleEncoder15.finish();
+let sampler67 = device0.createSampler(
+{
+label: '\ue3c8\ub7c6\u0799\u04e5\ue9c1\u3c27\u039b',
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 68.395,
+lodMaxClamp: 73.551,
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder2.setBindGroup(
+2,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(
+7,
+bindGroup12,
+new Uint32Array(7915),
+399,
+0
+);
+} catch {}
+try {
+commandEncoder52.clearBuffer(
+buffer19,
+18940,
+3548
+);
+dissociateBuffer(device0, buffer19);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 943, height: 1, depthOrArrayLayers: 1276}
+*/
+{
+  source: img7,
+  origin: { x: 198, y: 19 },
+  flipY: false,
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: { x: 805, y: 1, z: 210 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 4, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+window.someLabel = device0.label;
+} catch {}
+let commandEncoder54 = device0.createCommandEncoder();
+let renderBundleEncoder59 = device0.createRenderBundleEncoder(
+{
+label: '\u09b9\u{1f96f}\u{1f922}\u0379\u02de',
+colorFormats: [
+'r16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 213,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle52 = renderBundleEncoder7.finish(
+{
+label: '\u0349\u194c\uf17b\u968a\ub70e\u0cb1\u1b4e\u9bdc\u05a3\u0530'
+}
+);
+try {
+renderPassEncoder10.setBindGroup(
+6,
+bindGroup22
+);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(
+0,
+bindGroup22
+);
+} catch {}
+let arrayBuffer18 = buffer0.getMappedRange(
+22320,
+28
+);
+try {
+buffer16.unmap();
+} catch {}
+try {
+gpuCanvasContext6.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth32float',
+'rgba8unorm',
+'rgba8unorm'
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let shaderModule10 = device0.createShaderModule(
+{
+label: '\u020e\u{1f737}\u0a8c\u3e4a\u7845\u1df5\ub0a4\u0e1c',
+code: `
+
+@compute @workgroup_size(3, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: vec2<i32>,
+@location(2) f1: vec2<u32>,
+@location(5) f2: vec3<u32>,
+@location(7) f3: vec2<i32>,
+@location(4) f4: vec4<u32>,
+@location(1) f5: vec4<u32>,
+@location(0) f6: vec3<f32>,
+@builtin(frag_depth) f7: f32
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S12 {
+@location(9) f0: vec3<i32>,
+@location(15) f1: vec3<f16>,
+@location(0) f2: vec3<i32>,
+@location(4) f3: vec4<f16>,
+@location(10) f4: vec2<i32>,
+@location(16) f5: f16,
+@location(11) f6: vec4<i32>,
+@builtin(vertex_index) f7: u32,
+@location(8) f8: vec2<f32>,
+@location(1) f9: vec3<f32>,
+@builtin(instance_index) f10: u32,
+@location(5) f11: vec2<u32>,
+@location(3) f12: vec2<u32>,
+@location(14) f13: f32
+}
+
+@vertex
+fn vertex0(@location(13) a0: vec3<u32>, @location(7) a1: vec3<i32>, @location(6) a2: vec3<i32>, a3: S12, @location(12) a4: vec3<i32>, @location(2) a5: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let computePassEncoder23 = commandEncoder54.beginComputePass(
+{
+label: '\u2993\u063c\u{1fa32}\u05e2\ua306\u0798\u8b1c\u7d32\uc6a1'
+}
+);
+let renderBundleEncoder60 = device0.createRenderBundleEncoder(
+{
+label: '\u1216\ucbad',
+colorFormats: [
+'rgba32uint',
+'rgba8unorm-srgb',
+'r32uint',
+'r8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 327,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle53 = renderBundleEncoder23.finish();
+try {
+computePassEncoder22.setPipeline(
+pipeline4
+);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(
+buffer13,
+304016
+);
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(
+6,
+bindGroup27
+);
+} catch {}
+try {
+commandEncoder52.copyBufferToBuffer(
+buffer8,
+1348,
+buffer17,
+49640,
+164
+);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer17);
+} catch {}
+try {
+commandEncoder52.copyTextureToTexture(
+{
+  texture: texture1,
+  mipLevel: 1,
+  origin: { x: 3, y: 22, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 1,
+  origin: { x: 1, y: 13, z: 0 },
+  aspect: 'all',
+},
+{width: 3, height: 85, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder52.clearBuffer(
+buffer19
+);
+dissociateBuffer(device0, buffer19);
+} catch {}
+try {
+commandEncoder6.resolveQuerySet(
+querySet29,
+24,
+817,
+buffer10,
+7680
+);
+} catch {}
+let promise26 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 45, height: 1, depthOrArrayLayers: 31}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 76, y: 49 },
+  flipY: false,
+},
+{
+  texture: texture66,
+  mipLevel: 5,
+  origin: { x: 23, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 19, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline49 = device0.createComputePipeline(
+{
+label: '\ufdaf\ua5eb\uf973\ub492\u{1f7ec}\u{1fffe}\ufefa\uda5c\uac5d',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule10,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let gpuCanvasContext12 = offscreenCanvas16.getContext('webgpu');
+canvas10.height = 742;
+let texture70 = device0.createTexture(
+{
+label: '\u01e2\u{1f86d}\u4457\u0908',
+size: {width: 240, height: 1, depthOrArrayLayers: 223},
+mipLevelCount: 4,
+sampleCount: 1,
+dimension: '3d',
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb9e5ufloat',
+'rgb9e5ufloat',
+'rgb9e5ufloat'
+],
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+7,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer12,
+215992
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(
+buffer20,
+61312
+);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(
+0,
+bindGroup25,
+new Uint32Array(7836),
+285,
+0
+);
+} catch {}
+let promise27 = buffer18.mapAsync(
+GPUMapMode.WRITE,
+2576,
+32500
+);
+try {
+commandEncoder52.clearBuffer(
+buffer11,
+39404,
+1936
+);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+gpuCanvasContext8.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float',
+'bgra8unorm-srgb',
+'rgba32sint',
+'rgba16float'
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 180, height: 1, depthOrArrayLayers: 127}
+*/
+{
+  source: video5,
+  origin: { x: 5, y: 6 },
+  flipY: true,
+},
+{
+  texture: texture66,
+  mipLevel: 3,
+  origin: { x: 4, y: 1, z: 7 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 9, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let gpuCanvasContext13 = canvas12.getContext('webgpu');
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let texture71 = device0.createTexture(
+{
+label: '\u093a\ud032\u0b0e\u408b',
+size: [6768, 1, 161],
+mipLevelCount: 9,
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm',
+'rgba8unorm'
+],
+}
+);
+let renderBundleEncoder61 = device0.createRenderBundleEncoder(
+{
+label: '\u01a9\u8521\u{1f730}\u095a\u07ac\uaf81\u03fb\u34b1',
+colorFormats: [
+'bgra8unorm',
+'r16float',
+'rg11b10ufloat',
+'r8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 721,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler68 = device0.createSampler(
+{
+label: '\u0d05\u5720\u3314\u0c93\u0527\u15a8\u{1f889}\uf79b\ucc81',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 32.496,
+lodMaxClamp: 64.913,
+}
+);
+try {
+renderPassEncoder10.drawIndexed(
+64
+);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(
+buffer15,
+'uint32',
+38168,
+3307
+);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(
+9,
+buffer15,
+33580,
+6848
+);
+} catch {}
+try {
+device0.pushErrorScope(
+'internal'
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1444, height: 1, depthOrArrayLayers: 1017}
+*/
+{
+  source: imageData9,
+  origin: { x: 6, y: 96 },
+  flipY: true,
+},
+{
+  texture: texture66,
+  mipLevel: 0,
+  origin: { x: 457, y: 0, z: 258 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 19, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend(video4);
+try {
+adapter0.label = '\ud2b7\u{1f820}\u982e\u0d09\u{1ff6a}\u3307\uc743\u6299\ue084\u9f91';
+} catch {}
+let querySet58 = device0.createQuerySet(
+{
+label: '\u089c\u03d2\u5467\u{1f604}\u5f17\u8a00\u01ca\u0394\uffed',
+type: 'occlusion',
+count: 1434,
+}
+);
+try {
+renderPassEncoder22.setStencilReference(
+1545
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer20,
+303304
+);
+} catch {}
+try {
+commandEncoder6.resolveQuerySet(
+querySet55,
+335,
+613,
+buffer10,
+11264
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline50 = await device0.createComputePipelineAsync(
+{
+label: '\u2e2c\ub05a\u034f\ud547\u0b4f\ub66b\u0ef6\udcb1\u{1fbb0}',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.append('\u159c\ua846\u0f1f');
+let commandEncoder55 = device0.createCommandEncoder();
+let commandBuffer5 = commandEncoder55.finish(
+{
+label: '\u771a\ua769\u6f6d\u2237\u{1fc5e}\ud18e\u74ab',
+}
+);
+let renderPassEncoder32 = commandEncoder52.beginRenderPass(
+{
+label: '\u064d\u0f8e\u189f\u0dcb\u82c1\u{1f779}\u0721\u071e\u0fc8\u1bae\u{1fdf0}',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthReadOnly: true,
+stencilClearValue: 3756,
+},
+occlusionQuerySet: querySet0,
+maxDrawCount: 131008,
+}
+);
+let renderBundle54 = renderBundleEncoder21.finish();
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+computePassEncoder19.setPipeline(
+pipeline1
+);
+} catch {}
+try {
+renderPassEncoder10.draw(
+64,
+48,
+16,
+80
+);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(
+1,
+bindGroup23
+);
+} catch {}
+video3.height = 224;
+let imageBitmap14 = await createImageBitmap(videoFrame5);
+let querySet59 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 1906,
+}
+);
+let texture72 = device0.createTexture(
+{
+size: {width: 893, height: 1, depthOrArrayLayers: 474},
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rg32uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32uint'
+],
+}
+);
+let computePassEncoder24 = commandEncoder34.beginComputePass(
+{
+label: '\u69b8\u{1fcce}\u{1f638}\u{1f71b}\ua36a\u05ad\ub7e1\ueb3f\u05a2\u13ce'
+}
+);
+try {
+renderPassEncoder28.setBlendConstant(
+{
+r: -17.26,
+g: 906.1,
+b: 125.7,
+a: 833.8,
+}
+);
+} catch {}
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 91, height: 1, depthOrArrayLayers: 19}
+*/
+{
+  source: imageBitmap13,
+  origin: { x: 121, y: 131 },
+  flipY: false,
+},
+{
+  texture: texture31,
+  mipLevel: 3,
+  origin: { x: 1, y: 0, z: 10 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 89, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let bindGroupLayout31 = device0.createBindGroupLayout(
+{
+label: '\u04ee\uebfb\ub8f1\u0dca\u06f7\ub8c2\u{1fa17}\u{1f8ba}\u{1fa0d}\u{1ff4a}\u050b',
+entries: [
+{
+binding: 2575,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'storage', minBindingSize: 127149, hasDynamicOffset: true },
+},
+{
+binding: 532,
+visibility: GPUShaderStage.FRAGMENT,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+},
+{
+binding: 3210,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let texture73 = device0.createTexture(
+{
+label: '\u0086\ufe57\u7647\uc01f\u0635\u{1fd9f}\u46ba',
+size: [185],
+dimension: '1d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8snorm'
+],
+}
+);
+let sampler69 = device0.createSampler(
+{
+label: '\u389c\u7e29\u{1fef1}',
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 10.428,
+compare: 'equal',
+maxAnisotropy: 19,
+}
+);
+try {
+renderPassEncoder3.setViewport(
+2.542,
+5.403,
+0.1957,
+36.79,
+0.6196,
+0.6624
+);
+} catch {}
+try {
+commandEncoder6.copyTextureToBuffer(
+{
+  texture: texture42,
+  mipLevel: 0,
+  origin: { x: 3551, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 3913 widthInBlocks: 3913 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 39914 */
+offset: 39914,
+buffer: buffer9,
+},
+{width: 3913, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder6.copyTextureToTexture(
+{
+  texture: texture15,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture20,
+  mipLevel: 3,
+  origin: { x: 58, y: 0, z: 14 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder6.resolveQuerySet(
+querySet22,
+37,
+48,
+buffer21,
+19712
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let pipeline51 = device0.createRenderPipeline(
+{
+label: '\u{1fd6f}\u08ef\u013a\u{1fe76}\u0cd7\ubfe6\u9040\u083b\ud5c0\u0fc9',
+layout: pipelineLayout7,
+vertex: {
+module: shaderModule10,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 29772,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x3',
+offset: 928,
+shaderLocation: 12,
+},
+{
+format: 'sint8x2',
+offset: 11614,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x4',
+offset: 2944,
+shaderLocation: 4,
+},
+{
+format: 'sint16x4',
+offset: 27180,
+shaderLocation: 9,
+},
+{
+format: 'sint8x4',
+offset: 24176,
+shaderLocation: 11,
+},
+{
+format: 'sint32',
+offset: 27548,
+shaderLocation: 6,
+},
+{
+format: 'sint32x4',
+offset: 24992,
+shaderLocation: 0,
+},
+{
+format: 'float32',
+offset: 8144,
+shaderLocation: 1,
+},
+{
+format: 'float16x4',
+offset: 13184,
+shaderLocation: 8,
+},
+{
+format: 'float32',
+offset: 23128,
+shaderLocation: 14,
+},
+{
+format: 'uint32x2',
+offset: 18744,
+shaderLocation: 5,
+},
+{
+format: 'sint32x3',
+offset: 18484,
+shaderLocation: 10,
+},
+{
+format: 'uint32',
+offset: 2216,
+shaderLocation: 13,
+},
+{
+format: 'float32x2',
+offset: 26572,
+shaderLocation: 16,
+},
+{
+format: 'uint8x2',
+offset: 20998,
+shaderLocation: 3,
+},
+{
+format: 'float32x3',
+offset: 12760,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 6152,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 368,
+shaderLocation: 15,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule10,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'zero',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'zero',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilWriteMask: 3076,
+depthBias: 43,
+depthBiasSlopeScale: 57,
+depthBiasClamp: 20,
+},
+}
+);
+let renderBundleEncoder62 = device0.createRenderBundleEncoder(
+{
+label: '\u9ee2\u0766\u1ca3\u93e7\uc428\u1ac2',
+colorFormats: [
+'rg32sint',
+'rg16sint',
+'rgba8unorm',
+'bgra8unorm',
+'rgba32sint',
+undefined
+],
+sampleCount: 260,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle55 = renderBundleEncoder51.finish();
+try {
+renderPassEncoder3.setStencilReference(
+1864
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(
+24,
+40
+);
+} catch {}
+try {
+commandEncoder6.copyBufferToBuffer(
+buffer7,
+10356,
+buffer4,
+17704,
+2472
+);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let pipeline52 = device0.createComputePipeline(
+{
+layout: pipelineLayout0,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let video13 = await videoWithData();
+let buffer26 = device0.createBuffer(
+{
+label: '\u5a56\u0195\u{1fe0b}\u793d\u0cb6\uc9f4',
+size: 10786,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let commandEncoder56 = device0.createCommandEncoder(
+{
+label: '\u{1fbaa}\uf118',
+}
+);
+let texture74 = device0.createTexture(
+{
+size: [183, 1, 183],
+mipLevelCount: 8,
+dimension: '3d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'r16sint'
+],
+}
+);
+let computePassEncoder25 = commandEncoder56.beginComputePass(
+{
+label: '\u1f65\u1ac8\u3235'
+}
+);
+let sampler70 = device0.createSampler(
+{
+label: '\u2db6\ueffe\u{1f667}\u{1f63d}\u006a\u866e\uff48',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 15.404,
+}
+);
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(
+11,
+buffer6,
+8584
+);
+} catch {}
+try {
+renderBundleEncoder57.setBindGroup(
+0,
+bindGroup30
+);
+} catch {}
+try {
+buffer26.unmap();
+} catch {}
+try {
+commandEncoder6.copyBufferToBuffer(
+buffer3,
+49352,
+buffer21,
+48140,
+5400
+);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer21);
+} catch {}
+try {
+commandEncoder6.copyTextureToBuffer(
+{
+  texture: texture37,
+  mipLevel: 0,
+  origin: { x: 150, y: 9, z: 16 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 19394 widthInBlocks: 9697 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 44124 */
+offset: 44124,
+bytesPerRow: 19456,
+rowsPerImage: 177,
+buffer: buffer4,
+},
+{width: 9697, height: 6, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder6.copyTextureToTexture(
+{
+  texture: texture46,
+  mipLevel: 2,
+  origin: { x: 6, y: 1, z: 131 },
+  aspect: 'all',
+},
+{
+  texture: texture41,
+  mipLevel: 3,
+  origin: { x: 624, y: 1, z: 5 },
+  aspect: 'all',
+},
+{width: 28, height: 0, depthOrArrayLayers: 27}
+);
+} catch {}
+try {
+commandEncoder6.clearBuffer(
+buffer11,
+17928,
+19652
+);
+dissociateBuffer(device0, buffer11);
+} catch {}
+document.body.prepend('\u07a6\ueb26\u44c0\uaf75\u0636\u0243\u2ec6\u0701\u{1f7be}\u{1fe73}\u{1ff65}');
+let texture75 = device0.createTexture(
+{
+label: '\u{1fc02}\uaa8c\u{1f9db}\u30d6',
+size: {width: 103, height: 103, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rg16float',
+'rg16float',
+'rg16float'
+],
+}
+);
+let computePassEncoder26 = commandEncoder6.beginComputePass();
+let renderBundleEncoder63 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'bgra8unorm',
+'r16sint',
+'rgba16uint',
+'rgba8sint',
+'rgba8uint',
+'rg16float',
+'r8unorm'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 197,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder24.setPipeline(
+pipeline9
+);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(
+8,
+bindGroup5,
+new Uint32Array(8800),
+7870,
+0
+);
+} catch {}
+try {
+renderPassEncoder27.beginOcclusionQuery(
+80
+);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder29.setBlendConstant(
+{
+r: 178.0,
+g: -560.5,
+b: -958.0,
+a: 470.2,
+}
+);
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(
+2115
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer3,
+97472
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture54,
+  mipLevel: 4,
+  origin: { x: 0, y: 6, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer8,
+/* required buffer size: 287 */{
+offset: 287,
+},
+{width: 13, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 383, height: 1, depthOrArrayLayers: 334}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 219, y: 46 },
+  flipY: false,
+},
+{
+  texture: texture47,
+  mipLevel: 2,
+  origin: { x: 222, y: 0, z: 53 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 77, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await promise27;
+} catch {}
+document.body.append('\u99f2\u7f5b\u010b\u19dc\u088c\u68bb\u5a47');
+let texture76 = device0.createTexture(
+{
+label: '\u39be\u9d6d\u{1fb0a}\u0f63\u{1f883}\u{1ff8b}\u{1f8cb}\u9895\u5a6d',
+size: [1907],
+dimension: '1d',
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_DST,
+}
+);
+let textureView67 = texture16.createView(
+{
+label: '\u1642\u{1f741}\u1c72\u4560\u{1fb6e}\u{1fe5c}\u87cf',
+dimension: '2d-array',
+aspect: 'depth-only',
+mipLevelCount: 2,
+arrayLayerCount: 1,
+}
+);
+try {
+renderPassEncoder12.setBlendConstant(
+{
+r: -47.66,
+g: 732.4,
+b: -100.5,
+a: 763.1,
+}
+);
+} catch {}
+try {
+renderPassEncoder14.setViewport(
+1221.6,
+0.6850,
+446.1,
+0.07101,
+0.6179,
+0.6297
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer15,
+152888
+);
+} catch {}
+let pipeline53 = device0.createComputePipeline(
+{
+layout: pipelineLayout5,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let videoFrame12 = new VideoFrame(video12, {timestamp: 0});
+let bindGroup31 = device0.createBindGroup({
+layout: bindGroupLayout30,
+entries: [
+
+],
+});
+let commandEncoder57 = device0.createCommandEncoder(
+{
+label: '\u0a5a\u06da\u81b1\u43d6\u68b1\uf119\ua8b3',
+}
+);
+let querySet60 = device0.createQuerySet(
+{
+label: '\u84ae\u{1f769}\u358b\u4c4d\u0023\u2431',
+type: 'occlusion',
+count: 1902,
+}
+);
+let renderBundle56 = renderBundleEncoder56.finish();
+try {
+renderPassEncoder12.setBindGroup(
+3,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(
+56
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer23,
+42352
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer10,
+3688
+);
+} catch {}
+try {
+commandEncoder57.resolveQuerySet(
+querySet5,
+2667,
+36,
+buffer19,
+10240
+);
+} catch {}
+try {
+commandEncoder57.insertDebugMarker(
+'\u05da'
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture59,
+  mipLevel: 0,
+  origin: { x: 312, y: 0, z: 88 },
+  aspect: 'all',
+},
+new ArrayBuffer(25169036),
+/* required buffer size: 25169036 */{
+offset: 287,
+bytesPerRow: 627,
+rowsPerImage: 137,
+},
+{width: 171, height: 1, depthOrArrayLayers: 294}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 58, height: 1, depthOrArrayLayers: 79}
+*/
+{
+  source: offscreenCanvas3,
+  origin: { x: 141, y: 268 },
+  flipY: true,
+},
+{
+  texture: texture10,
+  mipLevel: 4,
+  origin: { x: 36, y: 1, z: 3 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline54 = device0.createRenderPipeline(
+{
+label: '\u{1f6c0}\u6329\u02d6\uce21',
+layout: pipelineLayout5,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 46424,
+attributes: [
+{
+format: 'float32',
+offset: 43216,
+shaderLocation: 14,
+},
+{
+format: 'uint16x2',
+offset: 20348,
+shaderLocation: 7,
+},
+{
+format: 'uint32x3',
+offset: 38648,
+shaderLocation: 2,
+},
+{
+format: 'float32',
+offset: 6584,
+shaderLocation: 13,
+},
+{
+format: 'uint8x4',
+offset: 23200,
+shaderLocation: 1,
+},
+{
+format: 'sint8x4',
+offset: 32916,
+shaderLocation: 4,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 26252,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 40500,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 7526,
+shaderLocation: 6,
+},
+{
+format: 'float32',
+offset: 26188,
+shaderLocation: 10,
+},
+{
+format: 'snorm8x2',
+offset: 34532,
+shaderLocation: 9,
+},
+{
+format: 'sint16x4',
+offset: 16360,
+shaderLocation: 11,
+},
+{
+format: 'unorm8x2',
+offset: 24974,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 59960,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 14492,
+shaderLocation: 8,
+},
+{
+format: 'uint32x4',
+offset: 57452,
+shaderLocation: 16,
+},
+{
+format: 'sint32',
+offset: 46868,
+shaderLocation: 15,
+},
+{
+format: 'float32',
+offset: 1952,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 3240,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 2964,
+shaderLocation: 3,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x50c5b1fc,
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'rg32sint',
+},
+undefined,
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.BLUE,
+},
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.RED,
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilWriteMask: 2218,
+depthBias: 87,
+depthBiasSlopeScale: 64,
+depthBiasClamp: 42,
+},
+}
+);
+try {
+await promise26;
+} catch {}
+let shaderModule11 = device0.createShaderModule(
+{
+label: '\uf544\u7e83\u8dbe',
+code: `
+
+@compute @workgroup_size(7, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: u32
+}
+
+@fragment
+fn fragment0(@location(32) a0: vec4<u32>, @location(37) a1: f32, @location(18) a2: vec2<f32>, @location(26) a3: vec2<u32>, @location(7) a4: f16, @location(49) a5: vec4<i32>, @location(21) a6: vec3<f16>, @location(31) a7: vec4<i32>, @location(0) a8: vec4<f16>, @location(43) a9: vec2<f16>, @location(42) a10: vec3<i32>, @builtin(sample_mask) a11: u32, @location(34) a12: f16, @location(8) a13: f32, @builtin(position) a14: vec4<f32>, @location(3) a15: vec3<f16>, @builtin(front_facing) a16: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(19) f135: vec4<f32>,
+@location(49) f136: vec4<i32>,
+@location(25) f137: vec4<f32>,
+@location(32) f138: vec4<u32>,
+@location(52) f139: vec3<f32>,
+@location(37) f140: f32,
+@location(8) f141: f32,
+@location(23) f142: vec4<i32>,
+@location(3) f143: vec3<f16>,
+@location(16) f144: vec2<f32>,
+@location(21) f145: vec3<f16>,
+@location(54) f146: vec3<u32>,
+@location(6) f147: vec3<f32>,
+@location(0) f148: vec4<f16>,
+@location(31) f149: vec4<i32>,
+@location(17) f150: vec4<f32>,
+@location(29) f151: f16,
+@location(42) f152: vec3<i32>,
+@location(47) f153: f32,
+@location(7) f154: f16,
+@location(26) f155: vec2<u32>,
+@location(14) f156: vec2<i32>,
+@location(43) f157: vec2<f16>,
+@builtin(position) f158: vec4<f32>,
+@location(34) f159: f16,
+@location(18) f160: vec2<f32>
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder58 = device0.createCommandEncoder(
+{
+label: '\u0ab4\u{1faaf}\u86fc\u0d82\u{1f78e}\u96c0\u0923\u{1fc6a}\uff3f\u085b',
+}
+);
+let sampler71 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 27.375,
+compare: 'greater-equal',
+}
+);
+try {
+renderPassEncoder28.setBindGroup(
+1,
+bindGroup20,
+new Uint32Array(4113),
+1393,
+0
+);
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(
+3197
+);
+} catch {}
+try {
+renderPassEncoder6.setViewport(
+1.250,
+26.02,
+1.213,
+3.522,
+0.5726,
+0.9565
+);
+} catch {}
+try {
+renderPassEncoder12.draw(
+24,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer26,
+67952
+);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(
+7,
+buffer9,
+30804
+);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(
+11,
+buffer23,
+1600,
+3100
+);
+} catch {}
+try {
+commandEncoder58.clearBuffer(
+buffer6,
+560
+);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let textureView68 = texture54.createView(
+{
+dimension: '2d-array',
+aspect: 'stencil-only',
+baseMipLevel: 4,
+}
+);
+let computePassEncoder27 = commandEncoder58.beginComputePass();
+let renderBundle57 = renderBundleEncoder49.finish(
+{
+label: '\u04ee\u829f\u7e12\u389d'
+}
+);
+try {
+computePassEncoder20.setBindGroup(
+5,
+bindGroup10,
+new Uint32Array(3278),
+2553,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.draw(
+24
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer5,
+96472
+);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(
+buffer22,
+'uint32',
+680,
+19897
+);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(
+1,
+buffer6,
+9112,
+247
+);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(
+2,
+bindGroup16
+);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(
+5,
+buffer6,
+476,
+3245
+);
+} catch {}
+try {
+commandEncoder57.copyBufferToBuffer(
+buffer7,
+4064,
+buffer26,
+7044,
+3340
+);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+commandEncoder57.copyTextureToTexture(
+{
+  texture: texture10,
+  mipLevel: 2,
+  origin: { x: 91, y: 1, z: 232 },
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 4,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+{width: 23, height: 0, depthOrArrayLayers: 70}
+);
+} catch {}
+let promise28 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext14 = canvas13.getContext('webgpu');
+let shaderModule12 = device0.createShaderModule(
+{
+label: '\u565d\u0b49\u0702\ufc17\u{1fd0e}',
+code: `
+
+@compute @workgroup_size(8, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S13 {
+@location(13) f0: vec4<u32>,
+@location(24) f1: vec2<u32>,
+@location(16) f2: i32,
+@location(10) f3: f16,
+@location(42) f4: f32,
+@location(43) f5: vec2<i32>,
+@location(39) f6: vec2<i32>,
+@location(59) f7: vec3<f32>
+}
+struct FragmentOutput0 {
+@location(5) f0: vec3<u32>,
+@location(0) f1: u32,
+@location(4) f2: vec4<u32>,
+@location(6) f3: vec2<f32>
+}
+
+@fragment
+fn fragment0(@location(48) a0: vec3<f16>, @builtin(sample_mask) a1: u32, @location(17) a2: f16, @location(1) a3: vec2<i32>, @location(26) a4: vec3<u32>, @location(58) a5: vec2<f32>, @location(15) a6: u32, a7: S13, @builtin(position) a8: vec4<f32>, @location(45) a9: vec4<f32>, @location(35) a10: vec2<u32>, @builtin(front_facing) a11: bool, @location(8) a12: vec2<u32>, @location(23) a13: vec3<f32>, @location(55) a14: f32, @location(3) a15: vec4<f32>, @location(44) a16: vec4<f32>, @location(28) a17: vec3<f16>, @location(18) a18: vec4<i32>, @location(41) a19: vec3<f32>, @builtin(sample_index) a20: u32, @location(49) a21: vec2<f16>, @location(52) a22: vec3<f16>, @location(36) a23: f16, @location(33) a24: vec2<i32>, @location(12) a25: u32, @location(54) a26: vec3<i32>, @location(57) a27: vec3<f32>, @location(19) a28: i32, @location(2) a29: vec3<i32>, @location(50) a30: vec3<f32>, @location(25) a31: vec2<f16>, @location(30) a32: vec4<f16>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(25) f161: vec2<f16>,
+@location(24) f162: vec2<u32>,
+@location(45) f163: vec4<f32>,
+@builtin(position) f164: vec4<f32>,
+@location(26) f165: vec3<u32>,
+@location(42) f166: f32,
+@location(57) f167: vec3<f32>,
+@location(18) f168: vec4<i32>,
+@location(49) f169: vec2<f16>,
+@location(54) f170: vec3<i32>,
+@location(33) f171: vec2<i32>,
+@location(1) f172: vec2<i32>,
+@location(43) f173: vec2<i32>,
+@location(19) f174: i32,
+@location(52) f175: vec3<f16>,
+@location(36) f176: f16,
+@location(50) f177: vec3<f32>,
+@location(41) f178: vec3<f32>,
+@location(17) f179: f16,
+@location(30) f180: vec4<f16>,
+@location(55) f181: f32,
+@location(13) f182: vec4<u32>,
+@location(28) f183: vec3<f16>,
+@location(8) f184: vec2<u32>,
+@location(16) f185: i32,
+@location(3) f186: vec4<f32>,
+@location(10) f187: f16,
+@location(12) f188: u32,
+@location(58) f189: vec2<f32>,
+@location(59) f190: vec3<f32>,
+@location(2) f191: vec3<i32>,
+@location(23) f192: vec3<f32>,
+@location(39) f193: vec2<i32>,
+@location(35) f194: vec2<u32>,
+@location(48) f195: vec3<f16>,
+@location(15) f196: u32,
+@location(44) f197: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: i32, @location(4) a1: vec2<f32>, @location(0) a2: i32, @location(11) a3: f16, @location(5) a4: vec2<f32>, @location(1) a5: vec3<u32>, @builtin(instance_index) a6: u32, @location(6) a7: vec3<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder59 = device0.createCommandEncoder();
+let querySet61 = device0.createQuerySet(
+{
+label: '\u1285\u5c57\u42aa\u{1f7ca}\ue9a4\u0ff0\u7ecb\ub876\u0339\u0450',
+type: 'occlusion',
+count: 3329,
+}
+);
+let renderPassEncoder33 = commandEncoder57.beginRenderPass(
+{
+label: '\u{1fe28}\u2002\u5966\u09a4\u06c0\u06e3\u15ec\u{1f728}\u069f',
+colorAttachments: [
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthClearValue: -3.459687663778352,
+depthReadOnly: true,
+stencilReadOnly: true,
+},
+maxDrawCount: 107352,
+}
+);
+try {
+computePassEncoder26.setPipeline(
+pipeline8
+);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant(
+{
+r: 508.0,
+g: -457.6,
+b: 772.1,
+a: 840.9,
+}
+);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(
+1,
+buffer11,
+20360,
+6668
+);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(
+6,
+bindGroup4,
+new Uint32Array(4014),
+773,
+0
+);
+} catch {}
+try {
+commandEncoder59.copyBufferToBuffer(
+buffer18,
+25912,
+buffer1,
+3548,
+2088
+);
+dissociateBuffer(device0, buffer18);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let promise29 = device0.queue.onSubmittedWorkDone();
+let commandEncoder60 = device0.createCommandEncoder(
+{
+label: '\u0df4\u008d\u0fdc\u0a3f\u0a52\u0751\ud85b\uc7c2\u6bd1\u5db9',
+}
+);
+let renderBundleEncoder64 = device0.createRenderBundleEncoder(
+{
+label: '\u{1fca4}\u01c8\ufba1\u7a45',
+colorFormats: [
+'rgba8sint',
+undefined,
+'rg16uint',
+'r32float',
+'rg32float',
+'rgba16float',
+'rg16sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 882,
+}
+);
+let renderBundle58 = renderBundleEncoder6.finish(
+{
+label: '\u{1ff22}\u0856\u{1fc1f}\u903b\ub0fd\u0cb1'
+}
+);
+let sampler72 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 1.917,
+}
+);
+let externalTexture0 = device0.importExternalTexture(
+{
+label: '\u0024\u1022\u931b\u{1f8e8}\u21ea\u0543\u3414\u{1f7f9}',
+source: videoFrame9,
+colorSpace: 'srgb',
+}
+);
+try {
+renderPassEncoder28.beginOcclusionQuery(
+80
+);
+} catch {}
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(
+buffer9,
+'uint32',
+6920,
+12729
+);
+} catch {}
+try {
+renderBundleEncoder59.setBindGroup(
+8,
+bindGroup25,
+new Uint32Array(6615),
+5469,
+0
+);
+} catch {}
+try {
+commandEncoder60.copyBufferToBuffer(
+buffer15,
+36828,
+buffer10,
+9516,
+332
+);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder59.resolveQuerySet(
+querySet54,
+98,
+673,
+buffer6,
+2304
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer26,
+5380,
+new BigUint64Array(27781),
+6670,
+508
+);
+} catch {}
+gc();
+document.body.prepend('\u{1fe22}\u0499\u07c1\uaf40\u0b4b');
+let pipelineLayout11 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout11,
+bindGroupLayout25,
+bindGroupLayout7,
+bindGroupLayout12
+],
+}
+);
+let textureView69 = texture37.createView(
+{
+label: '\uc15e\ube6f\u4993\u{1ff2d}\ua39b\uda8c\u{1f8e8}',
+dimension: '2d',
+baseMipLevel: 3,
+mipLevelCount: 1,
+baseArrayLayer: 37,
+}
+);
+let renderPassEncoder34 = commandEncoder59.beginRenderPass(
+{
+label: '\u0b14\u041e\u159b\u2eea\u2ab6\u{1f640}\ufcce\u3280\u6cdb\u{1f83d}\u659c',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthClearValue: 0.28087666675246536,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+stencilClearValue: 8347,
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet7,
+}
+);
+try {
+computePassEncoder14.setPipeline(
+pipeline1
+);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(
+8,
+bindGroup7
+);
+} catch {}
+try {
+renderPassEncoder34.setBlendConstant(
+{
+r: -555.7,
+g: 23.13,
+b: 278.8,
+a: -665.4,
+}
+);
+} catch {}
+try {
+renderPassEncoder31.setScissorRect(
+1050,
+0,
+1923,
+0
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer21,
+37832,
+new DataView(new ArrayBuffer(50151)),
+39945,
+7668
+);
+} catch {}
+let pipeline55 = device0.createComputePipeline(
+{
+layout: pipelineLayout10,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+},
+}
+);
+document.body.prepend(img3);
+let videoFrame13 = new VideoFrame(offscreenCanvas14, {timestamp: 0});
+let renderBundleEncoder65 = device0.createRenderBundleEncoder(
+{
+label: '\u54ed\u{1f7b6}\ua272\u{1f94e}\u5314\u7fd9\uc08a',
+colorFormats: [
+'r32float',
+'rg16sint'
+],
+sampleCount: 325,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle59 = renderBundleEncoder5.finish(
+{
+
+}
+);
+try {
+renderPassEncoder22.beginOcclusionQuery(
+8
+);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(
+10,
+buffer23,
+6460
+);
+} catch {}
+try {
+commandEncoder60.copyTextureToTexture(
+{
+  texture: texture48,
+  mipLevel: 0,
+  origin: { x: 23, y: 0, z: 36 },
+  aspect: 'all',
+},
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 497, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 219, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 45, height: 1, depthOrArrayLayers: 31}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 233, y: 155 },
+  flipY: true,
+},
+{
+  texture: texture66,
+  mipLevel: 5,
+  origin: { x: 12, y: 0, z: 13 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 12, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline56 = device0.createComputePipeline(
+{
+label: '\u{1fc06}\u{1fce8}\u{1fe4e}\u9426\u82c9\u077d\uaa8a\u4b79\u{1ff4d}\u{1fef8}\u2620',
+layout: 'auto',
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let texture77 = device0.createTexture(
+{
+label: '\uea2b\ubc0b\u{1fbbf}\u0176',
+size: {width: 225, height: 1, depthOrArrayLayers: 1873},
+mipLevelCount: 9,
+dimension: '3d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder66 = device0.createRenderBundleEncoder(
+{
+label: '\ud725\u0ca1\udfe3\ucb7c\u9da9\u2da6',
+colorFormats: [
+'bgra8unorm',
+'rgb10a2uint',
+'r32sint',
+'rgba16sint',
+'rg8unorm',
+'rg8sint',
+'rg32sint'
+],
+sampleCount: 0,
+stencilReadOnly: true,
+}
+);
+let sampler73 = device0.createSampler(
+{
+label: '\u0b52\u00f4\u6ae4\u01a9\uae70\u{1ff8d}',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 80.703,
+lodMaxClamp: 94.669,
+maxAnisotropy: 16,
+}
+);
+try {
+renderPassEncoder12.drawIndirect(
+buffer21,
+22080
+);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(
+buffer2,
+'uint16',
+25300
+);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(
+buffer9,
+'uint16',
+23800
+);
+} catch {}
+try {
+commandEncoder60.copyTextureToBuffer(
+{
+  texture: texture11,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 29088 */
+offset: 29088,
+bytesPerRow: 256,
+buffer: buffer10,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder60.clearBuffer(
+buffer11,
+5932,
+3496
+);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 734, height: 1, depthOrArrayLayers: 157}
+*/
+{
+  source: imageData2,
+  origin: { x: 56, y: 11 },
+  flipY: true,
+},
+{
+  texture: texture31,
+  mipLevel: 0,
+  origin: { x: 149, y: 0, z: 128 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 120, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let querySet62 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 1455,
+}
+);
+try {
+computePassEncoder25.setBindGroup(
+1,
+bindGroup25,
+new Uint32Array(9613),
+1661,
+0
+);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(
+0,
+bindGroup14,
+[]
+);
+} catch {}
+try {
+renderPassEncoder10.draw(
+40
+);
+} catch {}
+try {
+renderBundleEncoder60.setIndexBuffer(
+buffer11,
+'uint16'
+);
+} catch {}
+try {
+commandEncoder60.copyBufferToTexture(
+{
+/* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 26412 */
+offset: 26404,
+buffer: buffer2,
+},
+{
+  texture: texture21,
+  mipLevel: 8,
+  origin: { x: 5, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 2, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder60.copyTextureToTexture(
+{
+  texture: texture10,
+  mipLevel: 1,
+  origin: { x: 1, y: 1, z: 406 },
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: { x: 206, y: 1, z: 784 },
+  aspect: 'all',
+},
+{width: 180, height: 0, depthOrArrayLayers: 170}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 879, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(new ArrayBuffer(80)),
+/* required buffer size: 9411 */{
+offset: 653,
+rowsPerImage: 137,
+},
+{width: 4379, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline57 = device0.createComputePipeline(
+{
+label: '\u74a0\u{1f698}\u0f7c\u0265\u0353\u0fec',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule10,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let bindGroup32 = device0.createBindGroup({
+label: '\u32f6\u{1f7da}\u{1f9f9}\u0ec6\u9d2a\u0732\ue45c\u07b0\ua775\u2174\u{1fb51}',
+layout: bindGroupLayout13,
+entries: [
+
+],
+});
+let commandEncoder61 = device0.createCommandEncoder();
+let renderPassEncoder35 = commandEncoder61.beginRenderPass(
+{
+label: '\u0f57\u6813\u7b14\ub5ad\u6caa\u6c62\u{1fdef}\u02f0\u0ca7\u986c\uce29',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthReadOnly: true,
+},
+occlusionQuerySet: querySet30,
+maxDrawCount: 157624,
+}
+);
+let renderBundle60 = renderBundleEncoder29.finish(
+{
+label: '\u0b7c\u{1f817}\u4cb3\u0f4d\u{1fa64}\u6891'
+}
+);
+try {
+computePassEncoder22.end();
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+gpuCanvasContext4.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgba32sint'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let commandEncoder62 = device0.createCommandEncoder(
+{
+label: '\u{1f888}\u7976',
+}
+);
+let renderPassEncoder36 = commandEncoder48.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthClearValue: 7.65896854990109,
+depthLoadOp: 'load',
+depthStoreOp: 'discard',
+},
+occlusionQuerySet: querySet29,
+maxDrawCount: 35304,
+}
+);
+try {
+renderPassEncoder14.setBindGroup(
+4,
+bindGroup10
+);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+1,
+5,
+0,
+6
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer20,
+4504
+);
+} catch {}
+try {
+commandEncoder62.resolveQuerySet(
+querySet20,
+44,
+153,
+buffer4,
+29952
+);
+} catch {}
+document.body.prepend('\u{1f7b6}\u04b4\u0d75\u{1ff78}\uf83e\u3f28\u7934\u{1feff}\u{1f81c}');
+let commandEncoder63 = device0.createCommandEncoder(
+{
+label: '\u01c6\u5bc9\u1b11\u41dd\u9bd5\u81a5',
+}
+);
+let querySet63 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 41,
+}
+);
+let renderBundleEncoder67 = device0.createRenderBundleEncoder(
+{
+label: '\u9663\u0a4f\u771d',
+colorFormats: [
+'rgba32sint',
+'rg32sint',
+'r32sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 759,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder23.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder22.setViewport(
+2386.7,
+0.9850,
+255.3,
+0.00796,
+0.5742,
+0.8948
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer17,
+41728
+);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(
+89,
+undefined,
+3721291052,
+146064764
+);
+} catch {}
+try {
+commandEncoder60.copyBufferToBuffer(
+buffer1,
+5664,
+buffer22,
+48836,
+56
+);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer22);
+} catch {}
+let pipeline58 = await device0.createRenderPipelineAsync(
+{
+label: '\u4548\uf5c7\u0d91\u2bba\ua33a',
+layout: pipelineLayout6,
+vertex: {
+module: shaderModule7,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 15972,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 15212,
+shaderLocation: 5,
+},
+{
+format: 'sint16x4',
+offset: 9388,
+shaderLocation: 6,
+},
+{
+format: 'sint16x2',
+offset: 9764,
+shaderLocation: 2,
+},
+{
+format: 'sint8x4',
+offset: 7532,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x2',
+offset: 5420,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 46768,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 5236,
+shaderLocation: 13,
+},
+{
+format: 'uint32x2',
+offset: 7756,
+shaderLocation: 1,
+},
+{
+format: 'sint32x3',
+offset: 22228,
+shaderLocation: 8,
+},
+{
+format: 'uint8x2',
+offset: 44140,
+shaderLocation: 12,
+},
+{
+format: 'sint16x4',
+offset: 39816,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 27224,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x4',
+offset: 10832,
+shaderLocation: 11,
+},
+{
+format: 'unorm8x2',
+offset: 13992,
+shaderLocation: 10,
+},
+{
+format: 'float16x2',
+offset: 22484,
+shaderLocation: 15,
+},
+{
+format: 'float32x3',
+offset: 17996,
+shaderLocation: 0,
+},
+{
+format: 'unorm8x4',
+offset: 22324,
+shaderLocation: 4,
+},
+{
+format: 'uint32',
+offset: 7088,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x81bd8d0c,
+},
+fragment: {
+module: shaderModule7,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.BLUE,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'src',
+dstFactor: 'dst'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'dst-alpha',
+dstFactor: 'src-alpha-saturated'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+{
+format: 'r16sint',
+},
+{
+format: 'rg11b10ufloat',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+failOp: 'invert',
+depthFailOp: 'replace',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilWriteMask: 1004,
+depthBias: 5,
+depthBiasSlopeScale: 89,
+depthBiasClamp: 28,
+},
+}
+);
+offscreenCanvas4.height = 892;
+let video14 = await videoWithData();
+let querySet64 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 729,
+}
+);
+let textureView70 = texture32.createView(
+{
+label: '\u{1f605}\u3f19\ua4d0',
+format: 'r32float',
+}
+);
+let computePassEncoder28 = commandEncoder60.beginComputePass(
+{
+label: '\u{1ff56}\u9853\u036f\u0c4a'
+}
+);
+let externalTexture1 = device0.importExternalTexture(
+{
+label: '\u0fc5\ub972\u034a\u4ec2\u3e2a\u{1f79b}\ub83e',
+source: video4,
+colorSpace: 'srgb',
+}
+);
+try {
+renderPassEncoder26.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(
+32,
+56,
+80,
+-784,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer13,
+123048
+);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(
+buffer4,
+'uint16',
+378,
+25103
+);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(
+66,
+undefined,
+2363943360,
+959278331
+);
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(
+buffer18,
+55016,
+buffer2,
+11196,
+1540
+);
+dissociateBuffer(device0, buffer18);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+renderBundleEncoder52.pushDebugGroup(
+'\u0121'
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 2320, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(56),
+/* required buffer size: 10257 */{
+offset: 269,
+rowsPerImage: 130,
+},
+{width: 2497, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 183, height: 1, depthOrArrayLayers: 39}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 8, y: 15 },
+  flipY: false,
+},
+{
+  texture: texture31,
+  mipLevel: 2,
+  origin: { x: 162, y: 0, z: 18 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 7, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline59 = await device0.createComputePipelineAsync(
+{
+label: '\u0873\u{1ff8a}\u0b87\u9bca\u0b12',
+layout: pipelineLayout10,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+if (!arrayBuffer16.detached) { new Uint8Array(arrayBuffer16).fill(0x55) };
+} catch {}
+try {
+await promise28;
+} catch {}
+let commandEncoder64 = device0.createCommandEncoder(
+{
+}
+);
+let textureView71 = texture31.createView(
+{
+label: '\u{1f61d}\u0deb\u3171\u0634\u0f2c',
+format: 'rg8unorm',
+baseMipLevel: 3,
+}
+);
+let computePassEncoder29 = commandEncoder63.beginComputePass(
+{
+label: '\u8c4c\ueac4\u0fb2'
+}
+);
+try {
+computePassEncoder10.setPipeline(
+pipeline46
+);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(
+64
+);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+3,
+19,
+0,
+3
+);
+} catch {}
+try {
+renderPassEncoder12.draw(
+48,
+40,
+80,
+80
+);
+} catch {}
+try {
+commandEncoder62.copyBufferToBuffer(
+buffer12,
+31928,
+buffer23,
+8128,
+268
+);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer23);
+} catch {}
+try {
+commandEncoder62.resolveQuerySet(
+querySet6,
+52,
+25,
+buffer15,
+33280
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rgba8unorm',
+'rgba8unorm-srgb',
+'rgba8unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let textureView72 = texture74.createView(
+{
+label: '\udb24\u7b68\ua468\u061a\ua04d',
+baseMipLevel: 5,
+arrayLayerCount: 1,
+}
+);
+try {
+renderPassEncoder24.setBindGroup(
+1,
+bindGroup24,
+new Uint32Array(2313),
+1284,
+0
+);
+} catch {}
+try {
+renderPassEncoder29.end();
+} catch {}
+try {
+commandEncoder62.resolveQuerySet(
+querySet44,
+1175,
+25,
+buffer15,
+29952
+);
+} catch {}
+try {
+renderPassEncoder27.insertDebugMarker(
+'\u{1f976}'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer23,
+5348,
+new BigUint64Array(13387),
+1649,
+232
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture75,
+  mipLevel: 3,
+  origin: { x: 2, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer8,
+/* required buffer size: 4437 */{
+offset: 889,
+bytesPerRow: 320,
+rowsPerImage: 30,
+},
+{width: 7, height: 12, depthOrArrayLayers: 1}
+);
+} catch {}
+offscreenCanvas15.height = 638;
+document.body.prepend('\u7768\ub159\u3304\u{1feea}\u8dfa\u0c5c\u0555');
+let commandEncoder65 = device0.createCommandEncoder(
+{
+label: '\uc609\u{1fdd1}\u0f28\u{1fcbd}\u04be\uf89b',
+}
+);
+let renderPassEncoder37 = commandEncoder65.beginRenderPass(
+{
+label: '\ud144\u0fdd\uf568\u0832\u0240\u9d80\u6da4\u{1f8a9}\u{1fa6b}\uaf1d',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthLoadOp: 'load',
+depthStoreOp: 'store',
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet28,
+maxDrawCount: 23952,
+}
+);
+let sampler74 = device0.createSampler(
+{
+label: '\u3857\u9861\u{1fd53}\u062b\u8a69\u88f4\u{1fa2c}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 98.409,
+maxAnisotropy: 15,
+}
+);
+try {
+renderPassEncoder28.setBindGroup(
+2,
+bindGroup22,
+new Uint32Array(4310),
+3647,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder30.setStencilReference(
+1302
+);
+} catch {}
+try {
+renderPassEncoder26.setViewport(
+573.8,
+0.2423,
+997.8,
+0.1901,
+0.2649,
+0.3859
+);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(
+buffer12,
+'uint32',
+36868,
+15590
+);
+} catch {}
+try {
+renderBundleEncoder66.setVertexBuffer(
+0,
+buffer19,
+14676,
+7346
+);
+} catch {}
+try {
+commandEncoder62.copyBufferToTexture(
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 43992 */
+offset: 43992,
+bytesPerRow: 0,
+rowsPerImage: 138,
+buffer: buffer16,
+},
+{
+  texture: texture19,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 66 },
+  aspect: 'all',
+},
+{width: 0, height: 4, depthOrArrayLayers: 38}
+);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder62.clearBuffer(
+buffer10,
+25316,
+5416
+);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+await promise29;
+} catch {}
+document.body.prepend('\u0506\ue316\u09cb\uad66\u{1f70e}\u0627\ubdea\u95e0\u03c3\u064b');
+let commandEncoder66 = device0.createCommandEncoder(
+{
+label: '\u594a\u8789\u16a5\u09f6\u3ca1\u8b5e\u{1fba6}\u{1ffa7}\u0e26\uc772\u95e1',
+}
+);
+let renderBundleEncoder68 = device0.createRenderBundleEncoder(
+{
+label: '\u0be4\u{1f96f}\u78b9\ue563\u0789\u{1fbe1}\u068b\u{1fe2f}',
+colorFormats: [
+'rgba8sint',
+'r16uint',
+undefined,
+'r32float',
+'r16sint'
+],
+sampleCount: 650,
+}
+);
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder28.setViewport(
+1378.6,
+0.8537,
+1201.9,
+0.08631,
+0.8506,
+0.9418
+);
+} catch {}
+try {
+renderBundleEncoder68.setBindGroup(
+6,
+bindGroup17
+);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+commandEncoder66.resolveQuerySet(
+querySet34,
+1301,
+1074,
+buffer15,
+5120
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 383, height: 1, depthOrArrayLayers: 334}
+*/
+{
+  source: video6,
+  origin: { x: 0, y: 14 },
+  flipY: false,
+},
+{
+  texture: texture47,
+  mipLevel: 2,
+  origin: { x: 68, y: 0, z: 41 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 16, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let commandEncoder67 = device0.createCommandEncoder(
+{
+label: '\u0fec\u1141\u037f\u{1ff0b}\u{1faf2}\u7958\ub69f',
+}
+);
+let texture78 = device0.createTexture(
+{
+label: '\u1100\u79a7\u02e1\ufc61\u953a',
+size: [9025, 219, 214],
+mipLevelCount: 13,
+dimension: '2d',
+format: 'rgba32uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba32uint'
+],
+}
+);
+let renderPassEncoder38 = commandEncoder67.beginRenderPass(
+{
+colorAttachments: [
+
+],
+depthStencilAttachment: {
+view: textureView34,
+depthClearValue: 0.2974740194963843,
+depthLoadOp: 'clear',
+depthStoreOp: 'discard',
+depthReadOnly: false,
+stencilClearValue: 29031,
+},
+occlusionQuerySet: querySet52,
+maxDrawCount: 308352,
+}
+);
+let renderBundle61 = renderBundleEncoder51.finish(
+{
+label: '\u2f5a\u{1fba1}\u3cb4'
+}
+);
+try {
+renderPassEncoder13.setBindGroup(
+7,
+bindGroup25
+);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer20,
+165688
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(
+buffer21,
+32288
+);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(
+buffer9,
+'uint32',
+49424,
+1040
+);
+} catch {}
+try {
+commandEncoder62.clearBuffer(
+buffer1,
+3080,
+1204
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline60 = device0.createComputePipeline(
+{
+label: '\u0dbc\u{1f8e8}\u0760\u0097\uc5a9',
+layout: pipelineLayout7,
+compute: {
+module: shaderModule10,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend(img10);
+let bindGroup33 = device0.createBindGroup({
+label: '\u040a\u0725\u0428\ua7dc',
+layout: bindGroupLayout9,
+entries: [
+
+],
+});
+let texture79 = device0.createTexture(
+{
+label: '\u1f7b\u0d96\u287c\u{1fe2d}\u010d\u8c87\u6f3f\u{1f6a1}',
+size: [212, 38, 1],
+mipLevelCount: 6,
+format: 'r8uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8uint'
+],
+}
+);
+let renderPassEncoder39 = commandEncoder62.beginRenderPass(
+{
+label: '\u0cca\u0e34\u0408',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthClearValue: 0.46695269729798605,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+},
+occlusionQuerySet: querySet60,
+maxDrawCount: 18608,
+}
+);
+let renderBundleEncoder69 = device0.createRenderBundleEncoder(
+{
+label: '\ubbb3\u200a\u{1fbb8}\ua91d\u482c\u98bc',
+colorFormats: [
+'rgba32sint',
+'bgra8unorm',
+'rg16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 711,
+depthReadOnly: true,
+}
+);
+try {
+computePassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(
+1,
+bindGroup0
+);
+} catch {}
+try {
+commandEncoder29.copyBufferToBuffer(
+buffer24,
+6656,
+buffer9,
+27260,
+13328
+);
+dissociateBuffer(device0, buffer24);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder66.clearBuffer(
+buffer21,
+756,
+4896
+);
+dissociateBuffer(device0, buffer21);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 235, height: 1, depthOrArrayLayers: 319}
+*/
+{
+  source: offscreenCanvas17,
+  origin: { x: 275, y: 289 },
+  flipY: false,
+},
+{
+  texture: texture10,
+  mipLevel: 2,
+  origin: { x: 121, y: 0, z: 179 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 106, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend(canvas3);
+canvas4.height = 730;
+let shaderModule13 = device0.createShaderModule(
+{
+code: `
+
+@compute @workgroup_size(4, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S14 {
+@location(4) f0: vec4<i32>,
+@location(24) f1: f32,
+@builtin(front_facing) f2: bool,
+@location(8) f3: vec2<i32>,
+@location(44) f4: vec2<f32>,
+@location(51) f5: vec4<u32>,
+@location(20) f6: vec3<i32>,
+@location(13) f7: i32,
+@location(26) f8: vec2<i32>,
+@location(58) f9: vec3<u32>,
+@location(22) f10: vec3<u32>
+}
+struct FragmentOutput0 {
+@builtin(sample_mask) f0: u32,
+@location(2) f1: f32,
+@location(1) f2: vec2<i32>,
+@location(7) f3: vec3<f32>,
+@location(5) f4: vec4<i32>,
+@location(6) f5: vec2<i32>,
+@location(3) f6: vec4<u32>,
+@location(0) f7: vec2<u32>,
+@location(4) f8: vec2<i32>,
+@builtin(frag_depth) f9: f32
+}
+
+@fragment
+fn fragment0(@location(31) a0: vec3<i32>, @location(29) a1: vec4<f16>, @location(40) a2: f16, @location(23) a3: vec2<i32>, @location(32) a4: vec3<i32>, @location(36) a5: vec2<f32>, @location(53) a6: i32, @location(59) a7: vec4<f16>, @location(5) a8: vec3<f16>, @location(12) a9: vec3<f32>, @builtin(sample_index) a10: u32, @location(54) a11: vec3<u32>, @location(34) a12: vec3<f32>, @location(2) a13: i32, @location(3) a14: vec2<u32>, @location(39) a15: i32, @location(15) a16: vec4<f32>, @builtin(sample_mask) a17: u32, @location(10) a18: f32, @location(35) a19: vec3<i32>, @location(30) a20: f32, @location(27) a21: vec2<u32>, @location(21) a22: vec3<i32>, a23: S14) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(27) f198: vec2<u32>,
+@location(33) f199: vec3<i32>,
+@location(46) f200: vec2<f32>,
+@location(39) f201: i32,
+@location(53) f202: i32,
+@location(5) f203: vec3<f16>,
+@location(13) f204: i32,
+@location(30) f205: f32,
+@location(8) f206: vec2<i32>,
+@location(37) f207: i32,
+@location(31) f208: vec3<i32>,
+@location(12) f209: vec3<f32>,
+@location(36) f210: vec2<f32>,
+@location(7) f211: f32,
+@location(15) f212: vec4<f32>,
+@location(59) f213: vec4<f16>,
+@location(44) f214: vec2<f32>,
+@location(54) f215: vec3<u32>,
+@location(40) f216: f16,
+@location(4) f217: vec4<i32>,
+@location(10) f218: f32,
+@location(51) f219: vec4<u32>,
+@location(29) f220: vec4<f16>,
+@location(20) f221: vec3<i32>,
+@location(26) f222: vec2<i32>,
+@location(3) f223: vec2<u32>,
+@location(23) f224: vec2<i32>,
+@location(32) f225: vec3<i32>,
+@location(58) f226: vec3<u32>,
+@location(18) f227: vec4<f32>,
+@location(22) f228: vec3<u32>,
+@builtin(position) f229: vec4<f32>,
+@location(24) f230: f32,
+@location(35) f231: vec3<i32>,
+@location(2) f232: i32,
+@location(34) f233: vec3<f32>,
+@location(21) f234: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(16) a0: vec2<f16>, @location(4) a1: i32, @location(1) a2: vec2<f32>, @location(14) a3: vec2<i32>, @location(3) a4: vec2<u32>, @location(13) a5: vec4<f32>, @location(8) a6: vec2<f16>, @location(7) a7: vec3<f16>, @location(0) a8: vec3<f32>, @location(9) a9: vec4<i32>, @location(5) a10: f32, @location(6) a11: vec2<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let commandEncoder68 = device0.createCommandEncoder(
+{
+}
+);
+let textureView73 = texture58.createView(
+{
+label: '\u6757\ufbb3',
+baseMipLevel: 5,
+baseArrayLayer: 90,
+arrayLayerCount: 23,
+}
+);
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder16.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder15.setScissorRect(
+546,
+0,
+21,
+1
+);
+} catch {}
+try {
+renderPassEncoder25.setViewport(
+31.32,
+0.8695,
+2879.2,
+0.05907,
+0.6578,
+0.7537
+);
+} catch {}
+try {
+commandEncoder40.clearBuffer(
+buffer1,
+4640,
+48
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+gpuCanvasContext12.configure(
+{
+device: device0,
+format: 'r32uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rg8sint',
+'depth24plus'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 367, height: 1, depthOrArrayLayers: 78}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 5, y: 265 },
+  flipY: true,
+},
+{
+  texture: texture31,
+  mipLevel: 1,
+  origin: { x: 49, y: 0, z: 24 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 229, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let bindGroup34 = device0.createBindGroup({
+label: '\u03a8\u6ed0\u1f28',
+layout: bindGroupLayout30,
+entries: [
+
+],
+});
+let querySet65 = device0.createQuerySet(
+{
+label: '\u019d\u0bd4\u04ef\u8d18\u4b3e',
+type: 'occlusion',
+count: 1293,
+}
+);
+try {
+renderPassEncoder18.setBindGroup(
+6,
+bindGroup16,
+new Uint32Array(9384),
+6612,
+0
+);
+} catch {}
+try {
+renderPassEncoder37.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder30.setViewport(
+527.2,
+0.5347,
+2174.2,
+0.3474,
+0.9623,
+0.9632
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(
+buffer19,
+57064
+);
+} catch {}
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture27,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+new Int8Array(arrayBuffer9),
+/* required buffer size: 594 */{
+offset: 594,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture80 = device0.createTexture(
+{
+label: '\ufb6e\u52f2\u0c36\u{1f725}\u0087\u{1fa0d}\u{1fbbd}\u0318\u11f4\u551a',
+size: {width: 2904, height: 1, depthOrArrayLayers: 238},
+mipLevelCount: 8,
+format: 'r32float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'r32float'
+],
+}
+);
+let renderPassEncoder40 = commandEncoder68.beginRenderPass(
+{
+label: '\uf5e9\u94b8\uddcd\ub8ea\uedc4\ue5eb\u{1f641}\u{1fda7}',
+colorAttachments: [
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthReadOnly: true,
+stencilClearValue: 13542,
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet44,
+maxDrawCount: 4152,
+}
+);
+try {
+computePassEncoder26.setBindGroup(
+8,
+bindGroup10,
+new Uint32Array(5335),
+1832,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.draw(
+0,
+64
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(
+48
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(
+buffer5,
+268280
+);
+} catch {}
+try {
+commandEncoder29.copyTextureToTexture(
+{
+  texture: texture41,
+  mipLevel: 3,
+  origin: { x: 545, y: 0, z: 37 },
+  aspect: 'all',
+},
+{
+  texture: texture73,
+  mipLevel: 0,
+  origin: { x: 57, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 17, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline61 = await device0.createRenderPipelineAsync(
+{
+layout: pipelineLayout10,
+vertex: {
+module: shaderModule9,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 2744,
+attributes: [
+
+],
+},
+{
+arrayStride: 22176,
+attributes: [
+{
+format: 'uint32x3',
+offset: 10676,
+shaderLocation: 8,
+},
+{
+format: 'uint8x2',
+offset: 10654,
+shaderLocation: 1,
+},
+{
+format: 'uint32x4',
+offset: 4948,
+shaderLocation: 12,
+}
+],
+}
+]
+},
+multisample: {
+mask: 0x3f3b9ca9,
+},
+fragment: {
+module: shaderModule9,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+{
+format: 'r32float',
+writeMask: GPUColorWrite.RED,
+},
+{
+format: 'rg16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'rgba16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'dst-alpha',
+dstFactor: 'zero'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'rg32float',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 3735,
+stencilWriteMask: 3323,
+depthBias: 33,
+depthBiasSlopeScale: 91,
+depthBiasClamp: 28,
+},
+}
+);
+let adapter7 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let querySet66 = device0.createQuerySet(
+{
+label: '\u04c5\u{1f8f1}\u{1fbf0}\u7e9d\u7f31\ub4ed\u{1ffc6}\u{1fc33}\u{1ffad}\u{1f96f}\uf6bc',
+type: 'occlusion',
+count: 3735,
+}
+);
+let renderPassEncoder41 = commandEncoder66.beginRenderPass(
+{
+label: '\ua435\u4f0d\u60b4',
+colorAttachments: [
+
+],
+depthStencilAttachment: {
+view: textureView34,
+depthReadOnly: true,
+stencilClearValue: 21397,
+stencilReadOnly: true,
+},
+maxDrawCount: 56512,
+}
+);
+let renderBundle62 = renderBundleEncoder8.finish();
+let sampler75 = device0.createSampler(
+{
+label: '\u278e\ub807\u05bf\u1258\u{1fc79}\u406c\u4584\u0c06\uda71',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 72.328,
+lodMaxClamp: 73.821,
+compare: 'not-equal',
+}
+);
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: 532.4,
+g: 827.7,
+b: 820.7,
+a: -828.8,
+}
+);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(
+1,
+39,
+1,
+14
+);
+} catch {}
+try {
+renderPassEncoder12.draw(
+48,
+32,
+8,
+64
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(
+56
+);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(
+11,
+buffer9,
+29032,
+21062
+);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(
+9,
+buffer6
+);
+} catch {}
+try {
+commandEncoder29.resolveQuerySet(
+querySet11,
+2797,
+85,
+buffer19,
+5632
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let sampler76 = device0.createSampler(
+{
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 48.938,
+lodMaxClamp: 51.902,
+compare: 'equal',
+maxAnisotropy: 20,
+}
+);
+try {
+renderPassEncoder16.setStencilReference(
+2458
+);
+} catch {}
+try {
+renderPassEncoder10.draw(
+56,
+56,
+32
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(
+56,
+40,
+56,
+584,
+72
+);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(
+10,
+buffer15
+);
+} catch {}
+try {
+renderBundleEncoder60.setVertexBuffer(
+2,
+buffer11
+);
+} catch {}
+try {
+commandEncoder64.copyTextureToTexture(
+{
+  texture: texture3,
+  mipLevel: 2,
+  origin: { x: 10, y: 2, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 2,
+  origin: { x: 56, y: 0, z: 198 },
+  aspect: 'all',
+},
+{width: 31, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+renderBundleEncoder52.popDebugGroup();
+} catch {}
+try {
+commandEncoder29.insertDebugMarker(
+'\u0280'
+);
+} catch {}
+try {
+gpuCanvasContext8.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+document.body.prepend(img4);
+let video15 = await videoWithData();
+let buffer27 = device0.createBuffer(
+{
+label: '\u0f43\u{1fce1}\u{1f6e0}\u1dcd',
+size: 38564,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let querySet67 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 1614,
+}
+);
+try {
+renderPassEncoder16.setStencilReference(
+1442
+);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(
+buffer11,
+'uint16',
+23054,
+2499
+);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(
+0,
+buffer6
+);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+2,
+bindGroup15
+);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(
+1,
+bindGroup15,
+new Uint32Array(7722),
+2412,
+0
+);
+} catch {}
+try {
+renderBundleEncoder63.setVertexBuffer(
+2,
+buffer9,
+10424,
+13922
+);
+} catch {}
+try {
+commandEncoder64.copyTextureToTexture(
+{
+  texture: texture27,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture66,
+  mipLevel: 6,
+  origin: { x: 3, y: 0, z: 4 },
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer25,
+1224,
+new BigUint64Array(14332),
+4610,
+32
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1532, height: 1, depthOrArrayLayers: 1339}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 148, y: 5 },
+  flipY: false,
+},
+{
+  texture: texture47,
+  mipLevel: 0,
+  origin: { x: 1367, y: 0, z: 216 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 87, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\ue837\u33a4\uf32d\u084a\u0b41\u3505\u{1f7c5}\u0cdd\u2637\u8425');
+let imageBitmap15 = await createImageBitmap(imageData4);
+let bindGroupLayout32 = device0.createBindGroupLayout(
+{
+label: '\uad8a\uebef\ucec0\uab04',
+entries: [
+{
+binding: 908,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}
+],
+}
+);
+let computePassEncoder30 = commandEncoder29.beginComputePass(
+{
+
+}
+);
+let renderBundleEncoder70 = device0.createRenderBundleEncoder(
+{
+label: '\u09d3\u6dac\u993f\ua159',
+colorFormats: [
+'bgra8unorm-srgb',
+'rgba8unorm',
+'rg32sint'
+],
+sampleCount: 551,
+}
+);
+let renderBundle63 = renderBundleEncoder48.finish(
+{
+label: '\u{1f8c9}\u1db4\u556d\u{1fbd8}\u0d84\u63b8'
+}
+);
+let sampler77 = device0.createSampler(
+{
+label: '\u{1fab5}\u{1ff3b}\uf38c\u{1faee}\u0ae6\uc616',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 98.643,
+}
+);
+try {
+renderPassEncoder20.setBindGroup(
+0,
+bindGroup10
+);
+} catch {}
+try {
+renderPassEncoder23.beginOcclusionQuery(
+40
+);
+} catch {}
+try {
+renderPassEncoder27.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder30.setScissorRect(
+2132,
+1,
+351,
+0
+);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(
+buffer15,
+'uint16',
+30218,
+5765
+);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(
+buffer15,
+'uint32',
+9644,
+28238
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer21,
+52180,
+new Int16Array(10024),
+1527,
+376
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture9,
+  mipLevel: 8,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer15,
+/* required buffer size: 78 */{
+offset: 78,
+},
+{width: 4, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline62 = device0.createComputePipeline(
+{
+label: '\u{1f9aa}\uc282\u291d\u{1fa33}\u{1fe87}\u99c9\uac69',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.append('\u{1ffd7}\u{1fa2c}\u{1fadd}');
+let shaderModule14 = device0.createShaderModule(
+{
+label: '\u0080\u01a6\u9b66\u06be\u0193',
+code: `
+
+@compute @workgroup_size(6, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: vec4<i32>,
+@location(7) f1: vec4<f32>,
+@location(4) f2: i32,
+@builtin(frag_depth) f3: f32,
+@location(2) f4: f32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(15) a1: vec2<f32>, @location(12) a2: vec3<f32>, @location(7) a3: vec2<i32>, @location(2) a4: f32, @location(0) a5: f32, @builtin(vertex_index) a6: u32, @location(8) a7: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let querySet68 = device0.createQuerySet(
+{
+label: '\u6f92\ud3bf\u{1f761}',
+type: 'occlusion',
+count: 1949,
+}
+);
+let textureView74 = texture70.createView(
+{
+baseMipLevel: 3,
+arrayLayerCount: 1,
+}
+);
+let computePassEncoder31 = commandEncoder64.beginComputePass(
+{
+label: '\ucd19\u15e2\u04e4\u96b6\u598b'
+}
+);
+let renderBundleEncoder71 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'r16float'
+],
+sampleCount: 211,
+}
+);
+let sampler78 = device0.createSampler(
+{
+label: '\u480e\u{1ffef}\u6643\u91ab\ua12d\u4e08\u{1fc8e}\u{1fedb}',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 30.103,
+lodMaxClamp: 54.539,
+}
+);
+try {
+renderPassEncoder31.beginOcclusionQuery(
+80
+);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(
+1716
+);
+} catch {}
+try {
+commandEncoder40.copyTextureToTexture(
+{
+  texture: texture41,
+  mipLevel: 0,
+  origin: { x: 1182, y: 0, z: 13 },
+  aspect: 'all',
+},
+{
+  texture: texture46,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 5, height: 1, depthOrArrayLayers: 9}
+);
+} catch {}
+try {
+commandEncoder40.clearBuffer(
+buffer9,
+31728,
+15832
+);
+dissociateBuffer(device0, buffer9);
+} catch {}
+let querySet69 = device0.createQuerySet(
+{
+label: '\u{1f9c1}\uc2a4\ud056\u262e',
+type: 'occlusion',
+count: 939,
+}
+);
+let texture81 = device0.createTexture(
+{
+label: '\u5007\u0534\u8dc4\u871a\ueb77\ua566\ua913\u8cf6\u0a0b\u8391',
+size: {width: 5313, height: 1, depthOrArrayLayers: 77},
+mipLevelCount: 1,
+sampleCount: 1,
+format: 'depth32float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundle64 = renderBundleEncoder35.finish(
+{
+label: '\u8ff5\u{1fdcc}\u076d\uba26\u952b\u2949\u9a72\u0334\u{1fded}'
+}
+);
+try {
+renderPassEncoder31.setBlendConstant(
+{
+r: -954.8,
+g: -691.8,
+b: 188.4,
+a: 927.0,
+}
+);
+} catch {}
+try {
+renderPassEncoder12.draw(
+32,
+16,
+0,
+16
+);
+} catch {}
+try {
+renderBundleEncoder52.setBindGroup(
+6,
+bindGroup14,
+[]
+);
+} catch {}
+try {
+commandEncoder40.copyBufferToBuffer(
+buffer6,
+5520,
+buffer1,
+3140,
+1744
+);
+dissociateBuffer(device0, buffer6);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder40.copyTextureToBuffer(
+{
+  texture: texture9,
+  mipLevel: 8,
+  origin: { x: 2, y: 1, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 41548 */
+offset: 41548,
+buffer: buffer4,
+},
+{width: 3, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture17,
+  mipLevel: 0,
+  origin: { x: 465, y: 1, z: 183 },
+  aspect: 'all',
+},
+new ArrayBuffer(49721614),
+/* required buffer size: 49721614 */{
+offset: 30,
+bytesPerRow: 4048,
+rowsPerImage: 173,
+},
+{width: 481, height: 0, depthOrArrayLayers: 72}
+);
+} catch {}
+video0.width = 111;
+offscreenCanvas12.height = 462;
+gc();
+let offscreenCanvas18 = new OffscreenCanvas(799, 688);
+let pipelineLayout12 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout9,
+bindGroupLayout6
+],
+}
+);
+let computePassEncoder32 = commandEncoder40.beginComputePass(
+{
+
+}
+);
+try {
+computePassEncoder31.setBindGroup(
+1,
+bindGroup33
+);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(
+buffer2,
+'uint16',
+27846,
+2917
+);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(
+5,
+buffer9,
+384,
+25665
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture46,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 9 },
+  aspect: 'all',
+},
+new ArrayBuffer(72),
+/* required buffer size: 27828 */{
+offset: 272,
+bytesPerRow: 306,
+rowsPerImage: 30,
+},
+{width: 4, height: 1, depthOrArrayLayers: 4}
+);
+} catch {}
+try {
+if (!arrayBuffer16.detached) { new Uint8Array(arrayBuffer16).fill(0x55) };
+} catch {}
+let commandEncoder69 = device0.createCommandEncoder(
+{
+label: '\u09b1\u{1fa9d}\u68b3\ua1f2\u4a41\u056e\u06ee',
+}
+);
+let texture82 = device0.createTexture(
+{
+label: '\uacae\uf624\u{1f647}\u0beb\u{1ffc1}\u490b\u0397\ud04f\u{1ff24}\u0566',
+size: [10435, 35, 1],
+mipLevelCount: 4,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let textureView75 = texture22.createView(
+{
+label: '\u{1fdc0}\u0846\u0086\u{1f6ec}\u0074\u0c8d\u02e5\ufdb6\u759b\u0406',
+mipLevelCount: 1,
+}
+);
+try {
+renderPassEncoder28.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+1,
+53,
+2,
+0
+);
+} catch {}
+try {
+renderPassEncoder36.setViewport(
+823.6,
+0.1563,
+2000.5,
+0.1311,
+0.4637,
+0.5670
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(
+buffer9,
+119744
+);
+} catch {}
+try {
+commandEncoder69.copyTextureToBuffer(
+{
+  texture: texture50,
+  mipLevel: 0,
+  origin: { x: 213, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 11712 widthInBlocks: 1464 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 17256 */
+offset: 5544,
+buffer: buffer2,
+},
+{width: 1464, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let pipeline63 = device0.createRenderPipeline(
+{
+label: '\u0e28\u0583\u{1f743}\u016f',
+layout: 'auto',
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 16992,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 14968,
+shaderLocation: 7,
+},
+{
+format: 'sint16x4',
+offset: 16104,
+shaderLocation: 11,
+},
+{
+format: 'uint16x4',
+offset: 3276,
+shaderLocation: 1,
+},
+{
+format: 'uint8x4',
+offset: 15876,
+shaderLocation: 8,
+},
+{
+format: 'unorm8x4',
+offset: 11928,
+shaderLocation: 14,
+},
+{
+format: 'snorm8x2',
+offset: 7606,
+shaderLocation: 9,
+},
+{
+format: 'snorm8x4',
+offset: 12988,
+shaderLocation: 13,
+},
+{
+format: 'snorm8x4',
+offset: 16680,
+shaderLocation: 12,
+},
+{
+format: 'unorm8x4',
+offset: 9244,
+shaderLocation: 6,
+},
+{
+format: 'sint16x4',
+offset: 6756,
+shaderLocation: 15,
+},
+{
+format: 'unorm8x2',
+offset: 10126,
+shaderLocation: 10,
+},
+{
+format: 'sint16x2',
+offset: 11144,
+shaderLocation: 4,
+},
+{
+format: 'float16x2',
+offset: 276,
+shaderLocation: 3,
+},
+{
+format: 'float32x2',
+offset: 12676,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 40296,
+attributes: [
+{
+format: 'uint32x4',
+offset: 5488,
+shaderLocation: 16,
+},
+{
+format: 'float16x2',
+offset: 32832,
+shaderLocation: 0,
+},
+{
+format: 'uint32x3',
+offset: 3240,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+undefined,
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+passOp: 'keep',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'invert',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2217,
+stencilWriteMask: 752,
+depthBiasClamp: 70,
+},
+}
+);
+let offscreenCanvas19 = new OffscreenCanvas(799, 382);
+try {
+offscreenCanvas18.getContext('2d');
+} catch {}
+let bindGroupLayout33 = device0.createBindGroupLayout(
+{
+label: '\ud698\u08b7\u7875\ucde8\u0d49\u00cf\u3954\ubce8\u6f38\u065a\u261c',
+entries: [
+
+],
+}
+);
+let bindGroupLayout34 = pipeline25.getBindGroupLayout(2);
+let pipelineLayout13 = device0.createPipelineLayout(
+{
+label: '\u5068\u0c8c\u8343\ud0f1\u{1f8a6}\ucf20',
+bindGroupLayouts: [
+bindGroupLayout0,
+bindGroupLayout34,
+bindGroupLayout9,
+bindGroupLayout22,
+bindGroupLayout10
+],
+}
+);
+let commandEncoder70 = device0.createCommandEncoder(
+{
+}
+);
+let querySet70 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 2162,
+}
+);
+let renderBundleEncoder72 = device0.createRenderBundleEncoder(
+{
+label: '\u76f0\u0e34\u{1f784}\u033d\u{1fc2f}\u2680',
+colorFormats: [
+'rg32uint',
+'rg32uint',
+'rg32float'
+],
+sampleCount: 999,
+}
+);
+try {
+computePassEncoder27.setBindGroup(
+0,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(
+buffer2,
+'uint16',
+12902,
+14500
+);
+} catch {}
+try {
+renderBundleEncoder50.setBindGroup(
+8,
+bindGroup21
+);
+} catch {}
+try {
+computePassEncoder29.insertDebugMarker(
+'\u053a'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+24632,
+new BigUint64Array(26493),
+8662,
+640
+);
+} catch {}
+let imageData12 = new ImageData(220, 244);
+let sampler79 = device0.createSampler(
+{
+label: '\ud27a\u4b0a\u0436\u832f\u068c\u03be\u0150\u0997\u5e62',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 95.969,
+lodMaxClamp: 99.083,
+}
+);
+try {
+renderBundleEncoder61.setVertexBuffer(
+5,
+buffer4,
+44276,
+6257
+);
+} catch {}
+try {
+commandEncoder69.copyTextureToTexture(
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 322, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture48,
+  mipLevel: 0,
+  origin: { x: 48, y: 0, z: 53 },
+  aspect: 'all',
+},
+{width: 60, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder70.resolveQuerySet(
+querySet69,
+463,
+363,
+buffer19,
+17152
+);
+} catch {}
+try {
+renderBundleEncoder55.insertDebugMarker(
+'\u97c7'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer23,
+5092,
+new Float32Array(11735),
+9040,
+492
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 943, height: 1, depthOrArrayLayers: 1276}
+*/
+{
+  source: imageData12,
+  origin: { x: 8, y: 166 },
+  flipY: true,
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: { x: 730, y: 1, z: 94 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 183, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend('\u179f\uf687\u144d');
+let offscreenCanvas20 = new OffscreenCanvas(577, 738);
+let commandEncoder71 = device0.createCommandEncoder(
+{
+label: '\u97af\ue89c\u{1f8a7}\u8806\uc66f\u6f0f\u976f\u93b7\u16f6',
+}
+);
+let textureView76 = texture57.createView(
+{
+}
+);
+let computePassEncoder33 = commandEncoder69.beginComputePass(
+{
+label: '\ue624\u{1fa71}\u599b\ub170'
+}
+);
+try {
+renderPassEncoder14.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+0.1069,
+0.06820,
+0.4238,
+0.6925,
+0.5828,
+0.7676
+);
+} catch {}
+try {
+renderPassEncoder10.draw(
+0,
+16
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer24,
+155344
+);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(
+10,
+buffer11,
+23836,
+12555
+);
+} catch {}
+try {
+renderBundleEncoder53.setBindGroup(
+4,
+bindGroup5,
+new Uint32Array(1231),
+605,
+0
+);
+} catch {}
+try {
+await buffer26.mapAsync(
+GPUMapMode.READ,
+0,
+3868
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 12, height: 12, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 10, y: 52 },
+  flipY: false,
+},
+{
+  texture: texture75,
+  mipLevel: 3,
+  origin: { x: 0, y: 3, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 12, height: 9, depthOrArrayLayers: 0}
+);
+} catch {}
+video2.height = 271;
+let offscreenCanvas21 = new OffscreenCanvas(254, 994);
+let pipelineLayout14 = device0.createPipelineLayout(
+{
+label: '\u042a\u33cd\u{1f762}\ue54e\u0463\u{1f9ac}\ud1ff\ubc35\u0258\u3dfc\ua104',
+bindGroupLayouts: [
+bindGroupLayout19,
+bindGroupLayout14,
+bindGroupLayout11,
+bindGroupLayout31
+],
+}
+);
+let commandEncoder72 = device0.createCommandEncoder();
+let commandBuffer6 = commandEncoder72.finish();
+let textureView77 = texture13.createView(
+{
+label: '\u{1f77d}\uf4c1\ub91a',
+baseMipLevel: 0,
+}
+);
+let computePassEncoder34 = commandEncoder70.beginComputePass(
+{
+label: '\u086f\u{1f969}\u1625\u4077\u0aec\u2128\u{1f6eb}'
+}
+);
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder31.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(
+buffer2,
+'uint32',
+12620,
+16536
+);
+} catch {}
+document.body.prepend('\ud2fb\ud1f9');
+try {
+renderPassEncoder10.draw(
+56,
+80,
+24,
+8
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer23,
+79280
+);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(
+1,
+buffer11,
+15732,
+5040
+);
+} catch {}
+try {
+commandEncoder71.copyTextureToTexture(
+{
+  texture: texture15,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 2,
+  origin: { x: 49, y: 0, z: 3 },
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder71.resolveQuerySet(
+querySet48,
+1445,
+153,
+buffer23,
+5376
+);
+} catch {}
+try {
+renderBundleEncoder39.insertDebugMarker(
+'\ucee6'
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32sint',
+'rgba8unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 766, height: 1, depthOrArrayLayers: 669}
+*/
+{
+  source: video3,
+  origin: { x: 4, y: 15 },
+  flipY: true,
+},
+{
+  texture: texture47,
+  mipLevel: 1,
+  origin: { x: 91, y: 1, z: 227 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 9, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline64 = device0.createComputePipeline(
+{
+layout: pipelineLayout6,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+canvas3.height = 858;
+let device1 = await adapter2.requestDevice(
+{
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 5,
+maxColorAttachmentBytesPerSample: 54,
+maxVertexAttributes: 20,
+maxVertexBufferArrayStride: 23154,
+maxStorageTexturesPerShaderStage: 30,
+maxStorageBuffersPerShaderStage: 27,
+maxDynamicStorageBuffersPerPipelineLayout: 4772,
+maxBindingsPerBindGroup: 8234,
+maxTextureArrayLayers: 256,
+maxTextureDimension1D: 8965,
+maxTextureDimension2D: 13654,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 46275685,
+maxInterStageShaderVariables: 83,
+maxInterStageShaderComponents: 62,
+},
+}
+);
+let offscreenCanvas22 = new OffscreenCanvas(103, 780);
+let bindGroup35 = device0.createBindGroup({
+layout: bindGroupLayout0,
+entries: [
+
+],
+});
+let commandEncoder73 = device0.createCommandEncoder(
+{
+label: '\u4bb2\u8380',
+}
+);
+let textureView78 = texture11.createView(
+{
+label: '\ubec3\u{1fb8f}\u{1f6a7}\u4ec5\u0eab\u7827\u05a1\uf8ee\u4682\uf147\u0fd2',
+dimension: '2d-array',
+baseArrayLayer: 0,
+}
+);
+let renderBundleEncoder73 = device0.createRenderBundleEncoder(
+{
+label: '\u{1f75d}\u09a1\uf322\uf471\u48aa',
+colorFormats: [
+'r16float',
+'rg11b10ufloat',
+'r8uint',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 985,
+depthReadOnly: true,
+}
+);
+let sampler80 = device0.createSampler(
+{
+label: '\u{1fd40}\u010f\u483c\u4927\u02f3\u93fc\u{1fded}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 0.572,
+lodMaxClamp: 23.257,
+}
+);
+try {
+renderPassEncoder22.setBindGroup(
+4,
+bindGroup28,
+new Uint32Array(6538),
+4935,
+0
+);
+} catch {}
+try {
+renderPassEncoder32.end();
+} catch {}
+try {
+renderPassEncoder14.setViewport(
+2735.4,
+0.1719,
+233.2,
+0.8009,
+0.7513,
+0.7521
+);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+commandEncoder73.copyBufferToTexture(
+{
+/* bytesInLastRow: 592 widthInBlocks: 148 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 7688 */
+offset: 7688,
+bytesPerRow: 768,
+rowsPerImage: 205,
+buffer: buffer16,
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: { x: 198, y: 1, z: 4 },
+  aspect: 'all',
+},
+{width: 148, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder73.resolveQuerySet(
+querySet63,
+30,
+11,
+buffer10,
+4608
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer25,
+1480,
+new BigUint64Array(44111),
+13333,
+0
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture42,
+  mipLevel: 0,
+  origin: { x: 2877, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(24),
+/* required buffer size: 3227 */{
+offset: 536,
+},
+{width: 2691, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise30 = device0.createComputePipelineAsync(
+{
+layout: pipelineLayout13,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline65 = await device0.createRenderPipelineAsync(
+{
+label: '\u10ae\udfc9\u{1fb39}\u3265\u3808\u03b7',
+layout: pipelineLayout8,
+vertex: {
+module: shaderModule13,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 41732,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 31500,
+shaderLocation: 13,
+},
+{
+format: 'sint32',
+offset: 26496,
+shaderLocation: 14,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 10028,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x4',
+offset: 1300,
+shaderLocation: 16,
+},
+{
+format: 'uint32x2',
+offset: 8268,
+shaderLocation: 6,
+},
+{
+format: 'sint16x2',
+offset: 22972,
+shaderLocation: 9,
+},
+{
+format: 'uint16x4',
+offset: 15652,
+shaderLocation: 3,
+},
+{
+format: 'float16x4',
+offset: 19092,
+shaderLocation: 5,
+},
+{
+format: 'unorm8x2',
+offset: 3800,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 47664,
+attributes: [
+
+],
+},
+{
+arrayStride: 24732,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 39780,
+attributes: [
+{
+format: 'float16x4',
+offset: 15748,
+shaderLocation: 1,
+},
+{
+format: 'float32',
+offset: 30500,
+shaderLocation: 8,
+},
+{
+format: 'sint16x4',
+offset: 36696,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+multisample: {
+mask: 0xc99fb851,
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'decrement-wrap',
+depthFailOp: 'keep',
+passOp: 'invert',
+},
+stencilReadMask: 1599,
+stencilWriteMask: 2581,
+depthBias: 7,
+depthBiasClamp: 23,
+},
+}
+);
+document.body.append('\u{1ffaf}\u148c\u020e\u4405\u2192\u6305\u1ed6\u14ed\u070b\u7431');
+let buffer28 = device1.createBuffer(
+{
+size: 11035,
+usage: GPUBufferUsage.STORAGE,
+}
+);
+let gpuCanvasContext15 = offscreenCanvas22.getContext('webgpu');
+let img11 = await imageWithData(279, 290, '#c53378ea', '#77386f55');
+let bindGroup36 = device0.createBindGroup({
+label: '\u542b\u1bfc\uf353\uc9c1\uf35a\u5f92\u116e\u0d8a',
+layout: bindGroupLayout24,
+entries: [
+{
+binding: 999,
+resource: sampler41
+}
+],
+});
+let commandEncoder74 = device0.createCommandEncoder(
+{
+label: '\u09ac\ue10a\u0567\u4a32\u{1f83e}\u0856',
+}
+);
+let texture83 = device0.createTexture(
+{
+size: [26, 2, 250],
+mipLevelCount: 2,
+format: 'r16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundle65 = renderBundleEncoder33.finish(
+{
+label: '\u08b4\u{1f90d}\u0728\u{1f756}\u6714\u0d72'
+}
+);
+try {
+renderPassEncoder10.drawIndirect(
+buffer20,
+72304
+);
+} catch {}
+let texture84 = device0.createTexture(
+{
+label: '\u5e4a\u{1f6ad}',
+size: [7621, 249, 46],
+mipLevelCount: 3,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'depth24plus-stencil8',
+'depth24plus-stencil8'
+],
+}
+);
+let textureView79 = texture27.createView(
+{
+label: '\uab34\u{1f6f5}\udfae\u5798',
+dimension: '2d-array',
+aspect: 'all',
+}
+);
+try {
+renderPassEncoder35.setBindGroup(
+1,
+bindGroup6,
+new Uint32Array(5444),
+2343,
+0
+);
+} catch {}
+try {
+renderPassEncoder30.beginOcclusionQuery(
+8
+);
+} catch {}
+try {
+renderPassEncoder33.setStencilReference(
+1216
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(
+buffer26,
+292664
+);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(
+9,
+buffer19,
+11532,
+9260
+);
+} catch {}
+try {
+renderBundleEncoder57.setVertexBuffer(
+10,
+buffer4,
+48368
+);
+} catch {}
+try {
+buffer21.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+11948,
+new Float32Array(31037),
+20047,
+24
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 383, height: 1, depthOrArrayLayers: 334}
+*/
+{
+  source: imageData12,
+  origin: { x: 109, y: 171 },
+  flipY: false,
+},
+{
+  texture: texture47,
+  mipLevel: 2,
+  origin: { x: 87, y: 1, z: 157 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 78, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let shaderModule15 = device0.createShaderModule(
+{
+code: `
+
+@compute @workgroup_size(4, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: vec4<i32>,
+@location(2) f1: vec2<i32>,
+@location(1) f2: vec2<f32>,
+@location(5) f3: vec2<f32>,
+@location(7) f4: f32
+}
+
+@fragment
+fn fragment0(@location(15) a0: f32, @builtin(sample_index) a1: u32, @location(40) a2: f32, @location(31) a3: f32, @location(34) a4: vec3<f16>, @location(43) a5: vec3<f32>, @builtin(position) a6: vec4<f32>, @location(44) a7: f32, @location(5) a8: i32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(13) f235: f16,
+@location(40) f236: f32,
+@location(56) f237: vec2<u32>,
+@location(45) f238: vec3<f16>,
+@location(37) f239: vec4<i32>,
+@location(52) f240: i32,
+@location(0) f241: vec2<f16>,
+@location(10) f242: vec3<f16>,
+@location(2) f243: f32,
+@location(26) f244: vec2<f16>,
+@location(15) f245: f32,
+@location(31) f246: f32,
+@location(35) f247: f16,
+@location(50) f248: vec2<f32>,
+@location(44) f249: f32,
+@builtin(position) f250: vec4<f32>,
+@location(43) f251: vec3<f32>,
+@location(34) f252: vec3<f16>,
+@location(5) f253: i32
+}
+
+@vertex
+fn vertex0(@location(12) a0: u32, @location(9) a1: f16, @location(3) a2: u32, @location(13) a3: f32, @location(14) a4: u32, @location(16) a5: vec2<u32>, @location(1) a6: f16, @location(2) a7: vec2<f16>, @location(10) a8: vec4<u32>, @location(0) a9: vec4<f16>, @location(15) a10: f32, @builtin(instance_index) a11: u32, @location(5) a12: vec2<i32>, @location(6) a13: vec4<f16>, @builtin(vertex_index) a14: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let buffer29 = device0.createBuffer(
+{
+label: '\ufa51\u0ac1\u0500\u0476\u0947\u0260\u9a0c\u{1f981}\ueb47',
+size: 1714,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+}
+);
+let renderBundle66 = renderBundleEncoder33.finish();
+try {
+renderPassEncoder10.setIndexBuffer(
+buffer1,
+'uint32',
+3956,
+1079
+);
+} catch {}
+try {
+commandEncoder71.clearBuffer(
+buffer17
+);
+dissociateBuffer(device0, buffer17);
+} catch {}
+try {
+commandEncoder73.resolveQuerySet(
+querySet44,
+1079,
+3,
+buffer9,
+6656
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1532, height: 1, depthOrArrayLayers: 1339}
+*/
+{
+  source: video3,
+  origin: { x: 4, y: 7 },
+  flipY: false,
+},
+{
+  texture: texture47,
+  mipLevel: 0,
+  origin: { x: 35, y: 0, z: 97 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 10, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline66 = await device0.createComputePipelineAsync(
+{
+label: '\ub717\ue266\u86b2\uda11\u0191\u7ca6\u11ba\udcc8\u0d92\u37c3',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let img12 = await imageWithData(255, 185, '#709f81bc', '#de745c64');
+let imageBitmap16 = await createImageBitmap(offscreenCanvas18);
+let commandEncoder75 = device1.createCommandEncoder(
+{
+label: '\u01db\ua66b\uddd0\uf082\u{1fcaa}\u13f4\u8721\u{1f7be}\u0c98',
+}
+);
+let texture85 = device1.createTexture(
+{
+label: '\u0d65\u1df4\ud24e\u41e4\u000f\uec85',
+size: [205, 16, 1],
+mipLevelCount: 6,
+format: 'astc-5x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+try {
+gpuCanvasContext8.configure(
+{
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+document.body.prepend(img7);
+let img13 = await imageWithData(13, 69, '#e16b3b52', '#b30bd2ef');
+let bindGroupLayout35 = device1.createBindGroupLayout(
+{
+label: '\u784f\u{1f756}\ua20c\u76a7\u0a91\u2bf2\uf8bc\u040d\u1edb\u0a71\u{1ff57}',
+entries: [
+{
+binding: 7479,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+},
+{
+binding: 3994,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}
+],
+}
+);
+let sampler81 = device1.createSampler(
+{
+label: '\u{1f790}\udc03\ub95d\u0129\u7845\u{1fa5f}\u{1fcdf}\ue84d\u{1fe26}\u0353\u0f43',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 89.907,
+lodMaxClamp: 91.889,
+maxAnisotropy: 15,
+}
+);
+try {
+gpuCanvasContext10.configure(
+{
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'astc-4x4-unorm-srgb'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer18.detached) { new Uint8Array(arrayBuffer18).fill(0x55) };
+} catch {}
+let pipelineLayout15 = device1.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout35,
+bindGroupLayout35,
+bindGroupLayout35
+],
+}
+);
+let renderBundleEncoder74 = device1.createRenderBundleEncoder(
+{
+label: '\u5446\ud5d9\uf2b9\u{1fa19}\u70d0\ud115\u0ecb\u6c48',
+colorFormats: [
+'rg8sint',
+'rg32sint',
+'rgba16uint',
+'rg32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 781,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+gpuCanvasContext1.configure(
+{
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x5-unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+gc();
+try {
+offscreenCanvas21.getContext('webgpu');
+} catch {}
+let shaderModule16 = device1.createShaderModule(
+{
+label: '\ua3d1\u6f1c\ue531\u09af\u{1fdf8}\u0210\u6e57\u{1fca4}\u0484\u5ee8\u{1fe54}',
+code: `@group(1) @binding(7479)
+var<storage, read_write> global2: array<u32>;
+
+@compute @workgroup_size(6, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(3) f0: vec2<i32>,
+@builtin(sample_mask) f1: u32,
+@location(7) f2: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S15 {
+@location(16) f0: vec2<i32>,
+@location(4) f1: f16,
+@location(17) f2: vec4<f16>,
+@location(15) f3: i32,
+@location(18) f4: i32,
+@location(12) f5: vec2<u32>,
+@location(1) f6: vec2<f32>,
+@location(5) f7: vec3<u32>,
+@location(6) f8: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(13) a0: f16, @location(9) a1: vec2<i32>, @location(14) a2: vec4<f32>, @location(11) a3: vec2<f16>, @location(3) a4: vec4<u32>, @builtin(vertex_index) a5: u32, @location(8) a6: vec2<f32>, @location(10) a7: vec4<u32>, @builtin(instance_index) a8: u32, @location(19) a9: vec4<f16>, @location(7) a10: vec2<i32>, @location(0) a11: vec2<f32>, @location(2) a12: vec4<f32>, a13: S15) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroupLayout36 = device1.createBindGroupLayout(
+{
+label: '\ueefa\ua108\u81a8\u{1fcfc}\u0470\u4899\u03a9',
+entries: [
+
+],
+}
+);
+let computePassEncoder35 = commandEncoder75.beginComputePass(
+{
+label: '\u0fd6\u48e1\u01b5\u0e40\u{1f9fb}\u84e0\u{1fe79}\u0589\uf83d'
+}
+);
+try {
+buffer28.destroy();
+} catch {}
+let pipeline67 = device1.createComputePipeline(
+{
+layout: 'auto',
+compute: {
+module: shaderModule16,
+entryPoint: 'compute0',
+},
+}
+);
+document.body.append('\ub81d\u0166\u2a8b\ub6fd\u1232\u3218');
+try {
+adapter7.label = '\u089c\u0312\u734c\u8c4f\u098d\u{1fb08}\u6a13\u9dcb';
+} catch {}
+let texture86 = device1.createTexture(
+{
+label: '\ude1c\uc24a\ua4a2\ue513\ue4cf\u5923',
+size: {width: 5670, height: 6, depthOrArrayLayers: 104},
+mipLevelCount: 4,
+format: 'astc-10x6-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x6-unorm-srgb'
+],
+}
+);
+let textureView80 = texture86.createView(
+{
+label: '\u0a26\u{1f6d2}\u0c71',
+baseArrayLayer: 58,
+arrayLayerCount: 12,
+}
+);
+try {
+computePassEncoder35.end();
+} catch {}
+offscreenCanvas8.height = 116;
+let video16 = await videoWithData();
+let buffer30 = device0.createBuffer(
+{
+label: '\u0e0f\u0c47\u{1fe6d}\u0c82',
+size: 20840,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+try {
+renderPassEncoder35.setViewport(
+2749.2,
+0.2836,
+158.2,
+0.1577,
+0.1128,
+0.2712
+);
+} catch {}
+try {
+renderPassEncoder10.draw(
+24,
+8,
+48
+);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(
+6,
+buffer29,
+1308,
+198
+);
+} catch {}
+try {
+renderBundleEncoder55.setBindGroup(
+0,
+bindGroup30
+);
+} catch {}
+try {
+commandEncoder74.copyTextureToTexture(
+{
+  texture: texture9,
+  mipLevel: 1,
+  origin: { x: 754, y: 0, z: 103 },
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 4,
+  origin: { x: 35, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 31, height: 1, depthOrArrayLayers: 29}
+);
+} catch {}
+try {
+commandEncoder71.resolveQuerySet(
+querySet1,
+2812,
+22,
+buffer15,
+30208
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer1,
+4188,
+new Float32Array(60774),
+20693,
+212
+);
+} catch {}
+document.body.prepend('\u7a9b\u92c9\u070b\u{1f905}');
+let querySet71 = device1.createQuerySet(
+{
+label: '\ua21f\u2fef\u0c1b\ub867\u00ea\u{1fbab}\u{1fe3f}\u41a0\u00b0\u466d\u19d0',
+type: 'occlusion',
+count: 2093,
+}
+);
+let promise31 = device1.createComputePipelineAsync(
+{
+label: '\u{1fcd8}\u{1f982}\u5ecd\u48dd\u145e\u0e9e\ue012\ub1c3\u91ff\u2325',
+layout: pipelineLayout15,
+compute: {
+module: shaderModule16,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline68 = device1.createRenderPipeline(
+{
+label: '\uef74\u0004\u8acb\u4053\u{1fba3}\u06cb\uc57b\u92f2\ua49d\ufdf5\u0253',
+layout: pipelineLayout15,
+vertex: {
+module: shaderModule16,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 10660,
+attributes: [
+{
+format: 'float16x2',
+offset: 592,
+shaderLocation: 2,
+},
+{
+format: 'float32x4',
+offset: 2236,
+shaderLocation: 19,
+},
+{
+format: 'float16x2',
+offset: 2504,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 2732,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 112,
+shaderLocation: 17,
+},
+{
+format: 'sint8x2',
+offset: 172,
+shaderLocation: 6,
+},
+{
+format: 'sint32x3',
+offset: 112,
+shaderLocation: 15,
+},
+{
+format: 'float16x2',
+offset: 2520,
+shaderLocation: 14,
+},
+{
+format: 'unorm16x4',
+offset: 16,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 10796,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x2',
+offset: 3676,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x2',
+offset: 8522,
+shaderLocation: 8,
+},
+{
+format: 'float32x4',
+offset: 9356,
+shaderLocation: 11,
+},
+{
+format: 'sint16x4',
+offset: 4104,
+shaderLocation: 16,
+},
+{
+format: 'float16x4',
+offset: 4144,
+shaderLocation: 4,
+},
+{
+format: 'sint32x4',
+offset: 4104,
+shaderLocation: 9,
+},
+{
+format: 'uint32',
+offset: 8196,
+shaderLocation: 12,
+},
+{
+format: 'uint32x3',
+offset: 3724,
+shaderLocation: 5,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 9456,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 8520,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x4',
+offset: 6420,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 18412,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x3',
+offset: 9812,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 1232,
+attributes: [
+{
+format: 'sint16x2',
+offset: 900,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x51e156b,
+},
+fragment: {
+module: shaderModule16,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+{
+format: 'r16sint',
+writeMask: 0,
+},
+undefined,
+undefined
+],
+},
+}
+);
+try {
+offscreenCanvas20.getContext('webgpu');
+} catch {}
+let bindGroup37 = device1.createBindGroup({
+label: '\ua3cc\ubc15\uba01\u0f15\u055c\u0082\u0337',
+layout: bindGroupLayout36,
+entries: [
+
+],
+});
+let renderBundle67 = renderBundleEncoder74.finish(
+{
+
+}
+);
+let pipeline69 = await device1.createComputePipelineAsync(
+{
+label: '\u9929\uab5c\u7d28',
+layout: pipelineLayout15,
+compute: {
+module: shaderModule16,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let shaderModule17 = device0.createShaderModule(
+{
+label: '\u0eaa\u0ca2\u3dc5\u45fb',
+code: `
+
+@compute @workgroup_size(2, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: vec4<f32>,
+@location(4) f1: vec3<f32>,
+@location(0) f2: vec2<u32>,
+@location(1) f3: vec3<i32>,
+@location(3) f4: vec3<f32>,
+@location(5) f5: vec3<f32>,
+@location(7) f6: vec3<u32>,
+@location(2) f7: vec4<u32>,
+@builtin(frag_depth) f8: f32
+}
+
+@fragment
+fn fragment0(@location(32) a0: vec2<u32>, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(11) f254: vec4<f32>,
+@location(27) f255: vec2<f16>,
+@location(35) f256: vec2<i32>,
+@location(55) f257: vec4<i32>,
+@location(21) f258: vec2<i32>,
+@location(39) f259: vec2<f32>,
+@location(13) f260: vec4<u32>,
+@location(26) f261: vec4<f16>,
+@location(32) f262: vec2<u32>,
+@location(25) f263: vec2<f32>,
+@location(50) f264: vec3<i32>,
+@location(40) f265: vec2<f16>,
+@location(6) f266: vec4<i32>,
+@location(43) f267: u32,
+@location(42) f268: i32,
+@builtin(position) f269: vec4<f32>,
+@location(30) f270: vec4<i32>,
+@location(7) f271: f16,
+@location(8) f272: vec3<i32>,
+@location(17) f273: vec2<u32>,
+@location(20) f274: vec3<f16>,
+@location(56) f275: u32,
+@location(10) f276: i32,
+@location(34) f277: vec3<f32>,
+@location(58) f278: vec2<f32>,
+@location(41) f279: f16,
+@location(22) f280: vec4<f32>,
+@location(18) f281: vec3<f16>,
+@location(9) f282: vec4<f16>,
+@location(5) f283: vec3<i32>,
+@location(12) f284: vec4<i32>,
+@location(48) f285: vec4<i32>,
+@location(36) f286: vec4<u32>
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let computePassEncoder36 = commandEncoder71.beginComputePass();
+let renderPassEncoder42 = commandEncoder74.beginRenderPass(
+{
+label: '\u{1fbd5}\u0b32\u1ee8\u{1f67e}\u{1ff99}\u{1f8af}\ue4a2\u0026\u00d8\u00ec\u9147',
+colorAttachments: [
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthLoadOp: 'load',
+depthStoreOp: 'store',
+},
+occlusionQuerySet: querySet26,
+maxDrawCount: 14144,
+}
+);
+try {
+renderPassEncoder38.setBindGroup(
+6,
+bindGroup10
+);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(
+8,
+bindGroup3,
+new Uint32Array(1804),
+848,
+0
+);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder15.setStencilReference(
+2903
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(
+72,
+72,
+64
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer3,
+112760
+);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(
+buffer1,
+'uint32',
+3360
+);
+} catch {}
+try {
+commandEncoder73.copyTextureToTexture(
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: { x: 103, y: 0, z: 10 },
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 1,
+  origin: { x: 63, y: 0, z: 4 },
+  aspect: 'all',
+},
+{width: 167, height: 1, depthOrArrayLayers: 94}
+);
+} catch {}
+try {
+renderBundleEncoder52.insertDebugMarker(
+'\ua061'
+);
+} catch {}
+let pipeline70 = await promise30;
+let shaderModule18 = device0.createShaderModule(
+{
+label: '\u0d27\ufb33\u0f4f\ubd8a',
+code: `
+
+@compute @workgroup_size(8, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S16 {
+@location(51) f0: vec2<i32>,
+@location(17) f1: vec3<f32>,
+@location(33) f2: vec3<f16>,
+@builtin(sample_index) f3: u32
+}
+
+@fragment
+fn fragment0(@location(56) a0: vec4<u32>, @builtin(sample_mask) a1: u32, @location(2) a2: vec3<f16>, @location(47) a3: vec4<f32>, @location(50) a4: vec3<f16>, a5: S16, @builtin(position) a6: vec4<f32>, @builtin(front_facing) a7: bool) {
+
+}
+
+struct VertexOutput0 {
+@location(17) f287: vec3<f32>,
+@location(33) f288: vec3<f16>,
+@location(51) f289: vec2<i32>,
+@location(47) f290: vec4<f32>,
+@location(50) f291: vec3<f16>,
+@builtin(position) f292: vec4<f32>,
+@location(2) f293: vec3<f16>,
+@location(56) f294: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(0) a0: vec3<u32>, @location(2) a1: f32, @location(8) a2: vec4<i32>, @location(7) a3: vec3<f16>, @location(15) a4: vec3<f16>, @location(5) a5: vec4<f32>, @location(3) a6: f16, @location(6) a7: vec3<i32>, @location(11) a8: f16, @builtin(vertex_index) a9: u32, @location(16) a10: vec4<i32>, @location(12) a11: vec2<f32>, @builtin(instance_index) a12: u32, @location(4) a13: vec3<f32>, @location(9) a14: i32, @location(1) a15: vec3<f32>, @location(10) a16: vec4<f32>, @location(14) a17: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder76 = device0.createCommandEncoder(
+{
+label: '\u{1fac8}\ucb47\ufcbb\ud0b7\u09e9\u{1fbe8}\u08c9\ue346\u0043\u0305\u0f4f',
+}
+);
+let querySet72 = device0.createQuerySet(
+{
+label: '\u0b80\u29df\u{1f70e}\u0f14\uecdb',
+type: 'occlusion',
+count: 2488,
+}
+);
+let textureView81 = texture71.createView(
+{
+label: '\u{1fa0a}\u{1f945}\ue536\u089d',
+dimension: '2d',
+format: 'rgba8unorm',
+baseMipLevel: 7,
+baseArrayLayer: 75,
+}
+);
+let renderBundle68 = renderBundleEncoder7.finish(
+{
+label: '\u0015\u0ff7\u4d22\u1cee\u0d6f\u392f\u4329'
+}
+);
+try {
+renderPassEncoder12.draw(
+64,
+56,
+32
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(
+40,
+8,
+32,
+688,
+24
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer19,
+371936
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(
+buffer20,
+67704
+);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(
+11,
+buffer11,
+12900,
+21310
+);
+} catch {}
+try {
+commandEncoder76.copyBufferToBuffer(
+buffer6,
+5080,
+buffer30,
+9920,
+3844
+);
+dissociateBuffer(device0, buffer6);
+dissociateBuffer(device0, buffer30);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer11,
+25552,
+new DataView(new ArrayBuffer(43214)),
+14658,
+2804
+);
+} catch {}
+let pipeline71 = device0.createComputePipeline(
+{
+label: '\u{1ffd9}\uf02d\u0675\ud6d3',
+layout: pipelineLayout8,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let bindGroup38 = device1.createBindGroup({
+label: '\u330b\u{1fc3a}\u0958\u01e4\u{1f797}\u{1f8b8}\u0266\u24d0\u6368\u{1fe57}\ua251',
+layout: bindGroupLayout36,
+entries: [
+
+],
+});
+let textureView82 = texture85.createView(
+{
+label: '\u{1fa92}\uaeef\u77fc\u1c2b\uac2e\u032c',
+dimension: '2d-array',
+baseMipLevel: 3,
+mipLevelCount: 2,
+}
+);
+let renderBundleEncoder75 = device1.createRenderBundleEncoder(
+{
+label: '\u09a1\u0754\u29de\u6bb7\u{1fa51}\u{1fce6}\u1e52\u0a41\uf332\u57b6\ue0f3',
+colorFormats: [
+'bgra8unorm',
+'rg32sint',
+'rgba8unorm-srgb',
+'rgba16sint',
+'r32sint',
+'rgba32uint'
+],
+sampleCount: 634,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let pipeline72 = device1.createComputePipeline(
+{
+label: '\u925e\uae41\u05a6\u1f92\u{1fd7e}',
+layout: pipelineLayout15,
+compute: {
+module: shaderModule16,
+entryPoint: 'compute0',
+},
+}
+);
+let img14 = await imageWithData(274, 44, '#b5f8480f', '#2014cdf2');
+let video17 = await videoWithData();
+let sampler82 = device0.createSampler(
+{
+label: '\u6af0\u{1f9c1}\u0fde\u0900\u{1f6a0}\u{1f8b6}\u0daf\u{1f63d}\u0bef\udfd5\u6eb1',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 51.232,
+}
+);
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder24.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder28.setViewport(
+3032.9,
+0.1635,
+6.568,
+0.5144,
+0.8043,
+0.9701
+);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(
+7,
+bindGroup21
+);
+} catch {}
+try {
+commandEncoder73.copyBufferToBuffer(
+buffer7,
+2520,
+buffer22,
+52520,
+4564
+);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer22);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer30,
+16108,
+new DataView(new ArrayBuffer(21712)),
+19740
+);
+} catch {}
+canvas2.height = 1016;
+let img15 = await imageWithData(118, 131, '#3f7437d9', '#82c3f960');
+let imageData13 = new ImageData(184, 132);
+let sampler83 = device0.createSampler(
+{
+label: '\u9815\u03c7\u9320',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 9.726,
+lodMaxClamp: 71.208,
+}
+);
+try {
+computePassEncoder28.setPipeline(
+pipeline34
+);
+} catch {}
+try {
+renderPassEncoder42.setScissorRect(
+2096,
+1,
+768,
+0
+);
+} catch {}
+try {
+renderPassEncoder36.setViewport(
+863.2,
+0.6354,
+1418.0,
+0.1659,
+0.9740,
+0.9971
+);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(
+buffer12,
+'uint32',
+1980
+);
+} catch {}
+try {
+renderBundleEncoder73.setVertexBuffer(
+7,
+buffer6,
+7528,
+2375
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer9,
+37720,
+new DataView(new ArrayBuffer(30545)),
+27740,
+2480
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 761, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(1087),
+/* required buffer size: 1087 */{
+offset: 829,
+},
+{width: 129, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 361, height: 1, depthOrArrayLayers: 254}
+*/
+{
+  source: imageData8,
+  origin: { x: 43, y: 161 },
+  flipY: false,
+},
+{
+  texture: texture66,
+  mipLevel: 2,
+  origin: { x: 168, y: 1, z: 20 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 96, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let textureView83 = texture81.createView(
+{
+label: '\u0cfc\udf37',
+dimension: '2d',
+aspect: 'depth-only',
+baseArrayLayer: 75,
+arrayLayerCount: 1,
+}
+);
+let renderBundleEncoder76 = device0.createRenderBundleEncoder(
+{
+label: '\udb9c\u3411\u004f\u0b0d\u{1f9cd}',
+colorFormats: [
+'rgba16float',
+'rg8unorm',
+'rgba16uint',
+'rgba16sint'
+],
+sampleCount: 521,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle69 = renderBundleEncoder62.finish(
+{
+label: '\u0be5\u{1fe0c}\u9fde'
+}
+);
+try {
+renderPassEncoder31.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(
+56,
+16,
+16,
+-560,
+64
+);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(
+3,
+buffer2
+);
+} catch {}
+try {
+commandEncoder73.resolveQuerySet(
+querySet67,
+1159,
+3,
+buffer4,
+33536
+);
+} catch {}
+try {
+computePassEncoder23.insertDebugMarker(
+'\u7311'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer6,
+4132,
+new DataView(new ArrayBuffer(61136)),
+28547,
+332
+);
+} catch {}
+let shaderModule19 = device0.createShaderModule(
+{
+code: `
+
+@compute @workgroup_size(7, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S17 {
+@builtin(front_facing) f0: bool,
+@builtin(position) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0(a0: S17, @builtin(sample_mask) a1: u32, @builtin(sample_index) a2: u32) {
+
+}
+
+
+
+@vertex
+fn vertex0(@location(13) a0: vec2<i32>, @location(9) a1: f16, @location(4) a2: vec2<f16>, @location(10) a3: u32, @location(2) a4: vec3<f16>, @location(14) a5: vec4<i32>, @location(1) a6: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder77 = device0.createCommandEncoder(
+{
+}
+);
+try {
+renderPassEncoder24.beginOcclusionQuery(
+8
+);
+} catch {}
+try {
+renderPassEncoder40.setStencilReference(
+1264
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(
+64,
+32,
+8,
+552,
+32
+);
+} catch {}
+try {
+commandEncoder77.copyTextureToTexture(
+{
+  texture: texture15,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 0,
+  origin: { x: 222, y: 1, z: 17 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder76.resolveQuerySet(
+querySet51,
+2003,
+807,
+buffer16,
+33792
+);
+} catch {}
+document.body.append('\u0247\u0a09\ua9e6\u02bf\u0515\uf0e7\u1b6d');
+let commandEncoder78 = device0.createCommandEncoder(
+{
+label: '\u0288\u{1f689}\u0af1\u9089\u796d\u6837',
+}
+);
+let texture87 = device0.createTexture(
+{
+label: '\u27e4\u{1ff77}\u3643\u6df7\u{1fb18}\u{1fbab}\u32e8\u{1f782}',
+size: [95, 1, 383],
+mipLevelCount: 3,
+dimension: '3d',
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'r16uint'
+],
+}
+);
+try {
+renderPassEncoder16.setBindGroup(
+2,
+bindGroup33,
+new Uint32Array(8907),
+4034,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.draw(
+48
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(
+buffer21,
+31448
+);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(
+11,
+buffer29
+);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(
+2,
+bindGroup17,
+new Uint32Array(5576),
+1606,
+0
+);
+} catch {}
+try {
+commandEncoder77.copyBufferToTexture(
+{
+/* bytesInLastRow: 24728 widthInBlocks: 3091 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 13224 */
+offset: 13224,
+buffer: buffer16,
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: { x: 275, y: 1, z: 0 },
+  aspect: 'all',
+},
+{width: 3091, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder73.resolveQuerySet(
+querySet58,
+626,
+243,
+buffer4,
+10240
+);
+} catch {}
+document.body.prepend(img1);
+let video18 = await videoWithData();
+let textureView84 = texture86.createView(
+{
+label: '\u79fd\uaf6a\u{1fb61}\uff8d\u601f\u0b6c\u00f0\u{1fd44}\u{1f624}',
+baseMipLevel: 1,
+mipLevelCount: 2,
+baseArrayLayer: 27,
+arrayLayerCount: 60,
+}
+);
+let computePassEncoder37 = commandEncoder75.beginComputePass(
+{
+label: '\uc729\u094c\u03b6\u9c73\u0706\u{1f66c}\ufe1a\udb27\u013d'
+}
+);
+let sampler84 = device1.createSampler(
+{
+label: '\u0f59\u401b\u{1fb33}\ud1fe\u3abe\u063a\uf92c\u{1fafc}\u818a\uee64\u0054',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 53.624,
+lodMaxClamp: 75.413,
+maxAnisotropy: 16,
+}
+);
+try {
+gpuCanvasContext1.configure(
+{
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let pipeline73 = device1.createComputePipeline(
+{
+label: '\u24e2\u{1fe70}\uf402\u{1ff36}\ubd05\u0238\u174d',
+layout: pipelineLayout15,
+compute: {
+module: shaderModule16,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let gpuCanvasContext16 = offscreenCanvas19.getContext('webgpu');
+document.body.prepend('\uf43b\ucd7c\u{1fc44}\u0f77\u{1f7aa}\u{1fae1}\u276f\u42a2');
+let canvas14 = document.createElement('canvas');
+let buffer31 = device0.createBuffer(
+{
+label: '\ua845\u0119\u0eb8\u0895',
+size: 43010,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let textureView85 = texture51.createView(
+{
+label: '\u99e5\u2978\u3082\u{1fbd9}\u00a5',
+}
+);
+try {
+renderPassEncoder14.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setViewport(
+2.519,
+52.55,
+0.1440,
+1.291,
+0.2293,
+0.8713
+);
+} catch {}
+try {
+renderPassEncoder10.draw(
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer15,
+'uint16',
+12598
+);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(
+6,
+bindGroup13
+);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(
+3,
+buffer4,
+38932
+);
+} catch {}
+try {
+commandEncoder77.copyTextureToTexture(
+{
+  texture: texture47,
+  mipLevel: 1,
+  origin: { x: 6, y: 0, z: 18 },
+  aspect: 'all',
+},
+{
+  texture: texture47,
+  mipLevel: 2,
+  origin: { x: 36, y: 0, z: 52 },
+  aspect: 'all',
+},
+{width: 270, height: 1, depthOrArrayLayers: 138}
+);
+} catch {}
+try {
+commandEncoder77.clearBuffer(
+buffer11,
+32448,
+2840
+);
+dissociateBuffer(device0, buffer11);
+} catch {}
+let pipeline74 = await device0.createRenderPipelineAsync(
+{
+label: '\u0612\u2f6b\uff17\u0742\u070e',
+layout: pipelineLayout9,
+vertex: {
+module: shaderModule9,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 11200,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 34828,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 50280,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 27732,
+shaderLocation: 1,
+},
+{
+format: 'uint16x2',
+offset: 29392,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 26428,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 20820,
+shaderLocation: 12,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+},
+multisample: {
+mask: 0x8ba6b110,
+},
+fragment: {
+module: shaderModule9,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+undefined,
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'dst',
+dstFactor: 'zero'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.RED,
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+format: 'rgba32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'one',
+dstFactor: 'one-minus-dst-alpha'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'one-minus-dst',
+dstFactor: 'constant'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.BLUE,
+},
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'dst-alpha',
+dstFactor: 'dst'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'one-minus-dst',
+dstFactor: 'src-alpha-saturated'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'not-equal',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 396,
+stencilWriteMask: 3420,
+depthBiasSlopeScale: 95,
+},
+}
+);
+let imageData14 = new ImageData(212, 168);
+let videoFrame14 = new VideoFrame(videoFrame8, {timestamp: 0});
+let commandEncoder79 = device1.createCommandEncoder(
+{
+label: '\u9dae\u9160\u{1f73e}\u{1fa20}\u03ef\u712c\u{1ff3c}\u{1f776}\u0fcd\u7613',
+}
+);
+let computePassEncoder38 = commandEncoder79.beginComputePass();
+let renderBundleEncoder77 = device1.createRenderBundleEncoder(
+{
+label: '\u9a93\u0747\u75ef\u0fab\u87d0\u2e47\u49bc',
+colorFormats: [
+'r16sint',
+'rg32uint',
+undefined,
+'rgba32float',
+undefined,
+'r16float',
+'rgba8unorm',
+'r32float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 542,
+depthReadOnly: true,
+}
+);
+let sampler85 = device1.createSampler(
+{
+label: '\u01ae\u0c04\ud26d\u06fe\u{1fc63}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 97.609,
+lodMaxClamp: 97.965,
+}
+);
+let querySet73 = device0.createQuerySet(
+{
+label: '\ucfe0\u7032\u11c5\u5d77\ue23d\u05b1\ubdea\u0408\uddd3\uaf80',
+type: 'occlusion',
+count: 1420,
+}
+);
+let textureView86 = texture49.createView(
+{
+label: '\u0f25\u{1ff64}\u05f3\u096c\u090d\u8e7f',
+dimension: '2d',
+baseMipLevel: 4,
+mipLevelCount: 2,
+baseArrayLayer: 186,
+}
+);
+let renderBundle70 = renderBundleEncoder52.finish(
+{
+label: '\u0ea2\u8714\u02f7\u062f\u{1fe7d}\u0265'
+}
+);
+try {
+renderPassEncoder23.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(
+2046,
+0,
+830,
+0
+);
+} catch {}
+try {
+renderPassEncoder27.setStencilReference(
+1704
+);
+} catch {}
+try {
+renderPassEncoder10.draw(
+32
+);
+} catch {}
+try {
+renderBundleEncoder72.setBindGroup(
+3,
+bindGroup25,
+[]
+);
+} catch {}
+try {
+commandEncoder77.copyBufferToBuffer(
+buffer18,
+18172,
+buffer22,
+6820,
+45376
+);
+dissociateBuffer(device0, buffer18);
+dissociateBuffer(device0, buffer22);
+} catch {}
+gc();
+let videoFrame15 = new VideoFrame(imageBitmap14, {timestamp: 0});
+let bindGroup39 = device0.createBindGroup({
+layout: bindGroupLayout25,
+entries: [
+
+],
+});
+let textureView87 = texture25.createView(
+{
+label: '\u0180\u4659\u{1fa9b}\uc2f6\u{1ff3d}\u8670\u8669\u0fe2\u6b88\u33b6\u07ea',
+dimension: '2d',
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+let renderBundleEncoder78 = device0.createRenderBundleEncoder(
+{
+label: '\uf5cd\u03c9\u021a\ub5f2\u{1fe94}\u{1fbce}\u1401\ucaf0',
+colorFormats: [
+'bgra8unorm-srgb',
+'rgba32float',
+'rgb10a2uint',
+'rgba8unorm-srgb',
+undefined
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 276,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder17.setBlendConstant(
+{
+r: -353.1,
+g: -190.9,
+b: 241.0,
+a: 765.4,
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer23,
+3136,
+new BigUint64Array(29891),
+9090,
+116
+);
+} catch {}
+let imageBitmap17 = await createImageBitmap(videoFrame8);
+let bindGroupLayout37 = device1.createBindGroupLayout(
+{
+label: '\u1339\u087b\u00fd\uca6b',
+entries: [
+{
+binding: 2746,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '2d' },
+},
+{
+binding: 1569,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+},
+{
+binding: 31,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let pipelineLayout16 = device1.createPipelineLayout(
+{
+label: '\u0194\u356c\u00ac\u2f75\ue85c\u208c\u{1fd04}\u01e1',
+bindGroupLayouts: [
+bindGroupLayout37,
+bindGroupLayout35,
+bindGroupLayout35
+],
+}
+);
+try {
+renderBundleEncoder75.setBindGroup(
+0,
+bindGroup37
+);
+} catch {}
+let pipeline75 = await promise31;
+document.body.prepend('\u0770\u1fe6\u{1f63c}\u{1f68e}\u8e9e\u76ca');
+try {
+adapter7.label = '\ue04f\ufd65\ud516\uf9ea\u{1fdff}\u0c28\u7b9a\u0702\u{1fba4}\ue972\u38a7';
+} catch {}
+let shaderModule20 = device0.createShaderModule(
+{
+label: '\u904e\u05d4\u03a4\u73ab\u{1fc7c}\ua158\u{1fef5}\ud2f1\u1f10',
+code: `
+
+@compute @workgroup_size(4, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(1) f0: vec2<i32>,
+@location(0) f1: f32
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_mask) a1: u32, @builtin(sample_index) a2: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(14) a0: vec3<u32>, @builtin(vertex_index) a1: u32, @location(15) a2: vec3<i32>, @location(11) a3: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let renderPassEncoder43 = commandEncoder76.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthClearValue: 0.22566320977979104,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet50,
+}
+);
+try {
+computePassEncoder32.setPipeline(
+pipeline33
+);
+} catch {}
+try {
+renderPassEncoder42.beginOcclusionQuery(
+48
+);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder23.setBlendConstant(
+{
+r: -14.98,
+g: -134.1,
+b: 308.2,
+a: 43.68,
+}
+);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(
+312
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(
+64,
+80,
+56,
+-40,
+64
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer31,
+135128
+);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+4,
+buffer2,
+16308
+);
+} catch {}
+document.body.prepend(canvas4);
+document.body.append('\u{1f8aa}\u47b7\u{1f734}\u994b\u{1fd6a}\u0001\u0611\u3e4a\ucc7a');
+let adapter8 = await promise17;
+try {
+canvas14.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder80 = device1.createCommandEncoder();
+try {
+computePassEncoder37.setPipeline(
+pipeline72
+);
+} catch {}
+try {
+renderBundleEncoder77.setVertexBuffer(
+97,
+undefined,
+967912296
+);
+} catch {}
+let promise32 = device1.createComputePipelineAsync(
+{
+label: '\u3bd7\u0998\u03c4\u{1fc6d}',
+layout: pipelineLayout15,
+compute: {
+module: shaderModule16,
+entryPoint: 'compute0',
+},
+}
+);
+try {
+computePassEncoder38.setPipeline(
+pipeline73
+);
+} catch {}
+try {
+renderBundleEncoder75.insertDebugMarker(
+'\u57e2'
+);
+} catch {}
+let pipeline76 = device1.createRenderPipeline(
+{
+label: '\u0b6b\u8581\u2f24\u{1fe8e}\u04b4\u885e\u{1fd27}\u098b\uabf4\u07f0',
+layout: pipelineLayout16,
+vertex: {
+module: shaderModule16,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 6932,
+shaderLocation: 0,
+},
+{
+format: 'uint32x2',
+offset: 3544,
+shaderLocation: 5,
+},
+{
+format: 'unorm8x4',
+offset: 21384,
+shaderLocation: 1,
+},
+{
+format: 'sint16x2',
+offset: 14708,
+shaderLocation: 6,
+},
+{
+format: 'float16x2',
+offset: 22932,
+shaderLocation: 17,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 6916,
+shaderLocation: 4,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 14512,
+shaderLocation: 11,
+},
+{
+format: 'float16x4',
+offset: 13296,
+shaderLocation: 8,
+},
+{
+format: 'sint32',
+offset: 7112,
+shaderLocation: 9,
+},
+{
+format: 'snorm8x4',
+offset: 18648,
+shaderLocation: 14,
+},
+{
+format: 'unorm16x2',
+offset: 17148,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x2',
+offset: 7400,
+shaderLocation: 19,
+},
+{
+format: 'uint16x4',
+offset: 16960,
+shaderLocation: 10,
+},
+{
+format: 'snorm8x2',
+offset: 22846,
+shaderLocation: 13,
+},
+{
+format: 'sint32x2',
+offset: 2456,
+shaderLocation: 7,
+},
+{
+format: 'sint16x4',
+offset: 7728,
+shaderLocation: 15,
+},
+{
+format: 'uint32',
+offset: 7232,
+shaderLocation: 3,
+},
+{
+format: 'uint8x4',
+offset: 15148,
+shaderLocation: 12,
+},
+{
+format: 'sint8x4',
+offset: 5000,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 21888,
+attributes: [
+
+],
+},
+{
+arrayStride: 4540,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 19876,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 6764,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 13008,
+attributes: [
+
+],
+},
+{
+arrayStride: 328,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 0,
+shaderLocation: 18,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x41344982,
+},
+fragment: {
+module: shaderModule16,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+undefined,
+undefined,
+undefined
+],
+},
+}
+);
+video13.width = 200;
+document.body.append('\u7080\u{1fdaf}\u9790\uab0c\u49af\u4da8\u0b1e');
+let promise33 = adapter2.requestAdapterInfo();
+let bindGroup40 = device0.createBindGroup({
+layout: bindGroupLayout33,
+entries: [
+
+],
+});
+let texture88 = device0.createTexture(
+{
+label: '\u82d8\ud4ca\u{1fae2}\u6fcc\u9d11\ua077\u05b7\u8e85\u82c4\u0d23',
+size: {width: 62, height: 330, depthOrArrayLayers: 1},
+sampleCount: 1,
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32sint',
+'r32sint'
+],
+}
+);
+let textureView88 = texture15.createView(
+{
+label: '\u{1f9a9}\u42f1\u{1ff6a}\ud23e\u3b33\u10f0\u8438\u5446\uf764\u180d',
+format: 'rg16sint',
+baseMipLevel: 0,
+}
+);
+let computePassEncoder39 = commandEncoder77.beginComputePass();
+let renderBundleEncoder79 = device0.createRenderBundleEncoder(
+{
+label: '\uf8e7\u7973\u65d3\ufda2\u9ded\u95c4\u0afa\uc36a\ucb3b\u0dcc\u5875',
+colorFormats: [
+'rg32sint',
+'bgra8unorm-srgb',
+'rg32float',
+'r16float',
+'rg11b10ufloat',
+'rgba16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 933,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder41.setBlendConstant(
+{
+r: -412.7,
+g: -89.32,
+b: 828.7,
+a: 300.1,
+}
+);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(
+1072,
+0,
+580,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.draw(
+48
+);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(
+11,
+buffer2
+);
+} catch {}
+let canvas15 = document.createElement('canvas');
+let commandBuffer7 = commandEncoder80.finish(
+{
+label: '\u2866\u9417\u323e\uab7c\ubd28\uc80a\u0f08\u4f70\u{1f94e}',
+}
+);
+try {
+computePassEncoder38.setPipeline(
+pipeline69
+);
+} catch {}
+try {
+device1.queue.submit([
+commandBuffer7,
+]);
+} catch {}
+let pipeline77 = device1.createRenderPipeline(
+{
+label: '\u06f1\u{1ff01}\u015d',
+layout: pipelineLayout15,
+vertex: {
+module: shaderModule16,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 19172,
+attributes: [
+{
+format: 'uint32x3',
+offset: 3540,
+shaderLocation: 10,
+},
+{
+format: 'uint8x2',
+offset: 16378,
+shaderLocation: 5,
+},
+{
+format: 'float16x4',
+offset: 12316,
+shaderLocation: 11,
+},
+{
+format: 'sint32x2',
+offset: 13776,
+shaderLocation: 9,
+},
+{
+format: 'sint32',
+offset: 1820,
+shaderLocation: 18,
+},
+{
+format: 'float32',
+offset: 10056,
+shaderLocation: 19,
+},
+{
+format: 'sint8x2',
+offset: 13424,
+shaderLocation: 15,
+},
+{
+format: 'unorm8x2',
+offset: 8346,
+shaderLocation: 8,
+},
+{
+format: 'unorm16x2',
+offset: 1964,
+shaderLocation: 4,
+},
+{
+format: 'float16x4',
+offset: 18632,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 14456,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 3584,
+shaderLocation: 3,
+},
+{
+format: 'sint32x3',
+offset: 12716,
+shaderLocation: 16,
+},
+{
+format: 'sint8x2',
+offset: 10188,
+shaderLocation: 7,
+},
+{
+format: 'unorm16x4',
+offset: 4888,
+shaderLocation: 0,
+},
+{
+format: 'float16x2',
+offset: 13452,
+shaderLocation: 2,
+},
+{
+format: 'uint8x4',
+offset: 1280,
+shaderLocation: 12,
+},
+{
+format: 'sint32',
+offset: 5552,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 10952,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 8600,
+attributes: [
+{
+format: 'snorm16x2',
+offset: 2528,
+shaderLocation: 13,
+},
+{
+format: 'float32x3',
+offset: 5928,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 1912,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 1384,
+shaderLocation: 14,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x9ee4c7c1,
+},
+fragment: {
+module: shaderModule16,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+undefined,
+{
+format: 'r16sint',
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'replace',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 1935,
+stencilWriteMask: 1580,
+depthBias: 41,
+depthBiasSlopeScale: 9,
+depthBiasClamp: 90,
+},
+}
+);
+offscreenCanvas21.width = 923;
+document.body.prepend('\u05b6\ubac1\u{1f8ee}\u3f19\u7ce2\u0c10\u0bb2\u046d\ube4e\u{1fd6f}');
+try {
+canvas15.getContext('2d');
+} catch {}
+let querySet74 = device0.createQuerySet(
+{
+label: '\u{1f852}\u06ad\u340a',
+type: 'occlusion',
+count: 1303,
+}
+);
+let renderBundleEncoder80 = device0.createRenderBundleEncoder(
+{
+label: '\u{1f856}\u7cdb\u02ac\u090b\u{1f8ff}\u01e7\u006c\ub500',
+colorFormats: [
+'rgb10a2unorm',
+'r8unorm',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 706,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder16.setBlendConstant(
+{
+r: 465.2,
+g: 339.6,
+b: -327.3,
+a: -893.9,
+}
+);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(
+buffer9,
+'uint32',
+1592,
+9470
+);
+} catch {}
+try {
+renderBundleEncoder60.setBindGroup(
+5,
+bindGroup18
+);
+} catch {}
+let promise34 = device0.queue.onSubmittedWorkDone();
+try {
+await promise33;
+} catch {}
+document.body.append('\u{1ffe9}\u7700\u0e7d\uf7ba\u0aae\u83d7\u0d08\u{1fc65}\u6391\ucd56');
+let img16 = await imageWithData(182, 141, '#ab8c74b8', '#36601512');
+let videoFrame16 = new VideoFrame(imageBitmap12, {timestamp: 0});
+let pipeline78 = await device1.createRenderPipelineAsync(
+{
+label: '\u{1fbfb}\u0378\u{1fac9}\u0fee',
+layout: pipelineLayout16,
+vertex: {
+module: shaderModule16,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 12164,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 11872,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 9020,
+shaderLocation: 9,
+},
+{
+format: 'sint16x2',
+offset: 5488,
+shaderLocation: 6,
+},
+{
+format: 'sint32',
+offset: 9116,
+shaderLocation: 7,
+},
+{
+format: 'float16x4',
+offset: 4564,
+shaderLocation: 11,
+},
+{
+format: 'uint32x2',
+offset: 4308,
+shaderLocation: 12,
+},
+{
+format: 'unorm16x2',
+offset: 1160,
+shaderLocation: 19,
+},
+{
+format: 'uint16x4',
+offset: 1620,
+shaderLocation: 3,
+},
+{
+format: 'float16x2',
+offset: 6828,
+shaderLocation: 0,
+},
+{
+format: 'unorm8x4',
+offset: 1544,
+shaderLocation: 14,
+},
+{
+format: 'uint16x2',
+offset: 3776,
+shaderLocation: 5,
+},
+{
+format: 'sint8x4',
+offset: 6992,
+shaderLocation: 16,
+},
+{
+format: 'snorm8x4',
+offset: 2672,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 7012,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 6716,
+shaderLocation: 17,
+},
+{
+format: 'unorm16x4',
+offset: 1576,
+shaderLocation: 13,
+},
+{
+format: 'float16x4',
+offset: 1852,
+shaderLocation: 8,
+},
+{
+format: 'sint32x2',
+offset: 4080,
+shaderLocation: 15,
+},
+{
+format: 'snorm16x4',
+offset: 1292,
+shaderLocation: 2,
+},
+{
+format: 'sint32',
+offset: 4224,
+shaderLocation: 18,
+},
+{
+format: 'float16x2',
+offset: 5248,
+shaderLocation: 4,
+},
+{
+format: 'uint16x2',
+offset: 3280,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: false,
+},
+fragment: {
+module: shaderModule16,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+failOp: 'replace',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'zero',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 2947,
+stencilWriteMask: 3732,
+depthBias: 7,
+depthBiasSlopeScale: 66,
+depthBiasClamp: 20,
+},
+}
+);
+try {
+await promise34;
+} catch {}
+let imageBitmap18 = await createImageBitmap(video6);
+try {
+computePassEncoder27.setBindGroup(
+4,
+bindGroup14,
+new Uint32Array(8942),
+4707,
+0
+);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(
+2,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder16.beginOcclusionQuery(
+8
+);
+} catch {}
+try {
+renderPassEncoder26.setScissorRect(
+1123,
+0,
+598,
+0
+);
+} catch {}
+try {
+renderBundleEncoder59.setBindGroup(
+0,
+bindGroup26
+);
+} catch {}
+try {
+commandEncoder78.copyBufferToBuffer(
+buffer18,
+34756,
+buffer26,
+3352,
+1324
+);
+dissociateBuffer(device0, buffer18);
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+commandEncoder73.copyBufferToTexture(
+{
+/* bytesInLastRow: 2920 widthInBlocks: 2920 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 53306 */
+offset: 53306,
+buffer: buffer3,
+},
+{
+  texture: texture42,
+  mipLevel: 0,
+  origin: { x: 1573, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 2920, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let video19 = await videoWithData();
+let shaderModule21 = device0.createShaderModule(
+{
+code: `
+
+@compute @workgroup_size(5, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S18 {
+@location(16) f0: f16,
+@location(39) f1: vec2<f32>,
+@builtin(sample_index) f2: u32,
+@location(43) f3: f16,
+@location(0) f4: vec4<f16>,
+@location(10) f5: vec2<i32>,
+@location(40) f6: vec3<u32>,
+@location(24) f7: vec3<f16>,
+@location(23) f8: vec4<u32>,
+@location(31) f9: vec2<f16>,
+@location(36) f10: u32,
+@location(27) f11: vec2<u32>,
+@location(38) f12: vec4<u32>,
+@location(41) f13: vec2<i32>,
+@location(44) f14: vec4<i32>,
+@builtin(front_facing) f15: bool,
+@location(29) f16: vec4<f32>,
+@location(6) f17: vec2<f16>
+}
+struct FragmentOutput0 {
+@location(5) f0: f32,
+@builtin(frag_depth) f1: f32,
+@location(2) f2: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(2) a0: vec4<f16>, @location(1) a1: vec4<f32>, @builtin(position) a2: vec4<f32>, a3: S18, @location(28) a4: vec4<i32>, @location(30) a5: vec4<f16>, @builtin(sample_mask) a6: u32, @location(7) a7: vec2<u32>, @location(47) a8: vec2<i32>, @location(45) a9: u32, @location(53) a10: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(1) f295: vec4<f32>,
+@location(41) f296: vec2<i32>,
+@location(45) f297: u32,
+@location(43) f298: f16,
+@location(53) f299: vec4<f32>,
+@location(28) f300: vec4<i32>,
+@location(24) f301: vec3<f16>,
+@location(16) f302: f16,
+@builtin(position) f303: vec4<f32>,
+@location(47) f304: vec2<i32>,
+@location(40) f305: vec3<u32>,
+@location(31) f306: vec2<f16>,
+@location(38) f307: vec4<u32>,
+@location(27) f308: vec2<u32>,
+@location(36) f309: u32,
+@location(2) f310: vec4<f16>,
+@location(39) f311: vec2<f32>,
+@location(0) f312: vec4<f16>,
+@location(10) f313: vec2<i32>,
+@location(23) f314: vec4<u32>,
+@location(44) f315: vec4<i32>,
+@location(7) f316: vec2<u32>,
+@location(30) f317: vec4<f16>,
+@location(6) f318: vec2<f16>,
+@location(29) f319: vec4<f32>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(8) a1: vec2<i32>, @location(0) a2: vec4<f32>, @location(1) a3: vec3<i32>, @location(6) a4: vec3<f16>, @location(10) a5: vec4<f16>, @location(3) a6: vec4<f16>, @location(15) a7: u32, @location(5) a8: vec2<u32>, @location(2) a9: vec3<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let sampler86 = device0.createSampler(
+{
+label: '\u45b4\u4b38\u04ea\u07c8\u7846\uae85\u08c0\u{1ffbd}\u{1fe84}\u328a',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 44.146,
+lodMaxClamp: 98.349,
+}
+);
+try {
+renderBundleEncoder10.setVertexBuffer(
+8,
+buffer6,
+4480,
+4762
+);
+} catch {}
+try {
+commandEncoder78.copyBufferToBuffer(
+buffer1,
+1452,
+buffer23,
+6448,
+2076
+);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer23);
+} catch {}
+let promise35 = device0.queue.onSubmittedWorkDone();
+let renderBundleEncoder81 = device1.createRenderBundleEncoder(
+{
+label: '\u50f7\u{1fe56}\u760b\u6271\u{1fff5}\u122a\u5998\ub989\u4175',
+colorFormats: [
+'rgba32uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 828,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder38.setPipeline(
+pipeline75
+);
+} catch {}
+try {
+renderBundleEncoder81.insertDebugMarker(
+'\u{1fe96}'
+);
+} catch {}
+let bindGroup41 = device0.createBindGroup({
+label: '\u5e9b\u0ab5\u63c8\u0ddc',
+layout: bindGroupLayout12,
+entries: [
+
+],
+});
+let commandEncoder81 = device0.createCommandEncoder(
+{
+label: '\u0142\ub4d2\u0d63\u3063\u{1f6ee}\u{1f6ba}\u09ef\u{1f60f}\u0e72\u{1f874}',
+}
+);
+let renderBundleEncoder82 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8unorm',
+'r16float',
+'rgba8sint'
+],
+sampleCount: 309,
+stencilReadOnly: true,
+}
+);
+let sampler87 = device0.createSampler(
+{
+label: '\ua325\uc5b4\u6c72\u0e04\u{1fbb5}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 93.667,
+lodMaxClamp: 98.100,
+}
+);
+try {
+computePassEncoder19.setBindGroup(
+7,
+bindGroup1
+);
+} catch {}
+try {
+computePassEncoder23.setPipeline(
+pipeline64
+);
+} catch {}
+try {
+renderPassEncoder34.setViewport(
+1558.5,
+0.8740,
+1376.2,
+0.01676,
+0.3625,
+0.9954
+);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(
+buffer2,
+'uint32',
+12836,
+3842
+);
+} catch {}
+try {
+commandEncoder78.clearBuffer(
+buffer10,
+1680,
+20628
+);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline79 = await promise24;
+document.body.prepend(canvas2);
+let canvas16 = document.createElement('canvas');
+let img17 = await imageWithData(47, 216, '#32e14b6d', '#2bf335a7');
+try {
+canvas16.getContext('webgl');
+} catch {}
+let buffer32 = device1.createBuffer(
+{
+label: '\u{1f8e5}\u0efe\u{1fbc0}',
+size: 33423,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let querySet75 = device1.createQuerySet(
+{
+type: 'occlusion',
+count: 3239,
+}
+);
+let renderBundleEncoder83 = device1.createRenderBundleEncoder(
+{
+label: '\u0fb4\u0333\u{1f8e1}\u{1fbc8}\u{1fe92}\ub78d\u6c42\ucbbe\u33b7\u8690\u0fac',
+colorFormats: [
+'rg8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 156,
+stencilReadOnly: true,
+}
+);
+try {
+await promise35;
+} catch {}
+try {
+window.someLabel = renderPassEncoder23.label;
+} catch {}
+let querySet76 = device0.createQuerySet(
+{
+label: '\u9701\u0b98\u0c7a\u24d1\u023b\u2a79\u6cb4\ub07b\u0842\u2eb2\u07f6',
+type: 'occlusion',
+count: 436,
+}
+);
+let computePassEncoder40 = commandEncoder81.beginComputePass(
+{
+label: '\uce5d\u265c\u{1fdca}\ud48b\ub1d7\u01ff'
+}
+);
+let renderBundle71 = renderBundleEncoder40.finish(
+{
+label: '\u65a4\u865f\u70d9\u9dad\u1cdb\u0f2c\ub874'
+}
+);
+try {
+renderPassEncoder27.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+renderPassEncoder23.setBlendConstant(
+{
+r: 764.0,
+g: 337.7,
+b: 720.7,
+a: -233.3,
+}
+);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+0,
+43,
+2,
+11
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(
+24,
+32
+);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(
+buffer9,
+'uint32',
+40520,
+463
+);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(
+4,
+buffer2,
+5284
+);
+} catch {}
+try {
+renderBundleEncoder69.setBindGroup(
+3,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder66.setIndexBuffer(
+buffer4,
+'uint16',
+36108,
+6059
+);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(
+4,
+buffer23,
+3964
+);
+} catch {}
+try {
+commandEncoder78.copyBufferToTexture(
+{
+/* bytesInLastRow: 38936 widthInBlocks: 4867 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 53216 */
+offset: 53216,
+bytesPerRow: 39168,
+buffer: buffer3,
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: { x: 300, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 4867, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+document.body.append('\ufc4b\u0520\u05d8\ua40f\u3161\uce67');
+let bindGroupLayout38 = device0.createBindGroupLayout(
+{
+label: '\ub229\u101a',
+entries: [
+{
+binding: 1498,
+visibility: 0,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 1034,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+let querySet77 = device0.createQuerySet(
+{
+label: '\u{1fcf2}\ua22e\u04b5\u1b03\u2665\u75b0\u{1fb74}\ud3c4\u{1f653}',
+type: 'occlusion',
+count: 1313,
+}
+);
+try {
+computePassEncoder34.setPipeline(
+pipeline9
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(
+48,
+64,
+56,
+280,
+56
+);
+} catch {}
+try {
+renderBundleEncoder71.setBindGroup(
+3,
+bindGroup35
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture3,
+  mipLevel: 3,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+new BigInt64Array(arrayBuffer6),
+/* required buffer size: 519 */{
+offset: 519,
+bytesPerRow: 175,
+},
+{width: 7, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend(img17);
+let imageData15 = new ImageData(92, 244);
+let videoFrame17 = new VideoFrame(imageBitmap18, {timestamp: 0});
+let textureView89 = texture86.createView(
+{
+label: '\u0d86\u{1ffa5}\u{1f7e7}\u6dc0\u22e5\u4dff\u3fe9\u{1fc69}',
+baseMipLevel: 2,
+mipLevelCount: 1,
+baseArrayLayer: 88,
+arrayLayerCount: 15,
+}
+);
+try {
+computePassEncoder38.setBindGroup(
+0,
+bindGroup37,
+new Uint32Array(1738),
+1120,
+0
+);
+} catch {}
+let renderPassEncoder44 = commandEncoder78.beginRenderPass(
+{
+label: '\u0432\u03c2',
+colorAttachments: [
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthClearValue: -0.9971662209195529,
+depthLoadOp: 'load',
+depthStoreOp: 'store',
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet9,
+maxDrawCount: 3888,
+}
+);
+let renderBundleEncoder84 = device0.createRenderBundleEncoder(
+{
+label: '\u0525\u0457\u0420\u038b\u0014\uc62f\u036a\u032d\u01c5\u{1fc30}\ue9fd',
+colorFormats: [
+'bgra8unorm-srgb',
+'bgra8unorm-srgb',
+'r8sint',
+'r32uint',
+'r32float',
+'rgba32float'
+],
+sampleCount: 730,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder36.setBindGroup(
+4,
+bindGroup34,
+new Uint32Array(7403),
+1254,
+0
+);
+} catch {}
+try {
+renderPassEncoder35.setBlendConstant(
+{
+r: 752.9,
+g: -565.8,
+b: -494.3,
+a: 909.4,
+}
+);
+} catch {}
+try {
+renderPassEncoder17.setStencilReference(
+3213
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(
+48,
+56,
+64
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer22,
+304432
+);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(
+10,
+buffer15,
+2256
+);
+} catch {}
+try {
+commandEncoder73.copyBufferToBuffer(
+buffer20,
+49732,
+buffer26,
+6152,
+1868
+);
+dissociateBuffer(device0, buffer20);
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+commandEncoder73.resolveQuerySet(
+querySet3,
+804,
+92,
+buffer10,
+28928
+);
+} catch {}
+let promise36 = device0.createComputePipelineAsync(
+{
+layout: pipelineLayout4,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+},
+}
+);
+let videoFrame18 = new VideoFrame(imageBitmap16, {timestamp: 0});
+let bindGroup42 = device1.createBindGroup({
+label: '\u010d\u0596\u57ba\uc4bb\u9d83\u{1f6de}\u1fca',
+layout: bindGroupLayout36,
+entries: [
+
+],
+});
+let querySet78 = device1.createQuerySet(
+{
+label: '\u42fe\u{1f9de}\u{1fff0}\u0834\u00ad\u9204\u{1f811}\u{1ff27}',
+type: 'occlusion',
+count: 575,
+}
+);
+try {
+computePassEncoder38.setBindGroup(
+4,
+bindGroup38
+);
+} catch {}
+try {
+renderBundleEncoder77.setVertexBuffer(
+5,
+buffer32,
+19952
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer32,
+23428,
+new Float32Array(35156),
+34786,
+300
+);
+} catch {}
+let pipeline80 = device1.createRenderPipeline(
+{
+label: '\u052c\u{1f98e}\u213f\u5281\u{1f6d4}\u064b',
+layout: pipelineLayout15,
+vertex: {
+module: shaderModule16,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 11344,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 936,
+shaderLocation: 18,
+},
+{
+format: 'uint32',
+offset: 8088,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 4756,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 2400,
+shaderLocation: 0,
+},
+{
+format: 'unorm16x2',
+offset: 864,
+shaderLocation: 11,
+},
+{
+format: 'sint16x2',
+offset: 1196,
+shaderLocation: 6,
+},
+{
+format: 'unorm16x2',
+offset: 1528,
+shaderLocation: 13,
+},
+{
+format: 'float32',
+offset: 3588,
+shaderLocation: 14,
+},
+{
+format: 'uint8x2',
+offset: 2788,
+shaderLocation: 10,
+},
+{
+format: 'float32x3',
+offset: 2044,
+shaderLocation: 4,
+},
+{
+format: 'float16x2',
+offset: 1888,
+shaderLocation: 1,
+},
+{
+format: 'float32x2',
+offset: 2100,
+shaderLocation: 17,
+},
+{
+format: 'uint16x4',
+offset: 2832,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x2',
+offset: 236,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 21524,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x4',
+offset: 16192,
+shaderLocation: 12,
+},
+{
+format: 'sint32x2',
+offset: 10692,
+shaderLocation: 9,
+},
+{
+format: 'sint16x2',
+offset: 1772,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x4',
+offset: 7800,
+shaderLocation: 19,
+},
+{
+format: 'float32',
+offset: 1372,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 4628,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 7232,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 17252,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 3668,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 12376,
+attributes: [
+
+],
+},
+{
+arrayStride: 1340,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 14760,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 7044,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x4',
+offset: 4732,
+shaderLocation: 16,
+},
+{
+format: 'sint32',
+offset: 4752,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x5046d208,
+},
+fragment: {
+module: shaderModule16,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.GREEN,
+},
+undefined,
+undefined,
+undefined,
+{
+format: 'r32sint',
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'replace',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'invert',
+},
+stencilReadMask: 1192,
+stencilWriteMask: 3004,
+depthBias: 69,
+depthBiasSlopeScale: 67,
+depthBiasClamp: 50,
+},
+}
+);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let img18 = await imageWithData(44, 4, '#36d79390', '#6593f10e');
+try {
+computePassEncoder38.setBindGroup(
+1,
+bindGroup37,
+new Uint32Array(7095),
+3101,
+0
+);
+} catch {}
+try {
+renderBundleEncoder81.setBindGroup(
+2,
+bindGroup38
+);
+} catch {}
+document.body.prepend('\uef7c\u5a90\u01c8\u0066');
+let video20 = await videoWithData();
+let renderBundleEncoder85 = device1.createRenderBundleEncoder(
+{
+label: '\udc91\u44d7\uaaca\u{1fcdd}\uf52f\u00ca\u0f4e\u0e75',
+colorFormats: [
+'rg8sint',
+'rg16uint',
+'r16sint'
+],
+sampleCount: 320,
+}
+);
+document.body.prepend('\u0fe3\uadec\u02f1\ucc85\u{1fa40}\u7455');
+let imageData16 = new ImageData(180, 196);
+let bindGroup43 = device0.createBindGroup({
+label: '\u0a56\ue2a9',
+layout: bindGroupLayout20,
+entries: [
+{
+binding: 2976,
+resource: {
+buffer: buffer10,
+offset: 26368,
+size: 4364,
+}
+}
+],
+});
+let texture89 = device0.createTexture(
+{
+label: '\u{1ffb7}\u18cf\u{1fa9d}\u{1fd13}\u4a7e\uc110\uf829\u012f\uaaef\u{1fcec}\u053b',
+size: [773],
+dimension: '1d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg8sint'
+],
+}
+);
+let textureView90 = texture11.createView(
+{
+label: '\u0a3a\u2f71\u9f27\u{1faa1}\u24b1\u3d5e\u3ee8',
+baseMipLevel: 0,
+}
+);
+let computePassEncoder41 = commandEncoder73.beginComputePass(
+{
+label: '\u0bc4\u0fe4\u0adb\u0a7a\u{1f715}\u1fc1\u01d5\u022c'
+}
+);
+let sampler88 = device0.createSampler(
+{
+label: '\uf5d9\u7db2\u95f9\u068c\u7a5f\u0643',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 45.373,
+lodMaxClamp: 73.365,
+}
+);
+try {
+renderBundleEncoder65.setBindGroup(
+1,
+bindGroup4
+);
+} catch {}
+let promise37 = device0.createRenderPipelineAsync(
+{
+label: '\u91b3\u490b\u141e\u{1f933}\u79b7\u0ee4\u4293\u{1fa33}\ub984\u4957\udec9',
+layout: pipelineLayout9,
+vertex: {
+module: shaderModule6,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 57336,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 26512,
+shaderLocation: 2,
+},
+{
+format: 'uint32x2',
+offset: 13172,
+shaderLocation: 13,
+},
+{
+format: 'unorm16x2',
+offset: 43560,
+shaderLocation: 0,
+},
+{
+format: 'float32x3',
+offset: 54860,
+shaderLocation: 10,
+},
+{
+format: 'uint8x4',
+offset: 41196,
+shaderLocation: 16,
+},
+{
+format: 'uint32',
+offset: 52576,
+shaderLocation: 7,
+},
+{
+format: 'unorm16x4',
+offset: 26616,
+shaderLocation: 6,
+},
+{
+format: 'snorm16x2',
+offset: 22092,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 24348,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 5252,
+shaderLocation: 8,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x68ab552d,
+},
+fragment: {
+module: shaderModule6,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+},
+{
+format: 'rg8unorm',
+},
+undefined,
+undefined
+],
+},
+}
+);
+let canvas17 = document.createElement('canvas');
+pseudoSubmit(device0, commandEncoder48);
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder39.setScissorRect(
+2017,
+1,
+352,
+0
+);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(
+2,
+buffer4,
+18832,
+12409
+);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(
+8,
+bindGroup3
+);
+} catch {}
+try {
+renderBundleEncoder71.setBindGroup(
+2,
+bindGroup29,
+new Uint32Array(6613),
+2776,
+0
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+7484,
+new Int16Array(4413),
+1495,
+604
+);
+} catch {}
+offscreenCanvas11.width = 435;
+let bindGroup44 = device0.createBindGroup({
+label: '\u0661\u01e2\u0cea\u6f0f\u0abd\u{1f979}\u1661',
+layout: bindGroupLayout20,
+entries: [
+{
+binding: 2976,
+resource: {
+buffer: buffer7,
+offset: 10880,
+size: 1320,
+}
+}
+],
+});
+let commandEncoder82 = device0.createCommandEncoder(
+{
+label: '\ub8e5\u491a\u{1fd39}\u06af\ud95d\u03aa\u34ed\uadcb',
+}
+);
+let textureView91 = texture21.createView(
+{
+label: '\u00ef\u8a4c\u70e6\u0029\u018f\ud931',
+baseMipLevel: 8,
+}
+);
+let computePassEncoder42 = commandEncoder82.beginComputePass(
+{
+
+}
+);
+let renderBundleEncoder86 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8uint',
+'rgb10a2unorm',
+undefined,
+'r16sint'
+],
+sampleCount: 376,
+stencilReadOnly: true,
+}
+);
+let sampler89 = device0.createSampler(
+{
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 61.956,
+lodMaxClamp: 74.976,
+}
+);
+try {
+renderPassEncoder44.setIndexBuffer(
+buffer2,
+'uint16'
+);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(
+4,
+buffer6,
+5148
+);
+} catch {}
+try {
+renderBundleEncoder78.setVertexBuffer(
+3,
+buffer15,
+25072,
+4617
+);
+} catch {}
+let renderBundleEncoder87 = device1.createRenderBundleEncoder(
+{
+label: '\u{1f79a}\u327f',
+colorFormats: [
+'rgba8sint',
+'rg8sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 51,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let canvas18 = document.createElement('canvas');
+try {
+canvas17.getContext('webgl2');
+} catch {}
+let shaderModule22 = device0.createShaderModule(
+{
+label: '\u{1ff3e}\u0845\u0ed3\ubf63',
+code: `
+
+@compute @workgroup_size(3, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S20 {
+@location(27) f0: u32,
+@location(47) f1: u32,
+@location(13) f2: vec3<u32>,
+@location(10) f3: vec2<i32>,
+@location(52) f4: f32,
+@location(18) f5: vec2<u32>,
+@location(21) f6: vec3<f16>,
+@location(15) f7: u32,
+@location(43) f8: vec3<f32>,
+@location(11) f9: f32,
+@location(24) f10: vec2<f16>,
+@location(26) f11: u32,
+@location(28) f12: vec4<f16>,
+@location(41) f13: vec4<i32>,
+@location(36) f14: vec4<f16>,
+@location(23) f15: vec3<f32>,
+@location(14) f16: vec4<f16>,
+@location(40) f17: vec4<f32>,
+@location(53) f18: vec2<i32>,
+@location(33) f19: f16,
+@location(3) f20: vec4<u32>,
+@builtin(position) f21: vec4<f32>,
+@location(30) f22: vec2<u32>,
+@location(2) f23: i32,
+@builtin(sample_index) f24: u32,
+@builtin(front_facing) f25: bool
+}
+struct FragmentOutput0 {
+@builtin(frag_depth) f0: f32,
+@location(7) f1: vec4<u32>,
+@location(3) f2: u32,
+@location(5) f3: vec3<i32>,
+@location(6) f4: vec2<u32>,
+@location(1) f5: vec4<f32>,
+@location(0) f6: vec3<u32>
+}
+
+@fragment
+fn fragment0(@location(48) a0: u32, @location(35) a1: vec2<f16>, @location(45) a2: vec2<f32>, @location(50) a3: vec4<i32>, @location(31) a4: vec3<f16>, @location(19) a5: vec3<f32>, @location(7) a6: vec2<u32>, @builtin(sample_mask) a7: u32, @location(58) a8: vec3<u32>, @location(9) a9: vec3<f16>, @location(25) a10: f16, @location(22) a11: vec4<i32>, @location(8) a12: vec2<f32>, @location(32) a13: f32, @location(4) a14: i32, a15: S20) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S19 {
+@location(4) f0: vec4<f32>,
+@location(6) f1: vec4<u32>
+}
+struct VertexOutput0 {
+@location(50) f320: vec4<i32>,
+@location(23) f321: vec3<f32>,
+@location(28) f322: vec4<f16>,
+@location(27) f323: u32,
+@location(3) f324: vec4<u32>,
+@location(45) f325: vec2<f32>,
+@location(35) f326: vec2<f16>,
+@location(10) f327: vec2<i32>,
+@location(26) f328: u32,
+@builtin(position) f329: vec4<f32>,
+@location(4) f330: i32,
+@location(11) f331: f32,
+@location(52) f332: f32,
+@location(8) f333: vec2<f32>,
+@location(7) f334: vec2<u32>,
+@location(41) f335: vec4<i32>,
+@location(14) f336: vec4<f16>,
+@location(22) f337: vec4<i32>,
+@location(13) f338: vec3<u32>,
+@location(18) f339: vec2<u32>,
+@location(53) f340: vec2<i32>,
+@location(43) f341: vec3<f32>,
+@location(25) f342: f16,
+@location(31) f343: vec3<f16>,
+@location(58) f344: vec3<u32>,
+@location(32) f345: f32,
+@location(40) f346: vec4<f32>,
+@location(48) f347: u32,
+@location(2) f348: i32,
+@location(21) f349: vec3<f16>,
+@location(9) f350: vec3<f16>,
+@location(15) f351: u32,
+@location(30) f352: vec2<u32>,
+@location(36) f353: vec4<f16>,
+@location(24) f354: vec2<f16>,
+@location(47) f355: u32,
+@location(19) f356: vec3<f32>,
+@location(33) f357: f16
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec3<f16>, @location(7) a1: vec4<f32>, @builtin(instance_index) a2: u32, @location(3) a3: vec3<u32>, @location(13) a4: u32, @location(14) a5: vec4<i32>, @location(2) a6: vec4<u32>, @builtin(vertex_index) a7: u32, a8: S19, @location(16) a9: vec3<f32>, @location(5) a10: vec3<i32>, @location(8) a11: vec3<f32>, @location(1) a12: vec4<i32>, @location(0) a13: vec4<f16>, @location(11) a14: vec2<f32>, @location(10) a15: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture90 = device0.createTexture(
+{
+label: '\u{1fa52}\u08b9',
+size: {width: 9747, height: 1, depthOrArrayLayers: 72},
+mipLevelCount: 7,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+try {
+computePassEncoder14.setPipeline(
+pipeline40
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(
+buffer24,
+8136
+);
+} catch {}
+let arrayBuffer19 = buffer26.getMappedRange(
+0,
+300
+);
+let imageData17 = new ImageData(148, 132);
+let shaderModule23 = device0.createShaderModule(
+{
+label: '\u{1fc81}\u62db',
+code: `@group(4) @binding(3140)
+var<storage, read_write> global3: array<u32>;
+
+@compute @workgroup_size(8, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(3) f0: vec4<f32>,
+@location(0) f1: vec3<i32>,
+@location(5) f2: vec4<u32>,
+@location(1) f3: vec2<u32>,
+@location(6) f4: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(35) a0: vec4<f32>, @location(51) a1: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S21 {
+@location(8) f0: vec3<f32>,
+@location(2) f1: vec2<u32>,
+@location(12) f2: f32,
+@location(5) f3: f32,
+@location(13) f4: vec2<f16>,
+@location(1) f5: vec2<f16>
+}
+struct VertexOutput0 {
+@location(51) f358: vec4<f32>,
+@location(5) f359: vec4<i32>,
+@location(28) f360: vec3<f32>,
+@builtin(position) f361: vec4<f32>,
+@location(43) f362: vec2<u32>,
+@location(35) f363: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec4<f16>, @location(3) a1: vec3<f32>, @location(10) a2: f32, a3: S21, @location(16) a4: vec4<f32>, @location(0) a5: f16, @location(11) a6: vec2<f32>, @location(4) a7: vec4<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let commandEncoder83 = device0.createCommandEncoder(
+{
+label: '\u177a\ub448\u076d\u0b01\u{1fca4}',
+}
+);
+let renderPassEncoder45 = commandEncoder83.beginRenderPass(
+{
+label: '\ucf50\uf0c7\u0a02\u0a42\u097a\ucffd\u21f3\ufd94\uf1fc\u0b54',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthClearValue: 0.23981255082766373,
+depthLoadOp: 'clear',
+depthStoreOp: 'discard',
+stencilClearValue: 37538,
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet51,
+maxDrawCount: 18456,
+}
+);
+let sampler90 = device0.createSampler(
+{
+label: '\u7288\u5c07\uaf54\u{1fb32}\uf794\u046d\u00c2\u4155\u{1fdc6}\u0afd\u0e84',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 89.945,
+lodMaxClamp: 95.230,
+compare: 'greater-equal',
+}
+);
+try {
+computePassEncoder10.setPipeline(
+pipeline64
+);
+} catch {}
+try {
+renderPassEncoder20.beginOcclusionQuery(
+8
+);
+} catch {}
+try {
+renderPassEncoder42.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.draw(
+16,
+64,
+8,
+32
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(
+0,
+64,
+64,
+200
+);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(
+buffer1,
+'uint32',
+2496,
+1655
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture59,
+  mipLevel: 1,
+  origin: { x: 6, y: 0, z: 170 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 478541 */{
+offset: 517,
+bytesPerRow: 257,
+rowsPerImage: 124,
+},
+{width: 2, height: 1, depthOrArrayLayers: 16}
+);
+} catch {}
+let promise38 = device0.createComputePipelineAsync(
+{
+layout: pipelineLayout6,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+},
+}
+);
+let texture91 = device0.createTexture(
+{
+label: '\u{1ff6f}\uebcf\ufc59\ud922\uec48\u{1ffa1}\u0b35\ua305\u0147',
+size: [10344, 1, 100],
+mipLevelCount: 6,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'stencil8'
+],
+}
+);
+try {
+computePassEncoder10.setBindGroup(
+1,
+bindGroup31,
+new Uint32Array(7841),
+6128,
+0
+);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(
+1,
+bindGroup25,
+[]
+);
+} catch {}
+try {
+renderPassEncoder31.setBlendConstant(
+{
+r: -119.9,
+g: 390.6,
+b: 806.9,
+a: 974.3,
+}
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(
+buffer0,
+102112
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer25,
+73592
+);
+} catch {}
+try {
+renderBundleEncoder67.setIndexBuffer(
+buffer22,
+'uint16',
+35378,
+13362
+);
+} catch {}
+let arrayBuffer20 = buffer27.getMappedRange(
+35016
+);
+gc();
+let texture92 = device0.createTexture(
+{
+label: '\u{1fa1b}\u{1fbc6}\u5bdd\u6572',
+size: {width: 216, height: 50, depthOrArrayLayers: 114},
+mipLevelCount: 5,
+sampleCount: 1,
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_DST,
+}
+);
+let textureView92 = texture59.createView(
+{
+label: '\u{1fa5c}\u0cda\uf6ed\ubda2\u387d\u3fb0\u8b32',
+mipLevelCount: 1,
+baseArrayLayer: 0,
+}
+);
+let sampler91 = device0.createSampler(
+{
+label: '\u1e86\u6c60\uc5fd\u{1f7d2}',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+lodMaxClamp: 65.526,
+}
+);
+try {
+computePassEncoder33.setBindGroup(
+3,
+bindGroup3,
+new Uint32Array(3303),
+2569,
+0
+);
+} catch {}
+try {
+renderPassEncoder22.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder14.setScissorRect(
+1955,
+1,
+176,
+0
+);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(
+buffer9,
+'uint16'
+);
+} catch {}
+try {
+renderBundleEncoder68.setBindGroup(
+8,
+bindGroup18
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer21,
+47980,
+new DataView(new ArrayBuffer(21590)),
+3233,
+5304
+);
+} catch {}
+let pipeline81 = device0.createRenderPipeline(
+{
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule6,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 25064,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 4904,
+shaderLocation: 16,
+},
+{
+format: 'snorm8x4',
+offset: 9752,
+shaderLocation: 6,
+},
+{
+format: 'uint8x4',
+offset: 4500,
+shaderLocation: 2,
+},
+{
+format: 'uint8x4',
+offset: 348,
+shaderLocation: 13,
+},
+{
+format: 'uint32x3',
+offset: 15056,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 32320,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 15212,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 10940,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 18744,
+attributes: [
+
+],
+},
+{
+arrayStride: 7708,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 1024,
+shaderLocation: 0,
+},
+{
+format: 'float16x2',
+offset: 3316,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 13888,
+attributes: [
+
+],
+},
+{
+arrayStride: 27780,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 10792,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule6,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'rg32float',
+},
+undefined,
+undefined
+],
+},
+}
+);
+document.body.append('\u0e9a\u{1faa1}\u7656\u9e67\u0346\u{1ff47}\ufee5\u{1fc94}\u03ec\uad6e');
+let querySet79 = device0.createQuerySet(
+{
+label: '\ua333\u52f4',
+type: 'occlusion',
+count: 2158,
+}
+);
+try {
+computePassEncoder32.setBindGroup(
+7,
+bindGroup17,
+new Uint32Array(152),
+104,
+0
+);
+} catch {}
+try {
+renderPassEncoder39.setBlendConstant(
+{
+r: -262.9,
+g: -676.6,
+b: 656.3,
+a: -389.6,
+}
+);
+} catch {}
+try {
+renderPassEncoder42.setViewport(
+1904.2,
+0.7180,
+661.5,
+0.2129,
+0.1290,
+0.5884
+);
+} catch {}
+try {
+renderPassEncoder12.draw(
+8,
+56,
+64,
+72
+);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(
+9,
+buffer23,
+7344,
+636
+);
+} catch {}
+let arrayBuffer21 = buffer0.getMappedRange(
+22352,
+0
+);
+let promise39 = device0.createComputePipelineAsync(
+{
+layout: pipelineLayout10,
+compute: {
+module: shaderModule10,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let canvas19 = document.createElement('canvas');
+let bindGroup45 = device1.createBindGroup({
+label: '\u4636\u0a50\u0049\u{1ff32}\u{1fd16}\u0dd3\ua296',
+layout: bindGroupLayout36,
+entries: [
+
+],
+});
+let commandEncoder84 = device1.createCommandEncoder(
+{
+label: '\u540f\u0f29\u01e9\u{1fdc2}',
+}
+);
+let texture93 = device1.createTexture(
+{
+label: '\u{1ff22}\ue414\ub639\uaeae\uee96\u2a3d\u8d2d\ue7dd\u37f3',
+size: [10725, 45, 240],
+mipLevelCount: 14,
+format: 'astc-5x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-5x5-unorm',
+'astc-5x5-unorm'
+],
+}
+);
+try {
+renderBundleEncoder85.setBindGroup(
+2,
+bindGroup38
+);
+} catch {}
+try {
+commandEncoder84.clearBuffer(
+buffer32,
+18520,
+10008
+);
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer32,
+14080,
+new DataView(new ArrayBuffer(46661)),
+21867,
+11220
+);
+} catch {}
+let pipeline82 = device1.createComputePipeline(
+{
+label: '\u0f41\u{1fd9e}\ud3ca\u{1ff0c}',
+layout: pipelineLayout15,
+compute: {
+module: shaderModule16,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+video10.height = 200;
+let canvas20 = document.createElement('canvas');
+try {
+renderBundleEncoder87.setVertexBuffer(
+1,
+buffer32,
+19040,
+7136
+);
+} catch {}
+document.body.prepend(canvas15);
+let promise40 = adapter8.requestDevice(
+{
+requiredLimits: {
+maxBindGroups: 7,
+maxColorAttachmentBytesPerSample: 49,
+maxVertexAttributes: 16,
+maxVertexBufferArrayStride: 29188,
+maxStorageTexturesPerShaderStage: 13,
+maxStorageBuffersPerShaderStage: 34,
+maxDynamicStorageBuffersPerPipelineLayout: 35034,
+maxBindingsPerBindGroup: 6957,
+maxTextureDimension1D: 15949,
+maxTextureDimension2D: 14213,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 188040947,
+maxInterStageShaderVariables: 30,
+maxInterStageShaderComponents: 72,
+},
+}
+);
+let bindGroup46 = device0.createBindGroup({
+label: '\u0927\ud8c7\u0561\u0138\u0842\u{1fe8f}\u9732\u0fb5',
+layout: bindGroupLayout34,
+entries: [
+{
+binding: 1592,
+resource: externalTexture0
+}
+],
+});
+let textureView93 = texture64.createView(
+{
+label: '\u5bb8\u{1ffe2}\u2f72',
+format: 'bgra8unorm',
+}
+);
+let renderBundleEncoder88 = device0.createRenderBundleEncoder(
+{
+label: '\u59de\u6960\ue7b7\ufd0d\uee78\ud07e\u07c1\u796e\u{1f7c8}',
+colorFormats: [
+'rg8sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 621,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder29.setBindGroup(
+0,
+bindGroup9,
+new Uint32Array(3118),
+3059,
+0
+);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(
+2,
+bindGroup44
+);
+} catch {}
+try {
+renderPassEncoder20.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer18,
+198568
+);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(
+buffer11,
+'uint16',
+8624,
+14990
+);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(
+11,
+buffer23,
+1136,
+3345
+);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(
+8,
+bindGroup6,
+new Uint32Array(6302),
+5489,
+0
+);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(
+4,
+buffer11
+);
+} catch {}
+let promise41 = buffer25.mapAsync(
+GPUMapMode.READ,
+0,
+144
+);
+let gpuCanvasContext17 = canvas18.getContext('webgpu');
+document.body.prepend(video5);
+let shaderModule24 = device0.createShaderModule(
+{
+label: '\u{1ffd7}\ua66f\u{1f7df}\u2265\u4c57\u2152\u{1f6a5}\uf4fc\u38c1\u{1f8a6}\uf710',
+code: `
+
+@compute @workgroup_size(6, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: vec3<i32>,
+@location(1) f1: i32,
+@location(2) f2: vec4<u32>,
+@location(5) f3: vec3<u32>,
+@location(3) f4: i32,
+@location(7) f5: vec4<i32>,
+@location(4) f6: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(38) a0: f16, @location(46) a1: vec2<f32>, @location(52) a2: vec3<f16>, @location(57) a3: vec4<u32>, @location(26) a4: vec2<f32>, @builtin(sample_mask) a5: u32, @location(24) a6: i32, @location(31) a7: vec4<u32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(59) f364: vec2<u32>,
+@location(51) f365: vec2<i32>,
+@location(19) f366: vec2<f32>,
+@location(20) f367: f16,
+@location(29) f368: vec2<f16>,
+@location(57) f369: vec4<u32>,
+@location(25) f370: u32,
+@location(40) f371: vec3<f32>,
+@location(5) f372: vec2<u32>,
+@location(52) f373: vec3<f16>,
+@location(13) f374: vec3<u32>,
+@location(28) f375: vec3<i32>,
+@builtin(position) f376: vec4<f32>,
+@location(47) f377: vec2<f32>,
+@location(9) f378: vec3<u32>,
+@location(32) f379: f32,
+@location(10) f380: vec4<f32>,
+@location(26) f381: vec2<f32>,
+@location(31) f382: vec4<u32>,
+@location(39) f383: i32,
+@location(37) f384: f32,
+@location(35) f385: vec3<u32>,
+@location(6) f386: vec4<u32>,
+@location(2) f387: i32,
+@location(3) f388: vec3<f16>,
+@location(18) f389: i32,
+@location(55) f390: f32,
+@location(46) f391: vec2<f32>,
+@location(15) f392: vec3<u32>,
+@location(1) f393: vec2<i32>,
+@location(38) f394: f16,
+@location(21) f395: vec4<u32>,
+@location(11) f396: vec2<f16>,
+@location(42) f397: vec4<f32>,
+@location(4) f398: vec3<i32>,
+@location(24) f399: i32,
+@location(53) f400: i32,
+@location(0) f401: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec3<u32>, @location(6) a1: vec3<i32>, @builtin(vertex_index) a2: u32, @location(9) a3: vec4<i32>, @location(2) a4: u32, @location(8) a5: vec4<u32>, @location(7) a6: vec3<f32>, @location(10) a7: vec2<f32>, @location(13) a8: vec2<u32>, @location(4) a9: vec2<f16>, @location(11) a10: vec4<f16>, @location(16) a11: vec2<i32>, @location(3) a12: vec3<f16>, @builtin(instance_index) a13: u32, @location(1) a14: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let renderBundleEncoder89 = device0.createRenderBundleEncoder(
+{
+label: '\u6975\u32fd\u0d6f',
+colorFormats: [
+'rgba8unorm-srgb',
+'rgba16sint',
+'rg8unorm',
+'rgba32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 775,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder22.setStencilReference(
+2826
+);
+} catch {}
+try {
+renderPassEncoder38.setViewport(
+3033.6,
+0.8150,
+7.270,
+0.1506,
+0.6547,
+0.8260
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer27,
+65376
+);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(
+4,
+buffer11,
+19524
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 734, height: 1, depthOrArrayLayers: 157}
+*/
+{
+  source: canvas5,
+  origin: { x: 119, y: 75 },
+  flipY: true,
+},
+{
+  texture: texture31,
+  mipLevel: 0,
+  origin: { x: 474, y: 1, z: 156 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 152, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let querySet80 = device1.createQuerySet(
+{
+label: '\u01d0\ufcf0',
+type: 'occlusion',
+count: 2165,
+}
+);
+let renderBundle72 = renderBundleEncoder85.finish(
+{
+label: '\u0980\ucbe7\u6a99\u7e8c\u032e\ub26c\u{1f603}\u0a18\u6ec1\u0991\uf76b'
+}
+);
+try {
+device1.queue.writeBuffer(
+buffer32,
+30108,
+new DataView(new ArrayBuffer(27800)),
+25874,
+1424
+);
+} catch {}
+document.body.prepend('\u0494\uc5c0\u{1f6ff}\u0c30\ub084');
+let videoFrame19 = new VideoFrame(imageBitmap15, {timestamp: 0});
+let textureView94 = texture84.createView(
+{
+label: '\uc60d\u4127\u1553\ub1c5\u5381\u9dad\uf7e1\u3fba\u{1fc81}\u{1f9a6}\u051b',
+aspect: 'stencil-only',
+baseMipLevel: 2,
+baseArrayLayer: 20,
+arrayLayerCount: 14,
+}
+);
+let renderBundleEncoder90 = device0.createRenderBundleEncoder(
+{
+label: '\u04f9\u217d\u6859\u69d2\ufb6e\u03e2\u{1fb07}',
+colorFormats: [
+'rg32uint',
+'rgba8unorm',
+'r32float'
+],
+sampleCount: 746,
+depthReadOnly: true,
+}
+);
+let renderBundle73 = renderBundleEncoder24.finish();
+let sampler92 = device0.createSampler(
+{
+label: '\ub50f\u2781\u015c\ueed2\u069c\u8db8',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 54.164,
+lodMaxClamp: 74.355,
+maxAnisotropy: 1,
+}
+);
+let externalTexture2 = device0.importExternalTexture(
+{
+label: '\u7e28\u{1f7e6}\uc408\u5084\ue25a\u{1fdeb}\ua654\u0f13\ud6f6\u9919\u{1fd91}',
+source: video5,
+colorSpace: 'display-p3',
+}
+);
+try {
+renderPassEncoder31.setVertexBuffer(
+11,
+buffer31,
+41872,
+909
+);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer6,
+commandBuffer5,
+]);
+} catch {}
+let gpuCanvasContext18 = canvas19.getContext('webgpu');
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let canvas21 = document.createElement('canvas');
+try {
+computePassEncoder38.setPipeline(
+pipeline73
+);
+} catch {}
+try {
+renderBundleEncoder75.setBindGroup(
+4,
+bindGroup45,
+new Uint32Array(2952),
+1687,
+0
+);
+} catch {}
+try {
+commandEncoder84.clearBuffer(
+buffer32,
+15220,
+9772
+);
+dissociateBuffer(device1, buffer32);
+} catch {}
+let pipeline83 = device1.createComputePipeline(
+{
+label: '\ue9c5\ua17c\uacd7',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule16,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let img19 = await imageWithData(137, 28, '#28953ca9', '#a06e89ed');
+let shaderModule25 = device1.createShaderModule(
+{
+label: '\u9068\uff33\u05ff\u44a8\u{1f972}\u1a17\ucd5e\u{1fc17}\u{1fc5a}\u0ea2',
+code: `@group(2) @binding(7479)
+var<storage, read_write> function2: array<u32>;
+
+@compute @workgroup_size(7, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(18) a0: vec3<f16>, @builtin(instance_index) a1: u32, @location(16) a2: vec4<f32>, @location(10) a3: i32, @location(6) a4: vec2<u32>, @location(0) a5: f16, @location(11) a6: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder85 = device1.createCommandEncoder();
+let renderBundle74 = renderBundleEncoder77.finish(
+{
+label: '\ued1f\u{1f6b9}\u22b2\u61df\u{1fe7c}\ua765\u2f46\u85ef\ub4cd'
+}
+);
+let sampler93 = device1.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 71.380,
+lodMaxClamp: 96.873,
+}
+);
+try {
+commandEncoder84.copyTextureToTexture(
+{
+  texture: texture93,
+  mipLevel: 1,
+  origin: { x: 3580, y: 0, z: 106 },
+  aspect: 'all',
+},
+{
+  texture: texture93,
+  mipLevel: 3,
+  origin: { x: 85, y: 0, z: 46 },
+  aspect: 'all',
+},
+{width: 770, height: 0, depthOrArrayLayers: 111}
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture93,
+  mipLevel: 13,
+  origin: { x: 5, y: 0, z: 51 },
+  aspect: 'all',
+},
+arrayBuffer12,
+/* required buffer size: 7355115 */{
+offset: 747,
+bytesPerRow: 256,
+rowsPerImage: 189,
+},
+{width: 0, height: 5, depthOrArrayLayers: 153}
+);
+} catch {}
+let shaderModule26 = device1.createShaderModule(
+{
+label: '\uff95\u062b\u6155\udbb8\u044f\u0d74\u5002\u0207\u{1f8d4}\u0dfc\uf76c',
+code: `
+
+@compute @workgroup_size(5, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(0) f0: vec3<u32>,
+@location(4) f1: vec3<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S22 {
+@location(17) f0: vec3<i32>,
+@location(13) f1: vec2<i32>,
+@location(11) f2: vec3<i32>,
+@location(1) f3: vec3<i32>
+}
+
+@vertex
+fn vertex0(a0: S22, @location(9) a1: vec2<f16>, @location(0) a2: vec2<u32>, @builtin(instance_index) a3: u32, @location(18) a4: i32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+}
+);
+let renderBundleEncoder91 = device1.createRenderBundleEncoder(
+{
+label: '\u3f40\u3707\uead6\ue531\u0103\u15fa\ub54e\u68b8',
+colorFormats: [
+'rg8unorm',
+'r16sint',
+'rg32uint',
+'r32float',
+'rgba16uint',
+'rg11b10ufloat'
+],
+sampleCount: 845,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+buffer32.unmap();
+} catch {}
+try {
+commandEncoder84.copyTextureToTexture(
+{
+  texture: texture93,
+  mipLevel: 0,
+  origin: { x: 3180, y: 30, z: 123 },
+  aspect: 'all',
+},
+{
+  texture: texture93,
+  mipLevel: 0,
+  origin: { x: 1990, y: 15, z: 14 },
+  aspect: 'all',
+},
+{width: 5310, height: 10, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer32,
+22764,
+new DataView(new ArrayBuffer(42251)),
+20256,
+3184
+);
+} catch {}
+try {
+await promise41;
+} catch {}
+let imageData18 = new ImageData(28, 52);
+let commandEncoder86 = device1.createCommandEncoder();
+try {
+renderBundleEncoder75.setBindGroup(
+0,
+bindGroup45,
+new Uint32Array(8368),
+4538,
+0
+);
+} catch {}
+try {
+commandEncoder85.copyTextureToBuffer(
+{
+  texture: texture93,
+  mipLevel: 13,
+  origin: { x: 0, y: 0, z: 6 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 10256 */
+offset: 10256,
+bytesPerRow: 0,
+rowsPerImage: 207,
+buffer: buffer32,
+},
+{width: 0, height: 0, depthOrArrayLayers: 234}
+);
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+commandEncoder86.clearBuffer(
+buffer32,
+2112,
+15556
+);
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer32,
+32448,
+new BigUint64Array(31744),
+12116,
+48
+);
+} catch {}
+let promise42 = device1.createRenderPipelineAsync(
+{
+label: '\u387f\ub402\uca7c\u828a\ucff6\u{1fbde}\u{1ff1c}\u034c',
+layout: pipelineLayout16,
+vertex: {
+module: shaderModule16,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 2156,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32',
+offset: 128,
+shaderLocation: 3,
+},
+{
+format: 'float32x4',
+offset: 184,
+shaderLocation: 19,
+},
+{
+format: 'sint8x2',
+offset: 1538,
+shaderLocation: 15,
+},
+{
+format: 'sint32x3',
+offset: 1696,
+shaderLocation: 6,
+},
+{
+format: 'sint32x3',
+offset: 1248,
+shaderLocation: 18,
+},
+{
+format: 'float16x2',
+offset: 148,
+shaderLocation: 8,
+},
+{
+format: 'snorm16x4',
+offset: 1272,
+shaderLocation: 4,
+},
+{
+format: 'uint32',
+offset: 876,
+shaderLocation: 5,
+},
+{
+format: 'snorm8x2',
+offset: 260,
+shaderLocation: 14,
+},
+{
+format: 'sint16x4',
+offset: 892,
+shaderLocation: 7,
+},
+{
+format: 'float16x2',
+offset: 1804,
+shaderLocation: 11,
+},
+{
+format: 'snorm8x2',
+offset: 694,
+shaderLocation: 13,
+},
+{
+format: 'unorm16x2',
+offset: 728,
+shaderLocation: 0,
+},
+{
+format: 'sint16x4',
+offset: 1668,
+shaderLocation: 16,
+},
+{
+format: 'uint16x2',
+offset: 136,
+shaderLocation: 10,
+},
+{
+format: 'float32x2',
+offset: 560,
+shaderLocation: 2,
+},
+{
+format: 'float16x2',
+offset: 336,
+shaderLocation: 17,
+},
+{
+format: 'snorm16x4',
+offset: 1024,
+shaderLocation: 1,
+},
+{
+format: 'sint32x3',
+offset: 1484,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 18944,
+attributes: [
+
+],
+},
+{
+arrayStride: 96,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 18916,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 12124,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 16060,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 9212,
+attributes: [
+
+],
+},
+{
+arrayStride: 19972,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 8756,
+shaderLocation: 12,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+cullMode: 'back',
+},
+}
+);
+let bindGroup47 = device0.createBindGroup({
+layout: bindGroupLayout38,
+entries: [
+{
+binding: 1034,
+resource: {
+buffer: buffer11,
+offset: 27648,
+size: 5356,
+}
+},
+{
+binding: 1498,
+resource: {
+buffer: buffer15,
+offset: 41024,
+size: 192,
+}
+}
+],
+});
+let texture94 = device0.createTexture(
+{
+label: '\uc11a\u{1fd46}\u8eb0\u1c22\ufb52\u977a',
+size: {width: 2159, height: 57, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32float',
+'rgba32float',
+'rgba32float'
+],
+}
+);
+let textureView95 = texture22.createView(
+{
+}
+);
+let renderBundle75 = renderBundleEncoder79.finish(
+{
+label: '\uc8f0\u{1f9df}\u020c\u0f4e\u505a'
+}
+);
+let sampler94 = device0.createSampler(
+{
+label: '\ua83f\uce34\u1102\u{1f7be}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 25.769,
+lodMaxClamp: 27.283,
+compare: 'equal',
+maxAnisotropy: 5,
+}
+);
+try {
+renderPassEncoder28.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder35.setBlendConstant(
+{
+r: 932.6,
+g: 724.6,
+b: -930.8,
+a: -575.5,
+}
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndexedIndirect(
+buffer27,
+452024
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer2,
+49048
+);
+} catch {}
+try {
+renderBundleEncoder72.setVertexBuffer(
+8,
+buffer23,
+6024,
+772
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer4,
+22144,
+new BigUint64Array(48015),
+36564,
+1332
+);
+} catch {}
+document.body.append('\u069b\u0aa1\ud813\u6a03\u6bde\u{1f97b}\uad39\u{1f84a}\u{1f65d}');
+let commandBuffer8 = commandEncoder86.finish(
+{
+label: '\u70f5\uef9c\uad01\u7966\u22a1\u4b59\uc3f9\u{1fa09}',
+}
+);
+pseudoSubmit(device1, commandEncoder85);
+let renderBundleEncoder92 = device1.createRenderBundleEncoder(
+{
+label: '\u{1f6c7}\ua8b8\u0c95\u1252',
+colorFormats: [
+undefined,
+'bgra8unorm'
+],
+sampleCount: 873,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder87.setBindGroup(
+1,
+bindGroup38
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer32,
+23908,
+new DataView(new ArrayBuffer(29206)),
+26133,
+1188
+);
+} catch {}
+let promise43 = device1.queue.onSubmittedWorkDone();
+let promise44 = device1.createComputePipelineAsync(
+{
+label: '\u{1fb84}\u52ea\ue33f\u{1fb54}\u0cd8\udf32\u8322\u{1fc81}\u24e8',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule16,
+entryPoint: 'compute0',
+},
+}
+);
+let img20 = await imageWithData(29, 107, '#b1fa9abd', '#d187e308');
+let imageBitmap19 = await createImageBitmap(canvas16);
+let imageData19 = new ImageData(24, 16);
+let texture95 = device1.createTexture(
+{
+label: '\u01d6\u0765\u{1fbd0}\u0876\u0021',
+size: {width: 1800, height: 1, depthOrArrayLayers: 160},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rg32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg32float',
+'rg32float',
+'rg32float'
+],
+}
+);
+try {
+computePassEncoder38.setBindGroup(
+1,
+bindGroup45
+);
+} catch {}
+try {
+renderBundleEncoder91.setBindGroup(
+2,
+bindGroup42
+);
+} catch {}
+let pipeline84 = device1.createComputePipeline(
+{
+label: '\u0c29\u4723\u070d',
+layout: pipelineLayout15,
+compute: {
+module: shaderModule25,
+entryPoint: 'compute0',
+},
+}
+);
+let img21 = await imageWithData(282, 246, '#ef6132aa', '#0f634623');
+let querySet81 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 103,
+}
+);
+try {
+renderPassEncoder43.setBindGroup(
+5,
+bindGroup7
+);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder40.setStencilReference(
+3745
+);
+} catch {}
+try {
+renderPassEncoder12.draw(
+72,
+64,
+0,
+80
+);
+} catch {}
+try {
+renderPassEncoder9.insertDebugMarker(
+'\u8f7e'
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1532, height: 1, depthOrArrayLayers: 1339}
+*/
+{
+  source: video2,
+  origin: { x: 1, y: 7 },
+  flipY: false,
+},
+{
+  texture: texture47,
+  mipLevel: 0,
+  origin: { x: 748, y: 1, z: 1084 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 15, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\u301a\u{1f982}\u0113\u03d4\u{1fcb3}\u{1f69a}\ue48e\u4b0b');
+let sampler95 = device0.createSampler(
+{
+label: '\u7bf8\uce03\u0c79\u7dc3\u3402\u{1fb58}\u0931\u2c3f',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 18.169,
+lodMaxClamp: 96.796,
+}
+);
+try {
+renderPassEncoder36.setBindGroup(
+0,
+bindGroup17
+);
+} catch {}
+try {
+renderPassEncoder43.beginOcclusionQuery(
+0
+);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(
+3706
+);
+} catch {}
+try {
+renderPassEncoder10.draw(
+8,
+16,
+24,
+80
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(
+buffer27,
+145064
+);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(
+8,
+buffer19,
+8300
+);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(
+7,
+buffer15,
+33720
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer11,
+16836,
+new Float32Array(4415),
+731,
+1260
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture47,
+  mipLevel: 2,
+  origin: { x: 57, y: 1, z: 122 },
+  aspect: 'all',
+},
+new ArrayBuffer(171789448),
+/* required buffer size: 171789448 */{
+offset: 523,
+bytesPerRow: 4925,
+rowsPerImage: 231,
+},
+{width: 302, height: 0, depthOrArrayLayers: 152}
+);
+} catch {}
+let pipeline85 = await device0.createComputePipelineAsync(
+{
+label: '\u001e\ud29b\u2c40\u5e18\uc14f\uebdd\u03f8',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule19,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageData20 = new ImageData(108, 164);
+let videoFrame20 = new VideoFrame(imageBitmap0, {timestamp: 0});
+pseudoSubmit(device1, commandEncoder75);
+let renderBundle76 = renderBundleEncoder81.finish(
+{
+label: '\u8edf\u1ae6\u0d72'
+}
+);
+try {
+renderBundleEncoder87.setBindGroup(
+4,
+bindGroup45,
+new Uint32Array(4191),
+3597,
+0
+);
+} catch {}
+try {
+buffer32.unmap();
+} catch {}
+document.body.prepend('\u16d4\u1d9d\u21e9');
+let texture96 = device1.createTexture(
+{
+label: '\u0df7\u32cf\u8fe6\u32b4\u0221',
+size: [1567, 1, 207],
+mipLevelCount: 4,
+sampleCount: 1,
+dimension: '3d',
+format: 'rg32sint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32sint'
+],
+}
+);
+let renderBundleEncoder93 = device1.createRenderBundleEncoder(
+{
+label: '\u09b4\u{1fc21}\u523a\uc01b',
+colorFormats: [
+undefined,
+'r8uint',
+'bgra8unorm',
+'r32uint',
+'rg16uint',
+'rgb10a2uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 494,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle77 = renderBundleEncoder91.finish(
+{
+label: '\ubb22\u07d3\ud80c\u{1fdca}'
+}
+);
+try {
+computePassEncoder38.setPipeline(
+pipeline73
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer32,
+14756,
+new Int16Array(17369),
+16242,
+1056
+);
+} catch {}
+try {
+await promise43;
+} catch {}
+pseudoSubmit(device1, commandEncoder84);
+try {
+computePassEncoder38.setBindGroup(
+1,
+bindGroup38,
+new Uint32Array(4096),
+1316,
+0
+);
+} catch {}
+try {
+computePassEncoder38.insertDebugMarker(
+'\u4f43'
+);
+} catch {}
+let pipeline86 = device1.createComputePipeline(
+{
+label: '\u{1f881}\uc878\u0539\ubf2f\u0983\uff87\ueb29',
+layout: pipelineLayout15,
+compute: {
+module: shaderModule26,
+entryPoint: 'compute0',
+},
+}
+);
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+try {
+await adapter2.requestAdapterInfo();
+} catch {}
+try {
+window.someLabel = externalTexture2.label;
+} catch {}
+try {
+renderPassEncoder36.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.draw(
+24,
+48,
+24
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(
+buffer18,
+21512
+);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer1,
+'uint16',
+5526,
+190
+);
+} catch {}
+try {
+renderBundleEncoder68.setVertexBuffer(
+0,
+buffer6
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture61,
+  mipLevel: 0,
+  origin: { x: 1719, y: 1, z: 0 },
+  aspect: 'all',
+},
+new Uint32Array(arrayBuffer15),
+/* required buffer size: 194 */{
+offset: 194,
+bytesPerRow: 15894,
+},
+{width: 3925, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\ud41e\ufea0\uae2a\u520a\u195d\u{1fd8a}\u5f6e\u0ff9');
+let buffer33 = device0.createBuffer(
+{
+label: '\u{1fcaf}\u{1f983}\u0a94\u4718\u{1fac2}',
+size: 27340,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: false,
+}
+);
+let commandEncoder87 = device0.createCommandEncoder(
+{
+label: '\u{1f644}\u{1fc79}\u0de1',
+}
+);
+let textureView96 = texture44.createView(
+{
+label: '\ue286\ub850',
+dimension: '2d',
+baseMipLevel: 7,
+baseArrayLayer: 65,
+}
+);
+try {
+renderPassEncoder34.beginOcclusionQuery(
+32
+);
+} catch {}
+try {
+commandEncoder87.clearBuffer(
+buffer17
+);
+dissociateBuffer(device0, buffer17);
+} catch {}
+try {
+commandEncoder87.resolveQuerySet(
+querySet56,
+1538,
+837,
+buffer23,
+0
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer23,
+1524,
+new DataView(new ArrayBuffer(15812)),
+12035,
+1092
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture9,
+  mipLevel: 1,
+  origin: { x: 196, y: 0, z: 51 },
+  aspect: 'all',
+},
+new ArrayBuffer(8),
+/* required buffer size: 28576841 */{
+offset: 225,
+bytesPerRow: 2664,
+rowsPerImage: 173,
+},
+{width: 638, height: 1, depthOrArrayLayers: 63}
+);
+} catch {}
+let pipeline87 = device0.createRenderPipeline(
+{
+label: '\uca92\ue564\u0041\ud0f6\uf009',
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule11,
+entryPoint: 'vertex0',
+buffers: [
+
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0xc0c0a0fb,
+},
+fragment: {
+module: shaderModule11,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'zero',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilReadMask: 1732,
+stencilWriteMask: 3459,
+depthBiasSlopeScale: 42,
+},
+}
+);
+document.body.prepend(img13);
+let texture97 = device1.createTexture(
+{
+size: {width: 1263, height: 1, depthOrArrayLayers: 62},
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rgba32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32sint'
+],
+}
+);
+let sampler96 = device1.createSampler(
+{
+label: '\u{1fd9a}\u0979\u618a\u50a3\u{1fa71}',
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 50.304,
+lodMaxClamp: 81.407,
+maxAnisotropy: 19,
+}
+);
+try {
+computePassEncoder38.end();
+} catch {}
+try {
+commandEncoder79.clearBuffer(
+buffer32,
+13036,
+120
+);
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture95,
+  mipLevel: 0,
+  origin: { x: 797, y: 1, z: 103 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 6418248 */{
+offset: 190,
+bytesPerRow: 1681,
+rowsPerImage: 83,
+},
+{width: 193, height: 0, depthOrArrayLayers: 47}
+);
+} catch {}
+let bindGroup48 = device1.createBindGroup({
+label: '\u75ee\u9e29\u{1f895}\uc96e\u{1fed0}\u0a95\u344a',
+layout: bindGroupLayout36,
+entries: [
+
+],
+});
+let querySet82 = device1.createQuerySet(
+{
+label: '\u8d99\u0bd7\u9682\u03f7\u{1f741}\u2948\u{1f824}',
+type: 'occlusion',
+count: 263,
+}
+);
+let texture98 = device1.createTexture(
+{
+label: '\u376a\u0638\u{1f7e2}',
+size: {width: 7869, height: 11, depthOrArrayLayers: 58},
+mipLevelCount: 5,
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundleEncoder94 = device1.createRenderBundleEncoder(
+{
+label: '\u0cbf\u{1fe5b}\u{1fa4b}\u2dda\u{1ff89}\u0515',
+colorFormats: [
+'r8unorm',
+'rg16uint',
+'rg32float'
+],
+sampleCount: 822,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder83.setVertexBuffer(
+6,
+buffer32
+);
+} catch {}
+try {
+commandEncoder79.clearBuffer(
+buffer32,
+6144,
+15764
+);
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture97,
+  mipLevel: 2,
+  origin: { x: 23, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer18,
+/* required buffer size: 1934340 */{
+offset: 924,
+bytesPerRow: 3217,
+rowsPerImage: 50,
+},
+{width: 201, height: 1, depthOrArrayLayers: 13}
+);
+} catch {}
+let pipeline88 = device1.createRenderPipeline(
+{
+label: '\u76c5\u042d\u3662\u0350\u56d7\u0bcf\udf9f\u{1f8e3}\u57f0\u{1ff13}\u497b',
+layout: pipelineLayout16,
+vertex: {
+module: shaderModule25,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 10740,
+attributes: [
+{
+format: 'sint32x3',
+offset: 7956,
+shaderLocation: 10,
+},
+{
+format: 'snorm8x4',
+offset: 6916,
+shaderLocation: 16,
+},
+{
+format: 'float32x4',
+offset: 3036,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x2',
+offset: 3240,
+shaderLocation: 18,
+},
+{
+format: 'uint32x3',
+offset: 10180,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 10872,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 3668,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0x5309b543,
+},
+fragment: {
+module: shaderModule25,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'equal',
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 2224,
+stencilWriteMask: 3186,
+depthBias: 14,
+depthBiasSlopeScale: 57,
+depthBiasClamp: 15,
+},
+}
+);
+document.body.prepend('\uc0a6\u6e0c\u01a2\u013f\u24d5\u5ef5');
+let imageData21 = new ImageData(144, 8);
+let promise45 = adapter6.requestAdapterInfo();
+try {
+window.someLabel = pipeline68.label;
+} catch {}
+let shaderModule27 = device1.createShaderModule(
+{
+label: '\u53db\u0b41\u09da\u725a\u6f8c\u{1f835}',
+code: `@group(0) @binding(2746)
+var<storage, read_write> function3: array<u32>;
+
+@compute @workgroup_size(2, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: vec4<f32>,
+@location(2) f1: vec2<f32>,
+@location(1) f2: vec2<u32>,
+@location(5) f3: vec2<f32>,
+@location(0) f4: vec4<i32>,
+@location(6) f5: vec3<u32>,
+@location(3) f6: vec3<u32>,
+@location(7) f7: vec3<f32>,
+@builtin(frag_depth) f8: f32,
+@builtin(sample_mask) f9: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S23 {
+@location(9) f0: vec3<i32>,
+@location(3) f1: vec3<i32>,
+@location(10) f2: vec4<u32>,
+@location(4) f3: u32,
+@location(17) f4: vec3<i32>,
+@builtin(instance_index) f5: u32,
+@location(18) f6: u32,
+@location(11) f7: vec2<f16>,
+@location(7) f8: u32,
+@location(12) f9: vec2<i32>,
+@location(8) f10: vec4<i32>,
+@location(13) f11: vec2<i32>,
+@location(0) f12: vec3<u32>,
+@location(5) f13: u32,
+@location(6) f14: i32,
+@location(16) f15: vec2<f16>,
+@location(15) f16: vec3<u32>,
+@location(19) f17: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(1) a0: vec2<f16>, @location(2) a1: vec4<i32>, @builtin(vertex_index) a2: u32, a3: S23, @location(14) a4: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroup49 = device1.createBindGroup({
+label: '\u076a\ue0d4\ue420\u{1fa8e}\u0af3\u9a77',
+layout: bindGroupLayout36,
+entries: [
+
+],
+});
+let externalTexture3 = device1.importExternalTexture(
+{
+label: '\u05e7\uc040\u{1faf6}',
+source: videoFrame12,
+colorSpace: 'srgb',
+}
+);
+try {
+renderBundleEncoder94.setBindGroup(
+2,
+bindGroup49,
+[]
+);
+} catch {}
+try {
+renderBundleEncoder94.setVertexBuffer(
+3,
+buffer32,
+27608,
+4875
+);
+} catch {}
+let promise46 = device1.createRenderPipelineAsync(
+{
+layout: pipelineLayout16,
+vertex: {
+module: shaderModule26,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 3544,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x2',
+offset: 2958,
+shaderLocation: 18,
+},
+{
+format: 'snorm16x4',
+offset: 1736,
+shaderLocation: 9,
+},
+{
+format: 'sint32x4',
+offset: 276,
+shaderLocation: 1,
+},
+{
+format: 'sint16x2',
+offset: 1432,
+shaderLocation: 17,
+},
+{
+format: 'sint32',
+offset: 1728,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 8464,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 11228,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x4',
+offset: 6648,
+shaderLocation: 13,
+},
+{
+format: 'uint32',
+offset: 7552,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0xf0303f40,
+},
+fragment: {
+module: shaderModule26,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'greater',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 2374,
+stencilWriteMask: 2372,
+depthBias: 65,
+depthBiasSlopeScale: 86,
+},
+}
+);
+let adapter9 = await navigator.gpu.requestAdapter(
+{
+}
+);
+try {
+canvas20.getContext('2d');
+} catch {}
+pseudoSubmit(device1, commandEncoder79);
+let texture99 = device1.createTexture(
+{
+label: '\u6b68\u5436\u0507\uc21e',
+size: {width: 323},
+dimension: '1d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8snorm'
+],
+}
+);
+let renderBundleEncoder95 = device1.createRenderBundleEncoder(
+{
+label: '\u61f7\u{1ff39}',
+colorFormats: [
+'rg11b10ufloat',
+'rgba8unorm-srgb',
+'rg8uint',
+undefined,
+undefined
+],
+sampleCount: 179,
+depthReadOnly: true,
+}
+);
+document.body.prepend('\u07d9\u{1fa70}\u{1f8a2}\ua112\u{1fc57}\u971a\u08f6');
+try {
+textureView89.label = '\u0ade\u4511\u574a\u2a70\uc809\uee77\u{1f8d3}\u09c1\u0ad9';
+} catch {}
+let textureView97 = texture86.createView(
+{
+label: '\u057a\u90cc\u{1f848}\u{1fa41}',
+dimension: '2d',
+aspect: 'all',
+baseMipLevel: 3,
+baseArrayLayer: 49,
+}
+);
+try {
+renderBundleEncoder93.setBindGroup(
+3,
+bindGroup42
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer32,
+18784,
+new Float32Array(47769),
+15333,
+2052
+);
+} catch {}
+try {
+await promise45;
+} catch {}
+let shaderModule28 = device1.createShaderModule(
+{
+label: '\u06c8\u09e2\u0b2e\u6280',
+code: `@group(0) @binding(3994)
+var<storage, read_write> type1: array<u32>;
+
+@compute @workgroup_size(3, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S25 {
+@builtin(sample_index) f0: u32
+}
+struct FragmentOutput0 {
+@location(2) f0: vec3<f32>,
+@location(4) f1: vec4<u32>,
+@location(6) f2: vec2<f32>,
+@location(0) f3: f32,
+@location(7) f4: i32,
+@location(3) f5: vec2<i32>,
+@location(5) f6: vec3<u32>,
+@location(1) f7: vec3<i32>,
+@builtin(frag_depth) f8: f32
+}
+
+@fragment
+fn fragment0(a0: S25) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S24 {
+@location(6) f0: vec2<f16>,
+@location(17) f1: vec3<i32>,
+@location(9) f2: vec4<i32>,
+@location(16) f3: vec3<u32>,
+@location(8) f4: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(19) a0: vec4<f32>, @builtin(vertex_index) a1: u32, @location(2) a2: vec2<u32>, @builtin(instance_index) a3: u32, @location(13) a4: vec4<f32>, a5: S24, @location(0) a6: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroupLayout39 = device1.createBindGroupLayout(
+{
+entries: [
+{
+binding: 4906,
+visibility: 0,
+sampler: { type: 'comparison' },
+},
+{
+binding: 3968,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}
+],
+}
+);
+let buffer34 = device1.createBuffer(
+{
+label: '\u68f7\u0fb5',
+size: 39896,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+mappedAtCreation: true,
+}
+);
+let renderBundle78 = renderBundleEncoder91.finish(
+{
+label: '\ud380\u3508\u{1f783}\u{1fd43}\ue940\u0143\u0d50\u{1f7f0}\u9410'
+}
+);
+try {
+renderBundleEncoder94.setBindGroup(
+4,
+bindGroup37,
+new Uint32Array(7745),
+3350,
+0
+);
+} catch {}
+try {
+renderBundleEncoder87.setIndexBuffer(
+buffer34,
+'uint32',
+56,
+8601
+);
+} catch {}
+try {
+renderBundleEncoder87.setVertexBuffer(
+5,
+buffer32,
+16500,
+5679
+);
+} catch {}
+try {
+device1.queue.submit([
+]);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture97,
+  mipLevel: 1,
+  origin: { x: 41, y: 1, z: 3 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 2712538 */{
+offset: 103,
+bytesPerRow: 4835,
+rowsPerImage: 51,
+},
+{width: 288, height: 0, depthOrArrayLayers: 12}
+);
+} catch {}
+let video21 = await videoWithData();
+let videoFrame21 = new VideoFrame(offscreenCanvas12, {timestamp: 0});
+let commandEncoder88 = device1.createCommandEncoder(
+{
+label: '\u0ac6\u9a62\u3370\u0949\uea65',
+}
+);
+let computePassEncoder43 = commandEncoder88.beginComputePass(
+{
+label: '\ucddc\u05f4\uc602\u0757\u0200'
+}
+);
+try {
+renderBundleEncoder94.setVertexBuffer(
+3,
+buffer32,
+19784
+);
+} catch {}
+try {
+gpuCanvasContext5.configure(
+{
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+}
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture97,
+  mipLevel: 1,
+  origin: { x: 172, y: 0, z: 3 },
+  aspect: 'all',
+},
+new ArrayBuffer(3727614),
+/* required buffer size: 3727614 */{
+offset: 798,
+bytesPerRow: 2984,
+rowsPerImage: 156,
+},
+{width: 174, height: 1, depthOrArrayLayers: 9}
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let imageBitmap20 = await createImageBitmap(img2);
+let shaderModule29 = device1.createShaderModule(
+{
+code: `@group(0) @binding(7479)
+var<storage, read_write> type2: array<u32>;
+
+@compute @workgroup_size(7, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(2) f0: vec4<u32>,
+@location(4) f1: u32,
+@location(3) f2: vec4<i32>,
+@location(1) f3: vec3<u32>,
+@builtin(frag_depth) f4: f32,
+@location(0) f5: vec2<i32>,
+@location(6) f6: vec2<f32>,
+@builtin(sample_mask) f7: u32,
+@location(5) f8: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S26 {
+@builtin(vertex_index) f0: u32,
+@location(11) f1: f16,
+@location(8) f2: vec2<f16>,
+@location(14) f3: vec2<u32>,
+@location(0) f4: vec4<i32>,
+@location(4) f5: vec3<u32>,
+@location(12) f6: vec2<u32>,
+@location(16) f7: vec4<u32>,
+@location(18) f8: vec4<f32>,
+@location(9) f9: vec4<f32>,
+@location(5) f10: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(1) a0: vec4<u32>, @location(7) a1: vec3<i32>, @location(6) a2: vec3<i32>, @location(2) a3: f32, @location(17) a4: vec2<i32>, @builtin(instance_index) a5: u32, @location(15) a6: vec3<f16>, @location(19) a7: f32, a8: S26, @location(13) a9: i32, @location(3) a10: vec4<u32>, @location(10) a11: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture100 = device1.createTexture(
+{
+label: '\u{1fbf7}\ued03\u{1ff67}\u{1f8d2}\u2d6a\u{1f797}\u025e\uc3ca',
+size: [197, 75, 1],
+mipLevelCount: 5,
+format: 'r8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+renderBundleEncoder87.setVertexBuffer(
+90,
+undefined,
+1550667453,
+1119559078
+);
+} catch {}
+document.body.append('\ubc84\ua952\u44bd');
+try {
+canvas21.getContext('webgl');
+} catch {}
+let buffer35 = device1.createBuffer(
+{
+label: '\u02f8\u5517\u602d\u0e75\u65e3\u0ed2\u{1f65e}\u251c\u0ac1\udf94\uf376',
+size: 12654,
+usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+}
+);
+let texture101 = device1.createTexture(
+{
+label: '\u2ebc\u72dc\uc351\u6a38\u7ba5',
+size: [61, 61, 1],
+mipLevelCount: 2,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'depth32float',
+'depth32float'
+],
+}
+);
+let textureView98 = texture93.createView(
+{
+label: '\u0c12\u75c6\u80a0\u6c08\u7aad\u08e4\u0ad7\u4514\u{1fd92}\u2535',
+dimension: '2d',
+format: 'astc-5x5-unorm',
+baseMipLevel: 12,
+mipLevelCount: 1,
+baseArrayLayer: 141,
+arrayLayerCount: 1,
+}
+);
+let renderBundleEncoder96 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+'r32sint',
+'rg32uint',
+'r16float',
+undefined,
+'rgb10a2uint',
+'rg11b10ufloat'
+],
+sampleCount: 927,
+stencilReadOnly: true,
+}
+);
+let renderBundleEncoder97 = device1.createRenderBundleEncoder(
+{
+label: '\u{1fa0e}\u{1fdd7}\u0c74\u06a4\u0dae\uacf7\u{1f9ff}\u{1f807}\u0795\u0204\u{1fabd}',
+colorFormats: [
+'r8uint',
+'r8unorm',
+'rgba16sint',
+'r8uint',
+'rg8sint',
+'r32float',
+'rg8sint',
+'rgba16float'
+],
+sampleCount: 221,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder43.setBindGroup(
+4,
+bindGroup37
+);
+} catch {}
+try {
+computePassEncoder43.end();
+} catch {}
+let video22 = await videoWithData();
+let texture102 = device1.createTexture(
+{
+label: '\u24dc\u36af\u{1f90e}\u0ddc\u{1fc1b}\ufca0\u901f\u5651\u0f16',
+size: [185, 1, 210],
+mipLevelCount: 6,
+sampleCount: 1,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+renderBundleEncoder96.setIndexBuffer(
+buffer34,
+'uint32',
+16840,
+10382
+);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+try {
+commandEncoder88.copyTextureToBuffer(
+{
+  texture: texture98,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 47 },
+  aspect: 'stencil-only',
+},
+{
+/* bytesInLastRow: 7869 widthInBlocks: 7869 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 12800 */
+offset: 12800,
+bytesPerRow: 7936,
+buffer: buffer32,
+},
+{width: 7869, height: 11, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+commandEncoder88.clearBuffer(
+buffer32,
+5880,
+23660
+);
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+commandEncoder88.resolveQuerySet(
+querySet75,
+233,
+1584,
+buffer34,
+19456
+);
+} catch {}
+try {
+commandEncoder88.insertDebugMarker(
+'\u{1fa11}'
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer32,
+13184,
+new DataView(new ArrayBuffer(12425)),
+3211,
+8156
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture97,
+  mipLevel: 1,
+  origin: { x: 182, y: 0, z: 6 },
+  aspect: 'all',
+},
+new Float32Array(arrayBuffer19),
+/* required buffer size: 31618935 */{
+offset: 967,
+bytesPerRow: 7006,
+rowsPerImage: 188,
+},
+{width: 431, height: 1, depthOrArrayLayers: 25}
+);
+} catch {}
+let shaderModule30 = device1.createShaderModule(
+{
+label: '\uf193\u5b16\u4f98\u{1fb5e}\u6fd2\u4606\u07fe\u5abe',
+code: `
+
+@compute @workgroup_size(5, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S28 {
+@builtin(sample_mask) f0: u32,
+@builtin(sample_index) f1: u32
+}
+struct FragmentOutput0 {
+@location(7) f0: vec2<i32>,
+@location(2) f1: vec4<i32>,
+@location(6) f2: f32,
+@location(0) f3: vec2<i32>
+}
+
+@fragment
+fn fragment0(a0: S28, @builtin(position) a1: vec4<f32>, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S27 {
+@location(14) f0: vec3<f32>,
+@location(0) f1: vec3<f16>,
+@location(5) f2: vec2<u32>,
+@location(18) f3: vec2<f32>,
+@location(1) f4: vec2<f32>,
+@builtin(vertex_index) f5: u32,
+@location(16) f6: u32,
+@location(3) f7: f32
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec3<u32>, @location(13) a1: vec3<i32>, @location(7) a2: vec2<f32>, @location(8) a3: vec4<f32>, a4: S27, @location(19) a5: vec3<f16>, @location(12) a6: i32, @builtin(instance_index) a7: u32, @location(15) a8: vec4<f32>, @location(6) a9: vec3<f32>, @location(11) a10: vec4<u32>, @location(17) a11: vec2<f32>, @location(10) a12: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder89 = device1.createCommandEncoder(
+{
+label: '\u{1f80f}\u917d\u{1faff}\u{1fa96}\u197e\u057e\u0aca\u973f\u3061\u0264',
+}
+);
+let querySet83 = device1.createQuerySet(
+{
+type: 'occlusion',
+count: 756,
+}
+);
+let renderBundleEncoder98 = device1.createRenderBundleEncoder(
+{
+label: '\u0ab2\u3242\u480e\uff0a\uc973\u002f',
+colorFormats: [
+'rg16sint',
+'rgb10a2uint',
+'r8sint',
+'r32sint',
+'rgb10a2uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 958,
+depthReadOnly: true,
+}
+);
+let sampler97 = device1.createSampler(
+{
+label: '\u{1ff69}\u{1fa6b}\u{1fe23}\u367e\ufc11\u{1feda}\u{1f7b5}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 37.014,
+lodMaxClamp: 90.443,
+compare: 'greater',
+maxAnisotropy: 16,
+}
+);
+try {
+renderBundleEncoder97.setVertexBuffer(
+9,
+buffer32,
+29388,
+38
+);
+} catch {}
+try {
+commandEncoder88.copyBufferToBuffer(
+buffer34,
+1336,
+buffer32,
+17428,
+11908
+);
+dissociateBuffer(device1, buffer34);
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+commandEncoder89.resolveQuerySet(
+querySet82,
+11,
+198,
+buffer34,
+34048
+);
+} catch {}
+try {
+externalTexture1.label = '\u06d3\u0cbf\u{1f7ef}';
+} catch {}
+try {
+computePassEncoder25.setPipeline(
+pipeline25
+);
+} catch {}
+try {
+renderPassEncoder22.end();
+} catch {}
+try {
+renderPassEncoder20.beginOcclusionQuery(
+16
+);
+} catch {}
+try {
+renderPassEncoder37.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder26.setScissorRect(
+1713,
+1,
+1279,
+0
+);
+} catch {}
+try {
+renderPassEncoder21.setViewport(
+723.7,
+0.9866,
+1943.0,
+0.00574,
+0.4028,
+0.9005
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(
+buffer4,
+245720
+);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(
+10,
+buffer19,
+11692,
+4384
+);
+} catch {}
+try {
+commandEncoder87.copyBufferToBuffer(
+buffer16,
+24256,
+buffer23,
+2240,
+2488
+);
+dissociateBuffer(device0, buffer16);
+dissociateBuffer(device0, buffer23);
+} catch {}
+try {
+commandEncoder87.copyTextureToBuffer(
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 2345, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 6348 widthInBlocks: 1587 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 28980 */
+offset: 28980,
+buffer: buffer2,
+},
+{width: 1587, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+13080,
+new BigUint64Array(45627),
+1495,
+0
+);
+} catch {}
+let canvas22 = document.createElement('canvas');
+let bindGroupLayout40 = device0.createBindGroupLayout(
+{
+entries: [
+
+],
+}
+);
+let buffer36 = device0.createBuffer(
+{
+size: 49054,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+try {
+renderPassEncoder12.drawIndirect(
+buffer30,
+591728
+);
+} catch {}
+try {
+commandEncoder87.copyTextureToTexture(
+{
+  texture: texture30,
+  mipLevel: 0,
+  origin: { x: 3606, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture94,
+  mipLevel: 6,
+  origin: { x: 15, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 18, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.append('\u{1fc3b}\u7350\u3dc5\u69f5\u0ff8\u04f6\u{1f822}');
+let buffer37 = device1.createBuffer(
+{
+label: '\u0832\u3086\u05d1\u{1f839}\u5cf2',
+size: 24517,
+usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+}
+);
+let commandEncoder90 = device1.createCommandEncoder(
+{
+}
+);
+try {
+renderBundleEncoder75.setVertexBuffer(
+39,
+undefined,
+3512827577,
+316477454
+);
+} catch {}
+try {
+commandEncoder89.copyTextureToTexture(
+{
+  texture: texture95,
+  mipLevel: 1,
+  origin: { x: 35, y: 1, z: 4 },
+  aspect: 'all',
+},
+{
+  texture: texture95,
+  mipLevel: 0,
+  origin: { x: 999, y: 0, z: 32 },
+  aspect: 'all',
+},
+{width: 759, height: 0, depthOrArrayLayers: 73}
+);
+} catch {}
+let pipeline89 = await promise32;
+document.body.prepend(img6);
+let video23 = await videoWithData();
+try {
+await adapter9.requestAdapterInfo();
+} catch {}
+let bindGroup50 = device0.createBindGroup({
+label: '\u0e72\ud21b\u{1fd42}\u0a9f\u0420\u0bef',
+layout: bindGroupLayout24,
+entries: [
+{
+binding: 999,
+resource: sampler12
+}
+],
+});
+let commandEncoder91 = device0.createCommandEncoder(
+{
+}
+);
+let sampler98 = device0.createSampler(
+{
+label: '\u004a\u137c\u26c5\ub846\u0c3a\u01e3\u078f\uc160',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 27.023,
+lodMaxClamp: 97.891,
+maxAnisotropy: 2,
+}
+);
+try {
+renderPassEncoder23.beginOcclusionQuery(
+72
+);
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(
+2868
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(
+buffer8,
+622344
+);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(
+0,
+buffer6,
+8596
+);
+} catch {}
+try {
+commandEncoder91.copyTextureToTexture(
+{
+  texture: texture26,
+  mipLevel: 3,
+  origin: { x: 79, y: 1, z: 102 },
+  aspect: 'all',
+},
+{
+  texture: texture77,
+  mipLevel: 0,
+  origin: { x: 128, y: 0, z: 913 },
+  aspect: 'all',
+},
+{width: 54, height: 0, depthOrArrayLayers: 44}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer11,
+35984,
+new Float32Array(27588),
+9976,
+208
+);
+} catch {}
+gc();
+let computePassEncoder44 = commandEncoder91.beginComputePass(
+{
+
+}
+);
+let sampler99 = device0.createSampler(
+{
+label: '\u0ab5\u21a6\ub923\u36c6\u0307\u82c5',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 48.667,
+lodMaxClamp: 53.042,
+}
+);
+try {
+computePassEncoder33.setPipeline(
+pipeline14
+);
+} catch {}
+try {
+renderPassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder23.setViewport(
+1397.8,
+0.7959,
+1256.2,
+0.05232,
+0.9011,
+0.9723
+);
+} catch {}
+try {
+renderPassEncoder10.draw(
+64
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer33,
+36208
+);
+} catch {}
+try {
+commandEncoder87.copyBufferToBuffer(
+buffer3,
+2600,
+buffer19,
+13812,
+408
+);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer19);
+} catch {}
+try {
+commandEncoder87.copyTextureToBuffer(
+{
+  texture: texture49,
+  mipLevel: 5,
+  origin: { x: 1, y: 0, z: 18 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 27952 */
+offset: 27952,
+bytesPerRow: 0,
+rowsPerImage: 248,
+buffer: buffer11,
+},
+{width: 0, height: 4, depthOrArrayLayers: 62}
+);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+computePassEncoder44.insertDebugMarker(
+'\u3020'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer9,
+27620,
+new DataView(new ArrayBuffer(63936)),
+4340,
+7452
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture23,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(783),
+/* required buffer size: 783 */{
+offset: 783,
+rowsPerImage: 297,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 33, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas12,
+  origin: { x: 92, y: 149 },
+  flipY: false,
+},
+{
+  texture: texture94,
+  mipLevel: 6,
+  origin: { x: 3, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 28, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\u029a\u4903\u{1ff2a}\u0afa\u27a6\u{1f74f}\u06e0\u0c77\u0575\u763b\ua8e6');
+let buffer38 = device0.createBuffer(
+{
+label: '\u03cf\u502e\u04ad\u{1fdb8}\u39c6\u0ac6\uad6a\u9b7f\u0d45\u032e\uaf71',
+size: 30039,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT,
+}
+);
+let textureView99 = texture76.createView(
+{
+label: '\u0b4e\u2fba\u3dcf\ub73b\u{1f91c}\u{1f84b}\u3e88',
+}
+);
+let renderPassEncoder46 = commandEncoder87.beginRenderPass(
+{
+label: '\u{1fd3d}\uabc9\udee4\u3a5b\u8f26\uc9aa\u4d33\u24f7\u077d\u{1f9d8}',
+colorAttachments: [
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView34,
+depthClearValue: 4.88856727543185,
+depthReadOnly: true,
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet67,
+maxDrawCount: 82568,
+}
+);
+try {
+renderPassEncoder20.setBindGroup(
+5,
+bindGroup24
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(
+16
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(
+buffer25,
+16440
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer15,
+136808
+);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(
+buffer11,
+'uint32',
+10676,
+10735
+);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(
+9,
+buffer4
+);
+} catch {}
+try {
+renderBundleEncoder82.setBindGroup(
+0,
+bindGroup10,
+new Uint32Array(7075),
+4750,
+0
+);
+} catch {}
+try {
+renderBundleEncoder90.setIndexBuffer(
+buffer29,
+'uint16',
+428,
+94
+);
+} catch {}
+try {
+await buffer30.mapAsync(
+GPUMapMode.READ
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture61,
+  mipLevel: 0,
+  origin: { x: 1523, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer14,
+/* required buffer size: 878 */{
+offset: 878,
+rowsPerImage: 259,
+},
+{width: 100, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline90 = device0.createRenderPipeline(
+{
+label: '\u{1fd25}\uceef\u998f\uf7ed\ufaed',
+layout: pipelineLayout5,
+vertex: {
+module: shaderModule12,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 42520,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 23776,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 18216,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 8808,
+shaderLocation: 8,
+},
+{
+format: 'snorm16x2',
+offset: 5760,
+shaderLocation: 4,
+},
+{
+format: 'sint32',
+offset: 17632,
+shaderLocation: 0,
+},
+{
+format: 'unorm8x2',
+offset: 15182,
+shaderLocation: 11,
+},
+{
+format: 'uint8x4',
+offset: 7124,
+shaderLocation: 1,
+},
+{
+format: 'float32',
+offset: 6888,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0xe7e9df23,
+},
+fragment: {
+module: shaderModule12,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.BLUE,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'never',
+failOp: 'keep',
+depthFailOp: 'decrement-clamp',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'invert',
+},
+stencilReadMask: 3436,
+stencilWriteMask: 3093,
+depthBias: 65,
+depthBiasClamp: 30,
+},
+}
+);
+document.body.append('\u252d\u4333\u{1f804}\uf8ce\u{1fdb4}\u145b');
+let bindGroup51 = device1.createBindGroup({
+label: '\u7e0e\u09e0\ub386\u0546\u{1f83d}\u0c5b',
+layout: bindGroupLayout39,
+entries: [
+{
+binding: 4906,
+resource: sampler97
+},
+{
+binding: 3968,
+resource: externalTexture3
+}
+],
+});
+let texture103 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder45 = commandEncoder90.beginComputePass(
+{
+label: '\u45b0\u{1fd7a}'
+}
+);
+try {
+computePassEncoder45.end();
+} catch {}
+try {
+commandEncoder89.clearBuffer(
+buffer32,
+24848,
+2884
+);
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+gpuCanvasContext5.configure(
+{
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgba16float'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let promise47 = device1.queue.onSubmittedWorkDone();
+gc();
+let querySet84 = device1.createQuerySet(
+{
+label: '\u{1ff9b}\u{1fce9}',
+type: 'occlusion',
+count: 1360,
+}
+);
+let texture104 = device1.createTexture(
+{
+label: '\u8332\u585c\udd4b\ua5c1\u0fa6\u92d3',
+size: [3595],
+dimension: '1d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32float',
+'rgba32float',
+'rgba32float'
+],
+}
+);
+let renderBundle79 = renderBundleEncoder98.finish(
+{
+label: '\u3a45\u295e\u35e9\u0024'
+}
+);
+try {
+renderBundleEncoder87.setBindGroup(
+1,
+bindGroup49
+);
+} catch {}
+let pipeline91 = device1.createComputePipeline(
+{
+label: '\u4b17\uff47\u2e1b',
+layout: pipelineLayout15,
+compute: {
+module: shaderModule27,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+gc();
+document.body.prepend('\ud17d\u{1ff30}\u334a\ue991\u0bbd\u{1fffa}\u7050\u0ce9\ub6c3');
+try {
+canvas22.getContext('webgl');
+} catch {}
+let renderBundle80 = renderBundleEncoder91.finish(
+{
+label: '\u0f24\u8f4e\ub85b\u064c\u684b'
+}
+);
+try {
+renderBundleEncoder87.setBindGroup(
+4,
+bindGroup45
+);
+} catch {}
+try {
+renderBundleEncoder87.setBindGroup(
+1,
+bindGroup42,
+new Uint32Array(4740),
+2192,
+0
+);
+} catch {}
+try {
+renderBundleEncoder92.setIndexBuffer(
+buffer34,
+'uint16',
+15472,
+23399
+);
+} catch {}
+try {
+commandEncoder89.copyTextureToTexture(
+{
+  texture: texture93,
+  mipLevel: 11,
+  origin: { x: 0, y: 0, z: 62 },
+  aspect: 'all',
+},
+{
+  texture: texture93,
+  mipLevel: 5,
+  origin: { x: 295, y: 0, z: 4 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 133}
+);
+} catch {}
+try {
+commandEncoder88.clearBuffer(
+buffer32,
+10688,
+4256
+);
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+device1.queue.submit([
+]);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer32,
+24768,
+new Int16Array(33210),
+18943,
+3012
+);
+} catch {}
+let pipeline92 = device1.createRenderPipeline(
+{
+label: '\u0029\u0c57',
+layout: pipelineLayout15,
+vertex: {
+module: shaderModule16,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 21184,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 11248,
+shaderLocation: 4,
+},
+{
+format: 'uint32x4',
+offset: 17056,
+shaderLocation: 12,
+},
+{
+format: 'uint16x2',
+offset: 6356,
+shaderLocation: 5,
+},
+{
+format: 'unorm8x4',
+offset: 12368,
+shaderLocation: 8,
+},
+{
+format: 'uint32x3',
+offset: 9644,
+shaderLocation: 3,
+},
+{
+format: 'sint32x2',
+offset: 16076,
+shaderLocation: 9,
+},
+{
+format: 'sint32x3',
+offset: 11764,
+shaderLocation: 16,
+},
+{
+format: 'sint32',
+offset: 108,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 15016,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 8052,
+shaderLocation: 1,
+},
+{
+format: 'uint32',
+offset: 10532,
+shaderLocation: 10,
+},
+{
+format: 'float32x3',
+offset: 12340,
+shaderLocation: 11,
+},
+{
+format: 'float32x3',
+offset: 6116,
+shaderLocation: 0,
+},
+{
+format: 'float32',
+offset: 1168,
+shaderLocation: 13,
+},
+{
+format: 'sint16x4',
+offset: 848,
+shaderLocation: 18,
+},
+{
+format: 'unorm16x2',
+offset: 5168,
+shaderLocation: 19,
+},
+{
+format: 'unorm8x2',
+offset: 11120,
+shaderLocation: 2,
+},
+{
+format: 'sint32',
+offset: 11208,
+shaderLocation: 7,
+},
+{
+format: 'sint16x2',
+offset: 3220,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 17156,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 5176,
+shaderLocation: 14,
+},
+{
+format: 'unorm8x4',
+offset: 10212,
+shaderLocation: 17,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x260acaf3,
+},
+fragment: {
+module: shaderModule16,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+undefined,
+undefined,
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'less',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'invert',
+},
+stencilWriteMask: 2322,
+depthBiasSlopeScale: 59,
+depthBiasClamp: 5,
+},
+}
+);
+let bindGroup52 = device0.createBindGroup({
+layout: bindGroupLayout24,
+entries: [
+{
+binding: 999,
+resource: sampler16
+}
+],
+});
+let querySet85 = device0.createQuerySet(
+{
+label: '\u0194\u05cf',
+type: 'occlusion',
+count: 2358,
+}
+);
+try {
+computePassEncoder29.end();
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(
+0,
+bindGroup33,
+new Uint32Array(8746),
+683,
+0
+);
+} catch {}
+try {
+renderPassEncoder33.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(
+0,
+0,
+0,
+0
+);
+} catch {}
+let promise48 = buffer36.mapAsync(
+GPUMapMode.WRITE,
+0,
+12904
+);
+try {
+gpuCanvasContext9.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgba16float',
+'bgra8unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+document.body.append('\u00ac\uc70d\u{1f60d}');
+try {
+await adapter4.requestAdapterInfo();
+} catch {}
+let texture105 = device0.createTexture(
+{
+label: '\uc624\u27bb\ua6eb\u73b3\u9081\u01fa\u{1fd41}\u11c2\ua8c0\u5d90',
+size: [841, 1, 149],
+dimension: '3d',
+format: 'r32uint',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let textureView100 = texture7.createView(
+{
+label: '\u09d3\ucada',
+baseMipLevel: 6,
+mipLevelCount: 1,
+baseArrayLayer: 2,
+arrayLayerCount: 4,
+}
+);
+let renderBundle81 = renderBundleEncoder47.finish(
+{
+label: '\u52a0\u68d5'
+}
+);
+let sampler100 = device0.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+lodMinClamp: 59.419,
+lodMaxClamp: 65.653,
+}
+);
+try {
+computePassEncoder28.setBindGroup(
+1,
+bindGroup18
+);
+} catch {}
+try {
+renderPassEncoder15.setBlendConstant(
+{
+r: 66.31,
+g: 82.19,
+b: 516.1,
+a: 823.6,
+}
+);
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(
+9,
+1,
+1625,
+0
+);
+} catch {}
+try {
+renderBundleEncoder58.setBindGroup(
+3,
+bindGroup23
+);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(
+7,
+buffer31,
+16924,
+1839
+);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+try {
+computePassEncoder18.insertDebugMarker(
+'\u0b50'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer11,
+30804,
+new DataView(new ArrayBuffer(31792)),
+10424,
+1004
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 367, height: 1, depthOrArrayLayers: 78}
+*/
+{
+  source: videoFrame17,
+  origin: { x: 0, y: 7 },
+  flipY: true,
+},
+{
+  texture: texture31,
+  mipLevel: 1,
+  origin: { x: 87, y: 0, z: 25 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 15, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline93 = await device0.createRenderPipelineAsync(
+{
+layout: pipelineLayout12,
+vertex: {
+module: shaderModule12,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 27016,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 2396,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 27676,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 3912,
+shaderLocation: 11,
+},
+{
+format: 'uint32',
+offset: 23448,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 2636,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 35404,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 1960,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 43000,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 9596,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 36,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 15316,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x2',
+offset: 6556,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 25800,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 59972,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 26928,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule12,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'zero',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2260,
+stencilWriteMask: 647,
+depthBias: 60,
+depthBiasSlopeScale: 71,
+depthBiasClamp: 74,
+},
+}
+);
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+document.body.append('\u0654\u9b7d\u0b44\u0110');
+let textureView101 = texture98.createView(
+{
+label: '\uc2ce\uba2d\u02ab\u0eba\u098b\u66c8\u{1f920}\uaf29',
+dimension: '2d',
+baseMipLevel: 2,
+mipLevelCount: 2,
+baseArrayLayer: 51,
+}
+);
+try {
+renderBundleEncoder96.setBindGroup(
+2,
+bindGroup45
+);
+} catch {}
+let commandEncoder92 = device1.createCommandEncoder(
+{
+label: '\u0810\u476b\u{1fca7}\u773c\u2aba',
+}
+);
+let sampler101 = device1.createSampler(
+{
+label: '\ua7e0\u{1ff58}\u030e\u{1ff7a}',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 38.228,
+lodMaxClamp: 52.879,
+}
+);
+try {
+renderBundleEncoder95.setIndexBuffer(
+buffer34,
+'uint32',
+14324,
+1608
+);
+} catch {}
+try {
+commandEncoder88.copyBufferToBuffer(
+buffer34,
+10816,
+buffer32,
+13772,
+6096
+);
+dissociateBuffer(device1, buffer34);
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+commandEncoder90.copyTextureToTexture(
+{
+  texture: texture93,
+  mipLevel: 13,
+  origin: { x: 0, y: 0, z: 103 },
+  aspect: 'all',
+},
+{
+  texture: texture93,
+  mipLevel: 1,
+  origin: { x: 1870, y: 15, z: 33 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 135}
+);
+} catch {}
+try {
+gpuCanvasContext6.configure(
+{
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+document.body.prepend(img5);
+let bindGroupLayout41 = device0.createBindGroupLayout(
+{
+label: '\u0c96\u{1fcfe}\u{1fe18}\u2b7e\u15f3\u5a66',
+entries: [
+{
+binding: 1149,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+},
+{
+binding: 880,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 848445, hasDynamicOffset: true },
+}
+],
+}
+);
+let commandBuffer9 = commandEncoder63.finish(
+{
+label: '\u{1fbb1}\ud7ec\u0471\u41d1\u0811\u03d1\u{1f768}\u6b7a\u3151\u94e0',
+}
+);
+let texture106 = device0.createTexture(
+{
+label: '\u0ef6\u0af6',
+size: [2798],
+dimension: '1d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+let renderBundleEncoder99 = device0.createRenderBundleEncoder(
+{
+label: '\ubbc6\uc5eb\u{1fc32}\u16d5\u20b0',
+colorFormats: [
+'bgra8unorm-srgb',
+'rgb10a2uint',
+'rg11b10ufloat',
+undefined,
+'r16uint',
+'r32float',
+'r16sint',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 95,
+depthReadOnly: true,
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture92,
+  mipLevel: 0,
+  origin: { x: 43, y: 12, z: 68 },
+  aspect: 'all',
+},
+new Float32Array(arrayBuffer9),
+/* required buffer size: 1996130 */{
+offset: 527,
+bytesPerRow: 2795,
+rowsPerImage: 54,
+},
+{width: 173, height: 12, depthOrArrayLayers: 14}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 383, height: 1, depthOrArrayLayers: 334}
+*/
+{
+  source: img6,
+  origin: { x: 0, y: 35 },
+  flipY: true,
+},
+{
+  texture: texture47,
+  mipLevel: 2,
+  origin: { x: 1, y: 0, z: 271 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 9, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.destroy();
+} catch {}
+document.body.append('\u5cfc\u0931\u0565\u7ab2\u3a6f');
+let video24 = await videoWithData();
+let shaderModule31 = device1.createShaderModule(
+{
+code: `@group(2) @binding(7479)
+var<storage, read_write> function4: array<u32>;
+
+@compute @workgroup_size(3, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(3) f0: vec2<u32>,
+@location(7) f1: vec2<i32>,
+@location(6) f2: vec3<u32>,
+@builtin(sample_mask) f3: u32,
+@location(2) f4: vec3<i32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S29 {
+@location(2) f0: vec4<u32>,
+@location(3) f1: vec3<i32>,
+@location(1) f2: f16,
+@location(5) f3: vec4<f16>,
+@location(12) f4: vec2<i32>,
+@location(6) f5: vec2<f16>,
+@location(8) f6: vec2<u32>,
+@location(4) f7: vec2<u32>,
+@location(16) f8: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(13) a0: vec2<f16>, @location(9) a1: vec2<u32>, @location(18) a2: vec3<f16>, @builtin(vertex_index) a3: u32, @builtin(instance_index) a4: u32, @location(15) a5: f32, @location(0) a6: vec3<u32>, @location(19) a7: vec3<i32>, @location(17) a8: f32, @location(11) a9: f32, a10: S29, @location(14) a11: vec4<f16>, @location(10) a12: vec2<u32>, @location(7) a13: vec3<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture107 = device1.createTexture(
+{
+size: {width: 25, height: 1, depthOrArrayLayers: 451},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb'
+],
+}
+);
+let computePassEncoder46 = commandEncoder89.beginComputePass(
+{
+label: '\u5523\u85e5'
+}
+);
+try {
+computePassEncoder46.end();
+} catch {}
+try {
+commandEncoder92.copyBufferToBuffer(
+buffer34,
+6184,
+buffer32,
+22088,
+2464
+);
+dissociateBuffer(device1, buffer34);
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer32,
+9740,
+new Float32Array(2329),
+396,
+988
+);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let bindGroup53 = device1.createBindGroup({
+label: '\u0618\u{1fa4d}\u3cd1\u030a\uaf61',
+layout: bindGroupLayout36,
+entries: [
+
+],
+});
+let computePassEncoder47 = commandEncoder92.beginComputePass(
+{
+label: '\uae31\u{1f92e}\u3d0a\u0eef\u9624\u8f1c\u{1ff54}\u0e87\ud28c\u3980'
+}
+);
+try {
+computePassEncoder47.setBindGroup(
+0,
+bindGroup53,
+new Uint32Array(5625),
+864,
+0
+);
+} catch {}
+try {
+computePassEncoder47.setPipeline(
+pipeline83
+);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+try {
+commandEncoder89.clearBuffer(
+buffer32,
+25964,
+3004
+);
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+renderBundleEncoder97.pushDebugGroup(
+'\u{1f8fd}'
+);
+} catch {}
+offscreenCanvas4.height = 223;
+try {
+computePassEncoder47.setPipeline(
+pipeline91
+);
+} catch {}
+try {
+renderBundleEncoder94.setBindGroup(
+2,
+bindGroup37
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device1,
+format: 'astc-8x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-8x5-unorm',
+'astc-8x5-unorm',
+'astc-8x5-unorm-srgb',
+'rg8uint'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+try {
+device1.queue.submit([
+commandBuffer8,
+]);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture93,
+  mipLevel: 12,
+  origin: { x: 0, y: 0, z: 76 },
+  aspect: 'all',
+},
+new ArrayBuffer(3285603),
+/* required buffer size: 3285603 */{
+offset: 243,
+bytesPerRow: 120,
+rowsPerImage: 169,
+},
+{width: 0, height: 0, depthOrArrayLayers: 163}
+);
+} catch {}
+let shaderModule32 = device1.createShaderModule(
+{
+code: `@group(1) @binding(3994)
+var<storage, read_write> parameter3: array<u32>;
+
+@compute @workgroup_size(7, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: vec2<f32>,
+@location(1) f1: vec3<u32>,
+@location(7) f2: vec4<i32>,
+@location(6) f3: vec4<i32>,
+@location(5) f4: vec3<u32>,
+@builtin(frag_depth) f5: f32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(33) f402: i32,
+@location(45) f403: vec3<i32>,
+@location(11) f404: vec4<f32>,
+@builtin(position) f405: vec4<f32>,
+@location(62) f406: vec4<f16>,
+@location(2) f407: vec3<i32>,
+@location(23) f408: vec4<f16>,
+@location(57) f409: vec2<f32>,
+@location(67) f410: vec3<i32>,
+@location(41) f411: f16,
+@location(48) f412: vec2<f32>,
+@location(30) f413: vec3<i32>,
+@location(61) f414: vec2<i32>,
+@location(80) f415: vec3<i32>,
+@location(1) f416: vec2<u32>,
+@location(56) f417: vec2<u32>,
+@location(78) f418: vec4<f16>,
+@location(9) f419: vec4<i32>,
+@location(82) f420: vec4<f32>,
+@location(47) f421: vec2<f16>,
+@location(69) f422: vec2<i32>,
+@location(77) f423: vec2<u32>,
+@location(20) f424: i32,
+@location(74) f425: vec2<i32>,
+@location(54) f426: f32
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @builtin(vertex_index) a1: u32, @location(17) a2: vec4<i32>, @location(2) a3: f16, @location(8) a4: vec4<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let textureView102 = texture104.createView(
+{
+label: '\u25d2\u0e31\u0a4a\u37cc\u66f1\ue1b0\udb49',
+baseMipLevel: 0,
+}
+);
+let sampler102 = device1.createSampler(
+{
+label: '\u673a\u02ae\u4eec\u90a9\u89d6\u8500\u0bac\u95e2\u3486\uddec',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 84.540,
+compare: 'never',
+}
+);
+try {
+renderBundleEncoder75.setBindGroup(
+1,
+bindGroup37
+);
+} catch {}
+try {
+commandEncoder90.copyBufferToBuffer(
+buffer34,
+3448,
+buffer32,
+5852,
+15788
+);
+dissociateBuffer(device1, buffer34);
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+commandEncoder88.clearBuffer(
+buffer32,
+17588,
+4948
+);
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 12, height: 1, depthOrArrayLayers: 225}
+*/
+{
+  source: imageData10,
+  origin: { x: 58, y: 119 },
+  flipY: true,
+},
+{
+  texture: texture107,
+  mipLevel: 1,
+  origin: { x: 3, y: 0, z: 218 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 8, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+video1.height = 289;
+let videoFrame22 = new VideoFrame(offscreenCanvas6, {timestamp: 0});
+try {
+window.someLabel = commandEncoder25.label;
+} catch {}
+document.body.append('\u5064\u4a2c\u33d3\u8883\u048e\ud074');
+document.body.append('\u{1f81b}\uceea\uf32a\uf58b\u{1fc11}');
+let bindGroupLayout42 = pipeline86.getBindGroupLayout(1);
+let commandEncoder93 = device1.createCommandEncoder(
+{
+label: '\u{1fb6e}\u035e',
+}
+);
+let computePassEncoder48 = commandEncoder88.beginComputePass(
+{
+label: '\u0066\u88b6\u{1f7c7}\uadca\u1667\u5348\u9067'
+}
+);
+let sampler103 = device1.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 30.289,
+lodMaxClamp: 84.094,
+maxAnisotropy: 1,
+}
+);
+try {
+renderBundleEncoder93.setVertexBuffer(
+10,
+buffer37,
+6880,
+7331
+);
+} catch {}
+try {
+buffer37.destroy();
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer32,
+19412,
+new BigUint64Array(19109),
+6168,
+904
+);
+} catch {}
+let pipeline94 = await device1.createComputePipelineAsync(
+{
+layout: pipelineLayout16,
+compute: {
+module: shaderModule30,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+if (!arrayBuffer16.detached) { new Uint8Array(arrayBuffer16).fill(0x55) };
+} catch {}
+let imageData22 = new ImageData(240, 216);
+let video25 = await videoWithData();
+try {
+window.someLabel = pipelineLayout4.label;
+} catch {}
+document.body.prepend('\u9f94\u0f78\u0317\ub236\u3e3b\u5e0e');
+let video26 = await videoWithData();
+let querySet86 = device1.createQuerySet(
+{
+label: '\u0c93\u41cc',
+type: 'occlusion',
+count: 2852,
+}
+);
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+document.body.prepend('\u{1f61b}\u3f2b\ua371');
+let img22 = await imageWithData(33, 39, '#d2b5e48f', '#20b3b0ad');
+let querySet87 = device1.createQuerySet(
+{
+type: 'occlusion',
+count: 836,
+}
+);
+pseudoSubmit(device1, commandEncoder90);
+let sampler104 = device1.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 20.312,
+lodMaxClamp: 73.807,
+compare: 'always',
+maxAnisotropy: 9,
+}
+);
+try {
+computePassEncoder47.setBindGroup(
+3,
+bindGroup53,
+new Uint32Array(6326),
+307,
+0
+);
+} catch {}
+try {
+computePassEncoder48.setPipeline(
+pipeline91
+);
+} catch {}
+try {
+renderBundleEncoder92.setBindGroup(
+2,
+bindGroup45
+);
+} catch {}
+document.body.append('\u{1ffee}\u{1fa75}\u{1f863}\u{1fdc1}\u{1fd5d}\u4b2e\u5118\u0454');
+let imageData23 = new ImageData(52, 36);
+let computePassEncoder49 = commandEncoder93.beginComputePass(
+{
+label: '\u{1fea0}\u0c01\u0957\u021d\ud72a\u00a8\ub308'
+}
+);
+try {
+renderBundleEncoder92.setIndexBuffer(
+buffer34,
+'uint32',
+9648,
+4631
+);
+} catch {}
+try {
+renderBundleEncoder93.setVertexBuffer(
+4,
+buffer37,
+21192,
+3306
+);
+} catch {}
+try {
+commandEncoder89.copyBufferToBuffer(
+buffer34,
+17156,
+buffer32,
+25512,
+4048
+);
+dissociateBuffer(device1, buffer34);
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture97,
+  mipLevel: 2,
+  origin: { x: 151, y: 0, z: 2 },
+  aspect: 'all',
+},
+new ArrayBuffer(8437348),
+/* required buffer size: 8437348 */{
+offset: 869,
+bytesPerRow: 2653,
+rowsPerImage: 289,
+},
+{width: 162, height: 1, depthOrArrayLayers: 12}
+);
+} catch {}
+document.body.append('\u0e75\u{1f87a}\u3839');
+let device2 = await promise40;
+let shaderModule33 = device1.createShaderModule(
+{
+label: '\u75d0\u26f0\ud327\u{1fd80}\u{1feae}\u8b1b',
+code: `
+
+@compute @workgroup_size(7, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: u32,
+@location(0) f1: vec3<i32>,
+@builtin(frag_depth) f2: f32,
+@location(7) f3: vec2<f32>,
+@location(4) f4: u32,
+@builtin(sample_mask) f5: u32,
+@location(1) f6: vec3<u32>,
+@location(3) f7: vec2<u32>,
+@location(5) f8: vec2<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S30 {
+@builtin(vertex_index) f0: u32,
+@location(9) f1: u32,
+@location(0) f2: vec4<u32>,
+@location(4) f3: f16,
+@location(15) f4: f32,
+@location(13) f5: f16,
+@location(12) f6: vec2<u32>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(10) a1: vec3<u32>, @location(18) a2: vec4<u32>, @location(1) a3: vec2<f32>, a4: S30, @location(17) a5: u32, @location(8) a6: i32, @location(5) a7: vec4<f32>, @location(6) a8: vec2<i32>, @location(7) a9: vec3<i32>, @location(11) a10: u32, @location(19) a11: vec3<u32>, @location(16) a12: u32, @location(3) a13: f32, @location(2) a14: vec4<u32>, @location(14) a15: vec2<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroupLayout43 = device1.createBindGroupLayout(
+{
+label: '\u06ec\u31d8\uef7a\u{1f853}\u{1f721}\u{1fafa}\ue013\ua551\u8c8d',
+entries: [
+{
+binding: 2813,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'storage', minBindingSize: 722579, hasDynamicOffset: true },
+},
+{
+binding: 827,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+},
+{
+binding: 386,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}
+],
+}
+);
+let computePassEncoder50 = commandEncoder89.beginComputePass(
+{
+label: '\uf2b0\u{1ffc6}\ub95e\uf195\u3222\u0863\u6342\u1904\u0086\u35ff\u{1fdf5}'
+}
+);
+let renderBundle82 = renderBundleEncoder83.finish(
+{
+label: '\u9c8c\ue42f\u{1fd24}\u01cc'
+}
+);
+try {
+renderBundleEncoder75.setBindGroup(
+2,
+bindGroup53
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 3, height: 1, depthOrArrayLayers: 56}
+*/
+{
+  source: offscreenCanvas5,
+  origin: { x: 269, y: 131 },
+  flipY: true,
+},
+{
+  texture: texture107,
+  mipLevel: 3,
+  origin: { x: 2, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline95 = device1.createRenderPipeline(
+{
+label: '\u0cfa\uf06a\u0fef',
+layout: pipelineLayout15,
+vertex: {
+module: shaderModule28,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 7576,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 3312,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 3292,
+shaderLocation: 16,
+},
+{
+format: 'sint16x2',
+offset: 1660,
+shaderLocation: 9,
+},
+{
+format: 'sint8x4',
+offset: 1400,
+shaderLocation: 8,
+},
+{
+format: 'float32x2',
+offset: 3112,
+shaderLocation: 6,
+},
+{
+format: 'uint16x4',
+offset: 1916,
+shaderLocation: 2,
+},
+{
+format: 'float32x2',
+offset: 1696,
+shaderLocation: 19,
+},
+{
+format: 'snorm16x4',
+offset: 1808,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 22756,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x2',
+offset: 11092,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 20248,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 452,
+shaderLocation: 13,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule28,
+entryPoint: 'fragment0',
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+failOp: 'increment-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilReadMask: 673,
+depthBias: 35,
+},
+}
+);
+let videoFrame23 = new VideoFrame(videoFrame8, {timestamp: 0});
+document.body.prepend('\u2226\u{1ff27}\u0ddd\u2379');
+let commandEncoder94 = device2.createCommandEncoder(
+{
+label: '\u31cd\u95ed\u{1fb9d}\ufc50\u{1ff7e}',
+}
+);
+let sampler105 = device2.createSampler(
+{
+label: '\u09c0\u0825',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 65.362,
+lodMaxClamp: 69.421,
+maxAnisotropy: 10,
+}
+);
+let promise49 = device2.queue.onSubmittedWorkDone();
+let buffer39 = device2.createBuffer(
+{
+label: '\u{1f800}\u0606',
+size: 26642,
+usage: GPUBufferUsage.MAP_READ,
+mappedAtCreation: false,
+}
+);
+let renderBundleEncoder100 = device2.createRenderBundleEncoder(
+{
+label: '\u2708\u225a\u019e\u{1fbd4}\u{1ffac}\u2945\u{1fe14}\u8eef\u0f03\u0a91\u0cc6',
+colorFormats: [
+'rgba32float',
+'r32uint',
+'r16uint',
+'r16uint'
+],
+sampleCount: 298,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler106 = device2.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMinClamp: 33.908,
+lodMaxClamp: 64.405,
+compare: 'always',
+}
+);
+try {
+renderBundleEncoder100.setVertexBuffer(
+64,
+undefined,
+4255612289,
+29205947
+);
+} catch {}
+try {
+await promise47;
+} catch {}
+let imageData24 = new ImageData(176, 164);
+try {
+renderBundleEncoder100.setVertexBuffer(
+81,
+undefined,
+3863450255,
+257093086
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let canvas23 = document.createElement('canvas');
+let buffer40 = device1.createBuffer(
+{
+size: 34622,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+}
+);
+let textureView103 = texture102.createView(
+{
+label: '\u799b\u0b08\ue262\u60f8\u35a1\u0ac8',
+dimension: '2d',
+aspect: 'depth-only',
+baseMipLevel: 1,
+mipLevelCount: 3,
+baseArrayLayer: 136,
+}
+);
+let renderBundleEncoder101 = device1.createRenderBundleEncoder(
+{
+label: '\u0ba4\u0fe1\u09e3\u0c37\u{1fcf7}\u4fb8',
+colorFormats: [
+'rgb10a2unorm',
+'rg32uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 969,
+depthReadOnly: true,
+}
+);
+let renderBundle83 = renderBundleEncoder81.finish(
+{
+
+}
+);
+try {
+computePassEncoder50.setBindGroup(
+4,
+bindGroup37
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 12, height: 1, depthOrArrayLayers: 225}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 97, y: 31 },
+  flipY: false,
+},
+{
+  texture: texture107,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 49 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 10, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let videoFrame24 = new VideoFrame(video1, {timestamp: 0});
+let textureView104 = texture86.createView(
+{
+label: '\ua5df\u0f48\u619e\u0c87\u{1f9eb}\u0abe\u7a8b\u0a45\u02ff\u{1fbe6}',
+dimension: '2d',
+baseArrayLayer: 65,
+}
+);
+gc();
+let texture108 = device2.createTexture(
+{
+label: '\u4835\u664c\ua986\u31b6\u0b93\u0caa',
+size: [10676, 33, 1],
+mipLevelCount: 14,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundle84 = renderBundleEncoder100.finish(
+{
+label: '\u{1fbc1}\u{1f61a}\u{1fda0}\u2407\u{1fb57}\u{1f753}\u{1f9d2}\u4aa8\u302f\u3d4a\u1c28'
+}
+);
+let promise50 = device2.queue.onSubmittedWorkDone();
+document.body.append('\u085e\uc08d\ubf63');
+let img23 = await imageWithData(101, 100, '#e1927d59', '#c0959ddd');
+let shaderModule34 = device1.createShaderModule(
+{
+label: '\u0f9f\u{1fc6b}\u540d\uf76c\u9899\u9070\u015d\ueaa3\u0bed',
+code: `
+
+@compute @workgroup_size(2, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S31 {
+@builtin(front_facing) f0: bool,
+@builtin(position) f1: vec4<f32>
+}
+struct FragmentOutput0 {
+@location(2) f0: u32,
+@builtin(sample_mask) f1: u32,
+@builtin(frag_depth) f2: f32,
+@location(3) f3: vec4<f32>,
+@location(7) f4: vec2<i32>,
+@location(0) f5: vec3<f32>,
+@location(6) f6: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, a1: S31) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(17) a0: vec4<f32>, @location(14) a1: vec4<f32>, @location(9) a2: i32, @location(8) a3: vec3<i32>, @builtin(instance_index) a4: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture109 = device1.createTexture(
+{
+label: '\u8bfa\u02a1\ud18e\u5001\u460b\uc1be\u405c\u0a47\u{1f792}\u{1fb66}\u3d90',
+size: {width: 244, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'r32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32float',
+'r32float',
+'r32float'
+],
+}
+);
+let renderBundle85 = renderBundleEncoder85.finish(
+{
+label: '\u062b\u0436\u0ea6\u2b73\u{1f82e}\u0515\u0ed7\u{1fe24}\u{1f7d3}\ua3e3'
+}
+);
+try {
+computePassEncoder50.setPipeline(
+pipeline89
+);
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+try {
+adapter1.label = '\u2eb4\udc8e\u5ece\u{1fe65}\uc9f9';
+} catch {}
+document.body.prepend(video0);
+let videoFrame25 = new VideoFrame(img4, {timestamp: 0});
+let texture110 = device2.createTexture(
+{
+label: '\uef20\u5ef0',
+size: [11610, 201, 140],
+mipLevelCount: 7,
+sampleCount: 1,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundleEncoder102 = device2.createRenderBundleEncoder(
+{
+label: '\ue546\u44d6\u201d\u00d3\u0876\u{1f843}',
+colorFormats: [
+'r32sint',
+'rgba32float',
+'bgra8unorm-srgb'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 145,
+depthReadOnly: false,
+}
+);
+try {
+commandEncoder94.pushDebugGroup(
+'\u04a2'
+);
+} catch {}
+let commandEncoder95 = device1.createCommandEncoder(
+{
+label: '\ub8b3\u05aa\u{1ff85}\u0a77\ufdf9\u55e7\u03d3',
+}
+);
+pseudoSubmit(device1, commandEncoder95);
+try {
+renderBundleEncoder97.setVertexBuffer(
+6,
+buffer32,
+24868,
+7715
+);
+} catch {}
+try {
+texture102.destroy();
+} catch {}
+let promise51 = device1.createComputePipelineAsync(
+{
+label: '\u0f15\u{1f7dd}\u4c04\ufe94\ue47b\u1a2b\u59d1\u321f\uc856\u6c90\u0822',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule33,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline96 = device1.createRenderPipeline(
+{
+layout: pipelineLayout16,
+vertex: {
+module: shaderModule27,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 13448,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x3',
+offset: 5148,
+shaderLocation: 6,
+},
+{
+format: 'uint8x2',
+offset: 4882,
+shaderLocation: 10,
+},
+{
+format: 'sint32x4',
+offset: 8804,
+shaderLocation: 19,
+},
+{
+format: 'uint32x3',
+offset: 3232,
+shaderLocation: 5,
+},
+{
+format: 'sint32x3',
+offset: 12432,
+shaderLocation: 17,
+},
+{
+format: 'uint8x2',
+offset: 8394,
+shaderLocation: 18,
+},
+{
+format: 'uint32x4',
+offset: 11016,
+shaderLocation: 15,
+},
+{
+format: 'sint16x2',
+offset: 2448,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x2',
+offset: 10172,
+shaderLocation: 14,
+},
+{
+format: 'uint8x4',
+offset: 9788,
+shaderLocation: 0,
+},
+{
+format: 'sint32',
+offset: 12004,
+shaderLocation: 13,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 5168,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x2',
+offset: 8976,
+shaderLocation: 1,
+},
+{
+format: 'sint16x4',
+offset: 12608,
+shaderLocation: 3,
+},
+{
+format: 'uint32x3',
+offset: 5532,
+shaderLocation: 7,
+},
+{
+format: 'uint32x2',
+offset: 9140,
+shaderLocation: 4,
+},
+{
+format: 'sint32x4',
+offset: 8452,
+shaderLocation: 12,
+},
+{
+format: 'unorm16x4',
+offset: 3896,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 17740,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x4',
+offset: 15928,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 12196,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x2',
+offset: 6042,
+shaderLocation: 8,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule27,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rgba32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'dst-alpha',
+dstFactor: 'dst'
+},
+},
+format: 'rg8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALL,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+},
+stencilWriteMask: 3442,
+depthBias: 20,
+depthBiasSlopeScale: 17,
+depthBiasClamp: 41,
+},
+}
+);
+let texture111 = device2.createTexture(
+{
+label: '\u041f\u5fdf',
+size: {width: 14115, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'depth16unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth16unorm',
+'depth16unorm'
+],
+}
+);
+let computePassEncoder51 = commandEncoder94.beginComputePass(
+{
+label: '\uc95d\u03af\u032e'
+}
+);
+let commandEncoder96 = device2.createCommandEncoder(
+{
+label: '\ufce0\u7365\uf393\u17f1\u0e39',
+}
+);
+let renderBundleEncoder103 = device2.createRenderBundleEncoder(
+{
+label: '\u{1f7f9}\u1341\u7a2f\ub7b1\u59af\u0f4e\u00f2\u03cf',
+colorFormats: [
+'r16float',
+'rg8unorm',
+undefined
+],
+sampleCount: 329,
+stencilReadOnly: true,
+}
+);
+let renderBundle86 = renderBundleEncoder103.finish(
+{
+label: '\ufdaf\u0e72\uaac8\u0d5a\u0113'
+}
+);
+let sampler107 = device2.createSampler(
+{
+label: '\ub999\u12c1\ucc8b\ucff6',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 2.171,
+lodMaxClamp: 56.867,
+compare: 'never',
+maxAnisotropy: 11,
+}
+);
+try {
+computePassEncoder51.end();
+} catch {}
+document.body.append('\u{1f9f9}\u9081\ud2cf');
+let videoFrame26 = new VideoFrame(video22, {timestamp: 0});
+try {
+renderBundleEncoder102.setVertexBuffer(
+64,
+undefined,
+925733440,
+3257383239
+);
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55) };
+} catch {}
+try {
+canvas23.getContext('webgpu');
+} catch {}
+let renderBundleEncoder104 = device2.createRenderBundleEncoder(
+{
+label: '\u{1fc21}\uf2df',
+colorFormats: [
+'rgb10a2unorm',
+'rgba32sint'
+],
+sampleCount: 152,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler108 = device2.createSampler(
+{
+label: '\u{1fc5d}\u0363\u9b94\u{1fe1d}\u050e\uac06\u0dec',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 73.389,
+lodMaxClamp: 95.542,
+maxAnisotropy: 1,
+}
+);
+try {
+commandEncoder96.insertDebugMarker(
+'\u0569'
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture110,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 91 },
+  aspect: 'depth-only',
+},
+arrayBuffer15,
+/* required buffer size: 12094123 */{
+offset: 103,
+bytesPerRow: 5914,
+rowsPerImage: 146,
+},
+{width: 2902, height: 1, depthOrArrayLayers: 15}
+);
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+try {
+await promise49;
+} catch {}
+try {
+commandEncoder94.copyTextureToTexture(
+{
+  texture: texture110,
+  mipLevel: 1,
+  origin: { x: 2175, y: 2, z: 1 },
+  aspect: 'depth-only',
+},
+{
+  texture: texture110,
+  mipLevel: 6,
+  origin: { x: 0, y: 1, z: 7 },
+  aspect: 'depth-only',
+},
+{width: 181, height: 0, depthOrArrayLayers: 126}
+);
+} catch {}
+document.body.append('\u42c6\u498b\u5bae\u8e7b\u6c7f\u0b19\u053a\u6bd4\u{1ffeb}\u{1f766}\u091e');
+pseudoSubmit(device1, commandEncoder89);
+let renderBundle87 = renderBundleEncoder96.finish();
+try {
+computePassEncoder47.setBindGroup(
+0,
+bindGroup49,
+new Uint32Array(6896),
+874,
+0
+);
+} catch {}
+document.body.prepend(video2);
+let canvas24 = document.createElement('canvas');
+document.body.append('\u0bee\u46ab\uac80\u09fe\uc133\u03bf');
+try {
+canvas24.getContext('bitmaprenderer');
+} catch {}
+let canvas25 = document.createElement('canvas');
+let gpuCanvasContext19 = canvas25.getContext('webgpu');
+let img24 = await imageWithData(196, 132, '#993b3c18', '#3ff8e2b3');
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+offscreenCanvas19.height = 274;
+document.body.append('\u{1ffda}\ub435\u6cbc\u73e7\u5957\u7075\ucda4');
+let imageBitmap21 = await createImageBitmap(imageBitmap19);
+let bindGroup54 = device1.createBindGroup({
+label: '\u{1f96b}\u8a4f\u9d42\u{1f918}',
+layout: bindGroupLayout39,
+entries: [
+{
+binding: 3968,
+resource: externalTexture3
+},
+{
+binding: 4906,
+resource: sampler97
+}
+],
+});
+let textureView105 = texture107.createView(
+{
+format: 'rgba8unorm-srgb',
+baseMipLevel: 1,
+mipLevelCount: 2,
+baseArrayLayer: 0,
+}
+);
+let renderBundleEncoder105 = device1.createRenderBundleEncoder(
+{
+label: '\u0839\u{1f893}',
+colorFormats: [
+'rg16float',
+'rg8uint',
+'r16float',
+'bgra8unorm'
+],
+sampleCount: 105,
+}
+);
+let sampler109 = device1.createSampler(
+{
+label: '\ud8d8\u0b8c\u9bdc\u0cee\u7d6f\u05ea',
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 16.573,
+compare: 'greater-equal',
+maxAnisotropy: 2,
+}
+);
+try {
+renderBundleEncoder101.setVertexBuffer(
+0,
+buffer37,
+23776,
+218
+);
+} catch {}
+gc();
+let device3 = await adapter9.requestDevice(
+{
+label: '\u7313\u068f\u{1fb14}\u{1f64e}\u{1f60f}\u137c\u0e03\u{1f7cf}',
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 6,
+maxColorAttachmentBytesPerSample: 53,
+maxVertexAttributes: 24,
+maxVertexBufferArrayStride: 29799,
+maxStorageTexturesPerShaderStage: 40,
+maxStorageBuffersPerShaderStage: 34,
+maxDynamicStorageBuffersPerPipelineLayout: 13410,
+maxBindingsPerBindGroup: 4155,
+maxTextureDimension1D: 15492,
+maxTextureDimension2D: 9840,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 138988327,
+maxInterStageShaderVariables: 100,
+maxInterStageShaderComponents: 61,
+},
+}
+);
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+gc();
+document.body.append('\ua72d\u7263\u078d\u2eb8\uf91c\u2774\u0cc6\ud27e\uc66b\u{1f9e3}');
+document.body.append('\uc10e\u3422\u49cf\u832d');
+let canvas26 = document.createElement('canvas');
+let renderBundle88 = renderBundleEncoder100.finish(
+{
+
+}
+);
+try {
+commandEncoder96.copyTextureToTexture(
+{
+  texture: texture110,
+  mipLevel: 1,
+  origin: { x: 2289, y: 82, z: 81 },
+  aspect: 'depth-only',
+},
+{
+  texture: texture110,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 50 },
+  aspect: 'all',
+},
+{width: 181, height: 3, depthOrArrayLayers: 32}
+);
+} catch {}
+let img25 = await imageWithData(194, 269, '#0a4138da', '#907fb826');
+let sampler110 = device1.createSampler(
+{
+label: '\u3e08\u{1f6a5}\u911c\uf366\u0af1\ub7fe\u0b72',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 49.657,
+lodMaxClamp: 61.770,
+maxAnisotropy: 1,
+}
+);
+try {
+computePassEncoder48.setPipeline(
+pipeline84
+);
+} catch {}
+try {
+renderBundleEncoder94.setBindGroup(
+3,
+bindGroup49,
+new Uint32Array(4063),
+2154,
+0
+);
+} catch {}
+try {
+renderBundleEncoder93.setVertexBuffer(
+10,
+buffer37,
+22412,
+532
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext20 = canvas26.getContext('webgpu');
+try {
+await promise50;
+} catch {}
+video2.width = 200;
+let img26 = await imageWithData(272, 7, '#359afe1d', '#99bcf2f5');
+document.body.append('\u0bf5\u52e8\u010f\u3121\u80ef\u0bab\u848f\uf170\u8858');
+let promise52 = adapter8.requestAdapterInfo();
+let img27 = await imageWithData(46, 300, '#698c31ac', '#1fcafa9d');
+let textureView106 = texture93.createView(
+{
+label: '\u0132\u0a61',
+format: 'astc-5x5-unorm',
+baseMipLevel: 12,
+baseArrayLayer: 113,
+arrayLayerCount: 18,
+}
+);
+try {
+renderBundleEncoder87.setBindGroup(
+4,
+bindGroup53
+);
+} catch {}
+try {
+gpuCanvasContext15.configure(
+{
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'stencil8',
+'rgba8unorm',
+'rgba8unorm-srgb'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let pipeline97 = await device1.createRenderPipelineAsync(
+{
+label: '\u0d87\u03ee\u{1fde4}\u{1fa36}\u{1f6c4}\u{1fd61}\u0b4a\u4ec1\ue566\u0734',
+layout: pipelineLayout16,
+vertex: {
+module: shaderModule25,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 6460,
+attributes: [
+
+],
+},
+{
+arrayStride: 9364,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 3284,
+shaderLocation: 0,
+},
+{
+format: 'unorm16x4',
+offset: 3864,
+shaderLocation: 16,
+},
+{
+format: 'unorm8x2',
+offset: 7352,
+shaderLocation: 18,
+},
+{
+format: 'uint32x2',
+offset: 8520,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 2108,
+attributes: [
+{
+format: 'sint8x2',
+offset: 222,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 20156,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32',
+offset: 17576,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule25,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'zero',
+depthFailOp: 'invert',
+passOp: 'zero',
+},
+stencilReadMask: 3799,
+stencilWriteMask: 4050,
+depthBias: 37,
+depthBiasClamp: 95,
+},
+}
+);
+let texture112 = device3.createTexture(
+{
+label: '\uc713\u8799\u{1f6d8}\u{1fc29}\u{1f67c}\u86f3\u6204\u011e\u2559\u2ea1',
+size: {width: 1412, height: 80, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8unorm',
+'rg8unorm',
+'rg8unorm'
+],
+}
+);
+let textureView107 = texture112.createView(
+{
+label: '\u5972\u58ff\u00e4\u{1ff7d}\u0cf1\u5bf8\u4f8b\u{1ffd7}\u73b4',
+baseMipLevel: 1,
+}
+);
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer41 = device2.createBuffer(
+{
+label: '\u5e9d\uf95e\u0885\u7369',
+size: 3007,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let commandEncoder97 = device2.createCommandEncoder(
+{
+label: '\u0cfb\u2a4c\u748a\u24bc\u6d87\u0022\u0a10\u{1f7fd}\u8007',
+}
+);
+let renderBundleEncoder106 = device2.createRenderBundleEncoder(
+{
+label: '\u4979\u0588\uebe1',
+colorFormats: [
+'rgba8uint',
+'rgba8unorm-srgb',
+'r32uint',
+'rgba16uint',
+'r8uint',
+'rgba32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 415,
+}
+);
+let renderBundle89 = renderBundleEncoder102.finish();
+try {
+buffer41.unmap();
+} catch {}
+try {
+commandEncoder97.copyTextureToTexture(
+{
+  texture: texture110,
+  mipLevel: 4,
+  origin: { x: 0, y: 4, z: 26 },
+  aspect: 'all',
+},
+{
+  texture: texture110,
+  mipLevel: 3,
+  origin: { x: 36, y: 20, z: 17 },
+  aspect: 'depth-only',
+},
+{width: 725, height: 1, depthOrArrayLayers: 48}
+);
+} catch {}
+document.body.prepend(img0);
+document.body.append('\u{1fcaa}\u1e8e\u{1fa6e}\u{1fdf6}\u04af\u0323\u02fd\u{1f841}');
+let commandEncoder98 = device0.createCommandEncoder(
+{
+label: '\uf181\u0457\u{1fe60}\u0333\u56c7\ua7b0\u31e0\u{1f9f9}\u1861\udada\u0034',
+}
+);
+let computePassEncoder52 = commandEncoder98.beginComputePass(
+{
+label: '\u6922\ufefc\u8cdf\u5009\u05c1\u0b1a\u0b71\u1e51\u3607'
+}
+);
+let renderBundleEncoder107 = device0.createRenderBundleEncoder(
+{
+label: '\u03e5\u{1f649}\u006c\u7103\u{1ff34}\ua90a',
+colorFormats: [
+'rg32uint',
+'rgb10a2uint',
+'rgba16float',
+'rg16uint',
+'rgba8sint',
+undefined,
+'rg32float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 767,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle90 = renderBundleEncoder66.finish();
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder27.setViewport(
+2877.5,
+0.4258,
+37.49,
+0.01496,
+0.9138,
+0.9316
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture9,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(224),
+/* required buffer size: 224 */{
+offset: 224,
+bytesPerRow: 101,
+rowsPerImage: 262,
+},
+{width: 5, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\u0e58\u2a1e\ud69d\u03c3\ub37e');
+let canvas27 = document.createElement('canvas');
+let promise53 = adapter3.requestAdapterInfo();
+try {
+canvas27.getContext('2d');
+} catch {}
+let texture113 = device2.createTexture(
+{
+size: {width: 45, height: 2, depthOrArrayLayers: 118},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgba32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundleEncoder108 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba32float',
+'r8unorm',
+'rg32sint',
+'r8uint',
+'bgra8unorm-srgb',
+undefined,
+'rgba8unorm-srgb',
+'rg8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 341,
+depthReadOnly: true,
+}
+);
+try {
+commandEncoder97.copyTextureToTexture(
+{
+  texture: texture110,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 20 },
+  aspect: 'all',
+},
+{
+  texture: texture110,
+  mipLevel: 3,
+  origin: { x: 673, y: 2, z: 60 },
+  aspect: 'all',
+},
+{width: 725, height: 12, depthOrArrayLayers: 11}
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth24plus-stencil8',
+'r8unorm',
+'rgba8unorm'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+document.body.prepend('\u0591\u94df\uf615\u{1fdae}');
+canvas5.height = 567;
+let offscreenCanvas23 = new OffscreenCanvas(752, 352);
+let imageData25 = new ImageData(180, 148);
+let querySet88 = device3.createQuerySet(
+{
+label: '\u1264\u592d\u01c9\u0649\u2832\uf498\ub317',
+type: 'occlusion',
+count: 3079,
+}
+);
+let sampler111 = device3.createSampler(
+{
+label: '\u3d89\uc97f\u{1fd53}\u{1f8d7}\u1517\u091e\u73df\u0483\u4cad\ub4b8',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 14.625,
+lodMaxClamp: 61.609,
+maxAnisotropy: 16,
+}
+);
+try {
+renderBundle46.label = '\u{1f605}\u08b7\u0599\u7657\u6e90\u9681\u0522\ud114';
+} catch {}
+video2.height = 61;
+document.body.prepend('\u{1f60d}\u{1f7f9}');
+let textureView108 = texture86.createView(
+{
+label: '\u9394\u46d3\u3f4c\u042a\udc06\u53a2\u43a7\u990a\u{1fec8}',
+dimension: '2d',
+baseMipLevel: 3,
+baseArrayLayer: 36,
+}
+);
+let renderBundle91 = renderBundleEncoder105.finish();
+try {
+renderBundleEncoder75.setBindGroup(
+0,
+bindGroup51
+);
+} catch {}
+try {
+renderBundleEncoder97.setBindGroup(
+4,
+bindGroup48,
+new Uint32Array(9865),
+4132,
+0
+);
+} catch {}
+try {
+renderBundleEncoder95.setVertexBuffer(
+2,
+buffer37,
+17204,
+5783
+);
+} catch {}
+offscreenCanvas14.height = 839;
+document.body.append('\ucca0\u92d9\ub0f6\u{1fdb0}\u3ff6\u0ece\u75d8\u498f\u{1fd7f}');
+let imageData26 = new ImageData(220, 256);
+let commandEncoder99 = device2.createCommandEncoder(
+{
+label: '\uc984\u0f33\u059f\u0b77\u{1fb6a}\u01d1\ufa4c\u{1f942}\u0d30',
+}
+);
+let texture114 = device2.createTexture(
+{
+label: '\u4b2f\u{1fbe2}\ud648\u0137\u7bbe\ua549\u{1ffe3}\u843a',
+size: [24, 13, 1],
+mipLevelCount: 2,
+format: 'rgba8sint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8sint',
+'rgba8sint',
+'rgba8sint'
+],
+}
+);
+let renderBundleEncoder109 = device2.createRenderBundleEncoder(
+{
+label: '\u{1fc00}\ufae2',
+colorFormats: [
+'r8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 916,
+depthReadOnly: true,
+stencilReadOnly: false,
+}
+);
+let renderBundle92 = renderBundleEncoder104.finish();
+let video27 = await videoWithData();
+let renderBundleEncoder110 = device2.createRenderBundleEncoder(
+{
+label: '\uf9e0\u{1f843}\u0e0a',
+colorFormats: [
+'rgba16float',
+'rgba16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 240,
+stencilReadOnly: false,
+}
+);
+let sampler112 = device2.createSampler(
+{
+label: '\u{1f7c9}\uc0bc\u06b8\u{1fe5a}\u0eb1\ubb27\u{1f7ce}\u08a8\u{1f70d}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 55.600,
+lodMaxClamp: 58.202,
+}
+);
+try {
+commandEncoder99.copyTextureToTexture(
+{
+  texture: texture110,
+  mipLevel: 0,
+  origin: { x: 4325, y: 52, z: 75 },
+  aspect: 'all',
+},
+{
+  texture: texture110,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 84 },
+  aspect: 'all',
+},
+{width: 5805, height: 100, depthOrArrayLayers: 0}
+);
+} catch {}
+let videoFrame27 = new VideoFrame(imageBitmap16, {timestamp: 0});
+document.body.append('\u14fa\u{1fa3b}\u{1ff09}\u{1f8c1}\u{1fefc}\u{1fad6}\u{1f812}\u31e8\u{1f7ec}');
+try {
+querySet88.label = '\u{1f8da}\u{1f7c7}\u5ca0\u2fef\u6737';
+} catch {}
+let renderBundleEncoder111 = device3.createRenderBundleEncoder(
+{
+label: '\u{1f60a}\u0fc2\u043d\u0c01\u04fc\u062c\ueb17\u{1fc9d}\u0b5a\u096f\u0f10',
+colorFormats: [
+'r16float',
+'r16float',
+'rg8uint',
+'rgba8sint'
+],
+sampleCount: 418,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler113 = device3.createSampler(
+{
+label: '\u1e2e\uf67b\u08be\u90c4\u2325\u9abe\uafb1',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 72.843,
+lodMaxClamp: 98.422,
+maxAnisotropy: 14,
+}
+);
+let promise54 = device3.queue.onSubmittedWorkDone();
+let img28 = await imageWithData(187, 138, '#d3b43aa9', '#6f46bcd3');
+let textureView109 = texture110.createView(
+{
+label: '\u{1fb0f}\ud19c\ucc5b\u965d\ub986\ub70d\u{1f7e7}\uf927',
+dimension: '2d',
+aspect: 'depth-only',
+baseMipLevel: 5,
+mipLevelCount: 1,
+baseArrayLayer: 40,
+arrayLayerCount: 1,
+}
+);
+try {
+commandEncoder99.copyTextureToTexture(
+{
+  texture: texture110,
+  mipLevel: 6,
+  origin: { x: 0, y: 3, z: 14 },
+  aspect: 'depth-only',
+},
+{
+  texture: texture110,
+  mipLevel: 3,
+  origin: { x: 813, y: 2, z: 2 },
+  aspect: 'all',
+},
+{width: 181, height: 0, depthOrArrayLayers: 126}
+);
+} catch {}
+try {
+await promise53;
+} catch {}
+let canvas28 = document.createElement('canvas');
+try {
+adapter7.label = '\u6abd\u0ae7\u{1f946}\u93d1\u9879\u{1fba9}\u03a8\u769e\ua50c\u{1fd68}';
+} catch {}
+try {
+offscreenCanvas23.getContext('bitmaprenderer');
+} catch {}
+let renderBundleEncoder112 = device1.createRenderBundleEncoder(
+{
+label: '\u3c34\u{1fefe}\uca33\u3bde\u0515\ub329\u42bc\ucea5',
+colorFormats: [
+'bgra8unorm',
+'rgba8sint',
+'r16float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 354,
+depthReadOnly: false,
+}
+);
+let renderBundle93 = renderBundleEncoder101.finish(
+{
+label: '\u4f23\u0b17\u{1f66d}\u1c09\u09aa'
+}
+);
+try {
+renderBundleEncoder93.setVertexBuffer(
+74,
+undefined
+);
+} catch {}
+gc();
+let bindGroupLayout44 = device2.createBindGroupLayout(
+{
+label: '\u08eb\u049f\u5df8\u074b\u0028\u0022\u0550\u0ec3\u312e\uff49\u5db2',
+entries: [
+{
+binding: 3430,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+},
+{
+binding: 5749,
+visibility: 0,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+let commandEncoder100 = device2.createCommandEncoder(
+{
+}
+);
+let renderBundleEncoder113 = device2.createRenderBundleEncoder(
+{
+label: '\u112f\ub6db\uca67\uc994\u6b24\u045a\u0d77\u0d52\u793d\uf446\u{1fe9c}',
+colorFormats: [
+'rg8unorm',
+undefined,
+'r16sint',
+undefined,
+'rgba32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 552,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+commandEncoder99.copyTextureToTexture(
+{
+  texture: texture110,
+  mipLevel: 3,
+  origin: { x: 0, y: 5, z: 71 },
+  aspect: 'all',
+},
+{
+  texture: texture110,
+  mipLevel: 3,
+  origin: { x: 0, y: 10, z: 0 },
+  aspect: 'all',
+},
+{width: 1451, height: 1, depthOrArrayLayers: 23}
+);
+} catch {}
+try {
+await promise54;
+} catch {}
+try {
+canvas28.getContext('webgpu');
+} catch {}
+let buffer42 = device3.createBuffer(
+{
+label: '\u0364\u{1fae2}\u04f4\ub287\u8cc6\u7c19\u59ef\u2157\uec04\u{1fe98}\uffb3',
+size: 11499,
+usage: GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+}
+);
+try {
+renderBundleEncoder111.setVertexBuffer(
+6,
+buffer42,
+9676,
+735
+);
+} catch {}
+let video28 = await videoWithData();
+try {
+adapter0.label = '\u0874\ud890\u079d\u2bb6\u01c2\u3737\u0391\ubc66\u9003';
+} catch {}
+let bindGroupLayout45 = device1.createBindGroupLayout(
+{
+label: '\u{1fb3d}\u0d6f\ua170\u026c',
+entries: [
+{
+binding: 6167,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 2752,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+},
+{
+binding: 4272,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '1d' },
+}
+],
+}
+);
+let commandEncoder101 = device1.createCommandEncoder(
+{
+label: '\u0f8d\u0230\u{1f700}\u7802\u0be5\u5870\u0da6\u{1f61a}\u7c59',
+}
+);
+let computePassEncoder53 = commandEncoder101.beginComputePass(
+{
+label: '\u332c\u{1fdac}\u2b63\u0bca\u07d6\u06a2\u{1fd8c}\u{1fb05}'
+}
+);
+let renderBundleEncoder114 = device1.createRenderBundleEncoder(
+{
+label: '\ub22f\u0015\ua4f3\u0f5c\u67d3\u0478\uade5\u0fdc',
+colorFormats: [
+undefined,
+'rgba8unorm',
+'r32sint'
+],
+sampleCount: 274,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler114 = device1.createSampler(
+{
+label: '\u0959\u0ad3\u9585\ue09e\uce7e\uc765\u31c7\u{1fcf2}\u09bb',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 20.380,
+lodMaxClamp: 99.938,
+}
+);
+try {
+renderBundleEncoder95.setBindGroup(
+3,
+bindGroup54,
+[]
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer40,
+18376,
+new DataView(new ArrayBuffer(55185)),
+1882,
+1872
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture97,
+  mipLevel: 2,
+  origin: { x: 157, y: 0, z: 2 },
+  aspect: 'all',
+},
+new Int16Array(arrayBuffer1),
+/* required buffer size: 1218410 */{
+offset: 206,
+bytesPerRow: 2223,
+rowsPerImage: 137,
+},
+{width: 124, height: 0, depthOrArrayLayers: 5}
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let promise55 = device1.createRenderPipelineAsync(
+{
+label: '\ub691\uc7bd\u{1f9ab}\u{1fcc7}\uf965',
+layout: pipelineLayout16,
+vertex: {
+module: shaderModule30,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 10692,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x4',
+offset: 8684,
+shaderLocation: 16,
+},
+{
+format: 'sint32',
+offset: 84,
+shaderLocation: 12,
+},
+{
+format: 'float32x4',
+offset: 10464,
+shaderLocation: 8,
+},
+{
+format: 'uint16x4',
+offset: 7800,
+shaderLocation: 5,
+},
+{
+format: 'float32x3',
+offset: 7296,
+shaderLocation: 6,
+},
+{
+format: 'snorm8x2',
+offset: 9116,
+shaderLocation: 7,
+},
+{
+format: 'unorm16x4',
+offset: 4572,
+shaderLocation: 14,
+},
+{
+format: 'float32',
+offset: 8488,
+shaderLocation: 3,
+},
+{
+format: 'unorm16x2',
+offset: 4688,
+shaderLocation: 18,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 5692,
+shaderLocation: 17,
+},
+{
+format: 'uint16x2',
+offset: 4956,
+shaderLocation: 11,
+},
+{
+format: 'float32',
+offset: 7100,
+shaderLocation: 1,
+},
+{
+format: 'snorm16x2',
+offset: 3316,
+shaderLocation: 19,
+},
+{
+format: 'float32x2',
+offset: 636,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 5680,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 6564,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 1772,
+shaderLocation: 9,
+},
+{
+format: 'unorm8x4',
+offset: 2288,
+shaderLocation: 0,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 1056,
+shaderLocation: 10,
+},
+{
+format: 'sint32x2',
+offset: 3808,
+shaderLocation: 13,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule30,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8sint',
+writeMask: 0,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'equal',
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'invert',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 2501,
+depthBiasClamp: 3,
+},
+}
+);
+document.body.prepend(video28);
+let texture115 = device2.createTexture(
+{
+label: '\u{1faaf}\uc915\u{1fea5}\u0ae7\ue86b\u05c7\ub274\u054f\u0377\u084e',
+size: [4295, 38, 1],
+mipLevelCount: 7,
+format: 'rg32float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32float',
+'rg32float'
+],
+}
+);
+document.body.prepend('\ucc85\u{1f81c}\u88b5\u{1f729}\ucae1\u{1f7c7}\u8337\u4580\u6552');
+try {
+renderBundleEncoder111.setIndexBuffer(
+buffer42,
+'uint16',
+7450,
+3237
+);
+} catch {}
+try {
+renderBundleEncoder111.setVertexBuffer(
+7,
+buffer42,
+2644,
+5184
+);
+} catch {}
+try {
+gpuCanvasContext20.configure(
+{
+device: device3,
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+document.body.prepend('\udb34\u5fb7\u142e\u{1f89c}\u{1fe4a}\u{1fa59}\u9aa3\u0d2d\uab2a\u0cbc');
+let videoFrame28 = new VideoFrame(canvas23, {timestamp: 0});
+let commandEncoder102 = device1.createCommandEncoder(
+{
+label: '\u0401\u05fa\u04ed',
+}
+);
+let querySet89 = device1.createQuerySet(
+{
+label: '\u{1f71c}\u5b7e\u{1fc94}\u1b10\u0b7a',
+type: 'occlusion',
+count: 3338,
+}
+);
+pseudoSubmit(device1, commandEncoder93);
+let textureView110 = texture100.createView(
+{
+label: '\u0e62\u59f2\u043f\u0c16\ucb45\u24eb\u07f1',
+dimension: '2d-array',
+baseMipLevel: 1,
+mipLevelCount: 1,
+}
+);
+let renderBundleEncoder115 = device1.createRenderBundleEncoder(
+{
+label: '\u08f6\u5c88\u{1f8b9}\u{1f82e}\u8d9f\u{1fcf7}\u0581\u{1fa90}\u2190',
+colorFormats: [
+'r32uint',
+'rg16float',
+'rgba8sint',
+'rg11b10ufloat',
+'rg8uint',
+'rg8sint',
+'rg8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 624,
+}
+);
+try {
+computePassEncoder48.setPipeline(
+pipeline67
+);
+} catch {}
+try {
+commandEncoder102.copyTextureToBuffer(
+{
+  texture: texture109,
+  mipLevel: 1,
+  origin: { x: 37, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 268 widthInBlocks: 67 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 31612 */
+offset: 31344,
+buffer: buffer40,
+},
+{width: 67, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device1, buffer40);
+} catch {}
+let pipeline98 = device1.createComputePipeline(
+{
+layout: pipelineLayout15,
+compute: {
+module: shaderModule25,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+canvas11.height = 446;
+let pipelineLayout17 = device2.createPipelineLayout(
+{
+label: '\u9d2f\ud93b\u15bb',
+bindGroupLayouts: [
+bindGroupLayout44,
+bindGroupLayout44,
+bindGroupLayout44
+],
+}
+);
+let commandEncoder103 = device2.createCommandEncoder(
+{
+label: '\u0aa2\u05c9\ue58f\uaa2f\u05d3\u{1f7f7}',
+}
+);
+let computePassEncoder54 = commandEncoder99.beginComputePass(
+{
+label: '\ub5fe\uf744'
+}
+);
+let offscreenCanvas24 = new OffscreenCanvas(457, 1019);
+let pipelineLayout18 = device1.createPipelineLayout(
+{
+label: '\u{1fd47}\u0603\u9ca8\u0c36\u0ad8\u2683\u27fd\u68cd\u487d\uc399\u84b3',
+bindGroupLayouts: [
+
+],
+}
+);
+let texture116 = device1.createTexture(
+{
+label: '\u65db\u88b9\u{1fcea}\u080f\u{1fb8a}\u7f0a',
+size: {width: 224, height: 85, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+sampleCount: 1,
+format: 'astc-8x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-8x5-unorm'
+],
+}
+);
+gc();
+document.body.append('\u9cf5\u33cf\u{1f7cb}\u{1f8ce}\ue6e6\u645c\u0969\u{1feee}');
+let offscreenCanvas25 = new OffscreenCanvas(427, 606);
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+await promise52;
+} catch {}
+gc();
+let offscreenCanvas26 = new OffscreenCanvas(219, 676);
+try {
+offscreenCanvas24.getContext('webgl');
+} catch {}
+let buffer43 = device1.createBuffer(
+{
+label: '\u0b83\u1405\u0225\u4d7e',
+size: 25486,
+usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+}
+);
+let textureView111 = texture107.createView(
+{
+label: '\u0402\u56d6\u{1f75d}\u492d\u902f\u88b4\uaee3\ufdb8\u{1ff83}\u6e37',
+format: 'rgba8unorm-srgb',
+baseMipLevel: 0,
+mipLevelCount: 2,
+}
+);
+let computePassEncoder55 = commandEncoder102.beginComputePass(
+{
+label: '\u02d9\u937d\u0d6a'
+}
+);
+let renderBundleEncoder116 = device1.createRenderBundleEncoder(
+{
+label: '\u{1fcbc}\u0c24\u4701\u0919\u6b1f\u{1fb88}\u7529\u3c53\u9740',
+colorFormats: [
+'rgba16uint',
+'rgb10a2unorm',
+'r8uint',
+'rgb10a2unorm'
+],
+sampleCount: 869,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle94 = renderBundleEncoder92.finish(
+{
+label: '\u1266\u3328\u0a9a'
+}
+);
+try {
+computePassEncoder55.setPipeline(
+pipeline83
+);
+} catch {}
+try {
+renderBundleEncoder94.setVertexBuffer(
+5,
+buffer32,
+7056,
+3251
+);
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+document.body.prepend(canvas27);
+video4.width = 276;
+let renderBundleEncoder117 = device1.createRenderBundleEncoder(
+{
+label: '\u{1f98f}\u0242',
+colorFormats: [
+'r16float',
+'rgba8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 182,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let externalTexture4 = device1.importExternalTexture(
+{
+label: '\u{1f75d}\u20f2\u0e9b\ue575\u537f\u274f\u{1f8bb}\u25d8\u{1fb9b}',
+source: videoFrame20,
+colorSpace: 'srgb',
+}
+);
+try {
+renderBundleEncoder87.setBindGroup(
+3,
+bindGroup51
+);
+} catch {}
+try {
+await promise48;
+} catch {}
+document.body.prepend('\u054c\u{1fa8a}\u0f27\u028c\u0b72');
+let offscreenCanvas27 = new OffscreenCanvas(341, 279);
+let pipelineLayout19 = device2.createPipelineLayout(
+{
+label: '\u949b\uca64\u{1f956}\u345a\u89c0\ub618',
+bindGroupLayouts: [
+bindGroupLayout44,
+bindGroupLayout44,
+bindGroupLayout44
+],
+}
+);
+try {
+await buffer39.mapAsync(
+GPUMapMode.READ,
+0,
+4544
+);
+} catch {}
+let canvas29 = document.createElement('canvas');
+let bindGroup55 = device1.createBindGroup({
+label: '\u1013\u{1f60b}\u4963\u0756\u0cba\uc9d6\u05b5',
+layout: bindGroupLayout39,
+entries: [
+{
+binding: 3968,
+resource: externalTexture3
+},
+{
+binding: 4906,
+resource: sampler104
+}
+],
+});
+let querySet90 = device1.createQuerySet(
+{
+label: '\u63ed\u{1f787}\u0c69\uccc9\uf027\u7d25\u08d9\u06c2\ud903',
+type: 'occlusion',
+count: 2365,
+}
+);
+let texture117 = device1.createTexture(
+{
+label: '\u0ccd\u0639\ue830\u{1feb3}\u9f3d',
+size: [1907, 1, 1],
+mipLevelCount: 9,
+dimension: '2d',
+format: 'rgba8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+computePassEncoder47.setBindGroup(
+0,
+bindGroup37,
+new Uint32Array(1800),
+230,
+0
+);
+} catch {}
+document.body.prepend('\u7509\u{1fa7b}\ua3aa\uef07\u9edd\u{1fbbb}\u0477\u0774\u066a\u8693');
+let canvas30 = document.createElement('canvas');
+let querySet91 = device1.createQuerySet(
+{
+label: '\uef56\ud318\u0fff\ua5da\uce39\u9d8c\u016a\u{1f83c}\u{1fa78}',
+type: 'occlusion',
+count: 1477,
+}
+);
+let textureView112 = texture117.createView(
+{
+label: '\u05db\u{1ff54}\u061e\u1388\u4b60\u0c30\u011f',
+dimension: '2d-array',
+mipLevelCount: 5,
+}
+);
+let renderBundleEncoder118 = device1.createRenderBundleEncoder(
+{
+label: '\u833b\ud10c\u6b57',
+colorFormats: [
+'rgba8unorm',
+'rg8uint',
+'rg11b10ufloat'
+],
+sampleCount: 652,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder53.setBindGroup(
+1,
+bindGroup38
+);
+} catch {}
+try {
+renderBundleEncoder117.setIndexBuffer(
+buffer40,
+'uint32',
+15156,
+843
+);
+} catch {}
+try {
+renderBundleEncoder112.setVertexBuffer(
+8,
+buffer32,
+16828,
+586
+);
+} catch {}
+let pipeline99 = await promise46;
+offscreenCanvas27.width = 921;
+let bindGroupLayout46 = device1.createBindGroupLayout(
+{
+label: '\u{1fb45}\u851e',
+entries: [
+{
+binding: 1569,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'filtering' },
+},
+{
+binding: 975,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+},
+{
+binding: 6891,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+let pipelineLayout20 = device1.createPipelineLayout(
+{
+label: '\u0b97\u63c3\u07e4\u{1feb6}\uba0b\u61db\u0c56',
+bindGroupLayouts: [
+bindGroupLayout37,
+bindGroupLayout45,
+bindGroupLayout46,
+bindGroupLayout36,
+bindGroupLayout39
+],
+}
+);
+let commandEncoder104 = device1.createCommandEncoder(
+{
+}
+);
+let renderBundle95 = renderBundleEncoder74.finish(
+{
+label: '\uc1a8\ub22c\u595f\u4968\u0a70'
+}
+);
+try {
+computePassEncoder55.setPipeline(
+pipeline67
+);
+} catch {}
+try {
+renderBundleEncoder118.setBindGroup(
+2,
+bindGroup45
+);
+} catch {}
+let computePassEncoder56 = commandEncoder104.beginComputePass(
+{
+label: '\u869b\u{1f987}\u67d1\u{1ff5d}'
+}
+);
+try {
+renderBundleEncoder116.setBindGroup(
+0,
+bindGroup45,
+new Uint32Array(9772),
+9326,
+0
+);
+} catch {}
+try {
+buffer35.unmap();
+} catch {}
+try {
+gpuCanvasContext20.configure(
+{
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x10-unorm-srgb',
+'r8sint',
+'rgba16float'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let pipeline100 = await device1.createRenderPipelineAsync(
+{
+layout: pipelineLayout15,
+vertex: {
+module: shaderModule34,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 3124,
+attributes: [
+
+],
+},
+{
+arrayStride: 12264,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 8244,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 5572,
+shaderLocation: 14,
+},
+{
+format: 'sint32x4',
+offset: 4300,
+shaderLocation: 8,
+},
+{
+format: 'float16x4',
+offset: 5508,
+shaderLocation: 17,
+},
+{
+format: 'sint32',
+offset: 408,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0xd9dee1f6,
+},
+fragment: {
+module: shaderModule34,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2365,
+depthBias: 20,
+depthBiasSlopeScale: 3,
+depthBiasClamp: 82,
+},
+}
+);
+let gpuCanvasContext21 = offscreenCanvas27.getContext('webgpu');
+gc();
+let bindGroupLayout47 = device1.createBindGroupLayout(
+{
+label: '\u9d41\u194d\ucbe2\u44ad\u0c98\uf167\u0a89',
+entries: [
+{
+binding: 4846,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '2d-array' },
+}
+],
+}
+);
+let buffer44 = device1.createBuffer(
+{
+label: '\uebda\u{1f898}\u0dd5\u1423\u{1f617}\u0b4e\u01b4',
+size: 18404,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+try {
+renderBundleEncoder117.setBindGroup(
+0,
+bindGroup55,
+new Uint32Array(2250),
+529,
+0
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture95,
+  mipLevel: 0,
+  origin: { x: 577, y: 0, z: 20 },
+  aspect: 'all',
+},
+arrayBuffer15,
+/* required buffer size: 18520331 */{
+offset: 251,
+bytesPerRow: 8699,
+rowsPerImage: 76,
+},
+{width: 1076, height: 1, depthOrArrayLayers: 29}
+);
+} catch {}
+let videoFrame29 = new VideoFrame(video1, {timestamp: 0});
+try {
+offscreenCanvas26.getContext('bitmaprenderer');
+} catch {}
+let shaderModule35 = device1.createShaderModule(
+{
+label: '\u1261\u{1fa41}',
+code: `
+
+@compute @workgroup_size(4, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(7) f0: vec3<f32>,
+@location(6) f1: vec2<i32>,
+@location(1) f2: vec2<u32>,
+@location(0) f3: u32,
+@location(2) f4: vec2<u32>,
+@location(4) f5: f32
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_mask) a1: u32, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(10) a1: vec3<f32>, @location(7) a2: f32, @location(15) a3: vec4<f16>, @location(12) a4: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture118 = device1.createTexture(
+{
+label: '\u03fd\uc610\u{1fac7}\uf9bb\u39f1\u0f1e',
+size: [256, 96, 26],
+format: 'astc-8x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-8x6-unorm-srgb',
+'astc-8x6-unorm'
+],
+}
+);
+let textureView113 = texture107.createView(
+{
+label: '\ufb3f\ucd48\u{1ff46}',
+format: 'rgba8unorm',
+baseMipLevel: 3,
+}
+);
+let sampler115 = device1.createSampler(
+{
+label: '\ufefb\u09e9\u072d\u3d6f\uad1d\u{1fd04}\u6dba\u831e\u{1f809}\uea36\u87d0',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 45.767,
+lodMaxClamp: 59.900,
+}
+);
+let video29 = await videoWithData();
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.prepend(video10);
+let img29 = await imageWithData(50, 216, '#6d9ee176', '#df65f68a');
+let buffer45 = device1.createBuffer(
+{
+label: '\uc95d\u0260\u5467\ubcca\u0e49',
+size: 60717,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+}
+);
+let querySet92 = device1.createQuerySet(
+{
+type: 'occlusion',
+count: 1578,
+}
+);
+let texture119 = device1.createTexture(
+{
+size: {width: 28, height: 27, depthOrArrayLayers: 23},
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rg32sint',
+'rg32sint'
+],
+}
+);
+try {
+computePassEncoder48.setPipeline(
+pipeline82
+);
+} catch {}
+try {
+renderBundleEncoder97.setVertexBuffer(
+4,
+buffer43,
+6048,
+10907
+);
+} catch {}
+try {
+gpuCanvasContext14.configure(
+{
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+document.body.append('\u{1fbca}\u61a5\u04ea\u46e9\u{1fbcc}\u356a\u2f5c');
+try {
+gpuCanvasContext5.configure(
+{
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8snorm'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+document.body.prepend(img7);
+let imageData27 = new ImageData(156, 44);
+let renderBundleEncoder119 = device1.createRenderBundleEncoder(
+{
+label: '\u4148\u7040\u85bb\u44ab\u2b98\u0c13',
+colorFormats: [
+'rgb10a2unorm',
+'rg32float',
+'r32sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 801,
+depthReadOnly: true,
+}
+);
+let sampler116 = device1.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 82.839,
+lodMaxClamp: 92.460,
+maxAnisotropy: 1,
+}
+);
+try {
+renderBundleEncoder95.setBindGroup(
+0,
+bindGroup48
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture93,
+  mipLevel: 9,
+  origin: { x: 0, y: 0, z: 13 },
+  aspect: 'all',
+},
+new Int16Array(arrayBuffer4),
+/* required buffer size: 345182 */{
+offset: 116,
+bytesPerRow: 199,
+rowsPerImage: 34,
+},
+{width: 20, height: 0, depthOrArrayLayers: 52}
+);
+} catch {}
+let pipeline101 = await device1.createComputePipelineAsync(
+{
+label: '\uc158\ucab4\u01e4\u057f\ue392\u{1fa6b}\ud107\u3a0c\ud48c',
+layout: 'auto',
+compute: {
+module: shaderModule27,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let renderBundle96 = renderBundleEncoder111.finish(
+{
+label: '\u3c53\u332e\uaa13\u08f2\u0746\ucd01\u0d61\u4631\uf9b0\u0125\u05e4'
+}
+);
+let gpuCanvasContext22 = canvas30.getContext('webgpu');
+let canvas31 = document.createElement('canvas');
+try {
+canvas29.getContext('webgl');
+} catch {}
+let sampler117 = device1.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 58.658,
+lodMaxClamp: 70.458,
+maxAnisotropy: 18,
+}
+);
+try {
+renderBundleEncoder115.setBindGroup(
+0,
+bindGroup54,
+new Uint32Array(3380),
+1705,
+0
+);
+} catch {}
+try {
+renderBundleEncoder116.setIndexBuffer(
+buffer34,
+'uint32',
+23348,
+2508
+);
+} catch {}
+try {
+computePassEncoder37.insertDebugMarker(
+'\u686f'
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture93,
+  mipLevel: 12,
+  origin: { x: 0, y: 0, z: 33 },
+  aspect: 'all',
+},
+new BigUint64Array(arrayBuffer21),
+/* required buffer size: 15115098 */{
+offset: 273,
+bytesPerRow: 279,
+rowsPerImage: 275,
+},
+{width: 0, height: 0, depthOrArrayLayers: 198}
+);
+} catch {}
+let pipeline102 = device1.createRenderPipeline(
+{
+layout: pipelineLayout20,
+vertex: {
+module: shaderModule27,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 19148,
+attributes: [
+
+],
+},
+{
+arrayStride: 12936,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x3',
+offset: 3312,
+shaderLocation: 17,
+},
+{
+format: 'sint32',
+offset: 8476,
+shaderLocation: 9,
+},
+{
+format: 'uint8x2',
+offset: 7122,
+shaderLocation: 15,
+},
+{
+format: 'uint16x4',
+offset: 8576,
+shaderLocation: 5,
+},
+{
+format: 'sint32x2',
+offset: 3164,
+shaderLocation: 3,
+},
+{
+format: 'uint16x4',
+offset: 6216,
+shaderLocation: 10,
+},
+{
+format: 'uint32x2',
+offset: 5596,
+shaderLocation: 18,
+},
+{
+format: 'snorm8x4',
+offset: 11776,
+shaderLocation: 1,
+},
+{
+format: 'sint8x4',
+offset: 5228,
+shaderLocation: 8,
+},
+{
+format: 'sint16x4',
+offset: 8080,
+shaderLocation: 13,
+},
+{
+format: 'float32x2',
+offset: 10784,
+shaderLocation: 14,
+},
+{
+format: 'sint32x2',
+offset: 5452,
+shaderLocation: 12,
+},
+{
+format: 'uint32x3',
+offset: 2000,
+shaderLocation: 7,
+},
+{
+format: 'uint8x4',
+offset: 4556,
+shaderLocation: 4,
+},
+{
+format: 'uint8x4',
+offset: 220,
+shaderLocation: 0,
+},
+{
+format: 'sint16x4',
+offset: 12344,
+shaderLocation: 19,
+},
+{
+format: 'sint16x2',
+offset: 8056,
+shaderLocation: 2,
+},
+{
+format: 'float16x2',
+offset: 5256,
+shaderLocation: 11,
+},
+{
+format: 'unorm16x2',
+offset: 3800,
+shaderLocation: 16,
+},
+{
+format: 'sint32x2',
+offset: 424,
+shaderLocation: 6,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule27,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'rgba8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+},
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'zero',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'bgra8unorm-srgb',
+writeMask: GPUColorWrite.ALL,
+},
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'one',
+dstFactor: 'src'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'one-minus-constant',
+dstFactor: 'src-alpha-saturated'
+},
+},
+format: 'rg16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rg8unorm',
+writeMask: 0,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 926,
+stencilWriteMask: 3047,
+depthBias: 66,
+depthBiasClamp: 92,
+},
+}
+);
+let videoFrame30 = new VideoFrame(videoFrame10, {timestamp: 0});
+let querySet93 = device1.createQuerySet(
+{
+label: '\uc7b7\u02a7\u10a8\ufd7d\u052e\u{1fa57}',
+type: 'occlusion',
+count: 3039,
+}
+);
+let texture120 = device1.createTexture(
+{
+size: {width: 920, height: 158, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+buffer35.unmap();
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer32,
+1016,
+new DataView(new ArrayBuffer(6930)),
+6496,
+320
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 25, height: 1, depthOrArrayLayers: 451}
+*/
+{
+  source: offscreenCanvas27,
+  origin: { x: 10, y: 11 },
+  flipY: true,
+},
+{
+  texture: texture107,
+  mipLevel: 0,
+  origin: { x: 12, y: 1, z: 38 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 6, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let promise56 = device1.createComputePipelineAsync(
+{
+layout: pipelineLayout20,
+compute: {
+module: shaderModule32,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let commandEncoder105 = device3.createCommandEncoder(
+{
+label: '\u{1fe1a}\u82e5\u088b',
+}
+);
+try {
+buffer42.unmap();
+} catch {}
+let canvas32 = document.createElement('canvas');
+let shaderModule36 = device2.createShaderModule(
+{
+code: `
+
+@compute @workgroup_size(6, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: vec3<u32>,
+@location(6) f1: vec2<f32>,
+@location(3) f2: vec2<i32>,
+@location(0) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S32 {
+@location(5) f0: vec2<f16>,
+@location(15) f1: vec3<i32>,
+@location(13) f2: vec3<f32>,
+@location(7) f3: vec4<u32>,
+@location(8) f4: f16,
+@location(14) f5: f16,
+@location(3) f6: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec2<f16>, @location(6) a1: vec3<f16>, @location(11) a2: u32, @location(4) a3: vec3<u32>, a4: S32, @location(2) a5: vec3<f32>, @location(12) a6: f16, @location(1) a7: vec4<f32>, @location(10) a8: i32, @location(0) a9: vec3<i32>, @builtin(instance_index) a10: u32, @builtin(vertex_index) a11: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+}
+);
+let querySet94 = device2.createQuerySet(
+{
+label: '\u3c4f\u{1feb9}\ua326\u9a63\u767b\u064e',
+type: 'occlusion',
+count: 2725,
+}
+);
+let textureView114 = texture110.createView(
+{
+label: '\u5b07\ue20a\u12c3\u0a4d\ucdd4',
+baseMipLevel: 0,
+baseArrayLayer: 106,
+arrayLayerCount: 3,
+}
+);
+let renderBundle97 = renderBundleEncoder102.finish(
+{
+
+}
+);
+let pipeline103 = device2.createComputePipeline(
+{
+label: '\ud58b\ue4f0\u01ab\u2c85\u0e03\u6b0d\u0e7d\udbe9',
+layout: pipelineLayout17,
+compute: {
+module: shaderModule36,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let commandEncoder106 = device3.createCommandEncoder(
+{
+label: '\u01ad\u{1f765}\u{1fb1a}\ue0a6\u948b\u1609\u94b7\u0a4f\u3917\u0883\u0f8f',
+}
+);
+let textureView115 = texture112.createView(
+{
+label: '\u17b5\ud108',
+dimension: '2d-array',
+baseMipLevel: 1,
+mipLevelCount: 1,
+}
+);
+let computePassEncoder57 = commandEncoder105.beginComputePass(
+{
+label: '\uf2a8\ub323\ufced\u{1fe5d}\u8028\u134b'
+}
+);
+try {
+canvas31.getContext('webgl2');
+} catch {}
+try {
+window.someLabel = pipeline100.label;
+} catch {}
+let shaderModule37 = device1.createShaderModule(
+{
+label: '\u6837\u{1fcfb}\u0044\ub2b2\u08c3\uf152\u{1fc2e}\uc3a0\u0e4a\u0746\u4810',
+code: `
+
+@compute @workgroup_size(7, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: vec4<u32>,
+@location(2) f1: vec4<u32>,
+@location(1) f2: vec2<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(18) a0: vec2<u32>, @location(9) a1: f32, @location(16) a2: f32, @location(6) a3: vec3<i32>, @location(5) a4: vec3<u32>, @location(12) a5: vec4<u32>, @location(7) a6: vec3<i32>, @location(2) a7: vec4<f16>, @location(14) a8: vec4<u32>, @location(10) a9: vec3<i32>, @builtin(vertex_index) a10: u32, @location(17) a11: i32, @location(3) a12: vec4<i32>, @location(8) a13: vec2<u32>, @builtin(instance_index) a14: u32, @location(19) a15: vec2<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+}
+);
+let texture121 = device1.createTexture(
+{
+label: '\u465b\u{1fb22}\u0557\u0e8a\u{1f87a}\u58e9\u{1fdab}',
+size: {width: 3838},
+dimension: '1d',
+format: 'r8sint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8sint',
+'r8sint',
+'r8sint'
+],
+}
+);
+try {
+buffer32.destroy();
+} catch {}
+try {
+commandEncoder94.copyTextureToTexture(
+{
+  texture: texture110,
+  mipLevel: 3,
+  origin: { x: 0, y: 16, z: 123 },
+  aspect: 'depth-only',
+},
+{
+  texture: texture110,
+  mipLevel: 3,
+  origin: { x: 0, y: 22, z: 61 },
+  aspect: 'all',
+},
+{width: 1451, height: 1, depthOrArrayLayers: 8}
+);
+} catch {}
+document.body.prepend(canvas31);
+document.body.append('\u175c\u0287\uc930\u{1fd90}\u{1fbd6}');
+let computePassEncoder58 = commandEncoder94.beginComputePass(
+{
+label: '\u0bba\u196e\u{1f806}\u{1ff5d}\u0929\u4a61\u5ffa\u{1fcf4}\u00f0\ube3a\u6cc0'
+}
+);
+try {
+computePassEncoder58.setPipeline(
+pipeline103
+);
+} catch {}
+try {
+renderBundleEncoder110.setVertexBuffer(
+64,
+undefined,
+1664805904,
+1165104607
+);
+} catch {}
+try {
+commandEncoder103.copyTextureToTexture(
+{
+  texture: texture110,
+  mipLevel: 2,
+  origin: { x: 411, y: 48, z: 24 },
+  aspect: 'depth-only',
+},
+{
+  texture: texture110,
+  mipLevel: 6,
+  origin: { x: 0, y: 3, z: 31 },
+  aspect: 'all',
+},
+{width: 181, height: 0, depthOrArrayLayers: 93}
+);
+} catch {}
+let pipeline104 = device2.createRenderPipeline(
+{
+layout: pipelineLayout17,
+vertex: {
+module: shaderModule36,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 14136,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 1612,
+shaderLocation: 0,
+},
+{
+format: 'float16x2',
+offset: 6520,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x4',
+offset: 2032,
+shaderLocation: 3,
+},
+{
+format: 'sint32x4',
+offset: 7592,
+shaderLocation: 10,
+},
+{
+format: 'float32',
+offset: 11568,
+shaderLocation: 13,
+},
+{
+format: 'uint32x3',
+offset: 4384,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 23704,
+attributes: [
+{
+format: 'float32x2',
+offset: 23140,
+shaderLocation: 8,
+},
+{
+format: 'uint16x2',
+offset: 20916,
+shaderLocation: 7,
+},
+{
+format: 'float32x4',
+offset: 19292,
+shaderLocation: 14,
+},
+{
+format: 'float16x2',
+offset: 19780,
+shaderLocation: 1,
+},
+{
+format: 'snorm16x4',
+offset: 15580,
+shaderLocation: 6,
+},
+{
+format: 'uint16x4',
+offset: 6556,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 8164,
+attributes: [
+{
+format: 'float32x3',
+offset: 4372,
+shaderLocation: 9,
+},
+{
+format: 'float32x3',
+offset: 7780,
+shaderLocation: 12,
+},
+{
+format: 'sint8x4',
+offset: 2068,
+shaderLocation: 15,
+},
+{
+format: 'float32x2',
+offset: 6312,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: false,
+},
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+module: shaderModule36,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rgba16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.ALPHA,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'invert',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 101,
+stencilWriteMask: 4084,
+depthBias: 38,
+depthBiasSlopeScale: 23,
+depthBiasClamp: 39,
+},
+}
+);
+try {
+canvas32.getContext('bitmaprenderer');
+} catch {}
+let texture122 = device1.createTexture(
+{
+label: '\ub17f\u0b75\u7202\u{1fc3c}\u{1fcf7}\u0dff',
+size: [136, 11, 1],
+mipLevelCount: 8,
+dimension: '2d',
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32uint',
+'r32uint',
+'r32uint'
+],
+}
+);
+let sampler118 = device1.createSampler(
+{
+label: '\ud516\u3778\u{1f86e}\u{1fb77}\ua94b\u{1fcca}\u0934\uf1fa',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 38.008,
+lodMaxClamp: 76.852,
+compare: 'not-equal',
+}
+);
+try {
+device1.queue.writeBuffer(
+buffer40,
+12192,
+new Float32Array(20335),
+6238,
+4652
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture109,
+  mipLevel: 2,
+  origin: { x: 27, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer3,
+/* required buffer size: 278 */{
+offset: 278,
+},
+{width: 15, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline105 = await promise51;
+let gpuCanvasContext23 = offscreenCanvas25.getContext('webgpu');
+let promise57 = navigator.gpu.requestAdapter(
+{
+}
+);
+let img30 = await imageWithData(99, 89, '#74690282', '#45b3079d');
+let computePassEncoder59 = commandEncoder100.beginComputePass(
+{
+label: '\u{1f892}\u0d42\u0085\uf5dd\u07a4\ud3a3\u{1ff13}\u0919\u66ef'
+}
+);
+try {
+computePassEncoder54.setPipeline(
+pipeline103
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture108,
+  mipLevel: 2,
+  origin: { x: 0, y: 5, z: 0 },
+  aspect: 'stencil-only',
+},
+arrayBuffer11,
+/* required buffer size: 119 */{
+offset: 119,
+bytesPerRow: 2704,
+rowsPerImage: 197,
+},
+{width: 2669, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let texture123 = device2.createTexture(
+{
+label: '\u389d\u0114\u0187\ubc64\u1466',
+size: [1685],
+dimension: '1d',
+format: 'rgba32float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32float',
+'rgba32float'
+],
+}
+);
+let textureView116 = texture110.createView(
+{
+baseMipLevel: 3,
+mipLevelCount: 3,
+baseArrayLayer: 40,
+arrayLayerCount: 90,
+}
+);
+let arrayBuffer22 = buffer39.getMappedRange(
+0,
+2440
+);
+try {
+gpuCanvasContext18.configure(
+{
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture108,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'stencil-only',
+},
+new ArrayBuffer(64),
+/* required buffer size: 74 */{
+offset: 74,
+},
+{width: 166, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+let device4 = await adapter6.requestDevice(
+{
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-etc2',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 7,
+maxColorAttachmentBytesPerSample: 36,
+maxVertexAttributes: 24,
+maxVertexBufferArrayStride: 63849,
+maxStorageTexturesPerShaderStage: 12,
+maxStorageBuffersPerShaderStage: 11,
+maxDynamicStorageBuffersPerPipelineLayout: 8073,
+maxBindingsPerBindGroup: 3878,
+maxTextureDimension1D: 12039,
+maxTextureDimension2D: 11335,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 104478873,
+maxInterStageShaderVariables: 75,
+maxInterStageShaderComponents: 116,
+},
+}
+);
+let renderBundle98 = renderBundleEncoder75.finish(
+{
+label: '\ue92f\u4e36\u{1f6c2}\uf296\u347e'
+}
+);
+let sampler119 = device1.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 70.689,
+lodMaxClamp: 99.365,
+maxAnisotropy: 4,
+}
+);
+try {
+gpuCanvasContext15.configure(
+{
+device: device1,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-8x5-unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer45,
+17892,
+new BigUint64Array(17001),
+1614,
+556
+);
+} catch {}
+let offscreenCanvas28 = new OffscreenCanvas(386, 82);
+let commandEncoder107 = device1.createCommandEncoder(
+{
+label: '\u6539\u29a6\u0ab6',
+}
+);
+let texture124 = device1.createTexture(
+{
+label: '\u0e07\u{1f8e2}\u361a\u6801\u{1fb3b}\u{1fcfb}\u505c\u0aa9\u12f9',
+size: [50, 160, 91],
+mipLevelCount: 8,
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-10x10-unorm',
+'astc-10x10-unorm',
+'astc-10x10-unorm'
+],
+}
+);
+let renderBundle99 = renderBundleEncoder112.finish(
+{
+label: '\u1be2\ubf76'
+}
+);
+try {
+computePassEncoder47.setPipeline(
+pipeline89
+);
+} catch {}
+try {
+renderBundleEncoder117.setVertexBuffer(
+5,
+buffer32,
+32860,
+72
+);
+} catch {}
+try {
+commandEncoder107.resolveQuerySet(
+querySet93,
+2255,
+7,
+buffer37,
+11264
+);
+} catch {}
+try {
+renderBundleEncoder97.popDebugGroup();
+} catch {}
+let pipeline106 = device1.createRenderPipeline(
+{
+label: '\ua6d4\u{1ff69}\u0e51\u8871\u18d2',
+layout: pipelineLayout15,
+vertex: {
+module: shaderModule28,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 21496,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 6120,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x2',
+offset: 11268,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x4',
+offset: 8612,
+shaderLocation: 19,
+},
+{
+format: 'uint32x4',
+offset: 2112,
+shaderLocation: 16,
+},
+{
+format: 'float16x4',
+offset: 20600,
+shaderLocation: 13,
+},
+{
+format: 'unorm16x4',
+offset: 1188,
+shaderLocation: 6,
+},
+{
+format: 'uint16x4',
+offset: 13216,
+shaderLocation: 2,
+},
+{
+format: 'sint32x2',
+offset: 1312,
+shaderLocation: 17,
+},
+{
+format: 'sint32x3',
+offset: 19300,
+shaderLocation: 8,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: false,
+},
+fragment: {
+module: shaderModule28,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'one-minus-dst-alpha',
+dstFactor: 'constant'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'one-minus-src-alpha',
+dstFactor: 'src-alpha'
+},
+},
+format: 'r8unorm',
+},
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'rg16float',
+writeMask: 0,
+},
+{
+format: 'r32sint',
+},
+{
+format: 'rgba16uint',
+writeMask: 0,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'never',
+failOp: 'decrement-clamp',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 3732,
+stencilWriteMask: 2555,
+depthBias: 32,
+depthBiasSlopeScale: 54,
+depthBiasClamp: 21,
+},
+}
+);
+try {
+offscreenCanvas28.getContext('webgl');
+} catch {}
+let bindGroupLayout48 = device1.createBindGroupLayout(
+{
+label: '\u6580\uf696\uce0b\u744c\u074a',
+entries: [
+{
+binding: 4232,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+},
+{
+binding: 1665,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+try {
+computePassEncoder53.insertDebugMarker(
+'\u22f1'
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer40,
+10360,
+new BigUint64Array(26337),
+4814,
+2156
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 12, height: 1, depthOrArrayLayers: 225}
+*/
+{
+  source: videoFrame25,
+  origin: { x: 37, y: 4 },
+  flipY: true,
+},
+{
+  texture: texture107,
+  mipLevel: 1,
+  origin: { x: 3, y: 1, z: 216 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 6, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise58 = device1.createComputePipelineAsync(
+{
+label: '\u0ad3\u{1f612}\ue541\udbd9\u3970\u6712\u78ce\u{1f815}',
+layout: pipelineLayout20,
+compute: {
+module: shaderModule31,
+entryPoint: 'compute0',
+},
+}
+);
+let offscreenCanvas29 = new OffscreenCanvas(75, 784);
+let imageData28 = new ImageData(84, 252);
+let commandEncoder108 = device0.createCommandEncoder(
+{
+label: '\u2f1b\u4f4b\u9f34\u67ca',
+}
+);
+let texture125 = device0.createTexture(
+{
+label: '\u058c\ucbe2\u{1fe2e}\u9432\u63a9\u{1fdf7}',
+size: {width: 127, height: 1, depthOrArrayLayers: 234},
+mipLevelCount: 3,
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16uint'
+],
+}
+);
+let renderBundleEncoder120 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba32float',
+'rgba32uint',
+'rg32sint',
+undefined
+],
+sampleCount: 25,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle100 = renderBundleEncoder73.finish(
+{
+
+}
+);
+try {
+computePassEncoder10.setBindGroup(
+4,
+bindGroup16,
+[]
+);
+} catch {}
+try {
+renderPassEncoder44.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder15.setScissorRect(
+1285,
+1,
+1099,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(
+buffer22,
+71200
+);
+} catch {}
+let offscreenCanvas30 = new OffscreenCanvas(947, 584);
+let sampler120 = device2.createSampler(
+{
+label: '\u8b85\u005b\u4622\u{1fbe1}\u{1f932}\u{1fec9}\u{1f6f2}\ue065\u0ddd\u6b7a\u75f8',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 83.820,
+lodMaxClamp: 92.089,
+}
+);
+try {
+computePassEncoder54.setPipeline(
+pipeline103
+);
+} catch {}
+let promise59 = adapter5.requestDevice(
+{
+label: '\ubca5\u48e3',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxBindGroups: 7,
+maxColorAttachmentBytesPerSample: 46,
+maxVertexAttributes: 24,
+maxVertexBufferArrayStride: 12827,
+maxStorageTexturesPerShaderStage: 13,
+maxStorageBuffersPerShaderStage: 34,
+maxDynamicStorageBuffersPerPipelineLayout: 41406,
+maxBindingsPerBindGroup: 4745,
+maxTextureDimension1D: 16069,
+maxTextureDimension2D: 15305,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 256,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 240697418,
+maxInterStageShaderVariables: 83,
+maxInterStageShaderComponents: 83,
+},
+}
+);
+let adapter10 = await navigator.gpu.requestAdapter();
+let video30 = await videoWithData();
+document.body.append('\u{1f7e3}\u4917\u8698\uecb7\u0f80\u05ca\u{1fe7c}\u077f\uea4e');
+let device5 = await adapter10.requestDevice(
+{
+label: '\u6545\u0ab9\u{1fbc9}',
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 6,
+maxColorAttachmentBytesPerSample: 55,
+maxVertexAttributes: 19,
+maxVertexBufferArrayStride: 65066,
+maxStorageTexturesPerShaderStage: 43,
+maxStorageBuffersPerShaderStage: 29,
+maxDynamicStorageBuffersPerPipelineLayout: 40382,
+maxBindingsPerBindGroup: 1495,
+maxTextureDimension1D: 16350,
+maxTextureDimension2D: 10308,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 208726749,
+maxInterStageShaderVariables: 123,
+maxInterStageShaderComponents: 97,
+},
+}
+);
+let buffer46 = device2.createBuffer(
+{
+size: 51017,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+}
+);
+let renderBundleEncoder121 = device2.createRenderBundleEncoder(
+{
+label: '\u639b\u2027\u1bab\u03d1\u0f19\ue019\uebd0\u{1fd7c}\u9d01\u57ef',
+colorFormats: [
+'rg32float',
+undefined
+],
+sampleCount: 80,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler121 = device2.createSampler(
+{
+label: '\u06d9\u193a',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 85.421,
+lodMaxClamp: 94.912,
+}
+);
+try {
+commandEncoder103.copyTextureToTexture(
+{
+  texture: texture110,
+  mipLevel: 2,
+  origin: { x: 1028, y: 8, z: 4 },
+  aspect: 'depth-only',
+},
+{
+  texture: texture110,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 13 },
+  aspect: 'all',
+},
+{width: 181, height: 3, depthOrArrayLayers: 60}
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55) };
+} catch {}
+let gpuCanvasContext24 = offscreenCanvas29.getContext('webgpu');
+document.body.prepend('\ue912\u0050\u4a82\u32bd\u061b\uacbd\u4e78\ub1ba\udc6e');
+let imageBitmap22 = await createImageBitmap(offscreenCanvas29);
+try {
+offscreenCanvas30.getContext('webgpu');
+} catch {}
+offscreenCanvas30.height = 312;
+try {
+adapter7.label = '\ue872\u{1f8a1}\uaf49\ucbaf\u9cb4\u5e6e\u6e1c\u{1fa0c}\u34e4\u2122\u0e62';
+} catch {}
+let promise60 = device4.queue.onSubmittedWorkDone();
+let commandEncoder109 = device1.createCommandEncoder(
+{
+label: '\u{1ffe1}\u5085\ue742\u0040\u07e4\u0cd4\u{1f800}',
+}
+);
+let querySet95 = device1.createQuerySet(
+{
+label: '\u04d5\u{1ff40}\u0243\u5d54\uc7b9\u02a0\ub925',
+type: 'occlusion',
+count: 319,
+}
+);
+let textureView117 = texture104.createView(
+{
+label: '\u1437\u09b5\ud1c1\u5802\uef40\u1beb\u0eda\u0819',
+aspect: 'all',
+}
+);
+try {
+renderBundleEncoder116.setBindGroup(
+0,
+bindGroup37,
+new Uint32Array(1872),
+1448,
+0
+);
+} catch {}
+try {
+commandEncoder109.clearBuffer(
+buffer32,
+17100,
+6940
+);
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer40,
+676,
+new BigUint64Array(13383),
+5541,
+4108
+);
+} catch {}
+try {
+await promise60;
+} catch {}
+document.body.prepend('\u06c7\u{1f92d}\uae22\u61a8\u03a3\ua6b9\u043b\u0749\uad70\u0db0');
+let videoFrame31 = videoFrame12.clone();
+let querySet96 = device3.createQuerySet(
+{
+label: '\u1e40\u285e\uae80',
+type: 'occlusion',
+count: 2037,
+}
+);
+let renderBundleEncoder122 = device3.createRenderBundleEncoder(
+{
+label: '\u0839\u3743\u27fc',
+colorFormats: [
+'rg8uint',
+'rgba8uint',
+'rg8uint',
+'rg8uint',
+'rgba16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 140,
+depthReadOnly: true,
+}
+);
+let sampler122 = device3.createSampler(
+{
+label: '\udbac\u7d84\u060a\u46d2',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 33.744,
+lodMaxClamp: 60.629,
+}
+);
+video19.height = 21;
+document.body.prepend('\u0871\u38d5\ua075\ua8f0\u6751\u013b\u07ea\u0747');
+let querySet97 = device4.createQuerySet(
+{
+label: '\u308a\u046f\u5a85\u0b1b\ue1d3\u{1f662}\u397a',
+type: 'occlusion',
+count: 2983,
+}
+);
+document.body.append('\u{1fb06}\u0629\u{1fd76}\u0c5f\u7351\uea7e\u{1f84a}\u{1ff22}\u8788\uf3d5');
+let buffer47 = device4.createBuffer(
+{
+label: '\uf84d\u{1fa9f}\ubfd9\u57c3\ue03b\u01e2\u07f2\u53e3',
+size: 28671,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let commandEncoder110 = device4.createCommandEncoder(
+{
+label: '\u0853\u{1fe69}\uf004\u07e6\u{1f75f}\u502c\u076f\u1d20\uf959\ube92\u0c88',
+}
+);
+let computePassEncoder60 = commandEncoder110.beginComputePass(
+{
+label: '\u{1fe26}\u{1fe54}\u0846\u935d\u{1f8a9}\u{1f968}\u0276'
+}
+);
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+document.body.prepend('\u{1f6a2}\u{1f6ca}\u7149\ub597\u0173\u09c8\u{1fc34}\ubd47');
+let renderBundleEncoder123 = device4.createRenderBundleEncoder(
+{
+label: '\u{1ff97}\u33fb\ub438',
+colorFormats: [
+'rg8uint',
+'r16float',
+'rgba8unorm',
+'rgba8uint',
+'rg11b10ufloat',
+'rgba8unorm-srgb'
+],
+sampleCount: 550,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+device4.queue.writeBuffer(
+buffer47,
+2404,
+new DataView(new ArrayBuffer(27592)),
+25088,
+120
+);
+} catch {}
+video0.height = 296;
+let texture126 = gpuCanvasContext1.getCurrentTexture();
+try {
+commandEncoder107.clearBuffer(
+buffer32,
+16512,
+4548
+);
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+gpuCanvasContext21.configure(
+{
+device: device1,
+format: 'rg32float',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rg32float',
+'rg32float',
+'rg32float',
+'astc-12x12-unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer45,
+40828,
+new BigUint64Array(60996),
+16807,
+1516
+);
+} catch {}
+document.body.append('\u2fa8\u089f\u39c0');
+let commandEncoder111 = device3.createCommandEncoder(
+{
+label: '\u03cf\u3900\u0290\u78ad\u7c74\u67ae',
+}
+);
+let commandBuffer10 = commandEncoder111.finish();
+let texture127 = device3.createTexture(
+{
+label: '\u6519\u{1fdb5}\ub96b\uc86c\u1a89\u059d\u053e\ud3ac\u3489\u{1fed4}\u5363',
+size: {width: 1688, height: 1, depthOrArrayLayers: 147},
+mipLevelCount: 3,
+sampleCount: 1,
+dimension: '3d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16sint',
+'rgba16sint',
+'rgba16sint'
+],
+}
+);
+let computePassEncoder61 = commandEncoder106.beginComputePass(
+{
+
+}
+);
+let sampler123 = device3.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 14.769,
+maxAnisotropy: 1,
+}
+);
+try {
+gpuCanvasContext21.configure(
+{
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x8-unorm-srgb'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let commandEncoder112 = device4.createCommandEncoder(
+{
+label: '\u0f4d\u021a',
+}
+);
+let computePassEncoder62 = commandEncoder112.beginComputePass(
+{
+
+}
+);
+try {
+renderBundleEncoder123.setVertexBuffer(
+20,
+undefined,
+1941803485,
+1991392251
+);
+} catch {}
+try {
+gpuCanvasContext19.configure(
+{
+device: device4,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8sint',
+'rgba8unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer47,
+1044,
+new Float32Array(47435),
+40515,
+2180
+);
+} catch {}
+try {
+gpuCanvasContext19.unconfigure();
+} catch {}
+gc();
+document.body.prepend(video16);
+let canvas33 = document.createElement('canvas');
+let textureView118 = texture118.createView(
+{
+label: '\u50c1\u0929\u{1fcb4}\u{1ff44}\u{1f7fc}\ub959',
+format: 'astc-8x6-unorm-srgb',
+baseArrayLayer: 10,
+arrayLayerCount: 3,
+}
+);
+let sampler124 = device1.createSampler(
+{
+label: '\u6b15\u0519\ua145',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 64.583,
+lodMaxClamp: 85.491,
+compare: 'never',
+}
+);
+try {
+renderBundleEncoder119.setVertexBuffer(
+9,
+buffer43,
+23432,
+99
+);
+} catch {}
+try {
+commandEncoder109.clearBuffer(
+buffer32,
+10824,
+15332
+);
+dissociateBuffer(device1, buffer32);
+} catch {}
+let pipeline107 = await device1.createRenderPipelineAsync(
+{
+label: '\u89bf\u{1faf9}',
+layout: pipelineLayout16,
+vertex: {
+module: shaderModule35,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1468,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 812,
+shaderLocation: 7,
+},
+{
+format: 'snorm8x2',
+offset: 1188,
+shaderLocation: 12,
+},
+{
+format: 'float32x3',
+offset: 488,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 1048,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 208,
+shaderLocation: 15,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'back',
+},
+multisample: {
+count: 4,
+mask: 0x91f8b5d0,
+},
+fragment: {
+module: shaderModule35,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r32uint',
+writeMask: 0,
+}
+],
+},
+}
+);
+offscreenCanvas1.width = 60;
+document.body.append('\u8918\u5104');
+let video31 = await videoWithData();
+try {
+canvas33.getContext('2d');
+} catch {}
+let texture128 = device3.createTexture(
+{
+label: '\u7789\u0ae7\u2d9b',
+size: [252, 12, 209],
+mipLevelCount: 7,
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder124 = device3.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgb10a2unorm',
+'rg16float',
+'rgba32sint',
+'rgb10a2unorm',
+'rg32sint',
+undefined,
+'rgba8uint',
+undefined
+],
+sampleCount: 648,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+let querySet98 = device1.createQuerySet(
+{
+label: '\uc015\u{1fd2d}\ue267\u0174',
+type: 'occlusion',
+count: 1248,
+}
+);
+try {
+renderBundleEncoder115.setVertexBuffer(
+7,
+buffer43,
+3960,
+21374
+);
+} catch {}
+let pipeline108 = device1.createRenderPipeline(
+{
+label: '\ua65f\u05ed\u{1f7ec}\u9992\uab1a\u04c7',
+layout: pipelineLayout20,
+vertex: {
+module: shaderModule16,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 13608,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x4',
+offset: 4468,
+shaderLocation: 6,
+},
+{
+format: 'unorm16x4',
+offset: 9840,
+shaderLocation: 14,
+},
+{
+format: 'unorm8x4',
+offset: 13564,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x4',
+offset: 11284,
+shaderLocation: 8,
+},
+{
+format: 'float16x4',
+offset: 9600,
+shaderLocation: 1,
+},
+{
+format: 'sint32x3',
+offset: 3216,
+shaderLocation: 18,
+},
+{
+format: 'unorm16x4',
+offset: 11224,
+shaderLocation: 0,
+},
+{
+format: 'sint8x4',
+offset: 3260,
+shaderLocation: 16,
+},
+{
+format: 'uint16x2',
+offset: 492,
+shaderLocation: 5,
+},
+{
+format: 'snorm16x4',
+offset: 13180,
+shaderLocation: 13,
+},
+{
+format: 'uint8x4',
+offset: 8076,
+shaderLocation: 3,
+},
+{
+format: 'sint32x4',
+offset: 6380,
+shaderLocation: 9,
+},
+{
+format: 'float32x4',
+offset: 13408,
+shaderLocation: 19,
+},
+{
+format: 'uint32x2',
+offset: 5248,
+shaderLocation: 12,
+},
+{
+format: 'uint8x4',
+offset: 7252,
+shaderLocation: 10,
+},
+{
+format: 'snorm16x2',
+offset: 7920,
+shaderLocation: 17,
+},
+{
+format: 'unorm8x2',
+offset: 8072,
+shaderLocation: 2,
+},
+{
+format: 'sint32x3',
+offset: 8584,
+shaderLocation: 15,
+},
+{
+format: 'unorm8x2',
+offset: 9836,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 12592,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 7852,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 5972,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 252,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 17792,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 3688,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x3',
+offset: 3304,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0xd07fce1a,
+},
+}
+);
+let commandBuffer11 = commandEncoder107.finish(
+{
+label: '\u9b4e\u0c99\u41a7\u0a1e',
+}
+);
+let renderBundleEncoder125 = device1.createRenderBundleEncoder(
+{
+label: '\u0015\u8c05\u8b87\u0a62',
+colorFormats: [
+'rgba8uint',
+'rgba32sint',
+'rg8uint'
+],
+sampleCount: 375,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+let renderBundle101 = renderBundleEncoder75.finish(
+{
+label: '\ub06e\u{1f95f}\u0661\u99bc\u58b2\u0eba\u249d\u0341'
+}
+);
+try {
+querySet84.destroy();
+} catch {}
+try {
+commandEncoder109.copyTextureToTexture(
+{
+  texture: texture119,
+  mipLevel: 0,
+  origin: { x: 11, y: 8, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture119,
+  mipLevel: 0,
+  origin: { x: 10, y: 4, z: 12 },
+  aspect: 'all',
+},
+{width: 11, height: 4, depthOrArrayLayers: 11}
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer45,
+46060,
+new BigUint64Array(15686),
+13211,
+48
+);
+} catch {}
+document.body.append('\ua534\u0eb7\u{1ffcf}\u7ba6\u0c1f\u53ba\u{1f745}\u0212');
+let querySet99 = device5.createQuerySet(
+{
+label: '\ue03f\u727c\u{1ffb7}\u0bde\u{1f9f0}\ueb56\u5580',
+type: 'occlusion',
+count: 1744,
+}
+);
+let sampler125 = device5.createSampler(
+{
+label: '\u9d57\ua815\u0574\u{1f6bb}',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+}
+);
+canvas3.width = 836;
+document.body.append('\u{1ffcd}\u966f\u{1fa85}\u1d8f\u132d\u6940\u{1f886}\u{1fb3f}\u09e0\u7124\ua1a2');
+let textureView119 = texture57.createView(
+{
+label: '\u045e\u{1f86e}\u623c\u1cd5',
+}
+);
+let sampler126 = device0.createSampler(
+{
+label: '\u0565\u1a62\u7084',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 39.304,
+lodMaxClamp: 84.868,
+compare: 'always',
+maxAnisotropy: 11,
+}
+);
+try {
+computePassEncoder42.setBindGroup(
+6,
+bindGroup15
+);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(
+6,
+bindGroup10
+);
+} catch {}
+try {
+renderPassEncoder31.beginOcclusionQuery(
+40
+);
+} catch {}
+try {
+renderPassEncoder30.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant(
+{
+r: -471.8,
+g: -882.0,
+b: 205.7,
+a: -893.9,
+}
+);
+} catch {}
+try {
+renderPassEncoder41.setStencilReference(
+3371
+);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(
+buffer20,
+62328
+);
+} catch {}
+try {
+renderBundleEncoder84.setBindGroup(
+5,
+bindGroup35
+);
+} catch {}
+try {
+renderBundleEncoder89.setBindGroup(
+7,
+bindGroup41,
+new Uint32Array(5158),
+1129,
+0
+);
+} catch {}
+try {
+commandEncoder108.copyBufferToBuffer(
+buffer2,
+17164,
+buffer21,
+972,
+10124
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer21);
+} catch {}
+try {
+gpuCanvasContext16.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8snorm',
+'bgra8unorm-srgb',
+'bgra8unorm',
+'bgra8unorm-srgb'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+6644,
+new DataView(new ArrayBuffer(36357)),
+28976,
+4820
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture41,
+  mipLevel: 0,
+  origin: { x: 4083, y: 0, z: 0 },
+  aspect: 'all',
+},
+new BigUint64Array(arrayBuffer22),
+/* required buffer size: 1562255 */{
+offset: 323,
+bytesPerRow: 1406,
+rowsPerImage: 37,
+},
+{width: 318, height: 1, depthOrArrayLayers: 31}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 2159, height: 57, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 145, y: 85 },
+  flipY: true,
+},
+{
+  texture: texture94,
+  mipLevel: 0,
+  origin: { x: 1648, y: 23, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 78, height: 19, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline109 = await device0.createRenderPipelineAsync(
+{
+label: '\u0cb9\ua760\u0d10\u82dc\u0cff\u{1f7b7}\u872d\u0762\u0108\u{1f9ca}\u6b98',
+layout: pipelineLayout8,
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 18512,
+attributes: [
+{
+format: 'snorm8x2',
+offset: 3818,
+shaderLocation: 1,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 4972,
+shaderLocation: 7,
+},
+{
+format: 'float16x2',
+offset: 18012,
+shaderLocation: 12,
+},
+{
+format: 'unorm8x2',
+offset: 15760,
+shaderLocation: 10,
+},
+{
+format: 'snorm16x2',
+offset: 17396,
+shaderLocation: 15,
+},
+{
+format: 'float16x2',
+offset: 6268,
+shaderLocation: 8,
+},
+{
+format: 'sint32x2',
+offset: 5796,
+shaderLocation: 11,
+},
+{
+format: 'unorm16x4',
+offset: 9408,
+shaderLocation: 16,
+},
+{
+format: 'sint16x4',
+offset: 15728,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x4',
+offset: 5832,
+shaderLocation: 14,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule3,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+},
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'one-minus-dst-alpha',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'zero',
+dstFactor: 'src'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'rg11b10ufloat',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+compare: 'not-equal',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilReadMask: 3004,
+stencilWriteMask: 1512,
+depthBias: 5,
+depthBiasClamp: 81,
+},
+}
+);
+try {
+if (!arrayBuffer18.detached) { new Uint8Array(arrayBuffer18).fill(0x55) };
+} catch {}
+document.body.prepend('\ua58d\u9902\u{1fe5d}\u0487\u4d65\u3948\uf712\u8459\ubb8b');
+let commandEncoder113 = device5.createCommandEncoder();
+pseudoSubmit(device5, commandEncoder113);
+let texture129 = device5.createTexture(
+{
+label: '\u{1fc45}\u68a5\u0b4f\u0445\uff8d\u0e42\u1530\u0b45\u{1f9b3}',
+size: {width: 139, height: 143, depthOrArrayLayers: 202},
+mipLevelCount: 6,
+format: 'rgba32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba32uint',
+'rgba32uint',
+'rgba32uint'
+],
+}
+);
+try {
+device5.queue.writeTexture(
+{
+  texture: texture129,
+  mipLevel: 1,
+  origin: { x: 14, y: 3, z: 29 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 2082928 */{
+offset: 560,
+bytesPerRow: 980,
+rowsPerImage: 147,
+},
+{width: 53, height: 67, depthOrArrayLayers: 15}
+);
+} catch {}
+gc();
+try {
+buffer45.unmap();
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer45,
+32596,
+new Int16Array(26904),
+1685,
+3824
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture109,
+  mipLevel: 5,
+  origin: { x: 2, y: 1, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(37),
+/* required buffer size: 37 */{
+offset: 37,
+},
+{width: 5, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\u{1fb0d}\u171e\u0318\u7a1f\u{1fc95}\u{1f933}\u{1fb53}\u0619\u72a5\u085a');
+let querySet100 = device5.createQuerySet(
+{
+label: '\u0229\u0119\u{1f668}\u07d6\u4922\u836d\u58c7\uf2a8\u{1f830}',
+type: 'occlusion',
+count: 306,
+}
+);
+let texture130 = device5.createTexture(
+{
+label: '\u6bc9\u76a9\u9142\u3a50\u2095\ud6d3\u0097\ua3c0\u{1fd35}',
+size: [6112],
+dimension: '1d',
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_DST,
+}
+);
+try {
+if (!arrayBuffer18.detached) { new Uint8Array(arrayBuffer18).fill(0x55) };
+} catch {}
+let imageData29 = new ImageData(12, 76);
+let buffer48 = device3.createBuffer(
+{
+label: '\u0ef6\u{1ffa0}\u{1f892}\uaa2a\u01ea',
+size: 7554,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+}
+);
+try {
+renderBundleEncoder124.setVertexBuffer(
+5,
+buffer42,
+10964,
+414
+);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer48,
+3380,
+new Int16Array(60300),
+40094,
+1196
+);
+} catch {}
+let promise61 = device3.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext21.configure(
+{
+device: device4,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32uint',
+'rg8sint',
+'bgra8unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+gc();
+try {
+videoFrame2.close();
+} catch {}
+let renderBundle102 = renderBundleEncoder123.finish(
+{
+label: '\u{1f72e}\u3002\u7833\u{1fc82}\u{1f8e1}\u271f'
+}
+);
+let sampler127 = device4.createSampler(
+{
+label: '\u{1ffde}\u04c4\u0d2e\u{1fe3f}\u859f\u{1fc68}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 93.119,
+lodMaxClamp: 98.873,
+}
+);
+document.body.prepend('\u{1fa08}\u12c3\u0c28\u{1f65f}\u6178\u{1f650}\u02e3');
+try {
+await promise61;
+} catch {}
+document.body.prepend('\u0c64\u87cb\u058c\u0126\u0005\u8479\ub6ac\uf3f0\u4c4c\u1e35\u{1f866}');
+try {
+device5.destroy();
+} catch {}
+let offscreenCanvas31 = new OffscreenCanvas(402, 944);
+try {
+offscreenCanvas31.getContext('bitmaprenderer');
+} catch {}
+let querySet101 = device1.createQuerySet(
+{
+label: '\u{1fec5}\u{1fcea}\u0023\ub4cb\u08c5\u61e4\u{1fc4e}\u{1fbca}',
+type: 'occlusion',
+count: 782,
+}
+);
+let computePassEncoder63 = commandEncoder109.beginComputePass(
+{
+label: '\u{1fce3}\u8eec\ube73\u4ec9'
+}
+);
+let sampler128 = device1.createSampler(
+{
+label: '\u5556\uee12\u1b5a\u027c\u{1f9ef}\u5d36\u05b5\u0855',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 22.226,
+lodMaxClamp: 43.900,
+}
+);
+try {
+renderBundleEncoder97.setBindGroup(
+0,
+bindGroup54
+);
+} catch {}
+try {
+renderBundleEncoder94.setBindGroup(
+3,
+bindGroup53,
+new Uint32Array(5340),
+1091,
+0
+);
+} catch {}
+video6.width = 174;
+document.body.prepend('\u1509\u{1f807}\u12ce\ue2d0\u2cf8\ub689\u8163\u{1ff5c}\u9051');
+let texture131 = device4.createTexture(
+{
+label: '\u01be\u0c6a\u09a0\u032b\ua6b8\uf364\u0fbf',
+size: {width: 10666, height: 68, depthOrArrayLayers: 186},
+mipLevelCount: 12,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth24plus',
+'depth24plus'
+],
+}
+);
+let textureView120 = texture131.createView(
+{
+label: '\u0ca5\u{1f757}',
+baseMipLevel: 3,
+mipLevelCount: 5,
+baseArrayLayer: 76,
+arrayLayerCount: 56,
+}
+);
+try {
+device4.queue.writeBuffer(
+buffer47,
+26016,
+new BigUint64Array(55097),
+54700,
+196
+);
+} catch {}
+let canvas34 = document.createElement('canvas');
+let gpuCanvasContext25 = canvas34.getContext('webgpu');
+document.body.append('\ubacb\u6298\uc40a\u{1f9e7}\u{1fe58}\uc885\u{1f81d}');
+let renderBundleEncoder126 = device2.createRenderBundleEncoder(
+{
+label: '\u0a70\u0fac\u3cc5\u673c\u021d\u490f\u87ee',
+colorFormats: [
+'rgba8unorm',
+'bgra8unorm',
+'rg32uint',
+'rgba8sint',
+'rg32uint',
+'rgba16sint',
+'rg8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 550,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder54.setPipeline(
+pipeline103
+);
+} catch {}
+try {
+renderBundleEncoder110.setVertexBuffer(
+3,
+buffer46,
+13928,
+25455
+);
+} catch {}
+try {
+commandEncoder96.clearBuffer(
+buffer46,
+3908,
+8528
+);
+dissociateBuffer(device2, buffer46);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer46,
+8484,
+new BigUint64Array(28450),
+21681,
+4044
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture108,
+  mipLevel: 9,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'stencil-only',
+},
+new ArrayBuffer(64),
+/* required buffer size: 945 */{
+offset: 925,
+},
+{width: 20, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\u0a91\u085c\u0482\u9ed1\u8ded\u3714\u{1ffeb}\u03b2');
+let bindGroupLayout49 = device1.createBindGroupLayout(
+{
+label: '\u2491\u7483\u06be\u4a3c\u{1ff6c}\u{1fc46}\u{1fc2f}',
+entries: [
+{
+binding: 3269,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '1d' },
+},
+{
+binding: 1388,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let querySet102 = device1.createQuerySet(
+{
+label: '\ue2ea\u3da6\u0fdf\u65df\u3bc9\u2348',
+type: 'occlusion',
+count: 1931,
+}
+);
+let texture132 = device1.createTexture(
+{
+label: '\u0539\udbad\u7693',
+size: [7901, 162, 190],
+mipLevelCount: 2,
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb9e5ufloat',
+'rgb9e5ufloat'
+],
+}
+);
+try {
+computePassEncoder55.setPipeline(
+pipeline89
+);
+} catch {}
+try {
+renderBundleEncoder119.setVertexBuffer(
+0,
+buffer43,
+10676,
+7952
+);
+} catch {}
+document.body.prepend('\u8603\u{1f9de}\u8d50\u{1fd72}\ue6d8\u0078\u{1f9a4}\u0450\u0cfe\u{1fe87}\u{1ff1c}');
+let commandEncoder114 = device2.createCommandEncoder(
+{
+}
+);
+pseudoSubmit(device2, commandEncoder96);
+let textureView121 = texture115.createView(
+{
+label: '\u476c\u0d4c\u{1fe0e}\u0634\u0d2b',
+baseMipLevel: 6,
+}
+);
+let computePassEncoder64 = commandEncoder114.beginComputePass(
+{
+label: '\u0112\u0007\u1b89\u6b2a'
+}
+);
+let externalTexture5 = device2.importExternalTexture(
+{
+source: videoFrame0,
+colorSpace: 'display-p3',
+}
+);
+try {
+commandEncoder97.copyTextureToTexture(
+{
+  texture: texture110,
+  mipLevel: 5,
+  origin: { x: 0, y: 4, z: 2 },
+  aspect: 'all',
+},
+{
+  texture: texture110,
+  mipLevel: 0,
+  origin: { x: 5904, y: 131, z: 13 },
+  aspect: 'all',
+},
+{width: 362, height: 1, depthOrArrayLayers: 124}
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer46,
+13632,
+new DataView(new ArrayBuffer(479)),
+259,
+92
+);
+} catch {}
+let textureView122 = texture113.createView(
+{
+label: '\u{1f9e0}\u{1f9c8}\u{1fb56}\u{1f699}\ud7ec\uccd9',
+}
+);
+let computePassEncoder65 = commandEncoder103.beginComputePass(
+{
+
+}
+);
+let renderBundle103 = renderBundleEncoder106.finish();
+try {
+commandEncoder97.copyTextureToBuffer(
+{
+  texture: texture110,
+  mipLevel: 1,
+  origin: { x: 0, y: 51, z: 119 },
+  aspect: 'depth-only',
+},
+{
+/* bytesInLastRow: 11610 widthInBlocks: 5805 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 21724 */
+offset: 21724,
+buffer: buffer46,
+},
+{width: 5805, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device2, buffer46);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer46,
+15060,
+new Int16Array(37772),
+10253,
+11816
+);
+} catch {}
+let querySet103 = device3.createQuerySet(
+{
+label: '\u037a\u{1f745}\u1407',
+type: 'occlusion',
+count: 2041,
+}
+);
+try {
+renderBundleEncoder122.setVertexBuffer(
+0,
+buffer42,
+10552,
+682
+);
+} catch {}
+document.body.append('\u0038\u0884\u543e\u799e\u0bc9\u{1f852}\u6b43');
+let textureView123 = texture127.createView(
+{
+format: 'rgba16sint',
+baseMipLevel: 2,
+}
+);
+try {
+renderBundleEncoder124.setIndexBuffer(
+buffer42,
+'uint16'
+);
+} catch {}
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+buffer48.unmap();
+} catch {}
+let videoFrame32 = new VideoFrame(canvas28, {timestamp: 0});
+let texture133 = device3.createTexture(
+{
+label: '\u08b9\u29fd\u{1fe22}\u617e\u91ab\u086b\u{1ff5c}\u0357\u{1f979}\u090d\ud4de',
+size: [7613, 2, 1],
+mipLevelCount: 2,
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg16float',
+'rg16float'
+],
+}
+);
+let renderBundle104 = renderBundleEncoder122.finish(
+{
+label: '\udfed\u0388\u1927\u{1fe9e}\u{1ff2e}\u{1fe5a}'
+}
+);
+try {
+computePassEncoder57.end();
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+document.body.prepend(video28);
+let commandEncoder115 = device1.createCommandEncoder(
+{
+label: '\u0bf5\u{1fa70}\u{1f9dc}\uaac1',
+}
+);
+pseudoSubmit(device1, commandEncoder102);
+let texture134 = gpuCanvasContext16.getCurrentTexture();
+let textureView124 = texture119.createView(
+{
+label: '\udd86\u9e51\u{1fddc}\u0e71\u5a41',
+dimension: '2d',
+baseArrayLayer: 0,
+}
+);
+let renderBundleEncoder127 = device1.createRenderBundleEncoder(
+{
+label: '\u0180\u9565\u091d',
+colorFormats: [
+'rgba32float',
+'rg32uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 987,
+depthReadOnly: true,
+}
+);
+try {
+commandEncoder115.clearBuffer(
+buffer44
+);
+dissociateBuffer(device1, buffer44);
+} catch {}
+let imageData30 = new ImageData(28, 80);
+let commandEncoder116 = device3.createCommandEncoder();
+let renderPassEncoder47 = commandEncoder105.beginRenderPass(
+{
+label: '\u{1fd6f}\u{1fbc9}',
+colorAttachments: [
+{
+view: textureView115,
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined
+],
+occlusionQuerySet: querySet88,
+maxDrawCount: 18640,
+}
+);
+try {
+renderPassEncoder47.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+renderPassEncoder47.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder47.setBlendConstant(
+{
+r: 569.0,
+g: 176.3,
+b: 422.4,
+a: 736.6,
+}
+);
+} catch {}
+try {
+renderPassEncoder47.setViewport(
+653.0,
+24.75,
+3.312,
+10.38,
+0.3813,
+0.3977
+);
+} catch {}
+try {
+renderPassEncoder47.setIndexBuffer(
+buffer42,
+'uint16',
+6758,
+1777
+);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(
+6,
+buffer42,
+4556,
+1987
+);
+} catch {}
+try {
+renderBundleEncoder124.setVertexBuffer(
+2,
+buffer42,
+3484,
+2602
+);
+} catch {}
+try {
+commandEncoder116.copyTextureToTexture(
+{
+  texture: texture133,
+  mipLevel: 1,
+  origin: { x: 199, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture133,
+  mipLevel: 1,
+  origin: { x: 102, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 3298, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\u1279\ud964\u2a9c\u9a81\u033a');
+let video32 = await videoWithData();
+let shaderModule38 = device1.createShaderModule(
+{
+label: '\u648a\u{1fd6a}\u{1f8d2}\ue7be\ue428\u{1fa1b}',
+code: `
+
+@compute @workgroup_size(8, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: vec2<f32>,
+@location(3) f1: vec3<f32>,
+@location(6) f2: u32,
+@builtin(frag_depth) f3: f32
+}
+
+@fragment
+fn fragment0(@location(29) a0: vec4<f16>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(25) f427: vec3<f32>,
+@location(53) f428: u32,
+@location(67) f429: vec3<f16>,
+@location(82) f430: vec4<f32>,
+@location(73) f431: vec3<i32>,
+@location(0) f432: vec4<i32>,
+@location(72) f433: vec2<i32>,
+@location(76) f434: vec2<u32>,
+@location(42) f435: f16,
+@location(26) f436: vec3<i32>,
+@location(71) f437: f32,
+@location(59) f438: f32,
+@location(7) f439: vec3<f16>,
+@location(44) f440: vec3<f16>,
+@location(19) f441: vec3<i32>,
+@location(24) f442: vec3<u32>,
+@location(29) f443: vec4<f16>,
+@location(65) f444: vec3<i32>,
+@builtin(position) f445: vec4<f32>,
+@location(55) f446: vec2<i32>,
+@location(56) f447: f16,
+@location(52) f448: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(1) a0: vec2<u32>, @location(5) a1: i32, @builtin(vertex_index) a2: u32, @location(8) a3: vec4<f16>, @location(16) a4: vec2<f16>, @location(2) a5: vec3<u32>, @location(6) a6: vec4<f16>, @location(10) a7: vec3<f32>, @location(15) a8: f32, @location(3) a9: vec4<f16>, @location(7) a10: vec2<f16>, @location(4) a11: vec3<f16>, @location(12) a12: vec3<f16>, @location(19) a13: vec4<f16>, @location(14) a14: vec4<f16>, @location(18) a15: vec2<f32>, @location(17) a16: vec2<f32>, @location(0) a17: vec2<u32>, @location(11) a18: f16, @location(13) a19: vec3<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+}
+);
+let buffer49 = device1.createBuffer(
+{
+label: '\ua315\u1e66\u{1f83a}\u61b5\u{1fee4}',
+size: 22477,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let commandEncoder117 = device1.createCommandEncoder();
+let querySet104 = device1.createQuerySet(
+{
+type: 'occlusion',
+count: 2795,
+}
+);
+try {
+computePassEncoder53.setBindGroup(
+1,
+bindGroup37
+);
+} catch {}
+try {
+renderBundleEncoder127.setVertexBuffer(
+6,
+buffer49,
+5660,
+607
+);
+} catch {}
+try {
+commandEncoder115.copyTextureToBuffer(
+{
+  texture: texture103,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 28040 */
+offset: 28040,
+rowsPerImage: 276,
+buffer: buffer32,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+commandEncoder117.copyTextureToTexture(
+{
+  texture: texture93,
+  mipLevel: 5,
+  origin: { x: 120, y: 5, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture93,
+  mipLevel: 11,
+  origin: { x: 0, y: 0, z: 2 },
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 237}
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer40,
+8220,
+new DataView(new ArrayBuffer(19934)),
+3316,
+12856
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture95,
+  mipLevel: 1,
+  origin: { x: 17, y: 0, z: 18 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 13404357 */{
+offset: 450,
+bytesPerRow: 6881,
+rowsPerImage: 59,
+},
+{width: 825, height: 1, depthOrArrayLayers: 34}
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 6, height: 1, depthOrArrayLayers: 112}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 65, y: 15 },
+  flipY: false,
+},
+{
+  texture: texture107,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 62 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 4, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\u0add\u2563\u3f2f\u0da2\u86bd\u413b');
+let canvas35 = document.createElement('canvas');
+let imageData31 = new ImageData(132, 232);
+let texture135 = device4.createTexture(
+{
+label: '\u92d1\ud09a\u0b29\u{1fe7a}',
+size: [10340, 28, 181],
+mipLevelCount: 7,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+buffer47.unmap();
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.prepend('\uf851\u24f9\ub488\u31c5\u{1fdce}\u046c\u054c\u0a68\u2c2f');
+let querySet105 = device4.createQuerySet(
+{
+label: '\u9d87\ube9d\u{1fc38}',
+type: 'occlusion',
+count: 360,
+}
+);
+let renderBundle105 = renderBundleEncoder123.finish(
+{
+
+}
+);
+let sampler129 = device4.createSampler(
+{
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+lodMinClamp: 46.686,
+lodMaxClamp: 60.429,
+}
+);
+try {
+computePassEncoder60.end();
+} catch {}
+try {
+commandEncoder110.copyTextureToTexture(
+{
+  texture: texture131,
+  mipLevel: 11,
+  origin: { x: 0, y: 0, z: 60 },
+  aspect: 'all',
+},
+{
+  texture: texture131,
+  mipLevel: 0,
+  origin: { x: 5238, y: 53, z: 60 },
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 70}
+);
+} catch {}
+try {
+commandEncoder110.clearBuffer(
+buffer47,
+25284,
+3148
+);
+dissociateBuffer(device4, buffer47);
+} catch {}
+let video33 = await videoWithData();
+pseudoSubmit(device1, commandEncoder101);
+let texture136 = device1.createTexture(
+{
+size: {width: 219, height: 125, depthOrArrayLayers: 1},
+dimension: '2d',
+format: 'rgba32uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+let texture137 = gpuCanvasContext16.getCurrentTexture();
+let textureView125 = texture109.createView(
+{
+label: '\u8510\u86db\u03cf\u3979\uea3f',
+baseMipLevel: 2,
+mipLevelCount: 4,
+}
+);
+let renderBundleEncoder128 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+'r8sint',
+'rg8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 475,
+}
+);
+try {
+commandEncoder115.resolveQuerySet(
+querySet95,
+130,
+70,
+buffer34,
+22784
+);
+} catch {}
+let pipeline110 = device1.createRenderPipeline(
+{
+label: '\u0f10\u033b\u034b\u008f\u0da7\u0761\u0ea7\ued13\u{1f7e0}\u{1fce4}\u6709',
+layout: pipelineLayout16,
+vertex: {
+module: shaderModule37,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 2776,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 2584,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 5856,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x4',
+offset: 2208,
+shaderLocation: 19,
+},
+{
+format: 'uint8x4',
+offset: 2428,
+shaderLocation: 8,
+},
+{
+format: 'sint32x3',
+offset: 5416,
+shaderLocation: 7,
+},
+{
+format: 'sint16x2',
+offset: 3404,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 1240,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x3',
+offset: 1212,
+shaderLocation: 10,
+},
+{
+format: 'float32',
+offset: 592,
+shaderLocation: 9,
+},
+{
+format: 'uint16x4',
+offset: 356,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 1720,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 1284,
+shaderLocation: 6,
+},
+{
+format: 'sint32x3',
+offset: 928,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 2308,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x2',
+offset: 1004,
+shaderLocation: 14,
+},
+{
+format: 'float32',
+offset: 1540,
+shaderLocation: 2,
+},
+{
+format: 'uint16x2',
+offset: 1492,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 15228,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 18572,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+attributes: [
+
+],
+},
+{
+arrayStride: 936,
+attributes: [
+
+],
+},
+{
+arrayStride: 15084,
+attributes: [
+
+],
+},
+{
+arrayStride: 7384,
+attributes: [
+{
+format: 'uint32x3',
+offset: 1432,
+shaderLocation: 18,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x45c2a9dc,
+},
+fragment: {
+module: shaderModule37,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.BLUE,
+},
+{
+format: 'rgba8uint',
+},
+undefined,
+undefined
+],
+},
+}
+);
+let computePassEncoder66 = commandEncoder116.beginComputePass();
+try {
+renderBundleEncoder124.setVertexBuffer(
+5,
+buffer42,
+16,
+498
+);
+} catch {}
+try {
+gpuCanvasContext14.configure(
+{
+device: device3,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgba16float'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+let commandEncoder118 = device1.createCommandEncoder(
+{
+label: '\u{1fa5e}\u{1fdd6}\u08ba\u{1f764}\u373c\u6a8f\uf63a\u{1f93a}\u79cf\u71e8',
+}
+);
+let texture138 = device1.createTexture(
+{
+label: '\u8ca6\u7e1f\u{1faac}\u{1faff}',
+size: [6564],
+dimension: '1d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8snorm',
+'r8snorm'
+],
+}
+);
+let textureView126 = texture102.createView(
+{
+label: '\u9801\u{1fa83}\u044a\u{1f69c}\u9e10\u27cf\u0033\u0e00\ua08f\u6bc6',
+dimension: '2d',
+baseMipLevel: 2,
+mipLevelCount: 1,
+baseArrayLayer: 164,
+}
+);
+try {
+computePassEncoder63.setPipeline(
+pipeline72
+);
+} catch {}
+try {
+renderBundleEncoder117.setBindGroup(
+2,
+bindGroup48
+);
+} catch {}
+try {
+renderBundleEncoder119.setVertexBuffer(
+3,
+buffer49,
+9840,
+9329
+);
+} catch {}
+try {
+commandEncoder118.copyBufferToBuffer(
+buffer34,
+26772,
+buffer45,
+60264,
+188
+);
+dissociateBuffer(device1, buffer34);
+dissociateBuffer(device1, buffer45);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture107,
+  mipLevel: 2,
+  origin: { x: 4, y: 0, z: 24 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer15),
+/* required buffer size: 3105491 */{
+offset: 227,
+bytesPerRow: 154,
+rowsPerImage: 284,
+},
+{width: 2, height: 1, depthOrArrayLayers: 72}
+);
+} catch {}
+let pipeline111 = await promise58;
+let pipeline112 = device1.createRenderPipeline(
+{
+label: '\u5869\u{1fb54}\ue780\u6c38\ua343\u{1feb1}',
+layout: pipelineLayout20,
+vertex: {
+module: shaderModule25,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 14396,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 9940,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 204,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 88,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 15704,
+attributes: [
+
+],
+},
+{
+arrayStride: 20032,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x2',
+offset: 1692,
+shaderLocation: 11,
+},
+{
+format: 'sint8x4',
+offset: 3168,
+shaderLocation: 10,
+},
+{
+format: 'unorm8x4',
+offset: 10704,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x2',
+offset: 16168,
+shaderLocation: 18,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule25,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'not-equal',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'invert',
+},
+stencilReadMask: 417,
+stencilWriteMask: 2965,
+depthBias: 56,
+depthBiasSlopeScale: 81,
+depthBiasClamp: 50,
+},
+}
+);
+let img31 = await imageWithData(215, 294, '#44e93a63', '#b3f8db46');
+let gpuCanvasContext26 = canvas35.getContext('webgpu');
+let imageBitmap23 = await createImageBitmap(video15);
+let renderBundleEncoder129 = device3.createRenderBundleEncoder(
+{
+label: '\u3338\u51f2\u5209',
+colorFormats: [
+undefined,
+'rg16float',
+'rgba8sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 844,
+}
+);
+let renderBundle106 = renderBundleEncoder129.finish(
+{
+label: '\u108a\u80df'
+}
+);
+let sampler130 = device3.createSampler(
+{
+label: '\u5f87\u0688',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 83.285,
+lodMaxClamp: 97.436,
+}
+);
+try {
+renderPassEncoder47.setScissorRect(
+31,
+30,
+168,
+7
+);
+} catch {}
+try {
+renderPassEncoder47.setIndexBuffer(
+buffer42,
+'uint16'
+);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(
+7,
+buffer42
+);
+} catch {}
+try {
+renderBundleEncoder124.setVertexBuffer(
+3,
+buffer42,
+4684,
+5183
+);
+} catch {}
+let promise62 = device3.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.append('\u{1ffd6}\ue777\u{1fa4e}\u65ea');
+let promise63 = navigator.gpu.requestAdapter();
+document.body.prepend('\u{1ffdc}\ub012\uaba2\u3ee6\ua849\u00a7\ucb02\uf851\u04cb\u3461\u0f64');
+let texture139 = device4.createTexture(
+{
+label: '\ubb14\ue996\u0002\u0026\u0a30\u0116\u8b08\u{1fea7}\u{1fe41}',
+size: {width: 1967, height: 1, depthOrArrayLayers: 631},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32float'
+],
+}
+);
+let computePassEncoder67 = commandEncoder110.beginComputePass();
+try {
+device4.queue.writeBuffer(
+buffer47,
+17972,
+new DataView(new ArrayBuffer(55104)),
+41336,
+4512
+);
+} catch {}
+document.body.prepend('\u326f\u0770');
+try {
+renderPassEncoder47.setScissorRect(
+561,
+4,
+108,
+4
+);
+} catch {}
+try {
+await device3.popErrorScope();
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture127,
+  mipLevel: 0,
+  origin: { x: 740, y: 1, z: 2 },
+  aspect: 'all',
+},
+new Int32Array(arrayBuffer8),
+/* required buffer size: 85865278 */{
+offset: 356,
+bytesPerRow: 4481,
+rowsPerImage: 143,
+},
+{width: 555, height: 0, depthOrArrayLayers: 135}
+);
+} catch {}
+let canvas36 = document.createElement('canvas');
+let pipelineLayout21 = device2.createPipelineLayout(
+{
+label: '\u3fbe\u01ed\u{1fde6}\u3560\u4d77\u0b69',
+bindGroupLayouts: [
+
+],
+}
+);
+let renderBundle107 = renderBundleEncoder113.finish(
+{
+label: '\u5101\u3df1\u4b7d\u{1f741}\u0ef3\uc39a\u34f1'
+}
+);
+try {
+computePassEncoder64.setPipeline(
+pipeline103
+);
+} catch {}
+try {
+commandEncoder97.resolveQuerySet(
+querySet94,
+2713,
+12,
+buffer46,
+10240
+);
+} catch {}
+try {
+gpuCanvasContext11.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float',
+'rg8sint',
+'rgba16float',
+'rgba16float'
+],
+}
+);
+} catch {}
+let promise64 = device2.queue.onSubmittedWorkDone();
+let pipeline113 = device2.createComputePipeline(
+{
+label: '\u76aa\u90c9\uc937\u0fa8\u0e4c',
+layout: 'auto',
+compute: {
+module: shaderModule36,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend('\u2ae8\u{1feac}\ud864\u{1fa8b}\u9e36\u04c9\ud927\u0a02\u068b\u043e');
+let adapter11 = await navigator.gpu.requestAdapter(
+{
+powerPreference: 'low-power',
+}
+);
+let video34 = await videoWithData();
+let offscreenCanvas32 = new OffscreenCanvas(510, 300);
+let video35 = await videoWithData();
+let bindGroupLayout50 = device3.createBindGroupLayout(
+{
+label: '\u0302\ucc34\u5a6d\u0fa4\u3d56\u0ba8\u{1f6fb}\u{1fd6e}\u0910\ua0c5',
+entries: [
+
+],
+}
+);
+try {
+renderPassEncoder47.executeBundles([]);
+} catch {}
+let adapter12 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let shaderModule39 = device2.createShaderModule(
+{
+label: '\u5b70\u1e12\ub5db\ucc1b\u0021\u{1f96a}\u24b0\u8604\u528e',
+code: `@group(1) @binding(3430)
+var<storage, read_write> function5: array<u32>;
+
+@compute @workgroup_size(5, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S33 {
+@location(18) f0: vec2<f16>,
+@location(9) f1: f16,
+@location(8) f2: vec3<u32>,
+@builtin(position) f3: vec4<f32>,
+@location(28) f4: u32,
+@location(25) f5: vec4<u32>,
+@location(7) f6: vec4<u32>,
+@location(14) f7: vec3<f16>,
+@location(27) f8: u32
+}
+
+@fragment
+fn fragment0(@location(17) a0: vec4<u32>, @builtin(sample_index) a1: u32, @location(24) a2: f32, a3: S33, @location(10) a4: f16, @location(26) a5: u32, @location(2) a6: vec3<f16>, @location(21) a7: vec3<f32>, @location(19) a8: vec3<f32>, @location(16) a9: vec4<f16>, @location(6) a10: vec3<f16>, @location(13) a11: vec4<i32>, @location(12) a12: vec4<u32>, @location(0) a13: vec2<u32>, @location(15) a14: vec3<i32>, @location(20) a15: vec2<f32>, @location(29) a16: i32, @location(5) a17: vec3<i32>, @location(4) a18: vec4<i32>, @location(11) a19: f16) {
+
+}
+
+struct VertexOutput0 {
+@location(26) f449: u32,
+@location(9) f450: f16,
+@location(4) f451: vec4<i32>,
+@location(29) f452: i32,
+@location(17) f453: vec4<u32>,
+@location(7) f454: vec4<u32>,
+@location(10) f455: f16,
+@location(25) f456: vec4<u32>,
+@location(12) f457: vec4<u32>,
+@location(16) f458: vec4<f16>,
+@location(28) f459: u32,
+@location(13) f460: vec4<i32>,
+@builtin(position) f461: vec4<f32>,
+@location(5) f462: vec3<i32>,
+@location(15) f463: vec3<i32>,
+@location(11) f464: f16,
+@location(14) f465: vec3<f16>,
+@location(21) f466: vec3<f32>,
+@location(20) f467: vec2<f32>,
+@location(0) f468: vec2<u32>,
+@location(18) f469: vec2<f16>,
+@location(2) f470: vec3<f16>,
+@location(24) f471: f32,
+@location(27) f472: u32,
+@location(8) f473: vec3<u32>,
+@location(6) f474: vec3<f16>,
+@location(19) f475: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(12) a0: vec4<f16>, @location(8) a1: vec2<u32>, @location(1) a2: vec4<i32>, @location(0) a3: f32, @location(5) a4: vec2<u32>, @location(2) a5: vec3<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let renderBundle108 = renderBundleEncoder126.finish(
+{
+label: '\ue3a4\ud537'
+}
+);
+try {
+computePassEncoder59.setPipeline(
+pipeline103
+);
+} catch {}
+try {
+renderBundleEncoder109.setVertexBuffer(
+6,
+buffer46,
+41572
+);
+} catch {}
+try {
+commandEncoder97.copyTextureToTexture(
+{
+  texture: texture110,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 31 },
+  aspect: 'depth-only',
+},
+{
+  texture: texture110,
+  mipLevel: 2,
+  origin: { x: 1107, y: 3, z: 58 },
+  aspect: 'depth-only',
+},
+{width: 362, height: 6, depthOrArrayLayers: 36}
+);
+} catch {}
+try {
+commandEncoder97.clearBuffer(
+buffer46,
+37000,
+9880
+);
+dissociateBuffer(device2, buffer46);
+} catch {}
+try {
+commandEncoder97.resolveQuerySet(
+querySet94,
+1545,
+131,
+buffer46,
+19200
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture108,
+  mipLevel: 13,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'stencil-only',
+},
+new BigInt64Array(arrayBuffer17),
+/* required buffer size: 798 */{
+offset: 798,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+video0.width = 220;
+let video36 = await videoWithData();
+try {
+texture129.label = '\uf451\u{1fbbc}\u063e\u65d1\u{1f9fa}\uf556\ub4e7\u{1fe48}\u{1f694}\u07de';
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let gpuCanvasContext27 = offscreenCanvas32.getContext('webgpu');
+video9.height = 141;
+let promise65 = adapter1.requestAdapterInfo();
+try {
+await promise65;
+} catch {}
+try {
+device3.label = '\u05f4\u08fa\u392a';
+} catch {}
+let texture140 = device3.createTexture(
+{
+label: '\u{1fc16}\u9c31',
+size: [5592, 236, 1],
+mipLevelCount: 9,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'etc2-rgb8unorm'
+],
+}
+);
+try {
+renderPassEncoder47.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder47.setStencilReference(
+2563
+);
+} catch {}
+try {
+renderPassEncoder47.setIndexBuffer(
+buffer42,
+'uint16',
+8288,
+97
+);
+} catch {}
+try {
+await promise62;
+} catch {}
+let textureView127 = texture123.createView(
+{
+}
+);
+try {
+buffer39.destroy();
+} catch {}
+let promise66 = adapter0.requestAdapterInfo();
+try {
+canvas36.getContext('webgl');
+} catch {}
+let querySet106 = device2.createQuerySet(
+{
+label: '\u9ca9\u075e\u0c60\ue5a5\u0833\u05b7\u08bd\u826f\u0102\u21bc\uf3db',
+type: 'occlusion',
+count: 2000,
+}
+);
+let textureView128 = texture123.createView(
+{
+label: '\u09db\u0c4f\ucdfb\u{1faab}\u0832\u0c09\u9d65\ubedc\u6b6b\u{1fa01}\u1595',
+mipLevelCount: 1,
+}
+);
+let computePassEncoder68 = commandEncoder97.beginComputePass();
+let renderBundle109 = renderBundleEncoder109.finish(
+{
+label: '\u03a9\u4354\u{1fe35}\ubfd7\u2984\u{1fb34}\u0c74\u{1f6e8}\u06d2'
+}
+);
+try {
+device2.pushErrorScope(
+'validation'
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture108,
+  mipLevel: 3,
+  origin: { x: 0, y: 2, z: 0 },
+  aspect: 'stencil-only',
+},
+arrayBuffer2,
+/* required buffer size: 841 */{
+offset: 841,
+},
+{width: 1334, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline114 = await device2.createComputePipelineAsync(
+{
+label: '\u0043\u0087\u2db1\ub107\ub582\u0a8b\u63b6\u653d',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule36,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let bindGroup56 = device3.createBindGroup({
+label: '\ue132\u054a\u3f02\ue55f',
+layout: bindGroupLayout50,
+entries: [
+
+],
+});
+let commandEncoder119 = device3.createCommandEncoder(
+{
+label: '\uf640\u000e\u647b\u0594\u083c',
+}
+);
+try {
+renderPassEncoder47.setScissorRect(
+151,
+4,
+63,
+13
+);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(
+0,
+buffer42,
+11348,
+145
+);
+} catch {}
+try {
+renderBundleEncoder124.setBindGroup(
+3,
+bindGroup56
+);
+} catch {}
+try {
+commandEncoder119.clearBuffer(
+buffer48,
+2684,
+264
+);
+dissociateBuffer(device3, buffer48);
+} catch {}
+try {
+commandEncoder119.insertDebugMarker(
+'\u36db'
+);
+} catch {}
+try {
+window.someLabel = device1.label;
+} catch {}
+let buffer50 = device1.createBuffer(
+{
+label: '\ub5c5\u1a80\u533c\uf917\u83e9\ueea4\u{1f9ef}',
+size: 20806,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let querySet107 = device1.createQuerySet(
+{
+type: 'occlusion',
+count: 1605,
+}
+);
+let textureView129 = texture98.createView(
+{
+label: '\ud0e2\uc692\u0f18\u{1ffcd}\u847c\uc891\u0359\u4daa\u02c1\u3176\u08e7',
+dimension: '2d',
+aspect: 'depth-only',
+format: 'depth32float',
+baseMipLevel: 4,
+baseArrayLayer: 30,
+}
+);
+try {
+renderBundleEncoder87.setBindGroup(
+0,
+bindGroup45,
+new Uint32Array(2247),
+644,
+0
+);
+} catch {}
+try {
+renderBundleEncoder117.setVertexBuffer(
+0,
+buffer32
+);
+} catch {}
+let arrayBuffer23 = buffer44.getMappedRange(
+4544
+);
+try {
+commandEncoder118.copyTextureToBuffer(
+{
+  texture: texture93,
+  mipLevel: 9,
+  origin: { x: 10, y: 0, z: 58 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 37712 */
+offset: 37712,
+bytesPerRow: 0,
+rowsPerImage: 121,
+buffer: buffer45,
+},
+{width: 0, height: 5, depthOrArrayLayers: 169}
+);
+dissociateBuffer(device1, buffer45);
+} catch {}
+let pipeline115 = device1.createRenderPipeline(
+{
+label: '\u71ac\u{1f7b7}\u012f\u0317',
+layout: pipelineLayout16,
+vertex: {
+module: shaderModule33,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 10152,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 4728,
+shaderLocation: 16,
+},
+{
+format: 'uint32x2',
+offset: 764,
+shaderLocation: 12,
+},
+{
+format: 'sint8x4',
+offset: 8720,
+shaderLocation: 8,
+},
+{
+format: 'uint32',
+offset: 9136,
+shaderLocation: 19,
+},
+{
+format: 'snorm16x2',
+offset: 2684,
+shaderLocation: 5,
+},
+{
+format: 'float32x2',
+offset: 2532,
+shaderLocation: 4,
+},
+{
+format: 'unorm16x4',
+offset: 5840,
+shaderLocation: 1,
+},
+{
+format: 'uint8x4',
+offset: 1496,
+shaderLocation: 2,
+},
+{
+format: 'uint32x4',
+offset: 1756,
+shaderLocation: 11,
+},
+{
+format: 'snorm8x2',
+offset: 3150,
+shaderLocation: 3,
+},
+{
+format: 'float16x4',
+offset: 2384,
+shaderLocation: 13,
+},
+{
+format: 'uint32',
+offset: 684,
+shaderLocation: 10,
+},
+{
+format: 'sint32x3',
+offset: 696,
+shaderLocation: 14,
+},
+{
+format: 'sint32x2',
+offset: 1932,
+shaderLocation: 6,
+},
+{
+format: 'uint16x4',
+offset: 9300,
+shaderLocation: 17,
+},
+{
+format: 'sint16x2',
+offset: 2452,
+shaderLocation: 7,
+},
+{
+format: 'uint32x3',
+offset: 1040,
+shaderLocation: 0,
+},
+{
+format: 'uint32x4',
+offset: 808,
+shaderLocation: 18,
+},
+{
+format: 'uint32',
+offset: 3004,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 15880,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 4204,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 1432,
+shaderLocation: 15,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule33,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'replace',
+},
+stencilWriteMask: 704,
+depthBias: 76,
+depthBiasSlopeScale: 19,
+depthBiasClamp: 92,
+},
+}
+);
+document.body.prepend('\u{1f990}\u0a63\u{1fa85}\u0032\u07b2\u8c19\u{1f89b}\u{1fafd}\u{1fe0d}\u0158\u09fe');
+let promise67 = adapter4.requestAdapterInfo();
+let renderBundleEncoder130 = device4.createRenderBundleEncoder(
+{
+label: '\u{1f6a5}\ucf62\u771c\u{1f725}\u71ba',
+colorFormats: [
+'rgba8uint',
+'rg16float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 0,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+let externalTexture6 = device4.importExternalTexture(
+{
+label: '\u{1fded}\u4338\u{1fcd2}',
+source: video17,
+colorSpace: 'srgb',
+}
+);
+try {
+device4.queue.writeBuffer(
+buffer47,
+13744,
+new BigUint64Array(2172),
+201,
+1228
+);
+} catch {}
+let videoFrame33 = new VideoFrame(offscreenCanvas9, {timestamp: 0});
+let texture141 = device2.createTexture(
+{
+label: '\u{1f8e3}\u058a\ub958\u{1f72d}',
+size: [1075, 1, 51],
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+let renderBundleEncoder131 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+'r8sint',
+'rg8unorm',
+'r32float',
+'rgb10a2uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 120,
+depthReadOnly: true,
+}
+);
+let device6 = await adapter12.requestDevice(
+{
+label: '\u4512\u4eb8\u0e9a',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 58,
+maxVertexAttributes: 25,
+maxVertexBufferArrayStride: 42473,
+maxStorageTexturesPerShaderStage: 12,
+maxStorageBuffersPerShaderStage: 36,
+maxDynamicStorageBuffersPerPipelineLayout: 56582,
+maxBindingsPerBindGroup: 4744,
+maxTextureDimension1D: 13811,
+maxTextureDimension2D: 9283,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 245213529,
+maxInterStageShaderVariables: 88,
+maxInterStageShaderComponents: 112,
+},
+}
+);
+let imageBitmap24 = await createImageBitmap(offscreenCanvas18);
+try {
+device2.queue.label = '\u3b9f\uc022\u3f83\u{1fff4}\u1f71\u0af7\u0924\u{1f8c4}\u{1fc04}\u{1fc99}\ud100';
+} catch {}
+let buffer51 = device2.createBuffer(
+{
+label: '\u0bee\u9231\u75e7\u11c5',
+size: 2434,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let texture142 = device2.createTexture(
+{
+label: '\u046e\u13b1\u{1f804}',
+size: [12552, 1, 113],
+mipLevelCount: 7,
+dimension: '2d',
+format: 'depth16unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'depth16unorm',
+'depth16unorm'
+],
+}
+);
+let renderBundleEncoder132 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+'r16sint',
+'rgba32float',
+'rg16float'
+],
+sampleCount: 942,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder132.setIndexBuffer(
+buffer46,
+'uint32',
+46128,
+1895
+);
+} catch {}
+try {
+renderBundleEncoder110.setVertexBuffer(
+2,
+buffer46
+);
+} catch {}
+try {
+await promise66;
+} catch {}
+document.body.append('\u41fe\u318e\u{1ff1a}\u5215\uc109\u03cb\u{1fa64}');
+let device7 = await promise22;
+let canvas37 = document.createElement('canvas');
+let bindGroupLayout51 = device6.createBindGroupLayout(
+{
+label: '\u{1fefb}\uf451\uddfe\u{1f8c1}',
+entries: [
+{
+binding: 3073,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+},
+{
+binding: 3352,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+},
+{
+binding: 3121,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}
+],
+}
+);
+let querySet108 = device6.createQuerySet(
+{
+label: '\u0249\u{1ffd4}\u87c2',
+type: 'occlusion',
+count: 1533,
+}
+);
+let texture143 = device6.createTexture(
+{
+label: '\uc93a\u492f\u9b60\u{1fab2}\u9cd3\u0495\ua040',
+size: [164, 92, 1],
+format: 'eac-r11unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'eac-r11unorm'
+],
+}
+);
+let textureView130 = texture143.createView(
+{
+label: '\udc8f\u{1f72a}\ubb3d\u{1fe63}\u{1fec8}\u0004\u{1fb0b}\u0600\u31f2',
+dimension: '2d-array',
+baseArrayLayer: 0,
+}
+);
+let sampler131 = device6.createSampler(
+{
+label: '\u2bf2\u1c7b\uddbf',
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 63.140,
+maxAnisotropy: 1,
+}
+);
+document.body.append('\u9f49\u03e5\u087d\u560e\u{1f755}\u8a17\u1eb7\u22ee\u{1fb94}\u41ec');
+let textureView131 = texture100.createView(
+{
+label: '\u05ff\u2595\u371c\uedbe\u5db3\u9404\u9d3c\u0a30\uf4cb\u6c7e',
+baseMipLevel: 4,
+}
+);
+let computePassEncoder69 = commandEncoder118.beginComputePass(
+{
+label: '\u7d01\u{1f7ff}\u{1fcf6}'
+}
+);
+let renderPassEncoder48 = commandEncoder117.beginRenderPass(
+{
+colorAttachments: [
+undefined
+],
+depthStencilAttachment: {
+view: textureView129,
+depthClearValue: 0.8656687066327304,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+},
+occlusionQuerySet: querySet95,
+maxDrawCount: 50648,
+}
+);
+try {
+computePassEncoder63.setBindGroup(
+1,
+bindGroup51,
+new Uint32Array(6011),
+1292,
+0
+);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(
+6,
+buffer49
+);
+} catch {}
+try {
+renderBundleEncoder115.setVertexBuffer(
+4,
+buffer45
+);
+} catch {}
+try {
+commandEncoder115.copyBufferToBuffer(
+buffer34,
+23320,
+buffer32,
+17620,
+7432
+);
+dissociateBuffer(device1, buffer34);
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+computePassEncoder49.insertDebugMarker(
+'\u0932'
+);
+} catch {}
+let pipeline116 = device1.createRenderPipeline(
+{
+label: '\uf735\u0ef9\u0662\u7f29\ud733\u0ae6\u{1f66b}\u8df8\u2c69\ud0fe\u439f',
+layout: pipelineLayout18,
+vertex: {
+module: shaderModule26,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 19976,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32',
+offset: 7832,
+shaderLocation: 1,
+},
+{
+format: 'sint16x4',
+offset: 10168,
+shaderLocation: 11,
+},
+{
+format: 'sint32x2',
+offset: 19484,
+shaderLocation: 13,
+},
+{
+format: 'sint32',
+offset: 13948,
+shaderLocation: 18,
+},
+{
+format: 'sint32x3',
+offset: 16212,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 10376,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 8736,
+shaderLocation: 9,
+},
+{
+format: 'uint32x2',
+offset: 4192,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 1,
+mask: 0x4f76c68d,
+},
+fragment: {
+module: shaderModule26,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+undefined,
+undefined,
+undefined,
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+}
+],
+},
+}
+);
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let texture144 = device6.createTexture(
+{
+label: '\u05e8\u06f9\u13e0\u6f73\ufeb6\u29e2\u{1fe4e}\ua0f8\u01f8\ucbe3\u54cf',
+size: {width: 2988, height: 170, depthOrArrayLayers: 254},
+mipLevelCount: 4,
+format: 'astc-12x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let textureView132 = texture143.createView(
+{
+aspect: 'all',
+}
+);
+let renderBundleEncoder133 = device6.createRenderBundleEncoder(
+{
+label: '\ufda5\u2bd3\u0df4\u4179\ua44c\ud8e6\u07d4\u3c91\u0063\u6098',
+colorFormats: [
+'rg32sint',
+'rgb10a2uint',
+'r32uint',
+'r16sint',
+'r8uint',
+undefined
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 901,
+stencilReadOnly: true,
+}
+);
+let renderBundle110 = renderBundleEncoder133.finish(
+{
+label: '\ua8e4\u023e\ub008\uc0b0\u84d7\u0a45\u0a83\ue740\u{1fdcb}\u0388\u020a'
+}
+);
+document.body.prepend(video11);
+let img32 = await imageWithData(97, 184, '#1f183bc1', '#6992c5ed');
+try {
+renderBundleEncoder130.setVertexBuffer(
+0,
+undefined,
+1870822899,
+894718747
+);
+} catch {}
+let texture145 = device4.createTexture(
+{
+label: '\u019e\u10cc\u6940\u2d31\u063c\u{1f845}\u{1fe88}\u{1f92b}\u72eb',
+size: [1007, 10, 1],
+mipLevelCount: 6,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'depth32float',
+'depth32float'
+],
+}
+);
+let renderBundleEncoder134 = device4.createRenderBundleEncoder(
+{
+label: '\uab1d\u2f76\u0abd\u0096\u0602\u{1fe92}\u{1fb41}\ucf1c\u5aa5\u089c\u051a',
+colorFormats: [
+'rgba32uint',
+'bgra8unorm-srgb',
+'rg11b10ufloat',
+undefined,
+undefined
+],
+sampleCount: 371,
+depthReadOnly: true,
+}
+);
+try {
+gpuCanvasContext2.configure(
+{
+device: device4,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rg32uint'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer47,
+21232,
+new BigUint64Array(13961),
+6139,
+520
+);
+} catch {}
+document.body.append('\u0e52\u099d\u043a\u0a04\ud7bc\u8ee1');
+try {
+renderBundleEncoder134.setVertexBuffer(
+48,
+undefined,
+2867927552,
+193671922
+);
+} catch {}
+try {
+buffer47.unmap();
+} catch {}
+try {
+renderBundleEncoder134.pushDebugGroup(
+'\u0827'
+);
+} catch {}
+try {
+renderBundleEncoder130.insertDebugMarker(
+'\u2331'
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture135,
+  mipLevel: 2,
+  origin: { x: 1088, y: 8, z: 18 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer12),
+/* required buffer size: 4994593 */{
+offset: 193,
+bytesPerRow: 2081,
+rowsPerImage: 100,
+},
+{width: 972, height: 0, depthOrArrayLayers: 25}
+);
+} catch {}
+document.body.prepend('\u{1fa4a}\u{1f976}\u3317\uefd1\u{1fdbd}');
+let shaderModule40 = device2.createShaderModule(
+{
+label: '\u0503\u0a13\u8276\u208c',
+code: `
+
+@compute @workgroup_size(5, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(1) f0: vec3<u32>,
+@location(5) f1: vec4<i32>,
+@location(7) f2: vec4<f32>,
+@location(6) f3: vec3<i32>,
+@location(3) f4: vec3<u32>,
+@builtin(sample_mask) f5: u32
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S34 {
+@location(11) f0: u32,
+@location(6) f1: f16,
+@location(14) f2: vec3<f32>,
+@location(12) f3: vec2<i32>,
+@location(9) f4: i32,
+@location(5) f5: f16,
+@location(15) f6: f16,
+@location(4) f7: u32
+}
+
+@vertex
+fn vertex0(@location(7) a0: i32, @builtin(instance_index) a1: u32, @location(0) a2: vec4<i32>, @location(10) a3: u32, @location(1) a4: vec3<u32>, @location(8) a5: vec2<f32>, @location(3) a6: vec4<f16>, @location(13) a7: u32, @location(2) a8: vec4<f32>, a9: S34) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let pipelineLayout22 = device2.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout44,
+bindGroupLayout44,
+bindGroupLayout44,
+bindGroupLayout44
+],
+}
+);
+let querySet109 = device2.createQuerySet(
+{
+label: '\u{1f9eb}\u0d04\u0573\u09d7\u164d\ufd5e\u{1f9d4}',
+type: 'occlusion',
+count: 496,
+}
+);
+let texture146 = device2.createTexture(
+{
+label: '\u0fb0\ueb48\u3959\ufaec\u{1f78c}\u6ff3',
+size: [15313],
+dimension: '1d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_DST,
+}
+);
+let sampler132 = device2.createSampler(
+{
+label: '\uc8f9\uc853\u9417\u01fe',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 89.111,
+lodMaxClamp: 97.652,
+maxAnisotropy: 20,
+}
+);
+try {
+device2.queue.writeBuffer(
+buffer46,
+44680,
+new Float32Array(54231),
+26884,
+1232
+);
+} catch {}
+let canvas38 = document.createElement('canvas');
+try {
+canvas38.getContext('2d');
+} catch {}
+let querySet110 = device1.createQuerySet(
+{
+type: 'occlusion',
+count: 1320,
+}
+);
+let texture147 = device1.createTexture(
+{
+label: '\u068a\u{1fdf0}\uafaf\u{1fb31}\ua9c2\u3216\u{1fc86}\u428f\udf33\u07b5',
+size: {width: 12, height: 216, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'astc-12x12-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-12x12-unorm-srgb',
+'astc-12x12-unorm-srgb'
+],
+}
+);
+let textureView133 = texture137.createView(
+{
+format: 'bgra8unorm-srgb',
+}
+);
+let renderPassEncoder49 = commandEncoder115.beginRenderPass(
+{
+label: '\u05eb\u4f13\u8af8\u1733\u{1ffeb}\u1406\u653d',
+colorAttachments: [
+
+],
+depthStencilAttachment: {
+view: textureView129,
+depthClearValue: 0.23767758160167984,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+depthReadOnly: false,
+stencilClearValue: 24825,
+stencilReadOnly: false,
+},
+maxDrawCount: 319152,
+}
+);
+try {
+renderPassEncoder49.setBindGroup(
+3,
+bindGroup48
+);
+} catch {}
+try {
+renderBundleEncoder94.setBindGroup(
+3,
+bindGroup54,
+[]
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 25, height: 1, depthOrArrayLayers: 451}
+*/
+{
+  source: imageData18,
+  origin: { x: 8, y: 38 },
+  flipY: false,
+},
+{
+  texture: texture107,
+  mipLevel: 0,
+  origin: { x: 4, y: 0, z: 28 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 17, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\u0d00\u{1fafd}\u{1fe32}\u{1fd41}\u{1fa94}\u858c\u09c2\u{1f97b}\u0490\u8219\u004e');
+let img33 = await imageWithData(231, 5, '#4ee96f81', '#dfeec56c');
+let querySet111 = device4.createQuerySet(
+{
+label: '\u57c6\uc731\u0022\u8db5\u{1fb12}',
+type: 'occlusion',
+count: 3472,
+}
+);
+let renderBundle111 = renderBundleEncoder130.finish(
+{
+label: '\uad2a\uf450\u0a91\udc2b\u418a\u8539\u{1f9e7}\u6566\u{1fcfc}'
+}
+);
+try {
+device4.queue.writeTexture(
+{
+  texture: texture135,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 21 },
+  aspect: 'all',
+},
+new Int32Array(arrayBuffer10),
+/* required buffer size: 7080762 */{
+offset: 239,
+bytesPerRow: 1427,
+rowsPerImage: 121,
+},
+{width: 588, height: 4, depthOrArrayLayers: 42}
+);
+} catch {}
+let gpuCanvasContext28 = canvas37.getContext('webgpu');
+canvas6.height = 841;
+let pipelineLayout23 = device3.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout50,
+bindGroupLayout50,
+bindGroupLayout50,
+bindGroupLayout50
+],
+}
+);
+let querySet112 = device3.createQuerySet(
+{
+label: '\ubc3a\u0dc2\u7d29\u0312\u322d',
+type: 'occlusion',
+count: 1931,
+}
+);
+let renderBundle112 = renderBundleEncoder124.finish();
+let sampler133 = device3.createSampler(
+{
+label: '\u{1f93c}\u0860\u238c\u9668',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 9.088,
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder47.setBlendConstant(
+{
+r: -195.3,
+g: -885.4,
+b: -587.7,
+a: 632.8,
+}
+);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(
+0,
+buffer42,
+7324,
+3938
+);
+} catch {}
+try {
+buffer42.unmap();
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer48,
+6476,
+new DataView(new ArrayBuffer(56799)),
+31777,
+192
+);
+} catch {}
+let imageBitmap25 = await createImageBitmap(offscreenCanvas8);
+let pipelineLayout24 = device6.createPipelineLayout(
+{
+label: '\u08b8\u01da\u3117\ueeb2\u6176\uf28a\u3c14\u530a\u34ad',
+bindGroupLayouts: [
+bindGroupLayout51,
+bindGroupLayout51
+],
+}
+);
+let texture148 = device6.createTexture(
+{
+size: {width: 132, height: 132, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'r8uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'r8uint',
+'r8uint'
+],
+}
+);
+try {
+gpuCanvasContext7.configure(
+{
+device: device6,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'bgra8unorm-srgb',
+'bgra8unorm-srgb',
+'bgra8unorm-srgb'
+],
+}
+);
+} catch {}
+let canvas39 = document.createElement('canvas');
+let sampler134 = device6.createSampler(
+{
+label: '\u{1fa5e}\u3bd4\u0164\u04b9\ud663',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+lodMinClamp: 69.397,
+lodMaxClamp: 86.002,
+compare: 'equal',
+}
+);
+let promise68 = device6.queue.onSubmittedWorkDone();
+let gpuCanvasContext29 = canvas39.getContext('webgpu');
+let shaderModule41 = device2.createShaderModule(
+{
+label: '\u{1fecc}\u{1fe04}\u{1f7f5}\u{1fa4a}\u2759\u{1f74f}',
+code: `
+
+@compute @workgroup_size(6, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S36 {
+@location(25) f0: vec4<f16>,
+@location(6) f1: vec2<f32>,
+@location(1) f2: vec3<u32>,
+@location(4) f3: vec3<f16>,
+@location(12) f4: i32,
+@builtin(position) f5: vec4<f32>,
+@location(8) f6: vec2<f16>,
+@location(27) f7: u32,
+@location(21) f8: i32,
+@location(16) f9: f32,
+@location(20) f10: vec3<f32>,
+@location(13) f11: vec4<f32>,
+@location(2) f12: vec2<i32>
+}
+struct FragmentOutput0 {
+@location(5) f0: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(14) a0: vec3<u32>, a1: S36, @location(11) a2: vec2<f32>, @location(26) a3: vec2<i32>, @location(15) a4: vec4<f16>, @location(17) a5: vec3<f32>, @location(23) a6: vec4<f16>, @location(3) a7: vec2<f16>, @location(22) a8: u32, @location(10) a9: vec4<f32>, @builtin(sample_index) a10: u32, @location(19) a11: vec3<f16>, @builtin(front_facing) a12: bool, @location(9) a13: vec3<u32>, @location(18) a14: vec3<f16>, @location(7) a15: vec3<f32>, @builtin(sample_mask) a16: u32, @location(24) a17: vec2<u32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S35 {
+@location(11) f0: vec3<u32>,
+@location(8) f1: vec3<f16>,
+@location(13) f2: f32,
+@location(7) f3: vec3<f32>,
+@location(0) f4: vec3<u32>,
+@location(4) f5: vec2<u32>,
+@location(10) f6: vec2<f32>,
+@location(14) f7: f32
+}
+struct VertexOutput0 {
+@location(14) f476: vec3<u32>,
+@location(6) f477: vec2<f32>,
+@location(19) f478: vec3<f16>,
+@location(24) f479: vec2<u32>,
+@location(20) f480: vec3<f32>,
+@location(11) f481: vec2<f32>,
+@location(7) f482: vec3<f32>,
+@location(12) f483: i32,
+@location(16) f484: f32,
+@location(17) f485: vec3<f32>,
+@location(23) f486: vec4<f16>,
+@location(18) f487: vec3<f16>,
+@location(21) f488: i32,
+@location(22) f489: u32,
+@location(2) f490: vec2<i32>,
+@location(25) f491: vec4<f16>,
+@location(4) f492: vec3<f16>,
+@location(3) f493: vec2<f16>,
+@location(1) f494: vec3<u32>,
+@location(26) f495: vec2<i32>,
+@location(9) f496: vec3<u32>,
+@location(13) f497: vec4<f32>,
+@builtin(position) f498: vec4<f32>,
+@location(10) f499: vec4<f32>,
+@location(27) f500: u32,
+@location(15) f501: vec4<f16>,
+@location(8) f502: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec2<f32>, a1: S35, @location(15) a2: vec2<u32>, @location(5) a3: vec2<u32>, @location(2) a4: vec3<f32>, @builtin(instance_index) a5: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+pseudoSubmit(device2, commandEncoder94);
+let textureView134 = texture114.createView(
+{
+label: '\u0713\u{1faed}\ud240\u{1f80e}\u089a',
+}
+);
+try {
+computePassEncoder54.pushDebugGroup(
+'\u0157'
+);
+} catch {}
+try {
+gpuCanvasContext12.configure(
+{
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rg32uint',
+'rgba8unorm-srgb',
+'rgba8unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let renderBundle113 = renderBundleEncoder123.finish(
+{
+label: '\u9743\u{1f90a}'
+}
+);
+try {
+computePassEncoder67.end();
+} catch {}
+try {
+commandEncoder110.copyTextureToTexture(
+{
+  texture: texture145,
+  mipLevel: 0,
+  origin: { x: 886, y: 9, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture145,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'depth-only',
+},
+{width: 31, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder110.clearBuffer(
+buffer47,
+11656,
+15208
+);
+dissociateBuffer(device4, buffer47);
+} catch {}
+gc();
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer18.detached) { new Uint8Array(arrayBuffer18).fill(0x55) };
+} catch {}
+try {
+await promise64;
+} catch {}
+canvas14.width = 180;
+document.body.append('\ub322\u4c69\ubf08\u0725\uc891\u{1fdf3}\ue1d5\u0711');
+let imageBitmap26 = await createImageBitmap(canvas27);
+let commandEncoder120 = device7.createCommandEncoder(
+{
+label: '\u07f6\u2fbd\uaba5\u7a66\u51df',
+}
+);
+pseudoSubmit(device7, commandEncoder120);
+let texture149 = device7.createTexture(
+{
+label: '\u1e83\ufdb5\u0a53\ua0fb\u7d64\u{1ff45}\u629c\u0454\u0a1f\u{1fc9c}',
+size: [591, 5, 6],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgb10a2unorm',
+'rgb10a2unorm',
+'rgb10a2unorm'
+],
+}
+);
+let imageData32 = new ImageData(152, 256);
+let bindGroupLayout52 = device5.createBindGroupLayout(
+{
+label: '\u{1f88b}\u519d\u{1f676}\u074b\u186b\u0fb8\ub299\u3f5e',
+entries: [
+
+],
+}
+);
+let sampler135 = device5.createSampler(
+{
+label: '\u{1f842}\ud428\u{1f980}\u1201\u03ab',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 30.605,
+lodMaxClamp: 81.318,
+compare: 'never',
+}
+);
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55) };
+} catch {}
+let imageBitmap27 = await createImageBitmap(video23);
+let bindGroupLayout53 = device2.createBindGroupLayout(
+{
+label: '\u{1ff59}\uc5d4\u0081\u2163\u4450\u0cfe\u{1fb79}\u4fd3',
+entries: [
+{
+binding: 6782,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '2d-array' },
+},
+{
+binding: 3559,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '1d' },
+}
+],
+}
+);
+let texture150 = device2.createTexture(
+{
+label: '\uf715\uce17\u21d8\u0fa8\u{1f895}',
+size: [13, 27, 67],
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+computePassEncoder68.setPipeline(
+pipeline113
+);
+} catch {}
+try {
+computePassEncoder54.popDebugGroup();
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+offscreenCanvas14.width = 474;
+document.body.append('\u6e09\u80c8\u8a1d\ua522\u77a0\ua8b6');
+let imageBitmap28 = await createImageBitmap(offscreenCanvas9);
+let commandEncoder121 = device3.createCommandEncoder(
+{
+}
+);
+let commandBuffer12 = commandEncoder119.finish(
+{
+label: '\u5abd\ud45b\u0c5e\u0d60\ua54f\u039b\uc865\u3969\u7910\u9736\u0094',
+}
+);
+let texture151 = device3.createTexture(
+{
+size: [6198],
+sampleCount: 1,
+dimension: '1d',
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+try {
+renderPassEncoder47.setBindGroup(
+3,
+bindGroup56
+);
+} catch {}
+try {
+renderPassEncoder47.end();
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture151,
+  mipLevel: 0,
+  origin: { x: 806, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Int8Array(arrayBuffer14),
+/* required buffer size: 84 */{
+offset: 84,
+rowsPerImage: 74,
+},
+{width: 2632, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await promise67;
+} catch {}
+let renderBundle114 = renderBundleEncoder133.finish(
+{
+label: '\u295a\u0fb8\u0547'
+}
+);
+let commandEncoder122 = device7.createCommandEncoder(
+{
+label: '\u1d18\u02c8\u20d5',
+}
+);
+let computePassEncoder70 = commandEncoder122.beginComputePass(
+{
+
+}
+);
+try {
+gpuCanvasContext24.configure(
+{
+device: device7,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let imageBitmap29 = await createImageBitmap(imageBitmap2);
+let texture152 = device7.createTexture(
+{
+label: '\u871f\u08cc\u{1f7a3}\u{1f7e9}\uc07d\u{1fa48}\u37b3\u7b49\uda4c\u7b30',
+size: [934, 1, 518],
+mipLevelCount: 8,
+dimension: '3d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+document.body.append('\u{1ff8b}\u018f\u{1fb9a}\u0cb2\u1705\u8e90');
+let shaderModule42 = device6.createShaderModule(
+{
+label: '\u8df7\u01e1\u{1f7a1}\u08a4',
+code: `
+
+@compute @workgroup_size(1, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S38 {
+@location(80) f0: vec3<i32>,
+@location(83) f1: vec2<f32>,
+@location(47) f2: vec4<i32>,
+@location(32) f3: vec4<f16>,
+@location(71) f4: u32,
+@location(12) f5: u32,
+@location(11) f6: vec2<f16>,
+@location(86) f7: vec4<u32>,
+@location(18) f8: vec4<i32>,
+@location(45) f9: vec4<f32>,
+@location(73) f10: vec3<f32>,
+@location(26) f11: i32,
+@location(65) f12: vec4<i32>
+}
+struct FragmentOutput0 {
+@location(4) f0: i32,
+@location(3) f1: vec4<f32>,
+@location(0) f2: vec4<f32>,
+@location(7) f3: i32,
+@location(1) f4: i32,
+@location(6) f5: vec3<i32>,
+@location(2) f6: vec4<u32>,
+@location(5) f7: f32,
+@builtin(frag_depth) f8: f32,
+@builtin(sample_mask) f9: u32
+}
+
+@fragment
+fn fragment0(@location(21) a0: f16, @location(35) a1: vec4<u32>, @location(5) a2: vec3<u32>, @location(23) a3: vec3<f32>, @location(16) a4: u32, @location(2) a5: vec4<u32>, @location(50) a6: vec3<f16>, @location(43) a7: vec2<u32>, @location(70) a8: u32, @location(59) a9: vec4<i32>, @location(62) a10: vec4<u32>, @location(87) a11: vec3<f16>, @builtin(sample_mask) a12: u32, @location(46) a13: f16, @location(31) a14: vec3<u32>, @location(61) a15: i32, @location(51) a16: vec3<i32>, @location(75) a17: f16, @location(48) a18: f16, a19: S38, @location(42) a20: vec3<f16>, @location(69) a21: vec2<u32>, @location(36) a22: vec2<f16>, @location(58) a23: u32, @builtin(front_facing) a24: bool, @builtin(position) a25: vec4<f32>, @location(0) a26: vec2<u32>, @location(20) a27: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S37 {
+@location(18) f0: vec2<f32>,
+@location(3) f1: vec2<f32>,
+@location(19) f2: vec2<i32>
+}
+struct VertexOutput0 {
+@location(41) f503: f32,
+@location(43) f504: vec2<u32>,
+@location(26) f505: i32,
+@location(48) f506: f16,
+@location(87) f507: vec3<f16>,
+@location(0) f508: vec2<u32>,
+@location(56) f509: vec3<f16>,
+@location(85) f510: f32,
+@location(21) f511: f16,
+@location(80) f512: vec3<i32>,
+@location(65) f513: vec4<i32>,
+@location(50) f514: vec3<f16>,
+@location(62) f515: vec4<u32>,
+@location(37) f516: vec4<i32>,
+@location(20) f517: u32,
+@location(69) f518: vec2<u32>,
+@location(53) f519: vec3<u32>,
+@builtin(position) f520: vec4<f32>,
+@location(47) f521: vec4<i32>,
+@location(23) f522: vec3<f32>,
+@location(7) f523: u32,
+@location(61) f524: i32,
+@location(6) f525: vec2<i32>,
+@location(35) f526: vec4<u32>,
+@location(40) f527: vec2<f32>,
+@location(5) f528: vec3<u32>,
+@location(42) f529: vec3<f16>,
+@location(45) f530: vec4<f32>,
+@location(83) f531: vec2<f32>,
+@location(12) f532: u32,
+@location(59) f533: vec4<i32>,
+@location(86) f534: vec4<u32>,
+@location(51) f535: vec3<i32>,
+@location(18) f536: vec4<i32>,
+@location(75) f537: f16,
+@location(55) f538: f16,
+@location(2) f539: vec4<u32>,
+@location(46) f540: f16,
+@location(78) f541: u32,
+@location(58) f542: u32,
+@location(16) f543: u32,
+@location(33) f544: i32,
+@location(36) f545: vec2<f16>,
+@location(32) f546: vec4<f16>,
+@location(73) f547: vec3<f32>,
+@location(71) f548: u32,
+@location(31) f549: vec3<u32>,
+@location(11) f550: vec2<f16>,
+@location(70) f551: u32
+}
+
+@vertex
+fn vertex0(a0: S37, @location(15) a1: vec4<i32>, @location(10) a2: vec2<i32>, @location(20) a3: vec3<u32>, @location(0) a4: vec3<u32>, @location(24) a5: vec3<u32>, @location(2) a6: i32, @location(22) a7: vec2<u32>, @location(11) a8: vec4<f32>, @location(17) a9: vec3<i32>, @builtin(vertex_index) a10: u32, @builtin(instance_index) a11: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+try {
+gpuCanvasContext19.configure(
+{
+device: device6,
+format: 'etc2-rgb8a1unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+document.body.append('\u2a51\udf7e\u0e60\uffcd\ub2dd\u3d0d\ucc64');
+let promise69 = adapter4.requestAdapterInfo();
+let bindGroup57 = device1.createBindGroup({
+layout: bindGroupLayout48,
+entries: [
+{
+binding: 4232,
+resource: textureView129
+},
+{
+binding: 1665,
+resource: sampler117
+}
+],
+});
+let buffer52 = device1.createBuffer(
+{
+label: '\uac80\u0b60\u03c5\udf1f\u48b6\u1b2a\u91f4\u{1faab}',
+size: 6855,
+usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+}
+);
+let texture153 = device1.createTexture(
+{
+label: '\u0ca8\uc1fb\u1597\u01c7\u2980\u9218',
+size: [36, 84, 40],
+mipLevelCount: 3,
+dimension: '2d',
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+try {
+renderPassEncoder49.setVertexBuffer(
+8,
+buffer37,
+21736,
+232
+);
+} catch {}
+try {
+renderBundleEncoder128.setBindGroup(
+3,
+bindGroup49,
+new Uint32Array(8419),
+1447,
+0
+);
+} catch {}
+try {
+renderBundleEncoder97.setVertexBuffer(
+8,
+buffer37,
+9564,
+1010
+);
+} catch {}
+document.body.prepend('\uc3aa\u0c09\u{1f992}');
+try {
+textureView130.label = '\u{1f716}\u{1f823}\u0c63\u091d\ud8df\u{1f92c}';
+} catch {}
+let shaderModule43 = device6.createShaderModule(
+{
+label: '\u{1f618}\u9134',
+code: `@group(0) @binding(3073)
+var<storage, read_write> type3: array<u32>;
+
+@compute @workgroup_size(2, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: vec4<i32>,
+@location(4) f1: i32
+}
+
+@fragment
+fn fragment0(@location(52) a0: i32, @location(56) a1: vec4<u32>, @location(8) a2: f32, @location(10) a3: f32, @location(85) a4: vec3<u32>, @location(49) a5: vec4<f16>, @location(47) a6: vec4<i32>, @location(1) a7: f16, @location(54) a8: f32, @location(40) a9: vec4<f32>, @location(12) a10: vec4<f16>, @location(5) a11: vec3<f32>, @location(42) a12: vec3<f16>, @location(43) a13: i32, @location(66) a14: vec4<f16>, @builtin(front_facing) a15: bool, @location(87) a16: vec4<f32>, @location(60) a17: vec4<f16>, @location(30) a18: i32, @location(63) a19: vec3<f32>, @location(70) a20: vec4<i32>, @location(3) a21: vec4<u32>, @location(15) a22: vec2<u32>, @location(4) a23: vec4<f16>, @location(72) a24: vec2<f16>, @location(39) a25: vec2<f16>, @location(65) a26: vec4<u32>, @location(9) a27: vec4<f32>, @location(44) a28: vec2<f16>, @location(71) a29: vec3<i32>, @location(20) a30: u32, @location(19) a31: f32, @location(59) a32: vec3<f32>, @location(25) a33: f32, @builtin(sample_mask) a34: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S39 {
+@location(1) f0: vec2<f16>,
+@location(12) f1: vec3<f16>
+}
+struct VertexOutput0 {
+@location(85) f552: vec3<u32>,
+@location(20) f553: u32,
+@location(42) f554: vec3<f16>,
+@location(44) f555: vec2<f16>,
+@location(71) f556: vec3<i32>,
+@location(28) f557: vec4<f16>,
+@location(15) f558: vec2<u32>,
+@location(8) f559: f32,
+@location(47) f560: vec4<i32>,
+@location(9) f561: vec4<f32>,
+@location(65) f562: vec4<u32>,
+@location(12) f563: vec4<f16>,
+@location(49) f564: vec4<f16>,
+@location(1) f565: f16,
+@location(45) f566: vec3<i32>,
+@location(4) f567: vec4<f16>,
+@location(30) f568: i32,
+@location(19) f569: f32,
+@location(72) f570: vec2<f16>,
+@location(25) f571: f32,
+@location(70) f572: vec4<i32>,
+@location(87) f573: vec4<f32>,
+@location(52) f574: i32,
+@location(38) f575: vec3<f32>,
+@location(59) f576: vec3<f32>,
+@location(10) f577: f32,
+@location(66) f578: vec4<f16>,
+@location(40) f579: vec4<f32>,
+@location(39) f580: vec2<f16>,
+@location(82) f581: vec4<f16>,
+@location(84) f582: vec2<i32>,
+@location(21) f583: vec3<i32>,
+@location(63) f584: vec3<f32>,
+@location(51) f585: vec2<f16>,
+@location(43) f586: i32,
+@location(5) f587: vec3<f32>,
+@location(58) f588: vec2<i32>,
+@location(3) f589: vec4<u32>,
+@location(56) f590: vec4<u32>,
+@builtin(position) f591: vec4<f32>,
+@location(60) f592: vec4<f16>,
+@location(54) f593: f32
+}
+
+@vertex
+fn vertex0(@location(19) a0: vec4<f16>, @location(14) a1: vec2<f32>, @location(10) a2: vec3<i32>, @location(17) a3: vec3<f32>, @location(20) a4: vec2<f32>, @location(8) a5: vec3<f16>, @location(21) a6: vec3<f32>, a7: S39, @location(3) a8: vec2<i32>, @location(18) a9: i32, @builtin(vertex_index) a10: u32, @builtin(instance_index) a11: u32, @location(5) a12: f32, @location(22) a13: vec4<f32>, @location(11) a14: vec3<u32>, @location(6) a15: i32, @location(0) a16: i32, @location(2) a17: vec2<f16>, @location(4) a18: vec4<f16>, @location(9) a19: i32, @location(7) a20: f32, @location(13) a21: vec2<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline117 = device6.createComputePipeline(
+{
+label: '\u9a52\ub2bc\u185a\uea24\uc489\u{1ffe1}\u544e\u064d\u{1ff69}\u{1f6e3}',
+layout: pipelineLayout24,
+compute: {
+module: shaderModule43,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext23.unconfigure();
+} catch {}
+let bindGroupLayout54 = device7.createBindGroupLayout(
+{
+entries: [
+{
+binding: 766,
+visibility: 0,
+texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+},
+{
+binding: 694,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 344,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+}
+],
+}
+);
+pseudoSubmit(device7, commandEncoder122);
+document.body.append('\uf639\u0e4a\u{1fc40}\u69a3\u{1faa2}\uc025');
+let imageData33 = new ImageData(84, 216);
+try {
+computePassEncoder61.setBindGroup(
+3,
+bindGroup56,
+new Uint32Array(2751),
+2018,
+0
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture127,
+  mipLevel: 2,
+  origin: { x: 123, y: 1, z: 2 },
+  aspect: 'all',
+},
+arrayBuffer3,
+/* required buffer size: 4583909 */{
+offset: 485,
+bytesPerRow: 1492,
+rowsPerImage: 128,
+},
+{width: 164, height: 0, depthOrArrayLayers: 25}
+);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+querySet108.label = '\uf142\ufbe7\u5a7a\u39da\u0df6\u080c\u{1fcf8}';
+} catch {}
+let textureView135 = texture148.createView(
+{
+aspect: 'all',
+format: 'r8uint',
+baseMipLevel: 6,
+}
+);
+let sampler136 = device6.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMaxClamp: 91.758,
+}
+);
+try {
+device6.queue.writeTexture(
+{
+  texture: texture143,
+  mipLevel: 0,
+  origin: { x: 12, y: 12, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer10,
+/* required buffer size: 232 */{
+offset: 232,
+bytesPerRow: 292,
+rowsPerImage: 149,
+},
+{width: 76, height: 12, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let buffer53 = device4.createBuffer(
+{
+label: '\u5d43\u06e4\uc840\ub0b8',
+size: 40946,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let sampler137 = device4.createSampler(
+{
+label: '\uf9de\u0999\u7420',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 53.201,
+lodMaxClamp: 65.310,
+}
+);
+try {
+commandEncoder110.copyBufferToBuffer(
+buffer53,
+2216,
+buffer47,
+17296,
+7820
+);
+dissociateBuffer(device4, buffer53);
+dissociateBuffer(device4, buffer47);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture135,
+  mipLevel: 4,
+  origin: { x: 112, y: 4, z: 22 },
+  aspect: 'all',
+},
+new ArrayBuffer(10468923),
+/* required buffer size: 10468923 */{
+offset: 36,
+bytesPerRow: 1061,
+rowsPerImage: 299,
+},
+{width: 416, height: 0, depthOrArrayLayers: 34}
+);
+} catch {}
+let video37 = await videoWithData();
+gc();
+document.body.append('\u21ec\u2ba9\u60a1\u9ed7');
+let buffer54 = device3.createBuffer(
+{
+label: '\ue435\ue007\u13fc\u7cbe\u1887',
+size: 50560,
+usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+mappedAtCreation: true,
+}
+);
+let commandBuffer13 = commandEncoder121.finish(
+{
+}
+);
+offscreenCanvas31.width = 762;
+let querySet113 = device4.createQuerySet(
+{
+label: '\ud8ba\u{1f951}\u{1fb9d}\u0f9a\u08d7\u04b6',
+type: 'occlusion',
+count: 2726,
+}
+);
+let texture154 = device4.createTexture(
+{
+size: [123, 1, 125],
+mipLevelCount: 2,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'stencil8'
+],
+}
+);
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+try {
+commandEncoder110.copyBufferToBuffer(
+buffer53,
+428,
+buffer47,
+21788,
+2112
+);
+dissociateBuffer(device4, buffer53);
+dissociateBuffer(device4, buffer47);
+} catch {}
+try {
+commandEncoder110.clearBuffer(
+buffer47,
+4032,
+17228
+);
+dissociateBuffer(device4, buffer47);
+} catch {}
+try {
+commandEncoder110.insertDebugMarker(
+'\u47bf'
+);
+} catch {}
+let img34 = await imageWithData(17, 78, '#8efc38f6', '#6a14b7c0');
+let bindGroupLayout55 = device2.createBindGroupLayout(
+{
+label: '\ua652\uf16d\ueca8\u{1f96b}\u0c05\u0f76\uf477\u7738\u9fbb\u0c98\uc248',
+entries: [
+
+],
+}
+);
+let pipelineLayout25 = device2.createPipelineLayout(
+{
+label: '\u2b24\ua1fd\u6f9e\u0707\u{1fa64}\u{1f8b9}\u86a5\u{1fd94}\u00a0',
+bindGroupLayouts: [
+bindGroupLayout44
+],
+}
+);
+let buffer55 = device2.createBuffer(
+{
+label: '\u0e5c\u4403\u{1fb62}\u0c9f\u1e59\u{1fe0e}',
+size: 32112,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+mappedAtCreation: true,
+}
+);
+try {
+computePassEncoder59.setPipeline(
+pipeline103
+);
+} catch {}
+try {
+gpuCanvasContext13.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8uint',
+'r32uint',
+'rgba16float'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let texture155 = device6.createTexture(
+{
+size: {width: 80, height: 6, depthOrArrayLayers: 24},
+mipLevelCount: 5,
+dimension: '2d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let pipeline118 = device6.createRenderPipeline(
+{
+label: '\u1cac\uf309\ue846\ue447',
+layout: pipelineLayout24,
+vertex: {
+module: shaderModule42,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 5636,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x4',
+offset: 1696,
+shaderLocation: 3,
+},
+{
+format: 'float16x2',
+offset: 4064,
+shaderLocation: 11,
+},
+{
+format: 'uint32',
+offset: 2084,
+shaderLocation: 22,
+},
+{
+format: 'sint8x2',
+offset: 2446,
+shaderLocation: 2,
+},
+{
+format: 'uint16x2',
+offset: 564,
+shaderLocation: 24,
+},
+{
+format: 'sint8x2',
+offset: 2196,
+shaderLocation: 15,
+},
+{
+format: 'sint32x4',
+offset: 3176,
+shaderLocation: 17,
+},
+{
+format: 'uint8x2',
+offset: 2126,
+shaderLocation: 0,
+},
+{
+format: 'sint32',
+offset: 5400,
+shaderLocation: 10,
+},
+{
+format: 'sint32',
+offset: 1092,
+shaderLocation: 19,
+},
+{
+format: 'float32x2',
+offset: 3032,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 18796,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 3612,
+shaderLocation: 20,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0x3a779ff5,
+},
+fragment: {
+module: shaderModule42,
+entryPoint: 'fragment0',
+targets: [
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'src',
+dstFactor: 'one-minus-src-alpha'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.BLUE,
+},
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'src-alpha',
+dstFactor: 'one-minus-dst'
+},
+},
+format: 'rgba8unorm-srgb',
+writeMask: 0,
+},
+{
+format: 'r16sint',
+},
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'one',
+dstFactor: 'zero'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'not-equal',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 384,
+stencilWriteMask: 2280,
+depthBias: 79,
+depthBiasSlopeScale: 93,
+depthBiasClamp: 38,
+},
+}
+);
+document.body.prepend('\u18de\u{1fd8e}\ue65b\u53e8\u4aed\u03b7\u{1fcf1}');
+let videoFrame34 = new VideoFrame(imageBitmap28, {timestamp: 0});
+let querySet114 = device4.createQuerySet(
+{
+label: '\uf53e\u5044\ua795',
+type: 'occlusion',
+count: 3380,
+}
+);
+let commandBuffer14 = commandEncoder110.finish(
+{
+label: '\u{1fd1a}\u0576\uda07\u02be\u{1f972}\u0bfa\u0fca\u0c22\u977b\u{1fa93}\u8035',
+}
+);
+let sampler138 = device4.createSampler(
+{
+label: '\u{1ffb5}\u503c\u6349\u016b\u68c6\u493b\u{1fcf3}\u{1f6f2}\u{1fe71}\u{1f815}\u020d',
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 1.163,
+lodMaxClamp: 64.192,
+compare: 'never',
+}
+);
+try {
+computePassEncoder62.end();
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture135,
+  mipLevel: 5,
+  origin: { x: 104, y: 0, z: 42 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 1900422 */{
+offset: 153,
+bytesPerRow: 417,
+rowsPerImage: 217,
+},
+{width: 120, height: 0, depthOrArrayLayers: 22}
+);
+} catch {}
+let texture156 = device1.createTexture(
+{
+label: '\ucc8f\u0007\u93fc\u{1f733}\u{1feae}\u{1fe0d}\u4646\ud101\ub7b8\udcbc\u0209',
+size: [3944, 145, 1],
+mipLevelCount: 7,
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+computePassEncoder47.setBindGroup(
+3,
+bindGroup51,
+new Uint32Array(5927),
+335,
+0
+);
+} catch {}
+try {
+renderPassEncoder48.setBlendConstant(
+{
+r: -148.0,
+g: 304.4,
+b: 270.9,
+a: 775.1,
+}
+);
+} catch {}
+try {
+renderPassEncoder49.setScissorRect(
+261,
+1,
+130,
+0
+);
+} catch {}
+try {
+renderPassEncoder49.setViewport(
+15.28,
+0.8276,
+339.6,
+0.1161,
+0.3529,
+0.4814
+);
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(
+buffer34,
+'uint32',
+5000,
+10862
+);
+} catch {}
+try {
+device1.queue.submit([
+commandBuffer11,
+]);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer50,
+17440,
+new DataView(new ArrayBuffer(20208)),
+5534,
+448
+);
+} catch {}
+document.body.append('\u9e08\u{1fe78}\u54fb\u44f4');
+let texture157 = device4.createTexture(
+{
+label: '\u0234\ufb60\u5abd\u0f9b',
+size: {width: 4974, height: 1, depthOrArrayLayers: 37},
+mipLevelCount: 8,
+format: 'rg8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg8uint'
+],
+}
+);
+let sampler139 = device4.createSampler(
+{
+label: '\u{1fbf4}\u00d8\u0759\u0b6c\u5fb4\u00ba\u0044',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 3.913,
+lodMaxClamp: 6.122,
+compare: 'greater',
+}
+);
+try {
+commandEncoder112.copyBufferToBuffer(
+buffer53,
+33036,
+buffer47,
+15316,
+4720
+);
+dissociateBuffer(device4, buffer53);
+dissociateBuffer(device4, buffer47);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.prepend(img33);
+let commandEncoder123 = device7.createCommandEncoder(
+{
+}
+);
+let querySet115 = device7.createQuerySet(
+{
+type: 'occlusion',
+count: 79,
+}
+);
+let textureView136 = texture149.createView(
+{
+label: '\ua9e6\u1269\ue0df\u0a39\u0873\u0f56\u84bf\u05d2\u0db2\u5a41',
+baseMipLevel: 2,
+}
+);
+try {
+gpuCanvasContext9.configure(
+{
+device: device7,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8sint'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+document.body.append('\u3e12\u0e46\u{1f66c}\u{1fd91}\u2a6c\u{1ffe9}\u4f69\u059b');
+let bindGroup58 = device2.createBindGroup({
+label: '\u{1fc19}\uff90\ube7a\u07e8\u19d7\ubb23\u8ea7',
+layout: bindGroupLayout44,
+entries: [
+{
+binding: 3430,
+resource: sampler120
+},
+{
+binding: 5749,
+resource: {
+buffer: buffer55,
+offset: 17280,
+size: 10452,
+}
+}
+],
+});
+pseudoSubmit(device2, commandEncoder100);
+let renderBundleEncoder135 = device2.createRenderBundleEncoder(
+{
+label: '\udc75\u9703\u5ce2\u305b\u8c1d\ucf4b\u0c9a\u0639\u{1f897}\ue96c',
+colorFormats: [
+'rg32float',
+'rgba16sint',
+'rgba16sint',
+'rgba8uint',
+'r32float',
+undefined,
+'rgb10a2uint'
+],
+sampleCount: 598,
+depthReadOnly: false,
+}
+);
+let renderBundle115 = renderBundleEncoder104.finish(
+{
+label: '\uc4a1\ua3bc\u436b\u{1f969}\u08d4\uc1ce\uf8af\uf02a\u9fe4'
+}
+);
+let sampler140 = device2.createSampler(
+{
+label: '\ua8d8\u09e3\u9877\u7e1e\u345f\uf6c9\u0552',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 21.277,
+lodMaxClamp: 55.172,
+compare: 'greater',
+}
+);
+try {
+renderBundleEncoder108.setBindGroup(
+2,
+bindGroup58
+);
+} catch {}
+let pipeline119 = device2.createRenderPipeline(
+{
+label: '\u0397\u36f6\ue739\ufe4d',
+layout: pipelineLayout17,
+vertex: {
+module: shaderModule39,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 512,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x4',
+offset: 156,
+shaderLocation: 5,
+},
+{
+format: 'float16x4',
+offset: 216,
+shaderLocation: 0,
+},
+{
+format: 'sint32',
+offset: 368,
+shaderLocation: 1,
+},
+{
+format: 'float32x4',
+offset: 424,
+shaderLocation: 12,
+},
+{
+format: 'snorm16x2',
+offset: 96,
+shaderLocation: 2,
+},
+{
+format: 'uint16x4',
+offset: 252,
+shaderLocation: 8,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+unclippedDepth: false,
+},
+multisample: {
+count: 4,
+},
+fragment: {
+module: shaderModule39,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'greater',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilReadMask: 1416,
+stencilWriteMask: 2242,
+depthBias: 19,
+depthBiasSlopeScale: 49,
+depthBiasClamp: 83,
+},
+}
+);
+let bindGroup59 = device3.createBindGroup({
+label: '\u9613\u9dc1\u6d66\u0ffa',
+layout: bindGroupLayout50,
+entries: [
+
+],
+});
+let promise70 = device3.popErrorScope();
+try {
+device3.queue.writeTexture(
+{
+  texture: texture140,
+  mipLevel: 6,
+  origin: { x: 28, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(579),
+/* required buffer size: 579 */{
+offset: 579,
+},
+{width: 32, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let bindGroup60 = device2.createBindGroup({
+label: '\u{1ffe8}\u9ad7',
+layout: bindGroupLayout44,
+entries: [
+{
+binding: 5749,
+resource: {
+buffer: buffer55,
+offset: 18432,
+}
+},
+{
+binding: 3430,
+resource: sampler112
+}
+],
+});
+try {
+device2.queue.writeTexture(
+{
+  texture: texture113,
+  mipLevel: 1,
+  origin: { x: 1, y: 1, z: 5 },
+  aspect: 'all',
+},
+new Int16Array(new ArrayBuffer(48)),
+/* required buffer size: 590425 */{
+offset: 25,
+bytesPerRow: 41,
+rowsPerImage: 288,
+},
+{width: 0, height: 0, depthOrArrayLayers: 51}
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline120 = device2.createRenderPipeline(
+{
+label: '\uf5a8\u{1fc02}\u0eb0',
+layout: pipelineLayout21,
+vertex: {
+module: shaderModule39,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 7524,
+attributes: [
+{
+format: 'uint32x2',
+offset: 4576,
+shaderLocation: 8,
+},
+{
+format: 'unorm8x2',
+offset: 1340,
+shaderLocation: 2,
+},
+{
+format: 'uint32x3',
+offset: 5384,
+shaderLocation: 5,
+},
+{
+format: 'snorm16x4',
+offset: 3284,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 13964,
+attributes: [
+
+],
+},
+{
+arrayStride: 15424,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 25600,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 11920,
+shaderLocation: 1,
+},
+{
+format: 'float16x4',
+offset: 11912,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+},
+fragment: {
+module: shaderModule39,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'always',
+failOp: 'invert',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+passOp: 'replace',
+},
+stencilReadMask: 2626,
+stencilWriteMask: 815,
+depthBiasSlopeScale: 56,
+depthBiasClamp: 98,
+},
+}
+);
+try {
+await promise70;
+} catch {}
+document.body.prepend('\u0eb0\u81ae\u8972\u090d\u{1fe72}\u{1fe9a}\u{1f953}');
+let querySet116 = device3.createQuerySet(
+{
+label: '\u009d\ue064\ubfdc',
+type: 'occlusion',
+count: 3523,
+}
+);
+let texture158 = device3.createTexture(
+{
+label: '\u{1fa6b}\u0492\u0a76',
+size: [172, 1, 172],
+mipLevelCount: 7,
+dimension: '3d',
+format: 'r32sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32sint'
+],
+}
+);
+let textureView137 = texture128.createView(
+{
+baseMipLevel: 1,
+mipLevelCount: 4,
+baseArrayLayer: 200,
+arrayLayerCount: 4,
+}
+);
+let pipelineLayout26 = device7.createPipelineLayout(
+{
+label: '\u{1fa87}\u85ed\uf44b\ua705\u{1fbc1}\u{1ff69}',
+bindGroupLayouts: [
+bindGroupLayout54,
+bindGroupLayout54,
+bindGroupLayout54,
+bindGroupLayout54
+],
+}
+);
+let buffer56 = device7.createBuffer(
+{
+size: 46344,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+mappedAtCreation: true,
+}
+);
+let commandBuffer15 = commandEncoder123.finish(
+{
+label: '\u6715\uab27',
+}
+);
+try {
+gpuCanvasContext9.configure(
+{
+device: device7,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb',
+'rg32float'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+try {
+await device7.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append('\u{1f7e3}\u0044\u65ee\u0ede\u0868\u2324');
+document.body.append('\uee33\ubde1\ubfc7');
+let commandEncoder124 = device6.createCommandEncoder(
+{
+label: '\u3942\u01d6',
+}
+);
+let texture159 = device6.createTexture(
+{
+size: {width: 144, height: 48, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderPassEncoder50 = commandEncoder124.beginRenderPass(
+{
+label: '\u02b2\u0e86\u{1ffe8}\uc371',
+colorAttachments: [
+{
+view: textureView135,
+clearValue: {
+r: -881.7,
+g: -517.1,
+b: 42.87,
+a: -637.3,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet108,
+maxDrawCount: 248000,
+}
+);
+let renderBundleEncoder136 = device6.createRenderBundleEncoder(
+{
+label: '\u{1fed0}\u03a3\u7722\u0219\u449b\u5028',
+colorFormats: [
+'r32sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 727,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+device6.pushErrorScope(
+'out-of-memory'
+);
+} catch {}
+try {
+device6.queue.writeTexture(
+{
+  texture: texture143,
+  mipLevel: 0,
+  origin: { x: 60, y: 28, z: 0 },
+  aspect: 'all',
+},
+new Float32Array(new ArrayBuffer(0)),
+/* required buffer size: 678 */{
+offset: 678,
+bytesPerRow: 172,
+rowsPerImage: 134,
+},
+{width: 48, height: 52, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await promise69;
+} catch {}
+let textureView138 = texture140.createView(
+{
+label: '\u9b89\u{1f9fa}\u7423',
+dimension: '2d',
+baseMipLevel: 7,
+mipLevelCount: 2,
+}
+);
+let sampler141 = device3.createSampler(
+{
+label: '\u7017\u9681',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 13.912,
+lodMaxClamp: 80.848,
+}
+);
+try {
+computePassEncoder66.pushDebugGroup(
+'\u{1f6bc}'
+);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer48,
+488,
+new DataView(new ArrayBuffer(64786)),
+58863,
+2980
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture133,
+  mipLevel: 1,
+  origin: { x: 1019, y: 1, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer15,
+/* required buffer size: 194 */{
+offset: 194,
+},
+{width: 2419, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\u{1faed}\u6d5e\u{1f771}\ue249\u2fa6\u5da2');
+try {
+window.someLabel = device5.queue.label;
+} catch {}
+let pipelineLayout27 = device5.createPipelineLayout(
+{
+label: '\u1f6c\uc089\u{1f931}\u0016\u9448\u0e62\u2b7e',
+bindGroupLayouts: [
+bindGroupLayout52,
+bindGroupLayout52,
+bindGroupLayout52,
+bindGroupLayout52,
+bindGroupLayout52,
+bindGroupLayout52
+],
+}
+);
+document.body.prepend('\u137f\u{1fda3}\u0dae\ua3fe\u2f36\u0251\u2d3f\u49b1');
+let offscreenCanvas33 = new OffscreenCanvas(273, 241);
+let imageBitmap30 = await createImageBitmap(offscreenCanvas24);
+let texture160 = device7.createTexture(
+{
+label: '\u{1f7bd}\u937b\u1731\u0d54\u0a26\u91ee',
+size: {width: 1939, height: 1, depthOrArrayLayers: 236},
+mipLevelCount: 8,
+dimension: '3d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb10a2uint',
+'rgb10a2uint'
+],
+}
+);
+let renderBundleEncoder137 = device7.createRenderBundleEncoder(
+{
+label: '\u{1ff39}\u0bb6\u6611\u{1fa45}\u0042\ubb47',
+colorFormats: [
+'rg8unorm',
+'rgba32sint',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 240,
+stencilReadOnly: false,
+}
+);
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer21.detached) { new Uint8Array(arrayBuffer21).fill(0x55) };
+} catch {}
+let img35 = await imageWithData(254, 290, '#3a7cc319', '#5a9bfc47');
+let textureView139 = texture113.createView(
+{
+label: '\u{1f68c}\u{1f7e4}',
+baseMipLevel: 2,
+baseArrayLayer: 0,
+}
+);
+try {
+renderBundleEncoder110.setBindGroup(
+0,
+bindGroup60,
+new Uint32Array(1090),
+876,
+0
+);
+} catch {}
+try {
+renderBundleEncoder108.setVertexBuffer(
+4,
+buffer46,
+47848,
+853
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture146,
+  mipLevel: 0,
+  origin: { x: 382, y: 1, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(210),
+/* required buffer size: 210 */{
+offset: 210,
+},
+{width: 14237, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline121 = await device2.createComputePipelineAsync(
+{
+label: '\u4876\ue719\u04bc\u487a',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule40,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let bindGroup61 = device2.createBindGroup({
+label: '\u7d1b\u{1fdc2}\u{1f744}\uc960\ufe19\ued42\u0cb2',
+layout: bindGroupLayout55,
+entries: [
+
+],
+});
+let textureView140 = texture123.createView(
+{
+label: '\u{1fc83}\u08c2\uc1f6\uf4be\u8ccd\u450f\u07e7\uc342\u0522',
+}
+);
+try {
+renderBundleEncoder131.setVertexBuffer(
+7,
+buffer46,
+8872,
+14339
+);
+} catch {}
+try {
+renderBundleEncoder131.pushDebugGroup(
+'\u2731'
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture146,
+  mipLevel: 0,
+  origin: { x: 2015, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Int16Array(arrayBuffer3),
+/* required buffer size: 14305 */{
+offset: 161,
+},
+{width: 7072, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let imageData34 = new ImageData(60, 52);
+try {
+offscreenCanvas33.getContext('2d');
+} catch {}
+let renderBundleEncoder138 = device7.createRenderBundleEncoder(
+{
+label: '\uc99b\u0f43\u009f\u0db0\u8fca',
+colorFormats: [
+'rgba16float',
+'r8uint',
+'rgba8unorm-srgb',
+'rgba16sint',
+'r32uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 149,
+depthReadOnly: true,
+}
+);
+try {
+await promise68;
+} catch {}
+document.body.prepend('\ue663\ua4a6\u7cf2\u{1fd0c}\u{1ff88}\ucf66\u0cb0');
+let renderBundleEncoder139 = device1.createRenderBundleEncoder(
+{
+label: '\u{1ff75}\u0651\u13f3\u0efa\u0aa7\u3a58\u5378',
+colorFormats: [
+'bgra8unorm-srgb',
+'rg11b10ufloat',
+'r32sint',
+'rgba8sint',
+'rgba16uint',
+'rg16uint'
+],
+sampleCount: 917,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle116 = renderBundleEncoder139.finish(
+{
+label: '\u0e47\uba92'
+}
+);
+try {
+renderPassEncoder48.beginOcclusionQuery(
+40
+);
+} catch {}
+try {
+renderPassEncoder48.setStencilReference(
+539
+);
+} catch {}
+try {
+renderPassEncoder48.setViewport(
+397.7,
+0.6332,
+91.32,
+0.1241,
+0.8994,
+0.9486
+);
+} catch {}
+try {
+buffer44.unmap();
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer44,
+6884,
+new Float32Array(7362),
+6514
+);
+} catch {}
+let pipeline122 = device1.createRenderPipeline(
+{
+label: '\u{1f9cb}\u03c9\u{1f9fd}',
+layout: pipelineLayout16,
+vertex: {
+module: shaderModule38,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 84,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 12,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x2',
+offset: 8,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x4',
+offset: 72,
+shaderLocation: 18,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 52,
+shaderLocation: 14,
+},
+{
+format: 'snorm16x4',
+offset: 32,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x2',
+offset: 72,
+shaderLocation: 16,
+},
+{
+format: 'float16x2',
+offset: 4,
+shaderLocation: 3,
+},
+{
+format: 'snorm8x2',
+offset: 48,
+shaderLocation: 17,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 72,
+shaderLocation: 19,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 64,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 4440,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 7160,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 8724,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 7192,
+shaderLocation: 7,
+},
+{
+format: 'uint8x4',
+offset: 7396,
+shaderLocation: 1,
+},
+{
+format: 'float32x3',
+offset: 5316,
+shaderLocation: 13,
+},
+{
+format: 'uint32',
+offset: 8384,
+shaderLocation: 2,
+},
+{
+format: 'float16x4',
+offset: 4148,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x2',
+offset: 4670,
+shaderLocation: 6,
+},
+{
+format: 'snorm16x4',
+offset: 344,
+shaderLocation: 10,
+},
+{
+format: 'sint32x2',
+offset: 3132,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+unclippedDepth: false,
+},
+multisample: {
+count: 4,
+mask: 0x2dd43f31,
+},
+fragment: {
+module: shaderModule38,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'invert',
+depthFailOp: 'replace',
+passOp: 'keep',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'replace',
+depthFailOp: 'decrement-clamp',
+},
+stencilReadMask: 776,
+stencilWriteMask: 336,
+depthBias: 30,
+depthBiasSlopeScale: 25,
+},
+}
+);
+canvas3.width = 718;
+let pipelineLayout28 = device1.createPipelineLayout(
+{
+bindGroupLayouts: [
+
+],
+}
+);
+let querySet117 = device1.createQuerySet(
+{
+label: '\u46ae\u097d\u{1fb0c}\u{1fea7}\u{1f848}\ucd49\u6315',
+type: 'occlusion',
+count: 1068,
+}
+);
+try {
+computePassEncoder56.setBindGroup(
+4,
+bindGroup51,
+new Uint32Array(1590),
+1528,
+0
+);
+} catch {}
+try {
+renderPassEncoder49.setStencilReference(
+1320
+);
+} catch {}
+try {
+renderBundleEncoder118.setVertexBuffer(
+0,
+buffer32,
+33104,
+109
+);
+} catch {}
+let promise71 = buffer50.mapAsync(
+GPUMapMode.READ,
+0,
+5784
+);
+try {
+device1.queue.writeBuffer(
+buffer45,
+7164,
+new BigUint64Array(495),
+25,
+352
+);
+} catch {}
+pseudoSubmit(device3, commandEncoder105);
+try {
+device3.queue.writeBuffer(
+buffer48,
+496,
+new DataView(new ArrayBuffer(62003)),
+47821,
+2256
+);
+} catch {}
+canvas31.width = 800;
+let texture161 = device4.createTexture(
+{
+label: '\u1358\u{1f638}\uc846\u5713',
+size: [3620],
+dimension: '1d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder71 = commandEncoder112.beginComputePass(
+{
+label: '\u0cce\u0985\u40c5\u00b7\u{1f77a}\u0383\u2fea\u084d'
+}
+);
+let sampler142 = device4.createSampler(
+{
+label: '\u9306\u0f9c\ufdb1\u{1f7c1}\u00a4\ua739',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 42.708,
+lodMaxClamp: 78.162,
+maxAnisotropy: 16,
+}
+);
+document.body.append('\u28b5\u{1f672}\udcb3\u4871');
+let promise72 = adapter11.requestAdapterInfo();
+let renderBundle117 = renderBundleEncoder138.finish(
+{
+
+}
+);
+let arrayBuffer24 = buffer56.getMappedRange(
+0,
+7096
+);
+try {
+device7.queue.writeTexture(
+{
+  texture: texture152,
+  mipLevel: 5,
+  origin: { x: 6, y: 1, z: 4 },
+  aspect: 'all',
+},
+new Int16Array(arrayBuffer13),
+/* required buffer size: 63484 */{
+offset: 844,
+bytesPerRow: 48,
+rowsPerImage: 261,
+},
+{width: 22, height: 0, depthOrArrayLayers: 6}
+);
+} catch {}
+let pipelineLayout29 = device2.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout55,
+bindGroupLayout44
+],
+}
+);
+let textureView141 = texture114.createView(
+{
+label: '\uec11\uef81',
+baseMipLevel: 1,
+}
+);
+let sampler143 = device2.createSampler(
+{
+label: '\u{1fbd8}\u5b2e\u1e4e\u{1fc93}\u0d1a\u6390\ud178\u0275\ua155\u005a\u2f93',
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 88.909,
+lodMaxClamp: 91.621,
+maxAnisotropy: 3,
+}
+);
+let canvas40 = document.createElement('canvas');
+let bindGroup62 = device3.createBindGroup({
+label: '\u015c\u0cf9\u022c\u{1fa03}\u09af\u{1f9bf}\u{1f6f9}\u0226\u0e97',
+layout: bindGroupLayout50,
+entries: [
+
+],
+});
+let commandEncoder125 = device3.createCommandEncoder(
+{
+label: '\u0759\u1450\u2091\u08e0\u0dec\u413a\u0552\u{1f9db}\ucedd',
+}
+);
+let textureView142 = texture140.createView(
+{
+label: '\uddfc\ua717\u68e6\u0264\u0181\u{1fd3a}\u0ee7\u1da2\u0cda\u09fd\u{1fbf6}',
+dimension: '2d-array',
+format: 'etc2-rgb8unorm',
+baseMipLevel: 4,
+mipLevelCount: 4,
+baseArrayLayer: 0,
+}
+);
+let renderPassEncoder51 = commandEncoder125.beginRenderPass(
+{
+label: '\u078e\u9fb7\u797a\u9c68\u02bd\u8bc8\ue43e\u{1f73b}',
+colorAttachments: [
+undefined,
+{
+view: textureView115,
+clearValue: {
+r: 636.8,
+g: 622.3,
+b: -609.8,
+a: -300.4,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined
+],
+occlusionQuerySet: querySet96,
+maxDrawCount: 42016,
+}
+);
+try {
+renderPassEncoder51.setBindGroup(
+4,
+bindGroup62
+);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(
+3,
+buffer42,
+2760,
+6460
+);
+} catch {}
+let offscreenCanvas34 = new OffscreenCanvas(540, 203);
+let bindGroup63 = device2.createBindGroup({
+label: '\u556e\u{1fcec}\ue046\uf8a9\u{1faca}\u351f\u0546',
+layout: bindGroupLayout44,
+entries: [
+{
+binding: 5749,
+resource: {
+buffer: buffer55,
+offset: 7168,
+size: 23944,
+}
+},
+{
+binding: 3430,
+resource: sampler120
+}
+],
+});
+try {
+renderBundleEncoder110.setVertexBuffer(
+0,
+buffer46,
+41508,
+901
+);
+} catch {}
+try {
+await buffer51.mapAsync(
+GPUMapMode.READ,
+0,
+1956
+);
+} catch {}
+document.body.prepend('\u{1f6d1}\u{1f7f9}\u0017\u0888');
+let offscreenCanvas35 = new OffscreenCanvas(332, 694);
+let textureView143 = texture151.createView(
+{
+label: '\u0d0b\ufe9e\u{1fff0}\u651e\u54ac\u076f',
+dimension: '1d',
+}
+);
+let renderBundle118 = renderBundleEncoder111.finish(
+{
+label: '\u71fe\u78d9\u33cb\u0b70\ue726\uc161\u1738\u{1fc58}\u{1fcb8}\ue0a8'
+}
+);
+try {
+renderPassEncoder51.setBindGroup(
+3,
+bindGroup59
+);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(
+3,
+bindGroup59,
+new Uint32Array(8440),
+5019,
+0
+);
+} catch {}
+try {
+renderPassEncoder51.setBlendConstant(
+{
+r: -978.4,
+g: 844.1,
+b: -313.6,
+a: 955.1,
+}
+);
+} catch {}
+try {
+renderPassEncoder51.setStencilReference(
+3252
+);
+} catch {}
+try {
+buffer48.destroy();
+} catch {}
+let sampler144 = device7.createSampler(
+{
+label: '\u2736\u58db\uf7ee\u{1fcd4}\u67e9\u0789',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 95.900,
+maxAnisotropy: 18,
+}
+);
+try {
+device7.pushErrorScope(
+'validation'
+);
+} catch {}
+let gpuCanvasContext30 = canvas40.getContext('webgpu');
+document.body.prepend('\u0d7d\u9e66\u08d2\u{1f9e0}\uc6f1');
+let video38 = await videoWithData();
+document.body.prepend('\ufa8f\ue369\uf193');
+let buffer57 = device4.createBuffer(
+{
+label: '\u34ac\u4f6d\uac06\uf527\u7800\u0bb4\u0695\u019a\uf190\u0b5d\u0301',
+size: 54634,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let textureView144 = texture135.createView(
+{
+label: '\u73d7\u6055\u62dc',
+dimension: '2d',
+aspect: 'all',
+mipLevelCount: 4,
+baseArrayLayer: 85,
+}
+);
+let renderBundleEncoder140 = device4.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg8uint'
+],
+sampleCount: 416,
+}
+);
+try {
+adapter7.label = '\u7148\u670c\udcac\u0291\u0f41\u{1fe44}\ue1d4';
+} catch {}
+let texture162 = device1.createTexture(
+{
+label: '\u{1fd2a}\u0d84\u1c3e\u{1f7b0}\uc969\u0ca7\u{1fa56}\u{1f881}\u0c8d\uac0d\u29f2',
+size: {width: 7959},
+dimension: '1d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+renderPassEncoder48.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder48.setScissorRect(
+109,
+1,
+11,
+0
+);
+} catch {}
+try {
+renderBundleEncoder116.setBindGroup(
+1,
+bindGroup48
+);
+} catch {}
+try {
+renderBundleEncoder118.setBindGroup(
+2,
+bindGroup48,
+new Uint32Array(4350),
+920,
+0
+);
+} catch {}
+let pipeline123 = await promise44;
+document.body.append('\u7f26\ufa56\u0e58\ue26f\u{1f7fa}\ua1bc\u{1f9c6}\u0ca4\u00d6\ua283');
+let bindGroup64 = device2.createBindGroup({
+label: '\ub8be\u{1fc5e}',
+layout: bindGroupLayout55,
+entries: [
+
+],
+});
+let sampler145 = device2.createSampler(
+{
+label: '\ufc8a\ud863\u3ea9\u{1f623}\u064d\u{1fb50}\u069f\u000b\u{1fdf1}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 99.891,
+lodMaxClamp: 99.978,
+maxAnisotropy: 12,
+}
+);
+try {
+renderBundleEncoder131.setBindGroup(
+5,
+bindGroup61
+);
+} catch {}
+try {
+renderBundleEncoder121.setVertexBuffer(
+7,
+buffer46,
+43076
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer46,
+22564,
+new Float32Array(25452),
+22321,
+160
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+await promise72;
+} catch {}
+let offscreenCanvas36 = new OffscreenCanvas(23, 640);
+document.body.append('\u6132\u{1fa9d}\uee11\u0385\uca10\u{1f8b5}');
+document.body.prepend(img18);
+offscreenCanvas11.height = 844;
+let commandEncoder126 = device3.createCommandEncoder(
+{
+label: '\uaeed\u26d0',
+}
+);
+let computePassEncoder72 = commandEncoder126.beginComputePass(
+{
+
+}
+);
+let renderBundle119 = renderBundleEncoder111.finish(
+{
+label: '\u0105\u04a3\u{1f60a}\u{1feae}\u3450'
+}
+);
+try {
+renderPassEncoder51.setBlendConstant(
+{
+r: -754.2,
+g: -606.8,
+b: 849.2,
+a: -842.2,
+}
+);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(
+buffer42,
+'uint16'
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture127,
+  mipLevel: 0,
+  origin: { x: 779, y: 1, z: 18 },
+  aspect: 'all',
+},
+arrayBuffer18,
+/* required buffer size: 52042413 */{
+offset: 543,
+bytesPerRow: 2433,
+rowsPerImage: 230,
+},
+{width: 272, height: 0, depthOrArrayLayers: 94}
+);
+} catch {}
+let texture163 = device7.createTexture(
+{
+label: '\ud689\u0d6d\u{1f8ed}\u0c5b\u0121\u5f5b\u071c\u6024\u39c8\u{1f860}',
+size: {width: 4866, height: 15, depthOrArrayLayers: 4},
+mipLevelCount: 7,
+format: 'rg8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rg8uint',
+'rg8uint',
+'rg8uint'
+],
+}
+);
+try {
+gpuCanvasContext4.configure(
+{
+device: device7,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let imageData35 = new ImageData(148, 24);
+let commandEncoder127 = device3.createCommandEncoder(
+{
+label: '\uffd7\uf3d2\u{1f992}\u0aaa\u019f\u0da7\u0701\u0f67\u0046\u7008\u{1ff70}',
+}
+);
+try {
+computePassEncoder61.setBindGroup(
+5,
+bindGroup59,
+new Uint32Array(7995),
+2678,
+0
+);
+} catch {}
+try {
+renderPassEncoder51.beginOcclusionQuery(
+0
+);
+} catch {}
+try {
+await adapter3.requestAdapterInfo();
+} catch {}
+try {
+computePassEncoder54.setBindGroup(
+5,
+bindGroup58
+);
+} catch {}
+let promise73 = navigator.gpu.requestAdapter();
+let canvas41 = document.createElement('canvas');
+let sampler146 = device2.createSampler(
+{
+label: '\u08f9\ufd0e\u16f8\ue643\u0e8b\ue33b\ueed4\u8a3c\u3569',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+lodMinClamp: 7.856,
+lodMaxClamp: 98.375,
+}
+);
+try {
+renderBundleEncoder110.setBindGroup(
+0,
+bindGroup61
+);
+} catch {}
+let promise74 = device2.queue.onSubmittedWorkDone();
+let pipeline124 = await device2.createComputePipelineAsync(
+{
+label: '\u1517\u0c94\ucde7\u0dd3\u{1f861}\u28f3\u66d6\ua1c2',
+layout: pipelineLayout21,
+compute: {
+module: shaderModule39,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let promise75 = device2.createRenderPipelineAsync(
+{
+label: '\u{1f617}\u{1f9cb}\ucf80',
+layout: pipelineLayout21,
+vertex: {
+module: shaderModule40,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 13144,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 7488,
+shaderLocation: 15,
+},
+{
+format: 'uint32x3',
+offset: 12556,
+shaderLocation: 13,
+},
+{
+format: 'uint8x2',
+offset: 11016,
+shaderLocation: 11,
+},
+{
+format: 'sint32x2',
+offset: 1332,
+shaderLocation: 0,
+},
+{
+format: 'snorm8x4',
+offset: 11372,
+shaderLocation: 6,
+},
+{
+format: 'snorm16x2',
+offset: 5284,
+shaderLocation: 3,
+},
+{
+format: 'uint16x2',
+offset: 5112,
+shaderLocation: 1,
+},
+{
+format: 'sint16x2',
+offset: 12496,
+shaderLocation: 12,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 10684,
+shaderLocation: 2,
+},
+{
+format: 'sint8x4',
+offset: 11936,
+shaderLocation: 9,
+},
+{
+format: 'float32',
+offset: 3024,
+shaderLocation: 8,
+},
+{
+format: 'snorm16x2',
+offset: 12936,
+shaderLocation: 14,
+},
+{
+format: 'uint32x4',
+offset: 4436,
+shaderLocation: 10,
+},
+{
+format: 'uint8x4',
+offset: 6500,
+shaderLocation: 4,
+},
+{
+format: 'sint16x2',
+offset: 12300,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 23888,
+attributes: [
+
+],
+},
+{
+arrayStride: 16568,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x2',
+offset: 1984,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'back',
+},
+}
+);
+let canvas42 = document.createElement('canvas');
+try {
+canvas41.getContext('webgl');
+} catch {}
+let bindGroup65 = device3.createBindGroup({
+label: '\u60bf\u0fba\u0fd5',
+layout: bindGroupLayout50,
+entries: [
+
+],
+});
+let textureView145 = texture127.createView(
+{
+baseMipLevel: 1,
+mipLevelCount: 1,
+}
+);
+let renderBundle120 = renderBundleEncoder122.finish(
+{
+label: '\u32dd\u{1fc5c}\u{1fbdc}\u{1f908}\u4f19'
+}
+);
+let sampler147 = device3.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 43.854,
+lodMaxClamp: 86.693,
+}
+);
+try {
+renderPassEncoder51.end();
+} catch {}
+try {
+await device3.popErrorScope();
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture127,
+  mipLevel: 1,
+  origin: { x: 33, y: 1, z: 1 },
+  aspect: 'all',
+},
+new Int16Array(new ArrayBuffer(16)),
+/* required buffer size: 47030248 */{
+offset: 100,
+bytesPerRow: 6306,
+rowsPerImage: 226,
+},
+{width: 757, height: 0, depthOrArrayLayers: 34}
+);
+} catch {}
+let promise76 = navigator.gpu.requestAdapter(
+{
+}
+);
+let commandEncoder128 = device7.createCommandEncoder();
+let renderBundle121 = renderBundleEncoder138.finish(
+{
+label: '\u1482\u{1fee8}\u3463\u34f1\u0ae1\u{1ffee}'
+}
+);
+let adapter13 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let promise77 = adapter13.requestDevice(
+{
+label: '\u7238\u103a\u0ed9\u7584\u0505\u0271\u9e7f\u66dd\ub8d7\u17eb\u7684',
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 33,
+maxVertexAttributes: 28,
+maxVertexBufferArrayStride: 43402,
+maxStorageTexturesPerShaderStage: 32,
+maxStorageBuffersPerShaderStage: 19,
+maxDynamicStorageBuffersPerPipelineLayout: 30156,
+maxBindingsPerBindGroup: 2436,
+maxTextureDimension1D: 12842,
+maxTextureDimension2D: 12246,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 160287939,
+maxInterStageShaderVariables: 111,
+maxInterStageShaderComponents: 95,
+},
+}
+);
+let video39 = await videoWithData();
+pseudoSubmit(device3, commandEncoder126);
+try {
+commandEncoder127.clearBuffer(
+buffer48,
+248,
+4272
+);
+dissociateBuffer(device3, buffer48);
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let img36 = await imageWithData(46, 112, '#9e0dc10a', '#f8839235');
+try {
+offscreenCanvas35.getContext('2d');
+} catch {}
+let commandEncoder129 = device2.createCommandEncoder(
+{
+label: '\uda5a\u08be\u{1fdd7}\u0112\u0412\u0adc\u54b5\u902c\u0aa1',
+}
+);
+let commandBuffer16 = commandEncoder129.finish(
+{
+label: '\u{1f9e8}\ufde4\u47b2\u7e7d\u{1fe15}\u8def\u0f6e\u37e8\u{1f939}\u{1fcf9}\u0280',
+}
+);
+try {
+renderBundleEncoder110.setBindGroup(
+4,
+bindGroup64
+);
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+try {
+renderBundleEncoder131.popDebugGroup();
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture113,
+  mipLevel: 2,
+  origin: { x: 0, y: 1, z: 7 },
+  aspect: 'all',
+},
+new BigUint64Array(arrayBuffer21),
+/* required buffer size: 71 */{
+offset: 71,
+},
+{width: 11, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let gpuCanvasContext31 = offscreenCanvas34.getContext('webgpu');
+try {
+canvas42.getContext('webgpu');
+} catch {}
+let buffer58 = device4.createBuffer(
+{
+label: '\u{1ff8f}\u9d1a\u9d3b\u8f5c',
+size: 29124,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+mappedAtCreation: true,
+}
+);
+let renderBundleEncoder141 = device4.createRenderBundleEncoder(
+{
+label: '\u0820\u{1fc16}\ufd18\ua98a\u572e',
+colorFormats: [
+'rg32float',
+'rgba8uint',
+'r16uint',
+'rg11b10ufloat'
+],
+sampleCount: 384,
+stencilReadOnly: true,
+}
+);
+let renderBundle122 = renderBundleEncoder141.finish();
+try {
+device4.queue.writeBuffer(
+buffer47,
+4540,
+new Int16Array(13849),
+13435,
+204
+);
+} catch {}
+try {
+commandEncoder128.resolveQuerySet(
+querySet115,
+21,
+53,
+buffer56,
+32256
+);
+} catch {}
+try {
+device7.queue.writeTexture(
+{
+  texture: texture163,
+  mipLevel: 3,
+  origin: { x: 115, y: 0, z: 2 },
+  aspect: 'all',
+},
+new Uint8Array(arrayBuffer4),
+/* required buffer size: 220 */{
+offset: 220,
+},
+{width: 490, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend(img28);
+gc();
+let videoFrame35 = new VideoFrame(canvas33, {timestamp: 0});
+try {
+renderPassEncoder50.executeBundles([]);
+} catch {}
+try {
+await promise71;
+} catch {}
+  log('the end')
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -1634,6 +1634,7 @@ void CommandEncoder::copyTextureToTexture(const WGPUImageCopyTexture& source, co
     }
 
     id<MTLTexture> mtlDestinationTexture = destinationTexture.texture();
+    id<MTLTexture> mtlSourceTexture = fromAPI(source.texture).texture();
 
     // FIXME(PERFORMANCE): Is it actually faster to use the -[MTLBlitCommandEncoder copyFromTexture:...toTexture:...levelCount:]
     // variant, where possible, rather than calling the other variant in a loop?
@@ -1651,8 +1652,10 @@ void CommandEncoder::copyTextureToTexture(const WGPUImageCopyTexture& source, co
         for (uint32_t layer = 0; layer < copySize.depthOrArrayLayers; ++layer) {
             NSUInteger sourceSlice = source.origin.z + layer;
             NSUInteger destinationSlice = destination.origin.z + layer;
+            if (destinationSlice >= mtlDestinationTexture.arrayLength || sourceSlice >= mtlSourceTexture.arrayLength)
+                continue;
             [m_blitCommandEncoder
-                copyFromTexture:fromAPI(source.texture).texture()
+                copyFromTexture:mtlSourceTexture
                 sourceSlice:sourceSlice
                 sourceLevel:source.mipLevel
                 sourceOrigin:sourceOrigin
@@ -1677,8 +1680,10 @@ void CommandEncoder::copyTextureToTexture(const WGPUImageCopyTexture& source, co
         for (uint32_t layer = 0; layer < copySize.depthOrArrayLayers; ++layer) {
             NSUInteger sourceSlice = source.origin.z + layer;
             NSUInteger destinationSlice = destination.origin.z + layer;
+            if (destinationSlice >= mtlDestinationTexture.arrayLength || sourceSlice >= mtlSourceTexture.arrayLength)
+                continue;
             [m_blitCommandEncoder
-                copyFromTexture:fromAPI(source.texture).texture()
+                copyFromTexture:mtlSourceTexture
                 sourceSlice:sourceSlice
                 sourceLevel:source.mipLevel
                 sourceOrigin:sourceOrigin
@@ -1704,7 +1709,7 @@ void CommandEncoder::copyTextureToTexture(const WGPUImageCopyTexture& source, co
         auto destinationOrigin = MTLOriginMake(destination.origin.x, destination.origin.y, destination.origin.z);
 
         [m_blitCommandEncoder
-            copyFromTexture:fromAPI(source.texture).texture()
+            copyFromTexture:mtlSourceTexture
             sourceSlice:0
             sourceLevel:source.mipLevel
             sourceOrigin:sourceOrigin


### PR DESCRIPTION
#### ffdff3e6b9708b6d84619778093f27d7b50b631e
<pre>
[WebGPU] CommandEncoder::copyTexturToTexture fails metal validation in some cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=273023">https://bugs.webkit.org/show_bug.cgi?id=273023</a>
&lt;radar://126621339&gt;

Reviewed by Tadeu Zagallo.

Don&apos;t allow source slice to be outside the texture range but
until its determined this should be a validation error according
to the specification, treat as a no-op.

* LayoutTests/TestExpectations:
* LayoutTests/fast/webgpu/fuzz-273023-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-273023.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::copyTextureToTexture):

Canonical link: <a href="https://commits.webkit.org/277873@main">https://commits.webkit.org/277873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25a1a40d8861e056e3a96d868dddd774a45f2e59

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48832 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28045 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51799 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51519 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44898 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25573 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39921 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49414 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42109 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21022 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23159 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6887 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45090 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43779 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53430 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20152 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47225 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25146 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42318 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46176 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10752 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25954 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24866 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->