### PR TITLE
[WebCore] Use std::span instead of const InlineItemList& in AbstractLineBuilder

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/AbstractLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/AbstractLineBuilder.cpp
@@ -35,7 +35,7 @@ namespace Layout {
 
 AbstractLineBuilder::AbstractLineBuilder(InlineFormattingContext& inlineFormattingContext, const ElementBox& rootBox, HorizontalConstraints rootHorizontalConstraints, const InlineItemList& inlineItemList)
     : m_line(inlineFormattingContext)
-    , m_inlineItemList(inlineItemList)
+    , m_inlineItemList(inlineItemList.span())
     , m_inlineFormattingContext(inlineFormattingContext)
     , m_rootBox(rootBox)
     , m_rootHorizontalConstraints(rootHorizontalConstraints)

--- a/Source/WebCore/layout/formattingContexts/inline/AbstractLineBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/AbstractLineBuilder.h
@@ -73,7 +73,7 @@ protected:
 protected:
     Line m_line;
     InlineRect m_lineLogicalRect;
-    const InlineItemList& m_inlineItemList;
+    std::span<const InlineItem> m_inlineItemList;
     Vector<const InlineItem*, 32> m_wrapOpportunityList;
     std::optional<InlineTextItem> m_partialLeadingTextItem;
     std::optional<PreviousLine> m_previousLine { };

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.cpp
@@ -556,7 +556,7 @@ Vector<size_t> InlineContentBalancer::computeBreakOpportunities(InlineItemRange 
     Vector<size_t> breakOpportunities;
     size_t currentIndex = range.startIndex();
     while (currentIndex < range.endIndex()) {
-        currentIndex = m_inlineFormattingContext.formattingUtils().nextWrapOpportunity(currentIndex, range, m_inlineItemList);
+        currentIndex = m_inlineFormattingContext.formattingUtils().nextWrapOpportunity(currentIndex, range, m_inlineItemList.span());
         breakOpportunities.append(currentIndex);
     }
     return breakOpportunities;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
@@ -468,7 +468,7 @@ bool InlineFormattingUtils::isAtSoftWrapOpportunity(const InlineItem& previous, 
     return true;
 }
 
-size_t InlineFormattingUtils::nextWrapOpportunity(size_t startIndex, const InlineItemRange& layoutRange, const InlineItemList& inlineItemList) const
+size_t InlineFormattingUtils::nextWrapOpportunity(size_t startIndex, const InlineItemRange& layoutRange, std::span<const InlineItem> inlineItemList) const
 {
     // 1. Find the start candidate by skipping leading non-content items e.g "<span><span>start". Opportunity is after "<span><span>".
     // 2. Find the end candidate by skipping non-content items inbetween e.g. "<span><span>start</span>end". Opportunity is after "</span>".

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.h
@@ -62,7 +62,7 @@ public:
 
     InlineLayoutUnit inlineItemWidth(const InlineItem&, InlineLayoutUnit contentLogicalLeft, bool useFirstLineStyle) const;
 
-    size_t nextWrapOpportunity(size_t startIndex, const InlineItemRange& layoutRange, const InlineItemList&) const;
+    size_t nextWrapOpportunity(size_t startIndex, const InlineItemRange& layoutRange, std::span<const InlineItem>) const;
 
     static std::pair<InlineLayoutUnit, InlineLayoutUnit> textEmphasisForInlineBox(const Box&, const ElementBox& rootBox);
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -101,7 +101,7 @@ static inline Vector<int32_t> computedVisualOrder(const Line::RunList& lineRuns,
     return visualOrderList;
 }
 
-static bool hasTrailingSoftWrapOpportunity(size_t softWrapOpportunityIndex, size_t layoutRangeEnd, const InlineItemList& inlineItemList)
+static bool hasTrailingSoftWrapOpportunity(size_t softWrapOpportunityIndex, size_t layoutRangeEnd, std::span<const InlineItem> inlineItemList)
 {
     if (!softWrapOpportunityIndex || softWrapOpportunityIndex == layoutRangeEnd) {
         // This candidate inline content ends because the entire content ends and not because there's a soft wrap opportunity.

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.h
@@ -34,7 +34,7 @@ namespace Layout {
 struct LineContent;
 struct LineCandidate;
 
-class LineBuilder : public AbstractLineBuilder {
+class LineBuilder final : public AbstractLineBuilder {
 public:
     LineBuilder(InlineFormattingContext&, HorizontalConstraints rootHorizontalConstraints, const InlineItemList&);
     virtual ~LineBuilder() { };

--- a/Source/WebCore/layout/formattingContexts/inline/RangeBasedLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/RangeBasedLineBuilder.cpp
@@ -45,13 +45,13 @@ LineLayoutResult RangeBasedLineBuilder::layoutInlineContent(const LineInput& lin
     auto adjustedNeedsLayoutRange = [&] {
         auto needsLayoutRange = lineInput.needsLayoutRange;
         if (isFirstLine) {
-            ASSERT(m_inlineItemList[0].isInlineBoxStart());
+            ASSERT(m_inlineItemList.front().isInlineBoxStart());
             ASSERT(!needsLayoutRange.start.offset);
             // Skip leading InlineItemStart (e.g. <span>)
             ++needsLayoutRange.start.index;
         }
         // SKip trailing InlineItemEnd (e.g. </span>)
-        ASSERT(m_inlineItemList.last().isInlineBoxEnd());
+        ASSERT(m_inlineItemList.back().isInlineBoxEnd());
         ASSERT(!needsLayoutRange.end.offset);
         --needsLayoutRange.end.index;
         return needsLayoutRange;
@@ -62,7 +62,7 @@ LineLayoutResult RangeBasedLineBuilder::layoutInlineContent(const LineInput& lin
     auto lineLayoutResult = m_textOnlySimpleLineBuilder.layoutInlineContent({ needsLayoutRange, lineInput.initialLogicalRect }, previousLine);
 
     auto insertLeadingInlineBoxRun = [&] {
-        auto& leadingInlineItem = m_inlineItemList.first();
+        auto& leadingInlineItem = m_inlineItemList.front();
         ASSERT(leadingInlineItem.isInlineBoxStart());
 
         if (isFirstLine) {
@@ -79,7 +79,7 @@ LineLayoutResult RangeBasedLineBuilder::layoutInlineContent(const LineInput& lin
     auto appendTrailingInlineBoxRunIfNeeded = [&] {
         if (lineLayoutResult.inlineItemRange.end != needsLayoutRange.end)
             return;
-        auto& trailingInlineItem = m_inlineItemList.last();
+        auto& trailingInlineItem = m_inlineItemList.back();
         lineLayoutResult.inlineContent.append({ trailingInlineItem, isFirstLine ? trailingInlineItem.firstLineStyle() : trailingInlineItem.style(), lineLayoutResult.contentGeometry.logicalWidth });
         lineLayoutResult.inlineItemRange.end = lineInput.needsLayoutRange.end;
     };

--- a/Source/WebCore/layout/formattingContexts/inline/RangeBasedLineBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/RangeBasedLineBuilder.h
@@ -33,7 +33,7 @@ namespace Layout {
 
 class InlineContentBreaker;
 
-class RangeBasedLineBuilder : public AbstractLineBuilder {
+class RangeBasedLineBuilder final : public AbstractLineBuilder {
 public:
     RangeBasedLineBuilder(InlineFormattingContext&, HorizontalConstraints rootHorizontalConstraints, const InlineItemList&);
     LineLayoutResult layoutInlineContent(const LineInput&, const std::optional<PreviousLine>&) final;

--- a/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp
@@ -61,7 +61,7 @@ static inline InlineLayoutUnit measuredInlineTextItem(const InlineTextItem& inli
     return TextUtil::width(inlineTextItem, style.fontCascade(), inlineTextItem.start(), inlineTextItem.start() + 1, contentLogicalLeft);
 }
 
-static inline InlineItemPosition placedInlineItemEnd(size_t layoutRangeStartIndex, size_t placedInlineItemCount, size_t overflowingContentLength, const InlineItemList& inlineItemList)
+static inline InlineItemPosition placedInlineItemEnd(size_t layoutRangeStartIndex, size_t placedInlineItemCount, size_t overflowingContentLength, std::span<const InlineItem> inlineItemList)
 {
     if (!overflowingContentLength)
         return { layoutRangeStartIndex + placedInlineItemCount };
@@ -76,7 +76,7 @@ static inline bool isLastLineWithInlineContent(InlineItemPosition placedContentE
     return placedContentEnd.index == layoutRangeEndIndex && !placedContentEnd.offset;
 }
 
-static inline bool consumeTrailingLineBreakIfApplicable(const TextOnlyLineBreakResult& result, size_t trailingInlineItemIndex, size_t layoutRangeEnd, Line& line, const InlineItemList& inlineItemList)
+static inline bool consumeTrailingLineBreakIfApplicable(const TextOnlyLineBreakResult& result, size_t trailingInlineItemIndex, size_t layoutRangeEnd, Line& line, std::span<const InlineItem> inlineItemList)
 {
     // Trailing forced line break should be consumed after fully placed content.
     auto shouldConsumeTrailingLineBreak = [&] {

--- a/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.h
@@ -35,7 +35,7 @@ class InlineContentBreaker;
 struct CandidateTextContent;
 struct TextOnlyLineBreakResult;
 
-class TextOnlySimpleLineBuilder : public AbstractLineBuilder {
+class TextOnlySimpleLineBuilder final : public AbstractLineBuilder {
 public:
     TextOnlySimpleLineBuilder(InlineFormattingContext&, const ElementBox& rootBox, HorizontalConstraints rootHorizontalConstraints, const InlineItemList&);
     LineLayoutResult layoutInlineContent(const LineInput&, const std::optional<PreviousLine>&) final;


### PR DESCRIPTION
#### fb5264445a289d6a407ea8f089e7d4c121f778ef
<pre>
[WebCore] Use std::span instead of const InlineItemList&amp; in AbstractLineBuilder
<a href="https://bugs.webkit.org/show_bug.cgi?id=273034">https://bugs.webkit.org/show_bug.cgi?id=273034</a>
<a href="https://rdar.apple.com/126803864">rdar://126803864</a>

Reviewed by Alan Baradlay.

We found that InlineItemList&apos;s size / buffer getter accesses are very hot in AbstractLineBuilder related code.
This is interesting: since const InlineItemList&amp; is a pointer in fact (in assembly), compiler does not know whether
it can be changed or not during running AbstractLineBuilder&apos;s algorithm. So operator[] access to const InlineItemList&amp;
always need to get size and need to (index &lt; size) assertion, which takes a lot of cost.

But InlineItemList will not change during AbstractLineBuilder&apos;s processing. If we take it as a std::span and store it
in AbstractLineBuilder, compiler knows that this is immutable and we can do the above checks without tracing a lot of pointers.

This patch changes const InlineItemList&amp; to std::span in AbstractLineBuilder.

* Source/WebCore/layout/formattingContexts/inline/AbstractLineBuilder.cpp:
(WebCore::Layout::AbstractLineBuilder::AbstractLineBuilder):
* Source/WebCore/layout/formattingContexts/inline/AbstractLineBuilder.h:
* Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.cpp:
(WebCore::Layout::InlineContentBalancer::computeBreakOpportunities const):
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
(WebCore::Layout::InlineFormattingUtils::nextWrapOpportunity const):
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::hasTrailingSoftWrapOpportunity):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.h:
(WebCore::Layout::LineBuilder::~LineBuilder): Deleted.
(WebCore::Layout::LineBuilder::isFloatLayoutSuspended const): Deleted.
(WebCore::Layout::LineBuilder::isLineConstrainedByFloat const): Deleted.
(WebCore::Layout::LineBuilder::floatingContext const): Deleted.
* Source/WebCore/layout/formattingContexts/inline/RangeBasedLineBuilder.cpp:
(WebCore::Layout::RangeBasedLineBuilder::layoutInlineContent):
* Source/WebCore/layout/formattingContexts/inline/RangeBasedLineBuilder.h:
* Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp:
(WebCore::Layout::placedInlineItemEnd):
(WebCore::Layout::consumeTrailingLineBreakIfApplicable):
* Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.h:
(WebCore::Layout::TextOnlySimpleLineBuilder::isWrappingAllowed const): Deleted.

Canonical link: <a href="https://commits.webkit.org/277784@main">https://commits.webkit.org/277784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bda1ab157a1faf077761434a94dd4d7da7dc6f48

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48563 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51250 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44628 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50868 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33710 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25301 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39706 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49145 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25441 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41895 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20803 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22918 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43069 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6619 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44856 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43557 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/53164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23609 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19908 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47003 "layout-tests (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24875 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42101 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45927 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25679 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6921 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24597 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->