### PR TITLE
[Remote Inspection] Selector-based element targeting heuristic should include custom DOM attributes

### DIFF
--- a/LayoutTests/fast/element-targeting/prefer-succinct-selectors-expected.txt
+++ b/LayoutTests/fast/element-targeting/prefer-succinct-selectors-expected.txt
@@ -1,5 +1,5 @@
 PASS firstTarget is "#overlay"
-PASS secondTarget is ".fixed"
+PASS secondTarget is "DIV.fixed"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/element-targeting/prefer-succinct-selectors.html
+++ b/LayoutTests/fast/element-targeting/prefer-succinct-selectors.html
@@ -46,7 +46,7 @@ addEventListener("load", async () => {
     firstTarget = await UIHelper.adjustVisibilityForFrontmostTarget(150, 75);
     shouldBeEqualToString("firstTarget", "#overlay");
     secondTarget = await UIHelper.adjustVisibilityForFrontmostTarget(150, 75);
-    shouldBeEqualToString("secondTarget", ".fixed");
+    shouldBeEqualToString("secondTarget", "DIV.fixed");
     finishJSTest();
 });
 </script>

--- a/LayoutTests/fast/element-targeting/target-element-selectors-using-attributes-expected.txt
+++ b/LayoutTests/fast/element-targeting/target-element-selectors-using-attributes-expected.txt
@@ -1,0 +1,11 @@
+
+Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo. You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them. Because they change things. They push the human race forward. And while some may see them as the crazy ones, we see genius. Because the people who are crazy enough to think they can change the world, are the ones who do.
+
+
+PASS firstSelector is "IMG[aria-label='Image of dice']"
+PASS secondSelector is "IMG[src='../images/resources/boston.gif']"
+PASS thirdSelector is "P[customattribute]"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/element-targeting/target-element-selectors-using-attributes.html
+++ b/LayoutTests/fast/element-targeting/target-element-selectors-using-attributes.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+html, body {
+    margin: 0;
+    font-family: system-ui;
+}
+
+p {
+    font-size: 16px;
+    line-height: 1.5em;
+}
+    
+div.fixed-height {
+    height: 300px;
+}
+
+img {
+    width: 125px;
+    height: 125px;
+    object-fit: cover;
+    display: inline-block;
+    margin: 0;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    firstSelector = await UIHelper.adjustVisibilityForFrontmostTarget(50, 50);
+    secondSelector = await UIHelper.adjustVisibilityForFrontmostTarget(150, 50);
+    thirdSelector = await UIHelper.adjustVisibilityForFrontmostTarget(50, 150);
+
+    shouldBeEqualToString("firstSelector", "IMG[aria-label='Image of dice']");
+    shouldBeEqualToString("secondSelector", "IMG[src='../images/resources/boston.gif']");
+    shouldBeEqualToString("thirdSelector", "P[customattribute]");
+
+    await UIHelper.delayFor(1000);
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <img src="../images/resources/dice.png" aria-label="Image of dice" />
+    <img src="../images/resources/boston.gif" />
+    <p customattribute>Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo. You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them. Because they change things. They push the human race forward. And while some may see them as the crazy ones, we see genius. Because the people who are crazy enough to think they can change the world, are the ones who do.</p>
+    <a href="https://webkit.org" aria-label="Link to WebKit Home page"><img src="../images/resources/dice.png" /></a>
+    <p id="console"></p>
+</body>
+</html>

--- a/LayoutTests/fast/element-targeting/target-iframe-above-nav-bar-expected.txt
+++ b/LayoutTests/fast/element-targeting/target-iframe-above-nav-bar-expected.txt
@@ -2,7 +2,7 @@
 Navigation Bar
 This test requires WebKitTestRunner.
 
-PASS targetSelector is ".frame-wrapper"
+PASS targetSelector is "DIV.frame-wrapper"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/element-targeting/target-iframe-above-nav-bar.html
+++ b/LayoutTests/fast/element-targeting/target-iframe-above-nav-bar.html
@@ -51,7 +51,7 @@ iframe {
 jsTestIsAsync = true;
 addEventListener("load", async () => {
     targetSelector = await UIHelper.adjustVisibilityForFrontmostTarget(50, 100);
-    shouldBeEqualToString("targetSelector", ".frame-wrapper");
+    shouldBeEqualToString("targetSelector", "DIV.frame-wrapper");
     finishJSTest();
 });
 </script>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
@@ -144,7 +144,7 @@ TEST(ElementTargeting, BasicElementTargeting)
     {
         auto element = [elements objectAtIndex:0];
         EXPECT_EQ(element.positionType, _WKTargetedElementPositionFixed);
-        EXPECT_WK_STREQ(".fixed.container", element.selectors.firstObject);
+        EXPECT_WK_STREQ("DIV.fixed.container", element.selectors.firstObject);
         EXPECT_TRUE([element.renderedText containsString:@"The round pegs"]);
         EXPECT_EQ(element.renderedText.length, 70U);
         EXPECT_EQ(element.offsetEdges, _WKRectEdgeLeft | _WKRectEdgeTop);
@@ -198,16 +198,16 @@ TEST(ElementTargeting, NearbyOutOfFlowElements)
     EXPECT_FALSE([elements objectAtIndex:3].underPoint);
     EXPECT_FALSE([elements objectAtIndex:4].underPoint);
     // The two elements that are directly hit-tested should take precedence over nearby elements.
-    EXPECT_WK_STREQ(".fixed.container", [elements firstObject].selectors.firstObject);
-    EXPECT_WK_STREQ(".box", [elements objectAtIndex:1].selectors.firstObject);
+    EXPECT_WK_STREQ("DIV.fixed.container", [elements firstObject].selectors.firstObject);
+    EXPECT_WK_STREQ("DIV.box", [elements objectAtIndex:1].selectors.firstObject);
     __auto_type nextThreeSelectors = [NSSet setWithArray:@[
         [elements objectAtIndex:2].selectors.firstObject,
         [elements objectAtIndex:3].selectors.firstObject,
         [elements objectAtIndex:4].selectors.firstObject,
     ]];
-    EXPECT_TRUE([nextThreeSelectors containsObject:@".absolute.top-right"]);
-    EXPECT_TRUE([nextThreeSelectors containsObject:@".absolute.bottom-left"]);
-    EXPECT_TRUE([nextThreeSelectors containsObject:@".absolute.bottom-right"]);
+    EXPECT_TRUE([nextThreeSelectors containsObject:@"DIV.absolute.top-right"]);
+    EXPECT_TRUE([nextThreeSelectors containsObject:@"DIV.absolute.bottom-left"]);
+    EXPECT_TRUE([nextThreeSelectors containsObject:@"DIV.absolute.bottom-right"]);
 
     [webView adjustVisibilityForTargets:elements.get()];
     EXPECT_EQ([webView numberOfVisibilityAdjustmentRects], 1U);
@@ -369,7 +369,7 @@ TEST(ElementTargeting, TargetInFlowElements)
 
     [webView stringByEvaluatingJavaScript:@"scrollBy(0, 400)"];
     [webView waitForNextPresentationUpdate];
-    [webView expectSingleTargetedSelector:@".bottom-text" at:center];
+    [webView expectSingleTargetedSelector:@"P.bottom-text" at:center];
 }
 
 TEST(ElementTargeting, ReplacedRendererSizeIgnoresPageScaleAndZoom)


### PR DESCRIPTION
#### b7d3d40b4f0b12769021f7403a22a788669a1fc5
<pre>
[Remote Inspection] Selector-based element targeting heuristic should include custom DOM attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=273038">https://bugs.webkit.org/show_bug.cgi?id=273038</a>
<a href="https://rdar.apple.com/126633838">rdar://126633838</a>

Reviewed by Richard Robinson.

Make a couple more adjustments to the targeting heuristic, to make matching more robust (and to
avoid falling back to n-th child selectors in more cases):

-   Additionally surface unique selectors based on element attributes.
-   Return early if we&apos;ve already found unique selectors based on attributes solely based on the
    targeted element, to avoid the more expensive (and less stable) process of recursively finding
    parent- or child-relative selectors.

* LayoutTests/fast/element-targeting/prefer-succinct-selectors-expected.txt:
* LayoutTests/fast/element-targeting/prefer-succinct-selectors.html:

Rebaseline an existing layout test.

* LayoutTests/fast/element-targeting/target-element-selectors-using-attributes-expected.txt: Added.
* LayoutTests/fast/element-targeting/target-element-selectors-using-attributes.html: Added.

Add a new layout test to exercise the enhancements.

* LayoutTests/fast/element-targeting/target-iframe-above-nav-bar-expected.txt:
* LayoutTests/fast/element-targeting/target-iframe-above-nav-bar.html:

More rebaselining.

* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::querySelectorMatchesOneElement):
(WebCore::computeTagAndAttributeSelector):
(WebCore::computeTagAndClassSelector):
(WebCore::selectorForElementRecursive):
(WebCore::selectorsForTarget):
(WebCore::computeClassSelector): Deleted.

See above for more details.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm:
(TestWebKitAPI::TEST(ElementTargeting, BasicElementTargeting)):
(TestWebKitAPI::TEST(ElementTargeting, NearbyOutOfFlowElements)):
(TestWebKitAPI::TEST(ElementTargeting, TargetInFlowElements)):

Rebaseline existing API tests.

Canonical link: <a href="https://commits.webkit.org/277790@main">https://commits.webkit.org/277790@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c3eb7fbae4be22b12f7d6da6d2b49d57351ca20

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48578 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51265 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44643 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50883 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33725 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25318 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39723 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49160 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25455 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41909 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20820 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22932 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43083 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6634 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44870 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43571 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53173 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23624 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19922 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47015 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24890 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42115 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45939 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10709 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25694 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24612 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->