### PR TITLE
Decrease use of StringView::character8() / character16()

### DIFF
--- a/Source/JavaScriptCore/yarr/YarrParser.h
+++ b/Source/JavaScriptCore/yarr/YarrParser.h
@@ -774,7 +774,7 @@ private:
 
     Parser(Delegate& delegate, StringView pattern, CompileMode compileMode, unsigned backReferenceLimit, bool isNamedForwardReferenceAllowed)
         : m_delegate(delegate)
-        , m_data(pattern.characters<CharType>())
+        , m_data(pattern.span<CharType>().data())
         , m_size(pattern.length())
         , m_compileMode(compileMode)
         , m_backReferenceLimit(backReferenceLimit)

--- a/Source/WTF/wtf/text/AdaptiveStringSearcher.h
+++ b/Source/WTF/wtf/text/AdaptiveStringSearcher.h
@@ -542,20 +542,8 @@ int searchString(AdaptiveStringSearcherTables& tables, std::span<const SubjectCh
     return search.search(subject, startIndex);
 }
 
-// A wrapper function around SearchString that wraps raw pointers to the subject
-// and pattern as vectors before calling SearchString. Used from the
-// StringIndexOf builtin.
-template <typename SubjectChar, typename PatternChar>
-intptr_t searchStringRaw(AdaptiveStringSearcherTables& tables, const SubjectChar* subjectPtr, int subjectLength, const PatternChar* patternPtr, int patternLength, int startIndex)
-{
-    std::span<const SubjectChar> subject(subjectPtr, subjectLength);
-    std::span<const PatternChar> pattern(patternPtr, patternLength);
-    return searchString(tables, subject, pattern, startIndex);
-}
-
 } // namespace WTF
 
 using WTF::AdaptiveStringSearcher;
 using WTF::AdaptiveStringSearcherTables;
 using WTF::searchString;
-using WTF::searchStringRaw;

--- a/Source/WTF/wtf/text/Base64.cpp
+++ b/Source/WTF/wtf/text/Base64.cpp
@@ -263,10 +263,9 @@ std::optional<Vector<uint8_t>> base64Decode(std::span<const std::byte> input, Ba
 
 std::optional<Vector<uint8_t>> base64Decode(StringView input, Base64DecodeMode mode)
 {
-    unsigned length = input.length();
-    if (!length || input.is8Bit())
-        return base64DecodeInternal(std::span(input.characters8(), length), mode);
-    return base64DecodeInternal(std::span(input.characters16(), length), mode);
+    if (input.is8Bit())
+        return base64DecodeInternal(input.span8(), mode);
+    return base64DecodeInternal(input.span16(), mode);
 }
 
 String base64DecodeToString(StringView input, Base64DecodeMode mode)\
@@ -277,10 +276,9 @@ String base64DecodeToString(StringView input, Base64DecodeMode mode)\
         return String::adopt(WTFMove(*optionalBuffer));
     };
 
-    unsigned length = input.length();
-    if (!length || input.is8Bit())
-        return toString(base64DecodeInternal<LChar, StringImplMalloc>(std::span(input.characters8(), length), mode));
-    return toString(base64DecodeInternal<UChar, StringImplMalloc>(std::span(input.characters16(), length), mode));
+    if (input.is8Bit())
+        return toString(base64DecodeInternal<LChar, StringImplMalloc>(input.span8(), mode));
+    return toString(base64DecodeInternal<UChar, StringImplMalloc>(input.span16(), mode));
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -902,12 +902,12 @@ size_t StringImpl::find(StringView matchString)
     if (matchLength == 1) {
         if (is8Bit()) {
             if (matchString.is8Bit())
-                return WTF::find(span8(), matchString.characters8()[0]);
-            return WTF::find(span8(), matchString.characters16()[0]);
+                return WTF::find(span8(), matchString.span8().front());
+            return WTF::find(span8(), matchString.span16().front());
         }
         if (matchString.is8Bit())
-            return WTF::find(span16(), matchString.characters8()[0]);
-        return WTF::find(span16(), matchString.characters16()[0]);
+            return WTF::find(span16(), matchString.span8().front());
+        return WTF::find(span16(), matchString.span16().front());
     }
 
     // Check matchLength is in range.

--- a/Source/WTF/wtf/text/TextBreakIterator.cpp
+++ b/Source/WTF/wtf/text/TextBreakIterator.cpp
@@ -102,7 +102,8 @@ static UBreakIterator* setTextForIterator(UBreakIterator& iterator, StringView s
         utext_close(text);
     } else {
         UErrorCode setTextStatus = U_ZERO_ERROR;
-        ubrk_setText(&iterator, string.characters16(), string.length(), &setTextStatus);
+        auto characters = string.span16();
+        ubrk_setText(&iterator, characters.data(), characters.size(), &setTextStatus);
         if (U_FAILURE(setTextStatus))
             return nullptr;
     }
@@ -184,7 +185,7 @@ unsigned numGraphemeClusters(StringView string)
 
     // The only Latin-1 Extended Grapheme Cluster is CRLF.
     if (string.is8Bit()) {
-        auto* characters = string.characters8();
+        auto characters = string.span8();
         unsigned numCRLF = 0;
         for (unsigned i = 1; i < stringLength; ++i)
             numCRLF += characters[i - 1] == '\r' && characters[i] == '\n';
@@ -212,7 +213,7 @@ unsigned numCodeUnitsInGraphemeClusters(StringView string, unsigned numGraphemeC
 
     // The only Latin-1 Extended Grapheme Cluster is CRLF.
     if (string.is8Bit()) {
-        auto* characters = string.characters8();
+        auto characters = string.span8();
         unsigned i, j;
         for (i = 0, j = 0; i < numGraphemeClusters && j + 1 < stringLength; ++i, ++j)
             j += characters[j] == '\r' && characters[j + 1] == '\n';

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -107,6 +107,7 @@ public:
 
     // Return characters8() or characters16() depending on CharacterType.
     template<typename CharacterType> const CharacterType* characters() const;
+    template<typename CharacterType> std::span<const CharacterType> span() const;
 
     bool is8Bit() const { return !m_impl || m_impl->is8Bit(); }
 
@@ -439,6 +440,16 @@ template<> inline const LChar* String::characters<LChar>() const
 template<> inline const UChar* String::characters<UChar>() const
 {
     return characters16();
+}
+
+template<> inline std::span<const LChar> String::span<LChar>() const
+{
+    return span8();
+}
+
+template<> inline std::span<const UChar> String::span<UChar>() const
+{
+    return span16();
 }
 
 inline UChar String::characterAt(unsigned index) const

--- a/Source/WTF/wtf/text/cf/StringViewCF.cpp
+++ b/Source/WTF/wtf/text/cf/StringViewCF.cpp
@@ -35,18 +35,22 @@ namespace WTF {
 
 RetainPtr<CFStringRef> StringView::createCFString() const
 {
-    if (is8Bit())
-        return adoptCF(CFStringCreateWithBytes(kCFAllocatorDefault, characters8(), length(), kCFStringEncodingISOLatin1, false));
-    
-    return adoptCF(CFStringCreateWithCharacters(kCFAllocatorDefault, reinterpret_cast<const UniChar*>(characters16()), length()));
+    if (is8Bit()) {
+        auto characters = span8();
+        return adoptCF(CFStringCreateWithBytes(kCFAllocatorDefault, characters.data(), characters.size(), kCFStringEncodingISOLatin1, false));
+    }
+    auto characters = span16();
+    return adoptCF(CFStringCreateWithCharacters(kCFAllocatorDefault, reinterpret_cast<const UniChar*>(characters.data()), characters.size()));
 }
 
 RetainPtr<CFStringRef> StringView::createCFStringWithoutCopying() const
 {
-    if (is8Bit())
-        return adoptCF(CFStringCreateWithBytesNoCopy(kCFAllocatorDefault, characters8(), length(), kCFStringEncodingISOLatin1, false, kCFAllocatorNull));
-
-    return adoptCF(CFStringCreateWithCharactersNoCopy(kCFAllocatorDefault, reinterpret_cast<const UniChar*>(characters16()), length(), kCFAllocatorNull));
+    if (is8Bit()) {
+        auto characters = span8();
+        return adoptCF(CFStringCreateWithBytesNoCopy(kCFAllocatorDefault, characters.data(), characters.size(), kCFStringEncodingISOLatin1, false, kCFAllocatorNull));
+    }
+    auto characters = span16();
+    return adoptCF(CFStringCreateWithCharactersNoCopy(kCFAllocatorDefault, reinterpret_cast<const UniChar*>(characters.data()), characters.size(), kCFAllocatorNull));
 }
 
 }

--- a/Source/WTF/wtf/text/cocoa/StringViewCocoa.mm
+++ b/Source/WTF/wtf/text/cocoa/StringViewCocoa.mm
@@ -32,18 +32,22 @@ namespace WTF {
 
 RetainPtr<NSString> StringView::createNSString() const
 {
-    if (is8Bit())
-        return adoptNS([[NSString alloc] initWithBytes:const_cast<LChar*>(characters8()) length:length() encoding:NSISOLatin1StringEncoding]);
-
-    return adoptNS([[NSString alloc] initWithCharacters:reinterpret_cast<unichar*>(const_cast<UChar*>(characters16())) length:length()]);
+    if (is8Bit()) {
+        auto characters = span8();
+        return adoptNS([[NSString alloc] initWithBytes:const_cast<LChar*>(characters.data()) length:characters.size() encoding:NSISOLatin1StringEncoding]);
+    }
+    auto characters = span16();
+    return adoptNS([[NSString alloc] initWithCharacters:reinterpret_cast<unichar*>(const_cast<UChar*>(characters.data())) length:characters.size()]);
 }
 
 RetainPtr<NSString> StringView::createNSStringWithoutCopying() const
 {
-    if (is8Bit())
-        return adoptNS([[NSString alloc] initWithBytesNoCopy:const_cast<LChar*>(characters8()) length:length() encoding:NSISOLatin1StringEncoding freeWhenDone:NO]);
-
-    return adoptNS([[NSString alloc] initWithCharactersNoCopy:reinterpret_cast<unichar*>(const_cast<UChar*>(characters16())) length:length() freeWhenDone:NO]);
+    if (is8Bit()) {
+        auto characters = span8();
+        return adoptNS([[NSString alloc] initWithBytesNoCopy:const_cast<LChar*>(characters.data()) length:characters.size() encoding:NSISOLatin1StringEncoding freeWhenDone:NO]);
+    }
+    auto characters = span16();
+    return adoptNS([[NSString alloc] initWithCharactersNoCopy:reinterpret_cast<unichar*>(const_cast<UChar*>(characters.data())) length:characters.size() freeWhenDone:NO]);
 }
 
 }

--- a/Source/WTF/wtf/text/icu/TextBreakIteratorICU.h
+++ b/Source/WTF/wtf/text/icu/TextBreakIteratorICU.h
@@ -107,9 +107,9 @@ public:
         UErrorCode status = U_ZERO_ERROR;
         UText* text = nullptr;
         if (string.is8Bit())
-            text = openLatin1ContextAwareUTextProvider(&textLocal, string.characters8(), string.length(), priorContext, &status);
+            text = openLatin1ContextAwareUTextProvider(&textLocal, string.span8(), priorContext, &status);
         else
-            text = openUTF16ContextAwareUTextProvider(&textLocal.text, string.characters16(), string.length(), priorContext, &status);
+            text = openUTF16ContextAwareUTextProvider(&textLocal.text, string.span16(), priorContext, &status);
         ASSERT(U_SUCCESS(status));
         ASSERT(text);
 

--- a/Source/WTF/wtf/text/icu/UTextProvider.h
+++ b/Source/WTF/wtf/text/icu/UTextProvider.h
@@ -44,13 +44,14 @@ inline UTextProviderContext uTextProviderContext(const UText* text, int64_t nati
     return UTextProviderContext::PriorContext;
 }
 
-inline void initializeContextAwareUTextProvider(UText* text, const UTextFuncs* funcs, const void* string, unsigned length, std::span<const UChar> priorContext)
+template<typename CharacterType>
+inline void initializeContextAwareUTextProvider(UText* text, const UTextFuncs* funcs, std::span<const CharacterType> string, std::span<const UChar> priorContext)
 {
     text->pFuncs = funcs;
     text->providerProperties = 1 << UTEXT_PROVIDER_STABLE_CHUNKS;
-    text->context = string;
-    text->p = string;
-    text->a = length;
+    text->context = string.data();
+    text->p = string.data();
+    text->a = string.size();
     text->q = priorContext.data();
     text->b = priorContext.size();
 }

--- a/Source/WTF/wtf/text/icu/UTextProviderLatin1.cpp
+++ b/Source/WTF/wtf/text/icu/UTextProviderLatin1.cpp
@@ -373,11 +373,11 @@ static void uTextLatin1ContextAwareClose(UText* text)
     text->context = nullptr;
 }
 
-UText* openLatin1ContextAwareUTextProvider(UTextWithBuffer* utWithBuffer, const LChar* string, unsigned length, std::span<const UChar> priorContext, UErrorCode* status)
+UText* openLatin1ContextAwareUTextProvider(UTextWithBuffer* utWithBuffer, std::span<const LChar> string, std::span<const UChar> priorContext, UErrorCode* status)
 {
     if (U_FAILURE(*status))
         return nullptr;
-    if (!string || length > static_cast<unsigned>(std::numeric_limits<int32_t>::max())) {
+    if (!string.data() || string.size() > static_cast<unsigned>(std::numeric_limits<int32_t>::max())) {
         *status = U_ILLEGAL_ARGUMENT_ERROR;
         return nullptr;
     }
@@ -387,7 +387,7 @@ UText* openLatin1ContextAwareUTextProvider(UTextWithBuffer* utWithBuffer, const 
         return nullptr;
     }
 
-    initializeContextAwareUTextProvider(text, &textLatin1ContextAwareFuncs, string, length, priorContext);
+    initializeContextAwareUTextProvider(text, &textLatin1ContextAwareFuncs, string, priorContext);
     return text;
 }
 

--- a/Source/WTF/wtf/text/icu/UTextProviderLatin1.h
+++ b/Source/WTF/wtf/text/icu/UTextProviderLatin1.h
@@ -39,6 +39,6 @@ struct UTextWithBuffer {
 };
 
 UText* openLatin1UTextProvider(UTextWithBuffer* utWithBuffer, std::span<const LChar> string, UErrorCode* status);
-WTF_EXPORT_PRIVATE UText* openLatin1ContextAwareUTextProvider(UTextWithBuffer* utWithBuffer, const LChar* string, unsigned length, std::span<const UChar> priorContext, UErrorCode* status);
+WTF_EXPORT_PRIVATE UText* openLatin1ContextAwareUTextProvider(UTextWithBuffer* utWithBuffer, std::span<const LChar> string, std::span<const UChar> priorContext, UErrorCode* status);
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/icu/UTextProviderUTF16.cpp
+++ b/Source/WTF/wtf/text/icu/UTextProviderUTF16.cpp
@@ -162,11 +162,11 @@ static void uTextUTF16ContextAwareClose(UText* text)
     text->context = nullptr;
 }
 
-UText* openUTF16ContextAwareUTextProvider(UText* text, const UChar* string, unsigned length, std::span<const UChar> priorContext, UErrorCode* status)
+UText* openUTF16ContextAwareUTextProvider(UText* text, std::span<const UChar> string, std::span<const UChar> priorContext, UErrorCode* status)
 {
     if (U_FAILURE(*status))
         return nullptr;
-    if (!string || length > static_cast<unsigned>(std::numeric_limits<int32_t>::max())) {
+    if (!string.data() || string.size() > static_cast<unsigned>(std::numeric_limits<int32_t>::max())) {
         *status = U_ILLEGAL_ARGUMENT_ERROR;
         return nullptr;
     }
@@ -176,7 +176,7 @@ UText* openUTF16ContextAwareUTextProvider(UText* text, const UChar* string, unsi
         return nullptr;
     }
 
-    initializeContextAwareUTextProvider(text, &textUTF16ContextAwareFuncs, string, length, priorContext);
+    initializeContextAwareUTextProvider(text, &textUTF16ContextAwareFuncs, string, priorContext);
     return text;
 }
 

--- a/Source/WTF/wtf/text/icu/UTextProviderUTF16.h
+++ b/Source/WTF/wtf/text/icu/UTextProviderUTF16.h
@@ -29,6 +29,6 @@
 
 namespace WTF {
 
-WTF_EXPORT_PRIVATE UText* openUTF16ContextAwareUTextProvider(UText*, const UChar*, unsigned length, std::span<const UChar> priorContext, UErrorCode*);
+WTF_EXPORT_PRIVATE UText* openUTF16ContextAwareUTextProvider(UText*, std::span<const UChar>, std::span<const UChar> priorContext, UErrorCode*);
 
 } // namespace WTF

--- a/Source/WTF/wtf/unicode/icu/CollatorICU.cpp
+++ b/Source/WTF/wtf/unicode/icu/CollatorICU.cpp
@@ -238,7 +238,8 @@ UCharIterator createIterator(StringView string)
     if (string.is8Bit())
         return createLatin1Iterator(string.span8());
     UCharIterator iterator;
-    uiter_setString(&iterator, string.characters16(), string.length());
+    auto characters = string.span16();
+    uiter_setString(&iterator, characters.data(), characters.size());
     return iterator;
 }
 

--- a/Source/WebCore/dom/SpaceSplitString.cpp
+++ b/Source/WebCore/dom/SpaceSplitString.cpp
@@ -129,7 +129,7 @@ private:
 template <typename ValueCharacterType>
 static bool spaceSplitStringContainsValueInternal(StringView spaceSplitString, StringView value)
 {
-    TokenIsEqualToCharactersTokenProcessor<ValueCharacterType> tokenProcessor(value.characters<ValueCharacterType>(), value.length());
+    TokenIsEqualToCharactersTokenProcessor<ValueCharacterType> tokenProcessor(value.span<ValueCharacterType>().data(), value.length());
     tokenizeSpaceSplitString(tokenProcessor, spaceSplitString);
     return tokenProcessor.referenceStringWasFound();
 }


### PR DESCRIPTION
#### 4a5f7f431122a5e13b4d81f3cf9d4352e1338d98
<pre>
Decrease use of StringView::character8() / character16()
<a href="https://bugs.webkit.org/show_bug.cgi?id=273040">https://bugs.webkit.org/show_bug.cgi?id=273040</a>

Reviewed by Darin Adler.

Decrease use of StringView::character8() / character16() in preparation
for dropping them.

* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::Parser::Parser):
* Source/WTF/wtf/JSONValues.cpp:
(WTF::JSONImpl::Value::parseJSON):
* Source/WTF/wtf/text/AdaptiveStringSearcher.h:
(WTF::searchStringRaw): Deleted.
* Source/WTF/wtf/text/Base64.cpp:
(WTF::base64Decode):
(WTF::base64DecodeToString):
* Source/WTF/wtf/text/StringCommon.h:
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::find):
* Source/WTF/wtf/text/StringView.cpp:
(WTF::StringView::find const):
(WTF::getCharactersWithASCIICaseInternal):
(WTF::StringView::getCharactersWithASCIICase const):
(WTF::normalizedNFC):
(WTF::makeStringByReplacingAll):
(WTF::makeStringBySimplifyingNewLinesSlowCase):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::span8 const):
(WTF::StringView::span16 const):
(WTF::StringView::span&lt;LChar&gt; const):
(WTF::StringView::span&lt;UChar&gt; const):
(WTF::StringView::characterAt const):
(WTF::StringView::unsafeCharacterAt const):
(WTF::equal):
(WTF::StringView::CodePoints::Iterator::Iterator):
(WTF::StringView::trim const):
(WTF::startsWith):
(WTF::startsWithIgnoringASCIICase):
(WTF::endsWith):
(WTF::endsWithIgnoringASCIICase):
(WTF::StringView::characters8 const): Deleted.
(WTF::StringView::characters16 const): Deleted.
(WTF::StringView::characters&lt;LChar&gt; const): Deleted.
(WTF::StringView::characters&lt;UChar&gt; const): Deleted.
* Source/WTF/wtf/text/TextBreakIterator.cpp:
(WTF::setTextForIterator):
(WTF::numGraphemeClusters):
(WTF::numCodeUnitsInGraphemeClusters):
* Source/WTF/wtf/text/WTFString.h:
(WTF::String::span&lt;LChar&gt; const):
(WTF::String::span&lt;UChar&gt; const):
* Source/WTF/wtf/text/cf/StringViewCF.cpp:
(WTF::StringView::createCFString const):
(WTF::StringView::createCFStringWithoutCopying const):
* Source/WTF/wtf/text/cocoa/StringViewCocoa.mm:
(WTF::StringView::createNSString const):
(WTF::StringView::createNSStringWithoutCopying const):
* Source/WTF/wtf/text/icu/TextBreakIteratorICU.h:
(WTF::TextBreakIteratorICU::setText):
* Source/WTF/wtf/text/icu/UTextProvider.h:
(WTF::initializeContextAwareUTextProvider):
* Source/WTF/wtf/text/icu/UTextProviderLatin1.cpp:
(WTF::openLatin1ContextAwareUTextProvider):
* Source/WTF/wtf/text/icu/UTextProviderLatin1.h:
* Source/WTF/wtf/text/icu/UTextProviderUTF16.cpp:
(WTF::openUTF16ContextAwareUTextProvider):
* Source/WTF/wtf/text/icu/UTextProviderUTF16.h:
* Source/WTF/wtf/unicode/icu/CollatorICU.cpp:
(WTF::createIterator):
* Source/WebCore/dom/SpaceSplitString.cpp:
(WebCore::spaceSplitStringContainsValueInternal):

Canonical link: <a href="https://commits.webkit.org/277796@main">https://commits.webkit.org/277796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b0645298eb5d18b6c2f9caf89a146da28b663c2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48614 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51301 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44679 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50919 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25355 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39756 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49196 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25491 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41944 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20853 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22969 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43122 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6670 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/41913 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44907 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53209 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/48105 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23661 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19959 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47048 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24927 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42149 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/45976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25731 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55599 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6925 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24648 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11434 "Passed tests") | 
<!--EWS-Status-Bubble-End-->