### PR TITLE
[WK1] WebKit XML parsing can deny external entity loads from other in-process libxml2 clients

### DIFF
--- a/Source/WebCore/dom/ProcessingInstruction.cpp
+++ b/Source/WebCore/dom/ProcessingInstruction.cpp
@@ -81,11 +81,12 @@ Ref<Node> ProcessingInstruction::cloneNodeInternal(Document& targetDocument, Clo
 
 void ProcessingInstruction::checkStyleSheet()
 {
-    if (m_target == "xml-stylesheet"_s && document().frame() && parentNode() == &document()) {
+    Ref document = this->document();
+    if (m_target == "xml-stylesheet"_s && document->frame() && parentNode() == document.ptr()) {
         // see http://www.w3.org/TR/xml-stylesheet/
         // ### support stylesheet included in a fragment of this (or another) document
         // ### make sure this gets called when adding from javascript
-        auto attributes = parseAttributes(data());
+        auto attributes = parseAttributes(document->cachedResourceLoader(), data());
         if (!attributes)
             return;
         String type = attributes->get<HashTranslatorASCIILiteral>("type"_s);
@@ -108,7 +109,6 @@ void ProcessingInstruction::checkStyleSheet()
         if (m_alternate && m_title.isEmpty())
             return;
 
-        Ref document = this->document();
         if (href.length() > 1 && href[0] == '#') {
             m_localHref = href.substring(1);
 #if ENABLE(XSLT)

--- a/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
+++ b/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
@@ -146,9 +146,7 @@ static xmlDocPtr docLoaderFunc(const xmlChar* uri,
 
         // We don't specify an encoding here. Neither Gecko nor WinIE respects
         // the encoding specified in the HTTP headers.
-        xmlDocPtr doc = xmlReadMemory(data->dataAsCharPtr(), data->size(), (const char*)uri, nullptr, options);
-
-        return doc;
+        return xmlReadMemory(data->dataAsCharPtr(), data->size(), (const char*)uri, nullptr, options);
     }
     case XSLT_LOAD_STYLESHEET:
         return globalProcessor->xslStylesheet()->locateStylesheetSubResource(((xsltStylesheetPtr)ctxt)->doc, uri);

--- a/Source/WebCore/xml/parser/XMLDocumentParser.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.h
@@ -50,6 +50,7 @@ class XMLParserContext : public RefCounted<XMLParserContext> {
 public:
     static RefPtr<XMLParserContext> createMemoryParser(xmlSAXHandlerPtr, void* userData, const CString& chunk);
     static Ref<XMLParserContext> createStringParser(xmlSAXHandlerPtr, void* userData);
+    XMLParserContext() = delete;
     ~XMLParserContext();
     xmlParserCtxtPtr context() const { return m_context; }
 
@@ -74,6 +75,7 @@ public:
         return adoptRef(*new XMLDocumentParser(fragment, WTFMove(prefixToNamespaceMap), defaultNamespaceURI, parserContentPolicy));
     }
 
+    XMLDocumentParser() = delete;
     ~XMLDocumentParser();
 
     // Exposed for callbacks:
@@ -190,6 +192,8 @@ private:
 xmlDocPtr xmlDocPtrForString(CachedResourceLoader&, const String& source, const String& url);
 #endif
 
-std::optional<HashMap<String, String>> parseAttributes(const String&);
+xmlParserInputPtr externalEntityLoader(const char* url, const char* id, xmlParserCtxtPtr);
+
+std::optional<HashMap<String, String>> parseAttributes(CachedResourceLoader&, const String&);
 
 } // namespace WebCore

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -549,7 +549,7 @@ static void errorFunc(void*, const char*, ...)
 
 static xmlExternalEntityLoader defaultEntityLoader { nullptr };
 
-static xmlParserInputPtr entityLoader(const char* url, const char* id, xmlParserCtxtPtr context)
+xmlParserInputPtr externalEntityLoader(const char* url, const char* id, xmlParserCtxtPtr context)
 {
     if (!shouldAllowExternalLoad(URL(String::fromUTF8(url))))
         return nullptr;
@@ -564,7 +564,7 @@ static void initializeXMLParser()
         xmlRegisterInputCallbacks(matchFunc, openFunc, readFunc, closeFunc);
         xmlRegisterOutputCallbacks(matchFunc, openFunc, writeFunc, closeFunc);
         defaultEntityLoader = xmlGetExternalEntityLoader();
-        xmlSetExternalEntityLoader(entityLoader);
+        RELEASE_ASSERT_WITH_MESSAGE(defaultEntityLoader != WebCore::externalEntityLoader, "XMLDocumentParserScope was created too early");
         libxmlLoaderThread = &Thread::current();
     });
 }
@@ -1311,7 +1311,6 @@ void XMLDocumentParser::initializeParserContext(const CString& chunk)
     m_sawXSLTransform = false;
     m_sawFirstElement = false;
 
-    XMLDocumentParserScope scope(&document()->cachedResourceLoader());
     if (m_parsingFragment)
         m_context = XMLParserContext::createMemoryParser(&sax, this, chunk);
     else {
@@ -1451,6 +1450,7 @@ bool XMLDocumentParser::appendFragmentSource(const String& chunk)
         return false;
 
     initializeParserContext(chunkAsUTF8);
+    XMLDocumentParserScope scope(&document()->cachedResourceLoader());
     xmlParseContent(context());
     endDocument(); // Close any open text nodes.
 
@@ -1494,7 +1494,7 @@ static void attributesStartElementNsHandler(void* closure, const xmlChar* xmlLoc
     }
 }
 
-std::optional<HashMap<String, String>> parseAttributes(const String& string)
+std::optional<HashMap<String, String>> parseAttributes(CachedResourceLoader& cachedResourceLoader, const String& string)
 {
     String parseString = "<?xml version=\"1.0\"?><attrs " + string + " />";
 
@@ -1507,6 +1507,7 @@ std::optional<HashMap<String, String>> parseAttributes(const String& string)
 
     auto parser = XMLParserContext::createStringParser(&sax, &attributes);
 
+    XMLDocumentParserScope scope(&cachedResourceLoader);
     // FIXME: Can we parse 8-bit strings directly as Latin-1 instead of upconverting to UTF-16?
     xmlParseChunk(parser->context(), reinterpret_cast<const char*>(StringView(parseString).upconvertedCharacters().get()), parseString.length() * sizeof(UChar), 1);
 

--- a/Source/WebCore/xml/parser/XMLDocumentParserScope.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserScope.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "XMLDocumentParserScope.h"
 
+#include "XMLDocumentParser.h"
+
 namespace WebCore {
 
 WeakPtr<CachedResourceLoader>& XMLDocumentParserScope::currentCachedResourceLoader()
@@ -42,19 +44,23 @@ XMLDocumentParserScope::XMLDocumentParserScope(CachedResourceLoader* cachedResou
 #else
 XMLDocumentParserScope::XMLDocumentParserScope(CachedResourceLoader* cachedResourceLoader)
     : m_oldCachedResourceLoader(currentCachedResourceLoader())
+    , m_oldEntityLoader(xmlGetExternalEntityLoader())
 {
     currentCachedResourceLoader() = cachedResourceLoader;
+    xmlSetExternalEntityLoader(WebCore::externalEntityLoader);
 }
 #endif // ENABLE(XSLT)
 
 #if ENABLE(XSLT)
 XMLDocumentParserScope::XMLDocumentParserScope(CachedResourceLoader* cachedResourceLoader, xmlGenericErrorFunc genericErrorFunc, xmlStructuredErrorFunc structuredErrorFunc, void* errorContext)
     : m_oldCachedResourceLoader(currentCachedResourceLoader())
+    , m_oldEntityLoader(xmlGetExternalEntityLoader())
     , m_oldGenericErrorFunc(xmlGenericError)
     , m_oldStructuredErrorFunc(xmlStructuredError)
     , m_oldErrorContext(xmlGenericErrorContext)
 {
     currentCachedResourceLoader() = cachedResourceLoader;
+    xmlSetExternalEntityLoader(WebCore::externalEntityLoader);
     if (genericErrorFunc)
         xmlSetGenericErrorFunc(errorContext, genericErrorFunc);
     if (structuredErrorFunc)
@@ -65,6 +71,7 @@ XMLDocumentParserScope::XMLDocumentParserScope(CachedResourceLoader* cachedResou
 XMLDocumentParserScope::~XMLDocumentParserScope()
 {
     currentCachedResourceLoader() = m_oldCachedResourceLoader;
+    xmlSetExternalEntityLoader(m_oldEntityLoader);
 #if ENABLE(XSLT)
     xmlSetGenericErrorFunc(m_oldErrorContext, m_oldGenericErrorFunc);
     xmlSetStructuredErrorFunc(m_oldErrorContext, m_oldStructuredErrorFunc);

--- a/Source/WebCore/xml/parser/XMLDocumentParserScope.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParserScope.h
@@ -50,6 +50,7 @@ public:
 
 private:
     WeakPtr<CachedResourceLoader> m_oldCachedResourceLoader;
+    xmlExternalEntityLoader m_oldEntityLoader { nullptr };
 
 #if ENABLE(XSLT)
     xmlGenericErrorFunc m_oldGenericErrorFunc { nullptr };


### PR DESCRIPTION
#### 7b1fb05b974f0c50874da628b5388cca5b7292e2
<pre>
[WK1] WebKit XML parsing can deny external entity loads from other in-process libxml2 clients
<a href="https://bugs.webkit.org/show_bug.cgi?id=273045">https://bugs.webkit.org/show_bug.cgi?id=273045</a>
&lt;<a href="https://rdar.apple.com/126476952">rdar://126476952</a>&gt;

Reviewed by Alex Christensen and Michael Catanzaro.

The fix for Bug 259235 replaced the default libxml2 external entity
loader function with one from WebKit that implements a same-origin
policy for the web, but that means that WebKit1 clients that use libxml2
for parsing independent of WebKit also start using this function, which
can cause external entity load failures depending on the libxml2 API
used.

Fix this by setting the external entity loader using
XMLDocumentParserScope, then unsetting it when that object is
deallocated.

Add two more places where XMLDocumentParserScope was missing in
WebCore::XMLDocumentParser::appendFragmentSource() and
WebCore::parseAttributes().

Covered by these tests (among others):
    fast/xsl/xslt-bad-import-uri.html
    http/tests/misc/xslt-bad-import.html
    http/tests/security/contentSecurityPolicy/xsl-redirect-blocked.html
    http/tests/security/cross-origin-xsl-redirect-BLOCKED.html
    http/tests/security/xss-ALLOWED-xsl-external-entity-xslt-docloader.html
    http/tests/security/xss-DENIED-xsl-external-entity-xslt-docloader.html

* Source/WebCore/dom/ProcessingInstruction.cpp:
(WebCore::ProcessingInstruction::checkStyleSheet):
- Move Ref variable for Document to top of method instead of calling
  document() repeatedly.
- Pass extra argument added to WebCore::parseAttributes().

* Source/WebCore/xml/XSLTProcessorLibxslt.cpp:
(WebCore::docLoaderFunc):
- Minor clean-up to inline return statement.
* Source/WebCore/xml/parser/XMLDocumentParser.h:
(WebCore::XMLParserContext::XMLParserContext): Remove.
(WebCore::XMLDocumentParser::XMLDocumentParser): Remove.
- Delete default constructors.
(WebCore::externalEntityLoader): Add declaration.
(WebCore::parseAttributes):
- Add WebCore::CachedResourceLoader to argument list.
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::externalEntityLoader):
- Remove &apos;static&apos; keyword as this function is referenced outside this
  source file.
(WebCore::initializeXMLParser):
- Don&apos;t set external entity loader here since it will be set by
  XMLDocumentParserScope instead.
- Add RELEASE_ASSERT() that the external entity loader isn&apos;t already set
  to WebCore::externalEntityLoader.  This indicates that an
  XMLDocumentParserScope was created too early, and that external entity
  loading will result in a stack recursion crash later.
(WebCore::XMLDocumentParser::initializeParserContext):
- Remove unneeded XMLDocumentParserScope object.
(WebCore::XMLDocumentParser::appendFragmentSource):
- Add missing XMLDocumentParserScope object.
(WebCore::parseAttributes):
- Add WebCore::CachedResourceLoader to argument list so that an
  XMLDocumentParserScope object can be created before calling libxml2 to
  parse XML content.
* Source/WebCore/xml/parser/XMLDocumentParserScope.cpp:
(WebCore::XMLDocumentParserScope::XMLDocumentParserScope):
(WebCore::XMLDocumentParserScope::~XMLDocumentParserScope):
- Update to save the current external entity loader and set WebKit&apos;s
  external entity loader function.
* Source/WebCore/xml/parser/XMLDocumentParserScope.h:
(WebCore::XMLDocumentParserScope::m_oldEntityLoader): Add.
- Add instance variable for saving and restoring the external entity
  loader.

Canonical link: <a href="https://commits.webkit.org/278168@main">https://commits.webkit.org/278168@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2dbf864dfc1421e43a15994f97cc43d24dfdf72e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28762 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52719 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/153 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51784 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26382 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40391 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51580 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26304 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42629 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21509 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23764 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43812 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7849 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45678 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54231 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24563 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20746 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47757 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25834 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46773 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26674 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7151 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25557 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->