### PR TITLE
dataLog should print to both os_log and stderr for WebKit processes.

### DIFF
--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -66,11 +66,11 @@ static_assert(sizeof(bool) == 1, "LLInt and JIT assume sizeof(bool) is always 1 
 
 enum class JSCProfileTag { };
 
-void initialize()
+void initialize(ScopedLambda<void()> optionsCustomization)
 {
     static std::once_flag onceFlag;
 
-    std::call_once(onceFlag, [] {
+    std::call_once(onceFlag, [&] {
 #if USE(TZONE_MALLOC)
         // This is needed for apps that link with the JavaScriptCore ObjC API
         if (!WTF_TZONE_IS_READY()) {
@@ -81,6 +81,11 @@ void initialize()
 #endif
         WTF::initialize();
         Options::initialize();
+
+        {
+            Options::AllowUnfinalizedAccessScope scope;
+            optionsCustomization();
+        }
 
         initializePtrTagLookup();
 

--- a/Source/JavaScriptCore/runtime/InitializeThreading.h
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,9 +29,10 @@
 #pragma once
 
 #include "JSExportMacros.h"
+#include <wtf/ScopedLambda.h>
 
 namespace JSC {
 
-JS_EXPORT_PRIVATE void initialize();
+JS_EXPORT_PRIVATE void initialize(ScopedLambda<void()> optionsCustomization = scopedLambda<void()>([] { }));
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -129,7 +129,7 @@ bool hasCapacityToUseLargeGigacage();
     \
     v(Bool, useIterationIntrinsics, true, Normal, nullptr) \
     \
-    v(OSLogType, useOSLog, OSLogType::None, Normal, "Log dataLog()s to os_log instead of stderr") \
+    v(OSLogType, useOSLog, OSLogType::None, Normal, "Log dataLog()s to os_log instead of or in addition to stderr") \
     /* dumpDisassembly implies dumpDFGDisassembly. */ \
     v(Bool, needDisassemblySupport, false, Normal, nullptr) \
     v(Bool, dumpDisassembly, false, Normal, "dumps disassembly of all JIT compiled code upon compilation") \
@@ -695,7 +695,15 @@ enum class OSLogType : uint8_t {
     Info,
     Debug,
     Error,
-    Fault
+    Fault,
+    // These duplicate output to stderr and OS_LOG_TYPE_xxx.
+    DupDefault,
+    DupInfo,
+    DupDebug,
+    DupError,
+    DupFault,
+
+    FirstDuplicatedOSLogType = DupDefault,
 };
 
 struct OptionsStorage {

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -97,6 +97,8 @@
 		5311BD531EA71CAD00525281 /* Signals.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5311BD511EA71CAD00525281 /* Signals.cpp */; };
 		5311BD5C1EA822F900525281 /* ThreadMessage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5311BD5B1EA822F900525281 /* ThreadMessage.cpp */; };
 		53534F2A1EC0E10E00141B2F /* MachExceptions.defs in Sources */ = {isa = PBXBuildFile; fileRef = 53534F291EC0E10E00141B2F /* MachExceptions.defs */; settings = {ATTRIBUTES = (Client, Server, ); }; };
+		53A79B3D2BD33F6700400A9B /* DuplicatedPrintStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 53A79B3C2BD33F6700400A9B /* DuplicatedPrintStream.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		53A79B3E2BD33F6700400A9B /* DuplicatedPrintStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53A79B3B2BD33F6700400A9B /* DuplicatedPrintStream.cpp */; };
 		53FC70D023FB950C005B1990 /* OSLogPrintStream.mm in Sources */ = {isa = PBXBuildFile; fileRef = 53FC70CF23FB950C005B1990 /* OSLogPrintStream.mm */; };
 		5C1F05932164356B0039302C /* CFURLExtras.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C1F05912164356B0039302C /* CFURLExtras.cpp */; };
 		5C1F0595216437B30039302C /* URLCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C1F0594216437B30039302C /* URLCF.cpp */; };
@@ -1201,6 +1203,8 @@
 		5338EBA423AB04D100382662 /* EnumClassOperatorOverloads.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EnumClassOperatorOverloads.h; sourceTree = "<group>"; };
 		53534F291EC0E10E00141B2F /* MachExceptions.defs */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.mig; path = MachExceptions.defs; sourceTree = "<group>"; };
 		539EB0621D55284200C82EF7 /* LEBDecoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LEBDecoder.h; sourceTree = "<group>"; };
+		53A79B3B2BD33F6700400A9B /* DuplicatedPrintStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DuplicatedPrintStream.cpp; sourceTree = "<group>"; };
+		53A79B3C2BD33F6700400A9B /* DuplicatedPrintStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DuplicatedPrintStream.h; sourceTree = "<group>"; };
 		53EC253C1E95AD30000831B9 /* PriorityQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PriorityQueue.h; sourceTree = "<group>"; };
 		53F08A1BA39D49A8BAD369A1 /* StdSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StdSet.h; sourceTree = "<group>"; };
 		53F1D98620477B9800EBC6BF /* FunctionTraits.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = FunctionTraits.h; sourceTree = "<group>"; };
@@ -2119,6 +2123,8 @@
 				A8A47280151A825A004123FF /* DoublyLinkedList.h */,
 				A8A47297151A825A004123FF /* dtoa.cpp */,
 				A8A47298151A825A004123FF /* dtoa.h */,
+				53A79B3B2BD33F6700400A9B /* DuplicatedPrintStream.cpp */,
+				53A79B3C2BD33F6700400A9B /* DuplicatedPrintStream.h */,
 				0F0C03CF29981BEB0064230A /* EmbeddedFixedVector.cpp */,
 				E3538D4C276220880075DA50 /* EmbeddedFixedVector.h */,
 				5338EBA423AB04D100382662 /* EnumClassOperatorOverloads.h */,
@@ -3144,6 +3150,7 @@
 				FFE39CB72B1D7472004972B0 /* dragonbox.h in Headers */,
 				FFE39CB82B1D7472004972B0 /* dragonbox_to_chars.h in Headers */,
 				DD3DC92A27A4BF8E007E5B61 /* dtoa.h in Headers */,
+				53A79B3D2BD33F6700400A9B /* DuplicatedPrintStream.h in Headers */,
 				DDF306E627C08654006A526F /* dyldSPI.h in Headers */,
 				DD3DC94C27A4BF8E007E5B61 /* EmbeddedFixedVector.h in Headers */,
 				DDF3076327C086CD006A526F /* Entitlements.h in Headers */,
@@ -3898,6 +3905,7 @@
 				A8A473B0151A825B004123FF /* double-conversion.cc in Sources */,
 				FFE39CB62B1D7472004972B0 /* dragonbox_to_chars.cpp in Sources */,
 				A8A473BA151A825B004123FF /* dtoa.cpp in Sources */,
+				53A79B3E2BD33F6700400A9B /* DuplicatedPrintStream.cpp in Sources */,
 				0F0C03D029981BEB0064230A /* EmbeddedFixedVector.cpp in Sources */,
 				143DDE9620C8BC37007F76FA /* Entitlements.mm in Sources */,
 				50DE35F5215BB01500B979C7 /* ExternalStringImpl.cpp in Sources */,

--- a/Source/WTF/wtf/DuplicatedPrintStream.cpp
+++ b/Source/WTF/wtf/DuplicatedPrintStream.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,42 +23,18 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-#pragma once
-
-#if OS(DARWIN)
-
-#include <wtf/Lock.h>
-#include <wtf/PrintStream.h>
-#include <wtf/RecursiveLockAdapter.h>
-#include <wtf/text/CString.h>
-#include <wtf/Vector.h>
-
-#include <os/log.h>
+#include "config.h"
+#include "DuplicatedPrintStream.h"
 
 namespace WTF {
 
-class WTF_EXPORT_PRIVATE OSLogPrintStream final : public PrintStream {
-    WTF_MAKE_FAST_ALLOCATED;
-    WTF_MAKE_NONCOPYABLE(OSLogPrintStream);
-public:
-    OSLogPrintStream(os_log_t, os_log_type_t);
-    ~OSLogPrintStream() final;
-    
-    static std::unique_ptr<OSLogPrintStream> open(const char* subsystem, const char* category, os_log_type_t = OS_LOG_TYPE_DEFAULT);
-    
-    void vprintf(const char* format, va_list) final WTF_ATTRIBUTE_PRINTF(2, 0);
+DuplicatedPrintStream::~DuplicatedPrintStream() = default;
 
-private:
-    os_log_t m_log;
-    os_log_type_t m_logType;
-    Lock m_stringLock;
-    // We need a buffer because os_log doesn't wait for a new line to print the characters.
-    CString m_string WTF_GUARDED_BY_LOCK(m_stringLock);
-    size_t m_offset { 0 };
-};
+void DuplicatedPrintStream::vprintf(const char* format, va_list argList)
+{
+    for (auto& stream : m_streams)
+        stream->vprintf(format, argList);
+}
 
 } // namespace WTF
 
-using WTF::OSLogPrintStream;
-
-#endif

--- a/Source/WTF/wtf/DuplicatedPrintStream.h
+++ b/Source/WTF/wtf/DuplicatedPrintStream.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,40 +25,33 @@
 
 #pragma once
 
-#if OS(DARWIN)
-
-#include <wtf/Lock.h>
 #include <wtf/PrintStream.h>
-#include <wtf/RecursiveLockAdapter.h>
-#include <wtf/text/CString.h>
 #include <wtf/Vector.h>
-
-#include <os/log.h>
 
 namespace WTF {
 
-class WTF_EXPORT_PRIVATE OSLogPrintStream final : public PrintStream {
+class DuplicatedPrintStream final : public PrintStream {
     WTF_MAKE_FAST_ALLOCATED;
-    WTF_MAKE_NONCOPYABLE(OSLogPrintStream);
+    WTF_MAKE_NONCOPYABLE(DuplicatedPrintStream);
 public:
-    OSLogPrintStream(os_log_t, os_log_type_t);
-    ~OSLogPrintStream() final;
-    
-    static std::unique_ptr<OSLogPrintStream> open(const char* subsystem, const char* category, os_log_type_t = OS_LOG_TYPE_DEFAULT);
-    
-    void vprintf(const char* format, va_list) final WTF_ATTRIBUTE_PRINTF(2, 0);
+    DuplicatedPrintStream(Vector<std::unique_ptr<PrintStream>>&& streams)
+        : m_streams(WTFMove(streams))
+    { }
+
+    WTF_EXPORT_PRIVATE ~DuplicatedPrintStream() final;
+
+    template<typename... Stream>
+    static inline std::unique_ptr<DuplicatedPrintStream> open(Stream&&... streams)
+    {
+        return makeUnique<DuplicatedPrintStream>(Vector<std::unique_ptr<PrintStream>>::from(WTFMove(streams)...));
+    }
+
+    WTF_EXPORT_PRIVATE void vprintf(const char* format, va_list) final WTF_ATTRIBUTE_PRINTF(2, 0);
 
 private:
-    os_log_t m_log;
-    os_log_type_t m_logType;
-    Lock m_stringLock;
-    // We need a buffer because os_log doesn't wait for a new line to print the characters.
-    CString m_string WTF_GUARDED_BY_LOCK(m_stringLock);
-    size_t m_offset { 0 };
+    Vector<std::unique_ptr<PrintStream>> m_streams;
 };
 
 } // namespace WTF
 
-using WTF::OSLogPrintStream;
-
-#endif
+using WTF::DuplicatedPrintStream;


### PR DESCRIPTION
#### 7296f42d0926c771c91668e1d635214d60359b9f
<pre>
dataLog should print to both os_log and stderr for WebKit processes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=273047">https://bugs.webkit.org/show_bug.cgi?id=273047</a>
<a href="https://rdar.apple.com/126829243">rdar://126829243</a>

Reviewed by NOBODY (OOPS!).

Right now in order to get JSC logging to work in WebKit processes you have to pass __XPC_JSC_useOSLog=...
Instead we should just log dataLog to os_log and stderr for WebKit processes. This won&apos;t be noisy because
JSC only logs when options are overridden anyway. It also means passing one less option when debugging WebKit
processes for JSC devs.

This change also adds a DuplicatedPrintStream so we can log to more than one location at a time as well as
new OSLogType enum values that indicate we want to print to stderr and os_log.

* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::parse):
(JSC::asDarwinOSLogType):
(JSC::initializeDatafileToUseOSLog):
(JSC::asString):
(JSC::Options::notifyOptionsChanged):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/DuplicatedPrintStream.cpp: Copied from Source/WTF/wtf/darwin/OSLogPrintStream.h.
(WTF::DuplicatedPrintStream::vprintf):
* Source/WTF/wtf/DuplicatedPrintStream.h: Copied from Source/WTF/wtf/darwin/OSLogPrintStream.h.
* Source/WTF/wtf/darwin/OSLogPrintStream.h:
* Source/WebKit/Shared/Cocoa/WebKit2InitializeCocoa.mm:
(WebKit::runInitializationCode):
(WebKit::InitializeWebKit2):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7296f42d0926c771c91668e1d635214d60359b9f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27883 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51633 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51359 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44737 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39807 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49254 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25544 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42001 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20904 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23022 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43179 "Found 1 new test failure: fast/css/viewport-height-border.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6728 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/41971 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44960 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43692 "Found 8 new test failures: fast/webgpu/bind-group-layout-invalid.html, fast/webgpu/present-without-compute-pipeline.html, fast/webgpu/render-bundle-validation-color-format.html, fast/webgpu/type-checker-array-without-argument.html, fast/webgpu/write-to-destroyed-buffer.html, fullscreen/exit-full-screen-video-crash.html, http/tests/webshare/navigator-share-files-fail-access-control-checks-crash.html, inspector/model/remote-object/number.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53267 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/48163 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23719 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20018 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47098 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24985 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42206 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46030 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25789 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55658 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24706 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11453 "Passed tests") | 
<!--EWS-Status-Bubble-End-->