### PR TITLE
Use ASCIILiteral more

### DIFF
--- a/Source/WTF/wtf/Logger.h
+++ b/Source/WTF/wtf/Logger.h
@@ -55,6 +55,7 @@ struct LogArgument {
     template<typename U = T> static std::enable_if_t<std::is_same_v<typename std::remove_reference_t<U>, String>, String> toString(String argument) { return argument; }
     template<typename U = T> static std::enable_if_t<std::is_same_v<typename std::remove_reference_t<U>, StringBuilder*>, String> toString(StringBuilder* argument) { return argument->toString(); }
     template<typename U = T> static std::enable_if_t<std::is_same_v<U, const char*>, String> toString(const char* argument) { return String::fromLatin1(argument); }
+    template<typename U = T> static std::enable_if_t<std::is_same_v<U, ASCIILiteral>, String> toString(ASCIILiteral argument) { return argument; }
 #ifdef __OBJC__
     template<typename U = T> static std::enable_if_t<std::is_base_of_v<NSError, std::remove_pointer_t<U>>, String> toString(NSError *argument) { return String(argument.localizedDescription); }
     template<typename U = T> static std::enable_if_t<std::is_base_of_v<NSObject, std::remove_pointer_t<U>>, String> toString(NSObject *argument) { return String(argument.description); }

--- a/Source/WTF/wtf/text/TextStream.h
+++ b/Source/WTF/wtf/text/TextStream.h
@@ -109,6 +109,15 @@ public:
         ts.endGroup();
     }
 
+    template<typename T>
+    void dumpProperty(ASCIILiteral name, const T& value)
+    {
+        TextStream& ts = *this;
+        ts.startGroup();
+        ts << name << " "_s << value;
+        ts.endGroup();
+    }
+
     WTF_EXPORT_PRIVATE String release();
     
     WTF_EXPORT_PRIVATE void startGroup();

--- a/Source/WebCore/platform/xr/openxr/OpenXRInstance.cpp
+++ b/Source/WebCore/platform/xr/openxr/OpenXRInstance.cpp
@@ -56,7 +56,7 @@ Instance::Impl::Impl()
         if (!m_extensions)
             return;
 
-        static const char* s_applicationName = "WebXR (WebKit)";
+        static constexpr auto s_applicationName = "WebXR (WebKit)"_s;
         static const uint32_t s_applicationVersion = 1;
 
         const char* const enabledExtensions[] = {
@@ -66,7 +66,7 @@ Instance::Impl::Impl()
 
         auto createInfo = createStructure<XrInstanceCreateInfo, XR_TYPE_INSTANCE_CREATE_INFO>();
         createInfo.createFlags = 0;
-        std::memcpy(createInfo.applicationInfo.applicationName, s_applicationName, XR_MAX_APPLICATION_NAME_SIZE);
+        std::memcpy(createInfo.applicationInfo.applicationName, s_applicationName.characters(), XR_MAX_APPLICATION_NAME_SIZE);
         createInfo.applicationInfo.apiVersion = XR_CURRENT_API_VERSION;
         createInfo.applicationInfo.applicationVersion = s_applicationVersion;
         createInfo.enabledApiLayerCount = 0;

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1787,34 +1787,34 @@ void RenderLayerCompositor::logLayerInfo(const RenderLayer& layer, const char* p
     if (backing->graphicsLayer()->contentsOpaque() || backing->paintsIntoCompositedAncestor() || backing->foregroundLayer() || backing->backgroundLayer()) {
         logString.append('[');
 
-        const char* prefix = "";
+        auto prefix = ""_s;
         if (backing->graphicsLayer()->contentsOpaque()) {
-            logString.append("opaque");
-            prefix = ", ";
+            logString.append("opaque"_s);
+            prefix = ", "_s;
         }
 
         if (backing->paintsIntoCompositedAncestor()) {
-            logString.append(prefix, "paints into ancestor");
-            prefix = ", ";
+            logString.append(prefix, "paints into ancestor"_s);
+            prefix = ", "_s;
         }
 
         if (backing->foregroundLayer() || backing->backgroundLayer()) {
             if (backing->foregroundLayer() && backing->backgroundLayer()) {
-                logString.append(prefix, "+foreground+background");
-                prefix = ", ";
+                logString.append(prefix, "+foreground+background"_s);
+                prefix = ", "_s;
             } else if (backing->foregroundLayer()) {
-                logString.append(prefix, "+foreground");
-                prefix = ", ";
+                logString.append(prefix, "+foreground"_s);
+                prefix = ", "_s;
             } else {
-                logString.append(prefix, "+background");
-                prefix = ", ";
+                logString.append(prefix, "+background"_s);
+                prefix = ", "_s;
             }
         }
 
-        logString.append("] ");
+        logString.append("] "_s);
     }
 
-    logString.append(layer.name(), " - ", phase);
+    logString.append(layer.name(), " - "_s, phase);
 
     LOG(Compositing, "%s", logString.toString().utf8().data());
 }

--- a/Source/WebCore/svg/SVGLengthValue.cpp
+++ b/Source/WebCore/svg/SVGLengthValue.cpp
@@ -33,34 +33,34 @@
 
 namespace WebCore {
 
-static inline const char* lengthTypeToString(SVGLengthType lengthType)
+static inline ASCIILiteral lengthTypeToString(SVGLengthType lengthType)
 {
     switch (lengthType) {
     case SVGLengthType::Unknown:
     case SVGLengthType::Number:
-        return "";    
+        return ""_s;
     case SVGLengthType::Percentage:
-        return "%";
+        return "%"_s;
     case SVGLengthType::Ems:
-        return "em";
+        return "em"_s;
     case SVGLengthType::Exs:
-        return "ex";
+        return "ex"_s;
     case SVGLengthType::Pixels:
-        return "px";
+        return "px"_s;
     case SVGLengthType::Centimeters:
-        return "cm";
+        return "cm"_s;
     case SVGLengthType::Millimeters:
-        return "mm";
+        return "mm"_s;
     case SVGLengthType::Inches:
-        return "in";
+        return "in"_s;
     case SVGLengthType::Points:
-        return "pt";
+        return "pt"_s;
     case SVGLengthType::Picas:
-        return "pc";
+        return "pc"_s;
     }
 
     ASSERT_NOT_REACHED();
-    return "";
+    return ""_s;
 }
 
 template<typename CharacterType> static inline SVGLengthType parseLengthType(StringParsingBuffer<CharacterType>& buffer)

--- a/Source/WebCore/svg/SVGTransformValue.h
+++ b/Source/WebCore/svg/SVGTransformValue.h
@@ -216,26 +216,26 @@ public:
         return builder.toString();
     }
 
-    static const char* prefixForTransformType(SVGTransformType type)
+    static ASCIILiteral prefixForTransformType(SVGTransformType type)
     {
         switch (type) {
         case SVG_TRANSFORM_UNKNOWN:
-            return "";
+            return ""_s;
         case SVG_TRANSFORM_MATRIX:
-            return "matrix(";
+            return "matrix("_s;
         case SVG_TRANSFORM_TRANSLATE:
-            return "translate(";
+            return "translate("_s;
         case SVG_TRANSFORM_SCALE:
-            return "scale(";
+            return "scale("_s;
         case SVG_TRANSFORM_ROTATE:
-            return "rotate(";
+            return "rotate("_s;
         case SVG_TRANSFORM_SKEWX:
-            return "skewX(";
+            return "skewX("_s;
         case SVG_TRANSFORM_SKEWY:
-            return "skewY(";
+            return "skewY("_s;
         }
         ASSERT_NOT_REACHED();
-        return "";
+        return ""_s;
     }
 
 private:

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2724,26 +2724,26 @@ String Internals::parserMetaData(JSC::JSValue code)
     else
         return String();
 
-    const char* prefix;
+    ASCIILiteral prefix;
     String functionName;
-    const char* suffix = "";
+    ASCIILiteral suffix = ""_s;
 
     if (executable->isFunctionExecutable()) {
-        prefix = "function \"";
+        prefix = "function \""_s;
         functionName = static_cast<FunctionExecutable*>(executable)->ecmaName().string();
-        suffix = "\"";
+        suffix = "\""_s;
     } else if (executable->isEvalExecutable())
-        prefix = "eval";
+        prefix = "eval"_s;
     else if (executable->isModuleProgramExecutable())
-        prefix = "module";
+        prefix = "module"_s;
     else if (executable->isProgramExecutable())
-        prefix = "program";
+        prefix = "program"_s;
     else
         RELEASE_ASSERT_NOT_REACHED();
 
-    return makeString(prefix, functionName, suffix, " { ",
-        executable->firstLine(), ':', executable->startColumn(), " - ",
-        executable->lastLine(), ':', executable->endColumn(), " }");
+    return makeString(prefix, functionName, suffix, " { "_s,
+        executable->firstLine(), ':', executable->startColumn(), " - "_s,
+        executable->lastLine(), ':', executable->endColumn(), " }"_s);
 }
 
 void Internals::updateEditorUINowIfScheduled()
@@ -4126,58 +4126,58 @@ unsigned Internals::layoutCount() const
 }
 
 #if !PLATFORM(IOS_FAMILY)
-static const char* cursorTypeToString(Cursor::Type cursorType)
+static ASCIILiteral cursorTypeToString(Cursor::Type cursorType)
 {
     switch (cursorType) {
-    case Cursor::Type::Pointer: return "Pointer";
-    case Cursor::Type::Cross: return "Cross";
-    case Cursor::Type::Hand: return "Hand";
-    case Cursor::Type::IBeam: return "IBeam";
-    case Cursor::Type::Wait: return "Wait";
-    case Cursor::Type::Help: return "Help";
-    case Cursor::Type::EastResize: return "EastResize";
-    case Cursor::Type::NorthResize: return "NorthResize";
-    case Cursor::Type::NorthEastResize: return "NorthEastResize";
-    case Cursor::Type::NorthWestResize: return "NorthWestResize";
-    case Cursor::Type::SouthResize: return "SouthResize";
-    case Cursor::Type::SouthEastResize: return "SouthEastResize";
-    case Cursor::Type::SouthWestResize: return "SouthWestResize";
-    case Cursor::Type::WestResize: return "WestResize";
-    case Cursor::Type::NorthSouthResize: return "NorthSouthResize";
-    case Cursor::Type::EastWestResize: return "EastWestResize";
-    case Cursor::Type::NorthEastSouthWestResize: return "NorthEastSouthWestResize";
-    case Cursor::Type::NorthWestSouthEastResize: return "NorthWestSouthEastResize";
-    case Cursor::Type::ColumnResize: return "ColumnResize";
-    case Cursor::Type::RowResize: return "RowResize";
-    case Cursor::Type::MiddlePanning: return "MiddlePanning";
-    case Cursor::Type::EastPanning: return "EastPanning";
-    case Cursor::Type::NorthPanning: return "NorthPanning";
-    case Cursor::Type::NorthEastPanning: return "NorthEastPanning";
-    case Cursor::Type::NorthWestPanning: return "NorthWestPanning";
-    case Cursor::Type::SouthPanning: return "SouthPanning";
-    case Cursor::Type::SouthEastPanning: return "SouthEastPanning";
-    case Cursor::Type::SouthWestPanning: return "SouthWestPanning";
-    case Cursor::Type::WestPanning: return "WestPanning";
-    case Cursor::Type::Move: return "Move";
-    case Cursor::Type::VerticalText: return "VerticalText";
-    case Cursor::Type::Cell: return "Cell";
-    case Cursor::Type::ContextMenu: return "ContextMenu";
-    case Cursor::Type::Alias: return "Alias";
-    case Cursor::Type::Progress: return "Progress";
-    case Cursor::Type::NoDrop: return "NoDrop";
-    case Cursor::Type::Copy: return "Copy";
-    case Cursor::Type::None: return "None";
-    case Cursor::Type::NotAllowed: return "NotAllowed";
-    case Cursor::Type::ZoomIn: return "ZoomIn";
-    case Cursor::Type::ZoomOut: return "ZoomOut";
-    case Cursor::Type::Grab: return "Grab";
-    case Cursor::Type::Grabbing: return "Grabbing";
-    case Cursor::Type::Custom: return "Custom";
+    case Cursor::Type::Pointer: return "Pointer"_s;
+    case Cursor::Type::Cross: return "Cross"_s;
+    case Cursor::Type::Hand: return "Hand"_s;
+    case Cursor::Type::IBeam: return "IBeam"_s;
+    case Cursor::Type::Wait: return "Wait"_s;
+    case Cursor::Type::Help: return "Help"_s;
+    case Cursor::Type::EastResize: return "EastResize"_s;
+    case Cursor::Type::NorthResize: return "NorthResize"_s;
+    case Cursor::Type::NorthEastResize: return "NorthEastResize"_s;
+    case Cursor::Type::NorthWestResize: return "NorthWestResize"_s;
+    case Cursor::Type::SouthResize: return "SouthResize"_s;
+    case Cursor::Type::SouthEastResize: return "SouthEastResize"_s;
+    case Cursor::Type::SouthWestResize: return "SouthWestResize"_s;
+    case Cursor::Type::WestResize: return "WestResize"_s;
+    case Cursor::Type::NorthSouthResize: return "NorthSouthResize"_s;
+    case Cursor::Type::EastWestResize: return "EastWestResize"_s;
+    case Cursor::Type::NorthEastSouthWestResize: return "NorthEastSouthWestResize"_s;
+    case Cursor::Type::NorthWestSouthEastResize: return "NorthWestSouthEastResize"_s;
+    case Cursor::Type::ColumnResize: return "ColumnResize"_s;
+    case Cursor::Type::RowResize: return "RowResize"_s;
+    case Cursor::Type::MiddlePanning: return "MiddlePanning"_s;
+    case Cursor::Type::EastPanning: return "EastPanning"_s;
+    case Cursor::Type::NorthPanning: return "NorthPanning"_s;
+    case Cursor::Type::NorthEastPanning: return "NorthEastPanning"_s;
+    case Cursor::Type::NorthWestPanning: return "NorthWestPanning"_s;
+    case Cursor::Type::SouthPanning: return "SouthPanning"_s;
+    case Cursor::Type::SouthEastPanning: return "SouthEastPanning"_s;
+    case Cursor::Type::SouthWestPanning: return "SouthWestPanning"_s;
+    case Cursor::Type::WestPanning: return "WestPanning"_s;
+    case Cursor::Type::Move: return "Move"_s;
+    case Cursor::Type::VerticalText: return "VerticalText"_s;
+    case Cursor::Type::Cell: return "Cell"_s;
+    case Cursor::Type::ContextMenu: return "ContextMenu"_s;
+    case Cursor::Type::Alias: return "Alias"_s;
+    case Cursor::Type::Progress: return "Progress"_s;
+    case Cursor::Type::NoDrop: return "NoDrop"_s;
+    case Cursor::Type::Copy: return "Copy"_s;
+    case Cursor::Type::None: return "None"_s;
+    case Cursor::Type::NotAllowed: return "NotAllowed"_s;
+    case Cursor::Type::ZoomIn: return "ZoomIn"_s;
+    case Cursor::Type::ZoomOut: return "ZoomOut"_s;
+    case Cursor::Type::Grab: return "Grab"_s;
+    case Cursor::Type::Grabbing: return "Grabbing"_s;
+    case Cursor::Type::Custom: return "Custom"_s;
     case Cursor::Type::Invalid: break;
     }
 
     ASSERT_NOT_REACHED();
-    return "UNKNOWN";
+    return "UNKNOWN"_s;
 }
 #endif
 

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -192,7 +192,7 @@ void PresentationContextIOSurface::configure(Device& device, const WGPUSwapChain
     }
 
     if (!allowedFormat(descriptor.format)) {
-        generateAValidationError(device, [NSString stringWithFormat:@"Requested texture format %s is not a valid context format", Texture::formatToString(descriptor.format)], reportValidationErrors);
+        generateAValidationError(device, [NSString stringWithFormat:@"Requested texture format %s is not a valid context format", Texture::formatToString(descriptor.format).characters()], reportValidationErrors);
         return;
     }
 

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -415,75 +415,75 @@ static MTLVertexStepFunction stepFunction(WGPUVertexStepMode stepMode, auto arra
     }
 }
 
-static const char* name(WGPUVertexFormat format)
+static ASCIILiteral name(WGPUVertexFormat format)
 {
     switch (format) {
     case WGPUVertexFormat_Uint8x2:
-        return "UChar2";
+        return "UChar2"_s;
     case WGPUVertexFormat_Uint8x4:
-        return "UChar4";
+        return "UChar4"_s;
     case WGPUVertexFormat_Sint8x2:
-        return "Char2";
+        return "Char2"_s;
     case WGPUVertexFormat_Sint8x4:
-        return "Char4";
+        return "Char4"_s;
     case WGPUVertexFormat_Unorm8x2:
-        return "UChar2Normalized";
+        return "UChar2Normalized"_s;
     case WGPUVertexFormat_Unorm8x4:
-        return "UChar4Normalized";
+        return "UChar4Normalized"_s;
     case WGPUVertexFormat_Snorm8x2:
-        return "Char2Normalized";
+        return "Char2Normalized"_s;
     case WGPUVertexFormat_Snorm8x4:
-        return "Char4Normalized";
+        return "Char4Normalized"_s;
     case WGPUVertexFormat_Uint16x2:
-        return "UShort2";
+        return "UShort2"_s;
     case WGPUVertexFormat_Uint16x4:
-        return "UShort4";
+        return "UShort4"_s;
     case WGPUVertexFormat_Sint16x2:
-        return "Short2";
+        return "Short2"_s;
     case WGPUVertexFormat_Sint16x4:
-        return "Short4";
+        return "Short4"_s;
     case WGPUVertexFormat_Unorm16x2:
-        return "UShort2Normalized";
+        return "UShort2Normalized"_s;
     case WGPUVertexFormat_Unorm16x4:
-        return "UShort4Normalized";
+        return "UShort4Normalized"_s;
     case WGPUVertexFormat_Snorm16x2:
-        return "Short2Normalized";
+        return "Short2Normalized"_s;
     case WGPUVertexFormat_Snorm16x4:
-        return "Short4Normalized";
+        return "Short4Normalized"_s;
     case WGPUVertexFormat_Float16x2:
-        return "Half2";
+        return "Half2"_s;
     case WGPUVertexFormat_Float16x4:
-        return "Half4";
+        return "Half4"_s;
     case WGPUVertexFormat_Float32:
-        return "Float";
+        return "Float"_s;
     case WGPUVertexFormat_Float32x2:
-        return "Float2";
+        return "Float2"_s;
     case WGPUVertexFormat_Float32x3:
-        return "Float3";
+        return "Float3"_s;
     case WGPUVertexFormat_Float32x4:
-        return "Float4";
+        return "Float4"_s;
     case WGPUVertexFormat_Uint32:
-        return "UInt";
+        return "UInt"_s;
     case WGPUVertexFormat_Uint32x2:
-        return "UInt2";
+        return "UInt2"_s;
     case WGPUVertexFormat_Uint32x3:
-        return "UInt3";
+        return "UInt3"_s;
     case WGPUVertexFormat_Uint32x4:
-        return "UInt4";
+        return "UInt4"_s;
     case WGPUVertexFormat_Sint32:
-        return "Int";
+        return "Int"_s;
     case WGPUVertexFormat_Sint32x2:
-        return "Int2";
+        return "Int2"_s;
     case WGPUVertexFormat_Sint32x3:
-        return "Int3";
+        return "Int3"_s;
     case WGPUVertexFormat_Sint32x4:
-        return "Int4";
+        return "Int4"_s;
     case WGPUVertexFormat_Unorm10_10_10_2:
-        return "UInt1010102Normalized";
+        return "UInt1010102Normalized"_s;
     case WGPUVertexFormat_Force32:
     case WGPUVertexFormat_Undefined:
         ASSERT_NOT_REACHED();
-        return "none";
+        return "none"_s;
     }
 }
 
@@ -627,7 +627,7 @@ static MTLVertexDescriptor *createVertexDescriptor(WGPUVertexState vertexState, 
             WGPUVertexFormat otherFormat = WGPUVertexFormat_Undefined;
             if (it != stageIn.end())
                 otherFormat = it->value;
-            *error = [NSString stringWithFormat:@"!matchesFormat(attribute(%d), format(%s), size(%zu), otherFormat(%d)", shaderLocation, name(attributeFormat), formatSize, otherFormat];
+            *error = [NSString stringWithFormat:@"!matchesFormat(attribute(%d), format(%s), size(%zu), otherFormat(%d)", shaderLocation, name(attributeFormat).characters(), formatSize, otherFormat];
             return nil;
         }
     }
@@ -900,32 +900,32 @@ static std::pair<Ref<RenderPipeline>, NSString*> returnInvalidRenderPipeline(Web
     return returnInvalidRenderPipeline(object, isAsync, static_cast<NSString*>(error));
 }
 
-static constexpr const char* name(WGPUCompareFunction compare)
+static constexpr ASCIILiteral name(WGPUCompareFunction compare)
 {
     switch (compare) {
-    case WGPUCompareFunction_Undefined: return "undefined";
-    case WGPUCompareFunction_Never: return "never";
-    case WGPUCompareFunction_Less: return "less";
-    case WGPUCompareFunction_LessEqual: return "less-equal";
-    case WGPUCompareFunction_Greater: return "greater";
-    case WGPUCompareFunction_GreaterEqual: return "greater-equal";
-    case WGPUCompareFunction_Equal: return "equal";
-    case WGPUCompareFunction_NotEqual: return "not-equal";
-    case WGPUCompareFunction_Always: return "always";
+    case WGPUCompareFunction_Undefined: return "undefined"_s;
+    case WGPUCompareFunction_Never: return "never"_s;
+    case WGPUCompareFunction_Less: return "less"_s;
+    case WGPUCompareFunction_LessEqual: return "less-equal"_s;
+    case WGPUCompareFunction_Greater: return "greater"_s;
+    case WGPUCompareFunction_GreaterEqual: return "greater-equal"_s;
+    case WGPUCompareFunction_Equal: return "equal"_s;
+    case WGPUCompareFunction_NotEqual: return "not-equal"_s;
+    case WGPUCompareFunction_Always: return "always"_s;
     case WGPUCompareFunction_Force32: RELEASE_ASSERT_NOT_REACHED();
     }
 }
-static constexpr const char* name(WGPUStencilOperation operation)
+static constexpr ASCIILiteral name(WGPUStencilOperation operation)
 {
     switch (operation) {
-    case WGPUStencilOperation_Keep: return "keep";
-    case WGPUStencilOperation_Zero: return "zero";
-    case WGPUStencilOperation_Replace: return "replace";
-    case WGPUStencilOperation_Invert: return "invert";
-    case WGPUStencilOperation_IncrementClamp: return "increment-clamp";
-    case WGPUStencilOperation_DecrementClamp: return "decrement-clamp";
-    case WGPUStencilOperation_IncrementWrap: return "increment-wrap";
-    case WGPUStencilOperation_DecrementWrap: return "decrement-wrap";
+    case WGPUStencilOperation_Keep: return "keep"_s;
+    case WGPUStencilOperation_Zero: return "zero"_s;
+    case WGPUStencilOperation_Replace: return "replace"_s;
+    case WGPUStencilOperation_Invert: return "invert"_s;
+    case WGPUStencilOperation_IncrementClamp: return "increment-clamp"_s;
+    case WGPUStencilOperation_DecrementClamp: return "decrement-clamp"_s;
+    case WGPUStencilOperation_IncrementWrap: return "increment-wrap"_s;
+    case WGPUStencilOperation_DecrementWrap: return "decrement-wrap"_s;
     case WGPUStencilOperation_Force32: RELEASE_ASSERT_NOT_REACHED();
     }
 }
@@ -947,7 +947,7 @@ static NSString* errorValidatingDepthStencilState(const WGPUDepthStencilState& d
     };
     if (!isDefault(depthStencil.stencilFront) || !isDefault(depthStencil.stencilBack)) {
         if (!Texture::stencilOnlyAspectMetalFormat(depthStencil.format)) {
-            NSString *error = [NSString stringWithFormat:@"missing stencil format - stencilFront: compare = %s, failOp = %s, depthFailOp = %s, passOp = %s, stencilBack: compare = %s, failOp = %s, depthFailOp = %s, passOp = %s", name(depthStencil.stencilFront.compare), name(depthStencil.stencilFront.failOp), name(depthStencil.stencilFront.depthFailOp), name(depthStencil.stencilFront.passOp), name(depthStencil.stencilBack.compare), name(depthStencil.stencilBack.failOp), name(depthStencil.stencilBack.depthFailOp), name(depthStencil.stencilBack.passOp)];
+            NSString *error = [NSString stringWithFormat:@"missing stencil format - stencilFront: compare = %s, failOp = %s, depthFailOp = %s, passOp = %s, stencilBack: compare = %s, failOp = %s, depthFailOp = %s, passOp = %s", name(depthStencil.stencilFront.compare).characters(), name(depthStencil.stencilFront.failOp).characters(), name(depthStencil.stencilFront.depthFailOp).characters(), name(depthStencil.stencilFront.passOp).characters(), name(depthStencil.stencilBack.compare).characters(), name(depthStencil.stencilBack.failOp).characters(), name(depthStencil.stencilBack.depthFailOp).characters(), name(depthStencil.stencilBack.passOp).characters()];
             return ERROR_STRING(error);
         }
     }

--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -118,7 +118,7 @@ public:
     void recreateIfNeeded();
     void makeCanvasBacking();
     void setCommandEncoder(CommandEncoder&) const;
-    static const char* formatToString(WGPUTextureFormat);
+    static ASCIILiteral formatToString(WGPUTextureFormat);
     bool isCanvasBacking() const;
     void waitForCommandBufferCompletion();
 

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -2998,204 +2998,204 @@ void Texture::setCommandEncoder(CommandEncoder& commandEncoder) const
         commandEncoder.makeSubmitInvalid();
 }
 
-const char* Texture::formatToString(WGPUTextureFormat format)
+ASCIILiteral Texture::formatToString(WGPUTextureFormat format)
 {
     switch (format) {
     case WGPUTextureFormat_Undefined:
-        return "undefined";
+        return "undefined"_s;
     case WGPUTextureFormat_R8Unorm:
-        return "r8unorm";
+        return "r8unorm"_s;
     case WGPUTextureFormat_R8Snorm:
-        return "r8snorm";
+        return "r8snorm"_s;
     case WGPUTextureFormat_R8Uint:
-        return "r8uint";
+        return "r8uint"_s;
     case WGPUTextureFormat_R8Sint:
-        return "r8sint";
+        return "r8sint"_s;
     case WGPUTextureFormat_R16Uint:
-        return "r16uint";
+        return "r16uint"_s;
     case WGPUTextureFormat_R16Sint:
-        return "r16sint";
+        return "r16sint"_s;
     case WGPUTextureFormat_R16Float:
-        return "r16float";
+        return "r16float"_s;
     case WGPUTextureFormat_RG8Unorm:
-        return "rg8unorm";
+        return "rg8unorm"_s;
     case WGPUTextureFormat_RG8Snorm:
-        return "rg8snorm";
+        return "rg8snorm"_s;
     case WGPUTextureFormat_RG8Uint:
-        return "rg8uint";
+        return "rg8uint"_s;
     case WGPUTextureFormat_RG8Sint:
-        return "rg8sint";
+        return "rg8sint"_s;
     case WGPUTextureFormat_R32Float:
-        return "r32float";
+        return "r32float"_s;
     case WGPUTextureFormat_R32Uint:
-        return "r32uint";
+        return "r32uint"_s;
     case WGPUTextureFormat_R32Sint:
-        return "r32sint";
+        return "r32sint"_s;
     case WGPUTextureFormat_RG16Uint:
-        return "rg16uint";
+        return "rg16uint"_s;
     case WGPUTextureFormat_RG16Sint:
-        return "rg16sint";
+        return "rg16sint"_s;
     case WGPUTextureFormat_RG16Float:
-        return "rg16float";
+        return "rg16float"_s;
     case WGPUTextureFormat_RGBA8Unorm:
-        return "rgba8unorm";
+        return "rgba8unorm"_s;
     case WGPUTextureFormat_RGBA8UnormSrgb:
-        return "rgba8unorm-srgb";
+        return "rgba8unorm-srgb"_s;
     case WGPUTextureFormat_RGBA8Snorm:
-        return "rgba8snorm";
+        return "rgba8snorm"_s;
     case WGPUTextureFormat_RGBA8Uint:
-        return "rgba8uint";
+        return "rgba8uint"_s;
     case WGPUTextureFormat_RGBA8Sint:
-        return "rgba8sint";
+        return "rgba8sint"_s;
     case WGPUTextureFormat_BGRA8Unorm:
-        return "bgra8unorm";
+        return "bgra8unorm"_s;
     case WGPUTextureFormat_BGRA8UnormSrgb:
-        return "bgra8unorm-srgb";
+        return "bgra8unorm-srgb"_s;
     case WGPUTextureFormat_RGB10A2Uint:
-        return "rgb10a2uint";
+        return "rgb10a2uint"_s;
     case WGPUTextureFormat_RGB10A2Unorm:
-        return "rgb10a2unorm";
+        return "rgb10a2unorm"_s;
     case WGPUTextureFormat_RG11B10Ufloat:
-        return "rg11b10ufloat";
+        return "rg11b10ufloat"_s;
     case WGPUTextureFormat_RGB9E5Ufloat:
-        return "rgb9e5ufloat";
+        return "rgb9e5ufloat"_s;
     case WGPUTextureFormat_RG32Float:
-        return "rg32float";
+        return "rg32float"_s;
     case WGPUTextureFormat_RG32Uint:
-        return "rg32uint";
+        return "rg32uint"_s;
     case WGPUTextureFormat_RG32Sint:
-        return "rg32sint";
+        return "rg32sint"_s;
     case WGPUTextureFormat_RGBA16Uint:
-        return "rgba16uint";
+        return "rgba16uint"_s;
     case WGPUTextureFormat_RGBA16Sint:
-        return "rgba16sint";
+        return "rgba16sint"_s;
     case WGPUTextureFormat_RGBA16Float:
-        return "rgba16float";
+        return "rgba16float"_s;
     case WGPUTextureFormat_RGBA32Float:
-        return "rgba32float";
+        return "rgba32float"_s;
     case WGPUTextureFormat_RGBA32Uint:
-        return "rgba32uint";
+        return "rgba32uint"_s;
     case WGPUTextureFormat_RGBA32Sint:
-        return "rgba32sint";
+        return "rgba32sint"_s;
     case WGPUTextureFormat_Stencil8:
-        return "stencil8";
+        return "stencil8"_s;
     case WGPUTextureFormat_Depth16Unorm:
-        return "depth16unorm";
+        return "depth16unorm"_s;
     case WGPUTextureFormat_Depth24Plus:
-        return "depth24plus";
+        return "depth24plus"_s;
     case WGPUTextureFormat_Depth24PlusStencil8:
-        return "depth24plus-stencil8";
+        return "depth24plus-stencil8"_s;
     case WGPUTextureFormat_Depth32Float:
-        return "depth32float";
+        return "depth32float"_s;
     case WGPUTextureFormat_Depth32FloatStencil8:
-        return "depth32float-stencil8";
+        return "depth32float-stencil8"_s;
     case WGPUTextureFormat_BC1RGBAUnorm:
-        return "bc1-rgba-unorm";
+        return "bc1-rgba-unorm"_s;
     case WGPUTextureFormat_BC1RGBAUnormSrgb:
-        return "bc1-rgba-unorm-srgb";
+        return "bc1-rgba-unorm-srgb"_s;
     case WGPUTextureFormat_BC2RGBAUnorm:
-        return "bc2-rgba-unorm";
+        return "bc2-rgba-unorm"_s;
     case WGPUTextureFormat_BC2RGBAUnormSrgb:
-        return "bc2-rgba-unorm-srgb";
+        return "bc2-rgba-unorm-srgb"_s;
     case WGPUTextureFormat_BC3RGBAUnorm:
-        return "bc3-rgba-unorm";
+        return "bc3-rgba-unorm"_s;
     case WGPUTextureFormat_BC3RGBAUnormSrgb:
-        return "bc3-rgba-unorm-srgb";
+        return "bc3-rgba-unorm-srgb"_s;
     case WGPUTextureFormat_BC4RUnorm:
-        return "bc4-r-unorm";
+        return "bc4-r-unorm"_s;
     case WGPUTextureFormat_BC4RSnorm:
-        return "bc4-r-snorm";
+        return "bc4-r-snorm"_s;
     case WGPUTextureFormat_BC5RGUnorm:
-        return "bc5-rg-unorm";
+        return "bc5-rg-unorm"_s;
     case WGPUTextureFormat_BC5RGSnorm:
-        return "bc5-rg-snorm";
+        return "bc5-rg-snorm"_s;
     case WGPUTextureFormat_BC6HRGBUfloat:
-        return "bc6h-rgb-ufloat";
+        return "bc6h-rgb-ufloat"_s;
     case WGPUTextureFormat_BC6HRGBFloat:
-        return "bc6h-rgb-float";
+        return "bc6h-rgb-float"_s;
     case WGPUTextureFormat_BC7RGBAUnorm:
-        return "bc7-rgba-unorm";
+        return "bc7-rgba-unorm"_s;
     case WGPUTextureFormat_BC7RGBAUnormSrgb:
-        return "bc7-rgba-unorm-srgb";
+        return "bc7-rgba-unorm-srgb"_s;
     case WGPUTextureFormat_ETC2RGB8Unorm:
-        return "etc2-rgb8unorm";
+        return "etc2-rgb8unorm"_s;
     case WGPUTextureFormat_ETC2RGB8UnormSrgb:
-        return "etc2-rgb8unorm-srgb";
+        return "etc2-rgb8unorm-srgb"_s;
     case WGPUTextureFormat_ETC2RGB8A1Unorm:
-        return "etc2-rgb8a1unorm";
+        return "etc2-rgb8a1unorm"_s;
     case WGPUTextureFormat_ETC2RGB8A1UnormSrgb:
-        return "etc2-rgb8a1unorm-srgb";
+        return "etc2-rgb8a1unorm-srgb"_s;
     case WGPUTextureFormat_ETC2RGBA8Unorm:
-        return "etc2-rgba8unorm";
+        return "etc2-rgba8unorm"_s;
     case WGPUTextureFormat_ETC2RGBA8UnormSrgb:
-        return "etc2-rgba8unorm-srgb";
+        return "etc2-rgba8unorm-srgb"_s;
     case WGPUTextureFormat_EACR11Unorm:
-        return "eac-r11unorm";
+        return "eac-r11unorm"_s;
     case WGPUTextureFormat_EACR11Snorm:
-        return "eac-r11snorm";
+        return "eac-r11snorm"_s;
     case WGPUTextureFormat_EACRG11Unorm:
-        return "eac-rg11unorm";
+        return "eac-rg11unorm"_s;
     case WGPUTextureFormat_EACRG11Snorm:
-        return "eac-rg11snorm";
+        return "eac-rg11snorm"_s;
     case WGPUTextureFormat_ASTC4x4Unorm:
-        return "astc-4x4-unorm";
+        return "astc-4x4-unorm"_s;
     case WGPUTextureFormat_ASTC4x4UnormSrgb:
-        return "astc-4x4-unorm-srgb";
+        return "astc-4x4-unorm-srgb"_s;
     case WGPUTextureFormat_ASTC5x4Unorm:
-        return "astc-5x4-unorm";
+        return "astc-5x4-unorm"_s;
     case WGPUTextureFormat_ASTC5x4UnormSrgb:
-        return "astc-5x4-unorm-srgb";
+        return "astc-5x4-unorm-srgb"_s;
     case WGPUTextureFormat_ASTC5x5Unorm:
-        return "astc-5x5-unorm";
+        return "astc-5x5-unorm"_s;
     case WGPUTextureFormat_ASTC5x5UnormSrgb:
-        return "astc-5x5-unorm-srgb";
+        return "astc-5x5-unorm-srgb"_s;
     case WGPUTextureFormat_ASTC6x5Unorm:
-        return "astc-6x5-unorm";
+        return "astc-6x5-unorm"_s;
     case WGPUTextureFormat_ASTC6x5UnormSrgb:
-        return "astc-6x5-unorm-srgb";
+        return "astc-6x5-unorm-srgb"_s;
     case WGPUTextureFormat_ASTC6x6Unorm:
-        return "astc-6x6-unorm";
+        return "astc-6x6-unorm"_s;
     case WGPUTextureFormat_ASTC6x6UnormSrgb:
-        return "astc-6x6-unorm-srgb";
+        return "astc-6x6-unorm-srgb"_s;
     case WGPUTextureFormat_ASTC8x5Unorm:
-        return "astc-8x5-unorm";
+        return "astc-8x5-unorm"_s;
     case WGPUTextureFormat_ASTC8x5UnormSrgb:
-        return "astc-8x5-unorm-srgb";
+        return "astc-8x5-unorm-srgb"_s;
     case WGPUTextureFormat_ASTC8x6Unorm:
-        return "astc-8x6-unorm";
+        return "astc-8x6-unorm"_s;
     case WGPUTextureFormat_ASTC8x6UnormSrgb:
-        return "astc-8x6-unorm-srgb";
+        return "astc-8x6-unorm-srgb"_s;
     case WGPUTextureFormat_ASTC8x8Unorm:
-        return "astc-8x8-unorm";
+        return "astc-8x8-unorm"_s;
     case WGPUTextureFormat_ASTC8x8UnormSrgb:
-        return "astc-8x8-unorm-srgb";
+        return "astc-8x8-unorm-srgb"_s;
     case WGPUTextureFormat_ASTC10x5Unorm:
-        return "astc-10x5-unorm";
+        return "astc-10x5-unorm"_s;
     case WGPUTextureFormat_ASTC10x5UnormSrgb:
-        return "astc-10x5-unorm-srgb";
+        return "astc-10x5-unorm-srgb"_s;
     case WGPUTextureFormat_ASTC10x6Unorm:
-        return "astc-10x6-unorm";
+        return "astc-10x6-unorm"_s;
     case WGPUTextureFormat_ASTC10x6UnormSrgb:
-        return "astc-10x6-unorm-srgb";
+        return "astc-10x6-unorm-srgb"_s;
     case WGPUTextureFormat_ASTC10x8Unorm:
-        return "astc-10x8-unorm";
+        return "astc-10x8-unorm"_s;
     case WGPUTextureFormat_ASTC10x8UnormSrgb:
-        return "astc-10x8-unorm-srgb";
+        return "astc-10x8-unorm-srgb"_s;
     case WGPUTextureFormat_ASTC10x10Unorm:
-        return "astc-10x10-unorm";
+        return "astc-10x10-unorm"_s;
     case WGPUTextureFormat_ASTC10x10UnormSrgb:
-        return "astc-10x10-unorm-srgb";
+        return "astc-10x10-unorm-srgb"_s;
     case WGPUTextureFormat_ASTC12x10Unorm:
-        return "astc-12x10-unorm";
+        return "astc-12x10-unorm"_s;
     case WGPUTextureFormat_ASTC12x10UnormSrgb:
-        return "astc-12x10-unorm-srgb";
+        return "astc-12x10-unorm-srgb"_s;
     case WGPUTextureFormat_ASTC12x12Unorm:
-        return "astc-12x12-unorm";
+        return "astc-12x12-unorm"_s;
     case WGPUTextureFormat_ASTC12x12UnormSrgb:
-        return "astc-12x12-unorm-srgb";
+        return "astc-12x12-unorm-srgb"_s;
     case WGPUTextureFormat_Force32:
     default:
-        return "invalid format";
+        return "invalid format"_s;
     }
 }
 

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -528,7 +528,7 @@ void GPUConnectionToWebProcess::didReceiveInvalidMessage(IPC::Connection& connec
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif
-    RELEASE_LOG_FAULT(IPC, "Received an invalid message '%" PUBLIC_LOG_STRING "' from WebContent process %" PRIu64 ", requesting for it to be terminated.", description(messageName), m_webProcessIdentifier.toUInt64());
+    RELEASE_LOG_FAULT(IPC, "Received an invalid message '%" PUBLIC_LOG_STRING "' from WebContent process %" PRIu64 ", requesting for it to be terminated.", description(messageName).characters(), m_webProcessIdentifier.toUInt64());
     terminateWebProcess();
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -343,7 +343,7 @@ void NetworkConnectionToWebProcess::didReceiveMessage(IPC::Connection& connectio
         return;
 #endif
 
-    WTFLogAlways("Unhandled network process message '%s'", description(decoder.messageName()));
+    WTFLogAlways("Unhandled network process message '%s'", description(decoder.messageName()).characters());
     ASSERT_NOT_REACHED();
 }
 
@@ -422,7 +422,7 @@ bool NetworkConnectionToWebProcess::didReceiveSyncMessage(IPC::Connection& conne
         return true;
 #endif
 
-    WTFLogAlways("Unhandled network process message '%s'", description(decoder.messageName()));
+    WTFLogAlways("Unhandled network process message '%s'", description(decoder.messageName()).characters());
     ASSERT_NOT_REACHED();
     return false;
 }
@@ -481,7 +481,7 @@ void NetworkConnectionToWebProcess::didClose(IPC::Connection& connection)
 
 void NetworkConnectionToWebProcess::didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName messageName)
 {
-    RELEASE_LOG_FAULT(IPC, "Received an invalid message '%" PUBLIC_LOG_STRING "' from WebContent process %" PRIu64 ", requesting for it to be terminated.", description(messageName), m_webProcessIdentifier.toUInt64());
+    RELEASE_LOG_FAULT(IPC, "Received an invalid message '%" PUBLIC_LOG_STRING "' from WebContent process %" PRIu64 ", requesting for it to be terminated.", description(messageName).characters(), m_webProcessIdentifier.toUInt64());
     m_networkProcess->parentProcessConnection()->send(Messages::NetworkProcessProxy::TerminateWebProcess(m_webProcessIdentifier), 0);
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -208,7 +208,7 @@ void NetworkProcess::didReceiveMessage(IPC::Connection& connection, IPC::Decoder
 {
     ASSERT(parentProcessConnection() == &connection);
     if (parentProcessConnection() != &connection) {
-        WTFLogAlways("Ignored message '%s' because it did not come from the UIProcess (destination=%" PRIu64 ")", description(decoder.messageName()), decoder.destinationID());
+        WTFLogAlways("Ignored message '%s' because it did not come from the UIProcess (destination=%" PRIu64 ")", description(decoder.messageName()).characters(), decoder.destinationID());
         ASSERT_NOT_REACHED();
         return;
     }
@@ -235,7 +235,7 @@ bool NetworkProcess::didReceiveSyncMessage(IPC::Connection& connection, IPC::Dec
 {
     ASSERT(parentProcessConnection() == &connection);
     if (parentProcessConnection() != &connection) {
-        WTFLogAlways("Ignored message '%s' because it did not come from the UIProcess (destination=%" PRIu64 ")", description(decoder.messageName()), decoder.destinationID());
+        WTFLogAlways("Ignored message '%s' because it did not come from the UIProcess (destination=%" PRIu64 ")", description(decoder.messageName()).characters(), decoder.destinationID());
         ASSERT_NOT_REACHED();
         return false;
     }
@@ -1473,23 +1473,23 @@ bool NetworkProcess::privateClickMeasurementEnabled() const
 void NetworkProcess::notifyMediaStreamingActivity(bool activity)
 {
 #if PLATFORM(COCOA)
-    static const char* notifyMediaStreamingName = "com.apple.WebKit.mediaStreamingActivity";
+    static constexpr auto notifyMediaStreamingName = "com.apple.WebKit.mediaStreamingActivity"_s;
 
     if (m_mediaStreamingActivitityToken == NOTIFY_TOKEN_INVALID) {
         auto status = notify_register_check(notifyMediaStreamingName, &m_mediaStreamingActivitityToken);
         if (status != NOTIFY_STATUS_OK || m_mediaStreamingActivitityToken == NOTIFY_TOKEN_INVALID) {
-            RELEASE_LOG_ERROR(IPC, "notify_register_check() for %s failed with status (%d) 0x%X", notifyMediaStreamingName, status, status);
+            RELEASE_LOG_ERROR(IPC, "notify_register_check() for %s failed with status (%d) 0x%X", notifyMediaStreamingName.characters(), status, status);
             m_mediaStreamingActivitityToken = NOTIFY_TOKEN_INVALID;
             return;
         }
     }
     auto status = notify_set_state(m_mediaStreamingActivitityToken, activity ? 1 : 0);
     if (status != NOTIFY_STATUS_OK) {
-        RELEASE_LOG_ERROR(IPC, "notify_set_state() for %s failed with status (%d) 0x%X", notifyMediaStreamingName, status, status);
+        RELEASE_LOG_ERROR(IPC, "notify_set_state() for %s failed with status (%d) 0x%X", notifyMediaStreamingName.characters(), status, status);
         return;
     }
     status = notify_post(notifyMediaStreamingName);
-    RELEASE_LOG_ERROR_IF(status != NOTIFY_STATUS_OK, IPC, "notify_post() for %s failed with status (%d) 0x%X", notifyMediaStreamingName, status, status);
+    RELEASE_LOG_ERROR_IF(status != NOTIFY_STATUS_OK, IPC, "notify_post() for %s failed with status (%d) 0x%X", notifyMediaStreamingName.characters(), status, status);
 #else
     UNUSED_PARAM(activity);
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1853,9 +1853,9 @@ static void logCookieInformationInternal(NetworkConnectionToWebProcess& connecti
     auto size = cookies.size();
     decltype(size) count = 0;
     for (const auto& cookie : cookies) {
-        const char* trailingComma = ",";
+        auto trailingComma = ","_s;
         if (++count == size)
-            trailingComma = "";
+            trailingComma = ""_s;
 
         auto escapedName = escapeForJSON(cookie.name);
         auto escapedValue = escapeForJSON(cookie.value);
@@ -1876,7 +1876,7 @@ static void logCookieInformationInternal(NetworkConnectionToWebProcess& connecti
         LOCAL_LOG("    \"session\": %" PUBLIC_LOG_STRING ",", cookie.session ? "true" : "false");
         LOCAL_LOG("    \"comment\": \"%" PUBLIC_LOG_STRING "\",", escapedComment.utf8().data());
         LOCAL_LOG("    \"commentURL\": \"%" PUBLIC_LOG_STRING "\"", escapedCommentURL.utf8().data());
-        LOCAL_LOG("  }%" PUBLIC_LOG_STRING, trailingComma);
+        LOCAL_LOG("  }%" PUBLIC_LOG_STRING, trailingComma.characters());
     }
     LOCAL_LOG("]}");
 #undef LOCAL_LOG

--- a/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h
+++ b/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h
@@ -46,9 +46,9 @@ namespace WebPushD {
 
 struct ConnectionTraits {
     using MessageType = WebPushD::MessageType;
-    static constexpr const char* protocolVersionKey { WebPushD::protocolVersionKey };
+    static constexpr auto protocolVersionKey { WebPushD::protocolVersionKey };
     static constexpr uint64_t protocolVersionValue { WebPushD::protocolVersionValue };
-    static constexpr const char* protocolEncodedMessageKey { WebPushD::protocolEncodedMessageKey };
+    static constexpr auto protocolEncodedMessageKey { WebPushD::protocolEncodedMessageKey };
 };
 
 class Connection : public Daemon::ConnectionToMachService<ConnectionTraits>, public IPC::MessageSender {

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementConnection.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementConnection.h
@@ -38,9 +38,9 @@ enum class MessageType : uint8_t;
 
 struct ConnectionTraits {
     using MessageType = WebKit::PCM::MessageType;
-    static constexpr const char* protocolVersionKey { PCM::protocolVersionKey };
+    static constexpr auto protocolVersionKey { PCM::protocolVersionKey };
     static constexpr uint64_t protocolVersionValue { PCM::protocolVersionValue };
-    static constexpr const char* protocolEncodedMessageKey { PCM::protocolEncodedMessageKey };
+    static constexpr auto protocolEncodedMessageKey { PCM::protocolEncodedMessageKey };
 };
 
 class Connection : public Daemon::ConnectionToMachService<ConnectionTraits> {

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
@@ -403,8 +403,8 @@ String Database::privateClickMeasurementToStringForTesting() const
     unsigned unattributedNumber = 0;
     StringBuilder builder;
     while (unattributedScopedStatement->step() == SQLITE_ROW) {
-        const char* prefix = unattributedNumber ? "" : "Unattributed Private Click Measurements:";
-        builder.append(prefix, "\nWebCore::PrivateClickMeasurement ", ++unattributedNumber, '\n',
+        auto prefix = unattributedNumber ? ""_s : "Unattributed Private Click Measurements:"_s;
+        builder.append(prefix, "\nWebCore::PrivateClickMeasurement "_s, ++unattributedNumber, '\n',
             attributionToStringForTesting(buildPrivateClickMeasurementFromDatabase(*unattributedScopedStatement.get(), PrivateClickMeasurementAttributionType::Unattributed)));
     }
 

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.h
@@ -76,13 +76,13 @@ public:
     virtual void allowTLSCertificateChainForLocalPCMTesting(const WebCore::CertificateInfo&) = 0;
 };
 
-constexpr const char* protocolVersionKey { "version" };
+constexpr auto protocolVersionKey { "version"_s };
 constexpr uint64_t protocolVersionValue { 1 };
 
-constexpr const char* protocolDebugMessageLevelKey { "debug message level" };
-constexpr const char* protocolDebugMessageKey { "debug message" };
+constexpr auto protocolDebugMessageLevelKey { "debug message level"_s };
+constexpr auto protocolDebugMessageKey { "debug message"_s };
 
-constexpr const char* protocolMessageTypeKey { "message type" };
+constexpr auto protocolMessageTypeKey { "message type"_s };
 enum class MessageType : uint8_t {
     StoreUnattributed,
     HandleAttribution,
@@ -104,7 +104,7 @@ enum class MessageType : uint8_t {
     AllowTLSCertificateChainForLocalPCMTesting
 };
 
-constexpr const char* protocolEncodedMessageKey { "encoded message" };
+constexpr auto protocolEncodedMessageKey { "encoded message"_s };
 using EncodedMessage = Vector<uint8_t>;
 
 void decodeMessageAndSendToManager(const Daemon::Connection&, MessageType, std::span<const uint8_t> encodedMessage, CompletionHandler<void(Vector<uint8_t>&&)>&&);

--- a/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h
+++ b/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h
@@ -46,9 +46,9 @@ private:
     void startObserving(OSObjectPtr<xpc_connection_t>);
 
     // XPCEndpoint
-    const char* xpcEndpointMessageNameKey() const override;
-    const char* xpcEndpointMessageName() const override;
-    const char* xpcEndpointNameKey() const override;
+    ASCIILiteral xpcEndpointMessageNameKey() const override;
+    ASCIILiteral xpcEndpointMessageName() const override;
+    ASCIILiteral xpcEndpointNameKey() const override;
     void handleEvent(xpc_connection_t, xpc_object_t) override;
 
     // NetworkProcessSupplement

--- a/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
@@ -98,17 +98,17 @@ LaunchServicesDatabaseObserver::~LaunchServicesDatabaseObserver()
 #endif
 }
 
-const char* LaunchServicesDatabaseObserver::xpcEndpointMessageNameKey() const
+ASCIILiteral LaunchServicesDatabaseObserver::xpcEndpointMessageNameKey() const
 {
     return xpcMessageNameKey;
 }
 
-const char* LaunchServicesDatabaseObserver::xpcEndpointMessageName() const
+ASCIILiteral LaunchServicesDatabaseObserver::xpcEndpointMessageName() const
 {
     return LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseXPCEndpointMessageName;
 }
 
-const char* LaunchServicesDatabaseObserver::xpcEndpointNameKey() const
+ASCIILiteral LaunchServicesDatabaseObserver::xpcEndpointNameKey() const
 {
     return LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseXPCEndpointNameKey;
 }

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1840,13 +1840,13 @@ void NetworkStorageManager::cacheStorageRepresentation(CompletionHandler<void(St
         return codePointCompareLessThan(a, b);
     });
     StringBuilder builder;
-    builder.append("{ \"path\": \"", m_customCacheStoragePath, "\", \"origins\": [");
-    const char* divider = "";
+    builder.append("{ \"path\": \""_s, m_customCacheStoragePath, "\", \"origins\": ["_s);
+    ASCIILiteral divider = ""_s;
     for (auto& origin : originStrings) {
         builder.append(divider, origin);
-        divider = ",";
+        divider = ","_s;
     }
-    builder.append("]}");
+    builder.append("]}"_s);
     callback(builder.toString());
 }
 

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -772,7 +772,7 @@ auto Connection::waitForMessage(MessageName messageName, uint64_t destinationID,
         }
 
         if (UNLIKELY(m_inDispatchSyncMessageCount && !timeout.isInfinity())) {
-            RELEASE_LOG_ERROR(IPC, "Connection::waitForMessage(%" PUBLIC_LOG_STRING "): Exiting immediately, since we're handling a sync message already", description(messageName));
+            RELEASE_LOG_ERROR(IPC, "Connection::waitForMessage(%" PUBLIC_LOG_STRING "): Exiting immediately, since we're handling a sync message already", description(messageName).characters());
             m_waitingForMessage = nullptr;
             return makeUnexpected(Error::AttemptingToWaitInsideSyncMessageHandling);
         }
@@ -917,9 +917,9 @@ auto Connection::waitForSyncReply(SyncRequestID syncRequestID, MessageName messa
     }
 
 #if OS(DARWIN)
-    RELEASE_LOG_ERROR(IPC, "Connection::waitForSyncReply: Timed-out while waiting for reply for %" PUBLIC_LOG_STRING " from process %d, id=%" PRIu64, description(messageName), remoteProcessID(), syncRequestID.toUInt64());
+    RELEASE_LOG_ERROR(IPC, "Connection::waitForSyncReply: Timed-out while waiting for reply for %" PUBLIC_LOG_STRING " from process %d, id=%" PRIu64, description(messageName).characters(), remoteProcessID(), syncRequestID.toUInt64());
 #else
-    RELEASE_LOG_ERROR(IPC, "Connection::waitForSyncReply: Timed-out while waiting for reply for %s, id=%" PRIu64, description(messageName), syncRequestID.toUInt64());
+    RELEASE_LOG_ERROR(IPC, "Connection::waitForSyncReply: Timed-out while waiting for reply for %s, id=%" PRIu64, description(messageName).characters(), syncRequestID.toUInt64());
 #endif
 
     return makeUnexpected(Error::Timeout);
@@ -1466,7 +1466,7 @@ void Connection::dispatchIncomingMessages()
         messagesToProcess = numberOfMessagesToProcess(m_incomingMessages.size());
         if (messagesToProcess < m_incomingMessages.size()) {
             RELEASE_LOG_ERROR(IPC, "%p - Connection::dispatchIncomingMessages: IPC throttling was triggered (has %zu pending incoming messages, will only process %zu before yielding)", this, m_incomingMessages.size(), messagesToProcess);
-            RELEASE_LOG_ERROR(IPC, "%p - Connection::dispatchIncomingMessages: first IPC message in queue is %" PUBLIC_LOG_STRING, this, description(message->messageName()));
+            RELEASE_LOG_ERROR(IPC, "%p - Connection::dispatchIncomingMessages: first IPC message in queue is %" PUBLIC_LOG_STRING, this, description(message->messageName()).characters());
         }
 
         // Re-schedule ourselves *before* we dispatch the messages because we want to process follow-up messages if the client
@@ -1580,30 +1580,30 @@ std::optional<Connection::ConnectionIdentifierPair> Connection::createConnection
 }
 #endif
 
-const char* errorAsString(Error error)
+ASCIILiteral errorAsString(Error error)
 {
     switch (error) {
-    case Error::NoError: return "NoError";
-    case Error::InvalidConnection: return "InvalidConnection";
-    case Error::NoConnectionForIdentifier: return "NoConnectionForIdentifier";
-    case Error::NoMessageSenderConnection: return "NoMessageSenderConnection";
-    case Error::Timeout: return "Timeout";
-    case Error::Unspecified: return "Unspecified";
-    case Error::MultipleWaitingClients: return "MultipleWaitingClients";
-    case Error::AttemptingToWaitOnClosedConnection: return "AttemptingToWaitOnClosedConnection";
-    case Error::WaitingOnAlreadyDispatchedMessage: return "WaitingOnAlreadyDispatchedMessage";
-    case Error::AttemptingToWaitInsideSyncMessageHandling: return "AttemptingToWaitInsideSyncMessageHandling";
-    case Error::SyncMessageInterruptedWait: return "SyncMessageInterruptedWait";
-    case Error::CantWaitForSyncReplies: return "CantWaitForSyncReplies";
-    case Error::FailedToEncodeMessageArguments: return "FailedToEncodeMessageArguments";
-    case Error::FailedToDecodeReplyArguments: return "FailedToDecodeReplyArguments";
-    case Error::FailedToFindReplyHandler: return "FailedToFindReplyHandler";
-    case Error::FailedToAcquireBufferSpan: return "FailedToAcquireBufferSpan";
-    case Error::FailedToAcquireReplyBufferSpan: return "FailedToAcquireReplyBufferSpan";
-    case Error::StreamConnectionEncodingError: return "StreamConnectionEncodingError";
+    case Error::NoError: return "NoError"_s;
+    case Error::InvalidConnection: return "InvalidConnection"_s;
+    case Error::NoConnectionForIdentifier: return "NoConnectionForIdentifier"_s;
+    case Error::NoMessageSenderConnection: return "NoMessageSenderConnection"_s;
+    case Error::Timeout: return "Timeout"_s;
+    case Error::Unspecified: return "Unspecified"_s;
+    case Error::MultipleWaitingClients: return "MultipleWaitingClients"_s;
+    case Error::AttemptingToWaitOnClosedConnection: return "AttemptingToWaitOnClosedConnection"_s;
+    case Error::WaitingOnAlreadyDispatchedMessage: return "WaitingOnAlreadyDispatchedMessage"_s;
+    case Error::AttemptingToWaitInsideSyncMessageHandling: return "AttemptingToWaitInsideSyncMessageHandling"_s;
+    case Error::SyncMessageInterruptedWait: return "SyncMessageInterruptedWait"_s;
+    case Error::CantWaitForSyncReplies: return "CantWaitForSyncReplies"_s;
+    case Error::FailedToEncodeMessageArguments: return "FailedToEncodeMessageArguments"_s;
+    case Error::FailedToDecodeReplyArguments: return "FailedToDecodeReplyArguments"_s;
+    case Error::FailedToFindReplyHandler: return "FailedToFindReplyHandler"_s;
+    case Error::FailedToAcquireBufferSpan: return "FailedToAcquireBufferSpan"_s;
+    case Error::FailedToAcquireReplyBufferSpan: return "FailedToAcquireReplyBufferSpan"_s;
+    case Error::StreamConnectionEncodingError: return "StreamConnectionEncodingError"_s;
     }
 
-    return "";
+    return ""_s;
 }
 
 } // namespace IPC

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -109,7 +109,7 @@ enum class Error : uint8_t {
     StreamConnectionEncodingError,
 };
 
-extern const char* errorAsString(Error);
+extern ASCIILiteral errorAsString(Error);
 
 #define CONNECTION_STRINGIFY(line) #line
 #define CONNECTION_STRINGIFY_MACRO(line) CONNECTION_STRINGIFY(line)

--- a/Source/WebKit/Platform/IPC/MessageArgumentDescriptions.h
+++ b/Source/WebKit/Platform/IPC/MessageArgumentDescriptions.h
@@ -51,9 +51,9 @@ Vector<ASCIILiteral> serializedIdentifiers();
 #endif // ENABLE(IPC_TESTING_API)
 
 struct ArgumentDescription {
-    const char* name;
-    const char* type;
-    const char* enumName;
+    ASCIILiteral name;
+    ASCIILiteral type;
+    ASCIILiteral enumName;
     bool isOptional;
 };
 

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1308,7 +1308,7 @@ def generate_message_handler(receiver):
             result.append('    if (connection.protectedConnection()->ignoreInvalidMessageForTesting())\n')
             result.append('        return;\n')
             result.append('#endif // ENABLE(IPC_TESTING_API)\n')
-            result.append('    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());\n')
+            result.append('    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());\n')
         result.append('}\n')
     else:
         receive_variant = receiver.name if receiver.has_attribute(LEGACY_RECEIVER_ATTRIBUTE) else ''
@@ -1334,7 +1334,7 @@ def generate_message_handler(receiver):
                 result.append('    if (connection.ignoreInvalidMessageForTesting())\n')
                 result.append('        return;\n')
                 result.append('#endif // ENABLE(IPC_TESTING_API)\n')
-            result.append('    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());\n')
+            result.append('    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());\n')
         result.append('}\n')
 
     if not receiver.has_attribute(STREAM_ATTRIBUTE) and (sync_messages or receiver.has_attribute(WANTS_DISPATCH_MESSAGE_ATTRIBUTE)):
@@ -1356,7 +1356,7 @@ def generate_message_handler(receiver):
             result.append('    if (connection.ignoreInvalidMessageForTesting())\n')
             result.append('        return false;\n')
             result.append('#endif // ENABLE(IPC_TESTING_API)\n')
-        result.append('    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()), decoder.destinationID());\n')
+        result.append('    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());\n')
         result.append('    return false;\n')
         result.append('}\n')
 
@@ -1437,7 +1437,7 @@ def generate_message_names_header(receivers):
     result.append('\n')
     result.append('namespace Detail {\n')
     result.append('struct MessageDescription {\n')
-    result.append('    const char* const description;\n')
+    result.append('    ASCIILiteral description;\n')
     result.append('    ReceiverName receiverName;\n')
     for fname, _ in sorted(attributes_to_generate_validators.items()):
         result.append('    bool %s : 1;\n' % fname)
@@ -1446,7 +1446,7 @@ def generate_message_names_header(receivers):
     result.append('extern const MessageDescription messageDescriptions[static_cast<size_t>(MessageName::Count) + 1];\n')
     result.append('}\n')
     result.append('\n')
-    fnames = [('ReceiverName', 'receiverName'), ('const char*', 'description')]
+    fnames = [('ReceiverName', 'receiverName'), ('ASCIILiteral', 'description')]
     fnames += [('bool', fname) for fname, _ in sorted(attributes_to_generate_validators.items())]
     for returnType, fname in fnames:
         result.append('inline %s %s(MessageName messageName)\n' % (returnType, fname))
@@ -1498,14 +1498,14 @@ def generate_message_names_implementation(receivers):
         if condition:
             result.append('#if %s\n' % condition)
         for enumerator in enumerators:
-            result.append('    { "%s", ReceiverName::%s' % (enumerator, enumerator.receiver.name))
+            result.append('    { "%s"_s, ReceiverName::%s' % (enumerator, enumerator.receiver.name))
             for attr_list in sorted(attributes_to_generate_validators.values()):
                 value = "true" if set(attr_list).intersection(set(enumerator.messages[0].attributes).union(set(enumerator.receiver.attributes))) else "false"
                 result.append(', %s' % value)
             result.append(' },\n')
         if condition:
             result.append('#endif\n')
-    result.append('    { "<invalid message name>", ReceiverName::Invalid%s }\n' % (", false" * len(attributes_to_generate_validators)))
+    result.append('    { "<invalid message name>"_s, ReceiverName::Invalid%s }\n' % (", false" * len(attributes_to_generate_validators)))
     result.append('};\n')
     result.append('\n')
     result.append('} // namespace IPC::Detail\n')
@@ -1579,12 +1579,12 @@ def generate_js_argument_descriptions(receivers, function_name, arguments_from_m
                 enum_type = None
                 is_optional = False
                 if argument.kind.startswith('enum:'):
-                    enum_type = '"%s"' % argument_type
+                    enum_type = '"%s"_s' % argument_type
                     argument_type = argument.kind[5:]
                 if argument_type.startswith('std::optional<') and argument_type.endswith('>'):
                     argument_type = argument_type[14:-1]
                     is_optional = True
-                result.append('            { "%s", "%s", %s, %s },\n' % (argument.name, argument_type, enum_type or 'nullptr', 'true' if is_optional else 'false'))
+                result.append('            { "%s"_s, "%s"_s, %s, %s },\n' % (argument.name, argument_type, enum_type or 'ASCIILiteral()', 'true' if is_optional else 'false'))
             result.append('        };\n')
         if previous_message_condition:
             result.append('#endif\n')

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -741,12 +741,12 @@ std::optional<Vector<ArgumentDescription>> messageArgumentDescriptions(MessageNa
     switch (name) {
     case MessageName::TestWithSuperclass_LoadURL:
         return Vector<ArgumentDescription> {
-            { "url", "String", nullptr, false },
+            { "url"_s, "String"_s, ASCIILiteral(), false },
         };
 #if ENABLE(TEST_FEATURE)
     case MessageName::TestWithSuperclass_TestAsyncMessage:
         return Vector<ArgumentDescription> {
-            { "twoStateEnum", "bool", "WebKit::TestTwoStateEnum", false },
+            { "twoStateEnum"_s, "bool"_s, "WebKit::TestTwoStateEnum"_s, false },
         };
     case MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments:
         return Vector<ArgumentDescription> { };
@@ -754,232 +754,232 @@ std::optional<Vector<ArgumentDescription>> messageArgumentDescriptions(MessageNa
         return Vector<ArgumentDescription> { };
     case MessageName::TestWithSuperclass_TestAsyncMessageWithConnection:
         return Vector<ArgumentDescription> {
-            { "value", "int", nullptr, false },
+            { "value"_s, "int"_s, ASCIILiteral(), false },
         };
 #endif
     case MessageName::TestWithSuperclass_TestSyncMessage:
         return Vector<ArgumentDescription> {
-            { "param", "uint32_t", nullptr, false },
+            { "param"_s, "uint32_t"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithSuperclass_TestSynchronousMessage:
         return Vector<ArgumentDescription> {
-            { "value", "bool", nullptr, false },
+            { "value"_s, "bool"_s, ASCIILiteral(), false },
         };
 #if (ENABLE(WEBKIT2) && (NESTED_MASTER_CONDITION || MASTER_OR && MASTER_AND))
     case MessageName::TestWithLegacyReceiver_LoadURL:
         return Vector<ArgumentDescription> {
-            { "url", "String", nullptr, false },
+            { "url"_s, "String"_s, ASCIILiteral(), false },
         };
 #if ENABLE(TOUCH_EVENTS)
     case MessageName::TestWithLegacyReceiver_LoadSomething:
         return Vector<ArgumentDescription> {
-            { "url", "String", nullptr, false },
+            { "url"_s, "String"_s, ASCIILiteral(), false },
         };
 #endif
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
     case MessageName::TestWithLegacyReceiver_TouchEvent:
         return Vector<ArgumentDescription> {
-            { "event", "WebKit::WebTouchEvent", nullptr, false },
+            { "event"_s, "WebKit::WebTouchEvent"_s, ASCIILiteral(), false },
         };
 #endif
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
     case MessageName::TestWithLegacyReceiver_AddEvent:
         return Vector<ArgumentDescription> {
-            { "event", "WebKit::WebTouchEvent", nullptr, false },
+            { "event"_s, "WebKit::WebTouchEvent"_s, ASCIILiteral(), false },
         };
 #endif
 #if ENABLE(TOUCH_EVENTS)
     case MessageName::TestWithLegacyReceiver_LoadSomethingElse:
         return Vector<ArgumentDescription> {
-            { "url", "String", nullptr, false },
+            { "url"_s, "String"_s, ASCIILiteral(), false },
         };
 #endif
     case MessageName::TestWithLegacyReceiver_DidReceivePolicyDecision:
         return Vector<ArgumentDescription> {
-            { "frameID", "uint64_t", nullptr, false },
-            { "listenerID", "uint64_t", nullptr, false },
-            { "policyAction", "uint32_t", nullptr, false },
+            { "frameID"_s, "uint64_t"_s, ASCIILiteral(), false },
+            { "listenerID"_s, "uint64_t"_s, ASCIILiteral(), false },
+            { "policyAction"_s, "uint32_t"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithLegacyReceiver_Close:
         return Vector<ArgumentDescription> { };
     case MessageName::TestWithLegacyReceiver_PreferencesDidChange:
         return Vector<ArgumentDescription> {
-            { "store", "WebKit::WebPreferencesStore", nullptr, false },
+            { "store"_s, "WebKit::WebPreferencesStore"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithLegacyReceiver_SendDoubleAndFloat:
         return Vector<ArgumentDescription> {
-            { "d", "double", nullptr, false },
-            { "f", "float", nullptr, false },
+            { "d"_s, "double"_s, ASCIILiteral(), false },
+            { "f"_s, "float"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithLegacyReceiver_SendInts:
         return Vector<ArgumentDescription> {
-            { "ints", "Vector<uint64_t>", nullptr, false },
-            { "intVectors", "Vector<Vector<uint64_t>>", nullptr, false },
+            { "ints"_s, "Vector<uint64_t>"_s, ASCIILiteral(), false },
+            { "intVectors"_s, "Vector<Vector<uint64_t>>"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithLegacyReceiver_CreatePlugin:
         return Vector<ArgumentDescription> {
-            { "pluginInstanceID", "uint64_t", nullptr, false },
-            { "parameters", "WebKit::Plugin::Parameters", nullptr, false },
+            { "pluginInstanceID"_s, "uint64_t"_s, ASCIILiteral(), false },
+            { "parameters"_s, "WebKit::Plugin::Parameters"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithLegacyReceiver_RunJavaScriptAlert:
         return Vector<ArgumentDescription> {
-            { "frameID", "uint64_t", nullptr, false },
-            { "message", "String", nullptr, false },
+            { "frameID"_s, "uint64_t"_s, ASCIILiteral(), false },
+            { "message"_s, "String"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithLegacyReceiver_GetPlugins:
         return Vector<ArgumentDescription> {
-            { "refresh", "bool", nullptr, false },
+            { "refresh"_s, "bool"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithLegacyReceiver_GetPluginProcessConnection:
         return Vector<ArgumentDescription> {
-            { "pluginPath", "String", nullptr, false },
+            { "pluginPath"_s, "String"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithLegacyReceiver_TestMultipleAttributes:
         return Vector<ArgumentDescription> { };
     case MessageName::TestWithLegacyReceiver_TestParameterAttributes:
         return Vector<ArgumentDescription> {
-            { "foo", "uint64_t", nullptr, false },
-            { "bar", "double", nullptr, false },
-            { "baz", "double", nullptr, false },
+            { "foo"_s, "uint64_t"_s, ASCIILiteral(), false },
+            { "bar"_s, "double"_s, ASCIILiteral(), false },
+            { "baz"_s, "double"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithLegacyReceiver_TemplateTest:
         return Vector<ArgumentDescription> {
-            { "a", "HashMap<String, std::pair<String, uint64_t>>", nullptr, false },
+            { "a"_s, "HashMap<String, std::pair<String, uint64_t>>"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithLegacyReceiver_SetVideoLayerID:
         return Vector<ArgumentDescription> {
-            { "videoLayerID", "WebCore::PlatformLayerIdentifier", nullptr, false },
+            { "videoLayerID"_s, "WebCore::PlatformLayerIdentifier"_s, ASCIILiteral(), false },
         };
 #if PLATFORM(MAC)
     case MessageName::TestWithLegacyReceiver_DidCreateWebProcessConnection:
         return Vector<ArgumentDescription> {
-            { "connectionIdentifier", "MachSendRight", nullptr, false },
-            { "flags", "OptionSet<WebKit::SelectionFlags>", nullptr, false },
+            { "connectionIdentifier"_s, "MachSendRight"_s, ASCIILiteral(), false },
+            { "flags"_s, "OptionSet<WebKit::SelectionFlags>"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithLegacyReceiver_InterpretKeyEvent:
         return Vector<ArgumentDescription> {
-            { "type", "uint32_t", nullptr, false },
+            { "type"_s, "uint32_t"_s, ASCIILiteral(), false },
         };
 #endif
 #if ENABLE(DEPRECATED_FEATURE)
     case MessageName::TestWithLegacyReceiver_DeprecatedOperation:
         return Vector<ArgumentDescription> {
-            { "dummy", "IPC::DummyType", nullptr, false },
+            { "dummy"_s, "IPC::DummyType"_s, ASCIILiteral(), false },
         };
 #endif
 #if ENABLE(FEATURE_FOR_TESTING)
     case MessageName::TestWithLegacyReceiver_ExperimentalOperation:
         return Vector<ArgumentDescription> {
-            { "dummy", "IPC::DummyType", nullptr, false },
+            { "dummy"_s, "IPC::DummyType"_s, ASCIILiteral(), false },
         };
 #endif
 #endif
 #if (ENABLE(WEBKIT2) && (NESTED_MASTER_CONDITION || MASTER_OR && MASTER_AND))
     case MessageName::TestWithoutAttributes_LoadURL:
         return Vector<ArgumentDescription> {
-            { "url", "String", nullptr, false },
+            { "url"_s, "String"_s, ASCIILiteral(), false },
         };
 #if ENABLE(TOUCH_EVENTS)
     case MessageName::TestWithoutAttributes_LoadSomething:
         return Vector<ArgumentDescription> {
-            { "url", "String", nullptr, false },
+            { "url"_s, "String"_s, ASCIILiteral(), false },
         };
 #endif
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
     case MessageName::TestWithoutAttributes_TouchEvent:
         return Vector<ArgumentDescription> {
-            { "event", "WebKit::WebTouchEvent", nullptr, false },
+            { "event"_s, "WebKit::WebTouchEvent"_s, ASCIILiteral(), false },
         };
 #endif
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
     case MessageName::TestWithoutAttributes_AddEvent:
         return Vector<ArgumentDescription> {
-            { "event", "WebKit::WebTouchEvent", nullptr, false },
+            { "event"_s, "WebKit::WebTouchEvent"_s, ASCIILiteral(), false },
         };
 #endif
 #if ENABLE(TOUCH_EVENTS)
     case MessageName::TestWithoutAttributes_LoadSomethingElse:
         return Vector<ArgumentDescription> {
-            { "url", "String", nullptr, false },
+            { "url"_s, "String"_s, ASCIILiteral(), false },
         };
 #endif
     case MessageName::TestWithoutAttributes_DidReceivePolicyDecision:
         return Vector<ArgumentDescription> {
-            { "frameID", "uint64_t", nullptr, false },
-            { "listenerID", "uint64_t", nullptr, false },
-            { "policyAction", "uint32_t", nullptr, false },
+            { "frameID"_s, "uint64_t"_s, ASCIILiteral(), false },
+            { "listenerID"_s, "uint64_t"_s, ASCIILiteral(), false },
+            { "policyAction"_s, "uint32_t"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithoutAttributes_Close:
         return Vector<ArgumentDescription> { };
     case MessageName::TestWithoutAttributes_PreferencesDidChange:
         return Vector<ArgumentDescription> {
-            { "store", "WebKit::WebPreferencesStore", nullptr, false },
+            { "store"_s, "WebKit::WebPreferencesStore"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithoutAttributes_SendDoubleAndFloat:
         return Vector<ArgumentDescription> {
-            { "d", "double", nullptr, false },
-            { "f", "float", nullptr, false },
+            { "d"_s, "double"_s, ASCIILiteral(), false },
+            { "f"_s, "float"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithoutAttributes_SendInts:
         return Vector<ArgumentDescription> {
-            { "ints", "Vector<uint64_t>", nullptr, false },
-            { "intVectors", "Vector<Vector<uint64_t>>", nullptr, false },
+            { "ints"_s, "Vector<uint64_t>"_s, ASCIILiteral(), false },
+            { "intVectors"_s, "Vector<Vector<uint64_t>>"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithoutAttributes_CreatePlugin:
         return Vector<ArgumentDescription> {
-            { "pluginInstanceID", "uint64_t", nullptr, false },
-            { "parameters", "WebKit::Plugin::Parameters", nullptr, false },
+            { "pluginInstanceID"_s, "uint64_t"_s, ASCIILiteral(), false },
+            { "parameters"_s, "WebKit::Plugin::Parameters"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithoutAttributes_RunJavaScriptAlert:
         return Vector<ArgumentDescription> {
-            { "frameID", "uint64_t", nullptr, false },
-            { "message", "String", nullptr, false },
+            { "frameID"_s, "uint64_t"_s, ASCIILiteral(), false },
+            { "message"_s, "String"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithoutAttributes_GetPlugins:
         return Vector<ArgumentDescription> {
-            { "refresh", "bool", nullptr, false },
+            { "refresh"_s, "bool"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithoutAttributes_GetPluginProcessConnection:
         return Vector<ArgumentDescription> {
-            { "pluginPath", "String", nullptr, false },
+            { "pluginPath"_s, "String"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithoutAttributes_TestMultipleAttributes:
         return Vector<ArgumentDescription> { };
     case MessageName::TestWithoutAttributes_TestParameterAttributes:
         return Vector<ArgumentDescription> {
-            { "foo", "uint64_t", nullptr, false },
-            { "bar", "double", nullptr, false },
-            { "baz", "double", nullptr, false },
+            { "foo"_s, "uint64_t"_s, ASCIILiteral(), false },
+            { "bar"_s, "double"_s, ASCIILiteral(), false },
+            { "baz"_s, "double"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithoutAttributes_TemplateTest:
         return Vector<ArgumentDescription> {
-            { "a", "HashMap<String, std::pair<String, uint64_t>>", nullptr, false },
+            { "a"_s, "HashMap<String, std::pair<String, uint64_t>>"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithoutAttributes_SetVideoLayerID:
         return Vector<ArgumentDescription> {
-            { "videoLayerID", "WebCore::PlatformLayerIdentifier", nullptr, false },
+            { "videoLayerID"_s, "WebCore::PlatformLayerIdentifier"_s, ASCIILiteral(), false },
         };
 #if PLATFORM(MAC)
     case MessageName::TestWithoutAttributes_DidCreateWebProcessConnection:
         return Vector<ArgumentDescription> {
-            { "connectionIdentifier", "MachSendRight", nullptr, false },
-            { "flags", "OptionSet<WebKit::SelectionFlags>", nullptr, false },
+            { "connectionIdentifier"_s, "MachSendRight"_s, ASCIILiteral(), false },
+            { "flags"_s, "OptionSet<WebKit::SelectionFlags>"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithoutAttributes_InterpretKeyEvent:
         return Vector<ArgumentDescription> {
-            { "type", "uint32_t", nullptr, false },
+            { "type"_s, "uint32_t"_s, ASCIILiteral(), false },
         };
 #endif
 #if ENABLE(DEPRECATED_FEATURE)
     case MessageName::TestWithoutAttributes_DeprecatedOperation:
         return Vector<ArgumentDescription> {
-            { "dummy", "IPC::DummyType", nullptr, false },
+            { "dummy"_s, "IPC::DummyType"_s, ASCIILiteral(), false },
         };
 #endif
 #if ENABLE(FEATURE_FOR_TESTING)
     case MessageName::TestWithoutAttributes_ExperimentalOperation:
         return Vector<ArgumentDescription> {
-            { "dummy", "IPC::DummyType", nullptr, false },
+            { "dummy"_s, "IPC::DummyType"_s, ASCIILiteral(), false },
         };
 #endif
 #endif
@@ -991,94 +991,94 @@ std::optional<Vector<ArgumentDescription>> messageArgumentDescriptions(MessageNa
         return Vector<ArgumentDescription> { };
     case MessageName::TestWithoutUsingIPCConnection_MessageWithArgument:
         return Vector<ArgumentDescription> {
-            { "argument", "String", nullptr, false },
+            { "argument"_s, "String"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply:
         return Vector<ArgumentDescription> {
-            { "argument", "String", nullptr, false },
+            { "argument"_s, "String"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument:
         return Vector<ArgumentDescription> {
-            { "argument", "String", nullptr, false },
+            { "argument"_s, "String"_s, ASCIILiteral(), false },
         };
 #if PLATFORM(COCOA)
     case MessageName::TestWithIfMessage_LoadURL:
         return Vector<ArgumentDescription> {
-            { "url", "String", nullptr, false },
+            { "url"_s, "String"_s, ASCIILiteral(), false },
         };
 #endif
 #if PLATFORM(GTK)
     case MessageName::TestWithIfMessage_LoadURL:
         return Vector<ArgumentDescription> {
-            { "url", "String", nullptr, false },
-            { "value", "int64_t", nullptr, false },
+            { "url"_s, "String"_s, ASCIILiteral(), false },
+            { "value"_s, "int64_t"_s, ASCIILiteral(), false },
         };
 #endif
     case MessageName::TestWithSemaphore_SendSemaphore:
         return Vector<ArgumentDescription> {
-            { "s0", "IPC::Semaphore", nullptr, false },
+            { "s0"_s, "IPC::Semaphore"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithSemaphore_ReceiveSemaphore:
         return Vector<ArgumentDescription> { };
     case MessageName::TestWithImageData_SendImageData:
         return Vector<ArgumentDescription> {
-            { "s0", "RefPtr<WebCore::ImageData>", nullptr, false },
+            { "s0"_s, "RefPtr<WebCore::ImageData>"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithImageData_ReceiveImageData:
         return Vector<ArgumentDescription> { };
     case MessageName::TestWithStream_SendString:
         return Vector<ArgumentDescription> {
-            { "url", "String", nullptr, false },
+            { "url"_s, "String"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithStream_SendStringAsync:
         return Vector<ArgumentDescription> {
-            { "url", "String", nullptr, false },
+            { "url"_s, "String"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithStream_SendStringSync:
         return Vector<ArgumentDescription> {
-            { "url", "String", nullptr, false },
+            { "url"_s, "String"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithStream_CallWithIdentifier:
         return Vector<ArgumentDescription> { };
 #if PLATFORM(COCOA)
     case MessageName::TestWithStream_SendMachSendRight:
         return Vector<ArgumentDescription> {
-            { "a1", "MachSendRight", nullptr, false },
+            { "a1"_s, "MachSendRight"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithStream_ReceiveMachSendRight:
         return Vector<ArgumentDescription> { };
     case MessageName::TestWithStream_SendAndReceiveMachSendRight:
         return Vector<ArgumentDescription> {
-            { "a1", "MachSendRight", nullptr, false },
+            { "a1"_s, "MachSendRight"_s, ASCIILiteral(), false },
         };
 #endif
     case MessageName::TestWithStreamBatched_SendString:
         return Vector<ArgumentDescription> {
-            { "url", "String", nullptr, false },
+            { "url"_s, "String"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithStreamBuffer_SendStreamBuffer:
         return Vector<ArgumentDescription> {
-            { "stream", "IPC::StreamConnectionBuffer", nullptr, false },
+            { "stream"_s, "IPC::StreamConnectionBuffer"_s, ASCIILiteral(), false },
         };
 #if USE(AVFOUNDATION)
     case MessageName::TestWithCVPixelBuffer_SendCVPixelBuffer:
         return Vector<ArgumentDescription> {
-            { "s0", "RetainPtr<CVPixelBufferRef>", nullptr, false },
+            { "s0"_s, "RetainPtr<CVPixelBufferRef>"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer:
         return Vector<ArgumentDescription> { };
 #endif
     case MessageName::TestWithStreamServerConnectionHandle_SendStreamServerConnection:
         return Vector<ArgumentDescription> {
-            { "handle", "IPC::StreamServerConnectionHandle", nullptr, false },
+            { "handle"_s, "IPC::StreamServerConnectionHandle"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithEnabledIf_AlwaysEnabled:
         return Vector<ArgumentDescription> {
-            { "url", "String", nullptr, false },
+            { "url"_s, "String"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithEnabledIf_OnlyEnabledIfFeatureEnabled:
         return Vector<ArgumentDescription> {
-            { "url", "String", nullptr, false },
+            { "url"_s, "String"_s, ASCIILiteral(), false },
         };
     default:
         break;
@@ -1092,73 +1092,73 @@ std::optional<Vector<ArgumentDescription>> messageReplyArgumentDescriptions(Mess
 #if ENABLE(TEST_FEATURE)
     case MessageName::TestWithSuperclass_TestAsyncMessage:
         return Vector<ArgumentDescription> {
-            { "result", "uint64_t", nullptr, false },
+            { "result"_s, "uint64_t"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments:
         return Vector<ArgumentDescription> { };
     case MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments:
         return Vector<ArgumentDescription> {
-            { "flag", "bool", nullptr, false },
-            { "value", "uint64_t", nullptr, false },
+            { "flag"_s, "bool"_s, ASCIILiteral(), false },
+            { "value"_s, "uint64_t"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithSuperclass_TestAsyncMessageWithConnection:
         return Vector<ArgumentDescription> {
-            { "flag", "bool", nullptr, false },
+            { "flag"_s, "bool"_s, ASCIILiteral(), false },
         };
 #endif
     case MessageName::TestWithSuperclass_TestSyncMessage:
         return Vector<ArgumentDescription> {
-            { "reply", "uint8_t", nullptr, false },
+            { "reply"_s, "uint8_t"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithSuperclass_TestSynchronousMessage:
         return Vector<ArgumentDescription> {
-            { "optionalReply", "WebKit::TestClassName", nullptr, true },
+            { "optionalReply"_s, "WebKit::TestClassName"_s, ASCIILiteral(), true },
         };
 #if (ENABLE(WEBKIT2) && (NESTED_MASTER_CONDITION || MASTER_OR && MASTER_AND))
     case MessageName::TestWithLegacyReceiver_CreatePlugin:
         return Vector<ArgumentDescription> {
-            { "result", "bool", nullptr, false },
+            { "result"_s, "bool"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithLegacyReceiver_RunJavaScriptAlert:
         return Vector<ArgumentDescription> { };
     case MessageName::TestWithLegacyReceiver_GetPlugins:
         return Vector<ArgumentDescription> {
-            { "plugins", "Vector<WebCore::PluginInfo>", nullptr, false },
+            { "plugins"_s, "Vector<WebCore::PluginInfo>"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithLegacyReceiver_GetPluginProcessConnection:
         return Vector<ArgumentDescription> {
-            { "connectionHandle", "IPC::Connection::Handle", nullptr, false },
+            { "connectionHandle"_s, "IPC::Connection::Handle"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithLegacyReceiver_TestMultipleAttributes:
         return Vector<ArgumentDescription> { };
 #if PLATFORM(MAC)
     case MessageName::TestWithLegacyReceiver_InterpretKeyEvent:
         return Vector<ArgumentDescription> {
-            { "commandName", "Vector<WebCore::KeypressCommand>", nullptr, false },
+            { "commandName"_s, "Vector<WebCore::KeypressCommand>"_s, ASCIILiteral(), false },
         };
 #endif
 #endif
 #if (ENABLE(WEBKIT2) && (NESTED_MASTER_CONDITION || MASTER_OR && MASTER_AND))
     case MessageName::TestWithoutAttributes_CreatePlugin:
         return Vector<ArgumentDescription> {
-            { "result", "bool", nullptr, false },
+            { "result"_s, "bool"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithoutAttributes_RunJavaScriptAlert:
         return Vector<ArgumentDescription> { };
     case MessageName::TestWithoutAttributes_GetPlugins:
         return Vector<ArgumentDescription> {
-            { "plugins", "Vector<WebCore::PluginInfo>", nullptr, false },
+            { "plugins"_s, "Vector<WebCore::PluginInfo>"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithoutAttributes_GetPluginProcessConnection:
         return Vector<ArgumentDescription> {
-            { "connectionHandle", "IPC::Connection::Handle", nullptr, false },
+            { "connectionHandle"_s, "IPC::Connection::Handle"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithoutAttributes_TestMultipleAttributes:
         return Vector<ArgumentDescription> { };
 #if PLATFORM(MAC)
     case MessageName::TestWithoutAttributes_InterpretKeyEvent:
         return Vector<ArgumentDescription> {
-            { "commandName", "Vector<WebCore::KeypressCommand>", nullptr, false },
+            { "commandName"_s, "Vector<WebCore::KeypressCommand>"_s, ASCIILiteral(), false },
         };
 #endif
 #endif
@@ -1166,46 +1166,46 @@ std::optional<Vector<ArgumentDescription>> messageReplyArgumentDescriptions(Mess
         return Vector<ArgumentDescription> { };
     case MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument:
         return Vector<ArgumentDescription> {
-            { "reply", "String", nullptr, false },
+            { "reply"_s, "String"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply:
         return Vector<ArgumentDescription> { };
     case MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument:
         return Vector<ArgumentDescription> {
-            { "reply", "String", nullptr, false },
+            { "reply"_s, "String"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithSemaphore_ReceiveSemaphore:
         return Vector<ArgumentDescription> {
-            { "r0", "IPC::Semaphore", nullptr, false },
+            { "r0"_s, "IPC::Semaphore"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithImageData_ReceiveImageData:
         return Vector<ArgumentDescription> {
-            { "r0", "RefPtr<WebCore::ImageData>", nullptr, false },
+            { "r0"_s, "RefPtr<WebCore::ImageData>"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithStream_SendStringAsync:
         return Vector<ArgumentDescription> {
-            { "returnValue", "int64_t", nullptr, false },
+            { "returnValue"_s, "int64_t"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithStream_SendStringSync:
         return Vector<ArgumentDescription> {
-            { "returnValue", "int64_t", nullptr, false },
+            { "returnValue"_s, "int64_t"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithStream_CallWithIdentifier:
         return Vector<ArgumentDescription> { };
 #if PLATFORM(COCOA)
     case MessageName::TestWithStream_ReceiveMachSendRight:
         return Vector<ArgumentDescription> {
-            { "r1", "MachSendRight", nullptr, false },
+            { "r1"_s, "MachSendRight"_s, ASCIILiteral(), false },
         };
     case MessageName::TestWithStream_SendAndReceiveMachSendRight:
         return Vector<ArgumentDescription> {
-            { "r1", "MachSendRight", nullptr, false },
+            { "r1"_s, "MachSendRight"_s, ASCIILiteral(), false },
         };
 #endif
 #if USE(AVFOUNDATION)
     case MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer:
         return Vector<ArgumentDescription> {
-            { "r0", "RetainPtr<CVPixelBufferRef>", nullptr, false },
+            { "r0"_s, "RetainPtr<CVPixelBufferRef>"_s, ASCIILiteral(), false },
         };
 #endif
     default:

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
@@ -29,157 +29,157 @@ namespace IPC::Detail {
 
 const MessageDescription messageDescriptions[static_cast<size_t>(MessageName::Count) + 1] = {
 #if USE(AVFOUNDATION)
-    { "TestWithCVPixelBuffer_ReceiveCVPixelBuffer", ReceiverName::TestWithCVPixelBuffer, false, false },
-    { "TestWithCVPixelBuffer_SendCVPixelBuffer", ReceiverName::TestWithCVPixelBuffer, false, false },
+    { "TestWithCVPixelBuffer_ReceiveCVPixelBuffer"_s, ReceiverName::TestWithCVPixelBuffer, false, false },
+    { "TestWithCVPixelBuffer_SendCVPixelBuffer"_s, ReceiverName::TestWithCVPixelBuffer, false, false },
 #endif
-    { "TestWithEnabledIf_AlwaysEnabled", ReceiverName::TestWithEnabledIf, false, false },
-    { "TestWithEnabledIf_OnlyEnabledIfFeatureEnabled", ReceiverName::TestWithEnabledIf, false, false },
+    { "TestWithEnabledIf_AlwaysEnabled"_s, ReceiverName::TestWithEnabledIf, false, false },
+    { "TestWithEnabledIf_OnlyEnabledIfFeatureEnabled"_s, ReceiverName::TestWithEnabledIf, false, false },
 #if PLATFORM(COCOA) || PLATFORM(GTK)
-    { "TestWithIfMessage_LoadURL", ReceiverName::TestWithIfMessage, false, false },
+    { "TestWithIfMessage_LoadURL"_s, ReceiverName::TestWithIfMessage, false, false },
 #endif
-    { "TestWithImageData_ReceiveImageData", ReceiverName::TestWithImageData, false, false },
-    { "TestWithImageData_SendImageData", ReceiverName::TestWithImageData, false, false },
+    { "TestWithImageData_ReceiveImageData"_s, ReceiverName::TestWithImageData, false, false },
+    { "TestWithImageData_SendImageData"_s, ReceiverName::TestWithImageData, false, false },
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
-    { "TestWithLegacyReceiver_AddEvent", ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_AddEvent"_s, ReceiverName::TestWithLegacyReceiver, false, false },
 #endif
-    { "TestWithLegacyReceiver_Close", ReceiverName::TestWithLegacyReceiver, false, false },
-    { "TestWithLegacyReceiver_CreatePlugin", ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_Close"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_CreatePlugin"_s, ReceiverName::TestWithLegacyReceiver, false, false },
 #if ENABLE(DEPRECATED_FEATURE)
-    { "TestWithLegacyReceiver_DeprecatedOperation", ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_DeprecatedOperation"_s, ReceiverName::TestWithLegacyReceiver, false, false },
 #endif
 #if PLATFORM(MAC)
-    { "TestWithLegacyReceiver_DidCreateWebProcessConnection", ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_DidCreateWebProcessConnection"_s, ReceiverName::TestWithLegacyReceiver, false, false },
 #endif
-    { "TestWithLegacyReceiver_DidReceivePolicyDecision", ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_DidReceivePolicyDecision"_s, ReceiverName::TestWithLegacyReceiver, false, false },
 #if ENABLE(FEATURE_FOR_TESTING)
-    { "TestWithLegacyReceiver_ExperimentalOperation", ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_ExperimentalOperation"_s, ReceiverName::TestWithLegacyReceiver, false, false },
 #endif
-    { "TestWithLegacyReceiver_GetPlugins", ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_GetPlugins"_s, ReceiverName::TestWithLegacyReceiver, false, false },
 #if PLATFORM(MAC)
-    { "TestWithLegacyReceiver_InterpretKeyEvent", ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_InterpretKeyEvent"_s, ReceiverName::TestWithLegacyReceiver, false, false },
 #endif
 #if ENABLE(TOUCH_EVENTS)
-    { "TestWithLegacyReceiver_LoadSomething", ReceiverName::TestWithLegacyReceiver, false, false },
-    { "TestWithLegacyReceiver_LoadSomethingElse", ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_LoadSomething"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_LoadSomethingElse"_s, ReceiverName::TestWithLegacyReceiver, false, false },
 #endif
-    { "TestWithLegacyReceiver_LoadURL", ReceiverName::TestWithLegacyReceiver, false, false },
-    { "TestWithLegacyReceiver_PreferencesDidChange", ReceiverName::TestWithLegacyReceiver, false, false },
-    { "TestWithLegacyReceiver_RunJavaScriptAlert", ReceiverName::TestWithLegacyReceiver, false, false },
-    { "TestWithLegacyReceiver_SendDoubleAndFloat", ReceiverName::TestWithLegacyReceiver, false, false },
-    { "TestWithLegacyReceiver_SendInts", ReceiverName::TestWithLegacyReceiver, false, false },
-    { "TestWithLegacyReceiver_SetVideoLayerID", ReceiverName::TestWithLegacyReceiver, false, false },
-    { "TestWithLegacyReceiver_TemplateTest", ReceiverName::TestWithLegacyReceiver, false, false },
-    { "TestWithLegacyReceiver_TestParameterAttributes", ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_LoadURL"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_PreferencesDidChange"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_RunJavaScriptAlert"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_SendDoubleAndFloat"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_SendInts"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_SetVideoLayerID"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_TemplateTest"_s, ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_TestParameterAttributes"_s, ReceiverName::TestWithLegacyReceiver, false, false },
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
-    { "TestWithLegacyReceiver_TouchEvent", ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_TouchEvent"_s, ReceiverName::TestWithLegacyReceiver, false, false },
 #endif
-    { "TestWithSemaphore_ReceiveSemaphore", ReceiverName::TestWithSemaphore, false, false },
-    { "TestWithSemaphore_SendSemaphore", ReceiverName::TestWithSemaphore, false, false },
-    { "TestWithStreamBatched_SendString", ReceiverName::TestWithStreamBatched, true, false },
-    { "TestWithStreamBuffer_SendStreamBuffer", ReceiverName::TestWithStreamBuffer, false, false },
-    { "TestWithStreamServerConnectionHandle_SendStreamServerConnection", ReceiverName::TestWithStreamServerConnectionHandle, false, false },
-    { "TestWithStream_CallWithIdentifier", ReceiverName::TestWithStream, true, false },
+    { "TestWithSemaphore_ReceiveSemaphore"_s, ReceiverName::TestWithSemaphore, false, false },
+    { "TestWithSemaphore_SendSemaphore"_s, ReceiverName::TestWithSemaphore, false, false },
+    { "TestWithStreamBatched_SendString"_s, ReceiverName::TestWithStreamBatched, true, false },
+    { "TestWithStreamBuffer_SendStreamBuffer"_s, ReceiverName::TestWithStreamBuffer, false, false },
+    { "TestWithStreamServerConnectionHandle_SendStreamServerConnection"_s, ReceiverName::TestWithStreamServerConnectionHandle, false, false },
+    { "TestWithStream_CallWithIdentifier"_s, ReceiverName::TestWithStream, true, false },
 #if PLATFORM(COCOA)
-    { "TestWithStream_SendMachSendRight", ReceiverName::TestWithStream, true, false },
+    { "TestWithStream_SendMachSendRight"_s, ReceiverName::TestWithStream, true, false },
 #endif
-    { "TestWithStream_SendString", ReceiverName::TestWithStream, true, false },
-    { "TestWithStream_SendStringAsync", ReceiverName::TestWithStream, true, false },
-    { "TestWithSuperclass_LoadURL", ReceiverName::TestWithSuperclass, false, false },
+    { "TestWithStream_SendString"_s, ReceiverName::TestWithStream, true, false },
+    { "TestWithStream_SendStringAsync"_s, ReceiverName::TestWithStream, true, false },
+    { "TestWithSuperclass_LoadURL"_s, ReceiverName::TestWithSuperclass, false, false },
 #if ENABLE(TEST_FEATURE)
-    { "TestWithSuperclass_TestAsyncMessage", ReceiverName::TestWithSuperclass, false, false },
-    { "TestWithSuperclass_TestAsyncMessageWithConnection", ReceiverName::TestWithSuperclass, false, false },
-    { "TestWithSuperclass_TestAsyncMessageWithMultipleArguments", ReceiverName::TestWithSuperclass, false, false },
-    { "TestWithSuperclass_TestAsyncMessageWithNoArguments", ReceiverName::TestWithSuperclass, false, false },
+    { "TestWithSuperclass_TestAsyncMessage"_s, ReceiverName::TestWithSuperclass, false, false },
+    { "TestWithSuperclass_TestAsyncMessageWithConnection"_s, ReceiverName::TestWithSuperclass, false, false },
+    { "TestWithSuperclass_TestAsyncMessageWithMultipleArguments"_s, ReceiverName::TestWithSuperclass, false, false },
+    { "TestWithSuperclass_TestAsyncMessageWithNoArguments"_s, ReceiverName::TestWithSuperclass, false, false },
 #endif
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
-    { "TestWithoutAttributes_AddEvent", ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_AddEvent"_s, ReceiverName::TestWithoutAttributes, false, false },
 #endif
-    { "TestWithoutAttributes_Close", ReceiverName::TestWithoutAttributes, false, false },
-    { "TestWithoutAttributes_CreatePlugin", ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_Close"_s, ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_CreatePlugin"_s, ReceiverName::TestWithoutAttributes, false, false },
 #if ENABLE(DEPRECATED_FEATURE)
-    { "TestWithoutAttributes_DeprecatedOperation", ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_DeprecatedOperation"_s, ReceiverName::TestWithoutAttributes, false, false },
 #endif
 #if PLATFORM(MAC)
-    { "TestWithoutAttributes_DidCreateWebProcessConnection", ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_DidCreateWebProcessConnection"_s, ReceiverName::TestWithoutAttributes, false, false },
 #endif
-    { "TestWithoutAttributes_DidReceivePolicyDecision", ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_DidReceivePolicyDecision"_s, ReceiverName::TestWithoutAttributes, false, false },
 #if ENABLE(FEATURE_FOR_TESTING)
-    { "TestWithoutAttributes_ExperimentalOperation", ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_ExperimentalOperation"_s, ReceiverName::TestWithoutAttributes, false, false },
 #endif
-    { "TestWithoutAttributes_GetPlugins", ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_GetPlugins"_s, ReceiverName::TestWithoutAttributes, false, false },
 #if PLATFORM(MAC)
-    { "TestWithoutAttributes_InterpretKeyEvent", ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_InterpretKeyEvent"_s, ReceiverName::TestWithoutAttributes, false, false },
 #endif
 #if ENABLE(TOUCH_EVENTS)
-    { "TestWithoutAttributes_LoadSomething", ReceiverName::TestWithoutAttributes, false, false },
-    { "TestWithoutAttributes_LoadSomethingElse", ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_LoadSomething"_s, ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_LoadSomethingElse"_s, ReceiverName::TestWithoutAttributes, false, false },
 #endif
-    { "TestWithoutAttributes_LoadURL", ReceiverName::TestWithoutAttributes, false, false },
-    { "TestWithoutAttributes_PreferencesDidChange", ReceiverName::TestWithoutAttributes, false, false },
-    { "TestWithoutAttributes_RunJavaScriptAlert", ReceiverName::TestWithoutAttributes, false, false },
-    { "TestWithoutAttributes_SendDoubleAndFloat", ReceiverName::TestWithoutAttributes, false, false },
-    { "TestWithoutAttributes_SendInts", ReceiverName::TestWithoutAttributes, false, false },
-    { "TestWithoutAttributes_SetVideoLayerID", ReceiverName::TestWithoutAttributes, false, false },
-    { "TestWithoutAttributes_TemplateTest", ReceiverName::TestWithoutAttributes, false, false },
-    { "TestWithoutAttributes_TestParameterAttributes", ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_LoadURL"_s, ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_PreferencesDidChange"_s, ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_RunJavaScriptAlert"_s, ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_SendDoubleAndFloat"_s, ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_SendInts"_s, ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_SetVideoLayerID"_s, ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_TemplateTest"_s, ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_TestParameterAttributes"_s, ReceiverName::TestWithoutAttributes, false, false },
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
-    { "TestWithoutAttributes_TouchEvent", ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_TouchEvent"_s, ReceiverName::TestWithoutAttributes, false, false },
 #endif
-    { "TestWithoutUsingIPCConnection_MessageWithArgument", ReceiverName::TestWithoutUsingIPCConnection, false, false },
-    { "TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply", ReceiverName::TestWithoutUsingIPCConnection, false, false },
-    { "TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument", ReceiverName::TestWithoutUsingIPCConnection, false, false },
-    { "TestWithoutUsingIPCConnection_MessageWithoutArgument", ReceiverName::TestWithoutUsingIPCConnection, false, false },
-    { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply", ReceiverName::TestWithoutUsingIPCConnection, false, false },
-    { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument", ReceiverName::TestWithoutUsingIPCConnection, false, false },
+    { "TestWithoutUsingIPCConnection_MessageWithArgument"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false },
+    { "TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false },
+    { "TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false },
+    { "TestWithoutUsingIPCConnection_MessageWithoutArgument"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false },
+    { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false },
+    { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false },
 #if PLATFORM(COCOA)
-    { "InitializeConnection", ReceiverName::IPC, false, false },
+    { "InitializeConnection"_s, ReceiverName::IPC, false, false },
 #endif
-    { "LegacySessionState", ReceiverName::IPC, false, false },
-    { "ProcessOutOfStreamMessage", ReceiverName::IPC, false, false },
-    { "SetStreamDestinationID", ReceiverName::IPC, false, false },
-    { "SyncMessageReply", ReceiverName::IPC, false, false },
+    { "LegacySessionState"_s, ReceiverName::IPC, false, false },
+    { "ProcessOutOfStreamMessage"_s, ReceiverName::IPC, false, false },
+    { "SetStreamDestinationID"_s, ReceiverName::IPC, false, false },
+    { "SyncMessageReply"_s, ReceiverName::IPC, false, false },
 #if USE(AVFOUNDATION)
-    { "TestWithCVPixelBuffer_ReceiveCVPixelBufferReply", ReceiverName::AsyncReply, false, false },
+    { "TestWithCVPixelBuffer_ReceiveCVPixelBufferReply"_s, ReceiverName::AsyncReply, false, false },
 #endif
-    { "TestWithImageData_ReceiveImageDataReply", ReceiverName::AsyncReply, false, false },
-    { "TestWithLegacyReceiver_CreatePluginReply", ReceiverName::AsyncReply, false, false },
-    { "TestWithLegacyReceiver_GetPluginsReply", ReceiverName::AsyncReply, false, false },
+    { "TestWithImageData_ReceiveImageDataReply"_s, ReceiverName::AsyncReply, false, false },
+    { "TestWithLegacyReceiver_CreatePluginReply"_s, ReceiverName::AsyncReply, false, false },
+    { "TestWithLegacyReceiver_GetPluginsReply"_s, ReceiverName::AsyncReply, false, false },
 #if PLATFORM(MAC)
-    { "TestWithLegacyReceiver_InterpretKeyEventReply", ReceiverName::AsyncReply, false, false },
+    { "TestWithLegacyReceiver_InterpretKeyEventReply"_s, ReceiverName::AsyncReply, false, false },
 #endif
-    { "TestWithLegacyReceiver_RunJavaScriptAlertReply", ReceiverName::AsyncReply, false, false },
-    { "TestWithSemaphore_ReceiveSemaphoreReply", ReceiverName::AsyncReply, false, false },
-    { "TestWithStream_CallWithIdentifierReply", ReceiverName::AsyncReply, false, false },
-    { "TestWithStream_SendStringAsyncReply", ReceiverName::AsyncReply, false, false },
+    { "TestWithLegacyReceiver_RunJavaScriptAlertReply"_s, ReceiverName::AsyncReply, false, false },
+    { "TestWithSemaphore_ReceiveSemaphoreReply"_s, ReceiverName::AsyncReply, false, false },
+    { "TestWithStream_CallWithIdentifierReply"_s, ReceiverName::AsyncReply, false, false },
+    { "TestWithStream_SendStringAsyncReply"_s, ReceiverName::AsyncReply, false, false },
 #if ENABLE(TEST_FEATURE)
-    { "TestWithSuperclass_TestAsyncMessageReply", ReceiverName::AsyncReply, false, false },
-    { "TestWithSuperclass_TestAsyncMessageWithConnectionReply", ReceiverName::AsyncReply, false, false },
-    { "TestWithSuperclass_TestAsyncMessageWithMultipleArgumentsReply", ReceiverName::AsyncReply, false, false },
-    { "TestWithSuperclass_TestAsyncMessageWithNoArgumentsReply", ReceiverName::AsyncReply, false, false },
+    { "TestWithSuperclass_TestAsyncMessageReply"_s, ReceiverName::AsyncReply, false, false },
+    { "TestWithSuperclass_TestAsyncMessageWithConnectionReply"_s, ReceiverName::AsyncReply, false, false },
+    { "TestWithSuperclass_TestAsyncMessageWithMultipleArgumentsReply"_s, ReceiverName::AsyncReply, false, false },
+    { "TestWithSuperclass_TestAsyncMessageWithNoArgumentsReply"_s, ReceiverName::AsyncReply, false, false },
 #endif
-    { "TestWithoutAttributes_CreatePluginReply", ReceiverName::AsyncReply, false, false },
-    { "TestWithoutAttributes_GetPluginsReply", ReceiverName::AsyncReply, false, false },
+    { "TestWithoutAttributes_CreatePluginReply"_s, ReceiverName::AsyncReply, false, false },
+    { "TestWithoutAttributes_GetPluginsReply"_s, ReceiverName::AsyncReply, false, false },
 #if PLATFORM(MAC)
-    { "TestWithoutAttributes_InterpretKeyEventReply", ReceiverName::AsyncReply, false, false },
+    { "TestWithoutAttributes_InterpretKeyEventReply"_s, ReceiverName::AsyncReply, false, false },
 #endif
-    { "TestWithoutAttributes_RunJavaScriptAlertReply", ReceiverName::AsyncReply, false, false },
-    { "TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReplyReply", ReceiverName::AsyncReply, false, false },
-    { "TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgumentReply", ReceiverName::AsyncReply, false, false },
-    { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReplyReply", ReceiverName::AsyncReply, false, false },
-    { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgumentReply", ReceiverName::AsyncReply, false, false },
-    { "TestWithLegacyReceiver_GetPluginProcessConnection", ReceiverName::TestWithLegacyReceiver, true, false },
-    { "TestWithLegacyReceiver_TestMultipleAttributes", ReceiverName::TestWithLegacyReceiver, true, false },
+    { "TestWithoutAttributes_RunJavaScriptAlertReply"_s, ReceiverName::AsyncReply, false, false },
+    { "TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReplyReply"_s, ReceiverName::AsyncReply, false, false },
+    { "TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgumentReply"_s, ReceiverName::AsyncReply, false, false },
+    { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReplyReply"_s, ReceiverName::AsyncReply, false, false },
+    { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgumentReply"_s, ReceiverName::AsyncReply, false, false },
+    { "TestWithLegacyReceiver_GetPluginProcessConnection"_s, ReceiverName::TestWithLegacyReceiver, true, false },
+    { "TestWithLegacyReceiver_TestMultipleAttributes"_s, ReceiverName::TestWithLegacyReceiver, true, false },
 #if PLATFORM(COCOA)
-    { "TestWithStream_ReceiveMachSendRight", ReceiverName::TestWithStream, true, false },
-    { "TestWithStream_SendAndReceiveMachSendRight", ReceiverName::TestWithStream, true, false },
+    { "TestWithStream_ReceiveMachSendRight"_s, ReceiverName::TestWithStream, true, false },
+    { "TestWithStream_SendAndReceiveMachSendRight"_s, ReceiverName::TestWithStream, true, false },
 #endif
-    { "TestWithStream_SendStringSync", ReceiverName::TestWithStream, true, false },
-    { "TestWithSuperclass_TestSyncMessage", ReceiverName::TestWithSuperclass, true, false },
-    { "TestWithSuperclass_TestSynchronousMessage", ReceiverName::TestWithSuperclass, true, false },
-    { "TestWithoutAttributes_GetPluginProcessConnection", ReceiverName::TestWithoutAttributes, true, false },
-    { "TestWithoutAttributes_TestMultipleAttributes", ReceiverName::TestWithoutAttributes, true, false },
-    { "WrappedAsyncMessageForTesting", ReceiverName::IPC, true, false },
-    { "<invalid message name>", ReceiverName::Invalid, false, false }
+    { "TestWithStream_SendStringSync"_s, ReceiverName::TestWithStream, true, false },
+    { "TestWithSuperclass_TestSyncMessage"_s, ReceiverName::TestWithSuperclass, true, false },
+    { "TestWithSuperclass_TestSynchronousMessage"_s, ReceiverName::TestWithSuperclass, true, false },
+    { "TestWithoutAttributes_GetPluginProcessConnection"_s, ReceiverName::TestWithoutAttributes, true, false },
+    { "TestWithoutAttributes_TestMultipleAttributes"_s, ReceiverName::TestWithoutAttributes, true, false },
+    { "WrappedAsyncMessageForTesting"_s, ReceiverName::IPC, true, false },
+    { "<invalid message name>"_s, ReceiverName::Invalid, false, false }
 };
 
 } // namespace IPC::Detail

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.h
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.h
@@ -210,7 +210,7 @@ enum class MessageName : uint16_t {
 
 namespace Detail {
 struct MessageDescription {
-    const char* const description;
+    ASCIILiteral description;
     ReceiverName receiverName;
     bool messageAllowedWhenWaitingForSyncReply : 1;
     bool messageAllowedWhenWaitingForUnboundedSyncReply : 1;
@@ -225,7 +225,7 @@ inline ReceiverName receiverName(MessageName messageName)
     return Detail::messageDescriptions[static_cast<size_t>(messageName)].receiverName;
 }
 
-inline const char* description(MessageName messageName)
+inline ASCIILiteral description(MessageName messageName)
 {
     messageName = std::min(messageName, MessageName::Last);
     return Detail::messageDescriptions[static_cast<size_t>(messageName)].description;

--- a/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp
@@ -56,7 +56,7 @@ void TestWithCVPixelBuffer::didReceiveMessage(IPC::Connection& connection, IPC::
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessageReceiver.cpp
@@ -50,7 +50,7 @@ void TestWithEnabledIf::didReceiveMessage(IPC::Connection& connection, IPC::Deco
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessageReceiver.cpp
@@ -58,7 +58,7 @@ void TestWithIfMessage::didReceiveMessage(IPC::Connection& connection, IPC::Deco
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessageReceiver.cpp
@@ -52,7 +52,7 @@ void TestWithImageData::didReceiveMessage(IPC::Connection& connection, IPC::Deco
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp
@@ -128,7 +128,7 @@ void TestWithLegacyReceiver::didReceiveTestWithLegacyReceiverMessage(IPC::Connec
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
 }
 
 bool TestWithLegacyReceiver::didReceiveSyncTestWithLegacyReceiverMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
@@ -145,7 +145,7 @@ bool TestWithLegacyReceiver::didReceiveSyncTestWithLegacyReceiverMessage(IPC::Co
     if (connection.ignoreInvalidMessageForTesting())
         return false;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());
     return false;
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessageReceiver.cpp
@@ -49,7 +49,7 @@ void TestWithSemaphore::didReceiveMessage(IPC::Connection& connection, IPC::Deco
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp
@@ -47,7 +47,7 @@ void TestWithStreamBatched::didReceiveStreamMessage(IPC::StreamServerConnection&
     if (connection.protectedConnection()->ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp
@@ -47,7 +47,7 @@ void TestWithStreamBuffer::didReceiveMessage(IPC::Connection& connection, IPC::D
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp
@@ -66,7 +66,7 @@ void TestWithStream::didReceiveStreamMessage(IPC::StreamServerConnection& connec
     if (connection.protectedConnection()->ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessageReceiver.cpp
@@ -47,7 +47,7 @@ void TestWithStreamServerConnectionHandle::didReceiveMessage(IPC::Connection& co
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp
@@ -74,7 +74,7 @@ bool TestWithSuperclass::didReceiveSyncMessage(IPC::Connection& connection, IPC:
     if (connection.ignoreInvalidMessageForTesting())
         return false;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());
     return false;
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp
@@ -128,7 +128,7 @@ void TestWithoutAttributes::didReceiveMessage(IPC::Connection& connection, IPC::
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
 }
 
 bool TestWithoutAttributes::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
@@ -145,7 +145,7 @@ bool TestWithoutAttributes::didReceiveSyncMessage(IPC::Connection& connection, I
     if (connection.ignoreInvalidMessageForTesting())
         return false;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());
     return false;
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessageReceiver.cpp
@@ -53,7 +53,7 @@ void TestWithoutUsingIPCConnection::didReceiveMessageWithReplyHandler(IPC::Decod
     if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument::name())
         return IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument>(decoder, WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithArgumentAndReplyWithArgument);
     UNUSED_PARAM(decoder);
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Authentication/cocoa/ClientCertificateAuthenticationXPCConstants.cpp
+++ b/Source/WebKit/Shared/Authentication/cocoa/ClientCertificateAuthenticationXPCConstants.cpp
@@ -32,12 +32,12 @@ namespace WebKit {
 
 namespace ClientCertificateAuthentication {
 
-const char* const XPCCertificatesKey = "certificates";
-const char* const XPCChallengeIDKey = "challenge-id";
-const char* const XPCMessageNameKey = "message-name";
-const char* const XPCMessageNameValue = "client-certificate-credential";
-const char* const XPCPersistenceKey = "persistence";
-const char* const XPCSecKeyProxyEndpointKey = "sec-key-proxy-endpoint";
+const ASCIILiteral XPCCertificatesKey = "certificates"_s;
+const ASCIILiteral XPCChallengeIDKey = "challenge-id"_s;
+const ASCIILiteral XPCMessageNameKey = "message-name"_s;
+const ASCIILiteral XPCMessageNameValue = "client-certificate-credential"_s;
+const ASCIILiteral XPCPersistenceKey = "persistence"_s;
+const ASCIILiteral XPCSecKeyProxyEndpointKey = "sec-key-proxy-endpoint"_s;
 
 } // namespace ClientCertificateAuthentication
 

--- a/Source/WebKit/Shared/Authentication/cocoa/ClientCertificateAuthenticationXPCConstants.h
+++ b/Source/WebKit/Shared/Authentication/cocoa/ClientCertificateAuthenticationXPCConstants.h
@@ -31,12 +31,12 @@ namespace WebKit {
 
 namespace ClientCertificateAuthentication {
 
-extern const char* const XPCCertificatesKey;
-extern const char* const XPCChallengeIDKey;
-extern const char* const XPCMessageNameKey;
-extern const char* const XPCMessageNameValue;
-extern const char* const XPCPersistenceKey;
-extern const char* const XPCSecKeyProxyEndpointKey;
+extern const ASCIILiteral XPCCertificatesKey;
+extern const ASCIILiteral XPCChallengeIDKey;
+extern const ASCIILiteral XPCMessageNameKey;
+extern const ASCIILiteral XPCMessageNameValue;
+extern const ASCIILiteral XPCPersistenceKey;
+extern const ASCIILiteral XPCSecKeyProxyEndpointKey;
 
 } // namespace ClientCertificateAuthentication
 

--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -244,7 +244,7 @@ void AuxiliaryProcess::initializeSandbox(const AuxiliaryProcessInitializationPar
 
 void AuxiliaryProcess::didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName messageName)
 {
-    WTFLogAlways("Received invalid message: '%s'", description(messageName));
+    WTFLogAlways("Received invalid message: '%s'", description(messageName).characters());
     CRASH();
 }
 

--- a/Source/WebKit/Shared/Cocoa/XPCEndpoint.h
+++ b/Source/WebKit/Shared/Cocoa/XPCEndpoint.h
@@ -30,6 +30,7 @@
 #include <WebKit/WKBase.h>
 #include <wtf/OSObjectPtr.h>
 #include <wtf/spi/darwin/XPCSPI.h>
+#include <wtf/text/ASCIILiteral.h>
 
 namespace WebKit {
 
@@ -42,12 +43,12 @@ public:
 
     WK_EXPORT OSObjectPtr<xpc_endpoint_t> endpoint() const;
 
-    static constexpr auto xpcMessageNameKey = "message-name";
+    static constexpr auto xpcMessageNameKey = "message-name"_s;
 
 private:
-    virtual const char* xpcEndpointMessageNameKey() const = 0;
-    virtual const char* xpcEndpointMessageName() const = 0;
-    virtual const char* xpcEndpointNameKey() const = 0;
+    virtual ASCIILiteral xpcEndpointMessageNameKey() const = 0;
+    virtual ASCIILiteral xpcEndpointMessageName() const = 0;
+    virtual ASCIILiteral xpcEndpointNameKey() const = 0;
     virtual void handleEvent(xpc_connection_t, xpc_object_t) = 0;
 
     OSObjectPtr<xpc_connection_t> m_connection;

--- a/Source/WebKit/Shared/ProcessTerminationReason.cpp
+++ b/Source/WebKit/Shared/ProcessTerminationReason.cpp
@@ -28,32 +28,32 @@
 
 namespace WebKit {
 
-const char* processTerminationReasonToString(ProcessTerminationReason reason)
+ASCIILiteral processTerminationReasonToString(ProcessTerminationReason reason)
 {
     switch (reason) {
     case ProcessTerminationReason::ExceededMemoryLimit:
-        return "ExceededMemoryLimit";
+        return "ExceededMemoryLimit"_s;
     case ProcessTerminationReason::ExceededCPULimit:
-        return "ExceededCPULimit";
+        return "ExceededCPULimit"_s;
     case ProcessTerminationReason::RequestedByClient:
-        return "RequestedByClient";
+        return "RequestedByClient"_s;
     case ProcessTerminationReason::IdleExit:
-        return "IdleExit";
+        return "IdleExit"_s;
     case ProcessTerminationReason::Unresponsive:
-        return "Unresponsive";
+        return "Unresponsive"_s;
     case ProcessTerminationReason::Crash:
-        return "Crash";
+        return "Crash"_s;
     case ProcessTerminationReason::ExceededProcessCountLimit:
-        return "ExceededProcessCountLimit";
+        return "ExceededProcessCountLimit"_s;
     case ProcessTerminationReason::NavigationSwap:
-        return "NavigationSwap";
+        return "NavigationSwap"_s;
     case ProcessTerminationReason::RequestedByNetworkProcess:
-        return "RequestedByNetworkProcess";
+        return "RequestedByNetworkProcess"_s;
     case ProcessTerminationReason::RequestedByGPUProcess:
-        return "RequestedByGPUProcess";
+        return "RequestedByGPUProcess"_s;
     }
 
-    return "";
+    return ""_s;
 }
 
 }

--- a/Source/WebKit/Shared/ProcessTerminationReason.h
+++ b/Source/WebKit/Shared/ProcessTerminationReason.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Forward.h>
+
 namespace WebKit {
 
 enum class ProcessTerminationReason : uint8_t {
@@ -41,6 +43,6 @@ enum class ProcessTerminationReason : uint8_t {
     RequestedByGPUProcess
 };
 
-const char* processTerminationReasonToString(ProcessTerminationReason);
+ASCIILiteral processTerminationReasonToString(ProcessTerminationReason);
 
 }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -203,21 +203,21 @@ void RemoteLayerBackingStore::encode(IPC::Encoder& encoder) const
 
 void RemoteLayerBackingStoreProperties::dump(TextStream& ts) const
 {
-    auto dumpBuffer = [&](const char* name, const std::optional<BufferAndBackendInfo>& bufferInfo) {
+    auto dumpBuffer = [&](ASCIILiteral name, const std::optional<BufferAndBackendInfo>& bufferInfo) {
         ts.startGroup();
-        ts << name << " ";
+        ts << name << " "_s;
         if (bufferInfo)
-            ts << bufferInfo->resourceIdentifier << " backend generation " << bufferInfo->backendGeneration;
+            ts << bufferInfo->resourceIdentifier << " backend generation "_s << bufferInfo->backendGeneration;
         else
-            ts << "none";
+            ts << "none"_s;
         ts.endGroup();
     };
-    dumpBuffer("front buffer", m_frontBufferInfo);
-    dumpBuffer("back buffer", m_backBufferInfo);
-    dumpBuffer("secondaryBack buffer", m_secondaryBackBufferInfo);
+    dumpBuffer("front buffer"_s, m_frontBufferInfo);
+    dumpBuffer("back buffer"_s, m_backBufferInfo);
+    dumpBuffer("secondaryBack buffer"_s, m_secondaryBackBufferInfo);
 
-    ts.dumpProperty("is opaque", isOpaque());
-    ts.dumpProperty("has buffer handle", !!bufferHandle());
+    ts.dumpProperty("is opaque"_s, isOpaque());
+    ts.dumpProperty("has buffer handle"_s, !!bufferHandle());
 }
 
 bool RemoteLayerBackingStore::layerWillBeDisplayed()

--- a/Source/WebKit/Shared/WebPushDaemonConstants.h
+++ b/Source/WebKit/Shared/WebPushDaemonConstants.h
@@ -27,15 +27,17 @@
 
 #ifdef __cplusplus
 
+#include <wtf/text/ASCIILiteral.h>
+
 namespace WebKit::WebPushD {
 
 // If an origin processes more than this many silent pushes, then it will be unsubscribed from push.
 constexpr unsigned maxSilentPushCount = 3;
 
-constexpr const char* protocolVersionKey = "protocol version";
+constexpr auto protocolVersionKey = "protocol version"_s;
 constexpr uint64_t protocolVersionValue = 3;
-constexpr const char* protocolEncodedMessageKey = "encoded message";
-constexpr const char* protocolDebugMessageKey { "debug message" };
+constexpr auto protocolEncodedMessageKey = "encoded message"_s;
+constexpr auto protocolDebugMessageKey = "debug message"_s;
 
 // FIXME: ConnectionToMachService traits requires we have a message type, so keep this placeholder here
 // until we can remove that requirement.

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -212,18 +212,18 @@ static std::optional<Vector<char>> fileContents(const String& path, bool shouldL
 #if USE(APPLE_INTERNAL_SDK)
 // These strings must match the last segment of the "com.apple.rootless.storage.<this part must match>" entry in each
 // process's restricted entitlements file (ex. Configurations/Networking-OSX-restricted.entitlements).
-constexpr const char* processStorageClass(WebCore::AuxiliaryProcessType type)
+constexpr ASCIILiteral processStorageClass(WebCore::AuxiliaryProcessType type)
 {
     switch (type) {
     case WebCore::AuxiliaryProcessType::WebContent:
-        return "WebKitWebContentSandbox";
+        return "WebKitWebContentSandbox"_s;
     case WebCore::AuxiliaryProcessType::Network:
-        return "WebKitNetworkingSandbox";
+        return "WebKitNetworkingSandbox"_s;
     case WebCore::AuxiliaryProcessType::Plugin:
-        return "WebKitPluginSandbox";
+        return "WebKitPluginSandbox"_s;
 #if ENABLE(GPU_PROCESS)
     case WebCore::AuxiliaryProcessType::GPU:
-        return "WebKitGPUSandbox";
+        return "WebKitGPUSandbox"_s;
 #endif
     }
 }
@@ -314,7 +314,7 @@ static bool ensureSandboxCacheDirectory(const SandboxInfo& info)
     }
 
 #if USE(APPLE_INTERNAL_SDK)
-    const char* storageClass = processStorageClass(info.processType);
+    auto storageClass = processStorageClass(info.processType);
     CString directoryPath = FileSystem::fileSystemRepresentation(info.directoryPath);
     if (directoryPath.isNull())
         return false;

--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaTrackReader.cpp
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaTrackReader.cpp
@@ -147,18 +147,18 @@ void MediaTrackReader::finishParsing()
     m_sampleStorageCondition.notifyAll();
 }
 
-const char* MediaTrackReader::mediaTypeString() const
+ASCIILiteral MediaTrackReader::mediaTypeString() const
 {
     switch (m_mediaType) {
     case kCMMediaType_Video:
-        return "video";
+        return "video"_s;
     case kCMMediaType_Audio:
-        return "audio";
+        return "audio"_s;
     case kCMMediaType_Text:
-        return "text";
+        return "text"_s;
     }
     ASSERT_NOT_REACHED();
-    return "unknown";
+    return "unknown"_s;
 }
 
 OSStatus MediaTrackReader::copyProperty(CFStringRef key, CFAllocatorRef allocator, void* copiedValue)

--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaTrackReader.h
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaTrackReader.h
@@ -99,7 +99,7 @@ private:
         bool hasAllSamples { false };
     };
 
-    const char* mediaTypeString() const;
+    ASCIILiteral mediaTypeString() const;
     const char* logClassName() const { return "MediaTrackReader"; }
     const void* logIdentifier() const { return m_logIdentifier; }
     WTFLogChannel& logChannel() const;

--- a/Source/WebKit/Shared/mac/WebMemorySampler.mac.mm
+++ b/Source/WebKit/Shared/mac/WebMemorySampler.mac.mm
@@ -49,9 +49,9 @@ struct SystemMallocStats {
 
 SystemMallocStats WebMemorySampler::sampleSystemMalloc() const
 {
-    static const char* defaultMallocZoneName = "DefaultMallocZone";
-    static const char* dispatchContinuationMallocZoneName = "DispatchContinuations";
-    static const char* purgeableMallocZoneName = "DefaultPurgeableMallocZone";
+    static constexpr auto defaultMallocZoneName = "DefaultMallocZone"_s;
+    static constexpr auto dispatchContinuationMallocZoneName = "DispatchContinuations"_s;
+    static constexpr auto purgeableMallocZoneName = "DefaultPurgeableMallocZone"_s;
     SystemMallocStats mallocStats;
     vm_address_t* zones;
     unsigned count;

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -441,7 +441,7 @@ void AuxiliaryProcessProxy::connectionWillOpen(IPC::Connection&)
 
 void AuxiliaryProcessProxy::logInvalidMessage(IPC::Connection& connection, IPC::MessageName messageName)
 {
-    RELEASE_LOG_FAULT(IPC, "Received an invalid message '%" PUBLIC_LOG_STRING "' from the %" PUBLIC_LOG_STRING " process with PID %d", description(messageName), processName().characters(), processID());
+    RELEASE_LOG_FAULT(IPC, "Received an invalid message '%" PUBLIC_LOG_STRING "' from the %" PUBLIC_LOG_STRING " process with PID %d", description(messageName).characters(), processName().characters(), processID());
 }
 
 bool AuxiliaryProcessProxy::platformIsBeingDebugged() const

--- a/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
@@ -56,7 +56,7 @@ bool checkSandboxRequirementForType(MediaPermissionType type)
     static bool isAudioEntitled = true;
     static bool isVideoEntitled = true;
     
-    auto checkFunction = [](const char* operation, bool* entitled) {
+    auto checkFunction = [](ASCIILiteral operation, bool* entitled) {
         if (!currentProcessIsSandboxed())
             return;
 
@@ -68,10 +68,10 @@ bool checkSandboxRequirementForType(MediaPermissionType type)
 
     switch (type) {
     case MediaPermissionType::Audio:
-        std::call_once(audioFlag, checkFunction, "device-microphone", &isAudioEntitled);
+        std::call_once(audioFlag, checkFunction, "device-microphone"_s, &isAudioEntitled);
         return isAudioEntitled;
     case MediaPermissionType::Video:
-        std::call_once(videoFlag, checkFunction, "device-camera", &isVideoEntitled);
+        std::call_once(videoFlag, checkFunction, "device-camera"_s, &isVideoEntitled);
         return isVideoEntitled;
     }
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm
@@ -33,7 +33,7 @@
 #import "WebPageProxy.h"
 #import <WebCore/ResourceResponse.h>
 
-#define AUTHORIZATIONSESSION_RELEASE_LOG(fmt, ...) RELEASE_LOG(AppSSO, "%p - [InitiatingAction=%s][State=%s] NavigationSOAuthorizationSession::" fmt, this, initiatingActionString(), stateString(), ##__VA_ARGS__)
+#define AUTHORIZATIONSESSION_RELEASE_LOG(fmt, ...) RELEASE_LOG(AppSSO, "%p - [InitiatingAction=%s][State=%s] NavigationSOAuthorizationSession::" fmt, this, initiatingActionString().characters(), stateString().characters(), ##__VA_ARGS__)
 
 namespace WebKit {
 

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm
@@ -93,7 +93,7 @@
 
 @end
 
-#define AUTHORIZATIONSESSION_RELEASE_LOG(fmt, ...) RELEASE_LOG(AppSSO, "%p - [InitiatingAction=%s][State=%s] PopUpSOAuthorizationSession::" fmt, this, initiatingActionString(), stateString(), ##__VA_ARGS__)
+#define AUTHORIZATIONSESSION_RELEASE_LOG(fmt, ...) RELEASE_LOG(AppSSO, "%p - [InitiatingAction=%s][State=%s] PopUpSOAuthorizationSession::" fmt, this, initiatingActionString().characters(), stateString().characters(), ##__VA_ARGS__)
 
 namespace WebKit {
 

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/RedirectSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/RedirectSOAuthorizationSession.mm
@@ -34,7 +34,7 @@
 #import <WebCore/ResourceResponse.h>
 #import <wtf/cocoa/SpanCocoa.h>
 
-#define AUTHORIZATIONSESSION_RELEASE_LOG(fmt, ...) RELEASE_LOG(AppSSO, "%p - [InitiatingAction=%s][State=%s] RedirectSOAuthorizationSession::" fmt, this, initiatingActionString(), stateString(), ##__VA_ARGS__)
+#define AUTHORIZATIONSESSION_RELEASE_LOG(fmt, ...) RELEASE_LOG(AppSSO, "%p - [InitiatingAction=%s][State=%s] RedirectSOAuthorizationSession::" fmt, this, initiatingActionString().characters(), stateString().characters(), ##__VA_ARGS__)
 
 namespace WebKit {
 using namespace WebCore;

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h
@@ -94,8 +94,8 @@ protected:
     void start();
     WebPageProxy* page() const { return m_page.get(); }
     State state() const { return m_state; }
-    const char* stateString() const;
-    const char* initiatingActionString() const;
+    ASCIILiteral stateString() const;
+    ASCIILiteral initiatingActionString() const;
     void setState(State state) { m_state = state; }
     const API::NavigationAction* navigationAction() { return m_navigationAction.get(); }
     Ref<API::NavigationAction> releaseNavigationAction();

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -49,18 +49,18 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/Vector.h>
 
-#define AUTHORIZATIONSESSION_RELEASE_LOG(fmt, ...) RELEASE_LOG(AppSSO, "%p - [InitiatingAction=%s][State=%s] SOAuthorizationSession::" fmt, this, toString(m_action), stateString(), ##__VA_ARGS__)
+#define AUTHORIZATIONSESSION_RELEASE_LOG(fmt, ...) RELEASE_LOG(AppSSO, "%p - [InitiatingAction=%s][State=%s] SOAuthorizationSession::" fmt, this, toString(m_action).characters(), stateString().characters(), ##__VA_ARGS__)
 
 namespace WebKit {
 using namespace WebCore;
 
 namespace {
 
-static const char* Redirect = "Redirect";
-static const char* PopUp = "PopUp";
-static const char* SubFrame = "SubFrame";
+static constexpr auto Redirect = "Redirect"_s;
+static constexpr auto PopUp = "PopUp"_s;
+static constexpr auto SubFrame = "SubFrame"_s;
 
-static const char* toString(const SOAuthorizationSession::InitiatingAction& action)
+static ASCIILiteral toString(const SOAuthorizationSession::InitiatingAction& action)
 {
     switch (action) {
     case SOAuthorizationSession::InitiatingAction::Redirect:
@@ -72,7 +72,7 @@ static const char* toString(const SOAuthorizationSession::InitiatingAction& acti
     }
 
     ASSERT_NOT_REACHED();
-    return nullptr;
+    return { };
 }
 
 static Vector<WebCore::Cookie> toCookieVector(NSArray<NSHTTPCookie *> *cookies)
@@ -114,17 +114,17 @@ SOAuthorizationSession::~SOAuthorizationSession()
         dismissViewController();
 }
 
-const char* SOAuthorizationSession::initiatingActionString() const
+ASCIILiteral SOAuthorizationSession::initiatingActionString() const
 {
     return toString(m_action);
 }
 
-const char* SOAuthorizationSession::stateString() const
+ASCIILiteral SOAuthorizationSession::stateString() const
 {
-    static const char* Idle = "Idle";
-    static const char* Active = "Active";
-    static const char* Waiting = "Waiting";
-    static const char* Completed = "Completed";
+    static constexpr auto Idle = "Idle"_s;
+    static constexpr auto Active = "Active"_s;
+    static constexpr auto Waiting = "Waiting"_s;
+    static constexpr auto Completed = "Completed"_s;
 
     switch (m_state) {
     case State::Idle:

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
@@ -43,12 +43,12 @@
 namespace WebKit {
 using namespace WebCore;
 
-#define AUTHORIZATIONSESSION_RELEASE_LOG(fmt, ...) RELEASE_LOG(AppSSO, "%p - [InitiatingAction=%s][State=%s] SubFrameSOAuthorizationSession::" fmt, this, initiatingActionString(), stateString(), ##__VA_ARGS__)
+#define AUTHORIZATIONSESSION_RELEASE_LOG(fmt, ...) RELEASE_LOG(AppSSO, "%p - [InitiatingAction=%s][State=%s] SubFrameSOAuthorizationSession::" fmt, this, initiatingActionString().characters(), stateString().characters(), ##__VA_ARGS__)
 
 namespace {
 
-const char* soAuthorizationPostDidStartMessageToParent = "<script>parent.postMessage('SOAuthorizationDidStart', '*');</script>";
-const char* soAuthorizationPostDidCancelMessageToParent = "<script>parent.postMessage('SOAuthorizationDidCancel', '*');</script>";
+constexpr auto soAuthorizationPostDidStartMessageToParent = "<script>parent.postMessage('SOAuthorizationDidStart', '*');</script>"_s;
+constexpr auto soAuthorizationPostDidCancelMessageToParent = "<script>parent.postMessage('SOAuthorizationDidCancel', '*');</script>"_s;
 
 } // namespace
 

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -514,7 +514,7 @@ void GPUProcessProxy::gpuProcessExited(ProcessTerminationReason reason)
     case ProcessTerminationReason::IdleExit:
     case ProcessTerminationReason::Unresponsive:
     case ProcessTerminationReason::Crash:
-        RELEASE_LOG_ERROR(Process, "%p - GPUProcessProxy::gpuProcessExited: reason=%" PUBLIC_LOG_STRING, this, processTerminationReasonToString(reason));
+        RELEASE_LOG_ERROR(Process, "%p - GPUProcessProxy::gpuProcessExited: reason=%" PUBLIC_LOG_STRING, this, processTerminationReasonToString(reason).characters());
         break;
     case ProcessTerminationReason::ExceededProcessCountLimit:
     case ProcessTerminationReason::NavigationSwap:

--- a/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
+++ b/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
@@ -147,7 +147,7 @@ private:
     ProcessLauncher(Client*, LaunchOptions&&);
 
     void launchProcess();
-    void finishLaunchingProcess(const char* name);
+    void finishLaunchingProcess(ASCIILiteral name);
     void didFinishLaunchingProcess(ProcessID, IPC::Connection::Identifier);
 
     void platformInvalidate();

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -160,28 +160,28 @@ static void launchWithExtensionKit(ProcessLauncher& processLauncher, ProcessLaun
 #endif // USE(EXTENSIONKIT)
 
 #if !USE(EXTENSIONKIT) || !PLATFORM(IOS)
-static const char* webContentServiceName(const ProcessLauncher::LaunchOptions& launchOptions, ProcessLauncher::Client* client)
+static ASCIILiteral webContentServiceName(const ProcessLauncher::LaunchOptions& launchOptions, ProcessLauncher::Client* client)
 {
     if (client && client->shouldEnableLockdownMode())
-        return "com.apple.WebKit.WebContent.CaptivePortal";
+        return "com.apple.WebKit.WebContent.CaptivePortal"_s;
 
-    return launchOptions.nonValidInjectedCodeAllowed ? "com.apple.WebKit.WebContent.Development" : "com.apple.WebKit.WebContent";
+    return launchOptions.nonValidInjectedCodeAllowed ? "com.apple.WebKit.WebContent.Development"_s : "com.apple.WebKit.WebContent"_s;
 }
 
-static const char* serviceName(const ProcessLauncher::LaunchOptions& launchOptions, ProcessLauncher::Client* client)
+static ASCIILiteral serviceName(const ProcessLauncher::LaunchOptions& launchOptions, ProcessLauncher::Client* client)
 {
     switch (launchOptions.processType) {
     case ProcessLauncher::ProcessType::Web:
         return webContentServiceName(launchOptions, client);
     case ProcessLauncher::ProcessType::Network:
-        return "com.apple.WebKit.Networking";
+        return "com.apple.WebKit.Networking"_s;
 #if ENABLE(GPU_PROCESS)
     case ProcessLauncher::ProcessType::GPU:
-        return "com.apple.WebKit.GPU";
+        return "com.apple.WebKit.GPU"_s;
 #endif
 #if ENABLE(MODEL_PROCESS)
     case ProcessLauncher::ProcessType::Model:
-        return "com.apple.WebKit.Model";
+        return "com.apple.WebKit.Model"_s;
 #endif
     }
 }
@@ -238,7 +238,7 @@ void ProcessLauncher::launchProcess()
                 auto launcher = weakProcessLauncher.get();
                 if (!launcher)
                     return;
-                const char* name = serviceName(launcher->m_launchOptions, launcher->m_client);
+                auto name = serviceName(launcher->m_launchOptions, launcher->m_client);
                 launcher->m_xpcConnection = adoptOSObject(xpc_connection_create(name, nullptr));
                 launcher->finishLaunchingProcess(name);
             });
@@ -269,19 +269,19 @@ void ProcessLauncher::launchProcess()
             launcher->m_xpcConnection = WTFMove(xpcConnection);
             launcher->m_process = WTFMove(process);
             launcher->m_launchGrant = WTFMove(launchGrant);
-            launcher->finishLaunchingProcess(name.characters());
+            launcher->finishLaunchingProcess(name);
         });
     };
 
     launchWithExtensionKit(*this, m_launchOptions.processType, m_client, WTFMove(handler));
 #else
-    const char* name = serviceName(m_launchOptions, m_client);
+    auto name = serviceName(m_launchOptions, m_client);
     m_xpcConnection = adoptOSObject(xpc_connection_create(name, nullptr));
     finishLaunchingProcess(name);
 #endif
 }
 
-void ProcessLauncher::finishLaunchingProcess(const char* name)
+void ProcessLauncher::finishLaunchingProcess(ASCIILiteral name)
 {
     uuid_t uuid;
     uuid_generate(uuid);

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -734,7 +734,7 @@ void ProvisionalPageProxy::didReceiveMessage(IPC::Connection& connection, IPC::D
     }
 #endif
 
-    LOG(ProcessSwapping, "Unhandled message %s from provisional process", description(decoder.messageName()));
+    LOG(ProcessSwapping, "Unhandled message %s from provisional process", description(decoder.messageName()).characters());
 }
 
 bool ProvisionalPageProxy::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -292,7 +292,7 @@ void SuspendedPageProxy::didReceiveMessage(IPC::Connection& connection, IPC::Dec
 
 #if !LOG_DISABLED
     if (!messageNamesToIgnoreWhileSuspended().contains(decoder.messageName()))
-        LOG(ProcessSwapping, "SuspendedPageProxy received unexpected WebPageProxy message '%s'", description(decoder.messageName()));
+        LOG(ProcessSwapping, "SuspendedPageProxy received unexpected WebPageProxy message '%s'", description(decoder.messageName()).characters());
 #endif
 }
 

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -409,14 +409,14 @@ static bool deltaShouldCancelSwipe(FloatSize delta)
     return std::abs(delta.height()) >= std::abs(delta.width()) * minimumScrollEventRatioForSwipe;
 }
 
-const char* ViewGestureController::PendingSwipeTracker::stateToString(State state)
+ASCIILiteral ViewGestureController::PendingSwipeTracker::stateToString(State state)
 {
     switch (state) {
-    case State::None: return "None";
-    case State::WaitingForWebCore: return "WaitingForWebCore";
-    case State::InsufficientMagnitude: return "InsufficientMagnitude";
+    case State::None: return "None"_s;
+    case State::WaitingForWebCore: return "WaitingForWebCore"_s;
+    case State::InsufficientMagnitude: return "InsufficientMagnitude"_s;
     }
-    return "";
+    return ""_s;
 }
 
 ViewGestureController::PendingSwipeTracker::PendingSwipeTracker(WebPageProxy& webPageProxy, ViewGestureController& viewGestureController)
@@ -455,7 +455,7 @@ bool ViewGestureController::PendingSwipeTracker::handleEvent(PlatformScrollEvent
     LOG_WITH_STREAM(ViewGestures, stream << "PendingSwipeTracker::handleEvent - state " << stateToString(m_state));
 
     if (scrollEventCanEndSwipe(event)) {
-        reset("gesture ended");
+        reset("gesture ended"_s);
         return false;
     }
 
@@ -507,7 +507,7 @@ bool ViewGestureController::PendingSwipeTracker::tryToStartSwipe(PlatformScrollE
     LOG_WITH_STREAM(ViewGestures, stream << "PendingSwipeTracker::tryToStartSwipe - consumed event, cumulative delta " << m_cumulativeDelta);
 
     if (deltaShouldCancelSwipe(m_cumulativeDelta)) {
-        reset("cumulative delta became too vertical");
+        reset("cumulative delta became too vertical"_s);
         return false;
     }
 
@@ -519,7 +519,7 @@ bool ViewGestureController::PendingSwipeTracker::tryToStartSwipe(PlatformScrollE
     return true;
 }
 
-void ViewGestureController::PendingSwipeTracker::reset(const char* resetReason)
+void ViewGestureController::PendingSwipeTracker::reset(ASCIILiteral resetReason)
 {
     if (m_state != State::None)
         LOG_WITH_STREAM(ViewGestures, stream << "PendingSwipeTracker::reset - " << resetReason);
@@ -532,7 +532,7 @@ void ViewGestureController::startSwipeGesture(PlatformScrollEvent event, SwipeDi
 {
     ASSERT(m_activeGestureType == ViewGestureType::None);
 
-    m_pendingSwipeTracker.reset("starting to track swipe");
+    m_pendingSwipeTracker.reset("starting to track swipe"_s);
 
     m_webPageProxy.recordAutomaticNavigationSnapshot();
 

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -314,7 +314,7 @@ private:
         bool handleEvent(PlatformScrollEvent);
         void eventWasNotHandledByWebCore(PlatformScrollEvent);
 
-        void reset(const char* resetReasonForLogging);
+        void reset(ASCIILiteral resetReasonForLogging);
 
         bool shouldIgnorePinnedState() { return m_shouldIgnorePinnedState; }
         void setShouldIgnorePinnedState(bool ignore) { m_shouldIgnorePinnedState = ignore; }
@@ -333,7 +333,7 @@ private:
             WaitingForWebCore,
             InsufficientMagnitude
         };
-        static const char* stateToString(State);
+        static ASCIILiteral stateToString(State);
 
         State m_state { State::None };
         SwipeDirection m_direction;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9609,7 +9609,7 @@ URL WebPageProxy::currentResourceDirectoryURL() const
 void WebPageProxy::resetStateAfterProcessTermination(ProcessTerminationReason reason)
 {
     if (reason != ProcessTerminationReason::NavigationSwap)
-        WEBPAGEPROXY_RELEASE_LOG_ERROR(Process, "processDidTerminate: (pid %d), reason=%" PUBLIC_LOG_STRING, processID(), processTerminationReasonToString(reason));
+        WEBPAGEPROXY_RELEASE_LOG_ERROR(Process, "processDidTerminate: (pid %d), reason=%" PUBLIC_LOG_STRING, processID(), processTerminationReasonToString(reason).characters());
 
     ASSERT(m_hasRunningProcess);
 
@@ -9667,7 +9667,7 @@ static bool shouldReloadAfterProcessTermination(ProcessTerminationReason reason)
 
 void WebPageProxy::dispatchProcessDidTerminate(ProcessTerminationReason reason)
 {
-    WEBPAGEPROXY_RELEASE_LOG_ERROR(Loading, "dispatchProcessDidTerminate: reason=%" PUBLIC_LOG_STRING, processTerminationReasonToString(reason));
+    WEBPAGEPROXY_RELEASE_LOG_ERROR(Loading, "dispatchProcessDidTerminate: reason=%" PUBLIC_LOG_STRING, processTerminationReasonToString(reason).characters());
 
     bool handledByClient = false;
     if (m_loaderClient)

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -532,7 +532,7 @@ void WebProcessPool::gpuProcessDidFinishLaunching(ProcessID)
 
 void WebProcessPool::gpuProcessExited(ProcessID identifier, ProcessTerminationReason reason)
 {
-    WEBPROCESSPOOL_RELEASE_LOG(Process, "gpuProcessDidExit: PID=%d, reason=%" PUBLIC_LOG_STRING, identifier, processTerminationReasonToString(reason));
+    WEBPROCESSPOOL_RELEASE_LOG(Process, "gpuProcessDidExit: PID=%d, reason=%" PUBLIC_LOG_STRING, identifier, processTerminationReasonToString(reason).characters());
     m_gpuProcess = nullptr;
 
     if (shouldReportAuxiliaryProcessCrash(reason))

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1084,7 +1084,7 @@ void WebProcessProxy::gpuProcessDidFinishLaunching()
 
 void WebProcessProxy::gpuProcessExited(ProcessTerminationReason reason)
 {
-    WEBPROCESSPROXY_RELEASE_LOG_ERROR(Process, "gpuProcessExited: reason=%" PUBLIC_LOG_STRING, processTerminationReasonToString(reason));
+    WEBPROCESSPROXY_RELEASE_LOG_ERROR(Process, "gpuProcessExited: reason=%" PUBLIC_LOG_STRING, processTerminationReasonToString(reason).characters());
 
     for (Ref page : pages())
         page->gpuProcessExited(reason);
@@ -1177,7 +1177,7 @@ void WebProcessProxy::didClose(IPC::Connection& connection)
 
 void WebProcessProxy::processDidTerminateOrFailedToLaunch(ProcessTerminationReason reason)
 {
-    WEBPROCESSPROXY_RELEASE_LOG_ERROR(Process, "processDidTerminateOrFailedToLaunch: reason=%" PUBLIC_LOG_STRING, processTerminationReasonToString(reason));
+    WEBPROCESSPROXY_RELEASE_LOG_ERROR(Process, "processDidTerminateOrFailedToLaunch: reason=%" PUBLIC_LOG_STRING, processTerminationReasonToString(reason).characters());
 
     // Protect ourselves, as the call to shutDown() below may otherwise cause us
     // to be deleted before we can finish our work.

--- a/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
@@ -429,7 +429,7 @@ void ViewGestureController::handleSwipeGesture(WebBackForwardListItem*, double, 
 
 void ViewGestureController::cancelSwipe()
 {
-    m_pendingSwipeTracker.reset("cancelling swipe");
+    m_pendingSwipeTracker.reset("cancelling swipe"_s);
 
     if (m_activeGestureType == ViewGestureType::Swipe) {
         m_swipeProgressTracker.reset();

--- a/Source/WebKit/UIProcess/mac/WindowServerConnection.mm
+++ b/Source/WebKit/UIProcess/mac/WindowServerConnection.mm
@@ -89,7 +89,7 @@ WindowServerConnection::WindowServerConnection()
     struct OcclusionNotificationHandler {
         CGSNotificationType notificationType;
         CGSNotifyConnectionProcPtr handler;
-        const char* name;
+        ASCIILiteral name;
     };
 
     static auto windowModificationsStarted = [](CGSNotificationType, void*, uint32_t, void*, CGSConnectionID) {
@@ -101,14 +101,14 @@ WindowServerConnection::WindowServerConnection()
     };
 
     static const OcclusionNotificationHandler occlusionNotificationHandlers[] = {
-        { kCGSConnectionWindowModificationsStarted, windowModificationsStarted, "Application Window Modifications Started" },
-        { kCGSConnectionWindowModificationsStopped, windowModificationsStopped, "Application Window Modifications Stopped" },
+        { kCGSConnectionWindowModificationsStarted, windowModificationsStarted, "Application Window Modifications Started"_s },
+        { kCGSConnectionWindowModificationsStopped, windowModificationsStopped, "Application Window Modifications Stopped"_s },
     };
 
     for (const auto& occlusionNotificationHandler : occlusionNotificationHandlers) {
         bool result = registerOcclusionNotificationHandler(occlusionNotificationHandler.notificationType, occlusionNotificationHandler.handler);
         UNUSED_PARAM(result);
-        ASSERT_WITH_MESSAGE(result, "Registration of \"%s\" notification handler failed.\n", occlusionNotificationHandler.name);
+        ASSERT_WITH_MESSAGE(result, "Registration of \"%s\" notification handler failed.\n", occlusionNotificationHandler.name.characters());
     }
 #endif
 
@@ -122,18 +122,18 @@ WindowServerConnection::WindowServerConnection()
     struct ConnectionStateNotificationHandler {
         CGSNotificationType notificationType;
         CGSNotifyProcPtr handler;
-        const char* name;
+        ASCIILiteral name;
     };
 
     static const ConnectionStateNotificationHandler connectionStateNotificationHandlers[] = {
-        { kCGSessionConsoleWillDisconnect, consoleWillDisconnect, "Console Disconnected" },
-        { kCGSessionConsoleConnect, consoleWillConnect, "Console Connected" },
+        { kCGSessionConsoleWillDisconnect, consoleWillDisconnect, "Console Disconnected"_s },
+        { kCGSessionConsoleConnect, consoleWillConnect, "Console Connected"_s },
     };
 
     for (const auto& connectionStateNotificationHandler : connectionStateNotificationHandlers) {
         auto error = CGSRegisterNotifyProc(connectionStateNotificationHandler.handler, connectionStateNotificationHandler.notificationType, nullptr);
         UNUSED_PARAM(error);
-        ASSERT_WITH_MESSAGE(!error, "Registration of \"%s\" notification handler failed.\n", connectionStateNotificationHandler.name);
+        ASSERT_WITH_MESSAGE(!error, "Registration of \"%s\" notification handler failed.\n", connectionStateNotificationHandler.name.characters());
     }
 }
 

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -321,7 +321,7 @@ bool GPUProcessConnection::waitForDidInitialize()
     if (!m_hasInitialized) {
         auto result = m_connection->waitForAndDispatchImmediately<Messages::GPUProcessConnection::DidInitialize>(0, defaultTimeout);
         if (result != IPC::Error::NoError) {
-            RELEASE_LOG_ERROR(Process, "%p - GPUProcessConnection::waitForDidInitialize - failed, error:%" PUBLIC_LOG_STRING, this, IPC::errorAsString(result));
+            RELEASE_LOG_ERROR(Process, "%p - GPUProcessConnection::waitForDidInitialize - failed, error:%" PUBLIC_LOG_STRING, this, IPC::errorAsString(result).characters());
             invalidate();
             return false;
         }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -81,7 +81,7 @@ ALWAYS_INLINE void RemoteDisplayListRecorderProxy::send(T&& message)
     if (UNLIKELY(result != IPC::Error::NoError)) {
         auto& parameters = m_renderingBackend->parameters();
         RELEASE_LOG(RemoteLayerBuffers, "[pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", renderingBackend=%" PRIu64 "] RemoteDisplayListRecorderProxy::send - failed, name:%" PUBLIC_LOG_STRING ", error:%" PUBLIC_LOG_STRING,
-            parameters.pageProxyID.toUInt64(), parameters.pageID.toUInt64(), parameters.identifier.toUInt64(), IPC::description(T::name()), IPC::errorAsString(result));
+            parameters.pageProxyID.toUInt64(), parameters.pageID.toUInt64(), parameters.identifier.toUInt64(), IPC::description(T::name()).characters(), IPC::errorAsString(result).characters());
     }
 #else
     UNUSED_VARIABLE(result);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -89,7 +89,7 @@ ALWAYS_INLINE void RemoteImageBufferProxy::send(T&& message)
     if (UNLIKELY(result != IPC::Error::NoError)) {
         auto& parameters = m_remoteRenderingBackendProxy->parameters();
         RELEASE_LOG(RemoteLayerBuffers, "[pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", renderingBackend=%" PRIu64 "] RemoteImageBufferProxy::send - failed, name:%" PUBLIC_LOG_STRING ", error:%" PUBLIC_LOG_STRING,
-            parameters.pageProxyID.toUInt64(), parameters.pageID.toUInt64(), parameters.identifier.toUInt64(), IPC::description(T::name()), IPC::errorAsString(result));
+            parameters.pageProxyID.toUInt64(), parameters.pageID.toUInt64(), parameters.identifier.toUInt64(), IPC::description(T::name()).characters(), IPC::errorAsString(result).characters());
     }
 #else
     UNUSED_VARIABLE(result);
@@ -107,7 +107,7 @@ ALWAYS_INLINE auto RemoteImageBufferProxy::sendSync(T&& message)
     if (UNLIKELY(!result.succeeded())) {
         auto& parameters = m_remoteRenderingBackendProxy->parameters();
         RELEASE_LOG(RemoteLayerBuffers, "[pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", renderingBackend=%" PRIu64 "] RemoteDisplayListRecorderProxy::sendSync - failed, name:%" PUBLIC_LOG_STRING ", error:%" PUBLIC_LOG_STRING,
-            parameters.pageProxyID.toUInt64(), parameters.pageID.toUInt64(), parameters.identifier.toUInt64(), IPC::description(T::name()), IPC::errorAsString(result.error()));
+            parameters.pageProxyID.toUInt64(), parameters.pageID.toUInt64(), parameters.identifier.toUInt64(), IPC::description(T::name()).characters(), IPC::errorAsString(result.error()).characters());
     }
 #endif
     return result;
@@ -170,7 +170,7 @@ ImageBufferBackend* RemoteImageBufferProxy::ensureBackend() const
             auto& parameters = m_remoteRenderingBackendProxy->parameters();
 #endif
             RELEASE_LOG(RemoteLayerBuffers, "[pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", renderingBackend=%" PRIu64 "] RemoteImageBufferProxy::ensureBackendCreated - waitForAndDispatchImmediately returned error: %" PUBLIC_LOG_STRING,
-                parameters.pageProxyID.toUInt64(), parameters.pageID.toUInt64(), parameters.identifier.toUInt64(), IPC::errorAsString(error));
+                parameters.pageProxyID.toUInt64(), parameters.pageID.toUInt64(), parameters.identifier.toUInt64(), IPC::errorAsString(error).characters());
             return nullptr;
         }
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
@@ -119,7 +119,7 @@ ALWAYS_INLINE void RemoteImageBufferSetProxy::send(T&& message)
     if (UNLIKELY(result != IPC::Error::NoError)) {
         auto& parameters = m_remoteRenderingBackendProxy->parameters();
         RELEASE_LOG(RemoteLayerBuffers, "[pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", renderingBackend=%" PRIu64 "] Proxy::send - failed, name:%" PUBLIC_LOG_STRING ", error:%" PUBLIC_LOG_STRING,
-            parameters.pageProxyID.toUInt64(), parameters.pageID.toUInt64(), parameters.identifier.toUInt64(), IPC::description(T::name()), IPC::errorAsString(result));
+            parameters.pageProxyID.toUInt64(), parameters.pageID.toUInt64(), parameters.identifier.toUInt64(), IPC::description(T::name()).characters(), IPC::errorAsString(result).characters());
     }
 #else
     UNUSED_VARIABLE(result);
@@ -137,7 +137,7 @@ ALWAYS_INLINE auto RemoteImageBufferSetProxy::sendSync(T&& message)
     if (UNLIKELY(!result.succeeded())) {
         auto& parameters = m_remoteRenderingBackendProxy->parameters();
         RELEASE_LOG(RemoteLayerBuffers, "[pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", renderingBackend=%" PRIu64 "] Proxy::sendSync - failed, name:%" PUBLIC_LOG_STRING ", error:%" PUBLIC_LOG_STRING,
-            parameters.pageProxyID.toUInt64(), parameters.pageID.toUInt64(), parameters.identifier.toUInt64(), IPC::description(T::name()), IPC::errorAsString(result.error()));
+            parameters.pageProxyID.toUInt64(), parameters.pageID.toUInt64(), parameters.identifier.toUInt64(), IPC::description(T::name()).characters(), IPC::errorAsString(result.error()).characters());
     }
 #endif
     return result;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -117,7 +117,7 @@ auto RemoteRenderingBackendProxy::send(T&& message, ObjectIdentifierGeneric<U, V
     auto result = streamConnection().send(std::forward<T>(message), destination, defaultTimeout);
     if (UNLIKELY(result != IPC::Error::NoError)) {
         RELEASE_LOG(RemoteLayerBuffers, "[pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", renderingBackend=%" PRIu64 "] RemoteRenderingBackendProxy::send - failed, name:%" PUBLIC_LOG_STRING ", error:%" PUBLIC_LOG_STRING,
-            m_parameters.pageProxyID.toUInt64(), m_parameters.pageID.toUInt64(), m_parameters.identifier.toUInt64(), IPC::description(T::name()), IPC::errorAsString(result));
+            m_parameters.pageProxyID.toUInt64(), m_parameters.pageID.toUInt64(), m_parameters.identifier.toUInt64(), IPC::description(T::name()).characters(), IPC::errorAsString(result).characters());
     }
     return result;
 }
@@ -128,7 +128,7 @@ auto RemoteRenderingBackendProxy::sendSync(T&& message, ObjectIdentifierGeneric<
     auto result = streamConnection().sendSync(std::forward<T>(message), destination, defaultTimeout);
     if (UNLIKELY(!result.succeeded())) {
         RELEASE_LOG(RemoteLayerBuffers, "[pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", renderingBackend=%" PRIu64 "] RemoteRenderingBackendProxy::sendSync - failed, name:%" PUBLIC_LOG_STRING ", error:%" PUBLIC_LOG_STRING,
-            m_parameters.pageProxyID.toUInt64(), m_parameters.pageID.toUInt64(), m_parameters.identifier.toUInt64(), IPC::description(T::name()), IPC::errorAsString(result.error()));
+            m_parameters.pageProxyID.toUInt64(), m_parameters.pageID.toUInt64(), m_parameters.identifier.toUInt64(), IPC::description(T::name()).characters(), IPC::errorAsString(result.error()).characters());
     }
     return result;
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp
@@ -62,7 +62,7 @@ HashSet<String>& RemoteMediaPlayerMIMETypeCache::supportedTypes()
             addSupportedTypes(types);
             m_hasPopulatedSupportedTypesCacheFromGPUProcess = true;
         } else
-            RELEASE_LOG_ERROR(Media, "RemoteMediaPlayerMIMETypeCache::supportedTypes: Sync IPC to the GPUProcess failed with error %" PUBLIC_LOG_STRING, IPC::errorAsString(sendResult.error()));
+            RELEASE_LOG_ERROR(Media, "RemoteMediaPlayerMIMETypeCache::supportedTypes: Sync IPC to the GPUProcess failed with error %" PUBLIC_LOG_STRING, IPC::errorAsString(sendResult.error()).characters());
     }
     return m_supportedTypesCache;
 }

--- a/Source/WebKit/WebProcess/Model/ModelProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessConnection.cpp
@@ -141,7 +141,7 @@ bool ModelProcessConnection::waitForDidInitialize()
     if (!m_hasInitialized) {
         auto result = m_connection->waitForAndDispatchImmediately<Messages::ModelProcessConnection::DidInitialize>(0, defaultTimeout);
         if (result != IPC::Error::NoError) {
-            RELEASE_LOG_ERROR(Process, "%p - ModelProcessConnection::waitForDidInitialize - failed, error:%" PUBLIC_LOG_STRING, this, IPC::errorAsString(result));
+            RELEASE_LOG_ERROR(Process, "%p - ModelProcessConnection::waitForDidInitialize - failed, error:%" PUBLIC_LOG_STRING, this, IPC::errorAsString(result).characters());
             invalidate();
             return false;
         }

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -776,7 +776,7 @@ void WebLoaderStrategy::loadResourceSynchronously(FrameLoader& frameLoader, WebC
 
     auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::PerformSynchronousLoad(loadParameters), 0);
     if (!sendResult.succeeded()) {
-        WEBLOADERSTRATEGY_WITH_FRAMELOADER_RELEASE_LOG_ERROR("loadResourceSynchronously: failed sending synchronous network process message %" PUBLIC_LOG_STRING, IPC::errorAsString(sendResult.error()));
+        WEBLOADERSTRATEGY_WITH_FRAMELOADER_RELEASE_LOG_ERROR("loadResourceSynchronously: failed sending synchronous network process message %" PUBLIC_LOG_STRING, IPC::errorAsString(sendResult.error()).characters());
         if (page)
             page->diagnosticLoggingClient().logDiagnosticMessage(WebCore::DiagnosticLoggingKeys::internalErrorKey(), WebCore::DiagnosticLoggingKeys::synchronousMessageFailedKey(), WebCore::ShouldSample::No);
         response = ResourceResponse();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -173,7 +173,7 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const Navigat
         if (navigationAction.processingUserGesture() || !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::AsyncFragmentNavigationPolicyDecision)) {
             auto sendResult = webPage->sendSync(Messages::WebPageProxy::DecidePolicyForNavigationActionSync(*navigationActionData));
             if (!sendResult.succeeded()) {
-                WebFrameLoaderClient_RELEASE_LOG_ERROR(Network, "dispatchDecidePolicyForNavigationAction: ignoring because of failing to send sync IPC with error %" PUBLIC_LOG_STRING, IPC::errorAsString(sendResult.error()));
+                WebFrameLoaderClient_RELEASE_LOG_ERROR(Network, "dispatchDecidePolicyForNavigationAction: ignoring because of failing to send sync IPC with error %" PUBLIC_LOG_STRING, IPC::errorAsString(sendResult.error()).characters());
                 m_frame->didReceivePolicyDecision(listenerID, PolicyDecision { });
                 return;
             }

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -981,7 +981,7 @@ void WebProcess::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& de
         return;
     }
 
-    LOG_ERROR("Unhandled web process message '%s' (destination: %" PRIu64 " pid: %d)", description(decoder.messageName()), decoder.destinationID(), static_cast<int>(getCurrentProcessID()));
+    LOG_ERROR("Unhandled web process message '%s' (destination: %" PRIu64 " pid: %d)", description(decoder.messageName()).characters(), decoder.destinationID(), static_cast<int>(getCurrentProcessID()));
 }
 
 void WebProcess::didClose(IPC::Connection& connection)
@@ -1198,7 +1198,7 @@ static NetworkProcessConnectionInfo getNetworkProcessConnection(IPC::Connection&
     auto requestConnection = [&]() -> bool {
         auto sendResult = connection.sendSync(Messages::WebProcessProxy::GetNetworkProcessConnection(), 0);
         if (!sendResult.succeeded()) {
-            RELEASE_LOG_ERROR(Process, "getNetworkProcessConnection: Failed to send message or receive invalid message: error %" PUBLIC_LOG_STRING, IPC::errorAsString(sendResult.error()));
+            RELEASE_LOG_ERROR(Process, "getNetworkProcessConnection: Failed to send message or receive invalid message: error %" PUBLIC_LOG_STRING, IPC::errorAsString(sendResult.error()).characters());
             failedToGetNetworkProcessConnection();
         }
         std::tie(connectionInfo) = sendResult.takeReply();

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -790,12 +790,12 @@ static void prewarmLogs()
     // This would be desirable, since the WebContent process is blocking access to the container manager daemon.
     PublicSuffixStore::singleton().topPrivatelyControlledDomain("apple.com"_s);
 
-    static std::array<std::pair<const char*, const char*>, 5> logs { {
-        { "com.apple.CFBundle", "strings" },
-        { "com.apple.network", "" },
-        { "com.apple.CFNetwork", "ATS" },
-        { "com.apple.coremedia", "" },
-        { "com.apple.SafariShared", "Translation" },
+    static std::array<std::pair<ASCIILiteral, ASCIILiteral>, 5> logs { {
+        { "com.apple.CFBundle"_s, "strings"_s },
+        { "com.apple.network"_s, ""_s },
+        { "com.apple.CFNetwork"_s, "ATS"_s },
+        { "com.apple.coremedia"_s, ""_s },
+        { "com.apple.SafariShared"_s, "Translation"_s },
     } };
 
     for (auto& log : logs) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm
@@ -34,22 +34,22 @@ static bool clientConnectedToEndpoint = false;
 static bool endpointReceivedMessageFromClient = false;
 static bool clientReceivedMessageFromEndpoint = false;
 
-static constexpr auto testMessageFromEndpoint = "test-message-from-endpoint";
-static constexpr auto testMessageFromClient = "test-message-from-client";
+static constexpr auto testMessageFromEndpoint = "test-message-from-endpoint"_s;
+static constexpr auto testMessageFromClient = "test-message-from-client"_s;
 
 class XPCEndpoint final : public WebKit::XPCEndpoint {
 private:
-    const char* xpcEndpointMessageNameKey() const final
+    ASCIILiteral xpcEndpointMessageNameKey() const final
     {
-        return nullptr;
+        return { };
     }
-    const char* xpcEndpointMessageName() const final
+    ASCIILiteral xpcEndpointMessageName() const final
     {
-        return nullptr;
+        return { };
     }
-    const char* xpcEndpointNameKey() const final
+    ASCIILiteral xpcEndpointNameKey() const final
     {
-        return nullptr;
+        return { };
     }
     void handleEvent(xpc_connection_t connection, xpc_object_t event) final
     {


### PR DESCRIPTION
#### 3aa8e1d0177332635b2f93ebef41748ee350ee66
<pre>
Use ASCIILiteral more
<a href="https://bugs.webkit.org/show_bug.cgi?id=273049">https://bugs.webkit.org/show_bug.cgi?id=273049</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/Logger.h:
(WTF::LogArgument::toString):
* Source/WTF/wtf/text/TextStream.h:
(WTF::TextStream::dumpProperty):
* Source/WebCore/platform/xr/openxr/OpenXRInstance.cpp:
(PlatformXR::Instance::Impl::Impl):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::logLayerInfo):
* Source/WebCore/svg/SVGLengthValue.cpp:
(WebCore::lengthTypeToString):
* Source/WebCore/svg/SVGTransformValue.h:
(WebCore::SVGTransformValue::prefixForTransformType):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::parserMetaData):
(WebCore::cursorTypeToString):
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::configure):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::name):
(WebGPU::createVertexDescriptor):
(WebGPU::errorValidatingDepthStencilState):
* Source/WebGPU/WebGPU/Texture.h:
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::formatToString):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::didReceiveInvalidMessage):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::didReceiveMessage):
(WebKit::NetworkConnectionToWebProcess::didReceiveSyncMessage):
(WebKit::NetworkConnectionToWebProcess::didReceiveInvalidMessage):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::didReceiveMessage):
(WebKit::NetworkProcess::didReceiveSyncMessage):
(WebKit::NetworkProcess::notifyMediaStreamingActivity):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::logCookieInformationInternal):
* Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementConnection.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp:
(WebKit::PCM::Database::privateClickMeasurementToStringForTesting const):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.h:
* Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h:
* Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm:
(WebKit::LaunchServicesDatabaseObserver::xpcEndpointMessageNameKey const):
(WebKit::LaunchServicesDatabaseObserver::xpcEndpointMessageName const):
(WebKit::LaunchServicesDatabaseObserver::xpcEndpointNameKey const):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::cacheStorageRepresentation):
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::waitForMessage):
(IPC::Connection::waitForSyncReply):
(IPC::Connection::dispatchIncomingMessages):
(IPC::errorAsString):
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/Platform/IPC/MessageArgumentDescriptions.h:
* Source/WebKit/Scripts/webkit/messages.py:
(generate_message_handler):
(generate_message_names_header):
(generate_message_names_implementation):
(generate_js_argument_descriptions):
* Source/WebKit/Scripts/webkit/tests/MessageNames.h:
(IPC::description):
* Source/WebKit/Shared/Authentication/cocoa/ClientCertificateAuthenticationXPCConstants.cpp:
* Source/WebKit/Shared/Authentication/cocoa/ClientCertificateAuthenticationXPCConstants.h:
* Source/WebKit/Shared/Cocoa/XPCEndpoint.h:
* Source/WebKit/Shared/ProcessTerminationReason.cpp:
(WebKit::processTerminationReasonToString):
* Source/WebKit/Shared/ProcessTerminationReason.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStoreProperties::dump const):
* Source/WebKit/Shared/WebPushDaemonConstants.h:
(): Deleted.
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::processStorageClass):
(WebKit::ensureSandboxCacheDirectory):
* Source/WebKit/Shared/mac/MediaFormatReader/MediaTrackReader.cpp:
(WebKit::MediaTrackReader::mediaTypeString const):
* Source/WebKit/Shared/mac/MediaFormatReader/MediaTrackReader.h:
* Source/WebKit/Shared/mac/WebMemorySampler.mac.mm:
(WebKit::WebMemorySampler::sampleSystemMalloc const):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::logInvalidMessage):
* Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm:
(WebKit::checkSandboxRequirementForType):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/RedirectSOAuthorizationSession.mm:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::WebCore::toString):
(WebKit::SOAuthorizationSession::initiatingActionString const):
(WebKit::SOAuthorizationSession::stateString const):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::gpuProcessExited):
* Source/WebKit/UIProcess/Launcher/ProcessLauncher.h:
* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::webContentServiceName):
(WebKit::serviceName):
(WebKit::ProcessLauncher::launchProcess):
(WebKit::ProcessLauncher::finishLaunchingProcess):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::didReceiveMessage):
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::didReceiveMessage):
* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::PendingSwipeTracker::stateToString):
(WebKit::ViewGestureController::PendingSwipeTracker::handleEvent):
(WebKit::ViewGestureController::PendingSwipeTracker::tryToStartSwipe):
(WebKit::ViewGestureController::PendingSwipeTracker::reset):
(WebKit::ViewGestureController::startSwipeGesture):
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::resetStateAfterProcessTermination):
(WebKit::WebPageProxy::dispatchProcessDidTerminate):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::gpuProcessExited):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::gpuProcessExited):
(WebKit::WebProcessProxy::processDidTerminateOrFailedToLaunch):
* Source/WebKit/UIProcess/mac/WindowServerConnection.mm:
(WebKit::WindowServerConnection::WindowServerConnection):
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::waitForDidInitialize):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::send):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::send):
(WebKit::RemoteImageBufferProxy::sendSync):
(WebKit::RemoteImageBufferProxy::ensureBackend const):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp:
(WebKit::RemoteImageBufferSetProxy::send):
(WebKit::RemoteImageBufferSetProxy::sendSync):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::send):
(WebKit::RemoteRenderingBackendProxy::sendSync):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp:
(WebKit::RemoteMediaPlayerMIMETypeCache::supportedTypes):
* Source/WebKit/WebProcess/Model/ModelProcessConnection.cpp:
(WebKit::ModelProcessConnection::waitForDidInitialize):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::loadResourceSynchronously):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::didReceiveMessage):
(WebKit::getNetworkProcessConnection):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::prewarmLogs):
* Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm:

Canonical link: <a href="https://commits.webkit.org/277812@main">https://commits.webkit.org/277812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ba2c3bdaa10991af110beacbc8c0dd4548ba6de

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27843 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51319 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44697 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50937 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25373 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39768 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49214 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25504 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41960 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20865 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/48488 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22982 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43138 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6688 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/41931 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44920 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43624 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53227 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/48123 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23679 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19977 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47059 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24945 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45988 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25749 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55617 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6934 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24666 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11440 "Passed tests") | 
<!--EWS-Status-Bubble-End-->