### PR TITLE
Drop StringView::characters8() / characters16()

### DIFF
--- a/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
@@ -90,12 +90,12 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const S
     StringView view = source.view();
     RELEASE_ASSERT(!view.isNull());
     RELEASE_ASSERT(view.is8Bit());
-    auto* characters = view.characters8();
+    auto characters = view.span8();
     const char* regularFunctionBegin = "(function (";
     const char* asyncFunctionBegin = "(async function (";
     RELEASE_ASSERT(view.length() >= strlen("(function (){})"));
-    bool isAsyncFunction = view.length() >= strlen("(async function (){})") && !memcmp(characters, asyncFunctionBegin, strlen(asyncFunctionBegin));
-    RELEASE_ASSERT(isAsyncFunction || !memcmp(characters, regularFunctionBegin, strlen(regularFunctionBegin)));
+    bool isAsyncFunction = view.length() >= strlen("(async function (){})") && !memcmp(characters.data(), asyncFunctionBegin, strlen(asyncFunctionBegin));
+    RELEASE_ASSERT(isAsyncFunction || !memcmp(characters.data(), regularFunctionBegin, strlen(regularFunctionBegin)));
 
     unsigned asyncOffset = isAsyncFunction ? strlen("async ") : 0;
     unsigned parametersStart = strlen("function (") + asyncOffset;
@@ -166,7 +166,7 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const S
         if (!isInStrictContext && (characters[i] == '"' || characters[i] == '\'')) {
             const unsigned useStrictLength = strlen("use strict");
             if (i + 1 + useStrictLength < view.length()) {
-                if (!memcmp(characters + i + 1, "use strict", useStrictLength)) {
+                if (!memcmp(characters.data() + i + 1, "use strict", useStrictLength)) {
                     isInStrictContext = true;
                     i += 1 + useStrictLength;
                 }

--- a/Source/JavaScriptCore/parser/Lexer.h
+++ b/Source/JavaScriptCore/parser/Lexer.h
@@ -305,14 +305,14 @@ template <>
 ALWAYS_INLINE void Lexer<LChar>::setCodeStart(StringView sourceString)
 {
     ASSERT(sourceString.is8Bit());
-    m_codeStart = sourceString.characters8();
+    m_codeStart = sourceString.span8().data();
 }
 
 template <>
 ALWAYS_INLINE void Lexer<UChar>::setCodeStart(StringView sourceString)
 {
     ASSERT(!sourceString.is8Bit());
-    m_codeStart = sourceString.characters16();
+    m_codeStart = sourceString.span16().data();
 }
 
 template <typename T>

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -309,8 +309,8 @@ inline JSValue fastJoin(JSGlobalObject* globalObject, JSObject* thisObject, Stri
             if (length <= 1)
                 RELEASE_AND_RETURN(scope, jsEmptyString(vm));
             if (separator.is8Bit())
-                RELEASE_AND_RETURN(scope, repeatCharacter(globalObject, separator.characters8()[0], length - 1));
-            RELEASE_AND_RETURN(scope, repeatCharacter(globalObject, separator.characters16()[0], length - 1));
+                RELEASE_AND_RETURN(scope, repeatCharacter(globalObject, separator.span8().front(), length - 1));
+            RELEASE_AND_RETURN(scope, repeatCharacter(globalObject, separator.span16().front(), length - 1));
         default:
             JSString* result = jsEmptyString(vm);
             if (length <= 1)

--- a/Source/JavaScriptCore/runtime/JSBigInt.h
+++ b/Source/JavaScriptCore/runtime/JSBigInt.h
@@ -599,10 +599,10 @@ private:
     }
 
     template <typename CharType>
-    static JSValue parseInt(JSGlobalObject*, CharType*  data, unsigned length, ErrorParseMode);
+    static JSValue parseInt(JSGlobalObject*, std::span<const CharType> data, ErrorParseMode);
 
     template <typename CharType>
-    static JSValue parseInt(JSGlobalObject*, VM&, CharType* data, unsigned length, unsigned startIndex, unsigned radix, ErrorParseMode, ParseIntSign = ParseIntSign::Signed, ParseIntMode = ParseIntMode::AllowEmptyString);
+    static JSValue parseInt(JSGlobalObject*, VM&, std::span<const CharType> data, unsigned startIndex, unsigned radix, ErrorParseMode, ParseIntSign = ParseIntSign::Signed, ParseIntMode = ParseIntMode::AllowEmptyString);
 
     static JSBigInt* allocateFor(JSGlobalObject*, VM&, unsigned radix, unsigned charcount);
 

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -119,11 +119,11 @@ public:
         unsigned half = string.length() > sampleSize ? (string.length() - sampleSize) / 2 : 0;
         unsigned end = std::min(string.length(), half + sampleSize);
         if (string.is8Bit()) {
-            auto* characters8 = string.characters8();
+            auto characters8 = string.span8();
             for (unsigned i = half; i < end; ++i)
                 add(characters8[i]);
         } else {
-            auto* characters16 = string.characters16();
+            auto characters16 = string.span16();
             for (unsigned i = half; i < end; ++i)
                 add(characters16[i]);
         }

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -202,8 +202,9 @@ const char* Thread::normalizeThreadName(const char* threadName)
     if (result.length() > kLinuxThreadNameLimit)
         result = result.right(kLinuxThreadNameLimit);
 #endif
-    ASSERT(result.characters8()[result.length()] == '\0');
-    return reinterpret_cast<const char*>(result.characters8());
+    auto characters = result.span8();
+    ASSERT(characters[characters.size()] == '\0');
+    return reinterpret_cast<const char*>(characters.data());
 #endif
 }
 

--- a/Source/WTF/wtf/text/StringSearch.h
+++ b/Source/WTF/wtf/text/StringSearch.h
@@ -41,14 +41,14 @@ public:
     explicit BoyerMooreHorspoolTable(StringView pattern)
     {
         if (pattern.is8Bit())
-            initializeTable(std::span(pattern.characters8(), pattern.characters8() + pattern.length()));
+            initializeTable(pattern.span8());
         else
-            initializeTable(std::span(pattern.characters16(), pattern.characters16() + pattern.length()));
+            initializeTable(pattern.span16());
     }
 
     explicit constexpr BoyerMooreHorspoolTable(ASCIILiteral pattern)
     {
-        initializeTable(std::span(pattern.characters(), pattern.characters() + pattern.length()));
+        initializeTable(pattern.span8());
     }
 
     ALWAYS_INLINE size_t find(StringView string, StringView matchString) const

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -99,10 +99,6 @@ public:
     std::span<const UChar> span16() const;
     template<typename CharacterType> std::span<const CharacterType> span() const;
 
-    // FIXME: Port call sites to span8() / span16() and remove these.
-    const LChar* characters8() const { return span8().data(); }
-    const UChar* characters16() const { return span16().data(); }
-
     unsigned hash() const;
 
     bool containsOnlyASCII() const;

--- a/Source/WebCore/css/CSSFontFaceSet.cpp
+++ b/Source/WebCore/css/CSSFontFaceSet.cpp
@@ -372,8 +372,10 @@ static CodePointsMap codePointsFromString(StringView stringView)
         char32_t character = 0;
         if (cluster.is8Bit())
             character = cluster[0];
-        else
-            U16_GET(cluster.characters16(), 0, 0, cluster.length(), character);
+        else {
+            auto characters = cluster.span16();
+            U16_GET(characters, 0, 0, characters.size(), character);
+        }
         result.add(character);
     }
     return result;

--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -187,16 +187,16 @@ static RefPtr<CSSValue> parseSimpleLengthValue(CSSPropertyID propertyId, StringV
 // Returns the number of characters which form a valid double
 // and are terminated by the given terminator character
 template <typename CharacterType>
-static int checkForValidDouble(const CharacterType* string, const CharacterType* end, char terminator)
+static size_t checkForValidDouble(std::span<const CharacterType> string, char terminator)
 {
-    int length = end - string;
+    size_t length = string.size();
     if (length < 1)
         return 0;
 
     bool decimalMarkSeen = false;
-    int processedLength = 0;
+    size_t processedLength = 0;
 
-    for (int i = 0; i < length; ++i) {
+    for (size_t i = 0; i < string.size(); ++i) {
         if (string[i] == terminator) {
             processedLength = i;
             break;
@@ -218,13 +218,13 @@ static int checkForValidDouble(const CharacterType* string, const CharacterType*
 // Returns the number of characters consumed for parsing a valid double
 // terminated by the given terminator character
 template <typename CharacterType>
-static int parseDouble(const CharacterType* string, const CharacterType* end, char terminator, double& value)
+static size_t parseDouble(std::span<const CharacterType> string, char terminator, double& value)
 {
-    int length = checkForValidDouble(string, end, terminator);
+    size_t length = checkForValidDouble(string, terminator);
     if (!length)
         return 0;
 
-    int position = 0;
+    size_t position = 0;
     double localValue = 0;
 
     // The consumed characters here are guaranteed to be
@@ -254,67 +254,69 @@ static int parseDouble(const CharacterType* string, const CharacterType* end, ch
 }
 
 template <typename CharacterType>
-static std::optional<uint8_t> parseColorIntOrPercentage(const CharacterType*& string, const CharacterType* end, char terminator, CSSUnitType& expect)
+static std::optional<uint8_t> parseColorIntOrPercentage(std::span<const CharacterType>& string, char terminator, CSSUnitType& expect)
 {
-    auto* current = string;
+    auto current = string;
     double localValue = 0;
     bool negative = false;
-    while (current != end && isASCIIWhitespace<CharacterType>(*current))
-        current++;
-    if (current != end && *current == '-') {
+    while (!current.empty() && isASCIIWhitespace<CharacterType>(current.front()))
+        current = current.subspan(1);
+    if (!current.empty() && current.front() == '-') {
         negative = true;
-        current++;
+        current = current.subspan(1);
     }
-    if (current == end || !isASCIIDigit(*current))
+    if (current.empty() || !isASCIIDigit(current.front()))
         return std::nullopt;
-    while (current != end && isASCIIDigit(*current)) {
-        double newValue = localValue * 10 + *current++ - '0';
+    while (!current.empty() && isASCIIDigit(current.front())) {
+        double newValue = localValue * 10 + current.front() - '0';
+        current = current.subspan(1);
         if (newValue >= 255) {
             // Clamp values at 255.
             localValue = 255;
-            while (current != end && isASCIIDigit(*current))
-                ++current;
+            while (!current.empty() && isASCIIDigit(current.front()))
+                current = current.subspan(1);
             break;
         }
         localValue = newValue;
     }
 
-    if (current == end)
+    if (current.empty())
         return std::nullopt;
 
-    if (expect == CSSUnitType::CSS_NUMBER && (*current == '.' || *current == '%'))
+    if (expect == CSSUnitType::CSS_NUMBER && (current.front() == '.' || current.front() == '%'))
         return std::nullopt;
 
-    if (*current == '.') {
+    if (current.front() == '.') {
         // We already parsed the integral part, try to parse
         // the fraction part of the percentage value.
         double percentage = 0;
-        int numCharactersParsed = parseDouble(current, end, '%', percentage);
+        size_t numCharactersParsed = parseDouble(current, '%', percentage);
         if (!numCharactersParsed)
             return std::nullopt;
-        current += numCharactersParsed;
-        if (*current != '%')
+        current = current.subspan(numCharactersParsed);
+        if (current.front() != '%')
             return std::nullopt;
         localValue += percentage;
     }
 
-    if (expect == CSSUnitType::CSS_PERCENTAGE && *current != '%')
+    if (expect == CSSUnitType::CSS_PERCENTAGE && current.front() != '%')
         return std::nullopt;
 
-    if (*current == '%') {
+    if (current.front() == '%') {
         expect = CSSUnitType::CSS_PERCENTAGE;
         localValue = localValue / 100.0 * 255.0;
         // Clamp values at 255 for percentages over 100%
         if (localValue > 255)
             localValue = 255;
-        current++;
+        current = current.subspan(1);
     } else
         expect = CSSUnitType::CSS_NUMBER;
 
-    while (current != end && isASCIIWhitespace<CharacterType>(*current))
-        current++;
-    if (current == end || *current++ != terminator)
+    while (!current.empty() && isASCIIWhitespace<CharacterType>(current.front()))
+        current = current.subspan(1);
+    if (current.empty() || current.front() != terminator)
         return std::nullopt;
+    current = current.subspan(1);
     string = current;
 
     // Clamp negative values at zero.
@@ -323,72 +325,72 @@ static std::optional<uint8_t> parseColorIntOrPercentage(const CharacterType*& st
 }
 
 template <typename CharacterType>
-static inline bool isTenthAlpha(const CharacterType* string, int length)
+static inline bool isTenthAlpha(std::span<const CharacterType> string)
 {
     // "0.X"
-    if (length == 3 && string[0] == '0' && string[1] == '.' && isASCIIDigit(string[2]))
+    if (string.size() == 3 && string[0] == '0' && string[1] == '.' && isASCIIDigit(string[2]))
         return true;
 
     // ".X"
-    if (length == 2 && string[0] == '.' && isASCIIDigit(string[1]))
+    if (string.size() == 2 && string[0] == '.' && isASCIIDigit(string[1]))
         return true;
 
     return false;
 }
 
 template <typename CharacterType>
-static inline std::optional<uint8_t> parseAlphaValue(const CharacterType*& string, const CharacterType* end, char terminator)
+static inline std::optional<uint8_t> parseAlphaValue(std::span<const CharacterType>& string, char terminator)
 {
-    while (string != end && isASCIIWhitespace<CharacterType>(*string))
-        string++;
+    while (!string.empty() && isASCIIWhitespace<CharacterType>(string.front()))
+        string = string.subspan(1);
 
     bool negative = false;
 
-    if (string != end && *string == '-') {
+    if (!string.empty() && string.front() == '-') {
         negative = true;
-        string++;
+        string = string.subspan(1);
     }
 
-    int length = end - string;
+    size_t length = string.size();
     if (length < 2)
         return std::nullopt;
 
     if (string[length - 1] != terminator || !isASCIIDigit(string[length - 2]))
         return std::nullopt;
 
-    if (string[0] != '0' && string[0] != '1' && string[0] != '.') {
-        if (checkForValidDouble(string, end, terminator)) {
-            string = end;
+    if (string.front() != '0' && string.front() != '1' && string.front() != '.') {
+        if (checkForValidDouble(string, terminator)) {
+            string = { };
             return negative ? 0 : 255;
         }
         return std::nullopt;
     }
 
-    if (length == 2 && string[0] != '.') {
-        uint8_t result = !negative && string[0] == '1' ? 255 : 0;
-        string = end;
+    if (length == 2 && string.front() != '.') {
+        uint8_t result = !negative && string.front() == '1' ? 255 : 0;
+        string = { };
         return result;
     }
 
-    if (isTenthAlpha(string, length - 1)) {
+    if (isTenthAlpha(string.first(length - 1))) {
         static constexpr uint8_t tenthAlphaValues[] = { 0, 26, 51, 77, 102, 128, 153, 179, 204, 230 };
         uint8_t result = negative ? 0 : tenthAlphaValues[string[length - 2] - '0'];
-        string = end;
+        string = { };
         return result;
     }
 
     double alpha = 0;
-    if (!parseDouble(string, end, terminator, alpha))
+    if (!parseDouble(string, terminator, alpha))
         return std::nullopt;
 
-    string = end;
+    string = { };
     return negative ? 0 : convertFloatAlphaTo<uint8_t>(alpha);
 }
 
 template <typename CharacterType>
-static inline bool mightBeRGBA(const CharacterType* characters, unsigned length)
+static inline bool mightBeRGBA(std::span<const CharacterType> characters)
 {
-    if (length < 5)
+    if (characters.size() < 5)
         return false;
     return characters[4] == '('
         && isASCIIAlphaCaselessEqual(characters[0], 'r')
@@ -398,9 +400,9 @@ static inline bool mightBeRGBA(const CharacterType* characters, unsigned length)
 }
 
 template <typename CharacterType>
-static inline bool mightBeRGB(const CharacterType* characters, unsigned length)
+static inline bool mightBeRGB(std::span<const CharacterType> characters)
 {
-    if (length < 4)
+    if (characters.size() < 4)
         return false;
     return characters[3] == '('
         && isASCIIAlphaCaselessEqual(characters[0], 'r')
@@ -439,70 +441,67 @@ static std::optional<SRGBA<uint8_t>> finishParsingHexColor(uint32_t value, unsig
     return std::nullopt;
 }
 
-template<typename CharacterType> static std::optional<SRGBA<uint8_t>> parseHexColorInternal(const CharacterType* characters, unsigned length)
+template<typename CharacterType> static std::optional<SRGBA<uint8_t>> parseHexColorInternal(std::span<const CharacterType> characters)
 {
-    if (length != 3 && length != 4 && length != 6 && length != 8)
+    if (characters.size() != 3 && characters.size() != 4 && characters.size() != 6 && characters.size() != 8)
         return std::nullopt;
     uint32_t value = 0;
-    for (unsigned i = 0; i < length; ++i) {
-        auto digit = characters[i];
+    for (auto digit : characters) {
         if (!isASCIIHexDigit(digit))
             return std::nullopt;
         value <<= 4;
         value |= toASCIIHexValue(digit);
     }
-    return finishParsingHexColor(value, length);
+    return finishParsingHexColor(value, characters.size());
 }
 
-template<typename CharacterType> static std::optional<SRGBA<uint8_t>> parseNumericColor(const CharacterType* characters, unsigned length, bool strict)
+template<typename CharacterType> static std::optional<SRGBA<uint8_t>> parseNumericColor(std::span<const CharacterType> characters, bool strict)
 {
-    if (length >= 4 && characters[0] == '#') {
-        if (auto hexColor = parseHexColorInternal(characters + 1, length - 1))
+    if (characters.size() >= 4 && characters.front() == '#') {
+        if (auto hexColor = parseHexColorInternal(characters.subspan(1)))
             return *hexColor;
     }
 
-    if (!strict && (length == 3 || length == 6)) {
-        if (auto hexColor = parseHexColorInternal(characters, length))
+    if (!strict && (characters.size() == 3 || characters.size() == 6)) {
+        if (auto hexColor = parseHexColorInternal(characters))
             return *hexColor;
     }
 
     auto expect = CSSUnitType::CSS_UNKNOWN;
 
     // Try rgba() syntax.
-    if (mightBeRGBA(characters, length)) {
-        auto current = characters + 5;
-        auto end = characters + length;
-        auto red = parseColorIntOrPercentage(current, end, ',', expect);
+    if (mightBeRGBA(characters)) {
+        auto current = characters.subspan(5);
+        auto red = parseColorIntOrPercentage(current, ',', expect);
         if (!red)
             return std::nullopt;
-        auto green = parseColorIntOrPercentage(current, end, ',', expect);
+        auto green = parseColorIntOrPercentage(current, ',', expect);
         if (!green)
             return std::nullopt;
-        auto blue = parseColorIntOrPercentage(current, end, ',', expect);
+        auto blue = parseColorIntOrPercentage(current, ',', expect);
         if (!blue)
             return std::nullopt;
-        auto alpha = parseAlphaValue(current, end, ')');
+        auto alpha = parseAlphaValue(current, ')');
         if (!alpha)
             return std::nullopt;
-        if (current != end)
+        if (!current.empty())
             return std::nullopt;
         return SRGBA<uint8_t> { *red, *green, *blue, *alpha };
     }
 
     // Try rgb() syntax.
-    if (mightBeRGB(characters, length)) {
-        auto current = characters + 4;
-        auto end = characters + length;
-        auto red = parseColorIntOrPercentage(current, end, ',', expect);
+    if (mightBeRGB(characters)) {
+        auto current = characters.subspan(4);
+        auto red = parseColorIntOrPercentage(current, ',', expect);
         if (!red)
             return std::nullopt;
-        auto green = parseColorIntOrPercentage(current, end, ',', expect);
+        auto green = parseColorIntOrPercentage(current, ',', expect);
         if (!green)
             return std::nullopt;
-        auto blue = parseColorIntOrPercentage(current, end, ')', expect);
+        auto blue = parseColorIntOrPercentage(current, ')', expect);
         if (!blue)
             return std::nullopt;
-        if (current != end)
+        if (!current.empty())
             return std::nullopt;
         return SRGBA<uint8_t> { *red, *green, *blue };
     }
@@ -514,8 +513,8 @@ static std::optional<SRGBA<uint8_t>> parseNumericColor(StringView string, const 
 {
     bool strict = !isQuirksModeBehavior(context.mode);
     if (string.is8Bit())
-        return parseNumericColor(string.characters8(), string.length(), strict);
-    return parseNumericColor(string.characters16(), string.length(), strict);
+        return parseNumericColor(string.span8(), strict);
+    return parseNumericColor(string.span16(), strict);
 }
 
 static RefPtr<CSSValue> parseColor(StringView string, const CSSParserContext& context)
@@ -541,46 +540,46 @@ static std::optional<SRGBA<uint8_t>> finishParsingNamedColor(char* buffer, unsig
     return asSRGBA(PackedColor::ARGB { namedColor->ARGBValue });
 }
 
-template<typename CharacterType> static std::optional<SRGBA<uint8_t>> parseNamedColorInternal(const CharacterType* characters, unsigned length)
+template<typename CharacterType> static std::optional<SRGBA<uint8_t>> parseNamedColorInternal(std::span<const CharacterType> characters)
 {
     char buffer[64]; // Easily big enough for the longest color name.
-    if (length > sizeof(buffer) - 1)
+    if (characters.size() > sizeof(buffer) - 1)
         return std::nullopt;
-    for (unsigned i = 0; i < length; ++i) {
+    for (size_t i = 0; i < characters.size(); ++i) {
         auto character = characters[i];
         if (!character || !isASCII(character))
             return std::nullopt;
         buffer[i] = toASCIILower(static_cast<char>(character));
     }
-    return finishParsingNamedColor(buffer, length);
+    return finishParsingNamedColor(buffer, characters.size());
 }
 
-template<typename CharacterType> static std::optional<SRGBA<uint8_t>> parseSimpleColorInternal(const CharacterType* characters, unsigned length, bool strict)
+template<typename CharacterType> static std::optional<SRGBA<uint8_t>> parseSimpleColorInternal(std::span<const CharacterType> characters, bool strict)
 {
-    if (auto color = parseNumericColor(characters, length, strict))
+    if (auto color = parseNumericColor(characters, strict))
         return color;
-    return parseNamedColorInternal(characters, length);
+    return parseNamedColorInternal(characters);
 }
 
 std::optional<SRGBA<uint8_t>> CSSParserFastPaths::parseSimpleColor(StringView string, bool strict)
 {
     if (string.is8Bit())
-        return parseSimpleColorInternal(string.characters8(), string.length(), strict);
-    return parseSimpleColorInternal(string.characters16(), string.length(), strict);
+        return parseSimpleColorInternal(string.span8(), strict);
+    return parseSimpleColorInternal(string.span16(), strict);
 }
 
 std::optional<SRGBA<uint8_t>> CSSParserFastPaths::parseHexColor(StringView string)
 {
     if (string.is8Bit())
-        return parseHexColorInternal(string.characters8(), string.length());
-    return parseHexColorInternal(string.characters16(), string.length());
+        return parseHexColorInternal(string.span8());
+    return parseHexColorInternal(string.span16());
 }
 
 std::optional<SRGBA<uint8_t>> CSSParserFastPaths::parseNamedColor(StringView string)
 {
     if (string.is8Bit())
-        return parseNamedColorInternal(string.characters8(), string.length());
-    return parseNamedColorInternal(string.characters16(), string.length());
+        return parseNamedColorInternal(string.span8());
+    return parseNamedColorInternal(string.span16());
 }
 
 bool CSSParserFastPaths::isKeywordValidForStyleProperty(CSSPropertyID property, CSSValueID value, const CSSParserContext& context)

--- a/Source/WebCore/css/parser/CSSParserToken.cpp
+++ b/Source/WebCore/css/parser/CSSParserToken.cpp
@@ -404,13 +404,13 @@ CSSParserToken::CSSParserToken(HashTokenType type, StringView value)
 static StringView mergeIfAdjacent(StringView a, StringView b)
 {
     if (a.is8Bit() && b.is8Bit()) {
-        auto characters = a.characters8();
-        if (characters + a.length() == b.characters8())
-            return std::span { characters, a.length() + b.length() };
+        auto characters = a.span8();
+        if (characters.end() == b.span8().begin())
+            return std::span { characters.data(), a.length() + b.length() };
     } else if (!a.is8Bit() && !b.is8Bit()) {
-        auto characters = a.characters16();
-        if (characters + a.length() == b.characters16())
-            return std::span { characters, a.length() + b.length() };
+        auto characters = a.span16();
+        if (characters.end() == b.span16().begin())
+            return std::span { characters.data(), a.length() + b.length() };
     }
     return { };
 }

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -595,7 +595,7 @@ String HTMLAttachmentElement::attachmentTitleForDisplay() const
     auto filename = StringView(title).left(indexOfLastDot);
     auto extension = StringView(title).substring(indexOfLastDot);
 
-    if (isWideLayout() && !filename.is8Bit() && ubidi_getBaseDirection(filename.characters16(), filename.length()) == UBIDI_RTL) {
+    if (isWideLayout() && !filename.is8Bit() && ubidi_getBaseDirection(filename.span16().data(), filename.length()) == UBIDI_RTL) {
         // The filename is deemed RTL, it should be exposed as RTL overall, but keeping the extension to the right.
         return makeString(
             rightToLeftMark, // Make this whole text appear as RTL, the element's `dir="auto"` will right-align and put ellipsis on the left (if needed)

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -217,8 +217,8 @@ public:
 
     enum class CodePath : uint8_t { Auto, Simple, Complex, SimpleWithGlyphOverflow };
     WEBCORE_EXPORT CodePath codePath(const TextRun&, std::optional<unsigned> from = std::nullopt, std::optional<unsigned> to = std::nullopt) const;
-    static CodePath characterRangeCodePath(const LChar*, unsigned) { return CodePath::Simple; }
-    static CodePath characterRangeCodePath(const UChar*, unsigned len);
+    static CodePath characterRangeCodePath(std::span<const LChar>) { return CodePath::Simple; }
+    static CodePath characterRangeCodePath(std::span<const UChar>);
 
     bool primaryFontIsSystemFont() const;
 

--- a/Source/WebCore/platform/graphics/TextRun.h
+++ b/Source/WebCore/platform/graphics/TextRun.h
@@ -119,8 +119,10 @@ public:
     UChar operator[](unsigned i) const { RELEASE_ASSERT(i < m_text.length()); return m_text[i]; }
     const LChar* data8(unsigned i) const { ASSERT_WITH_SECURITY_IMPLICATION(i < m_text.length()); ASSERT(is8Bit()); return &m_text.characters8()[i]; }
     const UChar* data16(unsigned i) const { ASSERT_WITH_SECURITY_IMPLICATION(i < m_text.length()); ASSERT(!is8Bit()); return &m_text.characters16()[i]; }
-    std::span<const LChar> span8(unsigned i) { ASSERT(is8Bit()); return m_text.span8().subspan(i); }
-    std::span<const UChar> span16(unsigned i) { ASSERT(!is8Bit()); return m_text.span16().subspan(i); }
+    std::span<const LChar> span8() const { ASSERT(is8Bit()); return m_text.span8(); }
+    std::span<const UChar> span16() const { ASSERT(!is8Bit()); return m_text.span16(); }
+    std::span<const LChar> subspan8(unsigned i) const { return span8().subspan(i); }
+    std::span<const UChar> subspan16(unsigned i) const { return span16().subspan(i); }
 
     const LChar* characters8() const { ASSERT(is8Bit()); return m_text.characters8(); }
     const UChar* characters16() const { ASSERT(!is8Bit()); return m_text.characters16(); }

--- a/Source/WebCore/platform/graphics/cairo/FontCairoHarfbuzzNG.cpp
+++ b/Source/WebCore/platform/graphics/cairo/FontCairoHarfbuzzNG.cpp
@@ -105,12 +105,12 @@ const Font* FontCascade::fontForCombiningCharacterSequence(StringView stringView
     // Code below relies on normalizedNFC never narrowing a 16-bit input string into an 8-bit output string.
     // At the time of this writing, the function never does this, but in theory a future version could, and
     // we would then need to add code paths here for the simpler 8-bit case.
-    auto characters = normalizedString.view.characters16();
+    auto characters = normalizedString.view.span16();
     auto length = normalizedString.view.length();
 
     char32_t character;
     unsigned clusterLength = 0;
-    SurrogatePairAwareTextIterator iterator(characters, 0, length, length);
+    SurrogatePairAwareTextIterator iterator(characters.data(), 0, length, length);
     if (!iterator.consume(character, clusterLength))
         return nullptr;
 
@@ -144,7 +144,7 @@ const Font* FontCascade::fontForCombiningCharacterSequence(StringView stringView
             return systemFallback.get();
 
         // In case of emoji, if fallback font is colored try again without the variation selector character.
-        if (isEmoji && characters[length - 1] == 0xFE0F && systemFallback->platformData().isColorBitmapFont() && systemFallback->canRenderCombiningCharacterSequence(std::span { characters, length - 1 }))
+        if (isEmoji && characters[length - 1] == 0xFE0F && systemFallback->platformData().isColorBitmapFont() && systemFallback->canRenderCombiningCharacterSequence(characters.first(length - 1)))
             return systemFallback.get();
     }
 

--- a/Source/WebCore/platform/network/create-http-header-name-table
+++ b/Source/WebCore/platform/network/create-http-header-name-table
@@ -137,21 +137,20 @@ bool findHTTPHeaderName(StringView stringView, HTTPHeaderName& headerName)
         return false;
 
     if (stringView.is8Bit()) {
-        if (auto nameAndString = HTTPHeaderNamesHash::findHeaderNameImpl(reinterpret_cast<const char*>(stringView.characters8()), length)) {
+        if (auto nameAndString = HTTPHeaderNamesHash::findHeaderNameImpl(reinterpret_cast<const char*>(stringView.span8().data()), length)) {
             headerName = nameAndString->headerName;
             return true;
         }
     } else {
-        LChar characters[maxHTTPHeaderNameLength];
-        for (unsigned i = 0; i < length; ++i) {
-            UChar character = stringView.characters16()[i];
+        std::array<char, maxHTTPHeaderNameLength> characters;
+        size_t index = 0;
+        for (auto character : stringView.span16()) {
             if (!isASCII(character))
                 return false;
-                
-            characters[i] = static_cast<LChar>(character);
+            characters[index++] = static_cast<char>(character);
         }
         
-        if (auto nameAndString = HTTPHeaderNamesHash::findHeaderNameImpl(reinterpret_cast<const char*>(characters), length)) {
+        if (auto nameAndString = HTTPHeaderNamesHash::findHeaderNameImpl(characters.data(), length)) {
             headerName = nameAndString->headerName;
             return true;
         }

--- a/Source/WebCore/platform/sql/SQLiteStatement.cpp
+++ b/Source/WebCore/platform/sql/SQLiteStatement.cpp
@@ -123,9 +123,10 @@ int SQLiteStatement::bindText(int index, StringView text)
     ASSERT(static_cast<unsigned>(index) <= bindParameterCount());
 
     // Fast path when the input text is all ASCII.
-    if (text.is8Bit() && text.containsOnlyASCII())
-        return sqlite3_bind_text(m_statement, index, text.length() ? reinterpret_cast<const char*>(text.characters8()) : "", text.length(), SQLITE_TRANSIENT);
-
+    if (text.is8Bit() && text.containsOnlyASCII()) {
+        auto characters = spanReinterpretCast<const char>(text.span8());
+        return sqlite3_bind_text(m_statement, index, characters.empty() ? "" : characters.data(), characters.size(), SQLITE_TRANSIENT);
+    }
     auto utf8Text = text.utf8();
     return sqlite3_bind_text(m_statement, index, utf8Text.data(), utf8Text.length(), SQLITE_TRANSIENT);
 }

--- a/Source/WebCore/platform/text/SegmentedString.h
+++ b/Source/WebCore/platform/text/SegmentedString.h
@@ -155,9 +155,9 @@ inline SegmentedString::Substring::Substring(StringView passedStringView)
     if (length) {
         is8Bit = passedStringView.is8Bit();
         if (is8Bit)
-            currentCharacter8 = passedStringView.characters8();
+            currentCharacter8 = passedStringView.span8().data();
         else
-            currentCharacter16 = passedStringView.characters16();
+            currentCharacter16 = passedStringView.span16().data();
     }
 }
 

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -2038,7 +2038,7 @@ bool RenderText::computeCanUseSimpleFontCodePath() const
 {
     if (m_containsOnlyASCII || text().is8Bit())
         return true;
-    return FontCascade::characterRangeCodePath(text().characters16(), length()) == FontCascade::CodePath::Simple;
+    return FontCascade::characterRangeCodePath(text().span16()) == FontCascade::CodePath::Simple;
 }
 
 void RenderText::momentarilyRevealLastTypedCharacter(unsigned offsetAfterLastTypedCharacter)

--- a/Source/WebKit/Shared/API/c/WKString.cpp
+++ b/Source/WebKit/Shared/API/c/WKString.cpp
@@ -82,11 +82,11 @@ size_t WKStringGetUTF8CStringImpl(WKStringRef stringRef, char* buffer, size_t bu
     char* p = buffer;
 
     if (stringView.is8Bit()) {
-        const LChar* characters = stringView.characters8();
+        const LChar* characters = stringView.span8().data();
         if (!WTF::Unicode::convertLatin1ToUTF8(&characters, characters + stringView.length(), &p, p + bufferSize - 1))
             return 0;
     } else {
-        const UChar* characters = stringView.characters16();
+        const UChar* characters = stringView.span16().data();
         auto result = WTF::Unicode::convertUTF16ToUTF8(&characters, characters + stringView.length(), &p, p + bufferSize - 1, strict);
         if (result != WTF::Unicode::ConversionResult::Success && result != WTF::Unicode::ConversionResult::TargetExhausted)
             return 0;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp
@@ -177,8 +177,8 @@ void RemoteVideoCodecFactory::createEncoder(const String& codec, const WebCore::
     std::map<std::string, std::string> parameters;
     if (type == VideoCodecType::H264) {
         if (auto position = codec.find('.');position != notFound && position != codec.length()) {
-            auto profileLevelId = StringView(codec).substring(position + 1);
-            parameters["profile-level-id"] = std::string(reinterpret_cast<const char*>(profileLevelId.characters8()), profileLevelId.length());
+            auto profileLevelId = spanReinterpretCast<const char>(codec.span8().subspan(position + 1));
+            parameters["profile-level-id"] = std::string(profileLevelId.data(), profileLevelId.size());
         }
     }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMTextIterator.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMTextIterator.mm
@@ -79,9 +79,11 @@
     if (!length)
         return nullptr;
     if (!text.is8Bit())
-        return reinterpret_cast<const unichar*>(text.characters16());
-    if (_upconvertedText.isEmpty())
-        _upconvertedText.appendRange(text.characters8(), text.characters8() + length);
+        return reinterpret_cast<const unichar*>(text.span16().data());
+    if (_upconvertedText.isEmpty()) {
+        auto characters = text.span8();
+        _upconvertedText.appendRange(characters.begin(), characters.end());
+    }
     ASSERT(_upconvertedText.size() == text.length());
     return _upconvertedText.data();
 }

--- a/Source/WebKitLegacy/mac/WebView/WebTextIterator.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebTextIterator.mm
@@ -109,9 +109,11 @@
     if (!length)
         return nullptr;
     if (!text.is8Bit())
-        return reinterpret_cast<const unichar*>(text.characters16());
-    if (_private->_upconvertedText.isEmpty())
-        _private->_upconvertedText.appendRange(text.characters8(), text.characters8() + length);
+        return reinterpret_cast<const unichar*>(text.span16().data());
+    if (_private->_upconvertedText.isEmpty()) {
+        auto characters = text.span8();
+        _private->_upconvertedText.appendRange(characters.begin(), characters.end());
+    }
     ASSERT(_private->_upconvertedText.size() == text.length());
     return _private->_upconvertedText.data();
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/StringParsingBuffer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringParsingBuffer.cpp
@@ -51,8 +51,8 @@ TEST(WTF, StringParsingBufferInitial)
 
     EXPECT_FALSE(parsingBuffer.atEnd());
     EXPECT_TRUE(parsingBuffer.hasCharactersRemaining());
-    EXPECT_EQ(parsingBuffer.position(), string.characters8());
-    EXPECT_EQ(parsingBuffer.end(), string.characters8() + string.length());
+    EXPECT_EQ(parsingBuffer.position(), string.span8().data());
+    EXPECT_EQ(parsingBuffer.end(), string.span8().data() + string.length());
     EXPECT_EQ(parsingBuffer.lengthRemaining(), 3u);
     EXPECT_EQ(*parsingBuffer, 'a');
 }


### PR DESCRIPTION
#### b332f986be2c69a696e8ab2646b087123fc64cc4
<pre>
Drop StringView::characters8() / characters16()
<a href="https://bugs.webkit.org/show_bug.cgi?id=273052">https://bugs.webkit.org/show_bug.cgi?id=273052</a>

Reviewed by Darin Adler.

Drop StringView::characters8() / characters16(), in favor to span8() / span16().

* Source/JavaScriptCore/builtins/BuiltinExecutables.cpp:
(JSC::BuiltinExecutables::createExecutable):
* Source/JavaScriptCore/parser/Lexer.h:
(JSC::Lexer&lt;LChar&gt;::setCodeStart):
(JSC::Lexer&lt;UChar&gt;::setCodeStart):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::fastJoin):
* Source/JavaScriptCore/runtime/IntlCollator.cpp:
(JSC::IntlCollator::compareStrings const):
(JSC::IntlCollator::checkICULocaleInvariants):
* Source/JavaScriptCore/runtime/IntlObjectInlines.h:
(JSC::followedByNonLatinCharacter):
(JSC::compareASCIIWithUCADUCETLevel3):
(JSC::compareASCIIWithUCADUCET):
* Source/JavaScriptCore/runtime/JSBigInt.cpp:
(JSC::JSBigInt::parseInt):
* Source/JavaScriptCore/runtime/JSBigInt.h:
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSImmutableButterfly.cpp:
(JSC::JSImmutableButterfly::createFromString):
* Source/JavaScriptCore/runtime/ParseInt.h:
(JSC::parseInt):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::SubjectSampler::sample):
* Source/WTF/wtf/text/StringSearch.h:
(WTF::BoyerMooreHorspoolTable::BoyerMooreHorspoolTable):
* Source/WTF/wtf/text/StringView.h:
* Source/WebCore/css/CSSFontFaceSet.cpp:
(WebCore::codePointsFromString):
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::checkForValidDouble):
(WebCore::parseDouble):
(WebCore::parseColorIntOrPercentage):
(WebCore::isTenthAlpha):
(WebCore::parseAlphaValue):
(WebCore::mightBeRGBA):
(WebCore::mightBeRGB):
(WebCore::parseHexColorInternal):
(WebCore::parseNumericColor):
(WebCore::parseNamedColorInternal):
(WebCore::parseSimpleColorInternal):
(WebCore::CSSParserFastPaths::parseSimpleColor):
(WebCore::CSSParserFastPaths::parseHexColor):
(WebCore::CSSParserFastPaths::parseNamedColor):
* Source/WebCore/css/parser/CSSParserToken.cpp:
(WebCore::mergeIfAdjacent):
* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::attachmentTitleForDisplay const):
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::enclosingGlyphBoundsForText):
(WebCore::Layout::TextUtil::containsStrongDirectionalityText):
(WebCore::Layout::TextUtil::directionForTextContent):
(WebCore::Layout::TextUtil::canUseSimplifiedTextMeasuring):
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::widthForSimpleTextSlow const):
(WebCore::FontCascade::codePath const):
(WebCore::FontCascade::characterRangeCodePath):
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/TextRun.h:
* Source/WebCore/platform/network/create-http-header-name-table:
* Source/WebCore/platform/sql/SQLiteStatement.cpp:
(WebCore::SQLiteStatement::bindText):
* Source/WebCore/platform/text/SegmentedString.h:
(WebCore::SegmentedString::Substring::Substring):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::computeCanUseSimpleFontCodePath const):
* Source/WebKit/Shared/API/c/WKString.cpp:
(WKStringGetUTF8CStringImpl):
* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp:
(WebKit::RemoteVideoCodecFactory::createEncoder):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMTextIterator.mm:
(-[WKDOMTextIterator currentTextPointer]):
* Source/WebKitLegacy/mac/WebView/WebTextIterator.mm:
(-[WebTextIterator currentTextPointer]):
* Tools/TestWebKitAPI/Tests/WTF/StringParsingBuffer.cpp:
(TestWebKitAPI::TEST(WTF, StringParsingBufferInitial)):

Canonical link: <a href="https://commits.webkit.org/277836@main">https://commits.webkit.org/277836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0efc559e5c20bd73d5514114655123b6f43d2978

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48704 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27915 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51391 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44769 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25445 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39832 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49286 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25570 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42026 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20929 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23045 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43203 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6760 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/42003 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44986 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53300 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/48195 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23751 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20045 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47126 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25017 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42231 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46058 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25821 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55690 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6951 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24738 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11458 "Passed tests") | 
<!--EWS-Status-Bubble-End-->