### PR TITLE
[GStreamer] Improve support for AV1 colorimetry handling

### DIFF
--- a/Source/WebCore/platform/graphics/AV1Utilities.cpp
+++ b/Source/WebCore/platform/graphics/AV1Utilities.cpp
@@ -139,7 +139,7 @@ std::optional<AV1CodecConfigurationRecord> parseAV1CodecParameters(StringView co
     configuration.monochrome = *monochrome;
 
     if (++nextElement == codecSplit.end())
-        return std::nullopt;
+        return configuration;
 
     // The chromaSubsampling parameter value, represented by a three-digit decimal,
     // SHALL have its first digit equal to subsampling_x and its second digit equal
@@ -152,7 +152,7 @@ std::optional<AV1CodecConfigurationRecord> parseAV1CodecParameters(StringView co
     configuration.chromaSubsampling = static_cast<uint8_t>(*chromaSubsampling);
 
     if (++nextElement == codecSplit.end())
-        return std::nullopt;
+        return configuration;
 
     // The colorPrimaries, transferCharacteristics, matrixCoefficients, and videoFullRangeFlag
     // parameter values SHALL equal the value of matching fields in the Sequence Header OBU, if
@@ -164,7 +164,7 @@ std::optional<AV1CodecConfigurationRecord> parseAV1CodecParameters(StringView co
     configuration.colorPrimaries = static_cast<uint8_t>(*colorPrimaries);
 
     if (++nextElement == codecSplit.end())
-        return std::nullopt;
+        return configuration;
 
     auto transferCharacteristics = parseEnumFromStringView<AV1ConfigurationTransferCharacteristics>(*nextElement);
     if (!transferCharacteristics)
@@ -172,7 +172,7 @@ std::optional<AV1CodecConfigurationRecord> parseAV1CodecParameters(StringView co
     configuration.transferCharacteristics = static_cast<uint8_t>(*transferCharacteristics);
 
     if (++nextElement == codecSplit.end())
-        return std::nullopt;
+        return configuration;
 
     auto matrixCoefficients = parseEnumFromStringView<AV1ConfigurationMatrixCoefficients>(*nextElement);
     if (!matrixCoefficients)

--- a/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
@@ -22,6 +22,7 @@
 
 #if USE(GSTREAMER)
 
+#include "AV1Utilities.h"
 #include "HEVCUtilities.h"
 #include "VP9Utilities.h"
 #include <gst/pbutils/codec-utils.h>
@@ -226,10 +227,215 @@ static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> vpxCapsFromCodecString(cons
     return { inputCaps, outputCaps };
 }
 
+static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> av1CapsFromCodecString(const String& codecString, unsigned width, unsigned height, int framerateNumerator, int framerateDenominator)
+{
+    auto configurationRecord = parseAV1CodecParameters(codecString);
+    if (!configurationRecord)
+        return { nullptr, nullptr };
+
+    const char* profile;
+    switch (configurationRecord->profile) {
+    case AV1ConfigurationProfile::Main:
+        profile = "main";
+        break;
+    case AV1ConfigurationProfile::High:
+        profile = "high";
+        break;
+    case AV1ConfigurationProfile::Professional:
+        profile = "professional";
+        break;
+    }
+
+    auto outputCaps = adoptGRef(gst_caps_new_simple("video/x-av1", "profile", G_TYPE_STRING, profile, "bit-depth-luma", G_TYPE_UINT, configurationRecord->bitDepth, "bit-depth-chroma", G_TYPE_UINT, configurationRecord->bitDepth, nullptr));
+
+    const char* chromaFormat = nullptr;
+    const char* yuvFormat = "I420";
+    switch (static_cast<AV1ConfigurationChromaSubsampling>(configurationRecord->chromaSubsampling)) {
+    case AV1ConfigurationChromaSubsampling::Subsampling_422:
+        yuvFormat = "I422";
+        chromaFormat = "4:2:2";
+        break;
+    case AV1ConfigurationChromaSubsampling::Subsampling_444:
+        yuvFormat = "Y444";
+        chromaFormat = "4:4:4";
+        break;
+    case AV1ConfigurationChromaSubsampling::Subsampling_420_Unknown:
+    case AV1ConfigurationChromaSubsampling::Subsampling_420_Vertical:
+    case AV1ConfigurationChromaSubsampling::Subsampling_420_Colocated:
+        if (configurationRecord->monochrome)
+            chromaFormat = "4:0:0";
+        else
+            chromaFormat = "4:2:0";
+        break;
+    };
+
+    StringBuilder formatBuilder;
+    formatBuilder.append(yuvFormat);
+    if (configurationRecord->bitDepth > 8) {
+        formatBuilder.append('_', configurationRecord->bitDepth);
+#if G_BYTE_ORDER == G_LITTLE_ENDIAN
+        formatBuilder.append("LE"_s);
+#else
+        formatBuilder.append("BE"_s);
+#endif
+    }
+
+    auto formatString = formatBuilder.toString();
+    auto format = gst_video_format_from_string(formatString.ascii().data());
+    GstVideoInfo info;
+    gst_video_info_set_format(&info, format, width, height);
+
+    if (configurationRecord->videoFullRangeFlag == AV1ConfigurationRange::FullRange)
+        GST_VIDEO_INFO_COLORIMETRY(&info).range = GST_VIDEO_COLOR_RANGE_0_255;
+    else
+        GST_VIDEO_INFO_COLORIMETRY(&info).range = GST_VIDEO_COLOR_RANGE_16_235;
+
+    switch (static_cast<AV1ConfigurationColorPrimaries>(configurationRecord->colorPrimaries)) {
+    case AV1ConfigurationColorPrimaries::BT_709_6:
+        GST_VIDEO_INFO_COLORIMETRY(&info).primaries = GST_VIDEO_COLOR_PRIMARIES_BT709;
+        break;
+    case AV1ConfigurationColorPrimaries::Unspecified:
+        GST_VIDEO_INFO_COLORIMETRY(&info).primaries = GST_VIDEO_COLOR_PRIMARIES_UNKNOWN;
+        break;
+    case AV1ConfigurationColorPrimaries::BT_470_6_M:
+        GST_VIDEO_INFO_COLORIMETRY(&info).primaries = GST_VIDEO_COLOR_PRIMARIES_BT470M;
+        break;
+    case AV1ConfigurationColorPrimaries::BT_470_7_BG:
+        GST_VIDEO_INFO_COLORIMETRY(&info).primaries = GST_VIDEO_COLOR_PRIMARIES_BT470BG;
+        break;
+    case AV1ConfigurationColorPrimaries::BT_601_7:
+        GST_VIDEO_INFO_COLORIMETRY(&info).primaries = GST_VIDEO_COLOR_PRIMARIES_SMPTE170M;
+        break;
+    case AV1ConfigurationColorPrimaries::SMPTE_ST_240:
+        GST_VIDEO_INFO_COLORIMETRY(&info).primaries = GST_VIDEO_COLOR_PRIMARIES_SMPTE240M;
+        break;
+    case AV1ConfigurationColorPrimaries::Film:
+        GST_VIDEO_INFO_COLORIMETRY(&info).primaries = GST_VIDEO_COLOR_PRIMARIES_FILM;
+        break;
+    case AV1ConfigurationColorPrimaries::BT_2020_Nonconstant_Luminance:
+        GST_VIDEO_INFO_COLORIMETRY(&info).primaries = GST_VIDEO_COLOR_PRIMARIES_BT2020;
+        break;
+    case AV1ConfigurationColorPrimaries::SMPTE_ST_428_1:
+        GST_VIDEO_INFO_COLORIMETRY(&info).primaries = GST_VIDEO_COLOR_PRIMARIES_SMPTEST428;
+        break;
+    case AV1ConfigurationColorPrimaries::SMPTE_RP_431_2:
+        GST_VIDEO_INFO_COLORIMETRY(&info).primaries = GST_VIDEO_COLOR_PRIMARIES_SMPTERP431;
+        break;
+    case AV1ConfigurationColorPrimaries::SMPTE_EG_432_1:
+        GST_VIDEO_INFO_COLORIMETRY(&info).primaries = GST_VIDEO_COLOR_PRIMARIES_SMPTEEG432;
+        break;
+    case AV1ConfigurationColorPrimaries::EBU_Tech_3213_E:
+        GST_VIDEO_INFO_COLORIMETRY(&info).primaries = GST_VIDEO_COLOR_PRIMARIES_EBU3213;
+        break;
+    };
+
+    switch (static_cast<AV1ConfigurationTransferCharacteristics>(configurationRecord->transferCharacteristics)) {
+    case AV1ConfigurationTransferCharacteristics::BT_709_6:
+    case AV1ConfigurationTransferCharacteristics::BT_470_6_M:
+        GST_VIDEO_INFO_COLORIMETRY(&info).transfer = GST_VIDEO_TRANSFER_BT709;
+        break;
+    case AV1ConfigurationTransferCharacteristics::Unspecified:
+        GST_VIDEO_INFO_COLORIMETRY(&info).transfer = GST_VIDEO_TRANSFER_UNKNOWN;
+        break;
+    case AV1ConfigurationTransferCharacteristics::BT_470_7_BG:
+        GST_VIDEO_INFO_COLORIMETRY(&info).transfer = GST_VIDEO_TRANSFER_GAMMA28;
+        break;
+    case AV1ConfigurationTransferCharacteristics::BT_601_7:
+        GST_VIDEO_INFO_COLORIMETRY(&info).transfer = GST_VIDEO_TRANSFER_BT601;
+        break;
+    case AV1ConfigurationTransferCharacteristics::SMPTE_ST_240:
+        GST_VIDEO_INFO_COLORIMETRY(&info).transfer = GST_VIDEO_TRANSFER_SMPTE240M;
+        break;
+    case AV1ConfigurationTransferCharacteristics::Linear:
+        GST_VIDEO_INFO_COLORIMETRY(&info).transfer = GST_VIDEO_TRANSFER_GAMMA10;
+        break;
+    case AV1ConfigurationTransferCharacteristics::Logrithmic:
+        GST_VIDEO_INFO_COLORIMETRY(&info).transfer = GST_VIDEO_TRANSFER_LOG100;
+        break;
+    case AV1ConfigurationTransferCharacteristics::Logrithmic_Sqrt:
+        GST_VIDEO_INFO_COLORIMETRY(&info).transfer = GST_VIDEO_TRANSFER_LOG316;
+        break;
+    case AV1ConfigurationTransferCharacteristics::IEC_61966_2_4:
+        GST_VIDEO_INFO_COLORIMETRY(&info).transfer = GST_VIDEO_TRANSFER_SRGB;
+        break;
+    case AV1ConfigurationTransferCharacteristics::BT_1361_0:
+        break;
+    case AV1ConfigurationTransferCharacteristics::IEC_61966_2_1:
+        GST_WARNING("AV1ConfigurationTransferCharacteristics::IEC_61966_2_1 not supported");
+        GST_VIDEO_INFO_COLORIMETRY(&info).transfer = GST_VIDEO_TRANSFER_UNKNOWN;
+        break;
+    case AV1ConfigurationTransferCharacteristics::BT_2020_10bit:
+        GST_VIDEO_INFO_COLORIMETRY(&info).transfer = GST_VIDEO_TRANSFER_BT2020_10;
+        break;
+    case AV1ConfigurationTransferCharacteristics::BT_2020_12bit:
+        GST_VIDEO_INFO_COLORIMETRY(&info).transfer = GST_VIDEO_TRANSFER_BT2020_12;
+        break;
+    case AV1ConfigurationTransferCharacteristics::SMPTE_ST_2084:
+        GST_VIDEO_INFO_COLORIMETRY(&info).transfer = GST_VIDEO_TRANSFER_SMPTE2084;
+        break;
+    case AV1ConfigurationTransferCharacteristics::SMPTE_ST_428_1:
+        GST_WARNING("AV1ConfigurationTransferCharacteristics::SMPTE_ST_428_1 not supported");
+        GST_VIDEO_INFO_COLORIMETRY(&info).transfer = GST_VIDEO_TRANSFER_UNKNOWN;
+        break;
+    case AV1ConfigurationTransferCharacteristics::BT_2100_HLG:
+        GST_VIDEO_INFO_COLORIMETRY(&info).transfer = GST_VIDEO_TRANSFER_ARIB_STD_B67;
+        break;
+    };
+
+    switch (static_cast<AV1ConfigurationMatrixCoefficients>(configurationRecord->matrixCoefficients)) {
+    case AV1ConfigurationMatrixCoefficients::Identity:
+        GST_VIDEO_INFO_COLORIMETRY(&info).matrix = GST_VIDEO_COLOR_MATRIX_RGB;
+        break;
+    case AV1ConfigurationMatrixCoefficients::BT_709_6:
+        GST_VIDEO_INFO_COLORIMETRY(&info).matrix = GST_VIDEO_COLOR_MATRIX_BT709;
+        break;
+    case AV1ConfigurationMatrixCoefficients::Unspecified:
+        GST_VIDEO_INFO_COLORIMETRY(&info).matrix = GST_VIDEO_COLOR_MATRIX_UNKNOWN;
+        break;
+    case AV1ConfigurationMatrixCoefficients::FCC:
+        GST_VIDEO_INFO_COLORIMETRY(&info).matrix = GST_VIDEO_COLOR_MATRIX_FCC;
+        break;
+    case AV1ConfigurationMatrixCoefficients::BT_470_7_BG:
+        break;
+    case AV1ConfigurationMatrixCoefficients::BT_601_7:
+        GST_VIDEO_INFO_COLORIMETRY(&info).matrix = GST_VIDEO_COLOR_MATRIX_BT601;
+        break;
+    case AV1ConfigurationMatrixCoefficients::SMPTE_ST_240:
+        GST_VIDEO_INFO_COLORIMETRY(&info).matrix = GST_VIDEO_COLOR_MATRIX_SMPTE240M;
+        break;
+    case AV1ConfigurationMatrixCoefficients::YCgCo:
+        break;
+    case AV1ConfigurationMatrixCoefficients::BT_2020_Nonconstant_Luminance:
+    case AV1ConfigurationMatrixCoefficients::BT_2020_Constant_Luminance:
+        GST_VIDEO_INFO_COLORIMETRY(&info).matrix = GST_VIDEO_COLOR_MATRIX_BT2020;
+        break;
+    case AV1ConfigurationMatrixCoefficients::SMPTE_ST_2085:
+        break;
+    case AV1ConfigurationMatrixCoefficients::Chromacity_Nonconstant_Luminance:
+        break;
+    case AV1ConfigurationMatrixCoefficients::Chromacity_Constant_Luminance:
+        break;
+    case AV1ConfigurationMatrixCoefficients::BT_2100_ICC:
+        break;
+    };
+
+    if (!gst_video_colorimetry_matches(&GST_VIDEO_INFO_COLORIMETRY(&info), GST_VIDEO_COLORIMETRY_SRGB))
+        gst_caps_set_simple(outputCaps.get(), "chroma-format", G_TYPE_STRING, chromaFormat, nullptr);
+
+    auto inputCaps = adoptGRef(gst_video_info_to_caps(&info));
+    gst_caps_set_simple(inputCaps.get(), "framerate", GST_TYPE_FRACTION, framerateNumerator, framerateDenominator, nullptr);
+    GST_DEBUG("Codec %s maps to input %" GST_PTR_FORMAT " and output %" GST_PTR_FORMAT, codecString.ascii().data(), inputCaps.get(), outputCaps.get());
+    return { inputCaps, outputCaps };
+}
+
 std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> GStreamerCodecUtilities::capsFromCodecString(const String& codecString, unsigned width, unsigned height, int framerateNumerator, int framerateDenominator)
 {
+    ensureDebugCategoryInitialized();
     if (codecString.startsWith("vp8"_s) || codecString.startsWith("vp08"_s) || codecString.startsWith("vp9"_s) || codecString.startsWith("vp09"_s))
         return vpxCapsFromCodecString(codecString, width, height, framerateNumerator, framerateDenominator);
+
+    if (codecString.startsWith("av01"_s))
+        return av1CapsFromCodecString(codecString, width, height, framerateNumerator, framerateDenominator);
 
     if (codecString.startsWith("avc1"_s))
         return { nullptr, nullptr };


### PR DESCRIPTION
#### c3b1ffe5f3a0558820b7f75fa36664b2b7ef0408
<pre>
[GStreamer] Improve support for AV1 colorimetry handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=273059">https://bugs.webkit.org/show_bug.cgi?id=273059</a>

Reviewed by Xabier Rodriguez-Calvar.

The parsed av01 codec string can now be translated to GStreamer caps. While writing tests for this I
noticed a couple issues in `parseAV1CodecParameters()`, returning empty results after parsing
optional fields. That issue is now fixed and we have tests. Later on the encoder will be adapted in
order to make use of this code.

* Source/WebCore/platform/graphics/AV1Utilities.cpp:
(WebCore::parseAV1CodecParameters):
* Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp:
(WebCore::av1CapsFromCodecString):
(WebCore::GStreamerCodecUtilities::capsFromCodecString):
* Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/277857@main">https://commits.webkit.org/277857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e41a47347a55431462d03955522591524426da3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48662 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51349 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44727 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50967 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33810 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25403 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39794 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25534 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41989 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20891 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23012 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43167 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6718 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44950 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53257 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23709 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20005 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47083 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24975 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42194 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46013 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10746 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25779 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24696 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->