### PR TITLE
Use smart pointers for members of SVG classes

### DIFF
--- a/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.h
+++ b/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.h
@@ -84,7 +84,7 @@ private:
 
     void adjustBoxForClippingAndEffects(const DecorationOptions&, FloatRect& box, const DecorationOptions& optionsToCheckForFilters = filterBoundingBoxDecoration) const;
 
-    const RenderLayerModelObject& m_renderer;
+    SingleThreadWeakRef<const RenderLayerModelObject> m_renderer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGContainerLayout.cpp
+++ b/Source/WebCore/rendering/svg/SVGContainerLayout.cpp
@@ -51,7 +51,7 @@ SVGContainerLayout::SVGContainerLayout(RenderLayerModelObject& container)
 void SVGContainerLayout::layoutChildren(bool containerNeedsLayout)
 {
     bool layoutSizeChanged = layoutSizeOfNearestViewportChanged();
-    bool transformChanged = transformToRootChanged(&m_container);
+    bool transformChanged = transformToRootChanged(m_container.ptr());
 
     m_positionedChildren.clear();
     for (auto& child : childrenOfType<RenderObject>(m_container)) {
@@ -133,16 +133,16 @@ void SVGContainerLayout::positionChildrenRelativeToContainer()
         // only meaningful for the children of the RenderSVGRoot. RenderSVGRoot itself is positioned according to
         // the CSS box model object, where we need to respect border & padding, encoded in the contentBoxLocation().
         // -> Position all RenderSVGRoot children relative to the contentBoxLocation() to avoid intruding border/padding area.
-        if (CheckedPtr svgRoot = dynamicDowncast<RenderSVGRoot>(m_container))
+        if (CheckedPtr svgRoot = dynamicDowncast<RenderSVGRoot>(m_container.get()))
             return -svgRoot->contentBoxLocation();
 
         // For (inner) RenderSVGViewportContainer nominalSVGLayoutLocation() returns the viewport boundaries,
         // including the effect of the 'x'/'y' attribute values. Do not subtract the location, otherwise the
         // effect of the x/y translation is removed.
-        if (is<RenderSVGViewportContainer>(m_container) && !m_container.isAnonymous())
+        if (is<RenderSVGViewportContainer>(m_container) && !m_container->isAnonymous())
             return { };
 
-        return m_container.nominalSVGLayoutLocation();
+        return m_container->nominalSVGLayoutLocation();
     };
 
     // Arrange layout location for all child renderers relative to the container layout location.
@@ -204,7 +204,7 @@ void SVGContainerLayout::verifyLayoutLocationConsistency(const RenderLayerModelO
 
 bool SVGContainerLayout::layoutSizeOfNearestViewportChanged() const
 {
-    RenderElement* ancestor = &m_container;
+    RenderElement* ancestor = m_container.ptr();
     while (ancestor && !is<RenderSVGRoot>(ancestor) && !is<RenderSVGViewportContainer>(ancestor))
         ancestor = ancestor->parent();
 

--- a/Source/WebCore/rendering/svg/SVGContainerLayout.h
+++ b/Source/WebCore/rendering/svg/SVGContainerLayout.h
@@ -45,7 +45,7 @@ public:
 private:
     bool layoutSizeOfNearestViewportChanged() const;
 
-    RenderLayerModelObject& m_container;
+    SingleThreadWeakRef<RenderLayerModelObject> m_container;
     Vector<std::reference_wrapper<RenderLayerModelObject>> m_positionedChildren;
 };
 

--- a/Source/WebCore/rendering/svg/SVGLayerTransformComputation.h
+++ b/Source/WebCore/rendering/svg/SVGLayerTransformComputation.h
@@ -49,7 +49,7 @@ public:
         // anonymous RenderSVGViewportContainer (most noticeable: viewBox). Therefore we have to start
         // calling mapLocalToContainer() starting from the anonymous RenderSVGViewportContainer, and
         // not from its parent - RenderSVGRoot.
-        auto* renderer = &m_renderer;
+        auto* renderer = m_renderer.ptr();
         if (auto* svgRoot = dynamicDowncast<RenderSVGRoot>(renderer)) {
             renderer = svgRoot->viewportContainer();
             if (trackingMode == TransformState::TrackSVGCTMMatrix)
@@ -75,7 +75,7 @@ public:
         renderer->mapLocalToContainer(ancestorContainer, transformState, { UseTransforms, ApplyContainerFlip });
 
         if (trackingMode == TransformState::TrackSVGCTMMatrix) {
-            if (auto* svgRoot = dynamicDowncast<RenderSVGRoot>(m_renderer))
+            if (auto* svgRoot = dynamicDowncast<RenderSVGRoot>(m_renderer.get()))
                 transformState.move(-toLayoutSize(svgRoot->contentBoxLocation()));
             else if (ancestorContainer) {
                 // Continue to accumulate container offsets, excluding transforms, from the container of the current element ('ancestorContainer') up to RenderSVGRoot.
@@ -96,17 +96,17 @@ public:
 
         // When we've climbed the ancestor tree up to and including RenderSVGRoot, the CTM is aligned with the top-left of the renderers bounding box (= nominal SVG layout location).
         // However, for getCTM/getScreenCTM we're supposed to align by the top-left corner of the enclosing "viewport element" -- correct for that.
-        if (m_renderer.isRenderSVGRoot())
+        if (m_renderer->isRenderSVGRoot())
             return ctm;
 
-        ctm.translate(-toFloatSize(m_renderer.nominalSVGLayoutLocation()));
+        ctm.translate(-toFloatSize(m_renderer->nominalSVGLayoutLocation()));
         return ctm;
     }
 
     float calculateScreenFontSizeScalingFactor() const
     {
         // Walk up the render tree, accumulating transforms
-        auto* layer = m_renderer.enclosingLayer();
+        auto* layer = m_renderer->enclosingLayer();
 
         RenderLayer* stopAtLayer = nullptr;
         while (layer) {
@@ -120,14 +120,14 @@ public:
         }
 
         auto ctm = computeAccumulatedTransform(stopAtLayer ? &stopAtLayer->renderer() : nullptr, TransformState::TrackSVGScreenCTMMatrix);
-        ctm.scale(m_renderer.document().deviceScaleFactor());
-        if (!m_renderer.document().isSVGDocument())
-            ctm.scale(m_renderer.style().usedZoom());
+        ctm.scale(m_renderer->document().deviceScaleFactor());
+        if (!m_renderer->document().isSVGDocument())
+            ctm.scale(m_renderer->style().usedZoom());
         return narrowPrecisionToFloat(std::hypot(ctm.xScale(), ctm.yScale()) / sqrtOfTwoDouble);
     }
 
 private:
-    const RenderLayerModelObject& m_renderer;
+    SingleThreadWeakRef<const RenderLayerModelObject> m_renderer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGLayerTransformUpdater.h
+++ b/Source/WebCore/rendering/svg/SVGLayerTransformUpdater.h
@@ -21,6 +21,7 @@
 
 #include "RenderElementInlines.h"
 #include "RenderLayerModelObject.h"
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -30,28 +31,28 @@ public:
     SVGLayerTransformUpdater(RenderLayerModelObject& renderer)
         : m_renderer(renderer)
     {
-        if (!m_renderer.hasLayer())
+        if (!m_renderer->hasLayer())
             return;
 
-        m_transformReferenceBox = m_renderer.transformReferenceBoxRect();
-        m_layerTransform = m_renderer.layerTransform();
+        m_transformReferenceBox = m_renderer->transformReferenceBoxRect();
+        m_layerTransform = m_renderer->layerTransform();
 
-        m_renderer.updateLayerTransform();
+        m_renderer->updateLayerTransform();
     }
 
     ~SVGLayerTransformUpdater()
     {
-        if (!m_renderer.hasLayer())
+        if (!m_renderer->hasLayer())
             return;
-        if (m_renderer.transformReferenceBoxRect() == m_transformReferenceBox)
+        if (m_renderer->transformReferenceBoxRect() == m_transformReferenceBox)
             return;
 
-        m_renderer.updateLayerTransform();
+        m_renderer->updateLayerTransform();
     }
 
     bool layerTransformChanged() const
     {
-        auto* layerTransform = m_renderer.layerTransform();
+        auto* layerTransform = m_renderer->layerTransform();
 
         bool hasTransform = !!layerTransform;
         bool hadTransform = !!m_layerTransform;
@@ -62,7 +63,7 @@ public:
     }
 
 private:
-    RenderLayerModelObject& m_renderer;
+    SingleThreadWeakRef<RenderLayerModelObject> m_renderer;
     FloatRect m_transformReferenceBox;
     TransformationMatrix* m_layerTransform { nullptr };
 };

--- a/Source/WebCore/rendering/svg/SVGTextLayoutAttributes.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutAttributes.cpp
@@ -42,4 +42,6 @@ float SVGTextLayoutAttributes::emptyValue()
     return s_emptyValue;
 }
 
+RenderSVGInlineText& SVGTextLayoutAttributes::context() { return m_context.get(); }
+const RenderSVGInlineText& SVGTextLayoutAttributes::context() const { return m_context.get(); }
 }

--- a/Source/WebCore/rendering/svg/SVGTextLayoutAttributes.h
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutAttributes.h
@@ -48,8 +48,8 @@ public:
     void clear();
     static float emptyValue();
 
-    RenderSVGInlineText& context() { return m_context; }
-    const RenderSVGInlineText& context() const { return m_context; }
+    RenderSVGInlineText& context();
+    const RenderSVGInlineText& context() const;
     
     SVGCharacterDataMap& characterDataMap() { return m_characterDataMap; }
     const SVGCharacterDataMap& characterDataMap() const { return m_characterDataMap; }
@@ -57,7 +57,7 @@ public:
     Vector<SVGTextMetrics>& textMetricsValues() { return m_textMetricsValues; }
 
 private:
-    RenderSVGInlineText& m_context;
+    SingleThreadWeakRef<RenderSVGInlineText> m_context;
     SVGCharacterDataMap m_characterDataMap;
     Vector<SVGTextMetrics> m_textMetricsValues;
 };

--- a/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
@@ -24,12 +24,12 @@
 #include "RenderSVGInline.h"
 #include "RenderSVGInlineText.h"
 #include "RenderSVGText.h"
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
 SVGTextMetricsBuilder::SVGTextMetricsBuilder()
-    : m_text(0)
-    , m_run(StringView())
+    : m_run(StringView())
     , m_textPosition(0)
     , m_isComplexText(false)
     , m_totalWidth(0)

--- a/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.h
+++ b/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.h
@@ -47,7 +47,7 @@ private:
     void walkTree(RenderElement&, RenderSVGInlineText* stopAtLeaf, MeasureTextData&);
     std::tuple<unsigned, UChar> measureTextRenderer(RenderSVGInlineText&, const MeasureTextData&, std::tuple<unsigned, UChar>);
 
-    RenderSVGInlineText* m_text;
+    SingleThreadWeakPtr<RenderSVGInlineText> m_text;
     TextRun m_run;
     unsigned m_textPosition;
     bool m_isComplexText { false };


### PR DESCRIPTION
#### e05acd940a06b9c9070c748bdd563a8e0d8550f9
<pre>
Use smart pointers for members of SVG classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=273061">https://bugs.webkit.org/show_bug.cgi?id=273061</a>

Reviewed by Chris Dumez.

Use smart pointers for members of SVG classes instead of raw pointers.

* Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp:
(WebCore::SVGBoundingBoxComputation::handleShapeOrTextOrInline const):
(WebCore::SVGBoundingBoxComputation::handleRootOrContainer const):
(WebCore::SVGBoundingBoxComputation::handleForeignObjectOrImage const):
(WebCore::SVGBoundingBoxComputation::adjustBoxForClippingAndEffects const):
* Source/WebCore/rendering/svg/SVGBoundingBoxComputation.h:
* Source/WebCore/rendering/svg/SVGContainerLayout.cpp:
(WebCore::SVGContainerLayout::layoutChildren):
(WebCore::SVGContainerLayout::positionChildrenRelativeToContainer):
(WebCore::SVGContainerLayout::layoutSizeOfNearestViewportChanged const):
* Source/WebCore/rendering/svg/SVGContainerLayout.h:
* Source/WebCore/rendering/svg/SVGLayerTransformComputation.h:
(WebCore::SVGLayerTransformComputation::computeAccumulatedTransform const):
(WebCore::SVGLayerTransformComputation::calculateScreenFontSizeScalingFactor const):
* Source/WebCore/rendering/svg/SVGLayerTransformUpdater.h:
(WebCore::SVGLayerTransformUpdater::SVGLayerTransformUpdater):
(WebCore::SVGLayerTransformUpdater::~SVGLayerTransformUpdater):
(WebCore::SVGLayerTransformUpdater::layerTransformChanged const):
* Source/WebCore/rendering/svg/SVGTextLayoutAttributes.cpp:
(WebCore::SVGTextLayoutAttributes::context):
(WebCore::SVGTextLayoutAttributes::context const):
* Source/WebCore/rendering/svg/SVGTextLayoutAttributes.h:
(WebCore::SVGTextLayoutAttributes::context): Deleted.
(WebCore::SVGTextLayoutAttributes::context const): Deleted.
* Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp:
(WebCore::SVGTextMetricsBuilder::SVGTextMetricsBuilder):
* Source/WebCore/rendering/svg/SVGTextMetricsBuilder.h:

Canonical link: <a href="https://commits.webkit.org/278697@main">https://commits.webkit.org/278697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1483f790bbdd650a17a23cd1769d739a68ece2a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50041 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53284 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/718 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52342 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/287 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40825 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43040 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21941 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24336 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/280 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8411 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46387 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54866 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25135 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/302 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48219 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26393 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43240 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47263 "Build is in progress. Recent messages:Running apply-patch; Checked out pull request; 4 api tests failed or timed out; Running re-run-api-tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11230 "Built successfully and passed tests") | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-10-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26122 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->