### PR TITLE
[view-transitions] https://simple-set-demos.glitch.me/bounce doesn't animate correctly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-syntax.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-syntax.tentative-expected.txt
@@ -18,4 +18,5 @@ PASS Property animation-timing-function value 'linear(0 calc(min(50%, 60%)), 0 1
 PASS Property animation-timing-function value 'linear(0 0% 50%, 1 50% 100%)'
 PASS Property animation-timing-function value 'linear(0, 0.5 25% 75%, 1 100% 100%)'
 PASS Property animation-timing-function value 'linear(0, 1.3, 1, 0.92, 1, 0.99, 1, 0.998, 1 100% 100%)'
+PASS Property animation-timing-function value 'linear(0, 0 40%, 1, 0.5, 1)'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-syntax.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-syntax.tentative.html
@@ -34,6 +34,9 @@ test_computed_value("animation-timing-function", "linear(0 calc(min(50%, 60%)), 
 test_computed_value("animation-timing-function", "linear(0 0% 50%, 1 50% 100%)", "linear(0 0%, 0 50%, 1 50%, 1 100%)");
 test_computed_value("animation-timing-function", "linear(0, 0.5 25% 75%, 1 100% 100%)", "linear(0 0%, 0.5 25%, 0.5 75%, 1 100%, 1 100%)");
 test_computed_value("animation-timing-function", "linear(0, 1.3, 1, 0.92, 1, 0.99, 1, 0.998, 1 100% 100%)", "linear(0 0%, 1.3 12.5%, 1 25%, 0.92 37.5%, 1 50%, 0.99 62.5%, 1 75%, 0.998 87.5%, 1 100%, 1 100%)");
+
+test_computed_value("animation-timing-function", "linear(0, 0 40%, 1, 0.5, 1)", "linear(0 0%, 0 40%, 1 60%, 0.5 80%, 1 100%)");
+
 </script>
 </body>
 </html>

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -2917,12 +2917,12 @@ static RefPtr<CSSValue> consumeLinear(CSSParserTokenRange& range)
         }
 
         if (missingInputRunStart) {
-            double inputLow = missingInputRunStart > 0 ? *steps[*missingInputRunStart - 1].input : 0.0;
-            double inputHigh = i < steps.size() ? *steps[i].input : std::max(1.0, largestInput);
-            double inputAverage = (inputLow + inputHigh) / (i - *missingInputRunStart + 1);
-            for (size_t j = *missingInputRunStart; j < i; ++j)
-                points.append({ steps[j].output, inputAverage * (j - *missingInputRunStart + 1) });
-
+            auto startInput = *steps[*missingInputRunStart - 1].input;
+            auto endInput = *steps[i].input;
+            auto numberOfMissingInputs = i - *missingInputRunStart + 1;
+            auto increment = (endInput - startInput) / numberOfMissingInputs;
+            for (auto j = *missingInputRunStart; j < i; ++j)
+                points.append({ steps[j].output, startInput + increment * (j - *missingInputRunStart + 1) });
             missingInputRunStart = std::nullopt;
         }
 


### PR DESCRIPTION
#### 9b1d46ac8a7f149de038576205e6fbe8836b5670
<pre>
[view-transitions] <a href="https://simple-set-demos.glitch.me/bounce">https://simple-set-demos.glitch.me/bounce</a> doesn&apos;t animate correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=273065">https://bugs.webkit.org/show_bug.cgi?id=273065</a>
<a href="https://rdar.apple.com/126856305">rdar://126856305</a>

Reviewed by Tim Nguyen.

While it&apos;s not entirely clear to me what the parsing code for the `linear()` timing function
was attempting to do to resolve implicit input values into explicit values, the css-easing
spec at <a href="https://drafts.csswg.org/css-easing/#linear-easing-function-serializing">https://drafts.csswg.org/css-easing/#linear-easing-function-serializing</a> specifies
a simple linear interpolation behavior since the last explicit value. This wasn&apos;t correctly
tested by WPT, so we now have a test for this.

This makes <a href="https://simple-set-demos.glitch.me/bounce">https://simple-set-demos.glitch.me/bounce</a> work as expected since we not compute
the correct interpolated values during the bounce animation.

* LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-syntax.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-syntax.tentative.html:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeLinear):

Canonical link: <a href="https://commits.webkit.org/277821@main">https://commits.webkit.org/277821@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcc66b0f113404780a3b992b929aca31ceb842ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48670 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51631 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51357 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44735 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50975 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33818 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25411 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39803 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49252 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25540 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41997 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20900 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23018 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43175 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6726 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44956 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53265 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23717 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20015 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47094 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24983 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42202 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46026 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25787 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6941 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24704 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->