### PR TITLE
Drop mostly unused ActiveDOMObject::activeDOMObjectName()

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -146,7 +146,6 @@ private:
 
     // ActiveDOMObject.
     // FIXME: We probably need to override more methods to make this work properly.
-    const char* activeDOMObjectName() const final { return "GPUDevice"; }
     RefPtr<GPUPipelineLayout> createAutoPipelineLayout();
 
     // EventTarget.

--- a/Source/WebCore/Modules/applepay/ApplePaySession.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePaySession.cpp
@@ -949,11 +949,6 @@ void ApplePaySession::didCancelPaymentSession(PaymentSessionError&& error)
     dispatchEvent(event.get());
 }
 
-const char* ApplePaySession::activeDOMObjectName() const
-{
-    return "ApplePaySession";
-}
-
 bool ApplePaySession::canSuspendWithoutCanceling() const
 {
     switch (m_state) {

--- a/Source/WebCore/Modules/applepay/ApplePaySession.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySession.h
@@ -104,7 +104,6 @@ private:
     ApplePaySession(Document&, unsigned version, ApplePaySessionPaymentRequest&&);
 
     // ActiveDOMObject.
-    const char* activeDOMObjectName() const override;
     void stop() override;
     void suspend(ReasonForSuspension) override;
     bool virtualHasPendingActivity() const final;

--- a/Source/WebCore/Modules/applepay/ApplePaySetupWebCore.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySetupWebCore.h
@@ -55,7 +55,6 @@ private:
     ApplePaySetup(ScriptExecutionContext&, ApplePaySetupConfiguration&&);
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final { return "ApplePaySetup"; }
     void stop() final;
     void suspend(ReasonForSuspension) final;
 

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
@@ -133,11 +133,6 @@ void DOMAudioSession::stop()
 {
 }
 
-const char* DOMAudioSession::activeDOMObjectName() const
-{
-    return "AudioSession";
-}
-
 bool DOMAudioSession::virtualHasPendingActivity() const
 {
     return hasEventListeners(eventNames().statechangeEvent);

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.h
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.h
@@ -66,7 +66,6 @@ private:
 
     // ActiveDOMObject
     void stop() final;
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
 
     // InterruptionObserver

--- a/Source/WebCore/Modules/cache/DOMCache.cpp
+++ b/Source/WebCore/Modules/cache/DOMCache.cpp
@@ -576,9 +576,4 @@ void DOMCache::stop()
     m_connection->dereference(m_identifier);
 }
 
-const char* DOMCache::activeDOMObjectName() const
-{
-    return "Cache";
-}
-
 } // namespace WebCore

--- a/Source/WebCore/Modules/cache/DOMCache.h
+++ b/Source/WebCore/Modules/cache/DOMCache.h
@@ -70,7 +70,6 @@ private:
 
     // ActiveDOMObject
     void stop() final;
-    const char* activeDOMObjectName() const final;
 
     void putWithResponseData(DOMPromiseDeferred<void>&&, Ref<FetchRequest>&&, Ref<FetchResponse>&&, ExceptionOr<RefPtr<SharedBuffer>>&&);
 

--- a/Source/WebCore/Modules/cache/DOMCacheStorage.cpp
+++ b/Source/WebCore/Modules/cache/DOMCacheStorage.cpp
@@ -303,9 +303,4 @@ void DOMCacheStorage::stop()
     m_isStopped = true;
 }
 
-const char* DOMCacheStorage::activeDOMObjectName() const
-{
-    return "CacheStorage";
-}
-
 } // namespace WebCore

--- a/Source/WebCore/Modules/cache/DOMCacheStorage.h
+++ b/Source/WebCore/Modules/cache/DOMCacheStorage.h
@@ -52,7 +52,6 @@ private:
 
     // ActiveDOMObject
     void stop() final;
-    const char* activeDOMObjectName() const final;
 
     void doOpen(const String& name, DOMPromiseDeferred<IDLInterface<DOMCache>>&&);
     void doRemove(const String&, DOMPromiseDeferred<IDLBoolean>&&);

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -510,11 +510,6 @@ void CookieStore::cookiesDeleted(const String& host, const Vector<Cookie>& cooki
     queueTaskToDispatchEvent(*this, TaskSource::DOMManipulation, CookieChangeEvent::create(eventNames().changeEvent, WTFMove(eventInit), CookieChangeEvent::IsTrusted::Yes));
 }
 
-const char* CookieStore::activeDOMObjectName() const
-{
-    return "CookieStore";
-}
-
 void CookieStore::stop()
 {
     // FIXME: This should work for service worker contexts as well.

--- a/Source/WebCore/Modules/cookie-store/CookieStore.h
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.h
@@ -75,7 +75,6 @@ private:
     void cookiesDeleted(const String& host, const Vector<Cookie>&) final;
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final;
     void stop() final;
     bool virtualHasPendingActivity() const final;
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -814,11 +814,6 @@ bool MediaKeySession::virtualHasPendingActivity() const
     return !m_closed && m_keys;
 }
 
-const char* MediaKeySession::activeDOMObjectName() const
-{
-    return "MediaKeySession";
-}
-
 void MediaKeySession::stop()
 {
     if (m_closed) {

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
@@ -114,7 +114,6 @@ private:
     void derefEventTarget() override { deref(); }
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
     void stop() final;
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.h
@@ -55,9 +55,6 @@ public:
 private:
     MediaKeySystemAccess(Document&, const String& keySystem, MediaKeySystemConfiguration&&, Ref<CDM>&&);
 
-    // ActiveDOMObject
-    const char *activeDOMObjectName() const final { return "MediaKeySystemAccess"; }
-
     String m_keySystem;
     std::unique_ptr<MediaKeySystemConfiguration> m_configuration;
     Ref<CDM> m_implementation;

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp
@@ -115,11 +115,6 @@ void MediaKeySystemRequest::stop()
         controller->cancelMediaKeySystemRequest(*this);
 }
 
-const char* MediaKeySystemRequest::activeDOMObjectName() const
-{
-    return "MediaKeySystemRequest";
-}
-
 Document* MediaKeySystemRequest::document() const
 {
     return downcast<Document>(scriptExecutionContext());

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.h
@@ -63,7 +63,6 @@ private:
     MediaKeySystemRequest(Document&, const String& keySystem, Ref<DeferredPromise>&&);
 
     void stop() final;
-    const char* activeDOMObjectName() const final;
 
     String m_keySystem;
     Ref<DeferredPromise> m_promise;

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp
@@ -246,11 +246,6 @@ void WebKitMediaKeySession::stop()
     close();
 }
 
-const char* WebKitMediaKeySession::activeDOMObjectName() const
-{
-    return "WebKitMediaKeySession";
-}
-
 #if !RELEASE_LOG_DISABLED
 WTFLogChannel& WebKitMediaKeySession::logChannel() const
 {

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
@@ -77,7 +77,6 @@ private:
 
     // ActiveDOMObject.
     void stop() final;
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
 
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::WebKitMediaKeySession; }

--- a/Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.cpp
+++ b/Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.cpp
@@ -56,11 +56,6 @@ FileSystemDirectoryReader::FileSystemDirectoryReader(ScriptExecutionContext& con
 
 FileSystemDirectoryReader::~FileSystemDirectoryReader() = default;
 
-const char* FileSystemDirectoryReader::activeDOMObjectName() const
-{
-    return "FileSystemDirectoryReader";
-}
-
 Document* FileSystemDirectoryReader::document() const
 {
     return downcast<Document>(scriptExecutionContext());

--- a/Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.h
+++ b/Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.h
@@ -50,7 +50,6 @@ public:
 private:
     FileSystemDirectoryReader(ScriptExecutionContext&, FileSystemDirectoryEntry&);
 
-    const char* activeDOMObjectName() const final;
     Document* document() const;
 
     Ref<FileSystemDirectoryEntry> m_directory;

--- a/Source/WebCore/Modules/entriesapi/FileSystemEntry.cpp
+++ b/Source/WebCore/Modules/entriesapi/FileSystemEntry.cpp
@@ -56,11 +56,6 @@ DOMFileSystem& FileSystemEntry::filesystem() const
     return m_filesystem.get();
 }
 
-const char* FileSystemEntry::activeDOMObjectName() const
-{
-    return "FileSystemEntry";
-}
-
 Document* FileSystemEntry::document() const
 {
     return downcast<Document>(scriptExecutionContext());

--- a/Source/WebCore/Modules/entriesapi/FileSystemEntry.h
+++ b/Source/WebCore/Modules/entriesapi/FileSystemEntry.h
@@ -55,8 +55,6 @@ protected:
     Document* document() const;
 
 private:
-    const char* activeDOMObjectName() const final;
-
     Ref<DOMFileSystem> m_filesystem;
     String m_name;
     String m_virtualPath;

--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -364,11 +364,6 @@ void FetchRequest::stop()
     FetchBodyOwner::stop();
 }
 
-const char* FetchRequest::activeDOMObjectName() const
-{
-    return "Request";
-}
-
 WebCoreOpaqueRoot root(FetchRequest* request)
 {
     return WebCoreOpaqueRoot { request };

--- a/Source/WebCore/Modules/fetch/FetchRequest.h
+++ b/Source/WebCore/Modules/fetch/FetchRequest.h
@@ -102,7 +102,6 @@ private:
     ExceptionOr<void> setBody(FetchRequest&);
 
     void stop() final;
-    const char* activeDOMObjectName() const final;
 
     Ref<AbortSignal> protectedSignal() const { return m_signal; }
 

--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -567,11 +567,6 @@ void FetchResponse::stop()
         bodyLoader->stop();
 }
 
-const char* FetchResponse::activeDOMObjectName() const
-{
-    return "Response";
-}
-
 void FetchResponse::loadBody()
 {
     if (m_bodyLoader)

--- a/Source/WebCore/Modules/fetch/FetchResponse.h
+++ b/Source/WebCore/Modules/fetch/FetchResponse.h
@@ -137,7 +137,6 @@ private:
 
     // FetchBodyOwner
     void stop() final;
-    const char* activeDOMObjectName() const final;
     void loadBody() final;
 
     const ResourceResponse& filteredResponse() const;

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemHandle.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemHandle.cpp
@@ -86,11 +86,6 @@ void FileSystemHandle::move(FileSystemHandle& destinationHandle, const String& n
     });
 }
 
-const char* FileSystemHandle::activeDOMObjectName() const
-{
-    return "FileSystemHandle";
-}
-
 void FileSystemHandle::stop()
 {
     close();

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemHandle.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemHandle.h
@@ -61,7 +61,6 @@ protected:
 
 private:
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final;
     void stop() final;
 
     Kind m_kind { Kind::File };

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.cpp
@@ -151,11 +151,6 @@ ExceptionOr<unsigned long long> FileSystemSyncAccessHandle::write(BufferSource&&
     return result;
 }
 
-const char* FileSystemSyncAccessHandle::activeDOMObjectName() const
-{
-    return "FileSystemSyncAccessHandle";
-}
-
 void FileSystemSyncAccessHandle::stop()
 {
     closeInternal(ShouldNotifyBackend::Yes);

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.h
@@ -65,7 +65,6 @@ private:
     bool requestSpaceForWrite(uint64_t writeOffset, uint64_t writeLength);
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final;
     void stop() final;
 
     Ref<FileSystemFileHandle> m_source;

--- a/Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp
@@ -156,11 +156,6 @@ const Document* GamepadHapticActuator::document() const
     return downcast<Document>(scriptExecutionContext());
 }
 
-const char* GamepadHapticActuator::activeDOMObjectName() const
-{
-    return "GamepadHapticActuator";
-}
-
 void GamepadHapticActuator::suspend(ReasonForSuspension)
 {
     stopEffects([] { });

--- a/Source/WebCore/Modules/gamepad/GamepadHapticActuator.h
+++ b/Source/WebCore/Modules/gamepad/GamepadHapticActuator.h
@@ -65,7 +65,6 @@ private:
     RefPtr<DeferredPromise>& promiseForEffectType(EffectType);
 
     // ActiveDOMObject.
-    const char* activeDOMObjectName() const final;
     void suspend(ReasonForSuspension) final;
     void stop() final;
 

--- a/Source/WebCore/Modules/geolocation/Geolocation.cpp
+++ b/Source/WebCore/Modules/geolocation/Geolocation.cpp
@@ -282,11 +282,6 @@ void Geolocation::stop()
     m_pendingForPermissionNotifiers.clear();
 }
 
-const char* Geolocation::activeDOMObjectName() const
-{
-    return "Geolocation";
-}
-
 GeolocationPosition* Geolocation::lastPosition()
 {
     Page* page = this->page();

--- a/Source/WebCore/Modules/geolocation/Geolocation.h
+++ b/Source/WebCore/Modules/geolocation/Geolocation.h
@@ -87,7 +87,6 @@ private:
     void stop() override;
     void suspend(ReasonForSuspension) override;
     void resume() override;
-    const char* activeDOMObjectName() const override;
 
     bool isDenied() const { return m_allowGeolocation == No; }
 

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
@@ -303,12 +303,6 @@ void IDBDatabase::maybeCloseInServer()
     m_connectionProxy->databaseConnectionClosed(*this);
 }
 
-const char* IDBDatabase::activeDOMObjectName() const
-{
-    ASSERT(canCurrentThreadAccessThreadLocalData(originThread()));
-    return "IDBDatabase";
-}
-
 void IDBDatabase::stop()
 {
     LOG(IndexedDB, "IDBDatabase::stop - %" PRIu64, m_databaseConnectionIdentifier.toUInt64());

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.h
@@ -117,7 +117,6 @@ private:
 
     // ActiveDOMObject.
     bool virtualHasPendingActivity() const final;
-    const char* activeDOMObjectName() const final;
     void stop() final;
 
     void maybeCloseInServer();

--- a/Source/WebCore/Modules/indexeddb/IDBDatabaseNameAndVersionRequest.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabaseNameAndVersionRequest.cpp
@@ -58,12 +58,6 @@ void IDBDatabaseNameAndVersionRequest::complete(std::optional<Vector<IDBDatabase
         callback(WTFMove(databases));
 }
 
-const char* IDBDatabaseNameAndVersionRequest::activeDOMObjectName() const
-{
-    ASSERT(canCurrentThreadAccessThreadLocalData(originThread()));
-    return "IDBDatabaseNameAndVersionRequest";
-}
-
 bool IDBDatabaseNameAndVersionRequest::virtualHasPendingActivity() const
 {
     ASSERT(canCurrentThreadAccessThreadLocalData(originThread()) || Thread::mayBeGCThread());

--- a/Source/WebCore/Modules/indexeddb/IDBDatabaseNameAndVersionRequest.h
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabaseNameAndVersionRequest.h
@@ -63,7 +63,6 @@ private:
 
     // ActiveDOMObject.
     bool virtualHasPendingActivity() const final;
-    const char* activeDOMObjectName() const final;
     void stop() final;
 
     Ref<IDBClient::IDBConnectionProxy> m_connectionProxy;

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.cpp
@@ -64,11 +64,6 @@ IDBIndex::~IDBIndex()
     ASSERT(canCurrentThreadAccessThreadLocalData(m_objectStore.transaction().database().originThread()));
 }
 
-const char* IDBIndex::activeDOMObjectName() const
-{
-    return "IDBIndex";
-}
-
 bool IDBIndex::virtualHasPendingActivity() const
 {
     return m_objectStore.hasPendingActivity();

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.h
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.h
@@ -98,7 +98,6 @@ private:
     ExceptionOr<Ref<IDBRequest>> doGetAllKeys(std::optional<uint32_t> count, Function<ExceptionOr<RefPtr<IDBKeyRange>>()> &&);
 
     // ActiveDOMObject.
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
 
     IDBIndexInfo m_info;

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
@@ -76,11 +76,6 @@ IDBObjectStore::~IDBObjectStore()
     ASSERT(canCurrentThreadAccessThreadLocalData(m_transaction.database().originThread()));
 }
 
-const char* IDBObjectStore::activeDOMObjectName() const
-{
-    return "IDBObjectStore";
-}
-
 bool IDBObjectStore::virtualHasPendingActivity() const
 {
     return m_transaction.hasPendingActivity();

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.h
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.h
@@ -127,7 +127,6 @@ private:
     ExceptionOr<Ref<IDBRequest>> doGetAllKeys(std::optional<uint32_t> count, Function<ExceptionOr<RefPtr<IDBKeyRange>>()> &&);
 
     // ActiveDOMObject.
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
 
     IDBObjectStoreInfo m_info;

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.cpp
@@ -253,13 +253,6 @@ enum EventTargetInterfaceType IDBRequest::eventTargetInterface() const
     return EventTargetInterfaceType::IDBRequest;
 }
 
-const char* IDBRequest::activeDOMObjectName() const
-{
-    ASSERT(canCurrentThreadAccessThreadLocalData(originThread()));
-
-    return "IDBRequest";
-}
-
 bool IDBRequest::virtualHasPendingActivity() const
 {
     ASSERT(canCurrentThreadAccessThreadLocalData(originThread()) || Thread::mayBeGCThread());

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.h
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.h
@@ -152,7 +152,6 @@ private:
 
     // ActiveDOMObject.
     bool virtualHasPendingActivity() const final;
-    const char* activeDOMObjectName() const final;
     void stop() final;
 
     virtual void cancelForStop();

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -317,12 +317,6 @@ void IDBTransaction::abortOnServerAndCancelRequests(IDBClient::TransactionOperat
     ASSERT(m_pendingTransactionOperationQueue.isEmpty());
 }
 
-const char* IDBTransaction::activeDOMObjectName() const
-{
-    ASSERT(canCurrentThreadAccessThreadLocalData(m_database->originThread()));
-    return "IDBTransaction";
-}
-
 bool IDBTransaction::virtualHasPendingActivity() const
 {
     ASSERT(canCurrentThreadAccessThreadLocalData(m_database->originThread()) || Thread::mayBeGCThread());

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.h
@@ -161,7 +161,6 @@ private:
     IDBTransaction(IDBDatabase&, const IDBTransactionInfo&, IDBOpenDBRequest*);
 
     // ActiveDOMObject.
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
 
     void commitInternal();

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp
@@ -139,11 +139,6 @@ void MediaRecorder::suspend(ReasonForSuspension reason)
     queueTaskToDispatchEvent(*this, TaskSource::Networking, MediaRecorderErrorEvent::create(eventNames().errorEvent, Exception { ExceptionCode::UnknownError, "MediaStream recording was interrupted"_s }));
 }
 
-const char* MediaRecorder::activeDOMObjectName() const
-{
-    return "MediaRecorder";
-}
-
 ExceptionOr<void> MediaRecorder::startRecording(std::optional<unsigned> timeSlice)
 {
     if (!m_isActive)

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
@@ -100,7 +100,6 @@ private:
     // ActiveDOMObject API.
     void suspend(ReasonForSuspension) final;
     void stop() final;
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
     
     void stopRecordingInternal(CompletionHandler<void()>&& = [] { });

--- a/Source/WebCore/Modules/mediasession/MediaSession.h
+++ b/Source/WebCore/Modules/mediasession/MediaSession.h
@@ -138,7 +138,6 @@ private:
     void notifyReadyStateObservers();
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final { return "MediaSession"; }
     void suspend(ReasonForSuspension) final;
     void stop() final;
     bool virtualHasPendingActivity() const final;

--- a/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h
+++ b/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h
@@ -88,7 +88,6 @@ private:
     void eventListenersDidChange() final;
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final { return "MediaSessionCoordinator"; }
     bool virtualHasPendingActivity() const final;
 
     // MediaSession::Observer

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -1262,11 +1262,6 @@ void MediaSource::stop()
     m_private = nullptr;
 }
 
-const char* MediaSource::activeDOMObjectName() const
-{
-    return "MediaSource";
-}
-
 MediaSource::ReadyState MediaSource::readyState() const
 {
     return (m_openDeferred || !m_private) ? ReadyState::Closed : m_private->readyState();

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -190,7 +190,6 @@ private:
 
     // ActiveDOMObject.
     void stop() final;
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
     static bool isTypeSupported(ScriptExecutionContext&, const String& type, Vector<ContentType>&& contentTypesRequiringHardwareSupport);
 

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -567,11 +567,6 @@ bool SourceBuffer::virtualHasPendingActivity() const
     return m_source;
 }
 
-const char* SourceBuffer::activeDOMObjectName() const
-{
-    return "SourceBuffer";
-}
-
 bool SourceBuffer::isRemoved() const
 {
     return !m_source;

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -160,7 +160,6 @@ private:
     void derefEventTarget() final { deref(); }
 
     // ActiveDOMObject.
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
 
     Ref<MediaPromise> sourceBufferPrivateDidReceiveInitializationSegment(SourceBufferPrivateClient::InitializationSegment&&);

--- a/Source/WebCore/Modules/mediasource/SourceBufferList.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBufferList.cpp
@@ -105,11 +105,6 @@ void SourceBufferList::scheduleEvent(const AtomString& eventName)
     queueTaskToDispatchEvent(*this, TaskSource::MediaElement, Event::create(eventName, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
-const char* SourceBufferList::activeDOMObjectName() const
-{
-    return "SourceBufferList";
-}
-
 WebCoreOpaqueRoot root(SourceBufferList* list)
 {
     return WebCoreOpaqueRoot { list };

--- a/Source/WebCore/Modules/mediasource/SourceBufferList.h
+++ b/Source/WebCore/Modules/mediasource/SourceBufferList.h
@@ -80,8 +80,6 @@ private:
     void refEventTarget() override { ref(); }
     void derefEventTarget() override { deref(); }
 
-    const char* activeDOMObjectName() const final;
-
     Vector<RefPtr<SourceBuffer>> m_list;
 };
 

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
@@ -74,11 +74,6 @@ Ref<CanvasCaptureMediaStreamTrack::Source> CanvasCaptureMediaStreamTrack::Source
     return source;
 }
 
-const char* CanvasCaptureMediaStreamTrack::activeDOMObjectName() const
-{
-    return "CanvasCaptureMediaStreamTrack";
-}
-
 // FIXME: Give source id and name
 CanvasCaptureMediaStreamTrack::Source::Source(HTMLCanvasElement& canvas, std::optional<double>&& frameRequestRate)
     : RealtimeMediaSource(CaptureDevice { { }, CaptureDevice::DeviceType::Camera, "CanvasCaptureMediaStreamTrack"_s })

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h
@@ -50,8 +50,6 @@ public:
     RefPtr<MediaStreamTrack> clone() final;
 
 private:
-    const char* activeDOMObjectName() const override;
-
     class Source final : public RealtimeMediaSource, private CanvasObserver, private CanvasDisplayBufferObserver, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Source, WTF::DestructionThread::MainRunLoop> {
     public:
         static Ref<Source> create(HTMLCanvasElement&, std::optional<double>&& frameRequestRate);

--- a/Source/WebCore/Modules/mediastream/ImageCapture.cpp
+++ b/Source/WebCore/Modules/mediastream/ImageCapture.cpp
@@ -151,11 +151,6 @@ void ImageCapture::getPhotoSettings(DOMPromiseDeferred<IDLDictionary<PhotoSettin
     });
 }
 
-const char* ImageCapture::activeDOMObjectName() const
-{
-    return "ImageCapture";
-}
-
 #if !RELEASE_LOG_DISABLED
 WTFLogChannel& ImageCapture::logChannel() const
 {

--- a/Source/WebCore/Modules/mediastream/ImageCapture.h
+++ b/Source/WebCore/Modules/mediastream/ImageCapture.h
@@ -64,9 +64,6 @@ private:
     WTFLogChannel& logChannel() const;
 #endif
 
-    // ActiveDOMObject API.
-    const char* activeDOMObjectName() const final;
-
     Ref<MediaStreamTrack> m_track;
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -383,11 +383,6 @@ bool MediaDevices::virtualHasPendingActivity() const
     return hasEventListeners(m_eventNames.devicechangeEvent);
 }
 
-const char* MediaDevices::activeDOMObjectName() const
-{
-    return "MediaDevices";
-}
-
 void MediaDevices::listenForDeviceChanges()
 {
     RefPtr document = this->document();

--- a/Source/WebCore/Modules/mediastream/MediaDevices.h
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.h
@@ -109,7 +109,6 @@ private:
     friend class JSMediaDevicesOwner;
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final;
     void stop() final;
     bool virtualHasPendingActivity() const final;
 

--- a/Source/WebCore/Modules/mediastream/MediaStream.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStream.cpp
@@ -369,11 +369,6 @@ void MediaStream::stop()
     m_isActive = false;
 }
 
-const char* MediaStream::activeDOMObjectName() const
-{
-    return "MediaStream";
-}
-
 bool MediaStream::virtualHasPendingActivity() const
 {
     return m_isActive;

--- a/Source/WebCore/Modules/mediastream/MediaStream.h
+++ b/Source/WebCore/Modules/mediastream/MediaStream.h
@@ -137,7 +137,6 @@ private:
 
     // ActiveDOMObject API.
     void stop() final;
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
 
     void updateActiveState();

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -573,11 +573,6 @@ void MediaStreamTrack::configureTrackRendering()
     // ... media from the source only flows when a MediaStreamTrack object is both unmuted and enabled
 }
 
-const char* MediaStreamTrack::activeDOMObjectName() const
-{
-    return "MediaStreamTrack";
-}
-
 void MediaStreamTrack::suspend(ReasonForSuspension reason)
 {
     if (reason != ReasonForSuspension::BackForwardCache)

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -195,7 +195,6 @@ private:
 
     // ActiveDOMObject API.
     void stop() final { stopTrack(); }
-    const char* activeDOMObjectName() const override;
     void suspend(ReasonForSuspension) final;
     bool virtualHasPendingActivity() const final;
 

--- a/Source/WebCore/Modules/mediastream/RTCDTMFSender.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFSender.cpp
@@ -151,11 +151,6 @@ void RTCDTMFSender::stop()
     m_toneTimer.stop();
 }
 
-const char* RTCDTMFSender::activeDOMObjectName() const
-{
-    return "RTCDTMFSender";
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/mediastream/RTCDTMFSender.h
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFSender.h
@@ -57,7 +57,6 @@ private:
     RTCDTMFSender(ScriptExecutionContext&, RTCRtpSender&, std::unique_ptr<RTCDTMFSenderBackend>&&);
 
     void stop() final;
-    const char* activeDOMObjectName() const final;
 
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::RTCDTMFSender; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.h
@@ -108,7 +108,6 @@ private:
 
     // ActiveDOMObject API
     void stop() final;
-    const char* activeDOMObjectName() const final { return "RTCDataChannel"; }
     bool virtualHasPendingActivity() const final;
 
     // RTCDataChannelHandlerClient API

--- a/Source/WebCore/Modules/mediastream/RTCDtlsTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCDtlsTransport.h
@@ -67,7 +67,6 @@ private:
 
     // ActiveDOMObject
     void stop() final;
-    const char* activeDOMObjectName() const final { return "RTCDtlsTransport"; }
     bool virtualHasPendingActivity() const final;
 
     // RTCDtlsTransportBackend::Client

--- a/Source/WebCore/Modules/mediastream/RTCIceTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCIceTransport.h
@@ -79,7 +79,6 @@ private:
 
     // ActiveDOMObject
     void stop() final;
-    const char* activeDOMObjectName() const final { return "RTCIceTransport"; }
     bool virtualHasPendingActivity() const final;
 
     // RTCIceTransportBackend::Client

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -632,11 +632,6 @@ void RTCPeerConnection::unregisterFromController()
         m_controller->remove(*this);
 }
 
-const char* RTCPeerConnection::activeDOMObjectName() const
-{
-    return "RTCPeerConnection";
-}
-
 void RTCPeerConnection::suspend(ReasonForSuspension reason)
 {
     if (reason != ReasonForSuspension::BackForwardCache)

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -228,7 +228,6 @@ private:
 
     // ActiveDOMObject
     WEBCORE_EXPORT void stop() final;
-    const char* activeDOMObjectName() const final;
     void suspend(ReasonForSuspension) final;
     void resume() final;
     bool virtualHasPendingActivity() const final;

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
@@ -82,7 +82,6 @@ private:
     RTCRtpSFrameTransform(ScriptExecutionContext&, Options);
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final { return "RTCRtpSFrameTransform"; }
     bool virtualHasPendingActivity() const final;
 
     // EventTarget

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.h
@@ -65,9 +65,6 @@ private:
     bool setupTransformer(Ref<RTCRtpTransformBackend>&&);
     void clear(RTCRtpScriptTransformer::ClearCallback);
 
-    // ActiveDOMObject
-    const char* activeDOMObjectName() const final { return "RTCRtpScriptTransform"; }
-
     Ref<Worker> m_worker;
 
     bool m_isAttached { false };

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h
@@ -78,7 +78,6 @@ private:
     RTCRtpScriptTransformer(ScriptExecutionContext&, Ref<SerializedScriptValue>&&, Vector<Ref<MessagePort>>&&, Ref<ReadableStream>&&, Ref<SimpleReadableStreamSource>&&);
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final { return "RTCRtpScriptTransformer"; }
     void stop() final { stopPendingActivity(); }
 
     void stopPendingActivity() { auto pendingActivity = WTFMove(m_pendingActivity); }

--- a/Source/WebCore/Modules/mediastream/RTCSctpTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCSctpTransport.h
@@ -64,7 +64,6 @@ private:
 
     // ActiveDOMObject
     void stop() final;
-    const char* activeDOMObjectName() const final { return "RTCSctpTransport"; }
     bool virtualHasPendingActivity() const final;
 
     // RTCSctpTransport::Client

--- a/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
@@ -269,11 +269,6 @@ void UserMediaRequest::stop()
         controller->cancelUserMediaAccessRequest(*this);
 }
 
-const char* UserMediaRequest::activeDOMObjectName() const
-{
-    return "UserMediaRequest";
-}
-
 Document* UserMediaRequest::document() const
 {
     return downcast<Document>(scriptExecutionContext());

--- a/Source/WebCore/Modules/mediastream/UserMediaRequest.h
+++ b/Source/WebCore/Modules/mediastream/UserMediaRequest.h
@@ -84,7 +84,6 @@ private:
     UserMediaRequest(Document&, MediaStreamRequest&&, TrackConstraints&&, TrackConstraints&&, DOMPromiseDeferred<IDLInterface<MediaStream>>&&);
 
     void stop() final;
-    const char* activeDOMObjectName() const final;
 
     Vector<String> m_videoDeviceUIDs;
     Vector<String> m_audioDeviceUIDs;

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -728,11 +728,6 @@ void HTMLModelElement::setIsMuted(bool isMuted, DOMPromiseDeferred<void>&& promi
     });
 }
 
-const char* HTMLModelElement::activeDOMObjectName() const
-{
-    return "HTMLModelElement";
-}
-
 bool HTMLModelElement::virtualHasPendingActivity() const
 {
     // We need to ensure the JS wrapper is kept alive if a load is in progress and we may yet dispatch

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -140,7 +140,6 @@ private:
     HTMLModelElement& readyPromiseResolve();
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
 
     // DOM overrides.

--- a/Source/WebCore/Modules/notifications/Notification.cpp
+++ b/Source/WebCore/Modules/notifications/Notification.cpp
@@ -295,11 +295,6 @@ NotificationClient* Notification::clientFromContext()
     return nullptr;
 }
 
-const char* Notification::activeDOMObjectName() const
-{
-    return "Notification";
-}
-
 void Notification::stop()
 {
     ActiveDOMObject::stop();

--- a/Source/WebCore/Modules/notifications/Notification.h
+++ b/Source/WebCore/Modules/notifications/Notification.h
@@ -141,7 +141,6 @@ private:
     void stopResourcesLoader();
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final;
     void suspend(ReasonForSuspension);
     void stop() final;
     bool virtualHasPendingActivity() const final;

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.h
@@ -128,7 +128,6 @@ private:
     void closeActivePaymentHandler();
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final { return "PaymentRequest"; }
     void stop() final;
     void suspend(ReasonForSuspension) final;
 

--- a/Source/WebCore/Modules/paymentrequest/PaymentResponse.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentResponse.h
@@ -100,7 +100,6 @@ private:
     void finishConstruction();
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final { return "PaymentResponse"; }
     void stop() final;
     void suspend(ReasonForSuspension) final;
 

--- a/Source/WebCore/Modules/permissions/PermissionStatus.cpp
+++ b/Source/WebCore/Modules/permissions/PermissionStatus.cpp
@@ -105,11 +105,6 @@ void PermissionStatus::stateChanged(PermissionState newState)
     queueTaskToDispatchEvent(*this, TaskSource::Permission, Event::create(eventNames().changeEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
-const char* PermissionStatus::activeDOMObjectName() const
-{
-    return "PermissionStatus";
-}
-
 bool PermissionStatus::virtualHasPendingActivity() const
 {
     if (!m_hasChangeEventListener)

--- a/Source/WebCore/Modules/permissions/PermissionStatus.h
+++ b/Source/WebCore/Modules/permissions/PermissionStatus.h
@@ -57,7 +57,6 @@ private:
     PermissionStatus(ScriptExecutionContext&, PermissionState, PermissionDescriptor, PermissionQuerySource, SingleThreadWeakPtr<Page>&&);
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
 
     // EventTarget

--- a/Source/WebCore/Modules/pictureinpicture/PictureInPictureWindow.h
+++ b/Source/WebCore/Modules/pictureinpicture/PictureInPictureWindow.h
@@ -54,9 +54,6 @@ public:
 
 private:
     PictureInPictureWindow(Document&);
-        
-    // ActiveDOMObject
-    const char* activeDOMObjectName() const final { return "PictureInPictureWindow"; }
 
     // EventTarget
     void refEventTarget() final { ref(); }

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.cpp
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.cpp
@@ -435,11 +435,6 @@ void RemotePlayback::invalidate()
     m_mediaElement = nullptr;
 }
 
-const char* RemotePlayback::activeDOMObjectName() const
-{
-    return "RemotePlayback";
-}
-
 #if !RELEASE_LOG_DISABLED
 WTFLogChannel& RemotePlayback::logChannel() const
 {

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
@@ -88,9 +88,6 @@ private:
     void establishConnection();
     void disconnect();
 
-    // ActiveDOMObject.
-    const char* activeDOMObjectName() const final;
-
     // EventTarget.
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::RemotePlayback; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp
@@ -63,11 +63,6 @@ void WakeLockSentinel::release(WakeLockManager& manager)
         dispatchEvent(Event::create(eventNames().releaseEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
-const char* WakeLockSentinel::activeDOMObjectName() const
-{
-    return "WakeLockSentinel";
-}
-
 // https://www.w3.org/TR/screen-wake-lock/#garbage-collection
 bool WakeLockSentinel::virtualHasPendingActivity() const
 {

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.h
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.h
@@ -57,7 +57,6 @@ private:
     WakeLockSentinel(Document&, WakeLockType);
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
 
     // EventTarget

--- a/Source/WebCore/Modules/speech/SpeechRecognition.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognition.cpp
@@ -107,11 +107,6 @@ void SpeechRecognition::abortRecognition()
     m_state = State::Aborting;
 }
 
-const char* SpeechRecognition::activeDOMObjectName() const
-{
-    return "SpeechRecognition";
-}
-
 void SpeechRecognition::stop()
 {
     abortRecognition();

--- a/Source/WebCore/Modules/speech/SpeechRecognition.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognition.h
@@ -91,7 +91,6 @@ private:
     void didEnd() final;
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final;
     void suspend(ReasonForSuspension) final;
     void stop() final;
 

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
@@ -339,11 +339,6 @@ void SpeechSynthesis::simulateVoicesListChange()
         voicesDidChange();
 }
 
-const char* SpeechSynthesis::activeDOMObjectName() const
-{
-    return "SpeechSynthesis";
-}
-
 bool SpeechSynthesis::virtualHasPendingActivity() const
 {
     return m_voiceList && m_hasEventListener;

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.h
@@ -99,7 +99,6 @@ private:
     void voicesChanged() override;
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
 
     void startSpeakingImmediately(SpeechSynthesisUtterance&);

--- a/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp
@@ -115,11 +115,6 @@ void SpeechSynthesisUtterance::decrementActivityCountForEventDispatch()
     --m_activityCountForEventDispatch;
 }
 
-const char* SpeechSynthesisUtterance::activeDOMObjectName() const
-{
-    return "SpeechSynthesisUtterance";
-}
-
 bool SpeechSynthesisUtterance::virtualHasPendingActivity() const
 {
     return m_activityCountForEventDispatch && hasEventListeners();

--- a/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
@@ -85,7 +85,6 @@ private:
     void decrementActivityCountForEventDispatch();
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
 
     // EventTarget

--- a/Source/WebCore/Modules/web-locks/WebLockManager.cpp
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.cpp
@@ -367,9 +367,4 @@ bool WebLockManager::virtualHasPendingActivity() const
     return !m_pendingRequests.isEmpty() || !m_releasePromises.isEmpty();
 }
 
-const char* WebLockManager::activeDOMObjectName() const
-{
-    return "WebLockManager";
-}
-
 } // namespace WebCore

--- a/Source/WebCore/Modules/web-locks/WebLockManager.h
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.h
@@ -70,7 +70,6 @@ private:
 
     // ActiveDOMObject.
     void stop() final;
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
 
     class MainThreadBridge;

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.h
@@ -80,8 +80,6 @@ public:
     // If we are no longer playing, propogate silence ahead to downstream nodes.
     bool propagatesSilence() const final;
 
-    const char* activeDOMObjectName() const override { return "AudioBufferSourceNode"; }
-
 private:
     AudioBufferSourceNode(BaseAudioContext&);
 

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -440,11 +440,6 @@ void AudioContext::resume()
     document()->updateIsPlayingMedia();
 }
 
-const char* AudioContext::activeDOMObjectName() const
-{
-    return "AudioContext";
-}
-
 void AudioContext::suspendPlayback()
 {
     if (state() == State::Closed || !isInitialized())

--- a/Source/WebCore/Modules/webaudio/AudioContext.h
+++ b/Source/WebCore/Modules/webaudio/AudioContext.h
@@ -142,7 +142,6 @@ private:
     void mediaCanStart(Document&) final;
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final;
     void suspend(ReasonForSuspension) final;
     void resume() final;
     bool virtualHasPendingActivity() const final;

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
@@ -315,11 +315,6 @@ void AudioWorkletNode::fireProcessorErrorOnMainThread(ProcessorError error)
     });
 }
 
-const char* AudioWorkletNode::activeDOMObjectName() const
-{
-    return "AudioWorkletNode";
-}
-
 bool AudioWorkletNode::virtualHasPendingActivity() const
 {
     return !context().isClosed();

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.h
@@ -79,7 +79,6 @@ private:
     void updatePullStatus() final;
 
     // ActiveDOMObject.
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
 
     String m_name;

--- a/Source/WebCore/Modules/webaudio/ConstantSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/ConstantSourceNode.h
@@ -52,8 +52,6 @@ private:
     // If we are no longer playing, propogate silence ahead to downstream nodes.
     bool propagatesSilence() const final;
     
-    const char* activeDOMObjectName() const override { return "ConstantSourceNode"; }
-    
     Ref<AudioParam> m_offset;
     
     // Stores sample-accurate values calculated.

--- a/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
@@ -87,11 +87,6 @@ void OfflineAudioContext::uninitialize()
         promise->reject(Exception { ExceptionCode::InvalidStateError, "Context is going away"_s });
 }
 
-const char* OfflineAudioContext::activeDOMObjectName() const
-{
-    return "OfflineAudioContext";
-}
-
 void OfflineAudioContext::startRendering(Ref<DeferredPromise>&& promise)
 {
     if (isStopped()) {

--- a/Source/WebCore/Modules/webaudio/OfflineAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioContext.h
@@ -59,7 +59,6 @@ private:
     AudioBuffer* renderTarget() const { return destination().renderTarget(); }
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
 
     void settleRenderingPromise(ExceptionOr<Ref<AudioBuffer>>&&);

--- a/Source/WebCore/Modules/webaudio/OscillatorNode.h
+++ b/Source/WebCore/Modules/webaudio/OscillatorNode.h
@@ -41,8 +41,6 @@ public:
 
     virtual ~OscillatorNode();
 
-    const char* activeDOMObjectName() const final { return "OscillatorNode"; }
-
     OscillatorType typeForBindings() const { ASSERT(isMainThread()); return m_type; }
     ExceptionOr<void> setTypeForBindings(OscillatorType);
 

--- a/Source/WebCore/Modules/webaudio/ScriptProcessorNode.h
+++ b/Source/WebCore/Modules/webaudio/ScriptProcessorNode.h
@@ -56,8 +56,6 @@ public:
 
     virtual ~ScriptProcessorNode();
 
-    const char* activeDOMObjectName() const override { return "ScriptProcessorNode"; }
-
     // AudioNode
     void process(size_t framesToProcess) override;
     void initialize() override;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
@@ -315,11 +315,6 @@ void WebCodecsAudioDecoder::stop()
     m_internalDecoder = nullptr;
 }
 
-const char* WebCodecsAudioDecoder::activeDOMObjectName() const
-{
-    return "AudioDecoder";
-}
-
 bool WebCodecsAudioDecoder::virtualHasPendingActivity() const
 {
     return m_state == WebCodecsCodecState::Configured && (m_decodeQueueSize || m_beingDecodedQueueSize || m_isFlushing);

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
@@ -79,7 +79,6 @@ private:
 
     // ActiveDOMObject API.
     void stop() final;
-    const char* activeDOMObjectName() const final;
     void suspend(ReasonForSuspension) final;
     bool virtualHasPendingActivity() const final;
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
@@ -432,11 +432,6 @@ void WebCodecsAudioEncoder::stop()
     // FIXME: Implement.
 }
 
-const char* WebCodecsAudioEncoder::activeDOMObjectName() const
-{
-    return "AudioEncoder";
-}
-
 bool WebCodecsAudioEncoder::virtualHasPendingActivity() const
 {
     return m_state == WebCodecsCodecState::Configured && (m_encodeQueueSize || m_beingEncodedQueueSize || m_isFlushing);

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h
@@ -79,7 +79,6 @@ private:
 
     // ActiveDOMObject API.
     void stop() final;
-    const char* activeDOMObjectName() const final;
     void suspend(ReasonForSuspension) final;
     bool virtualHasPendingActivity() const final;
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -351,11 +351,6 @@ void WebCodecsVideoDecoder::stop()
     m_internalDecoder = nullptr;
 }
 
-const char* WebCodecsVideoDecoder::activeDOMObjectName() const
-{
-    return "VideoDecoder";
-}
-
 bool WebCodecsVideoDecoder::virtualHasPendingActivity() const
 {
     return m_state == WebCodecsCodecState::Configured && (m_decodeQueueSize || m_beingDecodedQueueSize || m_isFlushing);

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
@@ -77,7 +77,6 @@ private:
 
     // ActiveDOMObject API.
     void stop() final;
-    const char* activeDOMObjectName() const final;
     void suspend(ReasonForSuspension) final;
     bool virtualHasPendingActivity() const final;
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
@@ -413,11 +413,6 @@ void WebCodecsVideoEncoder::stop()
     // FIXME: Implement.
 }
 
-const char* WebCodecsVideoEncoder::activeDOMObjectName() const
-{
-    return "VideoEncoder";
-}
-
 bool WebCodecsVideoEncoder::virtualHasPendingActivity() const
 {
     return m_state == WebCodecsCodecState::Configured && (m_encodeQueueSize || m_beingEncodedQueueSize || m_isFlushing);

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
@@ -78,7 +78,6 @@ private:
 
     // ActiveDOMObject API.
     void stop() final;
-    const char* activeDOMObjectName() const final;
     void suspend(ReasonForSuspension) final;
     bool virtualHasPendingActivity() const final;
 

--- a/Source/WebCore/Modules/webdatabase/DatabaseContext.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseContext.h
@@ -73,7 +73,6 @@ private:
 
     void contextDestroyed() override;
     void stop() override;
-    const char* activeDOMObjectName() const override { return "DatabaseContext"; }
 
     RefPtr<DatabaseThread> m_databaseThread;
     bool m_hasOpenDatabases { false }; // This never changes back to false, even after the database thread is closed.

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -527,11 +527,6 @@ void WebSocket::stop()
     m_pendingActivity = nullptr;
 }
 
-const char* WebSocket::activeDOMObjectName() const
-{
-    return "WebSocket";
-}
-
 void WebSocket::didConnect()
 {
     LOG(Network, "WebSocket %p didConnect()", this);

--- a/Source/WebCore/Modules/websockets/WebSocket.h
+++ b/Source/WebCore/Modules/websockets/WebSocket.h
@@ -106,7 +106,6 @@ private:
     void suspend(ReasonForSuspension) final;
     void resume() final;
     void stop() final;
-    const char* activeDOMObjectName() const final;
 
     enum EventTargetInterfaceType eventTargetInterface() const final;
 

--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -151,11 +151,6 @@ RefPtr<WebTransportSession> WebTransport::session()
     return m_session;
 }
 
-const char* WebTransport::activeDOMObjectName() const
-{
-    return "WebTransport";
-}
-
 bool WebTransport::virtualHasPendingActivity() const
 {
     // https://www.w3.org/TR/webtransport/#web-transport-gc

--- a/Source/WebCore/Modules/webtransport/WebTransport.h
+++ b/Source/WebCore/Modules/webtransport/WebTransport.h
@@ -86,7 +86,6 @@ private:
     void initializeOverHTTP(SocketProvider&, ScriptExecutionContext&, URL&&, bool dedicated, bool http3Only, WebTransportCongestionControl, Vector<WebTransportHash>&&);
     void cleanup(Ref<DOMException>&&, std::optional<WebTransportCloseInfo>&&);
 
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
 
     void receiveDatagram(std::span<const uint8_t>) final;

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -414,11 +414,6 @@ ExceptionOr<void> WebXRSession::end(EndPromise&& promise)
     return { };
 }
 
-const char* WebXRSession::activeDOMObjectName() const
-{
-    return "XRSession";
-}
-
 void WebXRSession::stop()
 {
 }

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -115,7 +115,6 @@ private:
     void derefEventTarget() override { deref(); }
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const override;
     void stop() override;
 
     // PlatformXR::TrackingAndRenderingClient

--- a/Source/WebCore/Modules/webxr/WebXRSystem.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.cpp
@@ -566,11 +566,6 @@ void WebXRSystem::requestSession(Document& document, XRSessionMode mode, const X
     });
 }
 
-const char* WebXRSystem::activeDOMObjectName() const
-{
-    return "XRSystem";
-}
-
 void WebXRSystem::stop()
 {
 }

--- a/Source/WebCore/Modules/webxr/WebXRSystem.h
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.h
@@ -92,7 +92,6 @@ protected:
     void derefEventTarget() override { deref(); }
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const override;
     void stop() override;
 
 private:

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1416,11 +1416,6 @@ WebAnimation& WebAnimation::finishedPromiseResolve()
     return *this;
 }
 
-const char* WebAnimation::activeDOMObjectName() const
-{
-    return "Animation";
-}
-
 void WebAnimation::suspend(ReasonForSuspension)
 {
     setSuspended(true);

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -204,7 +204,6 @@ private:
     void setEffectiveFrameRate(std::optional<FramesPerSecond>);
 
     // ActiveDOMObject.
-    const char* activeDOMObjectName() const final;
     void suspend(ReasonForSuspension) final;
     void resume() final;
     void stop() final;

--- a/Source/WebCore/css/CSSFontSelector.h
+++ b/Source/WebCore/css/CSSFontSelector.h
@@ -117,9 +117,6 @@ private:
 
     void fontModified();
 
-    // ActiveDOMObject
-    const char* activeDOMObjectName() const final { return "CSSFontSelector"_s; }
-
     struct PendingFontFaceRule {
         StyleRuleFontFace& styleRuleFontFace;
         bool isInitiatingElementInUserAgentShadowTree;

--- a/Source/WebCore/css/FontFace.cpp
+++ b/Source/WebCore/css/FontFace.cpp
@@ -375,11 +375,6 @@ FontFace& FontFace::loadedPromiseResolve()
     return *this;
 }
 
-const char* FontFace::activeDOMObjectName() const
-{
-    return "FontFace";
-}
-
 bool FontFace::virtualHasPendingActivity() const
 {
     return m_mayLoadedPromiseBeScriptObservable && !m_loadedPromise->isFulfilled();

--- a/Source/WebCore/css/FontFace.h
+++ b/Source/WebCore/css/FontFace.h
@@ -99,7 +99,6 @@ private:
     explicit FontFace(ScriptExecutionContext*, CSSFontFace&);
 
     // ActiveDOMObject.
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
 
     // Callback for LoadedPromise.

--- a/Source/WebCore/css/FontFaceSet.h
+++ b/Source/WebCore/css/FontFaceSet.h
@@ -103,9 +103,6 @@ private:
     void startedLoading() final;
     void completedLoading() final;
 
-    // ActiveDOMObject
-    const char* activeDOMObjectName() const final { return "FontFaceSet"; }
-
     // EventTarget
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::FontFaceSet; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }

--- a/Source/WebCore/css/MediaQueryList.cpp
+++ b/Source/WebCore/css/MediaQueryList.cpp
@@ -145,11 +145,6 @@ void MediaQueryList::eventListenersDidChange()
     m_hasChangeEventListener = hasEventListeners(eventNames().changeEvent);
 }
 
-const char* MediaQueryList::activeDOMObjectName() const
-{
-    return "MediaQueryList";
-}
-
 bool MediaQueryList::virtualHasPendingActivity() const
 {
     return m_hasChangeEventListener && m_matcher;

--- a/Source/WebCore/css/MediaQueryList.h
+++ b/Source/WebCore/css/MediaQueryList.h
@@ -66,7 +66,6 @@ private:
     void eventListenersDidChange() final;
 
     // ActiveDOMObject.
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
 
     RefPtr<MediaQueryMatcher> m_matcher;

--- a/Source/WebCore/dom/ActiveDOMObject.cpp
+++ b/Source/WebCore/dom/ActiveDOMObject.cpp
@@ -102,8 +102,6 @@ void ActiveDOMObject::suspendIfNeeded()
 
 void ActiveDOMObject::assertSuspendIfNeededWasCalled() const
 {
-    if (!m_suspendIfNeededWasCalled)
-        WTFLogAlways("Failed to call suspendIfNeeded() for %s", activeDOMObjectName());
     ASSERT(m_suspendIfNeededWasCalled);
 }
 

--- a/Source/WebCore/dom/ActiveDOMObject.h
+++ b/Source/WebCore/dom/ActiveDOMObject.h
@@ -65,8 +65,6 @@ public:
     // That happens in step-by-step JS debugging for example - in this case it would be incorrect
     // to stop the object. Exact semantics of suspend is up to the object in cases like that.
 
-    virtual const char* activeDOMObjectName() const = 0;
-
     // These functions must not have a side effect of creating or destroying
     // any ActiveDOMObject. That means they must not result in calls to arbitrary JavaScript.
     virtual void suspend(ReasonForSuspension);

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -270,11 +270,6 @@ void BroadcastChannel::dispatchMessage(Ref<SerializedScriptValue>&& message)
     });
 }
 
-const char* BroadcastChannel::activeDOMObjectName() const
-{
-    return "BroadcastChannel";
-}
-
 void BroadcastChannel::eventListenersDidChange()
 {
     m_hasRelevantEventListener = hasEventListeners(eventNames().messageEvent);

--- a/Source/WebCore/dom/BroadcastChannel.h
+++ b/Source/WebCore/dom/BroadcastChannel.h
@@ -79,7 +79,6 @@ private:
     void eventListenersDidChange() final;
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
     void stop() final { close(); }
 

--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -380,11 +380,6 @@ bool MessagePort::removeEventListener(const AtomString& eventType, EventListener
     return result;
 }
 
-const char* MessagePort::activeDOMObjectName() const
-{
-    return "MessagePort";
-}
-
 WebCoreOpaqueRoot root(MessagePort* port)
 {
     return WebCoreOpaqueRoot { port };

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -103,7 +103,6 @@ private:
     bool removeEventListener(const AtomString& eventType, EventListener&, const EventListenerOptions&) final;
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final;
     void contextDestroyed() final;
     void stop() final { close(); }
     bool virtualHasPendingActivity() const final;

--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -399,11 +399,6 @@ URLRegistry& Blob::registry() const
     return BlobURLRegistry::registry();
 }
 
-const char* Blob::activeDOMObjectName() const
-{
-    return "Blob";
-}
-
 URLKeepingBlobAlive Blob::handle() const
 {
     return { m_internalURL };

--- a/Source/WebCore/fileapi/Blob.h
+++ b/Source/WebCore/fileapi/Blob.h
@@ -145,9 +145,6 @@ protected:
 private:
     void loadBlob(FileReaderLoader::ReadType, CompletionHandler<void(BlobLoader&)>&&);
 
-    // ActiveDOMObject.
-    const char* activeDOMObjectName() const override;
-
     String m_type;
     mutable std::optional<unsigned long long> m_size;
     size_t m_memoryCost { 0 };

--- a/Source/WebCore/fileapi/File.cpp
+++ b/Source/WebCore/fileapi/File.cpp
@@ -159,9 +159,4 @@ bool File::isDirectory() const
     return *m_isDirectory;
 }
 
-const char* File::activeDOMObjectName() const
-{
-    return "File";
-}
-
 } // namespace WebCore

--- a/Source/WebCore/fileapi/File.h
+++ b/Source/WebCore/fileapi/File.h
@@ -108,9 +108,6 @@ private:
     static void computeNameAndContentTypeForReplacedFile(const String& path, const String& nameOverride, String& effectiveName, String& effectiveContentType);
 #endif
 
-    // ActiveDOMObject.
-    const char* activeDOMObjectName() const final;
-
     String m_path;
     String m_relativePath;
     String m_name;

--- a/Source/WebCore/fileapi/FileReader.cpp
+++ b/Source/WebCore/fileapi/FileReader.cpp
@@ -70,11 +70,6 @@ FileReader::~FileReader()
         m_loader->cancel();
 }
 
-const char* FileReader::activeDOMObjectName() const
-{
-    return "FileReader";
-}
-
 void FileReader::stop()
 {
     m_pendingTasks.clear();

--- a/Source/WebCore/fileapi/FileReader.h
+++ b/Source/WebCore/fileapi/FileReader.h
@@ -82,7 +82,6 @@ private:
     explicit FileReader(ScriptExecutionContext&);
 
     // ActiveDOMObject.
-    const char* activeDOMObjectName() const final;
     void stop() final;
     bool virtualHasPendingActivity() const final;
 

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -934,11 +934,6 @@ void HTMLCanvasElement::clearCopiedImage() const
     m_didClearImageBuffer = false;
 }
 
-const char* HTMLCanvasElement::activeDOMObjectName() const
-{
-    return "HTMLCanvasElement";
-}
-
 bool HTMLCanvasElement::virtualHasPendingActivity() const
 {
 #if ENABLE(WEBGL)

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -149,7 +149,6 @@ private:
     bool isHTMLCanvasElement() const final { return true; }
 
     // ActiveDOMObject.
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
 
     // EventTarget.

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -982,11 +982,6 @@ void HTMLImageElement::setLoadManually(bool loadManually)
     m_imageLoader->setLoadManually(loadManually);
 }
 
-const char* HTMLImageElement::activeDOMObjectName() const
-{
-    return "HTMLImageElement";
-}
-
 bool HTMLImageElement::virtualHasPendingActivity() const
 {
     return m_imageLoader->hasPendingActivity();

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -206,7 +206,6 @@ private:
     Ref<Element> cloneElementWithoutAttributesAndChildren(Document& targetDocument) final;
 
     // ActiveDOMObject.
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
 
     void didAttachRenderers() override;

--- a/Source/WebCore/html/HTMLMarqueeElement.h
+++ b/Source/WebCore/html/HTMLMarqueeElement.h
@@ -60,7 +60,6 @@ private:
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
     void suspend(ReasonForSuspension) final;
     void resume() final;
-    const char* activeDOMObjectName() const final { return "HTMLMarqueeElement"; }
 
     RenderMarquee* renderMarquee() const;
 };

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -6502,11 +6502,6 @@ void HTMLMediaElement::clearMediaPlayer()
     updateRenderer();
 }
 
-const char* HTMLMediaElement::activeDOMObjectName() const
-{
-    return "HTMLMediaElement";
-}
-
 void HTMLMediaElement::stopWithoutDestroyingMediaPlayer()
 {
     INFO_LOG(LOGIDENTIFIER);

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -761,7 +761,6 @@ private:
     void willStopBeingFullscreenElement() override;
 
     // ActiveDOMObject API.
-    const char* activeDOMObjectName() const override;
     void suspend(ReasonForSuspension) override;
     void resume() override;
     void stop() override;

--- a/Source/WebCore/html/HTMLSourceElement.cpp
+++ b/Source/WebCore/html/HTMLSourceElement.cpp
@@ -155,11 +155,6 @@ bool HTMLSourceElement::attributeContainsURL(const Attribute& attribute) const
         || HTMLElement::attributeContainsURL(attribute);
 }
 
-const char* HTMLSourceElement::activeDOMObjectName() const
-{
-    return "HTMLSourceElement";
-}
-
 void HTMLSourceElement::stop()
 {
     cancelPendingErrorEvent();

--- a/Source/WebCore/html/HTMLSourceElement.h
+++ b/Source/WebCore/html/HTMLSourceElement.h
@@ -65,7 +65,6 @@ private:
     void addCandidateSubresourceURLs(ListHashSet<URL>&) const override;
 
     // ActiveDOMObject.
-    const char* activeDOMObjectName() const final;
     void stop() final;
 
 #if ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebCore/html/HTMLTrackElement.cpp
+++ b/Source/WebCore/html/HTMLTrackElement.cpp
@@ -320,11 +320,6 @@ RefPtr<HTMLMediaElement> HTMLTrackElement::mediaElement() const
     return dynamicDowncast<HTMLMediaElement>(parentElement());
 }
 
-const char* HTMLTrackElement::activeDOMObjectName() const
-{
-    return "HTMLTrackElement";
-}
-
 void HTMLTrackElement::eventListenersDidChange()
 {
     m_hasRelevantLoadEventsListener = hasEventListeners(eventNames().errorEvent)

--- a/Source/WebCore/html/HTMLTrackElement.h
+++ b/Source/WebCore/html/HTMLTrackElement.h
@@ -72,7 +72,6 @@ private:
     virtual ~HTMLTrackElement();
 
     // ActiveDOMObject.
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -769,7 +769,6 @@ private:
     }
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final { return "PendingImageBitmap"; }
     void stop() final { m_pendingActivity = nullptr; }
 
     // FileReaderLoaderClient

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -155,8 +155,6 @@ public:
 
     void commitToPlaceholderCanvas();
 
-    const char* activeDOMObjectName() const final { return "OffscreenCanvas"_s; }
-
     void queueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) final;
     void dispatchEvent(Event&) final;
     using RefCounted::ref;

--- a/Source/WebCore/html/PublicURLManager.cpp
+++ b/Source/WebCore/html/PublicURLManager.cpp
@@ -86,9 +86,4 @@ void PublicURLManager::stop()
     }
 }
 
-const char* PublicURLManager::activeDOMObjectName() const
-{
-    return "PublicURLManager";
-}
-
 } // namespace WebCore

--- a/Source/WebCore/html/PublicURLManager.h
+++ b/Source/WebCore/html/PublicURLManager.h
@@ -50,7 +50,6 @@ public:
 private:
     // ActiveDOMObject API.
     void stop() override;
-    const char* activeDOMObjectName() const override;
     
     bool m_isStopped { false };
 };

--- a/Source/WebCore/html/canvas/GPUCanvasContext.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.h
@@ -63,10 +63,6 @@ public:
     virtual ExceptionOr<RefPtr<ImageBitmap>> getCurrentTextureAsImageBitmap(ImageBuffer&, bool originClean) = 0;
 
     bool isWebGPU() const override { return true; }
-    const char* activeDOMObjectName() const override
-    {
-        return "GPUCanvasElement";
-    }
 
 protected:
     GPUCanvasContext(CanvasBase&);

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -74,10 +74,6 @@ public:
     ExceptionOr<RefPtr<ImageBitmap>> getCurrentTextureAsImageBitmap(ImageBuffer&, bool originClean) override;
 
     bool isWebGPU() const override { return true; }
-    const char* activeDOMObjectName() const override
-    {
-        return "GPUCanvasElement";
-    }
 
 private:
     explicit GPUCanvasContextCocoa(CanvasBase&, GPU&);

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -4727,11 +4727,6 @@ void WebGLRenderingContextBase::stop()
     }
 }
 
-const char* WebGLRenderingContextBase::activeDOMObjectName() const
-{
-    return "WebGLRenderingContext";
-}
-
 void WebGLRenderingContextBase::suspend(ReasonForSuspension)
 {
     m_isSuspended = true;

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -525,7 +525,6 @@ protected:
 
     // ActiveDOMObject
     void stop() override;
-    const char* activeDOMObjectName() const override;
     void suspend(ReasonForSuspension) override;
     void resume() override;
 

--- a/Source/WebCore/html/track/AudioTrackList.cpp
+++ b/Source/WebCore/html/track/AudioTrackList.cpp
@@ -108,10 +108,5 @@ enum EventTargetInterfaceType AudioTrackList::eventTargetInterface() const
     return EventTargetInterfaceType::AudioTrackList;
 }
 
-const char* AudioTrackList::activeDOMObjectName() const
-{
-    return "AudioTrackList";
-}
-
 } // namespace WebCore
 #endif

--- a/Source/WebCore/html/track/AudioTrackList.h
+++ b/Source/WebCore/html/track/AudioTrackList.h
@@ -58,8 +58,6 @@ public:
 
 private:
     AudioTrackList(ScriptExecutionContext*);
-
-    const char* activeDOMObjectName() const final;
 };
 static_assert(sizeof(AudioTrackList) == sizeof(TrackListBase));
 

--- a/Source/WebCore/html/track/TextTrack.cpp
+++ b/Source/WebCore/html/track/TextTrack.cpp
@@ -595,11 +595,6 @@ bool TextTrack::containsOnlyForcedSubtitles() const
     return m_kind == Kind::Forced;
 }
 
-const char* TextTrack::activeDOMObjectName() const
-{
-    return "TextTrack";
-}
-
 void TextTrack::setLanguage(const AtomString& language)
 {
     // 11.1 language, on setting:

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -160,9 +160,6 @@ private:
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 
-    // ActiveDOMObject
-    const char* activeDOMObjectName() const final;
-
 #if !RELEASE_LOG_DISABLED
     const char* logClassName() const override { return "TextTrack"; }
 #endif

--- a/Source/WebCore/html/track/TextTrackCue.cpp
+++ b/Source/WebCore/html/track/TextTrackCue.cpp
@@ -538,11 +538,6 @@ void TextTrackCue::rebuildDisplayTree()
     m_displayTreeNeedsUpdate = false;
 }
 
-const char* TextTrackCue::activeDOMObjectName() const
-{
-    return "TextTrackCue";
-}
-
 } // namespace WebCore
 
 #endif

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -154,9 +154,6 @@ private:
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::TextTrackCue; }
     ScriptExecutionContext* scriptExecutionContext() const final;
 
-    // ActiveDOMObject
-    const char* activeDOMObjectName() const final;
-
     void rebuildDisplayTree();
 
     AtomString m_id;

--- a/Source/WebCore/html/track/TextTrackList.cpp
+++ b/Source/WebCore/html/track/TextTrackList.cpp
@@ -261,10 +261,5 @@ enum EventTargetInterfaceType TextTrackList::eventTargetInterface() const
     return EventTargetInterfaceType::TextTrackList;
 }
 
-const char* TextTrackList::activeDOMObjectName() const
-{
-    return "TextTrackList";
-}
-
 } // namespace WebCore
 #endif

--- a/Source/WebCore/html/track/TextTrackList.h
+++ b/Source/WebCore/html/track/TextTrackList.h
@@ -67,7 +67,6 @@ public:
 
 private:
     TextTrackList(ScriptExecutionContext*);
-    const char* activeDOMObjectName() const final;
 
     void invalidateTrackIndexesAfterTrack(TextTrack&);
 

--- a/Source/WebCore/html/track/VideoTrackList.cpp
+++ b/Source/WebCore/html/track/VideoTrackList.cpp
@@ -114,10 +114,5 @@ enum EventTargetInterfaceType VideoTrackList::eventTargetInterface() const
     return EventTargetInterfaceType::VideoTrackList;
 }
 
-const char* VideoTrackList::activeDOMObjectName() const
-{
-    return "VideoTrackList";
-}
-
 } // namespace WebCore
 #endif

--- a/Source/WebCore/html/track/VideoTrackList.h
+++ b/Source/WebCore/html/track/VideoTrackList.h
@@ -58,8 +58,6 @@ public:
 
 private:
     VideoTrackList(ScriptExecutionContext*);
-
-    const char* activeDOMObjectName() const final;
 };
 static_assert(sizeof(VideoTrackList) == sizeof(TrackListBase));
 

--- a/Source/WebCore/page/DOMTimer.cpp
+++ b/Source/WebCore/page/DOMTimer.cpp
@@ -441,11 +441,6 @@ std::optional<MonotonicTime> ScriptExecutionContext::alignedFireTime(bool hasRea
     return adjustedFireTime - (adjustedFireTime % alignmentInterval) + alignmentInterval + randomizedOffset;
 }
 
-const char* DOMTimer::activeDOMObjectName() const
-{
-    return "DOMTimer";
-}
-
 void DOMTimer::makeImminentlyScheduledWorkScopeIfPossible(ScriptExecutionContext& context)
 {
     if (!m_oneShot || m_currentTimerInterval > 1_ms)

--- a/Source/WebCore/page/DOMTimer.h
+++ b/Source/WebCore/page/DOMTimer.h
@@ -80,7 +80,6 @@ private:
     void fired();
 
     // ActiveDOMObject API.
-    const char* activeDOMObjectName() const final;
     void stop() final;
 
     void makeImminentlyScheduledWorkScopeIfPossible(ScriptExecutionContext&);

--- a/Source/WebCore/page/EventSource.cpp
+++ b/Source/WebCore/page/EventSource.cpp
@@ -400,11 +400,6 @@ void EventSource::stop()
     close();
 }
 
-const char* EventSource::activeDOMObjectName() const
-{
-    return "EventSource";
-}
-
 void EventSource::suspend(ReasonForSuspension reason)
 {
     if (reason != ReasonForSuspension::BackForwardCache)

--- a/Source/WebCore/page/EventSource.h
+++ b/Source/WebCore/page/EventSource.h
@@ -95,7 +95,6 @@ private:
 
     // ActiveDOMObject
     void stop() final;
-    const char* activeDOMObjectName() const final;
     void suspend(ReasonForSuspension) final;
     void resume() final;
     bool virtualHasPendingActivity() const final;

--- a/Source/WebCore/page/ScreenOrientation.cpp
+++ b/Source/WebCore/page/ScreenOrientation.cpp
@@ -241,11 +241,6 @@ void ScreenOrientation::screenOrientationDidChange(ScreenOrientationType)
     queueTaskToDispatchEvent(*this, TaskSource::DOMManipulation, Event::create(eventNames().changeEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
-const char* ScreenOrientation::activeDOMObjectName() const
-{
-    return "ScreenOrientation";
-}
-
 void ScreenOrientation::suspend(ReasonForSuspension)
 {
     if (auto* manager = this->manager())

--- a/Source/WebCore/page/ScreenOrientation.h
+++ b/Source/WebCore/page/ScreenOrientation.h
@@ -81,7 +81,6 @@ private:
     void eventListenersDidChange() final;
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
     void suspend(ReasonForSuspension) final;
     void resume() final;

--- a/Source/WebCore/workers/Worker.cpp
+++ b/Source/WebCore/workers/Worker.cpp
@@ -155,11 +155,6 @@ void Worker::terminate()
     m_wasTerminated = true;
 }
 
-const char* Worker::activeDOMObjectName() const
-{
-    return "Worker";
-}
-
 void Worker::stop()
 {
     terminate();

--- a/Source/WebCore/workers/Worker.h
+++ b/Source/WebCore/workers/Worker.h
@@ -101,7 +101,6 @@ private:
     void stop() final;
     void suspend(ReasonForSuspension) final;
     void resume() final;
-    const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
 
     static void networkStateChanged(bool isOnLine);

--- a/Source/WebCore/workers/WorkerAnimationController.cpp
+++ b/Source/WebCore/workers/WorkerAnimationController.cpp
@@ -56,11 +56,6 @@ WorkerAnimationController::~WorkerAnimationController()
     ASSERT(!hasPendingActivity());
 }
 
-const char* WorkerAnimationController::activeDOMObjectName() const
-{
-    return "WorkerAnimationController";
-}
-
 bool WorkerAnimationController::virtualHasPendingActivity() const
 {
     return m_animationTimer.isActive();

--- a/Source/WebCore/workers/WorkerAnimationController.h
+++ b/Source/WebCore/workers/WorkerAnimationController.h
@@ -54,8 +54,6 @@ public:
 private:
     WorkerAnimationController(WorkerGlobalScope&);
 
-    const char* activeDOMObjectName() const final;
-
     bool virtualHasPendingActivity() const final;
     void stop() final;
     void suspend(ReasonForSuspension) final;

--- a/Source/WebCore/workers/service/ServiceWorker.cpp
+++ b/Source/WebCore/workers/service/ServiceWorker.cpp
@@ -137,11 +137,6 @@ ScriptExecutionContext* ServiceWorker::scriptExecutionContext() const
     return ContextDestructionObserver::scriptExecutionContext();
 }
 
-const char* ServiceWorker::activeDOMObjectName() const
-{
-    return "ServiceWorker";
-}
-
 void ServiceWorker::stop()
 {
     m_isStopped = true;

--- a/Source/WebCore/workers/service/ServiceWorker.h
+++ b/Source/WebCore/workers/service/ServiceWorker.h
@@ -80,7 +80,6 @@ private:
     void derefEventTarget() final { deref(); }
 
     // ActiveDOMObject.
-    const char* activeDOMObjectName() const final;
     void stop() final;
 
     SWClientConnection& swConnection();

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
@@ -567,11 +567,6 @@ void ServiceWorkerContainer::destroyJob(ServiceWorkerJob& job)
     m_jobMap.remove(job.identifier());
 }
 
-const char* ServiceWorkerContainer::activeDOMObjectName() const
-{
-    return "ServiceWorkerContainer";
-}
-
 SWClientConnection& ServiceWorkerContainer::ensureSWClientConnection()
 {
     ASSERT(scriptExecutionContext());

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.h
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.h
@@ -130,9 +130,6 @@ private:
 
     SWClientConnection& ensureSWClientConnection();
 
-    // ActiveDOMObject.
-    const char* activeDOMObjectName() const final;
-    
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::ServiceWorkerContainer; }
     void refEventTarget() final;

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.cpp
@@ -254,11 +254,6 @@ ScriptExecutionContext* ServiceWorkerRegistration::scriptExecutionContext() cons
     return ActiveDOMObject::scriptExecutionContext();
 }
 
-const char* ServiceWorkerRegistration::activeDOMObjectName() const
-{
-    return "ServiceWorkerRegistration";
-}
-
 void ServiceWorkerRegistration::stop()
 {
     removeAllEventListeners();

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.h
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.h
@@ -117,7 +117,6 @@ private:
     void derefEventTarget() final { deref(); }
 
     // ActiveDOMObject.
-    const char* activeDOMObjectName() const final;
     void stop() final;
     bool virtualHasPendingActivity() const final;
 

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.cpp
@@ -233,11 +233,6 @@ void BackgroundFetchRegistration::updateInformation(const BackgroundFetchInforma
     dispatchEvent(Event::create(eventNames().progressEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
-const char* BackgroundFetchRegistration::activeDOMObjectName() const
-{
-    return "BackgroundFetchRegistration";
-}
-
 void BackgroundFetchRegistration::stop()
 {
 }

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.h
@@ -82,7 +82,6 @@ private:
     void derefEventTarget() final { deref(); }
 
     // ActiveDOMObject
-    const char* activeDOMObjectName() const final;
     void stop() final;
     bool virtualHasPendingActivity() const final;
 

--- a/Source/WebCore/workers/shared/SharedWorker.cpp
+++ b/Source/WebCore/workers/shared/SharedWorker.cpp
@@ -136,11 +136,6 @@ ScriptExecutionContext* SharedWorker::scriptExecutionContext() const
     return ActiveDOMObject::scriptExecutionContext();
 }
 
-const char* SharedWorker::activeDOMObjectName() const
-{
-    return "SharedWorker";
-}
-
 enum EventTargetInterfaceType SharedWorker::eventTargetInterface() const
 {
     return EventTargetInterfaceType::SharedWorker;

--- a/Source/WebCore/workers/shared/SharedWorker.h
+++ b/Source/WebCore/workers/shared/SharedWorker.h
@@ -63,7 +63,6 @@ private:
     enum EventTargetInterfaceType eventTargetInterface() const final;
 
     // ActiveDOMObject.
-    const char* activeDOMObjectName() const final;
     void stop() final;
     bool virtualHasPendingActivity() const final;
     void suspend(ReasonForSuspension) final;

--- a/Source/WebCore/worklets/Worklet.cpp
+++ b/Source/WebCore/worklets/Worklet.cpp
@@ -105,9 +105,4 @@ void Worklet::finishPendingTasks(WorkletPendingTasks& tasks)
     m_pendingTasksSet.remove(&tasks);
 }
 
-const char* Worklet::activeDOMObjectName() const
-{
-    return "Worklet";
-}
-
 } // namespace WebCore

--- a/Source/WebCore/worklets/Worklet.h
+++ b/Source/WebCore/worklets/Worklet.h
@@ -60,9 +60,6 @@ protected:
 private:
     virtual Vector<Ref<WorkletGlobalScopeProxy>> createGlobalScopes() = 0;
 
-    // ActiveDOMObject.
-    const char* activeDOMObjectName() const final;
-
     String m_identifier;
     Vector<Ref<WorkletGlobalScopeProxy>> m_proxies;
     HashSet<RefPtr<WorkletPendingTasks>> m_pendingTasksSet;

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -1163,11 +1163,6 @@ void XMLHttpRequest::didReachTimeout()
     dispatchErrorEvents(eventNames().timeoutEvent);
 }
 
-const char* XMLHttpRequest::activeDOMObjectName() const
-{
-    return "XMLHttpRequest";
-}
-
 void XMLHttpRequest::suspend(ReasonForSuspension)
 {
     m_progressEventThrottle.suspend();

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -154,7 +154,6 @@ private:
     void suspend(ReasonForSuspension) override;
     void resume() override;
     void stop() override;
-    const char* activeDOMObjectName() const override;
     bool virtualHasPendingActivity() const final;
 
     void refEventTarget() override { ref(); }

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
@@ -466,9 +466,4 @@ void InjectedBundleNodeHandle::stop()
     }
 }
 
-const char* InjectedBundleNodeHandle::activeDOMObjectName() const
-{
-    return "InjectedBundleNodeHandle";
-}
-
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h
@@ -97,7 +97,6 @@ private:
 
     // ActiveDOMObject.
     void stop() final;
-    const char* activeDOMObjectName() const final;
 
     RefPtr<WebCore::Node> m_node;
 };


### PR DESCRIPTION
#### b8fbb2ae4605c2fe55bccfb12f74bd8d8eeba688
<pre>
Drop mostly unused ActiveDOMObject::activeDOMObjectName()
<a href="https://bugs.webkit.org/show_bug.cgi?id=273068">https://bugs.webkit.org/show_bug.cgi?id=273068</a>

Reviewed by Darin Adler.

Drop mostly unused ActiveDOMObject::activeDOMObjectName(). This was only used to
help debugging missing calls to suspendIfNeeded(). However, this hasn&apos;t really
been an issue in practice, so I don&apos;t think it is worth the extra code.

* Source/WebCore/Modules/WebGPU/GPUDevice.h:
* Source/WebCore/Modules/applepay/ApplePaySession.cpp:
(WebCore::ApplePaySession::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/applepay/ApplePaySession.h:
* Source/WebCore/Modules/applepay/ApplePaySetupWebCore.h:
(): Deleted.
* Source/WebCore/Modules/audiosession/DOMAudioSession.cpp:
(WebCore::DOMAudioSession::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/audiosession/DOMAudioSession.h:
* Source/WebCore/Modules/cache/DOMCache.cpp:
(WebCore::DOMCache::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/cache/DOMCache.h:
* Source/WebCore/Modules/cache/DOMCacheStorage.cpp:
(WebCore::DOMCacheStorage::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/cache/DOMCacheStorage.h:
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/cookie-store/CookieStore.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp:
(WebCore::MediaKeySession::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.h:
(): Deleted.
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp:
(WebCore::MediaKeySystemRequest::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.h:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp:
(WebCore::WebKitMediaKeySession::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h:
* Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.cpp:
(WebCore::FileSystemDirectoryReader::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.h:
* Source/WebCore/Modules/entriesapi/FileSystemEntry.cpp:
(WebCore::FileSystemEntry::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/entriesapi/FileSystemEntry.h:
* Source/WebCore/Modules/fetch/FetchRequest.cpp:
(WebCore::FetchRequest::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/fetch/FetchRequest.h:
* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/fetch/FetchResponse.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemHandle.cpp:
(WebCore::FileSystemHandle::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/filesystemaccess/FileSystemHandle.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.cpp:
(WebCore::FileSystemSyncAccessHandle::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.h:
* Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp:
(WebCore::GamepadHapticActuator::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/gamepad/GamepadHapticActuator.h:
* Source/WebCore/Modules/geolocation/Geolocation.cpp:
(WebCore::Geolocation::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/geolocation/Geolocation.h:
* Source/WebCore/Modules/indexeddb/IDBDatabase.cpp:
(WebCore::IDBDatabase::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/indexeddb/IDBDatabase.h:
* Source/WebCore/Modules/indexeddb/IDBDatabaseNameAndVersionRequest.cpp:
(WebCore::IDBDatabaseNameAndVersionRequest::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/indexeddb/IDBDatabaseNameAndVersionRequest.h:
* Source/WebCore/Modules/indexeddb/IDBIndex.cpp:
(WebCore::IDBIndex::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/indexeddb/IDBIndex.h:
* Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp:
(WebCore::IDBObjectStore::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/indexeddb/IDBObjectStore.h:
* Source/WebCore/Modules/indexeddb/IDBRequest.cpp:
(WebCore::IDBRequest::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/indexeddb/IDBRequest.h:
* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/indexeddb/IDBTransaction.h:
* Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp:
(WebCore::MediaRecorder::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/mediarecorder/MediaRecorder.h:
* Source/WebCore/Modules/mediasession/MediaSession.h:
* Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h:
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/Modules/mediasource/SourceBufferList.cpp:
(WebCore::SourceBufferList::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/mediasource/SourceBufferList.h:
* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp:
(WebCore::CanvasCaptureMediaStreamTrack::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/ImageCapture.cpp:
(WebCore::ImageCapture::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/mediastream/ImageCapture.h:
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::MediaDevices::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/mediastream/MediaDevices.h:
* Source/WebCore/Modules/mediastream/MediaStream.cpp:
(WebCore::MediaStream::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/mediastream/MediaStream.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/RTCDTMFSender.cpp:
(WebCore::RTCDTMFSender::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/mediastream/RTCDTMFSender.h:
* Source/WebCore/Modules/mediastream/RTCDataChannel.h:
* Source/WebCore/Modules/mediastream/RTCDtlsTransport.h:
* Source/WebCore/Modules/mediastream/RTCIceTransport.h:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::RTCPeerConnection::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/mediastream/RTCPeerConnection.h:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h:
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.h:
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h:
* Source/WebCore/Modules/mediastream/RTCSctpTransport.h:
* Source/WebCore/Modules/mediastream/UserMediaRequest.cpp:
(WebCore::UserMediaRequest::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/mediastream/UserMediaRequest.h:
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/notifications/Notification.cpp:
(WebCore::Notification::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/notifications/Notification.h:
* Source/WebCore/Modules/paymentrequest/PaymentRequest.h:
* Source/WebCore/Modules/paymentrequest/PaymentResponse.h:
* Source/WebCore/Modules/permissions/PermissionStatus.cpp:
(WebCore::PermissionStatus::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/permissions/PermissionStatus.h:
* Source/WebCore/Modules/pictureinpicture/PictureInPictureWindow.h:
* Source/WebCore/Modules/remoteplayback/RemotePlayback.cpp:
(WebCore::RemotePlayback::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/remoteplayback/RemotePlayback.h:
* Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp:
(WebCore::WakeLockSentinel::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.h:
* Source/WebCore/Modules/speech/SpeechRecognition.cpp:
(WebCore::SpeechRecognition::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/speech/SpeechRecognition.h:
* Source/WebCore/Modules/speech/SpeechSynthesis.cpp:
(WebCore::SpeechSynthesis::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/speech/SpeechSynthesis.h:
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp:
(WebCore::SpeechSynthesisUtterance::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h:
* Source/WebCore/Modules/web-locks/WebLockManager.cpp:
(WebCore::WebLockManager::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/web-locks/WebLockManager.h:
* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.h:
* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/webaudio/AudioContext.h:
* Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp:
(WebCore::AudioWorkletNode::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/webaudio/AudioWorkletNode.h:
* Source/WebCore/Modules/webaudio/ConstantSourceNode.h:
* Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp:
(WebCore::OfflineAudioContext::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/webaudio/OfflineAudioContext.h:
* Source/WebCore/Modules/webaudio/OscillatorNode.h:
* Source/WebCore/Modules/webaudio/ScriptProcessorNode.h:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp:
(WebCore::WebCodecsAudioDecoder::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp:
(WebCore::WebCodecsAudioEncoder::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::WebCodecsVideoDecoder::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::WebCodecsVideoEncoder::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h:
* Source/WebCore/Modules/webdatabase/DatabaseContext.h:
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::WebSocket::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/websockets/WebSocket.h:
* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::WebTransport::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/webtransport/WebTransport.h:
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/webxr/WebXRSession.h:
* Source/WebCore/Modules/webxr/WebXRSystem.cpp:
(WebCore::WebXRSystem::activeDOMObjectName const): Deleted.
* Source/WebCore/Modules/webxr/WebXRSystem.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::activeDOMObjectName const): Deleted.
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/css/CSSFontSelector.h:
* Source/WebCore/css/FontFace.cpp:
(WebCore::FontFace::activeDOMObjectName const): Deleted.
* Source/WebCore/css/FontFace.h:
* Source/WebCore/css/FontFaceSet.h:
* Source/WebCore/css/MediaQueryList.cpp:
(WebCore::MediaQueryList::activeDOMObjectName const): Deleted.
* Source/WebCore/css/MediaQueryList.h:
* Source/WebCore/dom/ActiveDOMObject.cpp:
(WebCore::ActiveDOMObject::assertSuspendIfNeededWasCalled const):
* Source/WebCore/dom/ActiveDOMObject.h:
* Source/WebCore/dom/BroadcastChannel.cpp:
(WebCore::BroadcastChannel::activeDOMObjectName const): Deleted.
* Source/WebCore/dom/BroadcastChannel.h:
* Source/WebCore/dom/MessagePort.cpp:
(WebCore::MessagePort::activeDOMObjectName const): Deleted.
* Source/WebCore/dom/MessagePort.h:
* Source/WebCore/fileapi/Blob.cpp:
(WebCore::Blob::activeDOMObjectName const): Deleted.
* Source/WebCore/fileapi/Blob.h:
* Source/WebCore/fileapi/File.cpp:
(WebCore::File::activeDOMObjectName const): Deleted.
* Source/WebCore/fileapi/File.h:
* Source/WebCore/fileapi/FileReader.cpp:
(WebCore::FileReader::activeDOMObjectName const): Deleted.
* Source/WebCore/fileapi/FileReader.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::activeDOMObjectName const): Deleted.
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::activeDOMObjectName const): Deleted.
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLMarqueeElement.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::activeDOMObjectName const): Deleted.
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLSourceElement.cpp:
(WebCore::HTMLSourceElement::activeDOMObjectName const): Deleted.
* Source/WebCore/html/HTMLSourceElement.h:
* Source/WebCore/html/HTMLTrackElement.cpp:
(WebCore::HTMLTrackElement::activeDOMObjectName const): Deleted.
* Source/WebCore/html/HTMLTrackElement.h:
* Source/WebCore/html/ImageBitmap.cpp:
* Source/WebCore/html/OffscreenCanvas.h:
* Source/WebCore/html/PublicURLManager.cpp:
(WebCore::PublicURLManager::activeDOMObjectName const): Deleted.
* Source/WebCore/html/PublicURLManager.h:
* Source/WebCore/html/canvas/GPUCanvasContext.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::activeDOMObjectName const): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/html/track/AudioTrackList.cpp:
(WebCore::AudioTrackList::activeDOMObjectName const): Deleted.
* Source/WebCore/html/track/AudioTrackList.h:
* Source/WebCore/html/track/TextTrack.cpp:
(WebCore::TextTrack::activeDOMObjectName const): Deleted.
* Source/WebCore/html/track/TextTrack.h:
* Source/WebCore/html/track/TextTrackCue.cpp:
(WebCore::TextTrackCue::activeDOMObjectName const): Deleted.
* Source/WebCore/html/track/TextTrackCue.h:
* Source/WebCore/html/track/TextTrackList.cpp:
(WebCore::TextTrackList::activeDOMObjectName const): Deleted.
* Source/WebCore/html/track/TextTrackList.h:
* Source/WebCore/html/track/VideoTrackList.cpp:
(WebCore::VideoTrackList::activeDOMObjectName const): Deleted.
* Source/WebCore/html/track/VideoTrackList.h:
* Source/WebCore/page/DOMTimer.cpp:
(WebCore::DOMTimer::activeDOMObjectName const): Deleted.
* Source/WebCore/page/DOMTimer.h:
* Source/WebCore/page/EventSource.cpp:
(WebCore::EventSource::activeDOMObjectName const): Deleted.
* Source/WebCore/page/EventSource.h:
* Source/WebCore/page/ScreenOrientation.cpp:
(WebCore::ScreenOrientation::lock):
* Source/WebCore/page/ScreenOrientation.h:
* Source/WebCore/workers/Worker.cpp:
(WebCore::Worker::activeDOMObjectName const): Deleted.
* Source/WebCore/workers/Worker.h:
* Source/WebCore/workers/WorkerAnimationController.cpp:
(WebCore::WorkerAnimationController::activeDOMObjectName const): Deleted.
* Source/WebCore/workers/WorkerAnimationController.h:
* Source/WebCore/workers/service/ServiceWorker.cpp:
(WebCore::ServiceWorker::activeDOMObjectName const): Deleted.
* Source/WebCore/workers/service/ServiceWorker.h:
* Source/WebCore/workers/service/ServiceWorkerContainer.cpp:
(WebCore::ServiceWorkerContainer::activeDOMObjectName const): Deleted.
* Source/WebCore/workers/service/ServiceWorkerContainer.h:
* Source/WebCore/workers/service/ServiceWorkerRegistration.cpp:
(WebCore::ServiceWorkerRegistration::activeDOMObjectName const): Deleted.
* Source/WebCore/workers/service/ServiceWorkerRegistration.h:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.cpp:
(WebCore::BackgroundFetchRegistration::activeDOMObjectName const): Deleted.
* Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.h:
* Source/WebCore/workers/shared/SharedWorker.cpp:
(WebCore::SharedWorker::activeDOMObjectName const): Deleted.
* Source/WebCore/workers/shared/SharedWorker.h:
* Source/WebCore/worklets/Worklet.cpp:
(WebCore::Worklet::activeDOMObjectName const): Deleted.
* Source/WebCore/worklets/Worklet.h:
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::activeDOMObjectName const): Deleted.
* Source/WebCore/xml/XMLHttpRequest.h:
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp:
(WebKit::InjectedBundleNodeHandle::activeDOMObjectName const): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h:

Canonical link: <a href="https://commits.webkit.org/277822@main">https://commits.webkit.org/277822@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac090b04f7761af66b93876ac32deb06e60ddb2b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48680 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51641 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51367 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44745 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50985 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33828 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25421 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39816 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42008 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20913 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/23029 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43186 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6736 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44967 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43673 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53281 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23727 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20027 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24993 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42213 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25797 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6942 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24714 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->