### PR TITLE
[WebGPU] RenderPassEncoder should use WeakPtr in more places

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2096,6 +2096,8 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-273021.html [ Pass Failure ]
 [ Debug ] fast/webgpu/fuzz-273023.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-273023.html [ Pass Failure ]
+[ Debug ] fast/webgpu/fuzz-126711484.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-126711484.html [ Pass Failure ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/fuzz-126711484-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-126711484-expected.txt
@@ -1,0 +1,799 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 873x7523
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x7523
+  RenderBlock {HTML} at (0,0) size 785x7523 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x7507
+      RenderText {#text} at (0,6) size 116x17
+        text run at (0,6) width 61: "\x{E311}\x{1B}\x{D83F}\x{DF87}\x{399}\x{D2A}\x{DE1}"
+        text run at (60,6) width 11 RTL: "\x{8BD}"
+        text run at (70,6) width 46: "\x{B71}\x{AA1}\x{3CD8}\x{3C6F}"
+      RenderText {#text} at (131,6) size 130x17
+        text run at (131,6) width 104: "\x{D83E}\x{DFFB}\x{244}\x{65AD}\x{BDFC}\x{5F4E}\x{772F}\x{3FE}\x{E8A}"
+        text run at (234,6) width 5 RTL: "\x{719}"
+        text run at (238,6) width 23: "\x{E62}\x{D83E}\x{DE69}"
+      RenderText {#text} at (260,6) size 106x17
+        text run at (260,6) width 64: "\x{D83E}\x{DE03}\x{6F01}\x{D83E}\x{DC85}\x{D83F}\x{DD0B}\x{3606}"
+        text run at (323,6) width 13 RTL: "\x{804}"
+        text run at (335,6) width 31: "\x{FE18}\x{6623}"
+      RenderText {#text} at (365,6) size 94x17
+        text run at (365,6) width 71: "\x{931}\x{D83E}\x{DD29}\x{1DF}\x{D83F}\x{DC56}\x{D83D}\x{DF50}\x{5B7}\x{D83F}\x{DFCF}"
+        text run at (435,6) width 9 RTL: "\x{677}"
+        text run at (443,6) width 16: "\x{61E3}"
+      RenderText {#text} at (458,6) size 129x17
+        text run at (458,6) width 129: "\x{919E}\x{6EF6}\x{41E9}\x{A4BB}\x{D83F}\x{DFAA}\x{34D}\x{D83D}\x{DF6E}\x{D83D}\x{DEB4}\x{8D60}\x{434}"
+      RenderText {#text} at (586,6) size 30x17
+        text run at (586,6) width 30: "\x{D83F}\x{DF71}\x{1F5}\x{D83F}\x{DD2F}"
+      RenderText {#text} at (300,164) size 84x17
+        text run at (300,164) width 48: "\x{7F94}\x{D83F}\x{DFC3}\x{B5A}\x{EE8}"
+        text run at (347,164) width 5 RTL: "\x{7CA}"
+        text run at (351,164) width 33: "\x{19E7}\x{D83E}\x{DD9E}"
+      RenderText {#text} at (399,164) size 78x17
+        text run at (399,164) width 58: "\x{640B}\x{9BB0}\x{DF}\x{D83E}\x{DD65}"
+        text run at (456,164) width 21 RTL: "\x{635}\x{68E}"
+      RenderText {#text} at (476,164) size 107x17
+        text run at (476,164) width 28: "\x{7FBA}\x{C26}"
+        text run at (503,164) width 14 RTL: "\x{804}"
+        text run at (516,164) width 67: "\x{13F9}\x{D83F}\x{DEFB}\x{3B7}\x{D83E}\x{DFEF}\x{D83F}\x{DCF8}\x{466A}"
+      RenderText {#text} at (582,164) size 89x17
+        text run at (582,164) width 89: "\x{418C}\x{A84}\x{8AAA}\x{D42}\x{D83D}\x{DE9F}\x{482D}"
+      RenderImage {IMG} at (670,107) size 44x70
+      RenderText {#text} at (0,164) size 729x179
+        text run at (713,164) width 16: "\x{D55D}"
+        text run at (0,326) width 28: "\x{1F8E}\x{F1EB}"
+        text run at (27,326) width 9 RTL: "\x{78D}"
+        text run at (35,326) width 80: "\x{1B41}\x{18A}\x{BE6}\x{CDEE}\x{48A}\x{1D8}"
+      RenderText {#text} at (114,326) size 126x17
+        text run at (114,326) width 7 RTL: "\x{68D}"
+        text run at (120,326) width 120: "\x{D83E}\x{DFB8}\x{D83F}\x{DCA0}\x{5DDA}\x{58C0}\x{541}\x{4BC6}\x{D83E}\x{DCE8}G\x{154}\x{FA76}"
+      RenderText {#text} at (239,326) size 95x17
+        text run at (239,326) width 95: "\x{D83D}\x{DFFE}\x{D83E}\x{DC02}\x{93D}\x{51D}\x{7F9B}\x{A7B2}\x{9662}\x{B206}\x{323}"
+      RenderText {#text} at (333,326) size 106x17
+        text run at (333,326) width 106: "\x{4D00}\x{D83F}\x{DCD9}\x{BF1}\x{D83E}\x{DEDA}\x{70AD}\x{D83E}\x{DFD9}\x{E7F3}\x{F846}"
+      RenderText {#text} at (738,326) size 31x17
+        text run at (738,326) width 31: "\x{72D9}\x{5978}\x{817}"
+      RenderText {#text} at (0,487) size 40x17
+        text run at (0,487) width 40: "\x{A8A}\x{32D}\x{8613}\x{D83F}\x{DFD4}"
+      RenderText {#text} at (455,487) size 30x17
+        text run at (455,487) width 30: "\x{8FB2}\x{D83D}\x{DF60}"
+      RenderText {#text} at (484,487) size 140x17
+        text run at (484,487) width 140: "\x{50B}\x{F003}\x{DAC}\x{F2FA}\x{939C}\x{8D26}\x{D83D}\x{DF08}\x{A4DE}\x{D83E}\x{DF94}\x{C9E}\x{D83E}\x{DD95}"
+      RenderText {#text} at (623,487) size 42x17
+        text run at (623,487) width 42: "\x{AA1E}\x{DA2}\x{D83F}\x{DCF3}"
+      RenderText {#text} at (0,487) size 752x187
+        text run at (664,487) width 12 RTL: "\x{61D}"
+        text run at (675,487) width 77: "\x{1535}\x{B7A5}\x{4D5}\x{946A}\x{823F}\x{302B}\x{936}"
+        text run at (0,657) width 15: "\x{B10A}"
+      RenderText {#text} at (14,657) size 86x17
+        text run at (14,657) width 15: "\x{A3F}"
+        text run at (28,657) width 11 RTL: "\x{7DA}"
+        text run at (38,657) width 62: "\x{52E}\x{D83D}\x{DF28}\x{F707}\x{3B7}\x{D83F}\x{DEF5}\x{3E3}"
+      RenderText {#text} at (99,657) size 79x17
+        text run at (99,657) width 79: "\x{C28}\x{84F4}\x{99}\x{DC6}\x{5322}\x{C4BB}"
+      RenderText {#text} at (177,657) size 46x17
+        text run at (177,657) width 46: "\x{7790}\x{7812}\x{31ED}f"
+      RenderText {#text} at (222,657) size 52x17
+        text run at (222,657) width 52: "\x{D83F}\x{DE16}\x{DB7F}\x{F14}\x{8107}\x{15A}"
+      RenderText {#text} at (273,657) size 109x17
+        text run at (273,657) width 109: "\x{3FE7}\x{22F}\x{83D1}\x{BE84}\x{D83E}\x{DFAD}\x{7AA1}\x{D83F}\x{DE92}\x{A35E}\x{E6F}"
+      RenderImage {IMG} at (381,507) size 162x163
+      RenderText {#text} at (543,657) size 83x17
+        text run at (543,657) width 83: "\x{72AB}\x{10}\x{D83E}\x{DDE3}\x{76BB}\x{D83D}\x{DF84}\x{D83F}\x{DE09}"
+      RenderText {#text} at (625,657) size 103x17
+        text run at (625,657) width 69: "\x{D83F}\x{DE6A}\x{8645}\x{1F91}\x{E811}\x{1432}\x{D83E}\x{DE02}"
+        text run at (693,657) width 10 RTL: "\x{6FC}"
+        text run at (702,657) width 26: "B\x{CFDA}"
+      RenderText {#text} at (0,657) size 762x725
+        text run at (743,657) width 19: "\x{2E1}\x{B373}"
+        text run at (0,1365) width 30: "\x{8EB4}\x{C41E}"
+      RenderText {#text} at (29,1365) size 36x17
+        text run at (29,1365) width 36: "\x{D83F}\x{DE82}\x{D41F}\x{2E16}"
+      RenderText {#text} at (364,1365) size 46x17
+        text run at (364,1365) width 46: "\x{4E50}\x{D294}\x{320D}"
+      RenderText {#text} at (409,1365) size 103x17
+        text run at (409,1365) width 75: "\x{4375}\x{C96}\x{E568}\x{D4EB}\x{994}\x{D83F}\x{DFA9}"
+        text run at (483,1365) width 14 RTL: "\x{833}"
+        text run at (496,1365) width 16: "\x{CB52}"
+      RenderText {#text} at (527,1365) size 108x17
+        text run at (527,1365) width 108: "\x{110E}S\x{D83F}\x{DE78}\x{D83F}\x{DEA9}\x{4285}\x{D83E}\x{DEE5}\x{5190}\x{2DF}\x{A023}"
+      RenderText {#text} at (634,1365) size 119x17
+        text run at (634,1365) width 11: "\x{141}"
+        text run at (644,1365) width 11 RTL: "\x{7CB}"
+        text run at (654,1365) width 60: "\x{3D72}\x{D83D}\x{DEE8}\x{379}\x{A3E1}\x{91C7}"
+        text run at (713,1365) width 14 RTL: "\x{77E}"
+        text run at (726,1365) width 27: "\x{E642}\x{6861}"
+      RenderText {#text} at (0,1612) size 41x17
+        text run at (0,1612) width 32: "\x{D06}\x{D83E}\x{DC6A}"
+        text run at (31,1612) width 10 RTL: "\x{792}"
+      RenderText {#text} at (40,1612) size 38x17
+        text run at (40,1612) width 38: "\x{D83F}\x{DE0C}\x{AD4}\x{67CE}"
+      RenderText {#text} at (77,1612) size 36x17
+        text run at (77,1612) width 36: "\x{DCD}\x{1FC}\x{D83F}\x{DE47}"
+      RenderText {#text} at (112,1612) size 128x17
+        text run at (112,1612) width 128: "\x{538}\x{A45}\x{2BD0}\x{F52}\x{53BD}\x{38C7}\x{D83E}\x{DFA4}\x{56A}\x{DBC9}\x{17}\x{5EF4}"
+      RenderText {#text} at (239,1612) size 97x17
+        text run at (239,1612) width 65: "\x{A574}\x{2919}\x{21A9}\x{6ED}\x{4AA}\x{D83F}\x{DE31}\x{2ED}"
+        text run at (303,1612) width 9 RTL: "\x{5D1}"
+        text run at (311,1612) width 25: "\x{3873}\x{A194}"
+      RenderImage {IMG} at (335,1384) size 288x241
+      RenderText {#text} at (622,1612) size 130x17
+        text run at (622,1612) width 130: "\x{8805}\x{C9A9}\x{1FB}\x{1E}\x{4803}\x{F52A}\x{8F3C}\x{1F}\x{11C3}\x{6A7B}"
+      RenderText {#text} at (600,1850) size 56x17
+        text run at (600,1850) width 56: "\x{C105}\x{D83E}\x{DCF0}\x{73A7}\x{9121}"
+      RenderImage {IMG} at (655,1634) size 55x229
+      RenderText {#text} at (0,1850) size 739x42
+        text run at (709,1850) width 12: "\x{EC5}"
+        text run at (720,1850) width 11 RTL: "\x{7D2}"
+        text run at (730,1850) width 9: "\x{666}"
+        text run at (0,1875) width 15: "\x{8949}"
+      RenderText {#text} at (15,1875) size 109x17
+        text run at (15,1875) width 45: "\x{309C}\x{232A}\x{715B}"
+        text run at (60,1875) width 10 RTL: "\x{6CC}"
+        text run at (69,1875) width 55: "\x{8EDF}\x{18B}\x{3E7C}\x{4008}"
+      RenderText {#text} at (123,1875) size 79x17
+        text run at (123,1875) width 79: "\x{FF9}\x{8E5}\x{9F6}\x{1C1}\x{6243}\x{57CF}\x{D83F}\x{DCB8}"
+      RenderText {#text} at (201,1875) size 127x17
+        text run at (201,1875) width 12: "\x{A7CF}"
+        text run at (212,1875) width 14 RTL: "\x{75C}"
+        text run at (225,1875) width 73: "\x{5E03}\x{D83F}\x{DFE6}\x{380}\x{D83D}\x{DEA7}\x{9821}"
+        text run at (297,1875) width 9: "\x{667}"
+        text run at (305,1875) width 23: "\x{4D27}\x{22D}"
+      RenderText {#text} at (327,1875) size 127x17
+        text run at (327,1875) width 127: "\x{D83F}\x{DDC0}\x{7}\x{D83E}\x{DF90}\x{CBC}\x{2DA}\x{8C65}\x{88B1}\x{D83E}\x{DE11}\x{303}\x{8702}\x{D83F}\x{DC7D}"
+      RenderText {#text} at (453,1875) size 20x17
+        text run at (453,1875) width 12: "\x{54D}"
+        text run at (464,1875) width 9 RTL: "\x{5DC}"
+      RenderText {#text} at (300,2590) size 86x17
+        text run at (300,2590) width 86: "\x{AABF}\x{2800}\x{C20}\x{D83E}\x{DFF5}\x{D83F}\x{DD02}\x{86FF}\x{D83D}\x{DEFC}"
+      RenderText {#text} at (385,2590) size 117x17
+        text run at (385,2590) width 117: "\x{D83E}\x{DFAD}\x{D83D}\x{DE6F}\x{6C35}\x{C958}\x{419E}\x{25D5}\x{D83F}\x{DC3C}\x{5A86}\x{4DB6}"
+      RenderText {#text} at (664,2590) size 21x17
+        text run at (664,2590) width 21: "\x{494}\x{963}"
+      RenderText {#text} at (684,2590) size 63x17
+        text run at (684,2590) width 63: "\x{7429}\x{D83D}\x{DF8E}\x{AA31}\x{EC5F}\x{699F}"
+      RenderImage {IMG} at (226,3107) size 155x232
+      RenderText {#text} at (381,3326) size 87x17
+        text run at (381,3326) width 87: "\x{D83E}\x{DC02}\x{3258}\x{D83F}\x{DCBD}\x{B46D}\x{82B}\x{BA08}\x{E7DA}\x{1CB9}"
+      RenderText {#text} at (467,3326) size 113x17
+        text run at (467,3326) width 113: "\x{DAE6}\x{B88E}\x{653}\x{661F}\x{D83E}\x{DE61}\x{C9A5}\x{33B5}\x{8000}\x{238D}"
+      RenderText {#text} at (579,3326) size 83x17
+        text run at (579,3326) width 83: "\x{D83D}\x{DE5A}\x{8930}\x{B4C8}\x{64D1}\x{1854}\x{F6A4}\x{1EA4}"
+      RenderText {#text} at (585,3852) size 102x17
+        text run at (585,3852) width 102: "\x{85}\x{EC1}\x{DD94}\x{5371}\x{3963}\x{4C2}\x{5B0C}\x{8D72}"
+      RenderText {#text} at (0,3852) size 762x322
+        text run at (686,3852) width 76: "\x{4F0D}\x{28BF}\x{5F14}\x{F33D}\x{D83D}\x{DF1D}\x{2F0A}"
+        text run at (0,4157) width 15: "\x{9306}"
+        text run at (15,4157) width 10 RTL: "\x{63D}"
+        text run at (24,4157) width 34: "\x{D83D}\x{DF88}\x{D83D}\x{DF0B}\x{AB6}"
+      RenderText {#text} at (57,4157) size 84x17
+        text run at (57,4157) width 84: "\x{D83E}\x{DC6E}\x{D83D}\x{DF23}\x{3CBC}\x{F3C6}\x{62D9}\x{CBC}\x{5C4B}"
+      RenderText {#text} at (140,4157) size 102x17
+        text run at (140,4157) width 33: "\x{D83F}\x{DE2B}\x{AAF8}\x{D83F}\x{DC38}"
+        text run at (172,4157) width 11 RTL: "\x{78B}"
+        text run at (182,4157) width 60: "\x{E7D}\x{DA79}\x{5414}\x{A69}\x{C06E}"
+      RenderText {#text} at (241,4157) size 107x17
+        text run at (241,4157) width 107: "\x{D83D}\x{DFE7}\x{C3BE}\x{D83F}\x{DDBE}\x{D83F}\x{DD59}\x{D83E}\x{DCA9}\x{9A2}\x{D83D}\x{DFD7}\x{D82}\x{2E82}"
+      RenderText {#text} at (347,4157) size 37x17
+        text run at (347,4157) width 23: "\x{D83F}\x{DC5E}\x{D83F}\x{DE50}"
+        text run at (369,4157) width 8 RTL: "\x{842}"
+        text run at (376,4157) width 8: "\x{29FF}"
+      RenderImage {IMG} at (383,3873) size 120x297
+      RenderText {#text} at (502,4157) size 134x17
+        text run at (502,4157) width 72: "\x{B0AA}\x{2B16}\x{DC36}\x{211F}\x{D83F}\x{DECD}\x{66C2}"
+        text run at (573,4157) width 12 RTL: "\x{864}"
+        text run at (584,4157) width 52: "\x{DB5}\x{D83F}\x{DE67}\x{7ACB}\x{5C9C}"
+      RenderText {#text} at (635,4157) size 99x17
+        text run at (635,4157) width 50: "\x{A0D7}\x{C68A}\x{D83F}\x{DCFD}\x{895D}"
+        text run at (684,4157) width 15 RTL: "\x{69A}"
+        text run at (698,4157) width 36: "\x{31CE}\x{D83E}\x{DE83}"
+      RenderText {#text} at (0,4157) size 755x275
+        text run at (733,4157) width 22: "\x{A04}\x{D83E}\x{DF0A}"
+        text run at (0,4415) width 68: "\x{C1FF}\x{CB55}\x{A6C5}\x{D83E}\x{DC51}\x{D83F}\x{DC4A}\x{2C3B}"
+      RenderImage {IMG} at (67,4178) size 234x250
+      RenderText {#text} at (300,4415) size 26x17
+        text run at (300,4415) width 26: "\x{25D2}\x{1025}"
+      RenderText {#text} at (325,4415) size 31x17
+        text run at (325,4415) width 31: "\x{58FE}\x{394F}"
+      RenderText {#text} at (0,4815) size 33x17
+        text run at (0,4815) width 33: "\x{D83E}\x{DC7C}\x{AB5A}\x{256A}"
+      RenderText {#text} at (97,4815) size 18x17
+        text run at (97,4815) width 18: "\x{EEF8}\x{2F5}"
+      RenderImage {IMG} at (414,4726) size 56x102
+      RenderText {#text} at (308,4970) size 107x17
+        text run at (308,4970) width 107: "\x{2FC9}\x{E28F}\x{3F3}\x{220}\x{81F9}\x{ACD}\x{AD6F}\x{CAE}\x{902}\x{34F}"
+      RenderText {#text} at (414,4970) size 71x17
+        text run at (414,4970) width 71: "\x{F66}\x{357}\x{F57}\x{FA75}\x{1CE}\x{D83D}\x{DE2E}\x{B10C}"
+      RenderText {#text} at (484,4970) size 119x17
+        text run at (484,4970) width 119: "\x{D83E}\x{DC56}\x{D83F}\x{DC4C}\x{28D}\x{EC0}\x{6E54}\x{6248}\x{58D9}\x{D83E}\x{DD17}\x{B910}"
+      RenderText {#text} at (602,4970) size 78x17
+        text run at (602,4970) width 78: "\x{E639}\x{BB4F}\x{E234}\x{4D95}\x{D83F}\x{DD4E}\x{8937}"
+      RenderText {#text} at (0,4970) size 766x43
+        text run at (679,4970) width 87: "\x{8102}\x{CF7F}\x{6776}\x{D83E}\x{DF9A}\x{65FF}\x{431A}"
+        text run at (0,4996) width 59: "\x{456B}\x{9AA}\x{9587}\x{E4C}\x{E8EC}"
+      RenderText {#text} at (58,4996) size 115x17
+        text run at (58,4996) width 115: "\x{9A73}\x{2669}\x{D83D}\x{DF76}\x{E94B}\x{8233}\x{D83F}\x{DE54}\x{D83F}\x{DC5A}\x{D83E}\x{DC4B}\x{B471}"
+      RenderImage {IMG} at (172,4999) size 247x10
+      RenderText {#text} at (418,4996) size 112x17
+        text run at (418,4996) width 60: "\x{B600}\x{C6B}\x{D83F}\x{DC84}\x{43EC}\x{C87}"
+        text run at (477,4996) width 8 RTL: "\x{FEA9}"
+        text run at (484,4996) width 46: "\x{6ABA}\x{9301}\x{5878}"
+      RenderText {#text} at (529,4996) size 87x17
+        text run at (529,4996) width 16: "\x{911E}"
+        text run at (544,4996) width 14 RTL: "\x{854}"
+        text run at (557,4996) width 59: "\x{585F}\x{DF32}\x{4F7}\x{BCB}"
+      RenderText {#text} at (615,4996) size 27x17
+        text run at (615,4996) width 27: "\x{8974}\x{D83F}\x{DD6E}"
+      RenderText {#text} at (641,4996) size 21x17
+        text run at (641,4996) width 21: "\x{E328}\x{BAA}"
+      RenderText {#text} at (661,4996) size 49x17
+        text run at (661,4996) width 22: "\x{DC5}\x{D83F}\x{DDDC}"
+        text run at (682,4996) width 8 RTL: "\x{765}"
+        text run at (689,4996) width 21: "\x{128}\x{327}\x{9B91}"
+      RenderText {#text} at (714,4996) size 19x17
+        text run at (714,4996) width 19: "\x{EB28}\x{F1B}"
+      RenderText {#text} at (732,4996) size 23x17
+        text run at (732,4996) width 23: "\x{4194}\x{1899}"
+      RenderText {#text} at (0,4996) size 766x224
+        text run at (754,4996) width 12: "\x{EDBE}"
+        text run at (0,5203) width 20: "\x{D83E}\x{DD94}"
+        text run at (20,5203) width 20 RTL: "\x{FCCC}\x{80F}"
+        text run at (39,5203) width 41: "\x{8EDF}\x{39C2}\x{D83F}\x{DD03}"
+      RenderImage {IMG} at (79,5018) size 217x198
+      RenderText {#text} at (295,5203) size 61x17
+        text run at (295,5203) width 61: "\x{B002}\x{3FA7}\x{C8EF}\x{4B0C}"
+      RenderImage {IMG} at (355,5026) size 140x190
+      RenderText {#text} at (494,5203) size 44x17
+        text run at (494,5203) width 9 RTL: "\x{FEA6}"
+        text run at (502,5203) width 36: "\x{B85}\x{D83E}\x{DE61}\x{94F}"
+      RenderText {#text} at (537,5203) size 107x17
+        text run at (537,5203) width 107: "\x{1126}\x{605C}\x{667A}\x{5D95}\x{51FD}\x{D83F}\x{DC4A}\x{D83E}\x{DDD6}"
+      RenderText {#text} at (643,5203) size 46x17
+        text run at (643,5203) width 46: "\x{4ED5}\x{78BE}\x{B9D5}"
+      RenderText {#text} at (0,5203) size 760x1001
+        text run at (688,5203) width 72: "\x{73A4}\x{D83F}\x{DC61}\x{FA5}\x{A351}\x{D83E}\x{DFDD}\x{B12B}"
+        text run at (0,6187) width 15: "\x{BC41}"
+      RenderText {#text} at (14,6187) size 63x17
+        text run at (14,6187) width 63: "\x{818E}\x{D83E}\x{DC51}\x{DF9}\x{3165}\x{944}"
+      RenderHTMLCanvas {CANVAS} at (76,5225) size 301x975
+      RenderText {#text} at (471,6343) size 69x17
+        text run at (471,6343) width 69: "\x{A25C}\x{5315}\x{416}\x{956}\x{F53}\x{4884}"
+      RenderText {#text} at (539,6343) size 16x17
+        text run at (539,6343) width 16: "\x{658}\x{C017}"
+      RenderText {#text} at (554,6343) size 32x17
+        text run at (554,6343) width 32: "\x{D83E}\x{DFFA}\x{D83E}\x{DE7A}"
+      RenderText {#text} at (585,6343) size 55x17
+        text run at (585,6343) width 55: "\x{A4BC}\x{D83F}\x{DE97}\x{E9FC}\x{2ABB}\x{D83F}\x{DCBA}"
+      RenderText {#text} at (639,6343) size 45x17
+        text run at (639,6343) width 16: "\x{F944}"
+        text run at (654,6343) width 7 RTL: "\x{6C6}"
+        text run at (660,6343) width 24: "\x{D1E6}\x{AA2}"
+      RenderText {#text} at (683,6343) size 49x17
+        text run at (683,6343) width 49: "\x{928}\x{E241}\x{D83D}\x{DE23}\x{BC0}"
+      RenderText {#text} at (0,6343) size 739x107
+        text run at (731,6343) width 8: "_"
+        text run at (0,6433) width 109: "\x{D83E}\x{DDB1}\x{FE5E}\x{D68}\x{175F}\x{D83F}\x{DF37}\x{8B77}\x{BE52}\x{F089}"
+      RenderText {#text} at (108,6433) size 131x17
+        text run at (108,6433) width 131: "\x{2FA}\x{6125}\x{11E3}\x{C1E}\x{CEB}\x{FC7}\x{28C}\x{D83F}\x{DF7E}\x{548C}\x{D83D}\x{DFD3}\x{7013}"
+      RenderText {#text} at (238,6433) size 70x17
+        text run at (238,6433) width 70: "\x{C261}\x{D83D}\x{DE25}\x{D6A2}\x{EED}\x{A008}"
+      RenderText {#text} at (307,6433) size 93x17
+        text run at (307,6433) width 93: "\x{869E}\x{D83F}\x{DC5C}\x{88BC}\x{CAA}\x{10D6}\x{D83E}\x{DEE3}\x{D83D}\x{DF85}"
+      RenderText {#text} at (399,6433) size 93x17
+        text run at (399,6433) width 12 RTL: "\x{FCEF}"
+        text run at (410,6433) width 71: "\x{D83E}\x{DECB}\x{D83F}\x{DC09}\x{B05}\x{D83E}\x{DE00}\x{E034}\x{2D53}\x{E0D}"
+        text run at (480,6433) width 12 RTL: "\x{FC12}"
+      RenderText {#text} at (491,6433) size 20x17
+        text run at (491,6433) width 20: "\x{471}\x{2697}"
+      RenderText {#text} at (510,6433) size 161x17
+        text run at (510,6433) width 161: "\x{B2A6}\x{4366}\x{D64A}\x{9E1B}\x{E4FD}\x{CAE9}\x{D516}\x{87F1}\x{1FC}\x{D83D}\x{DFE2}\x{2AE3}"
+      RenderText {#text} at (0,6433) size 756x252
+        text run at (734,6433) width 22: "\x{D83F}\x{DF01}\x{D83F}\x{DD7B}"
+        text run at (0,6668) width 24 RTL: "\x{FD24}"
+        text run at (23,6668) width 68: "\x{D83F}\x{DF47}\x{A8E}\x{B776}\x{B94A}\x{1D68}\x{1692}"
+      RenderText {#text} at (90,6668) size 41x17
+        text run at (90,6668) width 36: "\x{5A7B}\x{D83E}\x{DE97}"
+        text run at (125,6668) width 6 RTL: "\x{773}"
+      RenderText {#text} at (130,6668) size 93x17
+        text run at (130,6668) width 93: "\x{2EF2}\x{E025}\x{865E}\x{1A7}\x{56E}\x{267A}\x{E6BD}\x{980}"
+      RenderText {#text} at (222,6668) size 108x17
+        text run at (222,6668) width 108: "\x{CCF}\x{7706}\x{5B61}\x{B30B}\x{D83F}\x{DC9D}\x{4A90}\x{5E97}\x{1C0D}"
+      RenderText {#text} at (329,6668) size 147x17
+        text run at (329,6668) width 147: "\x{D83F}\x{DCEB}\x{CE92}\x{9F0}\x{D83E}\x{DD42}\x{568}\x{106D}\x{908F}\x{7465}\x{D83D}\x{DEE7}\x{7204}\x{18D3}"
+      RenderImage {IMG} at (475,6620) size 31x61
+      RenderText {#text} at (662,6668) size 70x17
+        text run at (662,6668) width 43: "\x{8EC9}\x{19E2}\x{9C36}"
+        text run at (704,6668) width 23 RTL: "\x{86B}\x{20DC}"
+        text run at (726,6668) width 6: "\x{EC4}"
+      RenderText {#text} at (731,6668) size 20x17
+        text run at (731,6668) width 20: "\x{A217}\x{16}"
+      RenderText {#text} at (0,6668) size 766x335
+        text run at (750,6668) width 16: "\x{711A}"
+        text run at (0,6986) width 10: "\x{29B}"
+      RenderText {#text} at (9,6986) size 134x17
+        text run at (9,6986) width 134: "\x{D83E}\x{DEE5}\x{1AE}\x{49F}\x{E378}\x{D10}\x{2353}\x{2E3}\x{D83F}\x{DCA4}\x{D83D}\x{DF79}\x{505}\x{E57}"
+      RenderText {#text} at (142,6986) size 69x17
+        text run at (142,6986) width 7: "\x{2E8}"
+        text run at (148,6986) width 11 RTL: "\x{754}"
+        text run at (158,6986) width 53: "\x{897B}\x{D83E}\x{DCA5}\x{AA0C}\x{C35}"
+      RenderText {#text} at (210,6986) size 60x17
+        text run at (210,6986) width 37: "\x{F01E}\x{8944}\x{EA26}"
+        text run at (246,6986) width 9 RTL: "\x{7DE}"
+        text run at (254,6986) width 16: "\x{B51E}"
+      RenderText {#text} at (269,6986) size 39x17
+        text run at (269,6986) width 39: "\x{AFE1}\x{E8A6}\x{C38}"
+      RenderImage {IMG} at (307,6700) size 156x299
+      RenderText {#text} at (462,6986) size 67x17
+        text run at (462,6986) width 67: "\x{FA31}\x{69D6}\x{E706}\x{A981}\x{5604}"
+      RenderText {#text} at (528,6986) size 108x17
+        text run at (528,6986) width 27: "\x{F3D5}\x{74D5}"
+        text run at (554,6986) width 9 RTL: "\x{716}"
+        text run at (562,6986) width 27: "\x{42A}\x{9195}"
+        text run at (588,6986) width 11 RTL: "\x{718}"
+        text run at (598,6986) width 38: "\x{3916}\x{607}\x{D83D}\x{DF21}"
+      RenderText {#text} at (635,6986) size 94x17
+        text run at (635,6986) width 94: "\x{8550}\x{3C92}\x{E75A}\x{6E4}\x{4F72}\x{B1C1}\x{E694}"
+      RenderText {#text} at (728,6986) size 36x17
+        text run at (728,6986) width 36: "\x{1D9C}\x{C707}\x{EA0}"
+      RenderText {#text} at (0,7019) size 51x17
+        text run at (0,7019) width 40: "\x{7AF7}\x{501}\x{7965}"
+        text run at (39,7019) width 12 RTL: "\x{5CB}"
+      RenderText {#text} at (50,7019) size 107x17
+        text run at (50,7019) width 107: "\x{BBF}\x{DEF2}\x{D6E1}\x{33D}\x{9C4C}\x{1}\x{17C9}\x{D83E}\x{DE74}\x{D68}"
+      RenderText {#text} at (156,7019) size 33x17
+        text run at (156,7019) width 33: "\x{E65C}\x{983}\x{E247}"
+      RenderText {#text} at (188,7019) size 56x17
+        text run at (188,7019) width 16: "\x{3B2B}"
+        text run at (203,7019) width 15 RTL: "\x{8A1}"
+        text run at (217,7019) width 27: "\x{59B4}\x{5BD}\x{D83F}\x{DF00}"
+      RenderText {#text} at (243,7019) size 28x17
+        text run at (243,7019) width 28: "\x{D83E}\x{DF70}\x{1079}"
+      RenderText {#text} at (270,7019) size 77x17
+        text run at (270,7019) width 77: "\x{D83F}\x{DFCA}\x{310}\x{A04}\x{D83D}\x{DF87}\x{A1DC}\x{36A2}\x{D942}"
+      RenderText {#text} at (346,7019) size 89x17
+        text run at (346,7019) width 89: "\x{11B3}\x{C51F}\x{D80}\x{D83F}\x{DEFC}\x{D83E}\x{DE3A}\x{5FF6}\x{E223}"
+      RenderText {#text} at (434,7019) size 139x17
+        text run at (434,7019) width 139: "\x{52A2}\x{EF2B}\x{EDBA}\x{D83E}\x{DD60}\x{E19}\x{D26}\x{6558}\x{126}\x{2A8D}\x{1B33}\x{D4F}"
+      RenderText {#text} at (572,7019) size 57x17
+        text run at (572,7019) width 57: "\x{FA85}\x{D83F}\x{DDE0}\x{D83E}\x{DD89}\x{CE2F}"
+      RenderText {#text} at (628,7019) size 118x17
+        text run at (628,7019) width 118: "\x{443C}\x{D83D}\x{DEBA}\x{D23}\x{D83F}\x{DDD9}\x{5093}\x{4203}\x{D83E}\x{DFFF}\x{4EA}"
+      RenderText {#text} at (0,7019) size 757x55
+        text run at (745,7019) width 12: "\x{4F4}"
+        text run at (0,7057) width 72: "\x{82E2}\x{1B3}\x{F091}\x{D83F}\x{DF1E}\x{B6C1}\x{10E}"
+      RenderText {#text} at (71,7057) size 94x17
+        text run at (71,7057) width 94: "\x{D83D}\x{DEDA}\x{A4F4}\x{5BFF}\x{4F3}\x{CDA5}\x{32F2}\x{124F}\x{22FE}"
+      RenderText {#text} at (164,7057) size 60x17
+        text run at (164,7057) width 60: "\x{D83D}\x{DEB5}\x{38F6}\x{88D6}\x{EA5}"
+      RenderText {#text} at (223,7057) size 57x17
+        text run at (223,7057) width 57: "\x{3A02}\x{B53}\x{5FA6}\x{81F7}"
+      RenderText {#text} at (279,7057) size 135x17
+        text run at (279,7057) width 135: "\x{35E5}\x{E53F}\x{13D6}\x{A885}\x{1022}\x{EDAE}\x{901A}\x{5DA3}\x{41F}\x{D83E}\x{DEE1}"
+      RenderText {#text} at (413,7057) size 107x17
+        text run at (413,7057) width 75: "\x{B38}\x{D83F}\x{DD67}\x{CE3E}\x{BB97}\x{5F37}\x{26E}"
+        text run at (487,7057) width 14 RTL: "\x{8B6}\x{DD4}"
+        text run at (500,7057) width 20: "\x{575}\x{D117}"
+      RenderText {#text} at (519,7057) size 53x17
+        text run at (519,7057) width 53: "\x{C45}\x{D83D}\x{DF71}\x{662B}\x{C834}"
+      RenderText {#text} at (571,7057) size 111x17
+        text run at (571,7057) width 111: "\x{1F2B}\x{539E}\x{D83D}\x{DE86}\x{D83F}\x{DD9B}\x{89E}\x{B5F}\x{13E3}\x{55C4}"
+      RenderText {#text} at (0,7057) size 762x55
+        text run at (681,7057) width 23: "\x{FF08}\x{969}\x{654}"
+        text run at (703,7057) width 14 RTL: "\x{841}"
+        text run at (716,7057) width 46: "\x{35DF}\x{D0BC}\x{482A}"
+        text run at (0,7095) width 25: "\x{267E}\x{87AD}"
+      RenderText {#text} at (24,7095) size 79x17
+        text run at (24,7095) width 79: "\x{CE9E}\x{A910}\x{4ABC}\x{88DB}\x{2F29}\x{442}"
+      RenderText {#text} at (102,7095) size 43x17
+        text run at (102,7095) width 43: "\x{EF55}\x{D83D}\x{DE17}\x{D83E}\x{DF61}"
+      RenderText {#text} at (144,7095) size 75x17
+        text run at (144,7095) width 75: "\x{4C3C}\x{D83D}\x{DE89}\x{FAE5}\x{3ABE}\x{2A37}"
+      RenderText {#text} at (218,7095) size 127x17
+        text run at (218,7095) width 90: "\x{8546}\x{43A5}\x{9E6}\x{51C}\x{29E2}\x{D83E}\x{DDD0}\x{90A}"
+        text run at (307,7095) width 23 RTL: "\x{FC2D}\x{85E}"
+        text run at (329,7095) width 16: "\x{C1B1}"
+      RenderText {#text} at (344,7095) size 103x17
+        text run at (344,7095) width 103: "\x{ECDF}\x{7D93}\x{D83F}\x{DE94}\x{2010}\x{3567}\x{D83E}\x{DF94}\x{17B}\x{39B5}\x{DA8}"
+      RenderText {#text} at (446,7095) size 38x17
+        text run at (446,7095) width 38: "\x{6F7C}\x{2EF}\x{2AE0}\x{E0A}"
+      RenderText {#text} at (483,7095) size 90x17
+        text run at (483,7095) width 90: "\x{F9A4}\x{D83F}\x{DDB2}\x{2B59}\x{D83E}\x{DFB3}\x{4EB2}\x{ECF4}\x{328C}"
+      RenderText {#text} at (572,7095) size 49x17
+        text run at (572,7095) width 16: "\x{573D}"
+        text run at (587,7095) width 12 RTL: "\x{8A3}"
+        text run at (598,7095) width 23: "\x{D83F}\x{DCB3}\x{ADC}"
+      RenderText {#text} at (620,7095) size 121x17
+        text run at (620,7095) width 121: "\x{D83F}\x{DCE5}\x{585D}\x{D83E}\x{DFBA}\x{2462}\x{D83D}\x{DE18}\x{1E66}\x{F397}\x{5CC5}\x{3875}"
+      RenderText {#text} at (0,7095) size 767x41
+        text run at (740,7095) width 12 RTL: "\x{784}"
+        text run at (751,7095) width 16: "\x{2662}"
+        text run at (0,7119) width 30: "\x{8081}\x{89F5}"
+      RenderText {#text} at (30,7119) size 148x17
+        text run at (30,7119) width 128: "\x{5253}\x{FFF}\x{72CB}\x{5973}\x{DC65}\x{6BF3}\x{C8E6}\x{D83F}\x{DCD8}\x{FB4}\x{3D9}"
+        text run at (157,7119) width 21 RTL: "\x{FD2D}"
+      RenderText {#text} at (177,7119) size 87x17
+        text run at (177,7119) width 87: "\x{5972}\x{6846}\x{D83D}\x{DF0E}\x{D83F}\x{DF80}\x{B98D}\x{D83E}\x{DCDD}\x{ECD0}"
+      RenderText {#text} at (263,7119) size 121x17
+        text run at (263,7119) width 121: "\x{D83F}\x{DD65}\x{F317}\x{3C72}\x{7414}\x{F0BD}\x{3A99}\x{49B}\x{D83E}\x{DE44}\x{D83D}\x{DF0E}\x{326C}"
+      RenderText {#text} at (383,7119) size 63x17
+        text run at (383,7119) width 63: "\x{D83E}\x{DF4E}\x{F13}\x{D83F}\x{DEA0}\x{980}\x{D7}\x{D289}"
+      RenderText {#text} at (445,7119) size 86x17
+        text run at (445,7119) width 86: "\x{2A6F}\x{8396}\x{2DF3}\x{D83F}\x{DD11}\x{4977}\x{AAD0}\x{F2B4}\x{BEE}"
+      RenderText {#text} at (530,7119) size 26x17
+        text run at (530,7119) width 26: "\x{481}\x{D83E}\x{DF33}\x{1E9}"
+      RenderText {#text} at (555,7119) size 24x17
+        text run at (555,7119) width 24: "\x{2AC9}\x{30FB}"
+      RenderText {#text} at (578,7119) size 99x17
+        text run at (578,7119) width 99: "\x{BC84}\x{92B}\x{D83F}\x{DECF}\x{365}\x{D83D}\x{DFD8}\x{94C1}\x{DD2}\x{75A0}"
+      RenderText {#text} at (676,7119) size 31x17
+        text run at (676,7119) width 31: "\x{BBE1}\x{596}\x{26D}\x{F75B}"
+      RenderText {#text} at (0,7119) size 763x45
+        text run at (706,7119) width 57: "\x{7444}\x{D83F}\x{DF2E}\x{A850}]\x{B69F}"
+        text run at (0,7147) width 69: "\x{A440}\x{D83E}\x{DEE1}\x{DB5F}\x{656A}\x{C9F7}"
+      RenderText {#text} at (68,7147) size 52x17
+        text run at (68,7147) width 52: "\x{2BA6}\x{1D5D}\x{1F6C}\x{F7AC}\x{D83D}\x{DF42}"
+      RenderText {#text} at (119,7147) size 26x17
+        text run at (119,7147) width 26: "\x{278F}\x{4DC6}"
+      RenderText {#text} at (144,7147) size 56x17
+        text run at (144,7147) width 56: "\x{173F}\x{F02}\x{D83F}\x{DD19}\x{193}\x{A07D}"
+      RenderText {#text} at (199,7147) size 130x17
+        text run at (199,7147) width 7 RTL: "\x{778}"
+        text run at (205,7147) width 124: "\x{5AA0}\x{10E}\x{D83F}\x{DD91}\x{D83F}\x{DECD}\x{631E}\x{5907}\x{D83E}\x{DD4A}\x{5A7D}\x{D83F}\x{DFC5}"
+      RenderText {#text} at (328,7147) size 57x17
+        text run at (328,7147) width 57: "\x{1C30}\x{36A2}\x{A127}\x{D83E}\x{DC62}\x{9613}"
+      RenderText {#text} at (384,7147) size 84x17
+        text run at (384,7147) width 61: "\x{FA94}\x{61DE}\x{6551}\x{A806}\x{F31}\x{D83F}\x{DDEE}"
+        text run at (444,7147) width 9 RTL: "\x{639}"
+        text run at (452,7147) width 16: "\x{5CB9}"
+      RenderText {#text} at (467,7147) size 123x17
+        text run at (467,7147) width 105: "\x{60D0}\x{6DB6}\x{D95C}\x{522D}\x{2A0}\x{B3}\x{7EE}\x{8405}\x{4E1}"
+        text run at (571,7147) width 8: "\x{663}"
+        text run at (578,7147) width 12: "\x{E675}"
+      RenderText {#text} at (589,7147) size 127x17
+        text run at (589,7147) width 46: "\x{4D1B}\x{C2E4}\x{5114}"
+        text run at (634,7147) width 11 RTL: "\x{62B}"
+        text run at (644,7147) width 72: "\x{C2AB}\x{94FF}\x{D83F}\x{DCE2}\x{82F6}\x{5BA9}\x{81E}"
+      RenderText {#text} at (0,7147) size 765x45
+        text run at (715,7147) width 50: "\x{46EE}\x{A414}\x{A45}\x{AFE1}"
+        text run at (0,7175) width 15: "\x{B18C}"
+      RenderText {#text} at (14,7175) size 32x17
+        text run at (14,7175) width 32: "\x{D83E}\x{DED6}\x{E6B1}"
+      RenderText {#text} at (45,7175) size 64x17
+        text run at (45,7175) width 27: "\x{9CB3}\x{B5A}"
+        text run at (71,7175) width 12: "\x{D83E}\x{DFF6}"
+        text run at (82,7175) width 12 RTL: "\x{6CD}"
+        text run at (93,7175) width 16: "\x{53E4}"
+      RenderText {#text} at (108,7175) size 33x17
+        text run at (108,7175) width 33: "\x{F5BE}\x{A5F}\x{D83E}\x{DC76}"
+      RenderText {#text} at (140,7175) size 127x17
+        text run at (140,7175) width 106: "\x{EFDB}\x{FF2}\x{408}\x{EB97}\x{F1C3}\x{93BE}\x{D83E}\x{DF1D}\x{6A1E}\x{4B63}"
+        text run at (245,7175) width 11 RTL: "\x{5D0}"
+        text run at (255,7175) width 12: "\x{A7D}"
+      RenderText {#text} at (266,7175) size 149x17
+        text run at (266,7175) width 149: "\x{BD5E}\x{4AE}\x{D05}\x{D83E}\x{DEC1}\x{5883}\x{A07}\x{D83F}\x{DC88}\x{1AC0}\x{52F9}\x{6223}\x{2DB}"
+      RenderText {#text} at (414,7175) size 30x17
+        text run at (414,7175) width 30: "\x{24F}\x{2273}\x{D931}"
+      RenderText {#text} at (443,7175) size 77x17
+        text run at (443,7175) width 77: "\x{8C4B}\x{5088}\x{1C05}\x{E266}\x{AFA5}\x{312C}"
+      RenderText {#text} at (519,7175) size 24x17
+        text run at (519,7175) width 24: "\x{B39E}\x{463}"
+      RenderText {#text} at (542,7175) size 53x17
+        text run at (542,7175) width 53: "\x{70CE}X\x{40BD}\x{D83F}\x{DC97}"
+      RenderText {#text} at (594,7175) size 66x17
+        text run at (594,7175) width 66: "\x{2E8}\x{D6AF}\x{917}\x{D83F}\x{DD2C}\x{7513}\x{D83E}\x{DCD3}"
+      RenderText {#text} at (659,7175) size 36x17
+        text run at (659,7175) width 36: "\x{A0F4}\x{6A47}\x{1BFB}"
+      RenderText {#text} at (0,7175) size 764x45
+        text run at (694,7175) width 70: "\x{1CCF}\x{F78}\x{E12B}\x{B48}\x{EC7}\x{9B42}"
+        text run at (0,7203) width 66: "\x{C894}\x{C25}\x{9CE}\x{6B51}\x{5BD0}"
+      RenderText {#text} at (65,7203) size 111x17
+        text run at (65,7203) width 26: "\x{5300}\x{D64}"
+        text run at (90,7203) width 12 RTL: "\x{887}"
+        text run at (101,7203) width 53: "\x{D83E}\x{DC4A}\x{13E6}\x{F28}\x{EA3}\x{7037}"
+        text run at (153,7203) width 12 RTL: "\x{80A}"
+        text run at (164,7203) width 12: "\x{D83F}\x{DF0D}"
+      RenderText {#text} at (175,7203) size 31x17
+        text run at (175,7203) width 31: "r\x{36D6}\x{EB6}\x{A4B}"
+      RenderText {#text} at (205,7203) size 53x17
+        text run at (205,7203) width 53: "\x{D83E}\x{DCEA}\x{D83E}\x{DC89}\x{B86E}\x{4D2D}"
+      RenderText {#text} at (257,7203) size 79x17
+        text run at (257,7203) width 49: "\x{9FA9}\x{EC0C}\x{3165}9"
+        text run at (305,7203) width 9 RTL: "\x{7D1}"
+        text run at (313,7203) width 23: "\x{F701}\x{619}"
+      RenderText {#text} at (335,7203) size 123x17
+        text run at (335,7203) width 42: "\x{5E54}\x{DF9C}\x{5EBE}"
+        text run at (376,7203) width 11 RTL: "\x{887}"
+        text run at (386,7203) width 72: "\x{C3}\x{D83F}\x{DD25}\x{D83F}\x{DEBD}\x{C26}\x{5272}\x{D83D}\x{DEE7}"
+      RenderText {#text} at (457,7203) size 126x17
+        text run at (457,7203) width 126: "\x{7E4A}\x{8E32}\x{E6}\x{549E}\x{D83E}\x{DFFF}\x{DF85}\x{70FC}\x{30FA}\x{A4F}\x{2CD0}"
+      RenderText {#text} at (582,7203) size 61x17
+        text run at (582,7203) width 61: "\x{D83F}\x{DCA1}\x{7D06}\x{96B}\x{F25D}\x{CB3E}"
+      RenderText {#text} at (0,7203) size 766x45
+        text run at (642,7203) width 124: "\x{D83E}\x{DCEA}\x{D83F}\x{DE52}\x{1128}\x{B29}\x{D83E}\x{DD9F}\x{D83E}\x{DCA8}\x{BF60}\x{854F}\x{735B}"
+        text run at (0,7231) width 10: "\x{259A}"
+      RenderText {#text} at (9,7231) size 115x17
+        text run at (9,7231) width 115: "\x{F75B}\x{1C68}\x{379}\x{CC03}\x{49B}\x{D83F}\x{DCE1}\x{1979}\x{C0C}\x{E031}\x{D40E}"
+      RenderText {#text} at (123,7231) size 41x17
+        text run at (123,7231) width 41: "\x{D83E}\x{DE9F}\x{D83D}\x{DE2E}"
+      RenderText {#text} at (163,7231) size 115x17
+        text run at (163,7231) width 115: "\x{D83F}\x{DE10}\x{D83F}\x{DD14}\x{D643}\x{A23}\x{D83D}\x{DE22}\x{A477}\x{34F}\x{D16F}\x{D83F}\x{DC20}\x{43F5}"
+      RenderText {#text} at (277,7231) size 127x17
+        text run at (277,7231) width 116: "\x{CAF9}\x{D3E}\x{998}\x{A33}\x{D83E}\x{DC19}\x{D83E}\x{DE3C}\x{E7E5}\x{F6DC}\x{D83E}\x{DD01}\x{D83F}\x{DFC9}"
+        text run at (392,7231) width 12 RTL: "\x{7B6}"
+      RenderText {#text} at (403,7231) size 132x17
+        text run at (403,7231) width 132: "\x{4A3E}\x{D83F}\x{DD04}\x{AC54}\x{AF6}\x{50C}\x{B80}\x{AFB}\x{3798}\x{2FA}\x{AC53}\x{D83D}\x{DF1B}"
+      RenderText {#text} at (534,7231) size 86x17
+        text run at (534,7231) width 21: "\x{D83D}\x{DF48}\x{196}"
+        text run at (554,7231) width 15 RTL: "\x{815}"
+        text run at (568,7231) width 52: "\x{AE08}\x{F0DE}\x{316}\x{3575}"
+      RenderText {#text} at (619,7231) size 118x17
+        text run at (619,7231) width 118: "\x{4898}\x{CCB1}\x{606F}\x{E7ED}\x{8BAA}\x{D83F}\x{DD60}\x{CD54}\x{D83D}\x{DEE5}"
+      RenderText {#text} at (736,7231) size 27x17
+        text run at (736,7231) width 27: "\x{5669}\x{F70F}"
+      RenderText {#text} at (0,7258) size 128x17
+        text run at (0,7258) width 128: "\x{CCDB}\x{7183}\x{22F4}\x{B721}\x{E7AD}\x{7B64}\x{CD8}>\x{E19}\x{D83E}\x{DE92}"
+      RenderText {#text} at (127,7258) size 33x17
+        text run at (127,7258) width 33: "\x{DECC}\x{D7D7}\x{1937}"
+      RenderText {#text} at (159,7258) size 121x17
+        text run at (159,7258) width 121: "\x{1418}\x{D83E}\x{DE74}\x{89DA}\x{C43}\x{D014}\x{C130}\x{E22C}\x{AE80}"
+      RenderText {#text} at (279,7258) size 110x17
+        text run at (279,7258) width 110: "\x{8465}\x{D83F}\x{DFEE}\x{667E}\x{850C}\x{454E}\x{D88}\x{3F19}\x{35F}\x{D83E}\x{DC3C}"
+      RenderText {#text} at (388,7258) size 84x17
+        text run at (388,7258) width 16: "\x{574C}"
+        text run at (403,7258) width 15 RTL: "\x{69A}"
+        text run at (417,7258) width 55: "\x{D83F}\x{DDA7}\x{A4BF}\x{95B}\x{A46}\x{3470}"
+      RenderText {#text} at (471,7258) size 31x17
+        text run at (471,7258) width 31: "\x{300C}\x{9CFB}"
+      RenderText {#text} at (501,7258) size 89x17
+        text run at (501,7258) width 17 RTL: "\x{79D}"
+        text run at (517,7258) width 73: "\x{581}\x{C45}\x{6B36}\x{D19}\x{4D5F}\x{BA}\x{387}"
+      RenderText {#text} at (589,7258) size 86x17
+        text run at (589,7258) width 86: "\x{D83F}\x{DC9F}\x{D83D}\x{DE75}\x{31D}\x{929}\x{2556}\x{D83E}\x{DDBC}\x{38F2}"
+      RenderText {#text} at (674,7258) size 85x17
+        text run at (674,7258) width 85: "\x{D83E}\x{DF17}\x{D83F}\x{DEC6}\x{D83E}\x{DC31}\x{D83E}\x{DDD1}\x{D83E}\x{DF08}\x{D83E}\x{DD96}"
+      RenderText {#text} at (0,7283) size 87x17
+        text run at (0,7283) width 87: "\x{D83F}\x{DE20}\x{A9B}\x{52A9}\x{D83D}\x{DE30}\x{F51}\x{87D1}\x{2078}"
+      RenderText {#text} at (86,7283) size 76x17
+        text run at (86,7283) width 76: "\x{BC5}\x{D83D}\x{DF7C}\x{7ADA}\x{D83D}\x{DF1F}\x{5F57}\x{4807}"
+      RenderText {#text} at (161,7283) size 49x17
+        text run at (161,7283) width 49: "\x{B1A}\x{583}\x{28D3}\x{8951}"
+      RenderText {#text} at (209,7283) size 128x17
+        text run at (209,7283) width 92: "\x{399C}\x{2942}\x{96E0}\x{2568}\x{375}\x{9548}\x{D83E}\x{DD1A}"
+        text run at (300,7283) width 10 RTL: "\x{FB4E}"
+        text run at (309,7283) width 28: "\x{BB6E}\x{D83D}\x{DF5C}"
+      RenderText {#text} at (336,7283) size 67x17
+        text run at (336,7283) width 67: "\x{7EC0}\x{D83E}\x{DDE5}\x{A7D5}\x{D83E}\x{DDD1}"
+      RenderText {#text} at (402,7283) size 29x17
+        text run at (402,7283) width 21: "\x{C2D}\x{FF9B}"
+        text run at (422,7283) width 9 RTL: "\x{716}"
+      RenderText {#text} at (430,7283) size 77x17
+        text run at (430,7283) width 77: "\x{8268}\x{CD47}\x{D83E}\x{DDE9}\x{C7A3}\x{D83F}\x{DF95}"
+      RenderText {#text} at (506,7283) size 83x17
+        text run at (506,7283) width 40: "\x{7741}\x{336}\x{705A}\x{18B}\x{364}"
+        text run at (545,7283) width 9 RTL: "\x{840}"
+        text run at (553,7283) width 36: "\x{CF3}\x{CE2F}\x{7F0}"
+      RenderText {#text} at (588,7283) size 33x17
+        text run at (588,7283) width 33: "\x{F30}\x{ECA}\x{4780}\x{F2}"
+      RenderText {#text} at (620,7283) size 121x17
+        text run at (620,7283) width 27: "\x{DA9D}\x{CBB7}"
+        text run at (646,7283) width 12 RTL: "\x{897}"
+        text run at (657,7283) width 84: "\x{D83E}\x{DC9B}\x{37C0}\x{DE0}\x{DB10}\x{AFD}\x{6018}\x{F30}"
+      RenderText {#text} at (0,7283) size 750x45
+        text run at (740,7283) width 10: "\x{918}"
+        text run at (0,7311) width 135: "\x{D83E}\x{DD55}\x{EBD0}\x{E0B0}\x{AA31}\x{6925}\x{8780}\x{3102}\x{9048}\x{D83F}\x{DDCC}\x{50E7}"
+      RenderText {#text} at (134,7311) size 41x17
+        text run at (134,7311) width 41: "\x{A8D9}\x{D83F}\x{DF66}\x{D83E}\x{DC15}\x{ED64}"
+      RenderText {#text} at (174,7311) size 17x17
+        text run at (174,7311) width 17: "\x{E6E3}\x{2D1}"
+      RenderText {#text} at (190,7311) size 144x17
+        text run at (190,7311) width 144: "\x{9131}\x{FCB}\x{BFAD}\x{E2D3}\x{D83F}\x{DE59}\x{E2C6}\x{5ECC}\x{CF59}\x{D83E}\x{DECC}\x{3E99}\x{A016}"
+      RenderText {#text} at (333,7311) size 27x17
+        text run at (333,7311) width 27: "\x{4445}\x{D83E}\x{DE48}"
+      RenderText {#text} at (359,7311) size 102x17
+        text run at (359,7311) width 102: "\x{D83F}\x{DD09}\x{D83E}\x{DDB1}\x{60C0}\x{B82A}\x{C487}\x{D83D}\x{DEEE}\x{F29}\x{A76B}"
+      RenderText {#text} at (460,7311) size 58x17
+        text run at (460,7311) width 27: "\x{601}"
+        text run at (486,7311) width 32: "\x{41D4}\x{2B5}\x{D83F}\x{DE16}"
+      RenderText {#text} at (517,7311) size 81x17
+        text run at (517,7311) width 81: "\x{D83D}\x{DE41}\x{2FB6}\x{50D1}\x{B18F}\x{61AA}"
+      RenderText {#text} at (597,7311) size 26x17
+        text run at (597,7311) width 26: "\x{DF5B}\x{913F}"
+      RenderText {#text} at (622,7311) size 66x17
+        text run at (622,7311) width 66: "\x{A77D}\x{D83F}\x{DDA2}\x{34F}\x{6A84}\x{B2E0}\x{9088}"
+      RenderText {#text} at (0,7311) size 758x45
+        text run at (687,7311) width 64: "\x{62BA}\x{2A5}\x{37F5}\x{D3DB}"
+        text run at (750,7311) width 8 RTL: "\x{84B}"
+        text run at (0,7339) width 60: "\x{BA54}\x{D83F}\x{DD26}\x{A344}\x{1CC4}"
+      RenderText {#text} at (59,7339) size 74x17
+        text run at (59,7339) width 74: "\x{4DD8}\x{BC1}\x{6D2D}\x{59D9}\x{99E}"
+      RenderText {#text} at (132,7339) size 115x17
+        text run at (132,7339) width 23: "\x{EF27}\x{D83E}\x{DC87}"
+        text run at (154,7339) width 11 RTL: "\x{877}"
+        text run at (164,7339) width 83: "\x{43A2}\x{EAEC}\x{FA3}\x{D13D}\x{823D}\x{8A33}"
+      RenderText {#text} at (246,7339) size 48x17
+        text run at (246,7339) width 48: "\x{C016}\x{D83F}\x{DFB1}\x{D83F}\x{DE82}\x{D83F}\x{DFF4}"
+      RenderText {#text} at (293,7339) size 125x17
+        text run at (293,7339) width 125: "\x{F451}\x{142D}\x{D83D}\x{DE0E}\x{D83E}\x{DFA6}\x{E255}\x{D83D}\x{DF66}\x{D83E}\x{DD25}\x{FAC4}\x{55F3}"
+      RenderText {#text} at (683,7339) size 86x17
+        text run at (683,7339) width 86 RTL: "\x{69B}\x{6BC}\x{202E}\x{CC07}\x{67E}\x{E35B}\x{B7EB}\x{8F7C}"
+      RenderText {#text} at (587,7339) size 97x17
+        text run at (587,7339) width 97 RTL: "\x{203}\x{4153}\x{F18}\x{8AA8}\x{35A2}\x{D83F}\x{DE2B}\x{CA4D}\x{D4F}"
+      RenderText {#text} at (444,7339) size 144x17
+        text run at (444,7339) width 144 RTL: "\x{6EA2}\x{D83E}\x{DD54}\x{7032}\x{D83E}\x{DFD2}\x{D83D}\x{DE8B}\x{588}\x{565}\x{D83D}\x{DE17}\x{7FC}\x{AE}"
+      RenderText {#text} at (417,7339) size 352x45
+        text run at (417,7339) width 28 RTL: "\x{38A2}\x{A96}"
+        text run at (738,7367) width 31 RTL: "\x{41D0}\x{D013}"
+      RenderText {#text} at (656,7367) size 83x17
+        text run at (656,7367) width 83 RTL: "\x{D83F}\x{DEAC}\x{603C}\x{9B39}\x{C4AA}\x{D83F}\x{DF7B}\x{98FE}"
+      RenderText {#text} at (636,7367) size 21x17
+        text run at (636,7367) width 21 RTL: "\x{D83F}\x{DDFE}\x{3D1}"
+      RenderText {#text} at (547,7367) size 90x17
+        text run at (547,7367) width 90 RTL: "\x{D83E}\x{DDEE}\x{4A72}\x{6D37}\x{FD91}\x{D83F}\x{DC37}\x{23A0}\x{271C}"
+      RenderText {#text} at (446,7367) size 102x17
+        text run at (446,7367) width 102 RTL: "\x{F9C4}\x{85DB}\x{130}\x{5F74}\x{171}\x{AB7A}\x{9599}\x{17B}\x{D83E}\x{DECA}"
+      RenderText {#text} at (327,7367) size 120x17
+        text run at (327,7367) width 120 RTL: "\x{76FE}\x{2775}\x{C23}\x{D83F}\x{DE0B}\x{C012}\x{D83E}\x{DCD5}\x{D83E}\x{DD2A}\x{9E24}\x{9E2B}"
+      RenderText {#text} at (292,7367) size 36x17
+        text run at (292,7367) width 36 RTL: "\x{DDE}\x{8E9}\x{4745}"
+      RenderText {#text} at (199,7367) size 94x17
+        text run at (199,7367) width 94 RTL: "\x{5A92}\x{D83D}\x{DE0D}\x{BBD}\x{A85}\x{9842}\x{D8E1}\x{E36}"
+      RenderText {#text} at (109,7367) size 91x17
+        text run at (109,7367) width 91 RTL: "\x{9C76}\x{A628}\x{668}\x{D83F}\x{DF85}\x{D83E}\x{DFC4}\x{88E}\x{7A90}\x{E777}"
+      RenderText {#text} at (15,7367) size 95x17
+        text run at (15,7367) width 95 RTL: "\x{14D}\x{9DE9}\x{774}\x{CF8}\x{E564}\x{D83E}\x{DE93}\x{EED}\x{49D4}"
+      RenderText {#text} at (0,7367) size 763x43
+        text run at (0,7367) width 15 RTL: "\x{11E8}"
+        text run at (718,7393) width 45 RTL: "\x{675}\x{BACC}\x{F8B}\x{90C}"
+      RenderText {#text} at (677,7393) size 42x17
+        text run at (677,7393) width 42 RTL: "\x{683E}\x{D83F}\x{DEF3}\x{3C93}"
+      RenderText {#text} at (637,7393) size 41x17
+        text run at (637,7393) width 41 RTL: "\x{78F5}\x{7F78}\x{D83F}\x{DF83}"
+      RenderText {#text} at (518,7393) size 120x17
+        text run at (518,7393) width 120 RTL: "\x{D83D}\x{DE09}\x{796}\x{D83F}\x{DCBC}D\x{19C2}\x{6A17}\x{7B70}\x{D83D}\x{DEEB}\x{A174}\x{34C}"
+      RenderText {#text} at (488,7393) size 31x17
+        text run at (488,7393) width 31 RTL: "\x{56F3}\x{6FCC}"
+      RenderText {#text} at (418,7393) size 71x17
+        text run at (418,7393) width 71 RTL: "\x{FE70}\x{521C}\x{AA06}\x{84E8}\x{D83E}\x{DF45}\x{D83F}\x{DE37}"
+      RenderText {#text} at (294,7393) size 125x17
+        text run at (294,7393) width 125 RTL: "\x{8CD}\x{B3D3}\x{D80F}\x{16B}\x{E08}\x{232}\x{B97}\x{D83E}\x{DE69}\x{1F3C}\x{488B}\x{8A11}"
+      RenderText {#text} at (198,7393) size 97x17
+        text run at (198,7393) width 97 RTL: "\x{4A5}\x{E74}\x{CAF4}\x{D34}\x{D83E}\x{DF1B}\x{4B6}\x{2BD}\x{9A45}\x{D83F}\x{DE1D}"
+      RenderText {#text} at (85,7393) size 114x17
+        text run at (85,7393) width 114 RTL: "\x{BAF5}\x{5E12}\x{B80}\x{89BF}\x{B118}\x{63C}\x{A084}\x{F6D}\x{63D}\x{77C}"
+      RenderText {#text} at (0,7393) size 728x45
+        text run at (0,7393) width 86 RTL: "\x{7EA2}\x{5644}\x{BE3F}\x{556}\x{181E}\x{7889}"
+        text run at (662,7421) width 66 RTL: "\x{CF5}\x{887E}\x{C83}\x{93F9}\x{D83E}\x{DE2E}"
+      RenderText {#text} at (542,7421) size 121x17
+        text run at (542,7421) width 121 RTL: "\x{D83F}\x{DFEC}\x{CEA0}\x{D83E}\x{DF45}\x{CFC}\x{5A89}\x{D83F}\x{DEC3}\x{7A7C}\x{54A4}\x{E65}\x{9F2}"
+      RenderText {#text} at (498,7421) size 45x17
+        text run at (498,7421) width 45 RTL: "\x{FDF3}\x{9EA}\x{9412}"
+      RenderText {#text} at (442,7421) size 57x17
+        text run at (442,7421) width 57 RTL: "\x{44B}\x{3CB2}\x{D83F}\x{DF31}\x{DE4E}\x{E2E}"
+      RenderText {#text} at (325,7421) size 118x17
+        text run at (325,7421) width 118 RTL: "\x{5144}\x{8AB}\x{196}\x{D83F}\x{DDBD}\x{D83E}\x{DEB9}\x{F091}\x{A9E}\x{D83F}\x{DFC5}\x{D83F}\x{DCE9}\x{8787}"
+      RenderText {#text} at (208,7421) size 118x17
+        text run at (208,7421) width 118 RTL: "\x{C2A5}\x{800}\x{9F46}\x{CF1}\x{F21}\x{66E7}\x{BF55}\x{A0FF}\x{BD8}\x{15}"
+      RenderText {#text} at (123,7421) size 86x17
+        text run at (123,7421) width 86 RTL: "\x{87F3}\x{A73D}\x{5D3C}\x{9312}\x{F4DD}\x{BA3}"
+      RenderText {#text} at (25,7421) size 99x17
+        text run at (25,7421) width 99 RTL: "\x{D83F}\x{DEE2}\x{46D}\x{4AD}\x{841}\x{6ECB}\x{7C9E}\x{E5CD}\x{82F}"
+      RenderText {#text} at (0,7421) size 26x17
+        text run at (0,7421) width 26 RTL: "\x{1AEB}\x{3AAB}"
+      RenderText {#text} at (665,7449) size 95x17
+        text run at (665,7449) width 95 RTL: "\x{2959}\x{1942}\x{D9F}\x{BCD}\x{A4B}\x{8BB5}\x{D83D}\x{DE88}\x{D83E}\x{DF26}"
+      RenderText {#text} at (592,7449) size 74x17
+        text run at (592,7449) width 74 RTL: "\x{3DFB}\x{E853}\x{902F}\x{784}\x{13E}\x{3133}"
+      RenderText {#text} at (557,7449) size 36x17
+        text run at (557,7449) width 36 RTL: "\x{FB8}\x{7912}\x{EC9E}"
+      RenderText {#text} at (523,7449) size 35x17
+        text run at (523,7449) width 35 RTL: "\x{504B}\x{D91A}\x{236}"
+      RenderText {#text} at (462,7449) size 62x17
+        text run at (462,7449) width 62 RTL: "\x{AAA}\x{F7DF}\x{384}\x{B4EC}\x{C45}\x{DC4}\x{E05E}"
+      RenderText {#text} at (365,7449) size 98x17
+        text run at (365,7449) width 98 RTL: "\x{D83D}\x{DE6C}\x{6645}\x{453}\x{D83F}\x{DF03}\x{F67}\x{FA0}\x{D83F}\x{DF1E}\x{D83E}\x{DF2C}\x{7162}"
+      RenderText {#text} at (336,7449) size 30x17
+        text run at (336,7449) width 30 RTL: "\x{89E5}\x{A3E}"
+      RenderText {#text} at (213,7449) size 124x17
+        text run at (213,7449) width 124 RTL: "\x{C8B8}\x{D04F}\x{4599}\x{3FFD}\x{61AF}\x{8B27}\x{D291}\x{EE6}\x{769}"
+      RenderText {#text} at (156,7449) size 58x17
+        text run at (156,7449) width 58 RTL: "\x{E85A}\x{9E6}\x{B96}\x{CC8}\x{541C}"
+      RenderText {#text} at (71,7449) size 86x17
+        text run at (71,7449) width 86 RTL: "\x{902}\x{E280}\x{4174}\x{F7E4}\x{7D6E}\x{2F9B}\x{687}"
+      RenderText {#text} at (0,7449) size 507x53
+        text run at (0,7449) width 72 RTL: "\x{C66}\x{C57C}\x{F094}\x{AA6F}\x{19B}\x{D150}"
+        text run at (466,7485) width 41 RTL: "\x{D83D}\x{DFEE}\x{645}\x{443}\x{C2B5}"
+      RenderText {#text} at (368,7485) size 99x17
+        text run at (368,7485) width 99 RTL: "\x{F89}\x{20D}\x{545C}\x{CDE9}\x{6ACF}\x{F15F}\x{D83F}\x{DF0F}\x{30A7}"
+      RenderText {#text} at (289,7485) size 80x17
+        text run at (289,7485) width 80 RTL: "\x{93EA}\x{329D}\x{9F1}\x{484}\x{A2E0}\x{D83F}\x{DD32}\x{DB2C}\x{F512}"
+      RenderText {#text} at (209,7485) size 81x17
+        text run at (209,7485) width 81 RTL: "\x{851D}\x{11BD}\x{D83F}\x{DDAF}\x{47B7}\x{3D2A}\x{A86D}"
+      RenderText {#text} at (83,7485) size 127x17
+        text run at (83,7485) width 127 RTL: "\x{E1F2}\x{4E8}\x{FA6}\x{D83F}\x{DE0B}\x{501B}\x{405D}\x{981}\x{492}\x{54B8}\x{D83E}\x{DE64}\x{313}"
+      RenderText {#text} at (67,7485) size 17x17
+        text run at (67,7485) width 17 RTL: "\x{F680}\x{1D6A}"
+      RenderText {#text} at (0,7485) size 68x17
+        text run at (0,7485) width 68 RTL: "\x{E09}\x{F66F}\x{684}\x{EC1}\x{717D}\x{CD50}\x{8D5}"
+layer at (124,11) size 16x16
+  RenderVideo {VIDEO} at (115,3) size 17x16
+layer at (8,35) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,27) size 300x150
+layer at (391,169) size 16x16
+  RenderVideo {VIDEO} at (383,161) size 17x16
+layer at (446,197) size 300x150
+  RenderHTMLCanvas {CANVAS} at (438,189) size 301x150
+layer at (47,492) size 16x16
+  RenderVideo {VIDEO} at (39,484) size 17x16
+layer at (63,358) size 100x150
+  RenderHTMLCanvas {CANVAS} at (55,350) size 101x150
+layer at (163,358) size 300x150
+  RenderHTMLCanvas {CANVAS} at (155,350) size 301x150
+layer at (736,662) size 16x16
+  RenderVideo {VIDEO} at (727,654) size 17x16
+layer at (73,687) size 300x699
+  RenderHTMLCanvas {CANVAS} at (64,679) size 301x699
+layer at (520,1370) size 16x16
+  RenderVideo {VIDEO} at (511,1362) size 17x16
+layer at (8,1721) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,1713) size 300x150
+layer at (308,1721) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,1713) size 300x150
+layer at (8,1903) size 300x708
+  RenderHTMLCanvas {CANVAS} at (0,1895) size 300x708
+layer at (510,2448) size 163x163
+  RenderVideo {VIDEO} at (501,2440) size 164x163
+layer at (8,2617) size 210x730
+  RenderHTMLCanvas {CANVAS} at (0,2609) size 210x730
+layer at (218,3331) size 16x16
+  RenderVideo {VIDEO} at (210,3323) size 16x16
+layer at (8,3354) size 585x519
+  RenderHTMLCanvas {CANVAS} at (0,3346) size 585x519
+layer at (8,4455) size 865x150
+  RenderHTMLCanvas {CANVAS} at (0,4447) size 865x150
+layer at (40,4605) size 65x231
+  RenderVideo {VIDEO} at (32,4597) size 66x231
+layer at (123,4686) size 300x150
+  RenderHTMLCanvas {CANVAS} at (114,4678) size 301x150
+layer at (8,4841) size 308x150
+  RenderHTMLCanvas {CANVAS} at (0,4833) size 308x150
+layer at (717,5012) size 5x5
+  RenderVideo {VIDEO} at (709,5004) size 6x5
+layer at (8,6214) size 471x150
+  RenderHTMLCanvas {CANVAS} at (0,6206) size 471x150
+layer at (678,6373) size 64x81
+  RenderVideo {VIDEO} at (670,6365) size 65x81
+layer at (514,6463) size 157x226
+  RenderVideo {VIDEO} at (505,6455) size 158x226

--- a/LayoutTests/fast/webgpu/fuzz-126711484.html
+++ b/LayoutTests/fast/webgpu/fuzz-126711484.html
@@ -1,0 +1,49853 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUCommandEncoder} commandEncoder
+ */
+function pseudoSubmit(device, commandEncoder) {
+  device.pushErrorScope('validation');
+  commandEncoder.clearBuffer(device.createBuffer({size: 0, usage: 0}), 0, 0);
+  device.popErrorScope().then(() => {});
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let promise0 = navigator.gpu.requestAdapter();
+let adapter0 = await promise0;
+let device0 = await adapter0.requestDevice(
+{
+label: '\u8a25\u0542\u{1fb0e}\ube0f\uf225\u2c56\u39d9',
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 34,
+maxVertexAttributes: 27,
+maxVertexBufferArrayStride: 16695,
+maxStorageTexturesPerShaderStage: 18,
+maxStorageBuffersPerShaderStage: 22,
+maxDynamicStorageBuffersPerPipelineLayout: 36575,
+maxBindingsPerBindGroup: 5784,
+maxTextureArrayLayers: 256,
+maxTextureDimension1D: 10975,
+maxTextureDimension2D: 14390,
+minStorageBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 218846480,
+maxInterStageShaderVariables: 111,
+maxInterStageShaderComponents: 121,
+},
+}
+);
+let commandEncoder0 = device0.createCommandEncoder(
+{
+label: '\ud66d\u{1f642}\u{1feb9}\u9b42\u0f69\u8682\u35d5\u{1fccd}\u041a\u469f',
+}
+);
+let computePassEncoder0 = commandEncoder0.beginComputePass(
+{
+label: '\u{1fe6d}\u1b03\u9f45\u04b9\udb46'
+}
+);
+let renderBundleEncoder0 = device0.createRenderBundleEncoder(
+{
+label: '\u851f\u{1fec9}\u70fd\u0a12\u30a3\uc175\u{1fda8}\ua07c\u0045',
+colorFormats: [
+'rg8unorm',
+'rgba32sint'
+],
+sampleCount: 488,
+stencilReadOnly: true,
+}
+);
+let renderBundle0 = renderBundleEncoder0.finish(
+{
+
+}
+);
+let renderBundleEncoder1 = device0.createRenderBundleEncoder(
+{
+label: '\u7334\u6b10\ue9dd\u847a\u037d\u0d73\u6a53\u{1f86b}',
+colorFormats: [
+'rg8unorm',
+'r16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 798,
+}
+);
+let renderBundle1 = renderBundleEncoder1.finish(
+{
+label: '\u7417\u73ce\u0b06'
+}
+);
+gc();
+document.body.append('\u52a2\uef2b\uedba\u{1f960}\u0e19\u0d26\u6558\u0126\u2a8d\u1b33\u0d4f');
+let sampler0 = device0.createSampler(
+{
+label: '\u2637\u{1fe5f}\u{1fea7}\u078e',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 52.402,
+lodMaxClamp: 98.400,
+}
+);
+document.body.prepend('\u11b3\uc51f\u0d80\u{1fefc}\u{1fa3a}\u5ff6\ue223');
+let canvas0 = document.createElement('canvas');
+let texture0 = device0.createTexture(
+{
+label: '\ub378\u08f2\u052c\u{1f9cd}\u{1fe12}\ub47a\u{1f82b}\ubdde',
+size: [6254],
+dimension: '1d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rg16float',
+'rg16float'
+],
+}
+);
+let renderBundleEncoder2 = device0.createRenderBundleEncoder(
+{
+label: '\u02ae\ua838\u8a7a\u0134\u17fc',
+colorFormats: [
+'rg16uint',
+'r8sint',
+'rgba32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 666,
+stencilReadOnly: true,
+}
+);
+document.body.prepend('\u{1ffca}\u0310\u0a04\u{1f787}\ua1dc\u36a2\ud942');
+try {
+canvas0.getContext('webgpu');
+} catch {}
+let commandEncoder1 = device0.createCommandEncoder(
+{
+label: '\u08e3\uf1a2\u95b9\ue215\u6041\u0b8b\u0beb\ubbf3',
+}
+);
+let querySet0 = device0.createQuerySet(
+{
+label: '\u{1f823}\u1139',
+type: 'occlusion',
+count: 2605,
+}
+);
+let commandBuffer0 = commandEncoder1.finish(
+{
+label: '\u{1fe7a}\uc44f\u{1ff56}\u24df',
+}
+);
+let renderBundleEncoder3 = device0.createRenderBundleEncoder(
+{
+label: '\u7c9b\ua804\u{1f977}\ud978\u6d47\u7b7e\u4ee7',
+colorFormats: [
+'rgba8uint'
+],
+sampleCount: 113,
+stencilReadOnly: true,
+}
+);
+let canvas1 = document.createElement('canvas');
+let renderBundleEncoder4 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8unorm',
+'rg32float',
+undefined,
+'rg16float',
+'rg16uint',
+'r16sint',
+'rgba16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 815,
+stencilReadOnly: false,
+}
+);
+let sampler1 = device0.createSampler(
+{
+label: '\u05ca\u089d',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 98.418,
+lodMaxClamp: 98.589,
+maxAnisotropy: 14,
+}
+);
+document.body.append('\ufa85\u{1fde0}\u{1f989}\uce2f');
+let renderBundleEncoder5 = device0.createRenderBundleEncoder(
+{
+label: '\ucded\u{1f6ec}',
+colorFormats: [
+'r16uint',
+'rgb10a2uint',
+'rg16uint',
+'rg32uint',
+'rgba8uint',
+'r32float'
+],
+sampleCount: 517,
+}
+);
+gc();
+let querySet1 = device0.createQuerySet(
+{
+label: '\u01d1\u{1fe2b}\u{1f7cd}\uad12\uaa0b\u9e89',
+type: 'occlusion',
+count: 1509,
+}
+);
+let renderBundleEncoder6 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg16float',
+'rg8unorm',
+'rgba32uint',
+'r8uint'
+],
+sampleCount: 971,
+stencilReadOnly: true,
+}
+);
+let renderBundle2 = renderBundleEncoder5.finish(
+{
+label: '\u{1f8c1}\u62b1\u0e5a\u0d00\ueeef\ubb66\u0451\u8d67'
+}
+);
+let sampler2 = device0.createSampler(
+{
+label: '\u{1fdf4}\u125d',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 0.684,
+lodMaxClamp: 2.719,
+}
+);
+try {
+renderBundleEncoder4.setVertexBuffer(
+90,
+undefined,
+1315667419,
+2687961863
+);
+} catch {}
+try {
+canvas1.getContext('bitmaprenderer');
+} catch {}
+let texture1 = device0.createTexture(
+{
+label: '\u8708\u{1f6aa}\u0a23\udc10\u0b5b\u08d6\u9fbc\u{1fd91}',
+size: [133, 250, 135],
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgb10a2unorm'
+],
+}
+);
+let renderBundle3 = renderBundleEncoder2.finish(
+{
+
+}
+);
+let renderBundle4 = renderBundleEncoder1.finish(
+{
+label: '\ud28c\u0533'
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 2040, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint32Array(new ArrayBuffer(40)),
+/* required buffer size: 12061 */{
+offset: 869,
+},
+{width: 2798, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+try {
+await promise1;
+} catch {}
+document.body.prepend('\u{1fb70}\u1079');
+let bindGroupLayout0 = device0.createBindGroupLayout(
+{
+entries: [
+{
+binding: 4207,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+}
+],
+}
+);
+let buffer0 = device0.createBuffer(
+{
+label: '\u030b\ufefe\u{1fbb0}\u{1f7ed}\u0f41\u1b05',
+size: 7049,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+}
+);
+let textureView0 = texture0.createView(
+{
+format: 'rg16float',
+}
+);
+let renderBundle5 = renderBundleEncoder2.finish(
+{
+label: '\u3aeb\u4f40\uc6f5\u077f\u338a\ub953'
+}
+);
+let promise2 = device0.queue.onSubmittedWorkDone();
+let pipelineLayout0 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0
+],
+}
+);
+let buffer1 = device0.createBuffer(
+{
+size: 46720,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+let querySet2 = device0.createQuerySet(
+{
+label: '\u0708\u00d5\u{1faa5}\u7e8d\u0546\u6ad8',
+type: 'occlusion',
+count: 1691,
+}
+);
+try {
+buffer1.destroy();
+} catch {}
+document.body.prepend('\u3b2b\u08a1\u59b4\u05bd\u{1ff00}');
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+texture0.destroy();
+} catch {}
+let textureView1 = texture0.createView(
+{
+label: '\u04ff\u0382\uf0de\u{1fb64}\u46bb\u{1fec3}\u128d',
+arrayLayerCount: 1,
+}
+);
+document.body.append('\u443c\u{1f6ba}\u0d23\u{1fdd9}\u5093\u4203\u{1fbff}\u04ea');
+try {
+adapter0.label = '\u{1f833}\u00f8\u13a2\u7575';
+} catch {}
+let shaderModule0 = device0.createShaderModule(
+{
+label: '\u6ba7\u0abe\u{1fc71}\uc776\u{1ffe5}\u{1f938}\u{1f64c}',
+code: `@group(1) @binding(4207)
+var<storage, read_write> local0: array<u32>;
+
+@compute @workgroup_size(2, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S1 {
+@builtin(sample_index) f0: u32,
+@builtin(sample_mask) f1: u32,
+@builtin(position) f2: vec4<f32>
+}
+struct FragmentOutput0 {
+@builtin(frag_depth) f0: f32
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, a1: S1) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S0 {
+@location(5) f0: f16,
+@location(20) f1: vec4<i32>,
+@builtin(vertex_index) f2: u32,
+@location(4) f3: vec3<i32>,
+@location(22) f4: vec4<f32>,
+@location(19) f5: f16,
+@location(14) f6: f32,
+@location(11) f7: vec2<u32>,
+@location(17) f8: vec4<f16>,
+@location(12) f9: vec2<f32>,
+@location(0) f10: vec4<i32>,
+@location(24) f11: f16,
+@location(10) f12: u32,
+@builtin(instance_index) f13: u32,
+@location(18) f14: f32,
+@location(8) f15: vec2<f32>,
+@location(3) f16: vec4<f32>,
+@location(21) f17: vec3<i32>,
+@location(25) f18: vec4<f16>,
+@location(9) f19: vec2<f32>,
+@location(6) f20: vec3<u32>,
+@location(1) f21: i32,
+@location(23) f22: i32,
+@location(2) f23: vec2<f16>,
+@location(26) f24: vec3<f32>,
+@location(16) f25: vec4<u32>,
+@location(7) f26: f32
+}
+
+@vertex
+fn vertex0(a0: S0, @location(13) a1: vec4<f32>, @location(15) a2: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let offscreenCanvas0 = new OffscreenCanvas(563, 757);
+let imageData0 = new ImageData(32, 8);
+let videoFrame0 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+let querySet3 = device0.createQuerySet(
+{
+label: '\u04cc\u0278\u63b5\u0d3e\u08f5\u{1faae}\ua041\u05e5\uc0be\ub882\u25a2',
+type: 'occlusion',
+count: 3811,
+}
+);
+pseudoSubmit(device0, commandEncoder0);
+let textureView2 = texture0.createView(
+{
+baseArrayLayer: 0,
+}
+);
+try {
+buffer1.destroy();
+} catch {}
+document.body.append('\u04f4\u82e2\u01b3\uf091\u{1ff1e}\ub6c1\u010e');
+let offscreenCanvas1 = new OffscreenCanvas(727, 667);
+try {
+device0.queue.writeBuffer(
+buffer0,
+4812,
+new BigUint64Array(54914),
+40499,
+124
+);
+} catch {}
+let canvas2 = document.createElement('canvas');
+let imageBitmap0 = await createImageBitmap(videoFrame0);
+let bindGroup0 = device0.createBindGroup({
+label: '\u4579\u25f2\u912e\u50ff\u776a',
+layout: bindGroupLayout0,
+entries: [
+{
+binding: 4207,
+resource: sampler2
+}
+],
+});
+let commandEncoder2 = device0.createCommandEncoder(
+{
+label: '\u0af6\u0e74',
+}
+);
+try {
+renderBundleEncoder4.setBindGroup(
+7,
+bindGroup0,
+new Uint32Array(9186),
+6253,
+0
+);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let pipeline0 = device0.createComputePipeline(
+{
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.append('\u{1f6da}\ua4f4\u5bff\u04f3\ucda5\u32f2\u124f\u22fe');
+try {
+adapter0.label = '\u9038\ua260\u{1f8e0}';
+} catch {}
+let querySet4 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 3316,
+}
+);
+try {
+commandEncoder2.resolveQuerySet(
+querySet4,
+270,
+18,
+buffer0,
+6144
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer0,
+820,
+new Int16Array(33945),
+19661,
+1084
+);
+} catch {}
+let texture2 = device0.createTexture(
+{
+label: '\u1471\u0dca',
+size: {width: 4789},
+mipLevelCount: 1,
+dimension: '1d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST,
+}
+);
+try {
+renderBundleEncoder6.setBindGroup(
+2,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+21,
+undefined,
+2022619383
+);
+} catch {}
+let gpuCanvasContext0 = offscreenCanvas1.getContext('webgpu');
+let commandEncoder3 = device0.createCommandEncoder();
+let textureView3 = texture0.createView(
+{
+label: '\u74e5\u07a5\u0870\u0045\u024a',
+}
+);
+let renderBundleEncoder7 = device0.createRenderBundleEncoder(
+{
+label: '\u3311\u{1f850}\u1e2a\u95b5\u9a21\u7f17\u1517\u3953',
+colorFormats: [
+'rg8sint',
+undefined,
+undefined,
+'rg8uint'
+],
+sampleCount: 166,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+commandEncoder3.resolveQuerySet(
+querySet3,
+2958,
+706,
+buffer0,
+512
+);
+} catch {}
+try {
+renderBundleEncoder7.insertDebugMarker(
+'\u11e4'
+);
+} catch {}
+let promise3 = device0.createComputePipelineAsync(
+{
+label: '\u72ae\u0093\u{1f9a5}',
+layout: 'auto',
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline1 = device0.createRenderPipeline(
+{
+label: '\uecd7\ufbba\u7ff4\u{1fa7c}\u{1fcde}\u01db',
+layout: 'auto',
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 8508,
+attributes: [
+{
+format: 'float16x2',
+offset: 6468,
+shaderLocation: 19,
+},
+{
+format: 'sint32x4',
+offset: 2372,
+shaderLocation: 0,
+},
+{
+format: 'sint8x4',
+offset: 3052,
+shaderLocation: 20,
+},
+{
+format: 'unorm16x2',
+offset: 7224,
+shaderLocation: 5,
+},
+{
+format: 'snorm16x2',
+offset: 6772,
+shaderLocation: 17,
+},
+{
+format: 'snorm8x4',
+offset: 5236,
+shaderLocation: 13,
+},
+{
+format: 'float32x3',
+offset: 856,
+shaderLocation: 14,
+},
+{
+format: 'sint16x2',
+offset: 4964,
+shaderLocation: 4,
+},
+{
+format: 'float32x4',
+offset: 1296,
+shaderLocation: 25,
+},
+{
+format: 'float32',
+offset: 1312,
+shaderLocation: 9,
+},
+{
+format: 'float16x4',
+offset: 4564,
+shaderLocation: 26,
+}
+],
+},
+{
+arrayStride: 1872,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 986,
+shaderLocation: 18,
+},
+{
+format: 'unorm16x2',
+offset: 1140,
+shaderLocation: 12,
+},
+{
+format: 'snorm16x2',
+offset: 116,
+shaderLocation: 3,
+},
+{
+format: 'snorm16x4',
+offset: 1640,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 8520,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 11348,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 5268,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 624,
+shaderLocation: 2,
+},
+{
+format: 'float16x2',
+offset: 488,
+shaderLocation: 24,
+},
+{
+format: 'uint32x4',
+offset: 1296,
+shaderLocation: 10,
+},
+{
+format: 'sint32x3',
+offset: 1156,
+shaderLocation: 23,
+},
+{
+format: 'uint32x4',
+offset: 400,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x2',
+offset: 1940,
+shaderLocation: 15,
+},
+{
+format: 'sint32x4',
+offset: 2628,
+shaderLocation: 21,
+},
+{
+format: 'float16x4',
+offset: 1300,
+shaderLocation: 22,
+},
+{
+format: 'uint32',
+offset: 912,
+shaderLocation: 6,
+},
+{
+format: 'float32',
+offset: 1188,
+shaderLocation: 7,
+},
+{
+format: 'sint32x4',
+offset: 4848,
+shaderLocation: 1,
+},
+{
+format: 'uint32',
+offset: 756,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+},
+multisample: {
+count: 4,
+mask: 0x7c0e8e65,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less',
+failOp: 'zero',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'always',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 1307,
+stencilWriteMask: 2417,
+depthBias: 78,
+depthBiasSlopeScale: 44,
+depthBiasClamp: 24,
+},
+}
+);
+let video0 = await videoWithData();
+try {
+offscreenCanvas0.getContext('webgl2');
+} catch {}
+let shaderModule1 = device0.createShaderModule(
+{
+label: '\u7e2f\u533a\ucae3\uf73b\u782c\u{1fe73}\u{1fc7a}\u05ac\u690f\u058d',
+code: `@group(1) @binding(4207)
+var<storage, read_write> function0: array<u32>;
+
+@compute @workgroup_size(4, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S2 {
+@location(30) f0: vec2<f16>,
+@location(46) f1: vec3<u32>,
+@location(107) f2: vec4<f16>,
+@location(17) f3: vec2<f16>,
+@location(73) f4: u32,
+@location(51) f5: vec4<i32>,
+@location(1) f6: vec4<f32>,
+@location(58) f7: f32,
+@location(23) f8: vec3<f16>,
+@location(76) f9: vec2<f32>,
+@location(8) f10: vec3<u32>,
+@location(57) f11: f16,
+@location(75) f12: vec3<i32>,
+@builtin(position) f13: vec4<f32>,
+@builtin(front_facing) f14: bool,
+@location(29) f15: vec4<f32>,
+@location(77) f16: i32,
+@location(28) f17: vec3<i32>,
+@builtin(sample_mask) f18: u32,
+@location(97) f19: vec4<f32>,
+@location(13) f20: vec2<u32>,
+@location(90) f21: vec2<u32>,
+@location(56) f22: vec4<i32>,
+@location(92) f23: vec4<i32>,
+@location(108) f24: vec2<f16>,
+@location(70) f25: vec2<f32>,
+@location(12) f26: i32,
+@location(79) f27: vec3<i32>
+}
+struct FragmentOutput0 {
+@location(6) f0: u32,
+@location(4) f1: vec3<i32>,
+@location(7) f2: vec2<i32>,
+@location(2) f3: u32,
+@location(3) f4: vec4<u32>,
+@location(1) f5: vec4<i32>
+}
+
+@fragment
+fn fragment0(a0: S2, @builtin(sample_index) a1: u32, @location(20) a2: vec4<f16>, @location(91) a3: vec2<f16>, @location(80) a4: vec4<f16>, @location(81) a5: vec3<f32>, @location(104) a6: vec4<i32>, @location(69) a7: vec2<u32>, @location(82) a8: vec2<f32>, @location(50) a9: vec2<u32>, @location(78) a10: vec2<f16>, @location(53) a11: vec3<f16>, @location(3) a12: vec2<f32>, @location(21) a13: vec3<u32>, @location(93) a14: vec2<f32>, @location(101) a15: vec2<f32>, @location(85) a16: vec2<u32>, @location(32) a17: vec2<f32>, @location(2) a18: vec3<f16>, @location(68) a19: u32, @location(39) a20: vec2<u32>, @location(45) a21: vec4<u32>, @location(88) a22: vec4<i32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(68) f0: u32,
+@location(45) f1: vec4<u32>,
+@location(39) f2: vec2<u32>,
+@location(93) f3: vec2<f32>,
+@location(13) f4: vec2<u32>,
+@location(70) f5: vec2<f32>,
+@location(12) f6: i32,
+@location(85) f7: vec2<u32>,
+@location(53) f8: vec3<f16>,
+@location(92) f9: vec4<i32>,
+@location(50) f10: vec2<u32>,
+@location(107) f11: vec4<f16>,
+@location(82) f12: vec2<f32>,
+@location(91) f13: vec2<f16>,
+@location(101) f14: vec2<f32>,
+@location(21) f15: vec3<u32>,
+@location(23) f16: vec3<f16>,
+@location(108) f17: vec2<f16>,
+@location(29) f18: vec4<f32>,
+@location(32) f19: vec2<f32>,
+@location(81) f20: vec3<f32>,
+@location(75) f21: vec3<i32>,
+@location(3) f22: vec2<f32>,
+@location(76) f23: vec2<f32>,
+@location(78) f24: vec2<f16>,
+@location(57) f25: f16,
+@builtin(position) f26: vec4<f32>,
+@location(80) f27: vec4<f16>,
+@location(17) f28: vec2<f16>,
+@location(56) f29: vec4<i32>,
+@location(73) f30: u32,
+@location(58) f31: f32,
+@location(88) f32: vec4<i32>,
+@location(46) f33: vec3<u32>,
+@location(104) f34: vec4<i32>,
+@location(1) f35: vec4<f32>,
+@location(28) f36: vec3<i32>,
+@location(51) f37: vec4<i32>,
+@location(20) f38: vec4<f16>,
+@location(90) f39: vec2<u32>,
+@location(8) f40: vec3<u32>,
+@location(97) f41: vec4<f32>,
+@location(30) f42: vec2<f16>,
+@location(2) f43: vec3<f16>,
+@location(69) f44: vec2<u32>,
+@location(77) f45: i32,
+@location(79) f46: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec3<u32>, @location(2) a1: f16, @location(3) a2: vec4<f32>, @location(5) a3: f16, @location(0) a4: vec2<f16>, @location(11) a5: vec3<f32>, @location(23) a6: vec2<f32>, @location(20) a7: f16, @location(9) a8: vec2<f32>, @location(24) a9: vec4<i32>, @location(6) a10: vec4<f32>, @builtin(instance_index) a11: u32, @location(12) a12: u32, @location(16) a13: f32, @location(19) a14: vec4<f32>, @location(4) a15: vec4<f16>, @location(15) a16: vec4<f16>, @location(26) a17: f16, @location(7) a18: u32, @builtin(vertex_index) a19: u32, @location(10) a20: f16, @location(8) a21: vec2<f32>, @location(1) a22: vec3<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroup1 = device0.createBindGroup({
+label: '\u2a45\u0435',
+layout: bindGroupLayout0,
+entries: [
+{
+binding: 4207,
+resource: sampler0
+}
+],
+});
+let sampler3 = device0.createSampler(
+{
+label: '\u84a7\u552e\u7754',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 9.560,
+lodMaxClamp: 29.326,
+}
+);
+try {
+renderBundleEncoder4.setBindGroup(
+3,
+bindGroup0
+);
+} catch {}
+try {
+commandEncoder3.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+await promise2;
+} catch {}
+offscreenCanvas1.height = 898;
+let shaderModule2 = device0.createShaderModule(
+{
+label: '\u{1fa19}\u{1f699}\u40f6',
+code: `@group(1) @binding(4207)
+var<storage, read_write> field0: array<u32>;
+@group(2) @binding(4207)
+var<storage, read_write> function1: array<u32>;
+
+@compute @workgroup_size(1, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) {
+
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+}
+);
+let bindGroup2 = device0.createBindGroup({
+label: '\ud1ff\u2e86\u08bc\u1aa2\u018e',
+layout: bindGroupLayout0,
+entries: [
+{
+binding: 4207,
+resource: sampler0
+}
+],
+});
+let pipelineLayout1 = device0.createPipelineLayout(
+{
+label: '\ue06d\u4f4b\u0063\u{1f8ef}\u6e8d\u083e\u{1fd63}\ub44b\u8655',
+bindGroupLayouts: [
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0
+],
+}
+);
+let commandEncoder4 = device0.createCommandEncoder(
+{
+}
+);
+let textureView4 = texture0.createView(
+{
+label: '\u7df4\u{1fe21}\u7675\u4a37\ue708',
+}
+);
+let renderBundleEncoder8 = device0.createRenderBundleEncoder(
+{
+label: '\u0ced\u038b\u0f11\u3c9b\u2501',
+colorFormats: [
+'rgba8uint',
+'rgba16float',
+'r32uint',
+'rgba8unorm-srgb',
+undefined,
+'rgba8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 237,
+stencilReadOnly: true,
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: { x: 831, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(16),
+/* required buffer size: 12291 */{
+offset: 807,
+rowsPerImage: 72,
+},
+{width: 2871, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+canvas1.width = 28;
+let commandEncoder5 = device0.createCommandEncoder(
+{
+label: '\u9118\u57a9\ue0c3\u{1f683}\u631f\u22ff\ufa94\u048f\u{1f825}\u{1fa12}\u0e2f',
+}
+);
+let querySet5 = device0.createQuerySet(
+{
+label: '\u85fe\u0970\u37f8\u0245\u0bd2\u8e0e',
+type: 'occlusion',
+count: 3687,
+}
+);
+let renderBundleEncoder9 = device0.createRenderBundleEncoder(
+{
+label: '\ucce6\ub285\u0f79\u0494\u0e63\u2da9\ua0e7',
+colorFormats: [
+undefined,
+'rgba16uint',
+'rg32uint',
+'r16float',
+'rgba16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 817,
+}
+);
+try {
+commandEncoder2.clearBuffer(
+buffer0,
+6000,
+616
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer0,
+]);
+} catch {}
+document.body.append('\u{1f6b5}\u38f6\u88d6\u0ea5');
+let shaderModule3 = device0.createShaderModule(
+{
+code: `
+
+@compute @workgroup_size(1, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S4 {
+@builtin(position) f0: vec4<f32>
+}
+struct FragmentOutput0 {
+@location(4) f0: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool, a2: S4) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S3 {
+@location(9) f0: u32,
+@location(15) f1: f16,
+@location(11) f2: vec3<f32>,
+@location(22) f3: vec3<f16>,
+@location(23) f4: vec3<i32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(3) a1: vec2<f16>, @location(6) a2: u32, @location(14) a3: f16, a4: S3, @location(13) a5: vec3<i32>, @builtin(instance_index) a6: u32, @location(4) a7: i32, @location(5) a8: vec4<f32>, @location(16) a9: f32, @location(21) a10: i32, @location(2) a11: u32, @location(25) a12: vec2<i32>, @location(26) a13: f16, @location(12) a14: vec2<f32>, @location(19) a15: i32, @location(0) a16: vec2<f16>, @location(20) a17: vec2<u32>, @location(8) a18: vec3<u32>, @location(18) a19: u32, @location(17) a20: vec2<f32>, @location(10) a21: vec4<f16>, @location(24) a22: vec2<u32>, @location(7) a23: vec3<u32>, @location(1) a24: vec3<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+}
+);
+let querySet6 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 3531,
+}
+);
+let texture3 = device0.createTexture(
+{
+label: '\u0927\ubd0e\u00a2\u3954\u{1fb9c}\uda92',
+size: [20, 1, 1747],
+mipLevelCount: 9,
+dimension: '3d',
+format: 'r8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8sint'
+],
+}
+);
+let renderBundle6 = renderBundleEncoder0.finish(
+{
+label: '\u{1f8b0}\ubc54\u0d41\u0ef5\u9e4c\u0436'
+}
+);
+let sampler4 = device0.createSampler(
+{
+label: '\u0a83\ue072\u5412\ub136',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 0.669,
+lodMaxClamp: 35.752,
+compare: 'greater',
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: { x: 7, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(24),
+/* required buffer size: 15129 */{
+offset: 897,
+},
+{width: 3558, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\u3a02\u0b53\u5fa6\u81f7');
+let bindGroup3 = device0.createBindGroup({
+layout: bindGroupLayout0,
+entries: [
+{
+binding: 4207,
+resource: sampler0
+}
+],
+});
+let buffer2 = device0.createBuffer(
+{
+label: '\u{1f871}\u25f0\u2267\u0dff\u{1fa58}\u77c4',
+size: 39580,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+}
+);
+let sampler5 = device0.createSampler(
+{
+label: '\u8326\u{1fdad}\u95e5\u04c5\u33cd\u3c0f\ua2bf\u476b\ue814\u{1f9e0}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMaxClamp: 51.985,
+}
+);
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer0,
+4652,
+new Float32Array(50346),
+25375,
+108
+);
+} catch {}
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder6 = device0.createCommandEncoder(
+{
+label: '\u1bad\u87c4\u0c06\u37ef\u05fb',
+}
+);
+let computePassEncoder1 = commandEncoder5.beginComputePass(
+{
+label: '\ub72f\u0bec\ue3d3\ub9b2\u{1f838}\u{1ff45}\u7332\u3009\u09cb'
+}
+);
+let sampler6 = device0.createSampler(
+{
+label: '\u{1fe18}\u{1f774}\u02da\u{1ffe7}\u4b86\u03f6\u0d33\ucdff\ub350',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 70.651,
+lodMaxClamp: 89.165,
+compare: 'equal',
+}
+);
+try {
+computePassEncoder1.setPipeline(
+pipeline0
+);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+10,
+bindGroup0
+);
+} catch {}
+try {
+commandEncoder6.clearBuffer(
+buffer0,
+6876,
+36
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline2 = await device0.createRenderPipelineAsync(
+{
+layout: 'auto',
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 10740,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x4',
+offset: 3932,
+shaderLocation: 10,
+},
+{
+format: 'unorm16x2',
+offset: 7844,
+shaderLocation: 16,
+},
+{
+format: 'float32x4',
+offset: 6528,
+shaderLocation: 5,
+},
+{
+format: 'sint16x2',
+offset: 5500,
+shaderLocation: 24,
+},
+{
+format: 'snorm8x4',
+offset: 6148,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 10860,
+attributes: [
+{
+format: 'snorm16x2',
+offset: 7060,
+shaderLocation: 20,
+},
+{
+format: 'unorm8x2',
+offset: 2138,
+shaderLocation: 6,
+},
+{
+format: 'uint32x3',
+offset: 10528,
+shaderLocation: 14,
+},
+{
+format: 'float32x2',
+offset: 5992,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 10920,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 10592,
+shaderLocation: 0,
+},
+{
+format: 'unorm16x4',
+offset: 10848,
+shaderLocation: 3,
+},
+{
+format: 'uint32x4',
+offset: 1768,
+shaderLocation: 12,
+},
+{
+format: 'float32',
+offset: 20,
+shaderLocation: 8,
+},
+{
+format: 'uint32x4',
+offset: 5088,
+shaderLocation: 7,
+},
+{
+format: 'float32',
+offset: 6788,
+shaderLocation: 15,
+},
+{
+format: 'float32x4',
+offset: 812,
+shaderLocation: 19,
+},
+{
+format: 'unorm8x2',
+offset: 1928,
+shaderLocation: 26,
+}
+],
+},
+{
+arrayStride: 15308,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x4',
+offset: 1224,
+shaderLocation: 1,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 9156,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 972,
+attributes: [
+
+],
+},
+{
+arrayStride: 4500,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 2188,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x4',
+offset: 1464,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: false,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'rgba16sint',
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+},
+{
+format: 'rgb10a2uint',
+},
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+undefined,
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r16sint',
+writeMask: 0,
+}
+],
+},
+}
+);
+let pipelineLayout2 = device0.createPipelineLayout(
+{
+label: '\u01b5\u0d30\u0752\u8c3e',
+bindGroupLayouts: [
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0
+],
+}
+);
+let texture4 = device0.createTexture(
+{
+label: '\u7aed\u082b\u{1fb88}\u{1ff74}\u{1fc78}\u0d51\u{1f606}',
+size: {width: 12021, height: 215, depthOrArrayLayers: 172},
+mipLevelCount: 2,
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let textureView5 = texture2.createView(
+{
+label: '\uc621\u{1fdee}',
+arrayLayerCount: 1,
+}
+);
+try {
+computePassEncoder1.setPipeline(
+pipeline0
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 774, y: 121, z: 77 },
+  aspect: 'all',
+},
+new ArrayBuffer(32),
+/* required buffer size: 65884 */{
+offset: 413,
+bytesPerRow: 5968,
+},
+{width: 5791, height: 11, depthOrArrayLayers: 1}
+);
+} catch {}
+let gpuCanvasContext1 = canvas2.getContext('webgpu');
+let bindGroup4 = device0.createBindGroup({
+label: '\uc251\u15a0\u019d\u{1fa44}\u{1f954}\udc7d\u{1f7c1}\u{1f691}\u4a82',
+layout: bindGroupLayout0,
+entries: [
+{
+binding: 4207,
+resource: sampler2
+}
+],
+});
+let commandEncoder7 = device0.createCommandEncoder(
+{
+label: '\u7256\u1e6a\ubdc4\u2e8f\u6155\u{1f954}\u046f',
+}
+);
+try {
+commandEncoder4.copyTextureToTexture(
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: { x: 3193, y: 10, z: 109 },
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: { x: 5680, y: 17, z: 99 },
+  aspect: 'all',
+},
+{width: 240, height: 89, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder();
+try {
+device0.pushErrorScope(
+'validation'
+);
+} catch {}
+try {
+commandEncoder2.copyBufferToBuffer(
+buffer2,
+16212,
+buffer1,
+34328,
+5148
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.copyTextureToTexture(
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: { x: 75, y: 31, z: 6 },
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: { x: 2300, y: 37, z: 116 },
+  aspect: 'all',
+},
+{width: 8, height: 27, depthOrArrayLayers: 27}
+);
+} catch {}
+try {
+commandEncoder4.resolveQuerySet(
+querySet3,
+1670,
+317,
+buffer0,
+512
+);
+} catch {}
+let pipeline3 = await device0.createRenderPipelineAsync(
+{
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 232,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 196,
+shaderLocation: 4,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 160,
+shaderLocation: 13,
+},
+{
+format: 'float32x2',
+offset: 104,
+shaderLocation: 22,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 144,
+shaderLocation: 15,
+},
+{
+format: 'unorm8x2',
+offset: 20,
+shaderLocation: 17,
+},
+{
+format: 'sint16x4',
+offset: 148,
+shaderLocation: 0,
+},
+{
+format: 'unorm16x2',
+offset: 212,
+shaderLocation: 19,
+},
+{
+format: 'float32',
+offset: 220,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x4',
+offset: 36,
+shaderLocation: 25,
+},
+{
+format: 'float32',
+offset: 52,
+shaderLocation: 26,
+},
+{
+format: 'snorm8x4',
+offset: 76,
+shaderLocation: 3,
+},
+{
+format: 'uint32x2',
+offset: 176,
+shaderLocation: 10,
+},
+{
+format: 'float16x4',
+offset: 132,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 9836,
+shaderLocation: 11,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 7872,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x2',
+offset: 11456,
+shaderLocation: 14,
+},
+{
+format: 'sint8x2',
+offset: 5226,
+shaderLocation: 1,
+},
+{
+format: 'snorm16x4',
+offset: 6852,
+shaderLocation: 5,
+},
+{
+format: 'uint32x3',
+offset: 4532,
+shaderLocation: 6,
+},
+{
+format: 'uint32x4',
+offset: 7584,
+shaderLocation: 16,
+},
+{
+format: 'unorm8x2',
+offset: 12098,
+shaderLocation: 24,
+},
+{
+format: 'sint16x2',
+offset: 1736,
+shaderLocation: 20,
+},
+{
+format: 'snorm16x4',
+offset: 3372,
+shaderLocation: 18,
+},
+{
+format: 'snorm8x2',
+offset: 15756,
+shaderLocation: 7,
+},
+{
+format: 'sint8x2',
+offset: 8626,
+shaderLocation: 23,
+},
+{
+format: 'snorm8x2',
+offset: 4946,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 7948,
+attributes: [
+{
+format: 'sint32x4',
+offset: 2628,
+shaderLocation: 21,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'invert',
+passOp: 'decrement-clamp',
+},
+stencilWriteMask: 257,
+depthBias: 54,
+depthBiasSlopeScale: 69,
+depthBiasClamp: 29,
+},
+}
+);
+document.body.append('\u35e5\ue53f\u13d6\ua885\u1022\uedae\u901a\u5da3\u041f\u{1fae1}');
+let commandEncoder9 = device0.createCommandEncoder(
+{
+label: '\uffc2\ue420\u3bd7\u0e2a\u3334\u{1fb4b}',
+}
+);
+let renderBundleEncoder10 = device0.createRenderBundleEncoder(
+{
+label: '\u38f4\uba6c\u04a6\u{1fba3}\udeda',
+colorFormats: [
+'rg8unorm',
+undefined,
+'r8uint',
+'rg8sint',
+'r8unorm',
+'rgba16float'
+],
+sampleCount: 257,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder8.setVertexBuffer(
+1,
+buffer2,
+27396,
+11698
+);
+} catch {}
+try {
+commandEncoder9.clearBuffer(
+buffer0,
+2452,
+3268
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture3,
+  mipLevel: 4,
+  origin: { x: 0, y: 1, z: 3 },
+  aspect: 'all',
+},
+new ArrayBuffer(72),
+/* required buffer size: 4811547 */{
+offset: 411,
+bytesPerRow: 264,
+rowsPerImage: 268,
+},
+{width: 1, height: 0, depthOrArrayLayers: 69}
+);
+} catch {}
+let pipeline4 = device0.createComputePipeline(
+{
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline5 = device0.createRenderPipeline(
+{
+label: '\u1f9e\u1b7f\ufb53',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 16492,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 2164,
+shaderLocation: 20,
+},
+{
+format: 'snorm8x4',
+offset: 3944,
+shaderLocation: 15,
+},
+{
+format: 'float32x3',
+offset: 2888,
+shaderLocation: 16,
+},
+{
+format: 'sint8x2',
+offset: 8568,
+shaderLocation: 21,
+},
+{
+format: 'unorm8x2',
+offset: 11912,
+shaderLocation: 0,
+},
+{
+format: 'sint32x3',
+offset: 7844,
+shaderLocation: 4,
+},
+{
+format: 'uint32x4',
+offset: 6868,
+shaderLocation: 24,
+},
+{
+format: 'sint16x2',
+offset: 4732,
+shaderLocation: 13,
+},
+{
+format: 'uint32x3',
+offset: 9260,
+shaderLocation: 18,
+},
+{
+format: 'uint16x2',
+offset: 15416,
+shaderLocation: 8,
+},
+{
+format: 'sint32x4',
+offset: 13164,
+shaderLocation: 23,
+},
+{
+format: 'unorm8x2',
+offset: 804,
+shaderLocation: 5,
+},
+{
+format: 'snorm8x4',
+offset: 12964,
+shaderLocation: 26,
+},
+{
+format: 'uint32',
+offset: 7788,
+shaderLocation: 2,
+},
+{
+format: 'float16x4',
+offset: 268,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x4',
+offset: 1584,
+shaderLocation: 12,
+},
+{
+format: 'uint32x3',
+offset: 7796,
+shaderLocation: 6,
+},
+{
+format: 'float32x2',
+offset: 2296,
+shaderLocation: 1,
+},
+{
+format: 'uint32x2',
+offset: 6656,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x2',
+offset: 7848,
+shaderLocation: 17,
+},
+{
+format: 'unorm8x4',
+offset: 15896,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 13436,
+attributes: [
+{
+format: 'uint16x2',
+offset: 6596,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 4436,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 60,
+shaderLocation: 25,
+},
+{
+format: 'unorm16x4',
+offset: 1136,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 5788,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 4864,
+shaderLocation: 3,
+},
+{
+format: 'float32x4',
+offset: 3044,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 6184,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 8816,
+attributes: [
+
+],
+},
+{
+arrayStride: 3240,
+attributes: [
+{
+format: 'sint8x4',
+offset: 540,
+shaderLocation: 19,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0xeee46c67,
+},
+fragment: {
+module: shaderModule3,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+{
+format: 'rgba16uint',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+let videoFrame1 = new VideoFrame(canvas1, {timestamp: 0});
+try {
+device0.label = '\ufcd7\u06b3\u03b0\u02ca\u0a29\u9a0a';
+} catch {}
+let shaderModule4 = device0.createShaderModule(
+{
+label: '\u{1fba7}\u{1fcd8}',
+code: `@group(5) @binding(4207)
+var<storage, read_write> local1: array<u32>;
+
+@compute @workgroup_size(2, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S6 {
+@location(73) f0: vec3<f32>,
+@location(76) f1: vec3<f32>,
+@location(75) f2: vec3<u32>,
+@location(44) f3: vec3<i32>,
+@location(0) f4: vec2<f32>,
+@location(59) f5: vec4<i32>,
+@location(88) f6: f16,
+@location(96) f7: vec2<f32>,
+@location(109) f8: f16,
+@location(101) f9: f16,
+@location(39) f10: f16,
+@location(6) f11: vec2<f32>,
+@location(35) f12: vec4<i32>,
+@builtin(sample_index) f13: u32,
+@location(95) f14: u32,
+@location(7) f15: f16,
+@location(63) f16: vec4<f32>,
+@location(69) f17: vec2<u32>,
+@location(18) f18: f32,
+@location(66) f19: i32,
+@location(43) f20: vec2<u32>,
+@location(25) f21: vec3<u32>,
+@location(47) f22: vec4<f16>,
+@location(20) f23: vec2<f16>,
+@builtin(position) f24: vec4<f32>,
+@location(105) f25: i32,
+@builtin(front_facing) f26: bool,
+@location(2) f27: vec2<f32>,
+@builtin(sample_mask) f28: u32,
+@location(30) f29: vec2<i32>,
+@location(81) f30: vec2<u32>,
+@location(54) f31: vec3<u32>,
+@location(53) f32: vec4<f32>,
+@location(21) f33: vec3<f16>,
+@location(24) f34: u32,
+@location(27) f35: vec4<i32>,
+@location(42) f36: vec3<f16>,
+@location(26) f37: vec2<u32>,
+@location(78) f38: vec2<u32>
+}
+struct FragmentOutput0 {
+@location(1) f0: u32,
+@location(6) f1: f32,
+@location(3) f2: vec2<f32>,
+@location(2) f3: vec2<i32>,
+@location(4) f4: vec2<i32>
+}
+
+@fragment
+fn fragment0(@location(29) a0: vec3<f16>, @location(110) a1: vec2<f16>, @location(23) a2: f16, @location(9) a3: u32, @location(11) a4: f32, @location(104) a5: vec2<u32>, @location(45) a6: vec3<u32>, @location(32) a7: vec3<f32>, @location(72) a8: vec2<u32>, @location(37) a9: vec4<f32>, @location(34) a10: vec4<i32>, @location(38) a11: vec3<f16>, a12: S6) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S5 {
+@location(13) f0: vec2<u32>,
+@location(0) f1: vec3<f32>,
+@location(7) f2: vec3<u32>,
+@location(14) f3: f32,
+@location(3) f4: u32,
+@location(23) f5: vec2<u32>,
+@location(17) f6: vec3<f16>,
+@location(8) f7: vec3<f16>,
+@location(19) f8: f32
+}
+struct VertexOutput0 {
+@location(29) f47: vec3<f16>,
+@location(6) f48: vec2<f32>,
+@location(23) f49: f16,
+@location(32) f50: vec3<f32>,
+@location(101) f51: f16,
+@location(63) f52: vec4<f32>,
+@location(42) f53: vec3<f16>,
+@location(109) f54: f16,
+@location(76) f55: vec3<f32>,
+@location(13) f56: vec2<u32>,
+@location(59) f57: vec4<i32>,
+@location(2) f58: vec2<f32>,
+@location(30) f59: vec2<i32>,
+@location(11) f60: f32,
+@location(21) f61: vec3<f16>,
+@location(27) f62: vec4<i32>,
+@location(38) f63: vec3<f16>,
+@location(26) f64: vec2<u32>,
+@location(35) f65: vec4<i32>,
+@location(64) f66: vec4<f32>,
+@location(20) f67: vec2<f16>,
+@location(18) f68: f32,
+@location(110) f69: vec2<f16>,
+@location(81) f70: vec2<u32>,
+@location(40) f71: vec2<i32>,
+@location(66) f72: i32,
+@location(39) f73: f16,
+@location(67) f74: vec3<f16>,
+@location(25) f75: vec3<u32>,
+@location(34) f76: vec4<i32>,
+@location(78) f77: vec2<u32>,
+@location(95) f78: u32,
+@location(54) f79: vec3<u32>,
+@location(44) f80: vec3<i32>,
+@location(105) f81: i32,
+@location(37) f82: vec4<f32>,
+@location(53) f83: vec4<f32>,
+@location(88) f84: f16,
+@location(9) f85: u32,
+@location(75) f86: vec3<u32>,
+@location(69) f87: vec2<u32>,
+@location(96) f88: vec2<f32>,
+@location(7) f89: f16,
+@location(104) f90: vec2<u32>,
+@location(43) f91: vec2<u32>,
+@builtin(position) f92: vec4<f32>,
+@location(0) f93: vec2<f32>,
+@location(47) f94: vec4<f16>,
+@location(72) f95: vec2<u32>,
+@location(73) f96: vec3<f32>,
+@location(45) f97: vec3<u32>,
+@location(24) f98: u32
+}
+
+@vertex
+fn vertex0(a0: S5, @location(2) a1: vec3<f16>, @builtin(vertex_index) a2: u32, @location(6) a3: vec4<f16>, @location(12) a4: vec4<i32>, @location(24) a5: vec4<u32>, @location(22) a6: vec3<i32>, @location(11) a7: vec4<i32>, @location(20) a8: vec4<f32>, @location(1) a9: vec4<i32>, @location(4) a10: vec3<i32>, @location(5) a11: vec2<u32>, @location(21) a12: vec4<u32>, @location(15) a13: vec2<i32>, @location(18) a14: f32, @location(9) a15: vec3<f16>, @location(16) a16: vec4<f32>, @builtin(instance_index) a17: u32, @location(10) a18: vec3<f32>, @location(25) a19: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+}
+);
+let buffer3 = device0.createBuffer(
+{
+label: '\u{1f757}\u189a\ue260\u06d4\u012c\u0ff7',
+size: 21120,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let querySet7 = device0.createQuerySet(
+{
+label: '\u94d2\ue085',
+type: 'occlusion',
+count: 1955,
+}
+);
+let texture5 = device0.createTexture(
+{
+label: '\ubab0\ubedf\u0094\u0f90\uab10\u561a\uda10',
+size: [7502],
+dimension: '1d',
+format: 'rg8uint',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+try {
+renderBundleEncoder4.setVertexBuffer(
+1,
+buffer2,
+39040,
+84
+);
+} catch {}
+try {
+commandEncoder6.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline6 = await device0.createRenderPipelineAsync(
+{
+label: '\u{1f8c1}\ud986\u{1fcd0}\u0a5e',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 7236,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 3516,
+shaderLocation: 4,
+},
+{
+format: 'float32x3',
+offset: 6620,
+shaderLocation: 0,
+},
+{
+format: 'float32x2',
+offset: 4740,
+shaderLocation: 9,
+},
+{
+format: 'snorm8x4',
+offset: 1952,
+shaderLocation: 5,
+},
+{
+format: 'snorm8x4',
+offset: 584,
+shaderLocation: 10,
+},
+{
+format: 'float32',
+offset: 7184,
+shaderLocation: 26,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 4916,
+shaderLocation: 16,
+},
+{
+format: 'uint32x2',
+offset: 6084,
+shaderLocation: 14,
+},
+{
+format: 'unorm16x2',
+offset: 4760,
+shaderLocation: 20,
+},
+{
+format: 'float16x4',
+offset: 6616,
+shaderLocation: 19,
+},
+{
+format: 'unorm8x4',
+offset: 4392,
+shaderLocation: 8,
+},
+{
+format: 'unorm8x2',
+offset: 4944,
+shaderLocation: 1,
+},
+{
+format: 'float16x4',
+offset: 1908,
+shaderLocation: 15,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 3396,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x2',
+offset: 2088,
+shaderLocation: 3,
+},
+{
+format: 'float16x4',
+offset: 6160,
+shaderLocation: 2,
+},
+{
+format: 'float32x3',
+offset: 1584,
+shaderLocation: 23,
+},
+{
+format: 'float32',
+offset: 7068,
+shaderLocation: 6,
+},
+{
+format: 'uint32x3',
+offset: 2348,
+shaderLocation: 12,
+},
+{
+format: 'uint16x4',
+offset: 324,
+shaderLocation: 7,
+},
+{
+format: 'sint8x4',
+offset: 4172,
+shaderLocation: 24,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'back',
+},
+multisample: {
+mask: 0xe4d77af1,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'replace',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilReadMask: 2048,
+stencilWriteMask: 2713,
+depthBias: 84,
+depthBiasSlopeScale: 86,
+depthBiasClamp: 64,
+},
+}
+);
+let commandEncoder10 = device0.createCommandEncoder(
+{
+label: '\u0800\u0ddf\u00f9\u{1fd3e}',
+}
+);
+let textureView6 = texture3.createView(
+{
+baseMipLevel: 5,
+mipLevelCount: 2,
+}
+);
+let computePassEncoder2 = commandEncoder6.beginComputePass(
+{
+label: '\u05a0\ucd65\u64f4\u1b2f'
+}
+);
+try {
+renderBundleEncoder6.setVertexBuffer(
+6,
+buffer2,
+7792
+);
+} catch {}
+try {
+commandEncoder3.copyBufferToTexture(
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 11863 */
+offset: 11863,
+bytesPerRow: 0,
+rowsPerImage: 142,
+buffer: buffer2,
+},
+{
+  texture: texture3,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 5}
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let videoFrame2 = new VideoFrame(canvas2, {timestamp: 0});
+let bindGroup5 = device0.createBindGroup({
+label: '\u{1fed0}\u{1fdee}\u97c6\u03eb\u0452\u07f2',
+layout: bindGroupLayout0,
+entries: [
+{
+binding: 4207,
+resource: sampler0
+}
+],
+});
+let querySet8 = device0.createQuerySet(
+{
+label: '\uc8e9\u47b2\u{1fdca}\u{1fbaa}\u979e\u77c2',
+type: 'occlusion',
+count: 2189,
+}
+);
+let textureView7 = texture0.createView(
+{
+label: '\u{1fd37}\u06e6\u3bd6',
+}
+);
+let sampler7 = device0.createSampler(
+{
+label: '\uee78\u7535\ud0c7\u{1ff29}\u{1f614}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 65.483,
+lodMaxClamp: 96.566,
+maxAnisotropy: 11,
+}
+);
+try {
+computePassEncoder2.setBindGroup(
+9,
+bindGroup1
+);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(
+3,
+bindGroup5,
+new Uint32Array(5737),
+1980,
+0
+);
+} catch {}
+let arrayBuffer0 = buffer3.getMappedRange(
+4312,
+8052
+);
+try {
+commandEncoder8.copyBufferToBuffer(
+buffer3,
+19268,
+buffer0,
+1660,
+8
+);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let canvas3 = document.createElement('canvas');
+let texture6 = device0.createTexture(
+{
+label: '\ue38d\u{1f60b}\u9a23\u027e\uca63\uff91\u735c\ud42c\u{1fd61}\u{1fd8e}\ufb80',
+size: {width: 10205},
+dimension: '1d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+try {
+renderBundleEncoder10.setVertexBuffer(
+60,
+undefined,
+3581609467,
+527690436
+);
+} catch {}
+try {
+commandEncoder4.copyBufferToBuffer(
+buffer2,
+15816,
+buffer0,
+2176,
+660
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+gc();
+let videoFrame3 = new VideoFrame(canvas2, {timestamp: 0});
+let bindGroup6 = device0.createBindGroup({
+label: '\u02e2\u{1f9c9}\u7a48\u0d4d\u{1fc0f}\u0957\u7426\u90d4\u{1feda}\u17be',
+layout: bindGroupLayout0,
+entries: [
+{
+binding: 4207,
+resource: sampler2
+}
+],
+});
+let texture7 = device0.createTexture(
+{
+label: '\uec82\u05ef',
+size: [47, 3, 153],
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rg32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rg32float',
+'rg32float',
+'rg32float'
+],
+}
+);
+let textureView8 = texture5.createView(
+{
+label: '\ud621\u{1f98c}',
+}
+);
+let renderBundle7 = renderBundleEncoder4.finish(
+{
+label: '\u{1fa09}\u{1fb88}\u{1f82d}\uc257\u20b3\u0838\u1598\u07db'
+}
+);
+try {
+computePassEncoder2.setPipeline(
+pipeline0
+);
+} catch {}
+try {
+commandEncoder4.clearBuffer(
+buffer0,
+3132,
+428
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline7 = device0.createRenderPipeline(
+{
+label: '\u07e1\u857b\u54e6\u085d\u{1ffeb}\u0dee\uc47d',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 8324,
+attributes: [
+{
+format: 'snorm8x4',
+offset: 6676,
+shaderLocation: 5,
+},
+{
+format: 'uint32x2',
+offset: 5016,
+shaderLocation: 6,
+},
+{
+format: 'float16x2',
+offset: 1132,
+shaderLocation: 9,
+},
+{
+format: 'uint8x2',
+offset: 3280,
+shaderLocation: 16,
+},
+{
+format: 'sint32',
+offset: 532,
+shaderLocation: 1,
+},
+{
+format: 'unorm8x2',
+offset: 6154,
+shaderLocation: 3,
+},
+{
+format: 'snorm16x2',
+offset: 8280,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 6752,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x2',
+offset: 1496,
+shaderLocation: 11,
+},
+{
+format: 'unorm16x2',
+offset: 2852,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x2',
+offset: 3822,
+shaderLocation: 12,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 1184,
+shaderLocation: 24,
+},
+{
+format: 'snorm8x2',
+offset: 6378,
+shaderLocation: 14,
+},
+{
+format: 'snorm16x4',
+offset: 60,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x4',
+offset: 4392,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 12800,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32',
+offset: 420,
+shaderLocation: 2,
+},
+{
+format: 'sint32',
+offset: 452,
+shaderLocation: 4,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 1808,
+shaderLocation: 22,
+},
+{
+format: 'float32x3',
+offset: 5904,
+shaderLocation: 25,
+},
+{
+format: 'unorm16x2',
+offset: 496,
+shaderLocation: 26,
+},
+{
+format: 'uint16x2',
+offset: 12632,
+shaderLocation: 10,
+},
+{
+format: 'sint32x4',
+offset: 5212,
+shaderLocation: 0,
+},
+{
+format: 'sint8x2',
+offset: 3670,
+shaderLocation: 20,
+},
+{
+format: 'float16x4',
+offset: 5328,
+shaderLocation: 13,
+},
+{
+format: 'sint32',
+offset: 4948,
+shaderLocation: 23,
+},
+{
+format: 'sint16x4',
+offset: 6920,
+shaderLocation: 21,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x2',
+offset: 13416,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 11664,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 1528,
+shaderLocation: 15,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+cullMode: 'back',
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'replace',
+},
+stencilBack: {
+failOp: 'decrement-wrap',
+depthFailOp: 'invert',
+passOp: 'zero',
+},
+stencilReadMask: 4072,
+stencilWriteMask: 3497,
+depthBias: 66,
+depthBiasSlopeScale: 99,
+depthBiasClamp: 81,
+},
+}
+);
+let imageBitmap1 = await createImageBitmap(canvas1);
+let texture8 = device0.createTexture(
+{
+label: '\u{1fe57}\u0df2\u0c1b',
+size: {width: 89, height: 13, depthOrArrayLayers: 237},
+mipLevelCount: 6,
+format: 'rgba32uint',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32uint',
+'rgba32uint'
+],
+}
+);
+try {
+renderBundleEncoder3.setBindGroup(
+0,
+bindGroup3
+);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+5,
+bindGroup3,
+new Uint32Array(898),
+289,
+0
+);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(
+0,
+buffer2
+);
+} catch {}
+try {
+commandEncoder9.copyBufferToBuffer(
+buffer2,
+12020,
+buffer0,
+7008,
+12
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder8.clearBuffer(
+buffer0,
+2124,
+3948
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let video1 = await videoWithData();
+let buffer4 = device0.createBuffer(
+{
+size: 41473,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let texture9 = device0.createTexture(
+{
+size: {width: 1349, height: 1, depthOrArrayLayers: 97},
+mipLevelCount: 10,
+dimension: '3d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'bgra8unorm'
+],
+}
+);
+let textureView9 = texture0.createView(
+{
+}
+);
+let computePassEncoder3 = commandEncoder9.beginComputePass();
+let renderBundleEncoder11 = device0.createRenderBundleEncoder(
+{
+label: '\u76c6\u66cf\u17fa\u{1f99c}\u00d6',
+colorFormats: [
+'rgb10a2unorm',
+'rgba32float',
+'rg32uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 119,
+stencilReadOnly: true,
+}
+);
+let promise4 = buffer4.mapAsync(
+GPUMapMode.READ,
+0,
+37796
+);
+try {
+device0.queue.writeBuffer(
+buffer0,
+5792,
+new BigUint64Array(53316),
+43448,
+92
+);
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+let promise6 = navigator.gpu.requestAdapter();
+let commandEncoder11 = device0.createCommandEncoder(
+{
+label: '\u9489\u51e2\ufa3c\u3040',
+}
+);
+let textureView10 = texture8.createView(
+{
+label: '\u03bf\u{1fd08}\u091c\u0763\u14f3\u0692\u8a4d\u58bd\u0da9\ue091\u0ad3',
+baseMipLevel: 1,
+mipLevelCount: 3,
+baseArrayLayer: 182,
+arrayLayerCount: 20,
+}
+);
+let computePassEncoder4 = commandEncoder11.beginComputePass(
+{
+label: '\u0e10\ub69b\u{1fd5a}\ueb76\ue1c7\uadb3'
+}
+);
+let renderBundleEncoder12 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'r32sint',
+'r16sint',
+'rgba32sint',
+'rg8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 70,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder4.setPipeline(
+pipeline0
+);
+} catch {}
+try {
+commandEncoder8.resolveQuerySet(
+querySet4,
+2064,
+803,
+buffer0,
+512
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture3,
+  mipLevel: 3,
+  origin: { x: 1, y: 0, z: 74 },
+  aspect: 'all',
+},
+new Float32Array(arrayBuffer0),
+/* required buffer size: 3154492 */{
+offset: 397,
+bytesPerRow: 85,
+rowsPerImage: 279,
+},
+{width: 0, height: 1, depthOrArrayLayers: 134}
+);
+} catch {}
+let computePassEncoder5 = commandEncoder4.beginComputePass(
+{
+label: '\u0c81\u{1ff70}\u515f\u0f76\ud676\u1ed1\u0d60\ufc3b\u5566\u0322'
+}
+);
+let renderBundle8 = renderBundleEncoder7.finish(
+{
+label: '\u0f51\u{1f756}\ud1be\uc401\u0ad7'
+}
+);
+try {
+computePassEncoder5.setPipeline(
+pipeline4
+);
+} catch {}
+try {
+commandEncoder7.copyBufferToBuffer(
+buffer3,
+8268,
+buffer4,
+30940,
+2348
+);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder10.resolveQuerySet(
+querySet5,
+2848,
+774,
+buffer0,
+256
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 2, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 166, y: 189 },
+  flipY: false,
+},
+{
+  texture: texture9,
+  mipLevel: 9,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline8 = device0.createRenderPipeline(
+{
+label: '\u086e\ud265\u4767\u08bf\u5abc\ue4b4\u66e0\u00da\u0fb9\u1d54\u0c8c',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule4,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 13436,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 1612,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 11948,
+attributes: [
+{
+format: 'float16x4',
+offset: 7196,
+shaderLocation: 8,
+},
+{
+format: 'float32x3',
+offset: 6536,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 4292,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x2',
+offset: 3918,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x2',
+offset: 666,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x2',
+offset: 2204,
+shaderLocation: 14,
+},
+{
+format: 'sint32x3',
+offset: 2016,
+shaderLocation: 11,
+},
+{
+format: 'uint16x2',
+offset: 476,
+shaderLocation: 7,
+},
+{
+format: 'sint32',
+offset: 3072,
+shaderLocation: 15,
+},
+{
+format: 'uint32x4',
+offset: 3208,
+shaderLocation: 24,
+},
+{
+format: 'float32x4',
+offset: 1448,
+shaderLocation: 10,
+},
+{
+format: 'uint16x4',
+offset: 3048,
+shaderLocation: 5,
+},
+{
+format: 'uint16x2',
+offset: 1156,
+shaderLocation: 13,
+},
+{
+format: 'sint8x4',
+offset: 2144,
+shaderLocation: 12,
+},
+{
+format: 'sint8x2',
+offset: 3688,
+shaderLocation: 1,
+},
+{
+format: 'uint32x2',
+offset: 3388,
+shaderLocation: 3,
+},
+{
+format: 'snorm16x2',
+offset: 2696,
+shaderLocation: 25,
+},
+{
+format: 'float16x4',
+offset: 2888,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 13980,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 2460,
+attributes: [
+{
+format: 'sint16x4',
+offset: 1040,
+shaderLocation: 22,
+},
+{
+format: 'uint16x2',
+offset: 936,
+shaderLocation: 23,
+},
+{
+format: 'float32',
+offset: 1748,
+shaderLocation: 20,
+},
+{
+format: 'unorm8x2',
+offset: 2300,
+shaderLocation: 18,
+},
+{
+format: 'snorm16x4',
+offset: 1948,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'float32x4',
+offset: 7760,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 3604,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 3244,
+shaderLocation: 21,
+},
+{
+format: 'unorm16x2',
+offset: 2712,
+shaderLocation: 16,
+},
+{
+format: 'snorm8x2',
+offset: 276,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'front',
+},
+fragment: {
+module: shaderModule4,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'r32uint',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+failOp: 'replace',
+depthFailOp: 'invert',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilReadMask: 4091,
+stencilWriteMask: 3647,
+depthBiasSlopeScale: 43,
+},
+}
+);
+try {
+await promise5;
+} catch {}
+let imageBitmap2 = await createImageBitmap(canvas0);
+try {
+device0.queue.label = '\u4da0\u098f\u{1f89e}\u{1fc33}\u{1fec9}\u6dd7\u{1f618}\u23b8\uf06c\u0e3c\u{1f979}';
+} catch {}
+let commandEncoder12 = device0.createCommandEncoder(
+{
+label: '\uabb6\u{1ffaf}\u0dd0\u0d73\u0427\u{1f6a3}\u9273\u0b8d\u0464\u{1f69f}',
+}
+);
+let querySet9 = device0.createQuerySet(
+{
+label: '\u0f44\u00e8\ud44c',
+type: 'occlusion',
+count: 2180,
+}
+);
+let texture10 = device0.createTexture(
+{
+label: '\u69ad\ue146\u086a\u{1fb10}\u06b1',
+size: [5024],
+dimension: '1d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rg11b10ufloat',
+'rg11b10ufloat',
+'rg11b10ufloat'
+],
+}
+);
+try {
+renderBundleEncoder3.setBindGroup(
+9,
+bindGroup4
+);
+} catch {}
+try {
+computePassEncoder4.insertDebugMarker(
+'\u0585'
+);
+} catch {}
+let pipeline9 = device0.createRenderPipeline(
+{
+label: '\u088f\u09ba\u{1f7e1}\u{1fd83}\u0038\u0f46\u0809\u0743\u0b56\u0ada',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 16,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 4,
+shaderLocation: 13,
+},
+{
+format: 'float32',
+offset: 4,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x2',
+offset: 0,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 12928,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 5432,
+shaderLocation: 18,
+},
+{
+format: 'uint32x3',
+offset: 2640,
+shaderLocation: 16,
+},
+{
+format: 'snorm8x2',
+offset: 2186,
+shaderLocation: 5,
+},
+{
+format: 'sint32x3',
+offset: 9888,
+shaderLocation: 20,
+},
+{
+format: 'unorm8x4',
+offset: 12036,
+shaderLocation: 12,
+},
+{
+format: 'sint16x2',
+offset: 6056,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 496,
+attributes: [
+
+],
+},
+{
+arrayStride: 14020,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 9796,
+shaderLocation: 24,
+},
+{
+format: 'float32x4',
+offset: 7812,
+shaderLocation: 17,
+},
+{
+format: 'sint16x4',
+offset: 11412,
+shaderLocation: 21,
+},
+{
+format: 'sint16x2',
+offset: 2108,
+shaderLocation: 0,
+},
+{
+format: 'float32',
+offset: 104,
+shaderLocation: 2,
+},
+{
+format: 'sint32x4',
+offset: 2252,
+shaderLocation: 1,
+},
+{
+format: 'float32x2',
+offset: 1196,
+shaderLocation: 7,
+},
+{
+format: 'float16x4',
+offset: 7836,
+shaderLocation: 8,
+},
+{
+format: 'unorm16x2',
+offset: 3468,
+shaderLocation: 9,
+},
+{
+format: 'snorm8x4',
+offset: 10896,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 10240,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 5272,
+shaderLocation: 26,
+},
+{
+format: 'unorm8x2',
+offset: 4320,
+shaderLocation: 14,
+},
+{
+format: 'uint32x3',
+offset: 3072,
+shaderLocation: 10,
+},
+{
+format: 'float32',
+offset: 1264,
+shaderLocation: 25,
+}
+],
+},
+{
+arrayStride: 1960,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 744,
+shaderLocation: 11,
+},
+{
+format: 'sint8x2',
+offset: 544,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 5124,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 1180,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 7760,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 844,
+shaderLocation: 19,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+failOp: 'decrement-wrap',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilReadMask: 410,
+stencilWriteMask: 3198,
+depthBiasSlopeScale: 98,
+depthBiasClamp: 12,
+},
+}
+);
+let gpuCanvasContext2 = canvas3.getContext('webgpu');
+gc();
+document.body.append('\u0b38\u{1fd67}\uce3e\ubb97\u5f37\u026e\u08b6\u0dd4\u0575\ud117');
+let bindGroup7 = device0.createBindGroup({
+label: '\ue5e3\ub66b',
+layout: bindGroupLayout0,
+entries: [
+{
+binding: 4207,
+resource: sampler2
+}
+],
+});
+let pipelineLayout3 = device0.createPipelineLayout(
+{
+label: '\u4b7a\ua258\ua86a\ue4e2\u40fc',
+bindGroupLayouts: [
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0
+],
+}
+);
+let commandEncoder13 = device0.createCommandEncoder(
+{
+label: '\u1a7a\uda5d\u8c9c\ue047\u06c7\u84ff\u0d76\u07c2\u6cf6\u{1f91d}\uf747',
+}
+);
+let renderBundle9 = renderBundleEncoder4.finish(
+{
+
+}
+);
+try {
+commandEncoder3.clearBuffer(
+buffer0,
+2704,
+4
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder8.resolveQuerySet(
+querySet1,
+649,
+124,
+buffer0,
+4608
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture3,
+  mipLevel: 7,
+  origin: { x: 1, y: 0, z: 2 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 24161 */{
+offset: 33,
+bytesPerRow: 52,
+rowsPerImage: 116,
+},
+{width: 0, height: 1, depthOrArrayLayers: 5}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1349, height: 1, depthOrArrayLayers: 97}
+*/
+{
+  source: video1,
+  origin: { x: 7, y: 6 },
+  flipY: false,
+},
+{
+  texture: texture9,
+  mipLevel: 0,
+  origin: { x: 34, y: 0, z: 42 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 8, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let imageData1 = new ImageData(100, 48);
+let commandEncoder14 = device0.createCommandEncoder();
+pseudoSubmit(device0, commandEncoder13);
+try {
+commandEncoder12.copyTextureToTexture(
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: { x: 4776, y: 38, z: 73 },
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 1390, y: 6, z: 65 },
+  aspect: 'all',
+},
+{width: 684, height: 38, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\u0c45\u{1f771}\u662b\uc834');
+let imageBitmap3 = await createImageBitmap(canvas3);
+let bindGroup8 = device0.createBindGroup({
+label: '\u73b9\u{1fc47}\u{1f82b}\u{1f71e}\u0c0d\u05b5',
+layout: bindGroupLayout0,
+entries: [
+{
+binding: 4207,
+resource: sampler2
+}
+],
+});
+let texture11 = device0.createTexture(
+{
+label: '\u85cd\uc634',
+size: [125, 1, 73],
+mipLevelCount: 7,
+dimension: '3d',
+format: 'r8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8sint',
+'r8sint'
+],
+}
+);
+let textureView11 = texture4.createView(
+{
+baseMipLevel: 1,
+baseArrayLayer: 35,
+arrayLayerCount: 108,
+}
+);
+let renderBundle10 = renderBundleEncoder2.finish(
+{
+
+}
+);
+let externalTexture0 = device0.importExternalTexture(
+{
+source: videoFrame0,
+}
+);
+try {
+renderBundleEncoder9.setVertexBuffer(
+5,
+buffer2,
+12548,
+1481
+);
+} catch {}
+try {
+commandEncoder14.copyBufferToBuffer(
+buffer2,
+4948,
+buffer0,
+5696,
+1116
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder8.copyTextureToBuffer(
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 3093, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 13386 widthInBlocks: 6693 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 41348 */
+offset: 41348,
+buffer: buffer1,
+},
+{width: 6693, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+renderBundleEncoder3.insertDebugMarker(
+'\u{1ffb1}'
+);
+} catch {}
+let textureView12 = texture10.createView(
+{
+}
+);
+let renderBundleEncoder13 = device0.createRenderBundleEncoder(
+{
+label: '\u{1fd6d}\u7ff2',
+colorFormats: [
+'rgba16float',
+undefined,
+'rg32sint',
+undefined,
+'rgba32float'
+],
+sampleCount: 527,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder2.setBindGroup(
+6,
+bindGroup8,
+new Uint32Array(3149),
+1810,
+0
+);
+} catch {}
+try {
+computePassEncoder4.setPipeline(
+pipeline4
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 42, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 288, y: 588 },
+  flipY: true,
+},
+{
+  texture: texture9,
+  mipLevel: 5,
+  origin: { x: 8, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 11, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline10 = device0.createComputePipeline(
+{
+label: '\u05f8\u0345\u4d5a\u370b\ua941\u9a94',
+layout: 'auto',
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline11 = await device0.createRenderPipelineAsync(
+{
+label: '\u{1f7ac}\u{1fda1}\udcb0\u{1f8ca}\u91cf\u2e4c\u045f\ube93\u{1fa6e}\u48d3',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'unorm16x4',
+offset: 14560,
+shaderLocation: 17,
+},
+{
+format: 'snorm16x2',
+offset: 10056,
+shaderLocation: 13,
+},
+{
+format: 'sint32x2',
+offset: 12444,
+shaderLocation: 23,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 15688,
+shaderLocation: 7,
+},
+{
+format: 'sint32x3',
+offset: 9024,
+shaderLocation: 20,
+},
+{
+format: 'unorm8x2',
+offset: 1990,
+shaderLocation: 14,
+},
+{
+format: 'uint32x3',
+offset: 5896,
+shaderLocation: 11,
+},
+{
+format: 'float16x4',
+offset: 13228,
+shaderLocation: 12,
+},
+{
+format: 'sint8x4',
+offset: 1544,
+shaderLocation: 4,
+},
+{
+format: 'unorm16x4',
+offset: 10000,
+shaderLocation: 22,
+},
+{
+format: 'sint8x2',
+offset: 3022,
+shaderLocation: 0,
+},
+{
+format: 'unorm8x4',
+offset: 13988,
+shaderLocation: 2,
+},
+{
+format: 'snorm8x2',
+offset: 16420,
+shaderLocation: 18,
+},
+{
+format: 'snorm16x4',
+offset: 1404,
+shaderLocation: 8,
+},
+{
+format: 'uint32x2',
+offset: 12524,
+shaderLocation: 10,
+},
+{
+format: 'float32',
+offset: 2216,
+shaderLocation: 19,
+},
+{
+format: 'uint32x3',
+offset: 768,
+shaderLocation: 16,
+},
+{
+format: 'float32',
+offset: 7180,
+shaderLocation: 25,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 312,
+shaderLocation: 9,
+},
+{
+format: 'unorm8x2',
+offset: 8486,
+shaderLocation: 15,
+},
+{
+format: 'float16x2',
+offset: 12484,
+shaderLocation: 24,
+},
+{
+format: 'uint32x2',
+offset: 7056,
+shaderLocation: 6,
+},
+{
+format: 'snorm16x4',
+offset: 7204,
+shaderLocation: 5,
+},
+{
+format: 'float16x2',
+offset: 3800,
+shaderLocation: 3,
+},
+{
+format: 'sint32',
+offset: 556,
+shaderLocation: 21,
+},
+{
+format: 'float16x4',
+offset: 13656,
+shaderLocation: 26,
+}
+],
+},
+{
+arrayStride: 13160,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x2',
+offset: 1012,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0x260d6367,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'keep',
+depthFailOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 3437,
+stencilWriteMask: 422,
+depthBias: 80,
+depthBiasSlopeScale: 35,
+depthBiasClamp: 52,
+},
+}
+);
+let computePassEncoder6 = commandEncoder7.beginComputePass(
+{
+label: '\u0015\u0145\uc982'
+}
+);
+try {
+computePassEncoder5.setPipeline(
+pipeline0
+);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(
+3,
+buffer2
+);
+} catch {}
+try {
+texture9.destroy();
+} catch {}
+try {
+commandEncoder8.copyBufferToBuffer(
+buffer2,
+7724,
+buffer0,
+2636,
+2248
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 1707, y: 85, z: 98 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 37267 */{
+offset: 904,
+bytesPerRow: 2285,
+},
+{width: 2088, height: 16, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline12 = await device0.createComputePipelineAsync(
+{
+label: '\uaadc\u08d9\u92a5\u9330\u2121\u6e8c\u{1f71d}\uce48\ub9d9',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let promise7 = device0.createRenderPipelineAsync(
+{
+label: '\u8cc4\u0a73\u{1faf1}\u1fea\uc3b4\ue32d\u17ba',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 13496,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 15824,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32',
+offset: 13288,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 14492,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 3288,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x4',
+offset: 112,
+shaderLocation: 18,
+},
+{
+format: 'uint8x2',
+offset: 10828,
+shaderLocation: 16,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 14072,
+shaderLocation: 24,
+},
+{
+format: 'sint8x2',
+offset: 14098,
+shaderLocation: 23,
+},
+{
+format: 'float32',
+offset: 8916,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x4',
+offset: 5708,
+shaderLocation: 22,
+},
+{
+format: 'snorm16x4',
+offset: 11432,
+shaderLocation: 17,
+},
+{
+format: 'sint32x3',
+offset: 6140,
+shaderLocation: 0,
+},
+{
+format: 'uint32x3',
+offset: 13716,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 14920,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 4380,
+shaderLocation: 21,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 12520,
+shaderLocation: 19,
+},
+{
+format: 'sint32x3',
+offset: 964,
+shaderLocation: 20,
+},
+{
+format: 'float32x2',
+offset: 12728,
+shaderLocation: 14,
+},
+{
+format: 'float32',
+offset: 724,
+shaderLocation: 25,
+}
+],
+},
+{
+arrayStride: 10200,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 1904,
+shaderLocation: 12,
+},
+{
+format: 'float16x4',
+offset: 7860,
+shaderLocation: 5,
+},
+{
+format: 'unorm8x2',
+offset: 6926,
+shaderLocation: 9,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 9952,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x4',
+offset: 1248,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 12332,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 6464,
+shaderLocation: 11,
+},
+{
+format: 'uint8x2',
+offset: 3266,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 13620,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 3938,
+shaderLocation: 26,
+},
+{
+format: 'sint8x4',
+offset: 13012,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'snorm8x2',
+offset: 584,
+shaderLocation: 15,
+},
+{
+format: 'sint16x2',
+offset: 13292,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+},
+multisample: {
+count: 4,
+mask: 0x22e42e51,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'never',
+failOp: 'invert',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilReadMask: 2977,
+stencilWriteMask: 404,
+depthBias: 56,
+depthBiasSlopeScale: 51,
+depthBiasClamp: 72,
+},
+}
+);
+let computePassEncoder7 = commandEncoder14.beginComputePass(
+{
+label: '\u9ee0\u60b9'
+}
+);
+try {
+renderBundleEncoder11.setVertexBuffer(
+3,
+buffer2,
+33292,
+1104
+);
+} catch {}
+try {
+commandEncoder8.copyBufferToBuffer(
+buffer3,
+10884,
+buffer0,
+1160,
+4312
+);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder8.clearBuffer(
+buffer0,
+1544,
+2812
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+document.body.append('\u1f2b\u539e\u{1f686}\u{1fd9b}\u089e\u0b5f\u13e3\u55c4');
+let buffer5 = device0.createBuffer(
+{
+label: '\u9ed3\u7f96\u04fe',
+size: 21032,
+usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+}
+);
+let texture12 = device0.createTexture(
+{
+label: '\u8e46\u0517\ua890\u08e8\u0cf1\u0434\u{1fee6}\u3815\u{1fdf5}\ub7e1',
+size: [120, 120, 1],
+mipLevelCount: 4,
+dimension: '2d',
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+renderBundleEncoder13.setVertexBuffer(
+6,
+buffer5,
+13688,
+6980
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 674, height: 1, depthOrArrayLayers: 48}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 534, y: 482 },
+  flipY: true,
+},
+{
+  texture: texture9,
+  mipLevel: 1,
+  origin: { x: 226, y: 1, z: 14 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 99, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline13 = device0.createComputePipeline(
+{
+label: '\u{1f873}\u{1ff89}',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend('\ue65c\u0983\ue247');
+let querySet10 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 768,
+}
+);
+let sampler8 = device0.createSampler(
+{
+label: '\u5051\u{1fea7}\u34c6\u013f\u0d28',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 57.340,
+lodMaxClamp: 62.523,
+maxAnisotropy: 8,
+}
+);
+try {
+renderBundleEncoder12.setVertexBuffer(
+1,
+buffer2
+);
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(
+querySet4,
+627,
+1591,
+buffer5,
+6144
+);
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+let img0 = await imageWithData(155, 299, '#3797d959', '#b5eff456');
+try {
+externalTexture0.label = '\u67a0\u3ce6\u5c24\u67fd\u2d18\u2fa8\u0f07\u59d2\u563e\u{1f979}\u514b';
+} catch {}
+let bindGroupLayout1 = device0.createBindGroupLayout(
+{
+entries: [
+{
+binding: 4653,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba16float', access: 'write-only', viewDimension: '1d' },
+},
+{
+binding: 5349,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+let textureView13 = texture0.createView(
+{
+label: '\u05ab\u867b\u1424\u9607',
+format: 'rg16float',
+baseArrayLayer: 0,
+}
+);
+let renderBundle11 = renderBundleEncoder10.finish(
+{
+
+}
+);
+document.body.append('\uff08\u0969\u0654\u0841\u35df\ud0bc\u482a\u267e\u87ad');
+let video2 = await videoWithData();
+let buffer6 = device0.createBuffer(
+{
+label: '\ubc18\u{1f670}\uf627\u0712\u{1fdf6}\u{1f85e}\ua185',
+size: 4442,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+}
+);
+let texture13 = device0.createTexture(
+{
+label: '\u02f7\u842d\uc09e\u{1f859}\u27a9\uc13f\u1da0\u06c4\u{1f810}\u{1fa0c}\u0699',
+size: {width: 4615, height: 1, depthOrArrayLayers: 161},
+mipLevelCount: 9,
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+commandEncoder12.clearBuffer(
+buffer4,
+436,
+16360
+);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let pipeline14 = await device0.createRenderPipelineAsync(
+{
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 12188,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 11272,
+shaderLocation: 8,
+},
+{
+format: 'sint8x2',
+offset: 10408,
+shaderLocation: 25,
+},
+{
+format: 'float16x2',
+offset: 3584,
+shaderLocation: 16,
+},
+{
+format: 'uint8x2',
+offset: 1330,
+shaderLocation: 9,
+},
+{
+format: 'unorm8x2',
+offset: 8702,
+shaderLocation: 11,
+},
+{
+format: 'sint8x2',
+offset: 10758,
+shaderLocation: 23,
+},
+{
+format: 'snorm8x2',
+offset: 6742,
+shaderLocation: 5,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 9068,
+shaderLocation: 12,
+},
+{
+format: 'uint8x4',
+offset: 1148,
+shaderLocation: 24,
+},
+{
+format: 'sint8x2',
+offset: 6890,
+shaderLocation: 19,
+},
+{
+format: 'snorm16x4',
+offset: 1984,
+shaderLocation: 15,
+},
+{
+format: 'sint32',
+offset: 520,
+shaderLocation: 21,
+},
+{
+format: 'float32x4',
+offset: 2060,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x2',
+offset: 5336,
+shaderLocation: 1,
+},
+{
+format: 'uint32',
+offset: 8212,
+shaderLocation: 20,
+},
+{
+format: 'sint32x2',
+offset: 7252,
+shaderLocation: 13,
+},
+{
+format: 'uint8x4',
+offset: 4420,
+shaderLocation: 6,
+},
+{
+format: 'unorm16x2',
+offset: 8336,
+shaderLocation: 0,
+},
+{
+format: 'float32x3',
+offset: 1092,
+shaderLocation: 10,
+},
+{
+format: 'float16x2',
+offset: 704,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 11036,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 804,
+shaderLocation: 26,
+},
+{
+format: 'uint16x4',
+offset: 1104,
+shaderLocation: 18,
+},
+{
+format: 'float32x2',
+offset: 6200,
+shaderLocation: 14,
+},
+{
+format: 'uint16x2',
+offset: 5892,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 13064,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 2768,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 4436,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x4',
+offset: 2920,
+shaderLocation: 4,
+},
+{
+format: 'uint32',
+offset: 2672,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'zero',
+depthFailOp: 'replace',
+passOp: 'decrement-wrap',
+},
+depthBias: 71,
+depthBiasClamp: 31,
+},
+}
+);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+canvas1.height = 694;
+let img1 = await imageWithData(162, 163, '#51109655', '#243b75e4');
+let imageBitmap4 = await createImageBitmap(videoFrame2);
+let renderBundleEncoder14 = device0.createRenderBundleEncoder(
+{
+label: '\u{1fcc4}\u{1f7a5}',
+colorFormats: [
+'r16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 856,
+depthReadOnly: false,
+}
+);
+try {
+computePassEncoder7.setPipeline(
+pipeline10
+);
+} catch {}
+try {
+commandEncoder10.copyBufferToBuffer(
+buffer3,
+708,
+buffer1,
+6692,
+18616
+);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder8.copyTextureToBuffer(
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: { x: 3, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 12246 widthInBlocks: 6123 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 43994 */
+offset: 43994,
+bytesPerRow: 12288,
+rowsPerImage: 126,
+buffer: buffer1,
+},
+{width: 6123, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+canvas3.height = 730;
+try {
+computePassEncoder2.setBindGroup(
+1,
+bindGroup3
+);
+} catch {}
+let pipeline15 = await device0.createRenderPipelineAsync(
+{
+label: '\ub2d2\u8246\ue414\ub2dd',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+cullMode: 'front',
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'equal',
+passOp: 'replace',
+},
+stencilBack: {
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 3763,
+stencilWriteMask: 1084,
+depthBias: 93,
+depthBiasClamp: 17,
+},
+}
+);
+document.body.prepend('\u0bbf\udef2\ud6e1\u033d\u9c4c\u0001\u17c9\u{1fa74}\u0d68');
+let renderBundleEncoder15 = device0.createRenderBundleEncoder(
+{
+label: '\u07d9\u506e\u9a48\u420c\u744f',
+colorFormats: [
+'rgb10a2uint'
+],
+sampleCount: 880,
+depthReadOnly: true,
+}
+);
+try {
+computePassEncoder2.setBindGroup(
+2,
+bindGroup3,
+new Uint32Array(840),
+572,
+0
+);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(
+9,
+bindGroup7
+);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(
+3,
+buffer2,
+13720,
+18805
+);
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let texture14 = device0.createTexture(
+{
+label: '\u5f01\u0ec7\uc485',
+size: [95, 166, 1],
+mipLevelCount: 8,
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb10a2uint',
+'rgb10a2uint',
+'rgb10a2uint'
+],
+}
+);
+try {
+renderBundleEncoder12.setBindGroup(
+9,
+bindGroup7,
+new Uint32Array(707),
+318,
+0
+);
+} catch {}
+let arrayBuffer1 = buffer3.getMappedRange(
+0,
+4132
+);
+try {
+device0.queue.writeBuffer(
+buffer0,
+5372,
+new Int16Array(31548),
+13424,
+484
+);
+} catch {}
+let imageBitmap5 = await createImageBitmap(img1);
+let imageData2 = new ImageData(52, 112);
+let querySet11 = device0.createQuerySet(
+{
+label: '\u0dfc\u{1fc55}\u{1fd00}\u0aea',
+type: 'occlusion',
+count: 742,
+}
+);
+pseudoSubmit(device0, commandEncoder8);
+let computePassEncoder8 = commandEncoder10.beginComputePass();
+try {
+computePassEncoder4.end();
+} catch {}
+let pipeline16 = await device0.createComputePipelineAsync(
+{
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+await promise4;
+} catch {}
+document.body.append('\uce9e\ua910\u4abc\u88db\u2f29\u0442');
+let commandBuffer1 = commandEncoder12.finish(
+{
+}
+);
+let texture15 = device0.createTexture(
+{
+label: '\u04fe\ubdd7\u{1fa54}\uc690\ua735\u435f\u08f1\u{1fde2}',
+size: [16, 42, 30],
+mipLevelCount: 4,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'bgra8unorm',
+'bgra8unorm',
+'bgra8unorm'
+],
+}
+);
+try {
+computePassEncoder8.setPipeline(
+pipeline0
+);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(
+2,
+bindGroup8,
+new Uint32Array(9320),
+7322,
+0
+);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(
+3,
+buffer2,
+5756,
+22597
+);
+} catch {}
+try {
+commandEncoder3.copyBufferToBuffer(
+buffer3,
+12596,
+buffer4,
+6912,
+7424
+);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer0,
+3052,
+new Int16Array(59747),
+28600,
+252
+);
+} catch {}
+try {
+await promise8;
+} catch {}
+gc();
+let commandBuffer2 = commandEncoder3.finish(
+{
+}
+);
+let computePassEncoder9 = commandEncoder11.beginComputePass(
+{
+label: '\u0ca2\u22d7\u7465\u2416'
+}
+);
+let renderBundle12 = renderBundleEncoder7.finish(
+{
+label: '\u0340\udf90\ucae9\u005a'
+}
+);
+try {
+computePassEncoder9.setPipeline(
+pipeline4
+);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+5,
+bindGroup7
+);
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(
+querySet7,
+964,
+459,
+buffer0,
+2816
+);
+} catch {}
+let pipeline17 = device0.createComputePipeline(
+{
+label: '\ubd07\ua073\u7918\uae73\u09e4\u63b7\ufb15\u2054\u9ef2',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+},
+}
+);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let videoFrame4 = new VideoFrame(video0, {timestamp: 0});
+let pipelineLayout4 = device0.createPipelineLayout(
+{
+label: '\u0cda\u9010\u4a3b',
+bindGroupLayouts: [
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout1
+],
+}
+);
+let texture16 = device0.createTexture(
+{
+label: '\u271d\u0ae0\uf835\uba4f\u{1f89f}',
+size: [2651],
+dimension: '1d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8uint',
+'rgba8uint',
+'rgba8uint'
+],
+}
+);
+let computePassEncoder10 = commandEncoder2.beginComputePass(
+{
+label: '\u001f\u0726\u0fad\u1058\ub665\uce7f\u48d8\uf469\ue9a7\u99d9'
+}
+);
+let renderBundleEncoder16 = device0.createRenderBundleEncoder(
+{
+label: '\u00a5\u0ad1\u0b24',
+colorFormats: [
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 431,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder6.setPipeline(
+pipeline16
+);
+} catch {}
+let pipeline18 = await promise3;
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder15 = device0.createCommandEncoder(
+{
+label: '\u02fb\uf96c\u{1fa79}\u0a54\u2ddb\u0c85\ud8fd\u{1fbc9}\u0d54',
+}
+);
+let texture17 = device0.createTexture(
+{
+label: '\ufc98\uf489\uac59\ucd2e\uc43e\uc65d\u{1fd76}',
+size: [12814, 1, 1],
+mipLevelCount: 14,
+sampleCount: 1,
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgba32float',
+'rgba32float'
+],
+}
+);
+let renderBundle13 = renderBundleEncoder9.finish();
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+commandEncoder15.copyBufferToTexture(
+{
+/* bytesInLastRow: 14688 widthInBlocks: 918 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 30736 */
+offset: 30736,
+buffer: buffer2,
+},
+{
+  texture: texture17,
+  mipLevel: 3,
+  origin: { x: 431, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 918, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder15.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture14,
+  mipLevel: 4,
+  origin: { x: 0, y: 2, z: 0 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer0),
+/* required buffer size: 2217 */{
+offset: 542,
+bytesPerRow: 237,
+rowsPerImage: 195,
+},
+{width: 4, height: 8, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 23, height: 1, depthOrArrayLayers: 76}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 59, y: 549 },
+  flipY: true,
+},
+{
+  texture: texture7,
+  mipLevel: 1,
+  origin: { x: 20, y: 0, z: 57 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 2, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\uef55\u{1f617}\u{1fb61}');
+let sampler9 = device0.createSampler(
+{
+label: '\u{1fddd}\ufa2c\ue7fb\u05fb\u059e\u0f2d',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 25.893,
+lodMaxClamp: 72.998,
+}
+);
+try {
+computePassEncoder5.setPipeline(
+pipeline13
+);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(
+2,
+bindGroup7
+);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder14.copyTextureToTexture(
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 7828, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture13,
+  mipLevel: 4,
+  origin: { x: 64, y: 0, z: 127 },
+  aspect: 'all',
+},
+{width: 60, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder14.resolveQuerySet(
+querySet7,
+1511,
+283,
+buffer5,
+4608
+);
+} catch {}
+try {
+renderBundleEncoder13.insertDebugMarker(
+'\ued5c'
+);
+} catch {}
+document.body.prepend('\u7af7\u0501\u7965\u05cb');
+let textureView14 = texture10.createView(
+{
+label: '\ufe3b\u28ad',
+}
+);
+let computePassEncoder11 = commandEncoder15.beginComputePass(
+{
+label: '\u06aa\uc711'
+}
+);
+let sampler10 = device0.createSampler(
+{
+label: '\u3410\ufee9\u4614\u6da1\u6a81\u0dfe\u{1fe21}\u08c8\ufd83\u483e',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 70.699,
+lodMaxClamp: 74.225,
+maxAnisotropy: 13,
+}
+);
+try {
+commandEncoder14.copyBufferToTexture(
+{
+/* bytesInLastRow: 5272 widthInBlocks: 1318 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 33900 */
+offset: 33900,
+bytesPerRow: 5376,
+buffer: buffer2,
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: { x: 1511, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 1318, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture14,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(40),
+/* required buffer size: 965 */{
+offset: 838,
+bytesPerRow: 123,
+},
+{width: 1, height: 2, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 2, height: 5, depthOrArrayLayers: 30}
+*/
+{
+  source: video1,
+  origin: { x: 4, y: 0 },
+  flipY: true,
+},
+{
+  texture: texture15,
+  mipLevel: 3,
+  origin: { x: 1, y: 3, z: 7 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline19 = device0.createRenderPipeline(
+{
+label: '\u94b6\ue4c3\udb03',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule4,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 12488,
+attributes: [
+{
+format: 'snorm8x4',
+offset: 2996,
+shaderLocation: 16,
+},
+{
+format: 'snorm16x4',
+offset: 7388,
+shaderLocation: 0,
+},
+{
+format: 'unorm16x4',
+offset: 10708,
+shaderLocation: 19,
+},
+{
+format: 'uint32',
+offset: 3856,
+shaderLocation: 13,
+},
+{
+format: 'float16x4',
+offset: 7568,
+shaderLocation: 18,
+},
+{
+format: 'float16x2',
+offset: 12468,
+shaderLocation: 20,
+},
+{
+format: 'uint8x2',
+offset: 9764,
+shaderLocation: 23,
+},
+{
+format: 'uint32x2',
+offset: 5388,
+shaderLocation: 5,
+},
+{
+format: 'sint32x4',
+offset: 2736,
+shaderLocation: 4,
+},
+{
+format: 'uint32x4',
+offset: 976,
+shaderLocation: 3,
+},
+{
+format: 'sint8x4',
+offset: 11496,
+shaderLocation: 12,
+},
+{
+format: 'sint16x4',
+offset: 3160,
+shaderLocation: 11,
+},
+{
+format: 'float32',
+offset: 5072,
+shaderLocation: 14,
+},
+{
+format: 'float16x2',
+offset: 3644,
+shaderLocation: 6,
+},
+{
+format: 'uint16x4',
+offset: 5664,
+shaderLocation: 21,
+},
+{
+format: 'uint32x3',
+offset: 8168,
+shaderLocation: 24,
+},
+{
+format: 'sint8x4',
+offset: 9824,
+shaderLocation: 15,
+},
+{
+format: 'float32',
+offset: 6580,
+shaderLocation: 8,
+},
+{
+format: 'float32',
+offset: 224,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x4',
+offset: 572,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x2',
+offset: 7316,
+shaderLocation: 25,
+},
+{
+format: 'snorm8x4',
+offset: 10892,
+shaderLocation: 10,
+},
+{
+format: 'sint16x2',
+offset: 3084,
+shaderLocation: 22,
+},
+{
+format: 'float32x4',
+offset: 8280,
+shaderLocation: 17,
+},
+{
+format: 'sint32x3',
+offset: 7512,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 16268,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 13688,
+attributes: [
+
+],
+},
+{
+arrayStride: 6776,
+attributes: [
+{
+format: 'uint32',
+offset: 3312,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+},
+multisample: {
+count: 4,
+mask: 0x6af534d0,
+},
+fragment: {
+module: shaderModule4,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'r16uint',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'invert',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'decrement-wrap',
+depthFailOp: 'invert',
+},
+stencilReadMask: 2738,
+stencilWriteMask: 1044,
+depthBias: 15,
+depthBiasClamp: 53,
+},
+}
+);
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+offscreenCanvas0.height = 487;
+let img2 = await imageWithData(105, 208, '#db31a387', '#24ce6fb5');
+let videoFrame5 = videoFrame4.clone();
+let textureView15 = texture6.createView(
+{
+label: '\u0678\u08df\ua4df\u{1fb5c}\u0d68\u8425\u2f44\u{1f6ef}',
+baseMipLevel: 0,
+mipLevelCount: 1,
+}
+);
+let computePassEncoder12 = commandEncoder14.beginComputePass();
+try {
+computePassEncoder3.setBindGroup(
+6,
+bindGroup4,
+new Uint32Array(7544),
+3727,
+0
+);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(
+5,
+buffer2
+);
+} catch {}
+try {
+computePassEncoder12.insertDebugMarker(
+'\u{1f606}'
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture14,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 6341 */{
+offset: 619,
+bytesPerRow: 545,
+},
+{width: 68, height: 11, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let buffer7 = device0.createBuffer(
+{
+label: '\u0c06\u6c73\u0cfa\u73a0\u8306\ue8f3',
+size: 23989,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+}
+);
+let querySet12 = device0.createQuerySet(
+{
+label: '\u01f4\u0f4a\u033c\u98e9\u0d55\u{1fe95}',
+type: 'occlusion',
+count: 1158,
+}
+);
+let texture18 = device0.createTexture(
+{
+label: '\u{1ff53}\u049b\uc96d',
+size: {width: 1037, height: 1, depthOrArrayLayers: 116},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+try {
+computePassEncoder6.setBindGroup(
+8,
+bindGroup8
+);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(
+buffer6,
+'uint16',
+2080,
+138
+);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(
+0,
+buffer7,
+19780,
+1757
+);
+} catch {}
+let arrayBuffer2 = buffer4.getMappedRange(
+0,
+22672
+);
+try {
+device0.queue.writeBuffer(
+buffer0,
+5732,
+new Int16Array(29259),
+18087,
+76
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: { x: 1099, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 495 */{
+offset: 495,
+},
+{width: 2943, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 2, height: 5, depthOrArrayLayers: 30}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 226, y: 138 },
+  flipY: true,
+},
+{
+  texture: texture15,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline20 = device0.createRenderPipeline(
+{
+label: '\u10ea\ud549\ue65e\u3e53\u0510',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule4,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 9300,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x4',
+offset: 6224,
+shaderLocation: 15,
+},
+{
+format: 'float32',
+offset: 7584,
+shaderLocation: 20,
+},
+{
+format: 'sint16x2',
+offset: 4500,
+shaderLocation: 1,
+},
+{
+format: 'snorm8x2',
+offset: 8854,
+shaderLocation: 10,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 6092,
+shaderLocation: 2,
+},
+{
+format: 'float32',
+offset: 1508,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 6172,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 2068,
+shaderLocation: 25,
+},
+{
+format: 'uint8x2',
+offset: 4532,
+shaderLocation: 23,
+},
+{
+format: 'snorm16x4',
+offset: 4500,
+shaderLocation: 0,
+},
+{
+format: 'sint16x2',
+offset: 1776,
+shaderLocation: 22,
+},
+{
+format: 'float32x2',
+offset: 1284,
+shaderLocation: 16,
+},
+{
+format: 'sint8x4',
+offset: 540,
+shaderLocation: 11,
+},
+{
+format: 'snorm8x4',
+offset: 4288,
+shaderLocation: 9,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 5676,
+shaderLocation: 6,
+},
+{
+format: 'uint16x2',
+offset: 456,
+shaderLocation: 5,
+},
+{
+format: 'float16x4',
+offset: 1492,
+shaderLocation: 14,
+},
+{
+format: 'uint32x3',
+offset: 4416,
+shaderLocation: 24,
+},
+{
+format: 'uint32x3',
+offset: 2196,
+shaderLocation: 13,
+},
+{
+format: 'float32x2',
+offset: 1528,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 192,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 24,
+shaderLocation: 19,
+},
+{
+format: 'uint16x2',
+offset: 28,
+shaderLocation: 3,
+},
+{
+format: 'uint32',
+offset: 152,
+shaderLocation: 21,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 128,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 10884,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x4',
+offset: 1288,
+shaderLocation: 7,
+},
+{
+format: 'sint8x4',
+offset: 7576,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 2636,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 5440,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 4980,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'front',
+},
+fragment: {
+module: shaderModule4,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'one-minus-dst',
+dstFactor: 'one-minus-dst-alpha'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'one-minus-src',
+dstFactor: 'src'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+undefined,
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+},
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'keep',
+depthFailOp: 'invert',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 920,
+stencilWriteMask: 922,
+depthBias: 65,
+depthBiasSlopeScale: 67,
+depthBiasClamp: 10,
+},
+}
+);
+let commandEncoder16 = device0.createCommandEncoder(
+{
+label: '\u15d8\uef1e\u1781\u6242\u8156\u0ffd\u4e52',
+}
+);
+try {
+computePassEncoder9.setPipeline(
+pipeline12
+);
+} catch {}
+try {
+commandEncoder16.resolveQuerySet(
+querySet2,
+496,
+420,
+buffer6,
+512
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+3888,
+new BigUint64Array(50655),
+40010,
+264
+);
+} catch {}
+document.body.prepend(canvas2);
+let canvas4 = document.createElement('canvas');
+let shaderModule5 = device0.createShaderModule(
+{
+code: `
+
+@compute @workgroup_size(4, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@builtin(sample_mask) f0: u32,
+@location(1) f1: i32,
+@location(5) f2: vec4<f32>,
+@location(2) f3: f32,
+@builtin(frag_depth) f4: f32,
+@location(6) f5: vec3<u32>,
+@location(0) f6: vec3<u32>,
+@location(3) f7: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S7 {
+@builtin(instance_index) f0: u32,
+@location(21) f1: vec4<f32>,
+@location(11) f2: vec3<u32>,
+@location(17) f3: f32,
+@location(0) f4: vec4<u32>,
+@location(15) f5: vec4<f16>,
+@location(26) f6: vec4<u32>,
+@location(24) f7: vec4<i32>,
+@location(10) f8: vec4<f32>,
+@location(5) f9: vec4<u32>,
+@location(22) f10: vec2<u32>,
+@location(13) f11: vec2<u32>,
+@location(16) f12: vec4<f32>,
+@builtin(vertex_index) f13: u32,
+@location(6) f14: u32,
+@location(4) f15: f32,
+@location(19) f16: vec2<i32>,
+@location(12) f17: vec4<f16>,
+@location(1) f18: vec2<f32>,
+@location(2) f19: vec3<f16>,
+@location(9) f20: i32,
+@location(3) f21: vec2<f32>,
+@location(8) f22: vec3<f16>
+}
+
+@vertex
+fn vertex0(a0: S7, @location(14) a1: vec2<f16>, @location(23) a2: vec4<f32>, @location(7) a3: vec3<i32>, @location(25) a4: vec4<u32>, @location(18) a5: vec3<f16>, @location(20) a6: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder17 = device0.createCommandEncoder(
+{
+label: '\u0641\u0346\u1451\u{1f9ec}\u0a24\u{1f9a5}',
+}
+);
+let querySet13 = device0.createQuerySet(
+{
+label: '\u3b3a\u001b\u6605\u8258\u9f12\u4bd1\ucfc1\u{1ff18}',
+type: 'occlusion',
+count: 2625,
+}
+);
+let texture19 = device0.createTexture(
+{
+label: '\u873f\u{1fed9}\u{1ffbb}\u6b90\u5eed\u0f67\u{1ff3a}',
+size: {width: 4104},
+dimension: '1d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView16 = texture14.createView(
+{
+label: '\u02fb\u0a97\u74bb',
+baseMipLevel: 2,
+mipLevelCount: 4,
+arrayLayerCount: 1,
+}
+);
+let renderBundle14 = renderBundleEncoder15.finish(
+{
+label: '\u4923\u751d\u{1ff3d}'
+}
+);
+let sampler11 = device0.createSampler(
+{
+label: '\u{1fff2}\u7ac4\u{1fcb0}\u0b50\u9368\u089a',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 32.644,
+lodMaxClamp: 41.153,
+maxAnisotropy: 12,
+}
+);
+try {
+computePassEncoder11.setBindGroup(
+2,
+bindGroup3,
+new Uint32Array(4843),
+2084,
+0
+);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(
+buffer5,
+'uint16',
+18948,
+402
+);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(
+6,
+buffer6
+);
+} catch {}
+try {
+commandEncoder17.clearBuffer(
+buffer0,
+4620,
+2304
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+document.body.prepend('\u1d9c\uc707\u0ea0');
+let texture20 = device0.createTexture(
+{
+label: '\u63b2\u0c6c',
+size: {width: 13843, height: 14, depthOrArrayLayers: 237},
+mipLevelCount: 2,
+dimension: '2d',
+format: 'stencil8',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'stencil8'
+],
+}
+);
+let sampler12 = device0.createSampler(
+{
+label: '\u4d39\u{1fc8f}\u7a9c\u751f\u{1f85b}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 81.859,
+lodMaxClamp: 88.460,
+maxAnisotropy: 8,
+}
+);
+try {
+computePassEncoder12.setBindGroup(
+4,
+bindGroup1,
+new Uint32Array(4564),
+1064,
+0
+);
+} catch {}
+try {
+commandEncoder17.copyTextureToBuffer(
+{
+  texture: texture14,
+  mipLevel: 1,
+  origin: { x: 1, y: 6, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 184 widthInBlocks: 46 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 36884 */
+offset: 17756,
+bytesPerRow: 256,
+buffer: buffer1,
+},
+{width: 46, height: 75, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline21 = await promise7;
+let texture21 = device0.createTexture(
+{
+label: '\u3719\uf2d0\u0c31\u9fe7\u6a57',
+size: {width: 47, height: 6, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+dimension: '2d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+try {
+renderBundleEncoder8.setBindGroup(
+5,
+bindGroup2
+);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(
+buffer6,
+'uint16',
+1966,
+974
+);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder17.resolveQuerySet(
+querySet7,
+385,
+866,
+buffer0,
+0
+);
+} catch {}
+try {
+renderBundleEncoder11.insertDebugMarker(
+'\u41ef'
+);
+} catch {}
+document.body.prepend('\u8550\u3c92\ue75a\u06e4\u4f72\ub1c1\ue694');
+let pipelineLayout5 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0
+],
+}
+);
+let commandEncoder18 = device0.createCommandEncoder(
+{
+label: '\u9312\u{1ff60}',
+}
+);
+try {
+renderBundleEncoder8.setIndexBuffer(
+buffer6,
+'uint16',
+1806,
+1893
+);
+} catch {}
+try {
+commandEncoder18.clearBuffer(
+buffer0,
+6676,
+80
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer0,
+1580,
+new DataView(new ArrayBuffer(15563)),
+10922,
+488
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 11, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 91, y: 89 },
+  flipY: false,
+},
+{
+  texture: texture21,
+  mipLevel: 2,
+  origin: { x: 10, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let videoFrame6 = new VideoFrame(canvas2, {timestamp: 0});
+let computePassEncoder13 = commandEncoder16.beginComputePass();
+try {
+renderBundleEncoder6.setIndexBuffer(
+buffer6,
+'uint32',
+3988,
+381
+);
+} catch {}
+try {
+commandEncoder18.resolveQuerySet(
+querySet13,
+1864,
+702,
+buffer0,
+0
+);
+} catch {}
+let shaderModule6 = device0.createShaderModule(
+{
+label: '\u{1fafa}\u{1fe3d}',
+code: `
+
+@compute @workgroup_size(5, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S9 {
+@builtin(sample_index) f0: u32,
+@location(104) f1: vec2<i32>,
+@location(95) f2: vec4<u32>,
+@location(60) f3: u32,
+@location(85) f4: vec2<f32>,
+@location(80) f5: vec4<f16>,
+@location(77) f6: u32,
+@location(74) f7: i32,
+@location(105) f8: u32,
+@location(58) f9: vec3<i32>,
+@location(15) f10: u32,
+@builtin(front_facing) f11: bool,
+@location(19) f12: vec3<i32>,
+@location(70) f13: vec3<f32>,
+@location(32) f14: vec2<u32>,
+@location(17) f15: vec4<i32>,
+@builtin(position) f16: vec4<f32>,
+@location(84) f17: vec4<u32>,
+@location(93) f18: i32,
+@location(5) f19: f16,
+@location(42) f20: vec4<i32>,
+@location(62) f21: vec2<u32>,
+@location(91) f22: vec3<f16>,
+@location(56) f23: vec3<u32>,
+@location(3) f24: vec2<f16>,
+@location(69) f25: f32,
+@location(34) f26: vec3<f32>,
+@location(97) f27: vec3<f32>,
+@location(30) f28: i32,
+@location(39) f29: vec2<u32>
+}
+struct FragmentOutput0 {
+@location(5) f0: vec4<f32>,
+@location(6) f1: vec3<u32>,
+@location(7) f2: vec3<i32>,
+@location(4) f3: vec2<f32>,
+@builtin(sample_mask) f4: u32,
+@builtin(frag_depth) f5: f32,
+@location(0) f6: vec2<f32>,
+@location(1) f7: vec3<i32>,
+@location(2) f8: vec2<i32>,
+@location(3) f9: vec2<f32>
+}
+
+@fragment
+fn fragment0(@location(10) a0: vec4<f32>, @builtin(sample_mask) a1: u32, @location(9) a2: f32, @location(110) a3: vec3<i32>, @location(92) a4: vec3<i32>, a5: S9, @location(96) a6: vec2<u32>, @location(44) a7: vec3<u32>, @location(38) a8: f16, @location(27) a9: vec3<i32>, @location(50) a10: i32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S8 {
+@location(3) f0: vec3<u32>,
+@location(26) f1: vec3<i32>,
+@location(11) f2: vec3<f16>,
+@location(25) f3: vec2<f16>,
+@location(22) f4: vec3<f32>
+}
+struct VertexOutput0 {
+@location(9) f99: f32,
+@location(95) f100: vec4<u32>,
+@location(15) f101: u32,
+@location(56) f102: vec3<u32>,
+@location(38) f103: f16,
+@location(74) f104: i32,
+@location(93) f105: i32,
+@location(105) f106: u32,
+@location(97) f107: vec3<f32>,
+@location(17) f108: vec4<i32>,
+@location(3) f109: vec2<f16>,
+@location(62) f110: vec2<u32>,
+@location(5) f111: f16,
+@location(39) f112: vec2<u32>,
+@location(85) f113: vec2<f32>,
+@location(34) f114: vec3<f32>,
+@location(60) f115: u32,
+@location(69) f116: f32,
+@location(10) f117: vec4<f32>,
+@location(96) f118: vec2<u32>,
+@location(19) f119: vec3<i32>,
+@location(44) f120: vec3<u32>,
+@location(84) f121: vec4<u32>,
+@location(27) f122: vec3<i32>,
+@location(30) f123: i32,
+@location(80) f124: vec4<f16>,
+@location(91) f125: vec3<f16>,
+@location(58) f126: vec3<i32>,
+@location(104) f127: vec2<i32>,
+@location(50) f128: i32,
+@location(77) f129: u32,
+@location(42) f130: vec4<i32>,
+@location(32) f131: vec2<u32>,
+@location(92) f132: vec3<i32>,
+@location(70) f133: vec3<f32>,
+@builtin(position) f134: vec4<f32>,
+@location(110) f135: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(4) a0: vec2<i32>, @location(12) a1: vec3<f32>, @location(21) a2: vec3<i32>, @location(18) a3: vec2<u32>, @location(20) a4: vec3<u32>, @location(14) a5: u32, @location(23) a6: vec4<i32>, @location(16) a7: i32, a8: S8, @location(7) a9: vec3<i32>, @location(10) a10: vec2<i32>, @location(0) a11: vec2<i32>, @location(15) a12: vec4<i32>, @location(1) a13: i32, @location(6) a14: vec3<i32>, @location(9) a15: vec3<i32>, @location(13) a16: vec3<i32>, @location(24) a17: vec4<f16>, @location(2) a18: vec2<f32>, @location(8) a19: f16, @location(17) a20: vec4<f16>, @location(19) a21: vec4<f16>, @location(5) a22: vec2<f16>, @builtin(instance_index) a23: u32, @builtin(vertex_index) a24: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder19 = device0.createCommandEncoder(
+{
+label: '\u{1f6f4}\u0d27\u0670\u666e\u{1fa7d}\u10a3\u0605\ue782\u7858',
+}
+);
+let textureView17 = texture10.createView(
+{
+label: '\u0d34\u{1f8eb}\uaa7f\u004a\u0b39\u06ed\u3cde\uecc6\u00eb\u0bce\u437f',
+dimension: '1d',
+baseMipLevel: 0,
+}
+);
+let computePassEncoder14 = commandEncoder19.beginComputePass();
+let renderBundleEncoder17 = device0.createRenderBundleEncoder(
+{
+label: '\u{1fadf}\u062e\u0841\u0f5f\u0cae\ue51b\ue4b6\u{1f9da}',
+colorFormats: [
+'rg32float',
+'rg16float',
+'rgba16float',
+'rg8uint',
+'rgb10a2unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 820,
+depthReadOnly: true,
+}
+);
+try {
+commandEncoder17.resolveQuerySet(
+querySet7,
+560,
+332,
+buffer6,
+512
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+14480,
+new DataView(new ArrayBuffer(61653)),
+57036,
+2772
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 47, height: 3, depthOrArrayLayers: 153}
+*/
+{
+  source: canvas1,
+  origin: { x: 20, y: 323 },
+  flipY: true,
+},
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: { x: 9, y: 2, z: 72 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 8, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder();
+try {
+computePassEncoder2.setPipeline(
+pipeline4
+);
+} catch {}
+let pipeline22 = await device0.createComputePipelineAsync(
+{
+layout: 'auto',
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let textureView18 = texture4.createView(
+{
+label: '\u4cb8\ub3f2\u666e\ud41c\u{1f776}\u733f',
+dimension: '2d',
+baseMipLevel: 1,
+mipLevelCount: 1,
+baseArrayLayer: 75,
+}
+);
+try {
+computePassEncoder5.setPipeline(
+pipeline17
+);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(
+3,
+buffer2,
+35444,
+1467
+);
+} catch {}
+try {
+commandEncoder20.clearBuffer(
+buffer4,
+15488,
+21980
+);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer1,
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer0,
+3384,
+new Float32Array(10892),
+5861,
+536
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 11, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 3, y: 2 },
+  flipY: false,
+},
+{
+  texture: texture21,
+  mipLevel: 2,
+  origin: { x: 7, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 4, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend(canvas2);
+let bindGroup9 = device0.createBindGroup({
+label: '\uc45a\u1a29\u8442\u5129\u8777\u186d\u{1fdda}\ue4f0\u{1f6ec}\u{1f926}\u0bc5',
+layout: bindGroupLayout0,
+entries: [
+{
+binding: 4207,
+resource: sampler2
+}
+],
+});
+let buffer8 = device0.createBuffer(
+{
+label: '\ubfd8\u48b4\u{1fde2}\u{1fc7b}\u89ef\ubb8e\u0932',
+size: 59844,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+mappedAtCreation: true,
+}
+);
+let querySet14 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 407,
+}
+);
+pseudoSubmit(device0, commandEncoder9);
+try {
+renderBundleEncoder16.setBindGroup(
+0,
+bindGroup3,
+new Uint32Array(3169),
+2941,
+0
+);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(
+7,
+buffer7,
+1140,
+7237
+);
+} catch {}
+let promise9 = device0.popErrorScope();
+try {
+device0.queue.writeTexture(
+{
+  texture: texture3,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 8 },
+  aspect: 'all',
+},
+new Int32Array(arrayBuffer2),
+/* required buffer size: 651395 */{
+offset: 195,
+bytesPerRow: 100,
+rowsPerImage: 37,
+},
+{width: 1, height: 0, depthOrArrayLayers: 177}
+);
+} catch {}
+let adapter1 = await promise6;
+let bindGroup10 = device0.createBindGroup({
+layout: bindGroupLayout0,
+entries: [
+{
+binding: 4207,
+resource: sampler2
+}
+],
+});
+let commandEncoder21 = device0.createCommandEncoder(
+{
+label: '\ued62\ue8e1\u9375\uec67\u7a61\u8991\u03ae\u748a\u{1fa65}\u2a10',
+}
+);
+let textureView19 = texture7.createView(
+{
+label: '\u{1fcf0}\u083a',
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+let computePassEncoder15 = commandEncoder17.beginComputePass(
+{
+label: '\u5ce6\uef80'
+}
+);
+try {
+commandEncoder20.copyBufferToBuffer(
+buffer8,
+25652,
+buffer1,
+13360,
+16160
+);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder18.copyTextureToBuffer(
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: { x: 4903, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 1700 widthInBlocks: 850 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 34448 */
+offset: 34448,
+rowsPerImage: 202,
+buffer: buffer1,
+},
+{width: 850, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder21.clearBuffer(
+buffer7,
+20644,
+1060
+);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+computePassEncoder13.insertDebugMarker(
+'\ua670'
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture17,
+  mipLevel: 9,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(801),
+/* required buffer size: 801 */{
+offset: 417,
+},
+{width: 24, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let gpuCanvasContext3 = canvas4.getContext('webgpu');
+canvas3.width = 996;
+let imageData3 = new ImageData(168, 76);
+let querySet15 = device0.createQuerySet(
+{
+label: '\ub17b\u5662\ue25c',
+type: 'occlusion',
+count: 2468,
+}
+);
+let textureView20 = texture20.createView(
+{
+label: '\u7b4e\ue073\uee97\u{1fe77}\u00b6\udf4b',
+dimension: '2d',
+baseMipLevel: 0,
+mipLevelCount: 1,
+baseArrayLayer: 165,
+}
+);
+try {
+renderBundleEncoder17.setVertexBuffer(
+6,
+buffer5,
+13504,
+7010
+);
+} catch {}
+try {
+commandEncoder20.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 2, height: 5, depthOrArrayLayers: 30}
+*/
+{
+  source: video2,
+  origin: { x: 14, y: 8 },
+  flipY: true,
+},
+{
+  texture: texture15,
+  mipLevel: 3,
+  origin: { x: 0, y: 1, z: 2 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 3, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\u4c3c\u{1f689}\ufae5\u3abe\u2a37');
+let video3 = await videoWithData();
+let commandEncoder22 = device0.createCommandEncoder(
+{
+}
+);
+let renderPassEncoder0 = commandEncoder20.beginRenderPass(
+{
+label: '\u6c0a\u062c\ua11f\u0e66\u{1fe71}\ub215\u{1fa75}\u3628\u0b56\ucfee\u7974',
+colorAttachments: [
+
+],
+depthStencilAttachment: {
+view: textureView20,
+depthReadOnly: false,
+stencilClearValue: 16285,
+stencilLoadOp: 'load',
+stencilStoreOp: 'store',
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet1,
+maxDrawCount: 235792,
+}
+);
+try {
+renderPassEncoder0.setScissorRect(
+12727,
+9,
+355,
+4
+);
+} catch {}
+try {
+commandEncoder21.copyBufferToBuffer(
+buffer2,
+36768,
+buffer7,
+9320,
+584
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture12,
+  mipLevel: 1,
+  origin: { x: 0, y: 22, z: 0 },
+  aspect: 'stencil-only',
+},
+arrayBuffer2,
+/* required buffer size: 346 */{
+offset: 346,
+},
+{width: 60, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let renderPassEncoder1 = commandEncoder22.beginRenderPass(
+{
+label: '\u{1faae}\u{1fc4e}\ue13f\u0b50\u{1f707}\uaf7b',
+colorAttachments: [
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView20,
+depthClearValue: -2.059179980337067,
+stencilLoadOp: 'load',
+stencilStoreOp: 'store',
+},
+occlusionQuerySet: querySet12,
+maxDrawCount: 188240,
+}
+);
+let sampler13 = device0.createSampler(
+{
+label: '\u5eef\ue4b5\u{1f66b}\u6698\u9fce\ua569',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+lodMaxClamp: 98.272,
+}
+);
+try {
+computePassEncoder6.setPipeline(
+pipeline16
+);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(
+4,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(
+72
+);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(
+buffer5,
+'uint16',
+8450,
+11988
+);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 4, height: 10, depthOrArrayLayers: 30}
+*/
+{
+  source: imageBitmap4,
+  origin: { x: 66, y: 79 },
+  flipY: false,
+},
+{
+  texture: texture15,
+  mipLevel: 2,
+  origin: { x: 0, y: 4, z: 10 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 4, height: 4, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await promise10;
+} catch {}
+let renderBundleEncoder18 = device0.createRenderBundleEncoder(
+{
+label: '\u26a0\u7644\u08eb',
+colorFormats: [
+'rgba16sint'
+],
+sampleCount: 32,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle15 = renderBundleEncoder5.finish(
+{
+label: '\u{1f789}\u{1fa24}\u{1f9f8}'
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+9,
+bindGroup2,
+new Uint32Array(2859),
+1952,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(
+118
+);
+} catch {}
+try {
+commandEncoder18.clearBuffer(
+buffer4,
+7284,
+3796
+);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder18.resolveQuerySet(
+querySet10,
+532,
+119,
+buffer0,
+2816
+);
+} catch {}
+let pipeline23 = await device0.createComputePipelineAsync(
+{
+label: '\u{1f670}\u0bdf\u0e40\u6579',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageBitmap6 = await createImageBitmap(canvas4);
+let querySet16 = device0.createQuerySet(
+{
+label: '\u78a5\ud2ab\ueade\u{1f64b}\ub060\uce1a\u040a',
+type: 'occlusion',
+count: 3653,
+}
+);
+let texture22 = device0.createTexture(
+{
+label: '\ue20c\u0c54\u0c7e\u07e2\u{1fb2c}\u{1faaa}\u66ba',
+size: {width: 244, height: 1, depthOrArrayLayers: 1720},
+mipLevelCount: 3,
+sampleCount: 1,
+dimension: '3d',
+format: 'rgba32uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba32uint',
+'rgba32uint',
+'rgba32uint'
+],
+}
+);
+try {
+computePassEncoder2.setPipeline(
+pipeline22
+);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(
+3,
+bindGroup9,
+new Uint32Array(9281),
+5404,
+0
+);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant(
+{
+r: -356.8,
+g: -647.1,
+b: 935.4,
+a: -86.79,
+}
+);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+18,
+undefined,
+2091862765,
+27283245
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'bgra8unorm',
+'rgb9e5ufloat',
+'r8unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let shaderModule7 = device0.createShaderModule(
+{
+label: '\uc6f4\u{1f91d}\u1ae1\u{1ff26}\u06a1',
+code: `
+
+@compute @workgroup_size(6, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0() -> @builtin(frag_depth) f32 {
+return f32();
+}
+
+struct S10 {
+@location(24) f0: vec4<f32>,
+@location(2) f1: vec2<f32>,
+@location(22) f2: u32,
+@location(3) f3: f32,
+@location(19) f4: f16,
+@location(17) f5: f16,
+@location(15) f6: vec4<f32>,
+@location(6) f7: vec2<i32>,
+@location(23) f8: vec3<i32>,
+@location(4) f9: vec4<i32>,
+@location(5) f10: vec4<f32>,
+@location(11) f11: vec4<u32>,
+@location(16) f12: vec4<u32>,
+@location(25) f13: vec4<f32>,
+@location(26) f14: vec4<u32>,
+@location(12) f15: f16,
+@location(13) f16: vec4<f16>,
+@location(21) f17: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec3<u32>, @location(7) a1: vec3<u32>, a2: S10, @location(18) a3: vec4<u32>, @location(1) a4: vec2<f16>, @location(9) a5: vec4<f32>, @location(0) a6: vec4<f32>, @location(8) a7: vec4<i32>, @location(20) a8: vec2<i32>, @location(10) a9: vec4<f32>, @builtin(vertex_index) a10: u32, @builtin(instance_index) a11: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+}
+);
+let commandEncoder23 = device0.createCommandEncoder();
+let texture23 = device0.createTexture(
+{
+label: '\ue356\u{1f770}\u{1f789}\ubdb1\u0d3a\u0b68',
+size: {width: 5161},
+sampleCount: 1,
+dimension: '1d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundle16 = renderBundleEncoder16.finish(
+{
+label: '\uc1a7\u{1fe95}\uab93'
+}
+);
+try {
+renderPassEncoder1.setBindGroup(
+8,
+bindGroup3
+);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(
+5,
+bindGroup7
+);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(
+5,
+bindGroup3,
+new Uint32Array(2351),
+831,
+0
+);
+} catch {}
+try {
+commandEncoder18.copyBufferToTexture(
+{
+/* bytesInLastRow: 30 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 56866 */
+offset: 49412,
+bytesPerRow: 256,
+buffer: buffer8,
+},
+{
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'stencil-only',
+},
+{width: 30, height: 30, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder18.copyTextureToTexture(
+{
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 0, y: 30, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 0, y: 7, z: 1 },
+  aspect: 'all',
+},
+{width: 30, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+let texture24 = device0.createTexture(
+{
+label: '\u{1f975}\ueee3\u{1ffed}\u0f2e\u8d22\u002c\uc05b\u98ac\u3b98',
+size: {width: 10513},
+dimension: '1d',
+format: 'rg8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8uint',
+'rg8uint'
+],
+}
+);
+try {
+computePassEncoder2.setPipeline(
+pipeline12
+);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(
+2343,
+4,
+1553,
+10
+);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(
+4074
+);
+} catch {}
+try {
+await buffer3.mapAsync(
+GPUMapMode.WRITE,
+0,
+1672
+);
+} catch {}
+try {
+commandEncoder23.copyTextureToTexture(
+{
+  texture: texture17,
+  mipLevel: 5,
+  origin: { x: 240, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 9,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 20, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder23.resolveQuerySet(
+querySet3,
+1481,
+396,
+buffer6,
+1024
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture11,
+  mipLevel: 0,
+  origin: { x: 41, y: 0, z: 7 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 478351 */{
+offset: 335,
+bytesPerRow: 97,
+rowsPerImage: 77,
+},
+{width: 29, height: 0, depthOrArrayLayers: 65}
+);
+} catch {}
+let bindGroupLayout2 = pipeline11.getBindGroupLayout(5);
+let commandEncoder24 = device0.createCommandEncoder(
+{
+label: '\u{1ff39}\u{1f9cf}\u1dea\uf464\u29cb',
+}
+);
+let texture25 = gpuCanvasContext1.getCurrentTexture();
+try {
+renderPassEncoder1.setBindGroup(
+6,
+bindGroup4,
+new Uint32Array(516),
+181,
+0
+);
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+7153.0,
+13.05,
+6607.0,
+0.2644,
+0.8482,
+0.8736
+);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+7,
+buffer2,
+21732,
+5192
+);
+} catch {}
+try {
+device0.pushErrorScope(
+'out-of-memory'
+);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let querySet17 = device0.createQuerySet(
+{
+label: '\u{1f911}\u0565\u919d\uab93',
+type: 'occlusion',
+count: 765,
+}
+);
+let textureView21 = texture6.createView(
+{
+label: '\u9271\u1fe0\ua628\u{1f653}\u2137\u{1f7be}',
+dimension: '1d',
+baseArrayLayer: 0,
+}
+);
+try {
+computePassEncoder12.setPipeline(
+pipeline17
+);
+} catch {}
+try {
+commandEncoder23.insertDebugMarker(
+'\u339d'
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+colorSpace: 'srgb',
+}
+);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer2,
+]);
+} catch {}
+let promise11 = navigator.gpu.requestAdapter(
+{
+}
+);
+let imageBitmap7 = await createImageBitmap(imageBitmap4);
+let buffer9 = device0.createBuffer(
+{
+label: '\u5c61\u10ba',
+size: 23157,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let commandEncoder25 = device0.createCommandEncoder(
+{
+}
+);
+let textureView22 = texture5.createView(
+{
+}
+);
+let computePassEncoder16 = commandEncoder24.beginComputePass(
+{
+label: '\u7d84\ub41b\u80be\u{1f706}\u{1fdc9}'
+}
+);
+try {
+renderPassEncoder1.setBlendConstant(
+{
+r: 641.9,
+g: 587.1,
+b: -931.8,
+a: 938.8,
+}
+);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(
+1,
+buffer6,
+812,
+3215
+);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(
+4,
+buffer9,
+10796,
+1043
+);
+} catch {}
+let commandBuffer3 = commandEncoder18.finish();
+let textureView23 = texture7.createView(
+{
+label: '\u05bc\u0e3a\u07b4\uf7c6\u5eca',
+mipLevelCount: 2,
+}
+);
+let computePassEncoder17 = commandEncoder23.beginComputePass(
+{
+label: '\u0a43\u4114\u8006'
+}
+);
+let renderPassEncoder2 = commandEncoder25.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView20,
+depthClearValue: 1.4450729046775344,
+stencilClearValue: 29204,
+stencilLoadOp: 'load',
+stencilStoreOp: 'discard',
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet9,
+}
+);
+try {
+renderPassEncoder1.setBindGroup(
+8,
+bindGroup4,
+[]
+);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer7,
+'uint16',
+9018
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+6,
+buffer2,
+5192
+);
+} catch {}
+document.body.prepend('\uf3d5\u74d5\u0716\u042a\u9195\u0718\u3916\u0607\u{1f721}');
+let imageBitmap8 = await createImageBitmap(imageData3);
+let bindGroup11 = device0.createBindGroup({
+label: '\u{1fad8}\u8d6f\u7927',
+layout: bindGroupLayout2,
+entries: [
+{
+binding: 4207,
+resource: sampler3
+}
+],
+});
+try {
+computePassEncoder10.setBindGroup(
+9,
+bindGroup1,
+new Uint32Array(5920),
+2221,
+0
+);
+} catch {}
+try {
+computePassEncoder16.setPipeline(
+pipeline12
+);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(
+0,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(
+4,
+bindGroup9,
+new Uint32Array(3421),
+1872,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant(
+{
+r: -107.1,
+g: 741.8,
+b: 876.2,
+a: -857.1,
+}
+);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+0,
+buffer6,
+2300
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+11340,
+new BigUint64Array(33616),
+32320,
+836
+);
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(264, 85);
+let commandEncoder26 = device0.createCommandEncoder(
+{
+label: '\u{1fe9c}\uc6d0\u8c64\uac96\u0540\u80ed',
+}
+);
+let textureView24 = texture2.createView(
+{
+arrayLayerCount: 1,
+}
+);
+try {
+renderPassEncoder1.setScissorRect(
+3066,
+12,
+5438,
+2
+);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(
+3521
+);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+11197.1,
+7.952,
+2607.2,
+4.164,
+0.02183,
+0.9802
+);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(
+buffer6,
+'uint32'
+);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(
+buffer8,
+'uint32',
+13084,
+32368
+);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(
+1,
+buffer9,
+320,
+477
+);
+} catch {}
+try {
+commandEncoder26.copyBufferToTexture(
+{
+/* bytesInLastRow: 1152 widthInBlocks: 72 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 35824 */
+offset: 34672,
+buffer: buffer2,
+},
+{
+  texture: texture17,
+  mipLevel: 7,
+  origin: { x: 24, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 72, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder26.clearBuffer(
+buffer9,
+14532,
+3556
+);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8unorm',
+'depth24plus-stencil8',
+'rgba16uint'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+3188,
+new Int16Array(2191),
+1460,
+224
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture21,
+  mipLevel: 2,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(16),
+/* required buffer size: 704 */{
+offset: 704,
+rowsPerImage: 4,
+},
+{width: 5, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let renderBundle17 = renderBundleEncoder13.finish(
+{
+label: '\u6de0\u049b'
+}
+);
+try {
+computePassEncoder1.setBindGroup(
+1,
+bindGroup3,
+new Uint32Array(4309),
+3864,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(
+7,
+bindGroup7,
+new Uint32Array(9434),
+9225,
+0
+);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(
+6,
+buffer5,
+8736,
+4934
+);
+} catch {}
+try {
+commandEncoder21.copyTextureToBuffer(
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 1415, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 4732 widthInBlocks: 1183 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 43404 */
+offset: 43404,
+buffer: buffer1,
+},
+{width: 1183, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder21.clearBuffer(
+buffer1,
+45520
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder26.resolveQuerySet(
+querySet5,
+494,
+99,
+buffer0,
+3072
+);
+} catch {}
+let pipeline24 = device0.createComputePipeline(
+{
+layout: pipelineLayout5,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline25 = await device0.createRenderPipelineAsync(
+{
+label: '\u0fa5\u0f74\u86bd\u075b\u22f8\u0526\u5c6f\u{1f749}\u7fcd\u118f',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule6,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 4936,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x4',
+offset: 3832,
+shaderLocation: 23,
+},
+{
+format: 'sint32x2',
+offset: 4056,
+shaderLocation: 21,
+},
+{
+format: 'sint32x3',
+offset: 1080,
+shaderLocation: 15,
+},
+{
+format: 'float32',
+offset: 2268,
+shaderLocation: 22,
+},
+{
+format: 'sint16x4',
+offset: 4572,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x2',
+offset: 548,
+shaderLocation: 17,
+},
+{
+format: 'sint32x4',
+offset: 3676,
+shaderLocation: 1,
+},
+{
+format: 'uint16x4',
+offset: 4224,
+shaderLocation: 20,
+},
+{
+format: 'sint32x3',
+offset: 1080,
+shaderLocation: 7,
+},
+{
+format: 'uint8x2',
+offset: 1530,
+shaderLocation: 14,
+},
+{
+format: 'unorm16x2',
+offset: 4340,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x4',
+offset: 0,
+shaderLocation: 19,
+},
+{
+format: 'sint8x4',
+offset: 4220,
+shaderLocation: 13,
+},
+{
+format: 'float32',
+offset: 4868,
+shaderLocation: 25,
+},
+{
+format: 'sint32',
+offset: 608,
+shaderLocation: 6,
+},
+{
+format: 'uint32x4',
+offset: 3276,
+shaderLocation: 18,
+},
+{
+format: 'float16x2',
+offset: 804,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 15992,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 5852,
+shaderLocation: 2,
+},
+{
+format: 'sint16x2',
+offset: 1272,
+shaderLocation: 10,
+},
+{
+format: 'sint8x2',
+offset: 14798,
+shaderLocation: 0,
+},
+{
+format: 'sint32x4',
+offset: 7348,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x4',
+offset: 2720,
+shaderLocation: 8,
+},
+{
+format: 'sint32x2',
+offset: 13748,
+shaderLocation: 26,
+},
+{
+format: 'sint16x4',
+offset: 2076,
+shaderLocation: 16,
+},
+{
+format: 'snorm8x4',
+offset: 5116,
+shaderLocation: 11,
+},
+{
+format: 'float32x4',
+offset: 13620,
+shaderLocation: 24,
+},
+{
+format: 'uint8x4',
+offset: 2424,
+shaderLocation: 3,
+}
+],
+}
+]
+},
+primitive: {
+cullMode: 'back',
+},
+multisample: {
+count: 1,
+},
+fragment: {
+module: shaderModule6,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg8unorm',
+writeMask: 0,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'less',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 972,
+depthBias: 51,
+depthBiasSlopeScale: 2,
+depthBiasClamp: 68,
+},
+}
+);
+video1.height = 266;
+document.body.prepend('\ufa31\u69d6\ue706\ua981\u5604');
+let bindGroupLayout3 = device0.createBindGroupLayout(
+{
+label: '\u{1faca}\u077b\ue766\uafc4\u09c8\u0603\u4c40',
+entries: [
+{
+binding: 1350,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '1d' },
+},
+{
+binding: 3034,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+},
+{
+binding: 1774,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let texture26 = device0.createTexture(
+{
+label: '\u{1fceb}\u0cc3\ubab5\u04e8\ue887\u05e8\u2768',
+size: {width: 213, height: 1, depthOrArrayLayers: 1325},
+mipLevelCount: 11,
+dimension: '3d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg11b10ufloat',
+'rg11b10ufloat',
+'rg11b10ufloat'
+],
+}
+);
+let textureView25 = texture9.createView(
+{
+label: '\u02dc\u2916\u0400\u{1fc38}\u{1f808}\u02c8\u55f3\u475b\ub503',
+baseMipLevel: 7,
+mipLevelCount: 2,
+}
+);
+try {
+computePassEncoder11.end();
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(
+3828
+);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(
+buffer6,
+'uint16',
+724,
+2844
+);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(
+2,
+buffer7,
+15524,
+2916
+);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(
+5,
+buffer7,
+20372,
+731
+);
+} catch {}
+let pipeline26 = await device0.createRenderPipelineAsync(
+{
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule5,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 14208,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 12420,
+shaderLocation: 16,
+},
+{
+format: 'float16x2',
+offset: 6676,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x4',
+offset: 6068,
+shaderLocation: 4,
+},
+{
+format: 'uint32x4',
+offset: 3564,
+shaderLocation: 13,
+},
+{
+format: 'sint8x4',
+offset: 11640,
+shaderLocation: 19,
+},
+{
+format: 'sint8x2',
+offset: 1874,
+shaderLocation: 7,
+},
+{
+format: 'sint32x2',
+offset: 4560,
+shaderLocation: 9,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 14180,
+shaderLocation: 2,
+},
+{
+format: 'float16x4',
+offset: 12384,
+shaderLocation: 15,
+},
+{
+format: 'uint32x2',
+offset: 14184,
+shaderLocation: 0,
+},
+{
+format: 'unorm8x4',
+offset: 4544,
+shaderLocation: 14,
+},
+{
+format: 'float16x2',
+offset: 3296,
+shaderLocation: 3,
+},
+{
+format: 'float32x4',
+offset: 5736,
+shaderLocation: 17,
+},
+{
+format: 'unorm8x4',
+offset: 11124,
+shaderLocation: 18,
+},
+{
+format: 'uint8x4',
+offset: 9976,
+shaderLocation: 6,
+},
+{
+format: 'unorm8x4',
+offset: 12432,
+shaderLocation: 8,
+},
+{
+format: 'uint32x2',
+offset: 9584,
+shaderLocation: 22,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 8692,
+shaderLocation: 10,
+},
+{
+format: 'uint32x3',
+offset: 2924,
+shaderLocation: 5,
+},
+{
+format: 'uint32x4',
+offset: 932,
+shaderLocation: 25,
+},
+{
+format: 'uint8x4',
+offset: 6652,
+shaderLocation: 26,
+},
+{
+format: 'snorm8x2',
+offset: 3122,
+shaderLocation: 20,
+},
+{
+format: 'unorm8x4',
+offset: 1384,
+shaderLocation: 23,
+},
+{
+format: 'uint32x3',
+offset: 6176,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x4',
+offset: 6500,
+shaderLocation: 21,
+},
+{
+format: 'sint32x2',
+offset: 7208,
+shaderLocation: 24,
+},
+{
+format: 'float32x4',
+offset: 1988,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: false,
+},
+fragment: {
+module: shaderModule5,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'one-minus-dst-alpha',
+dstFactor: 'constant'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.BLUE,
+},
+{
+format: 'r16float',
+writeMask: GPUColorWrite.BLUE,
+},
+undefined,
+{
+format: 'rgb10a2unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'invert',
+passOp: 'keep',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'decrement-wrap',
+passOp: 'invert',
+},
+stencilReadMask: 1196,
+stencilWriteMask: 2350,
+depthBias: 20,
+depthBiasSlopeScale: 3,
+depthBiasClamp: 85,
+},
+}
+);
+offscreenCanvas1.width = 712;
+let canvas5 = document.createElement('canvas');
+let offscreenCanvas3 = new OffscreenCanvas(82, 493);
+let img3 = await imageWithData(30, 61, '#ead0707c', '#5f896433');
+let bindGroup12 = device0.createBindGroup({
+label: '\u{1f850}\ua5be\uae1c\u5b00\u{1f765}\u09e5\ub1dc\u4fe4\ub68c\u{1fdae}\uc8aa',
+layout: bindGroupLayout2,
+entries: [
+{
+binding: 4207,
+resource: sampler13
+}
+],
+});
+let commandEncoder27 = device0.createCommandEncoder(
+{
+label: '\u2031\u0bfa',
+}
+);
+let textureView26 = texture26.createView(
+{
+label: '\ue3cb\u91a4\u065d\u04f8\u1793\u5e6d\u0842\u0a70\u0669\u068a\uf9fa',
+baseMipLevel: 6,
+mipLevelCount: 3,
+baseArrayLayer: 0,
+}
+);
+let computePassEncoder18 = commandEncoder21.beginComputePass(
+{
+
+}
+);
+try {
+renderPassEncoder1.setBindGroup(
+5,
+bindGroup2
+);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+1,
+bindGroup3
+);
+} catch {}
+try {
+commandEncoder27.resolveQuerySet(
+querySet13,
+876,
+270,
+buffer9,
+9472
+);
+} catch {}
+let pipeline27 = device0.createComputePipeline(
+{
+label: '\u66fd\u7f33',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let gpuCanvasContext4 = offscreenCanvas3.getContext('webgpu');
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+document.body.prepend(img0);
+let adapter2 = await promise11;
+let texture27 = device0.createTexture(
+{
+label: '\ufef7\u2e56\u812c',
+size: {width: 12699, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 13,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let textureView27 = texture13.createView(
+{
+mipLevelCount: 6,
+baseArrayLayer: 108,
+arrayLayerCount: 3,
+}
+);
+try {
+computePassEncoder14.setPipeline(
+pipeline22
+);
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+462.2,
+7.048,
+1264.4,
+3.117,
+0.7300,
+0.8273
+);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+3,
+buffer9,
+15888,
+6104
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+1,
+buffer7,
+15808,
+5975
+);
+} catch {}
+try {
+commandEncoder15.copyBufferToTexture(
+{
+/* bytesInLastRow: 17128 widthInBlocks: 4282 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 35072 */
+offset: 35072,
+rowsPerImage: 207,
+buffer: buffer2,
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: { x: 400, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 4282, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let bindGroupLayout4 = pipeline20.getBindGroupLayout(1);
+let commandEncoder28 = device0.createCommandEncoder(
+{
+}
+);
+let querySet18 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 588,
+}
+);
+try {
+renderPassEncoder1.beginOcclusionQuery(
+56
+);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+8791,
+9,
+2656,
+3
+);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(
+0,
+bindGroup9,
+new Uint32Array(3745),
+2934,
+0
+);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 2, height: 5, depthOrArrayLayers: 30}
+*/
+{
+  source: canvas3,
+  origin: { x: 484, y: 75 },
+  flipY: false,
+},
+{
+  texture: texture15,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 26 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 2, height: 5, depthOrArrayLayers: 1}
+);
+} catch {}
+gc();
+document.body.append('\u8546\u43a5\u09e6\u051c\u29e2\u{1f9d0}\u090a\ufc2d\u085e\uc1b1');
+let textureView28 = texture6.createView(
+{
+label: '\u0935\u1942\u{1f86b}\u{1fb93}',
+}
+);
+let sampler14 = device0.createSampler(
+{
+label: '\u{1faeb}\u{1f693}\u{1fdba}\uab2d\ucfbc\u{1fb8b}\u741f',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 71.538,
+lodMaxClamp: 95.985,
+maxAnisotropy: 13,
+}
+);
+try {
+renderPassEncoder0.setBindGroup(
+9,
+bindGroup8,
+[]
+);
+} catch {}
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(
+buffer7,
+'uint16'
+);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(
+1,
+buffer7,
+7152,
+15631
+);
+} catch {}
+try {
+commandEncoder28.resolveQuerySet(
+querySet3,
+152,
+437,
+buffer6,
+768
+);
+} catch {}
+let pipeline28 = await device0.createRenderPipelineAsync(
+{
+label: '\uac03\u0aef\u3344',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule5,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 15192,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 1040,
+shaderLocation: 7,
+},
+{
+format: 'sint32x3',
+offset: 9400,
+shaderLocation: 19,
+},
+{
+format: 'unorm8x2',
+offset: 6876,
+shaderLocation: 14,
+},
+{
+format: 'uint32x2',
+offset: 2760,
+shaderLocation: 26,
+},
+{
+format: 'snorm8x4',
+offset: 9820,
+shaderLocation: 12,
+},
+{
+format: 'snorm16x2',
+offset: 6236,
+shaderLocation: 15,
+},
+{
+format: 'sint16x2',
+offset: 7996,
+shaderLocation: 24,
+},
+{
+format: 'uint32',
+offset: 5948,
+shaderLocation: 5,
+},
+{
+format: 'float32',
+offset: 10412,
+shaderLocation: 21,
+},
+{
+format: 'float16x2',
+offset: 12328,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x2',
+offset: 6960,
+shaderLocation: 16,
+},
+{
+format: 'unorm8x2',
+offset: 3902,
+shaderLocation: 23,
+},
+{
+format: 'unorm8x2',
+offset: 1122,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 7264,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 6300,
+shaderLocation: 0,
+},
+{
+format: 'unorm8x4',
+offset: 5076,
+shaderLocation: 18,
+},
+{
+format: 'float32',
+offset: 4716,
+shaderLocation: 20,
+},
+{
+format: 'unorm8x4',
+offset: 1488,
+shaderLocation: 8,
+},
+{
+format: 'unorm16x2',
+offset: 1676,
+shaderLocation: 17,
+},
+{
+format: 'uint16x2',
+offset: 4128,
+shaderLocation: 13,
+},
+{
+format: 'unorm8x2',
+offset: 6406,
+shaderLocation: 10,
+},
+{
+format: 'sint8x4',
+offset: 3888,
+shaderLocation: 9,
+},
+{
+format: 'float32x2',
+offset: 2512,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 6280,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x4',
+offset: 5296,
+shaderLocation: 22,
+},
+{
+format: 'uint32',
+offset: 4408,
+shaderLocation: 25,
+},
+{
+format: 'float16x4',
+offset: 1876,
+shaderLocation: 1,
+},
+{
+format: 'uint32x2',
+offset: 1504,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 5064,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 1792,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 2740,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 11240,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x2',
+offset: 4608,
+shaderLocation: 6,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule5,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16uint',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'replace',
+passOp: 'replace',
+},
+depthBias: 70,
+depthBiasSlopeScale: 48,
+depthBiasClamp: 66,
+},
+}
+);
+let renderBundleEncoder19 = device0.createRenderBundleEncoder(
+{
+label: '\u0ea0\u0139\u01aa\u25bb\u4e69\u6992\u88bc',
+colorFormats: [
+'rg16sint',
+'rg16uint',
+'rg8sint',
+undefined,
+'rg8sint',
+'rg8uint',
+'r16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 752,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder0.beginOcclusionQuery(
+64
+);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant(
+{
+r: 90.82,
+g: 801.2,
+b: -745.4,
+a: -346.9,
+}
+);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(
+buffer6,
+'uint32',
+3624
+);
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(
+buffer8,
+46748,
+buffer7,
+5384,
+8296
+);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder15.clearBuffer(
+buffer0,
+1516,
+1552
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer9,
+8564,
+new DataView(new ArrayBuffer(10564)),
+505,
+3608
+);
+} catch {}
+offscreenCanvas0.width = 917;
+let pipelineLayout6 = device0.createPipelineLayout(
+{
+label: '\uc1f4\u{1fe1c}',
+bindGroupLayouts: [
+bindGroupLayout1,
+bindGroupLayout0,
+bindGroupLayout2,
+bindGroupLayout1
+],
+}
+);
+let buffer10 = device0.createBuffer(
+{
+size: 31389,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let texture28 = device0.createTexture(
+{
+size: [11863, 244, 1],
+mipLevelCount: 10,
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg8snorm'
+],
+}
+);
+let renderPassEncoder3 = commandEncoder27.beginRenderPass(
+{
+colorAttachments: [
+
+],
+depthStencilAttachment: {
+view: textureView20,
+depthClearValue: 0.49144330729075847,
+stencilClearValue: 11091,
+stencilLoadOp: 'clear',
+stencilStoreOp: 'discard',
+},
+occlusionQuerySet: querySet11,
+maxDrawCount: 506664,
+}
+);
+let renderBundle18 = renderBundleEncoder6.finish(
+{
+label: '\u3dc4\u{1fd6b}\u0fd5\uf4e5\u03c4\ue5a6\u{1fa85}\uf51e\u0753'
+}
+);
+let externalTexture1 = device0.importExternalTexture(
+{
+label: '\u{1f8a9}\u{1f931}\u0a20\u001a\u{1fd6e}\u1b4e\u0321',
+source: videoFrame1,
+colorSpace: 'srgb',
+}
+);
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+computePassEncoder5.setPipeline(
+pipeline24
+);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(
+10588,
+0,
+2040,
+12
+);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(
+7,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(
+5,
+bindGroup5,
+new Uint32Array(7342),
+1353,
+0
+);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(
+3,
+buffer7,
+2608
+);
+} catch {}
+let arrayBuffer3 = buffer3.getMappedRange(
+0,
+1160
+);
+try {
+buffer9.unmap();
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 272, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer3),
+/* required buffer size: 442 */{
+offset: 442,
+bytesPerRow: 9382,
+},
+{width: 2330, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 5, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas4,
+  origin: { x: 255, y: 77 },
+  flipY: false,
+},
+{
+  texture: texture21,
+  mipLevel: 3,
+  origin: { x: 2, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\uecdf\u7d93\u{1fe94}\u2010\u3567\u{1fb94}\u017b\u39b5\u0da8');
+let bindGroupLayout5 = device0.createBindGroupLayout(
+{
+label: '\u06c0\u{1f715}\ubbe7\u4003\u{1fb16}\u1fa5\uf7af\u0b75\uefe9',
+entries: [
+{
+binding: 365,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+},
+{
+binding: 4406,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 695,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let renderBundleEncoder20 = device0.createRenderBundleEncoder(
+{
+label: '\u{1fb05}\u{1f947}\u0d6d\ub209\u4f22\u0186\u0007\u9665\u64a1',
+colorFormats: [
+'r8sint',
+'rgba32float',
+'r16uint',
+'rg8uint',
+'rg16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 484,
+depthReadOnly: true,
+}
+);
+let sampler15 = device0.createSampler(
+{
+label: '\u5fe4\u05bd',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 2.158,
+maxAnisotropy: 17,
+}
+);
+try {
+renderPassEncoder3.beginOcclusionQuery(
+48
+);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(
+8,
+bindGroup1,
+[]
+);
+} catch {}
+try {
+device0.pushErrorScope(
+'validation'
+);
+} catch {}
+try {
+commandEncoder28.copyBufferToTexture(
+{
+/* bytesInLastRow: 9296 widthInBlocks: 2324 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 36 */
+offset: 36,
+buffer: buffer10,
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: { x: 1241, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 2324, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer0,
+1644,
+new BigUint64Array(18898),
+6327,
+544
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 674, height: 1, depthOrArrayLayers: 48}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 15, y: 20 },
+  flipY: false,
+},
+{
+  texture: texture9,
+  mipLevel: 1,
+  origin: { x: 144, y: 0, z: 26 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 278, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let texture29 = device0.createTexture(
+{
+label: '\uf0ce\u01cd\u0ad1\u3ca1\u{1fd7f}\ua86f\ucc9c',
+size: [8281],
+dimension: '1d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgba8snorm',
+'rgba8snorm',
+'rgba8snorm'
+],
+}
+);
+let sampler16 = device0.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 10.583,
+lodMaxClamp: 77.710,
+}
+);
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(
+2,
+bindGroup10
+);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(
+buffer5,
+'uint16',
+16102,
+2169
+);
+} catch {}
+try {
+commandEncoder28.copyBufferToTexture(
+{
+/* bytesInLastRow: 18160 widthInBlocks: 9080 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 20490 */
+offset: 2330,
+buffer: buffer8,
+},
+{
+  texture: texture24,
+  mipLevel: 0,
+  origin: { x: 1158, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 9080, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder26.clearBuffer(
+buffer0,
+368,
+6488
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder15.resolveQuerySet(
+querySet16,
+449,
+2044,
+buffer9,
+0
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 11, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap8,
+  origin: { x: 57, y: 56 },
+  flipY: true,
+},
+{
+  texture: texture21,
+  mipLevel: 2,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 3, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\uafe1\ue8a6\u0c38');
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+10106,
+12,
+3028,
+1
+);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(
+3485
+);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(
+5,
+buffer2,
+33236
+);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(
+buffer6,
+'uint16',
+220,
+2821
+);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(
+5,
+buffer7,
+14228,
+8141
+);
+} catch {}
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder28.resolveQuerySet(
+querySet7,
+508,
+1417,
+buffer5,
+3584
+);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+let texture30 = device0.createTexture(
+{
+label: '\ua527\u6089\u{1fd17}',
+size: [10566, 205, 240],
+mipLevelCount: 10,
+format: 'rg16uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let textureView29 = texture11.createView(
+{
+label: '\u{1fe33}\u012b\u45ba\u7013\u033a',
+baseMipLevel: 2,
+mipLevelCount: 2,
+}
+);
+try {
+computePassEncoder18.setBindGroup(
+8,
+bindGroup8
+);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(
+4,
+buffer2
+);
+} catch {}
+let gpuCanvasContext5 = offscreenCanvas2.getContext('webgpu');
+let commandEncoder29 = device0.createCommandEncoder();
+let texture31 = device0.createTexture(
+{
+label: '\u9a5b\u{1fecf}\u{1ff00}\uf7e3',
+size: [76, 1, 163],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let renderPassEncoder4 = commandEncoder10.beginRenderPass(
+{
+label: '\u010f\u0241\u{1fad8}\ud299\u{1ff6f}\u0edb\u3b2e\u0d19\uc488\uc983\u{1fee4}',
+colorAttachments: [
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView20,
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet10,
+maxDrawCount: 47400,
+}
+);
+let sampler17 = device0.createSampler(
+{
+label: '\u254f\u0019\u103e\u{1f67f}\u836e',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 83.810,
+lodMaxClamp: 99.003,
+}
+);
+try {
+renderPassEncoder0.setBindGroup(
+7,
+bindGroup12,
+new Uint32Array(6041),
+1749,
+0
+);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(
+2221
+);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(
+57,
+undefined,
+197330434,
+1998466082
+);
+} catch {}
+let promise12 = device0.createComputePipelineAsync(
+{
+label: '\u8677\u9e96\u863d\u0d2d\uca88\u{1f997}\u{1fcef}\u0452\u000f\u2547\u{1f853}',
+layout: 'auto',
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let commandEncoder30 = device0.createCommandEncoder(
+{
+label: '\ucd16\u0bc0\u55ea\u{1f71f}\u0d2e\u01f6\u018b',
+}
+);
+let querySet19 = device0.createQuerySet(
+{
+label: '\u{1feca}\u47c2\u{1faa3}\u{1f92a}\ud411\u62b5',
+type: 'occlusion',
+count: 3841,
+}
+);
+let texture32 = device0.createTexture(
+{
+label: '\u9f4c\ud754\u{1fac6}\ucdbd\ud380',
+size: {width: 5700},
+dimension: '1d',
+format: 'rg16uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg16uint',
+'rg16uint',
+'rg16uint'
+],
+}
+);
+let renderPassEncoder5 = commandEncoder30.beginRenderPass(
+{
+colorAttachments: [
+undefined
+],
+depthStencilAttachment: {
+view: textureView20,
+depthClearValue: -1.1384416560409338,
+depthReadOnly: false,
+stencilClearValue: 55397,
+stencilLoadOp: 'load',
+stencilStoreOp: 'store',
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet8,
+maxDrawCount: 156600,
+}
+);
+let renderBundle19 = renderBundleEncoder13.finish(
+{
+label: '\u{1f940}\u0c5a'
+}
+);
+try {
+computePassEncoder17.setBindGroup(
+3,
+bindGroup4,
+new Uint32Array(9357),
+2118,
+0
+);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(
+1215,
+5,
+90,
+0
+);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(
+4,
+buffer6,
+2016
+);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(
+6,
+buffer10,
+17356
+);
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 8, height: 21, depthOrArrayLayers: 30}
+*/
+{
+  source: canvas1,
+  origin: { x: 21, y: 639 },
+  flipY: false,
+},
+{
+  texture: texture15,
+  mipLevel: 1,
+  origin: { x: 1, y: 9, z: 8 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 7, height: 10, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+adapter2.label = '\u897c\u5573\ubff9\u3f7a\ubec0\ufb94';
+} catch {}
+let bindGroup13 = device0.createBindGroup({
+label: '\u0064\u0a63\u{1f70b}\uf2de\u{1f996}\u0c44',
+layout: bindGroupLayout4,
+entries: [
+{
+binding: 4207,
+resource: sampler2
+}
+],
+});
+let commandBuffer4 = commandEncoder15.finish(
+{
+label: '\ub4ac\u0ce7\u1de8\ud0d0\u0577\uabab',
+}
+);
+let renderPassEncoder6 = commandEncoder26.beginRenderPass(
+{
+label: '\u{1fabc}\u725b\u797d\u3d78\u09c4\ua5aa\u4211\ua7f2\u{1fdc7}',
+colorAttachments: [
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView20,
+depthClearValue: 6.191147699242283,
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet17,
+maxDrawCount: 24944,
+}
+);
+let renderBundle20 = renderBundleEncoder18.finish(
+{
+
+}
+);
+try {
+renderPassEncoder3.setBindGroup(
+1,
+bindGroup13,
+[]
+);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(
+12137,
+7,
+1184,
+5
+);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(
+4,
+buffer10
+);
+} catch {}
+try {
+commandEncoder29.clearBuffer(
+buffer7,
+5796,
+13712
+);
+dissociateBuffer(device0, buffer7);
+} catch {}
+let promise14 = device0.createComputePipelineAsync(
+{
+label: '\u{1f74f}\u08b6\u6e79\u2936\u0fcc\ub324\u40d3\u{1fcc7}',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let bindGroup14 = device0.createBindGroup({
+layout: bindGroupLayout4,
+entries: [
+{
+binding: 4207,
+resource: sampler3
+}
+],
+});
+let querySet20 = device0.createQuerySet(
+{
+label: '\u{1f98a}\ub286\u0779\u0a2f\udd5d\uefd5',
+type: 'occlusion',
+count: 3168,
+}
+);
+try {
+renderPassEncoder0.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant(
+{
+r: -194.8,
+g: 678.2,
+b: 174.3,
+a: 735.9,
+}
+);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(
+5,
+bindGroup0,
+new Uint32Array(7843),
+1096,
+0
+);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(
+6,
+buffer5,
+16856,
+2616
+);
+} catch {}
+try {
+commandEncoder29.copyBufferToBuffer(
+buffer2,
+14240,
+buffer4,
+39472,
+388
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder28.clearBuffer(
+buffer7,
+9912,
+3596
+);
+dissociateBuffer(device0, buffer7);
+} catch {}
+let promise15 = device0.queue.onSubmittedWorkDone();
+document.body.prepend('\uf01e\u8944\uea26\u07de\ub51e');
+let shaderModule8 = device0.createShaderModule(
+{
+code: `
+
+@compute @workgroup_size(3, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: i32,
+@location(1) f1: f32,
+@location(2) f2: f32,
+@location(3) f3: u32,
+@location(7) f4: vec4<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S11 {
+@builtin(instance_index) f0: u32,
+@location(8) f1: vec4<u32>,
+@location(1) f2: vec3<f32>,
+@location(26) f3: vec4<f32>,
+@location(16) f4: f16,
+@location(24) f5: vec4<f32>,
+@location(12) f6: vec3<f16>,
+@location(5) f7: vec4<f32>,
+@location(14) f8: vec2<f16>,
+@location(15) f9: vec3<i32>,
+@location(2) f10: vec3<f32>,
+@location(3) f11: vec4<f32>,
+@location(18) f12: vec4<f16>,
+@location(11) f13: vec3<u32>,
+@location(10) f14: i32,
+@builtin(vertex_index) f15: u32,
+@location(21) f16: f32
+}
+
+@vertex
+fn vertex0(@location(7) a0: i32, @location(17) a1: vec4<f16>, a2: S11, @location(23) a3: f32, @location(19) a4: vec2<u32>, @location(4) a5: vec3<i32>, @location(25) a6: f32, @location(13) a7: f32, @location(0) a8: vec3<u32>, @location(9) a9: vec2<f16>, @location(22) a10: vec4<u32>, @location(6) a11: f32, @location(20) a12: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let textureView30 = texture4.createView(
+{
+label: '\uf8ba\udcce\u0fde\u5cb3\u{1ffc9}\u029a\ucb35\u{1f7bc}\u0627',
+dimension: '2d',
+baseMipLevel: 1,
+baseArrayLayer: 20,
+}
+);
+try {
+renderPassEncoder4.setBindGroup(
+9,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(
+48
+);
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant(
+{
+r: 736.9,
+g: -863.6,
+b: -669.7,
+a: 415.3,
+}
+);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(
+buffer8,
+'uint32',
+17252,
+2686
+);
+} catch {}
+try {
+commandEncoder28.clearBuffer(
+buffer9,
+1044,
+3288
+);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+22076,
+new Int16Array(62986),
+8129,
+584
+);
+} catch {}
+let promise16 = device0.createComputePipelineAsync(
+{
+layout: pipelineLayout2,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+},
+}
+);
+video1.width = 121;
+let imageData4 = new ImageData(76, 152);
+let shaderModule9 = device0.createShaderModule(
+{
+label: '\u66ba\u{1f70b}\u{1fd8c}\u{1f8e4}',
+code: `@group(6) @binding(4207)
+var<storage, read_write> i0: array<u32>;
+
+@compute @workgroup_size(2, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S12 {
+@location(45) f0: vec2<u32>,
+@location(93) f1: vec3<i32>,
+@location(36) f2: vec4<i32>,
+@location(105) f3: f32,
+@location(108) f4: vec4<f16>,
+@location(30) f5: u32,
+@location(23) f6: i32,
+@location(94) f7: vec3<u32>,
+@location(32) f8: vec2<i32>,
+@location(13) f9: vec3<i32>,
+@location(18) f10: vec2<f16>,
+@location(100) f11: i32,
+@location(7) f12: vec3<i32>,
+@location(54) f13: u32,
+@location(27) f14: vec3<u32>,
+@builtin(front_facing) f15: bool,
+@location(8) f16: vec3<i32>,
+@location(5) f17: vec3<i32>,
+@location(80) f18: vec3<u32>,
+@location(68) f19: f32,
+@location(1) f20: i32
+}
+struct FragmentOutput0 {
+@location(1) f0: f32,
+@location(4) f1: vec4<f32>,
+@location(0) f2: vec3<i32>,
+@location(6) f3: u32,
+@location(5) f4: vec3<i32>,
+@builtin(sample_mask) f5: u32,
+@location(2) f6: vec2<i32>,
+@location(7) f7: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(72) a0: f32, @location(6) a1: vec4<i32>, @location(83) a2: vec3<u32>, @location(78) a3: i32, @builtin(sample_index) a4: u32, @builtin(sample_mask) a5: u32, @location(98) a6: i32, @location(70) a7: vec2<u32>, @location(62) a8: i32, @location(20) a9: vec4<f32>, @location(66) a10: vec3<u32>, a11: S12, @location(107) a12: i32, @location(49) a13: f16, @location(96) a14: f16, @location(55) a15: vec2<i32>, @location(103) a16: vec3<f16>, @location(11) a17: vec3<u32>, @location(56) a18: f16, @location(85) a19: vec3<f16>, @location(73) a20: vec3<f32>, @location(71) a21: vec4<u32>, @location(10) a22: u32, @location(61) a23: vec2<f16>, @location(86) a24: vec2<f16>, @location(53) a25: vec2<i32>, @location(25) a26: i32, @location(47) a27: i32, @location(101) a28: vec4<f16>, @location(44) a29: u32, @location(84) a30: vec2<f16>, @location(26) a31: i32, @location(110) a32: vec4<i32>, @location(2) a33: vec2<f32>, @builtin(position) a34: vec4<f32>, @location(63) a35: vec4<f16>, @location(57) a36: vec2<i32>, @location(88) a37: vec4<f16>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(68) f136: f32,
+@location(26) f137: i32,
+@location(96) f138: f16,
+@location(53) f139: vec2<i32>,
+@location(84) f140: vec2<f16>,
+@location(85) f141: vec3<f16>,
+@location(54) f142: u32,
+@location(1) f143: i32,
+@location(105) f144: f32,
+@location(44) f145: u32,
+@location(80) f146: vec3<u32>,
+@location(5) f147: vec3<i32>,
+@location(55) f148: vec2<i32>,
+@location(32) f149: vec2<i32>,
+@location(61) f150: vec2<f16>,
+@location(108) f151: vec4<f16>,
+@location(103) f152: vec3<f16>,
+@location(13) f153: vec3<i32>,
+@location(101) f154: vec4<f16>,
+@location(110) f155: vec4<i32>,
+@location(107) f156: i32,
+@location(27) f157: vec3<u32>,
+@location(23) f158: i32,
+@builtin(position) f159: vec4<f32>,
+@location(30) f160: u32,
+@location(25) f161: i32,
+@location(93) f162: vec3<i32>,
+@location(6) f163: vec4<i32>,
+@location(20) f164: vec4<f32>,
+@location(11) f165: vec3<u32>,
+@location(49) f166: f16,
+@location(100) f167: i32,
+@location(66) f168: vec3<u32>,
+@location(45) f169: vec2<u32>,
+@location(2) f170: vec2<f32>,
+@location(72) f171: f32,
+@location(62) f172: i32,
+@location(86) f173: vec2<f16>,
+@location(71) f174: vec4<u32>,
+@location(36) f175: vec4<i32>,
+@location(98) f176: i32,
+@location(63) f177: vec4<f16>,
+@location(47) f178: i32,
+@location(73) f179: vec3<f32>,
+@location(10) f180: u32,
+@location(78) f181: i32,
+@location(83) f182: vec3<u32>,
+@location(8) f183: vec3<i32>,
+@location(94) f184: vec3<u32>,
+@location(70) f185: vec2<u32>,
+@location(56) f186: f16,
+@location(88) f187: vec4<f16>,
+@location(7) f188: vec3<i32>,
+@location(18) f189: vec2<f16>,
+@location(57) f190: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(5) a0: f32, @location(8) a1: u32, @location(25) a2: vec2<i32>, @location(2) a3: vec2<u32>, @location(19) a4: vec4<f16>, @location(6) a5: vec4<f16>, @location(10) a6: f16, @location(1) a7: u32, @location(22) a8: vec2<f16>, @location(18) a9: vec2<u32>, @builtin(vertex_index) a10: u32, @location(20) a11: vec2<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let renderPassEncoder7 = commandEncoder28.beginRenderPass(
+{
+label: '\u0419\u08de\udd75\u66c1\u01ac\u7aa4\u{1fdd9}\uc1e8',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView20,
+stencilClearValue: 37020,
+stencilLoadOp: 'clear',
+stencilStoreOp: 'store',
+},
+occlusionQuerySet: querySet1,
+maxDrawCount: 339576,
+}
+);
+try {
+renderPassEncoder7.setBindGroup(
+4,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+12872.0,
+9.811,
+9.256,
+2.883,
+0.9488,
+0.9654
+);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(
+8,
+bindGroup6
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let arrayBuffer4 = buffer4.getMappedRange(
+22672,
+10276
+);
+let pipeline29 = await device0.createRenderPipelineAsync(
+{
+label: '\u70d5\uc825\u9988',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined
+],
+},
+depthStencil: {
+format: 'stencil8',
+stencilFront: {
+compare: 'always',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+passOp: 'replace',
+},
+stencilReadMask: 2871,
+stencilWriteMask: 2462,
+depthBias: 10,
+depthBiasClamp: 8,
+},
+}
+);
+let querySet21 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 2069,
+}
+);
+let computePassEncoder19 = commandEncoder29.beginComputePass();
+let sampler18 = device0.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 39.649,
+lodMaxClamp: 81.803,
+}
+);
+try {
+renderPassEncoder6.setBindGroup(
+4,
+bindGroup10
+);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(
+8
+);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+13075.2,
+1.005,
+334.3,
+9.686,
+0.9158,
+0.9227
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture14,
+  mipLevel: 6,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+new BigUint64Array(arrayBuffer3),
+/* required buffer size: 14 */{
+offset: 10,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline30 = await device0.createRenderPipelineAsync(
+{
+label: '\u{1fc0f}\ucf71\u0970',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule9,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 3716,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32',
+offset: 3484,
+shaderLocation: 6,
+},
+{
+format: 'sint32',
+offset: 2916,
+shaderLocation: 25,
+},
+{
+format: 'unorm8x4',
+offset: 2896,
+shaderLocation: 5,
+},
+{
+format: 'float32',
+offset: 1344,
+shaderLocation: 20,
+},
+{
+format: 'float16x2',
+offset: 1352,
+shaderLocation: 10,
+},
+{
+format: 'float32x2',
+offset: 552,
+shaderLocation: 22,
+},
+{
+format: 'uint32',
+offset: 2688,
+shaderLocation: 8,
+},
+{
+format: 'uint8x2',
+offset: 2202,
+shaderLocation: 1,
+},
+{
+format: 'snorm16x4',
+offset: 2712,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 10244,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 8488,
+shaderLocation: 2,
+},
+{
+format: 'uint32',
+offset: 4796,
+shaderLocation: 18,
+}
+],
+}
+]
+},
+multisample: {
+mask: 0x2d4df54d,
+},
+fragment: {
+module: shaderModule9,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'one-minus-src',
+dstFactor: 'src'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'src-alpha',
+dstFactor: 'dst'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'r8sint',
+},
+undefined,
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'zero',
+dstFactor: 'one-minus-constant'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rg16float',
+writeMask: GPUColorWrite.ALL,
+},
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r32sint',
+writeMask: 0,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'invert',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 3133,
+stencilWriteMask: 2408,
+depthBias: 21,
+depthBiasSlopeScale: 70,
+depthBiasClamp: 22,
+},
+}
+);
+let texture33 = device0.createTexture(
+{
+label: '\u0d08\u02f3\u{1fd3f}\u0b56\u{1f95f}\u83f3\u02e2\u183f\u033a',
+size: {width: 228, height: 51, depthOrArrayLayers: 1},
+sampleCount: 4,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let textureView31 = texture27.createView(
+{
+label: '\u{1fc88}\u0a8b\ue4ec\u{1fd64}\u0614',
+dimension: '2d-array',
+aspect: 'depth-only',
+baseMipLevel: 8,
+mipLevelCount: 4,
+}
+);
+try {
+computePassEncoder2.end();
+} catch {}
+document.body.append('\u6f7c\u02ef\u2ae0\u0e0a');
+let renderBundle21 = renderBundleEncoder16.finish(
+{
+label: '\u0807\ubc6f\u68c2\u045f\u{1f91e}\u0562\u0f66\u38e8\u7cc8'
+}
+);
+try {
+renderPassEncoder7.setBindGroup(
+10,
+bindGroup7
+);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant(
+{
+r: 285.3,
+g: 937.7,
+b: -806.5,
+a: 12.11,
+}
+);
+} catch {}
+try {
+renderPassEncoder5.setViewport(
+2423.2,
+7.865,
+4051.5,
+3.953,
+0.4628,
+0.7607
+);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline29);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder6.copyTextureToTexture(
+{
+  texture: texture18,
+  mipLevel: 1,
+  origin: { x: 126, y: 0, z: 20 },
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 0,
+  origin: { x: 149, y: 0, z: 43 },
+  aspect: 'all',
+},
+{width: 92, height: 1, depthOrArrayLayers: 28}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer9,
+4556,
+new Int16Array(13891),
+12687,
+256
+);
+} catch {}
+let canvas6 = document.createElement('canvas');
+let commandEncoder31 = device0.createCommandEncoder(
+{
+label: '\u896d\ufed6\u0e3a\u788f\u05b2\u0f3c\u81cb\u8465',
+}
+);
+let renderBundleEncoder21 = device0.createRenderBundleEncoder(
+{
+label: '\u7b86\u{1fe3f}',
+colorFormats: [
+'rgba32uint',
+'rgba8unorm',
+'rgba8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 103,
+}
+);
+try {
+computePassEncoder17.setBindGroup(
+10,
+bindGroup7,
+new Uint32Array(4316),
+1347,
+0
+);
+} catch {}
+try {
+computePassEncoder12.setPipeline(
+pipeline12
+);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(
+7,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(
+4276,
+13,
+1860,
+1
+);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(
+3454
+);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(
+buffer0,
+16488
+);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(
+buffer0,
+27992
+);
+} catch {}
+try {
+computePassEncoder1.pushDebugGroup(
+'\u01f5'
+);
+} catch {}
+try {
+computePassEncoder13.insertDebugMarker(
+'\uf61a'
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 337, height: 1, depthOrArrayLayers: 24}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 2, y: 9 },
+  flipY: false,
+},
+{
+  texture: texture9,
+  mipLevel: 2,
+  origin: { x: 295, y: 1, z: 22 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 12, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise17 = device0.createComputePipelineAsync(
+{
+label: '\u07bd\u821b\u{1fe01}\u0a25\u818b',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+video3.width = 64;
+let pipelineLayout7 = device0.createPipelineLayout(
+{
+label: '\u1f0a\u{1fad0}\ub68c\u{1fd83}\u{1ff78}\u0ec7\ub26f',
+bindGroupLayouts: [
+bindGroupLayout4,
+bindGroupLayout5,
+bindGroupLayout3,
+bindGroupLayout1,
+bindGroupLayout4
+],
+}
+);
+try {
+renderPassEncoder4.setVertexBuffer(
+0,
+buffer5,
+19040,
+87
+);
+} catch {}
+let pipeline31 = await device0.createRenderPipelineAsync(
+{
+label: '\u14b5\u{1fb87}\u02e6\u8ed9\u0ba2\u8810',
+layout: pipelineLayout5,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'invert',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'invert',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 2361,
+stencilWriteMask: 60,
+depthBias: 24,
+depthBiasSlopeScale: 62,
+depthBiasClamp: 32,
+},
+}
+);
+gc();
+let querySet22 = device0.createQuerySet(
+{
+label: '\u6a66\u2874\u4e60\u5ecb\u{1ff2c}\u0e94',
+type: 'occlusion',
+count: 967,
+}
+);
+let textureView32 = texture12.createView(
+{
+label: '\u0075\ue37b\u324d\ubb8e\u{1fa52}\udcbd\uc4f5\u5296\u9ddf',
+dimension: '2d-array',
+aspect: 'all',
+format: 'depth24plus-stencil8',
+baseMipLevel: 3,
+}
+);
+let computePassEncoder20 = commandEncoder31.beginComputePass(
+{
+label: '\u1858\u0483\u06d0\u0834\u26a2\u{1feb6}\u{1f881}\ua375\u{1fd48}'
+}
+);
+let renderPassEncoder8 = commandEncoder6.beginRenderPass(
+{
+label: '\u6ebe\u{1fd9b}\u0e24\u{1f98f}\u0ff3\u0d04\u6d92\u{1fe7a}',
+colorAttachments: [
+undefined
+],
+depthStencilAttachment: {
+view: textureView32,
+depthReadOnly: true,
+stencilLoadOp: 'load',
+stencilStoreOp: 'discard',
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet14,
+maxDrawCount: 119536,
+}
+);
+let renderBundleEncoder22 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'r8unorm',
+'rg8unorm',
+'rg8sint',
+'r32uint',
+'bgra8unorm',
+'r16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 390,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder8.setScissorRect(
+8,
+13,
+6,
+1
+);
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(
+3280
+);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(
+5,
+buffer6,
+812,
+3338
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer0,
+596,
+new DataView(new ArrayBuffer(56193)),
+31940,
+1644
+);
+} catch {}
+let video4 = await videoWithData();
+let texture34 = device0.createTexture(
+{
+size: {width: 5036},
+dimension: '1d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundle22 = renderBundleEncoder4.finish(
+{
+label: '\u85c9\u2203\u0d9b\u0b41\u83e5\uced1'
+}
+);
+try {
+renderPassEncoder0.setViewport(
+3915.7,
+11.04,
+14.27,
+0.3163,
+0.1829,
+0.5259
+);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(
+buffer5,
+'uint32',
+12564
+);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(
+7,
+buffer2,
+38692,
+469
+);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(
+2,
+buffer7
+);
+} catch {}
+let texture35 = device0.createTexture(
+{
+label: '\u0196\u0fa1',
+size: {width: 42, height: 42, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'rgba16sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16sint',
+'rgba16sint'
+],
+}
+);
+let sampler19 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 31.584,
+lodMaxClamp: 87.436,
+}
+);
+try {
+computePassEncoder17.setBindGroup(
+6,
+bindGroup13
+);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(
+4781,
+12,
+8911,
+2
+);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(
+3716
+);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(
+1,
+bindGroup12
+);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(
+5,
+buffer5,
+14028,
+699
+);
+} catch {}
+try {
+querySet7.destroy();
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+let pipeline32 = await device0.createRenderPipelineAsync(
+{
+label: '\u{1f9ec}\ud47c\u5f89',
+layout: pipelineLayout5,
+vertex: {
+module: shaderModule7,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 6616,
+shaderLocation: 6,
+},
+{
+format: 'uint16x2',
+offset: 8752,
+shaderLocation: 18,
+},
+{
+format: 'sint32x3',
+offset: 8060,
+shaderLocation: 4,
+},
+{
+format: 'snorm16x4',
+offset: 4244,
+shaderLocation: 13,
+},
+{
+format: 'snorm8x2',
+offset: 14288,
+shaderLocation: 12,
+},
+{
+format: 'float32x4',
+offset: 10372,
+shaderLocation: 15,
+},
+{
+format: 'uint32x2',
+offset: 2660,
+shaderLocation: 7,
+},
+{
+format: 'sint16x4',
+offset: 9784,
+shaderLocation: 23,
+},
+{
+format: 'float32',
+offset: 9096,
+shaderLocation: 1,
+},
+{
+format: 'float16x2',
+offset: 1116,
+shaderLocation: 19,
+},
+{
+format: 'float16x4',
+offset: 6248,
+shaderLocation: 21,
+},
+{
+format: 'uint16x4',
+offset: 476,
+shaderLocation: 26,
+},
+{
+format: 'sint8x4',
+offset: 12896,
+shaderLocation: 8,
+},
+{
+format: 'float32x3',
+offset: 11332,
+shaderLocation: 25,
+},
+{
+format: 'uint32x2',
+offset: 12848,
+shaderLocation: 22,
+},
+{
+format: 'float32x2',
+offset: 1124,
+shaderLocation: 24,
+},
+{
+format: 'uint32x4',
+offset: 3152,
+shaderLocation: 14,
+},
+{
+format: 'unorm16x2',
+offset: 2268,
+shaderLocation: 10,
+},
+{
+format: 'sint32x2',
+offset: 5360,
+shaderLocation: 20,
+},
+{
+format: 'unorm8x2',
+offset: 16654,
+shaderLocation: 0,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 92,
+shaderLocation: 5,
+},
+{
+format: 'unorm8x4',
+offset: 9680,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x2',
+offset: 3748,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 13488,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 9704,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 7720,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 4440,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 12668,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 164,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 6152,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 5404,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 1528,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 3328,
+attributes: [
+{
+format: 'uint16x2',
+offset: 2588,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'back',
+},
+fragment: {
+module: shaderModule7,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilReadMask: 2013,
+depthBias: 7,
+depthBiasSlopeScale: 22,
+depthBiasClamp: 21,
+},
+}
+);
+gc();
+let renderBundleEncoder23 = device0.createRenderBundleEncoder(
+{
+label: '\u4204\u{1fd7d}\u37c1\u024f\u{1faa2}\u0725',
+colorFormats: [
+'rgb10a2uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 627,
+}
+);
+let renderBundle23 = renderBundleEncoder4.finish(
+{
+label: '\u6fd3\u5734\u0b7e\u0bcd\u{1ff68}\u{1fb93}\u8382\u{1fdd5}\u54a3\u{1f90a}'
+}
+);
+try {
+renderPassEncoder8.executeBundles([
+renderBundle16,
+renderBundle16,
+renderBundle21,
+renderBundle21,
+renderBundle21,
+renderBundle21,
+renderBundle21,
+renderBundle21,
+renderBundle21
+]);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(
+9139,
+12,
+2190,
+1
+);
+} catch {}
+try {
+renderPassEncoder5.draw(
+8,
+48,
+16,
+72
+);
+} catch {}
+try {
+gpuCanvasContext4.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float',
+'r16sint',
+'rgba16float',
+'rg11b10ufloat'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+canvas2.height = 519;
+let bindGroupLayout6 = device0.createBindGroupLayout(
+{
+label: '\u04bb\u027b\u1d37\u{1f960}\ub00c\u{1f614}\u0263\u07a5\u{1feee}',
+entries: [
+
+],
+}
+);
+let querySet23 = device0.createQuerySet(
+{
+label: '\u2177\u{1ff95}\u09da\u107f',
+type: 'occlusion',
+count: 887,
+}
+);
+let texture36 = device0.createTexture(
+{
+label: '\ud14e\u{1fcbd}\u071d',
+size: {width: 257},
+dimension: '1d',
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rg16sint'
+],
+}
+);
+let renderBundleEncoder24 = device0.createRenderBundleEncoder(
+{
+label: '\u09c3\u5eaf\u8c11\u018d\ua98c\u0d40\u2645\uc8a1\u03dc\ud3d7\uc464',
+colorFormats: [
+'r16uint',
+'rg8unorm',
+'rg16float',
+'r8sint',
+'rgba32uint',
+'r32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 760,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder1.setPipeline(
+pipeline13
+);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(
+426,
+6,
+10396,
+6
+);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(
+buffer0,
+44200
+);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(
+buffer8,
+'uint32',
+21224,
+19566
+);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 4, height: 10, depthOrArrayLayers: 30}
+*/
+{
+  source: imageBitmap6,
+  origin: { x: 44, y: 42 },
+  flipY: true,
+},
+{
+  texture: texture15,
+  mipLevel: 2,
+  origin: { x: 1, y: 1, z: 13 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 3, height: 9, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline33 = device0.createComputePipeline(
+{
+label: '\u4d79\u379e\u07c2\u75d3\u7485\u1bed\u{1f79f}\u{1ffb0}\u{1f790}\u0bcc\uab41',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let texture37 = device0.createTexture(
+{
+label: '\u{1f730}\ua3b7\u{1f733}',
+size: [6383],
+dimension: '1d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let textureView33 = texture34.createView(
+{
+label: '\ub11b\u03d1\ub06d\uea40\u{1ff03}\uecec\u04c4',
+}
+);
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(
+8993,
+2,
+3199,
+9
+);
+} catch {}
+let pipeline34 = device0.createRenderPipeline(
+{
+label: '\u0c6f\uf2d3\u027a\u09dd\u{1fd3d}\u{1f995}\u96bc\uc72a\uf33e\u{1f6e0}\u05b5',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule5,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 13528,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x3',
+offset: 8228,
+shaderLocation: 26,
+},
+{
+format: 'snorm16x2',
+offset: 4684,
+shaderLocation: 15,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 4900,
+shaderLocation: 3,
+},
+{
+format: 'unorm16x4',
+offset: 11360,
+shaderLocation: 12,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 4748,
+shaderLocation: 16,
+},
+{
+format: 'uint32x2',
+offset: 7116,
+shaderLocation: 5,
+},
+{
+format: 'float32x3',
+offset: 3400,
+shaderLocation: 10,
+},
+{
+format: 'snorm8x2',
+offset: 3532,
+shaderLocation: 17,
+},
+{
+format: 'uint8x4',
+offset: 4216,
+shaderLocation: 25,
+},
+{
+format: 'float32',
+offset: 864,
+shaderLocation: 21,
+},
+{
+format: 'unorm8x4',
+offset: 11124,
+shaderLocation: 20,
+},
+{
+format: 'float32x2',
+offset: 13512,
+shaderLocation: 8,
+},
+{
+format: 'sint8x2',
+offset: 11508,
+shaderLocation: 7,
+},
+{
+format: 'sint8x2',
+offset: 11522,
+shaderLocation: 19,
+},
+{
+format: 'sint16x2',
+offset: 6492,
+shaderLocation: 24,
+},
+{
+format: 'sint32',
+offset: 9708,
+shaderLocation: 9,
+},
+{
+format: 'uint16x2',
+offset: 6272,
+shaderLocation: 13,
+},
+{
+format: 'float16x4',
+offset: 6360,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 14384,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x2',
+offset: 10074,
+shaderLocation: 22,
+},
+{
+format: 'unorm8x2',
+offset: 11490,
+shaderLocation: 23,
+},
+{
+format: 'uint16x2',
+offset: 12820,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 14784,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 10648,
+shaderLocation: 11,
+},
+{
+format: 'float32',
+offset: 5344,
+shaderLocation: 2,
+},
+{
+format: 'float16x2',
+offset: 9596,
+shaderLocation: 1,
+},
+{
+format: 'snorm8x2',
+offset: 4544,
+shaderLocation: 14,
+},
+{
+format: 'uint16x2',
+offset: 6952,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 8200,
+attributes: [
+
+],
+},
+{
+arrayStride: 9044,
+attributes: [
+{
+format: 'unorm16x2',
+offset: 284,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'back',
+},
+multisample: {
+count: 4,
+mask: 0xcc225c5e,
+},
+fragment: {
+module: shaderModule5,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.RED,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'one-minus-src',
+dstFactor: 'one-minus-src-alpha'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'invert',
+depthFailOp: 'replace',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2462,
+stencilWriteMask: 2396,
+depthBias: 77,
+depthBiasSlopeScale: 56,
+depthBiasClamp: 16,
+},
+}
+);
+document.body.prepend('\u02e8\u0754\u897b\u{1f8a5}\uaa0c\u0c35');
+let bindGroup15 = device0.createBindGroup({
+label: '\u5ed4\u5f01\u6ad8\u79ac\u{1fa1d}\u247f\u0845\u017b',
+layout: bindGroupLayout6,
+entries: [
+
+],
+});
+let pipelineLayout8 = device0.createPipelineLayout(
+{
+label: '\u447d\u5df8\u9495\u0655\uecaa\ubaf9\ue462\ud22e\u0fc1',
+bindGroupLayouts: [
+bindGroupLayout5
+],
+}
+);
+let texture38 = device0.createTexture(
+{
+label: '\u6866\u{1f9b9}\u021d\u0563\uc6f7\u8934\u4740\ubbbd\uee46\u0460',
+size: {width: 1573, height: 1, depthOrArrayLayers: 797},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder25 = device0.createRenderBundleEncoder(
+{
+label: '\u0ea0\u046b\u{1fa11}\ud3ca\u0526\u{1fcf3}',
+colorFormats: [
+'rgba16sint',
+'rgb10a2unorm',
+'r8uint'
+],
+sampleCount: 427,
+}
+);
+let renderBundle24 = renderBundleEncoder21.finish(
+{
+label: '\u05ec\u341e\u1d61\u3ea0'
+}
+);
+try {
+renderPassEncoder4.setBindGroup(
+7,
+bindGroup5
+);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(
+8
+);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(
+24,
+0,
+48
+);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(
+buffer5,
+41576
+);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(
+2,
+buffer2,
+24436,
+1336
+);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(
+10,
+bindGroup14,
+new Uint32Array(6750),
+2989,
+0
+);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(
+buffer8,
+'uint16'
+);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(
+1,
+buffer6,
+956,
+1079
+);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 5, height: 1, depthOrArrayLayers: 19}
+*/
+{
+  source: imageData2,
+  origin: { x: 36, y: 46 },
+  flipY: true,
+},
+{
+  texture: texture7,
+  mipLevel: 3,
+  origin: { x: 1, y: 0, z: 13 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 4, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let textureView34 = texture14.createView(
+{
+label: '\u{1fb22}\u9158\u8c76',
+dimension: '2d-array',
+baseMipLevel: 6,
+mipLevelCount: 1,
+}
+);
+try {
+device0.queue.writeBuffer(
+buffer7,
+10156,
+new BigUint64Array(27657),
+15696,
+448
+);
+} catch {}
+let pipeline35 = await device0.createComputePipelineAsync(
+{
+label: '\u09d3\u0b59\u8c67\u{1fd5d}\u2953\u6337\u01dc\ua9e8\u9ce1\u079a\u1d68',
+layout: pipelineLayout7,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let buffer11 = device0.createBuffer(
+{
+label: '\u5b46\ud8e1\u0731\uc231\uc348\u{1f80a}\u08d2\u0759\ufca5',
+size: 9389,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: false,
+}
+);
+try {
+renderPassEncoder6.setBlendConstant(
+{
+r: 246.5,
+g: 190.7,
+b: -361.5,
+a: -142.4,
+}
+);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(
+buffer2,
+23280
+);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(
+6,
+bindGroup7,
+new Uint32Array(2775),
+810,
+0
+);
+} catch {}
+document.body.append('\uf9a4\u{1fdb2}\u2b59\u{1fbb3}\u4eb2\uecf4\u328c');
+let querySet24 = device0.createQuerySet(
+{
+label: '\udf46\u{1f6b7}\u{1fccd}\u89c7\u0074\u52d0\u479d\u{1f769}',
+type: 'occlusion',
+count: 2661,
+}
+);
+try {
+computePassEncoder16.setBindGroup(
+9,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(
+buffer8,
+'uint16',
+23052,
+12600
+);
+} catch {}
+try {
+buffer11.destroy();
+} catch {}
+try {
+computePassEncoder1.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 23, height: 3, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 4 },
+  flipY: true,
+},
+{
+  texture: texture21,
+  mipLevel: 1,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 15, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline36 = await device0.createRenderPipelineAsync(
+{
+label: '\u0cef\udb33\u60a3\u7150\u9019\u1c68\u{1fd60}\u{1fe5f}\ubd28\uc078',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule4,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 12540,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32',
+offset: 12512,
+shaderLocation: 0,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 2488,
+shaderLocation: 2,
+},
+{
+format: 'sint16x2',
+offset: 1420,
+shaderLocation: 4,
+},
+{
+format: 'uint32',
+offset: 7400,
+shaderLocation: 23,
+},
+{
+format: 'unorm16x2',
+offset: 12068,
+shaderLocation: 25,
+},
+{
+format: 'float32x2',
+offset: 2628,
+shaderLocation: 16,
+},
+{
+format: 'uint32x2',
+offset: 2388,
+shaderLocation: 7,
+},
+{
+format: 'sint32x3',
+offset: 10484,
+shaderLocation: 15,
+},
+{
+format: 'float32x2',
+offset: 6116,
+shaderLocation: 10,
+},
+{
+format: 'uint8x4',
+offset: 6124,
+shaderLocation: 13,
+},
+{
+format: 'sint16x4',
+offset: 12404,
+shaderLocation: 12,
+},
+{
+format: 'uint8x2',
+offset: 2930,
+shaderLocation: 5,
+},
+{
+format: 'uint8x4',
+offset: 7848,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x4',
+offset: 5348,
+shaderLocation: 18,
+},
+{
+format: 'snorm8x4',
+offset: 3200,
+shaderLocation: 14,
+},
+{
+format: 'uint32x3',
+offset: 2600,
+shaderLocation: 24,
+},
+{
+format: 'unorm8x4',
+offset: 6252,
+shaderLocation: 20,
+},
+{
+format: 'sint32',
+offset: 6472,
+shaderLocation: 1,
+},
+{
+format: 'float32x3',
+offset: 3956,
+shaderLocation: 8,
+},
+{
+format: 'float16x2',
+offset: 7764,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 9656,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 3728,
+shaderLocation: 19,
+},
+{
+format: 'snorm8x4',
+offset: 8548,
+shaderLocation: 9,
+},
+{
+format: 'float16x4',
+offset: 7920,
+shaderLocation: 17,
+},
+{
+format: 'uint8x4',
+offset: 7848,
+shaderLocation: 21,
+},
+{
+format: 'sint32x3',
+offset: 3720,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 16516,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 15580,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x2',
+offset: 1256,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+frontFace: 'cw',
+cullMode: 'front',
+},
+fragment: {
+module: shaderModule4,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+},
+{
+format: 'rg16float',
+writeMask: 0,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'less-equal',
+depthFailOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'zero',
+depthFailOp: 'replace',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 1726,
+stencilWriteMask: 3408,
+depthBiasSlopeScale: 43,
+},
+}
+);
+document.body.append('\u573d\u08a3\u{1fcb3}\u0adc');
+try {
+canvas6.getContext('webgl');
+} catch {}
+let bindGroupLayout7 = device0.createBindGroupLayout(
+{
+label: '\u8531\u0dd0\ub49c\u0927\u0842\u{1fec7}',
+entries: [
+{
+binding: 2503,
+visibility: 0,
+externalTexture: {},
+}
+],
+}
+);
+let bindGroup16 = device0.createBindGroup({
+label: '\uaf7b\u7a32\u0bfe\u556e\u29d8\uf32c\u0b76\u05e1\uf405\u{1f95d}\u769f',
+layout: bindGroupLayout2,
+entries: [
+{
+binding: 4207,
+resource: sampler19
+}
+],
+});
+let pipelineLayout9 = device0.createPipelineLayout(
+{
+label: '\u241c\u{1f812}\udb40\u0ec3\u22ce\u1a6e\u0b99\u07c9\u{1f839}\ub102\u{1f653}',
+bindGroupLayouts: [
+
+],
+}
+);
+let textureView35 = texture12.createView(
+{
+label: '\u0685\u0778\ua2f1',
+aspect: 'depth-only',
+mipLevelCount: 3,
+}
+);
+let sampler20 = device0.createSampler(
+{
+label: '\u07f8\u0eb6\u{1ff69}\uc062',
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 2.882,
+lodMaxClamp: 52.203,
+maxAnisotropy: 17,
+}
+);
+try {
+computePassEncoder14.setPipeline(
+pipeline10
+);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline29);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(
+3,
+buffer6,
+400
+);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(
+3,
+bindGroup9,
+new Uint32Array(7150),
+267,
+0
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture18,
+  mipLevel: 1,
+  origin: { x: 257, y: 0, z: 9 },
+  aspect: 'all',
+},
+new ArrayBuffer(8),
+/* required buffer size: 835656 */{
+offset: 4,
+bytesPerRow: 866,
+rowsPerImage: 241,
+},
+{width: 207, height: 1, depthOrArrayLayers: 5}
+);
+} catch {}
+try {
+await promise13;
+} catch {}
+let imageData5 = new ImageData(20, 144);
+let videoFrame7 = new VideoFrame(img1, {timestamp: 0});
+let bindGroupLayout8 = device0.createBindGroupLayout(
+{
+entries: [
+{
+binding: 651,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+}
+],
+}
+);
+let textureView36 = texture19.createView(
+{
+label: '\uc6c2\u6347\u7121\u5286\ucd48\u0013\u10e9\u8683\ufbbe\u0390\u{1faf9}',
+mipLevelCount: 1,
+}
+);
+try {
+renderPassEncoder5.drawIndexedIndirect(
+buffer10,
+172904
+);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(
+1,
+bindGroup16,
+new Uint32Array(3140),
+2312,
+0
+);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture21,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 274 */{
+offset: 194,
+bytesPerRow: 364,
+},
+{width: 5, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\u{1fce5}\u585d\u{1fbba}\u2462\u{1f618}\u1e66\uf397\u5cc5\u3875');
+let img4 = await imageWithData(265, 161, '#128197de', '#434d26a4');
+let shaderModule10 = device0.createShaderModule(
+{
+label: '\udaf0\u0eca\ue47e\u22fe\u32a3',
+code: `
+
+@compute @workgroup_size(8, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S13 {
+@location(45) f0: vec3<i32>,
+@location(15) f1: vec4<u32>,
+@location(81) f2: f32,
+@location(23) f3: vec2<i32>,
+@location(90) f4: vec2<u32>,
+@location(29) f5: vec3<i32>,
+@location(62) f6: vec2<f32>,
+@location(10) f7: vec2<f16>,
+@location(38) f8: vec2<f32>,
+@location(13) f9: vec3<i32>,
+@location(50) f10: vec2<f32>,
+@location(57) f11: vec3<f16>,
+@location(63) f12: f32,
+@location(102) f13: vec2<i32>,
+@location(99) f14: vec2<f16>,
+@location(109) f15: vec4<i32>,
+@location(74) f16: vec2<i32>,
+@builtin(position) f17: vec4<f32>,
+@location(78) f18: vec2<f32>,
+@location(6) f19: vec2<f32>,
+@location(88) f20: f32,
+@location(55) f21: i32,
+@location(75) f22: vec2<u32>,
+@location(65) f23: vec3<f16>,
+@location(27) f24: vec3<u32>,
+@location(7) f25: f32,
+@location(86) f26: i32,
+@location(71) f27: vec2<u32>,
+@location(108) f28: f32,
+@location(49) f29: vec2<i32>,
+@location(104) f30: vec4<i32>,
+@location(54) f31: vec4<u32>,
+@location(89) f32: f16,
+@location(36) f33: vec2<i32>,
+@location(1) f34: vec4<f32>,
+@location(8) f35: vec3<u32>,
+@location(73) f36: vec2<f16>,
+@location(17) f37: vec4<f32>,
+@location(98) f38: vec4<u32>,
+@location(105) f39: vec2<u32>,
+@location(5) f40: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(58) a0: vec4<u32>, @builtin(front_facing) a1: bool, @builtin(sample_mask) a2: u32, a3: S13, @location(20) a4: vec4<i32>, @location(60) a5: vec2<f32>, @location(85) a6: vec2<f32>, @location(40) a7: f16, @location(76) a8: i32, @location(70) a9: vec4<f32>, @location(9) a10: f16, @builtin(sample_index) a11: u32, @location(25) a12: vec4<f32>, @location(32) a13: vec3<i32>) -> @location(6) vec3<i32> {
+return vec3<i32>();
+}
+
+struct VertexOutput0 {
+@location(25) f191: vec4<f32>,
+@location(15) f192: vec4<u32>,
+@location(86) f193: i32,
+@location(1) f194: vec4<f32>,
+@location(36) f195: vec2<i32>,
+@location(32) f196: vec3<i32>,
+@location(7) f197: f32,
+@location(65) f198: vec3<f16>,
+@location(60) f199: vec2<f32>,
+@location(55) f200: i32,
+@location(81) f201: f32,
+@location(10) f202: vec2<f16>,
+@location(108) f203: f32,
+@location(74) f204: vec2<i32>,
+@location(5) f205: vec3<i32>,
+@location(17) f206: vec4<f32>,
+@location(89) f207: f16,
+@location(8) f208: vec3<u32>,
+@location(62) f209: vec2<f32>,
+@location(90) f210: vec2<u32>,
+@location(104) f211: vec4<i32>,
+@location(6) f212: vec2<f32>,
+@location(71) f213: vec2<u32>,
+@location(70) f214: vec4<f32>,
+@location(27) f215: vec3<u32>,
+@location(88) f216: f32,
+@location(73) f217: vec2<f16>,
+@location(45) f218: vec3<i32>,
+@location(76) f219: i32,
+@location(23) f220: vec2<i32>,
+@location(58) f221: vec4<u32>,
+@location(38) f222: vec2<f32>,
+@location(54) f223: vec4<u32>,
+@location(63) f224: f32,
+@location(78) f225: vec2<f32>,
+@location(105) f226: vec2<u32>,
+@location(29) f227: vec3<i32>,
+@location(85) f228: vec2<f32>,
+@location(98) f229: vec4<u32>,
+@location(102) f230: vec2<i32>,
+@location(13) f231: vec3<i32>,
+@builtin(position) f232: vec4<f32>,
+@location(75) f233: vec2<u32>,
+@location(49) f234: vec2<i32>,
+@location(99) f235: vec2<f16>,
+@location(57) f236: vec3<f16>,
+@location(9) f237: f16,
+@location(40) f238: f16,
+@location(50) f239: vec2<f32>,
+@location(109) f240: vec4<i32>,
+@location(20) f241: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(18) a0: vec4<i32>, @builtin(instance_index) a1: u32, @location(0) a2: vec3<u32>, @location(19) a3: vec2<i32>, @location(13) a4: f16, @location(6) a5: vec4<f32>, @location(1) a6: vec3<u32>, @location(17) a7: vec2<f16>, @location(7) a8: vec4<i32>, @location(2) a9: vec4<f16>, @location(4) a10: vec2<i32>, @location(10) a11: vec4<i32>, @location(9) a12: f32, @location(21) a13: f32, @location(15) a14: vec3<i32>, @location(16) a15: vec3<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+}
+);
+let pipelineLayout10 = device0.createPipelineLayout(
+{
+label: '\u0adc\u0bca\u0b6e\u028b',
+bindGroupLayouts: [
+bindGroupLayout1,
+bindGroupLayout6,
+bindGroupLayout5,
+bindGroupLayout4,
+bindGroupLayout2,
+bindGroupLayout8,
+bindGroupLayout1,
+bindGroupLayout2,
+bindGroupLayout1
+],
+}
+);
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant(
+{
+r: -730.9,
+g: -400.1,
+b: -605.1,
+a: -459.7,
+}
+);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(
+402,
+13,
+5062,
+1
+);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(
+1306
+);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(
+4,
+buffer7,
+11160,
+1974
+);
+} catch {}
+let bindGroupLayout9 = pipeline23.getBindGroupLayout(1);
+let renderBundleEncoder26 = device0.createRenderBundleEncoder(
+{
+label: '\u037f\u{1fec4}\u5ab1\uae88\udb06\u06c0\u4ce1\uc79c',
+colorFormats: [
+'rgba8unorm-srgb',
+undefined,
+'rgba16uint',
+'rg16uint',
+'rg16uint'
+],
+sampleCount: 745,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder5.drawIndexed(
+56,
+48
+);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline29);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(
+2,
+buffer5
+);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(
+9,
+bindGroup14,
+new Uint32Array(9665),
+2628,
+0
+);
+} catch {}
+let pipeline37 = await device0.createComputePipelineAsync(
+{
+label: '\u0c85\u2a5a\u{1f96c}\u4c76\uc6bb\u0005\u0265',
+layout: pipelineLayout8,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+await promise18;
+} catch {}
+try {
+canvas5.getContext('bitmaprenderer');
+} catch {}
+let bindGroupLayout10 = device0.createBindGroupLayout(
+{
+label: '\ufe5c\u9993\u0b75',
+entries: [
+{
+binding: 4989,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+},
+{
+binding: 1012,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '2d' },
+},
+{
+binding: 1890,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+}
+],
+}
+);
+let bindGroup17 = device0.createBindGroup({
+label: '\u05bd\ubb0e\u{1fad8}\u{1fb2e}\uc7be\u0e4a\u0130',
+layout: bindGroupLayout4,
+entries: [
+{
+binding: 4207,
+resource: sampler19
+}
+],
+});
+let textureView37 = texture9.createView(
+{
+label: '\u1b80\u{1f80d}\u91fb\u{1ff0e}\u0cb3\u{1ffb8}\u0c9c\u07ee',
+baseMipLevel: 8,
+baseArrayLayer: 0,
+}
+);
+let sampler21 = device0.createSampler(
+{
+label: '\u{1fb51}\u7423',
+addressModeU: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMaxClamp: 91.896,
+maxAnisotropy: 1,
+}
+);
+try {
+computePassEncoder10.setBindGroup(
+10,
+bindGroup13
+);
+} catch {}
+try {
+computePassEncoder16.setPipeline(
+pipeline17
+);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(
+11031,
+1,
+557,
+10
+);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(
+6,
+buffer5,
+7740
+);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(
+5,
+bindGroup10,
+new Uint32Array(3379),
+662,
+0
+);
+} catch {}
+let promise19 = device0.createComputePipelineAsync(
+{
+label: '\u{1fca1}\u002d\u606b\u002a\u0398\u882f\uf4a8\u{1ff54}\u0169\u3bdf',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule9,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline38 = device0.createRenderPipeline(
+{
+layout: pipelineLayout5,
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 5300,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 4360,
+shaderLocation: 26,
+},
+{
+format: 'uint32x3',
+offset: 2000,
+shaderLocation: 24,
+},
+{
+format: 'sint16x2',
+offset: 4648,
+shaderLocation: 13,
+},
+{
+format: 'unorm16x2',
+offset: 4036,
+shaderLocation: 12,
+},
+{
+format: 'snorm16x2',
+offset: 3608,
+shaderLocation: 22,
+},
+{
+format: 'uint32x3',
+offset: 1240,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x4',
+offset: 1400,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 13544,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x3',
+offset: 11052,
+shaderLocation: 25,
+},
+{
+format: 'float16x4',
+offset: 8556,
+shaderLocation: 16,
+},
+{
+format: 'uint32x3',
+offset: 11156,
+shaderLocation: 2,
+},
+{
+format: 'sint32',
+offset: 13484,
+shaderLocation: 19,
+},
+{
+format: 'float16x4',
+offset: 12392,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x4',
+offset: 7820,
+shaderLocation: 1,
+},
+{
+format: 'uint8x2',
+offset: 3408,
+shaderLocation: 18,
+},
+{
+format: 'snorm16x2',
+offset: 9360,
+shaderLocation: 10,
+},
+{
+format: 'uint8x4',
+offset: 1840,
+shaderLocation: 20,
+},
+{
+format: 'unorm16x2',
+offset: 3672,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 1596,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x4',
+offset: 212,
+shaderLocation: 21,
+},
+{
+format: 'float32',
+offset: 612,
+shaderLocation: 5,
+},
+{
+format: 'sint8x2',
+offset: 1118,
+shaderLocation: 23,
+},
+{
+format: 'uint16x4',
+offset: 1164,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 12220,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x3',
+offset: 652,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 3508,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32',
+offset: 996,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 3484,
+attributes: [
+{
+format: 'snorm8x2',
+offset: 1524,
+shaderLocation: 3,
+},
+{
+format: 'uint16x2',
+offset: 128,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 16120,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 12412,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 9848,
+shaderLocation: 15,
+},
+{
+format: 'float16x4',
+offset: 8288,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+},
+multisample: {
+count: 4,
+mask: 0xe30c9c83,
+},
+fragment: {
+module: shaderModule3,
+entryPoint: 'fragment0',
+targets: [
+
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+compare: 'greater',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'not-equal',
+depthFailOp: 'zero',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 1507,
+depthBias: 61,
+depthBiasSlopeScale: 42,
+depthBiasClamp: 18,
+},
+}
+);
+try {
+renderPassEncoder5.drawIndexed(
+40
+);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(
+6,
+buffer2,
+1764,
+29244
+);
+} catch {}
+let promise20 = buffer3.mapAsync(
+GPUMapMode.WRITE,
+0,
+8468
+);
+let renderBundle25 = renderBundleEncoder15.finish(
+{
+label: '\u{1f8b2}\ue06d\u{1f84b}\u016f\uf7e5\u0a5a\u3844\u6066'
+}
+);
+let sampler22 = device0.createSampler(
+{
+label: '\u2f14\ufd70\u18c7',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 5.325,
+}
+);
+try {
+computePassEncoder12.setBindGroup(
+1,
+bindGroup17
+);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(
+3,
+bindGroup7
+);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(
+40
+);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(
+2837,
+13,
+1662,
+1
+);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(
+16,
+24,
+48,
+-464,
+40
+);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(
+buffer3,
+14408
+);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(
+buffer8,
+'uint16',
+41480
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture12,
+  mipLevel: 3,
+  origin: { x: 0, y: 13, z: 0 },
+  aspect: 'stencil-only',
+},
+arrayBuffer1,
+/* required buffer size: 936 */{
+offset: 921,
+},
+{width: 15, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let video5 = await videoWithData();
+let querySet25 = device0.createQuerySet(
+{
+label: '\u427a\u7758\u{1fb62}\u7739',
+type: 'occlusion',
+count: 3897,
+}
+);
+let renderBundleEncoder27 = device0.createRenderBundleEncoder(
+{
+label: '\u88d2\u7ef3\uce89\u0e0c\ud3cc\u0602\u21c1',
+colorFormats: [
+'rg8uint',
+'r32sint',
+'rg8uint',
+'r16uint',
+'bgra8unorm-srgb'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 970,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(
+7104,
+0,
+1636,
+10
+);
+} catch {}
+try {
+renderPassEncoder5.draw(
+72,
+64,
+72,
+80
+);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(
+buffer0,
+399208
+);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(
+7,
+bindGroup16
+);
+} catch {}
+try {
+renderBundleEncoder14.pushDebugGroup(
+'\ufddf'
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture14,
+  mipLevel: 4,
+  origin: { x: 1, y: 8, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 586 */{
+offset: 570,
+},
+{width: 4, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline39 = await device0.createRenderPipelineAsync(
+{
+label: '\u0800\ude1c\u08ff\u0dac\u0f72\u2a6f\u2ef1\uaaf8\u{1f938}',
+layout: 'auto',
+vertex: {
+module: shaderModule6,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1904,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 972,
+shaderLocation: 21,
+},
+{
+format: 'sint32x2',
+offset: 308,
+shaderLocation: 15,
+},
+{
+format: 'sint16x4',
+offset: 1116,
+shaderLocation: 10,
+},
+{
+format: 'sint32',
+offset: 696,
+shaderLocation: 16,
+},
+{
+format: 'sint16x4',
+offset: 1080,
+shaderLocation: 13,
+},
+{
+format: 'sint8x2',
+offset: 80,
+shaderLocation: 23,
+},
+{
+format: 'float32x2',
+offset: 388,
+shaderLocation: 25,
+}
+],
+},
+{
+arrayStride: 16000,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 3596,
+shaderLocation: 22,
+},
+{
+format: 'unorm16x2',
+offset: 11564,
+shaderLocation: 5,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 8184,
+shaderLocation: 19,
+},
+{
+format: 'sint32x3',
+offset: 2344,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 7124,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32',
+offset: 3240,
+shaderLocation: 18,
+},
+{
+format: 'sint32',
+offset: 1532,
+shaderLocation: 7,
+},
+{
+format: 'snorm8x2',
+offset: 1540,
+shaderLocation: 24,
+},
+{
+format: 'uint8x2',
+offset: 162,
+shaderLocation: 3,
+},
+{
+format: 'float16x4',
+offset: 1748,
+shaderLocation: 11,
+},
+{
+format: 'sint16x2',
+offset: 5164,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 4468,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x4',
+offset: 2236,
+shaderLocation: 12,
+},
+{
+format: 'sint32x2',
+offset: 4124,
+shaderLocation: 26,
+},
+{
+format: 'snorm16x4',
+offset: 2464,
+shaderLocation: 8,
+},
+{
+format: 'uint8x4',
+offset: 1728,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 15476,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 3744,
+shaderLocation: 0,
+},
+{
+format: 'sint32x3',
+offset: 2804,
+shaderLocation: 4,
+},
+{
+format: 'uint32x2',
+offset: 1060,
+shaderLocation: 20,
+},
+{
+format: 'sint32x3',
+offset: 7600,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 3752,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 3540,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 2208,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x4',
+offset: 560,
+shaderLocation: 2,
+},
+{
+format: 'float32x3',
+offset: 1704,
+shaderLocation: 17,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+cullMode: 'front',
+},
+multisample: {
+count: 4,
+mask: 0x73a05efc,
+},
+fragment: {
+module: shaderModule6,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+},
+{
+format: 'r8sint',
+writeMask: 0,
+},
+{
+format: 'rg16float',
+writeMask: GPUColorWrite.BLUE,
+},
+{
+format: 'rg32float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'one-minus-src-alpha',
+dstFactor: 'one-minus-constant'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'one-minus-src',
+dstFactor: 'dst'
+},
+},
+format: 'bgra8unorm',
+writeMask: GPUColorWrite.GREEN,
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 2757,
+stencilWriteMask: 3199,
+depthBias: 5,
+depthBiasSlopeScale: 86,
+depthBiasClamp: 77,
+},
+}
+);
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let commandEncoder32 = device0.createCommandEncoder(
+{
+label: '\u0090\u64e8\u431b\u0e67',
+}
+);
+let querySet26 = device0.createQuerySet(
+{
+label: '\u08fb\uab72\u{1f8c8}\uaef2',
+type: 'occlusion',
+count: 2907,
+}
+);
+let texture39 = gpuCanvasContext1.getCurrentTexture();
+let renderPassEncoder9 = commandEncoder32.beginRenderPass(
+{
+label: '\u{1ff0c}\u0004',
+colorAttachments: [
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView20,
+depthClearValue: -5.144457867814549,
+depthReadOnly: true,
+stencilClearValue: 64588,
+stencilLoadOp: 'load',
+stencilStoreOp: 'store',
+},
+occlusionQuerySet: querySet23,
+maxDrawCount: 38472,
+}
+);
+let renderBundle26 = renderBundleEncoder10.finish(
+{
+label: '\u07e6\u375b\u2716\u0146\uc9b6\u7e98\u{1f699}\u9706\u899f'
+}
+);
+try {
+renderPassEncoder7.setBindGroup(
+0,
+bindGroup7
+);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(
+206,
+2,
+5354,
+3
+);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(
+buffer10,
+17120
+);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(
+buffer6,
+'uint16',
+1400,
+1393
+);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(
+10,
+bindGroup1
+);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(
+3,
+bindGroup8,
+new Uint32Array(827),
+201,
+0
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 4, height: 10, depthOrArrayLayers: 30}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 188, y: 36 },
+  flipY: false,
+},
+{
+  texture: texture15,
+  mipLevel: 2,
+  origin: { x: 1, y: 0, z: 21 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 1, height: 3, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline40 = device0.createRenderPipeline(
+{
+label: '\u{1f89b}\u{1fb97}',
+layout: pipelineLayout9,
+vertex: {
+module: shaderModule4,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 5348,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 2752,
+shaderLocation: 21,
+},
+{
+format: 'float16x2',
+offset: 4772,
+shaderLocation: 20,
+},
+{
+format: 'snorm16x2',
+offset: 4476,
+shaderLocation: 8,
+},
+{
+format: 'uint16x2',
+offset: 5008,
+shaderLocation: 13,
+},
+{
+format: 'sint32x3',
+offset: 3832,
+shaderLocation: 11,
+},
+{
+format: 'uint8x2',
+offset: 2528,
+shaderLocation: 24,
+},
+{
+format: 'float32',
+offset: 4424,
+shaderLocation: 2,
+},
+{
+format: 'uint8x2',
+offset: 3152,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x2',
+offset: 1380,
+shaderLocation: 0,
+},
+{
+format: 'uint32',
+offset: 4132,
+shaderLocation: 23,
+},
+{
+format: 'sint16x2',
+offset: 1512,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x4',
+offset: 2976,
+shaderLocation: 18,
+},
+{
+format: 'float16x4',
+offset: 2372,
+shaderLocation: 6,
+},
+{
+format: 'sint32x3',
+offset: 2316,
+shaderLocation: 15,
+},
+{
+format: 'sint32x2',
+offset: 1392,
+shaderLocation: 22,
+},
+{
+format: 'float32x2',
+offset: 4140,
+shaderLocation: 16,
+},
+{
+format: 'unorm8x4',
+offset: 2904,
+shaderLocation: 10,
+},
+{
+format: 'unorm8x2',
+offset: 2432,
+shaderLocation: 19,
+},
+{
+format: 'uint16x4',
+offset: 3120,
+shaderLocation: 5,
+},
+{
+format: 'unorm8x4',
+offset: 1288,
+shaderLocation: 17,
+},
+{
+format: 'sint16x2',
+offset: 2368,
+shaderLocation: 1,
+},
+{
+format: 'uint32',
+offset: 4812,
+shaderLocation: 3,
+},
+{
+format: 'unorm16x2',
+offset: 3360,
+shaderLocation: 25,
+},
+{
+format: 'float32x2',
+offset: 2052,
+shaderLocation: 14,
+},
+{
+format: 'sint16x2',
+offset: 2972,
+shaderLocation: 12,
+},
+{
+format: 'unorm16x4',
+offset: 688,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+},
+multisample: {
+mask: 0xa6bbbe0,
+},
+fragment: {
+module: shaderModule4,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'less',
+failOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilWriteMask: 3265,
+depthBias: 72,
+depthBiasSlopeScale: 44,
+depthBiasClamp: 27,
+},
+}
+);
+let imageBitmap9 = await createImageBitmap(imageData0);
+let bindGroup18 = device0.createBindGroup({
+label: '\ub807\u7483\u0d9a\uaf30\u5d74\uf33c\u99dd\u9ba3',
+layout: bindGroupLayout6,
+entries: [
+
+],
+});
+let querySet27 = device0.createQuerySet(
+{
+label: '\u{1f739}\u05e7',
+type: 'occlusion',
+count: 3223,
+}
+);
+let texture40 = device0.createTexture(
+{
+label: '\u{1f6b2}\ud144\u90c0\ud9b0\ucf2e\u4401\u08b2\uee05\ucebf\u0cd3',
+size: [139, 1, 252],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'r16sint'
+],
+}
+);
+let texture41 = gpuCanvasContext2.getCurrentTexture();
+let sampler23 = device0.createSampler(
+{
+label: '\u0e20\u222f\u{1f65f}\u470f\u4af4\u5dd3\u0ecb\u{1f91e}\u0a25\u04c8\uc905',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 99.201,
+compare: 'less-equal',
+maxAnisotropy: 18,
+}
+);
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant(
+{
+r: 161.0,
+g: 854.2,
+b: 248.5,
+a: -953.3,
+}
+);
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+13382.6,
+6.905,
+269.1,
+5.432,
+0.6031,
+0.8431
+);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(
+48,
+32,
+72
+);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(
+buffer8,
+'uint16',
+37402,
+13137
+);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(
+5,
+buffer9,
+21772,
+491
+);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(
+4,
+bindGroup8,
+new Uint32Array(2819),
+1156,
+0
+);
+} catch {}
+try {
+await buffer4.mapAsync(
+GPUMapMode.READ,
+0,
+26184
+);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+let querySet28 = device0.createQuerySet(
+{
+label: '\u72cf\ue62f',
+type: 'occlusion',
+count: 2722,
+}
+);
+let texture42 = device0.createTexture(
+{
+label: '\u322c\u{1fbc8}\u{1f768}\u{1fd7d}\ua65b\u48db\u{1fbbb}\ubcba\u3a56',
+size: [13043, 57, 160],
+mipLevelCount: 12,
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8snorm'
+],
+}
+);
+try {
+computePassEncoder20.setBindGroup(
+2,
+bindGroup9,
+new Uint32Array(2362),
+1866,
+0
+);
+} catch {}
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(
+10,
+bindGroup5
+);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(
+7,
+bindGroup16,
+new Uint32Array(9514),
+506,
+0
+);
+} catch {}
+try {
+renderPassEncoder9.setViewport(
+3524.2,
+3.284,
+1597.5,
+4.123,
+0.3864,
+0.9590
+);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(
+1,
+bindGroup4
+);
+} catch {}
+try {
+buffer7.destroy();
+} catch {}
+try {
+commandEncoder14.copyBufferToBuffer(
+buffer3,
+18836,
+buffer9,
+12044,
+2212
+);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.destroy();
+} catch {}
+let canvas7 = document.createElement('canvas');
+try {
+canvas7.getContext('webgl2');
+} catch {}
+try {
+await promise9;
+} catch {}
+let video6 = await videoWithData();
+try {
+texture38.label = '\u{1fcd7}\u0e68\u0776\u70e5';
+} catch {}
+document.body.prepend('\u{1fae5}\u01ae\u049f\ue378\u0d10\u2353\u02e3\u{1fca4}\u{1f779}\u0505\u0e57');
+canvas1.width = 373;
+let canvas8 = document.createElement('canvas');
+let canvas9 = document.createElement('canvas');
+try {
+window.someLabel = externalTexture0.label;
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(486, 108);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+document.body.prepend(img3);
+try {
+canvas8.getContext('webgl2');
+} catch {}
+gc();
+let gpuCanvasContext6 = canvas9.getContext('webgpu');
+let gpuCanvasContext7 = offscreenCanvas4.getContext('webgpu');
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.append('\u0784\u2662\u8081\u89f5');
+let adapter3 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let img5 = await imageWithData(216, 198, '#72be97aa', '#789b56b8');
+let imageBitmap10 = await createImageBitmap(canvas9);
+offscreenCanvas0.width = 974;
+document.body.append('\u5253\u0fff\u72cb\u5973\udc65\u6bf3\uc8e6\u{1fcd8}\u0fb4\u03d9\ufd2d');
+let img6 = await imageWithData(39, 277, '#64a81fd7', '#b52f7db0');
+document.body.append('\u5972\u6846\u{1f70e}\u{1ff80}\ub98d\u{1f8dd}\uecd0');
+let video7 = await videoWithData();
+try {
+await promise20;
+} catch {}
+document.body.prepend(img3);
+gc();
+try {
+await promise15;
+} catch {}
+document.body.append('\u{1fd65}\uf317\u3c72\u7414\uf0bd\u3a99\u049b\u{1fa44}\u{1f70e}\u326c');
+let imageBitmap11 = await createImageBitmap(imageData0);
+try {
+adapter3.label = '\u1937\uf712\u09a9';
+} catch {}
+document.body.prepend('\u711a\u029b');
+let adapter4 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let imageData6 = new ImageData(156, 128);
+document.body.append('\u{1fb4e}\u0f13\u{1fea0}\u0980\u00d7\ud289');
+document.body.prepend('\ua217\u0016');
+let canvas10 = document.createElement('canvas');
+let gpuCanvasContext8 = canvas10.getContext('webgpu');
+let video8 = await videoWithData();
+let imageData7 = new ImageData(232, 72);
+let imageBitmap12 = await createImageBitmap(video2);
+let imageData8 = new ImageData(204, 172);
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.prepend('\u8ec9\u19e2\u9c36\u086b\u20dc\u0ec4');
+let videoFrame8 = new VideoFrame(imageBitmap4, {timestamp: 0});
+let imageData9 = new ImageData(60, 156);
+offscreenCanvas4.height = 88;
+let canvas11 = document.createElement('canvas');
+document.body.prepend(video1);
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+try {
+canvas11.getContext('webgpu');
+} catch {}
+try {
+window.someLabel = device0.label;
+} catch {}
+document.body.prepend(img3);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+video3.height = 81;
+let pipelineLayout11 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout0,
+bindGroupLayout10,
+bindGroupLayout2,
+bindGroupLayout2,
+bindGroupLayout1
+],
+}
+);
+let renderBundleEncoder28 = device0.createRenderBundleEncoder(
+{
+label: '\u0a1b\ue201\ud12e\ud15b',
+colorFormats: [
+'rg16sint',
+'r16float',
+'rg8uint',
+'r32sint',
+'rgba8unorm-srgb',
+'rgba16sint',
+undefined
+],
+sampleCount: 598,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle27 = renderBundleEncoder19.finish(
+{
+label: '\u{1fe9d}\u0dd2\u{1f994}'
+}
+);
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder8.setViewport(
+8.841,
+13.93,
+2.928,
+0.8493,
+0.5693,
+0.6873
+);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(
+buffer5,
+41448
+);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(
+buffer8,
+'uint16',
+34756,
+3700
+);
+} catch {}
+try {
+device0.pushErrorScope(
+'validation'
+);
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgba16float',
+'rgba16float'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let video9 = await videoWithData();
+video9.height = 119;
+offscreenCanvas2.height = 678;
+gc();
+document.body.append('\u2a6f\u8396\u2df3\u{1fd11}\u4977\uaad0\uf2b4\u0bee');
+let bindGroup19 = device0.createBindGroup({
+label: '\u5bb9\u5cbd\u95f6\u09c7\u0db5\u0479\u7c1d\u8e15\u879b\u40ec',
+layout: bindGroupLayout7,
+entries: [
+{
+binding: 2503,
+resource: externalTexture0
+}
+],
+});
+let renderPassEncoder10 = commandEncoder14.beginRenderPass(
+{
+label: '\u9b48\u36e4\u0a40\u92a3\u083b\ud08d\u8d93\ue127\u96ae\ufc95\ub886',
+colorAttachments: [
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView20,
+depthClearValue: -8.524461534208978,
+depthReadOnly: true,
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet20,
+maxDrawCount: 305160,
+}
+);
+let sampler24 = device0.createSampler(
+{
+label: '\u0908\u01d1\u0591\u10ec\u0bd5\u1951',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 30.032,
+lodMaxClamp: 98.792,
+}
+);
+try {
+computePassEncoder14.setPipeline(
+pipeline18
+);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(
+16
+);
+} catch {}
+try {
+renderPassEncoder5.setViewport(
+11843.5,
+9.466,
+1232.1,
+0.6228,
+0.4518,
+0.9857
+);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(
+6,
+buffer9,
+3016,
+6580
+);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(
+10,
+bindGroup17,
+new Uint32Array(5347),
+4732,
+0
+);
+} catch {}
+video4.height = 243;
+offscreenCanvas2.width = 54;
+document.body.append('\u0481\u{1fb33}\u01e9');
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+gc();
+let video10 = await videoWithData();
+gc();
+document.body.append('\u2ac9\u30fb');
+gc();
+let video11 = await videoWithData();
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+document.body.prepend('\u{1fceb}\uce92\u09f0\u{1f942}\u0568\u106d\u908f\u7465\u{1f6e7}\u7204\u18d3');
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+document.body.append('\ubc84\u092b\u{1fecf}\u0365\u{1f7d8}\u94c1\u0dd2\u75a0');
+let adapter5 = await navigator.gpu.requestAdapter(
+{
+powerPreference: 'low-power',
+}
+);
+let canvas12 = document.createElement('canvas');
+let videoFrame9 = new VideoFrame(video5, {timestamp: 0});
+video10.width = 65;
+document.body.append('\ubbe1\u0596\u026d\uf75b');
+let gpuCanvasContext9 = canvas12.getContext('webgpu');
+document.body.prepend('\u0ccf\u7706\u5b61\ub30b\u{1fc9d}\u4a90\u5e97\u1c0d');
+let imageData10 = new ImageData(160, 176);
+let videoFrame10 = new VideoFrame(videoFrame7, {timestamp: 0});
+document.body.prepend('\u2ef2\ue025\u865e\u01a7\u056e\u267a\ue6bd\u0980');
+let imageBitmap13 = await createImageBitmap(imageData7);
+try {
+textureView27.label = '\u0ed6\u008b\ubd62\u44ac\u05f2';
+} catch {}
+let img7 = await imageWithData(233, 250, '#aa3a56e9', '#2bff401b');
+try {
+externalTexture0.label = '\u9c9a\u3f01';
+} catch {}
+let bindGroup20 = device0.createBindGroup({
+label: '\u6413\ueb78\u2d1a\u8221\u{1f6c0}\u{1f9d6}\u01fd\u57c0\u{1f9c0}\u0aab\u01c3',
+layout: bindGroupLayout7,
+entries: [
+{
+binding: 2503,
+resource: externalTexture1
+}
+],
+});
+let pipelineLayout12 = device0.createPipelineLayout(
+{
+label: '\udb3f\u0167\u{1fe88}\uc2fb\ufddd\u0da9\u088f\u2b49\u{1f65c}',
+bindGroupLayouts: [
+bindGroupLayout4,
+bindGroupLayout5,
+bindGroupLayout1,
+bindGroupLayout1,
+bindGroupLayout3,
+bindGroupLayout10
+],
+}
+);
+let commandEncoder33 = device0.createCommandEncoder(
+{
+label: '\u{1fedd}\u0c1c\u0a75\u{1f82b}\u9961\u{1faae}',
+}
+);
+let renderBundleEncoder29 = device0.createRenderBundleEncoder(
+{
+label: '\u08e7\u1c89\u0676\u{1f727}\u9713',
+colorFormats: [
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 584,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.setStencilReference(
+1446
+);
+} catch {}
+try {
+renderPassEncoder9.setViewport(
+7092.6,
+9.493,
+1492.1,
+1.653,
+0.6560,
+0.6631
+);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(
+buffer6,
+'uint32',
+1728,
+205
+);
+} catch {}
+try {
+commandEncoder33.copyBufferToBuffer(
+buffer2,
+34812,
+buffer9,
+1532,
+76
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer9);
+} catch {}
+let pipeline41 = await promise12;
+let texture43 = device0.createTexture(
+{
+label: '\u2d97\u3b0f\u0000',
+size: {width: 81, height: 1, depthOrArrayLayers: 1611},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+}
+);
+let renderBundle28 = renderBundleEncoder4.finish(
+{
+label: '\u3d75\u{1fa77}\u09e0\u{1fba7}\u03b4\u0b87'
+}
+);
+try {
+renderPassEncoder6.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+renderPassEncoder8.setViewport(
+6.526,
+10.66,
+5.927,
+0.6823,
+0.2123,
+0.2968
+);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(
+6,
+buffer6,
+3356,
+564
+);
+} catch {}
+try {
+commandEncoder33.copyTextureToTexture(
+{
+  texture: texture42,
+  mipLevel: 9,
+  origin: { x: 12, y: 0, z: 60 },
+  aspect: 'all',
+},
+{
+  texture: texture29,
+  mipLevel: 0,
+  origin: { x: 7282, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 4, height: 10, depthOrArrayLayers: 30}
+*/
+{
+  source: video10,
+  origin: { x: 7, y: 0 },
+  flipY: true,
+},
+{
+  texture: texture15,
+  mipLevel: 2,
+  origin: { x: 0, y: 1, z: 21 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 2, height: 6, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline42 = device0.createComputePipeline(
+{
+label: '\ub636\u{1fdaf}\u{1f672}\u0bcc\u87d6\u{1f946}\u0e85\u5020\u46f3\u0b90',
+layout: pipelineLayout8,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.append('\u7444\u{1ff2e}\ua850\u005d\ub69f\ua440\u{1fae1}\udb5f\u656a\uc9f7');
+document.body.prepend('\u5a7b\u{1fa97}\u0773');
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+document.body.append('\u2ba6\u1d5d\u1f6c\uf7ac\u{1f742}');
+let video12 = await videoWithData();
+document.body.prepend(canvas9);
+let texture44 = device0.createTexture(
+{
+label: '\u6226\u4399\u186e\u{1fa41}\u3a18\u54dc\u6b1a\ufabf\u0607\u7c2c',
+size: [9864],
+dimension: '1d',
+format: 'rgba32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+computePassEncoder10.end();
+} catch {}
+try {
+renderPassEncoder5.draw(
+72,
+80,
+48,
+32
+);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(
+buffer5,
+'uint16',
+19762,
+558
+);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(
+buffer5,
+'uint16',
+9912
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer0,
+6384,
+new BigUint64Array(64058),
+1450,
+36
+);
+} catch {}
+let promise21 = device0.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+video10.height = 231;
+try {
+window.someLabel = texture30.label;
+} catch {}
+let video13 = await videoWithData();
+let videoFrame11 = new VideoFrame(video2, {timestamp: 0});
+canvas10.width = 1000;
+let device1 = await adapter3.requestDevice(
+{
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 7,
+maxColorAttachmentBytesPerSample: 33,
+maxVertexAttributes: 25,
+maxVertexBufferArrayStride: 55803,
+maxStorageTexturesPerShaderStage: 22,
+maxStorageBuffersPerShaderStage: 23,
+maxDynamicStorageBuffersPerPipelineLayout: 36755,
+maxBindingsPerBindGroup: 8706,
+maxTextureArrayLayers: 256,
+maxTextureDimension1D: 10029,
+maxTextureDimension2D: 13229,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 103430954,
+maxInterStageShaderVariables: 40,
+maxInterStageShaderComponents: 86,
+},
+}
+);
+let sampler25 = device1.createSampler(
+{
+label: '\u046a\u082e\u0426\u70ec\u64d7\uefb3\u93a8\ufd39',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 96.483,
+lodMaxClamp: 98.065,
+maxAnisotropy: 19,
+}
+);
+let img8 = await imageWithData(100, 187, '#8e9ea9d8', '#4d2db1da');
+let querySet29 = device1.createQuerySet(
+{
+label: '\u9205\u{1f668}\u016a\u0dfc\ud3bb\u{1f73c}',
+type: 'occlusion',
+count: 672,
+}
+);
+let canvas13 = document.createElement('canvas');
+let querySet30 = device1.createQuerySet(
+{
+type: 'occlusion',
+count: 2204,
+}
+);
+let renderBundleEncoder30 = device1.createRenderBundleEncoder(
+{
+label: '\u671e\u{1fbd8}\u0c5a',
+colorFormats: [
+'r32uint',
+undefined,
+'rgba16uint',
+'rgba8sint',
+'rgba8uint',
+'r32sint'
+],
+sampleCount: 836,
+stencilReadOnly: true,
+}
+);
+let renderBundle29 = renderBundleEncoder30.finish(
+{
+label: '\u68f5\u0883'
+}
+);
+let gpuCanvasContext10 = canvas13.getContext('webgpu');
+try {
+await promise21;
+} catch {}
+let renderBundle30 = renderBundleEncoder30.finish(
+{
+
+}
+);
+let sampler26 = device1.createSampler(
+{
+label: '\u04ab\uad6a\u008b\u0aac\ud4ba\u{1fef8}\u413d\u9b14\u057b',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 33.558,
+lodMaxClamp: 40.650,
+compare: 'always',
+}
+);
+let promise22 = adapter3.requestAdapterInfo();
+document.body.append('\u278f\u4dc6');
+document.body.prepend(video8);
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let sampler27 = device1.createSampler(
+{
+label: '\ubcb3\uf199\u77ff\u0e56\u0ca5\ufc6b\u17cd',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 27.656,
+lodMaxClamp: 36.215,
+}
+);
+document.body.append('\u173f\u0f02\u{1fd19}\u0193\ua07d');
+let imageData11 = new ImageData(92, 184);
+document.body.append('\u0778\u5aa0\u010e\u{1fd91}\u{1fecd}\u631e\u5907\u{1f94a}\u5a7d\u{1ffc5}');
+let offscreenCanvas5 = new OffscreenCanvas(919, 254);
+try {
+offscreenCanvas5.getContext('webgpu');
+} catch {}
+document.body.prepend('\u{1ff01}\u{1fd7b}\ufd24\u{1ff47}\u0a8e\ub776\ub94a\u1d68\u1692');
+let device2 = await adapter4.requestDevice(
+{
+label: '\ue731\u{1fe8e}\u{1f629}\u7505\uec0d\u7d74\u{1ff28}\u04ec\u0b39\u{1fd09}\u0c1b',
+requiredLimits: {
+maxBindGroups: 6,
+maxColorAttachmentBytesPerSample: 54,
+maxVertexAttributes: 29,
+maxVertexBufferArrayStride: 16159,
+maxStorageTexturesPerShaderStage: 40,
+maxStorageBuffersPerShaderStage: 18,
+maxDynamicStorageBuffersPerPipelineLayout: 15390,
+maxBindingsPerBindGroup: 4383,
+maxTextureDimension1D: 13704,
+maxTextureDimension2D: 8840,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 207135321,
+maxInterStageShaderVariables: 84,
+maxInterStageShaderComponents: 90,
+},
+}
+);
+let texture45 = device2.createTexture(
+{
+label: '\u{1ffc6}\uf1c6\u6326\u63fb\u{1fa31}\u5cbe\u77f4',
+size: {width: 2527, height: 1, depthOrArrayLayers: 224},
+mipLevelCount: 3,
+format: 'r32float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'r32float',
+'r32float'
+],
+}
+);
+let bindGroupLayout11 = device1.createBindGroupLayout(
+{
+label: '\u4c71\u4781',
+entries: [
+
+],
+}
+);
+let pipelineLayout13 = device1.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout11,
+bindGroupLayout11,
+bindGroupLayout11
+],
+}
+);
+let commandEncoder34 = device1.createCommandEncoder();
+try {
+await promise22;
+} catch {}
+offscreenCanvas5.height = 313;
+let video14 = await videoWithData();
+video7.height = 261;
+let commandEncoder35 = device2.createCommandEncoder(
+{
+label: '\u8db0\ud60a\u5e9a\uff33\u024c\ue3ee\uf17c\u35f6\ucac3\uc8b1\u00cd',
+}
+);
+document.body.prepend(video3);
+document.body.prepend('\ub2a6\u4366\ud64a\u9e1b\ue4fd\ucae9\ud516\u87f1\u01fc\u{1f7e2}\u2ae3');
+canvas4.width = 321;
+document.body.append('\u1c30\u36a2\ua127\u{1f862}\u9613');
+let offscreenCanvas6 = new OffscreenCanvas(166, 769);
+let videoFrame12 = new VideoFrame(videoFrame0, {timestamp: 0});
+let querySet31 = device1.createQuerySet(
+{
+label: '\u93bd\u6b70\u632d\u{1f910}\u0686\ua808\u7cb1',
+type: 'occlusion',
+count: 2346,
+}
+);
+let texture46 = device1.createTexture(
+{
+size: [226, 1, 1449],
+sampleCount: 1,
+dimension: '3d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rgba8uint',
+'rgba8uint',
+'rgba8uint'
+],
+}
+);
+let renderBundle31 = renderBundleEncoder30.finish(
+{
+label: '\u0a0d\u{1f79d}\ue84e\u15c4\u78d0\u7a5f\u{1f72c}\u95b1'
+}
+);
+let externalTexture2 = device1.importExternalTexture(
+{
+source: video8,
+}
+);
+let promise23 = device1.queue.onSubmittedWorkDone();
+let gpuCanvasContext11 = offscreenCanvas6.getContext('webgpu');
+let imageBitmap14 = await createImageBitmap(canvas5);
+let adapter6 = await navigator.gpu.requestAdapter(
+{
+}
+);
+try {
+await promise23;
+} catch {}
+gc();
+document.body.append('\ufa94\u61de\u6551\ua806\u0f31\u{1fdee}\u0639\u5cb9');
+let buffer12 = device2.createBuffer(
+{
+size: 11256,
+usage: GPUBufferUsage.MAP_READ,
+}
+);
+let querySet32 = device2.createQuerySet(
+{
+label: '\u6b34\ubb64',
+type: 'occlusion',
+count: 2160,
+}
+);
+let textureView38 = texture45.createView(
+{
+label: '\u5acd\uc4ae\u095c\ufb8d\u{1fcbd}\uf111\u0144',
+baseMipLevel: 1,
+baseArrayLayer: 3,
+arrayLayerCount: 175,
+}
+);
+let computePassEncoder21 = commandEncoder35.beginComputePass();
+let renderBundleEncoder31 = device2.createRenderBundleEncoder(
+{
+label: '\u{1fe2d}\u0527\u88b8\u0785\u793c\u08de\u3a39',
+colorFormats: [
+undefined
+],
+sampleCount: 935,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+let renderBundle32 = renderBundleEncoder31.finish(
+{
+label: '\u{1f885}\ucb0a\u6f71\u{1f6f3}\u43bd\u6cc8'
+}
+);
+let sampler28 = device2.createSampler(
+{
+label: '\u8230\u{1ff5f}\u0473\u076c\u{1f8c4}\uc492\u0974\u08a2\u06a5\u{1f6d5}\uefbc',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 63.778,
+lodMaxClamp: 68.350,
+maxAnisotropy: 11,
+}
+);
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas7 = new OffscreenCanvas(705, 57);
+let buffer13 = device2.createBuffer(
+{
+label: '\u225a\u8660\u0db0\u{1fa76}\ub7b2\u{1faba}',
+size: 40083,
+usage: GPUBufferUsage.MAP_READ,
+}
+);
+pseudoSubmit(device2, commandEncoder35);
+let renderBundle33 = renderBundleEncoder31.finish();
+let sampler29 = device2.createSampler(
+{
+label: '\u69b9\ucaa9\udd35\u{1ff57}\u0889\u{1f780}\u06dc\ue694\ud50c',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 7.681,
+lodMaxClamp: 17.184,
+maxAnisotropy: 12,
+}
+);
+let commandEncoder36 = device2.createCommandEncoder(
+{
+label: '\u{1ffbf}\u43a8\u{1fd34}',
+}
+);
+try {
+externalTexture2.label = '\u8bbc\u{1fbf9}\u3fcf\uc77a\u996d';
+} catch {}
+let buffer14 = device1.createBuffer(
+{
+label: '\u0324\u85e5\u9492\u78e3\uc847\ubab2\ubebb\u7d5c\u0c45\u76b3\u0b07',
+size: 37227,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let texture47 = device1.createTexture(
+{
+label: '\u03e0\u06e9\u0b55\u06d6\u03cd\u0fc5\u0262\u62ec\u0ca8\ue970\u7aee',
+size: {width: 256, height: 36, depthOrArrayLayers: 41},
+mipLevelCount: 8,
+sampleCount: 1,
+format: 'astc-8x6-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+buffer14.destroy();
+} catch {}
+try {
+commandEncoder34.resolveQuerySet(
+querySet30,
+2148,
+50,
+buffer14,
+24832
+);
+} catch {}
+let img9 = await imageWithData(246, 10, '#6dca0c27', '#ef398725');
+try {
+await adapter1.requestAdapterInfo();
+} catch {}
+let imageBitmap15 = await createImageBitmap(imageData2);
+document.body.prepend('\u0471\u2697');
+let adapter7 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let querySet33 = device0.createQuerySet(
+{
+type: 'occlusion',
+count: 2374,
+}
+);
+let texture48 = device0.createTexture(
+{
+size: {width: 10, height: 12, depthOrArrayLayers: 154},
+dimension: '3d',
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg16sint',
+'rg16sint'
+],
+}
+);
+try {
+computePassEncoder5.setBindGroup(
+3,
+bindGroup3,
+new Uint32Array(4498),
+2219,
+0
+);
+} catch {}
+try {
+commandEncoder33.copyBufferToBuffer(
+buffer2,
+1864,
+buffer4,
+36760,
+1548
+);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder33.copyTextureToTexture(
+{
+  texture: texture28,
+  mipLevel: 2,
+  origin: { x: 1636, y: 6, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 1263, y: 143, z: 0 },
+  aspect: 'all',
+},
+{width: 626, height: 54, depthOrArrayLayers: 0}
+);
+} catch {}
+let promise24 = device0.queue.onSubmittedWorkDone();
+let imageData12 = new ImageData(224, 108);
+let commandEncoder37 = device2.createCommandEncoder();
+let texture49 = device2.createTexture(
+{
+label: '\uf484\u6591\u42c8\u91e2\ud063\u0d98\ucf46\ud83c\u03c2\u3a9e',
+size: [176, 75, 1],
+mipLevelCount: 8,
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let sampler30 = device2.createSampler(
+{
+label: '\uffa3\u92b6\u61a9',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 65.207,
+lodMaxClamp: 89.977,
+compare: 'not-equal',
+maxAnisotropy: 9,
+}
+);
+try {
+adapter7.label = '\u02e5\uba00\u{1fdc5}\u7ea2\u0696';
+} catch {}
+let buffer15 = device2.createBuffer(
+{
+label: '\u599c\u0622\u08b9\u672e\u006f\u0528\u07ba\u9599',
+size: 25327,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+mappedAtCreation: false,
+}
+);
+let querySet34 = device2.createQuerySet(
+{
+label: '\u26e8\u{1fe58}\u{1f956}\uc456\u{1fe3c}',
+type: 'occlusion',
+count: 983,
+}
+);
+let texture50 = device2.createTexture(
+{
+label: '\u{1fd50}\u{1f8dd}\ube9d\ud1cd',
+size: {width: 332, height: 1, depthOrArrayLayers: 80},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView39 = texture50.createView(
+{
+mipLevelCount: 1,
+}
+);
+let renderBundleEncoder32 = device2.createRenderBundleEncoder(
+{
+label: '\ud25b\uea09\ub921\u{1f7f1}\u9d3d\ubcbd\u{1f65a}\u6d1b\u{1f643}\ua13c',
+colorFormats: [
+'rgba8sint',
+'rgba32float'
+],
+sampleCount: 657,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder32.setVertexBuffer(
+8,
+buffer15,
+3048
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+offscreenCanvas7.getContext('webgl');
+} catch {}
+let querySet35 = device1.createQuerySet(
+{
+label: '\uba62\u06ce\u2ebb\ucdca\u09d5\u8c26',
+type: 'occlusion',
+count: 2698,
+}
+);
+let renderBundleEncoder33 = device1.createRenderBundleEncoder(
+{
+label: '\u21d7\u{1fb03}\u{1faf4}\u114b\ud97b',
+colorFormats: [
+undefined
+],
+sampleCount: 845,
+}
+);
+let renderBundle34 = renderBundleEncoder30.finish();
+try {
+renderBundleEncoder33.setVertexBuffer(
+5,
+buffer14
+);
+} catch {}
+let textureView40 = texture49.createView(
+{
+label: '\ub1d2\uabb0\u07b9\ufce9\ude42\u2cbe\u{1fe51}\u0ccb\u{1f8ca}\u3955\u13c8',
+dimension: '2d-array',
+baseMipLevel: 1,
+baseArrayLayer: 0,
+}
+);
+let computePassEncoder22 = commandEncoder36.beginComputePass(
+{
+label: '\u0cf2\u9758\u1823'
+}
+);
+let renderBundleEncoder34 = device2.createRenderBundleEncoder(
+{
+label: '\u654e\ue3ea\u{1f6cc}\u8c2f\u08a0\uc17c\u7c34',
+colorFormats: [
+'r8sint',
+undefined,
+'bgra8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 458,
+depthReadOnly: true,
+}
+);
+let promise25 = device2.popErrorScope();
+let promise26 = buffer12.mapAsync(
+GPUMapMode.READ,
+0,
+8080
+);
+try {
+commandEncoder37.clearBuffer(
+buffer15,
+6184,
+7168
+);
+dissociateBuffer(device2, buffer15);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer15,
+6640,
+new Int16Array(45622),
+1727,
+8340
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 22, height: 9, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData11,
+  origin: { x: 73, y: 6 },
+  flipY: false,
+},
+{
+  texture: texture49,
+  mipLevel: 3,
+  origin: { x: 4, y: 3, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 18, height: 5, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+externalTexture2.label = '\u07be\u785d\u4a7e\u{1f750}\u35b4\u0182\u783b\u{1fbdc}\u45f3';
+} catch {}
+let pipelineLayout14 = device1.createPipelineLayout(
+{
+label: '\u2159\u{1ff73}\u{1fdc2}\u91ec',
+bindGroupLayouts: [
+
+],
+}
+);
+let textureView41 = texture46.createView(
+{
+label: '\u8bdc\u725e\u3afb\u5abf\u0829\u5a8a\u01be\u7f10',
+arrayLayerCount: 1,
+}
+);
+try {
+renderBundleEncoder33.setVertexBuffer(
+4,
+buffer14,
+26556,
+10288
+);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+commandEncoder34.resolveQuerySet(
+querySet35,
+776,
+1760,
+buffer14,
+18176
+);
+} catch {}
+try {
+await promise25;
+} catch {}
+let commandEncoder38 = device1.createCommandEncoder(
+{
+label: '\u0528\u{1fa4c}\u{1fc8a}\u40e4\u081c\u{1fa48}\u16ef',
+}
+);
+let querySet36 = device1.createQuerySet(
+{
+label: '\u{1ff03}\u0b24\u923c\u{1f9f6}\u0de3\uf2be\u072f\u9e7d\u0b46',
+type: 'occlusion',
+count: 347,
+}
+);
+let texture51 = device1.createTexture(
+{
+label: '\ue98a\u0186\ucab4\uac99',
+size: {width: 253, height: 209, depthOrArrayLayers: 1},
+sampleCount: 4,
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb'
+],
+}
+);
+let renderBundleEncoder35 = device1.createRenderBundleEncoder(
+{
+label: '\u0771\uf74d\u04d7\u{1fb4b}\uaa76\u0197\u654d\u{1f92b}\u9f1f\u{1f86e}\u0a18',
+colorFormats: [
+'rgba32sint',
+'rg11b10ufloat',
+'rgba16uint'
+],
+sampleCount: 831,
+}
+);
+try {
+commandEncoder38.copyTextureToTexture(
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 253, height: 209, depthOrArrayLayers: 0}
+);
+} catch {}
+offscreenCanvas1.width = 129;
+let video15 = await videoWithData();
+let computePassEncoder23 = commandEncoder37.beginComputePass(
+{
+label: '\u9539\u{1f683}\ua95e'
+}
+);
+let sampler31 = device2.createSampler(
+{
+label: '\u05da\u{1fbe8}\u06d4',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 75.728,
+lodMaxClamp: 87.308,
+}
+);
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video0,
+  origin: { x: 2, y: 8 },
+  flipY: true,
+},
+{
+  texture: texture49,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+renderBundleEncoder31.label = '\u0708\u{1ff2d}\u6d60\u07bb\u36ec\u{1f633}\u0db0\ude5c\u2694\u{1f707}\u3c5e';
+} catch {}
+let renderBundleEncoder36 = device2.createRenderBundleEncoder(
+{
+label: '\uc19e\uec58\ufa46\udbfd\u484b\u12a3',
+colorFormats: [
+'rgba16sint',
+'rgba32sint',
+'bgra8unorm',
+undefined,
+'r8sint',
+undefined,
+'rgba16float',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 369,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder36.setVertexBuffer(
+8,
+buffer15,
+20620,
+1480
+);
+} catch {}
+canvas2.width = 585;
+let commandEncoder39 = device2.createCommandEncoder(
+{
+label: '\u1087\ua6ac',
+}
+);
+let querySet37 = device2.createQuerySet(
+{
+type: 'occlusion',
+count: 1447,
+}
+);
+let computePassEncoder24 = commandEncoder39.beginComputePass(
+{
+label: '\ud9ca\u745d\u{1fa98}\u{1f872}\u0cad\u46d0'
+}
+);
+let renderBundleEncoder37 = device2.createRenderBundleEncoder(
+{
+label: '\u04b9\u03da\u0b8c\ud834\u8c90',
+colorFormats: [
+'r32uint',
+'rgb10a2unorm',
+'rg32float',
+'rgba32float',
+'r32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 900,
+stencilReadOnly: true,
+}
+);
+try {
+device2.queue.writeBuffer(
+buffer15,
+4768,
+new DataView(new ArrayBuffer(62703)),
+25381,
+7216
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture49,
+  mipLevel: 6,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 98 */{
+offset: 98,
+},
+{width: 2, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await promise26;
+} catch {}
+document.body.prepend('\ufcef\u{1facb}\u{1fc09}\u0b05\u{1fa00}\ue034\u2d53\u0e0d\ufc12');
+let videoFrame13 = new VideoFrame(imageBitmap7, {timestamp: 0});
+try {
+gpuCanvasContext9.configure(
+{
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x6-unorm',
+'rgba16float',
+'rgba16float'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+let promise27 = device1.queue.onSubmittedWorkDone();
+gc();
+gc();
+document.body.prepend('\u869e\u{1fc5c}\u88bc\u0caa\u10d6\u{1fae3}\u{1f785}');
+let commandEncoder40 = device2.createCommandEncoder();
+let textureView42 = texture45.createView(
+{
+label: '\u88c1\u0d3c\u0163\u06f7\u0eda\u{1fc81}\u9e25\u8e20',
+dimension: '2d',
+baseArrayLayer: 75,
+}
+);
+let renderPassEncoder11 = commandEncoder40.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+{
+view: textureView39,
+depthSlice: 43,
+clearValue: {
+r: -451.1,
+g: 862.4,
+b: 431.1,
+a: 826.1,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView39,
+depthSlice: 57,
+clearValue: {
+r: -376.7,
+g: 866.0,
+b: -273.0,
+a: -4.776,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView39,
+depthSlice: 3,
+clearValue: {
+r: 794.8,
+g: 953.7,
+b: 868.8,
+a: 70.82,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView39,
+depthSlice: 67,
+clearValue: {
+r: 302.4,
+g: 412.9,
+b: -854.0,
+a: 789.5,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined,
+{
+view: textureView39,
+depthSlice: 59,
+clearValue: {
+r: 341.0,
+g: -436.1,
+b: -604.8,
+a: -58.62,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined
+],
+occlusionQuerySet: querySet34,
+maxDrawCount: 29192,
+}
+);
+try {
+renderPassEncoder11.beginOcclusionQuery(
+32
+);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+5,
+buffer15,
+22644,
+710
+);
+} catch {}
+try {
+gpuCanvasContext4.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16float',
+'rgba16float',
+'rgba16float'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let offscreenCanvas8 = new OffscreenCanvas(636, 202);
+try {
+offscreenCanvas8.getContext('bitmaprenderer');
+} catch {}
+let bindGroupLayout12 = device1.createBindGroupLayout(
+{
+entries: [
+
+],
+}
+);
+let buffer16 = device1.createBuffer(
+{
+label: '\u0523\u86c6\u0dea',
+size: 41420,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+mappedAtCreation: true,
+}
+);
+let texture52 = device1.createTexture(
+{
+label: '\ua9ef\uf89c\u3fb0\u0a1d\u0b2b\u05c6\u2f55\ue5b7\u9afd\u02d3',
+size: [197, 1, 268],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder25 = commandEncoder34.beginComputePass(
+{
+label: '\u{1f7e8}\u0b72\u53c1\u0e04\u42a7\ue11e'
+}
+);
+let renderBundle35 = renderBundleEncoder35.finish();
+try {
+commandEncoder38.copyBufferToBuffer(
+buffer14,
+20912,
+buffer16,
+26592,
+8352
+);
+dissociateBuffer(device1, buffer14);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture46,
+  mipLevel: 0,
+  origin: { x: 14, y: 0, z: 108 },
+  aspect: 'all',
+},
+new ArrayBuffer(99729280),
+/* required buffer size: 99729280 */{
+offset: 469,
+bytesPerRow: 789,
+rowsPerImage: 273,
+},
+{width: 164, height: 0, depthOrArrayLayers: 464}
+);
+} catch {}
+gc();
+document.body.prepend('\uc261\u{1f625}\ud6a2\u0eed\ua008');
+try {
+renderPassEncoder11.setStencilReference(
+2456
+);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(
+1,
+buffer15,
+24656
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture50,
+  mipLevel: 1,
+  origin: { x: 4, y: 0, z: 11 },
+  aspect: 'all',
+},
+new BigInt64Array(new ArrayBuffer(64)),
+/* required buffer size: 719532 */{
+offset: 304,
+bytesPerRow: 282,
+rowsPerImage: 255,
+},
+{width: 64, height: 1, depthOrArrayLayers: 11}
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 88, height: 37, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap5,
+  origin: { x: 57, y: 100 },
+  flipY: false,
+},
+{
+  texture: texture49,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 88, height: 37, depthOrArrayLayers: 1}
+);
+} catch {}
+let video16 = await videoWithData();
+gc();
+let imageData13 = new ImageData(244, 40);
+let bindGroupLayout13 = device1.createBindGroupLayout(
+{
+label: '\u0d95\u0734\u0bfa\u0d36\u30fe\uf260\u26da\u097a\u5f98\u{1fba0}',
+entries: [
+{
+binding: 5717,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+},
+{
+binding: 8437,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '1d' },
+},
+{
+binding: 7467,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+}
+],
+}
+);
+let renderBundleEncoder38 = device1.createRenderBundleEncoder(
+{
+label: '\u8b89\u5ffc\u00ce',
+colorFormats: [
+'bgra8unorm-srgb',
+'r32sint',
+'rgb10a2unorm',
+'bgra8unorm-srgb'
+],
+sampleCount: 390,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder25.insertDebugMarker(
+'\u0723'
+);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let video17 = await videoWithData();
+let renderBundleEncoder39 = device1.createRenderBundleEncoder(
+{
+label: '\u98ae\u6d65',
+colorFormats: [
+'rg16sint',
+'rg16float',
+'rgba8unorm-srgb',
+'rg11b10ufloat',
+'r32float',
+'r32uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 60,
+depthReadOnly: true,
+}
+);
+let renderBundle36 = renderBundleEncoder39.finish(
+{
+label: '\u5d98\u04bc\u3a25\u0182\u8d75'
+}
+);
+try {
+querySet31.destroy();
+} catch {}
+let commandEncoder41 = device1.createCommandEncoder(
+{
+label: '\u0e8d\ue2ad\u6134\u{1f677}\u{1f78d}\u0f95\uf23b',
+}
+);
+let texture53 = device1.createTexture(
+{
+label: '\u{1f9ae}\u{1f7a6}\u{1f9d2}\u{1fcaf}\u069e\u{1f63c}',
+size: {width: 8040, height: 6, depthOrArrayLayers: 13},
+mipLevelCount: 8,
+sampleCount: 1,
+format: 'astc-10x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x6-unorm',
+'astc-10x6-unorm'
+],
+}
+);
+let sampler32 = device1.createSampler(
+{
+label: '\ua787\uf8f9',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMaxClamp: 88.217,
+}
+);
+try {
+renderBundleEncoder33.setIndexBuffer(
+buffer16,
+'uint16',
+34390,
+6046
+);
+} catch {}
+document.body.append('\u60d0\u6db6\ud95c\u522d\u02a0\u00b3\u07ee\u8405\u04e1\u0663\ue675');
+let imageData14 = new ImageData(212, 204);
+document.body.append('\u4d1b\uc2e4\u5114\u062b\uc2ab\u94ff\u{1fce2}\u82f6\u5ba9\u081e');
+let commandEncoder42 = device2.createCommandEncoder(
+{
+label: '\ud37c\u{1f78a}\u035f\u8cd1\u03a6\u6890\uf6c8',
+}
+);
+let computePassEncoder26 = commandEncoder42.beginComputePass(
+{
+
+}
+);
+let renderBundle37 = renderBundleEncoder34.finish();
+let sampler33 = device2.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 80.483,
+lodMaxClamp: 98.077,
+}
+);
+try {
+renderPassEncoder11.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant(
+{
+r: 93.51,
+g: 459.2,
+b: 901.5,
+a: -342.3,
+}
+);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(
+313,
+1,
+8,
+0
+);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(
+2081
+);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+5,
+buffer15
+);
+} catch {}
+gc();
+let imageData15 = new ImageData(24, 256);
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.executeBundles([]);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture49,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new BigInt64Array(arrayBuffer0),
+/* required buffer size: 67 */{
+offset: 67,
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 44, height: 18, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas2,
+  origin: { x: 341, y: 224 },
+  flipY: true,
+},
+{
+  texture: texture49,
+  mipLevel: 2,
+  origin: { x: 16, y: 2, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 24, height: 10, depthOrArrayLayers: 1}
+);
+} catch {}
+offscreenCanvas6.width = 512;
+try {
+await promise27;
+} catch {}
+document.body.append('\u46ee\ua414\u0a45\uafe1\ub18c');
+let adapter8 = await navigator.gpu.requestAdapter();
+let offscreenCanvas9 = new OffscreenCanvas(953, 804);
+let offscreenCanvas10 = new OffscreenCanvas(678, 907);
+let querySet38 = device2.createQuerySet(
+{
+label: '\u05b1\u{1ffaa}\u7cec\u{1fd1e}\u054c\u0b9b\u72ee\ue3ff',
+type: 'occlusion',
+count: 644,
+}
+);
+let texture54 = device2.createTexture(
+{
+label: '\u{1f607}\uebfb\u0e1c\u{1fce3}\u{1f66f}\ua5a1\u{1f932}\u{1f985}\u035e\u{1f833}',
+size: {width: 12439},
+sampleCount: 1,
+dimension: '1d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder40 = device2.createRenderBundleEncoder(
+{
+label: '\u1427\u1789\u01c9',
+colorFormats: [
+'rg32uint',
+'rg32sint',
+'rg16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 294,
+}
+);
+let sampler34 = device2.createSampler(
+{
+label: '\u{1fe48}\uead0\u193b\u059b',
+addressModeU: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 88.348,
+compare: 'greater',
+}
+);
+try {
+buffer15.unmap();
+} catch {}
+try {
+gpuCanvasContext6.configure(
+{
+device: device2,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+}
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer15,
+21656,
+new BigUint64Array(28354),
+9601,
+192
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 176, height: 75, depthOrArrayLayers: 1}
+*/
+{
+  source: img2,
+  origin: { x: 18, y: 24 },
+  flipY: true,
+},
+{
+  texture: texture49,
+  mipLevel: 0,
+  origin: { x: 110, y: 5, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 62, height: 70, depthOrArrayLayers: 0}
+);
+} catch {}
+let commandBuffer5 = commandEncoder41.finish(
+{
+label: '\u433f\u04f9\uc41e\ua114\ua429\u{1fd8f}',
+}
+);
+let renderBundle38 = renderBundleEncoder30.finish(
+{
+
+}
+);
+try {
+renderBundleEncoder38.setIndexBuffer(
+buffer14,
+'uint32'
+);
+} catch {}
+gc();
+document.body.prepend('\u02fa\u6125\u11e3\u0c1e\u0ceb\u0fc7\u028c\u{1ff7e}\u548c\u{1f7d3}\u7013');
+let buffer17 = device2.createBuffer(
+{
+size: 49030,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+}
+);
+let querySet39 = device2.createQuerySet(
+{
+label: '\u7594\u{1fdaf}\u{1fe7b}\u4989\u0fa2\u9102\u0392',
+type: 'occlusion',
+count: 3853,
+}
+);
+let textureView43 = texture54.createView(
+{
+label: '\u56f7\uf5f4\u{1fd3d}\u{1facc}\uda04\uf498\u0ffd',
+}
+);
+let renderBundle39 = renderBundleEncoder34.finish(
+{
+label: '\u256f\u8e20\u2aa0\uadfb\u{1f9eb}\uaf6d\uc38c\u0d5b\u8fef\u{1f723}'
+}
+);
+try {
+renderPassEncoder11.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant(
+{
+r: -642.4,
+g: 558.6,
+b: -953.5,
+a: 394.3,
+}
+);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(
+3538
+);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+3,
+buffer15,
+22416,
+712
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture50,
+  mipLevel: 1,
+  origin: { x: 58, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Int16Array(arrayBuffer1),
+/* required buffer size: 1024133 */{
+offset: 543,
+bytesPerRow: 351,
+rowsPerImage: 81,
+},
+{width: 37, height: 1, depthOrArrayLayers: 37}
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 166, height: 1, depthOrArrayLayers: 40}
+*/
+{
+  source: imageData4,
+  origin: { x: 37, y: 21 },
+  flipY: false,
+},
+{
+  texture: texture50,
+  mipLevel: 1,
+  origin: { x: 33, y: 0, z: 7 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 35, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let videoFrame14 = new VideoFrame(offscreenCanvas10, {timestamp: 0});
+let commandEncoder43 = device2.createCommandEncoder(
+{
+}
+);
+let texture55 = device2.createTexture(
+{
+label: '\u20f7\u5663\u3a6e',
+size: [189, 193, 105],
+mipLevelCount: 7,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder27 = commandEncoder43.beginComputePass();
+let renderBundleEncoder41 = device2.createRenderBundleEncoder(
+{
+label: '\uce96\u{1fe63}\u01e5\u{1fe99}\u0947\u9820',
+colorFormats: [
+'rg16float',
+'r8uint',
+'rgba32uint',
+'bgra8unorm',
+'rgba32uint',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 430,
+}
+);
+try {
+renderPassEncoder11.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant(
+{
+r: 768.0,
+g: 823.7,
+b: -648.8,
+a: -851.9,
+}
+);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(
+200
+);
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+226.2,
+0.02176,
+96.72,
+0.8889,
+0.2871,
+0.8083
+);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+6,
+buffer15,
+2908
+);
+} catch {}
+try {
+renderBundleEncoder38.setVertexBuffer(
+4,
+buffer14,
+8400
+);
+} catch {}
+try {
+commandEncoder38.copyBufferToBuffer(
+buffer14,
+3120,
+buffer16,
+8728,
+27924
+);
+dissociateBuffer(device1, buffer14);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+commandEncoder38.copyTextureToTexture(
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 0, y: 166, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 0, y: 123, z: 0 },
+  aspect: 'all',
+},
+{width: 253, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let querySet40 = device2.createQuerySet(
+{
+label: '\u{1fdc8}\u0ee6\u7eef',
+type: 'occlusion',
+count: 3467,
+}
+);
+try {
+renderPassEncoder11.end();
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(
+1,
+buffer15,
+16192,
+285
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer17,
+6040,
+new Int16Array(59091),
+41004,
+9784
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 44, height: 18, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+},
+{
+  texture: texture49,
+  mipLevel: 2,
+  origin: { x: 29, y: 5, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 2, height: 13, depthOrArrayLayers: 0}
+);
+} catch {}
+let offscreenCanvas11 = new OffscreenCanvas(850, 743);
+try {
+offscreenCanvas9.getContext('webgl');
+} catch {}
+try {
+offscreenCanvas11.getContext('2d');
+} catch {}
+let promise28 = navigator.gpu.requestAdapter();
+let texture56 = device1.createTexture(
+{
+label: '\u7d2e\u6528\u82c2\ucb2c\u5e1c',
+size: {width: 4646},
+mipLevelCount: 1,
+dimension: '1d',
+format: 'r8sint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'r8sint'
+],
+}
+);
+try {
+commandEncoder38.copyBufferToBuffer(
+buffer14,
+7240,
+buffer16,
+26544,
+13016
+);
+dissociateBuffer(device1, buffer14);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+commandEncoder38.clearBuffer(
+buffer16,
+14364
+);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+commandEncoder38.resolveQuerySet(
+querySet30,
+1126,
+39,
+buffer14,
+18432
+);
+} catch {}
+try {
+device1.queue.submit([
+commandBuffer5,
+]);
+} catch {}
+let gpuCanvasContext12 = offscreenCanvas10.getContext('webgpu');
+try {
+await promise24;
+} catch {}
+document.body.append('\u{1fad6}\ue6b1');
+let device3 = await adapter7.requestDevice(
+{
+label: '\u0bb9\u{1fb7c}\u6d02\u441e\u39c7\u587e\uc14a',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxColorAttachmentBytesPerSample: 35,
+maxVertexAttributes: 17,
+maxVertexBufferArrayStride: 21080,
+maxStorageTexturesPerShaderStage: 26,
+maxStorageBuffersPerShaderStage: 11,
+maxDynamicStorageBuffersPerPipelineLayout: 12369,
+maxBindingsPerBindGroup: 8491,
+maxTextureDimension1D: 13958,
+maxTextureDimension2D: 15804,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 256,
+maxUniformBufferBindingSize: 101869982,
+maxInterStageShaderVariables: 124,
+maxInterStageShaderComponents: 80,
+},
+}
+);
+let textureView44 = texture49.createView(
+{
+label: '\u{1f69f}\u5ccf\u{1f725}\u0311\u0899',
+baseMipLevel: 4,
+}
+);
+try {
+renderBundleEncoder37.setVertexBuffer(
+5,
+buffer15,
+17656,
+2545
+);
+} catch {}
+document.body.append('\u9cb3\u0b5a\u06cd\u{1fbf6}\u53e4');
+let device4 = await adapter6.requestDevice(
+{
+label: '\u4b1b\u5fda\u7861\ucc03',
+requiredLimits: {
+maxBindGroups: 5,
+maxColorAttachmentBytesPerSample: 46,
+maxVertexAttributes: 21,
+maxVertexBufferArrayStride: 2611,
+maxStorageTexturesPerShaderStage: 42,
+maxStorageBuffersPerShaderStage: 34,
+maxDynamicStorageBuffersPerPipelineLayout: 25702,
+maxBindingsPerBindGroup: 6303,
+maxTextureDimension1D: 15725,
+maxTextureDimension2D: 12450,
+maxVertexBuffers: 12,
+minUniformBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 30902782,
+maxInterStageShaderVariables: 31,
+maxInterStageShaderComponents: 62,
+},
+}
+);
+let renderBundleEncoder42 = device2.createRenderBundleEncoder(
+{
+label: '\u{1fa5c}\ue5ad\u05dd\u1e92',
+colorFormats: [
+undefined,
+'rgba8unorm-srgb'
+],
+sampleCount: 859,
+stencilReadOnly: false,
+}
+);
+try {
+device2.queue.writeTexture(
+{
+  texture: texture50,
+  mipLevel: 0,
+  origin: { x: 82, y: 0, z: 7 },
+  aspect: 'all',
+},
+new ArrayBuffer(1048477),
+/* required buffer size: 1048477 */{
+offset: 661,
+bytesPerRow: 594,
+rowsPerImage: 294,
+},
+{width: 176, height: 0, depthOrArrayLayers: 7}
+);
+} catch {}
+let buffer18 = device4.createBuffer(
+{
+label: '\u6409\u295b\ub065\u2a5e',
+size: 28723,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+try {
+await device4.popErrorScope();
+} catch {}
+document.body.append('\uf5be\u0a5f\u{1f876}');
+let imageData16 = new ImageData(124, 196);
+try {
+buffer18.destroy();
+} catch {}
+gc();
+let texture57 = device2.createTexture(
+{
+size: [6854],
+dimension: '1d',
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let textureView45 = texture54.createView(
+{
+label: '\u0a34\u9cc6\u05d7\u0326',
+}
+);
+let renderBundleEncoder43 = device2.createRenderBundleEncoder(
+{
+label: '\u0199\ua779\u0a8c',
+colorFormats: [
+'r32uint',
+undefined,
+'r8uint',
+'rg32uint',
+'rgb10a2uint',
+undefined,
+'r16uint',
+'rgba16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 8,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle40 = renderBundleEncoder40.finish();
+try {
+gpuCanvasContext1.configure(
+{
+device: device2,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+}
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer15,
+20340,
+new DataView(new ArrayBuffer(63126)),
+25150,
+3172
+);
+} catch {}
+let sampler35 = device4.createSampler(
+{
+label: '\u8718\u2b72',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 64.145,
+lodMaxClamp: 96.264,
+}
+);
+let canvas14 = document.createElement('canvas');
+let imageBitmap16 = await createImageBitmap(imageBitmap15);
+let img10 = await imageWithData(139, 190, '#78b62a2d', '#b7b1f4ed');
+try {
+canvas14.getContext('webgpu');
+} catch {}
+let bindGroupLayout14 = device4.createBindGroupLayout(
+{
+entries: [
+{
+binding: 3961,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}
+],
+}
+);
+let renderBundleEncoder44 = device4.createRenderBundleEncoder(
+{
+label: '\ue120\uf0c6\u152b',
+colorFormats: [
+'r8sint',
+'rg16float',
+'rgba16float',
+'rg32uint',
+'r32float'
+],
+sampleCount: 629,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let externalTexture3 = device4.importExternalTexture(
+{
+label: '\u8bf2\u05c9\u0a0f\u0d3c\u0107',
+source: video14,
+colorSpace: 'srgb',
+}
+);
+let bindGroupLayout15 = device1.createBindGroupLayout(
+{
+label: '\u0fc7\u2671\u2485\u07d5\u079d\u5e60\u547a\u0875\u0692\u0dd0\u80e8',
+entries: [
+{
+binding: 1330,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '2d' },
+},
+{
+binding: 8621,
+visibility: 0,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+},
+{
+binding: 4798,
+visibility: 0,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+let commandEncoder44 = device1.createCommandEncoder();
+let computePassEncoder28 = commandEncoder44.beginComputePass();
+let renderBundle41 = renderBundleEncoder35.finish();
+let sampler36 = device1.createSampler(
+{
+label: '\u06a4\u0602\u{1fa3b}\uec0b\u0faa\u62ac\u0bb9\u8b24\u96c3\u0fe3',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 1.693,
+lodMaxClamp: 77.062,
+}
+);
+try {
+commandEncoder38.copyBufferToBuffer(
+buffer14,
+30388,
+buffer16,
+31080,
+1044
+);
+dissociateBuffer(device1, buffer14);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+commandEncoder38.clearBuffer(
+buffer16
+);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture53,
+  mipLevel: 0,
+  origin: { x: 1380, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Float32Array(arrayBuffer0),
+/* required buffer size: 10424397 */{
+offset: 57,
+bytesPerRow: 9985,
+rowsPerImage: 116,
+},
+{width: 6220, height: 0, depthOrArrayLayers: 10}
+);
+} catch {}
+let textureView46 = texture45.createView(
+{
+label: '\u02d9\u0c18\u7f5a\u0608\ub6e4\u8486\u5141\u06e1\u0b31',
+baseMipLevel: 2,
+baseArrayLayer: 127,
+arrayLayerCount: 46,
+}
+);
+let renderBundle42 = renderBundleEncoder42.finish();
+try {
+computePassEncoder27.end();
+} catch {}
+let offscreenCanvas12 = new OffscreenCanvas(490, 84);
+let video18 = await videoWithData();
+let bindGroupLayout16 = device2.createBindGroupLayout(
+{
+label: '\u4786\u25da\u{1ff02}\u3391',
+entries: [
+
+],
+}
+);
+let computePassEncoder29 = commandEncoder43.beginComputePass(
+{
+label: '\ue987\u67db\u{1fe7b}'
+}
+);
+let sampler37 = device2.createSampler(
+{
+label: '\u4909\u0b86\u{1fb39}\u0f59\u{1f915}\u46b8\u050a\u2781\u{1fd24}\u0d0b\u{1f657}',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 88.643,
+lodMaxClamp: 99.347,
+compare: 'not-equal',
+}
+);
+let video19 = await videoWithData();
+let imageBitmap17 = await createImageBitmap(canvas8);
+let texture58 = device1.createTexture(
+{
+size: {width: 85, height: 255, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth24plus',
+'depth24plus',
+'depth24plus'
+],
+}
+);
+let computePassEncoder30 = commandEncoder38.beginComputePass(
+{
+label: '\u0cd5\u{1ff04}\uce31\u96af\ufd8a\u0287\u437b\u03e5\u5ddb'
+}
+);
+try {
+renderBundleEncoder33.setVertexBuffer(
+7,
+buffer14,
+8632,
+24199
+);
+} catch {}
+let arrayBuffer5 = buffer16.getMappedRange(
+17048,
+72
+);
+try {
+device1.queue.writeTexture(
+{
+  texture: texture53,
+  mipLevel: 4,
+  origin: { x: 230, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(48),
+/* required buffer size: 1097893 */{
+offset: 181,
+bytesPerRow: 504,
+rowsPerImage: 198,
+},
+{width: 270, height: 0, depthOrArrayLayers: 12}
+);
+} catch {}
+let promise29 = device1.queue.onSubmittedWorkDone();
+let gpuCanvasContext13 = offscreenCanvas12.getContext('webgpu');
+document.body.append('\uefdb\u0ff2\u0408\ueb97\uf1c3\u93be\u{1fb1d}\u6a1e\u4b63\u05d0\u0a7d');
+try {
+device2.label = '\u57af\u3e3a\u20bb\u{1fefe}\u0306\u{1ff95}\u{1feed}';
+} catch {}
+let bindGroup21 = device2.createBindGroup({
+label: '\ud720\u{1faee}\u5214\u8c14\u9cf2',
+layout: bindGroupLayout16,
+entries: [
+
+],
+});
+let pipelineLayout15 = device2.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout16,
+bindGroupLayout16
+],
+}
+);
+let textureView47 = texture50.createView(
+{
+label: '\u29ab\ua314\u0a2b\u0111\u848b\ufae4\u0be8\u{1fe7e}\u{1fe73}',
+format: 'rg8unorm',
+baseMipLevel: 1,
+}
+);
+try {
+computePassEncoder22.setBindGroup(
+4,
+bindGroup21,
+new Uint32Array(4513),
+4426,
+0
+);
+} catch {}
+try {
+renderBundleEncoder41.setIndexBuffer(
+buffer17,
+'uint32',
+28172,
+466
+);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(
+2,
+buffer15,
+8628,
+15494
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer15,
+8796,
+new DataView(new ArrayBuffer(52774)),
+26588,
+12816
+);
+} catch {}
+let promise30 = navigator.gpu.requestAdapter(
+{
+powerPreference: 'high-performance',
+}
+);
+let texture59 = device4.createTexture(
+{
+label: '\u0ace\u2182\u{1fd55}\u0a0b\u8489\ude1c\u{1f7d0}\uc2a7\u{1f9e8}\u006d\uc924',
+size: [204, 1, 118],
+mipLevelCount: 7,
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb10a2uint',
+'rgb10a2uint',
+'rgb10a2uint'
+],
+}
+);
+let textureView48 = texture59.createView(
+{
+label: '\u9b2d\u7ee6\u3ede\ud837\ub513',
+dimension: '2d',
+baseMipLevel: 1,
+mipLevelCount: 2,
+baseArrayLayer: 111,
+}
+);
+let renderBundle43 = renderBundleEncoder44.finish(
+{
+label: '\u2697\u{1f603}\ua52a\u{1f8a5}\u{1ff1e}\ubaab\u697f\u{1fe73}'
+}
+);
+let sampler38 = device4.createSampler(
+{
+label: '\u{1fa1c}\u090f\u{1fb53}\u0467',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 50.520,
+lodMaxClamp: 87.511,
+maxAnisotropy: 14,
+}
+);
+let querySet41 = device3.createQuerySet(
+{
+type: 'occlusion',
+count: 1219,
+}
+);
+let texture60 = device3.createTexture(
+{
+label: '\u004e\u68ba\u{1fdb6}\u67e8\u0e95\u{1ff02}',
+size: {width: 12422},
+dimension: '1d',
+format: 'rg32float',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let textureView49 = texture60.createView(
+{
+label: '\u83af\u{1f67c}\u{1fce1}\ubd1e\u5a57\u4379',
+dimension: '1d',
+arrayLayerCount: 1,
+}
+);
+let renderBundle44 = renderBundleEncoder38.finish(
+{
+label: '\ue70d\u6322\ufde0\u08ae\u{1ffdd}\u{1f660}\ue50e\ued91\u2661\uba2c'
+}
+);
+let adapter9 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let video20 = await videoWithData();
+gc();
+let buffer19 = device1.createBuffer(
+{
+label: '\u042a\u0adb\u042b',
+size: 41952,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+let querySet42 = device1.createQuerySet(
+{
+label: '\u2c2e\u041d\u761f\u7096\ue59c',
+type: 'occlusion',
+count: 642,
+}
+);
+let texture61 = device1.createTexture(
+{
+label: '\u7716\u{1fcf4}\ue533\u09e7\u0adc\u2759',
+size: [125, 1, 147],
+mipLevelCount: 4,
+sampleCount: 1,
+dimension: '3d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg8snorm',
+'rg8snorm'
+],
+}
+);
+let renderBundle45 = renderBundleEncoder38.finish(
+{
+label: '\u0878\ub57e\u082e\u07f0\u00df\ue29b'
+}
+);
+try {
+renderBundleEncoder33.setVertexBuffer(
+5,
+buffer14,
+1988,
+32861
+);
+} catch {}
+try {
+gpuCanvasContext8.configure(
+{
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8unorm',
+'rg16float'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+gc();
+let querySet43 = device0.createQuerySet(
+{
+label: '\u0d7d\u{1f6db}\u{1f725}\u1bb7',
+type: 'occlusion',
+count: 1623,
+}
+);
+let renderBundle46 = renderBundleEncoder19.finish(
+{
+label: '\u02e4\u{1ffc2}\u9cb3\u{1ffa0}'
+}
+);
+let sampler39 = device0.createSampler(
+{
+label: '\u3878\u0eba\u{1fb73}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 67.843,
+lodMaxClamp: 84.255,
+maxAnisotropy: 5,
+}
+);
+try {
+renderPassEncoder7.setScissorRect(
+5176,
+7,
+7531,
+5
+);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(
+buffer6,
+'uint16',
+694,
+798
+);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(
+2,
+buffer2,
+5076,
+20095
+);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(
+1,
+buffer9,
+1748,
+11878
+);
+} catch {}
+try {
+commandEncoder33.copyTextureToBuffer(
+{
+  texture: texture14,
+  mipLevel: 4,
+  origin: { x: 2, y: 4, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 12220 */
+offset: 11192,
+bytesPerRow: 256,
+buffer: buffer9,
+},
+{width: 1, height: 5, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer9,
+15184,
+new Float32Array(30954),
+25297,
+796
+);
+} catch {}
+let renderBundle47 = renderBundleEncoder44.finish(
+{
+label: '\u4315\u7bf1\ue235\ub680'
+}
+);
+try {
+device4.queue.writeTexture(
+{
+  texture: texture59,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 24 },
+  aspect: 'all',
+},
+new ArrayBuffer(231120),
+/* required buffer size: 231120 */{
+offset: 459,
+bytesPerRow: 319,
+rowsPerImage: 241,
+},
+{width: 6, height: 1, depthOrArrayLayers: 4}
+);
+} catch {}
+let offscreenCanvas13 = new OffscreenCanvas(341, 104);
+let img11 = await imageWithData(119, 297, '#3e20ec8c', '#5d363f16');
+try {
+offscreenCanvas13.getContext('2d');
+} catch {}
+let buffer20 = device4.createBuffer(
+{
+label: '\ua63c\u881a\u0071',
+size: 8507,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let renderBundleEncoder45 = device4.createRenderBundleEncoder(
+{
+label: '\u0857\uf593\u597e',
+colorFormats: [
+'rgba8uint',
+'rgba32uint'
+],
+sampleCount: 536,
+stencilReadOnly: true,
+}
+);
+let renderBundle48 = renderBundleEncoder44.finish(
+{
+label: '\u{1fe4f}\u5dfc\u{1fa1b}\u0093\u{1fab8}\u0225\u06bb\ue398'
+}
+);
+let adapter10 = await navigator.gpu.requestAdapter(
+{
+powerPreference: 'low-power',
+}
+);
+try {
+window.someLabel = device3.queue.label;
+} catch {}
+try {
+await promise29;
+} catch {}
+document.body.append('\ubd5e\u04ae\u0d05\u{1fac1}\u5883\u0a07\u{1fc88}\u1ac0\u52f9\u6223\u02db');
+let canvas15 = document.createElement('canvas');
+try {
+device2.queue.writeBuffer(
+buffer15,
+4880,
+new Int16Array(12145),
+11166,
+728
+);
+} catch {}
+document.body.prepend('\u005f\u{1f9b1}\ufe5e\u0d68\u175f\u{1ff37}\u8b77\ube52\uf089');
+let renderBundleEncoder46 = device2.createRenderBundleEncoder(
+{
+label: '\u083e\u57e1\u{1fda7}\u0fb1\u{1fce3}',
+colorFormats: [
+'rgba32float',
+undefined,
+'r8unorm',
+'rg8unorm',
+'rgba16sint'
+],
+sampleCount: 340,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let promise31 = buffer13.mapAsync(
+GPUMapMode.READ,
+34032,
+3680
+);
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+document.body.prepend('\u0928\ue241\u{1f623}\u0bc0');
+let offscreenCanvas14 = new OffscreenCanvas(716, 790);
+let bindGroup22 = device0.createBindGroup({
+layout: bindGroupLayout4,
+entries: [
+{
+binding: 4207,
+resource: sampler19
+}
+],
+});
+let sampler40 = device0.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 68.403,
+lodMaxClamp: 75.821,
+maxAnisotropy: 3,
+}
+);
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant(
+{
+r: 686.3,
+g: 186.9,
+b: -833.6,
+a: -114.8,
+}
+);
+} catch {}
+try {
+renderPassEncoder5.setStencilReference(
+404
+);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(
+buffer8,
+232744
+);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(
+buffer8,
+'uint32',
+48604,
+7072
+);
+} catch {}
+try {
+commandEncoder33.copyTextureToBuffer(
+{
+  texture: texture28,
+  mipLevel: 3,
+  origin: { x: 408, y: 17, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 2076 widthInBlocks: 1038 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 13782 */
+offset: 13782,
+bytesPerRow: 2560,
+buffer: buffer1,
+},
+{width: 1038, height: 6, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout17 = device3.createBindGroupLayout(
+{
+label: '\u034f\uf6a9\u16a0\u116c\u0654\u92e1\u9567\u0213\u9418\u{1fd7d}',
+entries: [
+{
+binding: 5955,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '2d-array' },
+}
+],
+}
+);
+let querySet44 = device3.createQuerySet(
+{
+label: '\u02c1\u0562\u9027\u0d5f\u{1fd4b}\u0faa\u{1ff8c}\u099d\u{1fd1d}\u{1f931}',
+type: 'occlusion',
+count: 3412,
+}
+);
+let renderBundleEncoder47 = device3.createRenderBundleEncoder(
+{
+label: '\u0dfa\u{1f65e}',
+colorFormats: [
+'rgba32uint',
+'rg16sint',
+'rg16sint',
+undefined
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 205,
+}
+);
+let renderBundle49 = renderBundleEncoder47.finish(
+{
+label: '\u0ad2\uc6bb\u1ec1\ufa0f\u02a9\ua47d\u015f\u0c1b'
+}
+);
+let img12 = await imageWithData(167, 87, '#8a8048ad', '#ccf5cbd9');
+let bindGroup23 = device1.createBindGroup({
+layout: bindGroupLayout12,
+entries: [
+
+],
+});
+let querySet45 = device1.createQuerySet(
+{
+label: '\u5b1b\u86dc\u02af\u{1fd44}\u3c48',
+type: 'occlusion',
+count: 2565,
+}
+);
+pseudoSubmit(device1, commandEncoder44);
+let texture62 = device1.createTexture(
+{
+label: '\u9f87\uf2c9\u408d\uf559\uaef1\u9bc2\u90a8',
+size: {width: 260, height: 8, depthOrArrayLayers: 49},
+mipLevelCount: 4,
+format: 'astc-10x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+let renderBundle50 = renderBundleEncoder35.finish(
+{
+label: '\u9a69\u10a9\u0658\uc7b4\uc663\uae01\udd2c\u33c1'
+}
+);
+try {
+computePassEncoder25.end();
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(
+3,
+bindGroup23,
+new Uint32Array(4944),
+1005,
+0
+);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(
+6,
+buffer14,
+24072,
+795
+);
+} catch {}
+try {
+await device1.popErrorScope();
+} catch {}
+try {
+commandEncoder34.clearBuffer(
+buffer16,
+1520
+);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+gpuCanvasContext6.configure(
+{
+device: device1,
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 253, height: 209, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame13,
+  origin: { x: 29, y: 121 },
+  flipY: false,
+},
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 0, y: 191, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 253, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let texture63 = device2.createTexture(
+{
+label: '\u{1fa26}\u09e6\u066f\u0a3c\u{1f799}\u7e11\u{1fae8}',
+size: {width: 4492, height: 193, depthOrArrayLayers: 1},
+mipLevelCount: 12,
+sampleCount: 1,
+format: 'r32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32float',
+'r32float'
+],
+}
+);
+let textureView50 = texture49.createView(
+{
+baseMipLevel: 4,
+mipLevelCount: 1,
+}
+);
+try {
+renderBundleEncoder36.setBindGroup(
+2,
+bindGroup21,
+new Uint32Array(6121),
+508,
+0
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture50,
+  mipLevel: 0,
+  origin: { x: 78, y: 0, z: 23 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(arrayBuffer3),
+/* required buffer size: 403762 */{
+offset: 829,
+bytesPerRow: 413,
+rowsPerImage: 39,
+},
+{width: 129, height: 1, depthOrArrayLayers: 26}
+);
+} catch {}
+document.body.prepend('\uf944\u06c6\ud1e6\u0aa2');
+try {
+await promise31;
+} catch {}
+document.body.prepend('\ua4bc\u{1fe97}\ue9fc\u2abb\u{1fcba}');
+let device5 = await adapter8.requestDevice(
+{
+label: '\u{1fac4}\u0759\u6691',
+requiredFeatures: [
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+}
+);
+let videoFrame15 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+let texture64 = device5.createTexture(
+{
+label: '\u022a\u0cf5\u798d\u00aa\u0832\u2587\u89f2\u7157',
+size: {width: 380, height: 1, depthOrArrayLayers: 198},
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let gpuCanvasContext14 = offscreenCanvas14.getContext('webgpu');
+document.body.prepend('\u{1fbfa}\u{1fa7a}');
+let canvas16 = document.createElement('canvas');
+let offscreenCanvas15 = new OffscreenCanvas(576, 426);
+let video21 = await videoWithData();
+try {
+await adapter5.requestAdapterInfo();
+} catch {}
+let bindGroup24 = device4.createBindGroup({
+label: '\u3b47\u5dba\u3ebe\u0e29\ufcc1\u06b9\ue490\ufef0\u0323',
+layout: bindGroupLayout14,
+entries: [
+{
+binding: 3961,
+resource: externalTexture3
+}
+],
+});
+let texture65 = device4.createTexture(
+{
+label: '\u{1f94d}\ua3ed',
+size: [7537, 1, 199],
+mipLevelCount: 4,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+buffer20.destroy();
+} catch {}
+let promise32 = device4.queue.onSubmittedWorkDone();
+document.body.prepend('\u0658\uc017');
+try {
+canvas15.getContext('webgl2');
+} catch {}
+let bindGroup25 = device1.createBindGroup({
+label: '\uacbf\u756c\u06af\u0c46\u0281',
+layout: bindGroupLayout12,
+entries: [
+
+],
+});
+pseudoSubmit(device1, commandEncoder38);
+let promise33 = device1.queue.onSubmittedWorkDone();
+let texture66 = device2.createTexture(
+{
+label: '\ua60d\u0e39\uefa5\ub2e3\u2c09\u{1f850}',
+size: {width: 1455, height: 1, depthOrArrayLayers: 112},
+mipLevelCount: 11,
+dimension: '3d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8uint'
+],
+}
+);
+let externalTexture4 = device2.importExternalTexture(
+{
+source: videoFrame6,
+colorSpace: 'srgb',
+}
+);
+try {
+buffer12.unmap();
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer17,
+36528,
+new BigUint64Array(47229),
+19381,
+1328
+);
+} catch {}
+document.body.prepend('\ua25c\u5315\u0416\u0956\u0f53\u4884');
+let bindGroup26 = device2.createBindGroup({
+label: '\u01fd\u05ec\u04ca\u5a3f\u4148\ub080\u03ae\ud14a\u0db0\uc8e2',
+layout: bindGroupLayout16,
+entries: [
+
+],
+});
+let renderBundle51 = renderBundleEncoder42.finish(
+{
+label: '\u{1fc08}\uea1d\u{1f6d6}\u{1fae8}\u{1ff6b}\ufe0a\u2d48\u0df9'
+}
+);
+try {
+device2.queue.writeTexture(
+{
+  texture: texture66,
+  mipLevel: 2,
+  origin: { x: 223, y: 1, z: 1 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(arrayBuffer1),
+/* required buffer size: 111768 */{
+offset: 228,
+bytesPerRow: 507,
+rowsPerImage: 10,
+},
+{width: 73, height: 0, depthOrArrayLayers: 23}
+);
+} catch {}
+let pipelineLayout16 = device3.createPipelineLayout(
+{
+label: '\u{1fe64}\u4356\u{1feb6}\u41ca\u{1fd28}\u0c8e',
+bindGroupLayouts: [
+
+],
+}
+);
+let commandEncoder45 = device3.createCommandEncoder();
+let img13 = await imageWithData(265, 62, '#757ba462', '#6fb4d9ca');
+let bindGroupLayout18 = device5.createBindGroupLayout(
+{
+label: '\u29ee\u07e0',
+entries: [
+
+],
+}
+);
+let textureView51 = texture64.createView(
+{
+label: '\ud56a\u{1fe8b}\u019c\u900e',
+baseMipLevel: 1,
+mipLevelCount: 3,
+}
+);
+let renderBundleEncoder48 = device5.createRenderBundleEncoder(
+{
+label: '\u{1fe30}\u{1f7e7}\u{1f71e}\u05d1\u3817\uaf19',
+colorFormats: [
+'r16uint',
+'bgra8unorm',
+'bgra8unorm-srgb',
+'rgba16float',
+'r16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 744,
+depthReadOnly: true,
+}
+);
+let device6 = await adapter5.requestDevice(
+{
+label: '\ud6df\ue204\u03a7',
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxColorAttachmentBytesPerSample: 54,
+maxVertexAttributes: 20,
+maxVertexBufferArrayStride: 29079,
+maxStorageTexturesPerShaderStage: 43,
+maxStorageBuffersPerShaderStage: 35,
+maxDynamicStorageBuffersPerPipelineLayout: 29906,
+maxBindingsPerBindGroup: 6611,
+maxTextureDimension1D: 16078,
+maxTextureDimension2D: 10685,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 250620790,
+maxInterStageShaderVariables: 83,
+maxInterStageShaderComponents: 71,
+},
+}
+);
+let sampler41 = device5.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 53.311,
+lodMaxClamp: 79.405,
+}
+);
+document.body.prepend(canvas4);
+let videoFrame16 = new VideoFrame(canvas6, {timestamp: 0});
+let pipelineLayout17 = device4.createPipelineLayout(
+{
+label: '\uee61\u6be6\u711e\u{1ff32}\u0c8a\u{1f956}\u5281\uee36\uae30\u{1fb14}',
+bindGroupLayouts: [
+bindGroupLayout14,
+bindGroupLayout14,
+bindGroupLayout14,
+bindGroupLayout14
+],
+}
+);
+let querySet46 = device4.createQuerySet(
+{
+label: '\u2936\u0924\uc850\u0c7f\u9b59\u0a88\u1adc\u0740\ud9ba\u6063',
+type: 'occlusion',
+count: 748,
+}
+);
+try {
+renderBundleEncoder45.setBindGroup(
+0,
+bindGroup24
+);
+} catch {}
+let device7 = await adapter10.requestDevice(
+{
+label: '\u0d19\u{1fd46}\u06bc\u0775\u02ab\u44fd',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 40,
+maxVertexAttributes: 27,
+maxVertexBufferArrayStride: 20117,
+maxStorageTexturesPerShaderStage: 30,
+maxStorageBuffersPerShaderStage: 40,
+maxDynamicStorageBuffersPerPipelineLayout: 36053,
+maxBindingsPerBindGroup: 1297,
+maxTextureDimension1D: 16370,
+maxTextureDimension2D: 15595,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 244251184,
+maxInterStageShaderVariables: 70,
+maxInterStageShaderComponents: 89,
+},
+}
+);
+let querySet47 = device2.createQuerySet(
+{
+label: '\u374f\u27f7\u{1f744}\u{1fa12}\u64a4\u8003',
+type: 'occlusion',
+count: 91,
+}
+);
+let texture67 = device2.createTexture(
+{
+label: '\ue43b\u2a4d\ufc35\u{1fa1f}\u0324\u0d37',
+size: [9767],
+dimension: '1d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8snorm',
+'rg8snorm',
+'rg8snorm'
+],
+}
+);
+let renderBundleEncoder49 = device2.createRenderBundleEncoder(
+{
+label: '\u{1f765}\u{1f910}\u0ad4\u03f5',
+colorFormats: [
+'rgb10a2unorm',
+'rg32sint',
+'rg32uint',
+'rg32uint'
+],
+sampleCount: 282,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle52 = renderBundleEncoder32.finish(
+{
+
+}
+);
+try {
+renderBundleEncoder46.setVertexBuffer(
+8,
+buffer15,
+10876,
+2181
+);
+} catch {}
+try {
+gpuCanvasContext8.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer15,
+22724,
+new DataView(new ArrayBuffer(19238)),
+14641,
+760
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 22, height: 9, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 61, y: 71 },
+  flipY: false,
+},
+{
+  texture: texture49,
+  mipLevel: 3,
+  origin: { x: 18, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 4, height: 8, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await promise32;
+} catch {}
+document.body.append('\u024f\u2273\ud931');
+let videoFrame17 = new VideoFrame(img12, {timestamp: 0});
+let querySet48 = device4.createQuerySet(
+{
+label: '\ufa4c\u0af4\u4831\u8ec4\u7028',
+type: 'occlusion',
+count: 2172,
+}
+);
+let textureView52 = texture65.createView(
+{
+label: '\ub710\u0faa\u7e8a',
+dimension: '2d',
+aspect: 'depth-only',
+baseMipLevel: 3,
+baseArrayLayer: 74,
+}
+);
+let renderBundleEncoder50 = device4.createRenderBundleEncoder(
+{
+label: '\u35a0\u{1fd79}\u{1f8cb}\u0532\u{1fb36}\ubc56\u02fb\u7772\u{1f699}',
+colorFormats: [
+'rgba32sint',
+'rg16float',
+'r32float',
+'rgba8sint',
+'r16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 94,
+stencilReadOnly: true,
+}
+);
+let renderBundle53 = renderBundleEncoder50.finish(
+{
+label: '\u{1fee1}\ub972\u0eee\uc773\u0fc7\uafd1\u0dd3\u0d52\u26bc\u00fd'
+}
+);
+try {
+renderBundleEncoder45.setVertexBuffer(
+11,
+buffer18
+);
+} catch {}
+let offscreenCanvas16 = new OffscreenCanvas(172, 612);
+let gpuCanvasContext15 = offscreenCanvas16.getContext('webgpu');
+document.body.prepend(canvas5);
+gc();
+let video22 = await videoWithData();
+let texture68 = device7.createTexture(
+{
+label: '\u0acd\u08b4\u{1f745}\ud399\u1227',
+size: [8119],
+dimension: '1d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder51 = device7.createRenderBundleEncoder(
+{
+label: '\u{1fe71}\u23fd\uc918\u050a\u78c1\u1714\u018f\u27f3\u0b2b\u{1fd27}\u0c22',
+colorFormats: [
+'rgb10a2unorm',
+'rg8uint',
+'rg8sint',
+'rgba8unorm',
+'r32uint',
+'rg16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 740,
+depthReadOnly: true,
+}
+);
+let renderBundle54 = renderBundleEncoder51.finish(
+{
+label: '\u71b7\u6051\u{1f862}\ucf63\ue10a\u6644'
+}
+);
+try {
+device7.queue.writeTexture(
+{
+  texture: texture68,
+  mipLevel: 0,
+  origin: { x: 1973, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer5),
+/* required buffer size: 529 */{
+offset: 529,
+},
+{width: 4052, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let videoFrame18 = new VideoFrame(offscreenCanvas4, {timestamp: 0});
+gc();
+document.body.prepend('\u818e\u{1f851}\u0df9\u3165\u0944');
+let gpuCanvasContext16 = offscreenCanvas15.getContext('webgpu');
+document.body.prepend(canvas6);
+let computePassEncoder31 = commandEncoder34.beginComputePass(
+{
+label: '\ucfca\u{1fdbf}'
+}
+);
+try {
+computePassEncoder31.setBindGroup(
+5,
+bindGroup23,
+new Uint32Array(6784),
+337,
+0
+);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(
+5,
+bindGroup25,
+new Uint32Array(3020),
+2313,
+0
+);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(
+7,
+buffer14,
+24484,
+9563
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture53,
+  mipLevel: 0,
+  origin: { x: 30, y: 6, z: 0 },
+  aspect: 'all',
+},
+new Uint8Array(arrayBuffer4),
+/* required buffer size: 8477719 */{
+offset: 415,
+bytesPerRow: 3586,
+rowsPerImage: 197,
+},
+{width: 2170, height: 0, depthOrArrayLayers: 13}
+);
+} catch {}
+let gpuCanvasContext17 = canvas16.getContext('webgpu');
+document.body.prepend('\u73a4\u{1fc61}\u0fa5\ua351\u{1fbdd}\ub12b\ubc41');
+document.body.prepend(video5);
+try {
+renderBundleEncoder33.setBindGroup(
+2,
+bindGroup23
+);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(
+5,
+buffer14,
+7152,
+23034
+);
+} catch {}
+let textureView53 = texture57.createView(
+{
+label: '\u2746\u0472\u00ae\u{1fd44}\u{1fb7c}\u05eb\u6048\u1958\u0c2f',
+}
+);
+let renderBundle55 = renderBundleEncoder43.finish();
+let sampler42 = device2.createSampler(
+{
+label: '\u{1fb0a}\u9214\u06c7\u0fe6',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 59.152,
+maxAnisotropy: 9,
+}
+);
+try {
+renderBundleEncoder41.setBindGroup(
+4,
+bindGroup21
+);
+} catch {}
+try {
+computePassEncoder22.pushDebugGroup(
+'\u01f5'
+);
+} catch {}
+try {
+gpuCanvasContext5.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32float',
+'rgba16float',
+'rgba16float'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+gc();
+let img14 = await imageWithData(76, 134, '#cfaa1e24', '#189fa1e4');
+let texture69 = device6.createTexture(
+{
+label: '\ue096\u22ed\ud44a\u{1ffd9}\ue99c\uc712\u0e4f\u0148\u1959',
+size: {width: 5410, height: 32, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-5x4-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-5x4-unorm-srgb'
+],
+}
+);
+document.body.append('\u8c4b\u5088\u1c05\ue266\uafa5\u312c');
+try {
+await promise33;
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device1,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'etc2-rgb8unorm',
+'bgra8unorm-srgb',
+'r16uint',
+'bgra8unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 253, height: 209, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 23, y: 121 },
+  flipY: true,
+},
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 0, y: 12, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 253, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.prepend('\u4ed5\u78be\ub9d5');
+let querySet49 = device1.createQuerySet(
+{
+label: '\u0cc8\u0932\u{1f887}\u0cd0\u013b\u469d\u4359',
+type: 'occlusion',
+count: 478,
+}
+);
+try {
+device1.queue.writeTexture(
+{
+  texture: texture61,
+  mipLevel: 0,
+  origin: { x: 3, y: 0, z: 23 },
+  aspect: 'all',
+},
+arrayBuffer5,
+/* required buffer size: 698731 */{
+offset: 411,
+bytesPerRow: 344,
+rowsPerImage: 35,
+},
+{width: 37, height: 0, depthOrArrayLayers: 59}
+);
+} catch {}
+try {
+adapter1.label = '\u{1fd9b}\u0899\uba9c';
+} catch {}
+let texture70 = device6.createTexture(
+{
+label: '\u1d71\u0ff4\u{1f7f6}\u0a74',
+size: [6204, 10, 226],
+mipLevelCount: 5,
+format: 'astc-12x10-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder52 = device6.createRenderBundleEncoder(
+{
+colorFormats: [
+undefined,
+undefined,
+'rg16sint',
+'rgba8unorm',
+'rgba8unorm',
+'r32uint',
+'rg32sint'
+],
+sampleCount: 559,
+stencilReadOnly: true,
+}
+);
+let renderBundle56 = renderBundleEncoder52.finish();
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+let promise34 = adapter2.requestDevice(
+{
+label: '\uda38\u6d58\u{1f902}\uf02c',
+requiredLimits: {
+maxBindGroups: 8,
+maxColorAttachmentBytesPerSample: 37,
+maxVertexAttributes: 21,
+maxVertexBufferArrayStride: 23649,
+maxStorageTexturesPerShaderStage: 37,
+maxStorageBuffersPerShaderStage: 41,
+maxDynamicStorageBuffersPerPipelineLayout: 2223,
+maxBindingsPerBindGroup: 1824,
+maxTextureDimension1D: 14937,
+maxTextureDimension2D: 11824,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 177256415,
+maxInterStageShaderVariables: 18,
+maxInterStageShaderComponents: 93,
+},
+}
+);
+let texture71 = device3.createTexture(
+{
+label: '\u465d\u0381\u{1f7bc}\ub8d4\ua491',
+size: {width: 1945, height: 5, depthOrArrayLayers: 115},
+mipLevelCount: 9,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-5x5-unorm',
+'astc-5x5-unorm-srgb',
+'astc-5x5-unorm-srgb'
+],
+}
+);
+let textureView54 = texture60.createView(
+{
+label: '\u05dd\u8d34',
+mipLevelCount: 1,
+}
+);
+let sampler43 = device3.createSampler(
+{
+label: '\u{1f9e5}\u7cad\u{1f8ea}\u{1fba6}\u{1feb7}\u0b99',
+addressModeU: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 52.878,
+lodMaxClamp: 90.781,
+}
+);
+try {
+gpuCanvasContext1.configure(
+{
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm',
+'rgba8unorm',
+'rgba8unorm',
+'rgba8unorm'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let video23 = await videoWithData();
+let bindGroup27 = device1.createBindGroup({
+label: '\u0fd8\u9518\u0cc8\u0e70\u26aa\u0e5c\u3896',
+layout: bindGroupLayout11,
+entries: [
+
+],
+});
+try {
+renderBundleEncoder33.setBindGroup(
+4,
+bindGroup27
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 253, height: 209, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 136, y: 439 },
+  flipY: false,
+},
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 0, y: 94, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 253, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\ub39e\u0463');
+let device8 = await promise34;
+let buffer21 = device6.createBuffer(
+{
+label: '\u3c23\ua3d4\u0f2f\ucd70\u30c2\ue0bb\u{1fc57}\ue865',
+size: 51644,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let textureView55 = texture69.createView(
+{
+label: '\u{1f715}\u{1ffc9}\u{1ff6f}\u{1fb10}\u0ebe\u642c\u0738\u{1ff2c}\u0f3e\u0b1a',
+format: 'astc-5x4-unorm-srgb',
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+let sampler44 = device6.createSampler(
+{
+label: '\u0bf8\u0ddc',
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 92.986,
+lodMaxClamp: 97.153,
+}
+);
+try {
+await device6.popErrorScope();
+} catch {}
+document.body.prepend('\u1126\u605c\u667a\u5d95\u51fd\u{1fc4a}\u{1f9d6}');
+let img15 = await imageWithData(120, 282, '#ede5a75e', '#8e2384e5');
+let querySet50 = device8.createQuerySet(
+{
+label: '\u{1ff34}\u4f97\u1232\u{1fadd}',
+type: 'occlusion',
+count: 20,
+}
+);
+let renderBundleEncoder53 = device3.createRenderBundleEncoder(
+{
+label: '\u08da\u9d4f\u0388\u3aea\u{1fc3e}\ufc43',
+colorFormats: [
+'r32float',
+'rgba8unorm-srgb'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 681,
+depthReadOnly: true,
+}
+);
+let renderBundle57 = renderBundleEncoder47.finish(
+{
+label: '\u0530\ud603'
+}
+);
+try {
+await device3.popErrorScope();
+} catch {}
+document.body.append('\u70ce\u0058\u40bd\u{1fc97}');
+let offscreenCanvas17 = new OffscreenCanvas(231, 915);
+try {
+adapter1.label = '\uacad\ud908\u{1fc81}';
+} catch {}
+let bindGroupLayout19 = device2.createBindGroupLayout(
+{
+label: '\u0d54\ud878\uf308\u5d56\u{1fbe2}\u{1fa75}',
+entries: [
+
+],
+}
+);
+let renderBundle58 = renderBundleEncoder42.finish();
+let sampler45 = device2.createSampler(
+{
+label: '\uffb6\u3217\u678b\u{1fc35}\udff0',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 9.480,
+lodMaxClamp: 33.916,
+maxAnisotropy: 1,
+}
+);
+try {
+querySet40.destroy();
+} catch {}
+try {
+gpuCanvasContext17.configure(
+{
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm',
+'stencil8',
+'rgba16float',
+'rgba32sint'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let textureView56 = texture68.createView(
+{
+label: '\ue43e\u32c6\u{1f99d}\u{1ff64}\uf77f\u32ff\u{1fe98}',
+arrayLayerCount: 1,
+}
+);
+let renderBundle59 = renderBundleEncoder51.finish(
+{
+label: '\u5f16\u29ac'
+}
+);
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+document.body.prepend('\ufea6\u0b85\u{1fa61}\u094f');
+let commandEncoder46 = device3.createCommandEncoder(
+{
+label: '\u{1fc08}\u{1f962}\u0c89\u3ba0\ubbc5\u07ae\u0d61\ue039',
+}
+);
+let renderBundle60 = renderBundleEncoder53.finish(
+{
+label: '\u221b\ud172\uf2e0\u708e\u0f05\u8720\u1d36\u052e\ua870\u{1fba4}'
+}
+);
+try {
+offscreenCanvas17.getContext('webgpu');
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+document.body.append('\u02e8\ud6af\u0917\u{1fd2c}\u7513\u{1f8d3}');
+let bindGroupLayout20 = device3.createBindGroupLayout(
+{
+label: '\ubb02\u{1f80d}\u016d',
+entries: [
+{
+binding: 7105,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'non-filtering' },
+},
+{
+binding: 3278,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '2d' },
+},
+{
+binding: 3187,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+let renderBundle61 = renderBundleEncoder53.finish(
+{
+
+}
+);
+let commandEncoder47 = device5.createCommandEncoder(
+{
+label: '\u01e4\u0ce4\u{1f9ba}',
+}
+);
+let renderBundleEncoder54 = device5.createRenderBundleEncoder(
+{
+label: '\ud2cf\u011d\ub823\u4579\u{1fd8a}\u0d2b\u2c74\u{1fa05}\ud641\u9611\u27bf',
+colorFormats: [
+'rg32sint',
+'rgba16uint',
+'r32uint',
+'rg32uint',
+'rg8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 165,
+depthReadOnly: false,
+}
+);
+let externalTexture5 = device5.importExternalTexture(
+{
+label: '\u4ab3\u132b\u0687\u{1f754}\u{1fc6b}\uaa47\u0768',
+source: video11,
+colorSpace: 'srgb',
+}
+);
+try {
+gpuCanvasContext3.configure(
+{
+device: device5,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float',
+'rgba16float',
+'astc-5x4-unorm-srgb',
+'rgba16float'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+let querySet51 = device5.createQuerySet(
+{
+label: '\u0440\u925b',
+type: 'occlusion',
+count: 4010,
+}
+);
+let texture72 = device5.createTexture(
+{
+label: '\u5f33\u{1fa5c}\u083d\u282d\u0516\ue55b',
+size: {width: 45, height: 5, depthOrArrayLayers: 30},
+mipLevelCount: 1,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder32 = commandEncoder47.beginComputePass(
+{
+label: '\u08c1\u0c12\u9711\uf0ea\u{1f7ed}\u4046\u81ac'
+}
+);
+let renderBundle62 = renderBundleEncoder48.finish(
+{
+label: '\ua7a8\u{1fcad}\u0935\u06b8'
+}
+);
+try {
+texture64.destroy();
+} catch {}
+let commandEncoder48 = device1.createCommandEncoder(
+{
+label: '\u0b02\u{1fa2d}\u25b2',
+}
+);
+let querySet52 = device1.createQuerySet(
+{
+label: '\u17c8\uff69\u8307\u{1fc0e}\u{1ff42}\u02e0\ucde3\u{1ff0c}\u07e1',
+type: 'occlusion',
+count: 2730,
+}
+);
+let computePassEncoder33 = commandEncoder48.beginComputePass(
+{
+label: '\u5cb4\u{1fae6}\u96f6\uf896\ub8c4\u8ba8'
+}
+);
+let renderBundleEncoder55 = device1.createRenderBundleEncoder(
+{
+label: '\ue195\u0c4f\u0b4d\u4b0a\ud88d\u{1f772}\u0c77\u{1fd34}\u8919\u165a',
+colorFormats: [
+'bgra8unorm',
+'rgba8sint',
+'rg32sint',
+'r8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 695,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 253, height: 209, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas5,
+  origin: { x: 4, y: 74 },
+  flipY: true,
+},
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 0, y: 46, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 253, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend(img10);
+offscreenCanvas0.height = 744;
+let commandEncoder49 = device7.createCommandEncoder();
+let sampler46 = device7.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 98.117,
+lodMaxClamp: 99.727,
+}
+);
+let renderBundleEncoder56 = device8.createRenderBundleEncoder(
+{
+label: '\u31bf\u1bb4\u248e\u740a\u0995\ua610\u3082\u{1f965}\u7c6c\u61e0',
+colorFormats: [
+'rgba16uint',
+'rg32sint',
+'rgba32float',
+'r8sint',
+undefined,
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 185,
+stencilReadOnly: true,
+}
+);
+let sampler47 = device8.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 14.132,
+lodMaxClamp: 93.792,
+compare: 'never',
+}
+);
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+document.body.append('\ua0f4\u6a47\u1bfb');
+let promise35 = adapter1.requestAdapterInfo();
+let computePassEncoder34 = commandEncoder46.beginComputePass(
+{
+label: '\u0939\u053b\u4cee\u0433\u0c9d\ue8a0\ued3b\u0aba'
+}
+);
+let buffer22 = device1.createBuffer(
+{
+label: '\u8f59\u0fef\ue304\u0cc0\u0e83\u2b08\u7a79\u8711\ubd20',
+size: 18211,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: false,
+}
+);
+let querySet53 = device1.createQuerySet(
+{
+label: '\u3df6\u{1fb5d}\u4eea\u041d\ue896\u0664\u4248\u05cf\u021d\u9563',
+type: 'occlusion',
+count: 571,
+}
+);
+try {
+renderBundleEncoder55.setBindGroup(
+4,
+bindGroup27
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append('\u1ccf\u0f78\ue12b\u0b48\u0ec7\u9b42\uc894\u0c25\u09ce\u6b51\u5bd0');
+let imageBitmap18 = await createImageBitmap(canvas6);
+let videoFrame19 = new VideoFrame(offscreenCanvas7, {timestamp: 0});
+let commandBuffer6 = commandEncoder49.finish(
+{
+}
+);
+let textureView57 = texture68.createView(
+{
+label: '\u00f8\u08f8\u0ccf\u31e3\u158d\u05c5\uae87\u27f9\u0e36',
+}
+);
+try {
+gpuCanvasContext5.configure(
+{
+device: device7,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'etc2-rgb8unorm-srgb',
+'astc-12x12-unorm',
+'rgba16float'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let pipelineLayout18 = device1.createPipelineLayout(
+{
+label: '\u6483\u0da5\u{1f618}\u{1f975}\u00d8\u970e\u2579\u{1fe50}\u8ca7\u8498\u9bcb',
+bindGroupLayouts: [
+bindGroupLayout13,
+bindGroupLayout13
+],
+}
+);
+let textureView58 = texture46.createView(
+{
+label: '\u{1ff55}\u{1fe60}\u5d2a\u2cb8\u001d',
+baseArrayLayer: 0,
+}
+);
+gc();
+document.body.prepend('\ub002\u3fa7\uc8ef\u4b0c');
+let bindGroup28 = device4.createBindGroup({
+label: '\u9724\u{1fbd6}',
+layout: bindGroupLayout14,
+entries: [
+{
+binding: 3961,
+resource: externalTexture3
+}
+],
+});
+let querySet54 = device4.createQuerySet(
+{
+label: '\uc9ad\u42c2\u{1fe30}\u2108\u34b2',
+type: 'occlusion',
+count: 3598,
+}
+);
+try {
+renderBundleEncoder45.setIndexBuffer(
+buffer20,
+'uint16'
+);
+} catch {}
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture59,
+  mipLevel: 1,
+  origin: { x: 26, y: 0, z: 13 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 12298652 */{
+offset: 332,
+bytesPerRow: 551,
+rowsPerImage: 279,
+},
+{width: 70, height: 0, depthOrArrayLayers: 81}
+);
+} catch {}
+try {
+await promise35;
+} catch {}
+gc();
+let bindGroupLayout21 = device1.createBindGroupLayout(
+{
+label: '\u{1f6d2}\u{1ff7f}\u10bc',
+entries: [
+
+],
+}
+);
+let textureView59 = texture52.createView(
+{
+label: '\u80f0\u0564\u0721\u1aa2\ua9fe',
+baseMipLevel: 2,
+}
+);
+let bindGroup29 = device5.createBindGroup({
+label: '\u{1fee2}\ub702\u{1ff2b}\u0d2b\u{1ff2a}\u3086\u05f4\u1c2c',
+layout: bindGroupLayout18,
+entries: [
+
+],
+});
+let texture73 = device5.createTexture(
+{
+label: '\u244d\u{1f759}',
+size: [32, 32, 1],
+mipLevelCount: 6,
+format: 'etc2-rgb8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let bindGroupLayout22 = device8.createBindGroupLayout(
+{
+entries: [
+{
+binding: 488,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+try {
+renderBundleEncoder56.setVertexBuffer(
+94,
+undefined,
+2208186335,
+496142250
+);
+} catch {}
+try {
+device8.pushErrorScope(
+'validation'
+);
+} catch {}
+let img16 = await imageWithData(89, 298, '#20991eff', '#86f799f3');
+let video24 = await videoWithData();
+let bindGroupLayout23 = device4.createBindGroupLayout(
+{
+label: '\u0caf\uc2c3\ud0cc\u0e19\u0074',
+entries: [
+{
+binding: 4225,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 767,
+visibility: 0,
+storageTexture: { format: 'rgba16sint', access: 'write-only', viewDimension: '2d-array' },
+},
+{
+binding: 3722,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+}
+],
+}
+);
+let commandEncoder50 = device4.createCommandEncoder();
+pseudoSubmit(device4, commandEncoder50);
+let textureView60 = texture59.createView(
+{
+label: '\u715a\u606a',
+baseMipLevel: 3,
+baseArrayLayer: 71,
+arrayLayerCount: 6,
+}
+);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder51 = device4.createCommandEncoder(
+{
+label: '\u9e1c\uf251\u{1f655}\uab7e\u0980\ufc8b',
+}
+);
+try {
+commandEncoder51.clearBuffer(
+buffer20,
+8496,
+8
+);
+dissociateBuffer(device4, buffer20);
+} catch {}
+let querySet55 = device1.createQuerySet(
+{
+label: '\u0b91\u29e0\u067a\u00b7\uc1e6\u57e3\ua6db\u3745',
+type: 'occlusion',
+count: 3848,
+}
+);
+try {
+renderBundleEncoder55.setVertexBuffer(
+1,
+buffer14,
+19380
+);
+} catch {}
+try {
+device1.pushErrorScope(
+'validation'
+);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+canvas11.width = 128;
+let adapter11 = await promise28;
+let renderPassEncoder12 = commandEncoder51.beginRenderPass(
+{
+label: '\uac9b\u5a50\u08c2\u0c8a\u8348\u7f49\u0dd5\u3313\u00f8\u{1f789}',
+colorAttachments: [
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView52,
+depthClearValue: 1.0752405502317472,
+depthLoadOp: 'load',
+depthStoreOp: 'store',
+},
+occlusionQuerySet: querySet46,
+maxDrawCount: 114312,
+}
+);
+let renderBundleEncoder57 = device4.createRenderBundleEncoder(
+{
+label: '\u{1fa1e}\u{1ff9d}\u2679\u4a54\u53ba\u{1fe99}\u0bd8',
+colorFormats: [
+'rg8uint',
+'bgra8unorm',
+'r8uint',
+undefined,
+'rgba8unorm-srgb',
+'r8uint'
+],
+sampleCount: 227,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder12.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+try {
+gpuCanvasContext15.configure(
+{
+device: device4,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+adapter10.label = '\u{1fcae}\u4f03\u0d81\u9d99\u0698\u60a3\u12c8';
+} catch {}
+let querySet56 = device1.createQuerySet(
+{
+label: '\u{1fe37}\ud523\udbf7\ua3f1',
+type: 'occlusion',
+count: 3210,
+}
+);
+let renderBundle63 = renderBundleEncoder55.finish(
+{
+label: '\u063d\ub909\u60dd\u2b07\uc56a\u33b8\u{1fe54}\u0158\u0650'
+}
+);
+try {
+renderBundleEncoder33.setIndexBuffer(
+buffer16,
+'uint32',
+4720,
+6492
+);
+} catch {}
+let device9 = await adapter9.requestDevice(
+{
+label: '\u8143\u0854\u0411\u11f6',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 7,
+maxColorAttachmentBytesPerSample: 44,
+maxVertexAttributes: 26,
+maxVertexBufferArrayStride: 9144,
+maxStorageTexturesPerShaderStage: 20,
+maxStorageBuffersPerShaderStage: 16,
+maxDynamicStorageBuffersPerPipelineLayout: 13417,
+maxBindingsPerBindGroup: 4397,
+maxTextureDimension1D: 12407,
+maxTextureDimension2D: 13170,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 176161986,
+maxInterStageShaderVariables: 63,
+maxInterStageShaderComponents: 86,
+},
+}
+);
+try {
+window.someLabel = device8.label;
+} catch {}
+try {
+querySet50.destroy();
+} catch {}
+let commandEncoder52 = device0.createCommandEncoder(
+{
+label: '\u{1fc85}\u5a53\uc8d3\ud120\u9421\uc887\u{1fb06}\u0a94',
+}
+);
+let querySet57 = device0.createQuerySet(
+{
+label: '\u{1f86e}\u{1f95c}\u9249\u0e51\uf873\ue4c1\ud071\ub83a',
+type: 'occlusion',
+count: 527,
+}
+);
+let textureView61 = texture37.createView(
+{
+}
+);
+let sampler48 = device0.createSampler(
+{
+label: '\u57d9\u3961\u2bcd\u27ec\u{1fe89}\u4e8d\u{1fe6a}\u{1fbea}\u3e1d\ue4b8',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 54.347,
+lodMaxClamp: 73.528,
+maxAnisotropy: 10,
+}
+);
+try {
+renderPassEncoder8.setBlendConstant(
+{
+r: 816.7,
+g: 672.2,
+b: 568.2,
+a: 293.6,
+}
+);
+} catch {}
+try {
+renderPassEncoder5.draw(
+24,
+40,
+0,
+64
+);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(
+0,
+48
+);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(
+buffer7,
+'uint16',
+1904,
+6116
+);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline29);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(
+6,
+buffer2,
+31548
+);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(
+7,
+buffer2
+);
+} catch {}
+try {
+commandEncoder52.copyTextureToTexture(
+{
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 0, y: 23, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 0, y: 16, z: 0 },
+  aspect: 'all',
+},
+{width: 30, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(
+querySet11,
+538,
+142,
+buffer10,
+3840
+);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer4,
+commandBuffer3,
+]);
+} catch {}
+let pipeline43 = await device0.createRenderPipelineAsync(
+{
+layout: pipelineLayout6,
+vertex: {
+module: shaderModule7,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 9404,
+attributes: [
+{
+format: 'float32',
+offset: 3316,
+shaderLocation: 5,
+},
+{
+format: 'uint32x4',
+offset: 6544,
+shaderLocation: 18,
+},
+{
+format: 'snorm8x4',
+offset: 8856,
+shaderLocation: 21,
+},
+{
+format: 'unorm8x2',
+offset: 5718,
+shaderLocation: 2,
+},
+{
+format: 'uint32x3',
+offset: 8576,
+shaderLocation: 11,
+},
+{
+format: 'uint8x2',
+offset: 2184,
+shaderLocation: 22,
+},
+{
+format: 'float32x3',
+offset: 8152,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x4',
+offset: 4948,
+shaderLocation: 3,
+},
+{
+format: 'uint32',
+offset: 8152,
+shaderLocation: 14,
+},
+{
+format: 'snorm8x4',
+offset: 5068,
+shaderLocation: 25,
+},
+{
+format: 'unorm8x2',
+offset: 2652,
+shaderLocation: 15,
+},
+{
+format: 'float16x2',
+offset: 2684,
+shaderLocation: 17,
+},
+{
+format: 'sint32x2',
+offset: 7960,
+shaderLocation: 23,
+},
+{
+format: 'uint32x3',
+offset: 2564,
+shaderLocation: 7,
+},
+{
+format: 'sint32x2',
+offset: 4808,
+shaderLocation: 4,
+},
+{
+format: 'uint32',
+offset: 2516,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x4',
+offset: 240,
+shaderLocation: 13,
+},
+{
+format: 'sint32x4',
+offset: 1416,
+shaderLocation: 8,
+},
+{
+format: 'sint16x4',
+offset: 1244,
+shaderLocation: 20,
+},
+{
+format: 'snorm8x2',
+offset: 7074,
+shaderLocation: 24,
+},
+{
+format: 'snorm16x4',
+offset: 1092,
+shaderLocation: 19,
+},
+{
+format: 'sint16x4',
+offset: 1348,
+shaderLocation: 6,
+},
+{
+format: 'snorm8x4',
+offset: 4436,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 4040,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 2904,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 1372,
+shaderLocation: 26,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 1728,
+shaderLocation: 12,
+},
+{
+format: 'snorm16x4',
+offset: 1592,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 540,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 11244,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 196,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+},
+fragment: {
+module: shaderModule7,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'never',
+failOp: 'replace',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'zero',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 3815,
+stencilWriteMask: 508,
+depthBias: 54,
+depthBiasSlopeScale: 56,
+depthBiasClamp: 51,
+},
+}
+);
+gc();
+document.body.append('\u5300\u0d64\u0887\u{1f84a}\u13e6\u0f28\u0ea3\u7037\u080a\u{1ff0d}');
+let commandEncoder53 = device5.createCommandEncoder(
+{
+}
+);
+let querySet58 = device5.createQuerySet(
+{
+label: '\u0d1d\u0eac\u67c6',
+type: 'occlusion',
+count: 642,
+}
+);
+let texture74 = device5.createTexture(
+{
+label: '\u8178\u08a0\u0c60\u{1fa2d}\u{1f821}\u44b4\u{1fc46}\u{1f6f8}\u2692',
+size: {width: 77, height: 2, depthOrArrayLayers: 121},
+dimension: '3d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb',
+'bgra8unorm-srgb',
+'bgra8unorm'
+],
+}
+);
+document.body.prepend(img5);
+video1.height = 270;
+let querySet59 = device7.createQuerySet(
+{
+label: '\u5446\u06aa\u9741\u0ca0',
+type: 'occlusion',
+count: 2835,
+}
+);
+let textureView62 = texture68.createView(
+{
+label: '\u05b3\ub5c7\uaf4a\u698f\u8f0c\u0447\u943c\u{1fcf8}\u00c8\u95a9',
+aspect: 'all',
+}
+);
+try {
+gpuCanvasContext9.configure(
+{
+device: device7,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let img17 = await imageWithData(7, 21, '#044bcc4c', '#d83214cf');
+try {
+renderBundleEncoder56.setVertexBuffer(
+50,
+undefined,
+1957758508,
+2165445724
+);
+} catch {}
+try {
+gpuCanvasContext10.configure(
+{
+device: device8,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rg16uint'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+let renderBundle64 = renderBundleEncoder30.finish(
+{
+label: '\u8ab8\u08c3\u{1feed}\u4f0b\ua94e\u{1f862}\uf9aa'
+}
+);
+let sampler49 = device1.createSampler(
+{
+label: '\u874a\u3b83\uce5c\u9ab8',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+lodMaxClamp: 89.926,
+}
+);
+try {
+renderBundleEncoder33.setBindGroup(
+0,
+bindGroup25,
+new Uint32Array(4682),
+2246,
+0
+);
+} catch {}
+try {
+gpuCanvasContext9.configure(
+{
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16float'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+let commandEncoder54 = device6.createCommandEncoder(
+{
+label: '\u5f60\u{1fd79}\u38bd\ucbec\ub107\uabd1\ue94e\u{1ff6a}\u8c50\u09aa',
+}
+);
+let renderBundleEncoder58 = device6.createRenderBundleEncoder(
+{
+label: '\u0d46\uef6f\u{1fc7f}\u8434\u{1f80c}\u24e6',
+colorFormats: [
+'rgba16uint',
+undefined,
+'r8unorm',
+'rgba16uint',
+'bgra8unorm',
+'rgba32sint'
+],
+sampleCount: 385,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder58.setVertexBuffer(
+7,
+buffer21,
+50664
+);
+} catch {}
+try {
+device6.addEventListener('uncapturederror', e => { log('device6.uncapturederror'); log(e); e.label = device6.label; });
+} catch {}
+try {
+device6.queue.writeTexture(
+{
+  texture: texture70,
+  mipLevel: 4,
+  origin: { x: 156, y: 0, z: 16 },
+  aspect: 'all',
+},
+new Int32Array(arrayBuffer5),
+/* required buffer size: 4034620 */{
+offset: 996,
+bytesPerRow: 446,
+rowsPerImage: 68,
+},
+{width: 240, height: 0, depthOrArrayLayers: 134}
+);
+} catch {}
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout24 = device7.createBindGroupLayout(
+{
+label: '\u0b84\u0d0b\u7441\u{1ff7b}',
+entries: [
+{
+binding: 885,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+},
+{
+binding: 1226,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+},
+{
+binding: 1232,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '2d-array' },
+}
+],
+}
+);
+let pipelineLayout19 = device7.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout24,
+bindGroupLayout24,
+bindGroupLayout24,
+bindGroupLayout24
+],
+}
+);
+let querySet60 = device7.createQuerySet(
+{
+label: '\u{1fa47}\u8c02\u{1fa7a}\u{1f966}\uf97e\u002a',
+type: 'occlusion',
+count: 2353,
+}
+);
+let renderBundleEncoder59 = device7.createRenderBundleEncoder(
+{
+label: '\u{1fccc}\u{1f9f3}',
+colorFormats: [
+'r16uint',
+'r16float',
+'rg8uint',
+'rgb10a2unorm',
+'rg8uint',
+'rgba8sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 565,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle65 = renderBundleEncoder51.finish(
+{
+
+}
+);
+try {
+device7.pushErrorScope(
+'out-of-memory'
+);
+} catch {}
+try {
+device7.queue.submit([
+]);
+} catch {}
+try {
+await device7.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device6.queue.label = '\u0ffa\uf504\u0fe9\u00be\ud0e4\u3211\u4fe4\ubea2\u0c37\u00b0';
+} catch {}
+let texture75 = device6.createTexture(
+{
+label: '\u0798\u7edf\ue8f9\u{1f802}\u{1fab9}\ucbc5\ud83b\u8293',
+size: {width: 200, height: 120, depthOrArrayLayers: 1},
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView63 = texture70.createView(
+{
+label: '\u{1fce7}\u55f1\u09b1\u4cde',
+aspect: 'all',
+baseMipLevel: 3,
+baseArrayLayer: 132,
+arrayLayerCount: 22,
+}
+);
+let renderBundleEncoder60 = device6.createRenderBundleEncoder(
+{
+label: '\u86e3\u0d44\ubb5a\u5966\u2107\ucaa7\u044a\u7a5c\u6acd',
+colorFormats: [
+'r32float',
+'rg32float'
+],
+sampleCount: 322,
+stencilReadOnly: true,
+}
+);
+try {
+buffer21.unmap();
+} catch {}
+document.body.prepend(img5);
+document.body.prepend('\uedbe\u{1f994}\ufccc\u080f\u8edf\u39c2\u{1fd03}');
+let canvas17 = document.createElement('canvas');
+let promise36 = adapter7.requestAdapterInfo();
+let commandEncoder55 = device4.createCommandEncoder(
+{
+}
+);
+let textureView64 = texture59.createView(
+{
+label: '\u0a2f\u{1f713}\uc024\u{1faa5}\u{1fd30}\u03af',
+dimension: '2d',
+baseMipLevel: 5,
+baseArrayLayer: 79,
+}
+);
+try {
+renderPassEncoder12.setScissorRect(
+213,
+1,
+421,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(
+999
+);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+2,
+buffer18,
+11808,
+8414
+);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(
+0,
+bindGroup28,
+[]
+);
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(
+9,
+buffer18,
+28628,
+94
+);
+} catch {}
+try {
+querySet48.destroy();
+} catch {}
+let texture76 = device6.createTexture(
+{
+label: '\u15b6\u{1ffd4}\u933f\u0cdb\u4153\u0660\ufd3c',
+size: [1912, 5, 1],
+mipLevelCount: 10,
+format: 'astc-8x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-8x5-unorm-srgb'
+],
+}
+);
+try {
+renderBundleEncoder58.setVertexBuffer(
+4,
+undefined,
+641673992,
+804923583
+);
+} catch {}
+try {
+gpuCanvasContext13.configure(
+{
+device: device6,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device6.queue.writeTexture(
+{
+  texture: texture75,
+  mipLevel: 0,
+  origin: { x: 16, y: 40, z: 0 },
+  aspect: 'all',
+},
+new Float32Array(arrayBuffer4),
+/* required buffer size: 362 */{
+offset: 362,
+bytesPerRow: 507,
+rowsPerImage: 265,
+},
+{width: 176, height: 24, depthOrArrayLayers: 0}
+);
+} catch {}
+let texture77 = device4.createTexture(
+{
+label: '\u61ce\u0962\u{1f9d6}\u8102\u{1fac2}\u930f\u7ddc\u169a\u0a36\u{1fa6c}',
+size: [113, 1, 207],
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rgba32sint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgba32sint',
+'rgba32sint',
+'rgba32sint'
+],
+}
+);
+let texture78 = gpuCanvasContext9.getCurrentTexture();
+let textureView65 = texture65.createView(
+{
+label: '\u{1f670}\ue2d5\u{1fc5b}\u{1f71d}\ua29b\u80c2\u{1f6c8}\u7578\u0c0b\ubd96\u6c95',
+dimension: '2d-array',
+aspect: 'stencil-only',
+format: 'stencil8',
+baseMipLevel: 2,
+mipLevelCount: 1,
+baseArrayLayer: 160,
+arrayLayerCount: 33,
+}
+);
+let renderBundle66 = renderBundleEncoder44.finish(
+{
+label: '\u05df\uad49\u{1fa07}\ua7f0\ud18d\u{1ffb9}'
+}
+);
+try {
+commandEncoder55.clearBuffer(
+buffer20,
+5048,
+2284
+);
+dissociateBuffer(device4, buffer20);
+} catch {}
+let gpuCanvasContext18 = canvas17.getContext('webgpu');
+let bindGroupLayout25 = device3.createBindGroupLayout(
+{
+label: '\u8f19\u060b\ub0c7\u{1febf}\u{1f771}\u0bbd\u0578\ue4a7\u{1fd80}\u0e8f\u{1fbca}',
+entries: [
+{
+binding: 649,
+visibility: 0,
+texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+},
+{
+binding: 2845,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let sampler50 = device3.createSampler(
+{
+label: '\u3aae\ub35b\u0198\uab77\u01db\u07d0\u{1fd2e}\u044f\u0bff\u{1f89d}\u{1fd39}',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+lodMinClamp: 1.290,
+lodMaxClamp: 70.971,
+compare: 'equal',
+}
+);
+let externalTexture6 = device3.importExternalTexture(
+{
+label: '\u077e\u511b\u075c',
+source: videoFrame6,
+colorSpace: 'display-p3',
+}
+);
+let adapter12 = await promise30;
+let imageBitmap19 = await createImageBitmap(img13);
+let pipelineLayout20 = device5.createPipelineLayout(
+{
+label: '\u0d7f\u{1ff8a}\u49b7\u{1f6fe}\u0e8a\uff0d',
+bindGroupLayouts: [
+bindGroupLayout18,
+bindGroupLayout18,
+bindGroupLayout18,
+bindGroupLayout18
+],
+}
+);
+let querySet61 = device5.createQuerySet(
+{
+label: '\u00bb\u{1fac3}\uaae2\u7c01\u{1f62c}\u0ac7\u01a7\u0b91\u63b9\u0a42',
+type: 'occlusion',
+count: 3006,
+}
+);
+let computePassEncoder35 = commandEncoder53.beginComputePass(
+{
+label: '\u01e0\u{1f817}\u{1fb65}\u9fc5\u594c\uda58\u05a7\u{1f742}\u1889\ub69d'
+}
+);
+try {
+await promise36;
+} catch {}
+document.body.prepend('\u4194\u1899');
+try {
+renderBundleEncoder54.setVertexBuffer(
+16,
+undefined,
+1318718918,
+2800649689
+);
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(
+/*
+{width: 77, height: 2, depthOrArrayLayers: 121}
+*/
+{
+  source: imageData5,
+  origin: { x: 6, y: 16 },
+  flipY: false,
+},
+{
+  texture: texture74,
+  mipLevel: 0,
+  origin: { x: 30, y: 0, z: 35 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 13, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend('\ueb28\u0f1b');
+try {
+renderBundleEncoder59.pushDebugGroup(
+'\u00ba'
+);
+} catch {}
+try {
+gpuCanvasContext13.configure(
+{
+device: device7,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let renderBundleEncoder61 = device3.createRenderBundleEncoder(
+{
+colorFormats: [
+undefined,
+undefined
+],
+sampleCount: 576,
+depthReadOnly: true,
+}
+);
+let renderBundle67 = renderBundleEncoder61.finish(
+{
+label: '\u07ba\ua479\u863a\u88ee\u0386\u383b\uede1\u177b\u0982\u2bce\u0b0f'
+}
+);
+try {
+gpuCanvasContext18.configure(
+{
+device: device3,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+document.body.append('\u0072\u36d6\u0eb6\u0a4b');
+let textureView66 = texture60.createView(
+{
+label: '\u2696\u0ac5\u535c\u3c00\uddc1\u856b',
+aspect: 'all',
+format: 'rg32float',
+mipLevelCount: 1,
+}
+);
+let bindGroup30 = device4.createBindGroup({
+label: '\u0f02\u{1fbd9}\u39ee\u91c9',
+layout: bindGroupLayout14,
+entries: [
+{
+binding: 3961,
+resource: externalTexture3
+}
+],
+});
+try {
+renderBundleEncoder45.setVertexBuffer(
+6,
+buffer18,
+10412,
+6991
+);
+} catch {}
+try {
+gpuCanvasContext7.configure(
+{
+device: device4,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgba8unorm',
+'rgba8unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+document.body.append('\u{1f8ea}\u{1f889}\ub86e\u4d2d');
+let img18 = await imageWithData(54, 229, '#8a33505d', '#570b9046');
+try {
+device5.label = '\u{1fea5}\u04cb';
+} catch {}
+let bindGroup31 = device5.createBindGroup({
+label: '\u{1fc5a}\u031f\u0344\u0e5b\u562b\u0e37\ue7f3\u0fa4\u0410',
+layout: bindGroupLayout18,
+entries: [
+
+],
+});
+let querySet62 = device5.createQuerySet(
+{
+label: '\u0d33\ucbdf\u7084\u{1fb49}\u{1fa42}\u02b3\u064e',
+type: 'occlusion',
+count: 3808,
+}
+);
+try {
+renderBundleEncoder54.setVertexBuffer(
+82,
+undefined,
+2064097450
+);
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(
+/*
+{width: 77, height: 2, depthOrArrayLayers: 121}
+*/
+{
+  source: img14,
+  origin: { x: 10, y: 49 },
+  flipY: false,
+},
+{
+  texture: texture74,
+  mipLevel: 0,
+  origin: { x: 10, y: 0, z: 4 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 58, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.append('\u9fa9\uec0c\u3165\u0039\u07d1\uf701\u0619');
+let videoFrame20 = new VideoFrame(video5, {timestamp: 0});
+let bindGroup32 = device5.createBindGroup({
+label: '\u77a5\u996b\u5aed\uf477\uabed',
+layout: bindGroupLayout18,
+entries: [
+
+],
+});
+let texture79 = device5.createTexture(
+{
+label: '\uccc1\u2cf7\u0fba\u8800\u0cb3\u16be\u0769\u090f',
+size: [1599, 1, 1675],
+mipLevelCount: 10,
+sampleCount: 1,
+dimension: '3d',
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm',
+'bgra8unorm'
+],
+}
+);
+let sampler51 = device5.createSampler(
+{
+label: '\ufeed\u{1fdca}\u661d\u{1fceb}\u8d8a\u1a69\u0c72',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 3.805,
+lodMaxClamp: 22.647,
+}
+);
+try {
+renderBundleEncoder54.setBindGroup(
+2,
+bindGroup31
+);
+} catch {}
+try {
+renderBundleEncoder54.insertDebugMarker(
+'\u{1f62f}'
+);
+} catch {}
+document.body.prepend(video24);
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+try {
+adapter9.label = '\u0c49\uaf1a\u525b';
+} catch {}
+let renderBundleEncoder62 = device8.createRenderBundleEncoder(
+{
+label: '\u0ae9\u04a0',
+colorFormats: [
+undefined,
+'rgba32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 476,
+}
+);
+let renderBundle68 = renderBundleEncoder62.finish(
+{
+label: '\ud51f\u9dac\u{1f8f2}\u023c\uc1de\ufb94\ua387\uf7b9\u909c\u0232\u1e73'
+}
+);
+document.body.prepend('\u0dc5\u{1fddc}\u0765\u0128\u0327\u9b91');
+let videoFrame21 = new VideoFrame(video21, {timestamp: 0});
+try {
+device2.queue.writeTexture(
+{
+  texture: texture67,
+  mipLevel: 0,
+  origin: { x: 7567, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint32Array(arrayBuffer5),
+/* required buffer size: 699 */{
+offset: 699,
+rowsPerImage: 82,
+},
+{width: 1662, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+document.body.append('\u5e54\udf9c\u5ebe\u0887\u00c3\u{1fd25}\u{1febd}\u0c26\u5272\u{1f6e7}');
+let imageData17 = new ImageData(60, 248);
+let texture80 = gpuCanvasContext5.getCurrentTexture();
+let sampler52 = device1.createSampler(
+{
+label: '\u{1f7cc}\u0b5e\u158a\u{1fc49}\u020d\u486a',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+lodMaxClamp: 99.182,
+}
+);
+document.body.prepend('\ue328\u0baa');
+let imageBitmap20 = await createImageBitmap(video5);
+canvas1.height = 667;
+let img19 = await imageWithData(287, 241, '#93707b5e', '#01b82a5c');
+let video25 = await videoWithData();
+let imageBitmap21 = await createImageBitmap(img10);
+document.body.append('\u7e4a\u8e32\u00e6\u549e\u{1fbff}\udf85\u70fc\u30fa\u0a4f\u2cd0');
+let renderBundle69 = renderBundleEncoder29.finish(
+{
+label: '\u8c14\u0178\u8147\u{1ff1f}\u46c3\u0a2f\u83c7'
+}
+);
+try {
+computePassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(
+7,
+bindGroup12,
+new Uint32Array(5676),
+4141,
+0
+);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(
+56
+);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant(
+{
+r: -407.0,
+g: 445.9,
+b: -939.5,
+a: -617.4,
+}
+);
+} catch {}
+let arrayBuffer6 = buffer4.getMappedRange(
+11912,
+12596
+);
+try {
+commandEncoder2.copyBufferToBuffer(
+buffer6,
+3748,
+buffer1,
+37140,
+152
+);
+dissociateBuffer(device0, buffer6);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline44 = device0.createComputePipeline(
+{
+label: '\ud3dc\u{1f999}\u0c5a\ubf01\uf3a9\u8b7f\u7542\uaafb\u{1faa3}\u{1ff41}',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+gc();
+let imageBitmap22 = await createImageBitmap(videoFrame8);
+let bindGroup33 = device1.createBindGroup({
+label: '\u000c\u{1fa21}\u370d\u1951',
+layout: bindGroupLayout11,
+entries: [
+
+],
+});
+let textureView67 = texture53.createView(
+{
+label: '\ud8a6\u0b0a',
+mipLevelCount: 2,
+baseArrayLayer: 1,
+arrayLayerCount: 6,
+}
+);
+let promise37 = device1.queue.onSubmittedWorkDone();
+document.body.append('\u{1fca1}\u7d06\u096b\uf25d\ucb3e');
+let canvas18 = document.createElement('canvas');
+let offscreenCanvas18 = new OffscreenCanvas(66, 598);
+let commandEncoder56 = device5.createCommandEncoder();
+let sampler53 = device5.createSampler(
+{
+label: '\u0e86\ued88\ue4b3\u0941\u096a\u8b67\uaf39\u072f\u0fd7',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 62.525,
+lodMaxClamp: 94.982,
+}
+);
+try {
+device5.queue.copyExternalImageToTexture(
+/*
+{width: 77, height: 2, depthOrArrayLayers: 121}
+*/
+{
+  source: videoFrame8,
+  origin: { x: 195, y: 16 },
+  flipY: false,
+},
+{
+  texture: texture74,
+  mipLevel: 0,
+  origin: { x: 29, y: 0, z: 103 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 47, height: 2, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend('\u8974\u{1fd6e}');
+let canvas19 = document.createElement('canvas');
+let bindGroup34 = device5.createBindGroup({
+label: '\u054e\u7e05\u44c4\u0ab0\u06d5\u{1fae3}\uea4a',
+layout: bindGroupLayout18,
+entries: [
+
+],
+});
+let querySet63 = device5.createQuerySet(
+{
+type: 'occlusion',
+count: 366,
+}
+);
+let computePassEncoder36 = commandEncoder56.beginComputePass(
+{
+
+}
+);
+let renderBundleEncoder63 = device5.createRenderBundleEncoder(
+{
+label: '\u{1f730}\u1307\u740d\u3267\u{1ff5d}\u{1f7f5}\u{1f695}\u0238',
+colorFormats: [
+'r16sint',
+'bgra8unorm-srgb'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 914,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder63.setBindGroup(
+2,
+bindGroup34,
+new Uint32Array(4585),
+717,
+0
+);
+} catch {}
+try {
+renderBundleEncoder63.setVertexBuffer(
+82,
+undefined,
+859657170,
+2884650797
+);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture79,
+  mipLevel: 4,
+  origin: { x: 34, y: 1, z: 3 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 5646940 */{
+offset: 376,
+bytesPerRow: 388,
+rowsPerImage: 147,
+},
+{width: 56, height: 0, depthOrArrayLayers: 100}
+);
+} catch {}
+document.body.prepend('\u911e\u0854\u585f\udf32\u04f7\u0bcb');
+let imageData18 = new ImageData(60, 240);
+let commandEncoder57 = device4.createCommandEncoder(
+{
+label: '\u8fe0\u397e\uf418\u092a\u58ee\u05c0\uc281\uaa3d',
+}
+);
+let querySet64 = device4.createQuerySet(
+{
+label: '\ub792\ud109\u000d\u{1ffda}\u4ea1\u{1ffa2}\u0e96\u0417\u732a\u9fb4\u9248',
+type: 'occlusion',
+count: 3554,
+}
+);
+let texture81 = device4.createTexture(
+{
+label: '\u0384\u5a64\u03b3\u{1fc79}\ua137\u{1f9aa}\u{1f777}\u5841',
+size: [6814, 1, 227],
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16sint',
+'rgba16sint',
+'rgba16sint'
+],
+}
+);
+try {
+renderPassEncoder12.setBindGroup(
+0,
+bindGroup24
+);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(
+1,
+bindGroup24,
+new Uint32Array(580),
+361,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.setViewport(
+472.4,
+0.2737,
+380.4,
+0.1862,
+0.5931,
+0.9477
+);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(
+buffer20,
+'uint32',
+3168
+);
+} catch {}
+try {
+commandEncoder57.clearBuffer(
+buffer20,
+5684,
+924
+);
+dissociateBuffer(device4, buffer20);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture59,
+  mipLevel: 4,
+  origin: { x: 3, y: 1, z: 42 },
+  aspect: 'all',
+},
+new ArrayBuffer(48),
+/* required buffer size: 793491 */{
+offset: 951,
+bytesPerRow: 153,
+rowsPerImage: 140,
+},
+{width: 6, height: 0, depthOrArrayLayers: 38}
+);
+} catch {}
+try {
+window.someLabel = device2.label;
+} catch {}
+let querySet65 = device2.createQuerySet(
+{
+type: 'occlusion',
+count: 2694,
+}
+);
+let texture82 = device2.createTexture(
+{
+label: '\u681b\u0e9f\u46aa\u7a8a\u0677\ueda9\u042e\u{1fdd7}\u0e9c\u89bd',
+size: {width: 2787, height: 1, depthOrArrayLayers: 189},
+mipLevelCount: 4,
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rg8unorm',
+'rg8unorm'
+],
+}
+);
+try {
+renderBundleEncoder41.setBindGroup(
+4,
+bindGroup21,
+new Uint32Array(3932),
+1983,
+0
+);
+} catch {}
+canvas9.width = 308;
+let video26 = await videoWithData();
+let renderBundleEncoder64 = device3.createRenderBundleEncoder(
+{
+label: '\u1a7a\u0958\u{1fc5b}',
+colorFormats: [
+undefined,
+'rgba32uint',
+'rgba32sint',
+'r16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 621,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder64.setVertexBuffer(
+29,
+undefined,
+1921323372,
+1318572370
+);
+} catch {}
+let renderBundleEncoder65 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba16uint',
+'rg16float',
+'rgba8sint',
+'rgba32uint'
+],
+sampleCount: 404,
+depthReadOnly: true,
+}
+);
+let renderBundle70 = renderBundleEncoder33.finish(
+{
+label: '\u2b7c\u48b0\u0b7b\u143c\ue372\u22d4\u00df'
+}
+);
+try {
+await buffer22.mapAsync(
+GPUMapMode.WRITE,
+0,
+9852
+);
+} catch {}
+let textureView68 = texture57.createView(
+{
+label: '\u01c8\u7fce\u8999\u305a\u0be8\u0352',
+format: 'rgb10a2unorm',
+mipLevelCount: 1,
+baseArrayLayer: 0,
+}
+);
+try {
+device2.queue.writeBuffer(
+buffer17,
+3344,
+new BigUint64Array(44291),
+10198,
+2700
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture66,
+  mipLevel: 0,
+  origin: { x: 35, y: 0, z: 17 },
+  aspect: 'all',
+},
+new Int32Array(arrayBuffer0),
+/* required buffer size: 4982971 */{
+offset: 829,
+bytesPerRow: 3973,
+rowsPerImage: 57,
+},
+{width: 925, height: 0, depthOrArrayLayers: 23}
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 696, height: 1, depthOrArrayLayers: 189}
+*/
+{
+  source: imageBitmap5,
+  origin: { x: 112, y: 99 },
+  flipY: false,
+},
+{
+  texture: texture82,
+  mipLevel: 2,
+  origin: { x: 624, y: 0, z: 38 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 42, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await promise37;
+} catch {}
+let shaderModule11 = device4.createShaderModule(
+{
+label: '\ueefc\u0e1e\ua24f',
+code: `
+
+@compute @workgroup_size(8, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S15 {
+@location(5) f0: f16,
+@location(21) f1: vec3<u32>,
+@location(24) f2: vec3<u32>,
+@location(4) f3: f32
+}
+struct FragmentOutput0 {
+@location(3) f0: vec2<i32>,
+@location(4) f1: u32,
+@location(2) f2: vec2<i32>,
+@location(0) f3: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(13) a0: vec4<f32>, @location(29) a1: u32, @location(1) a2: vec4<f16>, a3: S15, @location(6) a4: vec4<f32>, @builtin(front_facing) a5: bool, @location(23) a6: vec3<f32>, @location(3) a7: vec4<f16>, @builtin(sample_mask) a8: u32, @builtin(sample_index) a9: u32, @builtin(position) a10: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S14 {
+@location(9) f0: vec4<f32>,
+@location(14) f1: f16,
+@location(18) f2: vec3<f32>
+}
+struct VertexOutput0 {
+@location(1) f242: vec4<f16>,
+@builtin(position) f243: vec4<f32>,
+@location(13) f244: vec4<f32>,
+@location(4) f245: f32,
+@location(6) f246: vec4<f32>,
+@location(29) f247: u32,
+@location(21) f248: vec3<u32>,
+@location(3) f249: vec4<f16>,
+@location(5) f250: f16,
+@location(24) f251: vec3<u32>,
+@location(23) f252: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec2<i32>, @location(11) a1: u32, @location(20) a2: vec4<f32>, @location(2) a3: vec2<f32>, @location(16) a4: f16, @location(17) a5: f32, @location(12) a6: i32, @location(5) a7: vec2<f32>, @location(1) a8: vec4<f32>, @location(19) a9: vec4<f16>, @location(3) a10: vec4<f16>, @location(10) a11: vec2<i32>, a12: S14, @location(4) a13: i32, @location(13) a14: vec4<u32>, @builtin(vertex_index) a15: u32, @location(8) a16: f32, @location(6) a17: vec3<f16>, @location(0) a18: vec3<f16>, @location(7) a19: vec4<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+}
+);
+let textureView69 = texture78.createView(
+{
+label: '\u{1f7c2}\u039f\u9ffb',
+dimension: '2d-array',
+mipLevelCount: 1,
+arrayLayerCount: 1,
+}
+);
+let renderBundle71 = renderBundleEncoder45.finish(
+{
+label: '\u23dc\u02a4'
+}
+);
+try {
+renderPassEncoder12.setScissorRect(
+658,
+1,
+205,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+11,
+buffer20,
+996,
+3343
+);
+} catch {}
+try {
+renderBundleEncoder57.setBindGroup(
+0,
+bindGroup28
+);
+} catch {}
+try {
+commandEncoder57.copyBufferToBuffer(
+buffer18,
+444,
+buffer20,
+3800,
+2984
+);
+dissociateBuffer(device4, buffer18);
+dissociateBuffer(device4, buffer20);
+} catch {}
+try {
+commandEncoder55.copyTextureToTexture(
+{
+  texture: texture81,
+  mipLevel: 0,
+  origin: { x: 2980, y: 0, z: 92 },
+  aspect: 'all',
+},
+{
+  texture: texture81,
+  mipLevel: 0,
+  origin: { x: 4272, y: 0, z: 79 },
+  aspect: 'all',
+},
+{width: 654, height: 1, depthOrArrayLayers: 4}
+);
+} catch {}
+let pipeline45 = device4.createRenderPipeline(
+{
+label: '\u{1fb2e}\u0c42\uc65e\u318a\u0712\u02c2',
+layout: 'auto',
+vertex: {
+module: shaderModule11,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1212,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 788,
+shaderLocation: 18,
+},
+{
+format: 'unorm16x4',
+offset: 60,
+shaderLocation: 3,
+},
+{
+format: 'float32x4',
+offset: 408,
+shaderLocation: 0,
+},
+{
+format: 'unorm8x4',
+offset: 328,
+shaderLocation: 9,
+},
+{
+format: 'uint16x4',
+offset: 104,
+shaderLocation: 13,
+},
+{
+format: 'uint32x3',
+offset: 656,
+shaderLocation: 11,
+},
+{
+format: 'unorm16x4',
+offset: 1096,
+shaderLocation: 1,
+},
+{
+format: 'sint32x2',
+offset: 876,
+shaderLocation: 15,
+},
+{
+format: 'float32',
+offset: 168,
+shaderLocation: 19,
+},
+{
+format: 'float32x2',
+offset: 480,
+shaderLocation: 2,
+},
+{
+format: 'snorm8x4',
+offset: 96,
+shaderLocation: 8,
+},
+{
+format: 'float16x4',
+offset: 24,
+shaderLocation: 14,
+},
+{
+format: 'sint32x2',
+offset: 448,
+shaderLocation: 4,
+},
+{
+format: 'sint8x4',
+offset: 244,
+shaderLocation: 10,
+},
+{
+format: 'float16x4',
+offset: 944,
+shaderLocation: 5,
+},
+{
+format: 'sint8x4',
+offset: 1204,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 356,
+shaderLocation: 20,
+},
+{
+format: 'float32x2',
+offset: 368,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 520,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x4',
+offset: 472,
+shaderLocation: 7,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 452,
+shaderLocation: 17,
+},
+{
+format: 'unorm16x4',
+offset: 508,
+shaderLocation: 6,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+frontFace: 'cw',
+},
+fragment: {
+module: shaderModule11,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+undefined,
+{
+format: 'rg8sint',
+},
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}
+],
+},
+}
+);
+let gpuCanvasContext19 = canvas18.getContext('webgpu');
+document.body.append('\u{1f8ea}\u{1fe52}\u1128\u0b29\u{1f99f}\u{1f8a8}\ubf60\u854f\u735b\u259a');
+let bindGroup35 = device5.createBindGroup({
+label: '\u0177\u0d87\u0b89',
+layout: bindGroupLayout18,
+entries: [
+
+],
+});
+let pipelineLayout21 = device5.createPipelineLayout(
+{
+bindGroupLayouts: [
+
+],
+}
+);
+let texture83 = device5.createTexture(
+{
+size: [1426, 1, 1403],
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder66 = device5.createRenderBundleEncoder(
+{
+label: '\u710b\u2c07\u8997\u{1ff94}\u{1fd05}\ufb04',
+colorFormats: [
+'rgba8unorm'
+],
+sampleCount: 607,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder36.setBindGroup(
+1,
+bindGroup34,
+new Uint32Array(5169),
+2686,
+0
+);
+} catch {}
+try {
+device5.pushErrorScope(
+'out-of-memory'
+);
+} catch {}
+let promise38 = device5.popErrorScope();
+try {
+device5.queue.copyExternalImageToTexture(
+/*
+{width: 77, height: 2, depthOrArrayLayers: 121}
+*/
+{
+  source: videoFrame17,
+  origin: { x: 80, y: 16 },
+  flipY: true,
+},
+{
+  texture: texture74,
+  mipLevel: 0,
+  origin: { x: 4, y: 0, z: 109 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 65, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\uf75b\u1c68\u0379\ucc03\u049b\u{1fce1}\u1979\u0c0c\ue031\ud40e');
+let video27 = await videoWithData();
+let computePassEncoder37 = commandEncoder55.beginComputePass(
+{
+label: '\u0ccd\u{1fb5b}\u{1f6dc}\uc5a5\u0cfe\u0d99\u1d23\u03fe\u{1fe81}\ud0b4\ud348'
+}
+);
+let renderPassEncoder13 = commandEncoder57.beginRenderPass(
+{
+label: '\ua8f7\uc9e6\u0a90\u0fd0\ud574\u{1fd58}\uada2',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView52,
+depthClearValue: 0.9300263563945212,
+depthLoadOp: 'clear',
+depthStoreOp: 'discard',
+stencilClearValue: 27923,
+},
+occlusionQuerySet: querySet48,
+maxDrawCount: 61776,
+}
+);
+try {
+renderPassEncoder13.beginOcclusionQuery(
+64
+);
+} catch {}
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(
+143,
+1,
+799,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.setViewport(
+551.2,
+0.4954,
+205.9,
+0.07068,
+0.3019,
+0.8134
+);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(
+buffer20,
+'uint16',
+6732,
+466
+);
+} catch {}
+try {
+renderBundleEncoder57.setVertexBuffer(
+2,
+buffer20,
+6132,
+268
+);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+let gpuCanvasContext20 = canvas19.getContext('webgpu');
+pseudoSubmit(device5, commandEncoder53);
+let texture84 = device5.createTexture(
+{
+label: '\u0480\udb84\u00c8\uf757\u16a6\uddf4\u04f7\u2fba\u023b\u{1f779}\u{1fcf4}',
+size: [112, 187, 1],
+mipLevelCount: 7,
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundleEncoder67 = device5.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8uint',
+'r8sint',
+'rgba16sint',
+'r16float',
+undefined,
+'rgba16uint',
+'rgba16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 737,
+}
+);
+let sampler54 = device5.createSampler(
+{
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 49.788,
+lodMaxClamp: 63.603,
+}
+);
+try {
+device5.queue.writeTexture(
+{
+  texture: texture79,
+  mipLevel: 5,
+  origin: { x: 2, y: 0, z: 19 },
+  aspect: 'all',
+},
+arrayBuffer6,
+/* required buffer size: 1552639 */{
+offset: 511,
+bytesPerRow: 258,
+rowsPerImage: 188,
+},
+{width: 28, height: 0, depthOrArrayLayers: 33}
+);
+} catch {}
+let querySet66 = device7.createQuerySet(
+{
+label: '\u49c4\u9728\u5513\u7a91\uf0e8\u{1fd6a}\u82f1\u784a\u0e7c\u249d\ud660',
+type: 'occlusion',
+count: 1404,
+}
+);
+let renderBundle72 = renderBundleEncoder51.finish(
+{
+label: '\uc7ba\ub847\u{1fa24}\u{1fda1}\u3465\ufefe\u0770\ud44e\u5eb7\u8d52'
+}
+);
+try {
+device7.queue.writeTexture(
+{
+  texture: texture68,
+  mipLevel: 0,
+  origin: { x: 955, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Float64Array(new ArrayBuffer(24)),
+/* required buffer size: 596 */{
+offset: 596,
+bytesPerRow: 18873,
+},
+{width: 4647, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\u{1fa9f}\u{1f62e}');
+let imageData19 = new ImageData(188, 32);
+let videoFrame22 = new VideoFrame(imageBitmap14, {timestamp: 0});
+try {
+commandEncoder43.label = '\u0f38\u8b4c\u0c49\u977a\u0e21\u0b36\ue728\u{1f81c}\ub522\u7747';
+} catch {}
+let commandEncoder58 = device2.createCommandEncoder(
+{
+label: '\u74d9\ub741\u20d3\ubb88\u4d28\u{1f789}',
+}
+);
+let texture85 = device2.createTexture(
+{
+size: [4279],
+dimension: '1d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+renderBundleEncoder41.setBindGroup(
+1,
+bindGroup21
+);
+} catch {}
+try {
+commandEncoder58.copyTextureToBuffer(
+{
+  texture: texture66,
+  mipLevel: 10,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 45640 */
+offset: 45640,
+buffer: buffer17,
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device2, buffer17);
+} catch {}
+let imageBitmap23 = await createImageBitmap(imageBitmap13);
+let querySet67 = device5.createQuerySet(
+{
+label: '\ueb3e\u0ace',
+type: 'occlusion',
+count: 1242,
+}
+);
+let texture86 = device5.createTexture(
+{
+label: '\u7790\u76cf\u05ba\u8a00',
+size: {width: 3008, height: 76, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'eac-r11unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'eac-r11unorm'
+],
+}
+);
+try {
+renderBundleEncoder67.setBindGroup(
+1,
+bindGroup32,
+new Uint32Array(2275),
+477,
+0
+);
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(
+/*
+{width: 77, height: 2, depthOrArrayLayers: 121}
+*/
+{
+  source: offscreenCanvas11,
+  origin: { x: 742, y: 537 },
+  flipY: true,
+},
+{
+  texture: texture74,
+  mipLevel: 0,
+  origin: { x: 33, y: 1, z: 41 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 39, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\u{1fe10}\u{1fd14}\ud643\u0a23\u{1f622}\ua477\u034f\ud16f\u{1fc20}\u43f5');
+document.body.prepend('\ub600\u0c6b\u{1fc84}\u43ec\u0c87\ufea9\u6aba\u9301\u5878');
+let img20 = await imageWithData(16, 228, '#df135548', '#e2399dbb');
+let texture87 = device3.createTexture(
+{
+label: '\u{1ffa0}\u{1fa3a}',
+size: [9760, 170, 1],
+mipLevelCount: 7,
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'r16sint',
+'r16sint',
+'r16sint'
+],
+}
+);
+let renderBundle73 = renderBundleEncoder64.finish();
+let commandEncoder59 = device6.createCommandEncoder(
+{
+label: '\u904c\u{1f809}\u03d7',
+}
+);
+let textureView70 = texture76.createView(
+{
+label: '\ub8e8\u{1fef9}\ucd09\u6ece',
+dimension: '2d-array',
+aspect: 'all',
+baseMipLevel: 8,
+}
+);
+let renderBundle74 = renderBundleEncoder52.finish(
+{
+
+}
+);
+let sampler55 = device6.createSampler(
+{
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 84.759,
+lodMaxClamp: 85.108,
+maxAnisotropy: 19,
+}
+);
+try {
+renderBundleEncoder58.setVertexBuffer(
+4,
+buffer21,
+20688,
+21192
+);
+} catch {}
+try {
+commandEncoder54.copyBufferToTexture(
+{
+/* bytesInLastRow: 144 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 11120 */
+offset: 11120,
+bytesPerRow: 256,
+rowsPerImage: 223,
+buffer: buffer21,
+},
+{
+  texture: texture75,
+  mipLevel: 0,
+  origin: { x: 24, y: 40, z: 1 },
+  aspect: 'all',
+},
+{width: 72, height: 40, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device6, buffer21);
+} catch {}
+try {
+commandEncoder54.copyTextureToTexture(
+{
+  texture: texture76,
+  mipLevel: 9,
+  origin: { x: 0, y: 5, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture76,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device6.queue.writeTexture(
+{
+  texture: texture70,
+  mipLevel: 4,
+  origin: { x: 252, y: 0, z: 74 },
+  aspect: 'all',
+},
+new ArrayBuffer(0),
+/* required buffer size: 6210386 */{
+offset: 386,
+bytesPerRow: 180,
+rowsPerImage: 250,
+},
+{width: 60, height: 0, depthOrArrayLayers: 139}
+);
+} catch {}
+try {
+await promise38;
+} catch {}
+let imageBitmap24 = await createImageBitmap(imageBitmap12);
+let renderBundle75 = renderBundleEncoder48.finish(
+{
+label: '\u07cc\u02bd\u6f9a\u{1f8dc}\u1c43\u0078\u8695'
+}
+);
+try {
+computePassEncoder35.insertDebugMarker(
+'\u0b20'
+);
+} catch {}
+let img21 = await imageWithData(55, 102, '#19e2fc47', '#c7a06cd9');
+let computePassEncoder38 = commandEncoder58.beginComputePass(
+{
+label: '\u{1ff10}\u53d7\ud121\u0a7d\ue3ab\u5102\ub8bb\u{1f90b}\ub21b\u0f8d\u00c0'
+}
+);
+try {
+renderBundleEncoder36.setVertexBuffer(
+7,
+buffer15,
+3156,
+214
+);
+} catch {}
+try {
+offscreenCanvas18.getContext('webgpu');
+} catch {}
+document.body.prepend(img9);
+video19.height = 50;
+document.body.append('\ucaf9\u0d3e\u0998\u0a33\u{1f819}\u{1fa3c}\ue7e5\uf6dc\u{1f901}\u{1ffc9}\u07b6');
+let bindGroup36 = device2.createBindGroup({
+label: '\u78f6\udd2e\u5fa7\u{1fc01}\u{1f7f9}\u{1fb51}\uec2f\ufc13\u{1fb26}\u3cd5\u{1fc21}',
+layout: bindGroupLayout16,
+entries: [
+
+],
+});
+let textureView71 = texture50.createView(
+{
+label: '\u0cfc\u04a1\u0258\u{1fb83}\ud775\u7e9b\u61ef\u2e61\ub88b',
+format: 'rg8unorm',
+baseMipLevel: 1,
+baseArrayLayer: 0,
+}
+);
+try {
+computePassEncoder38.setBindGroup(
+2,
+bindGroup21,
+new Uint32Array(5026),
+3753,
+0
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer17,
+8932,
+new Int16Array(30272),
+23169,
+3256
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture49,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(48),
+/* required buffer size: 1464 */{
+offset: 886,
+bytesPerRow: 278,
+},
+{width: 11, height: 3, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+window.someLabel = texture85.label;
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 166, height: 1, depthOrArrayLayers: 40}
+*/
+{
+  source: video6,
+  origin: { x: 13, y: 7 },
+  flipY: false,
+},
+{
+  texture: texture50,
+  mipLevel: 1,
+  origin: { x: 71, y: 0, z: 16 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 3, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let bindGroup37 = device1.createBindGroup({
+label: '\u0d1e\ud32c\u84b0',
+layout: bindGroupLayout12,
+entries: [
+
+],
+});
+let texture88 = device1.createTexture(
+{
+label: '\u6f2b\u24c8\u2c8c\u{1faa9}\u{1fdfe}\ufa6d',
+size: [20, 10, 219],
+mipLevelCount: 4,
+format: 'astc-10x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-10x10-unorm'
+],
+}
+);
+let textureView72 = texture61.createView(
+{
+label: '\u7007\uda96\ud0bd\ub0c8\u{1f93c}\u0f78\u0ed9\u42c9\uab27\u0a5b\u0587',
+baseMipLevel: 3,
+}
+);
+try {
+renderBundleEncoder65.setIndexBuffer(
+buffer16,
+'uint16',
+33694,
+7074
+);
+} catch {}
+try {
+renderBundleEncoder65.setVertexBuffer(
+8,
+buffer14,
+31288,
+3278
+);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+document.body.append('\u4a3e\u{1fd04}\uac54\u0af6\u050c\u0b80\u0afb\u3798\u02fa\uac53\u{1f71b}');
+let pipelineLayout22 = device8.createPipelineLayout(
+{
+label: '\u29f1\u046d\u{1f9e1}\ub369\u0dee\u{1f8d3}\u{1f81d}\u0e07\u11df',
+bindGroupLayouts: [
+bindGroupLayout22,
+bindGroupLayout22
+],
+}
+);
+let renderBundleEncoder68 = device8.createRenderBundleEncoder(
+{
+label: '\ua896\u91d2\u{1ff84}\u8771\u2ad4\ucba3\u63ee',
+colorFormats: [
+'rgba8unorm-srgb',
+'rg16uint',
+undefined,
+'r8uint',
+'bgra8unorm-srgb'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 117,
+depthReadOnly: true,
+}
+);
+let renderBundle76 = renderBundleEncoder62.finish(
+{
+label: '\u6b82\u{1f926}\u{1f899}'
+}
+);
+document.body.prepend('\u9a73\u2669\u{1f776}\ue94b\u8233\u{1fe54}\u{1fc5a}\u{1f84b}\ub471');
+let querySet68 = device3.createQuerySet(
+{
+label: '\u09df\u6764\u777a\u6940',
+type: 'occlusion',
+count: 87,
+}
+);
+let img22 = await imageWithData(43, 70, '#cce34a7a', '#04a020cb');
+let imageBitmap25 = await createImageBitmap(imageData18);
+let querySet69 = device6.createQuerySet(
+{
+label: '\u0c3e\u0e88',
+type: 'occlusion',
+count: 3017,
+}
+);
+let textureView73 = texture70.createView(
+{
+label: '\u0bcc\u{1f763}\udd6b',
+dimension: '2d',
+baseMipLevel: 1,
+mipLevelCount: 1,
+baseArrayLayer: 161,
+}
+);
+try {
+gpuCanvasContext4.configure(
+{
+device: device6,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-12x12-unorm-srgb',
+'rgba16float',
+'r16sint'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend('\u8102\ucf7f\u6776\u{1fb9a}\u65ff\u431a\u456b\u09aa\u9587\u0e4c\ue8ec');
+let commandEncoder60 = device3.createCommandEncoder(
+{
+label: '\u0616\u0ab8\u0935\ueccd\u{1f706}\uced4\ud0aa',
+}
+);
+let computePassEncoder39 = commandEncoder60.beginComputePass(
+{
+label: '\u08fd\u{1f636}\u{1f9b2}\u{1fdfc}\u{1fecd}\u0396'
+}
+);
+let renderBundle77 = renderBundleEncoder64.finish(
+{
+label: '\u0d56\u397f\udb70\ue5d1\u24b9\u{1f7c3}\ud2dc\u3e33\u1361\u58af'
+}
+);
+gc();
+let img23 = await imageWithData(209, 40, '#44f12477', '#a3b7f4cb');
+document.body.append('\u{1f748}\u0196\u0815\uae08\uf0de\u0316\u3575');
+let buffer23 = device6.createBuffer(
+{
+label: '\u{1fa8d}\u{1f930}\ue0d0\u0711\ub201\u5c9f\u0386\u{1f7e2}\u2b6d\u0f4e\u48df',
+size: 31843,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let sampler56 = device6.createSampler(
+{
+label: '\u01c0\u8186\u795f\u{1f8a7}\u0629\ud774',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 24.860,
+lodMaxClamp: 98.130,
+}
+);
+try {
+commandEncoder59.copyTextureToTexture(
+{
+  texture: texture70,
+  mipLevel: 0,
+  origin: { x: 2520, y: 0, z: 39 },
+  aspect: 'all',
+},
+{
+  texture: texture70,
+  mipLevel: 3,
+  origin: { x: 660, y: 0, z: 94 },
+  aspect: 'all',
+},
+{width: 36, height: 0, depthOrArrayLayers: 70}
+);
+} catch {}
+try {
+device6.queue.writeBuffer(
+buffer23,
+16276,
+new Int16Array(4860),
+2374,
+192
+);
+} catch {}
+pseudoSubmit(device4, commandEncoder55);
+try {
+renderPassEncoder13.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder13.setStencilReference(
+580
+);
+} catch {}
+document.body.append('\u4898\uccb1\u606f\ue7ed\u8baa\u{1fd60}\ucd54\u{1f6e5}');
+let commandEncoder61 = device3.createCommandEncoder(
+{
+label: '\u04b0\ua78f\ueef6',
+}
+);
+let textureView74 = texture87.createView(
+{
+label: '\uebeb\u3462\ucc22\u{1fe0b}\u{1f8ab}\u{1fb98}\u8fb7',
+dimension: '2d-array',
+baseMipLevel: 4,
+mipLevelCount: 1,
+}
+);
+let sampler57 = device3.createSampler(
+{
+label: '\u0886\u984e\ube34',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+lodMinClamp: 93.823,
+lodMaxClamp: 96.261,
+compare: 'greater-equal',
+}
+);
+let bindGroup38 = device2.createBindGroup({
+label: '\ua35d\u2531\ub080\u9994\u{1f906}\u565c\u{1f899}\u0636\ubcb9',
+layout: bindGroupLayout16,
+entries: [
+
+],
+});
+let renderBundleEncoder69 = device2.createRenderBundleEncoder(
+{
+label: '\u0ac2\u4be1\u{1f9fc}\u08ad\u{1ffca}\u60c3\u9b36\u{1f784}\u0443\u6c45',
+colorFormats: [
+'r16float',
+undefined,
+'rgba8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 55,
+depthReadOnly: false,
+}
+);
+try {
+renderBundleEncoder37.setBindGroup(
+0,
+bindGroup21
+);
+} catch {}
+try {
+renderBundleEncoder69.setIndexBuffer(
+buffer17,
+'uint16'
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer17,
+46936,
+new BigUint64Array(25186),
+4269,
+24
+);
+} catch {}
+document.body.prepend('\ue639\ubb4f\ue234\u4d95\u{1fd4e}\u8937');
+let renderBundle78 = renderBundleEncoder39.finish(
+{
+label: '\u618f\ue7a9\u{1ff9f}\u0bba'
+}
+);
+try {
+renderBundleEncoder65.setBindGroup(
+0,
+bindGroup27
+);
+} catch {}
+let buffer24 = device3.createBuffer(
+{
+label: '\u{1fbde}\u{1faaa}\u{1f6a6}\u{1fe24}\u63ca\u{1f948}\u0300\u{1fd3e}\u0a86\u7fa9\u{1ff65}',
+size: 23301,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+}
+);
+let querySet70 = device3.createQuerySet(
+{
+label: '\u0cbb\uae78\u{1ff68}',
+type: 'occlusion',
+count: 619,
+}
+);
+let texture89 = device3.createTexture(
+{
+label: '\u067b\u09b5\u2b3d\u93be\u57c7\ucee3\u{1f742}\ueb20\u870a\u1c9a',
+size: [3433],
+dimension: '1d',
+format: 'rgba32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+let texture90 = gpuCanvasContext6.getCurrentTexture();
+let textureView75 = texture89.createView(
+{
+label: '\u1ddb\u{1f9e3}\ud8c6\u1e7d\u015d',
+}
+);
+let renderBundleEncoder70 = device3.createRenderBundleEncoder(
+{
+label: '\u035c\u8a4e\u1db9\u0012\u06f0\u0287\u0e35\u{1fa60}\u101e\u{1ff8e}\u00c1',
+colorFormats: [
+'r16uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 499,
+stencilReadOnly: false,
+}
+);
+try {
+device3.queue.writeTexture(
+{
+  texture: texture90,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer3,
+/* required buffer size: 210 */{
+offset: 210,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let canvas20 = document.createElement('canvas');
+let imageBitmap26 = await createImageBitmap(imageData10);
+let buffer25 = device4.createBuffer(
+{
+size: 42632,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+let textureView76 = texture78.createView(
+{
+label: '\u{1fb46}\u{1fed1}\ua42f\uf176\u{1fccb}\u5856\u8fc7',
+dimension: '2d-array',
+}
+);
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+let promise39 = adapter11.requestDevice(
+{
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'texture-compression-astc'
+],
+requiredLimits: {
+maxBindGroups: 7,
+maxVertexAttributes: 23,
+maxVertexBufferArrayStride: 34639,
+maxStorageTexturesPerShaderStage: 38,
+maxStorageBuffersPerShaderStage: 33,
+maxDynamicStorageBuffersPerPipelineLayout: 11285,
+maxBindingsPerBindGroup: 6525,
+maxTextureArrayLayers: 256,
+maxTextureDimension1D: 16050,
+maxTextureDimension2D: 9956,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 40712849,
+maxInterStageShaderVariables: 114,
+maxInterStageShaderComponents: 122,
+},
+}
+);
+let canvas21 = document.createElement('canvas');
+let buffer26 = device7.createBuffer(
+{
+size: 29847,
+usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+}
+);
+let textureView77 = texture68.createView(
+{
+label: '\u4c65\ucf5a\u0069\u{1fb08}\u{1f67e}\ub4b0\u027f\u8f1a\u{1f6ad}\u0381\ucdbd',
+aspect: 'all',
+baseArrayLayer: 0,
+}
+);
+try {
+renderBundleEncoder59.setVertexBuffer(
+93,
+undefined,
+2965293715
+);
+} catch {}
+try {
+renderBundleEncoder59.insertDebugMarker(
+'\u0060'
+);
+} catch {}
+try {
+gpuCanvasContext4.configure(
+{
+device: device7,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rg32sint'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+document.body.append('\u5669\uf70f');
+let imageBitmap27 = await createImageBitmap(video2);
+try {
+renderBundleEncoder65.setBindGroup(
+3,
+bindGroup23
+);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+try {
+canvas20.getContext('2d');
+} catch {}
+let computePassEncoder40 = commandEncoder54.beginComputePass(
+{
+label: '\u03d7\u06f2\u{1f720}\u{1f7a0}\u{1fd93}\uff12\u{1fddd}\u{1fe20}\u0d2d\ua14a'
+}
+);
+let renderBundleEncoder71 = device6.createRenderBundleEncoder(
+{
+label: '\ud434\u01b8\u2fb7\u22d7\u0612\u{1ffc5}\ud429\u{1fe2d}\u0b6f\u0eac',
+colorFormats: [
+'rgb10a2uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 343,
+stencilReadOnly: true,
+}
+);
+let sampler58 = device6.createSampler(
+{
+label: '\u0a9b\u0334\u0cb0\u091e\u023c\ue0ad\ud406\u{1fbaf}\u0924',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 61.175,
+lodMaxClamp: 75.040,
+maxAnisotropy: 10,
+}
+);
+try {
+commandEncoder59.copyTextureToTexture(
+{
+  texture: texture70,
+  mipLevel: 3,
+  origin: { x: 132, y: 0, z: 116 },
+  aspect: 'all',
+},
+{
+  texture: texture70,
+  mipLevel: 2,
+  origin: { x: 300, y: 0, z: 113 },
+  aspect: 'all',
+},
+{width: 612, height: 0, depthOrArrayLayers: 100}
+);
+} catch {}
+try {
+device6.queue.writeBuffer(
+buffer23,
+9168,
+new Float32Array(21665),
+5640,
+2644
+);
+} catch {}
+let imageBitmap28 = await createImageBitmap(imageBitmap6);
+try {
+adapter9.label = '\u0ee4\u01ad\u8209';
+} catch {}
+try {
+canvas21.getContext('bitmaprenderer');
+} catch {}
+let buffer27 = device4.createBuffer(
+{
+label: '\u56dc\u0f58\u{1fa2f}\ubcc8',
+size: 49931,
+usage: GPUBufferUsage.MAP_READ,
+}
+);
+let sampler59 = device4.createSampler(
+{
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 38.232,
+lodMaxClamp: 70.960,
+compare: 'less',
+}
+);
+try {
+renderPassEncoder12.setViewport(
+394.6,
+0.2390,
+136.4,
+0.5822,
+0.8963,
+0.9450
+);
+} catch {}
+try {
+renderBundleEncoder57.setBindGroup(
+0,
+bindGroup28,
+new Uint32Array(4629),
+790,
+0
+);
+} catch {}
+try {
+renderBundleEncoder57.setVertexBuffer(
+10,
+buffer20,
+8216,
+154
+);
+} catch {}
+let promise40 = device4.queue.onSubmittedWorkDone();
+let pipeline46 = await device4.createComputePipelineAsync(
+{
+layout: pipelineLayout17,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+canvas4.width = 404;
+let offscreenCanvas19 = new OffscreenCanvas(579, 369);
+let gpuCanvasContext21 = offscreenCanvas19.getContext('webgpu');
+canvas0.width = 100;
+let commandEncoder62 = device6.createCommandEncoder(
+{
+}
+);
+let textureView78 = texture75.createView(
+{
+label: '\u9a5e\u077f\u7356',
+baseMipLevel: 0,
+}
+);
+try {
+commandEncoder59.copyTextureToTexture(
+{
+  texture: texture70,
+  mipLevel: 1,
+  origin: { x: 1236, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture70,
+  mipLevel: 3,
+  origin: { x: 60, y: 0, z: 28 },
+  aspect: 'all',
+},
+{width: 96, height: 0, depthOrArrayLayers: 197}
+);
+} catch {}
+try {
+await promise40;
+} catch {}
+let bindGroupLayout26 = device1.createBindGroupLayout(
+{
+label: '\uf1ee\u{1fd7b}\u58dc\u03d7\u49f2\uab97\u4a5d\u4b4f\u{1fd21}',
+entries: [
+{
+binding: 4409,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+},
+{
+binding: 676,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let textureView79 = texture80.createView(
+{
+label: '\u6823\u3777\u0717\ueb26\u04d1\u73e5\u0ec0\u{1f8d3}\u6634\u0e7c',
+format: 'astc-12x12-unorm',
+}
+);
+try {
+computePassEncoder33.setBindGroup(
+6,
+bindGroup37,
+new Uint32Array(6430),
+1832,
+0
+);
+} catch {}
+try {
+renderBundleEncoder65.setIndexBuffer(
+buffer14,
+'uint32',
+5264,
+21902
+);
+} catch {}
+try {
+buffer14.destroy();
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+let device10 = await promise39;
+let querySet71 = device3.createQuerySet(
+{
+label: '\u{1fb22}\uf632\u02a0\u0b5e\u0f00\u{1f98b}\u4017\u3759\u5360\u09df',
+type: 'occlusion',
+count: 4079,
+}
+);
+let texture91 = device3.createTexture(
+{
+label: '\u{1f603}\u{1f88c}',
+size: {width: 233, height: 1, depthOrArrayLayers: 127},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let texture92 = gpuCanvasContext5.getCurrentTexture();
+let computePassEncoder41 = commandEncoder61.beginComputePass(
+{
+label: '\u22ad\u{1f9e9}\u8342\u0e65'
+}
+);
+let renderPassEncoder14 = commandEncoder45.beginRenderPass(
+{
+label: '\udbc7\u09d6',
+colorAttachments: [
+{
+view: textureView74,
+clearValue: {
+r: -526.9,
+g: 21.42,
+b: -309.2,
+a: -772.2,
+},
+loadOp: 'load',
+storeOp: 'store'
+}
+],
+maxDrawCount: 24584,
+}
+);
+let renderBundle79 = renderBundleEncoder53.finish(
+{
+label: '\u{1f769}\u09f5\u2d6f\ubd0b\u03cc\u5c52\uf861\u85ab\u02a1\ub16b\u101c'
+}
+);
+let texture93 = device2.createTexture(
+{
+size: {width: 6329},
+dimension: '1d',
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+let renderBundleEncoder72 = device2.createRenderBundleEncoder(
+{
+label: '\u0023\u0bef\u7fee\u0a72\ucadb\udb19\u{1f702}\u0e26\u00f7\u{1fab9}\ud33d',
+colorFormats: [
+'rgb10a2uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 71,
+depthReadOnly: true,
+}
+);
+try {
+computePassEncoder23.setBindGroup(
+1,
+bindGroup36,
+new Uint32Array(108),
+107,
+0
+);
+} catch {}
+let arrayBuffer7 = buffer13.getMappedRange(
+34032,
+1216
+);
+let sampler60 = device6.createSampler(
+{
+label: '\u7494\u5183\u{1fdda}\u9dbc\u0f20\uaf29\u0add\u{1fdb6}\u0aa2\u5bf7\ub956',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 81.702,
+lodMaxClamp: 94.715,
+}
+);
+try {
+device6.queue.writeTexture(
+{
+  texture: texture76,
+  mipLevel: 6,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 728 */{
+offset: 712,
+bytesPerRow: 288,
+},
+{width: 8, height: 5, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend('\u{1f856}\u{1fc4c}\u028d\u0ec0\u6e54\u6248\u58d9\u{1f917}\ub910');
+let videoFrame23 = new VideoFrame(imageBitmap25, {timestamp: 0});
+let buffer28 = device6.createBuffer(
+{
+label: '\u4315\u029b\u{1fb1e}',
+size: 48641,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let textureView80 = texture70.createView(
+{
+label: '\u0992\uc307\u0a41\u044b\u2cc2\u0915\u0371\u5257\uf0a5\u4bbb\ue860',
+mipLevelCount: 4,
+baseArrayLayer: 70,
+arrayLayerCount: 68,
+}
+);
+let computePassEncoder42 = commandEncoder59.beginComputePass();
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let textureView81 = texture79.createView(
+{
+label: '\u034d\u0732\u0ae5',
+format: 'bgra8unorm',
+baseMipLevel: 2,
+mipLevelCount: 5,
+}
+);
+let texture94 = device2.createTexture(
+{
+size: [50, 55, 218],
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+}
+);
+let textureView82 = texture57.createView(
+{
+label: '\u0c94\u{1fcbb}\u0666\u3f4d\u0ee6\u08e0\ud361',
+}
+);
+try {
+gpuCanvasContext21.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16float',
+'depth32float'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer15,
+12108,
+new BigUint64Array(53393),
+37710,
+1084
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture67,
+  mipLevel: 0,
+  origin: { x: 1755, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Int32Array(arrayBuffer3),
+/* required buffer size: 923 */{
+offset: 923,
+},
+{width: 6340, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\u0f66\u0357\u0f57\ufa75\u01ce\u{1f62e}\ub10c');
+let renderBundle80 = renderBundleEncoder64.finish(
+{
+label: '\u0787\u72ce\uab7e\u0692\ud562\u0ae0\u0142\ud42c\u{1fc59}\u64c7'
+}
+);
+try {
+computePassEncoder34.end();
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant(
+{
+r: 268.5,
+g: 110.9,
+b: -904.4,
+a: 214.3,
+}
+);
+} catch {}
+try {
+renderPassEncoder14.setStencilReference(
+1524
+);
+} catch {}
+gc();
+let imageData20 = new ImageData(152, 8);
+let querySet72 = device9.createQuerySet(
+{
+label: '\u0cb4\uf861\u3e28\u56e3\u0308\u0f42\u377d\u059d\u0adb\uc01e\u0b1a',
+type: 'occlusion',
+count: 2381,
+}
+);
+let commandEncoder63 = device10.createCommandEncoder(
+{
+label: '\u{1fa19}\u{1f68f}\u{1f656}\u3d16\u1f41\u{1f667}\ub456\ua04d',
+}
+);
+try {
+gpuCanvasContext7.configure(
+{
+device: device10,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-5x4-unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+canvas1.height = 708;
+let commandEncoder64 = device7.createCommandEncoder();
+let texture95 = device7.createTexture(
+{
+label: '\ub8ff\uca1c\u{1f81a}\u0add\u0a17\udaf7\u{1fcbc}\u09d7',
+size: [180, 48, 1],
+mipLevelCount: 5,
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-12x12-unorm',
+'astc-12x12-unorm-srgb'
+],
+}
+);
+let computePassEncoder43 = commandEncoder64.beginComputePass(
+{
+label: '\u4cfe\ue12c\u8d2b\ua8c9\u4f71\ub20e'
+}
+);
+try {
+renderBundleEncoder59.popDebugGroup();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let bindGroupLayout27 = device8.createBindGroupLayout(
+{
+label: '\u5c55\u3d9b\u073f\u8b68\u89e6\u57bb',
+entries: [
+{
+binding: 350,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 216,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+}
+],
+}
+);
+let renderBundleEncoder73 = device8.createRenderBundleEncoder(
+{
+label: '\u{1f878}\u357a\uea06\u{1f6f8}\ub598\u38d0\u0233',
+colorFormats: [
+'rgba8unorm-srgb'
+],
+sampleCount: 515,
+}
+);
+try {
+renderBundleEncoder73.setVertexBuffer(
+0,
+undefined,
+166969450,
+8134771
+);
+} catch {}
+try {
+gpuCanvasContext12.configure(
+{
+device: device8,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let texture96 = device10.createTexture(
+{
+size: [1594, 1, 35],
+mipLevelCount: 11,
+format: 'rg16uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg16uint',
+'rg16uint',
+'rg16uint'
+],
+}
+);
+let computePassEncoder44 = commandEncoder63.beginComputePass(
+{
+label: '\u0432\u0c03\u{1fd8c}\ue6cf\u819f\u0da1\uf09a\u4b3a\u014e\u{1fc43}\u8a74'
+}
+);
+let renderBundleEncoder74 = device10.createRenderBundleEncoder(
+{
+label: '\u0afb\udcf2\u{1f832}\u943c\u8fc5\u307d\u{1f606}\u0765\u{1fff5}\u{1f978}\u064f',
+colorFormats: [
+'r32sint',
+'r16sint',
+'rgba16uint',
+'rgba32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 805,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+gc();
+document.body.append('\uccdb\u7183\u22f4\ub721\ue7ad\u7b64\u0cd8\u003e\u0e19\u{1fa92}');
+let textureView83 = texture93.createView(
+{
+label: '\u0879\u6ede\u665a\u9ba6\u542d\u2a58\u64b3\u{1fc8f}',
+}
+);
+let renderBundleEncoder75 = device2.createRenderBundleEncoder(
+{
+label: '\u{1fe47}\u07ff\u{1fa73}\u{1f640}\u{1f7aa}\ue04c',
+colorFormats: [
+undefined,
+undefined,
+'rg32sint',
+'rg16float'
+],
+sampleCount: 480,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder41.setBindGroup(
+1,
+bindGroup38,
+new Uint32Array(4740),
+4117,
+0
+);
+} catch {}
+offscreenCanvas15.width = 128;
+let renderBundleEncoder76 = device4.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba32sint',
+'rgb10a2unorm',
+'rgb10a2uint',
+undefined,
+undefined
+],
+sampleCount: 830,
+stencilReadOnly: true,
+}
+);
+let renderBundle81 = renderBundleEncoder44.finish(
+{
+label: '\u0315\ua638\u3753\u4c3e\u38a9\u0b10\u{1f78e}'
+}
+);
+try {
+renderPassEncoder12.setBlendConstant(
+{
+r: -48.63,
+g: -977.4,
+b: -32.22,
+a: -534.7,
+}
+);
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(
+2425
+);
+} catch {}
+try {
+gpuCanvasContext4.configure(
+{
+device: device4,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture81,
+  mipLevel: 0,
+  origin: { x: 82, y: 0, z: 97 },
+  aspect: 'all',
+},
+new Int16Array(arrayBuffer2),
+/* required buffer size: 31444923 */{
+offset: 27,
+bytesPerRow: 53844,
+rowsPerImage: 292,
+},
+{width: 6713, height: 0, depthOrArrayLayers: 3}
+);
+} catch {}
+document.body.prepend('\u2fc9\ue28f\u03f3\u0220\u81f9\u0acd\uad6f\u0cae\u0902\u034f');
+try {
+adapter9.label = '\ub950\u2112\u{1f7be}\u0bb1\u298a\u9027\u{1fda8}\uc1f0';
+} catch {}
+let bindGroup39 = device4.createBindGroup({
+label: '\u5096\ud882\u3cd6\ubaf9\u16ca\u3091\u86d8\u3d97\u1a83\u54fc',
+layout: bindGroupLayout14,
+entries: [
+{
+binding: 3961,
+resource: externalTexture3
+}
+],
+});
+let textureView84 = texture65.createView(
+{
+dimension: '2d',
+mipLevelCount: 1,
+baseArrayLayer: 77,
+}
+);
+try {
+renderPassEncoder12.setBindGroup(
+0,
+bindGroup24
+);
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(
+56
+);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder13.setStencilReference(
+1866
+);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(
+10,
+buffer20,
+172,
+2344
+);
+} catch {}
+document.body.prepend(canvas9);
+let canvas22 = document.createElement('canvas');
+let video28 = await videoWithData();
+try {
+canvas22.getContext('2d');
+} catch {}
+let texture97 = device4.createTexture(
+{
+label: '\u6f0c\uf817',
+size: {width: 43, height: 1, depthOrArrayLayers: 179},
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm',
+'rgba8unorm',
+'rgba8unorm-srgb'
+],
+}
+);
+let textureView85 = texture65.createView(
+{
+aspect: 'depth-only',
+mipLevelCount: 2,
+baseArrayLayer: 31,
+arrayLayerCount: 152,
+}
+);
+try {
+renderPassEncoder12.setBindGroup(
+4,
+bindGroup24,
+new Uint32Array(5160),
+745,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(
+191
+);
+} catch {}
+try {
+renderBundleEncoder57.setVertexBuffer(
+4,
+buffer20,
+3180,
+2305
+);
+} catch {}
+try {
+computePassEncoder37.pushDebugGroup(
+'\u0318'
+);
+} catch {}
+let texture98 = device2.createTexture(
+{
+size: [10224],
+mipLevelCount: 1,
+dimension: '1d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16float',
+'r16float',
+'r16float'
+],
+}
+);
+let sampler61 = device2.createSampler(
+{
+label: '\u0da1\u{1fa5c}\ud82e',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 22.965,
+lodMaxClamp: 69.182,
+}
+);
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 332, height: 1, depthOrArrayLayers: 80}
+*/
+{
+  source: imageData14,
+  origin: { x: 109, y: 87 },
+  flipY: false,
+},
+{
+  texture: texture50,
+  mipLevel: 0,
+  origin: { x: 185, y: 0, z: 56 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 37, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let bindGroup40 = device5.createBindGroup({
+label: '\u01cb\ud152\u712d\u68a1\u6f08\u{1fad7}\uf49c\u248b',
+layout: bindGroupLayout18,
+entries: [
+
+],
+});
+let commandEncoder65 = device5.createCommandEncoder(
+{
+label: '\uafaf\u028b\ufc80',
+}
+);
+let texture99 = gpuCanvasContext5.getCurrentTexture();
+try {
+await device5.popErrorScope();
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture73,
+  mipLevel: 0,
+  origin: { x: 4, y: 4, z: 1 },
+  aspect: 'all',
+},
+new Int16Array(new ArrayBuffer(0)),
+/* required buffer size: 859 */{
+offset: 859,
+bytesPerRow: 191,
+rowsPerImage: 260,
+},
+{width: 24, height: 28, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await device5.queue.onSubmittedWorkDone();
+} catch {}
+let sampler62 = device3.createSampler(
+{
+label: '\u1232\u4714\ue147',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 84.730,
+maxAnisotropy: 14,
+}
+);
+try {
+renderPassEncoder14.executeBundles([]);
+} catch {}
+try {
+commandEncoder46.copyTextureToBuffer(
+{
+  texture: texture87,
+  mipLevel: 2,
+  origin: { x: 216, y: 6, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 2278 widthInBlocks: 1139 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 18360 */
+offset: 18360,
+bytesPerRow: 2304,
+rowsPerImage: 318,
+buffer: buffer24,
+},
+{width: 1139, height: 28, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device3, buffer24);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture87,
+  mipLevel: 4,
+  origin: { x: 105, y: 3, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer6,
+/* required buffer size: 697 */{
+offset: 697,
+bytesPerRow: 641,
+},
+{width: 272, height: 5, depthOrArrayLayers: 0}
+);
+} catch {}
+let imageData21 = new ImageData(184, 32);
+let videoFrame24 = new VideoFrame(videoFrame15, {timestamp: 0});
+let shaderModule12 = device8.createShaderModule(
+{
+label: '\u5654\u98b1\u0af1\u2267',
+code: `
+
+@compute @workgroup_size(3, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(5) f0: f32,
+@location(1) f1: vec4<u32>,
+@location(0) f2: vec2<f32>,
+@location(7) f3: f32,
+@location(3) f4: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(front_facing) a1: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S16 {
+@location(11) f0: f16,
+@location(18) f1: vec3<i32>,
+@builtin(vertex_index) f2: u32,
+@location(10) f3: vec4<i32>,
+@location(5) f4: u32,
+@location(6) f5: vec2<i32>,
+@location(8) f6: vec2<u32>,
+@location(13) f7: vec4<f32>,
+@location(3) f8: vec4<f16>,
+@location(7) f9: vec3<u32>,
+@location(9) f10: vec3<f32>,
+@location(0) f11: vec3<f32>,
+@location(15) f12: vec2<f32>,
+@location(16) f13: vec2<f16>,
+@location(19) f14: vec3<i32>,
+@builtin(instance_index) f15: u32,
+@location(2) f16: vec4<f16>,
+@location(1) f17: f16,
+@location(20) f18: vec4<u32>,
+@location(12) f19: vec4<f16>
+}
+
+@vertex
+fn vertex0(a0: S16, @location(14) a1: vec3<u32>, @location(4) a2: f32, @location(17) a3: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroupLayout28 = device8.createBindGroupLayout(
+{
+label: '\u15c3\ueebb\ua392',
+entries: [
+
+],
+}
+);
+let bindGroup41 = device8.createBindGroup({
+label: '\u6bb5\u{1ff08}\ud65d\ub8a0\u4c97',
+layout: bindGroupLayout28,
+entries: [
+
+],
+});
+let buffer29 = device8.createBuffer(
+{
+label: '\uc753\u{1fb80}\ua919',
+size: 12450,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+}
+);
+let querySet73 = device8.createQuerySet(
+{
+label: '\u3845\uc7ba\ud8b4\u6a96\ue5c0\u1c0e\u5576\u{1fbf7}',
+type: 'occlusion',
+count: 297,
+}
+);
+let renderBundle82 = renderBundleEncoder73.finish(
+{
+label: '\uc7c6\u279a\ucf69\u0706\u0399\ua58f\u78fe\uc728'
+}
+);
+try {
+renderBundleEncoder56.setBindGroup(
+3,
+bindGroup41,
+new Uint32Array(5633),
+601,
+0
+);
+} catch {}
+let pipeline47 = await device8.createRenderPipelineAsync(
+{
+label: '\uabe9\u4f27\u01d7\uff4b\u0f2a\u093d\u0848\u0994\u0d9a\u{1fd09}\ub46c',
+layout: pipelineLayout22,
+vertex: {
+module: shaderModule12,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 7756,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x4',
+offset: 4880,
+shaderLocation: 17,
+},
+{
+format: 'uint8x4',
+offset: 5536,
+shaderLocation: 8,
+},
+{
+format: 'float32x3',
+offset: 1088,
+shaderLocation: 12,
+},
+{
+format: 'uint32x4',
+offset: 2072,
+shaderLocation: 20,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 1600,
+shaderLocation: 13,
+},
+{
+format: 'snorm8x2',
+offset: 4340,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 18268,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x2',
+offset: 3560,
+shaderLocation: 15,
+},
+{
+format: 'sint16x4',
+offset: 5468,
+shaderLocation: 18,
+},
+{
+format: 'sint8x4',
+offset: 16244,
+shaderLocation: 6,
+},
+{
+format: 'uint32x2',
+offset: 17416,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x2',
+offset: 2636,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x4',
+offset: 15464,
+shaderLocation: 16,
+},
+{
+format: 'uint32',
+offset: 7128,
+shaderLocation: 5,
+},
+{
+format: 'uint32x3',
+offset: 16664,
+shaderLocation: 14,
+},
+{
+format: 'float32',
+offset: 4984,
+shaderLocation: 2,
+},
+{
+format: 'sint32x4',
+offset: 14872,
+shaderLocation: 10,
+},
+{
+format: 'float32',
+offset: 1968,
+shaderLocation: 3,
+},
+{
+format: 'unorm16x4',
+offset: 13960,
+shaderLocation: 9,
+},
+{
+format: 'sint16x4',
+offset: 11660,
+shaderLocation: 19,
+},
+{
+format: 'float32',
+offset: 3668,
+shaderLocation: 11,
+},
+{
+format: 'unorm16x2',
+offset: 8236,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+frontFace: 'cw',
+},
+multisample: {
+count: 4,
+mask: 0xcb0fba96,
+},
+fragment: {
+module: shaderModule12,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'less',
+failOp: 'replace',
+depthFailOp: 'decrement-clamp',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 3940,
+depthBias: 31,
+depthBiasSlopeScale: 52,
+depthBiasClamp: 96,
+},
+}
+);
+document.body.prepend(img21);
+offscreenCanvas2.height = 555;
+gc();
+let bindGroupLayout29 = device4.createBindGroupLayout(
+{
+label: '\u6893\u72b6\u7fbd\ud259\u3e2b\u2c89\ubf32\ud71a',
+entries: [
+{
+binding: 1328,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+}
+],
+}
+);
+let bindGroup42 = device4.createBindGroup({
+label: '\ub7cc\u0222\u0d49',
+layout: bindGroupLayout29,
+entries: [
+{
+binding: 1328,
+resource: externalTexture3
+}
+],
+});
+let texture100 = device4.createTexture(
+{
+label: '\u{1ff53}\u{1fff1}',
+size: [10888, 5, 214],
+mipLevelCount: 5,
+format: 'r8sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundle83 = renderBundleEncoder76.finish(
+{
+label: '\ue120\u3d7e\u90d2\u{1fa70}\uf6c4'
+}
+);
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(
+buffer20,
+'uint32',
+8004
+);
+} catch {}
+document.body.prepend(canvas6);
+document.body.prepend('\ueef8\u02f5');
+let shaderModule13 = device7.createShaderModule(
+{
+label: '\u8574\u1f3d\u00ba\u56ca\u{1fe29}\u34d9\ucc78\u05d6',
+code: `
+
+@compute @workgroup_size(7, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S17 {
+@location(39) f0: f32,
+@builtin(sample_mask) f1: u32,
+@location(36) f2: vec2<f16>
+}
+struct FragmentOutput0 {
+@location(4) f0: vec2<u32>,
+@location(0) f1: vec2<f32>,
+@location(5) f2: vec4<u32>,
+@location(2) f3: vec2<u32>
+}
+
+@fragment
+fn fragment0(@location(65) a0: f16, @location(41) a1: u32, @location(7) a2: vec2<u32>, @location(33) a3: vec4<f32>, @location(66) a4: f32, @location(9) a5: vec4<f16>, a6: S17, @location(64) a7: vec2<i32>, @builtin(position) a8: vec4<f32>, @location(48) a9: vec4<u32>, @location(31) a10: vec2<f32>, @builtin(sample_index) a11: u32, @location(19) a12: f32, @location(16) a13: i32, @location(4) a14: vec3<u32>, @location(61) a15: vec3<u32>, @location(11) a16: vec4<i32>, @builtin(front_facing) a17: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(61) f253: vec3<u32>,
+@location(66) f254: f32,
+@location(26) f255: vec3<f16>,
+@location(19) f256: f32,
+@builtin(position) f257: vec4<f32>,
+@location(22) f258: vec3<f16>,
+@location(44) f259: i32,
+@location(48) f260: vec4<u32>,
+@location(5) f261: i32,
+@location(37) f262: i32,
+@location(64) f263: vec2<i32>,
+@location(16) f264: i32,
+@location(41) f265: u32,
+@location(39) f266: f32,
+@location(11) f267: vec4<i32>,
+@location(65) f268: f16,
+@location(35) f269: vec2<f16>,
+@location(4) f270: vec3<u32>,
+@location(31) f271: vec2<f32>,
+@location(7) f272: vec2<u32>,
+@location(36) f273: vec2<f16>,
+@location(9) f274: vec4<f16>,
+@location(33) f275: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(12) a0: vec2<i32>, @location(23) a1: vec3<i32>, @location(26) a2: vec4<f16>, @location(8) a3: vec4<i32>, @location(0) a4: vec2<u32>, @location(21) a5: vec2<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let querySet74 = device7.createQuerySet(
+{
+label: '\u1d8b\ue26c\u79ae\u{1f9b6}\u{1fa77}\u{1f943}\u{1fbcc}\u8d49\u0144\u0b2c',
+type: 'occlusion',
+count: 2350,
+}
+);
+let textureView86 = texture95.createView(
+{
+label: '\u0b4d\u07ef\u{1f696}\u0aa8\u4f45\u94e3\u08f8\ub9df\u{1f9a1}\u0da8\u0e87',
+dimension: '2d-array',
+format: 'astc-12x12-unorm-srgb',
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+document.body.append('\udecc\ud7d7\u1937');
+let bindGroupLayout30 = device1.createBindGroupLayout(
+{
+label: '\u02fa\ucc02\ua6ce\u{1fe84}\u0133\u0aac\u39a6\u7c03',
+entries: [
+
+],
+}
+);
+let bindGroup43 = device1.createBindGroup({
+layout: bindGroupLayout26,
+entries: [
+{
+binding: 4409,
+resource: sampler27
+},
+{
+binding: 676,
+resource: sampler25
+}
+],
+});
+let querySet75 = device1.createQuerySet(
+{
+type: 'occlusion',
+count: 2842,
+}
+);
+let renderBundle84 = renderBundleEncoder55.finish(
+{
+label: '\ueebf\u{1fa8b}\u0f10\u205c\uc8b1\u9bc5\u9ab2\u7f09\ub88e\u9f55'
+}
+);
+try {
+renderBundleEncoder65.setBindGroup(
+2,
+bindGroup37,
+[]
+);
+} catch {}
+try {
+renderBundleEncoder65.setBindGroup(
+6,
+bindGroup25,
+new Uint32Array(904),
+398,
+0
+);
+} catch {}
+try {
+renderBundleEncoder65.setIndexBuffer(
+buffer14,
+'uint32',
+34108,
+2368
+);
+} catch {}
+let video29 = await videoWithData();
+try {
+renderPassEncoder12.setBindGroup(
+1,
+bindGroup39,
+new Uint32Array(2916),
+2344,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder13.setViewport(
+619.7,
+0.00615,
+284.0,
+0.1366,
+0.6488,
+0.8842
+);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+9,
+buffer20,
+3208,
+212
+);
+} catch {}
+try {
+computePassEncoder37.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext16.configure(
+{
+device: device4,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture81,
+  mipLevel: 0,
+  origin: { x: 46, y: 0, z: 208 },
+  aspect: 'all',
+},
+arrayBuffer7,
+/* required buffer size: 186092075 */{
+offset: 72,
+bytesPerRow: 47521,
+rowsPerImage: 261,
+},
+{width: 5911, height: 1, depthOrArrayLayers: 16}
+);
+} catch {}
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+try {
+adapter6.label = '\u6b21\u7c5e\u9be6\u7183\ud1c6\ub13f\u9ea4';
+} catch {}
+let bindGroup44 = device4.createBindGroup({
+label: '\u{1fc4f}\u{1f8d8}\uf1ae',
+layout: bindGroupLayout14,
+entries: [
+{
+binding: 3961,
+resource: externalTexture3
+}
+],
+});
+let textureView87 = texture59.createView(
+{
+label: '\uf728\u{1f7f6}\uf589\u{1fa7b}',
+dimension: '2d',
+baseMipLevel: 2,
+mipLevelCount: 2,
+baseArrayLayer: 92,
+arrayLayerCount: 1,
+}
+);
+let sampler63 = device4.createSampler(
+{
+label: '\u0e97\u{1ff45}\u54c5\ua150',
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 78.558,
+lodMaxClamp: 81.140,
+}
+);
+try {
+renderPassEncoder12.setVertexBuffer(
+2,
+buffer18,
+2804,
+15307
+);
+} catch {}
+let pipeline48 = device4.createRenderPipeline(
+{
+label: '\u0723\u1a54\uc857',
+layout: pipelineLayout17,
+vertex: {
+module: shaderModule11,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 668,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 540,
+shaderLocation: 5,
+},
+{
+format: 'sint16x2',
+offset: 20,
+shaderLocation: 4,
+},
+{
+format: 'unorm16x4',
+offset: 632,
+shaderLocation: 17,
+},
+{
+format: 'sint16x4',
+offset: 428,
+shaderLocation: 15,
+},
+{
+format: 'float16x4',
+offset: 516,
+shaderLocation: 8,
+},
+{
+format: 'unorm8x4',
+offset: 332,
+shaderLocation: 1,
+},
+{
+format: 'uint32x2',
+offset: 620,
+shaderLocation: 7,
+},
+{
+format: 'unorm16x2',
+offset: 652,
+shaderLocation: 16,
+},
+{
+format: 'float16x4',
+offset: 512,
+shaderLocation: 20,
+},
+{
+format: 'float16x4',
+offset: 196,
+shaderLocation: 3,
+},
+{
+format: 'sint32x3',
+offset: 628,
+shaderLocation: 10,
+},
+{
+format: 'unorm16x2',
+offset: 156,
+shaderLocation: 0,
+},
+{
+format: 'sint32x3',
+offset: 608,
+shaderLocation: 12,
+},
+{
+format: 'float32',
+offset: 408,
+shaderLocation: 14,
+},
+{
+format: 'float32x4',
+offset: 232,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x2',
+offset: 580,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 608,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 580,
+shaderLocation: 11,
+},
+{
+format: 'snorm8x2',
+offset: 570,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 2600,
+attributes: [
+{
+format: 'float32x3',
+offset: 88,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 1428,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 656,
+attributes: [
+
+],
+},
+{
+arrayStride: 300,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 472,
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 28,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 1972,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 1540,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 212,
+shaderLocation: 13,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+cullMode: 'back',
+},
+multisample: {
+mask: 0x8b2c7741,
+},
+fragment: {
+module: shaderModule11,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rgba8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+undefined,
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r16uint',
+}
+],
+},
+}
+);
+document.body.append('\u1418\u{1fa74}\u89da\u0c43\ud014\uc130\ue22c\uae80');
+let textureView88 = texture89.createView(
+{
+label: '\ube85\u0da7\ua8a1\u0236\u{1fc12}\u8613\u08d4\u04b4\u04ea',
+}
+);
+try {
+renderPassEncoder14.setVertexBuffer(
+10,
+buffer24
+);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer24,
+11500,
+new Float32Array(3254),
+2484,
+256
+);
+} catch {}
+document.body.prepend(video10);
+gc();
+let sampler64 = device2.createSampler(
+{
+label: '\u0e93\uf026\u000f\u{1fca4}\u0dcc\u064e\u0cf3\u{1f68a}\u51b1\u8050\u0966',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 57.254,
+lodMaxClamp: 62.650,
+}
+);
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 2787, height: 1, depthOrArrayLayers: 189}
+*/
+{
+  source: imageData5,
+  origin: { x: 10, y: 0 },
+  flipY: true,
+},
+{
+  texture: texture82,
+  mipLevel: 0,
+  origin: { x: 387, y: 0, z: 36 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 3, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.append('\u8465\u{1ffee}\u667e\u850c\u454e\u0d88\u3f19\u035f\u{1f83c}');
+let buffer30 = device1.createBuffer(
+{
+size: 36280,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let texture101 = device1.createTexture(
+{
+size: [50, 5, 175],
+mipLevelCount: 2,
+format: 'astc-10x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-10x5-unorm-srgb',
+'astc-10x5-unorm'
+],
+}
+);
+let textureView89 = texture51.createView(
+{
+label: '\u{1f742}\u000f\u0365\uafea\u057a\u{1fb09}\u86d0\u065c\ue781',
+aspect: 'all',
+}
+);
+try {
+renderBundleEncoder65.setVertexBuffer(
+34,
+undefined,
+1159606111,
+2888209735
+);
+} catch {}
+try {
+window.someLabel = querySet72.label;
+} catch {}
+let renderBundleEncoder77 = device9.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8unorm-srgb',
+'rg8sint',
+'bgra8unorm-srgb',
+'rg16sint',
+'r16uint',
+undefined
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 346,
+depthReadOnly: true,
+stencilReadOnly: false,
+}
+);
+let renderBundle85 = renderBundleEncoder77.finish(
+{
+label: '\u0b94\u72a4\u0474'
+}
+);
+try {
+gpuCanvasContext13.configure(
+{
+device: device9,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16float',
+'rgba16float',
+'rgba8unorm',
+'rgba16float'
+],
+}
+);
+} catch {}
+let bindGroup45 = device4.createBindGroup({
+label: '\u0133\u0b3b\u0a78\uf8ca\u68e3\u04c1\u{1f6b5}\u6953\u26f1\uefa9',
+layout: bindGroupLayout14,
+entries: [
+{
+binding: 3961,
+resource: externalTexture3
+}
+],
+});
+let buffer31 = device4.createBuffer(
+{
+size: 43883,
+usage: GPUBufferUsage.VERTEX,
+}
+);
+let querySet76 = device4.createQuerySet(
+{
+label: '\u4c73\u078d\u{1fdce}\u24e3\u040a\u7ba6\u0563\u060c',
+type: 'occlusion',
+count: 1188,
+}
+);
+let texture102 = device4.createTexture(
+{
+label: '\ua4ed\u1ae6\u{1fe82}\ubf01\u787d\u577e\uf986\u100c\u1127\u1592\u{1fd85}',
+size: {width: 1096, height: 1, depthOrArrayLayers: 1657},
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let texture103 = gpuCanvasContext5.getCurrentTexture();
+let renderBundleEncoder78 = device4.createRenderBundleEncoder(
+{
+label: '\uef1f\u0eb8\u0013\u{1ff57}\ud96e\ubd6f\u65d0\u{1fc64}\u{1f707}\u16ba\u0cae',
+colorFormats: [
+'rg8sint',
+'rgb10a2uint',
+'r16float',
+'rgb10a2unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 593,
+depthReadOnly: false,
+}
+);
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder57.setVertexBuffer(
+9,
+buffer18,
+12596,
+14410
+);
+} catch {}
+try {
+gpuCanvasContext17.configure(
+{
+device: device4,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16uint',
+'bgra8unorm',
+'r8snorm',
+'rg16sint'
+],
+}
+);
+} catch {}
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+document.body.append('\u574c\u069a\u{1fda7}\ua4bf\u095b\u0a46\u3470');
+let renderBundleEncoder79 = device8.createRenderBundleEncoder(
+{
+label: '\u{1fc2e}\u0ae2\u01ce\u0162\u07e2\uca6f\ubec4\u0034\ub510',
+colorFormats: [
+'r16sint'
+],
+sampleCount: 334,
+stencilReadOnly: true,
+}
+);
+let renderBundle86 = renderBundleEncoder68.finish(
+{
+label: '\u0887\u{1f8ff}\ua623\u{1fbb8}\u2eee\u{1f950}\u0008\u54ff\u308d\u0474'
+}
+);
+let imageData22 = new ImageData(232, 24);
+let bindGroupLayout31 = device2.createBindGroupLayout(
+{
+label: '\u9847\u0ba8\u{1fc86}\u{1ffc2}\u3aca\ubfe2\ua650',
+entries: [
+{
+binding: 3839,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}
+],
+}
+);
+let buffer32 = device2.createBuffer(
+{
+label: '\u8c88\ud88b\u{1f970}\u0712\ub670\u0297',
+size: 10197,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+mappedAtCreation: false,
+}
+);
+let commandEncoder66 = device2.createCommandEncoder(
+{
+label: '\u0fe4\u0717\u065d\ubbad\u{1fda0}',
+}
+);
+try {
+await buffer12.mapAsync(
+GPUMapMode.READ,
+0,
+9584
+);
+} catch {}
+try {
+commandEncoder66.copyTextureToBuffer(
+{
+  texture: texture93,
+  mipLevel: 0,
+  origin: { x: 4025, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 478 widthInBlocks: 478 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 29429 */
+offset: 29429,
+buffer: buffer17,
+},
+{width: 478, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device2, buffer17);
+} catch {}
+try {
+computePassEncoder22.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext6.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgba16float',
+'rg16uint'
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let bindGroupLayout32 = pipeline48.getBindGroupLayout(2);
+try {
+renderPassEncoder12.beginOcclusionQuery(
+48
+);
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant(
+{
+r: 753.0,
+g: 640.9,
+b: 554.6,
+a: 197.3,
+}
+);
+} catch {}
+try {
+renderPassEncoder13.setViewport(
+137.0,
+0.6535,
+112.4,
+0.2411,
+0.1999,
+0.3603
+);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(
+buffer20,
+'uint32',
+3168
+);
+} catch {}
+try {
+renderBundleEncoder57.setBindGroup(
+0,
+bindGroup44
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture103,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(new ArrayBuffer(32)),
+/* required buffer size: 531 */{
+offset: 531,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline49 = device4.createComputePipeline(
+{
+label: '\u0087\u2c64\u6d47\u8598\u1fc7',
+layout: pipelineLayout17,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+},
+}
+);
+let imageBitmap29 = await createImageBitmap(img15);
+let texture104 = device10.createTexture(
+{
+label: '\ubcd1\u776d\u{1f7e4}\uac23\uea9a\u0520\u0c5a\ub20d\u{1fccc}',
+size: {width: 1883, height: 1, depthOrArrayLayers: 124},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32float'
+],
+}
+);
+let textureView90 = texture96.createView(
+{
+label: '\u7536\u3444\u15cb\uaa75\ud903\u037b',
+format: 'rg16uint',
+baseMipLevel: 3,
+mipLevelCount: 4,
+baseArrayLayer: 30,
+}
+);
+let renderBundle87 = renderBundleEncoder74.finish(
+{
+label: '\ue6fb\u{1fcc2}\u069c\u0777\u08fc\u{1feeb}\u0e28\u00eb\u43d2\u{1f7dc}\u02cd'
+}
+);
+try {
+device10.queue.writeTexture(
+{
+  texture: texture104,
+  mipLevel: 2,
+  origin: { x: 67, y: 0, z: 26 },
+  aspect: 'all',
+},
+new ArrayBuffer(40),
+/* required buffer size: 207 */{
+offset: 207,
+bytesPerRow: 4852,
+},
+{width: 300, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let textureView91 = texture68.createView(
+{
+}
+);
+let promise41 = device7.queue.onSubmittedWorkDone();
+document.body.append('\u300c\u9cfb');
+try {
+textureView77.label = '\u0e94\ue70f\u0091\u2cee\ua5dc';
+} catch {}
+let commandEncoder67 = device7.createCommandEncoder(
+{
+}
+);
+let texture105 = device7.createTexture(
+{
+label: '\u51cd\u0fd1\ua8bc\u3257\u52f0\u6a8a\u1a92',
+size: {width: 260, height: 80, depthOrArrayLayers: 1},
+mipLevelCount: 9,
+format: 'astc-10x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-10x5-unorm-srgb',
+'astc-10x5-unorm-srgb'
+],
+}
+);
+let renderBundle88 = renderBundleEncoder59.finish(
+{
+label: '\u4dec\u5ad4\u{1fce3}\ue0b8\u1665\u8f38\ub38d\uc60d\u626d\u{1fc4a}'
+}
+);
+let pipeline50 = device7.createComputePipeline(
+{
+layout: pipelineLayout19,
+compute: {
+module: shaderModule13,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+await promise41;
+} catch {}
+let videoFrame25 = new VideoFrame(offscreenCanvas5, {timestamp: 0});
+let querySet77 = device8.createQuerySet(
+{
+label: '\u08a0\u9ce6\uf5f6\u{1fcb6}\u0f24\ue44d\u0172\u61ce\u0e61',
+type: 'occlusion',
+count: 1443,
+}
+);
+let texture106 = device8.createTexture(
+{
+label: '\uab17\ufeae\u0bcf',
+size: {width: 207, height: 1, depthOrArrayLayers: 67},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'r8snorm',
+'r8snorm',
+'r8snorm'
+],
+}
+);
+let pipeline51 = await device8.createComputePipelineAsync(
+{
+layout: pipelineLayout22,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend('\u{1f87c}\uab5a\u256a');
+let commandEncoder68 = device7.createCommandEncoder();
+let querySet78 = device7.createQuerySet(
+{
+label: '\u{1fd14}\ub04a\u7db3\u0988',
+type: 'occlusion',
+count: 819,
+}
+);
+let texture107 = device7.createTexture(
+{
+label: '\u03bd\u075e',
+size: {width: 10716, height: 10, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'astc-12x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-12x10-unorm'
+],
+}
+);
+let pipeline52 = device7.createRenderPipeline(
+{
+layout: pipelineLayout19,
+vertex: {
+module: shaderModule13,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 5436,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 2340,
+shaderLocation: 0,
+},
+{
+format: 'sint32x2',
+offset: 3828,
+shaderLocation: 8,
+},
+{
+format: 'sint32x2',
+offset: 1824,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 16376,
+attributes: [
+{
+format: 'uint8x2',
+offset: 7984,
+shaderLocation: 21,
+},
+{
+format: 'sint32x3',
+offset: 13168,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 18472,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 13984,
+shaderLocation: 26,
+}
+],
+}
+]
+},
+primitive: {
+cullMode: 'back',
+},
+multisample: {
+count: 4,
+mask: 0x4575fffb,
+},
+fragment: {
+module: shaderModule13,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r16float',
+writeMask: 0,
+},
+undefined,
+{
+format: 'r32uint',
+},
+undefined,
+{
+format: 'r16uint',
+},
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'equal',
+failOp: 'invert',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 3314,
+stencilWriteMask: 2347,
+depthBias: 46,
+depthBiasSlopeScale: 3,
+depthBiasClamp: 52,
+},
+}
+);
+let renderBundleEncoder80 = device5.createRenderBundleEncoder(
+{
+label: '\u42c4\ua22a\uc07d\u0e54\u0297\u053f\u0957\u7c46\uc2bb',
+colorFormats: [
+'rgba8sint',
+'rgba8uint',
+'rg11b10ufloat',
+'rg32float',
+undefined,
+'r8sint'
+],
+sampleCount: 879,
+stencilReadOnly: true,
+}
+);
+let renderBundle89 = renderBundleEncoder48.finish(
+{
+label: '\u{1f776}\ucf86\u7be3\u5b52\u0749\u5a45\uf438\u03f9'
+}
+);
+try {
+computePassEncoder36.setBindGroup(
+2,
+bindGroup35
+);
+} catch {}
+try {
+computePassEncoder32.end();
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture99,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer7,
+/* required buffer size: 914 */{
+offset: 906,
+rowsPerImage: 123,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let offscreenCanvas20 = new OffscreenCanvas(554, 445);
+let commandEncoder69 = device6.createCommandEncoder(
+{
+}
+);
+let renderBundleEncoder81 = device6.createRenderBundleEncoder(
+{
+colorFormats: [
+'r16uint',
+'r32sint',
+'rgba16float',
+'rgba32sint',
+'rg8uint',
+'rgba16uint',
+'rgba8sint',
+undefined
+],
+sampleCount: 663,
+depthReadOnly: false,
+}
+);
+try {
+commandEncoder69.clearBuffer(
+buffer23,
+5096,
+3860
+);
+dissociateBuffer(device6, buffer23);
+} catch {}
+try {
+commandEncoder62.resolveQuerySet(
+querySet69,
+56,
+1607,
+buffer28,
+32000
+);
+} catch {}
+try {
+gpuCanvasContext15.configure(
+{
+device: device6,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16float',
+'astc-8x8-unorm',
+'bgra8unorm',
+'rgba16sint'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device6.queue.writeBuffer(
+buffer28,
+29960,
+new Int16Array(50269),
+13571,
+9284
+);
+} catch {}
+let gpuCanvasContext22 = offscreenCanvas20.getContext('webgpu');
+document.body.prepend(canvas14);
+let querySet79 = device10.createQuerySet(
+{
+label: '\u09d7\u{1ffd7}\u0e11\uce75\u{1f888}\uc8cd\u9a27',
+type: 'occlusion',
+count: 1556,
+}
+);
+let texture108 = device10.createTexture(
+{
+size: [2976, 1, 20],
+mipLevelCount: 7,
+format: 'r16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+let renderBundle90 = renderBundleEncoder74.finish(
+{
+label: '\u69b5\ua479\u{1fac5}\u06f7\u{1fb54}\u0f45\u3db5\u28d6'
+}
+);
+let renderBundleEncoder82 = device10.createRenderBundleEncoder(
+{
+label: '\u{1fe2b}\u0e5f',
+colorFormats: [
+'r16float',
+undefined,
+'rgba8unorm-srgb',
+'r16float',
+undefined,
+'r8unorm',
+'rg8uint',
+'rgba16float'
+],
+sampleCount: 378,
+depthReadOnly: true,
+stencilReadOnly: false,
+}
+);
+let sampler65 = device10.createSampler(
+{
+label: '\uce5f\u7d7a\u169c\u{1f745}\uf705\u99e6\u{1fb50}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 33.569,
+lodMaxClamp: 60.035,
+maxAnisotropy: 2,
+}
+);
+try {
+gpuCanvasContext18.configure(
+{
+device: device10,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let commandEncoder70 = device4.createCommandEncoder(
+{
+label: '\u{1fb1b}\u{1f8f1}\u28f7\u8654\u{1fd2a}',
+}
+);
+try {
+renderPassEncoder12.setBindGroup(
+0,
+bindGroup42
+);
+} catch {}
+try {
+renderBundleEncoder78.setBindGroup(
+2,
+bindGroup28
+);
+} catch {}
+try {
+renderBundleEncoder57.setVertexBuffer(
+6,
+buffer31,
+26612,
+8928
+);
+} catch {}
+try {
+commandEncoder70.copyBufferToBuffer(
+buffer18,
+23588,
+buffer25,
+40560,
+1196
+);
+dissociateBuffer(device4, buffer18);
+dissociateBuffer(device4, buffer25);
+} catch {}
+gc();
+let texture109 = device7.createTexture(
+{
+size: {width: 79, height: 212, depthOrArrayLayers: 247},
+mipLevelCount: 4,
+sampleCount: 1,
+format: 'r8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8sint',
+'r8sint'
+],
+}
+);
+try {
+commandEncoder68.copyTextureToTexture(
+{
+  texture: texture107,
+  mipLevel: 2,
+  origin: { x: 288, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture107,
+  mipLevel: 4,
+  origin: { x: 72, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 336, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise42 = device7.createComputePipelineAsync(
+{
+label: '\ucb23\uce15',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule13,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline53 = device7.createRenderPipeline(
+{
+label: '\ud6ad\u04bd\u00ca\u0445\uf61a\ud01b\u0f84',
+layout: pipelineLayout19,
+vertex: {
+module: shaderModule13,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 624,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x4',
+offset: 232,
+shaderLocation: 0,
+},
+{
+format: 'uint8x2',
+offset: 72,
+shaderLocation: 21,
+},
+{
+format: 'sint32x3',
+offset: 288,
+shaderLocation: 12,
+},
+{
+format: 'float16x4',
+offset: 420,
+shaderLocation: 26,
+}
+],
+},
+{
+arrayStride: 9512,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x2',
+offset: 4034,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 10468,
+attributes: [
+
+],
+},
+{
+arrayStride: 14564,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 9288,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x4',
+offset: 8292,
+shaderLocation: 8,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule13,
+entryPoint: 'fragment0',
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'keep',
+depthFailOp: 'increment-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 3898,
+depthBiasSlopeScale: 75,
+},
+}
+);
+document.body.prepend('\u58fe\u394f');
+try {
+window.someLabel = bindGroupLayout18.label;
+} catch {}
+let bindGroup46 = device5.createBindGroup({
+layout: bindGroupLayout18,
+entries: [
+
+],
+});
+let commandEncoder71 = device5.createCommandEncoder(
+{
+label: '\u08da\u8a5f\ubbdb\u0b6b\ub5e6',
+}
+);
+try {
+renderBundleEncoder54.setBindGroup(
+3,
+bindGroup40
+);
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(
+/*
+{width: 77, height: 2, depthOrArrayLayers: 121}
+*/
+{
+  source: img23,
+  origin: { x: 164, y: 27 },
+  flipY: true,
+},
+{
+  texture: texture74,
+  mipLevel: 0,
+  origin: { x: 9, y: 0, z: 49 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 41, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let video30 = await videoWithData();
+let commandEncoder72 = device9.createCommandEncoder(
+{
+label: '\u{1fa5f}\u9bb0\u{1f61a}\u{1f88c}\u4737\u512b\u0d05\u{1f735}\u{1fc93}\u021d',
+}
+);
+let computePassEncoder45 = commandEncoder72.beginComputePass();
+document.body.append('\u079d\u0581\u0c45\u6b36\u0d19\u4d5f\u00ba\u0387');
+let sampler66 = device7.createSampler(
+{
+label: '\u{1f768}\u{1ff5c}\u95b9\u769d\ua277\u35b9',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 11.989,
+lodMaxClamp: 69.765,
+compare: 'not-equal',
+}
+);
+document.body.append('\u{1fc9f}\u{1f675}\u031d\u0929\u2556\u{1f9bc}\u38f2');
+let img24 = await imageWithData(150, 240, '#688c13a3', '#8b7f329e');
+pseudoSubmit(device6, commandEncoder59);
+let textureView92 = texture70.createView(
+{
+label: '\u{1f815}\u{1fc22}\ue895\u0524\u0732\u08cb\u3157\ud17f\ue7d2\u3022\ud58b',
+dimension: '2d',
+format: 'astc-12x10-unorm',
+baseMipLevel: 3,
+baseArrayLayer: 180,
+}
+);
+let renderBundleEncoder83 = device6.createRenderBundleEncoder(
+{
+label: '\u0490\u22f8\u57f2\u{1f648}',
+colorFormats: [
+'r32sint',
+'r32float',
+'rg16float'
+],
+sampleCount: 917,
+depthReadOnly: true,
+}
+);
+let sampler67 = device6.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 80.278,
+lodMaxClamp: 98.481,
+maxAnisotropy: 14,
+}
+);
+try {
+device6.pushErrorScope(
+'out-of-memory'
+);
+} catch {}
+try {
+buffer23.unmap();
+} catch {}
+try {
+device6.queue.writeTexture(
+{
+  texture: texture76,
+  mipLevel: 4,
+  origin: { x: 40, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Int16Array(new ArrayBuffer(32)),
+/* required buffer size: 551 */{
+offset: 551,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\u25d2\u1025');
+let imageBitmap30 = await createImageBitmap(img14);
+let buffer33 = device10.createBuffer(
+{
+size: 43403,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let commandEncoder73 = device10.createCommandEncoder(
+{
+label: '\ub2c8\u09c8\u{1f739}\u075e\udc50\u{1f83a}\u0822\u8f0a\u58d8',
+}
+);
+let querySet80 = device10.createQuerySet(
+{
+label: '\u77cc\u6faf\u0f0e',
+type: 'occlusion',
+count: 2442,
+}
+);
+let sampler68 = device10.createSampler(
+{
+label: '\u969f\ufe85\u37cf\u0469\u{1feec}\ubd86\u5ab9',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 91.792,
+lodMaxClamp: 97.150,
+}
+);
+document.body.prepend(img7);
+document.body.prepend('\u0a04\u{1fb0a}\uc1ff\ucb55\ua6c5\u{1f851}\u{1fc4a}\u2c3b');
+try {
+await adapter4.requestAdapterInfo();
+} catch {}
+let bindGroup47 = device5.createBindGroup({
+label: '\u{1fc05}\uaecf\u682c\u0893\u01e6\u1381\u052f',
+layout: bindGroupLayout18,
+entries: [
+
+],
+});
+let buffer34 = device5.createBuffer(
+{
+size: 25279,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let texture110 = device5.createTexture(
+{
+size: {width: 5320, height: 4, depthOrArrayLayers: 62},
+mipLevelCount: 2,
+format: 'etc2-rgba8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'etc2-rgba8unorm-srgb'
+],
+}
+);
+let computePassEncoder46 = commandEncoder71.beginComputePass(
+{
+label: '\u{1fab6}\uc1d3\u46b1\u3abb\u3ce8\ubb2c\u5083\u{1f76e}\u2ad8'
+}
+);
+let renderBundle91 = renderBundleEncoder66.finish(
+{
+label: '\u90f7\u0296\u{1f984}\u5a72\u{1f683}\u4854'
+}
+);
+try {
+computePassEncoder46.end();
+} catch {}
+try {
+renderBundleEncoder67.setBindGroup(
+2,
+bindGroup34
+);
+} catch {}
+try {
+commandEncoder47.copyTextureToTexture(
+{
+  texture: texture83,
+  mipLevel: 2,
+  origin: { x: 151, y: 1, z: 158 },
+  aspect: 'all',
+},
+{
+  texture: texture83,
+  mipLevel: 0,
+  origin: { x: 654, y: 0, z: 286 },
+  aspect: 'all',
+},
+{width: 165, height: 0, depthOrArrayLayers: 158}
+);
+} catch {}
+document.body.append('\u{1fb17}\u{1fec6}\u{1f831}\u{1f9d1}\u{1fb08}\u{1f996}');
+let querySet81 = device9.createQuerySet(
+{
+type: 'occlusion',
+count: 3228,
+}
+);
+let texture111 = device9.createTexture(
+{
+size: [248, 1, 65],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'bgra8unorm-srgb',
+'bgra8unorm'
+],
+}
+);
+let offscreenCanvas21 = new OffscreenCanvas(386, 63);
+let buffer35 = device1.createBuffer(
+{
+label: '\u75ad\ubb24\u2212\ua663\u0310\u{1f618}\u47db\u{1facd}',
+size: 22688,
+usage: GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+let renderBundle92 = renderBundleEncoder33.finish(
+{
+label: '\u4c27\ua702\ub908\u{1f831}\ua028\u08d7\u{1fc67}\u{1f85f}'
+}
+);
+let promise43 = device8.queue.onSubmittedWorkDone();
+let canvas23 = document.createElement('canvas');
+try {
+canvas23.getContext('webgl');
+} catch {}
+let commandBuffer7 = commandEncoder73.finish(
+{
+label: '\u0d54\ub9e9\u{1fa68}\u1406\u{1f955}\ue28e\u30ec\u{1ff6d}\uc9be\u9ec9\u0cca',
+}
+);
+try {
+renderBundleEncoder82.setVertexBuffer(
+2,
+buffer33,
+39188,
+3040
+);
+} catch {}
+try {
+buffer33.unmap();
+} catch {}
+try {
+device10.queue.submit([
+]);
+} catch {}
+let canvas24 = document.createElement('canvas');
+try {
+texture79.label = '\ua74f\u3aa2\u4b41\u6514\u141f';
+} catch {}
+let texture112 = device5.createTexture(
+{
+label: '\u31d4\u18a4\u54e2\u0923\u7a1c\u0f85\u08b8\u23c9\u6339\u0df0',
+size: [228, 250, 86],
+mipLevelCount: 8,
+format: 'astc-12x10-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let texture113 = gpuCanvasContext6.getCurrentTexture();
+let textureView93 = texture74.createView(
+{
+label: '\u0175\u3bbb\u44d9\u51b2',
+format: 'bgra8unorm-srgb',
+}
+);
+try {
+device5.queue.writeTexture(
+{
+  texture: texture79,
+  mipLevel: 4,
+  origin: { x: 62, y: 0, z: 44 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(arrayBuffer3),
+/* required buffer size: 1967527 */{
+offset: 673,
+bytesPerRow: 242,
+rowsPerImage: 301,
+},
+{width: 30, height: 1, depthOrArrayLayers: 28}
+);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+document.body.prepend('\ua0d7\uc68a\u{1fcfd}\u895d\u069a\u31ce\u{1fa83}');
+let adapter13 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let commandEncoder74 = device2.createCommandEncoder(
+{
+label: '\u1b66\u{1fa15}\u025f\u3ec0\u8131\u9e06\u0700\u585d',
+}
+);
+let texture114 = device2.createTexture(
+{
+label: '\u037b\u9d36\u6d96\u0729\u091d\u1048\u07c7',
+size: {width: 6628, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 11,
+dimension: '2d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'r8snorm'
+],
+}
+);
+let renderBundle93 = renderBundleEncoder41.finish(
+{
+label: '\u{1f60e}\u940d\u0498\u{1fdbe}\u{1f721}'
+}
+);
+try {
+renderBundleEncoder36.setVertexBuffer(
+2,
+buffer15,
+16652,
+5281
+);
+} catch {}
+try {
+commandEncoder74.copyBufferToBuffer(
+buffer15,
+24308,
+buffer17,
+32024,
+800
+);
+dissociateBuffer(device2, buffer15);
+dissociateBuffer(device2, buffer17);
+} catch {}
+try {
+gpuCanvasContext11.configure(
+{
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+await promise43;
+} catch {}
+let textureView94 = texture83.createView(
+{
+label: '\u{1f8da}\u{1f72c}\u02c2\u{1f671}\u0286',
+baseMipLevel: 1,
+mipLevelCount: 1,
+}
+);
+let renderPassEncoder15 = commandEncoder71.beginRenderPass(
+{
+label: '\ua552\u96ef\ub017\u{1fd7f}\u0daa\u05ae\uff1b\ua86d',
+colorAttachments: [
+undefined,
+{
+view: textureView93,
+depthSlice: 86,
+clearValue: {
+r: 877.6,
+g: -931.4,
+b: 824.1,
+a: 215.9,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView93,
+depthSlice: 30,
+clearValue: {
+r: 567.4,
+g: 168.1,
+b: -952.8,
+a: 692.5,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+undefined,
+undefined,
+{
+view: textureView93,
+depthSlice: 52,
+clearValue: {
+r: -785.5,
+g: 884.3,
+b: 242.7,
+a: 417.8,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView93,
+depthSlice: 89,
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet58,
+maxDrawCount: 423736,
+}
+);
+let renderBundle94 = renderBundleEncoder80.finish();
+try {
+commandEncoder65.clearBuffer(
+buffer34,
+9604,
+516
+);
+dissociateBuffer(device5, buffer34);
+} catch {}
+try {
+device5.queue.writeBuffer(
+buffer34,
+10088,
+new DataView(new ArrayBuffer(30775)),
+14165,
+9644
+);
+} catch {}
+try {
+await device5.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+let textureView95 = texture68.createView(
+{
+label: '\u{1fddf}\u2195',
+}
+);
+let externalTexture7 = device7.importExternalTexture(
+{
+source: videoFrame15,
+}
+);
+let pipeline54 = device7.createComputePipeline(
+{
+layout: pipelineLayout19,
+compute: {
+module: shaderModule13,
+entryPoint: 'compute0',
+},
+}
+);
+let gpuCanvasContext23 = canvas24.getContext('webgpu');
+document.body.append('\u{1fe20}\u0a9b\u52a9\u{1f630}\u0f51\u87d1\u2078');
+let canvas25 = document.createElement('canvas');
+let img25 = await imageWithData(131, 295, '#da6e9e33', '#798a1432');
+let video31 = await videoWithData();
+let imageData23 = new ImageData(116, 68);
+let textureView96 = texture106.createView(
+{
+label: '\ue148\u6109\u{1fa12}\u{1f951}\u610f',
+baseMipLevel: 0,
+mipLevelCount: 1,
+}
+);
+let renderBundle95 = renderBundleEncoder73.finish(
+{
+
+}
+);
+let sampler69 = device8.createSampler(
+{
+label: '\uef21\u4065\u0db2\u4061\u4e9f\u8b0b\ua9cb\ufef7\u{1ff2b}\u00af\u021a',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 95.566,
+compare: 'equal',
+maxAnisotropy: 18,
+}
+);
+try {
+renderBundleEncoder56.setBindGroup(
+6,
+bindGroup41
+);
+} catch {}
+try {
+gpuCanvasContext5.configure(
+{
+device: device8,
+format: 'r32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'r32float',
+'r32float',
+'r32float'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+document.body.append('\u0bc5\u{1f77c}\u7ada\u{1f71f}\u5f57\u4807');
+let offscreenCanvas22 = new OffscreenCanvas(325, 819);
+let renderPassEncoder16 = commandEncoder65.beginRenderPass(
+{
+label: '\u01bf\u0ce8\u0361\uda35\u2633',
+colorAttachments: [
+undefined,
+{
+view: textureView93,
+depthSlice: 78,
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined,
+{
+view: textureView93,
+depthSlice: 19,
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView93,
+depthSlice: 63,
+clearValue: {
+r: -422.9,
+g: 279.2,
+b: 297.4,
+a: 81.75,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView93,
+depthSlice: 118,
+clearValue: {
+r: -464.3,
+g: 460.9,
+b: -219.0,
+a: 94.13,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView93,
+depthSlice: 5,
+clearValue: {
+r: 306.3,
+g: -310.9,
+b: 693.5,
+a: 386.8,
+},
+loadOp: 'load',
+storeOp: 'store'
+}
+],
+maxDrawCount: 8744,
+}
+);
+try {
+renderBundleEncoder67.setBindGroup(
+0,
+bindGroup32,
+new Uint32Array(7555),
+3475,
+0
+);
+} catch {}
+try {
+renderBundleEncoder67.setVertexBuffer(
+23,
+undefined,
+2283832553,
+785304863
+);
+} catch {}
+try {
+commandEncoder47.copyTextureToTexture(
+{
+  texture: texture72,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 8 },
+  aspect: 'depth-only',
+},
+{
+  texture: texture72,
+  mipLevel: 0,
+  origin: { x: 0, y: 3, z: 19 },
+  aspect: 'all',
+},
+{width: 45, height: 1, depthOrArrayLayers: 11}
+);
+} catch {}
+gc();
+document.body.append('\u0b1a\u0583\u28d3\u8951');
+let pipelineLayout23 = device7.createPipelineLayout(
+{
+label: '\u{1fa9f}\u6f95\u9755\u5028\ufae3\u8176\u4e83',
+bindGroupLayouts: [
+bindGroupLayout24,
+bindGroupLayout24,
+bindGroupLayout24,
+bindGroupLayout24
+],
+}
+);
+let buffer36 = device7.createBuffer(
+{
+label: '\u{1f825}\ua6bc\u27b2\uee3b\u{1fffa}\u04bd\ue4bc\u{1fa77}',
+size: 58370,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT,
+}
+);
+let commandBuffer8 = commandEncoder68.finish(
+{
+label: '\u5a9e\u{1fa57}\u8890\u{1fb85}\u02f6\u1498\u8a35',
+}
+);
+let computePassEncoder47 = commandEncoder67.beginComputePass(
+{
+label: '\u519b\u2e12\u14ec'
+}
+);
+try {
+computePassEncoder43.setPipeline(
+pipeline50
+);
+} catch {}
+let texture115 = device2.createTexture(
+{
+label: '\u0df6\u{1f7ab}',
+size: {width: 5797, height: 53, depthOrArrayLayers: 187},
+mipLevelCount: 4,
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+}
+);
+try {
+commandEncoder74.copyBufferToBuffer(
+buffer15,
+10260,
+buffer17,
+30140,
+13144
+);
+dissociateBuffer(device2, buffer15);
+dissociateBuffer(device2, buffer17);
+} catch {}
+canvas8.height = 101;
+document.body.prepend('\ub0aa\u2b16\udc36\u211f\u{1fecd}\u66c2\u0864\u0db5\u{1fe67}\u7acb\u5c9c');
+let texture116 = device4.createTexture(
+{
+size: [10, 2, 27],
+format: 'rg8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let arrayBuffer8 = buffer25.getMappedRange(
+0,
+41848
+);
+try {
+commandEncoder70.clearBuffer(
+buffer20,
+7212,
+1192
+);
+dissociateBuffer(device4, buffer20);
+} catch {}
+let pipeline55 = device4.createRenderPipeline(
+{
+label: '\u3474\u0f22\u0687\u{1f725}\u9115\u{1fc1f}\u{1fce6}\u{1feb4}\u0a22',
+layout: pipelineLayout17,
+vertex: {
+module: shaderModule11,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 2208,
+shaderLocation: 15,
+},
+{
+format: 'uint32x4',
+offset: 792,
+shaderLocation: 13,
+},
+{
+format: 'unorm8x2',
+offset: 1360,
+shaderLocation: 3,
+},
+{
+format: 'float16x4',
+offset: 2036,
+shaderLocation: 9,
+},
+{
+format: 'unorm8x2',
+offset: 1630,
+shaderLocation: 0,
+},
+{
+format: 'snorm8x2',
+offset: 2498,
+shaderLocation: 2,
+},
+{
+format: 'float32x2',
+offset: 92,
+shaderLocation: 16,
+},
+{
+format: 'float32',
+offset: 180,
+shaderLocation: 14,
+},
+{
+format: 'uint32',
+offset: 1728,
+shaderLocation: 7,
+},
+{
+format: 'unorm16x4',
+offset: 2124,
+shaderLocation: 18,
+},
+{
+format: 'sint8x4',
+offset: 1676,
+shaderLocation: 4,
+},
+{
+format: 'sint16x2',
+offset: 724,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 1800,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 1000,
+shaderLocation: 17,
+},
+{
+format: 'float32x4',
+offset: 304,
+shaderLocation: 20,
+},
+{
+format: 'unorm8x2',
+offset: 1204,
+shaderLocation: 19,
+},
+{
+format: 'unorm8x4',
+offset: 1684,
+shaderLocation: 5,
+},
+{
+format: 'float16x2',
+offset: 1304,
+shaderLocation: 6,
+},
+{
+format: 'uint16x4',
+offset: 688,
+shaderLocation: 11,
+},
+{
+format: 'sint8x4',
+offset: 792,
+shaderLocation: 10,
+},
+{
+format: 'snorm16x4',
+offset: 40,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 300,
+attributes: [
+{
+format: 'float32x2',
+offset: 32,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+primitive: {
+},
+multisample: {
+count: 4,
+mask: 0x43731694,
+},
+fragment: {
+module: shaderModule11,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8sint',
+},
+undefined,
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthCompare: 'always',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'decrement-clamp',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'greater-equal',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 3086,
+stencilWriteMask: 1140,
+depthBias: 81,
+depthBiasSlopeScale: 74,
+depthBiasClamp: 32,
+},
+}
+);
+let imageData24 = new ImageData(204, 208);
+let sampler70 = device4.createSampler(
+{
+label: '\u63fc\u319e\ua137\u04f5\u923d\u0ff9\uaa37\u{1f8e4}\u{1f763}\u7959',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 71.855,
+lodMaxClamp: 88.446,
+}
+);
+try {
+renderPassEncoder13.setScissorRect(
+685,
+1,
+184,
+0
+);
+} catch {}
+try {
+renderBundleEncoder57.setIndexBuffer(
+buffer20,
+'uint16',
+1902,
+5500
+);
+} catch {}
+let promise44 = device4.popErrorScope();
+let pipeline56 = await device4.createComputePipelineAsync(
+{
+label: '\u{1fb05}\u{1faaf}\u6121\u0cef\u0276\u{1fba6}\ua020\u9252',
+layout: pipelineLayout17,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+renderBundleEncoder56.setBindGroup(
+0,
+bindGroup41,
+new Uint32Array(3133),
+894,
+0
+);
+} catch {}
+let pipeline57 = await device8.createComputePipelineAsync(
+{
+label: '\u6617\u{1f802}\u6ba1\u{1fd2c}\u{1ffe8}\ub86a\u4b2a\u0600\u010a',
+layout: pipelineLayout22,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline58 = device8.createRenderPipeline(
+{
+layout: pipelineLayout22,
+vertex: {
+module: shaderModule12,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 5056,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 2768,
+shaderLocation: 15,
+},
+{
+format: 'uint32',
+offset: 448,
+shaderLocation: 14,
+},
+{
+format: 'sint16x4',
+offset: 3132,
+shaderLocation: 10,
+},
+{
+format: 'unorm16x2',
+offset: 3324,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x4',
+offset: 2304,
+shaderLocation: 2,
+},
+{
+format: 'float32x2',
+offset: 812,
+shaderLocation: 11,
+},
+{
+format: 'uint32',
+offset: 1124,
+shaderLocation: 8,
+},
+{
+format: 'uint8x4',
+offset: 708,
+shaderLocation: 20,
+}
+],
+},
+{
+arrayStride: 6968,
+attributes: [
+{
+format: 'snorm8x4',
+offset: 880,
+shaderLocation: 12,
+},
+{
+format: 'float32x4',
+offset: 2624,
+shaderLocation: 17,
+},
+{
+format: 'sint16x2',
+offset: 956,
+shaderLocation: 6,
+},
+{
+format: 'sint32x2',
+offset: 5860,
+shaderLocation: 18,
+},
+{
+format: 'sint32x4',
+offset: 6880,
+shaderLocation: 19,
+},
+{
+format: 'snorm16x2',
+offset: 1476,
+shaderLocation: 3,
+},
+{
+format: 'float16x2',
+offset: 2580,
+shaderLocation: 16,
+},
+{
+format: 'float32x2',
+offset: 44,
+shaderLocation: 9,
+},
+{
+format: 'float32',
+offset: 452,
+shaderLocation: 13,
+},
+{
+format: 'float32x3',
+offset: 6528,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 21816,
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x4',
+offset: 3264,
+shaderLocation: 5,
+},
+{
+format: 'uint32',
+offset: 10192,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 21480,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 15180,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'back',
+},
+fragment: {
+module: shaderModule12,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.RED,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.GREEN,
+},
+undefined,
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALL,
+},
+undefined
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+failOp: 'invert',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'replace',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilWriteMask: 2540,
+depthBias: 97,
+depthBiasSlopeScale: 82,
+depthBiasClamp: 26,
+},
+}
+);
+document.body.prepend(img11);
+let bindGroup48 = device4.createBindGroup({
+label: '\u482c\u0609\u{1fc8a}\u0537\u13ec\u9e7b\u3087\u{1fd59}',
+layout: bindGroupLayout14,
+entries: [
+{
+binding: 3961,
+resource: externalTexture3
+}
+],
+});
+let computePassEncoder48 = commandEncoder70.beginComputePass(
+{
+label: '\ueefb\u70db\ub524\ub115\ud48c\u0d6a'
+}
+);
+let sampler71 = device4.createSampler(
+{
+label: '\u{1fbdf}\ua490\u8d33',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 74.273,
+lodMaxClamp: 88.958,
+}
+);
+try {
+renderPassEncoder12.setScissorRect(
+659,
+1,
+5,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.insertDebugMarker(
+'\u8250'
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture116,
+  mipLevel: 0,
+  origin: { x: 5, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 33461 */{
+offset: 929,
+bytesPerRow: 12,
+rowsPerImage: 271,
+},
+{width: 0, height: 2, depthOrArrayLayers: 11}
+);
+} catch {}
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+let device11 = await adapter13.requestDevice(
+{
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 7,
+maxColorAttachmentBytesPerSample: 58,
+maxVertexAttributes: 24,
+maxVertexBufferArrayStride: 45783,
+maxStorageTexturesPerShaderStage: 31,
+maxStorageBuffersPerShaderStage: 22,
+maxDynamicStorageBuffersPerPipelineLayout: 52039,
+maxBindingsPerBindGroup: 4997,
+maxTextureDimension1D: 11681,
+maxTextureDimension2D: 15549,
+maxVertexBuffers: 11,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 39543019,
+maxInterStageShaderVariables: 83,
+maxInterStageShaderComponents: 110,
+},
+}
+);
+let video32 = await videoWithData();
+let texture117 = device3.createTexture(
+{
+label: '\u0053\u4df6\u{1fb11}',
+size: [6107],
+dimension: '1d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+let computePassEncoder49 = commandEncoder46.beginComputePass(
+{
+label: '\u9f3c\u3130\u0522\u070e\u0dd4\u2bc0\u0869\u1a13'
+}
+);
+let renderBundle96 = renderBundleEncoder53.finish(
+{
+
+}
+);
+try {
+renderPassEncoder14.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder14.setViewport(
+349.2,
+3.627,
+142.1,
+4.071,
+0.1415,
+0.7945
+);
+} catch {}
+let offscreenCanvas23 = new OffscreenCanvas(314, 811);
+try {
+offscreenCanvas23.getContext('webgl2');
+} catch {}
+let textureView97 = texture117.createView(
+{
+label: '\u45c8\u59bb\u052f\u3f3e\u47ee\u095a\u098c\u0587\u098f\u0540',
+}
+);
+let renderBundle97 = renderBundleEncoder70.finish(
+{
+label: '\u0acb\u603b\u9777\u{1fbdb}\u0028\ud7b1\ue89d\u122a\u{1fa83}'
+}
+);
+try {
+renderPassEncoder14.executeBundles([]);
+} catch {}
+let imageBitmap31 = await createImageBitmap(video4);
+let commandEncoder75 = device6.createCommandEncoder(
+{
+}
+);
+let computePassEncoder50 = commandEncoder75.beginComputePass(
+{
+label: '\u0891\u0020\uccbe\u03a0\u9581\ubdfd'
+}
+);
+try {
+renderBundleEncoder58.setVertexBuffer(
+1,
+buffer28,
+38908,
+5336
+);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+try {
+commandEncoder62.insertDebugMarker(
+'\ua3d9'
+);
+} catch {}
+try {
+computePassEncoder40.insertDebugMarker(
+'\u{1ffb5}'
+);
+} catch {}
+let gpuCanvasContext24 = offscreenCanvas22.getContext('webgpu');
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+document.body.prepend('\u{1fc5e}\u{1fe50}\u0842\u29ff');
+let offscreenCanvas24 = new OffscreenCanvas(75, 654);
+let querySet82 = device4.createQuerySet(
+{
+type: 'occlusion',
+count: 3689,
+}
+);
+let texture118 = device4.createTexture(
+{
+label: '\u0718\u00a2\u74ed\u{1f870}\u{1fb78}\u90ac\u0dee\u{1f97b}\ufdd5',
+size: [64, 131, 1],
+mipLevelCount: 4,
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder84 = device4.createRenderBundleEncoder(
+{
+label: '\u751c\udb9b\u0e78\u606e',
+colorFormats: [
+'rgba16float',
+'rg32sint',
+'rg16uint',
+'r16sint',
+'r32sint'
+],
+sampleCount: 486,
+depthReadOnly: false,
+}
+);
+try {
+computePassEncoder48.setBindGroup(
+4,
+bindGroup24,
+new Uint32Array(670),
+494,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(
+722,
+0,
+107,
+1
+);
+} catch {}
+try {
+renderBundleEncoder84.setBindGroup(
+0,
+bindGroup42
+);
+} catch {}
+gc();
+document.body.prepend('\u{1f7e7}\uc3be\u{1fdbe}\u{1fd59}\u{1f8a9}\u09a2\u{1f7d7}\u0d82\u2e82');
+try {
+adapter2.label = '\ud818\u1264\u24a4\u9702\ue465\u4bd8\u97f0\u1c3a\u30e3\u0566';
+} catch {}
+try {
+window.someLabel = device10.label;
+} catch {}
+let renderBundleEncoder85 = device10.createRenderBundleEncoder(
+{
+label: '\u59af\ubb58\u094a\u0159\u0f27\ubdab\u9a6b',
+colorFormats: [
+'rgba16float',
+undefined,
+undefined,
+undefined,
+'rg16uint',
+undefined,
+'r32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 705,
+depthReadOnly: true,
+}
+);
+try {
+device10.queue.copyExternalImageToTexture(
+/*
+{width: 235, height: 1, depthOrArrayLayers: 15}
+*/
+{
+  source: img19,
+  origin: { x: 46, y: 119 },
+  flipY: true,
+},
+{
+  texture: texture104,
+  mipLevel: 3,
+  origin: { x: 7, y: 1, z: 6 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 148, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let texture119 = device7.createTexture(
+{
+label: '\u70eb\u0e6c\u95fb\u0efc\ucffc\uff4f\uee13\u1486',
+size: {width: 11100, height: 12, depthOrArrayLayers: 1},
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-12x12-unorm',
+'astc-12x12-unorm-srgb'
+],
+}
+);
+try {
+device7.queue.writeBuffer(
+buffer36,
+38920,
+new DataView(new ArrayBuffer(37953)),
+28194,
+6520
+);
+} catch {}
+let pipeline59 = await promise42;
+let gpuCanvasContext25 = offscreenCanvas24.getContext('webgpu');
+gc();
+let buffer37 = device1.createBuffer(
+{
+label: '\u9d7f\u{1f641}\udfa0\u79dc\u{1fc24}\u65b8\u{1f810}\ucc72\ufc93',
+size: 42976,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+}
+);
+try {
+device1.queue.writeTexture(
+{
+  texture: texture46,
+  mipLevel: 0,
+  origin: { x: 77, y: 0, z: 1279 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 2028041 */{
+offset: 533,
+bytesPerRow: 798,
+rowsPerImage: 127,
+},
+{width: 147, height: 1, depthOrArrayLayers: 21}
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 253, height: 209, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas14,
+  origin: { x: 22, y: 30 },
+  flipY: false,
+},
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 0, y: 164, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 253, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend('\u{1fe2b}\uaaf8\u{1fc38}\u078b\u0e7d\uda79\u5414\u0a69\uc06e');
+let commandEncoder76 = device9.createCommandEncoder(
+{
+label: '\u064f\u{1fec0}\ud6d6\uff1d\u673a\u0f70',
+}
+);
+let renderBundle98 = renderBundleEncoder77.finish(
+{
+label: '\u6986\u1cb5'
+}
+);
+try {
+computePassEncoder45.end();
+} catch {}
+let gpuCanvasContext26 = canvas25.getContext('webgpu');
+let commandBuffer9 = commandEncoder33.finish(
+{
+label: '\u{1fcec}\u{1fb6d}\u0640\u{1f6ca}\u{1f9d7}\u3618\u{1f734}\u5c05\u07e3',
+}
+);
+let renderBundle99 = renderBundleEncoder24.finish();
+let arrayBuffer9 = buffer3.getMappedRange(
+0,
+2664
+);
+try {
+commandEncoder19.clearBuffer(
+buffer1
+);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let commandEncoder77 = device10.createCommandEncoder(
+{
+}
+);
+try {
+renderBundleEncoder85.setVertexBuffer(
+7,
+buffer33,
+36292,
+5721
+);
+} catch {}
+try {
+commandEncoder77.copyTextureToTexture(
+{
+  texture: texture104,
+  mipLevel: 1,
+  origin: { x: 193, y: 1, z: 16 },
+  aspect: 'all',
+},
+{
+  texture: texture104,
+  mipLevel: 2,
+  origin: { x: 5, y: 0, z: 6 },
+  aspect: 'all',
+},
+{width: 429, height: 0, depthOrArrayLayers: 24}
+);
+} catch {}
+document.body.prepend('\u{1f86e}\u{1f723}\u3cbc\uf3c6\u62d9\u0cbc\u5c4b');
+let querySet83 = device11.createQuerySet(
+{
+label: '\ufa65\u{1fde2}\u{1fc8a}\u0f76\uf575\u{1f864}',
+type: 'occlusion',
+count: 133,
+}
+);
+try {
+adapter9.label = '\u61de\u00a7\u6448\u{1ff25}\uf955';
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(
+32
+);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+1,
+buffer31,
+5740,
+6160
+);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+let canvas26 = document.createElement('canvas');
+try {
+offscreenCanvas21.getContext('2d');
+} catch {}
+let textureView98 = texture99.createView(
+{
+label: '\u{1f786}\uf7ac\u4b98\u6097\u{1f702}',
+dimension: '2d-array',
+}
+);
+let renderPassEncoder17 = commandEncoder47.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView93,
+depthSlice: 20,
+clearValue: {
+r: -406.0,
+g: 872.7,
+b: 453.6,
+a: 463.5,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView93,
+depthSlice: 48,
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined,
+undefined,
+undefined,
+undefined,
+{
+view: textureView93,
+depthSlice: 5,
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+{
+view: textureView93,
+depthSlice: 97,
+clearValue: {
+r: 914.7,
+g: -462.8,
+b: -789.3,
+a: 903.9,
+},
+loadOp: 'load',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet58,
+maxDrawCount: 212744,
+}
+);
+try {
+renderPassEncoder16.setBlendConstant(
+{
+r: 768.0,
+g: 648.7,
+b: -766.8,
+a: -172.2,
+}
+);
+} catch {}
+try {
+renderPassEncoder16.setViewport(
+7.758,
+1.251,
+11.41,
+0.2895,
+0.6571,
+0.7255
+);
+} catch {}
+let gpuCanvasContext27 = canvas26.getContext('webgpu');
+document.body.append('\u399c\u2942\u96e0\u2568\u0375\u9548\u{1f91a}\ufb4e\ubb6e\u{1f75c}');
+try {
+await promise44;
+} catch {}
+let buffer38 = device7.createBuffer(
+{
+label: '\u0250\u6803\u0d2d\u8451\u{1fad4}\u59d5\u{1fbf6}\u4fbd',
+size: 53447,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let commandEncoder78 = device7.createCommandEncoder(
+{
+label: '\u{1ffa9}\u6885',
+}
+);
+try {
+computePassEncoder43.setPipeline(
+pipeline59
+);
+} catch {}
+try {
+device7.queue.writeBuffer(
+buffer36,
+32520,
+new Int16Array(41073),
+9261,
+3384
+);
+} catch {}
+let promise45 = device7.createComputePipelineAsync(
+{
+label: '\u0c0b\ue53b\ub356\ub67e\u8829',
+layout: pipelineLayout23,
+compute: {
+module: shaderModule13,
+entryPoint: 'compute0',
+},
+}
+);
+gc();
+let querySet84 = device9.createQuerySet(
+{
+label: '\ub5de\u{1fcd9}\u815b\u0b60\u{1f745}\u20bc',
+type: 'occlusion',
+count: 1007,
+}
+);
+let renderBundle100 = renderBundleEncoder77.finish(
+{
+label: '\u{1ffe5}\u6947\u902c\u0b20'
+}
+);
+try {
+gpuCanvasContext12.configure(
+{
+device: device9,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb',
+'bgra8unorm',
+'etc2-rgb8a1unorm'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let offscreenCanvas25 = new OffscreenCanvas(26, 39);
+let bindGroupLayout33 = device8.createBindGroupLayout(
+{
+label: '\u9d1c\u0678\u0ca3\u{1f6fd}\uc08f\u{1fa71}\u7746\ufd45\u03e7\u3250\u460b',
+entries: [
+{
+binding: 1171,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'non-filtering' },
+}
+],
+}
+);
+let renderBundleEncoder86 = device8.createRenderBundleEncoder(
+{
+label: '\u30c6\ua71d\u01b3',
+colorFormats: [
+undefined,
+'r32sint',
+'r32uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 762,
+depthReadOnly: true,
+}
+);
+let sampler72 = device8.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 79.007,
+lodMaxClamp: 89.005,
+}
+);
+try {
+renderBundleEncoder79.setBindGroup(
+0,
+bindGroup41,
+new Uint32Array(9477),
+3194,
+0
+);
+} catch {}
+let pipeline60 = await device8.createRenderPipelineAsync(
+{
+label: '\u33c9\u{1f6d6}\u0eef\u{1fd1e}\u07de\ucd48\udbfb\u002a\u230e\u7812',
+layout: pipelineLayout22,
+vertex: {
+module: shaderModule12,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 23184,
+attributes: [
+{
+format: 'sint32x2',
+offset: 4092,
+shaderLocation: 6,
+},
+{
+format: 'sint8x2',
+offset: 15432,
+shaderLocation: 10,
+},
+{
+format: 'float32x2',
+offset: 16064,
+shaderLocation: 13,
+},
+{
+format: 'unorm16x4',
+offset: 23084,
+shaderLocation: 16,
+},
+{
+format: 'uint32x3',
+offset: 10968,
+shaderLocation: 20,
+},
+{
+format: 'sint8x4',
+offset: 10704,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 19256,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 17052,
+shaderLocation: 3,
+},
+{
+format: 'snorm16x4',
+offset: 4180,
+shaderLocation: 1,
+},
+{
+format: 'unorm8x4',
+offset: 18748,
+shaderLocation: 17,
+},
+{
+format: 'uint32',
+offset: 15364,
+shaderLocation: 14,
+},
+{
+format: 'uint16x2',
+offset: 17392,
+shaderLocation: 7,
+},
+{
+format: 'uint32x2',
+offset: 14684,
+shaderLocation: 5,
+},
+{
+format: 'float32x2',
+offset: 1940,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x4',
+offset: 4352,
+shaderLocation: 9,
+},
+{
+format: 'unorm8x2',
+offset: 3700,
+shaderLocation: 15,
+},
+{
+format: 'sint16x4',
+offset: 260,
+shaderLocation: 19,
+},
+{
+format: 'uint32x2',
+offset: 19108,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 12848,
+attributes: [
+{
+format: 'float32x2',
+offset: 212,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 12840,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'unorm16x2',
+offset: 9724,
+shaderLocation: 12,
+},
+{
+format: 'float32x2',
+offset: 18616,
+shaderLocation: 2,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 20008,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+},
+fragment: {
+module: shaderModule12,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg8unorm',
+},
+{
+format: 'rgba32uint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}
+],
+},
+}
+);
+let offscreenCanvas26 = new OffscreenCanvas(21, 482);
+let querySet85 = device6.createQuerySet(
+{
+type: 'occlusion',
+count: 1549,
+}
+);
+let texture120 = gpuCanvasContext21.getCurrentTexture();
+let externalTexture8 = device6.importExternalTexture(
+{
+label: '\u{1f9ee}\uf89b\ue3a2\u9858\ud423\u0eba\u3c86',
+source: video5,
+}
+);
+try {
+commandEncoder69.copyTextureToBuffer(
+{
+  texture: texture70,
+  mipLevel: 0,
+  origin: { x: 2088, y: 0, z: 163 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 5312 widthInBlocks: 332 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 11280 */
+offset: 11280,
+buffer: buffer28,
+},
+{width: 3984, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device6, buffer28);
+} catch {}
+try {
+device6.queue.writeBuffer(
+buffer28,
+19936,
+new Float32Array(51767),
+13279,
+7068
+);
+} catch {}
+let imageBitmap32 = await createImageBitmap(imageBitmap20);
+let shaderModule14 = device7.createShaderModule(
+{
+label: '\u07d9\u3105\u185d\u1e90',
+code: `
+
+@compute @workgroup_size(6, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S18 {
+@builtin(sample_index) f0: u32,
+@location(54) f1: vec2<f32>,
+@location(13) f2: vec4<f32>,
+@location(44) f3: f16,
+@builtin(front_facing) f4: bool
+}
+struct FragmentOutput0 {
+@location(3) f0: vec4<i32>,
+@location(7) f1: vec2<f32>,
+@location(6) f2: f32,
+@location(0) f3: vec2<f32>,
+@location(4) f4: vec4<u32>,
+@location(5) f5: vec4<u32>,
+@location(1) f6: i32,
+@location(2) f7: vec3<u32>
+}
+
+@fragment
+fn fragment0(@location(37) a0: vec4<i32>, @location(30) a1: vec2<f16>, @location(57) a2: i32, @location(14) a3: vec2<f32>, @location(22) a4: u32, @location(24) a5: vec3<f16>, a6: S18, @builtin(sample_mask) a7: u32, @location(42) a8: u32, @location(20) a9: u32, @location(59) a10: vec2<i32>, @location(29) a11: vec4<f32>, @location(66) a12: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(24) f276: vec3<f16>,
+@location(18) f277: vec2<u32>,
+@location(44) f278: f16,
+@location(53) f279: vec4<u32>,
+@location(66) f280: vec4<f32>,
+@location(29) f281: vec4<f32>,
+@builtin(position) f282: vec4<f32>,
+@location(8) f283: vec4<f32>,
+@location(11) f284: f16,
+@location(42) f285: u32,
+@location(37) f286: vec4<i32>,
+@location(22) f287: u32,
+@location(1) f288: vec4<i32>,
+@location(30) f289: vec2<f16>,
+@location(9) f290: vec4<f16>,
+@location(38) f291: vec3<f16>,
+@location(16) f292: i32,
+@location(14) f293: vec2<f32>,
+@location(41) f294: vec4<f32>,
+@location(35) f295: vec2<i32>,
+@location(59) f296: vec2<i32>,
+@location(20) f297: u32,
+@location(3) f298: vec3<f32>,
+@location(61) f299: vec4<u32>,
+@location(54) f300: vec2<f32>,
+@location(28) f301: vec4<i32>,
+@location(64) f302: vec4<f32>,
+@location(48) f303: vec4<f32>,
+@location(58) f304: vec4<u32>,
+@location(13) f305: vec4<f32>,
+@location(15) f306: vec4<i32>,
+@location(57) f307: i32
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(10) a1: vec4<i32>, @location(14) a2: f16) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let externalTexture9 = device7.importExternalTexture(
+{
+source: videoFrame11,
+colorSpace: 'srgb',
+}
+);
+try {
+commandEncoder78.copyTextureToTexture(
+{
+  texture: texture107,
+  mipLevel: 3,
+  origin: { x: 360, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture107,
+  mipLevel: 1,
+  origin: { x: 2784, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 936, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+gpuCanvasContext15.configure(
+{
+device: device7,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgba16float',
+'rg16uint',
+'etc2-rgb8a1unorm-srgb'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device7.queue.writeBuffer(
+buffer38,
+16980,
+new Int16Array(25886),
+1307,
+5180
+);
+} catch {}
+try {
+device7.queue.writeTexture(
+{
+  texture: texture68,
+  mipLevel: 0,
+  origin: { x: 435, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer8,
+/* required buffer size: 28779 */{
+offset: 215,
+rowsPerImage: 170,
+},
+{width: 7141, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let bindGroupLayout34 = device5.createBindGroupLayout(
+{
+entries: [
+{
+binding: 372,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+},
+{
+binding: 235,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let commandEncoder79 = device5.createCommandEncoder(
+{
+label: '\u{1f7a3}\uba16\u{1f726}',
+}
+);
+let querySet86 = device5.createQuerySet(
+{
+type: 'occlusion',
+count: 3278,
+}
+);
+let renderPassEncoder18 = commandEncoder79.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView93,
+depthSlice: 80,
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView93,
+depthSlice: 106,
+clearValue: {
+r: 468.9,
+g: 584.9,
+b: 814.4,
+a: -63.70,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined,
+undefined,
+undefined,
+undefined
+],
+occlusionQuerySet: querySet67,
+maxDrawCount: 368,
+}
+);
+let renderBundleEncoder87 = device5.createRenderBundleEncoder(
+{
+label: '\u{1fb95}\u04bd\u1a13\u8d79\ubdfc\u5284',
+colorFormats: [
+'rgba8uint',
+'rg16float',
+'r16sint',
+'bgra8unorm-srgb',
+'r8sint',
+'rg32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 446,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder18.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+renderPassEncoder15.setScissorRect(
+57,
+2,
+14,
+0
+);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(
+21,
+undefined,
+2634616497,
+768415944
+);
+} catch {}
+document.body.prepend(canvas3);
+document.body.append('\u7ec0\u{1f9e5}\ua7d5\u{1f9d1}');
+let texture121 = device3.createTexture(
+{
+label: '\u{1ff50}\ufb3e',
+size: {width: 3983, height: 146, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'rgba32float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+renderPassEncoder14.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder14.setStencilReference(
+2038
+);
+} catch {}
+try {
+renderPassEncoder14.setViewport(
+40.68,
+8.599,
+293.6,
+0.9006,
+0.6362,
+0.9768
+);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+let shaderModule15 = device1.createShaderModule(
+{
+label: '\u0906\u009d\u0bea\u0c28\u6a3d\u0759',
+code: `
+
+@compute @workgroup_size(7, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(0) f0: vec4<i32>,
+@builtin(sample_mask) f1: u32,
+@location(2) f2: vec3<u32>,
+@location(1) f3: vec3<i32>,
+@location(6) f4: u32,
+@location(5) f5: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(12) a0: f32, @location(5) a1: vec3<u32>, @location(19) a2: vec3<i32>, @location(9) a3: vec3<f16>, @location(0) a4: vec2<u32>, @location(13) a5: f32, @location(14) a6: vec3<f16>, @location(1) a7: vec3<f16>, @location(22) a8: u32, @location(11) a9: vec2<i32>, @location(8) a10: f16, @location(10) a11: f32, @location(2) a12: vec3<i32>, @location(18) a13: vec4<i32>, @builtin(instance_index) a14: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture122 = device1.createTexture(
+{
+label: '\uacaa\u2519\u0fa4\u076b\u098a\u0954',
+size: {width: 5035},
+dimension: '1d',
+format: 'rg16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg16uint',
+'rg16uint'
+],
+}
+);
+let textureView99 = texture62.createView(
+{
+label: '\u05e9\u321f\u0e9b\ud736\u7cd7',
+aspect: 'all',
+baseMipLevel: 1,
+baseArrayLayer: 12,
+}
+);
+let renderBundle101 = renderBundleEncoder33.finish(
+{
+label: '\u{1f72b}\u3d0c\u{1f971}\udc2e\u{1faa1}'
+}
+);
+try {
+buffer19.unmap();
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture122,
+  mipLevel: 0,
+  origin: { x: 2909, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(181),
+/* required buffer size: 181 */{
+offset: 181,
+},
+{width: 1964, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipelineLayout24 = device3.createPipelineLayout(
+{
+label: '\u74fc\u6b3c\u0999\u0667\u{1f99e}\u6a87\u547f\u{1fc8d}\u2d1e\ufc45',
+bindGroupLayouts: [
+bindGroupLayout20,
+bindGroupLayout20
+],
+}
+);
+let renderBundleEncoder88 = device3.createRenderBundleEncoder(
+{
+label: '\u0a7b\ud846\u0017\uf5c6\ue6ca\uc7d0\u{1fd68}\u1c25\uc2a8\u0843\u{1fb6c}',
+colorFormats: [
+undefined,
+'rgba16sint',
+'rgba32float',
+'rg8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 313,
+stencilReadOnly: true,
+}
+);
+let renderBundle102 = renderBundleEncoder47.finish(
+{
+label: '\u01d0\u{1fb2c}\u7e89\u0f3a\u2587'
+}
+);
+try {
+await device3.popErrorScope();
+} catch {}
+let videoFrame26 = new VideoFrame(imageBitmap14, {timestamp: 0});
+let bindGroupLayout35 = device5.createBindGroupLayout(
+{
+label: '\u{1f702}\u{1f740}\u51af\u5ea5\ufb49\u06f4\u0c54\ud1f8\u0099\ucd18\u{1ffc8}',
+entries: [
+{
+binding: 706,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+}
+],
+}
+);
+let querySet87 = device5.createQuerySet(
+{
+label: '\u3451\ue686\u0dce\u7a83\u0ee3\u2732\u89a0\u8028\u0285\u66f7\u{1fe74}',
+type: 'occlusion',
+count: 2881,
+}
+);
+let texture123 = device5.createTexture(
+{
+size: [4772],
+dimension: '1d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg11b10ufloat',
+'rg11b10ufloat'
+],
+}
+);
+let gpuCanvasContext28 = offscreenCanvas25.getContext('webgpu');
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let imageBitmap33 = await createImageBitmap(video15);
+try {
+offscreenCanvas26.getContext('webgpu');
+} catch {}
+let shaderModule16 = device4.createShaderModule(
+{
+code: `
+
+@compute @workgroup_size(3, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: vec4<i32>,
+@location(4) f1: u32,
+@location(1) f2: f32,
+@location(3) f3: vec3<f32>,
+@builtin(sample_mask) f4: u32,
+@location(2) f5: vec4<i32>,
+@location(0) f6: f32,
+@location(7) f7: vec3<f32>,
+@location(5) f8: u32
+}
+
+@fragment
+fn fragment0(@location(12) a0: vec4<f32>, @location(19) a1: vec4<f16>, @location(3) a2: u32, @location(26) a3: vec3<f16>, @location(14) a4: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(22) f308: vec4<u32>,
+@builtin(position) f309: vec4<f32>,
+@location(26) f310: vec3<f16>,
+@location(29) f311: vec2<i32>,
+@location(19) f312: vec4<f16>,
+@location(28) f313: f32,
+@location(15) f314: vec2<i32>,
+@location(25) f315: vec3<i32>,
+@location(9) f316: vec4<f32>,
+@location(1) f317: vec3<f16>,
+@location(14) f318: u32,
+@location(5) f319: u32,
+@location(6) f320: f16,
+@location(27) f321: vec4<i32>,
+@location(3) f322: u32,
+@location(21) f323: vec4<f32>,
+@location(18) f324: vec2<f32>,
+@location(8) f325: vec2<f32>,
+@location(30) f326: vec2<f32>,
+@location(12) f327: vec4<f32>,
+@location(20) f328: vec3<i32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(7) a1: vec3<f32>, @location(2) a2: f16, @location(11) a3: vec4<u32>, @location(9) a4: vec2<f16>, @location(14) a5: vec2<i32>, @builtin(instance_index) a6: u32, @location(5) a7: vec3<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroup49 = device4.createBindGroup({
+label: '\u099d\u1cd4\u{1f7c4}\u{1f715}\uc54c\u0369',
+layout: bindGroupLayout14,
+entries: [
+{
+binding: 3961,
+resource: externalTexture3
+}
+],
+});
+let renderBundle103 = renderBundleEncoder78.finish();
+let sampler73 = device4.createSampler(
+{
+label: '\u6472\u{1fc9a}\uab36\u{1f900}\ue609\u00d1\u0f9e\u82a9\u3e89\u083b\uf251',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 61.929,
+lodMaxClamp: 63.156,
+maxAnisotropy: 3,
+}
+);
+try {
+renderPassEncoder12.setBindGroup(
+4,
+bindGroup42
+);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(
+buffer20,
+'uint16',
+5276,
+404
+);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+74,
+undefined,
+3256904262,
+379206058
+);
+} catch {}
+try {
+renderBundleEncoder84.setBindGroup(
+3,
+bindGroup24
+);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let texture124 = device10.createTexture(
+{
+label: '\u3be2\u3c8f\uc5b3',
+size: [1609, 1, 189],
+mipLevelCount: 11,
+dimension: '3d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+let renderBundleEncoder89 = device10.createRenderBundleEncoder(
+{
+colorFormats: [
+'bgra8unorm',
+'rg16sint',
+'r32float',
+'rgb10a2uint',
+'rg16float',
+'rg16float'
+],
+sampleCount: 902,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+device10.queue.writeBuffer(
+buffer33,
+9940,
+new Int16Array(26005),
+2954,
+5568
+);
+} catch {}
+try {
+device10.queue.copyExternalImageToTexture(
+/*
+{width: 1883, height: 1, depthOrArrayLayers: 124}
+*/
+{
+  source: offscreenCanvas16,
+  origin: { x: 86, y: 392 },
+  flipY: true,
+},
+{
+  texture: texture104,
+  mipLevel: 0,
+  origin: { x: 1760, y: 0, z: 50 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 19, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\u4f0d\u28bf\u5f14\uf33d\u{1f71d}\u2f0a\u9306\u063d\u{1f788}\u{1f70b}\u0ab6');
+let pipelineLayout25 = device3.createPipelineLayout(
+{
+label: '\u2ffc\u358b\u{1f609}\u{1fea4}\u{1f8cc}\uf28e\u53f2',
+bindGroupLayouts: [
+bindGroupLayout20,
+bindGroupLayout25,
+bindGroupLayout17,
+bindGroupLayout20
+],
+}
+);
+let renderBundleEncoder90 = device3.createRenderBundleEncoder(
+{
+label: '\u45ab\ued98\ue16e\u32f3',
+colorFormats: [
+'rgba16uint',
+'rgba8sint'
+],
+sampleCount: 554,
+stencilReadOnly: true,
+}
+);
+let sampler74 = device3.createSampler(
+{
+label: '\u0f85\u{1f97a}\udac4',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 97.592,
+lodMaxClamp: 99.374,
+compare: 'not-equal',
+maxAnisotropy: 17,
+}
+);
+try {
+renderPassEncoder14.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant(
+{
+r: -713.9,
+g: -1.528,
+b: 635.8,
+a: -713.5,
+}
+);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(
+7,
+buffer24,
+8364,
+1432
+);
+} catch {}
+try {
+querySet68.destroy();
+} catch {}
+document.body.append('\u0c2d\uff9b\u0716');
+let offscreenCanvas27 = new OffscreenCanvas(319, 329);
+let buffer39 = device7.createBuffer(
+{
+size: 206,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM,
+}
+);
+let commandEncoder80 = device7.createCommandEncoder(
+{
+label: '\uabca\u7119\ude0e\u925e\u91b8',
+}
+);
+let textureView100 = texture107.createView(
+{
+label: '\u{1fff5}\u0047\u4491\u{1fa41}\u{1f740}\ua0c4\u4fc5\u0042\u0da9\u09aa',
+dimension: '2d-array',
+mipLevelCount: 4,
+}
+);
+try {
+computePassEncoder43.setPipeline(
+pipeline50
+);
+} catch {}
+try {
+commandEncoder80.copyTextureToTexture(
+{
+  texture: texture109,
+  mipLevel: 3,
+  origin: { x: 3, y: 5, z: 2 },
+  aspect: 'all',
+},
+{
+  texture: texture109,
+  mipLevel: 3,
+  origin: { x: 2, y: 6, z: 111 },
+  aspect: 'all',
+},
+{width: 0, height: 13, depthOrArrayLayers: 102}
+);
+} catch {}
+try {
+commandEncoder78.clearBuffer(
+buffer36,
+9892,
+15468
+);
+dissociateBuffer(device7, buffer36);
+} catch {}
+video16.height = 283;
+let video33 = await videoWithData();
+let querySet88 = device10.createQuerySet(
+{
+label: '\u0fad\u04ca\u04d0\u0a24\u0cdd\u5cd5\u1993',
+type: 'occlusion',
+count: 2234,
+}
+);
+let renderBundleEncoder91 = device10.createRenderBundleEncoder(
+{
+label: '\u05da\u2a70\u23bb\u{1f9d2}\ud4bd\u{1f81e}\u{1f699}\uc7e2\ub55a',
+colorFormats: [
+'rgba16float',
+'bgra8unorm-srgb',
+'rgba32float'
+],
+sampleCount: 612,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder85.setVertexBuffer(
+2,
+buffer33,
+1768,
+17828
+);
+} catch {}
+try {
+buffer33.unmap();
+} catch {}
+try {
+commandEncoder77.clearBuffer(
+buffer33,
+28048,
+8768
+);
+dissociateBuffer(device10, buffer33);
+} catch {}
+try {
+renderBundleEncoder85.insertDebugMarker(
+'\u7f9f'
+);
+} catch {}
+try {
+device10.queue.submit([
+]);
+} catch {}
+try {
+device10.queue.copyExternalImageToTexture(
+/*
+{width: 235, height: 1, depthOrArrayLayers: 15}
+*/
+{
+  source: canvas3,
+  origin: { x: 268, y: 14 },
+  flipY: false,
+},
+{
+  texture: texture104,
+  mipLevel: 3,
+  origin: { x: 30, y: 0, z: 13 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 187, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let imageData25 = new ImageData(24, 252);
+let texture125 = device8.createTexture(
+{
+label: '\u0ffe\u949a\u559e\u68e6\u0dba\u6b4d\ue936',
+size: {width: 1270, height: 1, depthOrArrayLayers: 329},
+dimension: '3d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb'
+],
+}
+);
+let renderBundleEncoder92 = device8.createRenderBundleEncoder(
+{
+label: '\uccd0\u{1fb3d}\u{1fe3f}\ua3d6\u{1ffcb}\u5b27\u1069\u4bbe',
+colorFormats: [
+'rgb10a2unorm',
+'rg32sint'
+],
+sampleCount: 615,
+stencilReadOnly: true,
+}
+);
+document.body.prepend('\u0085\u0ec1\udd94\u5371\u3963\u04c2\u5b0c\u8d72');
+let textureView101 = texture117.createView(
+{
+label: '\ud79a\ud49e\u{1f72e}',
+}
+);
+let renderBundle104 = renderBundleEncoder70.finish(
+{
+label: '\u0d08\ufec8\u2cc3\u2421\u4534\u{1f6a9}'
+}
+);
+try {
+renderPassEncoder14.setStencilReference(
+2281
+);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(
+0,
+buffer24,
+5932
+);
+} catch {}
+try {
+gpuCanvasContext7.configure(
+{
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb'
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let texture126 = device1.createTexture(
+{
+label: '\u4d0e\ud63d\u0030\ud9dd\ua09e\u2327\u{1fc37}',
+size: [7771],
+dimension: '1d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let textureView102 = texture58.createView(
+{
+format: 'depth24plus',
+mipLevelCount: 1,
+baseArrayLayer: 0,
+}
+);
+gc();
+try {
+window.someLabel = device10.queue.label;
+} catch {}
+let computePassEncoder51 = commandEncoder77.beginComputePass(
+{
+label: '\uffab\ufcd3\u{1f7bb}\u1af9\u7522\u0c7c\u6de5'
+}
+);
+let sampler75 = device10.createSampler(
+{
+label: '\u2eb7\u54ba\u2763',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 12.149,
+lodMaxClamp: 49.584,
+}
+);
+try {
+renderBundleEncoder91.setVertexBuffer(
+7,
+buffer33,
+19816
+);
+} catch {}
+try {
+device10.queue.copyExternalImageToTexture(
+/*
+{width: 1883, height: 1, depthOrArrayLayers: 124}
+*/
+{
+  source: imageData2,
+  origin: { x: 8, y: 95 },
+  flipY: true,
+},
+{
+  texture: texture104,
+  mipLevel: 0,
+  origin: { x: 941, y: 0, z: 27 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 31, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+pseudoSubmit(device4, commandEncoder57);
+let texture127 = device4.createTexture(
+{
+size: [15242],
+dimension: '1d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg11b10ufloat'
+],
+}
+);
+try {
+renderPassEncoder13.setVertexBuffer(
+2,
+buffer20,
+3216
+);
+} catch {}
+try {
+renderBundleEncoder84.setVertexBuffer(
+0,
+buffer31,
+9236,
+31120
+);
+} catch {}
+let texture128 = device5.createTexture(
+{
+label: '\ubb17\ubc0a\u2395\u01b7\ub082\u{1ffff}\ud15a',
+size: {width: 2883, height: 7, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'rg32sint',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32sint',
+'rg32sint'
+],
+}
+);
+let texture129 = gpuCanvasContext13.getCurrentTexture();
+let renderBundleEncoder93 = device5.createRenderBundleEncoder(
+{
+label: '\u2dab\ucf2e\u0e02',
+colorFormats: [
+'rg16sint',
+'r16float',
+'rg8unorm',
+'r16sint',
+'rgba8unorm-srgb',
+'rg16uint',
+'rg8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 257,
+depthReadOnly: true,
+}
+);
+try {
+computePassEncoder36.setBindGroup(
+3,
+bindGroup32
+);
+} catch {}
+try {
+renderPassEncoder18.end();
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(
+32
+);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant(
+{
+r: 260.6,
+g: 843.1,
+b: -147.5,
+a: -910.8,
+}
+);
+} catch {}
+try {
+renderPassEncoder16.setViewport(
+27.32,
+1.259,
+29.80,
+0.2093,
+0.3854,
+0.9759
+);
+} catch {}
+let adapter14 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let pipelineLayout26 = device4.createPipelineLayout(
+{
+label: '\u03ed\u0717\u{1fe67}\ua6a2\u9b40\u0b7b\u082d',
+bindGroupLayouts: [
+bindGroupLayout29,
+bindGroupLayout23,
+bindGroupLayout23,
+bindGroupLayout32,
+bindGroupLayout23
+],
+}
+);
+let commandEncoder81 = device4.createCommandEncoder(
+{
+label: '\u06a0\u2d6b\u0332\u1d0d\u1f20',
+}
+);
+try {
+renderPassEncoder12.setBindGroup(
+1,
+bindGroup28
+);
+} catch {}
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.setViewport(
+45.14,
+0.08308,
+687.3,
+0.7781,
+0.6176,
+0.8124
+);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(
+1,
+buffer20,
+8408,
+21
+);
+} catch {}
+try {
+await buffer27.mapAsync(
+GPUMapMode.READ,
+16104,
+860
+);
+} catch {}
+try {
+commandEncoder81.copyBufferToBuffer(
+buffer18,
+6248,
+buffer25,
+36448,
+2288
+);
+dissociateBuffer(device4, buffer18);
+dissociateBuffer(device4, buffer25);
+} catch {}
+let renderBundleEncoder94 = device7.createRenderBundleEncoder(
+{
+label: '\u75ee\u4eaf',
+colorFormats: [
+'r16float',
+'r32sint',
+undefined,
+'rgba8uint',
+'r16float',
+'r32sint'
+],
+sampleCount: 892,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder43.setPipeline(
+pipeline50
+);
+} catch {}
+try {
+commandEncoder78.insertDebugMarker(
+'\u8473'
+);
+} catch {}
+try {
+device7.queue.writeTexture(
+{
+  texture: texture119,
+  mipLevel: 0,
+  origin: { x: 4644, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Int8Array(arrayBuffer8),
+/* required buffer size: 661 */{
+offset: 661,
+},
+{width: 2856, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await adapter1.requestAdapterInfo();
+} catch {}
+let textureView103 = texture50.createView(
+{
+label: '\u{1fa2a}\u15d9\u0585\u00ad\ua700',
+baseMipLevel: 1,
+mipLevelCount: 1,
+}
+);
+let renderBundle105 = renderBundleEncoder32.finish(
+{
+label: '\u13c9\u0211\u3d28'
+}
+);
+try {
+computePassEncoder29.setBindGroup(
+0,
+bindGroup21
+);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(
+4,
+buffer15,
+18520,
+1310
+);
+} catch {}
+try {
+commandEncoder74.copyTextureToTexture(
+{
+  texture: texture98,
+  mipLevel: 0,
+  origin: { x: 1911, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture115,
+  mipLevel: 2,
+  origin: { x: 634, y: 0, z: 115 },
+  aspect: 'all',
+},
+{width: 773, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder66.resolveQuerySet(
+querySet37,
+618,
+433,
+buffer32,
+768
+);
+} catch {}
+let img26 = await imageWithData(208, 150, '#a1a6edc2', '#cf523bd0');
+let imageBitmap34 = await createImageBitmap(canvas22);
+let querySet89 = device8.createQuerySet(
+{
+label: '\uc73b\u1cf3\u9497\u{1fea4}\u7cbc\u127c\uf391\u0231\uca3d',
+type: 'occlusion',
+count: 858,
+}
+);
+try {
+renderBundleEncoder79.setBindGroup(
+6,
+bindGroup41,
+new Uint32Array(9533),
+5328,
+0
+);
+} catch {}
+let pipeline61 = await device8.createComputePipelineAsync(
+{
+label: '\uf631\u6d01\ucccc\uf231\u0058\ucb9f\ua862\u0936\u{1ff33}',
+layout: pipelineLayout22,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.append('\u8268\ucd47\u{1f9e9}\uc7a3\u{1ff95}');
+let texture130 = device9.createTexture(
+{
+label: '\u{1fe30}\u8237\u{1f669}\u3544',
+size: [97, 1, 122],
+format: 'r8snorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8snorm',
+'r8snorm',
+'r8snorm'
+],
+}
+);
+let externalTexture10 = device9.importExternalTexture(
+{
+label: '\u{1f93c}\u{1fab2}\u098d\u04d6\u0180\u78b3',
+source: videoFrame18,
+colorSpace: 'srgb',
+}
+);
+let imageData26 = new ImageData(132, 80);
+try {
+window.someLabel = externalTexture2.label;
+} catch {}
+let bindGroup50 = device1.createBindGroup({
+label: '\u0349\uc283\u0d00\ua914\u501e\u0ed0\u8d68\u5ee9\u4b68\ud22b\ud825',
+layout: bindGroupLayout11,
+entries: [
+
+],
+});
+let texture131 = device1.createTexture(
+{
+size: [12900, 225, 238],
+mipLevelCount: 7,
+format: 'astc-10x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-10x5-unorm-srgb'
+],
+}
+);
+let renderBundle106 = renderBundleEncoder55.finish(
+{
+label: '\u012a\u006b\u2fe5\u7161'
+}
+);
+try {
+gpuCanvasContext1.configure(
+{
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture61,
+  mipLevel: 2,
+  origin: { x: 10, y: 1, z: 10 },
+  aspect: 'all',
+},
+new Uint32Array(new ArrayBuffer(16)),
+/* required buffer size: 191149 */{
+offset: 973,
+bytesPerRow: 48,
+rowsPerImage: 283,
+},
+{width: 18, height: 0, depthOrArrayLayers: 15}
+);
+} catch {}
+let pipeline62 = device1.createRenderPipeline(
+{
+label: '\uacb2\u{1f736}\ud176\u0705',
+layout: 'auto',
+vertex: {
+module: shaderModule15,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 55448,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 38772,
+shaderLocation: 11,
+},
+{
+format: 'uint32',
+offset: 13596,
+shaderLocation: 0,
+},
+{
+format: 'float16x2',
+offset: 45040,
+shaderLocation: 13,
+},
+{
+format: 'uint32x3',
+offset: 38492,
+shaderLocation: 5,
+},
+{
+format: 'float32x4',
+offset: 49044,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x2',
+offset: 29050,
+shaderLocation: 14,
+},
+{
+format: 'sint32',
+offset: 8804,
+shaderLocation: 2,
+},
+{
+format: 'unorm8x2',
+offset: 39288,
+shaderLocation: 1,
+},
+{
+format: 'uint32x2',
+offset: 35276,
+shaderLocation: 22,
+},
+{
+format: 'float32x4',
+offset: 45320,
+shaderLocation: 9,
+},
+{
+format: 'sint8x2',
+offset: 6592,
+shaderLocation: 19,
+},
+{
+format: 'sint16x2',
+offset: 8484,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 1336,
+attributes: [
+{
+format: 'snorm8x2',
+offset: 120,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 4220,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 3884,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule15,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rgba8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+let video34 = await videoWithData();
+let commandEncoder82 = device3.createCommandEncoder(
+{
+}
+);
+let textureView104 = texture89.createView(
+{
+label: '\u{1f8bd}\u{1fef6}\u077e\u06b3\u2969\u0381\u60e4\u9b68\u9538',
+}
+);
+try {
+renderBundleEncoder90.setVertexBuffer(
+5,
+buffer24
+);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer24,
+6292,
+new DataView(new ArrayBuffer(17412)),
+3683,
+12252
+);
+} catch {}
+try {
+device11.addEventListener('uncapturederror', e => { log('device11.uncapturederror'); log(e); e.label = device11.label; });
+} catch {}
+gc();
+document.body.append('\u7741\u0336\u705a\u018b\u0364\u0840\u0cf3\uce2f\u07f0');
+try {
+window.someLabel = device11.label;
+} catch {}
+let texture132 = device11.createTexture(
+{
+label: '\ucd05\u07aa\u7b66\u0388\u{1f645}',
+size: [4991],
+sampleCount: 1,
+dimension: '1d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let shaderModule17 = device7.createShaderModule(
+{
+code: `@group(0) @binding(1232)
+var<storage, read_write> field1: array<u32>;
+
+@compute @workgroup_size(4, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(0) f0: vec4<f32>,
+@builtin(sample_mask) f1: u32,
+@location(7) f2: u32,
+@location(1) f3: u32,
+@location(6) f4: vec4<i32>,
+@location(4) f5: vec3<i32>,
+@location(5) f6: f32,
+@location(2) f7: vec4<i32>,
+@location(3) f8: vec3<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(10) a1: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+}
+);
+let texture133 = device7.createTexture(
+{
+label: '\u85ec\u04af\u0fed\ue2aa\u0707\u4c3c\ufbcf',
+size: [120, 12, 64],
+mipLevelCount: 6,
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+let texture134 = gpuCanvasContext9.getCurrentTexture();
+let textureView105 = texture95.createView(
+{
+label: '\u056d\u5102\ud463\u022b',
+}
+);
+try {
+commandEncoder78.copyTextureToBuffer(
+{
+  texture: texture68,
+  mipLevel: 0,
+  origin: { x: 3350, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 14600 widthInBlocks: 3650 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 10096 */
+offset: 10096,
+bytesPerRow: 14848,
+rowsPerImage: 127,
+buffer: buffer36,
+},
+{width: 3650, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device7, buffer36);
+} catch {}
+let pipeline63 = await device7.createComputePipelineAsync(
+{
+label: '\ud390\ud9ba\u{1fdfc}\u{1f92a}\u6ff7\ued3e',
+layout: pipelineLayout23,
+compute: {
+module: shaderModule13,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend(canvas2);
+let img27 = await imageWithData(89, 14, '#a9c5f0e6', '#aa78bdfa');
+let video35 = await videoWithData();
+try {
+renderBundleEncoder86.setBindGroup(
+4,
+bindGroup41,
+[]
+);
+} catch {}
+try {
+gpuCanvasContext28.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+document.body.append('\u0f30\u0eca\u4780\u00f2');
+let imageData27 = new ImageData(112, 24);
+let texture135 = device2.createTexture(
+{
+label: '\u17c0\u067a\uf2da\u05ac\u05e1\u4b7b\ucc3a\u48e7',
+size: {width: 1009, height: 1, depthOrArrayLayers: 961},
+mipLevelCount: 9,
+dimension: '3d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rg8unorm',
+'rg8unorm'
+],
+}
+);
+let textureView106 = texture93.createView(
+{
+}
+);
+let renderBundle107 = renderBundleEncoder43.finish(
+{
+label: '\u44c0\uea60\u2e48\u{1fa07}\u10d3\u{1fb72}\u1180\u{1f807}\u{1fc19}\u04a2\u0e7a'
+}
+);
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext29 = offscreenCanvas27.getContext('webgpu');
+document.body.prepend('\u{1f65a}\u8930\ub4c8\u64d1\u1854\uf6a4\u1ea4');
+let bindGroup51 = device4.createBindGroup({
+label: '\ua5ff\u5f38\u{1f8ab}\uc7d5',
+layout: bindGroupLayout29,
+entries: [
+{
+binding: 1328,
+resource: externalTexture3
+}
+],
+});
+let computePassEncoder52 = commandEncoder81.beginComputePass(
+{
+label: '\u{1f92b}\ue812\u1e5a\u9ae4\u{1fd1a}\uc129\u{1f825}'
+}
+);
+try {
+renderPassEncoder13.beginOcclusionQuery(
+0
+);
+} catch {}
+try {
+renderBundleEncoder57.setIndexBuffer(
+buffer20,
+'uint32'
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture118,
+  mipLevel: 1,
+  origin: { x: 13, y: 5, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer7,
+/* required buffer size: 16074 */{
+offset: 110,
+bytesPerRow: 285,
+},
+{width: 2, height: 57, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline64 = await device4.createComputePipelineAsync(
+{
+label: '\u99c8\ua0ba',
+layout: pipelineLayout26,
+compute: {
+module: shaderModule16,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageBitmap35 = await createImageBitmap(img25);
+let bindGroupLayout36 = device9.createBindGroupLayout(
+{
+entries: [
+
+],
+}
+);
+let bindGroup52 = device9.createBindGroup({
+label: '\u02ca\u{1fcf0}\u0cec\u0a28\u{1fe34}\u778a\u7adf\ub20d\u0e57\uadf6\u0866',
+layout: bindGroupLayout36,
+entries: [
+
+],
+});
+let texture136 = device9.createTexture(
+{
+size: {width: 12850, height: 136, depthOrArrayLayers: 106},
+mipLevelCount: 8,
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder53 = commandEncoder72.beginComputePass(
+{
+label: '\u3d26\u783c\u{1f788}\u06e1\u0f47\u0670'
+}
+);
+let renderBundleEncoder95 = device9.createRenderBundleEncoder(
+{
+colorFormats: [
+'r32float',
+'rg16uint',
+'rgba8unorm'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 571,
+depthReadOnly: true,
+}
+);
+let renderBundle108 = renderBundleEncoder77.finish(
+{
+label: '\u{1fdcf}\u{1fd24}'
+}
+);
+try {
+computePassEncoder53.setBindGroup(
+0,
+bindGroup52,
+new Uint32Array(881),
+292,
+0
+);
+} catch {}
+try {
+device9.queue.writeTexture(
+{
+  texture: texture136,
+  mipLevel: 3,
+  origin: { x: 53, y: 0, z: 88 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(arrayBuffer5),
+/* required buffer size: 803829 */{
+offset: 454,
+bytesPerRow: 4727,
+rowsPerImage: 52,
+},
+{width: 1128, height: 14, depthOrArrayLayers: 4}
+);
+} catch {}
+try {
+device9.destroy();
+} catch {}
+let img28 = await imageWithData(155, 232, '#462bb16d', '#bf374da5');
+let imageData28 = new ImageData(116, 100);
+let querySet90 = device6.createQuerySet(
+{
+type: 'occlusion',
+count: 434,
+}
+);
+let textureView107 = texture69.createView(
+{
+label: '\u{1fe44}\u3f68\u0688\u{1f8e3}\u002f\ubcd8',
+dimension: '2d-array',
+baseMipLevel: 2,
+}
+);
+try {
+renderBundleEncoder58.setVertexBuffer(
+9,
+buffer21,
+25900,
+23329
+);
+} catch {}
+try {
+device6.queue.writeBuffer(
+buffer23,
+0,
+new BigUint64Array(32368),
+10757,
+836
+);
+} catch {}
+let canvas27 = document.createElement('canvas');
+let img29 = await imageWithData(87, 39, '#7c542547', '#a3ca1127');
+let bindGroup53 = device1.createBindGroup({
+label: '\u0c24\u0037',
+layout: bindGroupLayout11,
+entries: [
+
+],
+});
+let pipelineLayout27 = device1.createPipelineLayout(
+{
+label: '\u055f\u1e6c',
+bindGroupLayouts: [
+bindGroupLayout26,
+bindGroupLayout21,
+bindGroupLayout11,
+bindGroupLayout13
+],
+}
+);
+let sampler76 = device1.createSampler(
+{
+label: '\u{1fbc3}\u757c\u3da0\u{1fda4}\u009d\ufcaa\u013e\u1da3\u09f9\u{1fc6f}',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 4.871,
+lodMaxClamp: 43.961,
+maxAnisotropy: 9,
+}
+);
+try {
+device1.queue.writeBuffer(
+buffer19,
+10024,
+new Int16Array(34019),
+19032,
+7860
+);
+} catch {}
+let sampler77 = device5.createSampler(
+{
+label: '\u0eb4\u6c1c\u{1fb45}\uf42a',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 96.338,
+maxAnisotropy: 5,
+}
+);
+try {
+renderPassEncoder17.setBindGroup(
+3,
+bindGroup47
+);
+} catch {}
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder63.setBindGroup(
+3,
+bindGroup47,
+new Uint32Array(5678),
+4542,
+0
+);
+} catch {}
+let texture137 = device2.createTexture(
+{
+label: '\u6335\u{1fbd0}\u0f2d\uc9b0\u9455\u{1f78a}\u120a\ud645\uc6ad\u28e8',
+size: {width: 2807},
+dimension: '1d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+gpuCanvasContext8.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32uint',
+'rgba16float',
+'rgba16float',
+'rgba16float'
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 166, height: 1, depthOrArrayLayers: 40}
+*/
+{
+  source: img24,
+  origin: { x: 33, y: 200 },
+  flipY: false,
+},
+{
+  texture: texture50,
+  mipLevel: 1,
+  origin: { x: 31, y: 0, z: 7 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 111, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\uda9d\ucbb7\u0897\u{1f89b}\u37c0\u0de0\udb10\u0afd\u6018\u0f30');
+let textureView108 = texture70.createView(
+{
+label: '\ue68d\u6cd5\u2909\u04cc\ub52e\u492a\u8c27\u954f\u{1f7bc}',
+dimension: '2d',
+baseMipLevel: 4,
+baseArrayLayer: 222,
+}
+);
+try {
+commandEncoder62.copyBufferToTexture(
+{
+/* bytesInLastRow: 176 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 19696 */
+offset: 19696,
+bytesPerRow: 256,
+buffer: buffer21,
+},
+{
+  texture: texture75,
+  mipLevel: 0,
+  origin: { x: 56, y: 16, z: 0 },
+  aspect: 'all',
+},
+{width: 88, height: 72, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device6, buffer21);
+} catch {}
+try {
+commandEncoder62.resolveQuerySet(
+querySet85,
+554,
+824,
+buffer23,
+3072
+);
+} catch {}
+canvas25.height = 101;
+document.body.prepend('\udae6\ub88e\u0653\u661f\u{1fa61}\uc9a5\u33b5\u8000\u238d');
+let canvas28 = document.createElement('canvas');
+let shaderModule18 = device3.createShaderModule(
+{
+label: '\u0c16\u8f41\u883f\u3e91\u0876\u78b0\uae92',
+code: `
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S20 {
+@location(66) f0: f32,
+@location(19) f1: vec2<f16>,
+@location(62) f2: f32,
+@location(61) f3: f32,
+@location(35) f4: vec2<f32>,
+@location(123) f5: f32,
+@location(0) f6: f16,
+@location(86) f7: vec4<i32>,
+@location(104) f8: vec2<u32>
+}
+struct FragmentOutput0 {
+@location(7) f0: u32,
+@location(3) f1: vec4<i32>,
+@builtin(sample_mask) f2: u32,
+@location(1) f3: vec2<u32>,
+@location(0) f4: vec2<f32>,
+@location(5) f5: vec2<u32>
+}
+
+@fragment
+fn fragment0(@location(75) a0: f16, @location(113) a1: vec2<u32>, @location(81) a2: vec4<u32>, @location(111) a3: i32, @location(49) a4: vec4<f16>, @location(18) a5: vec4<f32>, @location(60) a6: u32, @location(32) a7: vec2<i32>, @location(3) a8: vec3<u32>, @location(22) a9: i32, @location(121) a10: vec3<f16>, a11: S20) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S19 {
+@location(13) f0: vec4<f16>,
+@location(3) f1: vec3<u32>,
+@location(6) f2: vec4<u32>,
+@location(1) f3: vec2<f16>,
+@builtin(instance_index) f4: u32,
+@location(0) f5: vec4<i32>,
+@location(7) f6: vec4<i32>,
+@location(4) f7: vec3<f16>,
+@location(15) f8: i32,
+@location(11) f9: i32,
+@location(16) f10: i32,
+@location(5) f11: vec2<f32>,
+@location(8) f12: i32,
+@location(14) f13: vec4<i32>,
+@builtin(vertex_index) f14: u32
+}
+struct VertexOutput0 {
+@location(113) f329: vec2<u32>,
+@location(86) f330: vec4<i32>,
+@location(115) f331: vec3<f32>,
+@location(32) f332: vec2<i32>,
+@location(62) f333: f32,
+@location(123) f334: f32,
+@location(71) f335: vec4<f16>,
+@location(121) f336: vec3<f16>,
+@location(0) f337: f16,
+@location(49) f338: vec4<f16>,
+@location(111) f339: i32,
+@location(103) f340: vec2<f16>,
+@location(75) f341: f16,
+@location(104) f342: vec2<u32>,
+@location(3) f343: vec3<u32>,
+@location(27) f344: f16,
+@location(89) f345: vec3<f32>,
+@location(58) f346: vec3<i32>,
+@location(22) f347: i32,
+@location(60) f348: u32,
+@location(61) f349: f32,
+@location(64) f350: vec4<u32>,
+@location(81) f351: vec4<u32>,
+@location(83) f352: vec4<f32>,
+@location(5) f353: vec3<i32>,
+@location(35) f354: vec2<f32>,
+@location(18) f355: vec4<f32>,
+@builtin(position) f356: vec4<f32>,
+@location(12) f357: vec2<f32>,
+@location(66) f358: f32,
+@location(114) f359: vec4<i32>,
+@location(106) f360: i32,
+@location(95) f361: vec4<i32>,
+@location(19) f362: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec3<i32>, @location(10) a1: vec4<i32>, @location(9) a2: i32, @location(12) a3: vec3<u32>, a4: S19) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder83 = device3.createCommandEncoder(
+{
+label: '\u00f0\u12cb\u8ff2\u0374\u071a\u0cec\u0374\ued3d\u5e97\u0f07\u{1f991}',
+}
+);
+let texture138 = device3.createTexture(
+{
+label: '\u9ee3\u07b5\u{1fb61}\u0e9c\u9dfc\u0fbc\u0733\u89ab',
+size: {width: 1431, height: 1, depthOrArrayLayers: 836},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let sampler78 = device3.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMaxClamp: 66.251,
+compare: 'not-equal',
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder14.end();
+} catch {}
+try {
+commandEncoder83.clearBuffer(
+buffer24,
+9320,
+10392
+);
+dissociateBuffer(device3, buffer24);
+} catch {}
+let pipeline65 = device3.createComputePipeline(
+{
+layout: pipelineLayout25,
+compute: {
+module: shaderModule18,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+document.body.prepend('\u{1f802}\u3258\u{1fcbd}\ub46d\u082b\uba08\ue7da\u1cb9');
+let textureView109 = texture125.createView(
+{
+}
+);
+let renderBundleEncoder96 = device8.createRenderBundleEncoder(
+{
+colorFormats: [
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 395,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+device8.pushErrorScope(
+'internal'
+);
+} catch {}
+document.body.append('\u0918\u{1f955}\uebd0\ue0b0\uaa31\u6925\u8780\u3102\u9048\u{1fdcc}\u50e7');
+let videoFrame27 = new VideoFrame(canvas14, {timestamp: 0});
+let texture139 = device4.createTexture(
+{
+label: '\u{1fb6d}\u{1fb33}\ucf51\u2f3f\u{1f924}\u3c70\u0328',
+size: [8845, 2, 1],
+mipLevelCount: 11,
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder97 = device4.createRenderBundleEncoder(
+{
+label: '\u0732\u0599\u0e73\u019a\u0bca\ubd57\u{1f954}',
+colorFormats: [
+'bgra8unorm',
+'rg16float',
+'r32uint',
+'rg8unorm',
+undefined,
+'rg8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 165,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler79 = device4.createSampler(
+{
+label: '\uc8b9\u0880\u9c76\u{1f707}\u3804\u08f1\u0f33\u{1f772}',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 21.122,
+compare: 'not-equal',
+maxAnisotropy: 14,
+}
+);
+try {
+computePassEncoder52.setBindGroup(
+0,
+bindGroup30
+);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(
+3,
+buffer18,
+6568,
+3914
+);
+} catch {}
+try {
+renderBundleEncoder84.setBindGroup(
+3,
+bindGroup39,
+new Uint32Array(6217),
+3477,
+0
+);
+} catch {}
+let commandBuffer10 = commandEncoder66.finish(
+{
+label: '\u{1ffa0}\u09cd\u0b32\u{1fc43}\u46b1\u34b5\u{1fdc8}\u031e\uf2e1\ub8e4',
+}
+);
+let textureView110 = texture63.createView(
+{
+label: '\u3ad5\u{1ff44}\uce0f\u{1f9b5}\u{1fbd3}\u1c60',
+aspect: 'all',
+baseMipLevel: 6,
+mipLevelCount: 4,
+}
+);
+try {
+buffer12.unmap();
+} catch {}
+try {
+commandEncoder74.resolveQuerySet(
+querySet39,
+2069,
+1552,
+buffer15,
+8192
+);
+} catch {}
+try {
+device2.queue.submit([
+commandBuffer10,
+]);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer17,
+38400,
+new DataView(new ArrayBuffer(48908)),
+11166,
+3388
+);
+} catch {}
+let promise46 = device2.queue.onSubmittedWorkDone();
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 63, height: 1, depthOrArrayLayers: 60}
+*/
+{
+  source: canvas25,
+  origin: { x: 232, y: 76 },
+  flipY: false,
+},
+{
+  texture: texture135,
+  mipLevel: 4,
+  origin: { x: 15, y: 0, z: 19 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 30, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device2.destroy();
+} catch {}
+let gpuCanvasContext30 = canvas28.getContext('webgpu');
+document.body.append('\ua8d9\u{1ff66}\u{1f815}\ued64');
+let commandEncoder84 = device6.createCommandEncoder();
+let querySet91 = device6.createQuerySet(
+{
+type: 'occlusion',
+count: 999,
+}
+);
+let textureView111 = texture70.createView(
+{
+label: '\u0dc0\ubfe5\u02d0\u2cb2\ubcdc\ubfdc\u43ee\ufb8d\u0582',
+dimension: '2d',
+baseMipLevel: 3,
+mipLevelCount: 1,
+baseArrayLayer: 84,
+}
+);
+let computePassEncoder54 = commandEncoder62.beginComputePass(
+{
+label: '\u4524\u7d61\u0a27\uc08e\u00b0\u{1f7b6}\u09fe\u{1f8c7}'
+}
+);
+let sampler80 = device6.createSampler(
+{
+label: '\u0f60\u0fa8\u2ed8\ue4fb\u{1ff77}\u0dc3\u{1ff72}\ube9e',
+addressModeV: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 0.901,
+lodMaxClamp: 33.414,
+}
+);
+try {
+renderBundleEncoder58.setVertexBuffer(
+1,
+buffer28,
+16536,
+24465
+);
+} catch {}
+document.body.prepend(img28);
+let offscreenCanvas28 = new OffscreenCanvas(350, 786);
+let shaderModule19 = device7.createShaderModule(
+{
+label: '\ud730\u317b',
+code: `@group(0) @binding(885)
+var<storage, read_write> field2: array<u32>;
+
+@compute @workgroup_size(1, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: vec2<u32>,
+@location(2) f1: vec3<u32>,
+@location(5) f2: vec2<i32>,
+@location(7) f3: vec2<i32>,
+@builtin(frag_depth) f4: f32,
+@location(0) f5: vec2<i32>,
+@location(6) f6: vec4<u32>,
+@builtin(sample_mask) f7: u32
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(21) a0: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let pipelineLayout28 = device7.createPipelineLayout(
+{
+label: '\u0e41\u01d9\u{1f8b9}',
+bindGroupLayouts: [
+bindGroupLayout24,
+bindGroupLayout24,
+bindGroupLayout24,
+bindGroupLayout24,
+bindGroupLayout24,
+bindGroupLayout24,
+bindGroupLayout24,
+bindGroupLayout24,
+bindGroupLayout24
+],
+}
+);
+let querySet92 = device7.createQuerySet(
+{
+label: '\u4c62\u{1fb88}\u0585\u{1fc60}\u974d\u014e\uef3f\ufc79\u225b',
+type: 'occlusion',
+count: 3920,
+}
+);
+let renderBundle109 = renderBundleEncoder94.finish(
+{
+label: '\u8d35\ue708\u3af3\u33b8\u05fe\u5423\u78c2\u{1fd0a}\u{1fffa}'
+}
+);
+let gpuCanvasContext31 = canvas27.getContext('webgpu');
+let canvas29 = document.createElement('canvas');
+let offscreenCanvas29 = new OffscreenCanvas(537, 591);
+try {
+canvas29.getContext('2d');
+} catch {}
+let commandEncoder85 = device5.createCommandEncoder();
+let querySet93 = device5.createQuerySet(
+{
+label: '\uc783\ua687\u{1fae6}\u065b\u18de',
+type: 'occlusion',
+count: 2905,
+}
+);
+try {
+renderPassEncoder17.setBindGroup(
+1,
+bindGroup47
+);
+} catch {}
+try {
+device5.queue.writeBuffer(
+buffer34,
+7936,
+new Int16Array(44854),
+12065,
+8056
+);
+} catch {}
+canvas17.width = 736;
+let adapter15 = await navigator.gpu.requestAdapter(
+{
+}
+);
+try {
+offscreenCanvas28.getContext('webgpu');
+} catch {}
+let img30 = await imageWithData(72, 156, '#a08529c5', '#4838a7c4');
+let commandEncoder86 = device5.createCommandEncoder(
+{
+label: '\u{1fdd3}\uc5fa\u2652\u1294\u0506\u{1f694}',
+}
+);
+let texture140 = device5.createTexture(
+{
+label: '\ua698\uf6e2\ubeb1\ua0f7',
+size: {width: 2, height: 27, depthOrArrayLayers: 456},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8snorm',
+'rgba8snorm',
+'rgba8snorm'
+],
+}
+);
+let sampler81 = device5.createSampler(
+{
+label: '\u2f59\u738f',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 93.074,
+}
+);
+try {
+computePassEncoder36.end();
+} catch {}
+try {
+renderBundleEncoder63.setBindGroup(
+3,
+bindGroup47,
+[]
+);
+} catch {}
+try {
+renderBundleEncoder63.setBindGroup(
+0,
+bindGroup31,
+new Uint32Array(3481),
+1748,
+0
+);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+try {
+commandEncoder56.clearBuffer(
+buffer34,
+10912,
+14332
+);
+dissociateBuffer(device5, buffer34);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture74,
+  mipLevel: 0,
+  origin: { x: 61, y: 0, z: 33 },
+  aspect: 'all',
+},
+arrayBuffer7,
+/* required buffer size: 1431605 */{
+offset: 800,
+bytesPerRow: 93,
+rowsPerImage: 181,
+},
+{width: 0, height: 0, depthOrArrayLayers: 86}
+);
+} catch {}
+try {
+gpuCanvasContext30.unconfigure();
+} catch {}
+video11.height = 294;
+canvas3.width = 210;
+try {
+offscreenCanvas29.getContext('webgl');
+} catch {}
+let bindGroupLayout37 = device8.createBindGroupLayout(
+{
+label: '\u032b\u8a00\u0f8b',
+entries: [
+{
+binding: 1403,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 619,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let texture141 = gpuCanvasContext9.getCurrentTexture();
+let renderBundleEncoder98 = device8.createRenderBundleEncoder(
+{
+label: '\u3b7e\u{1fa7d}\ud9a6\u4577\u0c29\u5b16',
+colorFormats: [
+'rgba8unorm-srgb',
+'rgb10a2uint',
+undefined,
+'rg16sint',
+'rg16float',
+'rgba8sint',
+'r32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 28,
+depthReadOnly: true,
+}
+);
+let pipeline66 = await device8.createRenderPipelineAsync(
+{
+label: '\udeb8\u6732\u0789\ufeb9\ud0d5\u{1f6d2}\u{1f666}',
+layout: pipelineLayout22,
+vertex: {
+module: shaderModule12,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 8112,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 4580,
+shaderLocation: 13,
+},
+{
+format: 'float32x4',
+offset: 6308,
+shaderLocation: 12,
+},
+{
+format: 'unorm16x4',
+offset: 7372,
+shaderLocation: 2,
+},
+{
+format: 'sint32',
+offset: 3832,
+shaderLocation: 18,
+},
+{
+format: 'uint32x3',
+offset: 5104,
+shaderLocation: 20,
+},
+{
+format: 'unorm8x4',
+offset: 6920,
+shaderLocation: 17,
+},
+{
+format: 'float32x3',
+offset: 6476,
+shaderLocation: 1,
+},
+{
+format: 'uint16x4',
+offset: 3216,
+shaderLocation: 14,
+},
+{
+format: 'float32',
+offset: 300,
+shaderLocation: 11,
+},
+{
+format: 'sint32',
+offset: 3492,
+shaderLocation: 10,
+},
+{
+format: 'unorm8x2',
+offset: 1696,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 23412,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 15340,
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 21168,
+shaderLocation: 7,
+},
+{
+format: 'snorm8x2',
+offset: 12680,
+shaderLocation: 16,
+},
+{
+format: 'unorm8x4',
+offset: 18952,
+shaderLocation: 4,
+},
+{
+format: 'sint8x2',
+offset: 12992,
+shaderLocation: 19,
+},
+{
+format: 'sint32',
+offset: 6464,
+shaderLocation: 6,
+},
+{
+format: 'uint8x4',
+offset: 2760,
+shaderLocation: 5,
+},
+{
+format: 'uint32',
+offset: 10752,
+shaderLocation: 8,
+},
+{
+format: 'float32',
+offset: 9596,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 11844,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 15652,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 13512,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 19668,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+},
+multisample: {
+mask: 0x27729088,
+},
+fragment: {
+module: shaderModule12,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32float',
+writeMask: 0,
+},
+{
+format: 'rg16uint',
+},
+undefined,
+{
+format: 'r8uint',
+},
+undefined
+],
+},
+}
+);
+let bindGroup54 = device4.createBindGroup({
+label: '\uf03e\u76b3\uaca0\ua54c\u4c38\u7962\u0518\ub0b6\u0734',
+layout: bindGroupLayout14,
+entries: [
+{
+binding: 3961,
+resource: externalTexture3
+}
+],
+});
+try {
+computePassEncoder52.setBindGroup(
+4,
+bindGroup30
+);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([]);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+document.body.prepend(video8);
+let bindGroupLayout38 = device4.createBindGroupLayout(
+{
+label: '\u{1fbb8}\u0b91\u5cca\u003c\u412f\u324d\u006a\u{1f8f9}\ufc89\u0403',
+entries: [
+{
+binding: 2215,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+},
+{
+binding: 3658,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+},
+{
+binding: 5838,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 269495, hasDynamicOffset: true },
+}
+],
+}
+);
+let texture142 = device4.createTexture(
+{
+label: '\u7ae2\u5d88\u76c5\uac48\u{1fb85}\u{1f9c7}',
+size: {width: 167, height: 43, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+sampleCount: 1,
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32sint'
+],
+}
+);
+try {
+computePassEncoder52.setBindGroup(
+2,
+bindGroup51,
+new Uint32Array(8111),
+2671,
+0
+);
+} catch {}
+try {
+computePassEncoder52.setPipeline(
+pipeline64
+);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(
+0,
+bindGroup30,
+new Uint32Array(3048),
+1664,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant(
+{
+r: -733.8,
+g: 985.1,
+b: 627.0,
+a: 365.5,
+}
+);
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(
+2362
+);
+} catch {}
+let imageBitmap36 = await createImageBitmap(img9);
+let bindGroup55 = device8.createBindGroup({
+layout: bindGroupLayout22,
+entries: [
+{
+binding: 488,
+resource: sampler72
+}
+],
+});
+let buffer40 = device8.createBuffer(
+{
+label: '\ud14a\u15a7\ubaae\u230b\ue918\u45b8\u6ef4\uc087',
+size: 13495,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let canvas30 = document.createElement('canvas');
+let imageBitmap37 = await createImageBitmap(img17);
+try {
+adapter13.label = '\ufc91\u7044\u{1fad5}\u{1fd6d}\u0a46\u{1fac9}';
+} catch {}
+document.body.prepend(canvas3);
+canvas16.height = 738;
+document.body.append('\ue6e3\u02d1');
+let imageBitmap38 = await createImageBitmap(img0);
+try {
+canvas30.getContext('2d');
+} catch {}
+document.body.prepend('\u7429\u{1f78e}\uaa31\uec5f\u699f');
+try {
+renderPassEncoder15.setStencilReference(
+105
+);
+} catch {}
+try {
+renderBundleEncoder63.setBindGroup(
+3,
+bindGroup34,
+new Uint32Array(1980),
+1907,
+0
+);
+} catch {}
+try {
+commandEncoder85.clearBuffer(
+buffer34,
+6772,
+14340
+);
+dissociateBuffer(device5, buffer34);
+} catch {}
+document.body.prepend('\u0494\u0963');
+let offscreenCanvas30 = new OffscreenCanvas(697, 911);
+let renderBundleEncoder99 = device5.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8sint',
+'rg8unorm',
+'bgra8unorm-srgb',
+'rg8uint',
+'rgba8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 774,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder17.setScissorRect(
+25,
+1,
+18,
+0
+);
+} catch {}
+try {
+renderBundleEncoder93.setVertexBuffer(
+23,
+undefined
+);
+} catch {}
+try {
+await device5.popErrorScope();
+} catch {}
+try {
+commandEncoder86.clearBuffer(
+buffer34,
+19792,
+108
+);
+dissociateBuffer(device5, buffer34);
+} catch {}
+try {
+device5.queue.writeBuffer(
+buffer34,
+12844,
+new BigUint64Array(34446),
+32240,
+316
+);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture123,
+  mipLevel: 0,
+  origin: { x: 37, y: 1, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(126),
+/* required buffer size: 126 */{
+offset: 126,
+},
+{width: 2766, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let texture143 = device11.createTexture(
+{
+label: '\u{1f6e4}\u7d00\u210d\ub3ce\u56a2\u{1fefa}\ua60f\ueced\ubdb9\uc3e4\uedc4',
+size: [123, 255, 81],
+mipLevelCount: 7,
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float',
+'rg8unorm',
+'rg8unorm'
+],
+}
+);
+try {
+await device11.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append('\u9131\u0fcb\ubfad\ue2d3\u{1fe59}\ue2c6\u5ecc\ucf59\u{1facc}\u3e99\ua016');
+let bindGroupLayout39 = device4.createBindGroupLayout(
+{
+label: '\u3a92\u0059\u{1fa7b}\ud78e\u0cd5\u00f3\u0bbe\ue732',
+entries: [
+{
+binding: 4830,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '1d' },
+},
+{
+binding: 4290,
+visibility: 0,
+storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d-array' },
+}
+],
+}
+);
+let textureView112 = texture116.createView(
+{
+label: '\u05d4\u6dc7',
+mipLevelCount: 1,
+baseArrayLayer: 11,
+arrayLayerCount: 15,
+}
+);
+let renderBundleEncoder100 = device4.createRenderBundleEncoder(
+{
+label: '\u{1fa5e}\u0456\u{1f7ee}',
+colorFormats: [
+'rgb10a2uint',
+'rg8unorm',
+'rg8sint',
+'rgba8uint',
+'rgb10a2uint',
+'rgba32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 327,
+depthReadOnly: true,
+stencilReadOnly: false,
+}
+);
+try {
+renderPassEncoder12.setBindGroup(
+3,
+bindGroup45
+);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(
+4,
+bindGroup54,
+new Uint32Array(1755),
+243,
+0
+);
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant(
+{
+r: -565.7,
+g: -331.4,
+b: 967.0,
+a: -442.5,
+}
+);
+} catch {}
+try {
+renderPassEncoder13.setViewport(
+454.4,
+0.02968,
+8.907,
+0.6021,
+0.5849,
+0.6056
+);
+} catch {}
+try {
+gpuCanvasContext12.configure(
+{
+device: device4,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device1.queue.label = '\u0e5a\uea98\u0f34\u009f\u063a\u5937';
+} catch {}
+let sampler82 = device1.createSampler(
+{
+label: '\u5e1b\u{1fff3}\u8ecb\u4bc6\u0b47\u9c33\u492c\u8a48\u038d\u6474',
+addressModeU: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 43.769,
+lodMaxClamp: 76.364,
+compare: 'greater',
+maxAnisotropy: 18,
+}
+);
+try {
+computePassEncoder31.setBindGroup(
+0,
+bindGroup27,
+new Uint32Array(4235),
+249,
+0
+);
+} catch {}
+try {
+renderBundleEncoder65.setVertexBuffer(
+4,
+buffer14,
+21940,
+13377
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture101,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 54 },
+  aspect: 'all',
+},
+new BigInt64Array(arrayBuffer0),
+/* required buffer size: 2553319 */{
+offset: 55,
+bytesPerRow: 306,
+rowsPerImage: 149,
+},
+{width: 20, height: 0, depthOrArrayLayers: 57}
+);
+} catch {}
+try {
+await promise46;
+} catch {}
+let gpuCanvasContext32 = offscreenCanvas30.getContext('webgpu');
+let buffer41 = device6.createBuffer(
+{
+label: '\u07ec\u0438\u0627',
+size: 64336,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let renderBundle110 = renderBundleEncoder71.finish(
+{
+
+}
+);
+try {
+commandEncoder69.copyBufferToBuffer(
+buffer23,
+2468,
+buffer28,
+25032,
+4564
+);
+dissociateBuffer(device6, buffer23);
+dissociateBuffer(device6, buffer28);
+} catch {}
+try {
+commandEncoder84.copyTextureToTexture(
+{
+  texture: texture76,
+  mipLevel: 4,
+  origin: { x: 72, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture76,
+  mipLevel: 5,
+  origin: { x: 40, y: 5, z: 0 },
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device6.queue.writeTexture(
+{
+  texture: texture75,
+  mipLevel: 0,
+  origin: { x: 8, y: 16, z: 0 },
+  aspect: 'all',
+},
+new Int8Array(arrayBuffer4),
+/* required buffer size: 2813 */{
+offset: 395,
+bytesPerRow: 426,
+},
+{width: 144, height: 48, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend(video5);
+document.body.append('\u4445\u{1fa48}');
+let computePassEncoder55 = commandEncoder80.beginComputePass(
+{
+label: '\u8b2f\u1b4a\u3f3c\u07e6'
+}
+);
+let pipeline67 = device7.createRenderPipeline(
+{
+label: '\u0986\u0ed4\u3d76\u6ac9\u5a3e\u{1fe83}\u06df\u34f9\u0673\u9352',
+layout: pipelineLayout19,
+vertex: {
+module: shaderModule17,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 8016,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32',
+offset: 7632,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+primitive: {
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x78704a2f,
+},
+fragment: {
+module: shaderModule17,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALL,
+},
+{
+format: 'rg8sint',
+},
+{
+format: 'rg32sint',
+},
+{
+format: 'rg8sint',
+}
+],
+},
+}
+);
+let texture144 = device5.createTexture(
+{
+label: '\u0ae4\u34fb\u192d\u5962\u06ce\udba2\u{1ff35}\ue2a5\u75db\u5b98',
+size: {width: 168, height: 84, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'astc-12x12-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-12x12-unorm-srgb',
+'astc-12x12-unorm-srgb',
+'astc-12x12-unorm-srgb'
+],
+}
+);
+let textureView113 = texture73.createView(
+{
+label: '\u0927\uc32b\u5862\u0482\uec53\ue16f\u33c0',
+dimension: '2d',
+baseMipLevel: 5,
+}
+);
+let computePassEncoder56 = commandEncoder85.beginComputePass();
+let renderBundleEncoder101 = device5.createRenderBundleEncoder(
+{
+label: '\u58e0\u2225\u0f59\u0894\u0155\ub966\uc843',
+colorFormats: [
+'r32uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 863,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder63.setBindGroup(
+1,
+bindGroup34
+);
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+document.body.prepend('\u{1fbad}\u{1f66f}\u6c35\uc958\u419e\u25d5\u{1fc3c}\u5a86\u4db6');
+let offscreenCanvas31 = new OffscreenCanvas(991, 706);
+let bindGroup56 = device4.createBindGroup({
+label: '\u3744\u{1f7b9}\u00a4\u{1f84a}\u{1f6d8}\u{1fa5f}\u{1ff7c}\u82d2\u{1fa60}\u2759\u{1f689}',
+layout: bindGroupLayout29,
+entries: [
+{
+binding: 1328,
+resource: externalTexture3
+}
+],
+});
+try {
+renderPassEncoder13.setBindGroup(
+3,
+bindGroup42
+);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(
+3,
+bindGroup45,
+new Uint32Array(5472),
+744,
+0
+);
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant(
+{
+r: -428.3,
+g: -44.23,
+b: 704.5,
+a: 546.3,
+}
+);
+} catch {}
+let promise47 = device4.queue.onSubmittedWorkDone();
+let imageBitmap39 = await createImageBitmap(canvas23);
+try {
+offscreenCanvas31.getContext('webgpu');
+} catch {}
+let videoFrame28 = new VideoFrame(offscreenCanvas12, {timestamp: 0});
+let buffer42 = device5.createBuffer(
+{
+label: '\u8d62\u{1fae8}',
+size: 47404,
+usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+mappedAtCreation: true,
+}
+);
+let computePassEncoder57 = commandEncoder56.beginComputePass(
+{
+label: '\u89c3\u6fe6\u007a\u1569\u8847\u6685\u0703'
+}
+);
+let renderBundleEncoder102 = device5.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba32float',
+'r16float',
+'rg16uint',
+undefined
+],
+sampleCount: 6,
+stencilReadOnly: true,
+}
+);
+let sampler83 = device5.createSampler(
+{
+label: '\u{1f8f5}\ua962\u7344\ud2b1\u619f\u50f3',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 56.339,
+lodMaxClamp: 66.289,
+}
+);
+try {
+renderPassEncoder16.setScissorRect(
+0,
+1,
+24,
+1
+);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(
+buffer42,
+'uint32',
+7608,
+14175
+);
+} catch {}
+try {
+renderBundleEncoder54.setVertexBuffer(
+5,
+buffer42,
+13876
+);
+} catch {}
+try {
+commandEncoder86.copyTextureToTexture(
+{
+  texture: texture129,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture113,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 1 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await promise47;
+} catch {}
+try {
+textureView64.label = '\u03d6\u0115';
+} catch {}
+let textureView114 = texture100.createView(
+{
+mipLevelCount: 3,
+baseArrayLayer: 32,
+arrayLayerCount: 157,
+}
+);
+let renderBundleEncoder103 = device4.createRenderBundleEncoder(
+{
+label: '\u8a48\u02e1\ub801\udce2\u0ac4\u20ae\uede6\u{1fe1d}\uc7af\u{1fe9a}',
+colorFormats: [
+'r8sint'
+],
+sampleCount: 648,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder12.setBindGroup(
+0,
+bindGroup30
+);
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant(
+{
+r: 207.5,
+g: -517.2,
+b: 161.7,
+a: -429.7,
+}
+);
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(
+639,
+1,
+189,
+0
+);
+} catch {}
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append('\u{1fd09}\u{1f9b1}\u60c0\ub82a\uc487\u{1f6ee}\u0f29\ua76b');
+let videoFrame29 = new VideoFrame(img12, {timestamp: 0});
+try {
+renderBundleEncoder65.setIndexBuffer(
+buffer14,
+'uint32',
+16008,
+2403
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture88,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 23 },
+  aspect: 'all',
+},
+new ArrayBuffer(48),
+/* required buffer size: 1743239 */{
+offset: 95,
+bytesPerRow: 78,
+rowsPerImage: 151,
+},
+{width: 0, height: 0, depthOrArrayLayers: 149}
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 253, height: 209, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap6,
+  origin: { x: 45, y: 12 },
+  flipY: true,
+},
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 0, y: 62, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 253, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let imageBitmap40 = await createImageBitmap(imageBitmap32);
+pseudoSubmit(device4, commandEncoder51);
+let textureView115 = texture97.createView(
+{
+label: '\ubdd8\u{1f932}',
+baseMipLevel: 2,
+baseArrayLayer: 0,
+}
+);
+let renderBundle111 = renderBundleEncoder45.finish(
+{
+label: '\u86fd\u0653\u0a5b\uce85\u80df\u2c83\u0074\u{1f8e7}\u{1f668}'
+}
+);
+try {
+computePassEncoder48.setBindGroup(
+4,
+bindGroup24,
+new Uint32Array(2171),
+879,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+10,
+buffer20,
+8428,
+75
+);
+} catch {}
+try {
+renderBundleEncoder97.setIndexBuffer(
+buffer20,
+'uint32',
+2468
+);
+} catch {}
+try {
+renderBundleEncoder57.setVertexBuffer(
+7,
+buffer20
+);
+} catch {}
+let arrayBuffer10 = buffer27.getMappedRange(
+16104,
+76
+);
+let pipeline68 = device4.createRenderPipeline(
+{
+label: '\u346f\udee3\u0290\u0c02\u0cb5',
+layout: pipelineLayout26,
+vertex: {
+module: shaderModule16,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 1620,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 1440,
+shaderLocation: 5,
+},
+{
+format: 'sint16x2',
+offset: 1404,
+shaderLocation: 14,
+},
+{
+format: 'unorm16x2',
+offset: 676,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x4',
+offset: 100,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x4',
+offset: 804,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 2152,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 1508,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 1676,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 1356,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'none',
+},
+multisample: {
+mask: 0x582665b8,
+},
+fragment: {
+module: shaderModule16,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'dst',
+dstFactor: 'zero'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'one-minus-dst-alpha',
+dstFactor: 'one-minus-src'
+},
+},
+format: 'r16float',
+},
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'dst-alpha',
+dstFactor: 'one-minus-dst-alpha'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'src-alpha',
+dstFactor: 'dst'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.BLUE,
+}
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthCompare: 'always',
+stencilFront: {
+compare: 'equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'equal',
+depthFailOp: 'invert',
+},
+stencilReadMask: 1366,
+stencilWriteMask: 2288,
+depthBiasSlopeScale: 85,
+depthBiasClamp: 99,
+},
+}
+);
+let device12 = await adapter14.requestDevice(
+{
+label: '\u3c50\uc436\u3007\u{1f9c8}\uf187\uf825\u0c91\u41a6\u0a61',
+requiredLimits: {
+maxBindGroups: 5,
+maxColorAttachmentBytesPerSample: 37,
+maxVertexAttributes: 19,
+maxVertexBufferArrayStride: 5196,
+maxStorageTexturesPerShaderStage: 20,
+maxStorageBuffersPerShaderStage: 14,
+maxDynamicStorageBuffersPerPipelineLayout: 1018,
+maxBindingsPerBindGroup: 5618,
+maxTextureDimension1D: 12787,
+maxTextureDimension2D: 12076,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 45225789,
+maxInterStageShaderVariables: 33,
+maxInterStageShaderComponents: 69,
+},
+}
+);
+let offscreenCanvas32 = new OffscreenCanvas(380, 359);
+try {
+offscreenCanvas32.getContext('2d');
+} catch {}
+try {
+device9.queue.label = '\u{1f6ab}\u{1febf}\u0c83\u{1fda7}';
+} catch {}
+let videoFrame30 = new VideoFrame(canvas28, {timestamp: 0});
+let texture145 = device3.createTexture(
+{
+label: '\u64cb\ubd8b\uaf95\u00c2\u1dc3',
+size: [2154, 6, 141],
+mipLevelCount: 4,
+format: 'astc-6x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderPassEncoder19 = commandEncoder83.beginRenderPass(
+{
+label: '\ufe9f\u33a3\u0601\u0e6b\ud317\u{1fa5b}\u4605\ua120\u8d80\u{1fca5}',
+colorAttachments: [
+{
+view: textureView74,
+clearValue: {
+r: -451.1,
+g: 928.7,
+b: -593.6,
+a: -371.5,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+undefined
+],
+occlusionQuerySet: querySet68,
+maxDrawCount: 88352,
+}
+);
+try {
+renderPassEncoder19.setViewport(
+334.3,
+7.418,
+184.8,
+2.257,
+0.4851,
+0.6524
+);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer24,
+19868,
+new Int16Array(35616),
+17486,
+444
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture138,
+  mipLevel: 1,
+  origin: { x: 294, y: 1, z: 24 },
+  aspect: 'all',
+},
+new ArrayBuffer(7232453),
+/* required buffer size: 7232453 */{
+offset: 781,
+bytesPerRow: 854,
+rowsPerImage: 29,
+},
+{width: 198, height: 0, depthOrArrayLayers: 293}
+);
+} catch {}
+let pipeline69 = device3.createRenderPipeline(
+{
+label: '\uc6de\u73b1\u38f8\u{1f968}\u3890\u69cb\u{1f8a9}\ue0ec\ucc2e\u{1fa3b}',
+layout: pipelineLayout16,
+vertex: {
+module: shaderModule18,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 368,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x4',
+offset: 296,
+shaderLocation: 14,
+},
+{
+format: 'sint32x3',
+offset: 264,
+shaderLocation: 0,
+},
+{
+format: 'sint8x2',
+offset: 18,
+shaderLocation: 11,
+},
+{
+format: 'sint32x4',
+offset: 148,
+shaderLocation: 10,
+},
+{
+format: 'uint8x4',
+offset: 124,
+shaderLocation: 6,
+},
+{
+format: 'unorm16x2',
+offset: 360,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 8728,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x4',
+offset: 2352,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 4876,
+shaderLocation: 3,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 9528,
+shaderLocation: 4,
+},
+{
+format: 'uint32',
+offset: 1264,
+shaderLocation: 12,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 9868,
+shaderLocation: 13,
+},
+{
+format: 'float16x2',
+offset: 11616,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 12248,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x2',
+offset: 9592,
+shaderLocation: 15,
+},
+{
+format: 'sint32x4',
+offset: 10292,
+shaderLocation: 2,
+},
+{
+format: 'sint32x2',
+offset: 7960,
+shaderLocation: 8,
+},
+{
+format: 'sint32x4',
+offset: 6060,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 19412,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 10248,
+attributes: [
+
+],
+},
+{
+arrayStride: 19196,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 6676,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 15948,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x3',
+offset: 6856,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule18,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rg16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+undefined,
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.GREEN,
+},
+undefined,
+{
+format: 'r16uint',
+},
+undefined,
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'less',
+failOp: 'keep',
+depthFailOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'keep',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilReadMask: 741,
+stencilWriteMask: 2637,
+depthBias: 62,
+depthBiasSlopeScale: 19,
+},
+}
+);
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let shaderModule20 = device1.createShaderModule(
+{
+label: '\uf5ba\uee92\u0d0e\u489a\u09f8\u0467\ufcf3\u{1fc1d}\u0213\uf9bc\u539b',
+code: `@group(1) @binding(7467)
+var<storage, read_write> parameter0: array<u32>;
+@group(1) @binding(8437)
+var<storage, read_write> local2: array<u32>;
+
+@compute @workgroup_size(1, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S22 {
+@location(3) f0: f32,
+@location(37) f1: f32,
+@location(17) f2: u32,
+@location(21) f3: vec2<f32>,
+@location(15) f4: vec2<i32>,
+@location(2) f5: vec4<f16>,
+@location(35) f6: vec4<f32>,
+@location(39) f7: vec4<u32>,
+@location(1) f8: u32,
+@builtin(front_facing) f9: bool,
+@location(16) f10: vec2<u32>,
+@location(28) f11: vec4<f32>,
+@location(23) f12: f16,
+@location(30) f13: vec4<f32>,
+@location(36) f14: vec3<f16>,
+@location(29) f15: vec3<u32>,
+@location(38) f16: vec2<u32>,
+@location(5) f17: vec3<i32>,
+@location(11) f18: vec2<f16>,
+@location(7) f19: vec4<f32>,
+@location(12) f20: vec2<i32>,
+@location(34) f21: f32
+}
+struct FragmentOutput0 {
+@location(1) f0: u32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, a1: S22, @location(18) a2: vec2<f16>, @location(24) a3: i32, @location(22) a4: vec4<f32>, @location(25) a5: vec2<u32>, @location(9) a6: vec4<u32>, @location(13) a7: u32, @builtin(sample_index) a8: u32, @builtin(sample_mask) a9: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S21 {
+@location(0) f0: u32,
+@location(10) f1: vec2<f16>,
+@location(22) f2: vec2<f16>,
+@location(1) f3: vec2<f16>,
+@location(23) f4: vec4<i32>,
+@location(21) f5: vec3<u32>,
+@location(19) f6: vec3<f16>,
+@location(5) f7: vec3<f16>,
+@location(13) f8: vec2<i32>,
+@location(24) f9: f32,
+@location(9) f10: f32,
+@location(16) f11: f32,
+@location(7) f12: vec3<f16>,
+@location(11) f13: vec2<f16>,
+@location(17) f14: vec4<f32>
+}
+struct VertexOutput0 {
+@location(38) f363: vec2<u32>,
+@location(23) f364: f16,
+@location(15) f365: vec2<i32>,
+@builtin(position) f366: vec4<f32>,
+@location(16) f367: vec2<u32>,
+@location(29) f368: vec3<u32>,
+@location(34) f369: f32,
+@location(2) f370: vec4<f16>,
+@location(13) f371: u32,
+@location(30) f372: vec4<f32>,
+@location(39) f373: vec4<u32>,
+@location(28) f374: vec4<f32>,
+@location(11) f375: vec2<f16>,
+@location(17) f376: u32,
+@location(3) f377: f32,
+@location(18) f378: vec2<f16>,
+@location(35) f379: vec4<f32>,
+@location(1) f380: u32,
+@location(21) f381: vec2<f32>,
+@location(5) f382: vec3<i32>,
+@location(24) f383: i32,
+@location(12) f384: vec2<i32>,
+@location(36) f385: vec3<f16>,
+@location(25) f386: vec2<u32>,
+@location(9) f387: vec4<u32>,
+@location(37) f388: f32,
+@location(7) f389: vec4<f32>,
+@location(22) f390: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(3) a0: u32, @location(12) a1: vec3<u32>, @location(18) a2: vec2<f32>, @location(14) a3: u32, @location(15) a4: vec2<f32>, @builtin(instance_index) a5: u32, @location(8) a6: vec3<f16>, @location(4) a7: vec3<u32>, @builtin(vertex_index) a8: u32, @location(2) a9: vec2<f16>, a10: S21, @location(6) a11: vec3<f16>, @location(20) a12: vec4<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let querySet94 = device1.createQuerySet(
+{
+label: '\u{1fc1f}\udcb1\ue71a\u041e\u0fcc\u98cb\u94e6\uc62d\u{1fcc7}\u0601\u04e5',
+type: 'occlusion',
+count: 3745,
+}
+);
+let textureView116 = texture61.createView(
+{
+label: '\ub8bd\u{1fd82}',
+baseMipLevel: 3,
+baseArrayLayer: 0,
+arrayLayerCount: 1,
+}
+);
+let renderBundle112 = renderBundleEncoder55.finish(
+{
+label: '\u9979\ub101\u0e52\u073d\ufe92\u008d'
+}
+);
+try {
+await buffer30.mapAsync(
+GPUMapMode.READ,
+0,
+13396
+);
+} catch {}
+try {
+renderBundleEncoder65.pushDebugGroup(
+'\u8ef7'
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer37,
+38356,
+new DataView(new ArrayBuffer(15361)),
+12711,
+1136
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture88,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 86 },
+  aspect: 'all',
+},
+new Uint8Array(arrayBuffer3),
+/* required buffer size: 2546862 */{
+offset: 87,
+bytesPerRow: 189,
+rowsPerImage: 175,
+},
+{width: 0, height: 0, depthOrArrayLayers: 78}
+);
+} catch {}
+let promise48 = device1.createRenderPipelineAsync(
+{
+label: '\u52a2\u{1f953}\uaf76\u2f92',
+layout: pipelineLayout13,
+vertex: {
+module: shaderModule20,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 12968,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 2980,
+shaderLocation: 23,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 10452,
+shaderLocation: 6,
+},
+{
+format: 'unorm16x2',
+offset: 6960,
+shaderLocation: 18,
+},
+{
+format: 'snorm16x2',
+offset: 444,
+shaderLocation: 8,
+},
+{
+format: 'uint32x2',
+offset: 4672,
+shaderLocation: 0,
+},
+{
+format: 'snorm8x2',
+offset: 8016,
+shaderLocation: 19,
+},
+{
+format: 'float32',
+offset: 4516,
+shaderLocation: 7,
+},
+{
+format: 'uint8x2',
+offset: 7160,
+shaderLocation: 21,
+},
+{
+format: 'float32x4',
+offset: 6336,
+shaderLocation: 22,
+},
+{
+format: 'float32x3',
+offset: 12184,
+shaderLocation: 5,
+},
+{
+format: 'float16x2',
+offset: 3680,
+shaderLocation: 10,
+},
+{
+format: 'float32x4',
+offset: 7640,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x2',
+offset: 596,
+shaderLocation: 17,
+},
+{
+format: 'snorm8x4',
+offset: 10776,
+shaderLocation: 15,
+},
+{
+format: 'uint32',
+offset: 6168,
+shaderLocation: 20,
+},
+{
+format: 'snorm8x4',
+offset: 4704,
+shaderLocation: 1,
+},
+{
+format: 'uint8x4',
+offset: 5160,
+shaderLocation: 4,
+},
+{
+format: 'uint32x2',
+offset: 1208,
+shaderLocation: 14,
+},
+{
+format: 'snorm16x4',
+offset: 6212,
+shaderLocation: 9,
+},
+{
+format: 'float32',
+offset: 7204,
+shaderLocation: 16,
+},
+{
+format: 'uint8x2',
+offset: 8328,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 19020,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 18596,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 52452,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 19768,
+shaderLocation: 13,
+},
+{
+format: 'unorm16x2',
+offset: 14916,
+shaderLocation: 2,
+},
+{
+format: 'float32x3',
+offset: 5656,
+shaderLocation: 24,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'back',
+},
+multisample: {
+count: 4,
+mask: 0x4927edf1,
+},
+fragment: {
+module: shaderModule20,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+{
+format: 'r8uint',
+},
+undefined
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+compare: 'always',
+failOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilWriteMask: 962,
+depthBias: 79,
+depthBiasSlopeScale: 87,
+depthBiasClamp: 67,
+},
+}
+);
+document.body.append('\u0601\u41d4\u02b5\u{1fe16}');
+let video36 = await videoWithData();
+let renderBundle113 = renderBundleEncoder83.finish(
+{
+
+}
+);
+try {
+commandEncoder84.copyBufferToBuffer(
+buffer41,
+2388,
+buffer23,
+2880,
+16236
+);
+dissociateBuffer(device6, buffer41);
+dissociateBuffer(device6, buffer23);
+} catch {}
+try {
+device6.queue.writeTexture(
+{
+  texture: texture75,
+  mipLevel: 0,
+  origin: { x: 56, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 5697 */{
+offset: 552,
+bytesPerRow: 381,
+},
+{width: 96, height: 112, depthOrArrayLayers: 1}
+);
+} catch {}
+video5.width = 52;
+let textureView117 = texture113.createView(
+{
+label: '\u5518\u{1ff5a}\u{1f9fe}\uf02a\u23d2\u23ac\ua3ee',
+format: 'rg16uint',
+}
+);
+try {
+renderPassEncoder17.setViewport(
+5.710,
+0.4534,
+3.221,
+1.269,
+0.2431,
+0.2582
+);
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame22,
+  origin: { x: 225, y: 137 },
+  flipY: true,
+},
+{
+  texture: texture113,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let shaderModule21 = device3.createShaderModule(
+{
+label: '\u013b\uf723\u{1f9a9}\u{1fcd9}\u705e\u0760\u{1f6fc}\u0115\u9e76\u04a1\u3926',
+code: `
+
+@compute @workgroup_size(8, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(5) f0: vec3<u32>,
+@location(1) f1: i32,
+@location(6) f2: vec2<f32>,
+@location(4) f3: vec3<u32>,
+@location(3) f4: vec2<u32>,
+@location(0) f5: vec3<f32>,
+@location(7) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(105) a0: vec3<u32>, @location(68) a1: vec2<f16>, @location(5) a2: vec4<i32>, @location(61) a3: vec4<u32>, @builtin(sample_index) a4: u32, @location(6) a5: vec3<f32>, @location(97) a6: vec4<f32>, @location(100) a7: vec4<f16>, @location(66) a8: vec2<i32>, @location(106) a9: vec4<i32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S23 {
+@location(11) f0: f32,
+@location(13) f1: vec4<f32>,
+@location(5) f2: f16
+}
+struct VertexOutput0 {
+@location(92) f391: vec2<f32>,
+@location(70) f392: vec3<f16>,
+@location(97) f393: vec4<f32>,
+@location(24) f394: vec4<f16>,
+@location(105) f395: vec3<u32>,
+@location(75) f396: vec3<u32>,
+@location(5) f397: vec4<i32>,
+@location(101) f398: vec2<f32>,
+@location(6) f399: vec3<f32>,
+@location(58) f400: vec2<f32>,
+@location(68) f401: vec2<f16>,
+@location(100) f402: vec4<f16>,
+@location(111) f403: vec4<f16>,
+@location(12) f404: vec2<i32>,
+@location(80) f405: i32,
+@location(29) f406: i32,
+@location(103) f407: vec4<i32>,
+@location(19) f408: vec3<u32>,
+@location(106) f409: vec4<i32>,
+@builtin(position) f410: vec4<f32>,
+@location(40) f411: f32,
+@location(55) f412: vec2<u32>,
+@location(71) f413: vec4<i32>,
+@location(72) f414: vec2<f16>,
+@location(49) f415: vec4<i32>,
+@location(61) f416: vec4<u32>,
+@location(117) f417: u32,
+@location(45) f418: f16,
+@location(66) f419: vec2<i32>,
+@location(47) f420: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: f32, @location(0) a1: i32, @location(7) a2: vec4<u32>, @location(1) a3: f32, @location(3) a4: vec3<f32>, @location(15) a5: vec2<f16>, a6: S23, @location(6) a7: i32, @location(4) a8: vec2<u32>, @builtin(instance_index) a9: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let querySet95 = device3.createQuerySet(
+{
+label: '\ud1e5\u{1ff27}\ue285\u8dc3\ufee9\u{1fd9f}\u{1fbb9}\u0c39',
+type: 'occlusion',
+count: 2691,
+}
+);
+let texture146 = device3.createTexture(
+{
+label: '\u7ba1\u29d1\u0074\u09cd\u7fa2\u{1fa9f}\u3419\ua94e',
+size: [207, 1, 206],
+mipLevelCount: 4,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth24plus'
+],
+}
+);
+let renderBundle114 = renderBundleEncoder70.finish();
+try {
+renderPassEncoder19.setViewport(
+104.8,
+2.841,
+161.9,
+1.229,
+0.5304,
+0.5997
+);
+} catch {}
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+commandEncoder82.clearBuffer(
+buffer24,
+5480,
+4096
+);
+dissociateBuffer(device3, buffer24);
+} catch {}
+let bindGroup57 = device4.createBindGroup({
+layout: bindGroupLayout32,
+entries: [
+{
+binding: 3961,
+resource: externalTexture3
+}
+],
+});
+let pipelineLayout29 = device4.createPipelineLayout(
+{
+label: '\u8091\ub972\u16ae\uc0a8\u0f5d\u4775',
+bindGroupLayouts: [
+bindGroupLayout14
+],
+}
+);
+let commandEncoder87 = device4.createCommandEncoder();
+try {
+computePassEncoder48.setPipeline(
+pipeline56
+);
+} catch {}
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant(
+{
+r: 748.9,
+g: 809.1,
+b: -564.5,
+a: 297.6,
+}
+);
+} catch {}
+try {
+commandEncoder87.copyBufferToBuffer(
+buffer18,
+28240,
+buffer20,
+8308,
+124
+);
+dissociateBuffer(device4, buffer18);
+dissociateBuffer(device4, buffer20);
+} catch {}
+try {
+commandEncoder87.clearBuffer(
+buffer20,
+7692,
+372
+);
+dissociateBuffer(device4, buffer20);
+} catch {}
+try {
+renderPassEncoder13.insertDebugMarker(
+'\u0bec'
+);
+} catch {}
+try {
+adapter2.label = '\u06b2\u0a07';
+} catch {}
+let querySet96 = device5.createQuerySet(
+{
+label: '\udd86\u{1f666}\u2d20\u08e9\u3378\u4c38\u0c96\u33b5\u2274',
+type: 'occlusion',
+count: 102,
+}
+);
+try {
+renderPassEncoder15.setBindGroup(
+3,
+bindGroup32
+);
+} catch {}
+try {
+renderBundleEncoder102.setVertexBuffer(
+5,
+buffer42,
+36596,
+2903
+);
+} catch {}
+try {
+commandEncoder86.clearBuffer(
+buffer34,
+22688,
+2124
+);
+dissociateBuffer(device5, buffer34);
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas5,
+  origin: { x: 879, y: 306 },
+  flipY: false,
+},
+{
+  texture: texture113,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let imageBitmap41 = await createImageBitmap(offscreenCanvas17);
+try {
+window.someLabel = device4.label;
+} catch {}
+let commandEncoder88 = device4.createCommandEncoder(
+{
+label: '\u5571\ued38\u9504\u02d7\ua989\u{1fd66}\u{1faeb}\u{1fad9}',
+}
+);
+let renderBundle115 = renderBundleEncoder57.finish();
+try {
+computePassEncoder52.setBindGroup(
+4,
+bindGroup30,
+new Uint32Array(3551),
+2372,
+0
+);
+} catch {}
+try {
+computePassEncoder48.setPipeline(
+pipeline49
+);
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(
+882,
+0,
+14,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.setViewport(
+386.6,
+0.5491,
+236.6,
+0.3648,
+0.1472,
+0.1949
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture116,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 11 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 21869 */{
+offset: 735,
+bytesPerRow: 120,
+rowsPerImage: 176,
+},
+{width: 7, height: 1, depthOrArrayLayers: 2}
+);
+} catch {}
+let offscreenCanvas33 = new OffscreenCanvas(18, 870);
+try {
+offscreenCanvas33.getContext('webgpu');
+} catch {}
+let querySet97 = device10.createQuerySet(
+{
+label: '\uc822\ud6d9\uf4bd\u25e7\u562b\u14c7\ud31a\u0489\ub7c7',
+type: 'occlusion',
+count: 290,
+}
+);
+let textureView118 = texture124.createView(
+{
+baseMipLevel: 8,
+mipLevelCount: 1,
+}
+);
+let sampler84 = device10.createSampler(
+{
+label: '\u040a\uacbf\u5434\u{1f75e}\u{1fba6}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 6.461,
+lodMaxClamp: 51.252,
+}
+);
+try {
+renderBundleEncoder85.setVertexBuffer(
+3,
+buffer33,
+148,
+35335
+);
+} catch {}
+let textureView119 = texture143.createView(
+{
+label: '\u{1f69d}\u092d\u09c4\u0338\ued13\u{1fcdf}\u792d\u{1fa5d}',
+format: 'rgba16float',
+baseMipLevel: 3,
+mipLevelCount: 1,
+baseArrayLayer: 30,
+arrayLayerCount: 16,
+}
+);
+let renderBundleEncoder104 = device11.createRenderBundleEncoder(
+{
+label: '\u89e0\u5871\u2f47\u0d72\u055d\u40df\u{1fdd2}\ufccb\u0d1e',
+colorFormats: [
+'rgb10a2uint',
+'rgba32sint',
+'rg8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 171,
+}
+);
+let commandEncoder89 = device11.createCommandEncoder(
+{
+label: '\u{1f7ab}\u0d32',
+}
+);
+let querySet98 = device11.createQuerySet(
+{
+label: '\u2015\ud3e4\u8cb7\u086a\u1210',
+type: 'occlusion',
+count: 3170,
+}
+);
+try {
+renderBundleEncoder104.setVertexBuffer(
+69,
+undefined,
+964779890,
+1114767730
+);
+} catch {}
+document.body.append('\u{1f641}\u2fb6\u50d1\ub18f\u61aa');
+let video37 = await videoWithData();
+let imageData29 = new ImageData(8, 156);
+pseudoSubmit(device6, commandEncoder62);
+let computePassEncoder58 = commandEncoder84.beginComputePass();
+let externalTexture11 = device6.importExternalTexture(
+{
+label: '\u0877\u69e9\u2887\u0aeb\u{1fc7e}\u0b89\u047b',
+source: videoFrame26,
+colorSpace: 'srgb',
+}
+);
+try {
+commandEncoder69.copyBufferToBuffer(
+buffer23,
+12036,
+buffer28,
+14284,
+44
+);
+dissociateBuffer(device6, buffer23);
+dissociateBuffer(device6, buffer28);
+} catch {}
+try {
+commandEncoder69.resolveQuerySet(
+querySet91,
+764,
+169,
+buffer28,
+26112
+);
+} catch {}
+let shaderModule22 = device8.createShaderModule(
+{
+label: '\u09ae\uced6',
+code: `
+
+@compute @workgroup_size(1, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S25 {
+@builtin(sample_mask) f0: u32
+}
+struct FragmentOutput0 {
+@location(7) f0: f32,
+@location(2) f1: i32,
+@location(4) f2: vec2<u32>,
+@location(6) f3: vec3<f32>,
+@location(3) f4: vec4<f32>,
+@location(5) f5: i32,
+@location(1) f6: i32,
+@location(0) f7: vec4<f32>,
+@builtin(frag_depth) f8: f32,
+@builtin(sample_mask) f9: u32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool, a3: S25) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S24 {
+@location(1) f0: vec2<u32>,
+@location(16) f1: vec4<i32>,
+@location(3) f2: vec4<f16>,
+@location(15) f3: vec4<f16>,
+@location(19) f4: u32,
+@location(9) f5: vec2<f16>,
+@location(6) f6: vec4<f32>,
+@location(5) f7: vec2<u32>,
+@location(17) f8: vec2<i32>,
+@location(13) f9: vec4<i32>,
+@location(0) f10: vec3<i32>,
+@builtin(vertex_index) f11: u32,
+@location(20) f12: vec4<u32>,
+@location(2) f13: vec3<f32>,
+@location(4) f14: f16,
+@builtin(instance_index) f15: u32,
+@location(12) f16: vec4<f16>,
+@location(11) f17: vec2<f32>,
+@location(8) f18: vec4<u32>,
+@location(7) f19: vec3<i32>
+}
+
+@vertex
+fn vertex0(a0: S24, @location(14) a1: vec3<u32>, @location(18) a2: f32, @location(10) a3: vec3<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let renderBundleEncoder105 = device8.createRenderBundleEncoder(
+{
+label: '\u{1fb2d}\u{1fa31}\uf7b4\u{1ffd7}\u6c52',
+colorFormats: [
+'r8uint',
+undefined,
+'rg8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 12,
+stencilReadOnly: true,
+}
+);
+let sampler85 = device8.createSampler(
+{
+label: '\u7f00\u1205\u0592\u{1fd42}\u0dcf\ua708',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+minFilter: 'linear',
+lodMaxClamp: 69.095,
+}
+);
+try {
+renderBundleEncoder96.setBindGroup(
+0,
+bindGroup55
+);
+} catch {}
+let buffer43 = device6.createBuffer(
+{
+label: '\u{1ffd1}\u5e94\u{1fa38}\u4e43',
+size: 53611,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+mappedAtCreation: false,
+}
+);
+let textureView120 = texture120.createView(
+{
+label: '\u{1fd22}\ua1d6',
+dimension: '2d',
+}
+);
+try {
+commandEncoder69.copyBufferToTexture(
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 29872 */
+offset: 29872,
+buffer: buffer21,
+},
+{
+  texture: texture76,
+  mipLevel: 7,
+  origin: { x: 8, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device6, buffer21);
+} catch {}
+try {
+commandEncoder69.clearBuffer(
+buffer23,
+8320,
+8156
+);
+dissociateBuffer(device6, buffer23);
+} catch {}
+try {
+device6.queue.writeBuffer(
+buffer28,
+38100,
+new Float32Array(28734),
+27885,
+372
+);
+} catch {}
+let imageData30 = new ImageData(204, 16);
+let querySet99 = device12.createQuerySet(
+{
+type: 'occlusion',
+count: 858,
+}
+);
+let sampler86 = device12.createSampler(
+{
+label: '\u{1fb07}\u15f2\u{1fdc2}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 48.682,
+lodMaxClamp: 88.062,
+maxAnisotropy: 1,
+}
+);
+try {
+await device12.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device11.queue.writeTexture(
+{
+  texture: texture132,
+  mipLevel: 0,
+  origin: { x: 358, y: 1, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer10,
+/* required buffer size: 646 */{
+offset: 646,
+},
+{width: 4372, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\udf5b\u913f');
+let imageData31 = new ImageData(176, 16);
+try {
+window.someLabel = externalTexture3.label;
+} catch {}
+let pipelineLayout30 = device4.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout14,
+bindGroupLayout39
+],
+}
+);
+let texture147 = device4.createTexture(
+{
+size: [8956, 35, 1],
+mipLevelCount: 8,
+format: 'r16sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16sint',
+'r16sint',
+'r16sint'
+],
+}
+);
+try {
+renderPassEncoder13.setBindGroup(
+4,
+bindGroup24,
+[]
+);
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(
+1258
+);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(
+1,
+buffer20,
+5692
+);
+} catch {}
+try {
+renderBundleEncoder84.setVertexBuffer(
+3,
+buffer20,
+1032,
+45
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture127,
+  mipLevel: 0,
+  origin: { x: 2166, y: 1, z: 0 },
+  aspect: 'all',
+},
+new Int32Array(arrayBuffer8),
+/* required buffer size: 727 */{
+offset: 727,
+},
+{width: 5032, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\ua77d\u{1fda2}\u034f\u6a84\ub2e0\u9088');
+let commandEncoder90 = device8.createCommandEncoder(
+{
+}
+);
+let computePassEncoder59 = commandEncoder90.beginComputePass();
+try {
+computePassEncoder59.setPipeline(
+pipeline61
+);
+} catch {}
+let pipeline70 = await device8.createRenderPipelineAsync(
+{
+layout: pipelineLayout22,
+vertex: {
+module: shaderModule22,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32',
+offset: 17496,
+shaderLocation: 13,
+},
+{
+format: 'snorm16x2',
+offset: 1840,
+shaderLocation: 10,
+},
+{
+format: 'sint16x2',
+offset: 1180,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x2',
+offset: 18380,
+shaderLocation: 2,
+},
+{
+format: 'sint16x2',
+offset: 5568,
+shaderLocation: 16,
+},
+{
+format: 'snorm16x2',
+offset: 22540,
+shaderLocation: 9,
+},
+{
+format: 'uint32x2',
+offset: 9912,
+shaderLocation: 8,
+},
+{
+format: 'float32x2',
+offset: 11012,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 11692,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32',
+offset: 1196,
+shaderLocation: 11,
+},
+{
+format: 'snorm8x2',
+offset: 3292,
+shaderLocation: 6,
+},
+{
+format: 'snorm8x4',
+offset: 2924,
+shaderLocation: 15,
+},
+{
+format: 'float32x4',
+offset: 4568,
+shaderLocation: 12,
+},
+{
+format: 'uint16x4',
+offset: 9076,
+shaderLocation: 19,
+},
+{
+format: 'uint32x4',
+offset: 2460,
+shaderLocation: 1,
+},
+{
+format: 'uint16x2',
+offset: 10956,
+shaderLocation: 5,
+},
+{
+format: 'sint32x2',
+offset: 6800,
+shaderLocation: 17,
+},
+{
+format: 'unorm8x4',
+offset: 7388,
+shaderLocation: 18,
+},
+{
+format: 'sint32x2',
+offset: 8872,
+shaderLocation: 0,
+},
+{
+format: 'uint32x2',
+offset: 4504,
+shaderLocation: 20,
+},
+{
+format: 'uint32x2',
+offset: 5540,
+shaderLocation: 14,
+},
+{
+format: 'float16x2',
+offset: 6744,
+shaderLocation: 3,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+},
+multisample: {
+},
+fragment: {
+module: shaderModule22,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rgb10a2unorm',
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'less',
+failOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'equal',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 3449,
+stencilWriteMask: 2605,
+depthBias: 59,
+depthBiasSlopeScale: 27,
+depthBiasClamp: 79,
+},
+}
+);
+document.body.prepend('\uaabf\u2800\u0c20\u{1fbf5}\u{1fd02}\u86ff\u{1f6fc}');
+let img31 = await imageWithData(43, 68, '#7acd5779', '#af118281');
+let renderPassEncoder20 = commandEncoder86.beginRenderPass(
+{
+label: '\u{1fc0d}\u0141\u7320\u51c0\u1129',
+colorAttachments: [
+{
+view: textureView93,
+depthSlice: 100,
+clearValue: {
+r: 19.65,
+g: -558.8,
+b: -673.3,
+a: -209.0,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView93,
+depthSlice: 61,
+clearValue: {
+r: -137.7,
+g: -348.6,
+b: -89.61,
+a: 255.3,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined
+],
+occlusionQuerySet: querySet87,
+}
+);
+let renderBundle116 = renderBundleEncoder63.finish(
+{
+label: '\u3fe4\u1010\u6884\u0444\u89d0\u{1f844}\u0002'
+}
+);
+try {
+renderPassEncoder15.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+renderPassEncoder17.setScissorRect(
+32,
+2,
+39,
+0
+);
+} catch {}
+try {
+device5.pushErrorScope(
+'validation'
+);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let canvas31 = document.createElement('canvas');
+let video38 = await videoWithData();
+try {
+device11.queue.writeTexture(
+{
+  texture: texture132,
+  mipLevel: 0,
+  origin: { x: 108, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Int32Array(new ArrayBuffer(80)),
+/* required buffer size: 973 */{
+offset: 973,
+},
+{width: 2392, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let renderBundleEncoder106 = device10.createRenderBundleEncoder(
+{
+colorFormats: [
+'r16uint',
+'r16float',
+'r8unorm',
+undefined,
+undefined,
+undefined,
+'bgra8unorm-srgb'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 995,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle117 = renderBundleEncoder89.finish(
+{
+label: '\u{1fe1c}\u26bc\u4ee9\u3c2b\uae59\u{1fd20}\u{1f8cc}\u{1fef6}\uc33f\u7226'
+}
+);
+try {
+computePassEncoder51.end();
+} catch {}
+canvas4.width = 405;
+let img32 = await imageWithData(27, 77, '#1f6bbe77', '#ed21fd8c');
+try {
+adapter1.label = '\ued6a\uad61\u851e\ufd66\u4e51\u{1fbaa}\u{1fad8}\u742e\u{1faa0}\u0bfe\u4a9d';
+} catch {}
+try {
+window.someLabel = device6.queue.label;
+} catch {}
+let buffer44 = device6.createBuffer(
+{
+label: '\ufeda\ue85b\u06fc\u1d4a\u033b\ud1fa\u04b9\u39ec\u{1fcbb}',
+size: 1020,
+usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+mappedAtCreation: true,
+}
+);
+let device13 = await adapter15.requestDevice(
+{
+label: '\u0820\u85ba\u0a8e\u071a',
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-astc',
+'indirect-first-instance',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 49,
+maxVertexAttributes: 29,
+maxVertexBufferArrayStride: 5881,
+maxStorageTexturesPerShaderStage: 27,
+maxStorageBuffersPerShaderStage: 17,
+maxDynamicStorageBuffersPerPipelineLayout: 46021,
+maxBindingsPerBindGroup: 5587,
+maxTextureDimension1D: 8974,
+maxTextureDimension2D: 10144,
+maxVertexBuffers: 10,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 67563885,
+maxInterStageShaderVariables: 121,
+maxInterStageShaderComponents: 99,
+},
+}
+);
+let commandEncoder91 = device12.createCommandEncoder(
+{
+}
+);
+let texture148 = device12.createTexture(
+{
+size: [7735, 3, 1],
+mipLevelCount: 5,
+format: 'rg32uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32uint'
+],
+}
+);
+try {
+gpuCanvasContext20.configure(
+{
+device: device12,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32float',
+'bgra8unorm-srgb'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let promise49 = device12.queue.onSubmittedWorkDone();
+try {
+await promise49;
+} catch {}
+try {
+computePassEncoder49.setPipeline(
+pipeline65
+);
+} catch {}
+try {
+buffer24.destroy();
+} catch {}
+video1.height = 226;
+let querySet100 = device10.createQuerySet(
+{
+label: '\udd0d\u{1f938}\u7561',
+type: 'occlusion',
+count: 1320,
+}
+);
+let texture149 = device10.createTexture(
+{
+size: {width: 48, height: 215, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+dimension: '2d',
+format: 'astc-6x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-6x5-unorm-srgb',
+'astc-6x5-unorm'
+],
+}
+);
+let renderBundle118 = renderBundleEncoder89.finish(
+{
+
+}
+);
+let sampler87 = device10.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 88.669,
+}
+);
+try {
+computePassEncoder44.end();
+} catch {}
+try {
+renderBundleEncoder106.setVertexBuffer(
+4,
+buffer33,
+23792,
+19301
+);
+} catch {}
+try {
+renderBundleEncoder106.insertDebugMarker(
+'\ubd7b'
+);
+} catch {}
+let textureView121 = texture120.createView(
+{
+label: '\u{1f843}\u577b\u0810\u7001\uccef\u1d63\u07f1\u0fac\u{1f62e}',
+arrayLayerCount: 1,
+}
+);
+try {
+buffer43.unmap();
+} catch {}
+try {
+commandEncoder69.resolveQuerySet(
+querySet90,
+166,
+234,
+buffer23,
+26624
+);
+} catch {}
+try {
+computePassEncoder58.pushDebugGroup(
+'\u1394'
+);
+} catch {}
+try {
+device6.queue.writeBuffer(
+buffer23,
+16420,
+new Int16Array(23729),
+3087,
+540
+);
+} catch {}
+document.body.prepend(canvas18);
+video27.height = 47;
+let texture150 = device2.createTexture(
+{
+size: [224, 1, 1020],
+mipLevelCount: 6,
+dimension: '3d',
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+let textureView122 = texture85.createView(
+{
+label: '\u3907\u{1f72f}\u07ee\ue48f',
+aspect: 'all',
+baseMipLevel: 0,
+mipLevelCount: 1,
+}
+);
+let renderPassEncoder21 = commandEncoder74.beginRenderPass(
+{
+label: '\u075b\u05e8',
+colorAttachments: [
+undefined,
+{
+view: textureView39,
+depthSlice: 75,
+clearValue: {
+r: 353.1,
+g: -908.9,
+b: -446.2,
+a: 984.2,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined,
+{
+view: textureView39,
+depthSlice: 79,
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView39,
+depthSlice: 66,
+loadOp: 'load',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet47,
+maxDrawCount: 25296,
+}
+);
+let renderBundle119 = renderBundleEncoder34.finish(
+{
+label: '\u0d9e\u1812\ubda8\u971b\u01e6\u0ed7\u0ff3\u0f56'
+}
+);
+try {
+computePassEncoder29.setBindGroup(
+4,
+bindGroup38,
+new Uint32Array(9118),
+2877,
+0
+);
+} catch {}
+try {
+renderPassEncoder21.beginOcclusionQuery(
+40
+);
+} catch {}
+try {
+renderPassEncoder21.insertDebugMarker(
+'\u1658'
+);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+document.body.append('\u62ba\u02a5\u37f5\ud3db\u084b\uba54\u{1fd26}\ua344\u1cc4');
+let bindGroupLayout40 = device1.createBindGroupLayout(
+{
+label: '\u97c7\u0524\u9901\u07e2\ua824\u9465\u{1f7e6}\u0c02\u547b\u08bd',
+entries: [
+{
+binding: 4970,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+}
+],
+}
+);
+let buffer45 = device1.createBuffer(
+{
+label: '\u2cc7\uc0ba',
+size: 50867,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM,
+}
+);
+let commandEncoder92 = device1.createCommandEncoder();
+let commandBuffer11 = commandEncoder92.finish();
+let texture151 = device1.createTexture(
+{
+label: '\u2d0d\u5660\u7971\u{1fcf1}\u0c9b\u{1fd83}\u8676\u{1f979}\u0531\u1b03',
+size: [7259],
+dimension: '1d',
+format: 'r32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32float'
+],
+}
+);
+let renderBundle120 = renderBundleEncoder30.finish(
+{
+label: '\uac64\u0762\ua5bc\ufd3a\u0198\u05b7\u0ea9\u{1fbd9}\u036e\u{1fcfd}'
+}
+);
+let sampler88 = device1.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 38.803,
+maxAnisotropy: 11,
+}
+);
+let promise50 = device1.createRenderPipelineAsync(
+{
+layout: pipelineLayout13,
+vertex: {
+module: shaderModule15,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 36816,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 23568,
+shaderLocation: 18,
+},
+{
+format: 'sint8x4',
+offset: 32620,
+shaderLocation: 11,
+},
+{
+format: 'unorm8x4',
+offset: 10156,
+shaderLocation: 13,
+},
+{
+format: 'float32x2',
+offset: 24016,
+shaderLocation: 14,
+},
+{
+format: 'sint8x4',
+offset: 31584,
+shaderLocation: 19,
+},
+{
+format: 'sint32x4',
+offset: 16112,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x2',
+offset: 16780,
+shaderLocation: 1,
+},
+{
+format: 'unorm16x2',
+offset: 22512,
+shaderLocation: 9,
+},
+{
+format: 'uint32x2',
+offset: 20980,
+shaderLocation: 5,
+},
+{
+format: 'unorm8x4',
+offset: 25392,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 14848,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 50724,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 44740,
+shaderLocation: 8,
+},
+{
+format: 'uint8x4',
+offset: 27948,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 9592,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 1140,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 3592,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 2588,
+shaderLocation: 12,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule15,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rgba16sint',
+},
+{
+format: 'rg16sint',
+},
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}
+],
+},
+}
+);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageData32 = new ImageData(168, 64);
+try {
+canvas31.getContext('webgl');
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+document.body.prepend('\u054d\u05dc');
+try {
+window.someLabel = device11.queue.label;
+} catch {}
+let commandEncoder93 = device11.createCommandEncoder(
+{
+label: '\u4e63\u8df2\u67de\uadbe\u3045\u043f\u0589\uff7c',
+}
+);
+let textureView123 = texture132.createView(
+{
+label: '\u0793\u{1fed5}\u{1fb82}\u02c7\u123f\u63d5\uf0dd\u01d3\u{1fce5}\u9c25\u7c6d',
+mipLevelCount: 1,
+}
+);
+let renderBundleEncoder107 = device11.createRenderBundleEncoder(
+{
+label: '\u0750\u01d4\u35bc',
+colorFormats: [
+'rg32sint',
+'r32uint'
+],
+sampleCount: 557,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder104.setVertexBuffer(
+26,
+undefined
+);
+} catch {}
+try {
+commandEncoder93.insertDebugMarker(
+'\u{1fa2a}'
+);
+} catch {}
+try {
+window.someLabel = texture112.label;
+} catch {}
+let buffer46 = device5.createBuffer(
+{
+label: '\ue92b\ud773\u01e0\u5cbe\u{1fb7e}\u{1f956}\u{1fa60}\ueee4\u0238\u0dbd',
+size: 55910,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let commandEncoder94 = device5.createCommandEncoder(
+{
+label: '\u0eeb\u0ee2\ue721\u4de3\u0665\u{1f84d}\u2f4c\ufc13\u2e8a\u{1f89a}\u6334',
+}
+);
+let computePassEncoder60 = commandEncoder94.beginComputePass(
+{
+label: '\u02a6\uff89\u7738\ue59b\u095b\u8a50\ua825\uf3d6\u170c\u2c29'
+}
+);
+try {
+renderPassEncoder17.beginOcclusionQuery(
+64
+);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant(
+{
+r: 874.5,
+g: -857.6,
+b: -628.0,
+a: 553.2,
+}
+);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(
+buffer42,
+'uint32',
+30564,
+9070
+);
+} catch {}
+try {
+renderBundleEncoder87.insertDebugMarker(
+'\ue577'
+);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+document.body.append('\u4dd8\u0bc1\u6d2d\u59d9\u099e');
+let buffer47 = device10.createBuffer(
+{
+size: 47377,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let textureView124 = texture96.createView(
+{
+label: '\ud3e3\u037a\uf0ee\u01d5\u0bdc\ua468\u{1f8eb}\u2bd6\u95bd\uf85b\u{1fb02}',
+baseMipLevel: 7,
+mipLevelCount: 1,
+baseArrayLayer: 32,
+arrayLayerCount: 1,
+}
+);
+let renderBundleEncoder108 = device10.createRenderBundleEncoder(
+{
+label: '\u61fb\u1524\u8d48',
+colorFormats: [
+'r16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 388,
+stencilReadOnly: true,
+}
+);
+let sampler89 = device10.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 84.800,
+lodMaxClamp: 95.924,
+maxAnisotropy: 11,
+}
+);
+try {
+commandEncoder63.clearBuffer(
+buffer33,
+37920,
+4324
+);
+dissociateBuffer(device10, buffer33);
+} catch {}
+let offscreenCanvas34 = new OffscreenCanvas(23, 250);
+let imageData33 = new ImageData(176, 116);
+let renderBundleEncoder109 = device0.createRenderBundleEncoder(
+{
+label: '\u{1f732}\u{1ff8a}\u{1f63f}\u9cbd\ud519\u{1ff5c}\u0078\uc72b\u08a0\u01e2\u06fe',
+colorFormats: [
+'bgra8unorm-srgb',
+'r16sint',
+undefined,
+'bgra8unorm',
+'rgba8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 254,
+stencilReadOnly: true,
+}
+);
+let renderBundle121 = renderBundleEncoder0.finish(
+{
+label: '\u{1f6c9}\u{1fb53}'
+}
+);
+try {
+computePassEncoder15.setPipeline(
+pipeline12
+);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(
+6,
+bindGroup7,
+new Uint32Array(3703),
+2870,
+0
+);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(
+56
+);
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant(
+{
+r: -186.5,
+g: -533.7,
+b: 80.52,
+a: -501.7,
+}
+);
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(
+794
+);
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+4998.6,
+4.042,
+576.7,
+5.264,
+0.5971,
+0.6026
+);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(
+buffer4,
+93344
+);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(
+2,
+buffer10,
+15564
+);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(
+8,
+bindGroup22,
+new Uint32Array(5227),
+4025,
+0
+);
+} catch {}
+try {
+commandEncoder52.copyBufferToBuffer(
+buffer8,
+35480,
+buffer9,
+10176,
+9416
+);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder52.copyTextureToTexture(
+{
+  texture: texture38,
+  mipLevel: 0,
+  origin: { x: 560, y: 0, z: 309 },
+  aspect: 'all',
+},
+{
+  texture: texture38,
+  mipLevel: 1,
+  origin: { x: 195, y: 0, z: 87 },
+  aspect: 'all',
+},
+{width: 179, height: 1, depthOrArrayLayers: 234}
+);
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(
+querySet15,
+3,
+2433,
+buffer5,
+768
+);
+} catch {}
+try {
+gpuCanvasContext6.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture17,
+  mipLevel: 2,
+  origin: { x: 802, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer9,
+/* required buffer size: 178 */{
+offset: 178,
+bytesPerRow: 16561,
+},
+{width: 1022, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline71 = device0.createRenderPipeline(
+{
+label: '\uab80\uff1a\u4e9b\u89da\ub75a\u0504\u{1fe84}',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule5,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 7908,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x3',
+offset: 7540,
+shaderLocation: 13,
+},
+{
+format: 'float32x4',
+offset: 660,
+shaderLocation: 14,
+},
+{
+format: 'snorm16x2',
+offset: 660,
+shaderLocation: 20,
+},
+{
+format: 'sint8x2',
+offset: 3338,
+shaderLocation: 7,
+},
+{
+format: 'uint32x3',
+offset: 4852,
+shaderLocation: 5,
+},
+{
+format: 'snorm16x2',
+offset: 4176,
+shaderLocation: 8,
+},
+{
+format: 'float32x2',
+offset: 7588,
+shaderLocation: 21,
+},
+{
+format: 'snorm8x2',
+offset: 7400,
+shaderLocation: 4,
+},
+{
+format: 'uint32x4',
+offset: 1788,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 684,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x2',
+offset: 124,
+shaderLocation: 15,
+},
+{
+format: 'sint32x3',
+offset: 404,
+shaderLocation: 24,
+},
+{
+format: 'float16x4',
+offset: 540,
+shaderLocation: 12,
+},
+{
+format: 'float32x2',
+offset: 584,
+shaderLocation: 18,
+},
+{
+format: 'snorm16x4',
+offset: 24,
+shaderLocation: 10,
+},
+{
+format: 'uint32x3',
+offset: 624,
+shaderLocation: 25,
+},
+{
+format: 'uint16x4',
+offset: 76,
+shaderLocation: 0,
+},
+{
+format: 'unorm16x2',
+offset: 240,
+shaderLocation: 3,
+},
+{
+format: 'unorm16x4',
+offset: 320,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 2964,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 13676,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x3',
+offset: 1176,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x2',
+offset: 4684,
+shaderLocation: 16,
+},
+{
+format: 'uint32x4',
+offset: 6348,
+shaderLocation: 6,
+},
+{
+format: 'float16x2',
+offset: 6988,
+shaderLocation: 23,
+},
+{
+format: 'float32x2',
+offset: 9848,
+shaderLocation: 1,
+},
+{
+format: 'uint32x4',
+offset: 11960,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 1308,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 11980,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 7676,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 15540,
+attributes: [
+
+],
+},
+{
+arrayStride: 3924,
+attributes: [
+{
+format: 'uint16x2',
+offset: 2008,
+shaderLocation: 26,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+},
+fragment: {
+module: shaderModule5,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'replace',
+depthFailOp: 'decrement-wrap',
+passOp: 'keep',
+},
+stencilBack: {
+compare: 'less',
+depthFailOp: 'increment-wrap',
+passOp: 'zero',
+},
+stencilWriteMask: 2572,
+depthBias: 53,
+depthBiasSlopeScale: 50,
+depthBiasClamp: 43,
+},
+}
+);
+let imageBitmap42 = await createImageBitmap(imageBitmap33);
+let imageData34 = new ImageData(16, 172);
+document.body.append('\uef27\u{1f887}\u0877\u43a2\ueaec\u0fa3\ud13d\u823d\u8a33');
+let img33 = await imageWithData(134, 207, '#4d5aa0ad', '#d210fa10');
+let buffer48 = device8.createBuffer(
+{
+size: 24415,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+}
+);
+let querySet101 = device8.createQuerySet(
+{
+label: '\u0790\u{1f670}\u05c9\u7f1b\u0ee5',
+type: 'occlusion',
+count: 1802,
+}
+);
+let renderBundleEncoder110 = device8.createRenderBundleEncoder(
+{
+label: '\u47f1\u61e8',
+colorFormats: [
+'rgba8sint',
+'bgra8unorm-srgb'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 684,
+depthReadOnly: true,
+}
+);
+let renderBundle122 = renderBundleEncoder96.finish(
+{
+label: '\u9b91\u5582\u{1febd}\u7e21\u{1f9f1}'
+}
+);
+try {
+gpuCanvasContext19.configure(
+{
+device: device8,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rg8unorm',
+'rgba32sint'
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let imageBitmap43 = await createImageBitmap(video13);
+try {
+videoFrame24.close();
+} catch {}
+let renderBundle123 = renderBundleEncoder67.finish();
+try {
+computePassEncoder56.setBindGroup(
+0,
+bindGroup31,
+new Uint32Array(440),
+50,
+0
+);
+} catch {}
+try {
+computePassEncoder56.insertDebugMarker(
+'\uc0dd'
+);
+} catch {}
+try {
+device5.queue.writeBuffer(
+buffer34,
+17860,
+new DataView(new ArrayBuffer(45734)),
+10281,
+1168
+);
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img21,
+  origin: { x: 42, y: 64 },
+  flipY: true,
+},
+{
+  texture: texture113,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+offscreenCanvas34.getContext('webgl2');
+} catch {}
+let buffer49 = device8.createBuffer(
+{
+label: '\u0bb9\uc3e4\u00b4\u052d\u{1f79f}\u0b64',
+size: 54711,
+usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+}
+);
+let commandEncoder95 = device8.createCommandEncoder(
+{
+label: '\u1136\u0aab',
+}
+);
+let renderBundleEncoder111 = device8.createRenderBundleEncoder(
+{
+label: '\u1404\u47e5\udeb6\u03d0\u0b45\u1aa8\u0bff\u{1fea4}',
+colorFormats: [
+'r32sint',
+'rgba8unorm-srgb',
+'rg32uint',
+'rgba32uint'
+],
+sampleCount: 868,
+stencilReadOnly: true,
+}
+);
+let renderBundle124 = renderBundleEncoder68.finish(
+{
+label: '\u6c62\u986e\u081b\ub026\u018a\ue1fc\u3966'
+}
+);
+try {
+computePassEncoder59.setPipeline(
+pipeline51
+);
+} catch {}
+try {
+renderBundleEncoder56.setBindGroup(
+0,
+bindGroup41
+);
+} catch {}
+try {
+commandEncoder95.copyBufferToBuffer(
+buffer29,
+3708,
+buffer40,
+10844,
+244
+);
+dissociateBuffer(device8, buffer29);
+dissociateBuffer(device8, buffer40);
+} catch {}
+try {
+device8.queue.writeBuffer(
+buffer48,
+22364,
+new Float32Array(30692),
+26821,
+236
+);
+} catch {}
+try {
+device13.addEventListener('uncapturederror', e => { log('device13.uncapturederror'); log(e); e.label = device13.label; });
+} catch {}
+try {
+await device13.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append('\uc016\u{1ffb1}\u{1fe82}\u{1fff4}');
+try {
+renderPassEncoder12.setViewport(
+251.4,
+0.2630,
+556.5,
+0.5823,
+0.9240,
+0.9250
+);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+11,
+buffer18,
+9740,
+16129
+);
+} catch {}
+try {
+renderBundleEncoder97.setBindGroup(
+1,
+bindGroup24,
+new Uint32Array(3923),
+2108,
+0
+);
+} catch {}
+try {
+commandEncoder88.clearBuffer(
+buffer25,
+35644
+);
+dissociateBuffer(device4, buffer25);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture59,
+  mipLevel: 5,
+  origin: { x: 3, y: 1, z: 13 },
+  aspect: 'all',
+},
+new Float32Array(new ArrayBuffer(40)),
+/* required buffer size: 3659640 */{
+offset: 390,
+bytesPerRow: 170,
+rowsPerImage: 287,
+},
+{width: 1, height: 0, depthOrArrayLayers: 76}
+);
+} catch {}
+let pipeline72 = await device4.createRenderPipelineAsync(
+{
+label: '\ue701\u03e4\u19a7\u0130\u{1fd87}\u849f\u396d',
+layout: pipelineLayout17,
+vertex: {
+module: shaderModule11,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 1078,
+shaderLocation: 2,
+},
+{
+format: 'unorm8x2',
+offset: 1716,
+shaderLocation: 8,
+},
+{
+format: 'sint32x4',
+offset: 1944,
+shaderLocation: 10,
+},
+{
+format: 'float16x2',
+offset: 208,
+shaderLocation: 1,
+},
+{
+format: 'snorm8x4',
+offset: 672,
+shaderLocation: 5,
+},
+{
+format: 'snorm16x2',
+offset: 2208,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x4',
+offset: 1644,
+shaderLocation: 18,
+},
+{
+format: 'sint16x4',
+offset: 880,
+shaderLocation: 12,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 952,
+shaderLocation: 19,
+},
+{
+format: 'float32x3',
+offset: 2036,
+shaderLocation: 14,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 300,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x2',
+offset: 814,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 1336,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 238,
+shaderLocation: 6,
+},
+{
+format: 'uint8x4',
+offset: 380,
+shaderLocation: 11,
+},
+{
+format: 'snorm8x4',
+offset: 1036,
+shaderLocation: 16,
+},
+{
+format: 'sint8x2',
+offset: 538,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 2384,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 1004,
+shaderLocation: 0,
+},
+{
+format: 'sint16x4',
+offset: 144,
+shaderLocation: 4,
+},
+{
+format: 'uint32x2',
+offset: 1008,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 1672,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32',
+offset: 984,
+shaderLocation: 20,
+}
+],
+},
+{
+arrayStride: 1960,
+attributes: [
+
+],
+},
+{
+arrayStride: 1668,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 1820,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 1656,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+},
+multisample: {
+count: 4,
+mask: 0x1a61e848,
+},
+fragment: {
+module: shaderModule11,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rgba8sint',
+},
+undefined,
+{
+format: 'rg32sint',
+writeMask: 0,
+},
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r32uint',
+},
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 3094,
+stencilWriteMask: 41,
+depthBiasSlopeScale: 82,
+depthBiasClamp: 59,
+},
+}
+);
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let buffer50 = device11.createBuffer(
+{
+label: '\u{1f930}\uc329',
+size: 55037,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: false,
+}
+);
+let commandEncoder96 = device11.createCommandEncoder(
+{
+label: '\u07f6\uc62c\u47ed\u0082',
+}
+);
+let texture152 = device11.createTexture(
+{
+size: {width: 232, height: 1, depthOrArrayLayers: 243},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgb10a2uint',
+'rgb10a2uint'
+],
+}
+);
+let texture153 = gpuCanvasContext16.getCurrentTexture();
+let renderBundle125 = renderBundleEncoder107.finish(
+{
+label: '\u{1f992}\u0ac8'
+}
+);
+let sampler90 = device11.createSampler(
+{
+label: '\u{1fbed}\u{1f970}\u02e1\u{1f638}\u307e\u{1fb12}\u{1fc7b}\u09a4\u23f2\u0820\ud67a',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 44.485,
+lodMaxClamp: 52.432,
+maxAnisotropy: 15,
+}
+);
+gc();
+let video39 = await videoWithData();
+let bindGroupLayout41 = device12.createBindGroupLayout(
+{
+label: '\uc7ce\uceed\ucc1d',
+entries: [
+
+],
+}
+);
+pseudoSubmit(device12, commandEncoder91);
+let textureView125 = texture148.createView(
+{
+label: '\u0d9d\ub38a\u0d33',
+dimension: '2d-array',
+baseMipLevel: 4,
+mipLevelCount: 1,
+}
+);
+document.body.append('\uf451\u142d\u{1f60e}\u{1fba6}\ue255\u{1f766}\u{1f925}\ufac4\u55f3');
+let canvas32 = document.createElement('canvas');
+let imageData35 = new ImageData(48, 224);
+let video40 = await videoWithData();
+let videoFrame31 = new VideoFrame(video11, {timestamp: 0});
+let bindGroup58 = device12.createBindGroup({
+label: '\u0080\u00fb\u5b25\u{1fb39}\u{1f849}\u{1fcba}\u6095\u02ff',
+layout: bindGroupLayout41,
+entries: [
+
+],
+});
+let pipelineLayout31 = device12.createPipelineLayout(
+{
+label: '\u09a0\u08ef\u5fda\u{1fff0}\u{1f9e9}\u0cca',
+bindGroupLayouts: [
+bindGroupLayout41,
+bindGroupLayout41,
+bindGroupLayout41,
+bindGroupLayout41,
+bindGroupLayout41
+],
+}
+);
+let texture154 = device12.createTexture(
+{
+label: '\u{1f927}\u0f73\u{1fda8}\u947d',
+size: {width: 6178},
+dimension: '1d',
+format: 'rg8sint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8sint',
+'rg8sint',
+'rg8sint'
+],
+}
+);
+let renderBundleEncoder112 = device12.createRenderBundleEncoder(
+{
+label: '\ue960\u7a8f',
+colorFormats: [
+'r8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 596,
+depthReadOnly: true,
+}
+);
+let sampler91 = device12.createSampler(
+{
+label: '\u686c\u{1fc9d}\u{1fbf0}\u03cd',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 97.264,
+lodMaxClamp: 99.726,
+compare: 'equal',
+}
+);
+try {
+renderBundleEncoder112.setBindGroup(
+4,
+bindGroup58,
+new Uint32Array(8716),
+4411,
+0
+);
+} catch {}
+document.body.append('\u069b\u06bc\u202e\ucc07\u067e\ue35b\ub7eb\u8f7c');
+let texture155 = device3.createTexture(
+{
+label: '\ua852\u09c2\u{1fbb2}\u0424\ua24b\u797a\u{1f65a}\u{1fc30}\ua62e\uecc0\u07cf',
+size: {width: 164, height: 136, depthOrArrayLayers: 1},
+sampleCount: 1,
+format: 'r32sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let computePassEncoder61 = commandEncoder82.beginComputePass(
+{
+label: '\u7ec6\u9584\u3fd4\u0380\u0f06\u976a'
+}
+);
+let renderBundleEncoder113 = device3.createRenderBundleEncoder(
+{
+label: '\u{1fcc9}\u00de',
+colorFormats: [
+'rg16uint',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 425,
+}
+);
+let renderBundle126 = renderBundleEncoder70.finish(
+{
+label: '\u0138\u2c98\uca4e\u{1fab7}\u{1fc6a}\u{1fa2c}'
+}
+);
+try {
+computePassEncoder39.end();
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant(
+{
+r: -238.7,
+g: -910.7,
+b: -365.6,
+a: -850.8,
+}
+);
+} catch {}
+try {
+renderPassEncoder19.setStencilReference(
+290
+);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(
+10,
+buffer24,
+3196,
+19211
+);
+} catch {}
+try {
+gpuCanvasContext16.configure(
+{
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'astc-10x8-unorm',
+'rgba8unorm',
+'etc2-rgb8a1unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(
+/*
+{width: 715, height: 1, depthOrArrayLayers: 418}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 30, y: 580 },
+  flipY: true,
+},
+{
+  texture: texture138,
+  mipLevel: 1,
+  origin: { x: 388, y: 0, z: 18 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 25, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline73 = await device3.createRenderPipelineAsync(
+{
+layout: pipelineLayout24,
+vertex: {
+module: shaderModule21,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 15400,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x2',
+offset: 15156,
+shaderLocation: 13,
+},
+{
+format: 'unorm16x2',
+offset: 9644,
+shaderLocation: 1,
+},
+{
+format: 'sint8x4',
+offset: 8,
+shaderLocation: 0,
+},
+{
+format: 'uint8x4',
+offset: 11416,
+shaderLocation: 4,
+},
+{
+format: 'unorm16x4',
+offset: 2812,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'uint32x2',
+offset: 3696,
+shaderLocation: 7,
+},
+{
+format: 'sint32x4',
+offset: 12924,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 7624,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 2516,
+shaderLocation: 5,
+},
+{
+format: 'float16x4',
+offset: 52,
+shaderLocation: 15,
+},
+{
+format: 'snorm8x4',
+offset: 5464,
+shaderLocation: 14,
+},
+{
+format: 'float16x4',
+offset: 240,
+shaderLocation: 3,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule21,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+},
+{
+format: 'r16sint',
+},
+undefined,
+{
+format: 'r8uint',
+}
+],
+},
+depthStencil: {
+format: 'stencil8',
+stencilFront: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 3063,
+depthBias: 48,
+depthBiasClamp: 60,
+},
+}
+);
+try {
+window.someLabel = device7.queue.label;
+} catch {}
+let commandEncoder97 = device7.createCommandEncoder(
+{
+label: '\ua33e\u3885\uafb0\u989f\ucd9d\u60c3\u2345\u{1faf1}\uf424\u{1f637}\u480f',
+}
+);
+let renderBundle127 = renderBundleEncoder51.finish(
+{
+label: '\u{1fd32}\ufebf\u{1f870}\u{1fad0}\u{1faff}\u0218\u6896\u0382\uda59'
+}
+);
+try {
+commandEncoder97.clearBuffer(
+buffer36,
+26184,
+26056
+);
+dissociateBuffer(device7, buffer36);
+} catch {}
+let pipeline74 = await device7.createRenderPipelineAsync(
+{
+label: '\u0327\u0664\u{1f683}\u{1fd2c}\u{1fa5f}\u01cc\uf097\u0002\uc6f7\u{1fe7f}',
+layout: pipelineLayout19,
+vertex: {
+module: shaderModule14,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 13704,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 13320,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 12276,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 350,
+shaderLocation: 14,
+},
+{
+format: 'sint8x2',
+offset: 11558,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+},
+fragment: {
+module: shaderModule14,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}
+],
+},
+}
+);
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+try {
+adapter12.label = '\u0c05\u0c62\u4725\u0522\u0930\uf323';
+} catch {}
+let texture156 = device10.createTexture(
+{
+label: '\u6a97\u0040\u{1f6ec}\u{1fd7e}',
+size: [183, 1, 392],
+dimension: '3d',
+format: 'rg32uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundle128 = renderBundleEncoder74.finish(
+{
+label: '\u36bb\u4d2f\ue154\ubb20\u3ed0\u3a59\u{1fc66}\uf78b\ud7c0\u467f'
+}
+);
+try {
+commandEncoder63.copyTextureToTexture(
+{
+  texture: texture104,
+  mipLevel: 0,
+  origin: { x: 932, y: 0, z: 10 },
+  aspect: 'all',
+},
+{
+  texture: texture104,
+  mipLevel: 2,
+  origin: { x: 187, y: 0, z: 26 },
+  aspect: 'all',
+},
+{width: 79, height: 1, depthOrArrayLayers: 5}
+);
+} catch {}
+try {
+await device10.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame32 = new VideoFrame(canvas22, {timestamp: 0});
+let buffer51 = device4.createBuffer(
+{
+size: 36725,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: false,
+}
+);
+let commandEncoder98 = device4.createCommandEncoder(
+{
+label: '\u8bf3\u{1ffae}\u{1ff03}',
+}
+);
+let computePassEncoder62 = commandEncoder88.beginComputePass(
+{
+label: '\u8bda\u0bf4\u948a\u{1f980}'
+}
+);
+try {
+computePassEncoder62.setPipeline(
+pipeline49
+);
+} catch {}
+try {
+commandEncoder87.copyBufferToBuffer(
+buffer18,
+22480,
+buffer20,
+4924,
+1808
+);
+dissociateBuffer(device4, buffer18);
+dissociateBuffer(device4, buffer20);
+} catch {}
+let promise51 = device4.createComputePipelineAsync(
+{
+label: '\u16e1\u0a9c\u{1fd4f}\u213e\u0992',
+layout: pipelineLayout29,
+compute: {
+module: shaderModule16,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext27.unconfigure();
+} catch {}
+let shaderModule23 = device1.createShaderModule(
+{
+label: '\u01e3\u04d7\u{1fead}\u0fb8\u60a3',
+code: `@group(3) @binding(8437)
+var<storage, read_write> function2: array<u32>;
+
+@compute @workgroup_size(4, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: vec2<f32>,
+@location(7) f1: vec3<u32>
+}
+
+@fragment
+fn fragment0(@location(39) a0: vec2<f32>, @location(7) a1: vec4<i32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S26 {
+@location(19) f0: vec2<f32>,
+@location(16) f1: vec2<f32>,
+@location(15) f2: vec3<u32>,
+@location(11) f3: vec3<u32>,
+@location(14) f4: vec3<f32>,
+@location(18) f5: vec2<f32>,
+@location(6) f6: vec4<f16>,
+@location(4) f7: vec4<f32>,
+@location(22) f8: vec4<f16>,
+@builtin(instance_index) f9: u32,
+@location(0) f10: u32,
+@location(21) f11: vec3<i32>,
+@location(9) f12: vec2<u32>,
+@location(3) f13: f32,
+@location(20) f14: vec3<u32>,
+@location(12) f15: vec4<f32>,
+@location(24) f16: vec2<f16>,
+@location(13) f17: vec2<i32>,
+@location(17) f18: f32
+}
+struct VertexOutput0 {
+@location(7) f421: vec4<i32>,
+@builtin(position) f422: vec4<f32>,
+@location(39) f423: vec2<f32>
+}
+
+@vertex
+fn vertex0(a0: S26, @location(10) a1: vec4<f32>, @location(23) a2: vec3<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroupLayout42 = pipeline62.getBindGroupLayout(0);
+let texture157 = device1.createTexture(
+{
+label: '\udebe\u{1fc24}\u079c\ua4f7',
+size: {width: 11772, height: 234, depthOrArrayLayers: 204},
+mipLevelCount: 11,
+format: 'astc-6x6-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-6x6-unorm',
+'astc-6x6-unorm',
+'astc-6x6-unorm'
+],
+}
+);
+let renderBundleEncoder114 = device1.createRenderBundleEncoder(
+{
+label: '\u1b52\u296f\u0b8e\u{1f934}\u9fbd\ucd68\u{1f76c}\u88a5',
+colorFormats: [
+'rgb10a2unorm',
+'rg8uint',
+'rg8sint',
+'r8sint',
+'rg8uint',
+'r16uint',
+'rgba16uint',
+undefined
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 321,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle129 = renderBundleEncoder39.finish(
+{
+label: '\uc20a\u4d08\u{1fe0a}\udb00\u07b5\u028c\ufa45\u0c21\u19ed\u4d3b'
+}
+);
+try {
+renderBundleEncoder65.setBindGroup(
+4,
+bindGroup53
+);
+} catch {}
+try {
+renderBundleEncoder114.setBindGroup(
+1,
+bindGroup53,
+new Uint32Array(2839),
+587,
+0
+);
+} catch {}
+try {
+renderBundleEncoder114.setVertexBuffer(
+7,
+buffer37,
+34224,
+7837
+);
+} catch {}
+try {
+computePassEncoder31.insertDebugMarker(
+'\uefe0'
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture61,
+  mipLevel: 0,
+  origin: { x: 41, y: 0, z: 50 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer8),
+/* required buffer size: 5162 */{
+offset: 974,
+bytesPerRow: 137,
+rowsPerImage: 10,
+},
+{width: 39, height: 1, depthOrArrayLayers: 4}
+);
+} catch {}
+let pipeline75 = await device1.createComputePipelineAsync(
+{
+label: '\uf9b0\u1b2e\u{1f7cc}\u082b\u5cf2\u{1fe71}\u{1fc6b}\ufff6',
+layout: pipelineLayout13,
+compute: {
+module: shaderModule20,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend('\u{1fdc0}\u0007\u{1fb90}\u0cbc\u02da\u8c65\u88b1\u{1fa11}\u0303\u8702\u{1fc7d}');
+let texture158 = device6.createTexture(
+{
+label: '\u{1fbfe}\u2039\uad91\u9f82\u{1ff9c}\u8413\uddd0\u{1f680}\ue05f\u7250\ud665',
+size: {width: 970, height: 1, depthOrArrayLayers: 73},
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rgba32float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba32float',
+'rgba32float'
+],
+}
+);
+let textureView126 = texture70.createView(
+{
+label: '\u864d\u9efa\u000d\u0aed',
+baseMipLevel: 2,
+mipLevelCount: 1,
+baseArrayLayer: 150,
+arrayLayerCount: 17,
+}
+);
+let computePassEncoder63 = commandEncoder69.beginComputePass(
+{
+label: '\u2dcf\u{1ff69}\u63b0\u{1fff8}\ubc13\u0714\u{1fd36}\ua5f8\u042d'
+}
+);
+try {
+gpuCanvasContext22.configure(
+{
+device: device6,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16sint',
+'bgra8unorm-srgb'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let offscreenCanvas35 = new OffscreenCanvas(230, 878);
+let canvas33 = document.createElement('canvas');
+let buffer52 = device10.createBuffer(
+{
+label: '\u0986\u3a85\ud8ad\u00b6\u{1fc16}\uff06\u8500\u0d97',
+size: 41324,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let textureView127 = texture124.createView(
+{
+label: '\u{1f6bb}\u2496\u{1fd19}\ud4ae',
+mipLevelCount: 8,
+}
+);
+let renderBundleEncoder115 = device10.createRenderBundleEncoder(
+{
+colorFormats: [
+'r8sint',
+'r8unorm',
+'rg16uint',
+'rgb10a2unorm',
+'rg32uint',
+'rg16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 551,
+depthReadOnly: true,
+}
+);
+let arrayBuffer11 = buffer52.getMappedRange(
+20984,
+18272
+);
+try {
+commandEncoder77.copyTextureToTexture(
+{
+  texture: texture104,
+  mipLevel: 3,
+  origin: { x: 17, y: 0, z: 4 },
+  aspect: 'all',
+},
+{
+  texture: texture104,
+  mipLevel: 1,
+  origin: { x: 665, y: 1, z: 7 },
+  aspect: 'all',
+},
+{width: 175, height: 0, depthOrArrayLayers: 8}
+);
+} catch {}
+try {
+renderBundleEncoder91.pushDebugGroup(
+'\u3289'
+);
+} catch {}
+try {
+device10.queue.writeBuffer(
+buffer47,
+24368,
+new Float32Array(6730),
+5210,
+1240
+);
+} catch {}
+video5.width = 163;
+let texture159 = device7.createTexture(
+{
+label: '\u0095\u71c6\u09ff\uceda\ue092\u5801\ub681',
+size: [6520, 44, 33],
+mipLevelCount: 7,
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let computePassEncoder64 = commandEncoder78.beginComputePass(
+{
+label: '\u71d0\u{1fd73}\ubd0f\u4538\u0c91\u05cf\u0212\u2fa7\u{1f73a}\u3d09\ufc34'
+}
+);
+let sampler92 = device7.createSampler(
+{
+label: '\u0c48\u0489\u{1f768}',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMaxClamp: 85.131,
+}
+);
+let externalTexture12 = device7.importExternalTexture(
+{
+label: '\u08d7\u74f7\ufd33\u226b\ucc6d\uf2f7',
+source: video4,
+colorSpace: 'display-p3',
+}
+);
+try {
+gpuCanvasContext31.configure(
+{
+device: device7,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device7.queue.writeTexture(
+{
+  texture: texture107,
+  mipLevel: 3,
+  origin: { x: 96, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Int16Array(arrayBuffer8),
+/* required buffer size: 118 */{
+offset: 118,
+bytesPerRow: 1826,
+},
+{width: 1164, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let commandEncoder99 = device3.createCommandEncoder(
+{
+label: '\u{1f8ea}\u8a5c\u1c9f\u{1fc54}\u{1fb6e}\uae15\u8f76\u80d2',
+}
+);
+let querySet102 = device3.createQuerySet(
+{
+label: '\u6b6b\u9276\u06ab\ub5c6\u0ab9\u0354\u{1fe9b}',
+type: 'occlusion',
+count: 2036,
+}
+);
+try {
+renderPassEncoder19.setBlendConstant(
+{
+r: -534.2,
+g: -14.25,
+b: -405.5,
+a: -589.9,
+}
+);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(
+9,
+buffer24,
+9556,
+8525
+);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(
+/*
+{width: 1431, height: 1, depthOrArrayLayers: 836}
+*/
+{
+  source: canvas22,
+  origin: { x: 18, y: 106 },
+  flipY: true,
+},
+{
+  texture: texture138,
+  mipLevel: 0,
+  origin: { x: 984, y: 0, z: 804 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 103, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let renderBundle130 = renderBundleEncoder112.finish(
+{
+label: '\u0310\u040e\u296b\u51d4\u0fae\uf5d7\u0dc3\u6d81\u{1f81b}\u{1ff74}\u3202'
+}
+);
+let sampler93 = device12.createSampler(
+{
+label: '\u93b7\u{1f84f}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 67.494,
+lodMaxClamp: 92.827,
+maxAnisotropy: 1,
+}
+);
+let promise52 = device12.queue.onSubmittedWorkDone();
+document.body.prepend('\ua7cf\u075c\u5e03\u{1ffe6}\u0380\u{1f6a7}\u9821\u0667\u4d27\u022d');
+try {
+computePassEncoder52.setBindGroup(
+3,
+bindGroup24,
+new Uint32Array(1790),
+1728,
+0
+);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(
+3,
+bindGroup24
+);
+} catch {}
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+try {
+commandEncoder87.copyBufferToBuffer(
+buffer51,
+14496,
+buffer25,
+30760,
+3144
+);
+dissociateBuffer(device4, buffer51);
+dissociateBuffer(device4, buffer25);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture103,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer3,
+/* required buffer size: 654 */{
+offset: 654,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let texture160 = device6.createTexture(
+{
+label: '\u70d2\u0099\u3051\u0f30\uff2e\u{1fce3}\u{1fa68}\u0647\u030d\u{1fafb}',
+size: {width: 9707},
+sampleCount: 1,
+dimension: '1d',
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16uint',
+'r16uint'
+],
+}
+);
+let renderBundle131 = renderBundleEncoder71.finish(
+{
+label: '\u{1ff01}\u4944\uf773\u6f0d\ub89e\uc951'
+}
+);
+try {
+renderBundleEncoder58.setVertexBuffer(
+2,
+buffer23
+);
+} catch {}
+let buffer53 = device13.createBuffer(
+{
+label: '\uda6e\ud9d7\u0ce6\u0d69\ue024\ua965\u0e2f\u0055\uf4de\u0bb8\u3cae',
+size: 30663,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+try {
+await promise52;
+} catch {}
+let offscreenCanvas36 = new OffscreenCanvas(676, 348);
+let pipelineLayout32 = device4.createPipelineLayout(
+{
+label: '\u0645\u1ac8\u9b73\u5cc4\u0596\udfd2\u{1f762}\ud4d9\uf061',
+bindGroupLayouts: [
+bindGroupLayout32,
+bindGroupLayout32,
+bindGroupLayout29
+],
+}
+);
+let texture161 = device4.createTexture(
+{
+label: '\u6ff1\uffe7\u{1f8ec}\ue48f\uf164\u1806\u{1f7ce}\u38b6\u{1fc88}',
+size: [8955],
+dimension: '1d',
+format: 'r8sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8sint',
+'r8sint'
+],
+}
+);
+try {
+renderPassEncoder12.setBindGroup(
+4,
+bindGroup51,
+new Uint32Array(2570),
+1972,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(
+buffer20,
+'uint32',
+776,
+5241
+);
+} catch {}
+try {
+renderBundleEncoder103.setVertexBuffer(
+4,
+buffer20,
+92
+);
+} catch {}
+let pipeline76 = device4.createRenderPipeline(
+{
+layout: pipelineLayout32,
+vertex: {
+module: shaderModule16,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1836,
+attributes: [
+{
+format: 'unorm16x2',
+offset: 980,
+shaderLocation: 2,
+},
+{
+format: 'float16x4',
+offset: 1352,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 2468,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x2',
+offset: 78,
+shaderLocation: 11,
+},
+{
+format: 'sint32x4',
+offset: 904,
+shaderLocation: 14,
+},
+{
+format: 'snorm8x4',
+offset: 1304,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 540,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 2288,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 2608,
+attributes: [
+{
+format: 'sint16x2',
+offset: 2160,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'back',
+},
+multisample: {
+count: 4,
+mask: 0xe05fea38,
+},
+fragment: {
+module: shaderModule16,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+canvas5.height = 975;
+let gpuCanvasContext33 = canvas32.getContext('webgpu');
+offscreenCanvas16.height = 909;
+document.body.append('\u0203\u4153\u0f18\u8aa8\u35a2\u{1fe2b}\uca4d\u0d4f');
+let textureView128 = texture89.createView(
+{
+label: '\u9331\u16c7\ub52c\u21ef\u05ae\u6b83\u{1fbe1}\u01a4',
+dimension: '1d',
+baseMipLevel: 0,
+}
+);
+let computePassEncoder65 = commandEncoder60.beginComputePass();
+try {
+renderPassEncoder19.setViewport(
+288.9,
+7.222,
+52.21,
+0.5912,
+0.4479,
+0.5466
+);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(
+11,
+buffer24,
+10216,
+11996
+);
+} catch {}
+try {
+await device3.popErrorScope();
+} catch {}
+try {
+commandEncoder99.copyTextureToTexture(
+{
+  texture: texture87,
+  mipLevel: 1,
+  origin: { x: 1246, y: 46, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture87,
+  mipLevel: 6,
+  origin: { x: 101, y: 2, z: 0 },
+  aspect: 'all',
+},
+{width: 15, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture87,
+  mipLevel: 3,
+  origin: { x: 540, y: 10, z: 0 },
+  aspect: 'all',
+},
+new Uint8Array(new ArrayBuffer(72)),
+/* required buffer size: 8739 */{
+offset: 95,
+bytesPerRow: 1088,
+},
+{width: 514, height: 8, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline77 = device3.createComputePipeline(
+{
+label: '\u{1fff7}\u0586\u{1fdf3}\ud33a\u016b\u0070\uf148\u876e',
+layout: pipelineLayout25,
+compute: {
+module: shaderModule18,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.append('\u6ea2\u{1f954}\u7032\u{1fbd2}\u{1f68b}\u0588\u0565\u{1f617}\u07fc\u00ae');
+let computePassEncoder66 = commandEncoder96.beginComputePass(
+{
+label: '\u{1fbed}\u{1f9b1}\u{1f8d2}\u9d45\u0df8'
+}
+);
+try {
+commandEncoder89.copyTextureToTexture(
+{
+  texture: texture143,
+  mipLevel: 5,
+  origin: { x: 0, y: 1, z: 9 },
+  aspect: 'all',
+},
+{
+  texture: texture143,
+  mipLevel: 2,
+  origin: { x: 12, y: 56, z: 2 },
+  aspect: 'all',
+},
+{width: 2, height: 5, depthOrArrayLayers: 69}
+);
+} catch {}
+try {
+commandEncoder89.clearBuffer(
+buffer50,
+29988,
+10068
+);
+dissociateBuffer(device11, buffer50);
+} catch {}
+try {
+device11.queue.writeTexture(
+{
+  texture: texture152,
+  mipLevel: 2,
+  origin: { x: 3, y: 0, z: 3 },
+  aspect: 'all',
+},
+new ArrayBuffer(24),
+/* required buffer size: 539772 */{
+offset: 432,
+bytesPerRow: 202,
+rowsPerImage: 178,
+},
+{width: 0, height: 1, depthOrArrayLayers: 16}
+);
+} catch {}
+document.body.prepend('\u0ff9\u08e5\u09f6\u01c1\u6243\u57cf\u{1fcb8}');
+try {
+renderBundleEncoder102.label = '\u8357\u8862\u1896\uf606\u0ce0\u{1fafc}';
+} catch {}
+let querySet103 = device5.createQuerySet(
+{
+label: '\ub782\u3f08\u0528\u0582\u013c\u7408\uf6a4',
+type: 'occlusion',
+count: 2364,
+}
+);
+try {
+renderPassEncoder17.setBlendConstant(
+{
+r: 240.6,
+g: 248.2,
+b: -644.2,
+a: -235.6,
+}
+);
+} catch {}
+try {
+renderBundleEncoder102.setVertexBuffer(
+3,
+buffer42,
+18600,
+14346
+);
+} catch {}
+video23.width = 115;
+document.body.prepend('\u309c\u232a\u715b\u06cc\u8edf\u018b\u3e7c\u4008');
+let renderBundle132 = renderBundleEncoder94.finish(
+{
+label: '\u002b\u122e\u8241\u4898\u7d80\uf40a\u0379'
+}
+);
+try {
+computePassEncoder43.setPipeline(
+pipeline63
+);
+} catch {}
+try {
+device7.queue.writeTexture(
+{
+  texture: texture68,
+  mipLevel: 0,
+  origin: { x: 2652, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 894 */{
+offset: 894,
+},
+{width: 3974, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let promise53 = device7.createComputePipelineAsync(
+{
+label: '\u04f7\u91d0\u2fd6\u0f65\u{1fb90}\u09dc\ucf3c\u6def\u58f8\ued1d',
+layout: 'auto',
+compute: {
+module: shaderModule17,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let videoFrame33 = new VideoFrame(video16, {timestamp: 0});
+let renderBundle133 = renderBundleEncoder107.finish();
+let sampler94 = device11.createSampler(
+{
+label: '\u0aae\u34d3\u774a\u8374\uf1d5\u5909\uf3fd\u83f3\u{1f89f}\u0c66\u{1f98d}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 93.965,
+lodMaxClamp: 98.414,
+maxAnisotropy: 2,
+}
+);
+try {
+device11.queue.writeBuffer(
+buffer50,
+15776,
+new BigUint64Array(10867),
+5246,
+1600
+);
+} catch {}
+let texture162 = device11.createTexture(
+{
+label: '\ube74\ub777\u25db\ub50f\u79ca\ua4cd\u{1fd1f}\u13cc\u03cd',
+size: [11328, 10, 1],
+mipLevelCount: 9,
+format: 'astc-12x10-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-12x10-unorm'
+],
+}
+);
+let sampler95 = device11.createSampler(
+{
+label: '\u7b39\u9e73',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'linear',
+lodMinClamp: 60.612,
+lodMaxClamp: 64.577,
+}
+);
+try {
+renderBundleEncoder104.setVertexBuffer(
+24,
+undefined
+);
+} catch {}
+document.body.prepend('\u0ec5\u0666\u07d2\u8949');
+let img34 = await imageWithData(50, 173, '#17a0b868', '#db6e79f5');
+let commandEncoder100 = device13.createCommandEncoder();
+pseudoSubmit(device13, commandEncoder100);
+let texture163 = device13.createTexture(
+{
+size: [1066, 243, 1],
+mipLevelCount: 8,
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16sint',
+'rgba16sint'
+],
+}
+);
+let sampler96 = device13.createSampler(
+{
+label: '\u{1fedb}\u{1f714}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 17.831,
+lodMaxClamp: 59.188,
+}
+);
+try {
+await device13.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext34 = canvas33.getContext('webgpu');
+document.body.append('\u38a2\u0a96\u41d0\ud013');
+let bindGroupLayout43 = device5.createBindGroupLayout(
+{
+label: '\u632b\uf794\ua4cc\ua101\u097c\u2942\u81f7\u0304\u410b\ub620',
+entries: [
+
+],
+}
+);
+let bindGroup59 = device5.createBindGroup({
+label: '\u81b4\u{1f736}\u513e\u{1fe79}',
+layout: bindGroupLayout43,
+entries: [
+
+],
+});
+let texture164 = device5.createTexture(
+{
+label: '\ub5b5\u0ea6\u10e3\uf2b2\u0109\u8991\ucc4f\u098c',
+size: [97, 96, 56],
+format: 'rgba32sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundleEncoder116 = device5.createRenderBundleEncoder(
+{
+label: '\u0c94\u0783\ub339\u58ad',
+colorFormats: [
+'rg11b10ufloat'
+],
+sampleCount: 315,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder15.setBindGroup(
+2,
+bindGroup59,
+new Uint32Array(6163),
+5583,
+0
+);
+} catch {}
+try {
+renderPassEncoder17.beginOcclusionQuery(
+8
+);
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant(
+{
+r: -697.3,
+g: 394.6,
+b: 686.4,
+a: -127.6,
+}
+);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+94,
+undefined,
+213912340,
+3125456379
+);
+} catch {}
+document.body.prepend(img18);
+let sampler97 = device6.createSampler(
+{
+label: '\uaf50\u09bc\u{1f7e4}\u0806\u645a\u0a5c\u0eea\u994c\uf45e\u19d3',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 61.354,
+lodMaxClamp: 67.953,
+}
+);
+let renderPassEncoder22 = commandEncoder87.beginRenderPass(
+{
+label: '\u4b4b\u5817\u0fdb\u{1f6f7}\ua191\u2504\uaf22\u5561\ufbf7',
+colorAttachments: [
+undefined
+],
+depthStencilAttachment: {
+view: textureView52,
+depthClearValue: 0.5133463950901581,
+depthLoadOp: 'clear',
+depthStoreOp: 'discard',
+depthReadOnly: false,
+stencilClearValue: 7736,
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet82,
+maxDrawCount: 15320,
+}
+);
+try {
+renderPassEncoder13.setStencilReference(
+984
+);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+11,
+buffer18,
+13244,
+11510
+);
+} catch {}
+try {
+renderBundleEncoder100.setBindGroup(
+4,
+bindGroup57,
+new Uint32Array(8495),
+4187,
+0
+);
+} catch {}
+try {
+renderBundleEncoder103.setVertexBuffer(
+11,
+buffer31,
+16124,
+15567
+);
+} catch {}
+try {
+commandEncoder98.copyBufferToBuffer(
+buffer51,
+30560,
+buffer20,
+4836,
+2528
+);
+dissociateBuffer(device4, buffer51);
+dissociateBuffer(device4, buffer20);
+} catch {}
+try {
+commandEncoder98.clearBuffer(
+buffer25,
+29360
+);
+dissociateBuffer(device4, buffer25);
+} catch {}
+try {
+buffer53.unmap();
+} catch {}
+let canvas34 = document.createElement('canvas');
+let pipelineLayout33 = device3.createPipelineLayout(
+{
+label: '\u{1fbfd}\u947c\u05ac\u53d3\u09a0\u0fe6\u{1fc9c}\ued8a\u{1fd60}',
+bindGroupLayouts: [
+bindGroupLayout17
+],
+}
+);
+let renderPassEncoder23 = commandEncoder99.beginRenderPass(
+{
+label: '\u{1fdea}\ub3a1\u0c66\u0366\uccf5\u{1fd19}\uf905\ua6d5',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+{
+view: textureView74,
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet70,
+maxDrawCount: 82024,
+}
+);
+let renderBundleEncoder117 = device3.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8unorm-srgb'
+],
+sampleCount: 682,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder19.setStencilReference(
+1294
+);
+} catch {}
+try {
+renderPassEncoder23.setViewport(
+468.2,
+7.777,
+127.4,
+1.364,
+0.6055,
+0.7038
+);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(
+6,
+buffer24,
+16324,
+6368
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture92,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Uint8Array(arrayBuffer2),
+/* required buffer size: 767 */{
+offset: 767,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let buffer54 = device12.createBuffer(
+{
+label: '\u{1f90d}\uf14c\ua465',
+size: 39837,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let commandEncoder101 = device12.createCommandEncoder();
+let texture165 = device12.createTexture(
+{
+label: '\u0185\u02bf\u0120\ud1df\u{1faed}\u93cf\u65ac\u9b5f',
+size: [2828, 155, 1],
+mipLevelCount: 12,
+format: 'rg16uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder118 = device12.createRenderBundleEncoder(
+{
+label: '\ub3cd\u6bdf\u06c4',
+colorFormats: [
+'rgba16float',
+'r16float',
+undefined,
+'rgb10a2unorm',
+'rg32sint',
+'r8sint',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 283,
+}
+);
+try {
+renderBundleEncoder118.setBindGroup(
+2,
+bindGroup58,
+[]
+);
+} catch {}
+let gpuCanvasContext35 = offscreenCanvas36.getContext('webgpu');
+let videoFrame34 = new VideoFrame(offscreenCanvas28, {timestamp: 0});
+let texture166 = device13.createTexture(
+{
+label: '\uf3c9\u4002\u{1fb7f}\u{1f957}\ud02c\u5ab1',
+size: [216, 140, 1],
+mipLevelCount: 4,
+format: 'astc-4x4-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView129 = texture163.createView(
+{
+label: '\u1a90\u818b\ua890',
+baseMipLevel: 3,
+mipLevelCount: 5,
+}
+);
+let sampler98 = device13.createSampler(
+{
+label: '\ud7c8\u47a5\u{1fa84}\u{1fdb9}',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 81.258,
+lodMaxClamp: 87.169,
+}
+);
+canvas11.width = 995;
+let shaderModule24 = device8.createShaderModule(
+{
+code: `
+
+@compute @workgroup_size(7, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(1) f0: vec3<f32>,
+@location(3) f1: vec3<u32>,
+@location(6) f2: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_mask) a1: u32, @builtin(sample_index) a2: u32, @builtin(position) a3: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S27 {
+@location(7) f0: vec4<i32>,
+@location(5) f1: vec2<f32>,
+@location(8) f2: vec3<f32>,
+@location(15) f3: i32
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec3<i32>, @location(11) a1: i32, @location(9) a2: vec2<i32>, @location(12) a3: vec2<f16>, a4: S27, @location(17) a5: vec3<i32>, @location(13) a6: vec2<f32>, @location(0) a7: vec3<i32>, @location(18) a8: vec3<f32>, @builtin(instance_index) a9: u32, @location(1) a10: vec4<i32>, @location(4) a11: vec2<f16>, @location(3) a12: vec4<u32>, @location(16) a13: vec2<f32>, @location(14) a14: vec3<i32>, @location(10) a15: i32, @location(19) a16: vec2<f16>, @builtin(vertex_index) a17: u32, @location(2) a18: i32, @location(20) a19: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroupLayout44 = device8.createBindGroupLayout(
+{
+label: '\u2acf\u0f0f\u{1f68d}\ua0c3\ud79d\u8692\u72da\u{1ffb8}\u0126\u02ea',
+entries: [
+{
+binding: 1434,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+},
+{
+binding: 137,
+visibility: 0,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+}
+],
+}
+);
+let querySet104 = device8.createQuerySet(
+{
+type: 'occlusion',
+count: 1215,
+}
+);
+let sampler99 = device8.createSampler(
+{
+label: '\u{1f746}\u00ca\u1605\u0712\u0666\u0b29\uadc9\u5ec7\u{1f98d}\u0431',
+addressModeU: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 30.981,
+lodMaxClamp: 70.963,
+compare: 'not-equal',
+maxAnisotropy: 14,
+}
+);
+try {
+computePassEncoder59.setBindGroup(
+5,
+bindGroup55
+);
+} catch {}
+try {
+computePassEncoder59.end();
+} catch {}
+try {
+renderBundleEncoder92.setBindGroup(
+1,
+bindGroup55
+);
+} catch {}
+let pipeline78 = device8.createComputePipeline(
+{
+label: '\u0824\u0008\u78bf\u7344\u{1ff88}\u012a\ud6f3',
+layout: pipelineLayout22,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+},
+}
+);
+let img35 = await imageWithData(151, 230, '#a8279306', '#fd5ee6c4');
+let bindGroupLayout45 = device5.createBindGroupLayout(
+{
+label: '\u721a\u2322\u{1fb4b}\uf977\ub474\ue05b\u{1fa91}\uf120\u10a3',
+entries: [
+{
+binding: 932,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+},
+{
+binding: 717,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'filtering' },
+},
+{
+binding: 846,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '1d' },
+}
+],
+}
+);
+let renderBundleEncoder119 = device5.createRenderBundleEncoder(
+{
+label: '\u{1fa82}\ubdd5\u{1fec1}\u{1fd89}',
+colorFormats: [
+'rgba16sint',
+undefined,
+'bgra8unorm',
+'rg32float',
+'rgba8unorm-srgb'
+],
+sampleCount: 791,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle134 = renderBundleEncoder102.finish(
+{
+label: '\u73f7\u74f3\u{1fa0b}\u086d\u0dc1\u04cd\u0406\ue6a9\u0b86\u040e\u3662'
+}
+);
+try {
+renderPassEncoder15.setBindGroup(
+1,
+bindGroup47
+);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder20.setScissorRect(
+36,
+1,
+21,
+1
+);
+} catch {}
+try {
+renderBundleEncoder116.setVertexBuffer(
+71,
+undefined,
+3839725162
+);
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(
+/*
+{width: 77, height: 2, depthOrArrayLayers: 121}
+*/
+{
+  source: offscreenCanvas13,
+  origin: { x: 234, y: 17 },
+  flipY: false,
+},
+{
+  texture: texture74,
+  mipLevel: 0,
+  origin: { x: 57, y: 0, z: 83 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 10, height: 2, depthOrArrayLayers: 1}
+);
+} catch {}
+let offscreenCanvas37 = new OffscreenCanvas(144, 684);
+let img36 = await imageWithData(154, 124, '#ff656143', '#dde39da8');
+let renderBundleEncoder120 = device10.createRenderBundleEncoder(
+{
+label: '\u{1ff9f}\u077b\u03b5\u0c27\u011d\u07cb\ucfb0\u9e7e\u0347\u{1f842}',
+colorFormats: [
+'bgra8unorm-srgb',
+'rg16sint',
+'r32uint',
+'r8sint'
+],
+sampleCount: 642,
+depthReadOnly: true,
+}
+);
+let renderBundle135 = renderBundleEncoder108.finish(
+{
+label: '\u9ef6\u6134'
+}
+);
+try {
+buffer47.unmap();
+} catch {}
+try {
+commandEncoder77.copyBufferToBuffer(
+buffer52,
+24196,
+buffer33,
+27592,
+12720
+);
+dissociateBuffer(device10, buffer52);
+dissociateBuffer(device10, buffer33);
+} catch {}
+try {
+commandEncoder63.copyTextureToTexture(
+{
+  texture: texture104,
+  mipLevel: 0,
+  origin: { x: 633, y: 0, z: 84 },
+  aspect: 'all',
+},
+{
+  texture: texture104,
+  mipLevel: 1,
+  origin: { x: 638, y: 0, z: 10 },
+  aspect: 'all',
+},
+{width: 148, height: 1, depthOrArrayLayers: 6}
+);
+} catch {}
+try {
+commandEncoder63.clearBuffer(
+buffer47,
+8696,
+9416
+);
+dissociateBuffer(device10, buffer47);
+} catch {}
+try {
+device10.queue.writeBuffer(
+buffer47,
+15700,
+new Float32Array(30688),
+6768,
+3704
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let texture167 = device12.createTexture(
+{
+size: [2232],
+dimension: '1d',
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'r8unorm',
+'r8unorm',
+'r8unorm'
+],
+}
+);
+let textureView130 = texture148.createView(
+{
+label: '\u0eed\u020e\u{1f638}\u{1fdd4}\u0971\uc1a6',
+dimension: '2d-array',
+baseMipLevel: 1,
+mipLevelCount: 3,
+}
+);
+let renderBundle136 = renderBundleEncoder118.finish(
+{
+
+}
+);
+try {
+device12.addEventListener('uncapturederror', e => { log('device12.uncapturederror'); log(e); e.label = device12.label; });
+} catch {}
+try {
+device12.queue.writeTexture(
+{
+  texture: texture167,
+  mipLevel: 0,
+  origin: { x: 14, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(24),
+/* required buffer size: 835 */{
+offset: 835,
+},
+{width: 2210, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let texture168 = device7.createTexture(
+{
+label: '\u6a1e\u3d29\ud857',
+size: {width: 13171, height: 86, depthOrArrayLayers: 100},
+mipLevelCount: 8,
+sampleCount: 1,
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView131 = texture68.createView(
+{
+label: '\u{1f8ff}\u0b30\u{1fad4}\u{1fc48}\u{1fbe3}\u{1f9c0}\u0178',
+}
+);
+try {
+commandEncoder97.copyBufferToBuffer(
+buffer39,
+52,
+buffer38,
+5868,
+48
+);
+dissociateBuffer(device7, buffer39);
+dissociateBuffer(device7, buffer38);
+} catch {}
+try {
+device7.queue.writeTexture(
+{
+  texture: texture159,
+  mipLevel: 5,
+  origin: { x: 4, y: 4, z: 11 },
+  aspect: 'all',
+},
+new ArrayBuffer(72),
+/* required buffer size: 1335609 */{
+offset: 9,
+bytesPerRow: 636,
+rowsPerImage: 175,
+},
+{width: 108, height: 0, depthOrArrayLayers: 13}
+);
+} catch {}
+let gpuCanvasContext36 = canvas34.getContext('webgpu');
+let buffer55 = device13.createBuffer(
+{
+label: '\u{1fa44}\u0460\uc2d4\u8c83\u{1f8d0}\u{1fef7}\u{1ff9e}\u{1f7c7}\u{1f98e}',
+size: 9194,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let commandEncoder102 = device13.createCommandEncoder(
+{
+label: '\u{1ffe8}\u42f8\u4a5b\u7b6a\u{1fa29}\u{1fa3e}\u{1fbe8}\u0726\u83ab\u41d0',
+}
+);
+let computePassEncoder67 = commandEncoder102.beginComputePass(
+{
+label: '\u5edf\u14ae\ubb35\u8a42\u{1fdc0}\u709f'
+}
+);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let offscreenCanvas38 = new OffscreenCanvas(614, 782);
+let commandEncoder103 = device10.createCommandEncoder(
+{
+label: '\u22da\ud4c8\u0faa\u0dea\u065b',
+}
+);
+let texture169 = device10.createTexture(
+{
+label: '\u{1f88b}\u{1ff50}\u08b3\udae6\u07ec\u8dfc',
+size: {width: 8144, height: 4, depthOrArrayLayers: 1},
+mipLevelCount: 11,
+format: 'astc-4x4-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let textureView132 = texture108.createView(
+{
+label: '\u{1f83b}\u{1fbf5}\u0848\u0858\u{1f8a9}\u5e72',
+dimension: '2d',
+baseArrayLayer: 17,
+}
+);
+let renderBundleEncoder121 = device10.createRenderBundleEncoder(
+{
+colorFormats: [
+undefined,
+'rgba8uint',
+'rg8uint',
+'rgba8unorm-srgb',
+'rgba8unorm-srgb',
+'rg11b10ufloat'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 331,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+commandEncoder77.copyBufferToBuffer(
+buffer52,
+29408,
+buffer33,
+33840,
+4236
+);
+dissociateBuffer(device10, buffer52);
+dissociateBuffer(device10, buffer33);
+} catch {}
+try {
+renderBundleEncoder91.popDebugGroup();
+} catch {}
+let texture170 = device3.createTexture(
+{
+label: '\uf789\uba1c\u74a0\u8b33\u6f54\ud8a2\ub006\u07af',
+size: [143, 1, 145],
+dimension: '3d',
+format: 'r16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16float',
+'r16float',
+'r16float'
+],
+}
+);
+try {
+renderBundleEncoder90.setVertexBuffer(
+4,
+buffer24,
+2800,
+2800
+);
+} catch {}
+let img37 = await imageWithData(49, 244, '#328a0bbf', '#91cba263');
+let querySet105 = device11.createQuerySet(
+{
+type: 'occlusion',
+count: 538,
+}
+);
+let textureView133 = texture162.createView(
+{
+label: '\u0b06\u0254\u1001\u4151\u5435\ue3a4\u0b34\uf39d\u016d',
+format: 'astc-12x10-unorm',
+baseMipLevel: 8,
+}
+);
+let renderBundle137 = renderBundleEncoder107.finish(
+{
+label: '\u03ef\u6426\u{1fe88}\u0692'
+}
+);
+try {
+renderBundleEncoder104.setVertexBuffer(
+63,
+undefined
+);
+} catch {}
+try {
+commandEncoder93.copyTextureToTexture(
+{
+  texture: texture143,
+  mipLevel: 5,
+  origin: { x: 0, y: 1, z: 18 },
+  aspect: 'all',
+},
+{
+  texture: texture143,
+  mipLevel: 3,
+  origin: { x: 13, y: 25, z: 17 },
+  aspect: 'all',
+},
+{width: 2, height: 4, depthOrArrayLayers: 59}
+);
+} catch {}
+try {
+device11.queue.writeBuffer(
+buffer50,
+11480,
+new Float32Array(12432),
+2100,
+8144
+);
+} catch {}
+let renderBundle138 = renderBundleEncoder52.finish(
+{
+label: '\u7d1c\u09fe\u4ab4\u046f\u{1fa6f}\u092b\u00fc'
+}
+);
+try {
+renderBundleEncoder81.setIndexBuffer(
+buffer44,
+'uint16',
+598
+);
+} catch {}
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+let textureView134 = texture109.createView(
+{
+label: '\u5e6c\u0872\u0cfc\u504a\u0328\u{1fb17}\u0dc1\u1802\u0c78\uc0e0',
+dimension: '2d',
+baseMipLevel: 1,
+mipLevelCount: 1,
+baseArrayLayer: 145,
+}
+);
+let sampler100 = device7.createSampler(
+{
+label: '\u336f\u97af\u562c\u{1f86d}\u0873\u{1fca6}\u1073\u052c\u05e1\u0453',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 91.215,
+maxAnisotropy: 20,
+}
+);
+try {
+device7.queue.submit([
+commandBuffer8,
+]);
+} catch {}
+document.body.append('\u{1feac}\u603c\u9b39\uc4aa\u{1ff7b}\u98fe');
+try {
+offscreenCanvas38.getContext('webgpu');
+} catch {}
+let bindGroupLayout46 = device7.createBindGroupLayout(
+{
+label: '\u07ac\u9350\u0347',
+entries: [
+{
+binding: 1151,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '3d' },
+}
+],
+}
+);
+let commandEncoder104 = device7.createCommandEncoder(
+{
+}
+);
+try {
+commandEncoder104.clearBuffer(
+buffer38,
+20992,
+3532
+);
+dissociateBuffer(device7, buffer38);
+} catch {}
+try {
+device7.queue.writeTexture(
+{
+  texture: texture119,
+  mipLevel: 0,
+  origin: { x: 3768, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Uint32Array(arrayBuffer8),
+/* required buffer size: 302 */{
+offset: 302,
+},
+{width: 6804, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+gc();
+let commandEncoder105 = device7.createCommandEncoder(
+{
+label: '\u2993\u00bd\uf38c\u00d8\u{1ff69}\u{1f8ef}\u7df2\ue1c4\u{1f8da}\u{1f7da}',
+}
+);
+let querySet106 = device7.createQuerySet(
+{
+label: '\u{1fc3e}\ubacf\u0056\uf1bb\u0e63\u{1fd3b}',
+type: 'occlusion',
+count: 2460,
+}
+);
+let textureView135 = texture107.createView(
+{
+label: '\uac9b\u03ec\u7876\u0155\u2922\u0cf4\u0dc1\u0a7a',
+aspect: 'all',
+format: 'astc-12x10-unorm',
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+try {
+querySet60.destroy();
+} catch {}
+try {
+commandEncoder104.copyTextureToTexture(
+{
+  texture: texture107,
+  mipLevel: 0,
+  origin: { x: 6048, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture107,
+  mipLevel: 0,
+  origin: { x: 3288, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 1488, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device7.queue.submit([
+]);
+} catch {}
+let pipeline79 = await device7.createComputePipelineAsync(
+{
+label: '\u8f73\u0621\u6e88\u21a6',
+layout: 'auto',
+compute: {
+module: shaderModule19,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+gc();
+let adapter16 = await navigator.gpu.requestAdapter();
+try {
+gpuCanvasContext15.configure(
+{
+device: device6,
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rg16uint'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device6.queue.writeTexture(
+{
+  texture: texture70,
+  mipLevel: 1,
+  origin: { x: 576, y: 0, z: 200 },
+  aspect: 'all',
+},
+new ArrayBuffer(8),
+/* required buffer size: 9847905 */{
+offset: 225,
+bytesPerRow: 1784,
+rowsPerImage: 276,
+},
+{width: 1236, height: 0, depthOrArrayLayers: 21}
+);
+} catch {}
+canvas10.height = 682;
+gc();
+let textureView136 = texture162.createView(
+{
+label: '\ua415\u86f8\u03b1\ue005\u{1fc23}\u0079\u0530',
+dimension: '2d-array',
+baseMipLevel: 1,
+}
+);
+let renderBundle139 = renderBundleEncoder107.finish(
+{
+
+}
+);
+try {
+device11.queue.writeTexture(
+{
+  texture: texture162,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer11,
+/* required buffer size: 787 */{
+offset: 787,
+bytesPerRow: 356,
+},
+{width: 72, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let imageBitmap44 = await createImageBitmap(imageData1);
+let video41 = await videoWithData();
+try {
+computePassEncoder60.setBindGroup(
+1,
+bindGroup32,
+new Uint32Array(825),
+202,
+0
+);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img27,
+  origin: { x: 50, y: 12 },
+  flipY: true,
+},
+{
+  texture: texture113,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.prepend('\uc105\u{1f8f0}\u73a7\u9121');
+let imageData36 = new ImageData(132, 156);
+let texture171 = device13.createTexture(
+{
+label: '\u0668\u{1fcb3}\u2ac5\u{1fd4c}\uf45f\u375d',
+size: {width: 8000, height: 10, depthOrArrayLayers: 1},
+mipLevelCount: 13,
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+let renderBundleEncoder122 = device13.createRenderBundleEncoder(
+{
+label: '\u17f8\ub448\u08c7\ue5d4\u7005\ucb22\u70bb\u0847',
+colorFormats: [
+'bgra8unorm-srgb',
+'rgba32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 660,
+depthReadOnly: false,
+}
+);
+let renderBundle140 = renderBundleEncoder122.finish();
+let sampler101 = device13.createSampler(
+{
+label: '\u0626\u0c7f\u82fc',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 15.248,
+lodMaxClamp: 69.757,
+}
+);
+try {
+device13.queue.writeBuffer(
+buffer55,
+6964,
+new BigUint64Array(28433),
+26835,
+272
+);
+} catch {}
+document.body.append('\u{1fdfe}\u03d1');
+let img38 = await imageWithData(145, 82, '#86fbfed1', '#959aedb9');
+try {
+offscreenCanvas35.getContext('bitmaprenderer');
+} catch {}
+let texture172 = device8.createTexture(
+{
+label: '\u0698\u{1f777}',
+size: [7645],
+sampleCount: 1,
+dimension: '1d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let sampler102 = device8.createSampler(
+{
+label: '\ub857\u{1fe4d}\u{1f93f}\u05e3\u0f3f\uf0d4\u8bbd\u03c1\ue9c5\u{1febe}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 42.293,
+lodMaxClamp: 43.686,
+maxAnisotropy: 6,
+}
+);
+try {
+commandEncoder95.clearBuffer(
+buffer48,
+12488,
+8932
+);
+dissociateBuffer(device8, buffer48);
+} catch {}
+let querySet107 = device4.createQuerySet(
+{
+label: '\uca93\u513e\u6708',
+type: 'occlusion',
+count: 4016,
+}
+);
+let textureView137 = texture127.createView(
+{
+label: '\u2378\u{1f7d7}\u0dba\u1a57',
+arrayLayerCount: 1,
+}
+);
+try {
+computePassEncoder52.setPipeline(
+pipeline64
+);
+} catch {}
+try {
+renderBundleEncoder84.setVertexBuffer(
+4,
+buffer18,
+18244,
+7900
+);
+} catch {}
+try {
+commandEncoder98.copyTextureToBuffer(
+{
+  texture: texture139,
+  mipLevel: 5,
+  origin: { x: 8, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 1184 widthInBlocks: 148 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 4344 */
+offset: 4344,
+buffer: buffer20,
+},
+{width: 148, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device4, buffer20);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture142,
+  mipLevel: 0,
+  origin: { x: 50, y: 29, z: 0 },
+  aspect: 'all',
+},
+new BigInt64Array(new ArrayBuffer(72)),
+/* required buffer size: 5788 */{
+offset: 244,
+bytesPerRow: 431,
+},
+{width: 93, height: 13, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline80 = device4.createRenderPipeline(
+{
+label: '\u4449\u{1ff1d}\uc1e1\udbea\u09ed\u0509\u9135\ud79e\u263a\u0d69\u0dbc',
+layout: pipelineLayout26,
+vertex: {
+module: shaderModule16,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 758,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 1744,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32',
+offset: 240,
+shaderLocation: 14,
+},
+{
+format: 'sint32x4',
+offset: 1304,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 2320,
+attributes: [
+{
+format: 'uint32x4',
+offset: 1360,
+shaderLocation: 11,
+},
+{
+format: 'snorm8x4',
+offset: 1976,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x4',
+offset: 1876,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule16,
+entryPoint: 'fragment0',
+targets: [
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'zero',
+dstFactor: 'one-minus-src'
+},
+},
+format: 'r16float',
+writeMask: 0,
+},
+{
+format: 'r16float',
+writeMask: GPUColorWrite.RED,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'one-minus-src',
+dstFactor: 'constant'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+let shaderModule25 = device4.createShaderModule(
+{
+label: '\u0e4e\u9ea7',
+code: `
+
+@compute @workgroup_size(6, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S29 {
+@location(26) f0: vec2<i32>,
+@location(7) f1: vec4<f16>,
+@location(12) f2: vec2<f16>,
+@builtin(sample_index) f3: u32,
+@location(13) f4: vec4<f16>,
+@location(22) f5: i32,
+@location(16) f6: u32,
+@location(8) f7: f32
+}
+
+@fragment
+fn fragment0(@location(15) a0: vec3<i32>, @location(27) a1: vec4<f16>, @location(21) a2: vec4<f32>, @location(25) a3: vec3<i32>, a4: S29, @location(23) a5: f16, @location(17) a6: vec4<i32>, @builtin(sample_mask) a7: u32, @location(28) a8: vec4<u32>, @location(6) a9: vec3<u32>, @location(0) a10: vec4<i32>, @location(1) a11: vec4<i32>, @location(19) a12: vec3<i32>, @location(30) a13: vec2<f32>, @location(10) a14: vec3<f16>, @location(5) a15: vec4<f32>, @builtin(front_facing) a16: bool, @builtin(position) a17: vec4<f32>) {
+
+}
+
+struct S28 {
+@builtin(vertex_index) f0: u32,
+@location(12) f1: vec3<u32>,
+@location(13) f2: f16,
+@location(19) f3: vec3<f32>,
+@location(20) f4: vec4<f16>,
+@location(1) f5: vec4<u32>,
+@location(6) f6: vec2<u32>,
+@location(10) f7: vec2<f32>,
+@location(7) f8: vec3<i32>,
+@location(17) f9: f32,
+@location(2) f10: vec4<i32>,
+@location(5) f11: vec2<u32>,
+@location(3) f12: f32
+}
+struct VertexOutput0 {
+@location(12) f424: vec2<f16>,
+@location(30) f425: vec2<f32>,
+@location(8) f426: f32,
+@location(6) f427: vec3<u32>,
+@location(28) f428: vec4<u32>,
+@location(10) f429: vec3<f16>,
+@location(0) f430: vec4<i32>,
+@location(22) f431: i32,
+@location(1) f432: vec4<i32>,
+@location(27) f433: vec4<f16>,
+@location(7) f434: vec4<f16>,
+@builtin(position) f435: vec4<f32>,
+@location(15) f436: vec3<i32>,
+@location(23) f437: f16,
+@location(16) f438: u32,
+@location(17) f439: vec4<i32>,
+@location(5) f440: vec4<f32>,
+@location(21) f441: vec4<f32>,
+@location(25) f442: vec3<i32>,
+@location(19) f443: vec3<i32>,
+@location(13) f444: vec4<f16>,
+@location(26) f445: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: i32, @location(4) a1: vec2<u32>, @location(11) a2: u32, @location(16) a3: f32, @location(15) a4: f32, @location(14) a5: vec3<f16>, @location(18) a6: vec4<f32>, a7: S28, @builtin(instance_index) a8: u32, @location(9) a9: vec4<i32>, @location(0) a10: vec3<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+try {
+renderPassEncoder22.setVertexBuffer(
+0,
+buffer18,
+2116,
+19975
+);
+} catch {}
+try {
+renderBundleEncoder84.setVertexBuffer(
+10,
+buffer20,
+6764
+);
+} catch {}
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout47 = device5.createBindGroupLayout(
+{
+entries: [
+
+],
+}
+);
+let renderBundle141 = renderBundleEncoder102.finish(
+{
+
+}
+);
+try {
+renderPassEncoder17.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder15.setStencilReference(
+42
+);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(
+4,
+buffer42
+);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture73,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+new BigInt64Array(new ArrayBuffer(48)),
+/* required buffer size: 401 */{
+offset: 401,
+bytesPerRow: 174,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend(canvas32);
+let texture173 = device5.createTexture(
+{
+label: '\u{1fa86}\u0e5a\u097d\u979c\ue152',
+size: {width: 5616, height: 75, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-6x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-6x5-unorm',
+'astc-6x5-unorm'
+],
+}
+);
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder15.setViewport(
+70.11,
+1.631,
+3.226,
+0.1820,
+0.06297,
+0.7627
+);
+} catch {}
+try {
+renderBundleEncoder101.setBindGroup(
+2,
+bindGroup34,
+[]
+);
+} catch {}
+try {
+renderBundleEncoder99.setBindGroup(
+2,
+bindGroup35,
+new Uint32Array(5177),
+678,
+0
+);
+} catch {}
+try {
+renderBundleEncoder101.setIndexBuffer(
+buffer42,
+'uint32',
+45492,
+801
+);
+} catch {}
+try {
+renderBundleEncoder101.insertDebugMarker(
+'\u03fc'
+);
+} catch {}
+let gpuCanvasContext37 = offscreenCanvas37.getContext('webgpu');
+let texture174 = device8.createTexture(
+{
+label: '\u{1fbb4}\u0b5d\u{1fca6}\u60af\ua9e6\u063d\u{1fe07}\u5649',
+size: {width: 2028, height: 1, depthOrArrayLayers: 913},
+mipLevelCount: 3,
+dimension: '3d',
+format: 'r8uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8uint',
+'r8uint',
+'r8uint'
+],
+}
+);
+let computePassEncoder68 = commandEncoder95.beginComputePass(
+{
+label: '\u38d6\u081e\ua05e\u04e5\u0f11\ua70a\u2afb\u8383'
+}
+);
+try {
+device8.pushErrorScope(
+'validation'
+);
+} catch {}
+try {
+commandEncoder90.copyBufferToBuffer(
+buffer29,
+960,
+buffer48,
+19764,
+3124
+);
+dissociateBuffer(device8, buffer29);
+dissociateBuffer(device8, buffer48);
+} catch {}
+try {
+device8.queue.writeBuffer(
+buffer48,
+12528,
+new Float32Array(30904),
+1605,
+2432
+);
+} catch {}
+let promise54 = device8.queue.onSubmittedWorkDone();
+document.body.prepend(canvas23);
+let textureView138 = texture141.createView(
+{
+}
+);
+let renderBundle142 = renderBundleEncoder92.finish(
+{
+label: '\u{1fe2b}\u1cd8\u{1f6f3}\u{1f650}\u0893\u0419\u6cdb\u8ca3\u822d'
+}
+);
+try {
+renderBundleEncoder110.setIndexBuffer(
+buffer48,
+'uint16',
+18202,
+1260
+);
+} catch {}
+let promise55 = buffer40.mapAsync(
+GPUMapMode.READ,
+0,
+3308
+);
+try {
+commandEncoder90.copyBufferToBuffer(
+buffer29,
+4928,
+buffer40,
+1420,
+2756
+);
+dissociateBuffer(device8, buffer29);
+dissociateBuffer(device8, buffer40);
+} catch {}
+try {
+device8.queue.writeTexture(
+{
+  texture: texture106,
+  mipLevel: 1,
+  origin: { x: 9, y: 0, z: 9 },
+  aspect: 'all',
+},
+new ArrayBuffer(567214),
+/* required buffer size: 567214 */{
+offset: 620,
+bytesPerRow: 275,
+rowsPerImage: 206,
+},
+{width: 94, height: 1, depthOrArrayLayers: 11}
+);
+} catch {}
+let pipeline81 = await device8.createRenderPipelineAsync(
+{
+label: '\u{1fafb}\ud1b9\u111f\u0545',
+layout: pipelineLayout22,
+vertex: {
+module: shaderModule12,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 16020,
+shaderLocation: 8,
+},
+{
+format: 'unorm8x2',
+offset: 11450,
+shaderLocation: 4,
+},
+{
+format: 'uint32',
+offset: 22848,
+shaderLocation: 14,
+},
+{
+format: 'snorm16x2',
+offset: 5680,
+shaderLocation: 11,
+},
+{
+format: 'unorm8x4',
+offset: 9912,
+shaderLocation: 17,
+},
+{
+format: 'float32x2',
+offset: 852,
+shaderLocation: 0,
+},
+{
+format: 'sint32x3',
+offset: 2192,
+shaderLocation: 10,
+},
+{
+format: 'sint32x2',
+offset: 20724,
+shaderLocation: 19,
+},
+{
+format: 'float32x3',
+offset: 6652,
+shaderLocation: 13,
+},
+{
+format: 'float16x4',
+offset: 22652,
+shaderLocation: 15,
+},
+{
+format: 'sint32x2',
+offset: 8028,
+shaderLocation: 6,
+},
+{
+format: 'uint8x2',
+offset: 18442,
+shaderLocation: 7,
+},
+{
+format: 'unorm16x2',
+offset: 22240,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 168,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 144,
+shaderLocation: 9,
+},
+{
+format: 'snorm8x4',
+offset: 36,
+shaderLocation: 16,
+},
+{
+format: 'snorm16x2',
+offset: 48,
+shaderLocation: 12,
+},
+{
+format: 'sint32x2',
+offset: 116,
+shaderLocation: 18,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 48,
+shaderLocation: 2,
+},
+{
+format: 'uint8x4',
+offset: 160,
+shaderLocation: 5,
+},
+{
+format: 'unorm16x4',
+offset: 12,
+shaderLocation: 3,
+},
+{
+format: 'uint32x4',
+offset: 0,
+shaderLocation: 20,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'front',
+},
+fragment: {
+module: shaderModule12,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'one-minus-src',
+dstFactor: 'src-alpha-saturated'
+},
+},
+format: 'rg8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+passOp: 'invert',
+},
+stencilReadMask: 3603,
+stencilWriteMask: 1193,
+depthBias: 28,
+depthBiasSlopeScale: 36,
+depthBiasClamp: 31,
+},
+}
+);
+let pipelineLayout34 = device5.createPipelineLayout(
+{
+label: '\u{1fcc6}\u0204\u{1ffd8}\u67a4\u0ccf\u063a\u033d\u07ef',
+bindGroupLayouts: [
+
+],
+}
+);
+pseudoSubmit(device5, commandEncoder86);
+try {
+computePassEncoder56.setBindGroup(
+0,
+bindGroup34
+);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder15.setScissorRect(
+57,
+0,
+14,
+0
+);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(
+1674
+);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(
+2,
+buffer42
+);
+} catch {}
+try {
+renderBundleEncoder101.setVertexBuffer(
+1,
+buffer42
+);
+} catch {}
+try {
+await device5.popErrorScope();
+} catch {}
+gc();
+let querySet108 = device8.createQuerySet(
+{
+label: '\u3215\ud748\ua691\u0a79\u2133\ue9fa\u76e6\u5db8',
+type: 'occlusion',
+count: 3102,
+}
+);
+let texture175 = device8.createTexture(
+{
+label: '\u2038\ucebf',
+size: {width: 252, height: 1, depthOrArrayLayers: 185},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm',
+'rgba8unorm-srgb',
+'rgba8unorm-srgb'
+],
+}
+);
+let sampler103 = device8.createSampler(
+{
+addressModeU: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 50.049,
+lodMaxClamp: 95.367,
+}
+);
+try {
+gpuCanvasContext17.configure(
+{
+device: device13,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let pipeline82 = device8.createComputePipeline(
+{
+layout: pipelineLayout22,
+compute: {
+module: shaderModule24,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let commandEncoder106 = device11.createCommandEncoder(
+{
+label: '\u86d3\u{1fcc3}\u6e3f\u1b11\u0306\u0a55\u146d\ue783\u{1f7f0}',
+}
+);
+let querySet109 = device11.createQuerySet(
+{
+label: '\u3f3b\u8121\u0497',
+type: 'occlusion',
+count: 1908,
+}
+);
+let texture176 = device11.createTexture(
+{
+label: '\u32b5\u7d72\u05ed\u107b\u42ef\u2bb3\udf74\u3863',
+size: [25, 12, 94],
+mipLevelCount: 2,
+format: 'astc-5x4-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-5x4-unorm',
+'astc-5x4-unorm-srgb'
+],
+}
+);
+let textureView139 = texture176.createView(
+{
+dimension: '2d',
+format: 'astc-5x4-unorm',
+baseMipLevel: 1,
+baseArrayLayer: 49,
+}
+);
+let renderBundleEncoder123 = device11.createRenderBundleEncoder(
+{
+label: '\u0c0c\u{1fe47}\u3670\u4618\ud202\u66c4\ud3ff\u1481\u{1f83e}\u{1f8b0}\u30ca',
+colorFormats: [
+'rg32uint',
+'rgba16uint',
+'r8unorm',
+'r16float',
+'rgba8unorm-srgb'
+],
+sampleCount: 569,
+stencilReadOnly: true,
+}
+);
+let buffer56 = device10.createBuffer(
+{
+label: '\u082e\ua0de\u{1fd3d}\u{1fea0}\u428e\u{1f6f0}\u440b\uf03a\u9dc5',
+size: 36488,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let computePassEncoder69 = commandEncoder77.beginComputePass(
+{
+label: '\u488b\uc609\u00c4\u79f2\u{1fca3}\u0551\u4a6d\u98e3\u3f79\u5d7a\ud304'
+}
+);
+let renderBundle143 = renderBundleEncoder89.finish();
+try {
+commandEncoder63.copyTextureToTexture(
+{
+  texture: texture104,
+  mipLevel: 1,
+  origin: { x: 76, y: 0, z: 4 },
+  aspect: 'all',
+},
+{
+  texture: texture104,
+  mipLevel: 3,
+  origin: { x: 54, y: 0, z: 2 },
+  aspect: 'all',
+},
+{width: 173, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await device10.queue.onSubmittedWorkDone();
+} catch {}
+let canvas35 = document.createElement('canvas');
+let commandEncoder107 = device10.createCommandEncoder();
+let textureView140 = texture108.createView(
+{
+baseMipLevel: 2,
+mipLevelCount: 2,
+baseArrayLayer: 3,
+arrayLayerCount: 12,
+}
+);
+try {
+renderBundleEncoder85.setVertexBuffer(
+0,
+buffer33
+);
+} catch {}
+try {
+commandEncoder63.clearBuffer(
+buffer33,
+24792,
+136
+);
+dissociateBuffer(device10, buffer33);
+} catch {}
+let textureView141 = texture175.createView(
+{
+mipLevelCount: 2,
+}
+);
+let renderBundleEncoder124 = device8.createRenderBundleEncoder(
+{
+label: '\u{1fca1}\u1435\ubf09\u0c36\u{1fdf2}\u{1ff1d}',
+colorFormats: [
+'rgba32uint',
+'rgba32float',
+undefined
+],
+sampleCount: 520,
+}
+);
+let sampler104 = device8.createSampler(
+{
+label: '\u9719\u{1f638}\uf5ef\u070a',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 39.925,
+lodMaxClamp: 53.785,
+maxAnisotropy: 13,
+}
+);
+try {
+computePassEncoder68.setPipeline(
+pipeline61
+);
+} catch {}
+try {
+commandEncoder90.copyBufferToTexture(
+{
+/* bytesInLastRow: 3748 widthInBlocks: 937 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 7892 */
+offset: 7892,
+bytesPerRow: 3840,
+buffer: buffer29,
+},
+{
+  texture: texture172,
+  mipLevel: 0,
+  origin: { x: 2049, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 937, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device8, buffer29);
+} catch {}
+document.body.append('\u{1f9ee}\u4a72\u6d37\ufd91\u{1fc37}\u23a0\u271c');
+document.body.prepend(canvas32);
+let imageBitmap45 = await createImageBitmap(img37);
+let querySet110 = device12.createQuerySet(
+{
+label: '\u0ae0\ue0e2',
+type: 'occlusion',
+count: 275,
+}
+);
+let renderBundleEncoder125 = device12.createRenderBundleEncoder(
+{
+label: '\u{1f830}\ud4c5\u6df4\u88fb\u{1fb6d}\ue567\u04c3\u7866\uc493\u{1ff70}',
+colorFormats: [
+undefined,
+undefined,
+'rgba32sint',
+'rg8unorm',
+'r32float',
+'r32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 994,
+depthReadOnly: true,
+}
+);
+let renderBundle144 = renderBundleEncoder125.finish(
+{
+label: '\u{1f953}\u82da\u0fe7\u0492\ud821\u0417\u{1f670}'
+}
+);
+try {
+device12.queue.writeBuffer(
+buffer54,
+27700,
+new Int16Array(61867),
+10097,
+5668
+);
+} catch {}
+let canvas36 = document.createElement('canvas');
+let bindGroupLayout48 = device5.createBindGroupLayout(
+{
+entries: [
+{
+binding: 996,
+visibility: GPUShaderStage.FRAGMENT,
+buffer: { type: 'read-only-storage', minBindingSize: 770364, hasDynamicOffset: true },
+}
+],
+}
+);
+let commandEncoder108 = device5.createCommandEncoder();
+let renderBundleEncoder126 = device5.createRenderBundleEncoder(
+{
+label: '\u{1fd45}\u0b33\u0cfb\u3824\u0d70\uf6ee\u0cc4\u{1fe02}',
+colorFormats: [
+'r32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 247,
+}
+);
+let externalTexture13 = device5.importExternalTexture(
+{
+source: videoFrame29,
+colorSpace: 'display-p3',
+}
+);
+try {
+renderPassEncoder15.setBlendConstant(
+{
+r: 555.2,
+g: 236.3,
+b: 61.87,
+a: -735.3,
+}
+);
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(
+55,
+0,
+2,
+1
+);
+} catch {}
+try {
+renderPassEncoder20.setStencilReference(
+45
+);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(
+buffer42,
+'uint32',
+30716,
+14876
+);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(
+1,
+buffer42,
+41500,
+3201
+);
+} catch {}
+try {
+commandEncoder108.copyBufferToBuffer(
+buffer46,
+3632,
+buffer34,
+18288,
+1028
+);
+dissociateBuffer(device5, buffer46);
+dissociateBuffer(device5, buffer34);
+} catch {}
+let gpuCanvasContext38 = canvas36.getContext('webgpu');
+try {
+await promise55;
+} catch {}
+canvas19.width = 459;
+let device14 = await adapter16.requestDevice(
+{
+label: '\u{1fb86}\u0191\u04f1\u02c9\ua29f\u04e8\uad11\ud564',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 52,
+maxVertexAttributes: 27,
+maxVertexBufferArrayStride: 27300,
+maxStorageTexturesPerShaderStage: 23,
+maxStorageBuffersPerShaderStage: 25,
+maxDynamicStorageBuffersPerPipelineLayout: 5165,
+maxBindingsPerBindGroup: 1485,
+maxTextureDimension1D: 13225,
+maxTextureDimension2D: 15061,
+maxVertexBuffers: 11,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 215825279,
+maxInterStageShaderVariables: 22,
+maxInterStageShaderComponents: 70,
+},
+}
+);
+try {
+renderBundleEncoder81.setVertexBuffer(
+3,
+buffer23,
+15352
+);
+} catch {}
+let querySet111 = device5.createQuerySet(
+{
+type: 'occlusion',
+count: 115,
+}
+);
+let renderBundleEncoder127 = device5.createRenderBundleEncoder(
+{
+label: '\u6064\u0fe9\u{1f7b0}\uc6d3\u{1fff6}\u13f8\u0334\u7b8d\u{1fe0c}\u0f41',
+colorFormats: [
+'rg8uint',
+undefined,
+'rgba16sint'
+],
+sampleCount: 673,
+stencilReadOnly: true,
+}
+);
+try {
+await device5.popErrorScope();
+} catch {}
+let arrayBuffer12 = buffer42.getMappedRange(
+0,
+13992
+);
+try {
+await promise54;
+} catch {}
+let texture177 = device4.createTexture(
+{
+size: [1056],
+dimension: '1d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb10a2uint',
+'rgb10a2uint'
+],
+}
+);
+let renderBundleEncoder128 = device4.createRenderBundleEncoder(
+{
+label: '\u1ae1\uf98c',
+colorFormats: [
+'rg16sint',
+'r32sint',
+'rg8uint',
+'rg32float',
+'rgba32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 188,
+depthReadOnly: true,
+}
+);
+try {
+computePassEncoder52.setPipeline(
+pipeline49
+);
+} catch {}
+try {
+renderBundleEncoder100.setIndexBuffer(
+buffer20,
+'uint16',
+90
+);
+} catch {}
+try {
+renderBundleEncoder100.setVertexBuffer(
+0,
+buffer20
+);
+} catch {}
+document.body.append('\uf9c4\u85db\u0130\u5f74\u0171\uab7a\u9599\u017b\u{1faca}');
+let renderBundle145 = renderBundleEncoder122.finish(
+{
+label: '\ua34c\ud831\u3af2\ua520\u{1f984}\u87ef\ua30a\u323d\u{1ff74}\u0a0e'
+}
+);
+let sampler105 = device13.createSampler(
+{
+label: '\u0778\u0550\u{1fa95}\u{1fa18}\u2a55\u{1f903}\u053f',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMaxClamp: 98.862,
+}
+);
+try {
+computePassEncoder67.end();
+} catch {}
+let querySet112 = device6.createQuerySet(
+{
+label: '\ufe76\u62b3\u22a3\u4044\u21f2\ub593\u0ca3\ub456\u16ec\u{1f6b0}\u2690',
+type: 'occlusion',
+count: 591,
+}
+);
+let renderBundle146 = renderBundleEncoder60.finish(
+{
+label: '\u9388\u00d4\u372b'
+}
+);
+try {
+computePassEncoder63.end();
+} catch {}
+try {
+commandEncoder69.copyBufferToBuffer(
+buffer23,
+26756,
+buffer43,
+2480,
+4616
+);
+dissociateBuffer(device6, buffer23);
+dissociateBuffer(device6, buffer43);
+} catch {}
+try {
+commandEncoder69.clearBuffer(
+buffer23,
+9076,
+19092
+);
+dissociateBuffer(device6, buffer23);
+} catch {}
+try {
+commandEncoder69.resolveQuerySet(
+querySet85,
+1222,
+127,
+buffer28,
+33792
+);
+} catch {}
+try {
+adapter1.label = '\u85b3\uf796\u0057\ub280\ub3fd\ubb92\u{1f858}\u047d';
+} catch {}
+let videoFrame35 = new VideoFrame(canvas31, {timestamp: 0});
+try {
+await adapter14.requestAdapterInfo();
+} catch {}
+let gpuCanvasContext39 = canvas35.getContext('webgpu');
+offscreenCanvas36.height = 480;
+let video42 = await videoWithData();
+let commandEncoder109 = device7.createCommandEncoder(
+{
+label: '\u2354\u06a1\u243f\u0b06\u{1fb34}\u668a',
+}
+);
+let textureView142 = texture107.createView(
+{
+label: '\u95ff\uecdb\ufcfe\u{1f66a}\u{1f61b}\u{1fd50}\u972f\u0234\u0ddc\u{1fec9}',
+}
+);
+let computePassEncoder70 = commandEncoder109.beginComputePass();
+try {
+device7.queue.writeBuffer(
+buffer38,
+27784,
+new DataView(new ArrayBuffer(19102)),
+11401,
+16
+);
+} catch {}
+let pipeline83 = device7.createComputePipeline(
+{
+layout: pipelineLayout19,
+compute: {
+module: shaderModule13,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let offscreenCanvas39 = new OffscreenCanvas(983, 229);
+let commandEncoder110 = device10.createCommandEncoder(
+{
+label: '\u594f\u065f\u40f2\ub3d3\u07a8\u050c',
+}
+);
+let querySet113 = device10.createQuerySet(
+{
+label: '\u{1ff82}\ue894\u466e\u{1f78b}\u32be\u4570\ub806\u9ed4\udb4b\u03c4',
+type: 'occlusion',
+count: 233,
+}
+);
+let texture178 = device10.createTexture(
+{
+label: '\u09e6\ub54a\u03ee\uf0c1\u9116\u162b\u8e78\ua906',
+size: {width: 245, height: 140, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+sampleCount: 1,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+let computePassEncoder71 = commandEncoder107.beginComputePass(
+{
+label: '\u139d\u88c4\u{1f996}\ud217'
+}
+);
+let sampler106 = device10.createSampler(
+{
+label: '\u{1f8c9}\u5b84\u5eb9\u4aa9\u{1ff65}\uc86f\uf0bc\u0ad6\u5e82\u07ec\ufe23',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 97.245,
+lodMaxClamp: 98.981,
+}
+);
+try {
+commandEncoder103.clearBuffer(
+buffer47,
+22748,
+23916
+);
+dissociateBuffer(device10, buffer47);
+} catch {}
+try {
+device10.queue.writeBuffer(
+buffer33,
+20400,
+new Int16Array(26067),
+24225,
+1172
+);
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+document.body.append('\u76fe\u2775\u0c23\u{1fe0b}\uc012\u{1f8d5}\u{1f92a}\u9e24\u9e2b');
+try {
+offscreenCanvas39.getContext('2d');
+} catch {}
+let sampler107 = device1.createSampler(
+{
+label: '\ua482\u{1fd38}\u{1fed5}\u0c57\u2063\u2eaf\u{1f78e}\u{1fd4d}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 91.705,
+}
+);
+document.body.append('\u0dde\u08e9\u4745');
+canvas7.height = 102;
+document.body.append('\u5a92\u{1f60d}\u0bbd\u0a85\u9842\ud8e1\u0e36');
+let videoFrame36 = new VideoFrame(videoFrame6, {timestamp: 0});
+let bindGroupLayout49 = device3.createBindGroupLayout(
+{
+label: '\u0e0c\u3a06\u050d\u0232\u09b0\u8b62\u0ba7',
+entries: [
+{
+binding: 273,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '2d' },
+},
+{
+binding: 8464,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 5369,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+let texture179 = device3.createTexture(
+{
+label: '\u{1f644}\u{1fd00}\u61db\u4869',
+size: {width: 13480, height: 5, depthOrArrayLayers: 15},
+mipLevelCount: 13,
+format: 'astc-10x5-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x5-unorm',
+'astc-10x5-unorm'
+],
+}
+);
+let textureView143 = texture90.createView(
+{
+dimension: '2d-array',
+format: 'r8uint',
+}
+);
+try {
+renderPassEncoder23.beginOcclusionQuery(
+8
+);
+} catch {}
+try {
+renderPassEncoder23.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder117.insertDebugMarker(
+'\u{1fbab}'
+);
+} catch {}
+let querySet114 = device12.createQuerySet(
+{
+label: '\u7007\u03df\u0ae8\u0ed1\u0572',
+type: 'occlusion',
+count: 722,
+}
+);
+let renderBundleEncoder129 = device12.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg16float'
+],
+sampleCount: 354,
+}
+);
+document.body.append('\u9c76\ua628\u0668\u{1ff85}\u{1fbc4}\u088e\u7a90\ue777');
+let offscreenCanvas40 = new OffscreenCanvas(301, 759);
+let commandBuffer12 = commandEncoder69.finish(
+{
+label: '\u5fda\u06aa',
+}
+);
+let textureView144 = texture120.createView(
+{
+label: '\u0cd6\uc6f1',
+dimension: '2d',
+}
+);
+try {
+computePassEncoder58.popDebugGroup();
+} catch {}
+try {
+device6.queue.submit([
+commandBuffer12,
+]);
+} catch {}
+try {
+device6.queue.writeBuffer(
+buffer23,
+13628,
+new Int16Array(62154),
+43441,
+8780
+);
+} catch {}
+try {
+device6.queue.writeTexture(
+{
+  texture: texture76,
+  mipLevel: 3,
+  origin: { x: 24, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer2),
+/* required buffer size: 847 */{
+offset: 847,
+},
+{width: 200, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let offscreenCanvas41 = new OffscreenCanvas(372, 87);
+let querySet115 = device4.createQuerySet(
+{
+label: '\u0939\u0c10\uf6a7\u0417\u1a82',
+type: 'occlusion',
+count: 1850,
+}
+);
+let renderPassEncoder24 = commandEncoder98.beginRenderPass(
+{
+colorAttachments: [
+
+],
+depthStencilAttachment: {
+view: textureView84,
+depthClearValue: 0.9048256547757024,
+depthLoadOp: 'clear',
+depthStoreOp: 'discard',
+depthReadOnly: false,
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet82,
+maxDrawCount: 21496,
+}
+);
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder24.setViewport(
+4841.4,
+0.9680,
+1510.7,
+0.02742,
+0.08508,
+0.7852
+);
+} catch {}
+try {
+renderBundleEncoder100.setIndexBuffer(
+buffer20,
+'uint32',
+5560,
+2198
+);
+} catch {}
+try {
+device4.pushErrorScope(
+'out-of-memory'
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture118,
+  mipLevel: 0,
+  origin: { x: 39, y: 22, z: 0 },
+  aspect: 'all',
+},
+new BigInt64Array(arrayBuffer8),
+/* required buffer size: 1200 */{
+offset: 878,
+bytesPerRow: 104,
+},
+{width: 5, height: 4, depthOrArrayLayers: 1}
+);
+} catch {}
+video13.width = 238;
+try {
+offscreenCanvas40.getContext('webgpu');
+} catch {}
+document.body.append('\u014d\u9de9\u0774\u0cf8\ue564\u{1fa93}\u0eed\u49d4');
+let bindGroupLayout50 = device13.createBindGroupLayout(
+{
+label: '\ub8d3\u65a4\ua682\u{1f8af}\ucc50\u19cd\u{1fdb6}\ub283\u0f66\u{1f6af}\u0acc',
+entries: [
+{
+binding: 4478,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+},
+{
+binding: 3961,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+},
+{
+binding: 2847,
+visibility: GPUShaderStage.FRAGMENT,
+buffer: { type: 'uniform', minBindingSize: 165047, hasDynamicOffset: true },
+}
+],
+}
+);
+let querySet116 = device13.createQuerySet(
+{
+label: '\u{1fe1c}\uba3f\u8d30',
+type: 'occlusion',
+count: 3726,
+}
+);
+pseudoSubmit(device13, commandEncoder102);
+let texture180 = device13.createTexture(
+{
+label: '\u{1fcc6}\u{1fb91}\u0def\u5615\u9e04',
+size: [123, 44, 1],
+mipLevelCount: 7,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'stencil8',
+'stencil8',
+'stencil8'
+],
+}
+);
+try {
+buffer53.destroy();
+} catch {}
+let commandEncoder111 = device5.createCommandEncoder(
+{
+label: '\u3f33\ub556\ud380\u{1ffc5}\u6ad6\ua9f9',
+}
+);
+let renderPassEncoder25 = commandEncoder108.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView93,
+depthSlice: 65,
+clearValue: {
+r: -415.5,
+g: 697.4,
+b: 218.5,
+a: 709.7,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+{
+view: textureView93,
+depthSlice: 21,
+clearValue: {
+r: -585.5,
+g: -857.1,
+b: 581.6,
+a: 675.7,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView93,
+depthSlice: 49,
+clearValue: {
+r: 409.7,
+g: 336.4,
+b: 618.4,
+a: -389.6,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined,
+undefined,
+{
+view: textureView93,
+depthSlice: 120,
+clearValue: {
+r: 618.4,
+g: 408.6,
+b: 629.2,
+a: 179.8,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+maxDrawCount: 316368,
+}
+);
+let renderBundle147 = renderBundleEncoder126.finish(
+{
+
+}
+);
+try {
+computePassEncoder57.setBindGroup(
+1,
+bindGroup59
+);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(
+4,
+buffer42,
+29576
+);
+} catch {}
+let commandEncoder112 = device7.createCommandEncoder(
+{
+}
+);
+try {
+computePassEncoder47.setPipeline(
+pipeline59
+);
+} catch {}
+try {
+commandEncoder112.copyBufferToBuffer(
+buffer39,
+188,
+buffer38,
+25364,
+4
+);
+dissociateBuffer(device7, buffer39);
+dissociateBuffer(device7, buffer38);
+} catch {}
+let commandEncoder113 = device10.createCommandEncoder(
+{
+label: '\u{1f6f4}\u{1fddc}\u064d\u0728\u{1fb31}',
+}
+);
+let renderBundleEncoder130 = device10.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg32uint',
+'r16sint',
+'rgba8unorm'
+],
+sampleCount: 598,
+depthReadOnly: false,
+}
+);
+try {
+renderBundleEncoder82.setVertexBuffer(
+4,
+buffer33
+);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant(
+{
+r: 977.6,
+g: 15.06,
+b: 886.9,
+a: 50.72,
+}
+);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+3221
+);
+} catch {}
+try {
+renderPassEncoder4.setViewport(
+10083.3,
+4.864,
+603.0,
+1.716,
+0.2162,
+0.2722
+);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(
+buffer4,
+3824
+);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(
+buffer8,
+'uint32'
+);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(
+1,
+buffer10,
+12784,
+9979
+);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(
+3,
+bindGroup2,
+new Uint32Array(5156),
+3031,
+0
+);
+} catch {}
+try {
+commandEncoder19.copyBufferToBuffer(
+buffer10,
+25984,
+buffer1,
+3032,
+4748
+);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder19.clearBuffer(
+buffer9,
+15616,
+1552
+);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 11, height: 1, depthOrArrayLayers: 38}
+*/
+{
+  source: video34,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+},
+{
+  texture: texture7,
+  mipLevel: 2,
+  origin: { x: 3, y: 1, z: 15 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 8, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline84 = device0.createRenderPipeline(
+{
+label: '\uf0eb\u4b40\u98c4\u{1f918}\u05da\u02de\u0cc3\u019c',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule6,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 1704,
+shaderLocation: 20,
+},
+{
+format: 'sint16x2',
+offset: 11520,
+shaderLocation: 16,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 9056,
+shaderLocation: 17,
+},
+{
+format: 'unorm8x4',
+offset: 12964,
+shaderLocation: 22,
+},
+{
+format: 'unorm16x2',
+offset: 8824,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 8440,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 3980,
+shaderLocation: 1,
+},
+{
+format: 'sint16x2',
+offset: 5988,
+shaderLocation: 13,
+},
+{
+format: 'sint16x4',
+offset: 92,
+shaderLocation: 9,
+},
+{
+format: 'sint16x4',
+offset: 7008,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 14648,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 4768,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 2964,
+shaderLocation: 25,
+},
+{
+format: 'float16x4',
+offset: 676,
+shaderLocation: 8,
+},
+{
+format: 'sint8x4',
+offset: 2256,
+shaderLocation: 6,
+},
+{
+format: 'unorm8x4',
+offset: 3924,
+shaderLocation: 19,
+},
+{
+format: 'unorm8x4',
+offset: 2156,
+shaderLocation: 5,
+},
+{
+format: 'sint32x2',
+offset: 4544,
+shaderLocation: 7,
+},
+{
+format: 'uint8x2',
+offset: 4520,
+shaderLocation: 3,
+},
+{
+format: 'sint8x2',
+offset: 468,
+shaderLocation: 26,
+}
+],
+},
+{
+arrayStride: 4712,
+attributes: [
+{
+format: 'sint8x4',
+offset: 3128,
+shaderLocation: 0,
+},
+{
+format: 'unorm8x4',
+offset: 4120,
+shaderLocation: 11,
+},
+{
+format: 'snorm8x4',
+offset: 2580,
+shaderLocation: 24,
+},
+{
+format: 'sint32x2',
+offset: 2440,
+shaderLocation: 23,
+},
+{
+format: 'sint32x2',
+offset: 680,
+shaderLocation: 21,
+},
+{
+format: 'uint16x2',
+offset: 4148,
+shaderLocation: 14,
+},
+{
+format: 'float32x4',
+offset: 1920,
+shaderLocation: 2,
+},
+{
+format: 'sint32x2',
+offset: 1588,
+shaderLocation: 10,
+},
+{
+format: 'uint32x3',
+offset: 3288,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 12280,
+attributes: [
+{
+format: 'sint16x4',
+offset: 4336,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+},
+multisample: {
+mask: 0xd2bf765e,
+},
+fragment: {
+module: shaderModule6,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'one-minus-dst',
+dstFactor: 'src-alpha-saturated'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+},
+{
+format: 'r8sint',
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'dst',
+dstFactor: 'one-minus-src'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rg16float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rg32float',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'equal',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'invert',
+},
+stencilWriteMask: 3355,
+depthBias: 61,
+depthBiasSlopeScale: 85,
+depthBiasClamp: 73,
+},
+}
+);
+document.body.append('\u11e8\u0675\ubacc\u0f8b\u090c');
+let querySet117 = device10.createQuerySet(
+{
+label: '\u1e30\ua454\u2393\u0d12\uc7b9\u09d5\uc2bb\u863e\ub92f',
+type: 'occlusion',
+count: 2854,
+}
+);
+let renderBundleEncoder131 = device10.createRenderBundleEncoder(
+{
+label: '\u0508\u{1f7f6}\uc764\u2142\u44a0\u{1fb0c}\udd8b\ue043',
+colorFormats: [
+'bgra8unorm-srgb',
+'rg16float',
+'r8unorm',
+'rg32sint',
+'rgba16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 610,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder115.setVertexBuffer(
+8,
+buffer33,
+612,
+716
+);
+} catch {}
+try {
+texture169.destroy();
+} catch {}
+try {
+buffer52.unmap();
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(
+buffer56,
+29248,
+buffer47,
+42312,
+316
+);
+dissociateBuffer(device10, buffer56);
+dissociateBuffer(device10, buffer47);
+} catch {}
+try {
+device10.queue.writeBuffer(
+buffer33,
+15056,
+new Float32Array(12036),
+3167,
+4340
+);
+} catch {}
+let offscreenCanvas42 = new OffscreenCanvas(574, 674);
+try {
+offscreenCanvas42.getContext('webgpu');
+} catch {}
+let pipelineLayout35 = device12.createPipelineLayout(
+{
+label: '\u051b\u0c3e\u{1fe51}\u{1f77e}\u330a\u644e\u{1f61d}',
+bindGroupLayouts: [
+bindGroupLayout41,
+bindGroupLayout41,
+bindGroupLayout41,
+bindGroupLayout41,
+bindGroupLayout41
+],
+}
+);
+let querySet118 = device12.createQuerySet(
+{
+label: '\u0e9a\u{1f757}',
+type: 'occlusion',
+count: 2707,
+}
+);
+let texture181 = device12.createTexture(
+{
+label: '\u{1f90e}\u4bc5\u089a\u65c8\ua22a\uf755\u46fe\u73bc\u{1fe40}',
+size: {width: 36, height: 1, depthOrArrayLayers: 264},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView145 = texture165.createView(
+{
+dimension: '2d-array',
+baseMipLevel: 10,
+}
+);
+let sampler108 = device12.createSampler(
+{
+label: '\u{1f95e}\u03fb\u{1ff68}\u0c5f\uf6c2\u{1ff8b}\u0aa0',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 36.432,
+lodMaxClamp: 61.142,
+maxAnisotropy: 10,
+}
+);
+let imageBitmap46 = await createImageBitmap(img34);
+let pipelineLayout36 = device5.createPipelineLayout(
+{
+label: '\u3642\u0b57\u0ae0\u0eb1\u0a08\u096d\u721b\ua7b4\u6a5a\u0543',
+bindGroupLayouts: [
+bindGroupLayout34
+],
+}
+);
+let buffer57 = device5.createBuffer(
+{
+label: '\u{1fff2}\u0008\u0d23\u{1f6f6}\u{1fe26}\u379a\u{1fa1b}\u02bb\u{1fd97}\ufc7e',
+size: 53041,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+}
+);
+let commandEncoder114 = device5.createCommandEncoder(
+{
+label: '\u0369\u0f26\u328a\u4c2a\u0f0a\u9c04\u{1f959}\u{1fbeb}\u62ec\ue237\u0d33',
+}
+);
+let renderPassEncoder26 = commandEncoder114.beginRenderPass(
+{
+label: '\u0dda\ua106\u6daa',
+colorAttachments: [
+{
+view: textureView93,
+depthSlice: 4,
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined
+],
+occlusionQuerySet: querySet86,
+maxDrawCount: 87584,
+}
+);
+let renderBundleEncoder132 = device5.createRenderBundleEncoder(
+{
+label: '\u1482\uc03f\u574d\uf5f7\u{1f62c}\u0db6\u06d3\u0bc5\u1b73\u08df\ub76e',
+colorFormats: [
+undefined,
+'rg16sint',
+'r8uint',
+'r8uint',
+'r16sint',
+'rg32float',
+'rgba16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 731,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle148 = renderBundleEncoder80.finish(
+{
+
+}
+);
+canvas27.height = 1016;
+let video43 = await videoWithData();
+let commandEncoder115 = device13.createCommandEncoder();
+try {
+commandEncoder115.clearBuffer(
+buffer55,
+4672,
+2228
+);
+dissociateBuffer(device13, buffer55);
+} catch {}
+try {
+device13.queue.writeBuffer(
+buffer55,
+5516,
+new Int16Array(60189),
+31940,
+28
+);
+} catch {}
+let imageBitmap47 = await createImageBitmap(img37);
+let querySet119 = device8.createQuerySet(
+{
+label: '\u3364\ue70f\ua708',
+type: 'occlusion',
+count: 2080,
+}
+);
+try {
+commandEncoder90.copyBufferToBuffer(
+buffer29,
+2816,
+buffer40,
+11944,
+1452
+);
+dissociateBuffer(device8, buffer29);
+dissociateBuffer(device8, buffer40);
+} catch {}
+try {
+commandEncoder90.clearBuffer(
+buffer48,
+23000,
+612
+);
+dissociateBuffer(device8, buffer48);
+} catch {}
+try {
+device8.queue.writeBuffer(
+buffer48,
+15316,
+new Int16Array(59040),
+53233,
+3484
+);
+} catch {}
+try {
+await device8.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder116 = device7.createCommandEncoder(
+{
+}
+);
+let textureView146 = texture168.createView(
+{
+aspect: 'stencil-only',
+baseMipLevel: 2,
+mipLevelCount: 3,
+baseArrayLayer: 55,
+arrayLayerCount: 2,
+}
+);
+let sampler109 = device7.createSampler(
+{
+label: '\u050e\u109f\u0aa3\uc8fa\ubdd8\u0f8b\u0798\u2bf0',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 18.757,
+}
+);
+try {
+commandEncoder97.copyBufferToBuffer(
+buffer39,
+96,
+buffer36,
+21016,
+52
+);
+dissociateBuffer(device7, buffer39);
+dissociateBuffer(device7, buffer36);
+} catch {}
+try {
+gpuCanvasContext7.configure(
+{
+device: device7,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgb10a2uint',
+'bgra8unorm-srgb',
+'bgra8unorm',
+'bgra8unorm-srgb'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let renderBundleEncoder133 = device12.createRenderBundleEncoder(
+{
+label: '\u8842\u0899\u2869\u157c\u0717\u317f\u0801\uc1d7',
+colorFormats: [
+'r8uint',
+'rg32uint',
+'rg8sint'
+],
+sampleCount: 522,
+stencilReadOnly: false,
+}
+);
+try {
+renderBundleEncoder129.setVertexBuffer(
+52,
+undefined,
+4227568857,
+37693965
+);
+} catch {}
+try {
+commandEncoder101.copyTextureToTexture(
+{
+  texture: texture181,
+  mipLevel: 6,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture181,
+  mipLevel: 0,
+  origin: { x: 8, y: 0, z: 71 },
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+gpuCanvasContext28.configure(
+{
+device: device12,
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8sint'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device12.queue.writeTexture(
+{
+  texture: texture167,
+  mipLevel: 0,
+  origin: { x: 27, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer12),
+/* required buffer size: 222 */{
+offset: 222,
+},
+{width: 2205, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\u683e\u{1fef3}\u3c93');
+let texture182 = device13.createTexture(
+{
+label: '\u23ac\u0ae6\u{1ff44}\u{1ff70}\u{1f868}\ucf9c\u3d25\u4032\ud520\ufc5a\u9ccc',
+size: {width: 16, height: 128, depthOrArrayLayers: 94},
+mipLevelCount: 4,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+commandEncoder115.copyBufferToTexture(
+{
+/* bytesInLastRow: 80 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 11456 */
+offset: 11456,
+bytesPerRow: 256,
+buffer: buffer53,
+},
+{
+  texture: texture166,
+  mipLevel: 2,
+  origin: { x: 20, y: 4, z: 0 },
+  aspect: 'all',
+},
+{width: 20, height: 20, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device13, buffer53);
+} catch {}
+document.body.prepend('\u8805\uc9a9\u01fb\u001e\u4803\uf52a\u8f3c\u001f\u11c3\u6a7b');
+let renderBundleEncoder134 = device4.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba16uint',
+undefined,
+'rgba32sint',
+'r16uint',
+'r32sint',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 952,
+}
+);
+let renderBundle149 = renderBundleEncoder57.finish(
+{
+label: '\ud317\u{1f8c8}\uea2d\ua4fb'
+}
+);
+try {
+renderPassEncoder24.setBindGroup(
+0,
+bindGroup45
+);
+} catch {}
+try {
+renderBundleEncoder128.setBindGroup(
+2,
+bindGroup42,
+new Uint32Array(2124),
+1578,
+0
+);
+} catch {}
+try {
+renderBundleEncoder134.setIndexBuffer(
+buffer20,
+'uint16',
+8092,
+134
+);
+} catch {}
+try {
+renderBundleEncoder134.setVertexBuffer(
+4,
+buffer18
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture81,
+  mipLevel: 0,
+  origin: { x: 411, y: 1, z: 106 },
+  aspect: 'all',
+},
+arrayBuffer9,
+/* required buffer size: 8121541 */{
+offset: 631,
+bytesPerRow: 38671,
+rowsPerImage: 210,
+},
+{width: 4805, height: 0, depthOrArrayLayers: 2}
+);
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+document.body.prepend(img19);
+let pipelineLayout37 = device13.createPipelineLayout(
+{
+label: '\u89f6\u9f43\uac86',
+bindGroupLayouts: [
+bindGroupLayout50,
+bindGroupLayout50,
+bindGroupLayout50,
+bindGroupLayout50,
+bindGroupLayout50,
+bindGroupLayout50,
+bindGroupLayout50
+],
+}
+);
+let renderBundle150 = renderBundleEncoder122.finish(
+{
+label: '\u0e8c\u0c6e\udc4e\u084f\ucea6\u{1fa63}\u56a3\u3e68'
+}
+);
+let sampler110 = device13.createSampler(
+{
+label: '\ub753\u6dd1',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 46.590,
+lodMaxClamp: 70.243,
+}
+);
+try {
+gpuCanvasContext7.configure(
+{
+device: device13,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg16uint',
+'bgra8unorm-srgb',
+'bgra8unorm-srgb',
+'bgra8unorm-srgb'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let imageBitmap48 = await createImageBitmap(imageData17);
+document.body.append('\u78f5\u7f78\u{1ff83}');
+let buffer58 = device12.createBuffer(
+{
+label: '\u03fd\u086a\u9a01\u{1fe06}\u{1f634}\u5ed5\u01ee\u{1f6e1}\u948f\u0ccd',
+size: 1556,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+}
+);
+let commandEncoder117 = device12.createCommandEncoder(
+{
+label: '\u571d\u{1ff28}\u078d\u1951\u6d0e\u07f4\u{1f8f2}',
+}
+);
+pseudoSubmit(device12, commandEncoder101);
+let textureView147 = texture167.createView(
+{
+label: '\u{1fe4e}\u01ac\ua37b\u0588\ua87d\u0ba4\u0feb',
+}
+);
+let promise56 = buffer54.mapAsync(
+GPUMapMode.READ,
+0,
+60
+);
+try {
+commandEncoder117.clearBuffer(
+buffer58,
+1036
+);
+dissociateBuffer(device12, buffer58);
+} catch {}
+try {
+commandEncoder117.resolveQuerySet(
+querySet110,
+274,
+0,
+buffer58,
+0
+);
+} catch {}
+document.body.prepend('\ua574\u2919\u21a9\u06ed\u04aa\u{1fe31}\u02ed\u05d1\u3873\ua194');
+let texture183 = device5.createTexture(
+{
+label: '\u578d\u{1f711}',
+size: {width: 688, height: 40, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder72 = commandEncoder111.beginComputePass(
+{
+label: '\u{1ffbb}\u47af\u0598\u07d4\u0f08\ud7f2\u3e64'
+}
+);
+let renderBundleEncoder135 = device5.createRenderBundleEncoder(
+{
+label: '\u6a59\uf926\u0fd0\u782a',
+colorFormats: [
+'rg8uint',
+'rgba8sint',
+'bgra8unorm-srgb'
+],
+sampleCount: 274,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder16.setBindGroup(
+1,
+bindGroup34
+);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(
+0,
+bindGroup35,
+new Uint32Array(6705),
+3039,
+0
+);
+} catch {}
+try {
+renderPassEncoder20.beginOcclusionQuery(
+32
+);
+} catch {}
+try {
+renderBundleEncoder93.setBindGroup(
+2,
+bindGroup46
+);
+} catch {}
+try {
+buffer57.unmap();
+} catch {}
+try {
+device5.queue.writeBuffer(
+buffer34,
+16640,
+new Int16Array(33698),
+14782,
+2140
+);
+} catch {}
+let bindGroup60 = device4.createBindGroup({
+label: '\u8c52\u03bb\u0c7a\u{1f62e}\ue17b\u{1fcff}\u0b1e\u{1fea4}',
+layout: bindGroupLayout29,
+entries: [
+{
+binding: 1328,
+resource: externalTexture3
+}
+],
+});
+pseudoSubmit(device4, commandEncoder81);
+let renderBundle151 = renderBundleEncoder84.finish(
+{
+label: '\u{1fc48}\u{1fe67}\u00da\u{1fd99}\u83df'
+}
+);
+try {
+renderPassEncoder24.setBlendConstant(
+{
+r: -961.7,
+g: 708.2,
+b: 699.5,
+a: -818.6,
+}
+);
+} catch {}
+try {
+renderPassEncoder24.setScissorRect(
+1751,
+1,
+3837,
+0
+);
+} catch {}
+try {
+renderPassEncoder22.setStencilReference(
+1555
+);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(
+5,
+buffer20
+);
+} catch {}
+try {
+gpuCanvasContext22.configure(
+{
+device: device4,
+format: 'r32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture97,
+  mipLevel: 0,
+  origin: { x: 16, y: 1, z: 12 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 9195058 */{
+offset: 510,
+bytesPerRow: 242,
+rowsPerImage: 242,
+},
+{width: 12, height: 0, depthOrArrayLayers: 158}
+);
+} catch {}
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append('\u{1f609}\u0796\u{1fcbc}\u0044\u19c2\u6a17\u7b70\u{1f6eb}\ua174\u034c');
+try {
+await promise56;
+} catch {}
+let textureView148 = texture96.createView(
+{
+label: '\u351b\u08e0',
+dimension: '2d',
+baseMipLevel: 3,
+mipLevelCount: 4,
+baseArrayLayer: 15,
+}
+);
+let renderBundleEncoder136 = device10.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg8uint',
+'rgba16float',
+'rg32sint',
+'rgb10a2uint'
+],
+sampleCount: 249,
+depthReadOnly: true,
+}
+);
+try {
+commandEncoder63.copyTextureToBuffer(
+{
+  texture: texture178,
+  mipLevel: 3,
+  origin: { x: 5, y: 15, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 64 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 37120 */
+offset: 37120,
+buffer: buffer47,
+},
+{width: 20, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device10, buffer47);
+} catch {}
+try {
+commandEncoder110.pushDebugGroup(
+'\udb89'
+);
+} catch {}
+document.body.prepend('\u0538\u0a45\u2bd0\u0f52\u53bd\u38c7\u{1fba4}\u056a\udbc9\u0017\u5ef4');
+let gpuCanvasContext40 = offscreenCanvas41.getContext('webgpu');
+let img39 = await imageWithData(175, 88, '#2909542c', '#04fe5ddd');
+let texture184 = device12.createTexture(
+{
+size: [185, 1, 252],
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rgba32float',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba32float'
+],
+}
+);
+let textureView149 = texture148.createView(
+{
+label: '\ueacd\u488d\u31d0\u{1f717}\u76e5',
+dimension: '2d',
+baseMipLevel: 3,
+mipLevelCount: 1,
+arrayLayerCount: 1,
+}
+);
+let computePassEncoder73 = commandEncoder117.beginComputePass();
+try {
+await device12.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout51 = device13.createBindGroupLayout(
+{
+label: '\u9f4e\u{1f7a6}\ub1f6\u{1fe3e}\u{1f704}\u54d5\u7dd1\u13da\u0426\u{1f8f6}',
+entries: [
+{
+binding: 2097,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+}
+],
+}
+);
+let querySet120 = device13.createQuerySet(
+{
+type: 'occlusion',
+count: 2534,
+}
+);
+let textureView150 = texture182.createView(
+{
+label: '\u0136\u0dac',
+baseMipLevel: 3,
+baseArrayLayer: 41,
+arrayLayerCount: 27,
+}
+);
+try {
+commandEncoder115.clearBuffer(
+buffer55,
+9000,
+96
+);
+dissociateBuffer(device13, buffer55);
+} catch {}
+try {
+await device13.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append('\u56f3\u6fcc');
+let texture185 = device13.createTexture(
+{
+label: '\u{1f817}\u{1fcec}\u2896\ucf61\u{1f61d}\u9b01\u0568\u{1fd98}\u07d7',
+size: [6432, 6, 1],
+mipLevelCount: 7,
+format: 'astc-6x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-6x6-unorm',
+'astc-6x6-unorm'
+],
+}
+);
+let textureView151 = texture182.createView(
+{
+label: '\u0916\u0e0b\u9c30\u096d\u9158\u{1f756}\u0c83\u0786',
+mipLevelCount: 1,
+baseArrayLayer: 91,
+arrayLayerCount: 2,
+}
+);
+let renderBundle152 = renderBundleEncoder122.finish(
+{
+label: '\u0be1\u32bc\u03ad\u{1f61d}\uf1a1\u6363\u0cb4\u{1ffdf}\u6c1e'
+}
+);
+try {
+commandEncoder115.copyBufferToBuffer(
+buffer53,
+19700,
+buffer55,
+4824,
+4080
+);
+dissociateBuffer(device13, buffer53);
+dissociateBuffer(device13, buffer55);
+} catch {}
+try {
+commandEncoder115.clearBuffer(
+buffer55,
+3060,
+4284
+);
+dissociateBuffer(device13, buffer55);
+} catch {}
+document.body.append('\ufe70\u521c\uaa06\u84e8\u{1fb45}\u{1fe37}');
+try {
+device0.label = '\u3671\u70a1\u6091\u0f9f\u{1fcbd}\u3ff6\u0618\uf01c\u0fe2';
+} catch {}
+document.body.prepend('\u0dcd\u01fc\u{1fe47}');
+let commandEncoder118 = device12.createCommandEncoder(
+{
+label: '\u11cb\u0071\uc0ac\u67ec\u083d',
+}
+);
+pseudoSubmit(device12, commandEncoder118);
+let texture186 = gpuCanvasContext15.getCurrentTexture();
+let sampler111 = device12.createSampler(
+{
+label: '\udd30\u{1ff4e}\u112d\u0e1a\u{1f959}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 95.128,
+lodMaxClamp: 98.984,
+maxAnisotropy: 3,
+}
+);
+let img40 = await imageWithData(131, 240, '#137af520', '#e715f7f0');
+let commandEncoder119 = device11.createCommandEncoder(
+{
+label: '\u04aa\u2b2e\ue027\u07b5\uae8b\u{1fc5d}\u{1ff78}\u2c05\u9cd4\u{1f630}\u4b8c',
+}
+);
+let querySet121 = device11.createQuerySet(
+{
+label: '\u9199\u0e12\u69fc\u{1fc6e}',
+type: 'occlusion',
+count: 3077,
+}
+);
+let texture187 = device11.createTexture(
+{
+label: '\u9d16\u0acd\u2fd4\uc3b7\u{1f783}\u0d36',
+size: [110, 60, 1],
+mipLevelCount: 7,
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x10-unorm',
+'astc-10x10-unorm',
+'astc-10x10-unorm-srgb'
+],
+}
+);
+let computePassEncoder74 = commandEncoder89.beginComputePass();
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+document.body.prepend('\u{1fe0c}\u0ad4\u67ce');
+let commandEncoder120 = device12.createCommandEncoder(
+{
+label: '\u{1fdf7}\u6aa5\ua957\ufcdb',
+}
+);
+try {
+buffer54.destroy();
+} catch {}
+try {
+device12.queue.writeBuffer(
+buffer58,
+360,
+new Float32Array(33034),
+13513,
+268
+);
+} catch {}
+let commandEncoder121 = device4.createCommandEncoder(
+{
+label: '\u0941\u{1f734}\u0a0e',
+}
+);
+pseudoSubmit(device4, commandEncoder98);
+let texture188 = device4.createTexture(
+{
+label: '\u45db\u01db\u309f\ub62a\ub46b\u3452',
+size: {width: 1151},
+dimension: '1d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rg8sint'
+],
+}
+);
+let computePassEncoder75 = commandEncoder121.beginComputePass(
+{
+label: '\u0fbc\u{1fbe5}\u{1ff20}\u83d9'
+}
+);
+let renderBundle153 = renderBundleEncoder97.finish();
+let sampler112 = device4.createSampler(
+{
+label: '\u2460\ub972\u0602\ufa42\u8760\ua732\u{1fc51}\ua12f\u{1f643}\u60e4\u{1fa73}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 91.799,
+lodMaxClamp: 94.956,
+compare: 'not-equal',
+maxAnisotropy: 10,
+}
+);
+try {
+computePassEncoder48.setPipeline(
+pipeline56
+);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder24.pushDebugGroup(
+'\u8c18'
+);
+} catch {}
+let pipeline85 = device4.createRenderPipeline(
+{
+label: '\u4bc2\u{1ffbf}\u{1ffc9}\ubdaa\uddd0\u05a0\u6bc7\ua6eb\u3378\ub8a1',
+layout: pipelineLayout17,
+vertex: {
+module: shaderModule16,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'sint8x4',
+offset: 944,
+shaderLocation: 14,
+},
+{
+format: 'unorm8x2',
+offset: 1040,
+shaderLocation: 2,
+},
+{
+format: 'float32x2',
+offset: 548,
+shaderLocation: 9,
+},
+{
+format: 'sint16x2',
+offset: 1876,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 960,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 1384,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 1012,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 864,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 180,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 744,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 816,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 1820,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 1476,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'back',
+},
+fragment: {
+module: shaderModule16,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'greater-equal',
+depthFailOp: 'increment-clamp',
+passOp: 'keep',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 174,
+stencilWriteMask: 3932,
+depthBiasSlopeScale: 19,
+depthBiasClamp: 70,
+},
+}
+);
+document.body.prepend('\u0d06\u{1f86a}\u0792');
+let texture189 = device13.createTexture(
+{
+label: '\u{1f846}\u8443\u{1ffe3}\u0abf\u017f\u42e9\ub1a5\u05d2\u2a43\ua436',
+size: [1722, 133, 1],
+mipLevelCount: 7,
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundle154 = renderBundleEncoder122.finish(
+{
+label: '\u598e\u{1f7cc}\ue57d\u{1faf8}\ucc1c\ub570\uee80\u88db'
+}
+);
+let buffer59 = device1.createBuffer(
+{
+label: '\u76f2\u0814\u8d8d\u62b3\u2529\u0136\u6ddb\u019c\u0673',
+size: 49013,
+usage: GPUBufferUsage.MAP_WRITE,
+}
+);
+let texture190 = device1.createTexture(
+{
+label: '\ud7da\u0838\u{1ff7e}\u{1f9fc}\u11e5\u1109\u{1fe07}',
+size: [242, 146, 228],
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8uint',
+'rgba8uint',
+'rgba8uint'
+],
+}
+);
+let textureView152 = texture131.createView(
+{
+label: '\ub2da\u{1f9e9}\u{1fba6}',
+dimension: '2d',
+baseMipLevel: 1,
+baseArrayLayer: 45,
+}
+);
+let sampler113 = device1.createSampler(
+{
+label: '\u52f9\uad12\u0bd3\ub69a\u061a\u15c0\u872b\ud0f5',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'linear',
+lodMinClamp: 76.046,
+lodMaxClamp: 76.145,
+maxAnisotropy: 1,
+}
+);
+try {
+device1.queue.writeTexture(
+{
+  texture: texture122,
+  mipLevel: 0,
+  origin: { x: 3652, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Uint32Array(arrayBuffer12),
+/* required buffer size: 929 */{
+offset: 929,
+},
+{width: 401, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline86 = await device1.createComputePipelineAsync(
+{
+label: '\uf3e1\ud7e2\ud132\ufb28',
+layout: pipelineLayout27,
+compute: {
+module: shaderModule23,
+entryPoint: 'compute0',
+},
+}
+);
+gc();
+let textureView153 = texture178.createView(
+{
+label: '\ucd71\u{1fb4c}\u0bbc\u0981\u8d34\u1014\u5c27\u{1fd1e}\u1efc\uf7ed',
+mipLevelCount: 1,
+}
+);
+let externalTexture14 = device10.importExternalTexture(
+{
+source: video8,
+colorSpace: 'srgb',
+}
+);
+try {
+renderBundleEncoder85.setVertexBuffer(
+3,
+buffer33,
+31416,
+11013
+);
+} catch {}
+try {
+device10.queue.writeBuffer(
+buffer33,
+600,
+new Float32Array(28593),
+7022,
+3776
+);
+} catch {}
+try {
+device10.queue.writeTexture(
+{
+  texture: texture104,
+  mipLevel: 0,
+  origin: { x: 107, y: 1, z: 6 },
+  aspect: 'all',
+},
+arrayBuffer5,
+/* required buffer size: 148269889 */{
+offset: 593,
+bytesPerRow: 27017,
+rowsPerImage: 98,
+},
+{width: 1681, height: 0, depthOrArrayLayers: 57}
+);
+} catch {}
+let imageBitmap49 = await createImageBitmap(canvas8);
+let commandEncoder122 = device5.createCommandEncoder();
+pseudoSubmit(device5, commandEncoder114);
+try {
+renderPassEncoder26.beginOcclusionQuery(
+80
+);
+} catch {}
+try {
+renderPassEncoder26.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(
+buffer57,
+'uint32'
+);
+} catch {}
+try {
+commandEncoder122.clearBuffer(
+buffer34,
+18792,
+1384
+);
+dissociateBuffer(device5, buffer34);
+} catch {}
+try {
+renderPassEncoder15.insertDebugMarker(
+'\u{1f9d6}'
+);
+} catch {}
+let buffer60 = device10.createBuffer(
+{
+label: '\u8d24\u365f\ua23e\u046c\u6dd9\uf1c2',
+size: 5336,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+}
+);
+let texture191 = device10.createTexture(
+{
+size: [7550, 246, 1],
+mipLevelCount: 9,
+format: 'astc-10x6-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x6-unorm-srgb'
+],
+}
+);
+let sampler114 = device10.createSampler(
+{
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 81.575,
+lodMaxClamp: 95.908,
+}
+);
+try {
+renderBundleEncoder115.setVertexBuffer(
+8,
+buffer60
+);
+} catch {}
+try {
+await buffer52.mapAsync(
+GPUMapMode.WRITE
+);
+} catch {}
+try {
+commandEncoder113.resolveQuerySet(
+querySet79,
+427,
+324,
+buffer60,
+512
+);
+} catch {}
+try {
+commandEncoder110.popDebugGroup();
+} catch {}
+try {
+commandEncoder103.insertDebugMarker(
+'\u81b3'
+);
+} catch {}
+try {
+device10.queue.copyExternalImageToTexture(
+/*
+{width: 470, height: 1, depthOrArrayLayers: 31}
+*/
+{
+  source: videoFrame24,
+  origin: { x: 292, y: 293 },
+  flipY: false,
+},
+{
+  texture: texture104,
+  mipLevel: 2,
+  origin: { x: 33, y: 0, z: 10 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 7, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\u0141\u07cb\u3d72\u{1f6e8}\u0379\ua3e1\u91c7\u077e\ue642\u6861');
+let texture192 = device1.createTexture(
+{
+label: '\uf411\u3dfa\u0cee\uf8b3\u7e00\u{1f8e0}\u6f21\u0f2a',
+size: {width: 6684},
+dimension: '1d',
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+}
+);
+try {
+gpuCanvasContext8.configure(
+{
+device: device1,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm',
+'rg16sint',
+'bgra8unorm-srgb',
+'rgba8unorm-srgb'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture46,
+  mipLevel: 0,
+  origin: { x: 154, y: 0, z: 664 },
+  aspect: 'all',
+},
+new ArrayBuffer(45164766),
+/* required buffer size: 45164766 */{
+offset: 638,
+bytesPerRow: 362,
+rowsPerImage: 214,
+},
+{width: 71, height: 1, depthOrArrayLayers: 584}
+);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+document.body.prepend(img1);
+offscreenCanvas39.height = 660;
+document.body.prepend('\u110e\u0053\u{1fe78}\u{1fea9}\u4285\u{1fae5}\u5190\u02df\ua023');
+let video44 = await videoWithData();
+try {
+await device14.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout52 = device3.createBindGroupLayout(
+{
+label: '\u{1f642}\u63e0\udf95\ua76f\u9d1d',
+entries: [
+{
+binding: 8345,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}
+],
+}
+);
+let texture193 = device3.createTexture(
+{
+label: '\u{1ffd9}\u6fbe',
+size: [8117],
+dimension: '1d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+let renderBundle155 = renderBundleEncoder70.finish(
+{
+
+}
+);
+try {
+computePassEncoder61.setPipeline(
+pipeline65
+);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(
+450,
+10,
+120,
+0
+);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(
+5,
+buffer24
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture92,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint16Array(new ArrayBuffer(40)),
+/* required buffer size: 900 */{
+offset: 900,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline87 = device3.createRenderPipeline(
+{
+label: '\ua377\u60e1\ua66e\u10cd\u{1f6bc}\u{1fe92}',
+layout: pipelineLayout24,
+vertex: {
+module: shaderModule18,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 11464,
+attributes: [
+{
+format: 'sint8x2',
+offset: 3430,
+shaderLocation: 11,
+},
+{
+format: 'sint32',
+offset: 8188,
+shaderLocation: 16,
+},
+{
+format: 'sint8x4',
+offset: 5232,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x2',
+offset: 6212,
+shaderLocation: 1,
+},
+{
+format: 'sint16x4',
+offset: 5832,
+shaderLocation: 15,
+},
+{
+format: 'uint8x2',
+offset: 8098,
+shaderLocation: 3,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 11244,
+shaderLocation: 13,
+},
+{
+format: 'sint16x4',
+offset: 3356,
+shaderLocation: 2,
+},
+{
+format: 'sint32x3',
+offset: 9264,
+shaderLocation: 10,
+},
+{
+format: 'uint32',
+offset: 1408,
+shaderLocation: 6,
+},
+{
+format: 'sint8x4',
+offset: 7508,
+shaderLocation: 0,
+},
+{
+format: 'unorm16x4',
+offset: 2628,
+shaderLocation: 5,
+},
+{
+format: 'sint16x4',
+offset: 8620,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 3840,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x4',
+offset: 448,
+shaderLocation: 4,
+},
+{
+format: 'uint8x4',
+offset: 1988,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 20,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x2',
+offset: 6,
+shaderLocation: 7,
+},
+{
+format: 'sint32x4',
+offset: 0,
+shaderLocation: 14,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'less',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+passOp: 'zero',
+},
+stencilBack: {
+failOp: 'zero',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 3207,
+stencilWriteMask: 1955,
+depthBias: 60,
+depthBiasClamp: 85,
+},
+}
+);
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+try {
+renderBundleEncoder121.setVertexBuffer(
+5,
+buffer33
+);
+} catch {}
+try {
+commandEncoder110.resolveQuerySet(
+querySet113,
+109,
+114,
+buffer60,
+256
+);
+} catch {}
+try {
+device10.queue.copyExternalImageToTexture(
+/*
+{width: 941, height: 1, depthOrArrayLayers: 62}
+*/
+{
+  source: canvas29,
+  origin: { x: 241, y: 144 },
+  flipY: false,
+},
+{
+  texture: texture104,
+  mipLevel: 1,
+  origin: { x: 912, y: 0, z: 49 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 3, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let imageData37 = new ImageData(64, 80);
+try {
+gpuCanvasContext32.configure(
+{
+device: device14,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+alphaMode: 'opaque',
+}
+);
+} catch {}
+document.body.prepend(video32);
+let canvas37 = document.createElement('canvas');
+let commandEncoder123 = device12.createCommandEncoder(
+{
+label: '\u0f8c\u3562\u6b00',
+}
+);
+let computePassEncoder76 = commandEncoder123.beginComputePass(
+{
+
+}
+);
+try {
+device12.pushErrorScope(
+'internal'
+);
+} catch {}
+try {
+device12.addEventListener('uncapturederror', e => { log('device12.uncapturederror'); log(e); e.label = device12.label; });
+} catch {}
+try {
+gpuCanvasContext10.configure(
+{
+device: device12,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth24plus-stencil8',
+'rgba8unorm',
+'bgra8unorm-srgb',
+'rgba8unorm'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let promise57 = navigator.gpu.requestAdapter(
+{
+}
+);
+let imageBitmap50 = await createImageBitmap(video19);
+try {
+canvas37.getContext('webgl');
+} catch {}
+let querySet122 = device13.createQuerySet(
+{
+label: '\ucc4c\u769e\ub3d7\u0b69\u1de5\ud173',
+type: 'occlusion',
+count: 1720,
+}
+);
+try {
+gpuCanvasContext32.configure(
+{
+device: device13,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8sint'
+],
+}
+);
+} catch {}
+document.body.prepend('\u4375\u0c96\ue568\ud4eb\u0994\u{1ffa9}\u0833\ucb52');
+let commandEncoder124 = device6.createCommandEncoder();
+let texture194 = device6.createTexture(
+{
+size: {width: 140, height: 8, depthOrArrayLayers: 192},
+mipLevelCount: 4,
+sampleCount: 1,
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x8-unorm',
+'astc-10x8-unorm'
+],
+}
+);
+let textureView154 = texture120.createView(
+{
+label: '\uab99\uc6e0',
+dimension: '2d-array',
+format: 'depth32float',
+baseMipLevel: 0,
+mipLevelCount: 1,
+}
+);
+try {
+commandEncoder124.copyBufferToBuffer(
+buffer21,
+35936,
+buffer43,
+48328,
+5148
+);
+dissociateBuffer(device6, buffer21);
+dissociateBuffer(device6, buffer43);
+} catch {}
+try {
+commandEncoder124.copyTextureToBuffer(
+{
+  texture: texture160,
+  mipLevel: 0,
+  origin: { x: 2813, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 11670 widthInBlocks: 5835 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 35528 */
+offset: 35528,
+buffer: buffer28,
+},
+{width: 5835, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device6, buffer28);
+} catch {}
+try {
+commandEncoder124.resolveQuerySet(
+querySet91,
+306,
+463,
+buffer23,
+24320
+);
+} catch {}
+try {
+commandEncoder124.insertDebugMarker(
+'\u{1feaa}'
+);
+} catch {}
+let imageData38 = new ImageData(72, 252);
+let texture195 = device5.createTexture(
+{
+label: '\u{1f79f}\u0061\u19a8\u{1fa84}\u59f5\u9965',
+size: {width: 885, height: 1, depthOrArrayLayers: 118},
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let sampler115 = device5.createSampler(
+{
+label: '\ua065\u7fa5\u7e9d\u8e5d',
+addressModeU: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 94.408,
+lodMaxClamp: 99.542,
+maxAnisotropy: 9,
+}
+);
+try {
+renderPassEncoder15.setBlendConstant(
+{
+r: 90.42,
+g: -917.8,
+b: -550.3,
+a: -796.7,
+}
+);
+} catch {}
+try {
+renderPassEncoder15.setStencilReference(
+1102
+);
+} catch {}
+try {
+renderPassEncoder25.setViewport(
+11.08,
+1.331,
+31.78,
+0.1409,
+0.9717,
+0.9756
+);
+} catch {}
+try {
+renderBundleEncoder127.setVertexBuffer(
+5,
+buffer42,
+39444,
+1311
+);
+} catch {}
+try {
+await device5.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+document.body.prepend('\u4e50\ud294\u320d');
+let commandEncoder125 = device13.createCommandEncoder(
+{
+label: '\u07fa\uc8e2\u{1ff8f}\u0f85\u0184\uc4ae\u0f5a',
+}
+);
+let texture196 = device13.createTexture(
+{
+label: '\u083f\u{1fd94}\u0733\u00c6\u0c12\ufabd\u0ef0',
+size: {width: 5880, height: 5, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'astc-10x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundleEncoder137 = device13.createRenderBundleEncoder(
+{
+label: '\u{1fa16}\u0722\u0a9a\u054a',
+colorFormats: [
+'r16sint',
+'rg8unorm',
+'bgra8unorm',
+'rg32sint',
+'rg32float',
+undefined,
+'rgba32float',
+'r32float'
+],
+sampleCount: 779,
+stencilReadOnly: true,
+}
+);
+try {
+commandEncoder125.copyBufferToBuffer(
+buffer53,
+13780,
+buffer55,
+7596,
+864
+);
+dissociateBuffer(device13, buffer53);
+dissociateBuffer(device13, buffer55);
+} catch {}
+let commandEncoder126 = device7.createCommandEncoder(
+{
+label: '\u0ec2\u536e\u08fe\u4d92\u04d4\uf5db\u1c08',
+}
+);
+let texture197 = device7.createTexture(
+{
+label: '\u913d\uf8f7\u{1fcf3}\u4099\u{1f9df}\u0894',
+size: {width: 90, height: 6, depthOrArrayLayers: 171},
+mipLevelCount: 7,
+format: 'astc-6x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-6x6-unorm',
+'astc-6x6-unorm-srgb',
+'astc-6x6-unorm'
+],
+}
+);
+let textureView155 = texture133.createView(
+{
+label: '\u788f\u7208\uc0d7\u{1f753}\u{1f657}\u0308\u74f9\u8fcd\u9459\u{1fbcc}',
+baseMipLevel: 4,
+baseArrayLayer: 44,
+arrayLayerCount: 6,
+}
+);
+try {
+device7.pushErrorScope(
+'internal'
+);
+} catch {}
+try {
+commandEncoder105.copyBufferToBuffer(
+buffer39,
+4,
+buffer36,
+10048,
+156
+);
+dissociateBuffer(device7, buffer39);
+dissociateBuffer(device7, buffer36);
+} catch {}
+try {
+device7.queue.writeBuffer(
+buffer38,
+44952,
+new DataView(new ArrayBuffer(54772)),
+4077,
+884
+);
+} catch {}
+let querySet123 = device13.createQuerySet(
+{
+label: '\ue1c6\ud7bb\ufcba\ud4a1\u{1ff5a}',
+type: 'occlusion',
+count: 762,
+}
+);
+pseudoSubmit(device13, commandEncoder115);
+let renderBundle156 = renderBundleEncoder122.finish();
+try {
+commandEncoder125.clearBuffer(
+buffer55,
+5280,
+1720
+);
+dissociateBuffer(device13, buffer55);
+} catch {}
+document.body.prepend(canvas25);
+let video45 = await videoWithData();
+document.body.prepend('\u{1fe82}\ud41f\u2e16');
+let texture198 = device4.createTexture(
+{
+label: '\uf8b2\ueba4\u{1fc2b}\u6b26',
+size: [44, 210, 1],
+mipLevelCount: 6,
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundle157 = renderBundleEncoder97.finish(
+{
+label: '\u12a0\uc0a6\u1913\ue2d7'
+}
+);
+try {
+renderPassEncoder24.setBlendConstant(
+{
+r: -358.9,
+g: 182.3,
+b: -617.4,
+a: -870.7,
+}
+);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(
+buffer20,
+'uint16',
+2824,
+3866
+);
+} catch {}
+let canvas38 = document.createElement('canvas');
+let videoFrame37 = new VideoFrame(video6, {timestamp: 0});
+gc();
+try {
+await device14.popErrorScope();
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+document.body.prepend('\u02e1\ub373\u8eb4\uc41e');
+let adapter17 = await promise57;
+let texture199 = device3.createTexture(
+{
+label: '\ud44b\u18d1\u6fc8\u04ba\u570d\u{1fdcd}\u047b\ubfbc\u{1f679}\u95fb\u00c8',
+size: {width: 29, height: 124, depthOrArrayLayers: 5},
+mipLevelCount: 5,
+format: 'rgba32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+renderPassEncoder19.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder19.setStencilReference(
+2020
+);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(
+/*
+{width: 715, height: 1, depthOrArrayLayers: 418}
+*/
+{
+  source: canvas23,
+  origin: { x: 144, y: 51 },
+  flipY: true,
+},
+{
+  texture: texture138,
+  mipLevel: 1,
+  origin: { x: 266, y: 0, z: 270 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 122, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend(video42);
+let renderBundle158 = renderBundleEncoder62.finish(
+{
+label: '\u{1fb12}\u02de\ubd53\u2d10'
+}
+);
+try {
+commandEncoder90.copyTextureToTexture(
+{
+  texture: texture125,
+  mipLevel: 0,
+  origin: { x: 187, y: 0, z: 315 },
+  aspect: 'all',
+},
+{
+  texture: texture172,
+  mipLevel: 0,
+  origin: { x: 7428, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 23, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder90.resolveQuerySet(
+querySet119,
+1555,
+214,
+buffer48,
+12288
+);
+} catch {}
+try {
+device8.queue.writeTexture(
+{
+  texture: texture172,
+  mipLevel: 0,
+  origin: { x: 2139, y: 0, z: 0 },
+  aspect: 'all',
+},
+new DataView(new ArrayBuffer(0)),
+/* required buffer size: 764 */{
+offset: 764,
+bytesPerRow: 18678,
+rowsPerImage: 194,
+},
+{width: 4652, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\u08cd\ub3d3\ud80f\u016b\u0e08\u0232\u0b97\u{1fa69}\u1f3c\u488b\u8a11');
+let promise58 = navigator.gpu.requestAdapter(
+{
+}
+);
+let videoFrame38 = new VideoFrame(offscreenCanvas6, {timestamp: 0});
+try {
+renderPassEncoder25.setBindGroup(
+3,
+bindGroup31
+);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder17.setScissorRect(
+60,
+2,
+3,
+0
+);
+} catch {}
+let gpuCanvasContext41 = canvas38.getContext('webgpu');
+let bindGroupLayout53 = device12.createBindGroupLayout(
+{
+label: '\u27d0\u76f1\u9140\u1e39',
+entries: [
+{
+binding: 3580,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+},
+{
+binding: 71,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let commandEncoder127 = device12.createCommandEncoder(
+{
+label: '\u1fcc\u0657',
+}
+);
+let renderBundleEncoder138 = device12.createRenderBundleEncoder(
+{
+label: '\u7218\u{1fee4}\u8eb6\u7f4a',
+colorFormats: [
+'r8sint',
+undefined,
+'r8sint',
+'rg8unorm',
+'bgra8unorm',
+'rg16float',
+'rgba8unorm'
+],
+sampleCount: 443,
+depthReadOnly: true,
+}
+);
+try {
+computePassEncoder76.setBindGroup(
+1,
+bindGroup58,
+new Uint32Array(2495),
+1437,
+0
+);
+} catch {}
+try {
+renderBundleEncoder138.setBindGroup(
+4,
+bindGroup58
+);
+} catch {}
+try {
+renderBundleEncoder133.setVertexBuffer(
+97,
+undefined,
+3438786939,
+613960037
+);
+} catch {}
+let texture200 = device1.createTexture(
+{
+label: '\u9186\u{1f827}\u1831\u{1f887}',
+size: {width: 5694, height: 125, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'astc-6x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-6x5-unorm-srgb',
+'astc-6x5-unorm-srgb'
+],
+}
+);
+let textureView156 = texture46.createView(
+{
+label: '\u005d\u547a\ubfb1\u27ff\ue99f\u{1fee4}\ufc43\u0909\u{1ff3f}\ud648',
+format: 'rgba8uint',
+}
+);
+let renderBundleEncoder139 = device1.createRenderBundleEncoder(
+{
+label: '\u03fe\ud16f\ue826\u{1fa89}\u01a1\ud918\u2789\u0592\u{1fa93}',
+colorFormats: [
+'r16uint',
+'rg16uint',
+'rg16sint',
+'rg16uint'
+],
+sampleCount: 126,
+stencilReadOnly: true,
+}
+);
+try {
+device1.queue.writeTexture(
+{
+  texture: texture88,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 95 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 700646 */{
+offset: 296,
+bytesPerRow: 161,
+rowsPerImage: 50,
+},
+{width: 0, height: 0, depthOrArrayLayers: 88}
+);
+} catch {}
+document.body.append('\u04a5\u0e74\ucaf4\u0d34\u{1fb1b}\u04b6\u02bd\u9a45\u{1fe1d}');
+let device15 = await adapter17.requestDevice(
+{
+label: '\u{1ff97}\u014b\u0dd9\uf27b\u{1f89d}\u033d\u31fd\u54f5\u54bb\ua5d4\udb05',
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 8,
+maxColorAttachmentBytesPerSample: 56,
+maxVertexBufferArrayStride: 59060,
+maxStorageTexturesPerShaderStage: 33,
+maxStorageBuffersPerShaderStage: 18,
+maxDynamicStorageBuffersPerPipelineLayout: 26399,
+maxBindingsPerBindGroup: 3940,
+maxTextureDimension1D: 15817,
+maxTextureDimension2D: 10857,
+maxVertexBuffers: 10,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 16161379,
+maxInterStageShaderVariables: 70,
+maxInterStageShaderComponents: 75,
+},
+}
+);
+let imageData39 = new ImageData(208, 24);
+gc();
+document.body.prepend('\u{1fe6a}\u8645\u1f91\ue811\u1432\u{1fa02}\u06fc\u0042\ucfda');
+let commandEncoder128 = device5.createCommandEncoder(
+{
+}
+);
+let querySet124 = device5.createQuerySet(
+{
+label: '\u9025\uc0c1\ue932\u3050\u075e\u0e52\u{1fb28}\u1e5b\u57d4',
+type: 'occlusion',
+count: 2571,
+}
+);
+let commandBuffer13 = commandEncoder128.finish(
+{
+label: '\u0f4f\u8766\u35da\u{1ffce}\u0160\u{1fe3b}\u071a\ue98e\u216b',
+}
+);
+let computePassEncoder77 = commandEncoder122.beginComputePass();
+let renderBundleEncoder140 = device5.createRenderBundleEncoder(
+{
+label: '\u692f\u038d\u0deb\ud818\u0e7c\u0475\u{1fa2e}\u50a1\u37f4\u4262',
+colorFormats: [
+undefined,
+'rg16uint',
+undefined,
+'r16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 981,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder20.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(
+buffer42,
+'uint32'
+);
+} catch {}
+try {
+renderBundleEncoder132.setBindGroup(
+0,
+bindGroup31
+);
+} catch {}
+try {
+renderBundleEncoder140.setBindGroup(
+0,
+bindGroup59,
+new Uint32Array(2042),
+1257,
+0
+);
+} catch {}
+try {
+device5.queue.submit([
+]);
+} catch {}
+try {
+await device5.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend('\u72ab\u0010\u{1f9e3}\u76bb\u{1f784}\u{1fe09}');
+let img41 = await imageWithData(160, 204, '#3549c2f2', '#2229370c');
+let pipelineLayout38 = device1.createPipelineLayout(
+{
+label: '\u{1fc0f}\ub25b\u{1f8f6}\u6481\u0029\ueab2\u0f18\udeab\udfd2\u241f',
+bindGroupLayouts: [
+bindGroupLayout26,
+bindGroupLayout40,
+bindGroupLayout15
+],
+}
+);
+let renderBundleEncoder141 = device1.createRenderBundleEncoder(
+{
+label: '\u{1fe30}\udc84',
+colorFormats: [
+'r32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 250,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle159 = renderBundleEncoder39.finish(
+{
+label: '\u0afc\u8fa3\u65de\u0cfa\u6c6a\u3264\u725a\u63da\u2140'
+}
+);
+try {
+renderBundleEncoder114.setBindGroup(
+2,
+bindGroup23
+);
+} catch {}
+gc();
+let querySet125 = device12.createQuerySet(
+{
+type: 'occlusion',
+count: 643,
+}
+);
+let textureView157 = texture184.createView(
+{
+aspect: 'all',
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+let computePassEncoder78 = commandEncoder120.beginComputePass(
+{
+label: '\ua724\u{1fefd}'
+}
+);
+try {
+commandEncoder127.copyTextureToTexture(
+{
+  texture: texture181,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 2 },
+  aspect: 'all',
+},
+{
+  texture: texture181,
+  mipLevel: 1,
+  origin: { x: 8, y: 1, z: 106 },
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 22}
+);
+} catch {}
+try {
+device12.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 4}
+*/
+{
+  source: imageBitmap27,
+  origin: { x: 10, y: 2 },
+  flipY: false,
+},
+{
+  texture: texture181,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+gpuCanvasContext30.unconfigure();
+} catch {}
+document.body.prepend(img1);
+let bindGroup61 = device13.createBindGroup({
+label: '\u6ca9\u007e\u{1f6ae}\u0464\u342c\u{1fd66}\u{1f930}\u5ace',
+layout: bindGroupLayout51,
+entries: [
+{
+binding: 2097,
+resource: textureView129
+}
+],
+});
+let commandEncoder129 = device13.createCommandEncoder(
+{
+label: '\uf54f\u3956\u0719',
+}
+);
+let querySet126 = device13.createQuerySet(
+{
+type: 'occlusion',
+count: 3780,
+}
+);
+try {
+commandEncoder129.copyBufferToBuffer(
+buffer53,
+20308,
+buffer55,
+52,
+780
+);
+dissociateBuffer(device13, buffer53);
+dissociateBuffer(device13, buffer55);
+} catch {}
+try {
+gpuCanvasContext36.configure(
+{
+device: device13,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+document.body.prepend('\u3fe7\u022f\u83d1\ube84\u{1fbad}\u7aa1\u{1fe92}\ua35e\u0e6f');
+let computePassEncoder79 = commandEncoder106.beginComputePass(
+{
+label: '\u0a53\u033c\u89c9\u04c8\u{1fe2f}\uf9a2\u86ee\uab4a\u01c8\u5397\u{1fd72}'
+}
+);
+let computePassEncoder80 = commandEncoder90.beginComputePass(
+{
+label: '\u{1fea3}\ua86a\u826c\udd54\ub7eb\u{1f9f8}\u00d0'
+}
+);
+try {
+renderBundleEncoder56.setBindGroup(
+4,
+bindGroup55
+);
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+let pipeline88 = device8.createComputePipeline(
+{
+label: '\uc094\uc194\uee88\u0591\u0b0e',
+layout: pipelineLayout22,
+compute: {
+module: shaderModule22,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageBitmap51 = await createImageBitmap(img18);
+let texture201 = device6.createTexture(
+{
+label: '\u{1f9e9}\u02c0\u1843',
+size: [487, 1, 399],
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float'
+],
+}
+);
+let textureView158 = texture76.createView(
+{
+label: '\u{1fefb}\u0434\ubc0f\u{1fb48}\u239c',
+baseMipLevel: 1,
+mipLevelCount: 4,
+}
+);
+let computePassEncoder81 = commandEncoder124.beginComputePass();
+let renderBundleEncoder142 = device6.createRenderBundleEncoder(
+{
+label: '\u701c\ude4f\ua091',
+colorFormats: [
+'r8unorm',
+'rg8unorm',
+'rg16uint',
+'r32float'
+],
+sampleCount: 797,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder81.setIndexBuffer(
+buffer44,
+'uint16',
+24,
+971
+);
+} catch {}
+try {
+renderBundleEncoder142.setVertexBuffer(
+9,
+buffer21,
+49340
+);
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+let videoFrame39 = videoFrame0.clone();
+let texture202 = device7.createTexture(
+{
+size: [1606, 1, 1008],
+mipLevelCount: 2,
+sampleCount: 1,
+dimension: '3d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16uint',
+'rgba16uint'
+],
+}
+);
+try {
+computePassEncoder70.setPipeline(
+pipeline63
+);
+} catch {}
+try {
+device7.addEventListener('uncapturederror', e => { log('device7.uncapturederror'); log(e); e.label = device7.label; });
+} catch {}
+try {
+device7.queue.writeTexture(
+{
+  texture: texture107,
+  mipLevel: 1,
+  origin: { x: 1224, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 110 */{
+offset: 110,
+},
+{width: 1260, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.append('\ubaf5\u5e12\u0b80\u89bf\ub118\u063c\ua084\u0f6d\u063d\u077c');
+try {
+adapter1.label = '\u0d0b\u01b0\udeee\ucfa8\ud6c0';
+} catch {}
+let textureView159 = texture72.createView(
+{
+label: '\u{1f769}\ubf69\u05eb\ua082\u9ae0\u2153',
+baseArrayLayer: 27,
+arrayLayerCount: 1,
+}
+);
+try {
+computePassEncoder60.setBindGroup(
+0,
+bindGroup46,
+new Uint32Array(1902),
+1695,
+0
+);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(
+3,
+bindGroup46
+);
+} catch {}
+try {
+renderPassEncoder26.setScissorRect(
+1,
+0,
+2,
+0
+);
+} catch {}
+try {
+renderPassEncoder15.setViewport(
+13.94,
+0.4347,
+16.24,
+0.7439,
+0.8248,
+0.8335
+);
+} catch {}
+try {
+renderBundleEncoder132.setBindGroup(
+3,
+bindGroup32
+);
+} catch {}
+try {
+renderBundleEncoder93.setIndexBuffer(
+buffer57,
+'uint32',
+8648
+);
+} catch {}
+try {
+device5.queue.submit([
+commandBuffer13,
+]);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture110,
+  mipLevel: 0,
+  origin: { x: 88, y: 0, z: 7 },
+  aspect: 'all',
+},
+arrayBuffer8,
+/* required buffer size: 2183496 */{
+offset: 40,
+bytesPerRow: 20408,
+rowsPerImage: 106,
+},
+{width: 5052, height: 4, depthOrArrayLayers: 2}
+);
+} catch {}
+document.body.prepend(canvas0);
+let querySet127 = device11.createQuerySet(
+{
+type: 'occlusion',
+count: 1476,
+}
+);
+let commandBuffer14 = commandEncoder119.finish(
+{
+label: '\u0a66\u{1ff49}\u9a49\u0b07\u3258\u03d2\u0dab\ue253\u0ebd\u8d6b\u35e3',
+}
+);
+let textureView160 = texture162.createView(
+{
+label: '\uddb6\udb0e\uf5e9\u17e9\u8b08\u{1f66c}\u02ae\u4ad6\u{1fe79}',
+dimension: '2d-array',
+}
+);
+try {
+gpuCanvasContext13.configure(
+{
+device: device11,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device11.queue.writeBuffer(
+buffer50,
+52596,
+new Int16Array(40448),
+18270,
+68
+);
+} catch {}
+canvas21.height = 764;
+let querySet128 = device7.createQuerySet(
+{
+label: '\ua466\u081c\u0a37\u5ef7\u7187\u{1fb46}\u8ad4\u0e31\u098f',
+type: 'occlusion',
+count: 1549,
+}
+);
+let texture203 = device7.createTexture(
+{
+label: '\u9e1c\u334b\u{1f64d}\u37d9\u8b7d\u{1faa6}\u49c4\u{1feb7}\ucba3\u{1ffa0}\u58b8',
+size: [1385, 1, 206],
+mipLevelCount: 11,
+dimension: '3d',
+format: 'rg8uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+let textureView161 = texture134.createView(
+{
+label: '\u02df\u3aeb\uc9ee\u090e\ube6c\u98d6\ucc32\u{1f6fd}\u1d8d\u9835',
+}
+);
+let promise59 = device7.queue.onSubmittedWorkDone();
+let adapter18 = await promise58;
+let canvas39 = document.createElement('canvas');
+let commandBuffer15 = commandEncoder127.finish(
+{
+}
+);
+try {
+computePassEncoder76.setBindGroup(
+2,
+bindGroup58,
+new Uint32Array(3276),
+2154,
+0
+);
+} catch {}
+try {
+device12.queue.submit([
+commandBuffer15,
+]);
+} catch {}
+try {
+device12.queue.writeBuffer(
+buffer58,
+944,
+new Int16Array(22460),
+11426,
+120
+);
+} catch {}
+let commandEncoder130 = device1.createCommandEncoder(
+{
+}
+);
+let renderBundle160 = renderBundleEncoder38.finish(
+{
+label: '\u0b02\u0c47\u0a94\u83ce\u0b06'
+}
+);
+let sampler116 = device1.createSampler(
+{
+label: '\u{1f957}\ua241\u2e3d\u0fec\u4cce\u0f48\u4b85',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 67.323,
+lodMaxClamp: 76.306,
+compare: 'less-equal',
+}
+);
+try {
+renderBundleEncoder139.setBindGroup(
+4,
+bindGroup27
+);
+} catch {}
+try {
+commandEncoder130.copyBufferToBuffer(
+buffer37,
+29264,
+buffer16,
+3104,
+10960
+);
+dissociateBuffer(device1, buffer37);
+dissociateBuffer(device1, buffer16);
+} catch {}
+document.body.prepend('\u{1fe16}\udb7f\u0f14\u8107\u015a');
+let bindGroupLayout54 = device8.createBindGroupLayout(
+{
+label: '\u{1f65a}\u3c8c',
+entries: [
+{
+binding: 1025,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}
+],
+}
+);
+let textureView162 = texture141.createView(
+{
+label: '\u0294\uef54',
+dimension: '2d-array',
+format: 'rgba16float',
+}
+);
+let renderBundleEncoder143 = device8.createRenderBundleEncoder(
+{
+label: '\u8097\u0a93\ua9c9\u0b51\u06f1\u007a\u{1f7e9}',
+colorFormats: [
+'bgra8unorm',
+'bgra8unorm-srgb',
+'rgba16sint',
+'rgba16sint',
+undefined,
+'rgba8sint'
+],
+sampleCount: 149,
+depthReadOnly: true,
+}
+);
+try {
+computePassEncoder80.setBindGroup(
+6,
+bindGroup55
+);
+} catch {}
+let canvas40 = document.createElement('canvas');
+let imageData40 = new ImageData(44, 164);
+try {
+await promise59;
+} catch {}
+document.body.prepend('\u7790\u7812\u31ed\u0066');
+let offscreenCanvas43 = new OffscreenCanvas(545, 899);
+let computePassEncoder82 = commandEncoder130.beginComputePass(
+{
+
+}
+);
+try {
+computePassEncoder31.setPipeline(
+pipeline86
+);
+} catch {}
+offscreenCanvas13.height = 914;
+try {
+gpuCanvasContext39.configure(
+{
+device: device15,
+format: 'astc-6x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let promise60 = device15.queue.onSubmittedWorkDone();
+let videoFrame40 = new VideoFrame(imageBitmap46, {timestamp: 0});
+let video46 = await videoWithData();
+let textureView163 = texture89.createView(
+{
+label: '\u60a0\ue702\u{1f7ee}\u1991\u0fec\u013b',
+format: 'rgba32uint',
+arrayLayerCount: 1,
+}
+);
+try {
+renderPassEncoder23.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(
+24,
+10,
+309,
+0
+);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(
+/*
+{width: 1431, height: 1, depthOrArrayLayers: 836}
+*/
+{
+  source: video34,
+  origin: { x: 5, y: 6 },
+  flipY: false,
+},
+{
+  texture: texture138,
+  mipLevel: 0,
+  origin: { x: 374, y: 0, z: 335 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 11, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+await promise60;
+} catch {}
+let querySet129 = device10.createQuerySet(
+{
+label: '\u0fe5\uc122\u35bf\uf25e\u0a32\u{1fc02}\u0bdd\ucf3f',
+type: 'occlusion',
+count: 2540,
+}
+);
+let commandBuffer16 = commandEncoder63.finish(
+{
+}
+);
+let renderBundleEncoder144 = device10.createRenderBundleEncoder(
+{
+label: '\u014e\u{1fad7}\u5676\u278e\uff9c\u0fda',
+colorFormats: [
+'rgba8uint',
+'bgra8unorm-srgb',
+'r16float',
+'rg16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 842,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder131.setVertexBuffer(
+74,
+undefined
+);
+} catch {}
+video24.height = 5;
+canvas30.height = 158;
+let buffer61 = device1.createBuffer(
+{
+label: '\u585e\ua014\u{1fad6}',
+size: 54664,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let commandEncoder131 = device1.createCommandEncoder(
+{
+label: '\u27e7\u38a2\u08dd\u33a6\u09af\u7306\u0b92\u{1fb76}',
+}
+);
+let querySet130 = device1.createQuerySet(
+{
+label: '\u009a\u051d\u{1fd90}\u{1fbf6}\u{1ffb1}\u073a\uc05b\u0ab8\u075d\u44e8\u{1f997}',
+type: 'occlusion',
+count: 1021,
+}
+);
+let renderPassEncoder27 = commandEncoder131.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView102,
+depthReadOnly: true,
+stencilClearValue: 27217,
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet52,
+maxDrawCount: 20592,
+}
+);
+try {
+device1.queue.submit([
+]);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer19,
+18000,
+new Int16Array(34762),
+9601,
+11728
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture80,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer7,
+/* required buffer size: 752 */{
+offset: 752,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline89 = device1.createRenderPipeline(
+{
+layout: 'auto',
+vertex: {
+module: shaderModule15,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x2',
+offset: 49872,
+shaderLocation: 1,
+},
+{
+format: 'sint32x2',
+offset: 11220,
+shaderLocation: 11,
+},
+{
+format: 'sint32x4',
+offset: 6636,
+shaderLocation: 2,
+},
+{
+format: 'uint16x4',
+offset: 7804,
+shaderLocation: 0,
+},
+{
+format: 'uint32',
+offset: 22232,
+shaderLocation: 22,
+},
+{
+format: 'unorm16x2',
+offset: 2536,
+shaderLocation: 8,
+},
+{
+format: 'float32x2',
+offset: 23624,
+shaderLocation: 14,
+},
+{
+format: 'sint16x2',
+offset: 26928,
+shaderLocation: 18,
+},
+{
+format: 'uint32x4',
+offset: 29760,
+shaderLocation: 5,
+},
+{
+format: 'snorm16x4',
+offset: 33860,
+shaderLocation: 9,
+},
+{
+format: 'snorm8x4',
+offset: 37908,
+shaderLocation: 13,
+},
+{
+format: 'sint32x2',
+offset: 4012,
+shaderLocation: 19,
+},
+{
+format: 'float16x4',
+offset: 19104,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 32888,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32',
+offset: 31292,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule15,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rgba32sint',
+writeMask: GPUColorWrite.ALPHA,
+}
+],
+},
+}
+);
+try {
+canvas39.getContext('2d');
+} catch {}
+let texture204 = device5.createTexture(
+{
+label: '\uc75f\u0bb3\u{1fbc1}\u{1f710}\ueeb6\u4605\ue504\u4c0d\u059a\u097b\u3a13',
+size: {width: 80, height: 72, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'astc-10x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x6-unorm',
+'astc-10x6-unorm',
+'astc-10x6-unorm-srgb'
+],
+}
+);
+try {
+renderPassEncoder17.beginOcclusionQuery(
+56
+);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture173,
+  mipLevel: 2,
+  origin: { x: 54, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 7083 */{
+offset: 914,
+bytesPerRow: 3145,
+},
+{width: 1134, height: 10, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise61 = device5.queue.onSubmittedWorkDone();
+try {
+device5.queue.copyExternalImageToTexture(
+/*
+{width: 77, height: 2, depthOrArrayLayers: 121}
+*/
+{
+  source: imageData33,
+  origin: { x: 103, y: 7 },
+  flipY: true,
+},
+{
+  texture: texture74,
+  mipLevel: 0,
+  origin: { x: 19, y: 1, z: 17 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 46, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+offscreenCanvas21.height = 467;
+document.body.prepend('\u0c28\u84f4\u0099\u0dc6\u5322\uc4bb');
+let imageData41 = new ImageData(88, 148);
+try {
+canvas40.getContext('2d');
+} catch {}
+let commandEncoder132 = device1.createCommandEncoder(
+{
+label: '\u952f\uae1b\u8551\u0cc3\uffd8',
+}
+);
+let computePassEncoder83 = commandEncoder132.beginComputePass(
+{
+label: '\u6ad9\ud4f8\u115e\u8a15\u94e2\u052f\u83c5\u7095\ubab0\u407d'
+}
+);
+try {
+renderPassEncoder27.setBindGroup(
+0,
+bindGroup27
+);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(
+5,
+bindGroup43,
+new Uint32Array(2991),
+2592,
+0
+);
+} catch {}
+try {
+renderPassEncoder27.beginOcclusionQuery(
+64
+);
+} catch {}
+try {
+renderPassEncoder27.setScissorRect(
+5,
+178,
+32,
+28
+);
+} catch {}
+try {
+renderPassEncoder27.setStencilReference(
+1711
+);
+} catch {}
+try {
+renderBundleEncoder114.setIndexBuffer(
+buffer16,
+'uint16',
+20074,
+21043
+);
+} catch {}
+try {
+renderBundleEncoder139.setVertexBuffer(
+3,
+undefined,
+2302806741,
+1925201845
+);
+} catch {}
+document.body.append('\u7ea2\u5644\ube3f\u0556\u181e\u7889\u0cf5\u887e\u0c83\u93f9\u{1fa2e}');
+let querySet131 = device11.createQuerySet(
+{
+label: '\uafed\u4744\u6ada\u06f0\u0dd8\ufc9c\u231e\uc918\ue3a5\u{1f62b}',
+type: 'occlusion',
+count: 3554,
+}
+);
+let computePassEncoder84 = commandEncoder93.beginComputePass(
+{
+label: '\u96dc\u{1fe6e}\u015b\u{1fa96}\u0672\u2b52\u{1f718}\ub1f2\u0000\u05c7\u6b4b'
+}
+);
+try {
+gpuCanvasContext23.configure(
+{
+device: device11,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba32uint',
+'astc-12x12-unorm',
+'rgba16float'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device11.queue.writeTexture(
+{
+  texture: texture132,
+  mipLevel: 0,
+  origin: { x: 791, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer6),
+/* required buffer size: 400 */{
+offset: 400,
+},
+{width: 1353, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let querySet132 = device8.createQuerySet(
+{
+type: 'occlusion',
+count: 908,
+}
+);
+let renderBundle161 = renderBundleEncoder92.finish(
+{
+label: '\udf53\u{1f8ad}\u02bd\u{1ff3e}\u361f\uda15'
+}
+);
+try {
+device8.queue.writeTexture(
+{
+  texture: texture172,
+  mipLevel: 0,
+  origin: { x: 452, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Int16Array(new ArrayBuffer(48)),
+/* required buffer size: 66 */{
+offset: 66,
+},
+{width: 5365, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let renderBundleEncoder145 = device6.createRenderBundleEncoder(
+{
+label: '\u{1f60e}\uc103\u0018\ubb32\u386c\u{1ff0d}\u4a38\u{1fab9}',
+colorFormats: [
+'r8uint',
+'rg8sint',
+'rgba8uint',
+undefined,
+'rgba8unorm-srgb',
+'r8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 866,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder40.insertDebugMarker(
+'\u5796'
+);
+} catch {}
+document.body.prepend('\u0a3f\u07da\u052e\u{1f728}\uf707\u03b7\u{1fef5}\u03e3');
+let imageBitmap52 = await createImageBitmap(video39);
+let imageData42 = new ImageData(84, 68);
+let bindGroupLayout55 = device5.createBindGroupLayout(
+{
+label: '\u0490\u94b3\u{1fc0d}',
+entries: [
+{
+binding: 158,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+},
+{
+binding: 328,
+visibility: GPUShaderStage.FRAGMENT,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}
+],
+}
+);
+let bindGroup62 = device5.createBindGroup({
+layout: bindGroupLayout47,
+entries: [
+
+],
+});
+let renderBundleEncoder146 = device5.createRenderBundleEncoder(
+{
+label: '\u3330\ud9e3\u0ec2\u7296\u5207\ud6d6\udb4d\u046a\u{1fe69}\uac89',
+colorFormats: [
+'rg16sint',
+'r16uint',
+'rgba8sint'
+],
+sampleCount: 533,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder26.beginOcclusionQuery(
+0
+);
+} catch {}
+try {
+renderBundleEncoder87.setIndexBuffer(
+buffer57,
+'uint16',
+4980,
+3707
+);
+} catch {}
+try {
+device5.queue.writeBuffer(
+buffer34,
+8988,
+new Int16Array(19321),
+7549,
+7268
+);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture79,
+  mipLevel: 5,
+  origin: { x: 19, y: 1, z: 6 },
+  aspect: 'all',
+},
+new ArrayBuffer(56),
+/* required buffer size: 1188874 */{
+offset: 10,
+bytesPerRow: 344,
+rowsPerImage: 108,
+},
+{width: 29, height: 0, depthOrArrayLayers: 33}
+);
+} catch {}
+document.body.append('\u{1ffec}\ucea0\u{1fb45}\u0cfc\u5a89\u{1fec3}\u7a7c\u54a4\u0e65\u09f2');
+try {
+await promise61;
+} catch {}
+let buffer62 = device5.createBuffer(
+{
+label: '\u{1fc73}\u34b5\u05d9\u001e\u5a40',
+size: 40807,
+usage: GPUBufferUsage.MAP_READ,
+}
+);
+try {
+renderPassEncoder16.setBindGroup(
+0,
+bindGroup34,
+new Uint32Array(7042),
+4257,
+0
+);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant(
+{
+r: 367.0,
+g: -428.6,
+b: 125.9,
+a: 803.1,
+}
+);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(
+7,
+buffer57,
+18488,
+11041
+);
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(
+2,
+bindGroup46
+);
+} catch {}
+try {
+device5.queue.writeBuffer(
+buffer34,
+12384,
+new Int16Array(62954),
+54058,
+4372
+);
+} catch {}
+let gpuCanvasContext42 = offscreenCanvas43.getContext('webgpu');
+document.body.prepend('\u061d\u1535\ub7a5\u04d5\u946a\u823f\u302b\u0936\ub10a');
+let adapter19 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let renderBundleEncoder147 = device12.createRenderBundleEncoder(
+{
+colorFormats: [
+'r8unorm',
+'rgba8sint',
+'rg16sint',
+'rg16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 655,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder73.setBindGroup(
+1,
+bindGroup58,
+new Uint32Array(7822),
+1495,
+0
+);
+} catch {}
+try {
+renderBundleEncoder133.setBindGroup(
+2,
+bindGroup58
+);
+} catch {}
+try {
+device12.queue.writeTexture(
+{
+  texture: texture167,
+  mipLevel: 0,
+  origin: { x: 1363, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 617 */{
+offset: 38,
+},
+{width: 579, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let buffer63 = device8.createBuffer(
+{
+label: '\u{1fd22}\u9950\u0bbe\u654a\u{1fe67}\u76ca',
+size: 28702,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+mappedAtCreation: false,
+}
+);
+let commandEncoder133 = device8.createCommandEncoder(
+{
+label: '\u0412\u0b52\u78d1\u0ef4\ua384\u0818\u1994',
+}
+);
+let texture205 = device8.createTexture(
+{
+label: '\ub7f6\ue70e\ue811\u{1f7e0}\uf2ae\u{1fc49}\u9ecd',
+size: {width: 246, height: 146, depthOrArrayLayers: 1},
+mipLevelCount: 1,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+commandEncoder133.clearBuffer(
+buffer48,
+15620,
+1744
+);
+dissociateBuffer(device8, buffer48);
+} catch {}
+try {
+device8.queue.writeBuffer(
+buffer63,
+8168,
+new BigUint64Array(62117),
+9871,
+272
+);
+} catch {}
+let adapter20 = await navigator.gpu.requestAdapter();
+let canvas41 = document.createElement('canvas');
+let img42 = await imageWithData(278, 236, '#b2ba8e0b', '#fc41b261');
+let commandEncoder134 = device10.createCommandEncoder(
+{
+}
+);
+let textureView164 = texture96.createView(
+{
+label: '\u0b04\u05e6\u7d98\ud60e\u069b\ua50f\u0c1b',
+format: 'rg16uint',
+baseMipLevel: 6,
+mipLevelCount: 2,
+baseArrayLayer: 13,
+arrayLayerCount: 2,
+}
+);
+try {
+commandEncoder110.resolveQuerySet(
+querySet80,
+1971,
+257,
+buffer60,
+256
+);
+} catch {}
+try {
+gpuCanvasContext15.configure(
+{
+device: device10,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+try {
+device10.queue.writeTexture(
+{
+  texture: texture149,
+  mipLevel: 0,
+  origin: { x: 24, y: 100, z: 0 },
+  aspect: 'all',
+},
+new BigUint64Array(arrayBuffer8),
+/* required buffer size: 2672 */{
+offset: 104,
+bytesPerRow: 140,
+},
+{width: 18, height: 95, depthOrArrayLayers: 1}
+);
+} catch {}
+let texture206 = device14.createTexture(
+{
+label: '\u{1fed8}\u0549',
+size: {width: 5203},
+dimension: '1d',
+format: 'rg32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView165 = texture206.createView(
+{
+label: '\uaa57\u{1ff06}\u092e\u0ac7\u62d5\u0be4\u2187\u6429',
+}
+);
+try {
+gpuCanvasContext5.configure(
+{
+device: device14,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+computePassEncoder46.label = '\u{1fce1}\u0808';
+} catch {}
+let texture207 = device5.createTexture(
+{
+size: {width: 6519},
+sampleCount: 1,
+dimension: '1d',
+format: 'r16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16float',
+'r16float'
+],
+}
+);
+let renderBundleEncoder148 = device5.createRenderBundleEncoder(
+{
+label: '\u09e1\u{1f644}\u4941\u{1fcd7}\u3ea3\u7b0b',
+colorFormats: [
+'bgra8unorm'
+],
+sampleCount: 363,
+}
+);
+try {
+renderPassEncoder26.setBindGroup(
+0,
+bindGroup31
+);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(
+buffer57,
+'uint16'
+);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(
+0,
+buffer57,
+3064,
+14243
+);
+} catch {}
+try {
+await buffer34.mapAsync(
+GPUMapMode.READ,
+2040,
+2484
+);
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(
+/*
+{width: 77, height: 2, depthOrArrayLayers: 121}
+*/
+{
+  source: video30,
+  origin: { x: 2, y: 0 },
+  flipY: true,
+},
+{
+  texture: texture74,
+  mipLevel: 0,
+  origin: { x: 37, y: 0, z: 34 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 11, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let gpuCanvasContext43 = canvas41.getContext('webgpu');
+document.body.append('\ufdf3\u09ea\u9412');
+let bindGroupLayout56 = device14.createBindGroupLayout(
+{
+label: '\u219e\u6607',
+entries: [
+{
+binding: 12,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d-array', sampleType: 'depth', multisampled: false },
+},
+{
+binding: 1174,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '1d' },
+}
+],
+}
+);
+let querySet133 = device14.createQuerySet(
+{
+label: '\u3e5d\u{1ff87}\u7ff6\uae25',
+type: 'occlusion',
+count: 1138,
+}
+);
+try {
+gpuCanvasContext40.configure(
+{
+device: device14,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'r8uint',
+'rgba8uint'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+document.body.prepend('\uaa1e\u0da2\u{1fcf3}');
+try {
+renderPassEncoder25.setVertexBuffer(
+4,
+buffer57,
+12832,
+14124
+);
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(
+1,
+bindGroup32
+);
+} catch {}
+try {
+renderBundleEncoder132.setIndexBuffer(
+buffer42,
+'uint16',
+19238,
+18724
+);
+} catch {}
+try {
+device5.pushErrorScope(
+'out-of-memory'
+);
+} catch {}
+try {
+gpuCanvasContext16.configure(
+{
+device: device5,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'r8uint',
+'eac-rg11snorm',
+'rgba8unorm',
+'astc-10x8-unorm-srgb'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+document.body.append('\u044b\u3cb2\u{1ff31}\ude4e\u0e2e');
+let canvas42 = document.createElement('canvas');
+pseudoSubmit(device7, commandEncoder67);
+let sampler117 = device7.createSampler(
+{
+label: '\u{1f873}\u02fc\ua285\u7db8\u061f',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 20.487,
+lodMaxClamp: 50.311,
+compare: 'never',
+}
+);
+try {
+computePassEncoder70.setPipeline(
+pipeline79
+);
+} catch {}
+try {
+commandEncoder116.copyTextureToTexture(
+{
+  texture: texture197,
+  mipLevel: 1,
+  origin: { x: 12, y: 0, z: 71 },
+  aspect: 'all',
+},
+{
+  texture: texture197,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 121 },
+  aspect: 'all',
+},
+{width: 24, height: 0, depthOrArrayLayers: 12}
+);
+} catch {}
+try {
+commandEncoder105.clearBuffer(
+buffer38,
+23136,
+15380
+);
+dissociateBuffer(device7, buffer38);
+} catch {}
+document.body.append('\u5144\u08ab\u0196\u{1fdbd}\u{1fab9}\uf091\u0a9e\u{1ffc5}\u{1fce9}\u8787');
+try {
+gpuCanvasContext42.configure(
+{
+device: device11,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+video16.height = 54;
+let videoFrame41 = new VideoFrame(video14, {timestamp: 0});
+try {
+canvas42.getContext('webgpu');
+} catch {}
+let pipelineLayout39 = device5.createPipelineLayout(
+{
+label: '\u0466\u600a\u436f\u0c79\uca06\u1acc\u{1fc98}\u0440\u70d0',
+bindGroupLayouts: [
+
+],
+}
+);
+let querySet134 = device5.createQuerySet(
+{
+label: '\u57d1\u9e3a\u5ab5\u5c88\u8857\uf695\u0d3a\u{1fea9}\uee04',
+type: 'occlusion',
+count: 237,
+}
+);
+let textureView166 = texture207.createView(
+{
+baseMipLevel: 0,
+}
+);
+let renderBundleEncoder149 = device5.createRenderBundleEncoder(
+{
+label: '\u00a9\uda55\u0ddd',
+colorFormats: [
+'rgb10a2unorm',
+'rg16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 528,
+stencilReadOnly: false,
+}
+);
+let renderBundle162 = renderBundleEncoder148.finish(
+{
+label: '\u08dd\u9a5f\u{1f73c}\u091c\u6f3b\u{1f90f}'
+}
+);
+try {
+computePassEncoder56.setBindGroup(
+2,
+bindGroup59,
+new Uint32Array(3224),
+2349,
+0
+);
+} catch {}
+try {
+computePassEncoder57.end();
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(
+1,
+bindGroup62,
+[]
+);
+} catch {}
+video43.width = 64;
+let video47 = await videoWithData();
+let bindGroup63 = device12.createBindGroup({
+label: '\u{1f775}\ub450\u1336',
+layout: bindGroupLayout41,
+entries: [
+
+],
+});
+let renderBundle163 = renderBundleEncoder147.finish(
+{
+label: '\u{1f68d}\u0cc8\u409f'
+}
+);
+try {
+renderBundleEncoder129.setBindGroup(
+4,
+bindGroup58
+);
+} catch {}
+try {
+renderBundleEncoder133.setVertexBuffer(
+87,
+undefined,
+160529510,
+508802461
+);
+} catch {}
+try {
+device12.queue.writeBuffer(
+buffer58,
+1000,
+new Int16Array(24127),
+9008,
+128
+);
+} catch {}
+document.body.prepend('\u050b\uf003\u0dac\uf2fa\u939c\u8d26\u{1f708}\ua4de\u{1fb94}\u0c9e\u{1f995}');
+try {
+await adapter4.requestAdapterInfo();
+} catch {}
+let querySet135 = device8.createQuerySet(
+{
+label: '\u47d6\u82dc\u08fc\u35e0\u0cb0\u0370\uf832\u0af7\u0907',
+type: 'occlusion',
+count: 2243,
+}
+);
+let renderBundle164 = renderBundleEncoder79.finish(
+{
+label: '\u0ddb\ubb3d\u4cd4'
+}
+);
+try {
+device8.queue.writeTexture(
+{
+  texture: texture175,
+  mipLevel: 2,
+  origin: { x: 22, y: 1, z: 0 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer1),
+/* required buffer size: 114621 */{
+offset: 741,
+bytesPerRow: 219,
+rowsPerImage: 104,
+},
+{width: 31, height: 0, depthOrArrayLayers: 6}
+);
+} catch {}
+let canvas43 = document.createElement('canvas');
+try {
+canvas43.getContext('webgl');
+} catch {}
+let buffer64 = device7.createBuffer(
+{
+size: 62678,
+usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let computePassEncoder85 = commandEncoder104.beginComputePass(
+{
+label: '\u2416\ua807\u070e\udf8d\u1264\uf45c\u11f9\u2bf4\uc35c\uf48b'
+}
+);
+try {
+commandEncoder116.copyTextureToTexture(
+{
+  texture: texture107,
+  mipLevel: 4,
+  origin: { x: 60, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture107,
+  mipLevel: 4,
+  origin: { x: 72, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 600, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline90 = device7.createComputePipeline(
+{
+label: '\ub124\u{1f79f}\u437f\u391e\u0819\u0216\u6c55\ud728\uf658\u{1f732}',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline91 = await device7.createRenderPipelineAsync(
+{
+label: '\u{1fbd1}\u73f3\u7e24\u9324\u{1ff36}\u{1f62c}',
+layout: pipelineLayout23,
+vertex: {
+module: shaderModule17,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 15400,
+attributes: [
+{
+format: 'uint32x4',
+offset: 12024,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+multisample: {
+mask: 0xb9886a5f,
+},
+fragment: {
+module: shaderModule17,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'src-alpha-saturated',
+dstFactor: 'src'
+},
+},
+format: 'rgb10a2unorm',
+writeMask: GPUColorWrite.ALPHA,
+}
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'increment-wrap',
+passOp: 'invert',
+},
+stencilReadMask: 1929,
+stencilWriteMask: 2758,
+depthBiasSlopeScale: 3,
+},
+}
+);
+let img43 = await imageWithData(36, 88, '#204649d3', '#18318ea9');
+let buffer65 = device10.createBuffer(
+{
+label: '\u{1fb91}\ub066\u{1fc53}\ucb8a\ud83e\u199d\u0b27',
+size: 21140,
+usage: GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+try {
+device10.queue.writeBuffer(
+buffer60,
+2828,
+new DataView(new ArrayBuffer(11741)),
+2076,
+1004
+);
+} catch {}
+video1.width = 177;
+let texture208 = device15.createTexture(
+{
+label: '\uf409\u{1facc}\u8ad2\u00cc\u{1f7a6}\u01dc\u{1fa30}\u0a8e\u0e07\u0a2e',
+size: [11697],
+dimension: '1d',
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8unorm'
+],
+}
+);
+let textureView167 = texture208.createView(
+{
+label: '\u0291\u083f',
+baseArrayLayer: 0,
+}
+);
+try {
+await device15.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder135 = device5.createCommandEncoder();
+let texture209 = device5.createTexture(
+{
+label: '\u04a7\ue0d5\u7f2f\ud588\u{1feab}\u{1fecb}',
+size: [1310],
+mipLevelCount: 1,
+dimension: '1d',
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'r32sint'
+],
+}
+);
+let computePassEncoder86 = commandEncoder135.beginComputePass();
+let renderPassEncoder28 = commandEncoder56.beginRenderPass(
+{
+label: '\uf504\u{1fe82}\u02f9\u3b9c\u0763\u73f9\u0d1e\u{1ffbf}',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView159,
+depthClearValue: 3.525843889153686,
+depthLoadOp: 'load',
+depthStoreOp: 'discard',
+depthReadOnly: false,
+stencilClearValue: 54026,
+},
+occlusionQuerySet: querySet87,
+maxDrawCount: 228728,
+}
+);
+let renderBundle165 = renderBundleEncoder119.finish(
+{
+label: '\u79b2\uaff0\uedbd\u95f6\u{1f91a}\u0e65'
+}
+);
+try {
+computePassEncoder72.end();
+} catch {}
+try {
+renderPassEncoder26.setScissorRect(
+33,
+1,
+26,
+0
+);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(
+buffer57,
+'uint16',
+32564,
+9074
+);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+6,
+buffer57,
+31596,
+2699
+);
+} catch {}
+try {
+renderBundleEncoder99.setBindGroup(
+0,
+bindGroup31
+);
+} catch {}
+try {
+commandEncoder111.copyTextureToTexture(
+{
+  texture: texture113,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture113,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder111.clearBuffer(
+buffer34,
+24604,
+516
+);
+dissociateBuffer(device5, buffer34);
+} catch {}
+let video48 = await videoWithData();
+let texture210 = gpuCanvasContext39.getCurrentTexture();
+let textureView168 = texture156.createView(
+{
+label: '\u0f07\u002f\u{1fb97}\ub265\u9928\uc070\u{1fba7}\u02cb\ucbb7\u3c39\u403b',
+}
+);
+let promise62 = device10.queue.onSubmittedWorkDone();
+let imageData43 = new ImageData(32, 68);
+let bindGroupLayout57 = device11.createBindGroupLayout(
+{
+entries: [
+{
+binding: 655,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+let texture211 = device11.createTexture(
+{
+label: '\u0fa0\u2444\u5f4d\u{1f66b}\uaa2a\u5b8a\u0d1c',
+size: [12762, 215, 221],
+mipLevelCount: 6,
+format: 'astc-6x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-6x5-unorm',
+'astc-6x5-unorm-srgb'
+],
+}
+);
+canvas14.width = 865;
+let imageData44 = new ImageData(56, 148);
+let commandEncoder136 = device11.createCommandEncoder(
+{
+}
+);
+let textureView169 = texture211.createView(
+{
+label: '\u08e2\u7e75',
+baseMipLevel: 5,
+baseArrayLayer: 4,
+arrayLayerCount: 4,
+}
+);
+let renderBundle166 = renderBundleEncoder107.finish(
+{
+
+}
+);
+let offscreenCanvas44 = new OffscreenCanvas(551, 870);
+let pipelineLayout40 = device5.createPipelineLayout(
+{
+label: '\u272c\u9e50\u{1f70a}\u1e35\u068a\uc35a\u823b',
+bindGroupLayouts: [
+bindGroupLayout18,
+bindGroupLayout35,
+bindGroupLayout47
+],
+}
+);
+let texture212 = device5.createTexture(
+{
+label: '\u537d\uc8e6',
+size: [6624, 96, 1],
+mipLevelCount: 4,
+format: 'etc2-rgba8unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let textureView170 = texture195.createView(
+{
+label: '\u032d\u{1f728}\u05ac',
+baseArrayLayer: 0,
+}
+);
+let renderBundleEncoder150 = device5.createRenderBundleEncoder(
+{
+colorFormats: [
+'r16float',
+'rgba8uint',
+'rgba8unorm-srgb',
+'rg32uint',
+undefined,
+'rg16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 736,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder16.setBindGroup(
+2,
+bindGroup34,
+new Uint32Array(3994),
+1277,
+0
+);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(
+16
+);
+} catch {}
+try {
+renderPassEncoder26.endOcclusionQuery();
+} catch {}
+let querySet136 = device6.createQuerySet(
+{
+label: '\u4dd2\u0390',
+type: 'occlusion',
+count: 2368,
+}
+);
+let texture213 = device6.createTexture(
+{
+label: '\uf107\u1ddb\u27bb\u{1ff84}\ub640\u0541\uf9df\u{1f6e8}\u0090\u0683',
+size: {width: 157, height: 229, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'depth16unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'depth16unorm',
+'depth16unorm'
+],
+}
+);
+let sampler118 = device6.createSampler(
+{
+label: '\u83f1\u{1ffb8}\u04cd\u0262\u0c92\u4f47\u22f8\u37a7',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 51.706,
+lodMaxClamp: 66.782,
+maxAnisotropy: 8,
+}
+);
+document.body.append('\uc2a5\u0800\u9f46\u0cf1\u0f21\u66e7\ubf55\ua0ff\u0bd8\u0015');
+let querySet137 = device12.createQuerySet(
+{
+label: '\u{1f693}\u{1fe45}\u{1f9b2}',
+type: 'occlusion',
+count: 1487,
+}
+);
+let texture214 = device12.createTexture(
+{
+size: {width: 1312},
+mipLevelCount: 1,
+dimension: '1d',
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm',
+'bgra8unorm-srgb'
+],
+}
+);
+let querySet138 = device12.createQuerySet(
+{
+label: '\u0fe3\u{1f7ba}\u0811',
+type: 'occlusion',
+count: 41,
+}
+);
+let texture215 = device12.createTexture(
+{
+label: '\u{1fb52}\u{1fed3}\u2ce0\u260c\u49e5\u0397\uaf25\uf6e3\u394d',
+size: [461, 16, 3],
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb'
+],
+}
+);
+try {
+renderBundleEncoder138.setBindGroup(
+0,
+bindGroup63,
+new Uint32Array(1790),
+1,
+0
+);
+} catch {}
+let imageData45 = new ImageData(244, 4);
+try {
+offscreenCanvas44.getContext('2d');
+} catch {}
+let textureView171 = texture79.createView(
+{
+label: '\u{1f7a9}\ud374\u3e4c\u0d0b\u53c7',
+format: 'bgra8unorm',
+baseMipLevel: 2,
+mipLevelCount: 7,
+}
+);
+try {
+renderPassEncoder26.setBindGroup(
+1,
+bindGroup29,
+new Uint32Array(8077),
+3771,
+0
+);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+3,
+buffer42,
+20204,
+3604
+);
+} catch {}
+try {
+renderBundleEncoder87.setBindGroup(
+0,
+bindGroup40
+);
+} catch {}
+try {
+renderBundleEncoder132.setVertexBuffer(
+2,
+buffer57,
+9140,
+19584
+);
+} catch {}
+let arrayBuffer13 = buffer42.getMappedRange(
+34560,
+9132
+);
+try {
+buffer62.unmap();
+} catch {}
+try {
+gpuCanvasContext30.configure(
+{
+device: device5,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+video17.height = 238;
+let device16 = await adapter20.requestDevice(
+{
+label: '\u9cdc\u{1f76f}\u{1fa2a}\u{1fd1f}\u{1f9cf}\u{1ffae}\u2fd5',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'indirect-first-instance',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+}
+);
+let canvas44 = document.createElement('canvas');
+let offscreenCanvas45 = new OffscreenCanvas(670, 21);
+try {
+window.someLabel = renderBundle68.label;
+} catch {}
+let buffer66 = device8.createBuffer(
+{
+size: 42472,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let renderBundle167 = renderBundleEncoder143.finish(
+{
+label: '\u0a7e\u{1f9ed}\u01c7'
+}
+);
+try {
+renderBundleEncoder56.setVertexBuffer(
+38,
+undefined,
+2928248551,
+416238277
+);
+} catch {}
+try {
+commandEncoder133.copyTextureToTexture(
+{
+  texture: texture172,
+  mipLevel: 0,
+  origin: { x: 702, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture175,
+  mipLevel: 4,
+  origin: { x: 4, y: 0, z: 2 },
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder133.clearBuffer(
+buffer48,
+20648,
+352
+);
+dissociateBuffer(device8, buffer48);
+} catch {}
+try {
+computePassEncoder68.insertDebugMarker(
+'\u4308'
+);
+} catch {}
+let pipeline92 = device8.createComputePipeline(
+{
+label: '\u0c0d\u016d\u0d85\u4d3b\ueb10\u8267\u0921',
+layout: 'auto',
+compute: {
+module: shaderModule22,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let video49 = await videoWithData();
+try {
+canvas44.getContext('bitmaprenderer');
+} catch {}
+let textureView172 = texture194.createView(
+{
+label: '\u{1ff34}\u40e3\u7f09',
+baseMipLevel: 3,
+baseArrayLayer: 73,
+arrayLayerCount: 47,
+}
+);
+try {
+computePassEncoder50.end();
+} catch {}
+try {
+device6.queue.writeTexture(
+{
+  texture: texture201,
+  mipLevel: 1,
+  origin: { x: 45, y: 0, z: 24 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 19359875 */{
+offset: 899,
+bytesPerRow: 1678,
+rowsPerImage: 206,
+},
+{width: 196, height: 1, depthOrArrayLayers: 57}
+);
+} catch {}
+document.body.append('\u87f3\ua73d\u5d3c\u9312\uf4dd\u0ba3');
+let shaderModule26 = device13.createShaderModule(
+{
+label: '\u5ae0\u{1ffec}\uabad\u0416',
+code: `@group(2) @binding(3961)
+var<storage, read_write> i1: array<u32>;
+@group(6) @binding(3961)
+var<storage, read_write> type0: array<u32>;
+@group(1) @binding(2847)
+var<storage, read_write> global0: array<u32>;
+@group(3) @binding(2847)
+var<storage, read_write> parameter1: array<u32>;
+
+@compute @workgroup_size(2, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S30 {
+@location(26) f0: f16,
+@location(18) f1: f16,
+@location(39) f2: vec4<u32>,
+@location(56) f3: vec2<f32>,
+@location(78) f4: vec4<f32>,
+@location(33) f5: vec4<i32>,
+@location(55) f6: i32,
+@location(41) f7: vec2<f32>,
+@location(53) f8: vec4<f16>,
+@builtin(sample_mask) f9: u32,
+@builtin(sample_index) f10: u32,
+@location(89) f11: f32
+}
+
+@fragment
+fn fragment0(a0: S30, @location(42) a1: vec3<f16>, @location(108) a2: i32, @location(34) a3: vec3<u32>, @location(28) a4: vec2<f32>, @builtin(front_facing) a5: bool) {
+
+}
+
+struct VertexOutput0 {
+@location(33) f446: vec4<i32>,
+@location(39) f447: vec4<u32>,
+@location(53) f448: vec4<f16>,
+@location(28) f449: vec2<f32>,
+@location(89) f450: f32,
+@location(55) f451: i32,
+@builtin(position) f452: vec4<f32>,
+@location(56) f453: vec2<f32>,
+@location(108) f454: i32,
+@location(26) f455: f16,
+@location(78) f456: vec4<f32>,
+@location(18) f457: f16,
+@location(42) f458: vec3<f16>,
+@location(41) f459: vec2<f32>,
+@location(34) f460: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(26) a0: vec2<i32>, @location(22) a1: i32, @location(19) a2: vec2<i32>, @location(9) a3: vec2<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let buffer67 = device13.createBuffer(
+{
+size: 31397,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+mappedAtCreation: false,
+}
+);
+let commandEncoder137 = device13.createCommandEncoder(
+{
+}
+);
+let querySet139 = device13.createQuerySet(
+{
+label: '\uc955\u{1fd21}\ue42d\u9288\u163c\u492c\u5a01',
+type: 'occlusion',
+count: 3599,
+}
+);
+let computePassEncoder87 = commandEncoder129.beginComputePass();
+let renderBundleEncoder151 = device13.createRenderBundleEncoder(
+{
+label: '\u58e3\u{1f897}\u{1fea0}\u0501\ua09f\u012e',
+colorFormats: [
+'r32float',
+'r8uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 25,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder151.setBindGroup(
+5,
+bindGroup61
+);
+} catch {}
+let pipeline93 = await device13.createComputePipelineAsync(
+{
+layout: pipelineLayout37,
+compute: {
+module: shaderModule26,
+entryPoint: 'compute0',
+},
+}
+);
+let pipeline94 = await device13.createRenderPipelineAsync(
+{
+label: '\u{1fe95}\u{1fcc3}\u1bce\u25ea',
+layout: pipelineLayout37,
+vertex: {
+module: shaderModule26,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 888,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 4924,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x4',
+offset: 500,
+shaderLocation: 26,
+}
+],
+},
+{
+arrayStride: 268,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 112,
+shaderLocation: 22,
+},
+{
+format: 'sint32x3',
+offset: 76,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 4836,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 4836,
+attributes: [
+{
+format: 'float32x2',
+offset: 2364,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule26,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+depthBias: 69,
+depthBiasSlopeScale: 92,
+},
+}
+);
+let videoFrame42 = new VideoFrame(offscreenCanvas45, {timestamp: 0});
+try {
+offscreenCanvas45.getContext('webgl');
+} catch {}
+try {
+gpuCanvasContext41.unconfigure();
+} catch {}
+document.body.append('\u{1fee2}\u046d\u04ad\u0841\u6ecb\u7c9e\ue5cd\u082f');
+let buffer68 = device10.createBuffer(
+{
+label: '\u08d7\u565f\u{1fe11}\u{1fa7e}\u8412\uaec4\u{1f6b6}',
+size: 234,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+pseudoSubmit(device10, commandEncoder77);
+let renderPassEncoder29 = commandEncoder110.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+{
+view: textureView168,
+depthSlice: 370,
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined,
+undefined
+],
+occlusionQuerySet: querySet117,
+}
+);
+try {
+renderPassEncoder29.end();
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device10,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+document.body.prepend('\u8fb2\u{1f760}');
+let commandEncoder138 = device12.createCommandEncoder();
+try {
+renderBundleEncoder129.setVertexBuffer(
+62,
+undefined,
+3243657169
+);
+} catch {}
+let textureView173 = texture124.createView(
+{
+baseMipLevel: 2,
+mipLevelCount: 4,
+}
+);
+try {
+renderBundleEncoder144.setVertexBuffer(
+8,
+buffer60,
+1460,
+1395
+);
+} catch {}
+try {
+commandEncoder103.clearBuffer(
+buffer33,
+24596,
+5880
+);
+dissociateBuffer(device10, buffer33);
+} catch {}
+try {
+renderBundleEncoder82.insertDebugMarker(
+'\u54ee'
+);
+} catch {}
+try {
+device10.queue.copyExternalImageToTexture(
+/*
+{width: 941, height: 1, depthOrArrayLayers: 62}
+*/
+{
+  source: imageBitmap20,
+  origin: { x: 4, y: 5 },
+  flipY: false,
+},
+{
+  texture: texture104,
+  mipLevel: 1,
+  origin: { x: 594, y: 1, z: 30 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 7, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+document.body.prepend(canvas33);
+let promise63 = navigator.gpu.requestAdapter(
+{
+}
+);
+try {
+await adapter19.requestAdapterInfo();
+} catch {}
+let textureView174 = texture206.createView(
+{
+label: '\udaa6\u{1f92c}\u88b5\u3d11\u0d27\u2c46\u081d',
+aspect: 'all',
+baseMipLevel: 0,
+arrayLayerCount: 1,
+}
+);
+let videoFrame43 = new VideoFrame(offscreenCanvas38, {timestamp: 0});
+let bindGroup64 = device8.createBindGroup({
+layout: bindGroupLayout33,
+entries: [
+{
+binding: 1171,
+resource: sampler72
+}
+],
+});
+let pipelineLayout41 = device8.createPipelineLayout(
+{
+label: '\u2bbe\u{1fe7b}\u8884',
+bindGroupLayouts: [
+bindGroupLayout27,
+bindGroupLayout44,
+bindGroupLayout37,
+bindGroupLayout27,
+bindGroupLayout44,
+bindGroupLayout37,
+bindGroupLayout33,
+bindGroupLayout28
+],
+}
+);
+let texture216 = device8.createTexture(
+{
+label: '\u{1f764}\u309a\u{1f8e8}\u48be\u0dbe\u00d2',
+size: [558, 120, 79],
+format: 'depth32float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'depth32float',
+'depth32float'
+],
+}
+);
+let arrayBuffer14 = buffer40.getMappedRange(
+2520,
+564
+);
+try {
+commandEncoder133.copyTextureToTexture(
+{
+  texture: texture172,
+  mipLevel: 0,
+  origin: { x: 1857, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture175,
+  mipLevel: 4,
+  origin: { x: 1, y: 1, z: 9 },
+  aspect: 'all',
+},
+{width: 12, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder133.resolveQuerySet(
+querySet50,
+4,
+3,
+buffer63,
+1536
+);
+} catch {}
+let commandEncoder139 = device10.createCommandEncoder(
+{
+label: '\u4469\u{1ff37}\u{1f8b5}\u8ac0\u349b\u0107\u0dc0',
+}
+);
+let querySet140 = device10.createQuerySet(
+{
+type: 'occlusion',
+count: 1613,
+}
+);
+let computePassEncoder88 = commandEncoder134.beginComputePass(
+{
+label: '\u8f4f\u04ea\ucd53\ua8d1\uee8a\uac0b\u02b0\ued18\u0ced\u{1f897}\u0eda'
+}
+);
+let renderPassEncoder30 = commandEncoder139.beginRenderPass(
+{
+label: '\u06f8\u{1f976}\u9714\u07e1\ud4f9\u11d8',
+colorAttachments: [
+{
+view: textureView168,
+depthSlice: 28,
+clearValue: {
+r: -875.4,
+g: 158.6,
+b: -866.2,
+a: 92.93,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView168,
+depthSlice: 178,
+clearValue: {
+r: -200.5,
+g: -734.1,
+b: 551.2,
+a: 609.4,
+},
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet113,
+maxDrawCount: 73416,
+}
+);
+try {
+renderBundleEncoder115.setIndexBuffer(
+buffer33,
+'uint16',
+32816,
+1802
+);
+} catch {}
+try {
+commandEncoder103.resolveQuerySet(
+querySet97,
+274,
+14,
+buffer60,
+0
+);
+} catch {}
+let buffer69 = device5.createBuffer(
+{
+label: '\u091e\uf8a2\ud526\u281a\u0622\uc55f\u0902',
+size: 1768,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+}
+);
+let computePassEncoder89 = commandEncoder111.beginComputePass(
+{
+label: '\u7913\u70eb'
+}
+);
+let renderBundleEncoder152 = device5.createRenderBundleEncoder(
+{
+colorFormats: [
+'r8unorm',
+'bgra8unorm',
+'rg16float',
+'r16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 875,
+}
+);
+let renderBundle168 = renderBundleEncoder48.finish(
+{
+label: '\u{1fdbd}\u003c\u10c0\uf4db\u{1f76d}\u{1ff5b}\u00f3'
+}
+);
+let sampler119 = device5.createSampler(
+{
+label: '\u2657\u07bd\u8aed\u33e5\ub894\u5e53\u8955\ubdad',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 72.345,
+lodMaxClamp: 75.000,
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(
+61,
+0,
+0,
+1
+);
+} catch {}
+try {
+renderBundleEncoder150.setVertexBuffer(
+2,
+buffer69,
+736,
+823
+);
+} catch {}
+let shaderModule27 = device4.createShaderModule(
+{
+label: '\u{1f755}\u{1f61d}\u3a95\ue923\u9c5a\ue5a2\u33b6\u48c0\u3b84\u93a3',
+code: `
+
+@compute @workgroup_size(6, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(1) f0: vec4<i32>,
+@location(2) f1: vec4<i32>,
+@location(7) f2: u32,
+@location(5) f3: f32,
+@location(6) f4: vec3<f32>,
+@location(4) f5: f32,
+@location(0) f6: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S31 {
+@location(17) f0: vec2<i32>,
+@location(9) f1: vec2<f32>,
+@location(15) f2: vec4<f16>,
+@location(0) f3: f32,
+@location(19) f4: vec4<i32>,
+@location(6) f5: f16,
+@location(20) f6: u32,
+@location(13) f7: u32,
+@location(4) f8: vec2<f16>,
+@location(18) f9: vec2<f16>,
+@location(3) f10: f32,
+@location(1) f11: vec2<f32>,
+@location(8) f12: vec3<u32>,
+@builtin(vertex_index) f13: u32,
+@location(10) f14: vec2<f32>,
+@location(16) f15: vec4<f32>,
+@location(7) f16: vec3<f32>,
+@location(11) f17: f16
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec4<i32>, a1: S31) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let textureView175 = texture100.createView(
+{
+aspect: 'all',
+format: 'r8sint',
+baseMipLevel: 0,
+mipLevelCount: 2,
+baseArrayLayer: 129,
+arrayLayerCount: 33,
+}
+);
+let sampler120 = device4.createSampler(
+{
+label: '\u6fb6\ubd48\ud43b\u8e7a\u940e',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 2.373,
+lodMaxClamp: 7.958,
+}
+);
+try {
+renderPassEncoder12.setBindGroup(
+4,
+bindGroup44
+);
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(
+54,
+0,
+438,
+1
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture198,
+  mipLevel: 3,
+  origin: { x: 3, y: 5, z: 0 },
+  aspect: 'all',
+},
+new Int32Array(arrayBuffer4),
+/* required buffer size: 849 */{
+offset: 849,
+bytesPerRow: 179,
+},
+{width: 0, height: 4, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline95 = device4.createRenderPipeline(
+{
+label: '\u05d5\u0439\u{1f7d3}',
+layout: pipelineLayout26,
+vertex: {
+module: shaderModule25,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 904,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 416,
+shaderLocation: 16,
+},
+{
+format: 'uint16x2',
+offset: 424,
+shaderLocation: 6,
+},
+{
+format: 'uint32x4',
+offset: 556,
+shaderLocation: 4,
+},
+{
+format: 'sint32',
+offset: 516,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 2084,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 1504,
+shaderLocation: 1,
+},
+{
+format: 'sint32x3',
+offset: 652,
+shaderLocation: 0,
+},
+{
+format: 'unorm16x2',
+offset: 176,
+shaderLocation: 13,
+},
+{
+format: 'snorm8x2',
+offset: 366,
+shaderLocation: 3,
+},
+{
+format: 'float16x2',
+offset: 1848,
+shaderLocation: 10,
+},
+{
+format: 'float16x4',
+offset: 1376,
+shaderLocation: 17,
+},
+{
+format: 'float32x2',
+offset: 1040,
+shaderLocation: 15,
+},
+{
+format: 'sint8x4',
+offset: 980,
+shaderLocation: 8,
+},
+{
+format: 'uint32x4',
+offset: 368,
+shaderLocation: 12,
+},
+{
+format: 'sint8x4',
+offset: 152,
+shaderLocation: 7,
+},
+{
+format: 'unorm16x2',
+offset: 316,
+shaderLocation: 20,
+},
+{
+format: 'unorm8x2',
+offset: 1886,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x2',
+offset: 1890,
+shaderLocation: 14,
+},
+{
+format: 'sint8x2',
+offset: 1790,
+shaderLocation: 2,
+},
+{
+format: 'uint32x2',
+offset: 828,
+shaderLocation: 5,
+},
+{
+format: 'uint8x4',
+offset: 1164,
+shaderLocation: 11,
+},
+{
+format: 'float16x2',
+offset: 1684,
+shaderLocation: 19,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'back',
+},
+multisample: {
+count: 4,
+mask: 0x32d1d4f0,
+},
+fragment: {
+module: shaderModule25,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 622,
+stencilWriteMask: 2755,
+depthBias: 29,
+depthBiasSlopeScale: 65,
+depthBiasClamp: 58,
+},
+}
+);
+try {
+await promise62;
+} catch {}
+let canvas45 = document.createElement('canvas');
+let offscreenCanvas46 = new OffscreenCanvas(789, 506);
+let imageData46 = new ImageData(152, 188);
+let renderBundleEncoder153 = device1.createRenderBundleEncoder(
+{
+label: '\u0a50\u{1fdf9}\ubff8',
+colorFormats: [
+'rgba32float',
+'rgba16uint',
+'bgra8unorm-srgb'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 999,
+stencilReadOnly: true,
+}
+);
+try {
+device1.queue.writeTexture(
+{
+  texture: texture61,
+  mipLevel: 0,
+  origin: { x: 88, y: 0, z: 34 },
+  aspect: 'all',
+},
+arrayBuffer5,
+/* required buffer size: 415931 */{
+offset: 75,
+bytesPerRow: 79,
+rowsPerImage: 188,
+},
+{width: 25, height: 0, depthOrArrayLayers: 29}
+);
+} catch {}
+let texture217 = device3.createTexture(
+{
+label: '\u85a8\ued28\u4df4\u{1fecc}',
+size: {width: 141, height: 1, depthOrArrayLayers: 116},
+mipLevelCount: 8,
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let renderBundle169 = renderBundleEncoder61.finish(
+{
+label: '\u02da\uf701\udc8e\u{1fb82}\u0066\u{1fe9b}\ub119'
+}
+);
+try {
+computePassEncoder41.end();
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(
+446,
+2,
+13,
+3
+);
+} catch {}
+try {
+renderBundleEncoder88.setVertexBuffer(
+10,
+buffer24,
+1696,
+13961
+);
+} catch {}
+try {
+commandEncoder61.clearBuffer(
+buffer24,
+6636,
+12332
+);
+dissociateBuffer(device3, buffer24);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture89,
+  mipLevel: 0,
+  origin: { x: 156, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer5,
+/* required buffer size: 633 */{
+offset: 633,
+rowsPerImage: 118,
+},
+{width: 1774, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(
+/*
+{width: 715, height: 1, depthOrArrayLayers: 418}
+*/
+{
+  source: videoFrame29,
+  origin: { x: 6, y: 2 },
+  flipY: false,
+},
+{
+  texture: texture138,
+  mipLevel: 1,
+  origin: { x: 14, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 84, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline96 = device3.createRenderPipeline(
+{
+label: '\udf1d\u0941\u0916\u{1f825}\u957a\u02ca\ud96c',
+layout: pipelineLayout33,
+vertex: {
+module: shaderModule18,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 19232,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x3',
+offset: 1960,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 14656,
+attributes: [
+{
+format: 'sint32',
+offset: 12040,
+shaderLocation: 10,
+},
+{
+format: 'float16x2',
+offset: 4000,
+shaderLocation: 13,
+},
+{
+format: 'sint8x4',
+offset: 4184,
+shaderLocation: 9,
+},
+{
+format: 'sint32x3',
+offset: 4884,
+shaderLocation: 0,
+},
+{
+format: 'uint8x2',
+offset: 12124,
+shaderLocation: 12,
+},
+{
+format: 'uint16x4',
+offset: 3744,
+shaderLocation: 3,
+},
+{
+format: 'snorm16x2',
+offset: 9144,
+shaderLocation: 4,
+},
+{
+format: 'sint32x2',
+offset: 12308,
+shaderLocation: 2,
+},
+{
+format: 'sint32x4',
+offset: 5032,
+shaderLocation: 16,
+},
+{
+format: 'sint16x4',
+offset: 4228,
+shaderLocation: 8,
+},
+{
+format: 'float32',
+offset: 8436,
+shaderLocation: 5,
+},
+{
+format: 'sint32x2',
+offset: 12316,
+shaderLocation: 11,
+},
+{
+format: 'uint32x4',
+offset: 11780,
+shaderLocation: 6,
+},
+{
+format: 'sint32',
+offset: 5588,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 13552,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x3',
+offset: 9692,
+shaderLocation: 7,
+},
+{
+format: 'float32x3',
+offset: 7232,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+primitive: {
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule18,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16float',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+document.body.prepend(canvas0);
+try {
+commandEncoder75.copyTextureToBuffer(
+{
+  texture: texture160,
+  mipLevel: 0,
+  origin: { x: 737, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 14074 widthInBlocks: 7037 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 28268 */
+offset: 14194,
+buffer: buffer23,
+},
+{width: 7037, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device6, buffer23);
+} catch {}
+try {
+commandEncoder75.resolveQuerySet(
+querySet112,
+288,
+178,
+buffer23,
+24064
+);
+} catch {}
+let canvas46 = document.createElement('canvas');
+let bindGroupLayout58 = device16.createBindGroupLayout(
+{
+label: '\u08c7\u74fc\u031c',
+entries: [
+{
+binding: 670,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 873,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+}
+],
+}
+);
+let pipelineLayout42 = device16.createPipelineLayout(
+{
+label: '\u0852\uddb0\u0b94\u{1ff58}\uefd7\u{1fb65}\u9b0b\u{1fb35}',
+bindGroupLayouts: [
+bindGroupLayout58
+],
+}
+);
+let commandEncoder140 = device16.createCommandEncoder(
+{
+label: '\u3615\uddb1\u5feb\u{1feac}\u0479\u075a\u0df8',
+}
+);
+let texture218 = device16.createTexture(
+{
+label: '\u00eb\u6a92\uc906\u0158\u{1ff32}',
+size: [4, 4, 195],
+mipLevelCount: 5,
+dimension: '3d',
+format: 'r32float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder90 = commandEncoder140.beginComputePass(
+{
+label: '\u07f4\u0cfb'
+}
+);
+let promise64 = device16.queue.onSubmittedWorkDone();
+let pipelineLayout43 = device14.createPipelineLayout(
+{
+label: '\u0463\u{1fca7}\ud4e1\ud3c0',
+bindGroupLayouts: [
+bindGroupLayout56,
+bindGroupLayout56,
+bindGroupLayout56,
+bindGroupLayout56,
+bindGroupLayout56,
+bindGroupLayout56,
+bindGroupLayout56
+],
+}
+);
+let commandEncoder141 = device14.createCommandEncoder(
+{
+label: '\u7c43\u{1fd54}\ufc2e\u8cd3\u529c\u0257\u74f0\u83b0\u027b',
+}
+);
+let texture219 = device14.createTexture(
+{
+label: '\uad3c\uae4d\u027d\ua14a\u0a67\u67e8\u2ee3\u0729',
+size: [1001, 1, 152],
+mipLevelCount: 9,
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let textureView176 = texture219.createView(
+{
+label: '\ua180\u307b\u5635\u{1f928}\u0834\u1b62\u0f45\u6280\u3410\u0ff2',
+baseMipLevel: 8,
+baseArrayLayer: 67,
+arrayLayerCount: 64,
+}
+);
+try {
+await promise64;
+} catch {}
+let canvas47 = document.createElement('canvas');
+let offscreenCanvas47 = new OffscreenCanvas(56, 463);
+let promise65 = adapter9.requestAdapterInfo();
+try {
+canvas45.getContext('2d');
+} catch {}
+let bindGroup65 = device1.createBindGroup({
+label: '\u03f6\u7a1c\ud01c\ud7d4\u{1fcd4}\u0d4b\u0f2f\u5fa1',
+layout: bindGroupLayout21,
+entries: [
+
+],
+});
+let querySet141 = device1.createQuerySet(
+{
+label: '\u0660\u0a4b\ud14a\u025a\u{1fe9d}\u013b\u1d34',
+type: 'occlusion',
+count: 1019,
+}
+);
+let texture220 = device1.createTexture(
+{
+label: '\ue234\u{1fc9d}\u{1fbda}\uac65\u968a\u9533',
+size: {width: 162, height: 84, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'astc-6x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-6x6-unorm'
+],
+}
+);
+let renderBundleEncoder154 = device1.createRenderBundleEncoder(
+{
+label: '\u0811\uec63\u2349\u6d96\u05b2\u{1fd79}\u73b1\u0562\u5190',
+colorFormats: [
+'rg8uint',
+'rg32float',
+'rgba8uint',
+'rgba32uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 536,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler121 = device1.createSampler(
+{
+label: '\u1452\u024b\u2d70\u{1f6fa}\u{1fd95}',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 73.579,
+maxAnisotropy: 18,
+}
+);
+try {
+computePassEncoder33.setPipeline(
+pipeline86
+);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(
+3,
+bindGroup65,
+new Uint32Array(17),
+10,
+0
+);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(
+7,
+buffer14,
+22492,
+5334
+);
+} catch {}
+try {
+renderBundleEncoder154.setVertexBuffer(
+3,
+buffer37,
+19808
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer37,
+34596,
+new Float32Array(3492),
+2104,
+1144
+);
+} catch {}
+let pipeline97 = device1.createRenderPipeline(
+{
+label: '\u{1f828}\ue255\ub028',
+layout: 'auto',
+vertex: {
+module: shaderModule20,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 26596,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x2',
+offset: 68,
+shaderLocation: 9,
+},
+{
+format: 'float32',
+offset: 40096,
+shaderLocation: 19,
+},
+{
+format: 'unorm16x2',
+offset: 33224,
+shaderLocation: 1,
+},
+{
+format: 'uint16x2',
+offset: 15280,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x4',
+offset: 45448,
+shaderLocation: 6,
+},
+{
+format: 'uint32x4',
+offset: 36632,
+shaderLocation: 21,
+},
+{
+format: 'uint32x2',
+offset: 32868,
+shaderLocation: 14,
+},
+{
+format: 'snorm16x2',
+offset: 24692,
+shaderLocation: 5,
+},
+{
+format: 'unorm16x4',
+offset: 24800,
+shaderLocation: 11,
+},
+{
+format: 'unorm8x4',
+offset: 42800,
+shaderLocation: 22,
+},
+{
+format: 'unorm16x4',
+offset: 45664,
+shaderLocation: 17,
+},
+{
+format: 'uint32',
+offset: 16564,
+shaderLocation: 20,
+},
+{
+format: 'unorm8x2',
+offset: 5490,
+shaderLocation: 24,
+}
+],
+},
+{
+arrayStride: 20772,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 21792,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32',
+offset: 316,
+shaderLocation: 2,
+},
+{
+format: 'unorm8x4',
+offset: 15184,
+shaderLocation: 8,
+},
+{
+format: 'uint16x4',
+offset: 12116,
+shaderLocation: 12,
+},
+{
+format: 'uint16x4',
+offset: 1752,
+shaderLocation: 0,
+},
+{
+format: 'uint32x4',
+offset: 18512,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 44432,
+attributes: [
+{
+format: 'float32x2',
+offset: 2952,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x2',
+offset: 35714,
+shaderLocation: 16,
+},
+{
+format: 'sint32',
+offset: 23996,
+shaderLocation: 13,
+},
+{
+format: 'unorm16x2',
+offset: 7624,
+shaderLocation: 10,
+},
+{
+format: 'sint8x2',
+offset: 9116,
+shaderLocation: 23,
+},
+{
+format: 'float32',
+offset: 5576,
+shaderLocation: 18,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+},
+fragment: {
+module: shaderModule20,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'invert',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 1688,
+stencilWriteMask: 288,
+depthBias: 15,
+depthBiasSlopeScale: 35,
+depthBiasClamp: 1,
+},
+}
+);
+try {
+gpuCanvasContext25.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+gc();
+let renderBundle170 = renderBundleEncoder71.finish(
+{
+label: '\u8037\u9ea4\u04bf\u6c1c\u904f\u0786\ua7b6\u{1faa8}\u0937'
+}
+);
+try {
+device6.queue.writeBuffer(
+buffer43,
+8868,
+new Float32Array(26297),
+12462,
+228
+);
+} catch {}
+try {
+await promise65;
+} catch {}
+let canvas48 = document.createElement('canvas');
+let renderPassEncoder31 = commandEncoder113.beginRenderPass(
+{
+label: '\u{1f91b}\u05c4\u0bd4\u9e5a\u04a7\u9e92',
+colorAttachments: [
+{
+view: textureView168,
+depthSlice: 197,
+clearValue: {
+r: 837.9,
+g: 626.6,
+b: 764.8,
+a: -506.5,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView168,
+depthSlice: 247,
+clearValue: {
+r: -760.5,
+g: 133.2,
+b: -70.09,
+a: 276.6,
+},
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+{
+view: textureView168,
+depthSlice: 172,
+clearValue: {
+r: 757.2,
+g: 836.2,
+b: -35.86,
+a: 643.5,
+},
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+maxDrawCount: 21544,
+}
+);
+try {
+renderPassEncoder30.setBlendConstant(
+{
+r: -36.57,
+g: 276.2,
+b: -606.7,
+a: -501.0,
+}
+);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(
+buffer33,
+'uint32',
+23796,
+3692
+);
+} catch {}
+let canvas49 = document.createElement('canvas');
+let bindGroupLayout59 = device3.createBindGroupLayout(
+{
+label: '\u0221\u{1ffee}\u{1fa4c}\ub98b\u6c4f',
+entries: [
+
+],
+}
+);
+let renderBundleEncoder155 = device3.createRenderBundleEncoder(
+{
+label: '\u0b2d\u032c\u{1ffde}\u08a9\u02b0\u891b',
+colorFormats: [
+'rg8unorm',
+undefined,
+'rg32sint',
+'rg32uint'
+],
+sampleCount: 584,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle171 = renderBundleEncoder117.finish(
+{
+label: '\u{1f8b5}\u0f78\uf85a\ufb6a\u6ad5\u07c4\u3457\u0f1d\u1126\u48b1'
+}
+);
+try {
+renderPassEncoder23.setStencilReference(
+1548
+);
+} catch {}
+try {
+renderBundleEncoder155.setVertexBuffer(
+2,
+buffer24,
+13024,
+8145
+);
+} catch {}
+try {
+commandEncoder61.copyTextureToTexture(
+{
+  texture: texture138,
+  mipLevel: 1,
+  origin: { x: 34, y: 0, z: 57 },
+  aspect: 'all',
+},
+{
+  texture: texture138,
+  mipLevel: 0,
+  origin: { x: 487, y: 0, z: 312 },
+  aspect: 'all',
+},
+{width: 340, height: 0, depthOrArrayLayers: 41}
+);
+} catch {}
+let gpuCanvasContext44 = offscreenCanvas47.getContext('webgpu');
+try {
+gpuCanvasContext20.unconfigure();
+} catch {}
+let videoFrame44 = new VideoFrame(video26, {timestamp: 0});
+try {
+canvas49.getContext('webgl');
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let canvas50 = document.createElement('canvas');
+let video50 = await videoWithData();
+try {
+canvas47.getContext('webgl');
+} catch {}
+try {
+window.someLabel = device2.label;
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let querySet142 = device5.createQuerySet(
+{
+label: '\u05df\u2cab\u69c7\u99a3\u99c7\u7341\u1ce2',
+type: 'occlusion',
+count: 2434,
+}
+);
+let texture221 = device5.createTexture(
+{
+label: '\u7713\u05aa\u01d7',
+size: [6016, 240, 85],
+mipLevelCount: 2,
+format: 'astc-8x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-8x6-unorm-srgb',
+'astc-8x6-unorm'
+],
+}
+);
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant(
+{
+r: 331.8,
+g: -517.7,
+b: 442.6,
+a: -900.1,
+}
+);
+} catch {}
+try {
+renderPassEncoder20.setStencilReference(
+202
+);
+} catch {}
+try {
+renderPassEncoder17.setViewport(
+6.377,
+0.9213,
+40.81,
+0.1921,
+0.9901,
+0.9939
+);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(
+buffer42,
+'uint16'
+);
+} catch {}
+try {
+renderBundleEncoder146.setVertexBuffer(
+4,
+buffer69,
+1744,
+8
+);
+} catch {}
+let querySet143 = device16.createQuerySet(
+{
+label: '\ua39c\u0429\u0798\udf78\u{1f971}\u81d2\u67d8\u{1fa5f}\uac02',
+type: 'occlusion',
+count: 1906,
+}
+);
+let renderBundleEncoder156 = device16.createRenderBundleEncoder(
+{
+label: '\u2f14\u9741\uc9cf',
+colorFormats: [
+'r16uint',
+'bgra8unorm-srgb',
+'r16uint',
+'r32uint'
+],
+sampleCount: 788,
+}
+);
+let renderBundle172 = renderBundleEncoder156.finish(
+{
+label: '\u02d4\u0bd9\u{1fccd}\u{1f71f}\u{1f928}\u811d\u9ef7\u{1fbe1}'
+}
+);
+let sampler122 = device16.createSampler(
+{
+label: '\u0947\ufe21\u0976\u5308\u17d3',
+addressModeU: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 67.100,
+lodMaxClamp: 99.513,
+maxAnisotropy: 12,
+}
+);
+let bindGroup66 = device1.createBindGroup({
+label: '\u139f\uacb9\u0cb7\u{1f98b}\u{1fa3c}\uab97\ufeea\u0408\ubf85\ubbca',
+layout: bindGroupLayout11,
+entries: [
+
+],
+});
+let textureView177 = texture56.createView(
+{
+label: '\u0312\u0618\u58b3\u{1fc0c}',
+dimension: '1d',
+mipLevelCount: 1,
+}
+);
+let sampler123 = device1.createSampler(
+{
+label: '\u0032\u9f94\u1e84\u0db8\ub923',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 30.375,
+lodMaxClamp: 56.458,
+maxAnisotropy: 5,
+}
+);
+try {
+computePassEncoder33.setBindGroup(
+5,
+bindGroup43
+);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(
+buffer16,
+'uint32'
+);
+} catch {}
+let arrayBuffer15 = buffer35.getMappedRange(
+19952
+);
+let pipeline98 = await device1.createComputePipelineAsync(
+{
+label: '\ue635\u05d3\u062b\u0b95\u0a9f\ubf42\u23af\u1224\uf7eb\u29ca\u0237',
+layout: pipelineLayout27,
+compute: {
+module: shaderModule15,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+document.body.append('\u1aeb\u3aab');
+let texture222 = device5.createTexture(
+{
+label: '\u{1ff0e}\u0536\u{1fae7}\u42f7\u17b0\u{1fad4}\u8317\ub181\u7496',
+size: [4270, 190, 1],
+mipLevelCount: 6,
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-10x10-unorm-srgb',
+'astc-10x10-unorm'
+],
+}
+);
+let sampler124 = device5.createSampler(
+{
+label: '\ucc91\u{1f9e0}\u1ab2\u06ed',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 3.073,
+lodMaxClamp: 77.043,
+maxAnisotropy: 3,
+}
+);
+try {
+renderPassEncoder17.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(
+5,
+buffer57,
+39220
+);
+} catch {}
+try {
+renderBundleEncoder150.setBindGroup(
+1,
+bindGroup29,
+[]
+);
+} catch {}
+try {
+renderBundleEncoder93.setVertexBuffer(
+4,
+buffer42,
+44708,
+563
+);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture74,
+  mipLevel: 0,
+  origin: { x: 4, y: 0, z: 9 },
+  aspect: 'all',
+},
+new ArrayBuffer(40),
+/* required buffer size: 9869502 */{
+offset: 942,
+bytesPerRow: 361,
+rowsPerImage: 268,
+},
+{width: 66, height: 1, depthOrArrayLayers: 103}
+);
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(
+/*
+{width: 77, height: 2, depthOrArrayLayers: 121}
+*/
+{
+  source: imageBitmap30,
+  origin: { x: 28, y: 119 },
+  flipY: false,
+},
+{
+  texture: texture74,
+  mipLevel: 0,
+  origin: { x: 21, y: 0, z: 11 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 45, height: 2, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+document.body.append('\u2959\u1942\u0d9f\u0bcd\u0a4b\u8bb5\u{1f688}\u{1fb26}');
+let canvas51 = document.createElement('canvas');
+let offscreenCanvas48 = new OffscreenCanvas(684, 777);
+let texture223 = device7.createTexture(
+{
+label: '\uf764\ue97a',
+size: {width: 168, height: 156, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-12x12-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundle173 = renderBundleEncoder59.finish();
+try {
+commandEncoder116.copyTextureToTexture(
+{
+  texture: texture159,
+  mipLevel: 5,
+  origin: { x: 48, y: 0, z: 12 },
+  aspect: 'all',
+},
+{
+  texture: texture159,
+  mipLevel: 5,
+  origin: { x: 116, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 20, height: 0, depthOrArrayLayers: 12}
+);
+} catch {}
+try {
+commandEncoder126.clearBuffer(
+buffer36,
+15660,
+12600
+);
+dissociateBuffer(device7, buffer36);
+} catch {}
+try {
+gpuCanvasContext25.configure(
+{
+device: device7,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'bgra8unorm-srgb'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device7.queue.writeBuffer(
+buffer36,
+55100,
+new BigUint64Array(40711),
+15634,
+48
+);
+} catch {}
+let pipeline99 = device7.createRenderPipeline(
+{
+label: '\u{1fa3a}\u9386\ud697\u05f2',
+layout: pipelineLayout28,
+vertex: {
+module: shaderModule17,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 5564,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x3',
+offset: 2712,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule17,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'one-minus-constant',
+dstFactor: 'src'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'one-minus-src',
+dstFactor: 'one'
+},
+},
+format: 'rg8unorm',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'r32uint',
+},
+{
+format: 'r32sint',
+},
+{
+format: 'rg32sint',
+},
+{
+format: 'rg16sint',
+},
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.GREEN,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'replace',
+},
+stencilReadMask: 4030,
+depthBiasSlopeScale: 85,
+depthBiasClamp: 52,
+},
+}
+);
+document.body.append('\u3dfb\ue853\u902f\u0784\u013e\u3133');
+let bindGroupLayout60 = device16.createBindGroupLayout(
+{
+label: '\u0102\u{1fb20}\u0c8a\u{1ff76}\u{1ffcd}\u0bbc\u{1fc79}\u{1fdb9}\u043e\u2632',
+entries: [
+{
+binding: 845,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 485,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+let commandEncoder142 = device16.createCommandEncoder(
+{
+}
+);
+let commandBuffer17 = commandEncoder142.finish();
+let renderBundleEncoder157 = device6.createRenderBundleEncoder(
+{
+label: '\ua6d7\u{1fe89}\u8a14\u92b3\u154b',
+colorFormats: [
+'r16uint',
+'rgba16uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 570,
+stencilReadOnly: true,
+}
+);
+try {
+commandEncoder75.copyTextureToTexture(
+{
+  texture: texture76,
+  mipLevel: 4,
+  origin: { x: 88, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture76,
+  mipLevel: 2,
+  origin: { x: 168, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 16, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device6.queue.writeTexture(
+{
+  texture: texture201,
+  mipLevel: 2,
+  origin: { x: 51, y: 1, z: 7 },
+  aspect: 'all',
+},
+new BigUint64Array(arrayBuffer11),
+/* required buffer size: 1049035 */{
+offset: 805,
+bytesPerRow: 613,
+rowsPerImage: 19,
+},
+{width: 57, height: 0, depthOrArrayLayers: 91}
+);
+} catch {}
+try {
+canvas48.getContext('webgl');
+} catch {}
+document.body.prepend(video33);
+let shaderModule28 = device14.createShaderModule(
+{
+label: '\u0d72\uf869\u{1fc1a}\u{1f87d}\u9a4f\u067f\u{1f79e}\u7424\u{1ffda}\uc83f\ueb85',
+code: `
+
+@compute @workgroup_size(4, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S33 {
+@builtin(front_facing) f0: bool,
+@builtin(sample_index) f1: u32,
+@builtin(position) f2: vec4<f32>
+}
+struct FragmentOutput0 {
+@location(0) f0: i32,
+@location(3) f1: vec4<f32>,
+@location(5) f2: vec4<u32>,
+@builtin(sample_mask) f3: u32,
+@location(1) f4: f32,
+@location(4) f5: vec2<f32>,
+@location(6) f6: vec4<u32>,
+@location(2) f7: vec4<i32>,
+@location(7) f8: vec2<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, a1: S33) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S32 {
+@location(0) f0: u32,
+@location(15) f1: vec2<f32>,
+@location(20) f2: vec3<i32>,
+@location(7) f3: vec3<f32>,
+@builtin(vertex_index) f4: u32,
+@location(1) f5: vec3<f16>,
+@location(21) f6: vec3<u32>,
+@location(10) f7: vec2<f16>,
+@location(4) f8: vec4<i32>,
+@location(3) f9: vec2<f32>,
+@location(9) f10: f16,
+@location(13) f11: vec4<i32>,
+@location(22) f12: vec2<f32>,
+@location(18) f13: vec2<f16>,
+@location(19) f14: vec2<f32>,
+@location(8) f15: vec2<i32>,
+@location(17) f16: vec2<i32>,
+@location(26) f17: vec4<u32>,
+@location(2) f18: vec3<f32>,
+@location(25) f19: vec2<f16>,
+@location(23) f20: vec3<f16>,
+@location(11) f21: vec2<i32>,
+@location(16) f22: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec2<f32>, @builtin(instance_index) a1: u32, @location(6) a2: f16, a3: S32, @location(12) a4: vec4<f32>, @location(24) a5: u32, @location(14) a6: vec2<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let textureView178 = texture206.createView(
+{
+label: '\u{1fa82}\u060f\u0e59\u0ad2\u{1fe60}',
+dimension: '1d',
+format: 'rg32float',
+}
+);
+try {
+gpuCanvasContext36.configure(
+{
+device: device14,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device14.queue.writeTexture(
+{
+  texture: texture219,
+  mipLevel: 0,
+  origin: { x: 450, y: 1, z: 8 },
+  aspect: 'all',
+},
+new BigInt64Array(new ArrayBuffer(40)),
+/* required buffer size: 38577421 */{
+offset: 625,
+bytesPerRow: 2369,
+rowsPerImage: 118,
+},
+{width: 541, height: 0, depthOrArrayLayers: 139}
+);
+} catch {}
+try {
+offscreenCanvas46.getContext('2d');
+} catch {}
+let querySet144 = device15.createQuerySet(
+{
+label: '\u71f0\uade3\u{1f7a3}\u04dc\u22ce\u{1f8a9}\u{1fa1e}',
+type: 'occlusion',
+count: 278,
+}
+);
+let texture224 = device15.createTexture(
+{
+size: {width: 1518, height: 12, depthOrArrayLayers: 1},
+format: 'astc-6x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-6x6-unorm',
+'astc-6x6-unorm-srgb',
+'astc-6x6-unorm'
+],
+}
+);
+try {
+device15.pushErrorScope(
+'out-of-memory'
+);
+} catch {}
+let bindGroupLayout61 = device10.createBindGroupLayout(
+{
+label: '\ucf50\u0d43\u4e9d\u{1fb2d}',
+entries: [
+{
+binding: 1692,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '2d' },
+}
+],
+}
+);
+let texture225 = device10.createTexture(
+{
+label: '\u04e9\ua1bb\ufbe2\ud453\u073b',
+size: {width: 87},
+dimension: '1d',
+format: 'r8sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8sint'
+],
+}
+);
+let computePassEncoder91 = commandEncoder103.beginComputePass(
+{
+label: '\u7a73\uee9d\u{1fdd1}'
+}
+);
+try {
+renderPassEncoder31.setVertexBuffer(
+3,
+buffer60,
+2640,
+1016
+);
+} catch {}
+try {
+renderBundleEncoder131.setVertexBuffer(
+2,
+buffer33,
+30628,
+5091
+);
+} catch {}
+try {
+device10.queue.copyExternalImageToTexture(
+/*
+{width: 941, height: 1, depthOrArrayLayers: 62}
+*/
+{
+  source: canvas20,
+  origin: { x: 181, y: 91 },
+  flipY: false,
+},
+{
+  texture: texture104,
+  mipLevel: 1,
+  origin: { x: 512, y: 0, z: 18 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 94, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext40.unconfigure();
+} catch {}
+document.body.append('\u0fb8\u7912\uec9e');
+let videoFrame45 = new VideoFrame(imageBitmap18, {timestamp: 0});
+let commandEncoder143 = device6.createCommandEncoder(
+{
+label: '\u0ce4\u{1fff5}',
+}
+);
+let renderBundle174 = renderBundleEncoder81.finish(
+{
+
+}
+);
+try {
+renderBundleEncoder145.setIndexBuffer(
+buffer44,
+'uint32',
+788
+);
+} catch {}
+try {
+device6.queue.writeTexture(
+{
+  texture: texture70,
+  mipLevel: 1,
+  origin: { x: 696, y: 10, z: 170 },
+  aspect: 'all',
+},
+new Int32Array(arrayBuffer15),
+/* required buffer size: 1343780 */{
+offset: 530,
+bytesPerRow: 3375,
+rowsPerImage: 199,
+},
+{width: 2316, height: 0, depthOrArrayLayers: 3}
+);
+} catch {}
+let gpuCanvasContext45 = canvas46.getContext('webgpu');
+document.body.append('\u504b\ud91a\u0236');
+let imageBitmap53 = await createImageBitmap(imageBitmap35);
+try {
+await adapter17.requestAdapterInfo();
+} catch {}
+let bindGroup67 = device8.createBindGroup({
+label: '\u0313\uf799',
+layout: bindGroupLayout22,
+entries: [
+{
+binding: 488,
+resource: sampler72
+}
+],
+});
+let querySet145 = device8.createQuerySet(
+{
+label: '\u{1ff41}\u{1fa87}\u6da1\u0fba',
+type: 'occlusion',
+count: 3808,
+}
+);
+let textureView179 = texture205.createView(
+{
+dimension: '2d-array',
+aspect: 'depth-only',
+}
+);
+let computePassEncoder92 = commandEncoder133.beginComputePass(
+{
+label: '\u7d37\u{1f9ce}\uaa6a\ud071\u{1fb7a}\u0033\udd2e\u0074\u25d5\u8bab'
+}
+);
+try {
+renderBundleEncoder98.setBindGroup(
+3,
+bindGroup67,
+[]
+);
+} catch {}
+gc();
+document.body.prepend('\u0a8a\u032d\u8613\u{1ffd4}');
+try {
+await adapter3.requestAdapterInfo();
+} catch {}
+let shaderModule29 = device16.createShaderModule(
+{
+label: '\u{1fbf5}\u0a5b\u{1f65a}\u9659\u7c04\uc330\u6ef7',
+code: `
+
+@compute @workgroup_size(8, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(3) f0: vec3<u32>,
+@location(1) f1: vec3<f32>,
+@location(7) f2: f32,
+@location(5) f3: u32,
+@location(2) f4: vec2<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(8) f461: vec4<u32>,
+@location(0) f462: vec3<f32>,
+@location(10) f463: vec3<i32>,
+@location(1) f464: vec4<f16>,
+@location(5) f465: vec4<i32>,
+@location(6) f466: f32,
+@location(14) f467: vec4<f32>,
+@location(13) f468: vec2<f32>,
+@location(4) f469: vec3<u32>,
+@location(11) f470: u32,
+@builtin(position) f471: vec4<f32>,
+@location(2) f472: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec3<f32>, @location(8) a1: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder144 = device16.createCommandEncoder(
+{
+label: '\ued1f\u28e8\u03e9\ueb0e\u1985\u{1fbfa}\u{1f8d8}\u6f09',
+}
+);
+let textureView180 = texture218.createView(
+{
+baseMipLevel: 1,
+mipLevelCount: 2,
+}
+);
+let renderBundle175 = renderBundleEncoder156.finish(
+{
+label: '\u7fc2\u3908\u18e4\udb4e\ua097\u2920\u3f70'
+}
+);
+try {
+device16.queue.submit([
+]);
+} catch {}
+let pipeline100 = await device16.createRenderPipelineAsync(
+{
+label: '\ub735\u6ed4\u3921\uc471\uf6e8\u{1f60c}',
+layout: pipelineLayout42,
+vertex: {
+module: shaderModule29,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 1252,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 460,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 260,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+multisample: {
+mask: 0xd8d221eb,
+},
+fragment: {
+module: shaderModule29,
+entryPoint: 'fragment0',
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'equal',
+depthFailOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'invert',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilReadMask: 1966,
+stencilWriteMask: 1565,
+depthBias: 0,
+depthBiasSlopeScale: 45,
+depthBiasClamp: 65,
+},
+}
+);
+let offscreenCanvas49 = new OffscreenCanvas(590, 630);
+let video51 = await videoWithData();
+let textureView181 = texture104.createView(
+{
+label: '\ua46a\u0db9\u084b\u387a\u{1f8f0}\u7981\u{1fbdd}\u{1fe55}\ud3c6\u{1f670}\u{1fe8f}',
+dimension: '3d',
+format: 'rgba32float',
+baseMipLevel: 2,
+}
+);
+let renderBundleEncoder158 = device10.createRenderBundleEncoder(
+{
+label: '\ua62e\u081b\u1cad\u71cf\u00b9',
+colorFormats: [
+'rgba8sint',
+'rg16uint',
+'rgba16uint',
+'rgba8unorm',
+'r8unorm',
+'r32sint'
+],
+sampleCount: 139,
+stencilReadOnly: true,
+}
+);
+let renderBundle176 = renderBundleEncoder121.finish(
+{
+
+}
+);
+try {
+computePassEncoder91.end();
+} catch {}
+try {
+renderPassEncoder30.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+renderPassEncoder30.setViewport(
+43.09,
+0.6814,
+38.39,
+0.3107,
+0.6661,
+0.7988
+);
+} catch {}
+let arrayBuffer16 = buffer65.getMappedRange(
+15936
+);
+try {
+commandEncoder103.copyBufferToBuffer(
+buffer52,
+24500,
+buffer47,
+6844,
+16004
+);
+dissociateBuffer(device10, buffer52);
+dissociateBuffer(device10, buffer47);
+} catch {}
+try {
+device10.queue.copyExternalImageToTexture(
+/*
+{width: 470, height: 1, depthOrArrayLayers: 31}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 185, y: 29 },
+  flipY: false,
+},
+{
+  texture: texture104,
+  mipLevel: 2,
+  origin: { x: 34, y: 1, z: 16 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 41, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let device17 = await adapter19.requestDevice(
+{
+requiredLimits: {
+maxBindGroups: 5,
+maxColorAttachmentBytesPerSample: 52,
+maxVertexAttributes: 18,
+maxVertexBufferArrayStride: 12523,
+maxStorageTexturesPerShaderStage: 30,
+maxStorageBuffersPerShaderStage: 32,
+maxDynamicStorageBuffersPerPipelineLayout: 42180,
+maxBindingsPerBindGroup: 5135,
+maxTextureDimension1D: 15819,
+maxTextureDimension2D: 11511,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 31913555,
+maxInterStageShaderVariables: 68,
+maxInterStageShaderComponents: 84,
+},
+}
+);
+let offscreenCanvas50 = new OffscreenCanvas(889, 551);
+document.body.prepend('\u72d9\u5978\u0817');
+let videoFrame46 = new VideoFrame(imageBitmap48, {timestamp: 0});
+let commandEncoder145 = device13.createCommandEncoder();
+let renderBundle177 = renderBundleEncoder137.finish(
+{
+label: '\u{1fd7c}\u8f59\u0cbf\ua10f\u{1fe05}\uf450\uba33'
+}
+);
+let sampler125 = device13.createSampler(
+{
+label: '\u0507\uda2b\u{1fd19}\u{1f671}\ud186\u0ab5\u2aa8\u30ec\uf979\u0719',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 99.841,
+lodMaxClamp: 99.955,
+maxAnisotropy: 4,
+}
+);
+try {
+computePassEncoder87.setBindGroup(
+9,
+bindGroup61,
+new Uint32Array(1031),
+778,
+0
+);
+} catch {}
+let promise66 = device13.createRenderPipelineAsync(
+{
+label: '\u0441\u{1fdde}\u6ef2',
+layout: pipelineLayout37,
+vertex: {
+module: shaderModule26,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 5316,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x2',
+offset: 3948,
+shaderLocation: 19,
+},
+{
+format: 'sint32x4',
+offset: 1760,
+shaderLocation: 22,
+},
+{
+format: 'sint32x4',
+offset: 4960,
+shaderLocation: 26,
+}
+],
+},
+{
+arrayStride: 1392,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 860,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x6dce9556,
+},
+fragment: {
+module: shaderModule26,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'less',
+depthFailOp: 'replace',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+passOp: 'replace',
+},
+stencilReadMask: 2615,
+stencilWriteMask: 2876,
+depthBias: 21,
+depthBiasSlopeScale: 92,
+depthBiasClamp: 31,
+},
+}
+);
+let offscreenCanvas51 = new OffscreenCanvas(745, 57);
+let texture226 = device17.createTexture(
+{
+label: '\u0235\u878f\u07d3\u4059\u5009\u05f8\ubf8d\ub4b3',
+size: [984, 191, 1],
+mipLevelCount: 8,
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let commandEncoder146 = device4.createCommandEncoder(
+{
+label: '\u677d\uf531\u8fe8\u21f4',
+}
+);
+let querySet146 = device4.createQuerySet(
+{
+label: '\u0300\u0688\u20c7\u4c3d',
+type: 'occlusion',
+count: 3233,
+}
+);
+pseudoSubmit(device4, commandEncoder88);
+try {
+renderPassEncoder24.setVertexBuffer(
+10,
+buffer20
+);
+} catch {}
+try {
+renderBundleEncoder103.setBindGroup(
+4,
+bindGroup44
+);
+} catch {}
+let promise67 = device4.queue.onSubmittedWorkDone();
+let pipeline101 = await device4.createComputePipelineAsync(
+{
+label: '\u8297\u7dc8\u{1f73a}\u59d9\uc255\u09e5\u08b6',
+layout: pipelineLayout29,
+compute: {
+module: shaderModule25,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.append('\u0aaa\uf7df\u0384\ub4ec\u0c45\u0dc4\ue05e');
+let canvas52 = document.createElement('canvas');
+let imageBitmap54 = await createImageBitmap(imageBitmap31);
+let shaderModule30 = device16.createShaderModule(
+{
+label: '\u0bb9\u98dc\u1f7b\u{1faa8}\u9455\u09b8',
+code: `
+
+@compute @workgroup_size(7, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@builtin(sample_mask) f0: u32,
+@location(4) f1: vec4<i32>,
+@location(3) f2: f32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@builtin(position) f473: vec4<f32>,
+@location(5) f474: vec3<u32>,
+@location(6) f475: vec4<f16>,
+@location(7) f476: vec3<i32>,
+@location(3) f477: vec2<f32>,
+@location(8) f478: vec3<f32>,
+@location(4) f479: vec4<f32>,
+@location(15) f480: vec3<u32>,
+@location(1) f481: vec3<i32>,
+@location(14) f482: vec2<f32>,
+@location(13) f483: u32,
+@location(0) f484: vec2<i32>,
+@location(2) f485: vec2<f16>,
+@location(9) f486: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture227 = device16.createTexture(
+{
+label: '\u0c5f\u0584\u793b\u0ed4\u7753\u0b26\u0ec6\ue566\uac48',
+size: [4980, 1, 202],
+mipLevelCount: 1,
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder93 = commandEncoder144.beginComputePass(
+{
+label: '\uf9e4\ua9e8\u5222\u9fd9\u{1fabc}\udb91\ued3c\ue560\u07d9\u4609\u2598'
+}
+);
+try {
+device16.queue.submit([
+commandBuffer17,
+]);
+} catch {}
+let promise68 = device16.createComputePipelineAsync(
+{
+label: '\u0d76\u6ae4\ue7f5\u040a\u{1ff50}\uef3c\u0ed3\ucc56\u5dab',
+layout: 'auto',
+compute: {
+module: shaderModule30,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let bindGroupLayout62 = pipeline93.getBindGroupLayout(0);
+let pipelineLayout44 = device13.createPipelineLayout(
+{
+label: '\u98df\u{1fad9}\u{1f8e4}\u{1ffa0}\u47be',
+bindGroupLayouts: [
+bindGroupLayout62,
+bindGroupLayout62,
+bindGroupLayout51
+],
+}
+);
+let renderBundle178 = renderBundleEncoder151.finish(
+{
+
+}
+);
+try {
+device13.queue.writeBuffer(
+buffer55,
+3948,
+new DataView(new ArrayBuffer(31472)),
+7636,
+2656
+);
+} catch {}
+let pipeline102 = device13.createRenderPipeline(
+{
+label: '\u{1f99f}\uf866\uce0a\u{1f78a}\u03c8\uccf7\u3642\u{1fd89}\u3ec3',
+layout: pipelineLayout44,
+vertex: {
+module: shaderModule26,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1756,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x4',
+offset: 916,
+shaderLocation: 26,
+},
+{
+format: 'snorm16x2',
+offset: 352,
+shaderLocation: 9,
+},
+{
+format: 'sint32x3',
+offset: 68,
+shaderLocation: 19,
+},
+{
+format: 'sint16x4',
+offset: 1636,
+shaderLocation: 22,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x4f18fe95,
+},
+fragment: {
+module: shaderModule26,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'invert',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 979,
+stencilWriteMask: 2732,
+depthBias: 32,
+depthBiasSlopeScale: 89,
+depthBiasClamp: 30,
+},
+}
+);
+let adapter21 = await promise63;
+pseudoSubmit(device5, commandEncoder122);
+let renderBundleEncoder159 = device5.createRenderBundleEncoder(
+{
+label: '\ue01d\u0500\u0d1f\u259c\uc3cd\uf164\u8e23\uc90f\u{1fe7c}\u3202',
+colorFormats: [
+'r8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 226,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder86.setBindGroup(
+3,
+bindGroup40,
+new Uint32Array(3578),
+3425,
+0
+);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder116.setVertexBuffer(
+0,
+buffer69,
+148,
+91
+);
+} catch {}
+try {
+await promise67;
+} catch {}
+let gpuCanvasContext46 = offscreenCanvas50.getContext('webgpu');
+let querySet147 = device1.createQuerySet(
+{
+label: '\ufeb5\u0329\u{1f9a1}\u047b\u9624\ufbb2\u663a\u5742',
+type: 'occlusion',
+count: 1891,
+}
+);
+let texture228 = device1.createTexture(
+{
+label: '\u01b6\u0444\u7e5f\u096c\u04cd\u083c\u064e\u0b3f\uabf0',
+size: [4824, 8, 191],
+mipLevelCount: 12,
+format: 'etc2-rgb8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'etc2-rgb8unorm-srgb'
+],
+}
+);
+let textureView182 = texture228.createView(
+{
+label: '\ue72e\u{1fdf7}\uab0a\u2574\u06dd\uda12\u2456\u{1fa27}\ud19b',
+dimension: '2d',
+aspect: 'all',
+baseMipLevel: 9,
+baseArrayLayer: 63,
+}
+);
+let renderBundleEncoder160 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba16uint',
+'rgba32uint'
+],
+sampleCount: 834,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder27.setViewport(
+80.54,
+96.95,
+3.743,
+45.91,
+0.1503,
+0.3560
+);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(
+buffer16,
+'uint16',
+6386,
+8625
+);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(
+1,
+buffer14,
+11180,
+16534
+);
+} catch {}
+try {
+renderBundleEncoder65.insertDebugMarker(
+'\u41ed'
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer37,
+24728,
+new BigUint64Array(29009),
+206,
+108
+);
+} catch {}
+document.body.append('\u{1f66c}\u6645\u0453\u{1ff03}\u0f67\u0fa0\u{1ff1e}\u{1fb2c}\u7162');
+let bindGroupLayout63 = device15.createBindGroupLayout(
+{
+label: '\u0333\u{1fca0}\u{1f603}\u56ce\u03ab\ubc7f\u8fe0',
+entries: [
+{
+binding: 2951,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 1667,
+visibility: GPUShaderStage.FRAGMENT,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+},
+{
+binding: 2190,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+let commandEncoder147 = device15.createCommandEncoder(
+{
+label: '\u{1fff0}\u8058\u01da\u3849\u4e56\u09be\ue4e5\u027a\u225f',
+}
+);
+let renderBundleEncoder161 = device15.createRenderBundleEncoder(
+{
+label: '\u{1fbab}\u08bb\uf046\ud1fa\u1eba\u{1fa5d}\u{1fa00}\u4a1b\u{1f89f}\u{1f885}\u{1f77f}',
+colorFormats: [
+'rg8sint',
+'r16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 885,
+stencilReadOnly: true,
+}
+);
+let renderBundle179 = renderBundleEncoder161.finish(
+{
+label: '\u03ea\u396f\u1b16\u8ecd\u0491\u31cb'
+}
+);
+try {
+device15.queue.writeTexture(
+{
+  texture: texture224,
+  mipLevel: 0,
+  origin: { x: 624, y: 6, z: 0 },
+  aspect: 'all',
+},
+new Uint8Array(arrayBuffer5),
+/* required buffer size: 429 */{
+offset: 429,
+rowsPerImage: 209,
+},
+{width: 798, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise69 = device15.queue.onSubmittedWorkDone();
+document.body.prepend(canvas38);
+canvas21.height = 132;
+document.body.append('\u89e5\u0a3e');
+let bindGroupLayout64 = device8.createBindGroupLayout(
+{
+label: '\u2034\u{1fb81}',
+entries: [
+{
+binding: 1575,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+}
+],
+}
+);
+let buffer70 = device8.createBuffer(
+{
+label: '\u{1fb82}\u09f4\u74ea',
+size: 59948,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+try {
+renderBundleEncoder110.setVertexBuffer(
+32,
+undefined,
+4181891312,
+5808609
+);
+} catch {}
+let buffer71 = device6.createBuffer(
+{
+label: '\ue745\u727c\ud2e4\u0f9f\u8eb3',
+size: 38516,
+usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+}
+);
+let commandEncoder148 = device6.createCommandEncoder(
+{
+}
+);
+let renderBundle180 = renderBundleEncoder81.finish(
+{
+
+}
+);
+try {
+commandEncoder148.copyTextureToTexture(
+{
+  texture: texture70,
+  mipLevel: 2,
+  origin: { x: 960, y: 0, z: 40 },
+  aspect: 'all',
+},
+{
+  texture: texture70,
+  mipLevel: 4,
+  origin: { x: 108, y: 0, z: 4 },
+  aspect: 'all',
+},
+{width: 60, height: 0, depthOrArrayLayers: 118}
+);
+} catch {}
+try {
+device6.queue.writeBuffer(
+buffer23,
+28844,
+new DataView(new ArrayBuffer(10801)),
+1909,
+2876
+);
+} catch {}
+let canvas53 = document.createElement('canvas');
+let imageData47 = new ImageData(44, 16);
+try {
+sampler122.label = '\uf62a\u0e5d\u2b0f';
+} catch {}
+let texture229 = device16.createTexture(
+{
+label: '\ube6c\u0a2c\ube79\u{1fe02}',
+size: [4048, 224, 1],
+mipLevelCount: 9,
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8snorm'
+],
+}
+);
+let renderBundle181 = renderBundleEncoder156.finish(
+{
+label: '\u553b\u9b0b\u{1fe22}\u0210\u5b69\u1580\u0552\u0021\ua57a\ucf5d\u9928'
+}
+);
+try {
+await promise69;
+} catch {}
+document.body.append('\uc8b8\ud04f\u4599\u3ffd\u61af\u8b27\ud291\u0ee6\u0769');
+let texture230 = device1.createTexture(
+{
+label: '\u{1ff98}\ub28e\u4b20\u0a81\u0a56\ub210\u0e61\uaa30\u{1f9d8}\u{1fb72}\u0283',
+size: [218, 1, 246],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'r32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundleEncoder162 = device1.createRenderBundleEncoder(
+{
+label: '\u0ebf\u127a\u461c\ufd93\ub68b\u7af0\u1d56\u{1fa43}',
+colorFormats: [
+'rgb10a2unorm',
+'r16sint',
+undefined,
+'r16uint',
+undefined,
+'rgb10a2unorm',
+'r32uint',
+'r8uint'
+],
+sampleCount: 435,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler126 = device1.createSampler(
+{
+label: '\u{1fb9f}\u851d\ud096\u339e\ud3ca\u{1f954}\u5e6f\u{1f927}\ua52f\u{1f641}\u7688',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 61.078,
+lodMaxClamp: 99.738,
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder27.setBlendConstant(
+{
+r: 414.8,
+g: -822.4,
+b: 699.5,
+a: -665.5,
+}
+);
+} catch {}
+try {
+renderBundleEncoder65.setVertexBuffer(
+4,
+buffer14,
+30936,
+3861
+);
+} catch {}
+let pipeline103 = await device1.createComputePipelineAsync(
+{
+label: '\ub5e6\u0e5d\u9653\u{1fa7e}\u{1fc6d}\uae43\u{1faad}\u29c2\u9bab',
+layout: pipelineLayout38,
+compute: {
+module: shaderModule23,
+entryPoint: 'compute0',
+},
+}
+);
+let gpuCanvasContext47 = offscreenCanvas51.getContext('webgpu');
+let bindGroupLayout65 = device12.createBindGroupLayout(
+{
+label: '\u8f92\u4a44\uac9a\u4749\u086b\u7c40\ub663',
+entries: [
+{
+binding: 5017,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '1d' },
+}
+],
+}
+);
+pseudoSubmit(device12, commandEncoder117);
+let sampler127 = device12.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 55.513,
+lodMaxClamp: 89.813,
+}
+);
+try {
+commandEncoder138.copyTextureToTexture(
+{
+  texture: texture215,
+  mipLevel: 2,
+  origin: { x: 29, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture215,
+  mipLevel: 0,
+  origin: { x: 134, y: 12, z: 1 },
+  aspect: 'all',
+},
+{width: 64, height: 4, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.append('\ue85a\u09e6\u0b96\u0cc8\u541c');
+try {
+canvas50.getContext('webgl');
+} catch {}
+let renderBundleEncoder163 = device6.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg11b10ufloat'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 853,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler128 = device6.createSampler(
+{
+label: '\u{1fc2c}\u0e22\u3e7f\u{1fd01}\u7582\u4b4f\u3508\u{1f8a2}',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 15.043,
+lodMaxClamp: 42.613,
+maxAnisotropy: 1,
+}
+);
+let gpuCanvasContext48 = offscreenCanvas49.getContext('webgpu');
+let commandEncoder149 = device7.createCommandEncoder(
+{
+label: '\u0072\u4951\u{1f9d0}\u92a1\u7e46\u0d0c',
+}
+);
+let textureView183 = texture119.createView(
+{
+label: '\u{1f97a}\u{1fdb8}\u03f4\u57f5\u{1f6f7}',
+dimension: '2d-array',
+format: 'astc-12x12-unorm',
+baseMipLevel: 0,
+}
+);
+let computePassEncoder94 = commandEncoder116.beginComputePass(
+{
+label: '\u69f4\u0849\u6ca6\uce78'
+}
+);
+let renderBundle182 = renderBundleEncoder51.finish(
+{
+label: '\u57e1\uef4f\u{1fbe4}\uf881\u7736\u9ca4\ue98e\u13ea\u9fb1'
+}
+);
+try {
+await device7.popErrorScope();
+} catch {}
+try {
+device7.queue.submit([
+]);
+} catch {}
+let imageData48 = new ImageData(128, 152);
+let commandEncoder150 = device17.createCommandEncoder(
+{
+label: '\uf981\u1551\u4bc0\u0626\u4c60\u3f40\ud929',
+}
+);
+let computePassEncoder95 = commandEncoder150.beginComputePass(
+{
+label: '\u{1f7c9}\u7f70'
+}
+);
+let renderBundleEncoder164 = device17.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg32float',
+'rgba16float',
+'rgba8unorm-srgb',
+'rgba8uint',
+'r8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 823,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+device17.queue.writeTexture(
+{
+  texture: texture226,
+  mipLevel: 5,
+  origin: { x: 4, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint8Array(new ArrayBuffer(80)),
+/* required buffer size: 911 */{
+offset: 325,
+bytesPerRow: 267,
+},
+{width: 13, height: 3, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+canvas51.getContext('webgl2');
+} catch {}
+let renderBundleEncoder165 = device13.createRenderBundleEncoder(
+{
+colorFormats: [
+'r32uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 471,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder165.setBindGroup(
+1,
+bindGroup61,
+new Uint32Array(1046),
+590,
+0
+);
+} catch {}
+try {
+buffer55.unmap();
+} catch {}
+try {
+commandEncoder145.copyBufferToBuffer(
+buffer53,
+7948,
+buffer55,
+5396,
+2504
+);
+dissociateBuffer(device13, buffer53);
+dissociateBuffer(device13, buffer55);
+} catch {}
+try {
+commandEncoder125.clearBuffer(
+buffer67,
+24908,
+4380
+);
+dissociateBuffer(device13, buffer67);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let bindGroup68 = device9.createBindGroup({
+label: '\u09ff\uf54c',
+layout: bindGroupLayout36,
+entries: [
+
+],
+});
+let querySet148 = device9.createQuerySet(
+{
+label: '\uf8d2\u5729\u{1fbf4}\u{1f983}\ub1d8',
+type: 'occlusion',
+count: 3847,
+}
+);
+let computePassEncoder96 = commandEncoder76.beginComputePass(
+{
+label: '\u8776\u7c57'
+}
+);
+let renderBundleEncoder166 = device9.createRenderBundleEncoder(
+{
+label: '\uf08f\u{1fed3}',
+colorFormats: [
+undefined,
+'rgba8unorm',
+'r8sint',
+'rg11b10ufloat',
+'r8sint',
+'rgba16sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 166,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+let renderBundle183 = renderBundleEncoder77.finish(
+{
+label: '\ueec2\u{1f621}\u0dfa\u1eb0\u7aa9\u0cb7\u{1fe0c}\u{1faad}\u91d3\udf22'
+}
+);
+try {
+renderBundleEncoder95.setVertexBuffer(
+22,
+undefined,
+3737892574,
+220835363
+);
+} catch {}
+try {
+gpuCanvasContext20.configure(
+{
+device: device9,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float',
+'rgba16float',
+'rgba16float'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+offscreenCanvas12.width = 369;
+try {
+renderPassEncoder16.setScissorRect(
+77,
+2,
+0,
+0
+);
+} catch {}
+canvas17.height = 948;
+let commandBuffer18 = commandEncoder141.finish(
+{
+label: '\u5080\u097f\u9797\ud515',
+}
+);
+let textureView184 = texture206.createView(
+{
+label: '\u{1f916}\u1349\u0fb7\u0fc5\u068e\u2067\u7059\u17e7\ue378\u64e5',
+dimension: '1d',
+}
+);
+try {
+device14.queue.writeTexture(
+{
+  texture: texture206,
+  mipLevel: 0,
+  origin: { x: 1312, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer10,
+/* required buffer size: 579 */{
+offset: 579,
+},
+{width: 938, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend('\u4d00\u{1fcd9}\u0bf1\u{1fada}\u70ad\u{1fbd9}\ue7f3\uf846');
+try {
+bindGroupLayout49.label = '\u5f1a\uf549';
+} catch {}
+let renderPassEncoder32 = commandEncoder61.beginRenderPass(
+{
+label: '\u995a\uaaef\u22ba\u04f4\u05ee',
+colorAttachments: [
+{
+view: textureView74,
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined,
+undefined
+],
+maxDrawCount: 16000,
+}
+);
+try {
+computePassEncoder65.setPipeline(
+pipeline65
+);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder19.setStencilReference(
+240
+);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(
+0,
+buffer24,
+18452,
+1821
+);
+} catch {}
+try {
+renderBundleEncoder155.setVertexBuffer(
+11,
+buffer24
+);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(
+/*
+{width: 1431, height: 1, depthOrArrayLayers: 836}
+*/
+{
+  source: canvas36,
+  origin: { x: 47, y: 100 },
+  flipY: false,
+},
+{
+  texture: texture138,
+  mipLevel: 0,
+  origin: { x: 1256, y: 1, z: 704 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 83, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline104 = await device3.createComputePipelineAsync(
+{
+label: '\uf857\uc5df\ube0f',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule18,
+entryPoint: 'compute0',
+},
+}
+);
+let gpuCanvasContext49 = canvas53.getContext('webgpu');
+let adapter22 = await navigator.gpu.requestAdapter();
+let commandEncoder151 = device8.createCommandEncoder(
+{
+label: '\u571e\u0786\u3ad6',
+}
+);
+let querySet149 = device8.createQuerySet(
+{
+type: 'occlusion',
+count: 60,
+}
+);
+let computePassEncoder97 = commandEncoder151.beginComputePass(
+{
+label: '\u093b\u0ae0\u8cf6\u0319\ubade\u940e'
+}
+);
+let renderBundleEncoder167 = device8.createRenderBundleEncoder(
+{
+label: '\ucb53\ufe6a\ue41e',
+colorFormats: [
+'r16sint',
+'rgba8sint',
+'rgba16float',
+'rg32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 237,
+}
+);
+try {
+computePassEncoder80.end();
+} catch {}
+try {
+commandEncoder90.copyBufferToBuffer(
+buffer29,
+312,
+buffer66,
+25816,
+6148
+);
+dissociateBuffer(device8, buffer29);
+dissociateBuffer(device8, buffer66);
+} catch {}
+try {
+commandEncoder90.clearBuffer(
+buffer66
+);
+dissociateBuffer(device8, buffer66);
+} catch {}
+try {
+gpuCanvasContext40.configure(
+{
+device: device8,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let promise70 = adapter18.requestDevice(
+{
+label: '\u0320\u{1f80f}\u9ca7\u{1ff33}\u5fae\u2d41\u86cc\u{1ffe4}',
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+}
+);
+let bindGroupLayout66 = device14.createBindGroupLayout(
+{
+label: '\u01ee\ucd6b\u010b\ue9bc\u2917\u9a12\ub3f2\u9178\u0547',
+entries: [
+
+],
+}
+);
+let textureView185 = texture219.createView(
+{
+label: '\u0a8d\u00b9\u2388\u03a6\u0e14\u{1f7ed}\u06e4\ud26d\u5679\u1df7\u5af8',
+baseMipLevel: 2,
+baseArrayLayer: 36,
+arrayLayerCount: 46,
+}
+);
+let renderBundleEncoder168 = device14.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg32sint',
+undefined,
+undefined
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 793,
+}
+);
+let sampler129 = device14.createSampler(
+{
+label: '\u50f5\u05c7\u0eeb\u{1f708}\uaa24\u{1fabc}\u{1f679}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 85.857,
+lodMaxClamp: 89.552,
+maxAnisotropy: 12,
+}
+);
+try {
+renderBundleEncoder168.setVertexBuffer(
+3,
+undefined,
+2386557300,
+921874645
+);
+} catch {}
+try {
+device14.queue.writeTexture(
+{
+  texture: texture219,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 122 },
+  aspect: 'all',
+},
+new Int8Array(new ArrayBuffer(8)),
+/* required buffer size: 433073 */{
+offset: 641,
+bytesPerRow: 143,
+rowsPerImage: 108,
+},
+{width: 12, height: 0, depthOrArrayLayers: 29}
+);
+} catch {}
+let pipeline105 = await device14.createComputePipelineAsync(
+{
+label: '\u{1f89f}\u{1faf8}\u0147',
+layout: pipelineLayout43,
+compute: {
+module: shaderModule28,
+entryPoint: 'compute0',
+},
+}
+);
+let bindGroup69 = device1.createBindGroup({
+layout: bindGroupLayout26,
+entries: [
+{
+binding: 676,
+resource: sampler121
+},
+{
+binding: 4409,
+resource: sampler52
+}
+],
+});
+let texture231 = device1.createTexture(
+{
+label: '\u1979\u0208\u5823\u3a68\u4491',
+size: {width: 6280, height: 40, depthOrArrayLayers: 1},
+mipLevelCount: 12,
+format: 'astc-4x4-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-4x4-unorm-srgb',
+'astc-4x4-unorm'
+],
+}
+);
+try {
+computePassEncoder82.setPipeline(
+pipeline86
+);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder27.setStencilReference(
+3655
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture53,
+  mipLevel: 6,
+  origin: { x: 20, y: 0, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(760383),
+/* required buffer size: 760383 */{
+offset: 855,
+bytesPerRow: 396,
+rowsPerImage: 274,
+},
+{width: 60, height: 0, depthOrArrayLayers: 8}
+);
+} catch {}
+let video52 = await videoWithData();
+let imageData49 = new ImageData(112, 16);
+let videoFrame47 = new VideoFrame(video15, {timestamp: 0});
+let bindGroupLayout67 = device15.createBindGroupLayout(
+{
+label: '\u8c5a\u0a74\ua185\u34a2',
+entries: [
+{
+binding: 675,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 3699,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+},
+{
+binding: 111,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d-array' },
+}
+],
+}
+);
+let computePassEncoder98 = commandEncoder147.beginComputePass(
+{
+label: '\u04d1\u0674\u23f2'
+}
+);
+try {
+device15.pushErrorScope(
+'internal'
+);
+} catch {}
+try {
+gpuCanvasContext17.configure(
+{
+device: device15,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'etc2-rgb8a1unorm-srgb',
+'astc-4x4-unorm',
+'rg8unorm',
+'rg16float'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+document.body.prepend('\u{1f7fe}\u{1f802}\u093d\u051d\u7f9b\ua7b2\u9662\ub206\u0323');
+let texture232 = gpuCanvasContext10.getCurrentTexture();
+let renderBundleEncoder169 = device4.createRenderBundleEncoder(
+{
+label: '\u06fa\u4818\u3df4\u7141\u0d82',
+colorFormats: [
+'rg32uint',
+'rg16sint',
+'rgb10a2unorm',
+'r8sint'
+],
+sampleCount: 513,
+depthReadOnly: true,
+stencilReadOnly: false,
+}
+);
+try {
+renderPassEncoder12.beginOcclusionQuery(
+56
+);
+} catch {}
+try {
+renderPassEncoder24.setStencilReference(
+3916
+);
+} catch {}
+try {
+renderBundleEncoder128.setBindGroup(
+4,
+bindGroup45
+);
+} catch {}
+try {
+renderPassEncoder24.popDebugGroup();
+} catch {}
+let pipeline106 = device4.createRenderPipeline(
+{
+label: '\u9e73\u322e\u01f6',
+layout: pipelineLayout26,
+vertex: {
+module: shaderModule27,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 2064,
+attributes: [
+{
+format: 'unorm16x2',
+offset: 20,
+shaderLocation: 15,
+},
+{
+format: 'sint32x4',
+offset: 1260,
+shaderLocation: 17,
+},
+{
+format: 'float32x4',
+offset: 896,
+shaderLocation: 10,
+},
+{
+format: 'sint32x3',
+offset: 76,
+shaderLocation: 19,
+},
+{
+format: 'float16x2',
+offset: 944,
+shaderLocation: 18,
+},
+{
+format: 'uint8x4',
+offset: 1004,
+shaderLocation: 20,
+},
+{
+format: 'float32x4',
+offset: 1316,
+shaderLocation: 9,
+},
+{
+format: 'sint32',
+offset: 804,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x4',
+offset: 1904,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 1016,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 456,
+shaderLocation: 3,
+},
+{
+format: 'unorm16x2',
+offset: 544,
+shaderLocation: 1,
+},
+{
+format: 'uint32x3',
+offset: 484,
+shaderLocation: 8,
+},
+{
+format: 'uint32x4',
+offset: 140,
+shaderLocation: 13,
+},
+{
+format: 'float16x4',
+offset: 188,
+shaderLocation: 16,
+},
+{
+format: 'snorm8x4',
+offset: 144,
+shaderLocation: 0,
+},
+{
+format: 'float32x4',
+offset: 568,
+shaderLocation: 7,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 688,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 2592,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x2',
+offset: 1916,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+},
+fragment: {
+module: shaderModule27,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+format: 'r16sint',
+writeMask: 0,
+},
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 2446,
+stencilWriteMask: 1949,
+depthBias: 27,
+depthBiasSlopeScale: 91,
+depthBiasClamp: 92,
+},
+}
+);
+document.body.prepend('\u068d\u{1fbb8}\u{1fca0}\u5dda\u58c0\u0541\u4bc6\u{1f8e8}\u0047\u0154\ufa76');
+let imageData50 = new ImageData(236, 84);
+let bindGroupLayout68 = device14.createBindGroupLayout(
+{
+entries: [
+{
+binding: 1091,
+visibility: GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 607774, hasDynamicOffset: false },
+},
+{
+binding: 1121,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '3d' },
+}
+],
+}
+);
+let pipelineLayout45 = device14.createPipelineLayout(
+{
+label: '\u{1f785}\u1c27\u86df\u07fe\u0889\u519d',
+bindGroupLayouts: [
+bindGroupLayout68,
+bindGroupLayout56,
+bindGroupLayout68,
+bindGroupLayout66,
+bindGroupLayout68,
+bindGroupLayout68
+],
+}
+);
+let commandEncoder152 = device14.createCommandEncoder(
+{
+label: '\u341a\u03f3\u03aa\u{1fcde}\ubed4\u0f94\u68c6\uf354\u{1fb47}',
+}
+);
+let renderBundle184 = renderBundleEncoder168.finish(
+{
+label: '\u0412\u3a20\ufb6c\u{1ff87}\u0e21\u{1fc31}'
+}
+);
+try {
+device14.queue.writeTexture(
+{
+  texture: texture219,
+  mipLevel: 7,
+  origin: { x: 0, y: 1, z: 3 },
+  aspect: 'all',
+},
+new Int32Array(arrayBuffer4),
+/* required buffer size: 1068218 */{
+offset: 206,
+bytesPerRow: 62,
+rowsPerImage: 198,
+},
+{width: 6, height: 0, depthOrArrayLayers: 88}
+);
+} catch {}
+let pipeline107 = await device14.createComputePipelineAsync(
+{
+label: '\uf2d9\ua487\u{1faf1}\ue356\u5171\u4ffb\u695a\u26a5',
+layout: pipelineLayout43,
+compute: {
+module: shaderModule28,
+entryPoint: 'compute0',
+},
+}
+);
+let gpuCanvasContext50 = canvas52.getContext('webgpu');
+try {
+gpuCanvasContext20.unconfigure();
+} catch {}
+let bindGroup70 = device14.createBindGroup({
+label: '\u0f34\uc24e\u9da2\uf56d\u{1f6bd}',
+layout: bindGroupLayout66,
+entries: [
+
+],
+});
+let texture233 = device14.createTexture(
+{
+label: '\uc397\u697e\u0fe8\uecec\u0744\uac0a\u9cb9\u{1fe80}',
+size: {width: 127, height: 11, depthOrArrayLayers: 17},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+let computePassEncoder99 = commandEncoder152.beginComputePass(
+{
+
+}
+);
+let renderBundleEncoder170 = device14.createRenderBundleEncoder(
+{
+label: '\u{1ffda}\u3958\u06e2',
+colorFormats: [
+'rgba8unorm-srgb',
+'r32sint',
+'rg32uint',
+'rgba32float',
+undefined,
+'rg32uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 757,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle185 = renderBundleEncoder170.finish(
+{
+
+}
+);
+let sampler130 = device14.createSampler(
+{
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 87.387,
+lodMaxClamp: 96.279,
+maxAnisotropy: 1,
+}
+);
+try {
+device14.queue.writeTexture(
+{
+  texture: texture206,
+  mipLevel: 0,
+  origin: { x: 405, y: 0, z: 0 },
+  aspect: 'all',
+},
+new DataView(new ArrayBuffer(40)),
+/* required buffer size: 1436 */{
+offset: 748,
+bytesPerRow: 958,
+rowsPerImage: 70,
+},
+{width: 86, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let commandEncoder153 = device12.createCommandEncoder(
+{
+}
+);
+let renderBundle186 = renderBundleEncoder147.finish(
+{
+label: '\ua8e5\u3073\ue548\u{1fcd7}\u5738\u0763\u7c23\u8303\u{1f717}\u574e'
+}
+);
+try {
+await device12.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append('\u0902\ue280\u4174\uf7e4\u7d6e\u2f9b\u0687');
+let buffer72 = device7.createBuffer(
+{
+label: '\u0528\u0d67\u1952\u{1fb63}\u36f5\u2582\u{1f690}',
+size: 16308,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let querySet150 = device7.createQuerySet(
+{
+label: '\u0615\u14e5\ud19f\ua8ee\u0134\u0aa3',
+type: 'occlusion',
+count: 1894,
+}
+);
+try {
+buffer72.unmap();
+} catch {}
+try {
+await buffer72.mapAsync(
+GPUMapMode.READ,
+2808
+);
+} catch {}
+try {
+commandEncoder105.copyBufferToBuffer(
+buffer39,
+8,
+buffer72,
+10880,
+68
+);
+dissociateBuffer(device7, buffer39);
+dissociateBuffer(device7, buffer72);
+} catch {}
+document.body.prepend('\ud55d\u1f8e\uf1eb\u078d\u1b41\u018a\u0be6\ucdee\u048a\u01d8');
+try {
+await adapter9.requestAdapterInfo();
+} catch {}
+try {
+offscreenCanvas48.getContext('webgl2');
+} catch {}
+let commandEncoder154 = device12.createCommandEncoder(
+{
+label: '\uba2d\u7390\u0e0c\u0fe1\u8e13\u1cfa',
+}
+);
+let sampler131 = device12.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 53.654,
+lodMaxClamp: 82.317,
+maxAnisotropy: 20,
+}
+);
+try {
+commandEncoder153.copyTextureToTexture(
+{
+  texture: texture181,
+  mipLevel: 3,
+  origin: { x: 3, y: 0, z: 12 },
+  aspect: 'all',
+},
+{
+  texture: texture181,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 4}
+);
+} catch {}
+try {
+commandEncoder138.resolveQuerySet(
+querySet125,
+225,
+3,
+buffer58,
+0
+);
+} catch {}
+let buffer73 = device3.createBuffer(
+{
+size: 29524,
+usage: GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+let renderBundle187 = renderBundleEncoder113.finish(
+{
+
+}
+);
+try {
+computePassEncoder61.setPipeline(
+pipeline77
+);
+} catch {}
+try {
+renderPassEncoder23.setStencilReference(
+1384
+);
+} catch {}
+try {
+renderBundleEncoder88.setVertexBuffer(
+0,
+buffer24,
+17632,
+2754
+);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(
+/*
+{width: 715, height: 1, depthOrArrayLayers: 418}
+*/
+{
+  source: imageBitmap16,
+  origin: { x: 12, y: 42 },
+  flipY: true,
+},
+{
+  texture: texture138,
+  mipLevel: 1,
+  origin: { x: 541, y: 0, z: 208 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let commandBuffer19 = commandEncoder136.finish();
+let textureView186 = texture132.createView(
+{
+label: '\ua4bf\u00d7',
+aspect: 'all',
+mipLevelCount: 1,
+}
+);
+let renderBundleEncoder171 = device11.createRenderBundleEncoder(
+{
+label: '\u0cf6\u26b3\u{1fcd7}\u0518\u5dc2\u{1fa04}\u062d\u6958\u0e00\u9696',
+colorFormats: [
+'rg8unorm',
+'bgra8unorm',
+'rg11b10ufloat',
+'rgba8unorm',
+'r32sint',
+'rgba16sint',
+'r8uint',
+'rg8sint'
+],
+sampleCount: 626,
+stencilReadOnly: true,
+}
+);
+let externalTexture15 = device11.importExternalTexture(
+{
+source: videoFrame39,
+colorSpace: 'srgb',
+}
+);
+try {
+device11.queue.writeBuffer(
+buffer50,
+45948,
+new Int16Array(59241),
+6807,
+3488
+);
+} catch {}
+document.body.prepend(img22);
+video1.width = 157;
+let shaderModule31 = device16.createShaderModule(
+{
+label: '\u0268\u{1f6e8}\uec6d\uc21d\u5383',
+code: `
+
+@compute @workgroup_size(3, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0() {
+
+}
+
+struct S34 {
+@location(6) f0: vec2<f32>,
+@builtin(instance_index) f1: u32,
+@location(13) f2: vec2<f32>,
+@location(1) f3: u32,
+@location(5) f4: i32,
+@location(7) f5: i32,
+@location(12) f6: vec3<u32>,
+@location(8) f7: vec2<f16>,
+@location(3) f8: f16
+}
+struct VertexOutput0 {
+@builtin(position) f487: vec4<f32>,
+@location(3) f488: u32
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(2) a1: vec3<f16>, a2: S34, @location(14) a3: f32, @location(15) a4: vec2<i32>, @location(4) a5: vec4<f32>, @location(9) a6: vec4<i32>, @location(11) a7: vec3<f16>, @location(0) a8: vec3<i32>, @location(10) a9: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let querySet151 = device16.createQuerySet(
+{
+label: '\u04c2\u6769\u0b59\u0d20\u0675\uf347\u8d99\u2ace\u0e04',
+type: 'occlusion',
+count: 750,
+}
+);
+pseudoSubmit(device16, commandEncoder144);
+try {
+texture227.destroy();
+} catch {}
+let pipeline108 = device16.createRenderPipeline(
+{
+label: '\u4b19\u3f67\ue117\u03b7\u{1fac5}\u9c23\u046e',
+layout: pipelineLayout42,
+vertex: {
+module: shaderModule29,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 2012,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 2032,
+attributes: [
+
+],
+},
+{
+arrayStride: 976,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 60,
+shaderLocation: 9,
+},
+{
+format: 'uint8x2',
+offset: 522,
+shaderLocation: 8,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule29,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'less',
+failOp: 'keep',
+depthFailOp: 'replace',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'zero',
+depthFailOp: 'increment-wrap',
+passOp: 'invert',
+},
+stencilReadMask: 3376,
+stencilWriteMask: 2875,
+depthBias: 29,
+depthBiasSlopeScale: 98,
+},
+}
+);
+try {
+gpuCanvasContext41.unconfigure();
+} catch {}
+let commandEncoder155 = device4.createCommandEncoder(
+{
+label: '\u{1f656}\u053f\u041f\u004a\u6651\u5cb2\u1719\u0240\uc1cc',
+}
+);
+let texture234 = device4.createTexture(
+{
+size: [1590, 1, 91],
+mipLevelCount: 9,
+dimension: '3d',
+format: 'rg16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg16float',
+'rg16float',
+'rg16float'
+],
+}
+);
+let renderBundle188 = renderBundleEncoder45.finish(
+{
+
+}
+);
+try {
+computePassEncoder75.setBindGroup(
+4,
+bindGroup30
+);
+} catch {}
+try {
+computePassEncoder75.setPipeline(
+pipeline49
+);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder100.setBindGroup(
+3,
+bindGroup44,
+new Uint32Array(2467),
+1263,
+0
+);
+} catch {}
+let arrayBuffer17 = buffer25.getMappedRange(
+41848,
+500
+);
+try {
+commandEncoder146.clearBuffer(
+buffer25
+);
+dissociateBuffer(device4, buffer25);
+} catch {}
+canvas24.height = 290;
+let textureView187 = texture225.createView(
+{
+label: '\u5146\u0cfc\uff02\u90b7\uf86e\u768c\u6569',
+}
+);
+let renderPassEncoder33 = commandEncoder103.beginRenderPass(
+{
+label: '\ud15d\u0e99\ua946\u14b5',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+{
+view: textureView168,
+depthSlice: 274,
+clearValue: {
+r: -515.8,
+g: -717.3,
+b: -597.4,
+a: 737.4,
+},
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined,
+{
+view: textureView168,
+depthSlice: 26,
+clearValue: {
+r: -58.50,
+g: -575.8,
+b: 12.00,
+a: 883.2,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView168,
+depthSlice: 146,
+clearValue: {
+r: 709.9,
+g: -411.3,
+b: -734.1,
+a: 206.1,
+},
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined,
+{
+view: textureView168,
+depthSlice: 41,
+clearValue: {
+r: 687.5,
+g: -856.7,
+b: 799.1,
+a: 751.6,
+},
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet129,
+maxDrawCount: 346304,
+}
+);
+let renderBundleEncoder172 = device10.createRenderBundleEncoder(
+{
+label: '\uff54\ud76e',
+colorFormats: [
+'rg11b10ufloat',
+'rgba32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 449,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder31.setViewport(
+142.7,
+0.1633,
+31.97,
+0.05321,
+0.8793,
+0.9458
+);
+} catch {}
+try {
+renderBundleEncoder82.setIndexBuffer(
+buffer33,
+'uint32'
+);
+} catch {}
+let bindGroup71 = device14.createBindGroup({
+label: '\u{1fa14}\u8649\u80a6\ufe1b\u0f49',
+layout: bindGroupLayout66,
+entries: [
+
+],
+});
+let buffer74 = device14.createBuffer(
+{
+label: '\u2af6\u7ca4',
+size: 41291,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let querySet152 = device14.createQuerySet(
+{
+label: '\ucc3f\ucd43\u766b\u8235\ubf52\u{1fad2}\u5c4a\u94dd',
+type: 'occlusion',
+count: 3617,
+}
+);
+let texture235 = device14.createTexture(
+{
+label: '\ub46b\u{1fbba}\u282d\u{1f913}',
+size: {width: 14964, height: 168, depthOrArrayLayers: 147},
+mipLevelCount: 9,
+sampleCount: 1,
+format: 'astc-12x12-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-12x12-unorm-srgb'
+],
+}
+);
+let textureView188 = texture206.createView(
+{
+label: '\u4ca2\u1fe4\u9c35\u{1f7d5}\u82b7\u0767\u7948\u0fc4\uf63e',
+dimension: '1d',
+}
+);
+let pipeline109 = await device14.createComputePipelineAsync(
+{
+label: '\u0bb8\u0c53\u50c7\ud578\u{1fdce}\u9ff9\u0471\u{1ff36}\u0e63\u19f4',
+layout: pipelineLayout43,
+compute: {
+module: shaderModule28,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let textureView189 = texture208.createView(
+{
+baseArrayLayer: 0,
+}
+);
+let imageData51 = new ImageData(20, 220);
+let querySet153 = device1.createQuerySet(
+{
+label: '\u{1fe5f}\u088a\u03cf\u0112\u{1fac9}\u5ef4\u09bf\u0858\ucc2a\u{1ff13}\u2ba4',
+type: 'occlusion',
+count: 3140,
+}
+);
+let texture236 = gpuCanvasContext30.getCurrentTexture();
+let renderBundle189 = renderBundleEncoder162.finish();
+try {
+renderPassEncoder27.setScissorRect(
+83,
+88,
+0,
+142
+);
+} catch {}
+try {
+renderPassEncoder27.setViewport(
+75.74,
+132.8,
+7.641,
+75.00,
+0.9707,
+0.9861
+);
+} catch {}
+try {
+renderPassEncoder27.insertDebugMarker(
+'\u7340'
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer37,
+27404,
+new DataView(new ArrayBuffer(12837)),
+10208,
+2444
+);
+} catch {}
+let pipeline110 = await device1.createRenderPipelineAsync(
+{
+label: '\ue467\u{1f734}\u{1f908}\u0c05\u{1fc23}\u7ff5\u01e0',
+layout: pipelineLayout13,
+vertex: {
+module: shaderModule20,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 44936,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 32072,
+shaderLocation: 6,
+},
+{
+format: 'uint16x4',
+offset: 5448,
+shaderLocation: 21,
+},
+{
+format: 'snorm16x2',
+offset: 9432,
+shaderLocation: 22,
+},
+{
+format: 'float32x2',
+offset: 10256,
+shaderLocation: 2,
+},
+{
+format: 'float32x3',
+offset: 17780,
+shaderLocation: 16,
+},
+{
+format: 'float16x4',
+offset: 23100,
+shaderLocation: 11,
+},
+{
+format: 'snorm8x4',
+offset: 37212,
+shaderLocation: 15,
+},
+{
+format: 'float16x4',
+offset: 19892,
+shaderLocation: 7,
+},
+{
+format: 'sint8x4',
+offset: 4752,
+shaderLocation: 13,
+},
+{
+format: 'uint32',
+offset: 100,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 9636,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 3644,
+shaderLocation: 12,
+},
+{
+format: 'uint32x4',
+offset: 8676,
+shaderLocation: 20,
+},
+{
+format: 'float16x2',
+offset: 5768,
+shaderLocation: 9,
+},
+{
+format: 'float16x4',
+offset: 7348,
+shaderLocation: 1,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 4412,
+shaderLocation: 5,
+},
+{
+format: 'unorm16x4',
+offset: 2116,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 52704,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x2',
+offset: 11008,
+shaderLocation: 10,
+},
+{
+format: 'uint16x4',
+offset: 18828,
+shaderLocation: 3,
+},
+{
+format: 'uint16x2',
+offset: 25416,
+shaderLocation: 0,
+},
+{
+format: 'uint8x2',
+offset: 11260,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 42872,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 53468,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 26884,
+shaderLocation: 23,
+},
+{
+format: 'unorm16x4',
+offset: 24528,
+shaderLocation: 19,
+},
+{
+format: 'snorm8x2',
+offset: 3688,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 46056,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 7672,
+shaderLocation: 8,
+},
+{
+format: 'float32x3',
+offset: 3880,
+shaderLocation: 24,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule20,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+{
+format: 'r32uint',
+},
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+}
+);
+let imageBitmap55 = await createImageBitmap(imageData3);
+let texture237 = device3.createTexture(
+{
+label: '\u{1fe67}\u0721\u055e\u0d89',
+size: [13380, 10, 1],
+mipLevelCount: 8,
+format: 'astc-10x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x10-unorm',
+'astc-10x10-unorm-srgb',
+'astc-10x10-unorm'
+],
+}
+);
+let renderBundle190 = renderBundleEncoder64.finish(
+{
+label: '\u2851\u1afa\uc43b\u{1fec3}\u252b\u{1fb0d}\u81e6\u{1fa3b}\u04b9\u{1f9b4}\u3e65'
+}
+);
+try {
+computePassEncoder49.end();
+} catch {}
+try {
+computePassEncoder61.setPipeline(
+pipeline104
+);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([]);
+} catch {}
+let pipeline111 = device3.createComputePipeline(
+{
+layout: pipelineLayout16,
+compute: {
+module: shaderModule18,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+pseudoSubmit(device17, commandEncoder150);
+let querySet154 = device5.createQuerySet(
+{
+label: '\u01fd\u060a\ud989\u{1f94f}\uc403\u91f8\u0000\u{1f7a6}',
+type: 'occlusion',
+count: 3966,
+}
+);
+let textureView190 = texture129.createView(
+{
+label: '\uc206\u{1fff3}\u0288\uab59\u9eac\ubb8e\u{1f878}\u{1fdc6}\u685c\u6a59',
+dimension: '2d-array',
+}
+);
+let renderBundleEncoder173 = device5.createRenderBundleEncoder(
+{
+label: '\u7634\ub086\u7a2e\u0723\uae6b\u{1fb52}\u1bc1\u0c3e\u9df0\u01e8\u{1f819}',
+colorFormats: [
+'rg32sint',
+'rg8uint',
+'rg8unorm',
+'rgba16sint',
+'r8sint',
+'rg32uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 503,
+}
+);
+let renderBundle191 = renderBundleEncoder116.finish(
+{
+label: '\u3d89\u3bef\uac44\u6474\ub482\u1bc2\u{1fc7c}\u{1f8ad}\ub34c\u08a1'
+}
+);
+let sampler132 = device5.createSampler(
+{
+label: '\uf0a7\u0d08\u206d\ud61d\ue21f\u{1f78e}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 33.968,
+lodMaxClamp: 45.284,
+}
+);
+try {
+renderPassEncoder17.setBlendConstant(
+{
+r: -157.5,
+g: -169.4,
+b: 594.7,
+a: -846.3,
+}
+);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(
+buffer42,
+'uint16',
+29476,
+9330
+);
+} catch {}
+try {
+renderBundleEncoder127.setBindGroup(
+1,
+bindGroup35,
+new Uint32Array(7908),
+1902,
+0
+);
+} catch {}
+try {
+await buffer62.mapAsync(
+GPUMapMode.READ,
+0,
+11932
+);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture86,
+  mipLevel: 3,
+  origin: { x: 112, y: 8, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer10,
+/* required buffer size: 221 */{
+offset: 221,
+},
+{width: 232, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let img44 = await imageWithData(160, 21, '#4e45690b', '#d78ae28b');
+let bindGroupLayout69 = device5.createBindGroupLayout(
+{
+entries: [
+{
+binding: 589,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+},
+{
+binding: 138,
+visibility: GPUShaderStage.FRAGMENT,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+},
+{
+binding: 617,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+try {
+renderBundleEncoder173.setBindGroup(
+1,
+bindGroup31
+);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture222,
+  mipLevel: 0,
+  origin: { x: 2440, y: 20, z: 1 },
+  aspect: 'all',
+},
+new Uint8Array(arrayBuffer13),
+/* required buffer size: 647 */{
+offset: 647,
+bytesPerRow: 700,
+},
+{width: 270, height: 150, depthOrArrayLayers: 0}
+);
+} catch {}
+let renderBundle192 = renderBundleEncoder105.finish(
+{
+label: '\u{1f78f}\u{1f74f}\u838b\u0ab9\u0602'
+}
+);
+let sampler133 = device8.createSampler(
+{
+label: '\u5e5a\ucd87\u{1f914}\ua0f1',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 19.800,
+lodMaxClamp: 62.544,
+}
+);
+try {
+renderBundleEncoder111.setBindGroup(
+0,
+bindGroup67
+);
+} catch {}
+try {
+computePassEncoder92.insertDebugMarker(
+'\u0181'
+);
+} catch {}
+try {
+device8.queue.writeTexture(
+{
+  texture: texture172,
+  mipLevel: 0,
+  origin: { x: 610, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Int16Array(arrayBuffer4),
+/* required buffer size: 595 */{
+offset: 595,
+},
+{width: 6930, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await device8.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline112 = await device8.createRenderPipelineAsync(
+{
+label: '\u{1f955}\u4151\u68d6\u0990\u88bc\u55c6',
+layout: pipelineLayout22,
+vertex: {
+module: shaderModule22,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x4',
+offset: 10900,
+shaderLocation: 7,
+},
+{
+format: 'float32x3',
+offset: 14492,
+shaderLocation: 18,
+},
+{
+format: 'float32',
+offset: 13152,
+shaderLocation: 3,
+},
+{
+format: 'uint8x2',
+offset: 9596,
+shaderLocation: 1,
+},
+{
+format: 'unorm16x2',
+offset: 2420,
+shaderLocation: 6,
+},
+{
+format: 'float32x3',
+offset: 7060,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32',
+offset: 22352,
+shaderLocation: 17,
+},
+{
+format: 'snorm8x4',
+offset: 2780,
+shaderLocation: 11,
+},
+{
+format: 'sint16x4',
+offset: 22984,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 3836,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32',
+offset: 344,
+shaderLocation: 5,
+},
+{
+format: 'float16x2',
+offset: 1508,
+shaderLocation: 12,
+},
+{
+format: 'sint32x2',
+offset: 3600,
+shaderLocation: 13,
+},
+{
+format: 'snorm8x4',
+offset: 1580,
+shaderLocation: 15,
+},
+{
+format: 'uint32x2',
+offset: 1864,
+shaderLocation: 8,
+},
+{
+format: 'snorm16x4',
+offset: 348,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x2',
+offset: 3824,
+shaderLocation: 10,
+},
+{
+format: 'uint32',
+offset: 3616,
+shaderLocation: 14,
+},
+{
+format: 'sint8x4',
+offset: 3680,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 10756,
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+attributes: [
+
+],
+},
+{
+arrayStride: 5320,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 20936,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 10696,
+shaderLocation: 9,
+},
+{
+format: 'uint32x3',
+offset: 19796,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 15604,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x2',
+offset: 14202,
+shaderLocation: 20,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: false,
+},
+fragment: {
+module: shaderModule22,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'dst-alpha',
+dstFactor: 'constant'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'one',
+dstFactor: 'src-alpha'
+},
+},
+format: 'r16float',
+writeMask: 0,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r16sint',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilReadMask: 3664,
+stencilWriteMask: 865,
+depthBias: 83,
+depthBiasSlopeScale: 18,
+depthBiasClamp: 69,
+},
+}
+);
+canvas36.height = 839;
+document.body.prepend('\u418c\u0a84\u8aaa\u0d42\u{1f69f}\u482d');
+document.body.prepend('\u7fba\u0c26\u0804\u13f9\u{1fefb}\u03b7\u{1fbef}\u{1fcf8}\u466a');
+let imageBitmap56 = await createImageBitmap(canvas22);
+let pipelineLayout46 = device10.createPipelineLayout(
+{
+label: '\ud2c9\u3b41\u{1fcb3}',
+bindGroupLayouts: [
+bindGroupLayout61,
+bindGroupLayout61,
+bindGroupLayout61,
+bindGroupLayout61
+],
+}
+);
+try {
+renderPassEncoder33.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder30.setScissorRect(
+122,
+1,
+31,
+0
+);
+} catch {}
+try {
+renderPassEncoder33.setViewport(
+25.96,
+0.4109,
+81.98,
+0.3476,
+0.7365,
+0.9048
+);
+} catch {}
+try {
+adapter8.label = '\u6440\u2a4b\uc046\uee40\u2b6d\ua184';
+} catch {}
+let commandEncoder156 = device12.createCommandEncoder(
+{
+label: '\ud65d\u3faf\u{1f6a7}\u{1f9d8}\u0361',
+}
+);
+let renderPassEncoder34 = commandEncoder154.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+{
+view: textureView149,
+clearValue: {
+r: -207.9,
+g: -762.0,
+b: -143.5,
+a: -683.6,
+},
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet138,
+maxDrawCount: 19216,
+}
+);
+try {
+renderPassEncoder34.setBindGroup(
+2,
+bindGroup58
+);
+} catch {}
+try {
+commandEncoder156.clearBuffer(
+buffer58
+);
+dissociateBuffer(device12, buffer58);
+} catch {}
+try {
+commandEncoder156.resolveQuerySet(
+querySet125,
+442,
+157,
+buffer58,
+256
+);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let videoFrame48 = new VideoFrame(canvas47, {timestamp: 0});
+let renderBundleEncoder174 = device4.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba32uint',
+'rg16float',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 49,
+depthReadOnly: false,
+}
+);
+let renderBundle193 = renderBundleEncoder78.finish(
+{
+
+}
+);
+try {
+computePassEncoder48.setBindGroup(
+4,
+bindGroup39,
+new Uint32Array(4625),
+2864,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant(
+{
+r: 231.9,
+g: -424.1,
+b: 617.3,
+a: -974.6,
+}
+);
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(
+749,
+1,
+131,
+0
+);
+} catch {}
+try {
+renderPassEncoder22.setStencilReference(
+3155
+);
+} catch {}
+try {
+renderBundleEncoder103.setVertexBuffer(
+9,
+buffer20,
+5072,
+373
+);
+} catch {}
+try {
+await buffer51.mapAsync(
+GPUMapMode.WRITE,
+36272,
+448
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture59,
+  mipLevel: 6,
+  origin: { x: 1, y: 0, z: 68 },
+  aspect: 'all',
+},
+new Float32Array(arrayBuffer2),
+/* required buffer size: 822490 */{
+offset: 903,
+bytesPerRow: 81,
+rowsPerImage: 207,
+},
+{width: 1, height: 1, depthOrArrayLayers: 50}
+);
+} catch {}
+let pipeline113 = await device4.createComputePipelineAsync(
+{
+label: '\u0f5a\udb99\ue52b\ue2d4\ud13d\u{1fb08}\u58fa\uc87d\u0992',
+layout: pipelineLayout26,
+compute: {
+module: shaderModule25,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let commandEncoder157 = device14.createCommandEncoder(
+{
+label: '\u06d3\u07df\u16fe\u0871\uf50e\u0742\u079b',
+}
+);
+try {
+computePassEncoder99.setPipeline(
+pipeline105
+);
+} catch {}
+try {
+commandEncoder157.copyTextureToTexture(
+{
+  texture: texture219,
+  mipLevel: 8,
+  origin: { x: 3, y: 0, z: 120 },
+  aspect: 'all',
+},
+{
+  texture: texture219,
+  mipLevel: 2,
+  origin: { x: 147, y: 0, z: 24 },
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 15}
+);
+} catch {}
+try {
+device14.queue.writeBuffer(
+buffer74,
+27468,
+new DataView(new ArrayBuffer(8708)),
+8139,
+492
+);
+} catch {}
+document.body.prepend('\u640b\u9bb0\u00df\u{1f965}\u0635\u068e');
+let commandEncoder158 = device6.createCommandEncoder(
+{
+label: '\u0020\u09fb',
+}
+);
+let querySet155 = device6.createQuerySet(
+{
+label: '\ud589\u28b5\ua7d1\u0824\u64da\u{1fea6}\u{1fd07}\u0bc5',
+type: 'occlusion',
+count: 94,
+}
+);
+pseudoSubmit(device6, commandEncoder54);
+let texture238 = device6.createTexture(
+{
+label: '\u{1f851}\u2f94\u{1f754}',
+size: {width: 9012, height: 30, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-12x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+
+],
+}
+);
+let sampler134 = device6.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 52.438,
+lodMaxClamp: 73.367,
+maxAnisotropy: 11,
+}
+);
+try {
+renderBundleEncoder145.setVertexBuffer(
+9,
+buffer23,
+16160,
+1632
+);
+} catch {}
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+let querySet156 = device6.createQuerySet(
+{
+label: '\u011d\u3963\uc18f',
+type: 'occlusion',
+count: 3692,
+}
+);
+pseudoSubmit(device6, commandEncoder148);
+let renderBundleEncoder175 = device6.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba16sint',
+'rgba8uint',
+'r32uint',
+'rgba8unorm',
+'rgba8sint',
+'rg16float',
+'rgba8unorm',
+'r16uint'
+],
+sampleCount: 845,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle194 = renderBundleEncoder83.finish(
+{
+
+}
+);
+try {
+computePassEncoder58.end();
+} catch {}
+let device18 = await adapter21.requestDevice(
+{
+label: '\ud5c6\u{1fb0f}\u0b78\u03d8\ufbc4\udc8e\u071b\u1804\u{1fb58}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 7,
+maxColorAttachmentBytesPerSample: 43,
+maxVertexAttributes: 17,
+maxVertexBufferArrayStride: 45407,
+maxStorageTexturesPerShaderStage: 10,
+maxStorageBuffersPerShaderStage: 36,
+maxDynamicStorageBuffersPerPipelineLayout: 58222,
+maxBindingsPerBindGroup: 6306,
+maxTextureDimension1D: 8895,
+maxTextureDimension2D: 12872,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 214815806,
+maxInterStageShaderVariables: 116,
+maxInterStageShaderComponents: 115,
+},
+}
+);
+let shaderModule32 = device13.createShaderModule(
+{
+label: '\u005b\ue8b3\u08d5\uce7a\u{1ff0f}\uaef8\u094b\u06d9',
+code: `@group(2) @binding(4478)
+var<storage, read_write> local3: array<u32>;
+@group(0) @binding(2847)
+var<storage, read_write> i2: array<u32>;
+
+@compute @workgroup_size(5, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_mask) a1: u32, @builtin(sample_index) a2: u32, @builtin(position) a3: vec4<f32>) {
+
+}
+
+struct S35 {
+@location(27) f0: vec3<u32>,
+@location(28) f1: u32
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec3<f32>, @location(3) a1: vec3<i32>, @location(23) a2: vec2<f32>, @location(9) a3: vec2<f32>, @location(7) a4: vec4<f32>, @location(10) a5: vec2<f16>, @location(14) a6: vec2<i32>, @location(20) a7: f16, a8: S35, @location(5) a9: f16, @location(19) a10: vec3<i32>, @location(2) a11: vec3<f32>, @location(22) a12: vec4<f32>, @location(26) a13: vec2<i32>, @location(25) a14: vec3<f16>, @location(12) a15: u32, @location(6) a16: vec2<f32>, @location(21) a17: vec4<f32>, @location(18) a18: vec3<i32>, @location(24) a19: vec4<f32>, @location(17) a20: vec2<i32>, @location(11) a21: vec3<u32>, @location(8) a22: vec2<f32>, @location(16) a23: vec3<f32>, @location(13) a24: f32, @location(0) a25: vec3<f16>, @location(1) a26: vec3<i32>, @builtin(instance_index) a27: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let renderBundle195 = renderBundleEncoder165.finish(
+{
+label: '\u{1ffc5}\u6ef8\u{1fd6e}\u{1ff4b}\u4dcc\u6d19\uc86c\uc8be\u204e\u094f\uab74'
+}
+);
+let offscreenCanvas52 = new OffscreenCanvas(577, 282);
+try {
+window.someLabel = externalTexture1.label;
+} catch {}
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+document.body.prepend(video14);
+document.body.prepend('\u7f94\u{1ffc3}\u0b5a\u0ee8\u07ca\u19e7\u{1f99e}');
+let computePassEncoder100 = commandEncoder112.beginComputePass(
+{
+label: '\ud549\ueccb'
+}
+);
+let renderBundleEncoder176 = device7.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba16uint',
+'rgba8sint'
+],
+sampleCount: 27,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder176.setVertexBuffer(
+4,
+buffer64,
+26164,
+21401
+);
+} catch {}
+try {
+await buffer38.mapAsync(
+GPUMapMode.READ,
+0,
+3876
+);
+} catch {}
+try {
+commandEncoder97.copyTextureToTexture(
+{
+  texture: texture133,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 46 },
+  aspect: 'all',
+},
+{
+  texture: texture223,
+  mipLevel: 1,
+  origin: { x: 24, y: 24, z: 0 },
+  aspect: 'all',
+},
+{width: 24, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device7.queue.writeBuffer(
+buffer36,
+12264,
+new Float32Array(13104),
+7938,
+1124
+);
+} catch {}
+let bindGroupLayout70 = device16.createBindGroupLayout(
+{
+label: '\u56a7\u798d\u139f\u7d19\u0b2c\ua1f5\u04f5',
+entries: [
+
+],
+}
+);
+let pipelineLayout47 = device16.createPipelineLayout(
+{
+label: '\u{1fc37}\u7c1d\u0298\u5b9a\u0e0c\u{1f9ef}\u{1fc34}\u0467\u{1f6dd}',
+bindGroupLayouts: [
+
+],
+}
+);
+let textureView191 = texture229.createView(
+{
+label: '\u7592\uaffb\u8c89\u0d75\u{1ffb8}',
+baseMipLevel: 8,
+}
+);
+let video53 = await videoWithData();
+let pipeline114 = device16.createRenderPipeline(
+{
+label: '\u{1f66d}\u{1f66b}',
+layout: pipelineLayout42,
+vertex: {
+module: shaderModule30,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 2016,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 1572,
+attributes: [
+{
+format: 'uint32x2',
+offset: 400,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x499430a0,
+},
+fragment: {
+module: shaderModule30,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+{
+format: 'r16float',
+writeMask: 0,
+},
+{
+format: 'r8sint',
+writeMask: 0,
+},
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+failOp: 'decrement-wrap',
+depthFailOp: 'replace',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'invert',
+depthFailOp: 'decrement-clamp',
+passOp: 'replace',
+},
+stencilReadMask: 3449,
+stencilWriteMask: 3119,
+depthBiasClamp: 71,
+},
+}
+);
+video19.width = 200;
+let commandEncoder159 = device5.createCommandEncoder();
+let textureView192 = texture123.createView(
+{
+label: '\u3b8a\u3f6f\u{1fb0e}\u{1fc4c}',
+}
+);
+try {
+renderPassEncoder17.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+renderPassEncoder20.setStencilReference(
+168
+);
+} catch {}
+try {
+texture110.destroy();
+} catch {}
+try {
+commandEncoder159.resolveQuerySet(
+querySet103,
+517,
+355,
+buffer42,
+20224
+);
+} catch {}
+try {
+device5.queue.writeBuffer(
+buffer69,
+980,
+new Int16Array(36996),
+32326,
+180
+);
+} catch {}
+try {
+offscreenCanvas52.getContext('webgpu');
+} catch {}
+let bindGroup72 = device13.createBindGroup({
+label: '\u0704\u1b2d\u72df\ue33f\u4793\u07e0',
+layout: bindGroupLayout51,
+entries: [
+{
+binding: 2097,
+resource: textureView129
+}
+],
+});
+let pipelineLayout48 = device13.createPipelineLayout(
+{
+label: '\u{1fc00}\u6112\u{1f6ae}\u7ef4\u1f3b\u0f85\u3b5c\uc4da',
+bindGroupLayouts: [
+bindGroupLayout62,
+bindGroupLayout50,
+bindGroupLayout50,
+bindGroupLayout51,
+bindGroupLayout62,
+bindGroupLayout50,
+bindGroupLayout62
+],
+}
+);
+let sampler135 = device13.createSampler(
+{
+label: '\u{1ff6a}\u6c30\u80e6\u{1f7b5}\u0b06\ud60c\u38ec\u08b4\u258c\uff2f',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 89.007,
+lodMaxClamp: 96.425,
+}
+);
+try {
+computePassEncoder87.setBindGroup(
+0,
+bindGroup72,
+new Uint32Array(7773),
+1787,
+0
+);
+} catch {}
+try {
+computePassEncoder87.setPipeline(
+pipeline93
+);
+} catch {}
+try {
+commandEncoder125.copyBufferToTexture(
+{
+/* bytesInLastRow: 384 widthInBlocks: 24 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 18976 */
+offset: 13984,
+bytesPerRow: 768,
+buffer: buffer53,
+},
+{
+  texture: texture166,
+  mipLevel: 0,
+  origin: { x: 28, y: 64, z: 0 },
+  aspect: 'all',
+},
+{width: 96, height: 28, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device13, buffer53);
+} catch {}
+try {
+device13.queue.writeTexture(
+{
+  texture: texture189,
+  mipLevel: 1,
+  origin: { x: 622, y: 7, z: 1 },
+  aspect: 'all',
+},
+new Int32Array(new ArrayBuffer(0)),
+/* required buffer size: 542 */{
+offset: 542,
+bytesPerRow: 1051,
+},
+{width: 218, height: 47, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline115 = device13.createRenderPipeline(
+{
+label: '\ueb4a\u07fc',
+layout: pipelineLayout44,
+vertex: {
+module: shaderModule32,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 5532,
+attributes: [
+
+],
+},
+{
+arrayStride: 324,
+attributes: [
+{
+format: 'snorm16x2',
+offset: 256,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 2096,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 80,
+shaderLocation: 11,
+},
+{
+format: 'unorm16x4',
+offset: 948,
+shaderLocation: 23,
+},
+{
+format: 'sint32x3',
+offset: 16,
+shaderLocation: 1,
+},
+{
+format: 'float32x4',
+offset: 200,
+shaderLocation: 9,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 936,
+shaderLocation: 6,
+},
+{
+format: 'snorm16x2',
+offset: 1912,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x2',
+offset: 1484,
+shaderLocation: 5,
+},
+{
+format: 'sint32x3',
+offset: 852,
+shaderLocation: 14,
+},
+{
+format: 'sint32x2',
+offset: 1192,
+shaderLocation: 18,
+},
+{
+format: 'float32x2',
+offset: 2056,
+shaderLocation: 2,
+},
+{
+format: 'sint8x2',
+offset: 1264,
+shaderLocation: 26,
+},
+{
+format: 'float16x2',
+offset: 1504,
+shaderLocation: 20,
+},
+{
+format: 'float32x4',
+offset: 796,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 3400,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 1600,
+shaderLocation: 13,
+},
+{
+format: 'uint32x3',
+offset: 552,
+shaderLocation: 28,
+},
+{
+format: 'float32x3',
+offset: 1900,
+shaderLocation: 21,
+},
+{
+format: 'snorm8x2',
+offset: 2138,
+shaderLocation: 0,
+},
+{
+format: 'unorm8x2',
+offset: 1698,
+shaderLocation: 8,
+},
+{
+format: 'float32x3',
+offset: 1960,
+shaderLocation: 25,
+},
+{
+format: 'sint8x4',
+offset: 2016,
+shaderLocation: 17,
+},
+{
+format: 'sint32x2',
+offset: 1964,
+shaderLocation: 19,
+},
+{
+format: 'uint8x2',
+offset: 2692,
+shaderLocation: 27,
+},
+{
+format: 'uint32',
+offset: 2684,
+shaderLocation: 12,
+},
+{
+format: 'float32',
+offset: 2080,
+shaderLocation: 24,
+},
+{
+format: 'snorm8x4',
+offset: 2716,
+shaderLocation: 7,
+},
+{
+format: 'sint16x2',
+offset: 820,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 424,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 5016,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32',
+offset: 4420,
+shaderLocation: 22,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0xd3bee8b9,
+},
+fragment: {
+module: shaderModule32,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'stencil8',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+},
+stencilReadMask: 3517,
+stencilWriteMask: 3649,
+depthBiasClamp: 75,
+},
+}
+);
+document.body.prepend(canvas20);
+let renderBundleEncoder177 = device1.createRenderBundleEncoder(
+{
+label: '\u4d93\u63f4\u072f\u03b7\u026b\u04f2\u8d77\u61f2',
+colorFormats: [
+'rgba8unorm',
+'rgba8sint',
+undefined,
+'rg32sint',
+'rg32uint',
+'rgba8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 761,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder27.setViewport(
+31.55,
+78.52,
+36.00,
+100.7,
+0.4414,
+0.9125
+);
+} catch {}
+try {
+device1.pushErrorScope(
+'internal'
+);
+} catch {}
+try {
+buffer14.destroy();
+} catch {}
+document.body.append('\u0c66\uc57c\uf094\uaa6f\u019b\ud150\u{1f7ee}\u0645\u0443\uc2b5');
+let imageData52 = new ImageData(60, 44);
+let shaderModule33 = device7.createShaderModule(
+{
+label: '\u2dcf\u64ff\ue031\u779e\u174e\u0225\u0b3d\ud5db\u{1f9f0}',
+code: `@group(1) @binding(885)
+var<storage, read_write> field3: array<u32>;
+
+@compute @workgroup_size(1, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(5) f0: vec2<u32>,
+@location(1) f1: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(front_facing) a1: bool, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S36 {
+@location(4) f0: vec3<f16>,
+@location(23) f1: u32,
+@location(8) f2: i32,
+@location(20) f3: vec4<f16>,
+@location(9) f4: vec4<f32>,
+@location(3) f5: vec2<f16>,
+@location(15) f6: vec2<u32>,
+@location(19) f7: u32,
+@location(10) f8: i32,
+@location(17) f9: i32,
+@builtin(vertex_index) f10: u32,
+@location(11) f11: vec3<i32>,
+@location(22) f12: vec3<f16>,
+@location(21) f13: vec4<f32>
+}
+
+@vertex
+fn vertex0(a0: S36, @location(16) a1: vec4<f32>, @location(26) a2: vec2<f32>, @location(6) a3: u32, @location(5) a4: vec4<f32>, @location(2) a5: vec3<f16>, @builtin(instance_index) a6: u32, @location(24) a7: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+try {
+commandEncoder97.copyTextureToTexture(
+{
+  texture: texture159,
+  mipLevel: 1,
+  origin: { x: 80, y: 8, z: 21 },
+  aspect: 'all',
+},
+{
+  texture: texture159,
+  mipLevel: 2,
+  origin: { x: 184, y: 0, z: 8 },
+  aspect: 'all',
+},
+{width: 1388, height: 8, depthOrArrayLayers: 7}
+);
+} catch {}
+try {
+device7.queue.writeBuffer(
+buffer36,
+14380,
+new Int16Array(3086),
+2131,
+300
+);
+} catch {}
+let textureView193 = texture227.createView(
+{
+label: '\u151f\u0e9f\u76ba\u{1fba2}\u{1f707}',
+dimension: '2d',
+aspect: 'stencil-only',
+baseArrayLayer: 95,
+}
+);
+let imageData53 = new ImageData(228, 152);
+let sampler136 = device4.createSampler(
+{
+label: '\u88fa\uf4ef\u9574\u007f\u{1fc8d}\udc78\u{1f784}\ue43e\u13f5',
+addressModeU: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 2.322,
+lodMaxClamp: 95.304,
+compare: 'always',
+}
+);
+try {
+renderPassEncoder12.setBindGroup(
+1,
+bindGroup49
+);
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.executeBundles([]);
+} catch {}
+try {
+buffer51.unmap();
+} catch {}
+try {
+gpuCanvasContext37.configure(
+{
+device: device4,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let pipeline116 = await device4.createRenderPipelineAsync(
+{
+label: '\u01ab\u09d5\ub38c\u87bd\u9b0a\u0f2e\u{1fd76}\u2fbc',
+layout: pipelineLayout26,
+vertex: {
+module: shaderModule11,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 188,
+attributes: [
+{
+format: 'snorm16x2',
+offset: 52,
+shaderLocation: 16,
+},
+{
+format: 'snorm8x4',
+offset: 80,
+shaderLocation: 14,
+},
+{
+format: 'uint32',
+offset: 76,
+shaderLocation: 7,
+},
+{
+format: 'uint16x2',
+offset: 128,
+shaderLocation: 13,
+},
+{
+format: 'unorm16x2',
+offset: 156,
+shaderLocation: 2,
+},
+{
+format: 'sint32',
+offset: 32,
+shaderLocation: 12,
+},
+{
+format: 'float32x4',
+offset: 112,
+shaderLocation: 18,
+},
+{
+format: 'sint32',
+offset: 144,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x2',
+offset: 168,
+shaderLocation: 19,
+},
+{
+format: 'float32x3',
+offset: 172,
+shaderLocation: 6,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 104,
+shaderLocation: 0,
+},
+{
+format: 'unorm16x2',
+offset: 164,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 112,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 92,
+shaderLocation: 11,
+},
+{
+format: 'unorm8x4',
+offset: 12,
+shaderLocation: 5,
+},
+{
+format: 'snorm16x4',
+offset: 88,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 2236,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x3',
+offset: 800,
+shaderLocation: 10,
+},
+{
+format: 'sint8x2',
+offset: 504,
+shaderLocation: 4,
+},
+{
+format: 'snorm16x4',
+offset: 1372,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 644,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 388,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 1616,
+shaderLocation: 20,
+},
+{
+format: 'snorm16x2',
+offset: 632,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+multisample: {
+count: 1,
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'less',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'invert',
+},
+stencilReadMask: 3724,
+stencilWriteMask: 2408,
+depthBias: 14,
+depthBiasSlopeScale: 80,
+depthBiasClamp: 87,
+},
+}
+);
+document.body.append('\u0f89\u020d\u545c\ucde9\u6acf\uf15f\u{1ff0f}\u30a7');
+try {
+computePassEncoder79.end();
+} catch {}
+try {
+device11.queue.writeTexture(
+{
+  texture: texture152,
+  mipLevel: 2,
+  origin: { x: 36, y: 1, z: 5 },
+  aspect: 'all',
+},
+new Int32Array(arrayBuffer10),
+/* required buffer size: 1843202 */{
+offset: 452,
+bytesPerRow: 250,
+rowsPerImage: 189,
+},
+{width: 8, height: 0, depthOrArrayLayers: 40}
+);
+} catch {}
+let promise71 = device11.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext42.unconfigure();
+} catch {}
+let querySet157 = device14.createQuerySet(
+{
+label: '\u217e\u229f\u0380\u{1fe16}\u5083\ub383\u0f87\u05f1\u3760',
+type: 'occlusion',
+count: 1369,
+}
+);
+let texture239 = device14.createTexture(
+{
+label: '\u00a4\ue005\u0804\u0cd6\u0251',
+size: {width: 8887, height: 1, depthOrArrayLayers: 254},
+mipLevelCount: 3,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth32float'
+],
+}
+);
+let textureView194 = texture235.createView(
+{
+label: '\ud97e\u6462\u{1fc43}',
+format: 'astc-12x12-unorm',
+baseMipLevel: 6,
+mipLevelCount: 1,
+baseArrayLayer: 72,
+arrayLayerCount: 39,
+}
+);
+try {
+computePassEncoder99.setBindGroup(
+5,
+bindGroup71
+);
+} catch {}
+try {
+computePassEncoder99.setPipeline(
+pipeline105
+);
+} catch {}
+video52.width = 186;
+canvas25.height = 699;
+try {
+commandEncoder150.label = '\u{1f98f}\u1436\u017a\u3f1e\ued35';
+} catch {}
+let texture240 = gpuCanvasContext8.getCurrentTexture();
+video15.width = 19;
+document.body.append('\u93ea\u329d\u09f1\u0484\ua2e0\u{1fd32}\udb2c\uf512');
+let imageBitmap57 = await createImageBitmap(offscreenCanvas14);
+let computePassEncoder101 = commandEncoder106.beginComputePass(
+{
+label: '\u9d02\u3afd\u0d6c\u{1fc36}\u{1f966}\u5d08\ud9ea\u{1f636}'
+}
+);
+try {
+device11.queue.writeBuffer(
+buffer50,
+30232,
+new DataView(new ArrayBuffer(28066)),
+18607,
+7380
+);
+} catch {}
+let video54 = await videoWithData();
+let videoFrame49 = new VideoFrame(canvas18, {timestamp: 0});
+let renderBundle196 = renderBundleEncoder140.finish(
+{
+label: '\ubf46\u39ea\u{1fb85}\u7b69\u0c91\u018a\u1413'
+}
+);
+try {
+renderPassEncoder16.setBindGroup(
+3,
+bindGroup47,
+new Uint32Array(9766),
+172,
+0
+);
+} catch {}
+try {
+renderPassEncoder20.beginOcclusionQuery(
+24
+);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(
+buffer42,
+'uint16',
+31924,
+6462
+);
+} catch {}
+try {
+await buffer46.mapAsync(
+GPUMapMode.WRITE,
+0,
+21992
+);
+} catch {}
+try {
+commandEncoder159.clearBuffer(
+buffer69
+);
+dissociateBuffer(device5, buffer69);
+} catch {}
+try {
+commandEncoder159.resolveQuerySet(
+querySet111,
+39,
+39,
+buffer42,
+4608
+);
+} catch {}
+try {
+gpuCanvasContext24.configure(
+{
+device: device5,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgba16float',
+'depth32float',
+'depth24plus-stencil8',
+'rg16sint'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture195,
+  mipLevel: 2,
+  origin: { x: 10, y: 0, z: 4 },
+  aspect: 'all',
+},
+new ArrayBuffer(1339249),
+/* required buffer size: 1339249 */{
+offset: 329,
+bytesPerRow: 895,
+rowsPerImage: 187,
+},
+{width: 169, height: 0, depthOrArrayLayers: 9}
+);
+} catch {}
+try {
+await device5.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(
+/*
+{width: 77, height: 2, depthOrArrayLayers: 121}
+*/
+{
+  source: imageData32,
+  origin: { x: 82, y: 47 },
+  flipY: false,
+},
+{
+  texture: texture74,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 59 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 74, height: 2, depthOrArrayLayers: 1}
+);
+} catch {}
+let offscreenCanvas53 = new OffscreenCanvas(986, 885);
+try {
+offscreenCanvas53.getContext('webgl2');
+} catch {}
+try {
+computePassEncoder78.setBindGroup(
+3,
+bindGroup58
+);
+} catch {}
+try {
+renderPassEncoder34.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder34.setStencilReference(
+3805
+);
+} catch {}
+try {
+renderPassEncoder34.setViewport(
+608.3,
+0.4931,
+354.7,
+0.2104,
+0.7896,
+0.8441
+);
+} catch {}
+try {
+commandEncoder153.copyTextureToTexture(
+{
+  texture: texture215,
+  mipLevel: 0,
+  origin: { x: 230, y: 15, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture215,
+  mipLevel: 1,
+  origin: { x: 25, y: 7, z: 0 },
+  aspect: 'all',
+},
+{width: 160, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+computePassEncoder73.insertDebugMarker(
+'\u{1ffad}'
+);
+} catch {}
+try {
+gpuCanvasContext32.configure(
+{
+device: device12,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+try {
+device12.queue.writeTexture(
+{
+  texture: texture181,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 5 },
+  aspect: 'all',
+},
+new Uint32Array(arrayBuffer8),
+/* required buffer size: 174503 */{
+offset: 767,
+bytesPerRow: 57,
+rowsPerImage: 127,
+},
+{width: 3, height: 0, depthOrArrayLayers: 25}
+);
+} catch {}
+let bindGroup73 = device8.createBindGroup({
+label: '\u056d\u{1f8ea}',
+layout: bindGroupLayout33,
+entries: [
+{
+binding: 1171,
+resource: sampler133
+}
+],
+});
+let commandEncoder160 = device8.createCommandEncoder(
+{
+label: '\u0fcc\u0921',
+}
+);
+let querySet158 = device8.createQuerySet(
+{
+label: '\uc894\u0258\u5cdc',
+type: 'occlusion',
+count: 695,
+}
+);
+let textureView195 = texture106.createView(
+{
+label: '\u{1f6ee}\u23bb',
+arrayLayerCount: 1,
+}
+);
+let sampler137 = device8.createSampler(
+{
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 70.323,
+lodMaxClamp: 90.822,
+compare: 'not-equal',
+maxAnisotropy: 4,
+}
+);
+try {
+computePassEncoder68.setPipeline(
+pipeline57
+);
+} catch {}
+try {
+renderBundleEncoder111.setIndexBuffer(
+buffer48,
+'uint32'
+);
+} catch {}
+let arrayBuffer18 = buffer40.getMappedRange(
+3264,
+20
+);
+try {
+commandEncoder90.clearBuffer(
+buffer70
+);
+dissociateBuffer(device8, buffer70);
+} catch {}
+try {
+await device8.queue.onSubmittedWorkDone();
+} catch {}
+let texture241 = device6.createTexture(
+{
+label: '\u{1fb5d}\u0fb3\u07af\ufe40\u8ad3\u4988',
+size: {width: 4709},
+dimension: '1d',
+format: 'rgba8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8sint',
+'rgba8sint',
+'rgba8sint'
+],
+}
+);
+let computePassEncoder102 = commandEncoder75.beginComputePass(
+{
+label: '\u01b6\u{1f96b}\u0c55\u62bb'
+}
+);
+try {
+renderBundleEncoder175.setVertexBuffer(
+6,
+buffer28,
+15952,
+28524
+);
+} catch {}
+try {
+commandEncoder158.copyTextureToTexture(
+{
+  texture: texture120,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture201,
+  mipLevel: 2,
+  origin: { x: 8, y: 0, z: 28 },
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder84.resolveQuerySet(
+querySet112,
+583,
+6,
+buffer28,
+20736
+);
+} catch {}
+let computePassEncoder103 = commandEncoder84.beginComputePass(
+{
+label: '\u4a3e\u9ed5\u0c19\u2a72\u{1ff15}\u0b32\u6ae2\u{1fadb}'
+}
+);
+try {
+commandEncoder158.copyTextureToBuffer(
+{
+  texture: texture76,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 112 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 51376 */
+offset: 51376,
+bytesPerRow: 256,
+rowsPerImage: 255,
+buffer: buffer43,
+},
+{width: 56, height: 5, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device6, buffer43);
+} catch {}
+try {
+device6.queue.writeBuffer(
+buffer23,
+10252,
+new BigUint64Array(17641),
+12644,
+1768
+);
+} catch {}
+document.body.prepend('\u{1ff71}\u01f5\u{1fd2f}');
+let imageData54 = new ImageData(168, 200);
+let pipelineLayout49 = device15.createPipelineLayout(
+{
+label: '\uc40c\u{1ff0d}\ue9b0\u3f16\u074a\u{1fa9f}\u0508',
+bindGroupLayouts: [
+
+],
+}
+);
+let texture242 = device15.createTexture(
+{
+label: '\u3112\u0bdb',
+size: {width: 5290, height: 8, depthOrArrayLayers: 43},
+mipLevelCount: 5,
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x8-unorm'
+],
+}
+);
+let renderBundle197 = renderBundleEncoder161.finish(
+{
+label: '\u5bdd\u05cb'
+}
+);
+let sampler138 = device15.createSampler(
+{
+label: '\u92e4\u28a4\u08fb\u{1fc9d}\u7a4b\u03ba\u0831\u00c1\udb65\ue9e5',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 59.223,
+lodMaxClamp: 88.345,
+maxAnisotropy: 1,
+}
+);
+try {
+await device15.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend('\u919e\u6ef6\u41e9\ua4bb\u{1ffaa}\u034d\u{1f76e}\u{1f6b4}\u8d60\u0434');
+try {
+adapter3.label = '\u7c93\u0fc7\u0cf1';
+} catch {}
+let buffer75 = device1.createBuffer(
+{
+label: '\ud246\u0653\ue78d',
+size: 22550,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let texture243 = device1.createTexture(
+{
+label: '\u{1fd18}\u8562\u8797\uc2b8\udbf6\ua007\u8fc5\uacf1\u{1f723}\u0fd3\u0204',
+size: {width: 219, height: 1, depthOrArrayLayers: 234},
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rg8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8uint',
+'rg8uint'
+],
+}
+);
+let renderBundle198 = renderBundleEncoder30.finish(
+{
+label: '\ucf60\ua5ca\uf13b\uc108\u0a6b'
+}
+);
+try {
+renderPassEncoder27.setVertexBuffer(
+6,
+buffer14,
+20152,
+10431
+);
+} catch {}
+try {
+gpuCanvasContext27.configure(
+{
+device: device1,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb',
+'bgra8unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let adapter23 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let video55 = await videoWithData();
+try {
+commandEncoder158.copyTextureToTexture(
+{
+  texture: texture76,
+  mipLevel: 2,
+  origin: { x: 80, y: 5, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture76,
+  mipLevel: 8,
+  origin: { x: 0, y: 5, z: 1 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder143.clearBuffer(
+buffer43,
+7544,
+35096
+);
+dissociateBuffer(device6, buffer43);
+} catch {}
+try {
+await device18.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append('\u851d\u11bd\u{1fdaf}\u47b7\u3d2a\ua86d');
+let promise72 = adapter23.requestDevice(
+{
+label: '\u331a\udbb9\u02a8\u0cd8',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 6,
+maxColorAttachmentBytesPerSample: 41,
+maxVertexAttributes: 23,
+maxVertexBufferArrayStride: 39866,
+maxStorageTexturesPerShaderStage: 14,
+maxStorageBuffersPerShaderStage: 16,
+maxDynamicStorageBuffersPerPipelineLayout: 54617,
+maxBindingsPerBindGroup: 6044,
+maxTextureDimension1D: 13220,
+maxTextureDimension2D: 14261,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 17505210,
+maxInterStageShaderVariables: 111,
+maxInterStageShaderComponents: 119,
+},
+}
+);
+let canvas54 = document.createElement('canvas');
+let img45 = await imageWithData(127, 201, '#7833f02a', '#50a10c25');
+pseudoSubmit(device4, commandEncoder155);
+try {
+renderPassEncoder13.setBindGroup(
+4,
+bindGroup60,
+new Uint32Array(5655),
+3886,
+0
+);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(
+buffer20,
+'uint16'
+);
+} catch {}
+video49.height = 249;
+canvas18.height = 708;
+let img46 = await imageWithData(107, 122, '#dcf42851', '#73b30287');
+try {
+adapter11.label = '\ube5e\u1966\u3b09\ucc70\u47d8\u{1f836}\ud229\u09a3';
+} catch {}
+let bindGroup74 = device13.createBindGroup({
+label: '\u4252\u0221\ufb16\ufac2\u{1fac1}\u88aa\u{1f7b0}\u98a7\ub62c\u{1ffbe}',
+layout: bindGroupLayout51,
+entries: [
+{
+binding: 2097,
+resource: textureView129
+}
+],
+});
+try {
+buffer55.unmap();
+} catch {}
+let promise73 = device13.queue.onSubmittedWorkDone();
+document.body.prepend('\u0931\u{1f929}\u01df\u{1fc56}\u{1f750}\u05b7\u{1ffcf}\u0677\u61e3');
+let commandEncoder161 = device13.createCommandEncoder(
+{
+label: '\u5b39\uf466\uaf00\u{1f8a6}\u0329\u{1fcf1}\u7400\u083e\u08f7\u11ca',
+}
+);
+let texture244 = device13.createTexture(
+{
+label: '\uad8d\u4194\uc0e7',
+size: [700, 80, 1],
+mipLevelCount: 7,
+format: 'astc-4x4-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-4x4-unorm',
+'astc-4x4-unorm',
+'astc-4x4-unorm-srgb'
+],
+}
+);
+let textureView196 = texture189.createView(
+{
+label: '\u03ab\u0bc8\u5454\uea07\u{1f860}\u0689\udf16\u{1fa02}\u{1f797}\u7683\u7367',
+dimension: '2d-array',
+mipLevelCount: 6,
+}
+);
+let sampler139 = device13.createSampler(
+{
+label: '\u73f9\u{1f74c}\u0331\u08f8\u5d12\u0278\u05b7\u{1f93a}\u0898',
+addressModeU: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 77.733,
+maxAnisotropy: 6,
+}
+);
+try {
+commandEncoder125.copyBufferToBuffer(
+buffer53,
+12296,
+buffer55,
+2144,
+2896
+);
+dissociateBuffer(device13, buffer53);
+dissociateBuffer(device13, buffer55);
+} catch {}
+try {
+commandEncoder145.clearBuffer(
+buffer55,
+1312,
+6308
+);
+dissociateBuffer(device13, buffer55);
+} catch {}
+let pipeline117 = device13.createRenderPipeline(
+{
+layout: pipelineLayout37,
+vertex: {
+module: shaderModule32,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'uint32x4',
+offset: 5096,
+shaderLocation: 28,
+},
+{
+format: 'float16x2',
+offset: 5524,
+shaderLocation: 20,
+},
+{
+format: 'unorm16x4',
+offset: 528,
+shaderLocation: 25,
+},
+{
+format: 'unorm16x2',
+offset: 3264,
+shaderLocation: 2,
+},
+{
+format: 'sint32',
+offset: 5864,
+shaderLocation: 14,
+},
+{
+format: 'uint32x4',
+offset: 4236,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 724,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 716,
+shaderLocation: 10,
+},
+{
+format: 'float32x4',
+offset: 272,
+shaderLocation: 16,
+},
+{
+format: 'sint32',
+offset: 164,
+shaderLocation: 17,
+},
+{
+format: 'uint32',
+offset: 632,
+shaderLocation: 11,
+},
+{
+format: 'float32x3',
+offset: 8,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x2',
+offset: 2708,
+shaderLocation: 6,
+},
+{
+format: 'uint32',
+offset: 4,
+shaderLocation: 27,
+},
+{
+format: 'float32x4',
+offset: 2464,
+shaderLocation: 5,
+},
+{
+format: 'snorm8x4',
+offset: 5052,
+shaderLocation: 15,
+},
+{
+format: 'float16x4',
+offset: 524,
+shaderLocation: 24,
+},
+{
+format: 'snorm16x2',
+offset: 3804,
+shaderLocation: 21,
+},
+{
+format: 'unorm16x2',
+offset: 5624,
+shaderLocation: 22,
+},
+{
+format: 'sint8x2',
+offset: 4114,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 48,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 16,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 2868,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 4512,
+attributes: [
+{
+format: 'unorm16x2',
+offset: 2212,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x2',
+offset: 4328,
+shaderLocation: 0,
+},
+{
+format: 'snorm8x2',
+offset: 2604,
+shaderLocation: 7,
+},
+{
+format: 'sint8x2',
+offset: 856,
+shaderLocation: 26,
+},
+{
+format: 'float32x3',
+offset: 1928,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 3720,
+attributes: [
+{
+format: 'sint32x4',
+offset: 1524,
+shaderLocation: 18,
+},
+{
+format: 'sint32x4',
+offset: 1204,
+shaderLocation: 1,
+},
+{
+format: 'sint32',
+offset: 2580,
+shaderLocation: 19,
+}
+],
+}
+]
+},
+multisample: {
+mask: 0x7ff66257,
+},
+fragment: {
+module: shaderModule32,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'decrement-wrap',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+},
+stencilReadMask: 2429,
+stencilWriteMask: 303,
+depthBiasSlopeScale: 23,
+depthBiasClamp: 9,
+},
+}
+);
+document.body.append('\ue1f2\u04e8\u0fa6\u{1fe0b}\u501b\u405d\u0981\u0492\u54b8\u{1fa64}\u0313');
+let renderBundleEncoder178 = device13.createRenderBundleEncoder(
+{
+label: '\ua967\ua7bb\u0f00\u{1f657}',
+colorFormats: [
+'rg11b10ufloat',
+'r16uint',
+undefined,
+'rg8sint'
+],
+sampleCount: 493,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder178.setBindGroup(
+4,
+bindGroup72,
+new Uint32Array(2085),
+1062,
+0
+);
+} catch {}
+try {
+commandEncoder125.copyBufferToBuffer(
+buffer53,
+104,
+buffer55,
+276,
+1020
+);
+dissociateBuffer(device13, buffer53);
+dissociateBuffer(device13, buffer55);
+} catch {}
+try {
+device13.queue.writeBuffer(
+buffer67,
+11900,
+new Int16Array(415),
+414,
+0
+);
+} catch {}
+try {
+await device13.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append('\uf680\u1d6a');
+let commandEncoder162 = device7.createCommandEncoder(
+{
+label: '\u1e40\uff1d\uf077\u640b\u{1f978}\u0fda\u08ff',
+}
+);
+let texture245 = device7.createTexture(
+{
+label: '\u60b8\u35a3\u8590\u0b38\ua2f1',
+size: [1850, 8, 1],
+mipLevelCount: 4,
+format: 'astc-5x4-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let textureView197 = texture203.createView(
+{
+label: '\u5667\u0d1c\u2088\u01a3\u{1f78a}\u{1f722}\u7196\u{1fc26}\uae11\uff39',
+baseMipLevel: 2,
+mipLevelCount: 8,
+}
+);
+let renderBundle199 = renderBundleEncoder51.finish(
+{
+label: '\u5f25\ube7f\u0183'
+}
+);
+try {
+commandEncoder149.copyBufferToBuffer(
+buffer39,
+180,
+buffer36,
+20836,
+24
+);
+dissociateBuffer(device7, buffer39);
+dissociateBuffer(device7, buffer36);
+} catch {}
+try {
+device7.queue.submit([
+commandBuffer6,
+]);
+} catch {}
+let offscreenCanvas54 = new OffscreenCanvas(106, 998);
+let bindGroupLayout71 = device7.createBindGroupLayout(
+{
+label: '\u0b51\u{1ff46}',
+entries: [
+{
+binding: 999,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let renderBundle200 = renderBundleEncoder51.finish(
+{
+label: '\u{1f81b}\u6754\u68ac\u{1faa1}\uc1a1\u04d9\u9019'
+}
+);
+try {
+commandEncoder149.clearBuffer(
+buffer72
+);
+dissociateBuffer(device7, buffer72);
+} catch {}
+let pipeline118 = device7.createComputePipeline(
+{
+label: '\u7077\u0b5f\u64f0',
+layout: pipelineLayout23,
+compute: {
+module: shaderModule17,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let gpuCanvasContext51 = offscreenCanvas54.getContext('webgpu');
+document.body.prepend('\u{1fa03}\u6f01\u{1f885}\u{1fd0b}\u3606\u0804\ufe18\u6623');
+let commandEncoder163 = device15.createCommandEncoder(
+{
+label: '\u{1f739}\u70e5\u0b8e\ubadf\u{1f645}\u0345\u85d9\udacc\u{1f935}\u{1f8a6}',
+}
+);
+let textureView198 = texture224.createView(
+{
+label: '\ubd7c\u0f29\u0fb3\u14a5',
+dimension: '2d-array',
+format: 'astc-6x6-unorm',
+}
+);
+let computePassEncoder104 = commandEncoder163.beginComputePass(
+{
+label: '\u6ebd\u3e9f\u651a\uc353'
+}
+);
+let renderBundleEncoder179 = device15.createRenderBundleEncoder(
+{
+label: '\u8821\u00d7\u45ee\ub46d\u{1f757}',
+colorFormats: [
+'rgba8unorm',
+'rg16float',
+undefined,
+'rgba16sint',
+'rg32uint',
+'rg16float',
+undefined,
+'rgba8sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 300,
+stencilReadOnly: true,
+}
+);
+try {
+gpuCanvasContext48.configure(
+{
+device: device15,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device15.queue.writeTexture(
+{
+  texture: texture242,
+  mipLevel: 0,
+  origin: { x: 680, y: 0, z: 16 },
+  aspect: 'all',
+},
+arrayBuffer7,
+/* required buffer size: 1187299 */{
+offset: 179,
+bytesPerRow: 2698,
+rowsPerImage: 55,
+},
+{width: 1580, height: 0, depthOrArrayLayers: 9}
+);
+} catch {}
+document.body.prepend('\u{1fbfb}\u0244\u65ad\ubdfc\u5f4e\u772f\u03fe\u0e8a\u0719\u0e62\u{1fa69}');
+let textureView199 = texture189.createView(
+{
+dimension: '2d-array',
+baseMipLevel: 2,
+mipLevelCount: 3,
+}
+);
+let computePassEncoder105 = commandEncoder125.beginComputePass(
+{
+label: '\u{1fbf0}\uf68c'
+}
+);
+let renderBundleEncoder180 = device13.createRenderBundleEncoder(
+{
+label: '\uc5cd\u0de0\u0ee3\u0b28\uc168\u{1f83c}',
+colorFormats: [
+'rgb10a2uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 683,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder105.end();
+} catch {}
+try {
+computePassEncoder87.setPipeline(
+pipeline93
+);
+} catch {}
+try {
+device13.pushErrorScope(
+'validation'
+);
+} catch {}
+try {
+buffer55.unmap();
+} catch {}
+document.body.prepend(video0);
+let textureView200 = texture240.createView(
+{
+label: '\u5b15\u0e12\ubb4b\u0870\u851f\u09c7\u5589\u{1fdec}\ub05f\u8339',
+dimension: '2d-array',
+format: 'rgba8unorm-srgb',
+}
+);
+let renderBundle201 = renderBundleEncoder164.finish(
+{
+label: '\uccba\u364f\u8ecb\u000f'
+}
+);
+let buffer76 = device13.createBuffer(
+{
+label: '\ubdfc\u0028\u0b69\u6715\u02eb\u02a9\u{1fcfc}\u{1fa54}\uf112\u21e4',
+size: 41943,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+try {
+device13.queue.writeTexture(
+{
+  texture: texture166,
+  mipLevel: 0,
+  origin: { x: 0, y: 16, z: 1 },
+  aspect: 'all',
+},
+new Int8Array(new ArrayBuffer(40)),
+/* required buffer size: 530 */{
+offset: 530,
+bytesPerRow: 868,
+},
+{width: 212, height: 76, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+canvas54.getContext('webgl2');
+} catch {}
+let textureView201 = texture240.createView(
+{
+format: 'rgba8unorm-srgb',
+}
+);
+try {
+adapter1.label = '\u08b3\u0abb\u074b\uda5c\udb44\ufc1b\u{1fbc5}\u65c8\ueea3';
+} catch {}
+let texture246 = device11.createTexture(
+{
+label: '\u071a\u0876\ude75\u0046\u{1f7e5}\u6c6b\u{1f9ed}',
+size: [6467],
+dimension: '1d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8snorm',
+'rgba8snorm',
+'rgba8snorm'
+],
+}
+);
+let textureView202 = texture132.createView(
+{
+label: '\u0dd0\u{1fd4d}\u337c\u024e\u62ee\u19e1\u0d28\ud8c1\u{1fd4c}\ud14d',
+}
+);
+try {
+device11.queue.writeTexture(
+{
+  texture: texture143,
+  mipLevel: 1,
+  origin: { x: 1, y: 64, z: 57 },
+  aspect: 'all',
+},
+new ArrayBuffer(64),
+/* required buffer size: 838751 */{
+offset: 557,
+bytesPerRow: 135,
+rowsPerImage: 294,
+},
+{width: 57, height: 35, depthOrArrayLayers: 22}
+);
+} catch {}
+canvas4.width = 471;
+let device19 = await adapter22.requestDevice(
+{
+label: '\ua73e\u{1f640}\u0af0\u0d94\u07d7\u0d7f\u78a6\u{1fbad}',
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxColorAttachmentBytesPerSample: 45,
+maxVertexAttributes: 21,
+maxVertexBufferArrayStride: 33543,
+maxStorageTexturesPerShaderStage: 11,
+maxStorageBuffersPerShaderStage: 32,
+maxDynamicStorageBuffersPerPipelineLayout: 37020,
+maxBindingsPerBindGroup: 1966,
+maxTextureDimension1D: 14201,
+maxTextureDimension2D: 12577,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 98007231,
+maxInterStageShaderVariables: 116,
+maxInterStageShaderComponents: 79,
+},
+}
+);
+try {
+await promise71;
+} catch {}
+let canvas55 = document.createElement('canvas');
+let bindGroupLayout72 = device4.createBindGroupLayout(
+{
+entries: [
+
+],
+}
+);
+let bindGroup75 = device4.createBindGroup({
+label: '\u2025\u4d8a\ub088\u3437\u0c08\uc3d4\u09cf\u08c1',
+layout: bindGroupLayout72,
+entries: [
+
+],
+});
+let renderPassEncoder35 = commandEncoder146.beginRenderPass(
+{
+label: '\ude77\u{1fcc7}\u8425\ua9cc\uc1a2\u04a4\u0b33',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView52,
+depthClearValue: -3.763780278434135,
+depthReadOnly: true,
+},
+occlusionQuerySet: querySet115,
+}
+);
+let renderBundleEncoder181 = device4.createRenderBundleEncoder(
+{
+label: '\u7c5b\u913e\u184e',
+colorFormats: [
+'rgb10a2unorm',
+'rgba32sint',
+'r8unorm',
+'r8uint',
+'rgba8sint',
+'rgba8uint',
+'rg16sint',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 390,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder12.setBindGroup(
+0,
+bindGroup54
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture118,
+  mipLevel: 2,
+  origin: { x: 0, y: 11, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(2978),
+/* required buffer size: 2978 */{
+offset: 77,
+bytesPerRow: 261,
+},
+{width: 15, height: 12, depthOrArrayLayers: 1}
+);
+} catch {}
+let gpuCanvasContext52 = canvas55.getContext('webgpu');
+try {
+computePassEncoder99.setBindGroup(
+4,
+bindGroup70,
+new Uint32Array(2493),
+347,
+0
+);
+} catch {}
+try {
+buffer74.unmap();
+} catch {}
+let pipeline119 = await device14.createComputePipelineAsync(
+{
+label: '\u1feb\u{1ffe4}\u0cd1\u091a\u0703\u0b23',
+layout: pipelineLayout45,
+compute: {
+module: shaderModule28,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let videoFrame50 = new VideoFrame(video49, {timestamp: 0});
+gc();
+document.body.append('\u0e09\uf66f\u0684\u0ec1\u717d\ucd50\u08d5');
+let canvas56 = document.createElement('canvas');
+let imageData55 = new ImageData(192, 20);
+let renderBundleEncoder182 = device18.createRenderBundleEncoder(
+{
+label: '\u7e70\u0107',
+colorFormats: [
+'rg32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 351,
+stencilReadOnly: true,
+}
+);
+let sampler140 = device18.createSampler(
+{
+label: '\u{1fae2}\u1e1f\u0ee5\u0255\u6e85\u{1f864}\u093f\ud758',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 89.574,
+lodMaxClamp: 98.404,
+maxAnisotropy: 4,
+}
+);
+try {
+renderBundleEncoder182.setVertexBuffer(
+59,
+undefined
+);
+} catch {}
+try {
+gpuCanvasContext20.unconfigure();
+} catch {}
+let commandEncoder164 = device8.createCommandEncoder(
+{
+label: '\u0223\u{1fcdf}\uaa4a\u176f\u0aee\u{1fe84}\u{1f79a}',
+}
+);
+let renderBundle202 = renderBundleEncoder124.finish(
+{
+label: '\u8cdb\u04fc\u01b8'
+}
+);
+try {
+device8.addEventListener('uncapturederror', e => { log('device8.uncapturederror'); log(e); e.label = device8.label; });
+} catch {}
+try {
+device8.queue.writeTexture(
+{
+  texture: texture172,
+  mipLevel: 0,
+  origin: { x: 4442, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer5,
+/* required buffer size: 2936 */{
+offset: 572,
+},
+{width: 591, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let canvas57 = document.createElement('canvas');
+let renderBundle203 = renderBundleEncoder179.finish(
+{
+label: '\u{1ff30}\u6141\u6c2f'
+}
+);
+try {
+gpuCanvasContext44.unconfigure();
+} catch {}
+let shaderModule34 = device5.createShaderModule(
+{
+label: '\u0c25\ud3d7',
+code: `
+
+@compute @workgroup_size(2, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(5) f0: vec2<f32>,
+@location(6) f1: vec3<i32>,
+@location(7) f2: u32,
+@location(1) f3: vec4<f32>,
+@location(0) f4: vec3<i32>,
+@location(3) f5: vec4<i32>,
+@location(4) f6: vec2<i32>,
+@location(2) f7: u32,
+@builtin(frag_depth) f8: f32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(front_facing) a2: bool, @builtin(sample_index) a3: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(2) a0: vec2<u32>, @builtin(instance_index) a1: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+pseudoSubmit(device5, commandEncoder111);
+try {
+computePassEncoder86.setBindGroup(
+3,
+bindGroup59,
+new Uint32Array(1923),
+836,
+0
+);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder16.setViewport(
+6.586,
+0.2034,
+14.05,
+1.143,
+0.1779,
+0.2958
+);
+} catch {}
+try {
+commandEncoder159.copyTextureToTexture(
+{
+  texture: texture74,
+  mipLevel: 0,
+  origin: { x: 53, y: 0, z: 86 },
+  aspect: 'all',
+},
+{
+  texture: texture79,
+  mipLevel: 7,
+  origin: { x: 7, y: 0, z: 6 },
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 2}
+);
+} catch {}
+try {
+commandEncoder159.clearBuffer(
+buffer34,
+3456,
+20552
+);
+dissociateBuffer(device5, buffer34);
+} catch {}
+let commandEncoder165 = device1.createCommandEncoder(
+{
+label: '\u{1fd6e}\u17ba\u7602\u48d6\u0b8c\u{1fecd}\ub585\u3ff8',
+}
+);
+let textureView203 = texture190.createView(
+{
+label: '\u02b6\u1d15',
+baseArrayLayer: 152,
+arrayLayerCount: 56,
+}
+);
+let sampler141 = device1.createSampler(
+{
+label: '\u0ec4\u{1fd95}\u0840\u74eb\u061f\u{1fa2c}',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 30.117,
+lodMaxClamp: 69.682,
+}
+);
+try {
+computePassEncoder33.setPipeline(
+pipeline98
+);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(
+6,
+buffer37,
+2148,
+12738
+);
+} catch {}
+try {
+commandEncoder165.clearBuffer(
+buffer37
+);
+dissociateBuffer(device1, buffer37);
+} catch {}
+document.body.prepend('\ue311\u001b\u{1ff87}\u0399\u0d2a\u0de1\u08bd\u0b71\u0aa1\u3cd8\u3c6f');
+let promise74 = navigator.gpu.requestAdapter(
+{
+powerPreference: 'low-power',
+}
+);
+try {
+await adapter4.requestAdapterInfo();
+} catch {}
+pseudoSubmit(device15, commandEncoder147);
+let textureView204 = texture208.createView(
+{
+label: '\u1e0e\u94bc\u0cf7\ucf8c\u9c3f',
+}
+);
+let renderBundleEncoder183 = device15.createRenderBundleEncoder(
+{
+label: '\u43f7\u{1ffea}\u0b63\u4249\u0951\u0554\ub4d1\u4e4e',
+colorFormats: [
+'rgba32float',
+'r8uint',
+undefined,
+'rg16float'
+],
+sampleCount: 547,
+stencilReadOnly: false,
+}
+);
+let renderBundle204 = renderBundleEncoder183.finish(
+{
+label: '\u48de\u7f45\u29e2\u6cdd\u93cf\ua10e\u7e87\ud51e\u0164'
+}
+);
+try {
+querySet144.destroy();
+} catch {}
+let promise75 = navigator.gpu.requestAdapter(
+{
+}
+);
+try {
+canvas56.getContext('webgl');
+} catch {}
+let querySet159 = device13.createQuerySet(
+{
+label: '\u0c89\u{1ff9d}\ub3c0\u00d5\u{1f71a}\u0676\ud38d\u0729',
+type: 'occlusion',
+count: 1054,
+}
+);
+let texture247 = device13.createTexture(
+{
+label: '\u8e4a\u{1f6ab}\uabb4\u514c\u881a\u0d45\u57cf\u9a73\ua45a\u823f\uf3ec',
+size: {width: 6730, height: 150, depthOrArrayLayers: 1},
+mipLevelCount: 12,
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+commandEncoder161.clearBuffer(
+buffer67,
+1292,
+11436
+);
+dissociateBuffer(device13, buffer67);
+} catch {}
+let promise76 = device13.queue.onSubmittedWorkDone();
+let bindGroupLayout73 = device17.createBindGroupLayout(
+{
+label: '\u6e2e\u08a2\u{1fd0f}\u00c0\u0675\udaa5',
+entries: [
+{
+binding: 478,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+},
+{
+binding: 3684,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+let querySet160 = device17.createQuerySet(
+{
+label: '\u{1fbbc}\udbd7\u{1fb1c}\uc20c',
+type: 'occlusion',
+count: 2058,
+}
+);
+let texture248 = device17.createTexture(
+{
+size: {width: 5706},
+dimension: '1d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundle205 = renderBundleEncoder164.finish(
+{
+
+}
+);
+let sampler142 = device17.createSampler(
+{
+label: '\u8e82\uaf31\u{1fb4c}\uae7f\u0302\u0a87\u{1f820}\u0b5f\u01eb\uc614\u48f3',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 5.436,
+lodMaxClamp: 61.425,
+}
+);
+try {
+gpuCanvasContext8.configure(
+{
+device: device17,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float',
+'rgba16float',
+'rg8sint',
+'r32float'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+try {
+device17.queue.writeTexture(
+{
+  texture: texture226,
+  mipLevel: 1,
+  origin: { x: 14, y: 37, z: 1 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(arrayBuffer17),
+/* required buffer size: 913 */{
+offset: 913,
+bytesPerRow: 1357,
+},
+{width: 276, height: 47, depthOrArrayLayers: 0}
+);
+} catch {}
+let gpuCanvasContext53 = canvas57.getContext('webgpu');
+let commandEncoder166 = device13.createCommandEncoder(
+{
+label: '\u{1ff67}\u6432\u07d1\u03f6\u{1fd60}\u03be\u{1fbad}\u4cac',
+}
+);
+let renderBundle206 = renderBundleEncoder178.finish(
+{
+
+}
+);
+try {
+commandEncoder166.copyBufferToBuffer(
+buffer53,
+30396,
+buffer76,
+12972,
+148
+);
+dissociateBuffer(device13, buffer53);
+dissociateBuffer(device13, buffer76);
+} catch {}
+try {
+commandEncoder166.copyTextureToTexture(
+{
+  texture: texture171,
+  mipLevel: 9,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture247,
+  mipLevel: 9,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device13.queue.writeBuffer(
+buffer55,
+5180,
+new Int16Array(48739),
+31657,
+572
+);
+} catch {}
+let promise77 = device13.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let bindGroupLayout74 = device8.createBindGroupLayout(
+{
+label: '\u0ced\ueecf\u399e',
+entries: [
+
+],
+}
+);
+let texture249 = device8.createTexture(
+{
+size: {width: 5154},
+dimension: '1d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'r8uint',
+'r8uint',
+'r8uint'
+],
+}
+);
+let computePassEncoder106 = commandEncoder90.beginComputePass();
+let renderBundleEncoder184 = device8.createRenderBundleEncoder(
+{
+label: '\u0c8f\u0ceb\uc912\u0e9d\u{1f74c}\u0ad7\u09d8\u6514\uea28\u06ed',
+colorFormats: [
+'rgba32sint',
+'rg16sint',
+'bgra8unorm',
+'rgba8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 212,
+depthReadOnly: true,
+}
+);
+try {
+await buffer66.mapAsync(
+GPUMapMode.READ
+);
+} catch {}
+try {
+commandEncoder160.copyBufferToBuffer(
+buffer29,
+11892,
+buffer40,
+12452,
+476
+);
+dissociateBuffer(device8, buffer29);
+dissociateBuffer(device8, buffer40);
+} catch {}
+try {
+commandEncoder164.copyTextureToTexture(
+{
+  texture: texture125,
+  mipLevel: 0,
+  origin: { x: 278, y: 0, z: 166 },
+  aspect: 'all',
+},
+{
+  texture: texture175,
+  mipLevel: 2,
+  origin: { x: 6, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 34, height: 1, depthOrArrayLayers: 43}
+);
+} catch {}
+let computePassEncoder107 = commandEncoder158.beginComputePass(
+{
+
+}
+);
+try {
+renderBundleEncoder145.setVertexBuffer(
+2,
+buffer71,
+22736
+);
+} catch {}
+  log('the end')
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/RenderBundle.h
+++ b/Source/WebGPU/WebGPU/RenderBundle.h
@@ -81,7 +81,7 @@ public:
 
     void replayCommands(RenderPassEncoder&) const;
     void updateMinMaxDepths(float minDepth, float maxDepth);
-    bool validateRenderPass(bool depthReadOnly, bool stencilReadOnly, const WGPURenderPassDescriptor&) const;
+    bool validateRenderPass(bool depthReadOnly, bool stencilReadOnly, const WGPURenderPassDescriptor&, const Vector<WeakPtr<TextureView>>&, const WeakPtr<TextureView>&) const;
     bool validatePipeline(const RenderPipeline*);
     uint64_t drawCount() const;
     NSString* lastError() const;

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -703,7 +703,7 @@ void RenderPassEncoder::executeBundles(Vector<std::reference_wrapper<RenderBundl
 
         renderBundle.updateMinMaxDepths(m_minDepth, m_maxDepth);
 
-        if (!renderBundle.validateRenderPass(m_depthReadOnly, m_stencilReadOnly, m_descriptor) || !renderBundle.validatePipeline(m_pipeline.get())) {
+        if (!renderBundle.validateRenderPass(m_depthReadOnly, m_stencilReadOnly, m_descriptor, m_colorAttachmentViews, m_depthStencilView) || !renderBundle.validatePipeline(m_pipeline.get())) {
             makeInvalid(@"executeBundles: validation failed");
             return;
         }


### PR DESCRIPTION
#### f3b5e76d12f5e8c9eb8dbfea08f91f741290f856
<pre>
[WebGPU] RenderPassEncoder should use WeakPtr in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=273077">https://bugs.webkit.org/show_bug.cgi?id=273077</a>
<a href="https://rdar.apple.com/126711484">rdar://126711484</a>

Reviewed by Mike Wyrzykowski.

This is very similar to 277742@main, where the use of raw C++ pointers in the
descriptor can lead to UAF. In this case, we should also use the same WeakPtrs
created in the previous commit in `RenderBundle::validateRenderPass`.

* LayoutTests/fast/webgpu/fuzz-126711484-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-126711484.html: Added.
* Source/WebGPU/WebGPU/RenderBundle.h:
* Source/WebGPU/WebGPU/RenderBundle.mm:
(WebGPU::RenderBundle::validateRenderPass const):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::executeBundles):

Canonical link: <a href="https://commits.webkit.org/277979@main">https://commits.webkit.org/277979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8911a9a20380ba13d531032535835912411bd118

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52140 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51929 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45223 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25971 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40154 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50757 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42347 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21267 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23426 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43521 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7455 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45354 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44028 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53838 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24209 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20414 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47473 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25487 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42552 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46455 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10807 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26297 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25206 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->