### PR TITLE
[Remote Inspection] Add support for targets in nested shadow roots

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -332,8 +332,8 @@ public:
     bool allowsActiveContentRuleListActionsForURL(const String& contentRuleListIdentifier, const URL&) const;
     WEBCORE_EXPORT void setActiveContentRuleListActionPatterns(const HashMap<String, Vector<String>>&);
 
-    const HashSet<String>& visibilityAdjustmentSelectors() const { return m_visibilityAdjustmentSelectors; }
-    void setVisibilityAdjustmentSelectors(HashSet<String>&& selectors) { m_visibilityAdjustmentSelectors = WTFMove(selectors); }
+    const Vector<Vector<HashSet<String>>>& visibilityAdjustmentSelectors() const { return m_visibilityAdjustmentSelectors; }
+    void setVisibilityAdjustmentSelectors(Vector<Vector<HashSet<String>>>&& selectors) { m_visibilityAdjustmentSelectors = WTFMove(selectors); }
 
 #if ENABLE(DEVICE_ORIENTATION)
     DeviceOrientationOrMotionPermissionState deviceOrientationAndMotionAccessState() const { return m_deviceOrientationAndMotionAccessState; }
@@ -700,7 +700,7 @@ private:
     MemoryCompactRobinHoodHashMap<String, Vector<UserContentURLPattern>> m_activeContentRuleListActionPatterns;
     ContentExtensionEnablement m_contentExtensionEnablement { ContentExtensionDefaultEnablement::Enabled, { } };
 
-    HashSet<String> m_visibilityAdjustmentSelectors;
+    Vector<Vector<HashSet<String>>> m_visibilityAdjustmentSelectors;
 
     ScriptExecutionContextIdentifier m_resultingClientId;
 

--- a/Source/WebCore/page/ElementTargetingController.h
+++ b/Source/WebCore/page/ElementTargetingController.h
@@ -69,8 +69,8 @@ private:
     SingleThreadWeakPtr<Page> m_page;
     DeferrableOneShotTimer m_recentAdjustmentClientRectsCleanUpTimer;
     HashMap<ElementIdentifier, IntRect> m_recentAdjustmentClientRects;
-    std::optional<HashSet<String>> m_remainingVisibilityAdjustmentSelectors;
     ApproximateTime m_startTimeForSelectorBasedVisibilityAdjustment;
+    std::optional<Vector<Vector<HashSet<String>>>> m_remainingVisibilityAdjustmentSelectors;
     Region m_adjustmentClientRegion;
     Region m_repeatedAdjustmentClientRegion;
     WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_adjustedElements;

--- a/Source/WebCore/page/ElementTargetingTypes.h
+++ b/Source/WebCore/page/ElementTargetingTypes.h
@@ -47,13 +47,14 @@ struct TargetedElementInfo {
     ScriptExecutionContextIdentifier documentIdentifier;
     RectEdges<bool> offsetEdges;
     String renderedText;
-    Vector<String> selectors;
+    Vector<Vector<String>> selectors;
     FloatRect boundsInRootView;
     FloatRect boundsInClientCoordinates;
     PositionType positionType { PositionType::Static };
     Vector<FrameIdentifier> childFrameIdentifiers;
     bool isUnderPoint { true };
     bool isPseudoElement { false };
+    bool isInShadowTree { false };
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -895,13 +895,14 @@ header: <WebCore/ElementTargetingTypes.h>
     WebCore::ScriptExecutionContextIdentifier documentIdentifier
     WebCore::RectEdges<bool> offsetEdges
     String renderedText
-    Vector<String> selectors
+    Vector<Vector<String>> selectors
     WebCore::FloatRect boundsInRootView
     WebCore::FloatRect boundsInClientCoordinates
     WebCore::PositionType positionType
     Vector<WebCore::FrameIdentifier> childFrameIdentifiers
     bool isUnderPoint
     bool isPseudoElement
+    bool isInShadowTree
 };
 
 header: <WebCore/RenderStyleConstants.h>

--- a/Source/WebKit/Shared/WebsitePoliciesData.h
+++ b/Source/WebKit/Shared/WebsitePoliciesData.h
@@ -59,7 +59,7 @@ public:
 
     HashMap<String, Vector<String>> activeContentRuleListActionPatterns;
     Vector<WebCore::CustomHeaderFields> customHeaderFields;
-    HashSet<String> visibilityAdjustmentSelectors;
+    Vector<Vector<HashSet<String>>> visibilityAdjustmentSelectors;
     String customUserAgent;
     String customUserAgentAsSiteSpecificQuirks;
     String customNavigatorPlatform;

--- a/Source/WebKit/Shared/WebsitePoliciesData.serialization.in
+++ b/Source/WebKit/Shared/WebsitePoliciesData.serialization.in
@@ -53,7 +53,7 @@ enum class WebKit::WebContentMode : uint8_t {
 struct WebKit::WebsitePoliciesData {
     HashMap<String, Vector<String>> activeContentRuleListActionPatterns;
     Vector<WebCore::CustomHeaderFields> customHeaderFields;
-    HashSet<String> visibilityAdjustmentSelectors;
+    Vector<Vector<HashSet<String>>> visibilityAdjustmentSelectors;
     String customUserAgent;
     String customUserAgentAsSiteSpecificQuirks;
     String customNavigatorPlatform;

--- a/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
@@ -51,7 +51,7 @@ public:
     WebCore::RectEdges<bool> offsetEdges() const { return m_info.offsetEdges; }
 
     const WTF::String& renderedText() const { return m_info.renderedText; }
-    const Vector<WTF::String>& selectors() const { return m_info.selectors; }
+    const Vector<Vector<WTF::String>>& selectors() const { return m_info.selectors; }
     WebCore::PositionType positionType() const { return m_info.positionType; }
     WebCore::FloatRect boundsInRootView() const { return m_info.boundsInRootView; }
     WebCore::FloatRect boundsInWebView() const;
@@ -59,6 +59,7 @@ public:
 
     bool isUnderPoint() const { return m_info.isUnderPoint; }
     bool isPseudoElement() const { return m_info.isPseudoElement; }
+    bool isInShadowTree() const { return m_info.isInShadowTree; }
 
     void childFrames(CompletionHandler<void(Vector<Ref<FrameTreeNode>>&&)>&&) const;
 

--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
@@ -135,8 +135,8 @@ public:
     bool allowPrivacyProxy() const { return m_data.allowPrivacyProxy; }
     void setAllowPrivacyProxy(bool allow) { m_data.allowPrivacyProxy = allow; }
 
-    const HashSet<WTF::String>& visibilityAdjustmentSelectors() const { return m_data.visibilityAdjustmentSelectors; }
-    void setVisibilityAdjustmentSelectors(HashSet<WTF::String>&& selectors) { m_data.visibilityAdjustmentSelectors = WTFMove(selectors); }
+    const Vector<Vector<HashSet<WTF::String>>>& visibilityAdjustmentSelectors() const { return m_data.visibilityAdjustmentSelectors; }
+    void setVisibilityAdjustmentSelectors(Vector<Vector<HashSet<WTF::String>>>&& selectors) { m_data.visibilityAdjustmentSelectors = WTFMove(selectors); }
 
 private:
     WebKit::WebsitePoliciesData m_data;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -656,20 +656,61 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
     _websitePolicies->setAdvancedPrivacyProtections(webCorePolicy);
 }
 
+- (void)_setVisibilityAdjustmentSelectorsIncludingShadowHosts:(NSArray<NSArray<NSSet<NSString *> *> *> *)elements
+{
+    Vector<Vector<HashSet<String>>> result;
+    result.reserveInitialCapacity(elements.count);
+    for (NSArray<NSSet<NSString *> *> *nsSelectorsForElement in elements) {
+        Vector<HashSet<String>> selectorsForElement;
+        selectorsForElement.reserveInitialCapacity(nsSelectorsForElement.count);
+        for (NSSet<NSString *> *nsSelectors in nsSelectorsForElement) {
+            HashSet<String> selectors;
+            selectors.reserveInitialCapacity(nsSelectors.count);
+            for (NSString *selector in nsSelectors)
+                selectors.add(selector);
+            selectorsForElement.append(WTFMove(selectors));
+        }
+        result.append(WTFMove(selectorsForElement));
+    }
+    _websitePolicies->setVisibilityAdjustmentSelectors(WTFMove(result));
+}
+
+- (NSArray<NSArray<NSSet<NSString *> *> *> *)_visibilityAdjustmentSelectorsIncludingShadowHosts
+{
+    RetainPtr result = adoptNS([[NSMutableArray alloc] initWithCapacity:_websitePolicies->visibilityAdjustmentSelectors().size()]);
+    for (auto& selectorsForElement : _websitePolicies->visibilityAdjustmentSelectors()) {
+        RetainPtr nsSelectorsForElement = adoptNS([[NSMutableArray alloc] initWithCapacity:selectorsForElement.size()]);
+        for (auto& selectors : selectorsForElement) {
+            RetainPtr nsSelectors = adoptNS([[NSMutableSet alloc] initWithCapacity:selectors.size()]);
+            for (auto& selector : selectors)
+                [nsSelectors addObject:selector];
+            [nsSelectorsForElement addObject:nsSelectors.get()];
+        }
+        [result addObject:nsSelectorsForElement.get()];
+    }
+    return result.autorelease();
+}
+
 - (void)_setVisibilityAdjustmentSelectors:(NSSet<NSString *> *)nsSelectors
 {
-    HashSet<String> selectors;
-    selectors.reserveInitialCapacity(nsSelectors.count);
-    for (NSString *selector in nsSelectors)
-        selectors.add(selector);
-    _websitePolicies->setVisibilityAdjustmentSelectors(WTFMove(selectors));
+    RetainPtr elements = adoptNS([[NSMutableArray alloc] initWithCapacity:nsSelectors.count]);
+    for (NSString *selector : nsSelectors)
+        [elements addObject:@[ [NSSet setWithObject:selector] ]];
+    self._visibilityAdjustmentSelectorsIncludingShadowHosts = elements.get();
 }
 
 - (NSSet<NSString *> *)_visibilityAdjustmentSelectors
 {
-    RetainPtr selectors = adoptNS([[NSMutableSet alloc] initWithCapacity:_websitePolicies->visibilityAdjustmentSelectors().size()]);
-    for (auto& selector : _websitePolicies->visibilityAdjustmentSelectors())
-        [selectors addObject:selector];
+    RetainPtr selectors = adoptNS([[NSMutableSet alloc] init]);
+    for (auto& elementSelectors : _websitePolicies->visibilityAdjustmentSelectors()) {
+        if (elementSelectors.size() != 1) {
+            // Ignore shadow roots for compatibility with this soon-to-be deprecated method.
+            continue;
+        }
+
+        for (auto& selector : elementSelectors.first())
+            [selectors addObject:selector];
+    }
     return selectors.autorelease();
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
@@ -120,6 +120,7 @@ typedef NS_OPTIONS(NSUInteger, _WKWebsiteNetworkConnectionIntegrityPolicy) {
 @property (nonatomic, setter=_setNetworkConnectionIntegrityEnabled:) BOOL _networkConnectionIntegrityEnabled WK_API_AVAILABLE(macos(13.3), ios(16.4));
 @property (nonatomic, setter=_setNetworkConnectionIntegrityPolicy:) _WKWebsiteNetworkConnectionIntegrityPolicy _networkConnectionIntegrityPolicy WK_API_AVAILABLE(macos(13.3), ios(16.4));
 
+@property (nonatomic, copy, setter=_setVisibilityAdjustmentSelectorsIncludingShadowHosts:) NSArray<NSArray<NSSet<NSString *> *> *> *_visibilityAdjustmentSelectorsIncludingShadowHosts WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 @property (nonatomic, copy, setter=_setVisibilityAdjustmentSelectors:) NSSet<NSString *> *_visibilityAdjustmentSelectors WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 - (void)_setContentRuleListsEnabled:(BOOL)enabled exceptions:(NSSet<NSString *> *)exceptions WK_API_AVAILABLE(macos(14.0), ios(17.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h
@@ -45,8 +45,10 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @property (nonatomic, readonly) CGRect boundsInClientCoordinates;
 @property (nonatomic, readonly, getter=isUnderPoint) BOOL underPoint;
 @property (nonatomic, readonly, getter=isPseudoElement) BOOL pseudoElement;
+@property (nonatomic, readonly, getter=isInShadowTree) BOOL inShadowTree;
 
 @property (nonatomic, readonly, copy) NSArray<NSString *> *selectors;
+@property (nonatomic, readonly, copy) NSArray<NSArray<NSString *> *> *selectorsIncludingShadowHosts;
 @property (nonatomic, readonly, copy) NSString *renderedText;
 @property (nonatomic, readonly) _WKRectEdge offsetEdges;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
@@ -83,7 +83,25 @@
 
 - (NSArray<NSString *> *)selectors
 {
-    return createNSArray(_info->selectors()).autorelease();
+    if (_info->selectors().isEmpty())
+        return @[ ];
+
+    if (_info->isInShadowTree())
+        return @[ ];
+
+    return createNSArray(_info->selectors().first()).autorelease();
+}
+
+- (NSArray<NSArray<NSString *> *> *)selectorsIncludingShadowHosts
+{
+    RetainPtr result = adoptNS([[NSMutableArray alloc] initWithCapacity:_info->selectors().size()]);
+    for (auto& selectors : _info->selectors()) {
+        RetainPtr nsSelectors = adoptNS([[NSMutableArray alloc] initWithCapacity:selectors.size()]);
+        for (auto& selector : selectors)
+            [nsSelectors addObject:selector];
+        [result addObject:nsSelectors.get()];
+    }
+    return result.autorelease();
 }
 
 - (NSString *)renderedText
@@ -128,6 +146,11 @@
 - (BOOL)isPseudoElement
 {
     return _info->isPseudoElement();
+}
+
+- (BOOL)isInShadowTree
+{
+    return _info->isInShadowTree();
 }
 
 @end

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1186,6 +1186,7 @@
 		F44A9AF72649BBDD00E7CB16 /* ImmediateActionTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F44A9AF62649BBDD00E7CB16 /* ImmediateActionTests.mm */; };
 		F44C7A0020F9EEBF0014478C /* ParserYieldTokenPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = F44C79FB20F9E50C0014478C /* ParserYieldTokenPlugIn.mm */; };
 		F44C7A0520FAAE3C0014478C /* text-with-deferred-script.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F44C7A0420FAAE320014478C /* text-with-deferred-script.html */; };
+		F44CD9D12BD6ABFD0080A6C7 /* element-targeting-8.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F44CD9C92BD6ABF00080A6C7 /* element-targeting-8.html */; };
 		F44D06451F395C26001A0E29 /* editor-state-test-harness.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F44D06441F395C0D001A0E29 /* editor-state-test-harness.html */; };
 		F45033F5206BEC95009351CE /* TextAutosizingBoost.mm in Sources */ = {isa = PBXBuildFile; fileRef = F45033F4206BEC95009351CE /* TextAutosizingBoost.mm */; };
 		F4512E131F60C44600BB369E /* DataTransferItem-getAsEntry.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4512E121F60C43400BB369E /* DataTransferItem-getAsEntry.html */; };
@@ -1639,6 +1640,7 @@
 				F4FB84A82BC9F1F6000D0B47 /* element-targeting-5.html in Copy Resources */,
 				F41289A92BCC97E700D6E0E7 /* element-targeting-6.html in Copy Resources */,
 				F405F8AD2BD1D4DC0020E6AB /* element-targeting-7.html in Copy Resources */,
+				F44CD9D12BD6ABFD0080A6C7 /* element-targeting-8.html in Copy Resources */,
 				51C8E1A91F27F49600BF731B /* EmptyGrandfatheredResourceLoadStatistics.plist in Copy Resources */,
 				49D902B328209B3300E2C3B8 /* emptyTable.html in Copy Resources */,
 				A14AAB651E78DC5400C1ADC2 /* encrypted.pdf in Copy Resources */,
@@ -3568,6 +3570,7 @@
 		F44C79FD20F9E8710014478C /* ParserYieldTokenTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParserYieldTokenTests.h; sourceTree = "<group>"; };
 		F44C79FE20F9E8710014478C /* ParserYieldTokenTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ParserYieldTokenTests.mm; sourceTree = "<group>"; };
 		F44C7A0420FAAE320014478C /* text-with-deferred-script.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "text-with-deferred-script.html"; sourceTree = "<group>"; };
+		F44CD9C92BD6ABF00080A6C7 /* element-targeting-8.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "element-targeting-8.html"; sourceTree = "<group>"; };
 		F44D06441F395C0D001A0E29 /* editor-state-test-harness.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "editor-state-test-harness.html"; sourceTree = "<group>"; };
 		F44D06461F395C4D001A0E29 /* EditorStateTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = EditorStateTests.mm; sourceTree = "<group>"; };
 		F44D06481F3962E3001A0E29 /* EditingTestHarness.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EditingTestHarness.h; sourceTree = "<group>"; };
@@ -4865,6 +4868,7 @@
 				F4FB84A02BC9F13A000D0B47 /* element-targeting-5.html */,
 				F41289A12BCC97DA00D6E0E7 /* element-targeting-6.html */,
 				F405F8A42BD1D1B90020E6AB /* element-targeting-7.html */,
+				F44CD9C92BD6ABF00080A6C7 /* element-targeting-8.html */,
 				51C8E1A81F27F47300BF731B /* EmptyGrandfatheredResourceLoadStatistics.plist */,
 				F4C2AB211DD6D94100E06D5B /* enormous-video-with-sound.html */,
 				F407FE381F1D0DE60017CF25 /* enormous.svg */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-8.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-8.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+body, html, main {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+}
+
+section {
+    display: inline-block;
+}
+</style>
+<script>
+addEventListener("load", () => {
+    const outerShadowRoot = document.querySelector("main").attachShadow({ mode: "open" });
+    outerShadowRoot.innerHTML = `
+        <style>
+            section {
+                width: 400px;
+                height: 600px;
+                border: 2px solid black;
+            }
+        </style>
+        <section></section>`;
+
+    const innerShadowRoot = outerShadowRoot.querySelector("section").attachShadow({ mode: "open" });
+    innerShadowRoot.innerHTML = `
+        <style>
+            div {
+                width: 400px;
+                height: 200px;
+                box-sizing: border-box;
+            }
+            .red { background-color: rgb(255, 59, 48); }
+            .green { background-color: rgb(52, 199, 89); }
+            .blue { background-color: rgb(0, 122, 255); }
+        </style>
+        <div class="red"></div>
+        <div class="green"></div>
+        <div class="blue"></div>`;
+});
+</script>
+</head>
+<body>
+<main></main>
+</body>
+</html>


### PR DESCRIPTION
#### c318bffec39ae54ee6bcfefaf129d1ab52790bde
<pre>
[Remote Inspection] Add support for targets in nested shadow roots
<a href="https://bugs.webkit.org/show_bug.cgi?id=273076">https://bugs.webkit.org/show_bug.cgi?id=273076</a>
<a href="https://rdar.apple.com/123160948">rdar://123160948</a>

Reviewed by Tim Horton, Abrar Protyasha and Aditya Keerthi.

Currently, `visibilityAdjustmentSelectors` is a flattened list of CSS selectors, which correspond to
an arbitrary number of targeted elements. This has a couple of drawbacks:

1.  We might resolve more targets than there originally were (in the case where a targeted element
    had multiple potential selectors, but one of them now maps to something else).

2.  It&apos;s unable to resolve targeted elements inside of shadow roots.

I previously worked around this in 277171@main by just returning an empty list in the case where the
element is inside of a shadow tree, but that only fixed the case where the targeted element itself
contained a shadow root (rather than being inside of the shadow DOM). This patch actually fixes this
issue, by revamping how we both surface and ingest CSS selectors corresponding to targeted elements:

•   `TargetedElementInfo` now contains a array of array of selectors. Each element in the outer
    array corresponds to an enclosing shadow host element that contains the targeted element (such
    that the final array maps to the targeted element itself). For targets that are not inside
    shadow roots, this simply means that there&apos;s a single outer array. The inner array, like before,
    represents a array of selectors (sorted by length) that can be used to resolve the target (or
    shadow host containing the target) within its tree scope.

•   `WKWebpagePreferences` now has a `_visibilityAdjustmentSelectorsIncludingShadowHosts` property,
    which consists of an array of array of sets of strings. To unpack this:

    1.  Each array in the outermost (first) array represents a single targeted element.

    2.  Each set in the second array represents a targeted element or shadow host containing the
        targeted element. The last element is the targeted element itself, and the first element (if
        the targeted element is inside of a shadow root) is the outermost shadow host element in the
        document.

    3.  Each string in the set represents a CSS selector that can potentially be used to resolve the
        targeted element or one of its hosts, within its tree scope.

To make this work, we:

(a) Make `TargetedElementController` recursively ascend the DOM by shadow host, to construct a
    `Vector&lt;Vector&lt;String&gt;&gt;` for each targeted element.

(b) Teach `TargetedElementController` to ingest the array of array of sets described above to
    resolve targeted elements that reside inside shadow trees.

There is no change in behavior for the case where targeted elements aren&apos;t inside the shadow DOM.

Test: ElementTargeting.AdjustVisibilityForTargetsInShadowRoot

* Source/WebCore/loader/DocumentLoader.h:
(WebCore::DocumentLoader::visibilityAdjustmentSelectors const):
(WebCore::DocumentLoader::setVisibilityAdjustmentSelectors):
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::querySelectorMatchesOneElement):
(WebCore::computeIDSelector):
(WebCore::selectorsForTarget):

For elements inside of shadow roots, teach this to recursively find selectors that resolve to shadow
hosts, and return a list of lists of selectors.

(WebCore::targetedElementInfo):
(WebCore::ElementTargetingController::applyVisibilityAdjustmentFromSelectors):

Teach this to apply visibility adjustment to content inside of shadow roots.

* Source/WebCore/page/ElementTargetingController.h:
* Source/WebCore/page/ElementTargetingTypes.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Turn the list of selectors for each targeted element into a list of lists instead. See comments
above for more detail.

* Source/WebKit/Shared/WebsitePoliciesData.h:
* Source/WebKit/Shared/WebsitePoliciesData.serialization.in:

Turn the set of selectors into a list of list of sets. See comments above for more detail.

* Source/WebKit/UIProcess/API/APITargetedElementInfo.h:
* Source/WebKit/UIProcess/API/APIWebsitePolicies.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences _setVisibilityAdjustmentSelectorsIncludingShadowHosts:]):
(-[WKWebpagePreferences _visibilityAdjustmentSelectorsIncludingShadowHosts]):
(-[WKWebpagePreferences _setVisibilityAdjustmentSelectors:]):
(-[WKWebpagePreferences _visibilityAdjustmentSelectors]):

Implement these on top of the new `_visibilityAdjustmentSelectorsIncludingShadowHosts` property.
Once no internal client relies on this anymore, we can simply remove it.

* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm:
(-[_WKTargetedElementInfo selectors]):
(-[_WKTargetedElementInfo selectorsIncludingShadowHosts]):
(-[_WKTargetedElementInfo isInShadowTree]):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm:
(TestWebKitAPI::TEST(ElementTargeting, AdjustVisibilityFromPseudoSelectors)):
(TestWebKitAPI::TEST(ElementTargeting, AdjustVisibilityForTargetsInShadowRoot)):
(TestWebKitAPI::TEST(ElementTargeting, TargetContainsShadowRoot)):
(TestWebKitAPI::TEST(ElementTargeting, ContentInsideShadowRoot)): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-8.html: Added.

Add an API test to exercise all three of the new SPIs. Also rename `ContentInsideShadowRoot` to
`TargetContainsShadowRoot`, the latter of which is a more accurate name (since the targeted element
itself isn&apos;t inside the shadow DOM).

Canonical link: <a href="https://commits.webkit.org/277907@main">https://commits.webkit.org/277907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45187dfbbbd6cba1fd6884e2349ccb6643d2d4c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48879 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51846 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51566 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44945 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51184 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25620 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39959 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25744 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42148 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21062 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23205 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43322 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6934 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45137 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43820 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53477 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23930 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20196 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47268 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25193 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42357 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46220 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10774 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26002 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24913 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->