### PR TITLE
Web Extension popup is slow and jittery when presenting.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -70,12 +70,12 @@ constexpr CGFloat minimumPopoverWidth = 50;
 constexpr CGFloat minimumPopoverHeight = 50;
 
 #ifdef NDEBUG
-constexpr NSTimeInterval popoverShowTimeout = 1;
-constexpr NSTimeInterval popoverStableSizeDuration = 0.1;
+constexpr auto popoverShowTimeout = 250_ms;
+constexpr auto popoverStableSizeDuration = 75_ms;
 #else
-// Debug builds are slower, so give rendering more time.
-constexpr NSTimeInterval popoverShowTimeout = 2;
-constexpr NSTimeInterval popoverStableSizeDuration = 0.2;
+// Debug builds are about 3x slower, so give rendering more time.
+constexpr auto popoverShowTimeout = 750_ms;
+constexpr auto popoverStableSizeDuration = 225_ms;
 #endif
 
 using namespace WebKit;
@@ -192,6 +192,7 @@ static void* kvoContext = &kvoContext;
 
 @interface _WKWebExtensionActionWebView : WKWebView
 
+@property (nonatomic, readonly) CGSize contentSize;
 @property (nonatomic, readonly) BOOL contentSizeHasStabilized;
 
 @end
@@ -246,7 +247,7 @@ static void* kvoContext = &kvoContext;
 }
 #endif // PLATFORM(IOS_FAMILY)
 
-- (CGSize)_contentSize
+- (CGSize)contentSize
 {
 #if PLATFORM(IOS_FAMILY)
     return self.scrollView.contentSize;
@@ -260,31 +261,29 @@ static void* kvoContext = &kvoContext;
     if (!_webExtensionAction)
         return;
 
-    CGSize contentSize = self._contentSize;
+    auto contentSize = self.contentSize;
     if (CGSizeEqualToSize(contentSize, _previousContentSize))
         return;
 
-    SEL contentSizeStabilizedSelector = @selector(_checkIfContentSizeStabilizedAndPresentPopup);
+    SEL contentSizeStabilizedSelector = @selector(_contentSizeHasStabilized);
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:contentSizeStabilizedSelector object:nil];
-    [self performSelector:contentSizeStabilizedSelector withObject:nil afterDelay:popoverStableSizeDuration];
+    [self performSelector:contentSizeStabilizedSelector withObject:nil afterDelay:popoverStableSizeDuration.seconds()];
 
     _previousContentSize = contentSize;
 }
 
-- (void)_checkIfContentSizeStabilizedAndPresentPopup
+- (void)_contentSizeHasStabilized
 {
     if (!_webExtensionAction || self.loading)
         return;
 
-    _webExtensionAction->popupSizeDidChange();
-
-    CGSize contentSize = self._contentSize;
+    auto contentSize = self.contentSize;
     if (contentSize.width < minimumPopoverWidth || contentSize.height < minimumPopoverHeight)
         return;
 
     _contentSizeHasStabilized = YES;
 
-    _webExtensionAction->readyToPresentPopup();
+    _webExtensionAction->popupSizeDidChange();
 }
 
 @end
@@ -460,7 +459,7 @@ static void* kvoContext = &kvoContext;
 
     auto *viewController = [[NSViewController alloc] init];
     viewController.view = _popupWebView;
-    viewController.preferredContentSize = _popupWebView.intrinsicContentSize;
+    viewController.preferredContentSize = _popupWebView.contentSize;
 
     self.contentViewController = viewController;
     self.behavior = NSPopoverBehaviorSemitransient;
@@ -515,15 +514,15 @@ WebExtensionAction::WebExtensionAction(WebExtensionContext& extensionContext)
 }
 
 WebExtensionAction::WebExtensionAction(WebExtensionContext& extensionContext, WebExtensionTab& tab)
-    : WebExtensionAction(extensionContext)
+    : m_extensionContext(extensionContext)
+    , m_tab(&tab)
 {
-    m_tab = &tab;
 }
 
 WebExtensionAction::WebExtensionAction(WebExtensionContext& extensionContext, WebExtensionWindow& window)
-    : WebExtensionAction(extensionContext)
+    : m_extensionContext(extensionContext)
+    , m_window(&window)
 {
-    m_window = &window;
 }
 
 bool WebExtensionAction::operator==(const WebExtensionAction& other) const
@@ -755,12 +754,12 @@ void WebExtensionAction::detectPopoverColorScheme()
 }
 #endif // PLATFORM(MAC)
 
-WKWebView *WebExtensionAction::popupWebView(LoadOnFirstAccess loadOnFirstAccess)
+WKWebView *WebExtensionAction::popupWebView()
 {
     if (!presentsPopup() || !extensionContext())
         return nil;
 
-    if (m_popupWebView || loadOnFirstAccess == LoadOnFirstAccess::No)
+    if (m_popupWebView)
         return m_popupWebView.get();
 
     auto *webViewConfiguration = extensionContext()->webViewConfiguration(WebExtensionContext::WebViewPurpose::Popup);
@@ -777,6 +776,12 @@ WKWebView *WebExtensionAction::popupWebView(LoadOnFirstAccess loadOnFirstAccess)
 #if PLATFORM(MAC)
     m_popupWebView.get()._sizeToContentAutoSizeMaximumSize = CGSizeMake(maximumPopoverWidth, maximumPopoverHeight);
     m_popupWebView.get()._useSystemAppearance = YES;
+
+    // Add the web view temporarily to a window to force it to layout. The window does not need to be shown on screen.
+    auto *temporaryWindow = [[NSWindow alloc] initWithContentRect:NSZeroRect styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:NO];
+    [temporaryWindow.contentView addSubview:m_popupWebView.get()];
+    [m_popupWebView removeFromSuperview];
+    temporaryWindow = nil;
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -808,36 +813,55 @@ void WebExtensionAction::presentPopupWhenReady()
     if (!extensionContext())
         return;
 
+    // The popup might have presented already or is already scheduled to present when ready.
+    if (popupPresented() || presentsPopupWhenReady())
+        return;
+
     if (!canProgrammaticallyPresentPopup()) {
         RELEASE_LOG_ERROR(Extensions, "Delegate does not implement the webExtensionController:presentPopupForAction:forExtensionContext:completionHandler: method");
         return;
     }
 
-    // The popup might have presented already.
-    if (m_popupPresented)
-        return;
+    RELEASE_LOG_DEBUG(Extensions, "Present popup when ready");
 
-    popupWebView(LoadOnFirstAccess::Yes);
+    m_presentsPopupWhenReady = true;
+
+    // Access the web view to load it.
+    popupWebView();
 }
 
 void WebExtensionAction::popupDidFinishDocumentLoad()
 {
+    if (!extensionContext())
+        return;
+
     // The popup might have presented or closed already.
-    if (m_popupPresented || !m_popupWebView)
+    if (popupPresented() || !hasPopupWebView() || !presentsPopupWhenReady())
         return;
 
     // Delay showing the popup until a minimum size or a timeout is reached.
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(popoverShowTimeout * NSEC_PER_SEC)), dispatch_get_main_queue(), makeBlockPtr([this, protectedThis = Ref { *this }] {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, popoverShowTimeout.nanosecondsAs<int64_t>()), dispatch_get_main_queue(), makeBlockPtr([this, protectedThis = Ref { *this }] {
+        if (popupPresented() || !hasPopupWebView() || !presentsPopupWhenReady() || !extensionContext())
+            return;
+
+        RELEASE_LOG_DEBUG(Extensions, "Presenting popup after %{public}.0fms timeout", popoverShowTimeout.milliseconds());
+
         readyToPresentPopup();
     }).get());
 }
 
 void WebExtensionAction::readyToPresentPopup()
 {
+    ASSERT(presentsPopupWhenReady());
     ASSERT(canProgrammaticallyPresentPopup());
 
+    m_presentsPopupWhenReady = false;
+
+    if (!extensionContext())
+        return;
+
     // The popup might have presented or closed already.
-    if (m_popupPresented || !m_popupWebView)
+    if (popupPresented() || !hasPopupWebView())
         return;
 
     setHasUnreadBadgeText(false);
@@ -845,8 +869,10 @@ void WebExtensionAction::readyToPresentPopup()
     m_popupPresented = true;
 
     dispatch_async(dispatch_get_main_queue(), makeBlockPtr([this, protectedThis = Ref { *this }]() {
-        if (!extensionContext())
+        if (!extensionContext() || !popupPresented())
             return;
+
+        ASSERT(hasPopupWebView());
 
         RefPtr extensionController = extensionContext()->extensionController();
         auto delegate = extensionController ? extensionController->delegate() : nil;
@@ -873,18 +899,36 @@ void WebExtensionAction::readyToPresentPopup()
 
 void WebExtensionAction::popupSizeDidChange()
 {
+    ASSERT(hasPopupWebView());
+
 #if PLATFORM(IOS_FAMILY)
     [m_popupViewController _updatePopoverContentSize];
 #endif
 
 #if PLATFORM(MAC)
-    m_popupPopover.get().contentViewController.preferredContentSize = m_popupWebView.get().intrinsicContentSize;
+    m_popupPopover.get().contentViewController.preferredContentSize = m_popupWebView.get().contentSize;
 #endif
+
+    if (!presentsPopupWhenReady())
+        return;
+
+    auto contentSize = m_popupWebView.get().contentSize;
+    RELEASE_LOG_DEBUG(Extensions, "Presenting popup with size { %{public}.0f, %{public}.0f }", contentSize.width, contentSize.height);
+
+    readyToPresentPopup();
 }
 
 void WebExtensionAction::closePopup()
 {
+    ASSERT(hasPopupWebView());
+
+    RELEASE_LOG_DEBUG(Extensions, "Popup closed");
+
+    m_popupPresented = false;
+    m_presentsPopupWhenReady = false;
+
     [m_popupWebView _close];
+    m_popupWebView = nil;
 
 #if PLATFORM(IOS_FAMILY)
     [m_popupViewController dismissViewControllerAnimated:YES completion:nil];
@@ -895,9 +939,6 @@ void WebExtensionAction::closePopup()
     [m_popupPopover close];
     m_popupPopover = nil;
 #endif
-
-    m_popupWebView = nil;
-    m_popupPresented = false;
 }
 
 String WebExtensionAction::label(FallbackWhenEmpty fallback) const

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
@@ -70,7 +70,6 @@ public:
     explicit WebExtensionAction(WebExtensionContext&, WebExtensionTab&);
     explicit WebExtensionAction(WebExtensionContext&, WebExtensionWindow&);
 
-    enum class LoadOnFirstAccess { No, Yes };
     enum class FallbackWhenEmpty { No, Yes };
 
 #if PLATFORM(MAC)
@@ -122,7 +121,12 @@ public:
     void setPopupPopoverAppearance(Appearance);
 #endif
 
-    WKWebView *popupWebView(LoadOnFirstAccess = LoadOnFirstAccess::Yes);
+    WKWebView *popupWebView();
+    bool hasPopupWebView() const { return !!m_popupWebView; }
+
+    bool presentsPopupWhenReady() const { return m_presentsPopupWhenReady; }
+    bool popupPresented() const { return m_popupPresented; }
+
     void presentPopupWhenReady();
     void popupDidFinishDocumentLoad();
     void readyToPresentPopup();
@@ -165,6 +169,7 @@ private:
     ssize_t m_blockedResourceCount { 0 };
     std::optional<bool> m_customEnabled;
     std::optional<bool> m_hasUnreadBadgeText;
+    bool m_presentsPopupWhenReady : 1 { false };
     bool m_popupPresented : 1 { false };
 };
 


### PR DESCRIPTION
#### da4ea518b228c320fb16ae92d065a990ff3dab17
<pre>
Web Extension popup is slow and jittery when presenting.
<a href="https://webkit.org/b/273079">https://webkit.org/b/273079</a>
<a href="https://rdar.apple.com/126646845">rdar://126646845</a>

Reviewed by Brian Weinstein.

Fixes a few issues where popups were not presenting fast and jittering when animating open.
* Add the web view temporarily to a window to force it to layout. This was the primary issue,
  since WebKit was not laying-out various extension popups before it was added to a window.
* Stop updating the popover size when the size hasn&apos;t changed above the minimum.
* Reduced the timeout to 250ms in Release builds (and triple in Debug). All popups now
  display in less than 100ms on an M3 MacBook Pro. This can be reduced because the timeout
  starts after the document load, not prior to the load like it did before 275454@main.
* Prevent the delegate method from being called when just accessing the popupWebView property
  on the action. It should only be called when the performActionForTab: method is called.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(-[_WKWebExtensionActionWebView contentSize]): Renamed from _contentSize to be public.
(-[_WKWebExtensionActionWebView _contentSizeDidChange]): Only call popupSizeDidChange
when the size is above the minimum.
(-[_WKWebExtensionActionWebView _contentSizeHasStabilized]): Renamed from
_checkIfContentSizeStabilizedAndPresentPopup to be clearer.
(-[_WKWebExtensionActionPopover initWithWebExtensionAction:]):
(WebKit::WebExtensionAction::WebExtensionAction):
(WebKit::WebExtensionAction::popupWebView): Remove unused LoadOnFirstAccess parameter.
(WebKit::WebExtensionAction::presentPopupWhenReady):
(WebKit::WebExtensionAction::popupDidFinishDocumentLoad):
(WebKit::WebExtensionAction::readyToPresentPopup):
(WebKit::WebExtensionAction::popupSizeDidChange): Moved readyToPresentPopup() call here.
(WebKit::WebExtensionAction::closePopup):
(-[_WKWebExtensionActionWebView _contentSize]): Deleted.
(-[_WKWebExtensionActionWebView _checkIfContentSizeStabilizedAndPresentPopup]): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionAction.h:
(WebKit::WebExtensionAction::shouldPresentPopupWhenReady const):

Canonical link: <a href="https://commits.webkit.org/277838@main">https://commits.webkit.org/277838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53f4393a3987b0155a59e011c60340c1e0cec39c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48716 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51403 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44781 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33864 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25457 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39837 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49298 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25580 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42033 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20935 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23054 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6772 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/44996 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53312 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23763 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20054 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47136 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25029 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42239 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46069 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25833 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6952 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/24750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->