### PR TITLE
Stop sending CloneSessionStorageNamespace message from web process

### DIFF
--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -513,8 +513,6 @@ class EmptyStorageNamespaceProvider final : public StorageNamespaceProvider {
 
     Ref<StorageNamespace> createLocalStorageNamespace(unsigned, PAL::SessionID) final;
     Ref<StorageNamespace> createTransientLocalStorageNamespace(SecurityOrigin&, unsigned, PAL::SessionID) final;
-
-    void copySessionStorageNamespace(Page&, Page&) final { };
     RefPtr<StorageNamespace> sessionStorageNamespace(const SecurityOrigin&, Page&, ShouldCreateNamespace) final;
 };
 

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -211,11 +211,6 @@ RefPtr<Page> Chrome::createWindow(LocalFrame& frame, const WindowFeatures& featu
     if (!newPage)
         return nullptr;
 
-    if (!features.wantsNoOpener()) {
-        Ref page = m_page.get();
-        page->protectedStorageNamespaceProvider()->copySessionStorageNamespace(page, *newPage);
-    }
-
     return newPage;
 }
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -863,7 +863,7 @@ public:
     Ref<CookieJar> protectedCookieJar() const;
 
     StorageNamespaceProvider& storageNamespaceProvider() { return m_storageNamespaceProvider.get(); }
-    Ref<StorageNamespaceProvider> protectedStorageNamespaceProvider() const;
+    WEBCORE_EXPORT Ref<StorageNamespaceProvider> protectedStorageNamespaceProvider() const;
 
     PluginInfoProvider& pluginInfoProvider();
     Ref<PluginInfoProvider> protectedPluginInfoProvider() const;

--- a/Source/WebCore/storage/StorageNamespaceProvider.h
+++ b/Source/WebCore/storage/StorageNamespaceProvider.h
@@ -55,7 +55,7 @@ public:
     WEBCORE_EXPORT void setSessionIDForTesting(PAL::SessionID);
 
     void setSessionStorageQuota(unsigned quota) { m_sessionStorageQuota = quota; }
-    virtual void copySessionStorageNamespace(Page&, Page&) = 0;
+    virtual void cloneSessionStorageNamespaceForPage(Page&, Page&) { RELEASE_ASSERT_NOT_REACHED(); }
 
 protected:
     StorageNamespace* optionalLocalStorageNamespace() { return m_localStorageNamespace.get(); }

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -777,6 +777,16 @@ void NetworkStorageManager::cloneSessionStorageForWebPage(WebPageProxyIdentifier
     });
 }
 
+void NetworkStorageManager::cloneSessionStorageNamespace(StorageNamespaceIdentifier fromIdentifier, StorageNamespaceIdentifier toIdentifier)
+{
+    assertIsCurrent(workQueue());
+
+    for (auto& manager : m_originStorageManagers.values()) {
+        if (auto* sessionStorageManager = manager->existingSessionStorageManager())
+            sessionStorageManager->cloneStorageArea(fromIdentifier, toIdentifier);
+    }
+}
+
 void NetworkStorageManager::didIncreaseQuota(WebCore::ClientOrigin&& origin, QuotaIncreaseRequestIdentifier identifier, std::optional<uint64_t> newQuota)
 {
     ASSERT(RunLoop::isMain());
@@ -1445,16 +1455,6 @@ void NetworkStorageManager::disconnectFromStorageArea(IPC::Connection& connectio
         originStorageManager(storageArea->origin()).localStorageManager(*m_storageAreaRegistry).disconnectFromStorageArea(connection.uniqueID(), identifier);
     else
         originStorageManager(storageArea->origin()).sessionStorageManager(*m_storageAreaRegistry).disconnectFromStorageArea(connection.uniqueID(), identifier);
-}
-
-void NetworkStorageManager::cloneSessionStorageNamespace(StorageNamespaceIdentifier fromIdentifier, StorageNamespaceIdentifier toIdentifier)
-{
-    assertIsCurrent(workQueue());
-
-    for (auto& manager : m_originStorageManagers.values()) {
-        if (auto* sessionStorageManager = manager->existingSessionStorageManager())
-            sessionStorageManager->cloneStorageArea(fromIdentifier, toIdentifier);
-    }
 }
 
 void NetworkStorageManager::setItem(IPC::Connection& connection, StorageAreaIdentifier identifier, StorageAreaImplIdentifier implIdentifier, String&& key, String&& value, String&& urlString, CompletionHandler<void(bool, HashMap<String, String>&&)>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -181,7 +181,6 @@ private:
     void connectToStorageAreaSync(IPC::Connection&, WebCore::StorageType, StorageAreaMapIdentifier, std::optional<StorageNamespaceIdentifier>, const WebCore::ClientOrigin&, CompletionHandler<void(StorageAreaIdentifier, HashMap<String, String>, uint64_t)>&&);
     void cancelConnectToStorageArea(IPC::Connection&, WebCore::StorageType, std::optional<StorageNamespaceIdentifier>, const WebCore::ClientOrigin&);
     void disconnectFromStorageArea(IPC::Connection&, StorageAreaIdentifier);
-    void cloneSessionStorageNamespace(StorageNamespaceIdentifier, StorageNamespaceIdentifier);
     void setItem(IPC::Connection&, StorageAreaIdentifier, StorageAreaImplIdentifier, String&& key, String&& value, String&& urlString, CompletionHandler<void(bool, HashMap<String, String>&&)>&&);
     void removeItem(IPC::Connection&, StorageAreaIdentifier, StorageAreaImplIdentifier, String&& key, String&& urlString, CompletionHandler<void(bool, HashMap<String, String>&&)>&&);
     void clear(IPC::Connection&, StorageAreaIdentifier, StorageAreaImplIdentifier, String&& urlString, CompletionHandler<void()>&&);
@@ -228,6 +227,7 @@ private:
     void cacheStorageClearMemoryRepresentation(const WebCore::ClientOrigin&, CompletionHandler<void(std::optional<WebCore::DOMCacheEngine::Error>&&)>&&);
     void cacheStorageRepresentation(CompletionHandler<void(String&&)>&&);
 
+    void cloneSessionStorageNamespace(StorageNamespaceIdentifier, StorageNamespaceIdentifier);
     bool shouldManageServiceWorkerRegistrationsByOrigin();
     void migrateServiceWorkerRegistrationsToOrigins();
     Vector<WebCore::ServiceWorkerScripts> updateServiceWorkerRegistrationsByOrigin(Vector<WebCore::ServiceWorkerContextData>&&, Vector<WebCore::ServiceWorkerRegistrationKey>&&);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
@@ -46,7 +46,6 @@
     ConnectToStorageAreaSync(WebCore::StorageType type, WebKit::StorageAreaMapIdentifier sourceIdentifier, std::optional<WebKit::StorageNamespaceIdentifier> namespaceIdentifier, struct WebCore::ClientOrigin origin) -> (WebKit::StorageAreaIdentifier identifier, HashMap<String, String> items, uint64_t messageIdentifier) Synchronous
     CancelConnectToStorageArea(WebCore::StorageType type, std::optional<WebKit::StorageNamespaceIdentifier> namespaceIdentifier, struct WebCore::ClientOrigin origin)
     DisconnectFromStorageArea(WebKit::StorageAreaIdentifier identifier)
-    CloneSessionStorageNamespace(WebKit::StorageNamespaceIdentifier fromStorageNamespaceID, WebKit::StorageNamespaceIdentifier toStorageNamespaceID)
     SetItem(WebKit::StorageAreaIdentifier identifier, WebKit::StorageAreaImplIdentifier implIdentifier, String key, String value, String urlString) -> (bool hasError, HashMap<String, String> allItems)
     RemoveItem(WebKit::StorageAreaIdentifier identifier, WebKit::StorageAreaImplIdentifier implIdentifier, String key, String urlString) -> (bool hasError, HashMap<String, String> allItems)
     Clear(WebKit::StorageAreaIdentifier identifier, WebKit::StorageAreaImplIdentifier implIdentifier, String urlString) -> ()

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2080,7 +2080,7 @@ struct WebCore::WindowFeatures {
 
     std::optional<bool> fullscreen;
     std::optional<bool> dialog;
-    [NotSerialized] std::optional<bool> noopener;
+    std::optional<bool> noopener;
     [NotSerialized] std::optional<bool> noreferrer;
 
     [NotSerialized] Vector<String> additionalFeatures;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -102,6 +102,8 @@
 #include <WebCore/TextIndicator.h>
 #include <WebCore/TextRecognitionOptions.h>
 
+#include <WebCore/WindowFeatures.h>
+
 #if HAVE(WEBGPU_IMPLEMENTATION)
 #import <WebCore/WebGPUCreateImpl.h>
 #endif

--- a/Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.h
+++ b/Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.h
@@ -46,7 +46,6 @@ private:
     Ref<WebCore::StorageNamespace> createTransientLocalStorageNamespace(WebCore::SecurityOrigin&, unsigned quota, PAL::SessionID) override;
 
     RefPtr<WebCore::StorageNamespace> sessionStorageNamespace(const WebCore::SecurityOrigin&, WebCore::Page&, ShouldCreateNamespace) final;
-    void copySessionStorageNamespace(WebCore::Page&, WebCore::Page&) final;
     struct SessionStorageNamespaces {
         unsigned useCount { 0 };
         HashMap<WebCore::SecurityOriginData, RefPtr<WebCore::StorageNamespace>> map;

--- a/Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.cpp
+++ b/Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.cpp
@@ -130,7 +130,7 @@ RefPtr<StorageNamespace> WebStorageNamespaceProvider::sessionStorageNamespace(co
     return sessionStorageNamespaceIt->value;
 }
 
-void WebStorageNamespaceProvider::copySessionStorageNamespace(WebCore::Page& srcPage, WebCore::Page& dstPage)
+void WebStorageNamespaceProvider::cloneSessionStorageNamespaceForPage(WebCore::Page& srcPage, WebCore::Page& dstPage)
 {
     ASSERT(sessionStorageQuota() != WebCore::StorageMap::noQuota);
 

--- a/Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.h
+++ b/Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.h
@@ -55,7 +55,7 @@ private:
     Ref<WebCore::StorageNamespace> createTransientLocalStorageNamespace(WebCore::SecurityOrigin&, unsigned quota, PAL::SessionID) override;
 
     RefPtr<WebCore::StorageNamespace> sessionStorageNamespace(const WebCore::SecurityOrigin&, WebCore::Page&, ShouldCreateNamespace) final;
-    void copySessionStorageNamespace(WebCore::Page&, WebCore::Page&) final;
+    void cloneSessionStorageNamespaceForPage(WebCore::Page&, WebCore::Page&) final;
 
     const String m_localStorageDatabasePath;
     SingleThreadWeakHashMap<WebCore::Page, HashMap<WebCore::SecurityOriginData, RefPtr<WebCore::StorageNamespace>>> m_sessionStorageNamespaces;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
@@ -84,6 +84,7 @@
 #import <WebCore/PlatformScreen.h>
 #import <WebCore/ResourceRequest.h>
 #import <WebCore/SerializedCryptoKeyWrap.h>
+#import <WebCore/StorageNamespaceProvider.h>
 #import <WebCore/UniversalAccessZoom.h>
 #import <WebCore/Widget.h>
 #import <WebCore/WindowFeatures.h>
@@ -298,7 +299,12 @@ Page* WebChromeClient::createWindow(LocalFrame& frame, const WindowFeatures& fea
         newWebView = CallUIDelegate(m_webView, @selector(webView:createWebViewModalDialogWithRequest:), nil);
     else
         newWebView = CallUIDelegate(m_webView, @selector(webView:createWebViewWithRequest:), nil);
-    return core(newWebView);
+
+    auto* newPage = core(newWebView);
+    if (newPage && !features.wantsNoOpener())
+        m_webView.page->protectedStorageNamespaceProvider()->cloneSessionStorageNamespaceForPage(*m_webView.page, *newPage);
+
+    return newPage;
 }
 
 void WebChromeClient::show()


### PR DESCRIPTION
#### 3533fb3edb8034827a24eeeb72feb65c247b06b0
<pre>
Stop sending CloneSessionStorageNamespace message from web process
<a href="https://bugs.webkit.org/show_bug.cgi?id=273082">https://bugs.webkit.org/show_bug.cgi?id=273082</a>
<a href="https://rdar.apple.com/126879290">rdar://126879290</a>

Reviewed by Alex Christensen.

Currently web process sends CloneSessionStorageNamespace message to network process when creating new window (page). On
receiving the message, network process copies SessionStorage of the existing page to new page. Since web process cannot
be trusted, network process is supposed to validate that the sender process has access to both pages before performing
the copy, but it currently doesn&apos;t. To fix this, this patch moves the message from web process to UI process. UI process
is a trusted process, so network process does not need to do the validation. Also, UI process is reponsible for creating
new page (see WebPageProxy::CreateNewPage), so it knows what pages need the copy.

This is for hardening and it should not change existing behavior. The SessionStorage copy behavior is covered by
existing tests like storage/domstorage/sessionstorage/window-open.html and
imported/w3c/web-platform-tests/webstorage/storage_session_window_noopener.window.html.

* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/page/Chrome.cpp:
(WebCore::Chrome::createWindow):
* Source/WebCore/page/Page.h:
* Source/WebCore/storage/StorageNamespaceProvider.h:
(WebCore::StorageNamespaceProvider::cloneSessionStorageNamespaceForPage):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::cloneSessionStorageNamespace):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::createNewPage):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
* Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.cpp:
(WebKit::WebStorageNamespaceProvider::copySessionStorageNamespace): Deleted.
* Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.h:
* Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.cpp:
(WebKit::WebStorageNamespaceProvider::cloneSessionStorageNamespaceForPage):
(WebKit::WebStorageNamespaceProvider::copySessionStorageNamespace): Deleted.
* Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm:
(WebChromeClient::createWindow):

Canonical link: <a href="https://commits.webkit.org/277988@main">https://commits.webkit.org/277988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46d51d694ab807cdd8983c9db73f7c6c7205d024

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49032 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51737 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45102 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51336 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25781 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40079 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50239 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25886 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42275 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21187 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23355 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43449 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7135 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45266 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43953 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53653 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24088 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20343 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47395 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25361 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42483 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46365 "Found 5 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/listbox, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/menulist, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/value/basic, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10811 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26158 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25082 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->