### PR TITLE
Update LoggerHelper::logClassName() to return an ASCIILiteral

### DIFF
--- a/Source/WTF/wtf/Logger.h
+++ b/Source/WTF/wtf/Logger.h
@@ -278,7 +278,7 @@ public:
         {
         }
 
-        LogSiteIdentifier(const char* className, const char* methodName, const void* objectPtr)
+        LogSiteIdentifier(ASCIILiteral className, const char* methodName, const void* objectPtr)
             : className { className }
             , methodName { methodName }
             , objectPtr { reinterpret_cast<uintptr_t>(objectPtr) }
@@ -287,7 +287,7 @@ public:
 
         WTF_EXPORT_PRIVATE String toString() const;
 
-        const char* className { nullptr };
+        ASCIILiteral className;
         const char* methodName { nullptr };
         const uintptr_t objectPtr { 0 };
     };

--- a/Source/WTF/wtf/LoggerHelper.h
+++ b/Source/WTF/wtf/LoggerHelper.h
@@ -35,7 +35,7 @@ public:
     virtual ~LoggerHelper() = default;
 
     virtual const Logger& logger() const = 0;
-    virtual const char* logClassName() const = 0;
+    virtual ASCIILiteral logClassName() const = 0;
     virtual WTFLogChannel& logChannel() const = 0;
     virtual const void* logIdentifier() const = 0;
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
@@ -123,7 +123,7 @@ private:
 #if !RELEASE_LOG_DISABLED
     // LoggerHelper
     const Logger& logger() const { return m_logger; }
-    const char* logClassName() const { return "MediaKeySession"; }
+    ASCIILiteral logClassName() const { return "MediaKeySession"_s; }
     WTFLogChannel& logChannel() const;
     const void* logIdentifier() const { return m_logIdentifier; }
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
@@ -47,7 +47,7 @@ namespace WebCore {
 
 #if !RELEASE_LOG_DISABLED
 static WTFLogChannel& logChannel() { return LogEME; }
-static const char* logClassName() { return "MediaKeys"; }
+static ASCIILiteral logClassName() { return "MediaKeys"_s; }
 #endif
 
 MediaKeys::MediaKeys(Document& document, bool useDistinctiveIdentifier, bool persistentStateAllowed, const Vector<MediaKeySessionType>& supportedSessionTypes, Ref<CDM>&& implementation, Ref<CDMInstance>&& instance)

--- a/Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp
@@ -89,7 +89,7 @@ void NavigatorEME::requestMediaKeySystemAccess(Navigator& navigator, Document& d
 {
     // https://w3c.github.io/encrypted-media/#dom-navigator-requestmediakeysystemaccess
     // W3C Editor's Draft 09 November 2016
-    auto identifier = Logger::LogSiteIdentifier("NavigatorEME", __func__, &navigator);
+    auto identifier = Logger::LogSiteIdentifier("NavigatorEME"_s, __func__, &navigator);
     Ref<Logger> logger = document.logger();
 
     infoLog(logger, identifier, "keySystem(", keySystem, "), supportedConfigurations(", supportedConfigurations, ")");

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
@@ -85,7 +85,7 @@ private:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
     const void* logIdentifier() const final { return m_logIdentifier; }
-    const char* logClassName() const { return "WebKitMediaKeySession"; }
+    ASCIILiteral logClassName() const { return "WebKitMediaKeySession"_s; }
     WTFLogChannel& logChannel() const;
 
     Ref<Logger> m_logger;

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -60,9 +60,9 @@ static WTFLogChannel& logChannel()
     return LogMedia;
 }
 
-static const char* logClassName()
+static ASCIILiteral logClassName()
 {
-    return "MediaSession";
+    return "MediaSession"_s;
 }
 #endif
 

--- a/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h
+++ b/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h
@@ -108,7 +108,7 @@ private:
     const Logger& logger() const { return m_logger; }
     const void* logIdentifier() const { return m_logIdentifier; }
     static WTFLogChannel& logChannel();
-    static const char* logClassName() { return "MediaSessionCoordinator"; }
+    static ASCIILiteral logClassName() { return "MediaSessionCoordinator"_s; }
     bool shouldFireEvents() const;
 
     WeakPtr<MediaSession> m_session;

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -142,7 +142,7 @@ public:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
     const void* logIdentifier() const final { return m_logIdentifier; }
-    const char* logClassName() const final { return "MediaSource"; }
+    ASCIILiteral logClassName() const final { return "MediaSource"_s; }
     WTFLogChannel& logChannel() const final;
     void setLogIdentifier(const void*);
 

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -141,7 +141,7 @@ public:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
     const void* logIdentifier() const final { return m_logIdentifier; }
-    const char* logClassName() const final { return "SourceBuffer"; }
+    ASCIILiteral logClassName() const final { return "SourceBuffer"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
 

--- a/Source/WebCore/Modules/mediastream/ImageCapture.h
+++ b/Source/WebCore/Modules/mediastream/ImageCapture.h
@@ -60,7 +60,7 @@ private:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger.get(); }
     const void* logIdentifier() const { return m_logIdentifier; }
-    const char* logClassName() const { return "ImageCapture"; }
+    ASCIILiteral logClassName() const { return "ImageCapture"_s; }
     WTFLogChannel& logChannel() const;
 #endif
 

--- a/Source/WebCore/Modules/mediastream/MediaStream.h
+++ b/Source/WebCore/Modules/mediastream/MediaStream.h
@@ -113,7 +113,7 @@ protected:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_private->logger(); }
     WTFLogChannel& logChannel() const final;
-    const char* logClassName() const final { return "MediaStream"; }
+    ASCIILiteral logClassName() const final { return "MediaStream"_s; }
 #endif
 
 private:

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -216,7 +216,7 @@ private:
     bool wantsToCaptureAudio() const final;
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const final { return "MediaStreamTrack"; }
+    ASCIILiteral logClassName() const final { return "MediaStreamTrack"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
 

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
@@ -160,7 +160,7 @@ public:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
     const void* logIdentifier() const final { return m_logIdentifier; }
-    const char* logClassName() const override { return "PeerConnectionBackend"; }
+    ASCIILiteral logClassName() const override { return "PeerConnectionBackend"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
 

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -204,7 +204,7 @@ public:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
     const void* logIdentifier() const final { return m_logIdentifier; }
-    const char* logClassName() const final { return "RTCPeerConnection"; }
+    ASCIILiteral logClassName() const final { return "RTCPeerConnection"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpReceiver.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpReceiver.h
@@ -87,7 +87,7 @@ private:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
     const void* logIdentifier() const final { return m_logIdentifier; }
-    const char* logClassName() const final { return "RTCRtpReceiver"; }
+    ASCIILiteral logClassName() const final { return "RTCRtpReceiver"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpSender.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSender.h
@@ -102,7 +102,7 @@ private:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
     const void* logIdentifier() const final { return m_logIdentifier; }
-    const char* logClassName() const final { return "RTCRtpSender"; }
+    ASCIILiteral logClassName() const final { return "RTCRtpSender"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -1656,11 +1656,11 @@ void GStreamerMediaEndpoint::processStats(const GValue* value)
     if (logger().willLog(logChannel(), WTFLogLevel::Debug)) {
         // Stats are very verbose, let's only display them in inspector console in verbose mode.
         logger().debug(LogWebRTC,
-            Logger::LogSiteIdentifier("GStreamerMediaEndpoint", "onStatsDelivered", logIdentifier()),
+            Logger::LogSiteIdentifier("GStreamerMediaEndpoint"_s, "onStatsDelivered"_s, logIdentifier()),
             RTCStatsLogger { structure });
     } else {
         logger().logAlways(LogWebRTCStats,
-            Logger::LogSiteIdentifier("GStreamerMediaEndpoint", "onStatsDelivered", logIdentifier()),
+            Logger::LogSiteIdentifier("GStreamerMediaEndpoint"_s, "onStatsDelivered"_s, logIdentifier()),
             RTCStatsLogger { structure });
     }
 }

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
@@ -169,7 +169,7 @@ private:
 
     const Logger& logger() const final { return m_logger.get(); }
     const void* logIdentifier() const final { return m_logIdentifier; }
-    const char* logClassName() const final { return "GStreamerMediaEndpoint"; }
+    ASCIILiteral logClassName() const final { return "GStreamerMediaEndpoint"_s; }
     WTFLogChannel& logChannel() const final;
 
     Seconds statsLogInterval(Seconds) const;

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
@@ -819,9 +819,9 @@ void LibWebRTCMediaEndpoint::OnStatsDelivered(const rtc::scoped_refptr<const web
 
             if (logger().willLog(logChannel(), WTFLogLevel::Debug)) {
                 // Stats are very verbose, let's only display them in inspector console in verbose mode.
-                logger().debug(LogWebRTC, Logger::LogSiteIdentifier("LibWebRTCMediaEndpoint", "OnStatsDelivered", logIdentifier()), statsLogger);
+                logger().debug(LogWebRTC, Logger::LogSiteIdentifier("LibWebRTCMediaEndpoint"_s, "OnStatsDelivered"_s, logIdentifier()), statsLogger);
             } else
-                logger().logAlways(LogWebRTCStats, Logger::LogSiteIdentifier("LibWebRTCMediaEndpoint", "OnStatsDelivered", logIdentifier()), statsLogger);
+                logger().logAlways(LogWebRTCStats, Logger::LogSiteIdentifier("LibWebRTCMediaEndpoint"_s, "OnStatsDelivered"_s, logIdentifier()), statsLogger);
         }
     });
 #else

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
@@ -172,7 +172,7 @@ private:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
     const void* logIdentifier() const final { return m_logIdentifier; }
-    const char* logClassName() const final { return "LibWebRTCMediaEndpoint"; }
+    ASCIILiteral logClassName() const final { return "LibWebRTCMediaEndpoint"_s; }
     WTFLogChannel& logChannel() const final;
 
     Seconds statsLogInterval(int64_t) const;

--- a/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h
+++ b/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h
@@ -69,7 +69,7 @@ public:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
     const void* logIdentifier() const final { return m_logIdentifier; }
-    const char* logClassName() const final { return "HTMLVideoElementPictureInPicture"; }
+    ASCIILiteral logClassName() const final { return "HTMLVideoElementPictureInPicture"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
 

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
@@ -96,7 +96,7 @@ private:
     const Logger& logger() const { return m_logger.get(); }
     const void* logIdentifier() const { return m_logIdentifier; }
     WTFLogChannel& logChannel() const;
-    const char* logClassName() const { return "RemotePlayback"; }
+    ASCIILiteral logClassName() const { return "RemotePlayback"_s; }
 
     Ref<const Logger> m_logger;
     const void* m_logIdentifier { nullptr };

--- a/Source/WebCore/Modules/webaudio/AudioNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioNode.h
@@ -226,7 +226,7 @@ protected:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
     const void* logIdentifier() const final { return m_logIdentifier; }
-    const char* logClassName() const final { return "AudioNode"; }
+    ASCIILiteral logClassName() const final { return "AudioNode"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
 

--- a/Source/WebCore/Modules/webaudio/AudioParam.h
+++ b/Source/WebCore/Modules/webaudio/AudioParam.h
@@ -126,7 +126,7 @@ private:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
     const void* logIdentifier() const final { return m_logIdentifier; }
-    const char* logClassName() const final { return "AudioParam"; }
+    ASCIILiteral logClassName() const final { return "AudioParam"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
     

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -239,7 +239,7 @@ protected:
     virtual void uninitialize();
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const final { return "BaseAudioContext"; }
+    ASCIILiteral logClassName() const final { return "BaseAudioContext"_s; }
 #endif
 
     void addReaction(State, DOMPromiseDeferred<void>&&);

--- a/Source/WebCore/dom/FullscreenManager.h
+++ b/Source/WebCore/dom/FullscreenManager.h
@@ -110,7 +110,7 @@ private:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return document().logger(); }
     const void* logIdentifier() const { return m_logIdentifier; }
-    const char* logClassName() const { return "FullscreenManager"; }
+    ASCIILiteral logClassName() const { return "FullscreenManager"_s; }
     WTFLogChannel& logChannel() const;
 #endif
 

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -589,7 +589,7 @@ public:
     const Logger& logger() const final { return *m_logger.get(); }
     Ref<Logger> protectedLogger() const;
     const void* logIdentifier() const final { return m_logIdentifier; }
-    const char* logClassName() const final { return "HTMLMediaElement"; }
+    ASCIILiteral logClassName() const final { return "HTMLMediaElement"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
 

--- a/Source/WebCore/html/MediaElementSession.h
+++ b/Source/WebCore/html/MediaElementSession.h
@@ -167,7 +167,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const void* logIdentifier() const final { return m_logIdentifier; }
-    const char* logClassName() const final { return "MediaElementSession"; }
+    ASCIILiteral logClassName() const final { return "MediaElementSession"_s; }
 #endif
 
 #if ENABLE(MEDIA_SESSION)

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h
@@ -89,7 +89,7 @@ private:
     const Logger& logger() const final;
     const void* logIdentifier() const final;
     WTFLogChannel& logChannel() const final;
-    const char* logClassName() const final { return "MediaControlTextTrackContainerElement"; }
+    ASCIILiteral logClassName() const final { return "MediaControlTextTrackContainerElement"_s; }
     mutable RefPtr<Logger> m_logger;
     mutable const void* m_logIdentifier { nullptr };
 #endif

--- a/Source/WebCore/html/track/AudioTrack.h
+++ b/Source/WebCore/html/track/AudioTrack.h
@@ -88,7 +88,7 @@ private:
     void updateConfigurationFromPrivate();
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const final { return "AudioTrack"; }
+    ASCIILiteral logClassName() const final { return "AudioTrack"_s; }
 #endif
 
     WeakPtr<AudioTrackList> m_audioTrackList;

--- a/Source/WebCore/html/track/InbandDataTextTrack.h
+++ b/Source/WebCore/html/track/InbandDataTextTrack.h
@@ -48,7 +48,7 @@ private:
     bool shouldPurgeCuesFromUnbufferedRanges() const final { return true; }
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const final { return "DataCue"; }
+    ASCIILiteral logClassName() const final { return "DataCue"_s; }
 #endif
 
 #if ENABLE(DATACUE_VALUE)

--- a/Source/WebCore/html/track/InbandGenericTextTrack.h
+++ b/Source/WebCore/html/track/InbandGenericTextTrack.h
@@ -80,7 +80,7 @@ private:
     bool shouldPurgeCuesFromUnbufferedRanges() const final { return true; }
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const final { return "InbandGenericTextTrack"; }
+    ASCIILiteral logClassName() const final { return "InbandGenericTextTrack"_s; }
 #endif
 
     GenericTextTrackCueMap m_cueMap;

--- a/Source/WebCore/html/track/InbandWebVTTTextTrack.h
+++ b/Source/WebCore/html/track/InbandWebVTTTextTrack.h
@@ -52,7 +52,7 @@ private:
     void fileFailedToParse() final;
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const final { return "InbandWebVTTTextTrack"; }
+    ASCIILiteral logClassName() const final { return "InbandWebVTTTextTrack"_s; }
 #endif
 
     std::unique_ptr<WebVTTParser> m_webVTTParser;

--- a/Source/WebCore/html/track/LoadableTextTrack.h
+++ b/Source/WebCore/html/track/LoadableTextTrack.h
@@ -60,7 +60,7 @@ private:
     void loadTimerFired();
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const override { return "LoadableTextTrack"; }
+    ASCIILiteral logClassName() const override { return "LoadableTextTrack"_s; }
 #endif
 
     HTMLTrackElement* m_trackElement;

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -161,7 +161,7 @@ private:
     void derefEventTarget() final { deref(); }
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const override { return "TextTrack"; }
+    ASCIILiteral logClassName() const override { return "TextTrack"_s; }
 #endif
 
     VTTRegionList& ensureVTTRegionList();

--- a/Source/WebCore/html/track/VTTCue.h
+++ b/Source/WebCore/html/track/VTTCue.h
@@ -262,7 +262,7 @@ private:
     const Logger& logger() const final { return *m_logger; }
     const void* logIdentifier() const final;
     WTFLogChannel& logChannel() const final;
-    const char* logClassName() const final { return "VTTCue"; }
+    ASCIILiteral logClassName() const final { return "VTTCue"_s; }
 #endif
 
     String m_content;

--- a/Source/WebCore/html/track/VideoTrack.h
+++ b/Source/WebCore/html/track/VideoTrack.h
@@ -92,7 +92,7 @@ private:
     void updateConfigurationFromPrivate();
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const final { return "VideoTrack"; }
+    ASCIILiteral logClassName() const final { return "VideoTrack"_s; }
 #endif
 
     WeakPtr<VideoTrackList> m_videoTrackList;

--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -162,7 +162,7 @@ protected:
     void activeStateChanged();
 
     Logger& logger();
-    const char* logClassName() const { return "AudioSession"; }
+    ASCIILiteral logClassName() const { return "AudioSession"_s; }
     WTFLogChannel& logChannel() const;
     const void* logIdentifier() const { return nullptr; }
 

--- a/Source/WebCore/platform/audio/PlatformMediaSession.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.h
@@ -216,7 +216,7 @@ public:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
     const void* logIdentifier() const override { return m_logIdentifier; }
-    const char* logClassName() const override { return "PlatformMediaSession"; }
+    ASCIILiteral logClassName() const override { return "PlatformMediaSession"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
 

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
@@ -214,7 +214,7 @@ protected:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
     const void* logIdentifier() const final { return nullptr; }
-    const char* logClassName() const override { return "PlatformMediaSessionManager"; }
+    ASCIILiteral logClassName() const override { return "PlatformMediaSessionManager"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
 

--- a/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.h
@@ -67,7 +67,7 @@ public:
     const Logger& logger() const final { return m_logger.get(); }
     const void* logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
-    const char* logClassName() const final { return "AudioFileReaderCocoa"; }
+    ASCIILiteral logClassName() const final { return "AudioFileReaderCocoa"_s; }
 #endif
 
 private:

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.h
@@ -98,7 +98,7 @@ private:
     MediaTime hostTime() const;
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const final { return "AudioSampleDataSource"; }
+    ASCIILiteral logClassName() const final { return "AudioSampleDataSource"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
 

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
@@ -108,7 +108,7 @@ protected:
 
 private:
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const override { return "MediaSessionManagerCocoa"; }
+    ASCIILiteral logClassName() const override { return "MediaSessionManagerCocoa"_s; }
 #endif
 
     // NowPlayingManager::Client

--- a/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h
+++ b/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h
@@ -83,7 +83,7 @@ protected:
 
 private:
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const override { return "MediaSessionManagerGLib"; }
+    ASCIILiteral logClassName() const override { return "MediaSessionManagerGLib"_s; }
 #endif
 
     // NowPlayingManager::Client

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
@@ -87,7 +87,7 @@ private:
     void isPlayingToAutomotiveHeadUnitDidChange(PlayingToAutomotiveHeadUnit) final;
     void activeAudioRouteSupportsSpatialPlaybackDidChange(SupportsSpatialAudioPlayback) final;
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const final { return "MediaSessionManageriOS"; }
+    ASCIILiteral logClassName() const final { return "MediaSessionManageriOS"_s; }
 #endif
 
 #if !PLATFORM(WATCHOS)

--- a/Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.h
+++ b/Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.h
@@ -63,7 +63,7 @@ public:
 
 private:
     const Logger& logger();
-    const char* logClassName() const { return "SharedRoutingArbitrator"; }
+    ASCIILiteral logClassName() const { return "SharedRoutingArbitrator"_s; }
     WTFLogChannel& logChannel() const;
 
     std::optional<AudioSession::CategoryType> m_currentCategory { AudioSession::CategoryType::None };

--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h
@@ -79,7 +79,7 @@ public:
     const Logger* loggerPtr() const final;
     WEBCORE_EXPORT const void* logIdentifier() const final;
     WEBCORE_EXPORT const void* nextChildIdentifier() const final;
-    const char* logClassName() const { return "VideoPresentationModelVideoElement"; }
+    ASCIILiteral logClassName() const { return "VideoPresentationModelVideoElement"_s; }
     WTFLogChannel& logChannel() const;
 #endif
 

--- a/Source/WebCore/platform/graphics/AudioTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/AudioTrackPrivate.h
@@ -81,7 +81,7 @@ public:
     }
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const override { return "AudioTrackPrivate"; }
+    ASCIILiteral logClassName() const override { return "AudioTrackPrivate"_s; }
 #endif
 
     Type type() const final { return Type::Audio; }

--- a/Source/WebCore/platform/graphics/InbandTextTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/InbandTextTrackPrivate.h
@@ -90,7 +90,7 @@ public:
     }
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const override { return "InbandTextTrackPrivate"; }
+    ASCIILiteral logClassName() const override { return "InbandTextTrackPrivate"_s; }
 #endif
 
     Type type() const final { return Type::Text; };

--- a/Source/WebCore/platform/graphics/TrackBuffer.h
+++ b/Source/WebCore/platform/graphics/TrackBuffer.h
@@ -113,7 +113,7 @@ public:
     void setLogger(const Logger&, const void*);
     const Logger& logger() const final { ASSERT(m_logger); return *m_logger.get(); }
     const void* logIdentifier() const final { return m_logIdentifier; }
-    const char* logClassName() const final { return "TrackBuffer"; }
+    ASCIILiteral logClassName() const final { return "TrackBuffer"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
     

--- a/Source/WebCore/platform/graphics/VideoTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/VideoTrackPrivate.h
@@ -55,7 +55,7 @@ public:
     virtual Kind kind() const { return Kind::None; }
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const final { return "VideoTrackPrivate"; }
+    ASCIILiteral logClassName() const final { return "VideoTrackPrivate"_s; }
 #endif
 
     using SelectedChangedCallback = Function<void(VideoTrackPrivate&, bool selected)>;

--- a/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.h
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.h
@@ -61,7 +61,7 @@ public:
     void setLogIdentifier(const void* logIdentifier) final { m_logIdentifier = logIdentifier; }
     const Logger& logger() const { return m_logger; };
     const void* logIdentifier() const { return m_logIdentifier; }
-    const char* logClassName() const { return "CDMPrivateFairPlayStreaming"; }
+    ASCIILiteral logClassName() const { return "CDMPrivateFairPlayStreaming"_s; }
 #endif
 
     Vector<AtomString> supportedInitDataTypes() const override;

--- a/Source/WebCore/platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.h
+++ b/Source/WebCore/platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.h
@@ -61,7 +61,7 @@ private:
     InbandMetadataTextTrackPrivateAVF(Kind, TrackID, CueFormat);
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const final { return "InbandMetadataTextTrackPrivateAVF"; }
+    ASCIILiteral logClassName() const final { return "InbandMetadataTextTrackPrivateAVF"_s; }
 #endif
 
     Kind m_kind;

--- a/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.h
+++ b/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.h
@@ -92,7 +92,7 @@ protected:
 
 private:
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const final { return "InbandTextTrackPrivateAVF"; }
+    ASCIILiteral logClassName() const final { return "InbandTextTrackPrivateAVF"_s; }
 #endif
 
     MediaTime m_currentCueStartTime;

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
@@ -151,7 +151,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    const char* logClassName() const override { return "MediaPlayerPrivateAVFoundation"; }
+    ASCIILiteral logClassName() const override { return "MediaPlayerPrivateAVFoundation"_s; }
     const void* logIdentifier() const final { return reinterpret_cast<const void*>(m_logIdentifier); }
     WTFLogChannel& logChannel() const final;
 #endif

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
@@ -147,7 +147,7 @@ public:
     void setLogIdentifier(const void* logIdentifier) final { m_logIdentifier = logIdentifier; }
     const Logger& logger() const { return m_logger; };
     const void* logIdentifier() const { return m_logIdentifier; }
-    const char* logClassName() const { return "CDMInstanceFairPlayStreamingAVFObjC"; }
+    ASCIILiteral logClassName() const { return "CDMInstanceFairPlayStreamingAVFObjC"_s; }
 #endif
 
 private:
@@ -247,7 +247,7 @@ private:
     void setLogIdentifier(const void* logIdentifier) final { m_logIdentifier = logIdentifier; }
     const Logger& logger() const { return m_logger; };
     const void* logIdentifier() const { return m_logIdentifier; }
-    const char* logClassName() const { return "CDMInstanceSessionFairPlayStreamingAVFObjC"; }
+    ASCIILiteral logClassName() const { return "CDMInstanceSessionFairPlayStreamingAVFObjC"_s; }
 #endif
 
     // ContentKeyGroupDataSource

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
@@ -77,7 +77,7 @@ protected:
     RetainPtr<AVContentKeyRequest> contentKeyRequest() const;
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const { return "CDMSessionAVContentKeySession"; }
+    ASCIILiteral logClassName() const { return "CDMSessionAVContentKeySession"_s; }
 #endif
 
     RetainPtr<AVContentKeySession> m_contentKeySession;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.h
@@ -58,7 +58,7 @@ private:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger; }
     const void* logIdentifier() const { return m_logIdentifier; }
-    const char* logClassName() const { return "CDMSessionAVFoundationObjC"; }
+    ASCIILiteral logClassName() const { return "CDMSessionAVFoundationObjC"_s; }
     WTFLogChannel& logChannel() const;
 #endif
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.h
@@ -58,7 +58,7 @@ private:
     InbandChapterTrackPrivateAVFObjC(RetainPtr<NSLocale>, TrackID);
 
     AtomString inBandMetadataTrackDispatchType() const final { return "com.apple.chapters"_s; }
-    const char* logClassName() const final { return "InbandChapterTrackPrivateAVFObjC"; }
+    ASCIILiteral logClassName() const final { return "InbandChapterTrackPrivateAVFObjC"_s; }
 
     struct ChapterData {
         MediaTime m_startTime;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -332,7 +332,7 @@ private:
     Ref<VideoPlaybackQualityMetricsPromise> asyncVideoPlaybackQualityMetrics() final;
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const final { return "MediaPlayerPrivateAVFoundationObjC"; }
+    ASCIILiteral logClassName() const final { return "MediaPlayerPrivateAVFoundationObjC"_s; }
 #endif
 
     AVPlayer *objCAVFoundationAVPlayer() const final { return m_avPlayer.get(); }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -4326,7 +4326,7 @@ NSArray* playerKVOProperties()
         }
 
         if (player.logger().willLog(player.logChannel(), WTFLogLevel::Debug) && !([keyPath isEqualToString:@"loadedTimeRanges"] || [keyPath isEqualToString:@"seekableTimeRanges"])) {
-            auto identifier = Logger::LogSiteIdentifier("MediaPlayerPrivateAVFoundation", "observeValueForKeyPath", player.logIdentifier());
+            auto identifier = Logger::LogSiteIdentifier("MediaPlayerPrivateAVFoundation"_s, "observeValueForKeyPath"_s, player.logIdentifier());
 
             if (shouldLogValue) {
                 if ([keyPath isEqualToString:@"duration"])

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -167,7 +167,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    const char* logClassName() const override { return "MediaPlayerPrivateMediaSourceAVFObjC"; }
+    ASCIILiteral logClassName() const override { return "MediaPlayerPrivateMediaSourceAVFObjC"_s; }
     const void* logIdentifier() const final { return reinterpret_cast<const void*>(m_logIdentifier); }
     WTFLogChannel& logChannel() const final;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -86,7 +86,7 @@ public:
     void destroyLayers();
 
     const Logger& logger() const final { return m_logger.get(); }
-    const char* logClassName() const override { return "MediaPlayerPrivateMediaStreamAVFObjC"; }
+    ASCIILiteral logClassName() const override { return "MediaPlayerPrivateMediaStreamAVFObjC"_s; }
     const void* logIdentifier() const final { return reinterpret_cast<const void*>(m_logIdentifier); }
     WTFLogChannel& logChannel() const final;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
@@ -99,7 +99,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    const char* logClassName() const final { return "MediaSourcePrivateAVFObjC"; }
+    ASCIILiteral logClassName() const final { return "MediaSourcePrivateAVFObjC"_s; }
     const void* logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h
@@ -78,7 +78,7 @@ private:
     const Logger* loggerPtr() const { return m_logger.get(); }
     const Logger& logger() const final { ASSERT(m_logger); return *m_logger.get(); }
     const void* logIdentifier() const final { return m_logIdentifier; }
-    const char* logClassName() const final { return "SourceBufferParserAVFObjC"; }
+    ASCIILiteral logClassName() const final { return "SourceBufferParserAVFObjC"_s; }
     WTFLogChannel& logChannel() const final { return LogMedia; }
 #endif
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -137,7 +137,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    const char* logClassName() const override { return "SourceBufferPrivateAVFObjC"; }
+    ASCIILiteral logClassName() const override { return "SourceBufferPrivateAVFObjC"_s; }
     const void* logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
     const Logger& sourceBufferLogger() const final { return m_logger.get(); }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.h
@@ -79,7 +79,7 @@ private:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
     const void* logIdentifier() const final { return m_logIdentifier; }
-    const char* logClassName() const final { return "VideoLayerManagerObjC"; }
+    ASCIILiteral logClassName() const final { return "VideoLayerManagerObjC"_s; }
     WTFLogChannel& logChannel() const final;
 
     Ref<const Logger> m_logger;

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -250,7 +250,7 @@ private:
     void videoRendererReadyForDisplayChanged(WebSampleBufferVideoRendering *, bool isReadyForDisplay) final;
 
     const Logger& logger() const final { return m_logger.get(); }
-    const char* logClassName() const final { return "MediaPlayerPrivateWebM"; }
+    ASCIILiteral logClassName() const final { return "MediaPlayerPrivateWebM"_s; }
     const void* logIdentifier() const final { return reinterpret_cast<const void*>(m_logIdentifier); }
     WTFLogChannel& logChannel() const final;
 

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
@@ -220,7 +220,7 @@ public:
         void flushPendingSamples();
 
     private:
-        const char* logClassName() const { return "VideoTrackData"; }
+        ASCIILiteral logClassName() const { return "VideoTrackData"_s; }
         webm::Status consumeFrameData(webm::Reader&, const webm::FrameMetadata&, uint64_t*, const MediaTime&) final;
         void resetCompletedFramesState() final;
         void processPendingMediaSamples(const MediaTime&);
@@ -246,7 +246,7 @@ public:
     private:
         webm::Status consumeFrameData(webm::Reader&, const webm::FrameMetadata&, uint64_t*, const MediaTime&) final;
         void resetCompletedFramesState() final;
-        const char* logClassName() const { return "AudioTrackData"; }
+        ASCIILiteral logClassName() const { return "AudioTrackData"_s; }
 
         std::unique_ptr<PacketDurationParser> m_packetDurationParser;
 #if !HAVE(AUDIOFORMATPROPERTY_VARIABLEPACKET_SUPPORTED)
@@ -286,7 +286,7 @@ private:
     const Logger* loggerPtr() const { return m_logger.get(); }
     const Logger& logger() const final { ASSERT(m_logger); return *m_logger.get(); }
     const void* logIdentifier() const final { return m_logIdentifier; }
-    const char* logClassName() const final { return "WebMParser"; }
+    ASCIILiteral logClassName() const final { return "WebMParser"_s; }
 
     std::unique_ptr<SourceBufferParser::InitializationSegment> m_initializationSegment;
     Vector<std::pair<uint64_t, Ref<SharedBuffer>>> m_keyIds;
@@ -360,7 +360,7 @@ private:
     const Logger* loggerPtr() const { return m_logger.get(); }
     const Logger& logger() const final { ASSERT(m_logger); return *m_logger.get(); }
     const void* logIdentifier() const final { return m_logIdentifier; }
-    const char* logClassName() const final { return "SourceBufferParserWebM"; }
+    ASCIILiteral logClassName() const final { return "SourceBufferParserWebM"_s; }
     WTFLogChannel& logChannel() const final;
 
     DidParseTrimmingDataCallback m_didParseTrimmingDataCallback;

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -234,7 +234,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
-    const char* logClassName() const override { return "MediaPlayerPrivateGStreamer"; }
+    ASCIILiteral logClassName() const override { return "MediaPlayerPrivateGStreamer"_s; }
     const void* logIdentifier() const final { return reinterpret_cast<const void*>(m_logIdentifier); }
     WTFLogChannel& logChannel() const override;
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
@@ -75,7 +75,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
-    const char* logClassName() const override { return "MediaSourcePrivateGStreamer"; }
+    ASCIILiteral logClassName() const override { return "MediaSourcePrivateGStreamer"_s; }
     const void* logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
@@ -83,7 +83,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    const char* logClassName() const override { return "SourceBufferPrivateGStreamer"; }
+    ASCIILiteral logClassName() const override { return "SourceBufferPrivateGStreamer"_s; }
     const void* logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
     const Logger& sourceBufferLogger() const final { return m_logger; }

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
@@ -54,7 +54,7 @@ public:
     void mutedChanged(bool) final;
     void volumeChanged(double) final;
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const final;
+    ASCIILiteral logClassName() const final;
 #endif
 
 private:

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm
@@ -238,9 +238,9 @@ void PlaybackSessionInterfaceAVKit::volumeChanged(double volume)
 }
 
 #if !RELEASE_LOG_DISABLED
-const char* PlaybackSessionInterfaceAVKit::logClassName() const
+ASCIILiteral PlaybackSessionInterfaceAVKit::logClassName() const
 {
-    return "PlaybackSessionInterfaceAVKit";
+    return "PlaybackSessionInterfaceAVKit"_s;
 }
 #endif
 } // namespace WebCore

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
@@ -88,7 +88,7 @@ public:
 #if !RELEASE_LOG_DISABLED
     const void* logIdentifier() const;
     const Logger* loggerPtr() const;
-    virtual const char* logClassName() const = 0;
+    virtual ASCIILiteral logClassName() const = 0;
     WTFLogChannel& logChannel() const;
 #endif
 

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.h
@@ -50,7 +50,7 @@ public:
     WEBCORE_EXPORT void hasVideoChanged(bool) final;
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const { return "VideoPresentationInterfaceAVKit"; };
+    ASCIILiteral logClassName() const { return "VideoPresentationInterfaceAVKit"_s; };
 #endif
 
     WEBCORE_EXPORT AVPlayerViewController *avPlayerViewController() const final;

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -167,7 +167,7 @@ public:
 #if !RELEASE_LOG_DISABLED
     const void* logIdentifier() const;
     const Logger* loggerPtr() const;
-    const char* logClassName() const { return "VideoPresentationInterfaceIOS"; };
+    ASCIILiteral logClassName() const { return "VideoPresentationInterfaceIOS"_s; };
     WTFLogChannel& logChannel() const;
 #endif
 

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
@@ -83,7 +83,7 @@ public:
 #if !RELEASE_LOG_DISABLED
     const void* logIdentifier() const;
     const Logger* loggerPtr() const;
-    const char* logClassName() const { return "PlaybackSessionInterfaceMac"; };
+    ASCIILiteral logClassName() const { return "PlaybackSessionInterfaceMac"_s; };
     WTFLogChannel& logChannel() const;
 #endif
 

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
@@ -108,7 +108,7 @@ public:
 #if !RELEASE_LOG_DISABLED
     const void* logIdentifier() const;
     const Logger* loggerPtr() const;
-    const char* logClassName() const { return "VideoPresentationInterfaceMac"; };
+    ASCIILiteral logClassName() const { return "VideoPresentationInterfaceMac"_s; };
     WTFLogChannel& logChannel() const;
 #endif
 

--- a/Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.cpp
+++ b/Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.cpp
@@ -71,6 +71,22 @@ WTFLogChannel& AudioMediaStreamTrackRenderer::logChannel() const
 {
     return LogMedia;
 }
+
+const Logger& AudioMediaStreamTrackRenderer::logger() const
+{
+    return m_logger.get();
+
+}
+
+const void* AudioMediaStreamTrackRenderer::logIdentifier() const
+{
+    return m_logIdentifier;
+}
+
+ASCIILiteral AudioMediaStreamTrackRenderer::logClassName() const
+{
+    return "AudioMediaStreamTrackRenderer"_s;
+}
 #endif
 
 }

--- a/Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.h
+++ b/Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.h
@@ -74,7 +74,7 @@ protected:
     const Logger& logger() const final;
     const void* logIdentifier() const final;
 
-    const char* logClassName() const final;
+    ASCIILiteral logClassName() const final;
     WTFLogChannel& logChannel() const final;
 #endif
 
@@ -119,24 +119,6 @@ inline void AudioMediaStreamTrackRenderer::crashed()
 inline LibWebRTCAudioModule* AudioMediaStreamTrackRenderer::audioModule()
 {
     return m_audioModule.get();
-}
-#endif
-
-#if !RELEASE_LOG_DISABLED
-inline const Logger& AudioMediaStreamTrackRenderer::logger() const
-{
-    return m_logger.get();
-    
-}
-
-inline const void* AudioMediaStreamTrackRenderer::logIdentifier() const
-{
-    return m_logIdentifier;
-}
-
-inline const char* AudioMediaStreamTrackRenderer::logClassName() const
-{
-    return "AudioMediaStreamTrackRenderer";
 }
 #endif
 

--- a/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h
+++ b/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h
@@ -69,7 +69,7 @@ public:
     bool muted() const { return m_muted; }
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const final { return "AudioTrackPrivateMediaStream"; }
+    ASCIILiteral logClassName() const final { return "AudioTrackPrivateMediaStream"_s; }
 #endif
 
 private:

--- a/Source/WebCore/platform/mediastream/MediaStreamPrivate.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamPrivate.h
@@ -126,7 +126,7 @@ private:
     void forEachObserver(const Function<void(Observer&)>&);
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const final { return "MediaStreamPrivate"; }
+    ASCIILiteral logClassName() const final { return "MediaStreamPrivate"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
 

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
@@ -167,7 +167,7 @@ private:
     void forEachObserver(const Function<void(Observer&)>&);
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const final { return "MediaStreamTrackPrivate"; }
+    ASCIILiteral logClassName() const final { return "MediaStreamTrackPrivate"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
 

--- a/Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.h
@@ -69,7 +69,7 @@ protected:
     RealtimeIncomingAudioSource(rtc::scoped_refptr<webrtc::AudioTrackInterface>&&, String&&);
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const final { return "RealtimeIncomingAudioSource"; }
+    ASCIILiteral logClassName() const final { return "RealtimeIncomingAudioSource"_s; }
 #endif
 
     // RealtimeMediaSource API

--- a/Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.h
@@ -69,7 +69,7 @@ protected:
     RealtimeIncomingVideoSource(rtc::scoped_refptr<webrtc::VideoTrackInterface>&&, String&&);
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const final { return "RealtimeIncomingVideoSource"; }
+    ASCIILiteral logClassName() const final { return "RealtimeIncomingVideoSource"_s; }
 #endif
 
     static VideoFrameTimeMetadata metadataFromVideoFrame(const webrtc::VideoFrame&);

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -265,7 +265,7 @@ public:
     const Logger* loggerPtr() const { return m_logger.get(); }
     const Logger& logger() const final { ASSERT(m_logger); return *m_logger.get(); }
     const void* logIdentifier() const final { return m_logIdentifier; }
-    const char* logClassName() const override { return "RealtimeMediaSource"; }
+    ASCIILiteral logClassName() const override { return "RealtimeMediaSource"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
 

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingAudioSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingAudioSource.h
@@ -85,7 +85,7 @@ protected:
     // LoggerHelper API
     const Logger& logger() const final { return m_audioSource->logger(); }
     const void* logIdentifier() const final { return m_audioSource->logIdentifier(); }
-    const char* logClassName() const final { return "RealtimeOutgoingAudioSource"; }
+    ASCIILiteral logClassName() const final { return "RealtimeOutgoingAudioSource"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
 

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
@@ -91,7 +91,7 @@ protected:
     // LoggerHelper API
     const Logger& logger() const final { return m_logger.get(); }
     const void* logIdentifier() const final { return m_logIdentifier; }
-    const char* logClassName() const final { return "RealtimeOutgoingVideoSource"; }
+    ASCIILiteral logClassName() const final { return "RealtimeOutgoingVideoSource"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
 

--- a/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h
@@ -101,7 +101,7 @@ private:
     Ref<TakePhotoNativePromise> takePhoto(PhotoSettings&&) final;
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const override { return "RealtimeVideoCaptureSource"; }
+    ASCIILiteral logClassName() const override { return "RealtimeVideoCaptureSource"_s; }
 #endif
 
     std::optional<VideoPreset> m_currentPreset;

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
@@ -143,7 +143,7 @@ private:
     void setSizeFrameRateAndZoom(std::optional<int> width, std::optional<int> height, std::optional<double>, std::optional<double>) final;
     double observedFrameRate() const final;
 
-    const char* logClassName() const final { return "DisplayCaptureSourceCocoa"; }
+    ASCIILiteral logClassName() const final { return "DisplayCaptureSourceCocoa"_s; }
     void setLogger(const Logger&, const void*) final;
 
     // CapturerObserver

--- a/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h
@@ -75,7 +75,7 @@ private:
 #if !RELEASE_LOG_DISABLED
     // LoggerHelper.
     const Logger& logger() const final;
-    const char* logClassName() const final { return "IncomingAudioMediaStreamTrackRendererUnit"; }
+    ASCIILiteral logClassName() const final { return "IncomingAudioMediaStreamTrackRendererUnit"_s; }
     WTFLogChannel& logChannel() const final;
     const void* logIdentifier() const final;
 #endif

--- a/Source/WebCore/platform/mediastream/gstreamer/MockDisplayCaptureSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockDisplayCaptureSourceGStreamer.h
@@ -38,7 +38,7 @@ public:
     const IntSize size() const final { return m_source->size(); }
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const final { return "MockDisplayCaptureSourceGStreamer"; }
+    ASCIILiteral logClassName() const final { return "MockDisplayCaptureSourceGStreamer"_s; }
 #endif
 
 protected:

--- a/Source/WebCore/platform/mediastream/ios/ReplayKitCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/ios/ReplayKitCaptureSource.h
@@ -62,7 +62,7 @@ private:
     virtual IntSize intrinsicSize() const { return m_intrinsicSize; }
 
     // LoggerHelper
-    const char* logClassName() const final { return "ReplayKitCaptureSource"; }
+    ASCIILiteral logClassName() const final { return "ReplayKitCaptureSource"_s; }
 
     void screenRecorderDidOutputVideoSample(RetainPtr<CMSampleBufferRef>&&);
     void startCaptureWatchdogTimer();

--- a/Source/WebCore/platform/mediastream/ios/ReplayKitCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/ios/ReplayKitCaptureSource.mm
@@ -80,7 +80,7 @@ using namespace WebCore;
 
 #if !RELEASE_LOG_DISABLED
     if (_callback->loggerPtr()) {
-        auto identifier = Logger::LogSiteIdentifier("ReplayKitCaptureSource", "observeValueForKeyPath", _callback->logIdentifier());
+        auto identifier = Logger::LogSiteIdentifier("ReplayKitCaptureSource"_s, "observeValueForKeyPath"_s, _callback->logIdentifier());
         RetainPtr<NSString> valueString = adoptNS([[NSString alloc] initWithFormat:@"%@", newValue]);
         _callback->logger().logAlways(_callback->logChannel(), identifier, willChange ? "will" : "did", " change '", [keyPath UTF8String], "' to ", [valueString.get() UTF8String]);
     }

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
@@ -128,7 +128,7 @@ private:
     IntDegrees sensorOrientationFromVideoOutput();
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const override { return "AVVideoCaptureSource"; }
+    ASCIILiteral logClassName() const override { return "AVVideoCaptureSource"_s; }
 #endif
 
     void beginConfiguration();

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -1376,7 +1376,7 @@ void AVVideoCaptureSource::deviceDisconnected(RetainPtr<NSNotification> notifica
 
 #if !RELEASE_LOG_DISABLED
     if (m_callback->loggerPtr()) {
-        auto identifier = Logger::LogSiteIdentifier("AVVideoCaptureSource", "observeValueForKeyPath", m_callback->logIdentifier());
+        auto identifier = Logger::LogSiteIdentifier("AVVideoCaptureSource"_s, "observeValueForKeyPath"_s, m_callback->logIdentifier());
         RetainPtr<NSString> valueString = adoptNS([[NSString alloc] initWithFormat:@"%@", newValue]);
         m_callback->logger().logAlways(m_callback->logChannel(), identifier, willChange ? "will" : "did", " change '", [keyPath UTF8String], "' to ", [valueString UTF8String]);
     }

--- a/Source/WebCore/platform/mediastream/mac/CGDisplayStreamScreenCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CGDisplayStreamScreenCaptureSource.h
@@ -57,7 +57,7 @@ private:
     DisplaySurfaceType surfaceType() const final { return DisplaySurfaceType::Monitor; }
     IntSize intrinsicSize() const final;
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const final { return "CGDisplayStreamScreenCaptureSource"; }
+    ASCIILiteral logClassName() const final { return "CGDisplayStreamScreenCaptureSource"_s; }
 #endif
 
     // CGDisplayStreamCaptureSource

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -105,7 +105,7 @@ private:
     void audioUnitWillStart();
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const override { return "CoreAudioCaptureSource"; }
+    ASCIILiteral logClassName() const override { return "CoreAudioCaptureSource"_s; }
 #endif
 
     uint32_t m_captureDeviceID { 0 };

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
@@ -81,7 +81,7 @@ private:
     IntSize intrinsicSize() const final;
 
     // LoggerHelper
-    const char* logClassName() const final { return "ScreenCaptureKitCaptureSource"; }
+    ASCIILiteral logClassName() const final { return "ScreenCaptureKitCaptureSource"_s; }
 
     // ScreenCaptureKitSharingSessionManager::Observer
     void sessionFilterDidChange(SCContentFilter*) final;

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -150,7 +150,7 @@ private:
     CaptureDevice::DeviceType deviceType() const final { return CaptureDevice::DeviceType::Screen; }
     IntSize intrinsicSize() const final;
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const final { return "MockDisplayCapturer"; }
+    ASCIILiteral logClassName() const final { return "MockDisplayCapturer"_s; }
 #endif
     Ref<MockRealtimeVideoSource> m_source;
     RealtimeMediaSourceSettings m_settings;

--- a/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h
@@ -59,7 +59,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    const char* logClassName() const override { return "MockMediaSourcePrivate"; }
+    ASCIILiteral logClassName() const override { return "MockMediaSourcePrivate"_s; }
     const void* logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
 

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h
@@ -70,7 +70,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    const char* logClassName() const override { return "MockSourceBufferPrivate"; }
+    ASCIILiteral logClassName() const override { return "MockSourceBufferPrivate"_s; }
     const void* logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
 

--- a/Source/WebCore/testing/MockMediaSessionCoordinator.h
+++ b/Source/WebCore/testing/MockMediaSessionCoordinator.h
@@ -61,7 +61,7 @@ private:
     void playbackStateChanged(MediaSessionPlaybackState) final;
     void trackIdentifierChanged(const String&) final;
 
-    const char* logClassName() const { return "MockMediaSessionCoordinator"; }
+    ASCIILiteral logClassName() const { return "MockMediaSessionCoordinator"_s; }
     WTFLogChannel& logChannel() const;
 
     std::optional<Exception> result() const;

--- a/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.h
+++ b/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.h
@@ -60,7 +60,7 @@ private:
     void leaveRoutingAbritration() final;
 
     Logger& logger();
-    const char* logClassName() const { return "LocalAudioSessionRoutingArbitrator"; }
+    ASCIILiteral logClassName() const { return "LocalAudioSessionRoutingArbitrator"_s; }
     WTFLogChannel& logChannel() const;
     const void* logIdentifier() const final { return m_logIdentifier; }
     bool canLog() const final;

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
@@ -74,7 +74,7 @@ private:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
     const void* logIdentifier() const final { return m_logIdentifier; }
-    const char* logClassName() const { return "RemoteLegacyCDMSessionProxy"; }
+    ASCIILiteral logClassName() const { return "RemoteLegacyCDMSessionProxy"_s; }
     WTFLogChannel& logChannel() const;
 #endif
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -377,7 +377,7 @@ private:
     const void* mediaPlayerLogIdentifier() { return reinterpret_cast<const void*>(m_configuration.logIdentifier); }
     const Logger& logger() { return mediaPlayerLogger(); }
     const void* logIdentifier() { return mediaPlayerLogIdentifier(); }
-    const char* logClassName() const { return "RemoteMediaPlayerProxy"; }
+    ASCIILiteral logClassName() const { return "RemoteMediaPlayerProxy"_s; }
     WTFLogChannel& logChannel() const;
 #endif
 

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h
@@ -63,7 +63,7 @@ public:
     void startObservingNowPlayingMetadata() final;
     void stopObservingNowPlayingMetadata() final;
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const final;
+    ASCIILiteral logClassName() const final;
 #endif
 
     void nowPlayingMetadataChanged(const WebCore::NowPlayingMetadata&);

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
@@ -373,9 +373,9 @@ void PlaybackSessionInterfaceLMK::nowPlayingMetadataChanged(const WebCore::NowPl
 }
 
 #if !RELEASE_LOG_DISABLED
-const char* PlaybackSessionInterfaceLMK::logClassName() const
+ASCIILiteral PlaybackSessionInterfaceLMK::logClassName() const
 {
-    return "PlaybackSessionInterfaceLMK";
+    return "PlaybackSessionInterfaceLMK"_s;
 }
 #endif
 

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
@@ -46,7 +46,7 @@ class VideoPresentationInterfaceLMK final : public VideoPresentationInterfaceIOS
 public:
     static Ref<VideoPresentationInterfaceLMK> create(PlaybackSessionInterfaceIOS&);
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const { return "VideoPresentationInterfaceLMK"; };
+    ASCIILiteral logClassName() const { return "VideoPresentationInterfaceLMK"_s; };
 #endif
     ~VideoPresentationInterfaceLMK();
 

--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaFormatReader.h
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaFormatReader.h
@@ -85,7 +85,7 @@ private:
     
     static const void* nextLogIdentifier();
     static WTFLogChannel& logChannel();
-    static const char* logClassName() { return "MediaFormatReader"; }
+    static ASCIILiteral logClassName() { return "MediaFormatReader"_s; }
     const void* logIdentifier() const { return m_logIdentifier; }
 
     RetainPtr<MTPluginByteSourceRef> m_byteSource WTF_GUARDED_BY_LOCK(m_parseTracksLock);

--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleCursor.h
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleCursor.h
@@ -104,7 +104,7 @@ private:
     OSStatus getPlayableHorizon(CMTime*) const;
 
     const WTF::Logger& logger() const { return m_logger; }
-    const char* logClassName() const { return "MediaSampleCursor"; }
+    ASCIILiteral logClassName() const { return "MediaSampleCursor"_s; }
     const void* logIdentifier() const { return m_logIdentifier; }
     WTFLogChannel& logChannel() const;
 

--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaTrackReader.h
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaTrackReader.h
@@ -100,7 +100,7 @@ private:
     };
 
     ASCIILiteral mediaTypeString() const;
-    const char* logClassName() const { return "MediaTrackReader"; }
+    ASCIILiteral logClassName() const { return "MediaTrackReader"_s; }
     const void* logIdentifier() const { return m_logIdentifier; }
     WTFLogChannel& logChannel() const;
 

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -146,7 +146,7 @@ private:
     const void* logIdentifier() const final { return m_logIdentifier; }
     const Logger* loggerPtr() const;
 
-    const char* logClassName() const { return "PlaybackSessionModelContext"; };
+    ASCIILiteral logClassName() const { return "PlaybackSessionModelContext"_s; };
     WTFLogChannel& logChannel() const;
 #endif
 
@@ -282,7 +282,7 @@ private:
 
     const Logger& logger() const { return m_logger; }
     const void* logIdentifier() const { return m_logIdentifier; }
-    const char* logClassName() const { return "VideoPresentationManagerProxy"; }
+    ASCIILiteral logClassName() const { return "VideoPresentationManagerProxy"_s; }
     WTFLogChannel& logChannel() const;
 #endif
 

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -128,7 +128,7 @@ private:
     const void* nextChildIdentifier() const final;
     const Logger* loggerPtr() const final;
 
-    const char* logClassName() const { return "VideoPresentationModelContext"; };
+    ASCIILiteral logClassName() const { return "VideoPresentationModelContext"_s; };
     WTFLogChannel& logChannel() const;
 #endif
 
@@ -262,7 +262,7 @@ private:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const;
     const void* logIdentifier() const;
-    const char* logClassName() const;
+    ASCIILiteral logClassName() const;
     WTFLogChannel& logChannel() const;
 #endif
 

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -1356,7 +1356,7 @@ const void* VideoPresentationManagerProxy::logIdentifier() const
     return m_playbackSessionManagerProxy->logIdentifier();
 }
 
-const char* VideoPresentationManagerProxy::logClassName() const
+ASCIILiteral VideoPresentationManagerProxy::logClassName() const
 {
     return m_playbackSessionManagerProxy->logClassName();
 }

--- a/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h
+++ b/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h
@@ -69,7 +69,7 @@ public:
 protected:
     Logger& logger();
     const void* logIdentifier() const { return m_logIdentifier; }
-    const char* logClassName() const { return "AudioSessionRoutingArbitrator"; }
+    ASCIILiteral logClassName() const { return "AudioSessionRoutingArbitrator"_s; }
     WTFLogChannel& logChannel() const;
 
 private:

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h
@@ -86,7 +86,7 @@ private:
 #if !RELEASE_LOG_DISABLED
     const WTF::Logger& logger() const { return m_logger; }
     const void* logIdentifier() const { return m_logIdentifier; }
-    const char* logClassName() const { return "RemoteMediaSessionCoordinatorProxy"; }
+    ASCIILiteral logClassName() const { return "RemoteMediaSessionCoordinatorProxy"_s; }
     WTFLogChannel& logChannel() const;
 #endif
 

--- a/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
@@ -46,9 +46,9 @@ namespace WebKit {
 using namespace WebCore;
 
 #if !RELEASE_LOG_DISABLED
-static const char* logClassName()
+static ASCIILiteral logClassName()
 {
-    return "MediaKeySystemPermissionRequestManagerProxy";
+    return "MediaKeySystemPermissionRequestManagerProxy"_s;
 }
 
 static WTFLogChannel& logChannel()

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
@@ -133,7 +133,7 @@ private:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final;
     const void* logIdentifier() const final { return m_logIdentifier; }
-    const char* logClassName() const override { return "UserMediaPermissionRequestManagerProxy"; }
+    ASCIILiteral logClassName() const override { return "UserMediaPermissionRequestManagerProxy"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
 

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -123,7 +123,7 @@ private:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger; }
     const void* logIdentifier() const { return m_logIdentifier; }
-    const char* logClassName() const { return "WebFullScreenManagerProxy"; }
+    ASCIILiteral logClassName() const { return "WebFullScreenManagerProxy"_s; }
     WTFLogChannel& logChannel() const;
 #endif
 

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
@@ -117,7 +117,7 @@ private:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger; }
     const void* logIdentifier() const { return m_logIdentifier; }
-    const char* logClassName() const { return "WebFullScreenManager"; }
+    ASCIILiteral logClassName() const { return "WebFullScreenManager"_s; }
     WTFLogChannel& logChannel() const;
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -235,7 +235,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
-    const char* logClassName() const override { return "MediaPlayerPrivateRemote"; }
+    ASCIILiteral logClassName() const override { return "MediaPlayerPrivateRemote"_s; }
     const void* logIdentifier() const final { return reinterpret_cast<const void*>(m_logIdentifier); }
     WTFLogChannel& logChannel() const final;
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -118,7 +118,7 @@ private:
     std::atomic<WebCore::MediaPlayer::ReadyState> m_mediaPlayerReadyState { WebCore::MediaPlayer::ReadyState::HaveNothing };
 
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const override { return "MediaSourcePrivateRemote"; }
+    ASCIILiteral logClassName() const override { return "MediaSourcePrivateRemote"_s; }
     const void* logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.h
@@ -61,7 +61,7 @@ private:
     // WTF::LoggerHelper
     const Logger& logger() const final { return m_logger.get(); }
     const void* logIdentifier() const final { return m_logIdentifier; }
-    const char* logClassName() const final { return "RemoteAudioSourceProvider"; }
+    ASCIILiteral logClassName() const final { return "RemoteAudioSourceProvider"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -167,7 +167,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    const char* logClassName() const override { return "SourceBufferPrivateRemote"; }
+    ASCIILiteral logClassName() const override { return "SourceBufferPrivateRemote"_s; }
     const void* logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
     const Logger& sourceBufferLogger() const final { return m_logger.get(); }

--- a/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.h
+++ b/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.h
@@ -74,7 +74,7 @@ private:
     void playbackStateChanged(WebCore::MediaSessionPlaybackState) final;
     void trackIdentifierChanged(const String&) final;
 
-    const char* logClassName() const { return "RemoteMediaSessionCoordinator"; }
+    ASCIILiteral logClassName() const { return "RemoteMediaSessionCoordinator"_s; }
     WTFLogChannel& logChannel() const;
 
     WebPage& m_page;

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -192,7 +192,7 @@ private:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger; }
     const void* logIdentifier() const { return m_logIdentifier; }
-    const char* logClassName() const { return "VideoPresentationManager"; }
+    ASCIILiteral logClassName() const { return "VideoPresentationManager"_s; }
     WTFLogChannel& logChannel() const;
 #endif
 

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -208,7 +208,7 @@ protected:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const;
     const void* logIdentifier() const;
-    const char* logClassName() const;
+    ASCIILiteral logClassName() const;
     WTFLogChannel& logChannel() const;
 #endif
 

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -853,7 +853,7 @@ const void* VideoPresentationManager::logIdentifier() const
     return m_playbackSessionManager->logIdentifier();
 }
 
-const char* VideoPresentationManager::logClassName() const
+ASCIILiteral VideoPresentationManager::logClassName() const
 {
     return m_playbackSessionManager->logClassName();
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/Logging.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/Logging.cpp
@@ -102,7 +102,7 @@ public:
     }
 
     const Logger& logger() const final { return m_logger.get(); }
-    const char* logClassName() const final { return "LoggingTest"; }
+    ASCIILiteral logClassName() const final { return "LoggingTest"_s; }
     WTFLogChannel& logChannel() const final { return TestChannel1; }
     const void* logIdentifier() const final { return reinterpret_cast<const void*>(123456789); }
 
@@ -290,7 +290,7 @@ TEST_F(LoggingTest, DISABLED_Logger)
     logger->debug(TestChannel1, "You're using coconuts!");
     EXPECT_EQ(0u, output().length());
 
-    logger->error(TestChannel1, Logger::LogSiteIdentifier("LoggingTest::Logger", this) , ": test output");
+    logger->error(TestChannel1, Logger::LogSiteIdentifier("LoggingTest::Logger"_s, this) , ": test output");
     EXPECT_TRUE(output().containsIgnoringASCIICase("LoggingTest::Logger("_s));
 
     logger->error(TestChannel1, "What is ", 1, " + " , 12.5F, "?");


### PR DESCRIPTION
#### bd4b75d88899cf73fdaf55a7d42116dbbf45b61e
<pre>
Update LoggerHelper::logClassName() to return an ASCIILiteral
<a href="https://bugs.webkit.org/show_bug.cgi?id=273087">https://bugs.webkit.org/show_bug.cgi?id=273087</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/Logger.h:
(WTF::Logger::LogSiteIdentifier::LogSiteIdentifier):
* Source/WTF/wtf/LoggerHelper.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp:
(WebCore::logClassName):
* Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp:
(WebCore::NavigatorEME::requestMediaKeySystemAccess):
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h:
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::logClassName):
* Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h:
(WebCore::MediaSessionCoordinator::logClassName):
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/Modules/mediastream/ImageCapture.h:
(WebCore::ImageCapture::logClassName const):
* Source/WebCore/Modules/mediastream/MediaStream.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.h:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.h:
* Source/WebCore/Modules/mediastream/RTCRtpReceiver.h:
* Source/WebCore/Modules/mediastream/RTCRtpSender.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::processStats):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp:
(WebCore::LibWebRTCMediaEndpoint::OnStatsDelivered):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h:
* Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h:
* Source/WebCore/Modules/remoteplayback/RemotePlayback.h:
* Source/WebCore/Modules/webaudio/AudioNode.h:
* Source/WebCore/Modules/webaudio/AudioParam.h:
* Source/WebCore/Modules/webaudio/BaseAudioContext.h:
* Source/WebCore/dom/FullscreenManager.h:
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/MediaElementSession.h:
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h:
* Source/WebCore/html/track/AudioTrack.h:
* Source/WebCore/html/track/InbandDataTextTrack.h:
* Source/WebCore/html/track/InbandGenericTextTrack.h:
* Source/WebCore/html/track/InbandWebVTTTextTrack.h:
* Source/WebCore/html/track/LoadableTextTrack.h:
* Source/WebCore/html/track/TextTrack.h:
* Source/WebCore/html/track/VTTCue.h:
* Source/WebCore/html/track/VideoTrack.h:
* Source/WebCore/platform/audio/AudioSession.h:
* Source/WebCore/platform/audio/PlatformMediaSession.h:
* Source/WebCore/platform/audio/PlatformMediaSessionManager.h:
* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.h:
* Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h:
* Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h:
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h:
* Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.h:
* Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h:
* Source/WebCore/platform/graphics/AudioTrackPrivate.h:
* Source/WebCore/platform/graphics/InbandTextTrackPrivate.h:
* Source/WebCore/platform/graphics/TrackBuffer.h:
* Source/WebCore/platform/graphics/VideoTrackPrivate.h:
* Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.h:
* Source/WebCore/platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.h:
* Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.h:
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h:
(WebCore::CDMSessionAVContentKeySession::logClassName const):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(-[WebCoreAVFMovieObserver observeValueForKeyPath:ofObject:change:context:]):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h:
(WebCore::WebMParser::VideoTrackData::logClassName const):
(WebCore::WebMParser::AudioTrackData::logClassName const):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm:
(WebCore::PlaybackSessionInterfaceAVKit::logClassName const):
* Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
(WebCore::VideoPresentationInterfaceIOS::logClassName const):
* Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h:
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h:
* Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.h:
(WebCore::AudioMediaStreamTrackRenderer::logClassName const):
* Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h:
* Source/WebCore/platform/mediastream/MediaStreamPrivate.h:
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h:
* Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.h:
* Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/RealtimeOutgoingAudioSource.h:
* Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h:
* Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h:
* Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h:
* Source/WebCore/platform/mediastream/gstreamer/MockDisplayCaptureSourceGStreamer.h:
* Source/WebCore/platform/mediastream/ios/ReplayKitCaptureSource.h:
* Source/WebCore/platform/mediastream/ios/ReplayKitCaptureSource.mm:
(-[WebCoreReplayKitScreenRecorderHelper observeValueForKeyPath:ofObject:change:context:]):
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(-[WebCoreAVVideoCaptureSourceObserver observeValueForKeyPath:ofObject:change:context:]):
* Source/WebCore/platform/mediastream/mac/CGDisplayStreamScreenCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h:
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:
* Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h:
* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h:
* Source/WebCore/testing/MockMediaSessionCoordinator.h:
(WebCore::MockMediaSessionCoordinator::logClassName const):
* Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h:
(WebKit::RemoteLegacyCDMSessionProxy::logClassName const):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h:
* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm:
(WebKit::PlaybackSessionInterfaceLMK::logClassName const):
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h:
* Source/WebKit/Shared/mac/MediaFormatReader/MediaFormatReader.h:
* Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleCursor.h:
(WebKit::MediaSampleCursor::logClassName const):
* Source/WebKit/Shared/mac/MediaFormatReader/MediaTrackReader.h:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
(WebKit::PlaybackSessionManagerProxy::logClassName const):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::logClassName const):
* Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h:
(WebKit::AudioSessionRoutingArbitratorProxy::logClassName const):
* Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h:
(WebKit::RemoteMediaSessionCoordinatorProxy::logClassName const):
* Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp:
(WebKit::logClassName):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
(WebKit::WebFullScreenManagerProxy::logClassName const):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.h:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:
* Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
(WebKit::PlaybackSessionManager::logClassName const):
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::logClassName const):
* Tools/TestWebKitAPI/Tests/WebCore/Logging.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/277849@main">https://commits.webkit.org/277849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c009ab9f94dca423b3c0e2373b65f3a17c91f1cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48746 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51708 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51433 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44811 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51051 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25487 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39859 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42049 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20957 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23082 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6802 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/42046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45015 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53342 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/48237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23795 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20076 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47168 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/25060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42254 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25865 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55732 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6957 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/24780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11470 "Passed tests") | 
<!--EWS-Status-Bubble-End-->