### PR TITLE
REGRESSION (277389@main): [iOS] AutoFill not offered on autofocus with an attached hardware keyboard

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -470,6 +470,7 @@ $(PROJECT_DIR)/Shared/cf/CoreIPCSecKeychainItem.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCSecTrust.serialization.in
 $(PROJECT_DIR)/Shared/ios/DynamicViewportSizeUpdate.serialization.in
 $(PROJECT_DIR)/Shared/ios/GestureTypes.serialization.in
+$(PROJECT_DIR)/Shared/ios/HardwareKeyboardState.serialization.in
 $(PROJECT_DIR)/Shared/ios/InteractionInformationAtPosition.serialization.in
 $(PROJECT_DIR)/Shared/ios/InteractionInformationRequest.serialization.in
 $(PROJECT_DIR)/Shared/ios/WebAutocorrectionContext.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -623,6 +623,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/InspectorExtensionTypes.serialization.in \
 	Shared/ios/DynamicViewportSizeUpdate.serialization.in \
 	Shared/ios/GestureTypes.serialization.in \
+	Shared/ios/HardwareKeyboardState.serialization.in \
 	Shared/ios/InteractionInformationAtPosition.serialization.in \
 	Shared/ios/InteractionInformationRequest.serialization.in \
 	Shared/ios/WebAutocorrectionContext.serialization.in \

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -76,6 +76,10 @@
 #include "DMABufRendererBufferFormat.h"
 #endif
 
+#if PLATFORM(IOS_FAMILY)
+#include "HardwareKeyboardState.h"
+#endif
+
 namespace IPC {
 class Decoder;
 class Encoder;
@@ -197,7 +201,7 @@ struct WebPageCreationParameters {
     WebCore::FloatSize overrideAvailableScreenSize;
     float textAutosizingWidth;
     WebCore::IntDegrees deviceOrientation { 0 };
-    bool keyboardIsAttached { false };
+    HardwareKeyboardState hardwareKeyboardState;
     bool canShowWhileLocked { false };
     bool isCapturingScreen { false };
     WebCore::Color insertionPointColor;

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -130,7 +130,7 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
     WebCore::FloatSize overrideAvailableScreenSize;
     float textAutosizingWidth;
     WebCore::IntDegrees deviceOrientation;
-    bool keyboardIsAttached;
+    WebKit::HardwareKeyboardState hardwareKeyboardState;
     bool canShowWhileLocked;
     bool isCapturingScreen;
     WebCore::Color insertionPointColor;

--- a/Source/WebKit/Shared/ios/HardwareKeyboardState.cpp
+++ b/Source/WebKit/Shared/ios/HardwareKeyboardState.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,36 +23,29 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#import <wtf/Platform.h>
+#include "config.h"
+#include "HardwareKeyboardState.h"
 
 #if PLATFORM(IOS_FAMILY)
 
-#if USE(APPLE_INTERNAL_SDK)
+#import <pal/spi/ios/GraphicsServicesSPI.h>
 
-#import <GraphicsServices/GraphicsServices.h>
+namespace WebKit {
 
-#endif
+HardwareKeyboardState currentHardwareKeyboardState()
+{
+    return {
+        !!GSEventIsHardwareKeyboardAttached(),
+        GSEventGetHardwareKeyboardCountry(),
+        GSEventGetHardwareKeyboardType()
+    };
+}
 
-WTF_EXTERN_C_BEGIN
+void setHardwareKeyboardState(HardwareKeyboardState state)
+{
+    GSEventSetHardwareKeyboardAttachedWithCountryCodeAndType(state.isAttached, state.countryCode, state.keyboardType);
+}
 
-void GSInitialize(void);
-uint64_t GSCurrentEventTimestamp(void);
-CFStringRef GSSystemRootDirectory(void);
-void GSFontInitialize(void);
-void GSFontPurgeFontCache(void);
+} // namespace WebKit
 
-typedef struct __GSKeyboard* GSKeyboardRef;
-uint32_t GSKeyboardGetModifierState(GSKeyboardRef);
-Boolean GSEventIsHardwareKeyboardAttached(void);
-uint8_t GSEventGetHardwareKeyboardCountry(void);
-uint8_t GSEventGetHardwareKeyboardType(void);
-void GSEventSetHardwareKeyboardAttached(Boolean attached, uint8_t country);
-void GSEventSetHardwareKeyboardAttachedWithCountryCodeAndType(Boolean attached, uint8_t country, uint8_t type);
-
-extern const char *kGSEventHardwareKeyboardAvailabilityChangedNotification;
-
-WTF_EXTERN_C_END
-
-#endif
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/Shared/ios/HardwareKeyboardState.h
+++ b/Source/WebKit/Shared/ios/HardwareKeyboardState.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,34 +25,21 @@
 
 #pragma once
 
-#import <wtf/Platform.h>
-
 #if PLATFORM(IOS_FAMILY)
 
-#if USE(APPLE_INTERNAL_SDK)
+namespace WebKit {
 
-#import <GraphicsServices/GraphicsServices.h>
+struct HardwareKeyboardState {
+    bool isAttached { false };
+    uint8_t countryCode { 0 };
+    uint8_t keyboardType { 0 };
 
-#endif
+    bool operator==(const HardwareKeyboardState&) const = default;
+};
 
-WTF_EXTERN_C_BEGIN
+HardwareKeyboardState currentHardwareKeyboardState();
+void setHardwareKeyboardState(HardwareKeyboardState);
 
-void GSInitialize(void);
-uint64_t GSCurrentEventTimestamp(void);
-CFStringRef GSSystemRootDirectory(void);
-void GSFontInitialize(void);
-void GSFontPurgeFontCache(void);
+} // namespace WebKit
 
-typedef struct __GSKeyboard* GSKeyboardRef;
-uint32_t GSKeyboardGetModifierState(GSKeyboardRef);
-Boolean GSEventIsHardwareKeyboardAttached(void);
-uint8_t GSEventGetHardwareKeyboardCountry(void);
-uint8_t GSEventGetHardwareKeyboardType(void);
-void GSEventSetHardwareKeyboardAttached(Boolean attached, uint8_t country);
-void GSEventSetHardwareKeyboardAttachedWithCountryCodeAndType(Boolean attached, uint8_t country, uint8_t type);
-
-extern const char *kGSEventHardwareKeyboardAvailabilityChangedNotification;
-
-WTF_EXTERN_C_END
-
-#endif
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/Shared/ios/HardwareKeyboardState.serialization.in
+++ b/Source/WebKit/Shared/ios/HardwareKeyboardState.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2024 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if PLATFORM(IOS_FAMILY)
+
+struct WebKit::HardwareKeyboardState {
+    bool isAttached;
+    uint8_t countryCode;
+    uint8_t keyboardType;
+};
+
+#endif

--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleCursor.h
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleCursor.h
@@ -35,6 +35,7 @@
 #include <wtf/Identified.h>
 #include <wtf/Lock.h>
 #include <wtf/MediaTime.h>
+#include <wtf/ObjectIdentifier.h>
 
 DECLARE_CORE_MEDIA_TRAITS(SampleCursor);
 

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -197,6 +197,7 @@ Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
 Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
 
 Shared/ios/AuxiliaryProcessIOS.mm
+Shared/ios/HardwareKeyboardState.cpp
 Shared/ios/InteractionInformationAtPosition.mm
 Shared/ios/InteractionInformationRequest.cpp
 Shared/ios/NativeWebKeyboardEventIOS.mm

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -332,8 +332,7 @@ static void hardwareKeyboardAvailabilityChangedCallback(CFNotificationCenterRef,
     RetainPtr webView { (__bridge WKWebView *)observer };
     if (!webView)
         return;
-    [webView->_contentView _hardwareKeyboardAvailabilityChanged];
-    webView->_page->hardwareKeyboardAvailabilityChanged(GSEventIsHardwareKeyboardAttached());
+    webView->_page->hardwareKeyboardAvailabilityChanged();
 }
 #endif
 

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -535,6 +535,8 @@ public:
     virtual void scrollingNodeScrollDidEndScroll(WebCore::ScrollingNodeID) = 0;
     virtual Vector<String> mimeTypesWithCustomContentProviders() = 0;
 
+    virtual void hardwareKeyboardAvailabilityChanged() = 0;
+
     virtual void showInspectorHighlight(const WebCore::InspectorOverlay::Highlight&) = 0;
     virtual void hideInspectorHighlight() = 0;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10131,7 +10131,7 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     parameters.textAutosizingWidth = textAutosizingWidth();
     parameters.mimeTypesWithCustomContentProviders = protectedPageClient()->mimeTypesWithCustomContentProviders();
     parameters.deviceOrientation = m_deviceOrientation;
-    parameters.keyboardIsAttached = isInHardwareKeyboardMode();
+    parameters.hardwareKeyboardState = internals().hardwareKeyboardState;
     parameters.canShowWhileLocked = m_configuration->canShowWhileLocked();
     parameters.insertionPointColor = protectedPageClient()->insertionPointColor();
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1043,7 +1043,7 @@ public:
     void storeSelectionForAccessibility(bool);
     void startAutoscrollAtPosition(const WebCore::FloatPoint& positionInWindow);
     void cancelAutoscroll();
-    void hardwareKeyboardAvailabilityChanged(bool keyboardIsAttached);
+    void hardwareKeyboardAvailabilityChanged();
     bool isScrollingOrZooming() const { return m_isScrollingOrZooming; }
     void requestEvasionRectsAboveSelection(CompletionHandler<void(const Vector<WebCore::FloatRect>&)>&&);
     void updateSelectionWithDelta(int64_t locationDelta, int64_t lengthDelta, CompletionHandler<void()>&&);
@@ -2969,10 +2969,6 @@ private:
 
     void didFinishServiceWorkerPageRegistration(bool success);
     void callLoadCompletionHandlersIfNecessary(bool success);
-
-#if PLATFORM(IOS_FAMILY)
-    static bool isInHardwareKeyboardMode();
-#endif
 
     void waitForInitialLinkDecorationFilteringData(WebFramePolicyListenerProxy&);
     void sendCachedLinkDecorationFilteringData();

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -90,6 +90,10 @@
 #include "MediaCapability.h"
 #endif
 
+#if PLATFORM(IOS_FAMILY)
+#include "HardwareKeyboardState.h"
+#endif
+
 namespace WebKit {
 
 class WebPageProxyFrameLoadStateObserver;
@@ -307,6 +311,10 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
 
 #if ENABLE(EXTENSION_CAPABILITIES)
     std::optional<MediaCapability> mediaCapability;
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+    HardwareKeyboardState hardwareKeyboardState;
 #endif
 
 #if ENABLE(WINDOW_PROXY_PROPERTY_ACCESS_NOTIFICATION)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -205,6 +205,8 @@ private:
     void showPlaybackTargetPicker(bool hasVideo, const WebCore::IntRect& elementRect, WebCore::RouteSharingPolicy, const String&) override;
     void showDataDetectorsUIForPositionInformation(const InteractionInformationAtPosition&) override;
 
+    void hardwareKeyboardAvailabilityChanged() override;
+
     bool handleRunOpenPanel(WebPageProxy*, WebFrameProxy*, const FrameInfoData&, API::OpenPanelParameters*, WebOpenPanelResultListenerProxy*) override;
     bool showShareSheet(const WebCore::ShareDataWithParsedURL&, WTF::CompletionHandler<void(bool)>&&) override;
     void showContactPicker(const WebCore::ContactsRequestData&, WTF::CompletionHandler<void(std::optional<Vector<WebCore::ContactInfo>>&&)>&&) override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -1091,6 +1091,11 @@ void PageClientImpl::showDataDetectorsUIForPositionInformation(const Interaction
     [contentView() _showDataDetectorsUIForPositionInformation:positionInformation];
 }
 
+void PageClientImpl::hardwareKeyboardAvailabilityChanged()
+{
+    [contentView() _hardwareKeyboardAvailabilityChanged];
+}
+
 #if ENABLE(VIDEO_PRESENTATION_MODE)
 
 void PageClientImpl::didExitFullscreen()

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2452,6 +2452,7 @@
 		E4D54D0421F1D72D007E3C36 /* ScrollingTreeFrameScrollingNodeRemoteIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = E40C1F9321F0B96E00530718 /* ScrollingTreeFrameScrollingNodeRemoteIOS.h */; };
 		E4E57F6B21A83B1200345F3C /* RemoteLayerTreeNode.h in Headers */ = {isa = PBXBuildFile; fileRef = E4E57F6A21A83B1100345F3C /* RemoteLayerTreeNode.h */; };
 		E50620922542102000C43091 /* ContactsUISPI.h in Headers */ = {isa = PBXBuildFile; fileRef = E50620912542102000C43091 /* ContactsUISPI.h */; };
+		E50F80F62BD648720079DBDE /* HardwareKeyboardState.h in Headers */ = {isa = PBXBuildFile; fileRef = E50F80F52BD648620079DBDE /* HardwareKeyboardState.h */; };
 		E51BD9D02BC5F32300F40647 /* UnifiedTextReplacementSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = E51BD9CF2BC5F32300F40647 /* UnifiedTextReplacementSoftLink.h */; };
 		E5227D8427A11261008EAB57 /* WebFoundTextRange.h in Headers */ = {isa = PBXBuildFile; fileRef = E5227D8227A11231008EAB57 /* WebFoundTextRange.h */; };
 		E52CF55220A35C3A00DADA27 /* WebDataListSuggestionPicker.h in Headers */ = {isa = PBXBuildFile; fileRef = E52CF55020A35C3A00DADA27 /* WebDataListSuggestionPicker.h */; };
@@ -8046,6 +8047,9 @@
 		E4E57F6821A83B0300345F3C /* RemoteLayerTreeNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RemoteLayerTreeNode.mm; sourceTree = "<group>"; };
 		E4E57F6A21A83B1100345F3C /* RemoteLayerTreeNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoteLayerTreeNode.h; sourceTree = "<group>"; };
 		E50620912542102000C43091 /* ContactsUISPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ContactsUISPI.h; sourceTree = "<group>"; };
+		E50F80F42BD648620079DBDE /* HardwareKeyboardState.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = HardwareKeyboardState.cpp; path = ios/HardwareKeyboardState.cpp; sourceTree = "<group>"; };
+		E50F80F52BD648620079DBDE /* HardwareKeyboardState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = HardwareKeyboardState.h; path = ios/HardwareKeyboardState.h; sourceTree = "<group>"; };
+		E50F80F72BD649100079DBDE /* HardwareKeyboardState.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = HardwareKeyboardState.serialization.in; path = ios/HardwareKeyboardState.serialization.in; sourceTree = "<group>"; };
 		E51BD9CF2BC5F32300F40647 /* UnifiedTextReplacementSoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UnifiedTextReplacementSoftLink.h; sourceTree = "<group>"; };
 		E51BD9D12BC5F35000F40647 /* UnifiedTextReplacementSoftLink.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = UnifiedTextReplacementSoftLink.mm; sourceTree = "<group>"; };
 		E5227D8227A11231008EAB57 /* WebFoundTextRange.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebFoundTextRange.h; sourceTree = "<group>"; };
@@ -10956,6 +10960,9 @@
 				2DA6731920C754B1003CB401 /* DynamicViewportSizeUpdate.h */,
 				2DA9449D1884E4F000ED86DB /* GestureTypes.h */,
 				2DA301AD2B0385F700F3B129 /* GestureTypes.serialization.in */,
+				E50F80F42BD648620079DBDE /* HardwareKeyboardState.cpp */,
+				E50F80F52BD648620079DBDE /* HardwareKeyboardState.h */,
+				E50F80F72BD649100079DBDE /* HardwareKeyboardState.serialization.in */,
 				C5BCE5DA1C50761D00CDE3FA /* InteractionInformationAtPosition.h */,
 				C5BCE5DB1C50761D00CDE3FA /* InteractionInformationAtPosition.mm */,
 				86DA60CA28EB11830044FE4D /* InteractionInformationAtPosition.serialization.in */,
@@ -16274,6 +16281,7 @@
 				2DA049B8180CCD0A00AAFA9E /* GraphicsLayerCARemote.h in Headers */,
 				C0CE72AD1247E78D00BC0EC4 /* HandleMessage.h in Headers */,
 				1AC75A1B1B3368270056745B /* HangDetectionDisabler.h in Headers */,
+				E50F80F62BD648720079DBDE /* HardwareKeyboardState.h in Headers */,
 				57AC8F50217FEED90055438C /* HidConnection.h in Headers */,
 				2DD5A72B1EBF09A7009BA597 /* HiddenPageThrottlingAutoIncreasesCounter.h in Headers */,
 				5772F206217DBD6A0056BF2C /* HidService.h in Headers */,

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -134,6 +134,7 @@ void WebPage::platformInitialize(const WebPageCreationParameters& parameters)
 #endif
 #if PLATFORM(IOS_FAMILY)
     setInsertionPointColor(parameters.insertionPointColor);
+    setHardwareKeyboardState(parameters.hardwareKeyboardState);
 #endif
     WebCore::setAdditionalSupportedImageTypes(parameters.additionalSupportedImageTypes);
     WebCore::setImageSourceAllowableTypes(WebCore::allowableImageTypes());

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -588,7 +588,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     , m_overrideScreenSize(parameters.overrideScreenSize)
     , m_overrideAvailableScreenSize(parameters.overrideAvailableScreenSize)
     , m_deviceOrientation(parameters.deviceOrientation)
-    , m_keyboardIsAttached(parameters.keyboardIsAttached)
+    , m_keyboardIsAttached(parameters.hardwareKeyboardState.isAttached)
     , m_canShowWhileLocked(parameters.canShowWhileLocked)
     , m_updateFocusedElementInformationTimer(*this, &WebPage::updateFocusedElementInformation, updateFocusedElementInformationDebounceInterval)
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1255,7 +1255,7 @@ public:
 
     bool platformPrefersTextLegibilityBasedZoomScaling() const;
 
-    void hardwareKeyboardAvailabilityChanged(bool keyboardIsAttached);
+    void hardwareKeyboardAvailabilityChanged(HardwareKeyboardState);
     bool hardwareKeyboardIsAttached() const { return m_keyboardIsAttached; }
 
     void updateStringForFind(const String&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -129,7 +129,7 @@ messages -> WebPage LegacyReceiver {
     StartAutoscrollAtPosition(WebCore::FloatPoint positionInWindow)
     CancelAutoscroll()
     RequestFocusedElementInformation() -> (std::optional<WebKit::FocusedElementInformation> info)
-    HardwareKeyboardAvailabilityChanged(bool keyboardIsAttached)
+    HardwareKeyboardAvailabilityChanged(struct WebKit::HardwareKeyboardState state)
     SetIsShowingInputViewForFocusedElement(bool showingInputView)
     UpdateSelectionWithDelta(int64_t locationDelta, int64_t lengthDelta) -> ()
     RequestDocumentEditingContext(struct WebKit::DocumentEditingContextRequest request) -> (struct WebKit::DocumentEditingContext response)

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4861,9 +4861,10 @@ OptionSet<PointerCharacteristics> WebPage::pointerCharacteristicsOfAllAvailableP
     return result;
 }
 
-void WebPage::hardwareKeyboardAvailabilityChanged(bool keyboardIsAttached)
+void WebPage::hardwareKeyboardAvailabilityChanged(HardwareKeyboardState state)
 {
-    m_keyboardIsAttached = keyboardIsAttached;
+    m_keyboardIsAttached = state.isAttached;
+    setHardwareKeyboardState(state);
 
     if (RefPtr focusedFrame = m_page->checkedFocusController()->focusedLocalFrame())
         focusedFrame->eventHandler().capsLockStateMayHaveChanged();

--- a/WebKitLibraries/SDKs/appletvos16.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
+++ b/WebKitLibraries/SDKs/appletvos16.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
@@ -5,6 +5,7 @@ install-name: /System/Library/PrivateFrameworks/GraphicsServices.framework/Graph
 current-version: 14
 exports:
 -       targets: [arm64-tvos, arm64e-tvos]
-        symbols: [_GSCurrentEventTimestamp, _GSEventIsHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttached, _GSFontInitialize,
-                _GSFontPurgeFontCache, _GSInitialize, _GSKeyboardGetModifierState, _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
+        symbols: [_GSCurrentEventTimestamp, _GSEventGetHardwareKeyboardCountry, _GSEventGetHardwareKeyboardType, _GSEventIsHardwareKeyboardAttached,
+                _GSEventSetHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttachedWithCountryCodeAndType, _GSFontInitialize, _GSFontPurgeFontCache,
+                _GSInitialize, _GSKeyboardGetModifierState, _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
 ...

--- a/WebKitLibraries/SDKs/appletvos17.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
+++ b/WebKitLibraries/SDKs/appletvos17.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
@@ -5,6 +5,7 @@ install-name: /System/Library/PrivateFrameworks/GraphicsServices.framework/Graph
 current-version: 14
 exports:
 -       targets: [arm64-tvos, arm64e-tvos]
-        symbols: [_GSCurrentEventTimestamp, _GSEventIsHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttached, _GSFontInitialize,
-                _GSFontPurgeFontCache, _GSInitialize, _GSKeyboardGetModifierState, _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
+        symbols: [_GSCurrentEventTimestamp, _GSEventGetHardwareKeyboardCountry, _GSEventGetHardwareKeyboardType, _GSEventIsHardwareKeyboardAttached,
+                _GSEventSetHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttachedWithCountryCodeAndType, _GSFontInitialize, _GSFontPurgeFontCache,
+                _GSInitialize, _GSKeyboardGetModifierState, _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
 ...

--- a/WebKitLibraries/SDKs/appletvsimulator16.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
+++ b/WebKitLibraries/SDKs/appletvsimulator16.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
@@ -5,6 +5,7 @@ install-name: /System/Library/PrivateFrameworks/GraphicsServices.framework/Graph
 current-version: 14
 exports:
 -       targets: [x86_64-tvos-simulator, arm64-tvos-simulator]
-        symbols: [_GSCurrentEventTimestamp, _GSEventIsHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttached, _GSInitialize,
+        symbols: [_GSCurrentEventTimestamp, _GSEventGetHardwareKeyboardCountry, _GSEventGetHardwareKeyboardType, _GSEventIsHardwareKeyboardAttached,
+                _GSEventSetHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttachedWithCountryCodeAndType, _GSInitialize,
                 _GSKeyboardGetModifierState, _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
 ...

--- a/WebKitLibraries/SDKs/appletvsimulator17.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
+++ b/WebKitLibraries/SDKs/appletvsimulator17.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
@@ -5,6 +5,7 @@ install-name: /System/Library/PrivateFrameworks/GraphicsServices.framework/Graph
 current-version: 14
 exports:
 -       targets: [x86_64-tvos-simulator, arm64-tvos-simulator]
-        symbols: [_GSCurrentEventTimestamp, _GSEventIsHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttached, _GSInitialize,
+        symbols: [_GSCurrentEventTimestamp, _GSEventGetHardwareKeyboardCountry, _GSEventGetHardwareKeyboardType, _GSEventIsHardwareKeyboardAttached,
+                _GSEventSetHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttachedWithCountryCodeAndType, _GSInitialize,
                 _GSKeyboardGetModifierState, _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
 ...

--- a/WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
+++ b/WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
@@ -5,6 +5,7 @@ install-name: /System/Library/PrivateFrameworks/GraphicsServices.framework/Graph
 current-version: 14
 exports:
 -       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
-        symbols: [_GSCurrentEventTimestamp, _GSEventIsHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttached, _GSFontInitialize,
-                _GSFontPurgeFontCache, _GSInitialize, _GSKeyboardGetModifierState, _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
+        symbols: [_GSCurrentEventTimestamp, _GSEventGetHardwareKeyboardCountry, _GSEventGetHardwareKeyboardType, _GSEventIsHardwareKeyboardAttached,
+                _GSEventSetHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttachedWithCountryCodeAndType, _GSFontInitialize, _GSFontPurgeFontCache,
+                _GSInitialize, _GSKeyboardGetModifierState, _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
 ...

--- a/WebKitLibraries/SDKs/iphoneos17.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
+++ b/WebKitLibraries/SDKs/iphoneos17.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
@@ -5,6 +5,7 @@ install-name: /System/Library/PrivateFrameworks/GraphicsServices.framework/Graph
 current-version: 14
 exports:
 -       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
-        symbols: [_GSCurrentEventTimestamp, _GSEventIsHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttached, _GSFontInitialize,
-                _GSFontPurgeFontCache, _GSInitialize, _GSKeyboardGetModifierState, _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
+        symbols: [_GSCurrentEventTimestamp, _GSEventGetHardwareKeyboardCountry, _GSEventGetHardwareKeyboardType, _GSEventIsHardwareKeyboardAttached,
+                _GSEventSetHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttachedWithCountryCodeAndType, _GSFontInitialize, _GSFontPurgeFontCache,
+                _GSInitialize, _GSKeyboardGetModifierState, _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
 ...

--- a/WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
@@ -5,6 +5,7 @@ install-name: /System/Library/PrivateFrameworks/GraphicsServices.framework/Graph
 current-version: 14
 exports:
 -       targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
-        symbols: [_GSCurrentEventTimestamp, _GSEventIsHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttached, _GSInitialize,
+        symbols: [_GSCurrentEventTimestamp, _GSEventGetHardwareKeyboardCountry, _GSEventGetHardwareKeyboardType, _GSEventIsHardwareKeyboardAttached,
+                _GSEventSetHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttachedWithCountryCodeAndType, _GSInitialize,
                 _GSKeyboardGetModifierState, _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
 ...

--- a/WebKitLibraries/SDKs/iphonesimulator17.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator17.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
@@ -5,6 +5,7 @@ install-name: /System/Library/PrivateFrameworks/GraphicsServices.framework/Graph
 current-version: 14
 exports:
 -       targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
-        symbols: [_GSCurrentEventTimestamp, _GSEventIsHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttached, _GSInitialize,
+        symbols: [_GSCurrentEventTimestamp, _GSEventGetHardwareKeyboardCountry, _GSEventGetHardwareKeyboardType, _GSEventIsHardwareKeyboardAttached,
+                _GSEventSetHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttachedWithCountryCodeAndType, _GSInitialize,
                 _GSKeyboardGetModifierState, _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
 ...

--- a/WebKitLibraries/SDKs/watchos10.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
+++ b/WebKitLibraries/SDKs/watchos10.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
@@ -5,6 +5,7 @@ install-name: /System/Library/PrivateFrameworks/GraphicsServices.framework/Graph
 current-version: 14
 exports:
 -       targets: [armv7k-watchos, arm64-watchos, arm64e-watchos, arm64_32-watchos]
-        symbols: [_GSCurrentEventTimestamp, _GSEventIsHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttached, _GSFontInitialize,
-                _GSFontPurgeFontCache, _GSInitialize, _GSKeyboardGetModifierState, _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
+        symbols: [_GSCurrentEventTimestamp, _GSEventGetHardwareKeyboardCountry, _GSEventGetHardwareKeyboardType, _GSEventIsHardwareKeyboardAttached,
+                _GSEventSetHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttachedWithCountryCodeAndType, _GSFontInitialize, _GSFontPurgeFontCache,
+                _GSInitialize, _GSKeyboardGetModifierState, _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
 ...

--- a/WebKitLibraries/SDKs/watchos9.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
+++ b/WebKitLibraries/SDKs/watchos9.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
@@ -5,6 +5,7 @@ install-name: /System/Library/PrivateFrameworks/GraphicsServices.framework/Graph
 current-version: 14
 exports:
 -       targets: [armv7k-watchos, arm64-watchos, arm64e-watchos, arm64_32-watchos]
-        symbols: [_GSCurrentEventTimestamp, _GSEventIsHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttached, _GSFontInitialize,
-                _GSFontPurgeFontCache, _GSInitialize, _GSKeyboardGetModifierState, _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
+        symbols: [_GSCurrentEventTimestamp, _GSEventGetHardwareKeyboardCountry, _GSEventGetHardwareKeyboardType, _GSEventIsHardwareKeyboardAttached,
+                _GSEventSetHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttachedWithCountryCodeAndType, _GSFontInitialize, _GSFontPurgeFontCache,
+                _GSInitialize, _GSKeyboardGetModifierState, _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
 ...

--- a/WebKitLibraries/SDKs/watchsimulator10.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
+++ b/WebKitLibraries/SDKs/watchsimulator10.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
@@ -5,6 +5,7 @@ install-name: /System/Library/PrivateFrameworks/GraphicsServices.framework/Graph
 current-version: 14
 exports:
 -       targets: [i386-watchos-simulator, x86_64-watchos-simulator, arm64-watchos-simulator]
-        symbols: [_GSCurrentEventTimestamp, _GSEventIsHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttached, _GSInitialize,
+        symbols: [_GSCurrentEventTimestamp, _GSEventGetHardwareKeyboardCountry, _GSEventGetHardwareKeyboardType, _GSEventIsHardwareKeyboardAttached,
+                _GSEventSetHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttachedWithCountryCodeAndType, _GSInitialize,
                 _GSKeyboardGetModifierState, _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
 ...

--- a/WebKitLibraries/SDKs/watchsimulator9.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
+++ b/WebKitLibraries/SDKs/watchsimulator9.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
@@ -5,6 +5,7 @@ install-name: /System/Library/PrivateFrameworks/GraphicsServices.framework/Graph
 current-version: 14
 exports:
 -       targets: [i386-watchos-simulator, x86_64-watchos-simulator, arm64-watchos-simulator]
-        symbols: [_GSCurrentEventTimestamp, _GSEventIsHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttached, _GSInitialize,
+        symbols: [_GSCurrentEventTimestamp, _GSEventGetHardwareKeyboardCountry, _GSEventGetHardwareKeyboardType, _GSEventIsHardwareKeyboardAttached,
+                _GSEventSetHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttachedWithCountryCodeAndType, _GSInitialize,
                 _GSKeyboardGetModifierState, _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
 ...


### PR DESCRIPTION
#### e1e849f259d0a32e603e644d6fc6b6ef8774ed22
<pre>
REGRESSION (277389@main): [iOS] AutoFill not offered on autofocus with an attached hardware keyboard
<a href="https://bugs.webkit.org/show_bug.cgi?id=273086">https://bugs.webkit.org/show_bug.cgi?id=273086</a>
<a href="https://rdar.apple.com/126653124">rdar://126653124</a>

Reviewed by Chris Dumez, Abrar Rahman Protyasha and Richard Robinson.

Focusing a field without user interaction should not offer AutoFill unless there
is a hardware keyboard attached. In order to implement this behavior, Safari
checks the returned value of `GSEventIsHardwareKeyboardAttached()` in their
injected bundle.

Since that call is made in the web process, where notifyd is blocked following
277389@main, it always returns false, as `GSEventIsHardwareKeyboardAttached()`
relies on libnotify. Consequently, AutoFill is not offered until the user
actually taps on a field, even when a hardware keyboard is attached.

Simply updating `WebProcessPool::registerNotificationObservers` to register
for the hardware keyboard notification is not sufficient, as the returned value
of `GSEventIsHardwareKeyboardAttached()` will be incorrect if the process is
launched with the hardware keyboard already attached.

Fix by explicitly setting the state at process creation time, and whenever the
value changes, using `GSEventSetHardwareKeyboardAttachedWithCountryCodeAndType()`.
A new `HardwareKeyboardState` struct is introduced to represent the state across
process boundaries. Additionally suppress updates in the UI process if the state
is unchanged, to avoid notification loops in the simulator.

* Source/WebCore/PAL/pal/spi/ios/GraphicsServicesSPI.h:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/Shared/ios/HardwareKeyboardState.cpp: Copied from Source/WebCore/PAL/pal/spi/ios/GraphicsServicesSPI.h.
(WebKit::currentHardwareKeyboardState):
(WebKit::setHardwareKeyboardState):
* Source/WebKit/Shared/ios/HardwareKeyboardState.h: Copied from Source/WebCore/PAL/pal/spi/ios/GraphicsServicesSPI.h.
* Source/WebKit/Shared/ios/HardwareKeyboardState.serialization.in: Added.
* Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleCursor.h:

Unified sources build fix.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(hardwareKeyboardAvailabilityChangedCallback):
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::hardwareKeyboardAvailabilityChanged):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::platformInitialize):
(WebKit::WebPageProxy::applicationWillEnterForeground):
(WebKit::WebPageProxy::hardwareKeyboardAvailabilityChanged):
(WebKit::WebPageProxy::isInHardwareKeyboardMode): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::platformInitialize):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::hardwareKeyboardAvailabilityChanged):
* WebKitLibraries/SDKs/appletvos16.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd:
* WebKitLibraries/SDKs/appletvos17.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd:
* WebKitLibraries/SDKs/appletvsimulator16.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd:
* WebKitLibraries/SDKs/appletvsimulator17.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd:
* WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd:
* WebKitLibraries/SDKs/iphoneos17.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd:
* WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd:
* WebKitLibraries/SDKs/iphonesimulator17.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd:
* WebKitLibraries/SDKs/watchos10.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd:
* WebKitLibraries/SDKs/watchos9.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd:
* WebKitLibraries/SDKs/watchsimulator10.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd:
* WebKitLibraries/SDKs/watchsimulator9.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd:

Canonical link: <a href="https://commits.webkit.org/277961@main">https://commits.webkit.org/277961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d926157209bef3d504ee9086b7cc82811ab263d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49085 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28324 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/52075 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51830 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/45162 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40108 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50566 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25926 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/52075 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21221 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23381 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/52075 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7283 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/52075 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53744 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/24161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20369 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47430 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/25441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/52075 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10794 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/26229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/25160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->