### PR TITLE
Make WTF::negate work correctly when negating non-negative integers

### DIFF
--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -782,10 +782,11 @@ template<typename T> constexpr T fabsConstExpr(T value)
 }
 
 // For use in places where we could negate std::numeric_limits<T>::min and would like to avoid UB.
-template<typename T> constexpr typename std::enable_if_t<std::is_integral_v<T> && std::is_signed_v<T>, std::make_unsigned_t<T>> negate(T v)
+template<typename T>
+requires std::is_integral_v<T>
+constexpr T negate(T v)
 {
-    ASSERT(v <= 0);
-    return ~static_cast<std::make_unsigned_t<T>>(v) + 1U;
+    return static_cast<T>(~static_cast<std::make_unsigned_t<T>>(v) + 1U);
 }
 
 template<typename BitsType, typename InputType>

--- a/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
@@ -643,37 +643,37 @@ TEST(WTF, fastLog2)
 
 TEST(WTF, negate)
 {
-    auto expected_uint8_t = WTF::negate<int8_t>(0);
-    EXPECT_TRUE((std::is_same_v<uint8_t, decltype(expected_uint8_t)>));
-    auto expected_uint16_t = WTF::negate<int16_t>(0);
-    EXPECT_TRUE((std::is_same_v<uint16_t, decltype(expected_uint16_t)>));
-    auto expected_uint32_t = WTF::negate<int32_t>(0);
-    EXPECT_TRUE((std::is_same_v<uint32_t, decltype(expected_uint32_t)>));
-    auto expected_uint64_t = WTF::negate<int64_t>(0);
-    EXPECT_TRUE((std::is_same_v<uint64_t, decltype(expected_uint64_t)>));
-    auto expected_unsigned_long_long = WTF::negate<long long>(0);
-    EXPECT_TRUE((std::is_same_v<unsigned long long, decltype(expected_unsigned_long_long)>));
+    auto expected_int8_t = WTF::negate<int8_t>(0);
+    EXPECT_TRUE((std::is_same_v<int8_t, decltype(expected_int8_t)>));
+    auto expected_int16_t = WTF::negate<int16_t>(0);
+    EXPECT_TRUE((std::is_same_v<int16_t, decltype(expected_int16_t)>));
+    auto expected_int32_t = WTF::negate<int32_t>(0);
+    EXPECT_TRUE((std::is_same_v<int32_t, decltype(expected_int32_t)>));
+    auto expected_int64_t = WTF::negate<int64_t>(0);
+    EXPECT_TRUE((std::is_same_v<int64_t, decltype(expected_int64_t)>));
+    auto expected_long_long = WTF::negate<long long>(0);
+    EXPECT_TRUE((std::is_same_v<long long, decltype(expected_long_long)>));
 
-    EXPECT_EQ(WTF::negate<int8_t>(std::numeric_limits<int8_t>::min()), static_cast<uint8_t>(std::numeric_limits<int8_t>::max()) + 1U);
-    EXPECT_EQ(WTF::negate<int8_t>(std::numeric_limits<int8_t>::min() + 1), static_cast<uint8_t>(std::numeric_limits<int8_t>::max()));
-    EXPECT_EQ(WTF::negate<int8_t>(-1), 1U);
-    EXPECT_EQ(WTF::negate<int8_t>(0), 0U);
-    EXPECT_EQ(WTF::negate<int16_t>(std::numeric_limits<int16_t>::min()), static_cast<uint16_t>(std::numeric_limits<int16_t>::max()) + 1U);
-    EXPECT_EQ(WTF::negate<int16_t>(std::numeric_limits<int16_t>::min() + 1), static_cast<uint16_t>(std::numeric_limits<int16_t>::max()));
-    EXPECT_EQ(WTF::negate<int16_t>(-1), 1U);
-    EXPECT_EQ(WTF::negate<int16_t>(0), 0U);
-    EXPECT_EQ(WTF::negate<int32_t>(std::numeric_limits<int32_t>::min()), static_cast<uint32_t>(std::numeric_limits<int32_t>::max()) + 1U);
-    EXPECT_EQ(WTF::negate<int32_t>(std::numeric_limits<int32_t>::min() + 1), static_cast<uint32_t>(std::numeric_limits<int32_t>::max()));
-    EXPECT_EQ(WTF::negate<int32_t>(-1), 1U);
-    EXPECT_EQ(WTF::negate<int32_t>(0), 0U);
-    EXPECT_EQ(WTF::negate<int64_t>(std::numeric_limits<int64_t>::min()), static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1UL);
-    EXPECT_EQ(WTF::negate<int64_t>(std::numeric_limits<int64_t>::min() + 1L), static_cast<uint64_t>(std::numeric_limits<int64_t>::max()));
-    EXPECT_EQ(WTF::negate<int64_t>(-1L), 1UL);
-    EXPECT_EQ(WTF::negate<int64_t>(0L), 0UL);
-    EXPECT_EQ(WTF::negate<long long>(std::numeric_limits<long long>::min()), static_cast<unsigned long long>(std::numeric_limits<long long>::max()) + 1ULL);
-    EXPECT_EQ(WTF::negate<long long>(std::numeric_limits<long long>::min() + 1LL), static_cast<unsigned long long>(std::numeric_limits<long long>::max()));
-    EXPECT_EQ(WTF::negate<long long>(-1LL), 1ULL);
-    EXPECT_EQ(WTF::negate<long long>(0LL), 0ULL);
+    EXPECT_EQ(WTF::negate<int8_t>(std::numeric_limits<int8_t>::min()), std::numeric_limits<int8_t>::min());
+    EXPECT_EQ(WTF::negate<int8_t>(std::numeric_limits<int8_t>::min() + 1), std::numeric_limits<int8_t>::max());
+    EXPECT_EQ(WTF::negate<int8_t>(-1), 1);
+    EXPECT_EQ(WTF::negate<int8_t>(0), 0);
+    EXPECT_EQ(WTF::negate<int16_t>(std::numeric_limits<int16_t>::min()), std::numeric_limits<int16_t>::min());
+    EXPECT_EQ(WTF::negate<int16_t>(std::numeric_limits<int16_t>::min() + 1), std::numeric_limits<int16_t>::max());
+    EXPECT_EQ(WTF::negate<int16_t>(-1), 1);
+    EXPECT_EQ(WTF::negate<int16_t>(0), 0);
+    EXPECT_EQ(WTF::negate<int32_t>(std::numeric_limits<int32_t>::min()), std::numeric_limits<int32_t>::min());
+    EXPECT_EQ(WTF::negate<int32_t>(std::numeric_limits<int32_t>::min() + 1), std::numeric_limits<int32_t>::max());
+    EXPECT_EQ(WTF::negate<int32_t>(-1), 1);
+    EXPECT_EQ(WTF::negate<int32_t>(0), 0);
+    EXPECT_EQ(WTF::negate<int64_t>(std::numeric_limits<int64_t>::min()), std::numeric_limits<int64_t>::min());
+    EXPECT_EQ(WTF::negate<int64_t>(std::numeric_limits<int64_t>::min() + 1L), std::numeric_limits<int64_t>::max());
+    EXPECT_EQ(WTF::negate<int64_t>(-1L), 1L);
+    EXPECT_EQ(WTF::negate<int64_t>(0L), 0L);
+    EXPECT_EQ(WTF::negate<long long>(std::numeric_limits<long long>::min()), std::numeric_limits<long long>::min());
+    EXPECT_EQ(WTF::negate<long long>(std::numeric_limits<long long>::min() + 1LL), std::numeric_limits<long long>::max());
+    EXPECT_EQ(WTF::negate<long long>(-1LL), 1LL);
+    EXPECT_EQ(WTF::negate<long long>(0LL), 0LL);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 884c93a89477439436e11c1081dcc73312599cd7
<pre>
Make WTF::negate work correctly when negating non-negative integers
<a href="https://bugs.webkit.org/show_bug.cgi?id=273048">https://bugs.webkit.org/show_bug.cgi?id=273048</a>
<a href="https://rdar.apple.com/problem/126872453">rdar://problem/126872453</a>

Reviewed by Yusuke Suzuki and Keith Miller.

WTF::negate statically accepts signed integers, but ASSERTs that its input is
already negative so it can return a non-negative result. This is pretty surprising
behavior, and since the operation of WTF::negate is a simple two&apos;s-complement
negate, it should be fine to allow it to return negative results as well.

* Source/WTF/wtf/MathExtras.h:
(WTF::negate):

Canonical link: <a href="https://commits.webkit.org/277883@main">https://commits.webkit.org/277883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e74d32db5f4265a65d4ab009ed064c3ca8a60f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27952 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51428 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44806 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51046 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25482 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39864 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49323 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25599 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42051 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20962 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23081 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43272 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6797 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/42040 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45014 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43716 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53337 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/48232 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23788 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20073 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47152 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25055 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42256 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46086 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10759 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25860 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55727 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24775 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11468 "Passed tests") | 
<!--EWS-Status-Bubble-End-->