### PR TITLE
Replace OpaqueJSString::characters8() / characters16() with span equivalents

### DIFF
--- a/Source/JavaScriptCore/API/JSStringRef.cpp
+++ b/Source/JavaScriptCore/API/JSStringRef.cpp
@@ -102,12 +102,11 @@ size_t JSStringGetUTF8CString(JSStringRef string, char* buffer, size_t bufferSiz
 
     char* destination = buffer;
     bool failed = false;
-    if (string->is8Bit()) {
-        const LChar* source = string->characters8();
-        convertLatin1ToUTF8(&source, source + string->length(), &destination, destination + bufferSize - 1);
-    } else {
-        const UChar* source = string->characters16();
-        auto result = convertUTF16ToUTF8(&source, source + string->length(), &destination, destination + bufferSize - 1);
+    if (string->is8Bit())
+        convertLatin1ToUTF8(string->span8(), &destination, destination + bufferSize - 1);
+    else {
+        auto characters = string->span16();
+        auto result = convertUTF16ToUTF8(characters, &destination, destination + bufferSize - 1);
         failed = result != ConversionResult::Success && result != ConversionResult::TargetExhausted;
     }
 

--- a/Source/JavaScriptCore/API/JSStringRefCF.cpp
+++ b/Source/JavaScriptCore/API/JSStringRefCF.cpp
@@ -60,8 +60,10 @@ CFStringRef JSStringCopyCFString(CFAllocatorRef allocator, JSStringRef string)
     if (!string || !string->length())
         return CFSTR("");
 
-    if (string->is8Bit())
-        return CFStringCreateWithBytes(allocator, reinterpret_cast<const UInt8*>(string->characters8()), string->length(), kCFStringEncodingISOLatin1, false);
-
-    return CFStringCreateWithCharacters(allocator, reinterpret_cast<const UniChar*>(string->characters16()), string->length());
+    if (string->is8Bit()) {
+        auto characters = string->span8();
+        return CFStringCreateWithBytes(allocator, reinterpret_cast<const UInt8*>(characters.data()), characters.size(), kCFStringEncodingISOLatin1, false);
+    }
+    auto characters = string->span16();
+    return CFStringCreateWithCharacters(allocator, reinterpret_cast<const UniChar*>(characters.data()), characters.size());
 }

--- a/Source/JavaScriptCore/API/OpaqueJSString.h
+++ b/Source/JavaScriptCore/API/OpaqueJSString.h
@@ -57,8 +57,8 @@ struct OpaqueJSString : public ThreadSafeRefCounted<OpaqueJSString> {
     JS_EXPORT_PRIVATE ~OpaqueJSString();
 
     bool is8Bit() { return m_string.is8Bit(); }
-    const LChar* characters8() { return m_string.characters8(); }
-    const UChar* characters16() { return m_string.characters16(); }
+    std::span<const LChar> span8() { return m_string.span8(); }
+    std::span<const UChar> span16() { return m_string.span16(); }
     unsigned length() { return m_string.length(); }
 
     const UChar* characters();

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -1410,7 +1410,7 @@ inline Expected<std::invoke_result_t<Func, std::span<const char>>, UTF8Conversio
         memcpy(buffer, characters.data(), prefixLength);
         buffer += prefixLength;
 
-        auto success = Unicode::convertLatin1ToUTF8(&nonASCII, characters.data() + characters.size(), &buffer, buffer + (bufferVector.size() - prefixLength));
+        auto success = Unicode::convertLatin1ToUTF8(characters.subspan(nonASCII - characters.data()), &buffer, buffer + (bufferVector.size() - prefixLength));
         ASSERT_UNUSED(success, success); // (characters.size() * 2) should be sufficient for any conversion from Latin1
         return function(std::span(bufferVector.data(), buffer));
     }
@@ -1418,8 +1418,7 @@ inline Expected<std::invoke_result_t<Func, std::span<const char>>, UTF8Conversio
 #else
     Vector<char, 1024> bufferVector(characters.size() * 2);
     char* buffer = bufferVector.data();
-    const LChar* source = characters.data();
-    bool success = Unicode::convertLatin1ToUTF8(&source, source + characters.size(), &buffer, buffer + bufferVector.size());
+    bool success = Unicode::convertLatin1ToUTF8(characters, &buffer, buffer + bufferVector.size());
     ASSERT_UNUSED(success, success); // (characters.size() * 2) should be sufficient for any conversion from Latin1
     return function(std::span(bufferVector.data(), buffer));
 #endif

--- a/Source/WTF/wtf/unicode/UTF8Conversion.h
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.h
@@ -46,8 +46,8 @@ enum class ConversionResult : uint8_t {
 
 WTF_EXPORT_PRIVATE bool convertUTF8ToUTF16(std::span<const char8_t> source, UChar** targetStart, const UChar* targetEnd, bool* isSourceAllASCII = nullptr);
 WTF_EXPORT_PRIVATE bool convertUTF8ToUTF16ReplacingInvalidSequences(std::span<const char8_t> source, UChar** targetStart, const UChar* targetEnd, bool* isSourceAllASCII = nullptr);
-WTF_EXPORT_PRIVATE bool convertLatin1ToUTF8(const LChar** sourceStart, const LChar* sourceEnd, char** targetStart, const char* targetEnd);
-WTF_EXPORT_PRIVATE ConversionResult convertUTF16ToUTF8(const UChar** sourceStart, const UChar* sourceEnd, char** targetStart, const char* targetEnd, bool strict = true);
+WTF_EXPORT_PRIVATE bool convertLatin1ToUTF8(std::span<const LChar> source, char** targetStart, const char* targetEnd);
+WTF_EXPORT_PRIVATE ConversionResult convertUTF16ToUTF8(std::span<const UChar>& source, char** targetStart, const char* targetEnd, bool strict = true);
 WTF_EXPORT_PRIVATE unsigned calculateStringHashAndLengthFromUTF8MaskingTop8Bits(std::span<const char> data, unsigned& dataLength, unsigned& utf16Length);
 
 // Like the other functions above, the computeUTFLengths function is strict.

--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -746,12 +746,11 @@ RefPtr<SharedBuffer> utf8Buffer(const String& string)
     char* p = reinterpret_cast<char*>(buffer.data());
     if (length) {
         if (string.is8Bit()) {
-            const LChar* d = string.characters8();
-            if (!WTF::Unicode::convertLatin1ToUTF8(&d, d + length, &p, p + buffer.size()))
+            if (!WTF::Unicode::convertLatin1ToUTF8(string.span8(), &p, p + buffer.size()))
                 return nullptr;
         } else {
-            const UChar* d = string.characters16();
-            if (WTF::Unicode::convertUTF16ToUTF8(&d, d + length, &p, p + buffer.size()) != WTF::Unicode::ConversionResult::Success)
+            auto span = string.span16();
+            if (WTF::Unicode::convertUTF16ToUTF8(span, &p, p + buffer.size()) != WTF::Unicode::ConversionResult::Success)
                 return nullptr;
         }
     }

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -1150,9 +1150,7 @@ static xmlEntityPtr sharedXHTMLEntity()
 static size_t convertUTF16EntityToUTF8(std::span<const UChar> utf16Entity, char* target, size_t targetSize)
 {
     const char* originalTarget = target;
-    auto start = utf16Entity.data();
-    auto end = start + utf16Entity.size();
-    auto conversionResult = WTF::Unicode::convertUTF16ToUTF8(&start, end, &target, target + targetSize);
+    auto conversionResult = WTF::Unicode::convertUTF16ToUTF8(utf16Entity, &target, target + targetSize);
     if (conversionResult != WTF::Unicode::ConversionResult::Success)
         return 0;
 

--- a/Source/WebKit/Shared/API/c/WKString.cpp
+++ b/Source/WebKit/Shared/API/c/WKString.cpp
@@ -82,12 +82,11 @@ size_t WKStringGetUTF8CStringImpl(WKStringRef stringRef, char* buffer, size_t bu
     char* p = buffer;
 
     if (stringView.is8Bit()) {
-        const LChar* characters = stringView.span8().data();
-        if (!WTF::Unicode::convertLatin1ToUTF8(&characters, characters + stringView.length(), &p, p + bufferSize - 1))
+        if (!WTF::Unicode::convertLatin1ToUTF8(stringView.span8(), &p, p + bufferSize - 1))
             return 0;
     } else {
-        const UChar* characters = stringView.span16().data();
-        auto result = WTF::Unicode::convertUTF16ToUTF8(&characters, characters + stringView.length(), &p, p + bufferSize - 1, strict);
+        auto characters = stringView.span16();
+        auto result = WTF::Unicode::convertUTF16ToUTF8(characters, &p, p + bufferSize - 1, strict);
         if (result != WTF::Unicode::ConversionResult::Success && result != WTF::Unicode::ConversionResult::TargetExhausted)
             return 0;
     }


### PR DESCRIPTION
#### 9fb6599ff25c6305a75f2213d87c54a8d476c625
<pre>
Replace OpaqueJSString::characters8() / characters16() with span equivalents
<a href="https://bugs.webkit.org/show_bug.cgi?id=273096">https://bugs.webkit.org/show_bug.cgi?id=273096</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/API/JSStringRef.cpp:
(JSStringGetUTF8CString):
* Source/JavaScriptCore/API/JSStringRefCF.cpp:
(JSStringCopyCFString):
* Source/JavaScriptCore/API/OpaqueJSString.h:
(OpaqueJSString::span8):
(OpaqueJSString::span16):
(OpaqueJSString::characters8): Deleted.
(OpaqueJSString::characters16): Deleted.
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::utf8ForCharactersIntoBuffer):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::tryGetUTF8ForCharacters):
* Source/WTF/wtf/unicode/UTF8Conversion.cpp:
(WTF::Unicode::convertLatin1ToUTF8):
(WTF::Unicode::convertUTF16ToUTF8):
* Source/WTF/wtf/unicode/UTF8Conversion.h:
* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::utf8Buffer):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::convertUTF16EntityToUTF8):
* Source/WebKit/Shared/API/c/WKString.cpp:
(WKStringGetUTF8CStringImpl):

Canonical link: <a href="https://commits.webkit.org/277880@main">https://commits.webkit.org/277880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9f4489e6f3af9c2560d46685c20545fc21e52bc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48767 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51453 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44831 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51072 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33919 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25508 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39874 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49349 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25627 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20973 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23099 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43243 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6822 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/42066 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45028 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53388 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/48257 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23815 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20088 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47182 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25080 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42262 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46125 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25889 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55752 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6969 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24800 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11473 "Passed tests") | 
<!--EWS-Status-Bubble-End-->