### PR TITLE
[view-transitions] Handle overflow:hidden on ::view-transition-new/old.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-overflow-hidden-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-overflow-hidden-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html style="background:pink">
+<title>View transitions: overflow:hidden is respected on pseudo elements</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<style>
+body {
+  margin: 0px;
+}
+div {
+  width: 200px;
+  height: 200px;
+}
+#target {
+  position: absolute;
+  width: 200px;
+  height: 200px;
+  background: green;
+  overflow: hidden;
+}
+#inner {
+  position: relative;
+  left: 100px;
+  top: 100px;
+  background: blue;
+}
+.offset {
+  left: 400px;
+}
+</style>
+
+<div id="target"><div id="inner"></div></div>
+<div id="target" class="offset"><div id="inner"></div></div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-overflow-hidden-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-overflow-hidden-ref.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html style="background:pink">
+<title>View transitions: overflow:hidden is respected on pseudo elements</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<style>
+body {
+  margin: 0px;
+}
+div {
+  width: 200px;
+  height: 200px;
+}
+#target {
+  position: absolute;
+  width: 200px;
+  height: 200px;
+  background: green;
+  overflow: hidden;
+}
+#inner {
+  position: relative;
+  left: 100px;
+  top: 100px;
+  background: blue;
+}
+.offset {
+  left: 400px;
+}
+</style>
+
+<div id="target"><div id="inner"></div></div>
+<div id="target" class="offset"><div id="inner"></div></div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-overflow-hidden.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-overflow-hidden.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>View transitions: overflow:hidden is respected on pseudo elements</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<link rel="author" href="mailto:mattwoodrow@apple.com">
+<link rel="match" href="pseudo-element-overflow-hidden-ref.html">
+<script src="/common/reftest-wait.js"></script>
+<style>
+body {
+  margin: 0px;
+}
+div {
+  width: 200px;
+  height: 200px;
+}
+#target {
+  width: 200px;
+  height: 200px;
+  background: green;
+  view-transition-name: target;
+}
+#inner {
+  position: relative;
+  left: 100px;
+  top: 100px;
+  background: blue;
+}
+
+/* We're verifying what we capture, so just display both of the captures for 5 minutes.  */
+html::view-transition-group(*) { animation-duration: 300s; }
+html::view-transition-new(*) { animation: unset; opacity: 1; }
+html::view-transition-old(*) { animation: unset; opacity: 1; }
+/* hide the root so we show transition background to ensure we're in a transition */
+html::view-transition-group(root) { animation: unset; opacity: 0; }
+html::view-transition { background: pink; }
+
+html::view-transition-new(target) {
+  overflow:hidden;
+}
+html::view-transition-old(target) {
+  left: 400px;
+  overflow: hidden;
+}
+</style>
+
+<div id="target"><div id="inner"></div></div>
+<script>
+failIfNot(document.startViewTransition, "Missing document.startViewTransition");
+
+async function runTest() {
+  let t = document.startViewTransition();
+  t.ready.then(takeScreenshot);
+}
+onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>
+
+</html>

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -710,8 +710,12 @@ ExceptionOr<void> ViewTransition::updatePseudoElementStyles()
             if (RefPtr documentElement = document()->documentElement()) {
                 Styleable styleable(*documentElement, Style::PseudoElementIdentifier { PseudoId::ViewTransitionNew, name });
                 CheckedPtr renderer = styleable.renderer();
-                if (CheckedPtr viewTransitionCapture = dynamicDowncast<RenderViewTransitionCapture>(renderer.get()))
+                if (CheckedPtr viewTransitionCapture = dynamicDowncast<RenderViewTransitionCapture>(renderer.get())) {
                     viewTransitionCapture->setSize(boxSize, overflowRect);
+
+                    RefPtr<ImageBuffer> image = viewTransitionCapture->canUseExistingLayers() ? nullptr : snapshotElementVisualOverflowClippedToViewport(*m_document->frame(), *newElement, overflowRect);
+                    viewTransitionCapture->setImage(image);
+                }
             }
         } else
             properties = capturedElement->oldProperties;

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -65,6 +65,7 @@
 #include "RenderStyleInlines.h"
 #include "RenderVideo.h"
 #include "RenderView.h"
+#include "RenderViewTransitionCapture.h"
 #include "RotateTransformOperation.h"
 #include "SVGGraphicsElement.h"
 #include "ScaleTransformOperation.h"
@@ -1398,6 +1399,9 @@ void RenderLayerCompositor::traverseUnchangedSubtree(RenderLayer* ancestorLayer,
 void RenderLayerCompositor::collectViewTransitionNewContentLayers(RenderLayer& layer, Vector<Ref<GraphicsLayer>>& childList)
 {
     if (layer.renderer().style().pseudoElementType() != PseudoId::ViewTransitionNew || !layer.hasVisibleContent())
+        return;
+
+    if (!downcast<RenderViewTransitionCapture>(layer.renderer()).canUseExistingLayers())
         return;
 
     RefPtr activeViewTransition = layer.renderer().document().activeViewTransition();

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
@@ -80,6 +80,14 @@ void RenderViewTransitionCapture::layout()
     addVisualOverflow(m_localOverflowRect);
 }
 
+void RenderViewTransitionCapture::updateFromStyle()
+{
+    RenderReplaced::updateFromStyle();
+
+    if (effectiveOverflowX() != Overflow::Visible || effectiveOverflowY() != Overflow::Visible)
+        setHasNonVisibleOverflow();
+}
+
 LayoutPoint RenderViewTransitionCapture::captureContentInset() const
 {
     LayoutPoint location = m_localOverflowRect.location();

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.h
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.h
@@ -52,9 +52,13 @@ public:
     // Inset of the scaled capture from the visualOverflowRect()
     LayoutPoint captureContentInset() const;
 
+    bool canUseExistingLayers() const { return !hasNonVisibleOverflow(); }
+
 private:
     ASCIILiteral renderName() const override { return "RenderViewTransitionCapture"_s; }
     String debugDescription() const override;
+
+    void updateFromStyle() override;
 
     RefPtr<ImageBuffer> m_oldImage;
     LayoutRect m_overflowRect;


### PR DESCRIPTION
#### b4321a0a6e7085a38a340b6353a0ddef31d9f5f8
<pre>
[view-transitions] Handle overflow:hidden on ::view-transition-new/old.
<a href="https://bugs.webkit.org/show_bug.cgi?id=273058">https://bugs.webkit.org/show_bug.cgi?id=273058</a>
&lt;<a href="https://rdar.apple.com/126888144">rdar://126888144</a>&gt;

Reviewed by Tim Nguyen.

Implement updateFromStyle, and make sure setHasNonVisibleOverflow gets called if necessary. Normally this only
happens for RenderBlock subclasses, not RenderReplaced (which don&apos;t really support overflow properly yet, see
bug 273055).

If overflow is hidden, fall back to snapshotting each frame of the transition instead of using compositing
layer attachment, since overflow hidden isn&apos;t supported there either.

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-overflow-hidden-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-overflow-hidden-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-overflow-hidden.html: Added.
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::updatePseudoElementStyles):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::collectViewTransitionNewContentLayers):
* Source/WebCore/rendering/RenderViewTransitionCapture.cpp:
(WebCore::RenderViewTransitionCapture::updateFromStyle):
* Source/WebCore/rendering/RenderViewTransitionCapture.h:

Canonical link: <a href="https://commits.webkit.org/277959@main">https://commits.webkit.org/277959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b487b25d75aa16c59be62237034b875cf129f00

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48771 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51732 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51457 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44836 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51076 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33923 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39869 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25624 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42058 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20968 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23092 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43244 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6826 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45026 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43729 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53367 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23819 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20094 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47167 "Found 1 new test failure: http/tests/inspector/network/har/har-page.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25084 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42263 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46107 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10795 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25891 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24804 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->