### PR TITLE
[visionOS] When transitioning from video fullscreen to element fullscreen, the element fullscreen window is not frontmost

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -797,14 +797,6 @@ void PlaybackSessionManagerProxy::setVideoReceiverEndpoint(PlaybackSessionContex
     if (!xpcConnection)
         return;
 
-    // FIXME 125816935: element fullscreen is expected to exit when switching to LinearMediaPlayer
-    // fullscreen, but in order to do so in a way that's not visible to the user we need an API
-    // from LinearMediaKit to know when its scene swap transition has occurred. For now we just
-    // exit element fullscreen when we receive the video receiver endpoint, but this causes the
-    // element fullscreen window to close before the LinearMediaKit scene is visible.
-    if (endpoint && m_page->fullScreenManager() && m_page->fullScreenManager()->isFullScreen())
-        m_page->fullScreenManager()->requestExitFullScreen();
-
     VideoReceiverEndpointMessage endpointMessage(WTFMove(processIdentifier), WTFMove(playerIdentifier), endpoint);
     xpc_connection_send_message(xpcConnection.get(), endpointMessage.encode().get());
 #else

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7572,6 +7572,7 @@ void WebPageProxy::fullscreenMayReturnToInline()
 
 void WebPageProxy::didEnterFullscreen(PlaybackSessionContextIdentifier identifier)
 {
+    protectedPageClient()->didEnterFullscreen();
     m_uiClient->didEnterFullscreen(this);
 
     internals().currentFullscreenVideoSessionIdentifier = identifier;
@@ -7583,6 +7584,7 @@ void WebPageProxy::didExitFullscreen(PlaybackSessionContextIdentifier identifier
     if (m_screenOrientationManager)
         m_screenOrientationManager->unlockIfNecessary();
 
+    protectedPageClient()->didExitFullscreen();
     m_uiClient->didExitFullscreen(this);
 
     if (internals().currentFullscreenVideoSessionIdentifier == identifier) {

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -335,7 +335,7 @@ private:
     bool hasResizableWindows() const final;
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-    void didEnterFullscreen() final;
+    void didEnterFullscreen() final { };
     void didExitFullscreen() final;
 #endif
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -1093,14 +1093,11 @@ void PageClientImpl::showDataDetectorsUIForPositionInformation(const Interaction
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
 
-void PageClientImpl::didEnterFullscreen()
-{
-    [contentView() _didEnterFullscreen];
-}
-
 void PageClientImpl::didExitFullscreen()
 {
-    [contentView() _didExitFullscreen];
+#if ENABLE(FULLSCREEN_API)
+    [[webView() fullScreenWindowController] didExitFullscreen];
+#endif
 }
 
 #endif // ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -822,11 +822,6 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 - (void)updateTextSuggestionsForInputDelegate;
 #endif
 
-#if ENABLE(VIDEO_PRESENTATION_MODE)
-- (void)_didEnterFullscreen;
-- (void)_didExitFullscreen;
-#endif
-
 - (void)_updateRuntimeProtocolConformanceIfNeeded;
 
 - (void)_requestTextInputContextsInRect:(CGRect)rect completionHandler:(void (^)(NSArray<_WKTextInputContext *> *))completionHandler;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -11551,20 +11551,6 @@ static BOOL applicationIsKnownToIgnoreMouseEvents(const char* &warningVersion)
 
 #endif // HAVE(PENCILKIT_TEXT_INPUT)
 
-#if ENABLE(VIDEO_PRESENTATION_MODE)
-
-- (void)_didEnterFullscreen
-{
-    [self _startSuppressingSelectionAssistantForReason:WebKit::SuppressSelectionAssistantReason::ShowingFullscreenVideo];
-}
-
-- (void)_didExitFullscreen
-{
-    [self _stopSuppressingSelectionAssistantForReason:WebKit::SuppressSelectionAssistantReason::ShowingFullscreenVideo];
-}
-
-#endif // ENABLE(VIDEO_PRESENTATION_MODE)
-
 #if ENABLE(ATTACHMENT_ELEMENT)
 
 #if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
@@ -50,6 +50,7 @@
 - (void)close;
 - (void)webViewDidRemoveFromSuperviewWhileInFullscreen;
 - (void)videoControlsManagerDidChange;
+- (void)didExitFullscreen;
 
 #if PLATFORM(VISION)
 - (void)toggleSceneDimming;

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -1926,6 +1926,22 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 #endif
 }
 
+- (void)didExitFullscreen
+{
+#if PLATFORM(VISION)
+    if (!self.isFullScreen || !WebKit::useSpatialFullScreenTransition())
+        return;
+
+    // FIXME 126894293: When entering video fullscreen, LinearMediaKit changes the client scene's
+    // windows' transform3D, then fails to restore them to their original values when exiting
+    // fullscreen. As a result, the element fullscreen window may no longer be frontmost when
+    // exiting back to element fullscreen from video fullscreen. Work around this by restoring the
+    // expected transform3D values here.
+    [_lastKnownParentWindow setTransform3D:CATransform3DTranslate([_lastKnownParentWindow transform3D], 0, 0, kOutgoingWindowZOffset)];
+    [_window setTransform3D:[_parentWindowState transform3D]];
+#endif
+}
+
 @end
 
 #if PLATFORM(VISION) && ENABLE(QUICKLOOK_FULLSCREEN)


### PR DESCRIPTION
#### 4fb78297f66382824d32daea416bcdccc940a801
<pre>
[visionOS] When transitioning from video fullscreen to element fullscreen, the element fullscreen window is not frontmost
<a href="https://bugs.webkit.org/show_bug.cgi?id=273100">https://bugs.webkit.org/show_bug.cgi?id=273100</a>
<a href="https://rdar.apple.com/126642251">rdar://126642251</a>

Reviewed by Wenson Hsieh and Aditya Keerthi.

When entering video fullscreen LinearMediaKit changes the client scene&apos;s windows&apos; transform3D, then
fails to restore them to their original values when exiting fullscreen. As a result, the element
fullscreen window may no longer be frontmost when exiting back to element fullscreen.

This issue was originally worked around in 277031@main by exiting element fullscreen when entering
video fullscreen, but this was suboptimal since users expect to return to element fullscreen if
that&apos;s the state they were in when entering video fullscreen. This change improves the workaround by
instead restoring the expected transform3Ds on both the element fullscreen window and WKWebView&apos;s
window when exiting video fullscreen.

Note that this change also removes dead code in -[WKContentViewInteraction _did(Enter|Exit)Fullscreen]
so that hooking up PageClientImpl::did(Enter|Exit)Fullscreen does not cause an unintended behavior
change.

* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionManagerProxy::setVideoReceiverEndpoint):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didEnterFullscreen):
(WebKit::WebPageProxy::didExitFullscreen):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::didExitFullscreen):
(WebKit::PageClientImpl::didEnterFullscreen): Deleted.
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _didEnterFullscreen]): Deleted.
(-[WKContentView _didExitFullscreen]): Deleted.
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController didExitFullscreen]):

Canonical link: <a href="https://commits.webkit.org/277877@main">https://commits.webkit.org/277877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be70f9cf38df3a351f3b10327d38c43aab68b34c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48809 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51775 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51495 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44875 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33964 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25550 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39898 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25665 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42085 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20999 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23134 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6864 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45062 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43755 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53411 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20129 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47202 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25123 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42292 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46147 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10755 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25930 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24843 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->