### PR TITLE
Re-deploy CheckedPtr in Node / ContainerNode

### DIFF
--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -95,7 +95,7 @@ ALWAYS_INLINE auto ContainerNode::removeAllChildrenWithScriptAssertion(ChildChan
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
         RELEASE_ASSERT(!connectedSubframeCount() && !hasRareData() && !wrapper());
         bool hadElementChild = false;
-        while (RefPtr child = m_firstChild) {
+        while (RefPtr child = m_firstChild.get()) {
             hadElementChild |= is<Element>(*child);
             removeBetween(nullptr, child->protectedNextSibling().get(), *child);
         }
@@ -137,7 +137,7 @@ ALWAYS_INLINE auto ContainerNode::removeAllChildrenWithScriptAssertion(ChildChan
 
         RefAllowingPartiallyDestroyed<Document> { document() }->nodeChildrenWillBeRemoved(*this);
 
-        while (RefPtr child = m_firstChild) {
+        while (RefPtr child = m_firstChild.get()) {
             if (is<Element>(*child))
                 hadElementChild = true;
 
@@ -577,14 +577,14 @@ void ContainerNode::insertBeforeCommon(Node& nextChild, Node& newChild)
     ASSERT(!newChild.isShadowRoot());
 
     RefPtr previousSibling = nextChild.previousSibling();
-    ASSERT(m_lastChild != previousSibling);
+    ASSERT(m_lastChild.get() != previousSibling);
     nextChild.setPreviousSibling(&newChild);
     if (previousSibling) {
-        ASSERT(m_firstChild != &nextChild);
+        ASSERT(m_firstChild.get() != &nextChild);
         ASSERT(previousSibling->nextSibling() == &nextChild);
         previousSibling->setNextSibling(&newChild);
     } else {
-        ASSERT(m_firstChild == &nextChild);
+        ASSERT(m_firstChild.get() == &nextChild);
         m_firstChild = &newChild;
     }
     newChild.setParentNode(this);
@@ -747,19 +747,19 @@ void ContainerNode::removeBetween(Node* previousChild, Node* nextChild, Node& ol
         nextChild->setPreviousSibling(previousChild);
         oldChild.setNextSibling(nullptr);
     } else {
-        ASSERT(m_lastChild == &oldChild);
+        ASSERT(m_lastChild.get() == &oldChild);
         m_lastChild = previousChild;
     }
     if (previousChild) {
         previousChild->setNextSibling(nextChild);
         oldChild.setPreviousSibling(nullptr);
     } else {
-        ASSERT(m_firstChild == &oldChild);
+        ASSERT(m_firstChild.get() == &oldChild);
         m_firstChild = nextChild;
     }
 
-    ASSERT(m_firstChild != &oldChild);
-    ASSERT(m_lastChild != &oldChild);
+    ASSERT(m_firstChild.get() != &oldChild);
+    ASSERT(m_lastChild.get() != &oldChild);
     ASSERT(!oldChild.previousSibling());
     ASSERT(!oldChild.nextSibling());
     oldChild.setParentNode(nullptr);

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -37,14 +37,14 @@ class ContainerNode : public Node {
 public:
     virtual ~ContainerNode();
 
-    Node* firstChild() const { return m_firstChild; }
-    RefPtr<Node> protectedFirstChild() const { return m_firstChild; }
+    Node* firstChild() const { return m_firstChild.get(); }
+    RefPtr<Node> protectedFirstChild() const { return m_firstChild.get(); }
     static ptrdiff_t firstChildMemoryOffset() { return OBJECT_OFFSETOF(ContainerNode, m_firstChild); }
-    Node* lastChild() const { return m_lastChild; }
-    RefPtr<Node> protectedLastChild() const { return m_lastChild; }
+    Node* lastChild() const { return m_lastChild.get(); }
+    RefPtr<Node> protectedLastChild() const { return m_lastChild.get(); }
     static ptrdiff_t lastChildMemoryOffset() { return OBJECT_OFFSETOF(ContainerNode, m_lastChild); }
-    bool hasChildNodes() const { return m_firstChild; }
-    bool hasOneChild() const { return m_firstChild && m_firstChild == m_lastChild; }
+    bool hasChildNodes() const { return !!m_firstChild; }
+    bool hasOneChild() const { return !!m_firstChild && m_firstChild.get() == m_lastChild.get(); }
 
     bool directChildNeedsStyleRecalc() const { return hasStyleFlag(NodeStyleFlag::DirectChildNeedsStyleResolution); }
     void setDirectChildNeedsStyleRecalc() { setStyleFlag(NodeStyleFlag::DirectChildNeedsStyleResolution); }
@@ -173,8 +173,8 @@ private:
 
     bool isContainerNode() const = delete;
 
-    Node* m_firstChild { nullptr };
-    Node* m_lastChild { nullptr };
+    CheckedPtr<Node> m_firstChild;
+    CheckedPtr<Node> m_lastChild;
 };
 
 inline ContainerNode::ContainerNode(Document& document, NodeType type, OptionSet<TypeFlag> typeFlags)

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -109,7 +109,7 @@ WTF_MAKE_COMPACT_ISO_ALLOCATED_IMPL(Node);
 
 using namespace HTMLNames;
 
-struct SameSizeAsNode : EventTarget {
+struct SameSizeAsNode : EventTarget, CanMakeCheckedPtr<SameSizeAsNode> {
 #if ASSERT_ENABLED
     uint32_t m_isAllocatedMemory;
     bool inRemovedLastRefFunction;

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -96,8 +96,9 @@ using NodeOrStringOrTrustedScript = std::variant<RefPtr<Node>, String, RefPtr<Tr
 const int initialNodeVectorSize = 11; // Covers 99.5%. See webkit.org/b/80706
 typedef Vector<Ref<Node>, initialNodeVectorSize> NodeVector;
 
-class Node : public EventTarget {
+class Node : public EventTarget, public CanMakeCheckedPtr<Node> {
     WTF_MAKE_COMPACT_ISO_ALLOCATED(Node);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Node);
 
     friend class Document;
     friend class TreeScope;
@@ -159,8 +160,8 @@ public:
 #else
     static uintptr_t previousSiblingPointerMask() { return -1; }
 #endif
-    Node* nextSibling() const { return m_next; }
-    RefPtr<Node> protectedNextSibling() const { return m_next; }
+    Node* nextSibling() const { return m_next.get(); }
+    RefPtr<Node> protectedNextSibling() const { return m_next.get(); }
     static ptrdiff_t nextSiblingMemoryOffset() { return OBJECT_OFFSETOF(Node, m_next); }
     WEBCORE_EXPORT RefPtr<NodeList> childNodes();
     Node* firstChild() const;
@@ -804,10 +805,10 @@ private:
     const uint16_t m_typeBitFields;
     mutable OptionSet<StateFlag> m_stateFlags;
 
-    ContainerNode* m_parentNode { nullptr };
+    CheckedPtr<ContainerNode> m_parentNode;
     TreeScope* m_treeScope { nullptr };
     CompactPointerTuple<Node*, uint16_t> m_previous;
-    Node* m_next { nullptr };
+    CheckedPtr<Node> m_next;
     CompactPointerTuple<RenderObject*, uint16_t> m_rendererWithStyleFlags;
     CompactUniquePtrTuple<NodeRareData, uint16_t> m_rareDataWithBitfields;
 };
@@ -909,7 +910,7 @@ inline void addSubresourceURL(ListHashSet<URL>& urls, const URL& url)
 inline ContainerNode* Node::parentNode() const
 {
     ASSERT(isMainThreadOrGCThread());
-    return m_parentNode;
+    return m_parentNode.get();
 }
 
 inline ContainerNode* Node::parentNodeGuaranteedHostFree() const


### PR DESCRIPTION
#### b49a6df95f7d4e1c2a728c12d09a95dbcd624415
<pre>
Re-deploy CheckedPtr in Node / ContainerNode
<a href="https://bugs.webkit.org/show_bug.cgi?id=273107">https://bugs.webkit.org/show_bug.cgi?id=273107</a>

Reviewed by NOBODY (OOPS!).

Re-deploy CheckedPtr in Node / ContainerNode, now that CheckedPtr
crashes should be more debuggable.

* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::removeAllChildrenWithScriptAssertion):
(WebCore::ContainerNode::insertBeforeCommon):
(WebCore::ContainerNode::removeBetween):
* Source/WebCore/dom/ContainerNode.h:
(WebCore::ContainerNode::firstChild const):
(WebCore::ContainerNode::protectedFirstChild const):
(WebCore::ContainerNode::lastChild const):
(WebCore::ContainerNode::protectedLastChild const):
(WebCore::ContainerNode::hasChildNodes const):
(WebCore::ContainerNode::hasOneChild const):
(): Deleted.
* Source/WebCore/dom/Node.cpp:
* Source/WebCore/dom/Node.h:
(WebCore::Node::nextSibling const):
(WebCore::Node::protectedNextSibling const):
(WebCore::Node::parentNode const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b49a6df95f7d4e1c2a728c12d09a95dbcd624415

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48792 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51755 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51478 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44858 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51097 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25533 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39886 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49374 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25645 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42080 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20985 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23111 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43261 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6847 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45047 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43750 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53389 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23842 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20110 "Found 60 new test failures: accessibility/ARIA-reflection.html, accessibility/accessibility-crash-focused-element-change.html, accessibility/accessibility-crash-setattribute.html, accessibility/combobox/aria-combobox-control-owns-elements.html, accessibility/combobox/aria-combobox-hierarchy.html, accessibility/combobox/aria-combobox-no-owns.html, accessibility/combobox/aria-combobox.html, accessibility/combobox/mac/aria-combobox-activedescendant.html, accessibility/combobox/mac/combobox-activedescendant-notifications.html, accessibility/combobox/mac/combobox-value.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47188 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25105 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42286 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46131 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25913 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24826 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->