### PR TITLE
[webkitpy] Wrong simulator sometimes chosen when a device is named "Managed 0"

### DIFF
--- a/Tools/Scripts/webkitpy/xcode/simulated_device.py
+++ b/Tools/Scripts/webkitpy/xcode/simulated_device.py
@@ -290,7 +290,7 @@ class SimulatedDeviceManager(object):
         assert device_identifier is not None
 
         for device in cls.available_devices(host):
-            if device.platform_device.name == name:
+            if device.platform_device.name == name and device.platform_device.device_type == device_type and device.platform_device.build_version == runtime.build_version:
                 device.platform_device._delete()
                 break
 
@@ -300,7 +300,7 @@ class SimulatedDeviceManager(object):
         # We just added a device, so our list of _available_devices needs to be re-synced.
         cls.populate_available_devices(host)
         for device in cls.available_devices(host):
-            if device.platform_device.name == name:
+            if device.platform_device.name == name and device.platform_device.device_type == device_type and device.platform_device.build_version == runtime.build_version:
                 device.platform_device.managed_by_script = True
                 return device
         return None


### PR DESCRIPTION
#### 7b0e37e37c6f855170b488cba2cbd456c6eb4623
<pre>
[webkitpy] Wrong simulator sometimes chosen when a device is named &quot;Managed 0&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=273105">https://bugs.webkit.org/show_bug.cgi?id=273105</a>
<a href="https://rdar.apple.com/126884847">rdar://126884847</a>

Reviewed by Jonathan Bedard.

When running webkit tests in a simulator, webkitpy needs to either find or create a device
that satisfies the request. For instance, if a user passes the `--ios-simulator` flag,
webkitpy needs to either find a booted simulator that matches the request, or create and
boot such a device.

By default, devices are named &quot;Managed X&quot;, where X is an integer that increments with each
simulator that is booted. When webkitpy was created, iOS was the only simulator, so the
only check to validate a simulator after creation is that the name matches the next
available iteration of X.

Now that there are more types of OS simulators, having, for instance, a visionOS simulator
with the name &quot;Managed 0&quot; will override the --ios-simulator flag such that the existing
visionOS simulator is booted instead of the newly created iOS simulator with the same name.

This PR adds extra heuristics to check the device&apos;s type and OS build version before
assuming it&apos;s a match. This locks the simulator device and OS to the requested version,
ensuring the correct simulator is always booted.

* Tools/Scripts/webkitpy/xcode/simulated_device.py:
(SimulatedDeviceManager._create_or_find_device_for_request): Added check for device type and OS build version when finding a newly created simulated device.

Canonical link: <a href="https://commits.webkit.org/277884@main">https://commits.webkit.org/277884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24ea070e6a0b31421ed7f3bcc616bf816d7ec900

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51479 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44859 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51098 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25534 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39891 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49375 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25648 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42071 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20990 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/48702 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23122 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43252 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6848 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45050 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53390 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23843 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20108 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47184 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25108 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46127 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10762 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25914 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24827 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->