### PR TITLE
Avoid creating compositing scrolling layers for zero-sized scrollers

### DIFF
--- a/LayoutTests/compositing/scrolling/async-overflow-scrolling/no-compositing-for-zero-sized-scrollers-expected.txt
+++ b/LayoutTests/compositing/scrolling/async-overflow-scrolling/no-compositing-for-zero-sized-scrollers-expected.txt
@@ -1,0 +1,82 @@
+ 
+ 
+ 
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (position 18.00 10.00)
+          (bounds 110.00 110.00)
+          (drawsContent 1)
+          (children 2
+            (GraphicsLayer
+              (offsetFromRenderer width=5 height=5)
+              (position 5.00 5.00)
+              (bounds 100.00 85.00)
+              (clips 1)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=5 height=5)
+                  (anchor 0.00 0.00)
+                  (bounds 200.00 85.00)
+                  (drawsContent 1)
+                )
+              )
+            )
+            (GraphicsLayer
+              (position 5.00 5.00)
+              (bounds 100.00 100.00)
+              (clips 1)
+              (children 1
+                (GraphicsLayer
+                  (position 0.00 85.00)
+                  (bounds 100.00 15.00)
+                  (drawsContent 1)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 18.00 370.00)
+          (bounds 11.00 110.00)
+          (drawsContent 1)
+          (children 2
+            (GraphicsLayer
+              (offsetFromRenderer width=5 height=5)
+              (position 5.00 5.00)
+              (bounds 1.00 85.00)
+              (clips 1)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=5 height=5)
+                  (anchor 0.00 0.00)
+                  (bounds 4.00 85.00)
+                  (drawsContent 1)
+                )
+              )
+            )
+            (GraphicsLayer
+              (position 5.00 5.00)
+              (bounds 1.00 100.00)
+              (clips 1)
+              (children 1
+                (GraphicsLayer
+                  (position 0.00 85.00)
+                  (bounds 1.00 15.00)
+                  (drawsContent 1)
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/scrolling/async-overflow-scrolling/no-compositing-for-zero-sized-scrollers.html
+++ b/LayoutTests/compositing/scrolling/async-overflow-scrolling/no-compositing-for-zero-sized-scrollers.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        .scroller {
+            margin: 10px;
+            width: 100px;
+            height: 100px;
+            overflow: auto;
+            border: 5px solid black;
+        }
+        
+        .contents {
+            width: 200%;
+        }
+    </style>
+
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        window.addEventListener('load', () => {
+            setTimeout(() => {
+                if (window.internals)
+                    document.getElementById('layers').innerText = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_CLIPPING);
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+            }, 0);
+        }, false);
+    </script>
+
+</head>
+<body>
+    <div class="scroller">
+        <div class="contents">&nbsp;</div>
+    </div>
+    <div class="scroller" style="width: 0px">
+        <div class="contents">&nbsp;</div>
+    </div>
+    <div class="scroller" style="width: 0.3px">
+        <div class="contents">&nbsp;</div>
+    </div>
+    <div class="scroller" style="width: 0.5px">
+        <div class="contents">&nbsp;</div>
+    </div>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/LayoutTests/compositing/updates/no-updates-in-non-composited-iframe-expected.txt
+++ b/LayoutTests/compositing/updates/no-updates-in-non-composited-iframe-expected.txt
@@ -1,4 +1,4 @@
-Test that compositing updates do not happen in an iframe with no compoting layers.
+Test that compositing updates do not happen in an iframe with no compositing layers.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 

--- a/LayoutTests/compositing/updates/no-updates-in-non-composited-iframe.html
+++ b/LayoutTests/compositing/updates/no-updates-in-non-composited-iframe.html
@@ -4,7 +4,7 @@
 <head>
     <script src="../../resources/js-test-pre.js"></script>
     <script>
-        description('Test that compositing updates do not happen in an iframe with no compoting layers.');
+        description('Test that compositing updates do not happen in an iframe with no compositing layers.');
         window.jsTestIsAsync = true;
 
         let updateCount;

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1710,15 +1710,31 @@ bool RenderLayer::updateLayerPosition(OptionSet<UpdateLayerPositionsFlag>* flags
     auto layerRect = computeLayerPositionAndIntegralSize(renderer());
     auto localPoint = layerRect.location();
 
-    if (IntSize newSize(layerRect.width().toInt(), layerRect.height().toInt()); newSize != size()) {
+    auto newSize = flooredIntSize(layerRect.size());
+    if (newSize != size()) {
         setSize(newSize);
 
         if (flags && renderer().hasNonVisibleOverflow())
             flags->add(ContainingClippingLayerChangedSize);
+    }
 
-        // Trigger RenderLayerCompositor::requiresCompositingForFrame() which depends on the contentBoxRect size.
-        if (compositor().hasCompositedWidgetContents(renderer()))
+    if (auto* box = renderBox(); box && box->scrollsOverflow()) {
+        auto clientSize = LayoutSize { box->clientWidth(), box->clientHeight() };
+        if (!m_haveClientSizeAtLastLayout || m_clientSizeAtLastLayout != clientSize) {
             setNeedsPostLayoutCompositingUpdate();
+            m_clientSizeAtLastLayout = clientSize;
+            m_haveClientSizeAtLastLayout = true;
+        }
+    }
+
+    if (compositor().hasCompositedWidgetContents(renderer())) {
+        auto snappedContentBoxSize = snappedIntRect(renderBox()->contentBoxRect()).size();
+
+        if (!m_haveContentBoxSizeAtLastLayout || m_contentBoxSizeAtLastLayout != snappedContentBoxSize) {
+            setNeedsPostLayoutCompositingUpdate();
+            m_contentBoxSizeAtLastLayout = snappedContentBoxSize;
+            m_haveContentBoxSizeAtLastLayout = true;
+        }
     }
 
     if (!renderer().isOutOfFlowPositioned()) {
@@ -5493,8 +5509,6 @@ void RenderLayer::styleChanged(StyleDifference diff, const RenderStyle* oldStyle
 #if PLATFORM(IOS_FAMILY) && ENABLE(TOUCH_EVENTS)
     if (diff == StyleDifference::RecompositeLayer || diff >= StyleDifference::LayoutPositionedMovementOnly)
         renderer().document().invalidateRenderingDependentRegions();
-#else
-    UNUSED_PARAM(diff);
 #endif
 }
 

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1262,6 +1262,8 @@ private:
     bool m_hasNotIsolatedBlendingDescendants : 1;
     bool m_hasNotIsolatedBlendingDescendantsStatusDirty : 1;
     bool m_repaintRectsValid : 1;
+    bool m_haveClientSizeAtLastLayout : 1 { false };
+    bool m_haveContentBoxSizeAtLastLayout : 1 { false };
 
     RenderLayerModelObject& m_renderer;
 
@@ -1294,6 +1296,9 @@ private:
 
     // The layer's width/height
     IntSize m_layerSize;
+
+    LayoutSize m_clientSizeAtLastLayout; // Valid if m_haveClientSizeAtLastLayout is true.
+    IntSize m_contentBoxSizeAtLastLayout; // Valid if m_haveContentBoxSizeAtLastLayout is true.
 
     std::unique_ptr<ClipRectsCache> m_clipRectsCache;
 


### PR DESCRIPTION
#### 33321a3fb2c03d726cb701e8efad2e4e4d7d1f71
<pre>
Avoid creating compositing scrolling layers for zero-sized scrollers
<a href="https://bugs.webkit.org/show_bug.cgi?id=273110">https://bugs.webkit.org/show_bug.cgi?id=273110</a>
<a href="https://rdar.apple.com/113980927">rdar://113980927</a>

Reviewed by NOBODY (OOPS!).

Some CMSs can create large tables with many columns which may have &lt; 1px widths. If the cells in these columns have scrollable
overflow, then we can create composited scrollers for many layers which have zero height or width, making them not interactive.
In such cases, we can avoid the overhead of composited scrolling, which also avoids the backing sharing code which has poor
performance with many sibling scrollers.

Fix by adjusting `RenderLayerScrollableArea::canUseCompositedScrolling()` to return false if the clientWidth or clientHeight
of the layer is zero (this is the area used by scrollable content).

Because `canUseCompositedScrolling()` now depends on layout, we need to have `RenderLayer::updateLayerPosition()` set the
&quot;NeedsPostLayoutCompositingUpdate&quot; bit on the RenderLayer when the client size changes. The existing code keyed off of
the layer size changing for a similar invalidation relating to composited widgets, but this was incorrect, as the code
in question actually checks the content box size, so fix both code paths to use a &quot;size at last layout&quot; caching strategy.

* LayoutTests/compositing/scrolling/async-overflow-scrolling/no-compositing-for-zero-sized-scrollers-expected.txt: Added.
* LayoutTests/compositing/scrolling/async-overflow-scrolling/no-compositing-for-zero-sized-scrollers.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::updateLayerPosition):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::canUseCompositedScrolling const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33321a3fb2c03d726cb701e8efad2e4e4d7d1f71

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48802 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51488 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44868 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33956 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25543 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39893 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-contain/contain-size-block-003.html, imported/w3c/web-platform-tests/css/css-contain/contain-size-inline-block-003.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49384 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25661 "Found 60 new test failures: accessibility/ios-simulator/scroll-in-overflow-div.html, compositing/backing/foreground-layer-no-paints-into-ancestor.html, compositing/clipping/border-radius-async-overflow-non-stacking.html, compositing/geometry/fixed-inside-overflow-scroll.html, compositing/geometry/rtl-overflow-scroll.html, compositing/ios/rtl-overflow-scrolling-2.html, compositing/layer-creation/absolute-in-async-overflow-scroll.html, compositing/layer-creation/clipping-scope/deeply-nested-overflow.html, compositing/layer-creation/clipping-scope/nested-scroller-overlap.html, compositing/layer-creation/clipping-scope/overlap-constrained-inside-scroller.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42081 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20992 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23123 "Exiting early after 10 failures. 20 tests run. 1 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43262 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6857 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45055 "Found 81 new API test failures: TestWebKitAPI.TextManipulation.CompleteTextManipulationAddsOverflowHiddenToAvoidBreakingLayout, TestWebKitAPI.DragAndDropTests.CanPreventStart, TestWebKitAPI.DragAndDropTests.SinglePlainTextWordTypeIdentifiers, TestWebKitAPI.DragAndDropTests.ExternalSourceMapItemIntoEditableAreas, TestWebKitAPI.WKNavigation.WebProcessLimit, TestWebKitAPI.HSTS.Preconnect, TestWebKitAPI.WebAuthenticationPanel.NoPanelHidSuccess, TestWebKitAPI.WebAuthenticationPanel.PanelHidSuccess1, TestWebKitAPI.URLSchemeHandler.Exceptions, TestWebKitAPI.UIPasteboardTests.PasteURLWithPlainTextAsURL ... (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43751 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-contain/contain-size-block-003.html, imported/w3c/web-platform-tests/css/css-contain/contain-size-inline-block-003.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53399 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23853 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20122 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-contain/contain-size-block-003.html, imported/w3c/web-platform-tests/css/css-contain/contain-size-inline-block-003.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47194 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25116 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42287 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46138 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25923 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24836 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->