### PR TITLE
[LBSE] Adopt more smart pointers in SVG code

### DIFF
--- a/Source/WebCore/rendering/ReferencedSVGResources.cpp
+++ b/Source/WebCore/rendering/ReferencedSVGResources.cpp
@@ -91,7 +91,7 @@ ReferencedSVGResources::ReferencedSVGResources(RenderElement& renderer)
 
 ReferencedSVGResources::~ReferencedSVGResources()
 {
-    auto& treeScope = m_renderer.treeScopeForSVGReferences();
+    Ref treeScope = m_renderer.treeScopeForSVGReferences();
     for (auto& targetID : copyToVector(m_elementClients.keys()))
         removeClientForTarget(treeScope, targetID);
 }
@@ -237,7 +237,7 @@ RefPtr<SVGClipPathElement> ReferencedSVGResources::referencedClipPathElement(Tre
 
 RefPtr<SVGMarkerElement> ReferencedSVGResources::referencedMarkerElement(TreeScope& treeScope, const String& markerResource)
 {
-    auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(markerResource, treeScope.documentScope());
+    auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(markerResource, treeScope.protectedDocumentScope());
     if (resourceID.isEmpty())
         return nullptr;
 
@@ -247,11 +247,11 @@ RefPtr<SVGMarkerElement> ReferencedSVGResources::referencedMarkerElement(TreeSco
 
 RefPtr<SVGMaskElement> ReferencedSVGResources::referencedMaskElement(TreeScope& treeScope, const StyleImage& maskImage)
 {
-    auto reresolvedURL = maskImage.reresolvedURL(treeScope.documentScope());
+    auto reresolvedURL = maskImage.reresolvedURL(treeScope.protectedDocumentScope());
     if (reresolvedURL.isEmpty())
         return nullptr;
 
-    auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(reresolvedURL.string(), treeScope.documentScope());
+    auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(reresolvedURL.string(), treeScope.protectedDocumentScope());
     if (resourceID.isEmpty())
         return nullptr;
 
@@ -261,7 +261,7 @@ RefPtr<SVGMaskElement> ReferencedSVGResources::referencedMaskElement(TreeScope& 
 
 RefPtr<SVGElement> ReferencedSVGResources::referencedPaintServerElement(TreeScope& treeScope, const String& uri)
 {
-    auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(uri, treeScope.documentScope());
+    auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(uri, treeScope.protectedDocumentScope());
     if (resourceID.isEmpty())
         return nullptr;
 

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -484,7 +484,7 @@ RenderSVGResourceMasker* RenderLayerModelObject::svgMaskerResourceFromStyle() co
     if (reresolvedURL.isEmpty())
         return nullptr;
 
-    auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(reresolvedURL.string(), document());
+    auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(reresolvedURL.string(), protectedDocument());
 
     if (RefPtr referencedMaskElement = ReferencedSVGResources::referencedMaskElement(treeScopeForSVGReferences(), *maskImage)) {
         if (auto* referencedMaskerRenderer = dynamicDowncast<RenderSVGResourceMasker>(referencedMaskElement->renderer()))

--- a/Source/WebCore/rendering/style/StyleCachedImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCachedImage.cpp
@@ -106,7 +106,7 @@ LegacyRenderSVGResourceContainer* StyleCachedImage::uncheckedRenderSVGResource(c
         return nullptr;
     }
 
-    auto& document = renderer->document();
+    Ref document = renderer->document();
     auto reresolvedURL = this->reresolvedURL(document);
 
     if (!m_cachedImage) {

--- a/Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp
@@ -77,7 +77,7 @@ void RenderSVGGradientStop::layout()
 
 SVGGradientElement* RenderSVGGradientStop::gradientElement()
 {
-    return dynamicDowncast<SVGGradientElement>(element().parentElement());
+    return dynamicDowncast<SVGGradientElement>(element().protectedParentElement().get());
 }
 
 }

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -358,7 +358,7 @@ void RenderSVGImage::imageChanged(WrappedImagePtr newImage, const IntRect* rect)
 
     repaintOrMarkForLayout(rect);
 
-    if (AXObjectCache* cache = document().existingAXObjectCache())
+    if (CheckedPtr cache = document().existingAXObjectCache())
         cache->deferRecomputeIsIgnoredIfNeeded(protectedImageElement().ptr());
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -278,7 +278,7 @@ Path RenderSVGModelObject::computeClipPath(AffineTransform& transform) const
     if (layer()->isTransformed())
         transform.multiply(layer()->currentTransform(RenderStyle::individualTransformOperations()).toAffineTransform());
 
-    if (RefPtr useElement = dynamicDowncast<SVGUseElement>(element())) {
+    if (RefPtr useElement = dynamicDowncast<SVGUseElement>(protectedElement())) {
         if (CheckedPtr clipChildRenderer = useElement->rendererClipChild())
             transform.multiply(downcast<RenderLayerModelObject>(*clipChildRenderer).checkedLayer()->currentTransform(RenderStyle::individualTransformOperations()).toAffineTransform());
         if (RefPtr clipChild = useElement->clipChild())

--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
@@ -87,14 +87,14 @@ static inline void notifyResourceChanged(SVGElement& element)
 
 void RenderSVGResourceContainer::registerResource()
 {
-    auto& treeScope = this->treeScopeForSVGReferences();
-    if (!treeScope.isIdOfPendingSVGResource(m_id))
+    Ref treeScope = this->treeScopeForSVGReferences();
+    if (!treeScope->isIdOfPendingSVGResource(m_id))
         return;
 
-    auto elements = copyToVectorOf<Ref<SVGElement>>(treeScope.removePendingSVGResource(m_id));
+    auto elements = copyToVectorOf<Ref<SVGElement>>(treeScope->removePendingSVGResource(m_id));
     for (auto& element : elements) {
         ASSERT(element->hasPendingResources());
-        treeScope.clearHasPendingSVGResourcesIfPossible(element);
+        treeScope->clearHasPendingSVGResourcesIfPossible(element);
         notifyResourceChanged(element.get());
     }
 }

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp
@@ -91,16 +91,16 @@ void RenderSVGResourceMarker::updateLayerTransform()
     ASSERT(hasLayer());
 
     // First update the supplemental layer transform.
-    auto& useMarkerElement = markerElement();
+    Ref useMarkerElement = markerElement();
     auto viewportSize = this->viewportSize();
 
     m_supplementalLayerTransform.makeIdentity();
 
-    if (useMarkerElement.hasAttribute(SVGNames::viewBoxAttr)) {
+    if (useMarkerElement->hasAttribute(SVGNames::viewBoxAttr)) {
         // An empty viewBox disables the rendering -- dirty the visible descendant status!
-        if (useMarkerElement.hasEmptyViewBox())
+        if (useMarkerElement->hasEmptyViewBox())
             layer()->dirtyVisibleContentStatus();
-        else if (auto viewBoxTransform = useMarkerElement.viewBoxToViewTransform(viewportSize.width(), viewportSize.height()); !viewBoxTransform.isIdentity())
+        else if (auto viewBoxTransform = useMarkerElement->viewBoxToViewTransform(viewportSize.width(), viewportSize.height()); !viewBoxTransform.isIdentity())
             m_supplementalLayerTransform = viewBoxTransform;
     }
 
@@ -124,11 +124,11 @@ void RenderSVGResourceMarker::applyTransform(TransformationMatrix& transform, co
 
 LayoutRect RenderSVGResourceMarker::overflowClipRect(const LayoutPoint& location, RenderFragmentContainer*, OverlayScrollbarSizeRelevancy, PaintPhase) const
 {
-    auto& useMarkerElement = markerElement();
+    Ref useMarkerElement = markerElement();
 
     auto clipRect = enclosingLayoutRect(viewport());
-    if (useMarkerElement.hasAttribute(SVGNames::viewBoxAttr)) {
-        if (useMarkerElement.hasEmptyViewBox())
+    if (useMarkerElement->hasAttribute(SVGNames::viewBoxAttr)) {
+        if (useMarkerElement->hasEmptyViewBox())
             return { };
 
         if (!m_supplementalLayerTransform.isIdentity())

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
@@ -98,8 +98,8 @@ void RenderSVGResourceMasker::applyMask(PaintInfo& paintInfo, const RenderLayerM
         context.translate(coordinateSystemOriginTranslation);
 
     AffineTransform contentTransform;
-    auto& maskElement = this->maskElement();
-    if (maskElement.maskContentUnits() == SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX) {
+    Ref maskElement = this->maskElement();
+    if (maskElement->maskContentUnits() == SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX) {
         contentTransform.translate(objectBoundingBox.x(), objectBoundingBox.y());
         contentTransform.scale(objectBoundingBox.width(), objectBoundingBox.height());
     }

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -276,7 +276,7 @@ void SVGRenderSupport::layoutChildren(RenderElement& start, bool selfNeedsLayout
 
         if (layoutSizeChanged) {
             // When selfNeedsLayout is false and the layout size changed, we have to check whether this child uses relative lengths
-            if (auto* element = dynamicDowncast<SVGElement>(*child.node()); element && element->hasRelativeLengths()) {
+            if (RefPtr element = dynamicDowncast<SVGElement>(child.node()); element && element->hasRelativeLengths()) {
                 // When the layout size changed and when using relative values tell the LegacyRenderSVGShape to update its shape object
                 if (CheckedPtr shape = dynamicDowncast<LegacyRenderSVGShape>(child))
                     shape->setNeedsShapeUpdate();
@@ -447,7 +447,7 @@ bool SVGRenderSupport::pointInClippingArea(const RenderElement& renderer, const 
 
 void SVGRenderSupport::applyStrokeStyleToContext(GraphicsContext& context, const RenderStyle& style, const RenderElement& renderer)
 {
-    RefPtr element = dynamicDowncast<SVGElement>(renderer.element());
+    auto element = dynamicDowncast<SVGElement>(renderer.protectedElement());
     if (!element) {
         ASSERT_NOT_REACHED();
         return;
@@ -507,15 +507,15 @@ bool SVGRenderSupport::isolatesBlending(const RenderStyle& style)
 
 void SVGRenderSupport::updateMaskedAncestorShouldIsolateBlending(const RenderElement& renderer)
 {
-    ASSERT(renderer.element());
-    ASSERT(renderer.element()->isSVGElement());
-
-    for (auto& ancestor : ancestorsOfType<SVGGraphicsElement>(*renderer.protectedElement())) {
-        auto* style = ancestor.computedStyle();
+    RefPtr element = renderer.element();
+    ASSERT(element);
+    ASSERT(element->isSVGElement());
+    for (Ref ancestor : ancestorsOfType<SVGGraphicsElement>(*element)) {
+        auto* style = ancestor->computedStyle();
         if (!style || !isolatesBlending(*style))
             continue;
         if (style->hasPositionedMask())
-            ancestor.setShouldIsolateBlending(renderer.style().hasBlendMode());
+            ancestor->setShouldIsolateBlending(renderer.style().hasBlendMode());
         return;
     }
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp
@@ -178,7 +178,7 @@ static void removeFromCacheAndInvalidateDependencies(RenderElement& renderer, bo
             clipper->removeClientFromCache(renderer);
     }
 
-    RefPtr svgElement = dynamicDowncast<SVGElement>(renderer.element());
+    auto svgElement = dynamicDowncast<SVGElement>(renderer.protectedElement());
     if (!svgElement)
         return;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
@@ -194,20 +194,20 @@ void LegacyRenderSVGResourceContainer::removeClientRenderLayer(RenderLayer& clie
 
 void LegacyRenderSVGResourceContainer::registerResource()
 {
-    auto& treeScope = this->treeScopeForSVGReferences();
-    if (!treeScope.isIdOfPendingSVGResource(m_id)) {
-        treeScope.addSVGResource(m_id, *this);
+    Ref treeScope = this->treeScopeForSVGReferences();
+    if (!treeScope->isIdOfPendingSVGResource(m_id)) {
+        treeScope->addSVGResource(m_id, *this);
         return;
     }
 
-    auto elements = copyToVectorOf<Ref<SVGElement>>(treeScope.removePendingSVGResource(m_id));
+    auto elements = copyToVectorOf<Ref<SVGElement>>(treeScope->removePendingSVGResource(m_id));
 
-    treeScope.addSVGResource(m_id, *this);
+    treeScope->addSVGResource(m_id, *this);
 
     // Update cached resources of pending clients.
     for (auto& client : elements) {
         ASSERT(client->hasPendingResources());
-        treeScope.clearHasPendingSVGResourcesIfPossible(client);
+        treeScope->clearHasPendingSVGResourcesIfPossible(client);
         auto* renderer = client->renderer();
         if (!renderer)
             continue;

--- a/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
@@ -238,7 +238,7 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
             const FilterOperations& filterOperations = style.filter();
             if (filterOperations.size() == 1) {
                 if (RefPtr referenceFilterOperation = dynamicDowncast<ReferenceFilterOperation>(*filterOperations.at(0))) {
-                    AtomString id = SVGURIReference::fragmentIdentifierFromIRIString(referenceFilterOperation->url(), element->protectedDocument());
+                    AtomString id = SVGURIReference::fragmentIdentifierFromIRIString(referenceFilterOperation->url(), document);
                     if (auto* filter = getRenderSVGResourceById<LegacyRenderSVGResourceFilter>(treeScope, id))
                         ensureResources(foundResources).setFilter(filter);
                     else


### PR DESCRIPTION
#### b2ca06dc3d84b356d01cdf09a82049f80515fbfe
<pre>
[LBSE] Adopt more smart pointers in SVG code
<a href="https://bugs.webkit.org/show_bug.cgi?id=273113">https://bugs.webkit.org/show_bug.cgi?id=273113</a>

Reviewed by Sihui Liu.

Based on [alpha.webkit.UncountedCallArgsChecker] warnings.

* Source/WebCore/rendering/ReferencedSVGResources.cpp:
(WebCore::ReferencedSVGResources::~ReferencedSVGResources):
(WebCore::ReferencedSVGResources::referencedMarkerElement):
(WebCore::ReferencedSVGResources::referencedMaskElement):
(WebCore::ReferencedSVGResources::referencedPaintServerElement):
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::svgMaskerResourceFromStyle const):
* Source/WebCore/rendering/style/StyleCachedImage.cpp:
(WebCore::StyleCachedImage::uncheckedRenderSVGResource const):
* Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp:
(WebCore::RenderSVGGradientStop::gradientElement):
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
(WebCore::RenderSVGImage::imageChanged):
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::computeClipPath const):
* Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp:
(WebCore::RenderSVGResourceContainer::registerResource):
* Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp:
(WebCore::RenderSVGResourceMarker::updateLayerTransform):
(WebCore::RenderSVGResourceMarker::overflowClipRect const):
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp:
(WebCore::RenderSVGResourceMasker::applyMask):
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::layoutChildren):
(WebCore::SVGRenderSupport::applyStrokeStyleToContext):
(WebCore::SVGRenderSupport::updateMaskedAncestorShouldIsolateBlending):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp:
(WebCore::removeFromCacheAndInvalidateDependencies):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp:
(WebCore::LegacyRenderSVGResourceContainer::registerResource):
* Source/WebCore/rendering/svg/legacy/SVGResources.cpp:
(WebCore::SVGResources::buildCachedResources):

Canonical link: <a href="https://commits.webkit.org/277969@main">https://commits.webkit.org/277969@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6dab38d6ede463fc4f33223bd59fd51f55391881

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51634 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45017 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51252 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25688 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40012 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49792 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25805 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42200 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21120 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23265 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43370 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7002 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45193 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43874 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53545 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23998 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20256 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47322 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25261 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42409 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46280 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10801 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26070 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24981 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->