### PR TITLE
[Skia] Create the fence after flush and submit

### DIFF
--- a/Source/WebCore/platform/graphics/egl/GLFence.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLFence.cpp
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-bool isGLFenceSyncSupported()
+bool GLFence::isSupported()
 {
     static std::once_flag onceFlag;
     static bool supported = false;
@@ -51,14 +51,15 @@ bool isGLFenceSyncSupported()
     return supported;
 }
 
-std::unique_ptr<GLFence> GLFence::create()
+std::unique_ptr<GLFence> GLFence::create(ShouldFlush shouldFlush)
 {
     if (!GLContextWrapper::currentContext())
         return nullptr;
 
-    if (isGLFenceSyncSupported()) {
+    if (isSupported()) {
         if (auto* sync = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0)) {
-            glFlush();
+            if (shouldFlush == ShouldFlush::Yes)
+                glFlush();
             return makeUnique<GLFence>(sync);
         }
         return nullptr;

--- a/Source/WebCore/platform/graphics/egl/GLFence.h
+++ b/Source/WebCore/platform/graphics/egl/GLFence.h
@@ -30,7 +30,9 @@ class GLFence {
     WTF_MAKE_NONCOPYABLE(GLFence);
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    WEBCORE_EXPORT static std::unique_ptr<GLFence> create();
+    static bool isSupported();
+    enum class ShouldFlush : bool { No, Yes };
+    WEBCORE_EXPORT static std::unique_ptr<GLFence> create(ShouldFlush = ShouldFlush::Yes);
     explicit GLFence(GLsync);
     ~GLFence();
 


### PR DESCRIPTION
#### 83c5e98d79948e06e2644c4ac2d0f81efdda5c63
<pre>
[Skia] Create the fence after flush and submit
<a href="https://bugs.webkit.org/show_bug.cgi?id=273115">https://bugs.webkit.org/show_bug.cgi?id=273115</a>

Reviewed by Miguel Gomez.

There might still be glitches because we create the GLFence before the
submit. Expose isGLFenceSyncSupported as static function
GLFence::isSupported() and use it to decide whether to sync cpu or not
in flushAndSubmit call. Also make the glFlush() in GLFence::create()
optional.

* Source/WebCore/platform/graphics/egl/GLFence.cpp:
(WebCore::GLFence::isSupported):
(WebCore::GLFence::create):
(WebCore::isGLFenceSyncSupported): Deleted.
* Source/WebCore/platform/graphics/egl/GLFence.h:
* Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp:
(Nicosia::AcceleratedBuffer::completePainting):

Canonical link: <a href="https://commits.webkit.org/277862@main">https://commits.webkit.org/277862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e530e9d4801fa51aa3b44d3f64c83ed15aa16302

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48822 "Failed to checkout and rebase branch from PR 27621") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51508 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44888 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51127 "Failed to checkout and rebase branch from PR 27621") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33980 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25563 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39911 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49404 "Failed to checkout and rebase branch from PR 27621") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/25683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21012 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/23146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6877 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53420 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23873 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47215 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25136 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46159 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25944 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6962 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24856 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->