### PR TITLE
Build failure with -Werror=overloaded-virtual on GCC 13

### DIFF
--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
@@ -65,10 +65,10 @@ NetworkSendQueue WebSocketChannel::createMessageQueue(Document& document, WebSoc
     return { document, [&channel](auto& utf8String) {
         auto data = utf8String.span();
         channel.notifySendFrame(WebSocketFrame::OpCode::OpCodeText, data);
-        channel.sendMessage(Messages::NetworkSocketChannel::SendString { data }, utf8String.length());
+        channel.sendMessageInternal(Messages::NetworkSocketChannel::SendString { data }, utf8String.length());
     }, [&channel](auto span) {
         channel.notifySendFrame(WebSocketFrame::OpCode::OpCodeBinary, span);
-        channel.sendMessage(Messages::NetworkSocketChannel::SendData { span }, span.size());
+        channel.sendMessageInternal(Messages::NetworkSocketChannel::SendData { span }, span.size());
     }, [&channel](ExceptionCode exceptionCode) {
         auto code = static_cast<int>(exceptionCode);
         channel.fail(makeString("Failed to load Blob: exception code = ", code));
@@ -194,7 +194,7 @@ void WebSocketChannel::decreaseBufferedAmount(size_t byteLength)
         m_client->didUpdateBufferedAmount(m_bufferedAmount);
 }
 
-template<typename T> void WebSocketChannel::sendMessage(T&& message, size_t byteLength)
+template<typename T> void WebSocketChannel::sendMessageInternal(T&& message, size_t byteLength)
 {
     CompletionHandler<void()> completionHandler = [this, protectedThis = Ref { *this }, byteLength] {
         decreaseBufferedAmount(byteLength);

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.h
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.h
@@ -98,7 +98,7 @@ private:
 
     bool increaseBufferedAmount(size_t);
     void decreaseBufferedAmount(size_t);
-    template<typename T> void sendMessage(T&&, size_t byteLength);
+    template<typename T> void sendMessageInternal(T&&, size_t byteLength);
 
     const WebCore::WebSocketChannelInspector* channelInspector() const final { return &m_inspector; }
     WebCore::WebSocketChannelIdentifier progressIdentifier() const final { return m_inspector.progressIdentifier(); }


### PR DESCRIPTION
#### 619e39d2eab19c9e206788a0f351897b312cefb9
<pre>
Build failure with -Werror=overloaded-virtual on GCC 13
<a href="https://bugs.webkit.org/show_bug.cgi?id=273097">https://bugs.webkit.org/show_bug.cgi?id=273097</a>

Reviewed by Darin Adler.

WebSocketChannel inherits from IPC::MessageSender which has a virtual sendMessage()
method. However, WebSocketChannel also had a private sendMessage() method which was
overloading IPC::MessageSender::sendMessage(). There is a warning for this with
-Woverloaded-virtual in GCC, which is included in -Wall on GCC 13. Coupled with -Werror,
we get a build failure in developer mode.

To fix this, renamed WebSocketChannel&apos;s sendMessage to sendMessageInternal.

* Source/WebKit/WebProcess/Network/WebSocketChannel.cpp:
(WebKit::WebSocketChannel::createMessageQueue):
(WebKit::WebSocketChannel::sendMessageInternal):
(WebKit::WebSocketChannel::sendMessage): Deleted.
* Source/WebKit/WebProcess/Network/WebSocketChannel.h:

Canonical link: <a href="https://commits.webkit.org/277904@main">https://commits.webkit.org/277904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05a40bdb45d8bd6cc13abf0c48694534bb2be43c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48854 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51821 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51541 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44920 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34017 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25595 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39941 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49436 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25717 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42130 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21043 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23180 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6909 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45111 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43800 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53452 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23905 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20173 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47258 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25168 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42339 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46209 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10773 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25976 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24888 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->