### PR TITLE
[git-webkit] Add screen-reader friendly review wizard (Part 1)

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,6 +47,7 @@ from .log import Log
 from .pull import Pull
 from .pull_request import PullRequest
 from .revert import Revert
+from .review import Review
 from .setup_git_svn import SetupGitSvn
 from .setup import Setup
 from .show import Show
@@ -93,7 +94,7 @@ def main(
     programs = [
         Blame, Branch, Canonicalize, Checkout,
         Clean, Clone, Find, Info, Land, Log, Pull,
-        PullRequest, Revert, Setup, InstallGitLFS,
+        PullRequest, Revert, Review, Setup, InstallGitLFS,
         Credentials, Commit, DeletePRBranches, Squash,
         Pickable, CherryPick, Trace, Track, Show, Publish,
         Classify, InstallHooks,

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/review.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/review.py
@@ -1,0 +1,234 @@
+# Copyright (C) 2024 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import difflib
+import os
+import re
+import shutil
+import sys
+import tempfile
+
+from .command import Command
+from .pull_request import PullRequest
+
+from webkitcorepy import arguments, run, string_utils, Terminal
+from webkitscmpy import local, log, remote
+
+
+class Review(Command):
+    name = 'review'
+    help = "Run a command-line wizard to review a specific pull-request or commit in a project"
+    DETAILS_RE = r'<details>.+</details>'
+    INDENT_SIZE = 4
+    PR_RE = re.compile(r'^\[?([Pp][Rr][ -]?)?(?P<number>\d+)]?$')
+    PR_URL_RES = [
+        re.compile(r'\A(?P<url>https?://\S+/projects/\S+/repos/\S+)/pull-requests/(?P<number>\d+)(/overview)?(/diff)?\Z'),
+        re.compile(r'\A(?P<url>https?://github.\S+/\S+)/pull/(?P<number>\d+)(/files)?\Z'),
+    ]
+    SEPERATOR_SIZE = 80
+    URL_RE = re.compile(r'\Ahttps?://')
+
+    @classmethod
+    def parser(cls, parser, loggers=None):
+        parser.add_argument(
+            'argument', nargs=1,
+            type=str, default=None,
+            help='String representation of a pull request (pr-#), commit or URL to review',
+        )
+        parser.add_argument(
+            '--remote', dest='remote', type=str, default=None,
+            help='Specify remote to search for pull request from.',
+        )
+        parser.add_argument(
+            '--dry-run', '-n', '--no-dry-run',
+            dest='dry_run', default=False,
+            help='View but do not edit a pull-request',
+            action=arguments.NoAction,
+        )
+
+    @classmethod
+    def editor(cls, repository):
+        from_config = None
+        if isinstance(repository, local.Git):
+            from_config = repository.config().get('core.editor', None)
+        if not from_config:
+            from_config = local.Git.config().get('core.editor', None)
+        if from_config:
+            return from_config.split(' ')
+        return [shutil.which('vim')]
+
+    @classmethod
+    def args_for_url(cls, url):
+        url = url.split('?')[0]
+        url = url.split('#')[0]
+        for candidate in cls.PR_URL_RES:
+            match = candidate.match(url)
+            if match:
+                return match.group('number'), remote.Scm.from_url(match.group('url'))
+        return None, None
+
+    @classmethod
+    def invoke_wizard(
+        cls, editor, name,
+        header=None,
+        messages=None,
+        comments=None,
+        diff=None,
+    ):
+        # Textual wizards are split into 4 sections, seperated by a line of '=' characters
+        output = [[], [], [], []]
+        edited_path = os.path.join(tempfile.gettempdir(), str(os.getpid()), '{}.diff'.format(name))
+        if not os.path.exists(os.path.dirname(edited_path)):
+            os.makedirs(os.path.dirname(edited_path))
+
+        # 1st section: metadata
+        sanitized_header = {
+            key.rstrip().lstrip(): value.rstrip().lstrip() if value else None
+            for key, value in (header or {}).items()
+        }
+        for key, value in sanitized_header.items():
+            if not value:
+                continue
+            output[0].append('{}: {}'.format(key.rstrip().lstrip(), value.rstrip().lstrip()))
+
+        # 2nd section: commit message
+        for message in messages or []:
+            for line in message.splitlines():
+                output[1].append((' ' * cls.INDENT_SIZE + line).rstrip())
+            output[1].append(' ' * cls.INDENT_SIZE + '-' * (cls.SEPERATOR_SIZE - cls.INDENT_SIZE))
+        if output[1]:
+            output[1].pop()
+
+        # 3rd section: PR or commit comments
+        comment_for_lines = {}
+        for comment in comments or []:
+            for line in comment.splitlines():
+                comment_for_lines[len(output[2])] = comment
+                output[2].append(line.rstrip())
+            comment_for_lines[len(output[2])] = comment
+            output[2].append('-' * cls.SEPERATOR_SIZE)
+        if output[2]:
+            output[2].pop()
+
+        # 4th section: Diff
+        for line in diff:
+            output[3].append(line.rstrip())
+
+        with open(edited_path, 'w') as ofile:
+            cnt = 0
+            while cnt < len(output):
+                for line in output[cnt]:
+                    ofile.write(line + '\n')
+                if output[cnt] and cnt + 1 < len(output):
+                    ofile.write('=' * cls.SEPERATOR_SIZE + '\n')
+                cnt += 1
+
+        run(editor + [edited_path])
+
+        input = [[], [], [], []]
+        with open(edited_path, 'r') as ifile:
+            cnt = 0
+            for line in ifile.readlines():
+                line = line.rstrip()
+                if cnt >= len(input):
+                    sys.stderr.write('Exceeded number of expected blocks in textual input\n')
+                    break
+                if line.startswith('=' * cls.SEPERATOR_SIZE):
+                    cnt += 1
+                    while cnt < len(output) and not output[cnt]:
+                        cnt += 1
+                    continue
+                input[cnt].append(line)
+
+        return dict()
+
+    @classmethod
+    def main(cls, args, repository, **kwargs):
+        editor = cls.editor(repository)
+
+        target = args.argument[0]
+        if cls.URL_RE.match(target):
+            target, repository = cls.args_for_url(target)
+            if not repository:
+                sys.stderr.write("Failed to extract repository from '{}'\n".format(args.argument[0]))
+                return 1
+            if not target:
+                sys.stderr.write("Failed to determine target from '{}'\n".format(args.argument[0]))
+                return 1
+
+        if not repository:
+            sys.stderr.write('No repository provided\n')
+            return 1
+
+        if isinstance(repository, local.Git):
+            original = repository
+            repository = repository.remote(name=args.remote)
+            if not repository:
+                sys.stderr.write("'{}' is not a remote in '{}'\n".format(args.remote, original.path))
+                return 1
+        elif args.remote:
+            sys.stderr.write("User provided '--remote={}',\n".format(args.remote))
+            sys.stderr.write("but '{}' is already a remote repository\n".format(repository.url))
+            return 1
+
+        if not isinstance(repository, remote.GitHub) and not isinstance(repository, remote.BitBucket):
+            sys.stderr.write('Provided repository is not a known remote git repository with pull-requests\n')
+            return 1
+
+        if not repository.pull_requests:
+            sys.stderr.write('No pull-requests associated with repository\n')
+            return 1
+
+        match = cls.PR_RE.match(target)
+        if match:
+            pull_request = repository.pull_requests.get(number=int(match.group('number')))
+        else:
+            pull_request = PullRequest.find_existing_pull_request(repository, rmt, branch=target)
+        if not pull_request:
+            sys.stderr.write("\nCannot extract PR number from '{}'\n".format(target))
+            return 1
+
+        header = {
+            'Title': pull_request.title,
+            'Status': ('Draft' if pull_request.draft else 'Opened') if pull_request.opened else ('Merged' if pull_request.merged else 'Closed'),
+            'Author': str(pull_request.author),
+            'Approved by': string_utils.join([person.name for person in pull_request.approvers]) if pull_request.approvers else None,
+            'Blocked by': string_utils.join([person.name for person in pull_request.blockers]) if pull_request.blockers else None,
+        }
+        if pull_request._metadata and pull_request._metadata.get('issue'):
+            pr_issue = pull_request._metadata['issue']
+            if pr_issue.labels:
+                header['Labels'] = string_utils.join(pr_issue.labels)
+
+        print('Waiting for user to modify textual pull-request...')
+        response = cls.invoke_wizard(
+            editor=editor,
+            name='pr-{}'.format(pull_request.number),
+            header=header,
+            messages=([pull_request.body] if pull_request.body else []) + [commit.message for commit in pull_request.commits or []],
+            comments=[
+                '{}: {}'.format(comment.author, re.sub(cls.DETAILS_RE, '', comment.content, flags=re.S))
+                for comment in pull_request.comments
+            ], diff=pull_request.diff(comments=True),
+        )
+
+        return 0

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/review_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/review_unittest.py
@@ -1,0 +1,339 @@
+# Copyright (C) 2024 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import logging
+import shutil
+import sys
+
+from webkitbugspy import github
+from webkitcorepy import OutputCapture, testing, run
+from webkitcorepy.mocks import Terminal as MockTerminal
+from webkitscmpy import local, remote, mocks, program
+from webkitscmpy.remote import BitBucket, GitHub
+
+
+class TestReview(testing.PathTestCase):
+    basepath = 'mock/repository'
+
+    from webkitscmpy.test.pull_request_unittest import TestNetworkPullRequestBitBucket, TestNetworkPullRequestGitHub
+
+    @classmethod
+    def editor_callback(cls, will_print=True):
+        def callback(path, will_print=will_print):
+            if will_print:
+                with open(path, 'r') as input_file:
+                    for line in input_file.readlines():
+                        sys.stdout.write(line)
+
+        return callback
+
+    def test_bitbucket(self):
+        pr_id, remote_repo = program.Review.args_for_url('{}/pull-requests/1234/overview'.format(self.TestNetworkPullRequestBitBucket.remote))
+        self.assertEqual(pr_id, '1234')
+        self.assertEqual(self.TestNetworkPullRequestBitBucket.remote, remote_repo.url)
+
+    def test_bitbucket_diff(self):
+        pr_id, remote_repo = program.Review.args_for_url('{}/pull-requests/1234/diff#Tools%2FScripts%2Fexample.py'.format(self.TestNetworkPullRequestBitBucket.remote))
+        self.assertEqual(pr_id, '1234')
+        self.assertEqual(self.TestNetworkPullRequestBitBucket.remote, remote_repo.url)
+
+    def test_github(self):
+        pr_id, remote_repo = program.Review.args_for_url('{}/pull/1234'.format(self.TestNetworkPullRequestGitHub.remote))
+        self.assertEqual(pr_id, '1234')
+        self.assertEqual(self.TestNetworkPullRequestGitHub.remote, remote_repo.url)
+
+    def test_github_files(self):
+        pr_id, remote_repo = program.Review.args_for_url('{}/pull/1234/files#diff-abcdefabcdef'.format(self.TestNetworkPullRequestGitHub.remote))
+        self.assertEqual(pr_id, '1234')
+        self.assertEqual(self.TestNetworkPullRequestGitHub.remote, remote_repo.url)
+
+    def test_invalid_pr_url(self):
+        self.assertEqual(
+            (None, None),
+            program.Review.args_for_url('https://commits.webkit.org'),
+        )
+
+    def test_pr_argument(self):
+        self.assertEqual('1234', program.Review.PR_RE.match('1234').group('number'))
+        self.assertEqual('1234', program.Review.PR_RE.match('pr1234').group('number'))
+        self.assertEqual('1234', program.Review.PR_RE.match('pr-1234').group('number'))
+        self.assertEqual('1234', program.Review.PR_RE.match('pr 1234').group('number'))
+
+        self.assertEqual(None, program.Review.PR_RE.match('pr  1234'))
+        self.assertEqual(None, program.Review.PR_RE.match('deadbeef'))
+        self.assertEqual(None, program.Review.PR_RE.match('1234@main'))
+        self.assertEqual(None, program.Review.PR_RE.match('r1234'))
+
+    def test_editor_no_repo(self):
+        with mocks.local.Git(self.path):
+            self.assertEqual([shutil.which('vim')], program.Review.editor(None))
+
+    def test_editor_repo(self):
+        with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path, editor=lambda path: print(path)):
+            self.assertEqual(['/bin/example', '-n', '-w'], program.Review.editor(local.Git(self.path)))
+            self.assertEqual(run(['/bin/example', '-n', '-w', 'PATH']).returncode, 0)
+
+        self.assertEqual(captured.stdout.getvalue(), 'PATH\n')
+
+    def test_invoke_wizard(self):
+        with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(
+            self.path, editor=self.editor_callback(),
+        ):
+            self.assertEqual(
+                program.Review.invoke_wizard(
+                    editor=program.Review.editor(local.Git(self.path)),
+                    name='pr-1234',
+                    header={
+                        'Title': 'Example Change',
+                        'Status': 'Opened'
+                    },
+                    messages=['Example Change\nhttps://bugs.webkit.org/show_bug.cgi?id=1234\n\nReviewed by NOBODY (OOPS!).\n\n* Source/file.cpp:\n'],
+                    comments=['Person <person@webkit.org>: Top-level comment'],
+                    diff=[
+                        '--- a/ChangeLog\n',
+                        '+++ b/ChangeLog\n',
+                        '@@ -1,0 +1,0 @@\n',
+                        '+Example Change\n',
+                        '+https://bugs.webkit.org/show_bug.cgi?id=1234\n',
+                        '+\n',
+                        '+Reviewed by NOBODY (OOPS!).\n',
+                        '+* Source/file.cpp:\n',
+                    ],
+                ), dict(),
+            )
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Title: Example Change\n'
+            'Status: Opened\n'
+            '================================================================================\n'
+            '    Example Change\n'
+            '    https://bugs.webkit.org/show_bug.cgi?id=1234\n'
+            '\n'
+            '    Reviewed by NOBODY (OOPS!).\n'
+            '\n'
+            '    * Source/file.cpp:\n'
+            '================================================================================\n'
+            'Person <person@webkit.org>: Top-level comment\n'
+            '================================================================================\n'
+            '--- a/ChangeLog\n'
+            '+++ b/ChangeLog\n'
+            '@@ -1,0 +1,0 @@\n'
+            '+Example Change\n'
+            '+https://bugs.webkit.org/show_bug.cgi?id=1234\n'
+            '+\n'
+            '+Reviewed by NOBODY (OOPS!).\n'
+            '+* Source/file.cpp:\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), [])
+
+    def test_help(self):
+        with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path):
+            with self.assertRaises(SystemExit):
+                program.main(
+                    args=('review', '--help'),
+                    path=self.path,
+                )
+
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), [])
+
+    def test_bitbucket_read(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestBitBucket.webserver() as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(),
+        ):
+            result = program.main(
+                args=('review', '1', '-n', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(0, result)
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n'
+            'Title: Example Change\n'
+            'Status: Opened\n'
+            'Author: Tim Contributor <tcontributor@apple.com>\n'
+            'Approved by: Eager Reviewer\n'
+            'Blocked by: Suspicious Reviewer\n'
+            '================================================================================\n'
+            '    Example Change\n'
+            '    https://bugs.webkit.org/show_bug.cgi?id=1234\n'
+            '\n'
+            '    Reviewed by NOBODY (OOPS!).\n'
+            '\n'
+            '    * Source/file.cpp:\n'
+            '================================================================================\n'
+            '--- a/ChangeLog\n'
+            '+++ b/ChangeLog\n'
+            '@@ -1,0 +1,0 @@\n'
+            '+Example Change\n'
+            '+https://bugs.webkit.org/show_bug.cgi?id=1234\n'
+            '+\n'
+            '+Reviewed by NOBODY (OOPS!).\n'
+            '+* Source/file.cpp:\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), [])
+
+    def test_github_read(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestGitHub.webserver() as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(),
+        ):
+            github.Tracker('https://{}'.format(rmt.remote)).issue(1).set_labels(['bug', 'good first issue'])
+
+            result = program.main(
+                args=('review', '1', '-n', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(0, result)
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n'
+            'Title: Example Change\n'
+            'Status: Opened\n'
+            'Author: tcontributor <?>\n'
+            'Approved by: Eager Reviewer\n'
+            'Blocked by: Suspicious Reviewer\n'
+            'Labels: bug and good first issue\n'
+            '================================================================================\n'
+            '    Example Change\n'
+            '    https://bugs.webkit.org/show_bug.cgi?id=1234\n'
+            '\n'
+            '    Reviewed by NOBODY (OOPS!).\n'
+            '\n'
+            '    * Source/file.cpp:\n'
+            '================================================================================\n'
+            'diff --git a/ChangeLog b/ChangeLog\n'
+            '--- a/ChangeLog\n'
+            '+++ b/ChangeLog\n'
+            '@@ -1,0 +1,0 @@\n'
+            '+Example Change\n'
+            '+https://bugs.webkit.org/show_bug.cgi?id=1234\n'
+            '+\n'
+            '+Reviewed by NOBODY (OOPS!).\n'
+            '+* Source/file.cpp:\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), [])
+
+    def test_bitbucket_read_comments(self):
+        self.maxDiff = None
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestBitBucket.webserver() as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(),
+        ):
+            pr = remote.BitBucket('https://{}'.format(rmt.remote)).pull_requests.get(1)
+            pr.comment('High-level comment')
+            pr.review(diff_comments=dict(ChangeLog={4: ['Inline comment']}))
+
+            result = program.main(
+                args=('review', '1', '-n', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(0, result)
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n'
+            'Title: Example Change\n'
+            'Status: Opened\n'
+            'Author: Tim Contributor <tcontributor@apple.com>\n'
+            'Approved by: Eager Reviewer\n'
+            'Blocked by: Suspicious Reviewer\n'
+            '================================================================================\n'
+            '    Example Change\n'
+            '    https://bugs.webkit.org/show_bug.cgi?id=1234\n'
+            '\n'
+            '    Reviewed by NOBODY (OOPS!).\n'
+            '\n'
+            '    * Source/file.cpp:\n'
+            '================================================================================\n'
+            'Tim Committer <committer@webkit.org>: High-level comment\n'
+            '================================================================================\n'
+            '--- a/ChangeLog\n'
+            '+++ b/ChangeLog\n'
+            '@@ -1,0 +1,0 @@\n'
+            '+Example Change\n'
+            '+https://bugs.webkit.org/show_bug.cgi?id=1234\n'
+            '+\n'
+            '+Reviewed by NOBODY (OOPS!).\n'
+            '>>>>\n'
+            'Tim Committer <committer@webkit.org>: Inline comment\n'
+            '<<<<\n'
+            '+* Source/file.cpp:\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), [])
+
+    def test_github_read_comments(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestGitHub.webserver() as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(),
+        ):
+            pr = remote.GitHub('https://{}'.format(rmt.remote)).pull_requests.get(1)
+            pr.comment('High-level comment')
+            pr.review(diff_comments=dict(ChangeLog={4: ['Inline comment']}))
+
+            result = program.main(
+                args=('review', '1', '-n', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(0, result)
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n'
+            'Title: Example Change\n'
+            'Status: Opened\n'
+            'Author: tcontributor <?>\n'
+            'Approved by: Eager Reviewer\n'
+            'Blocked by: Suspicious Reviewer\n'
+            '================================================================================\n'
+            '    Example Change\n'
+            '    https://bugs.webkit.org/show_bug.cgi?id=1234\n'
+            '\n'
+            '    Reviewed by NOBODY (OOPS!).\n'
+            '\n'
+            '    * Source/file.cpp:\n'
+            '================================================================================\n'
+            'tcontributor <?>: High-level comment\n'
+            '================================================================================\n'
+            'diff --git a/ChangeLog b/ChangeLog\n'
+            '--- a/ChangeLog\n'
+            '+++ b/ChangeLog\n'
+            '@@ -1,0 +1,0 @@\n'
+            '+Example Change\n'
+            '+https://bugs.webkit.org/show_bug.cgi?id=1234\n'
+            '+\n'
+            '+Reviewed by NOBODY (OOPS!).\n'
+            '>>>>\n'
+            'tcontributor <?>: Inline comment\n'
+            '<<<<\n'
+            '+* Source/file.cpp:\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), [])


### PR DESCRIPTION
#### 26ef083bdcb33ab3c78a317860a6fa1b3aa3a9a1
<pre>
[git-webkit] Add screen-reader friendly review wizard (Part 1)
<a href="https://bugs.webkit.org/show_bug.cgi?id=261242">https://bugs.webkit.org/show_bug.cgi?id=261242</a>
<a href="https://rdar.apple.com/115083100">rdar://115083100</a>

Reviewed by Elliott Williams.

Add a read-only text-based PR review tool to git-webkit.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
(Git.__init__): Add an &quot;editor&quot; argument which allows a caller to define
an editor callback which is invoke when the mock commit message editor is
called during the testing context.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py: Add Review program.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/review.py: Added.
(Review.parser): Define arguments for the sub-program.
(Review.editor): Use a repository object to determine the user&apos;s prefered editor, matching
the editor used to edit commit messages.
(Review.args_for_url): Extract PR number and repository object from a URL, allowing a
user to specify a PR URL instead of a number and remote.
(Review.invoke_wizard): Generate a local file representing a PR, which includes the PR
diff and comments made against that diff. Open that local file in the user&apos;s prefered editor.
(Review.main): Extract a remote pull-request from the provided arguments and invoke the local
wizard with the pull-request details.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/review_unittest.py: Added.
(TestReview):
(TestReview.editor_callback):
(TestReview.editor_callback.callback):
(TestReview.test_bitbucket):
(TestReview.test_bitbucket_diff):
(TestReview.test_github):
(TestReview.test_github_files):
(TestReview.test_invalid_pr_url):
(TestReview.test_pr_argument):
(TestReview.test_editor_no_repo):
(TestReview.test_editor_repo):
(TestReview.test_invoke_wizard):
(TestReview.test_help):
(TestReview.test_bitbucket_read):
(TestReview.test_github_read):
(TestReview.test_bitbucket_read_comments):
(TestReview.test_github_read_comments):

Canonical link: <a href="https://commits.webkit.org/279244@main">https://commits.webkit.org/279244@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7983bbf2f11e1379f884c4e72d0f93dd345d661

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52912 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5399 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/56191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/3635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55217 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39001 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3360 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/56191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/3635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55010 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45669 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/56191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/52756 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2989 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1794 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3144 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57784 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/28053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/52919 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/29273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45886 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/30192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7768 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/29027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->