### PR TITLE
[Remote Inspection] Adjust targeting to skip non-interactable containers that cover the viewport

### DIFF
--- a/LayoutTests/fast/element-targeting/targeted-element-ignores-pointer-events-none-overlay-expected.txt
+++ b/LayoutTests/fast/element-targeting/targeted-element-ignores-pointer-events-none-overlay-expected.txt
@@ -1,0 +1,10 @@
+PASS firstSelector is "DIV.box"
+PASS secondSelector is "DIV.overlay.dimmed"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo.
+
+You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them.
+
+Because they change things. They push the human race forward. And while some may see them as the crazy ones, we see genius. Because the people who are crazy enough to think they can change the world, are the ones who do.

--- a/LayoutTests/fast/element-targeting/targeted-element-ignores-pointer-events-none-overlay.html
+++ b/LayoutTests/fast/element-targeting/targeted-element-ignores-pointer-events-none-overlay.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+body, html {
+    width: 100%;
+    height: 100%;
+    line-height: 1.5;
+    font-family: system-ui;
+}
+
+.overlay {
+    position: fixed;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    top: 0;
+    left: 0;
+}
+
+.box {
+    width: 100px;
+    height: 200px;
+    border: 2px black solid;
+    background: tomato;
+    margin-top: 50px;
+    margin-left: 10px;
+    pointer-events: auto;
+}
+
+.dimmed {
+    pointer-events: auto;
+    background-color: rgba(0, 0, 0, 0.25);
+}
+</style>
+<script>
+jsTestIsAsync = true;
+addEventListener("load", async () => {
+    firstSelector = await UIHelper.adjustVisibilityForFrontmostTarget(50, 100);
+    shouldBeEqualToString("firstSelector", "DIV.box");
+
+    document.querySelector(".overlay").classList.add("dimmed");
+    await UIHelper.ensurePresentationUpdate();
+
+    secondSelector = await UIHelper.adjustVisibilityForFrontmostTarget(50, 100);
+    shouldBeEqualToString("secondSelector", "DIV.overlay.dimmed");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+<div class="overlay">
+    <div class="box"></div>
+</div>
+<main>
+    <p>Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo.</p>
+    <p>You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them.</p>
+    <p>Because they change things. They push the human race forward. And while some may see them as the crazy ones, we see genius. Because the people who are crazy enough to think they can change the world, are the ones who do.</p>
+</main>
+</body>
+</html>


### PR DESCRIPTION
#### 8824aec206772ee607381b372c9da62892f501e4
<pre>
[Remote Inspection] Adjust targeting to skip non-interactable containers that cover the viewport
<a href="https://bugs.webkit.org/show_bug.cgi?id=273124">https://bugs.webkit.org/show_bug.cgi?id=273124</a>
<a href="https://rdar.apple.com/126818923">rdar://126818923</a>

Reviewed by Megan Gardner.

Fine-tune the targeting heuristic further, by adding logic to skip over full-viewport-sized elements
that are either z-ordered below the rest of the content, or out-of-flow and non-interactable (i.e.
`pointer-events: none;`) with no visible background either.

* LayoutTests/fast/element-targeting/targeted-element-ignores-pointer-events-none-overlay-expected.txt: Added.
* LayoutTests/fast/element-targeting/targeted-element-ignores-pointer-events-none-overlay.html: Added.
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::ElementTargetingController::findTargets):

Canonical link: <a href="https://commits.webkit.org/277876@main">https://commits.webkit.org/277876@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab7c4cfeef24746a111dee07cad84b00f0c7b3f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48835 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28048 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51802 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51522 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44901 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51140 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25576 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39925 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49417 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25699 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21026 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23162 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6890 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45093 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43780 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53433 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23886 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20155 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47228 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42319 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46175 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10757 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25957 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24869 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->