### PR TITLE
in in-window mode, video play/pauses when moving media controls

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/button.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/button.js
@@ -150,7 +150,6 @@ class Button extends LayoutItem
 
     handleEvent(event)
     {
-        event.stopPropagation();
         if (event.target === this._imageSource) {
             if (event.type === "load")
                 this._imageSourceDidLoad();

--- a/Source/WebCore/Modules/modern-media-controls/controls/macos-fullscreen-media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/macos-fullscreen-media-controls.js
@@ -84,6 +84,7 @@ class MacOSFullscreenMediaControls extends MediaControls
 
     handleEvent(event)
     {
+        event.stopPropagation();
         if (event.type === "mousedown" && event.currentTarget === this.bottomControlsBar.element)
             this._handleMousedown(event);
         else if (event.type === "mousemove" && event.currentTarget === this.element)


### PR DESCRIPTION
#### edf05350b9fb49af69ba20327ff7201f7b282979
<pre>
in in-window mode, video play/pauses when moving media controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=273127">https://bugs.webkit.org/show_bug.cgi?id=273127</a>
<a href="https://rdar.apple.com/126300898">rdar://126300898</a>

Reviewed by Jer Noble.

On youtube.com, the click event on the media controls propagates down to the video element,
Where YouTube handles the event by toggling play/pause on the video. To fix this, we do
Not want events on the media controls to propagate down. And so the call to stopPropagation() on
The event should be moved from the button class to the macOSFullscreenMediaControls class.

* Source/WebCore/Modules/modern-media-controls/controls/button.js:
(Button.prototype.handleEvent):
* Source/WebCore/Modules/modern-media-controls/controls/macos-fullscreen-media-controls.js:
(MacOSFullscreenMediaControls.prototype.handleEvent):

Canonical link: <a href="https://commits.webkit.org/277938@main">https://commits.webkit.org/277938@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59789fd05225ea4fa58932956ae900d1f4109caf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48848 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28061 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51535 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44914 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51153 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25589 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39936 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49430 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25712 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42124 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21038 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23175 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43300 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6903 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45106 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43794 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53446 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23899 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20168 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47238 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25162 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42333 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46187 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25970 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7012 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24882 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->