### PR TITLE
Avoid changing the ordering of attributes when markup is not created for saving page

### DIFF
--- a/LayoutTests/http/tests/dom/resources/simple-iframe.html
+++ b/LayoutTests/http/tests/dom/resources/simple-iframe.html
@@ -1,0 +1,1 @@
+<html>Hello World</html>

--- a/LayoutTests/http/tests/dom/serialize-fragment-attributes-order-expected.txt
+++ b/LayoutTests/http/tests/dom/serialize-fragment-attributes-order-expected.txt
@@ -1,0 +1,10 @@
+Verifies the order of attributes in markup is the same as the order they are added
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS frame.outerHTML is "<iframe id=\"frameID\" crossorigin=\"anonymous\" src=\"http://localhost:8000/dom/resources/simple-iframe.html\"></iframe>"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/dom/serialize-fragment-attributes-order.html
+++ b/LayoutTests/http/tests/dom/serialize-fragment-attributes-order.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Verifies the order of attributes in markup is the same as the order they are added");
+
+jsTestIsAsync = true;
+
+var frame = document.createElement('iframe');
+frame.setAttribute("id", "frameID");
+frame.setAttribute("crossorigin", "anonymous");
+frame.setAttribute("src", "http://localhost:8000/dom/resources/simple-iframe.html");
+frame.onload = () => {
+    shouldBeEqualToString("frame.outerHTML", '<iframe id="frameID" crossorigin="anonymous" src="http://localhost:8000/dom/resources/simple-iframe.html"></iframe>');
+
+    finishJSTest();
+}
+document.body.appendChild(frame);
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3829,7 +3829,7 @@ ExceptionOr<void> Element::setHTMLUnsafe(const String& html)
 
 String Element::getHTML(GetHTMLOptions&& options) const
 {
-    return serializeFragment(*this, SerializedNodes::SubtreesOfChildren, nullptr, ResolveURLs::NoExcludingURLsForPrivacy, SerializationSyntax::HTML, { }, { }, options.serializableShadowRoots ? SerializeShadowRoots::Serializable : SerializeShadowRoots::Explicit, WTFMove(options.shadowRoots));
+    return serializeFragment(*this, SerializedNodes::SubtreesOfChildren, nullptr, ResolveURLs::NoExcludingURLsForPrivacy, SerializationSyntax::HTML, options.serializableShadowRoots ? SerializeShadowRoots::Serializable : SerializeShadowRoots::Explicit, WTFMove(options.shadowRoots));
 }
 
 ExceptionOr<void> Element::mergeWithNextTextNode(Text& node)

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -213,7 +213,7 @@ ExceptionOr<void> ShadowRoot::setHTMLUnsafe(const String& html)
 
 String ShadowRoot::getHTML(GetHTMLOptions&& options) const
 {
-    return serializeFragment(*this, SerializedNodes::SubtreesOfChildren, nullptr, ResolveURLs::NoExcludingURLsForPrivacy, SerializationSyntax::HTML, { }, { }, options.serializableShadowRoots ? SerializeShadowRoots::Serializable : SerializeShadowRoots::Explicit, WTFMove(options.shadowRoots));
+    return serializeFragment(*this, SerializedNodes::SubtreesOfChildren, nullptr, ResolveURLs::NoExcludingURLsForPrivacy, SerializationSyntax::HTML, options.serializableShadowRoots ? SerializeShadowRoots::Serializable : SerializeShadowRoots::Explicit, WTFMove(options.shadowRoots));
 }
 
 String ShadowRoot::innerHTML() const

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -193,12 +193,10 @@ void MarkupAccumulator::appendCharactersReplacingEntities(StringBuilder& result,
         appendCharactersReplacingEntitiesInternal<UChar>(result, source, offset, length, entityMask);
 }
 
-MarkupAccumulator::MarkupAccumulator(Vector<Ref<Node>>* nodes, ResolveURLs resolveURLs, SerializationSyntax serializationSyntax, HashMap<String, String>&& replacementURLStrings, HashMap<RefPtr<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet, SerializeShadowRoots serializeShadowRoots, Vector<Ref<ShadowRoot>>&& explicitShadowRoots, const Vector<MarkupExclusionRule>& exclusionRules)
+MarkupAccumulator::MarkupAccumulator(Vector<Ref<Node>>* nodes, ResolveURLs resolveURLs, SerializationSyntax serializationSyntax, SerializeShadowRoots serializeShadowRoots, Vector<Ref<ShadowRoot>>&& explicitShadowRoots, const Vector<MarkupExclusionRule>& exclusionRules)
     : m_nodes(nodes)
     , m_resolveURLs(resolveURLs)
     , m_serializationSyntax(serializationSyntax)
-    , m_replacementURLStrings(WTFMove(replacementURLStrings))
-    , m_replacementURLStringsForCSSStyleSheet(WTFMove(replacementURLStringsForCSSStyleSheet))
     , m_serializeShadowRoots(serializeShadowRoots)
     , m_explicitShadowRoots(WTFMove(explicitShadowRoots))
     , m_exclusionRules(exclusionRules)
@@ -208,6 +206,11 @@ MarkupAccumulator::MarkupAccumulator(Vector<Ref<Node>>* nodes, ResolveURLs resol
 
 MarkupAccumulator::~MarkupAccumulator() = default;
 
+void MarkupAccumulator::enableURLReplacement(HashMap<String, String>&& replacementURLStrings, HashMap<RefPtr<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet)
+{
+    m_urlReplacementData = URLReplacementData { WTFMove(replacementURLStrings), WTFMove(replacementURLStringsForCSSStyleSheet) };
+}
+
 String MarkupAccumulator::serializeNodes(Node& targetNode, SerializedNodes root)
 {
     serializeNodesWithNamespaces(targetNode, root, 0);
@@ -216,18 +219,18 @@ String MarkupAccumulator::serializeNodes(Node& targetNode, SerializedNodes root)
 
 bool MarkupAccumulator::appendContentsForNode(StringBuilder& result, const Node& targetNode)
 {
-    RefPtr styleElement = dynamicDowncast<HTMLStyleElement>(targetNode);
-    if (!styleElement)
+    if (!m_urlReplacementData)
         return false;
 
-    if (m_replacementURLStrings.isEmpty() && m_replacementURLStringsForCSSStyleSheet.isEmpty())
+    RefPtr styleElement = dynamicDowncast<HTMLStyleElement>(targetNode);
+    if (!styleElement)
         return false;
 
     RefPtr cssStyleSheet = styleElement->sheet();
     if (!cssStyleSheet)
         return false;
 
-    result.append(cssStyleSheet->cssTextWithReplacementURLs(m_replacementURLStrings, m_replacementURLStringsForCSSStyleSheet));
+    result.append(cssStyleSheet->cssTextWithReplacementURLs(m_urlReplacementData->replacementURLStrings, m_urlReplacementData->replacementURLStringsForCSSStyleSheet));
     return true;
 }
 
@@ -347,23 +350,23 @@ void MarkupAccumulator::serializeNodesWithNamespaces(Node& targetNode, Serialize
 
 std::pair<String, MarkupAccumulator::IsCreatedByURLReplacement> MarkupAccumulator::resolveURLIfNeeded(const Element& element, const String& urlString) const
 {
-    if (RefPtr link = dynamicDowncast<HTMLLinkElement>(element); link && !m_replacementURLStringsForCSSStyleSheet.isEmpty()) {
+    if (RefPtr link = dynamicDowncast<HTMLLinkElement>(element); link && m_urlReplacementData) {
         if (RefPtr cssStyleSheet = link->sheet()) {
-            auto replacementURLString = m_replacementURLStringsForCSSStyleSheet.get(cssStyleSheet);
+            auto replacementURLString = m_urlReplacementData->replacementURLStringsForCSSStyleSheet.get(cssStyleSheet);
             if (!replacementURLString.isEmpty())
                 return { replacementURLString, IsCreatedByURLReplacement::Yes };
         }
     }
 
-    if (!m_replacementURLStrings.isEmpty()) {
+    if (m_urlReplacementData) {
         if (RefPtr frame = frameForAttributeReplacement(element)) {
-            auto replacementURLString = m_replacementURLStrings.get(frame->frameID().toString());
+            auto replacementURLString = m_urlReplacementData->replacementURLStrings.get(frame->frameID().toString());
             if (!replacementURLString.isEmpty())
                 return { replacementURLString, IsCreatedByURLReplacement::Yes };
         }
 
         auto resolvedURLString = element.resolveURLStringIfNeeded(urlString);
-        auto replacementURLString = m_replacementURLStrings.get(resolvedURLString);
+        auto replacementURLString = m_urlReplacementData->replacementURLStrings.get(resolvedURLString);
         if (!replacementURLString.isEmpty())
             return { replacementURLString, IsCreatedByURLReplacement::Yes };
     }
@@ -574,10 +577,8 @@ static bool isURLAttributeForElement(const Element& element, const Attribute& at
     return element.isURLAttribute(attribute) || element.isHTMLContentAttribute(attribute);
 }
 
-void MarkupAccumulator::appendStartTag(StringBuilder& result, const Element& element, Namespaces* namespaces)
+void MarkupAccumulator::appendStartTagWithURLReplacement(StringBuilder& result, const Element& element, Namespaces* namespaces)
 {
-    appendOpenTag(result, element, namespaces);
-
     bool hasURLAttribute = false;
     bool isURLReplaced = false;
     Vector<Attribute> attributesToAppendIfURLNotReplaced;
@@ -591,6 +592,7 @@ void MarkupAccumulator::appendStartTag(StringBuilder& result, const Element& ele
 
             if (!hasURLAttribute && isURLAttributeForElement(element, attribute))
                 hasURLAttribute = true;
+
             auto updatedAttribute = replaceAttributeIfNecessary(element, attribute);
             if (appendAttribute(result, element, updatedAttribute, namespaces))
                 isURLReplaced = true;
@@ -600,10 +602,27 @@ void MarkupAccumulator::appendStartTag(StringBuilder& result, const Element& ele
     if (!hasURLAttribute && appendURLAttributeForReplacementIfNecessary(result, element, namespaces))
         isURLReplaced = true;
 
-    if (!isURLReplaced) {
-        for (auto& attribute : attributesToAppendIfURLNotReplaced)
-            appendAttribute(result, element, attribute, namespaces);
+    if (isURLReplaced)
+        return;
+
+    for (auto& attribute : attributesToAppendIfURLNotReplaced)
+        appendAttribute(result, element, attribute, namespaces);
+}
+
+void MarkupAccumulator::appendStartTag(StringBuilder& result, const Element& element, Namespaces* namespaces)
+{
+    appendOpenTag(result, element, namespaces);
+
+    if (m_urlReplacementData) {
+        // This function might change ordering of attributes in markup, so it should only be used for URL replacement case.
+        appendStartTagWithURLReplacement(result, element, namespaces);
+    } else {
+        if (element.hasAttributes()) {
+            for (const Attribute& attribute : element.attributesIterator())
+                appendAttribute(result, element, attribute, namespaces);
+        }
     }
+
     // Give an opportunity to subclasses to add their own attributes.
     appendCustomAttributes(result, element, namespaces);
 
@@ -695,7 +714,7 @@ QualifiedName MarkupAccumulator::xmlAttributeSerialization(const Attribute& attr
 
 LocalFrame* MarkupAccumulator::frameForAttributeReplacement(const Element& element) const
 {
-    if (inXMLFragmentSerialization() || m_replacementURLStrings.isEmpty())
+    if (inXMLFragmentSerialization())
         return nullptr;
 
     RefPtr frameElement = dynamicDowncast<HTMLFrameElementBase>(element);
@@ -707,29 +726,35 @@ LocalFrame* MarkupAccumulator::frameForAttributeReplacement(const Element& eleme
 
 Attribute MarkupAccumulator::replaceAttributeIfNecessary(const Element& element, const Attribute& attribute)
 {
+    if (!m_urlReplacementData)
+        return attribute;
+
     if (element.isHTMLContentAttribute(attribute)) {
         RefPtr frame = frameForAttributeReplacement(element);
         if (!frame || !frame->loader().documentLoader()->response().url().isAboutSrcDoc())
             return attribute;
 
-        auto replacementURLString = m_replacementURLStrings.get(frame->frameID().toString());
-        if (replacementURLString.isNull())
+        auto replacementURLString = m_urlReplacementData->replacementURLStrings.get(frame->frameID().toString());
+        if (replacementURLString.isEmpty())
             return attribute;
 
         return { srcAttr, AtomString { replacementURLString } };
     }
 
-    return element.replaceURLsInAttributeValue(attribute, m_replacementURLStrings);
+    return element.replaceURLsInAttributeValue(attribute, m_urlReplacementData->replacementURLStrings);
 }
 
 bool MarkupAccumulator::appendURLAttributeForReplacementIfNecessary(StringBuilder& result, const Element& element, Namespaces* namespaces)
 {
+    if (!m_urlReplacementData)
+        return false;
+
     RefPtr frame = frameForAttributeReplacement(element);
     if (!frame)
         return false;
 
-    auto replacementURLString = m_replacementURLStrings.get(frame->frameID().toString());
-    if (!replacementURLString)
+    auto replacementURLString = m_urlReplacementData->replacementURLStrings.get(frame->frameID().toString());
+    if (replacementURLString.isEmpty())
         return false;
 
     appendAttribute(result, element, Attribute { srcAttr, AtomString { replacementURLString } }, namespaces);

--- a/Source/WebCore/editing/MarkupAccumulator.h
+++ b/Source/WebCore/editing/MarkupAccumulator.h
@@ -67,12 +67,13 @@ constexpr auto EntityMaskInHTMLAttributeValue = { EntityMask::Amp, EntityMask::Q
 class MarkupAccumulator {
     WTF_MAKE_NONCOPYABLE(MarkupAccumulator);
 public:
-    MarkupAccumulator(Vector<Ref<Node>>*, ResolveURLs, SerializationSyntax, HashMap<String, String>&& replacementURLStrings = { }, HashMap<RefPtr<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet = { }, SerializeShadowRoots = SerializeShadowRoots::Explicit, Vector<Ref<ShadowRoot>>&& explicitShadowRoots = { }, const Vector<MarkupExclusionRule>& exclusionRules = { });
+    MarkupAccumulator(Vector<Ref<Node>>*, ResolveURLs, SerializationSyntax, SerializeShadowRoots = SerializeShadowRoots::Explicit, Vector<Ref<ShadowRoot>>&& explicitShadowRoots = { }, const Vector<MarkupExclusionRule>& exclusionRules = { });
     virtual ~MarkupAccumulator();
 
     String serializeNodes(Node& targetNode, SerializedNodes);
 
     static void appendCharactersReplacingEntities(StringBuilder&, const String&, unsigned, unsigned, OptionSet<EntityMask>);
+    void enableURLReplacement(HashMap<String, String>&& replacementURLStrings, HashMap<RefPtr<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet);
 
 protected:
     unsigned length() const { return m_markup.length(); }
@@ -118,6 +119,7 @@ private:
     bool appendURLAttributeForReplacementIfNecessary(StringBuilder&, const Element&, Namespaces*);
     const ShadowRoot* suitableShadowRoot(const Node&);
     bool shouldExcludeElement(const Element&);
+    void appendStartTagWithURLReplacement(StringBuilder&, const Element&, Namespaces*);
 
     StringBuilder m_markup;
     const ResolveURLs m_resolveURLs;
@@ -128,6 +130,11 @@ private:
     SerializeShadowRoots m_serializeShadowRoots;
     Vector<Ref<ShadowRoot>> m_explicitShadowRoots;
     Vector<MarkupExclusionRule> m_exclusionRules;
+    struct URLReplacementData {
+        HashMap<String, String> replacementURLStrings;
+        HashMap<RefPtr<CSSStyleSheet>, String> replacementURLStringsForCSSStyleSheet;
+    };
+    std::optional<URLReplacementData> m_urlReplacementData;
 };
 
 inline void MarkupAccumulator::endAppendingNode(const Node& node)

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -1207,11 +1207,22 @@ Ref<DocumentFragment> createFragmentFromMarkup(Document& document, const String&
     return fragment;
 }
 
-String serializeFragment(const Node& node, SerializedNodes root, Vector<Ref<Node>>* nodes, ResolveURLs resolveURLs, std::optional<SerializationSyntax> serializationSyntax, HashMap<String, String>&& replacementURLStrings, HashMap<RefPtr<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet, SerializeShadowRoots serializeShadowRoots, Vector<Ref<ShadowRoot>>&& explicitShadowRoots, const Vector<MarkupExclusionRule>& exclusionRules)
+String serializeFragment(const Node& node, SerializedNodes root, Vector<Ref<Node>>* nodes, ResolveURLs resolveURLs, std::optional<SerializationSyntax> serializationSyntax, SerializeShadowRoots serializeShadowRoots, Vector<Ref<ShadowRoot>>&& explicitShadowRoots, const Vector<MarkupExclusionRule>& exclusionRules)
 {
     if (!serializationSyntax)
         serializationSyntax = node.document().isHTMLDocument() ? SerializationSyntax::HTML : SerializationSyntax::XML;
-    MarkupAccumulator accumulator(nodes, resolveURLs, *serializationSyntax, WTFMove(replacementURLStrings), WTFMove(replacementURLStringsForCSSStyleSheet), serializeShadowRoots, WTFMove(explicitShadowRoots), exclusionRules);
+
+    MarkupAccumulator accumulator(nodes, resolveURLs, *serializationSyntax, serializeShadowRoots, WTFMove(explicitShadowRoots), exclusionRules);
+    return accumulator.serializeNodes(const_cast<Node&>(node), root);
+}
+
+String serializeFragmentWithURLReplacement(const Node& node, SerializedNodes root, Vector<Ref<Node>>* nodes, ResolveURLs resolveURLs, std::optional<SerializationSyntax> serializationSyntax, HashMap<String, String>&& replacementURLStrings, HashMap<RefPtr<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet, SerializeShadowRoots serializeShadowRoots, Vector<Ref<ShadowRoot>>&& explicitShadowRoots, const Vector<MarkupExclusionRule>& exclusionRules)
+{
+    if (!serializationSyntax)
+        serializationSyntax = node.document().isHTMLDocument() ? SerializationSyntax::HTML : SerializationSyntax::XML;
+
+    MarkupAccumulator accumulator(nodes, resolveURLs, *serializationSyntax, serializeShadowRoots, WTFMove(explicitShadowRoots), exclusionRules);
+    accumulator.enableURLReplacement(WTFMove(replacementURLStrings), WTFMove(replacementURLStringsForCSSStyleSheet));
     return accumulator.serializeNodes(const_cast<Node&>(node), root);
 }
 

--- a/Source/WebCore/editing/markup.h
+++ b/Source/WebCore/editing/markup.h
@@ -103,7 +103,8 @@ String serializePreservingVisualAppearance(const VisibleSelection&, ResolveURLs 
 enum class SerializedNodes : uint8_t { SubtreeIncludingNode, SubtreesOfChildren };
 enum class SerializationSyntax : uint8_t { HTML, XML };
 enum class SerializeShadowRoots : uint8_t { Explicit, Serializable, AllForInterchange };
-WEBCORE_EXPORT String serializeFragment(const Node&, SerializedNodes, Vector<Ref<Node>>* = nullptr, ResolveURLs = ResolveURLs::No, std::optional<SerializationSyntax> = std::nullopt, HashMap<String, String>&& replacementURLStrings = { }, HashMap<RefPtr<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet = { }, SerializeShadowRoots = SerializeShadowRoots::Explicit, Vector<Ref<ShadowRoot>>&& explicitShadowRoots = { }, const Vector<MarkupExclusionRule>& exclusionRules = { });
+WEBCORE_EXPORT String serializeFragment(const Node&, SerializedNodes, Vector<Ref<Node>>* = nullptr, ResolveURLs = ResolveURLs::No, std::optional<SerializationSyntax> = std::nullopt, SerializeShadowRoots = SerializeShadowRoots::Explicit, Vector<Ref<ShadowRoot>>&& explicitShadowRoots = { }, const Vector<MarkupExclusionRule>& exclusionRules = { });
+WEBCORE_EXPORT String serializeFragmentWithURLReplacement(const Node&, SerializedNodes, Vector<Ref<Node>>*, ResolveURLs, std::optional<SerializationSyntax>, HashMap<String, String>&& replacementURLStrings, HashMap<RefPtr<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet, SerializeShadowRoots = SerializeShadowRoots::Explicit, Vector<Ref<ShadowRoot>>&& explicitShadowRoots = { }, const Vector<MarkupExclusionRule>& exclusionRules = { });
 
 String urlToMarkup(const URL&, const String& title);
 

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -496,7 +496,7 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::create(Node& node, Function<bool(Loca
         markupExclusionRules.append(MarkupExclusionRule { AtomString { "base"_s }, { } });
 
     Vector<Ref<Node>> nodeList;
-    String markupString = serializeFragment(node, SerializedNodes::SubtreeIncludingNode, &nodeList, ResolveURLs::No, std::nullopt, { }, { }, SerializeShadowRoots::AllForInterchange, { }, markupExclusionRules);
+    String markupString = serializeFragment(node, SerializedNodes::SubtreeIncludingNode, &nodeList, ResolveURLs::No, std::nullopt, SerializeShadowRoots::AllForInterchange, { }, markupExclusionRules);
     auto nodeType = node.nodeType();
     if (nodeType != Node::DOCUMENT_NODE && nodeType != Node::DOCUMENT_TYPE_NODE)
         markupString = documentTypeString(node.document()) + markupString;
@@ -765,7 +765,7 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::create(const String& markupString, Lo
         if (!document->baseElementURL().isEmpty() && baseElementExcluded)
             resolveURLs = ResolveURLs::Yes;
 
-        String updatedMarkupString = serializeFragment(*document, SerializedNodes::SubtreeIncludingNode, nullptr, resolveURLs, std::nullopt, WTFMove(uniqueSubresources), WTFMove(uniqueCSSStyleSheets), SerializeShadowRoots::AllForInterchange, { }, markupExclusionRules);
+        String updatedMarkupString = serializeFragmentWithURLReplacement(*document, SerializedNodes::SubtreeIncludingNode, nullptr, resolveURLs, std::nullopt, WTFMove(uniqueSubresources), WTFMove(uniqueCSSStyleSheets), SerializeShadowRoots::AllForInterchange, { }, markupExclusionRules);
         mainResource = ArchiveResource::create(utf8Buffer(updatedMarkupString), responseURL, response.mimeType(), "UTF-8"_s, frame.tree().uniqueName(), ResourceResponse(), filePathWithExtension);
     }
 


### PR DESCRIPTION
#### d10b5ad2c28f6657737d54517e5d8486568c35c9
<pre>
Avoid changing the ordering of attributes when markup is not created for saving page
<a href="https://bugs.webkit.org/show_bug.cgi?id=273130">https://bugs.webkit.org/show_bug.cgi?id=273130</a>
<a href="https://rdar.apple.com/126120490">rdar://126120490</a>

Reviewed by Ryosuke Niwa.

URL replacement mode in MarkupAccumulator is introduced specifically for saving web page, and it should not affect
result of other cases; otherwise it might break existing usecases. 276043@main accidentally changes the ordering of
attributes by appending crossorigin attribute to the end -- even when MarkupAccumulator is not created with URL
replacement mode. This patch fixes that by appending attributes in original order when URL replacement is not enabled.
(see MarkupAccumulator::appendStartTag).

Also, to make it easier to distinguish between URL replacement mode and others, this patch adds two functions:
serializeFragmentWithURLReplacement and MarkupAccumulator::enableURLReplacement.

* LayoutTests/http/tests/dom/resources/simple-iframe.html: Added.
* LayoutTests/http/tests/dom/serialize-fragment-attributes-order-expected.txt: Added.
* LayoutTests/http/tests/dom/serialize-fragment-attributes-order.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::getHTML const):
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::getHTML const):
* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::MarkupAccumulator::MarkupAccumulator):
(WebCore::MarkupAccumulator::enableURLReplacement):
(WebCore::MarkupAccumulator::appendContentsForNode):
(WebCore::MarkupAccumulator::resolveURLIfNeeded const):
(WebCore::MarkupAccumulator::appendStartTagWithURLReplacement):
(WebCore::MarkupAccumulator::appendStartTag):
(WebCore::MarkupAccumulator::frameForAttributeReplacement const):
(WebCore::MarkupAccumulator::replaceAttributeIfNecessary):
(WebCore::MarkupAccumulator::appendURLAttributeForReplacementIfNecessary):
* Source/WebCore/editing/MarkupAccumulator.h:
(WebCore::MarkupAccumulator::MarkupAccumulator):
* Source/WebCore/editing/markup.cpp:
(WebCore::serializeFragment):
(WebCore::serializeFragmentWithURLReplacement):
* Source/WebCore/editing/markup.h:
(WebCore::serializeFragment):
(WebCore::serializeFragmentWithURLReplacement):
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::create):

Canonical link: <a href="https://commits.webkit.org/277944@main">https://commits.webkit.org/277944@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6e4348fc8d6ed70a329cb50c8c9369db5a5f40e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51953 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51674 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45056 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51291 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25727 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40043 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49945 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25846 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42236 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21151 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23304 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43405 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7041 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45230 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43910 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53584 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24037 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20291 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47354 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25300 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42444 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46320 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10787 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26109 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25020 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->