### PR TITLE
[SOUP] Add missing CheckedPtr macro to NetworkSessionSoup

### DIFF
--- a/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp
@@ -63,9 +63,7 @@ NetworkSessionSoup::NetworkSessionSoup(NetworkProcess& networkProcess, const Net
         m_networkSession->setHSTSPersistentStorage(parameters.hstsStorageDirectory);
 }
 
-NetworkSessionSoup::~NetworkSessionSoup()
-{
-}
+NetworkSessionSoup::~NetworkSessionSoup() = default;
 
 SoupSession* NetworkSessionSoup::soupSession() const
 {

--- a/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.h
+++ b/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.h
@@ -44,6 +44,8 @@ class WebSocketTask;
 struct NetworkSessionCreationParameters;
 
 class NetworkSessionSoup final : public NetworkSession {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NetworkSessionSoup);
 public:
     static std::unique_ptr<NetworkSession> create(NetworkProcess& networkProcess, const NetworkSessionCreationParameters& parameters)
     {


### PR DESCRIPTION
#### 0613dc5b12781d2d63ea3fc4987c0b3ff3c44634
<pre>
[SOUP] Add missing CheckedPtr macro to NetworkSessionSoup
<a href="https://bugs.webkit.org/show_bug.cgi?id=273134">https://bugs.webkit.org/show_bug.cgi?id=273134</a>

Reviewed by Michael Catanzaro.

Since 277590@main, all subclasses of classes using CheckedPtr
should adopt this macro. Not having it can cause assertions
during runtime in debug builds. Since NetworkSession uses
CheckedPtr, NetworkSessionSoup was missing it.

* Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp:
(WebKit::NetworkSessionSoup::~NetworkSessionSoup): Deleted.
* Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.h:

Canonical link: <a href="https://commits.webkit.org/277919@main">https://commits.webkit.org/277919@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f736ad5a4867003d78cbce94a2ebe1a715f20dbf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51828 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51548 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44927 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25602 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39946 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49443 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25731 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42144 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21108 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23193 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6916 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45125 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43816 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53459 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23912 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20183 "Found 1 new test failure: inspector/console/console-oom.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47250 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25175 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42353 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46199 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25983 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6998 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24895 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->