### PR TITLE
Rebuild continuations when position property changes

### DIFF
--- a/LayoutTests/fast/block/positioning/fixed-container-with-relative-parent-expected.html
+++ b/LayoutTests/fast/block/positioning/fixed-container-with-relative-parent-expected.html
@@ -2,24 +2,74 @@
 <html>
 <head>
 <title>It tests that fixed (auto)positioned element is placed properly when the parent element is relative positioned.</title>
+<style>
+.fixed { position: fixed; }
+</style>
 </head>
 <body>
-<div style="position: relative; left: 10px; width: 22px; height: 22px; background-color: green;"></div>
-<div style="position: relative; left: 10px; margin-top: 1px; width: 22px; height: 22px; background-color: green;"></div>
-<div style="position: relative; left: 10px; margin-top: 1px; width: 22px; height: 22px; background-color: green;"></div>
-<div style="position: relative; left: 10px; margin-top: 1px; width: 22px; height: 22px; background-color: green;"></div>
-<div style="position: relative; left: 10px; margin-top: 1px; width: 22px; height: 22px; background-color: green;"></div>
-<div style="position: relative; left: 10px; margin-top: 1px; width: 22px; height: 22px; background-color: green;"></div>
-<div style="position: relative; left: 10px; margin-top: 1px; width: 22px; height: 22px; background-color: green;"></div>
-<div style="position: relative; left: 10px; margin-top: 1px; width: 22px; height: 22px; background-color: green;"></div>
+<div style="position: relative; left: 10px; width: 20px; height: 20px; border: 1px solid green;">
+  <div class=fixed style="width: 20px; height: 20px; background-color: green;"></div>
+</div>
 
-<div dir=rtl style="position: absolute; right: 8px; top: 99px;">
-  <div style="position: relative; right: 10px; width: 22px; height: 22px; background-color: green;"></div>
-  <div style="position: relative; right: 10px; margin-top: 1px; width: 22px; height: 22px; background-color: green;"></div>
-  <div style="position: relative; right: 10px; margin-top: 1px; width: 22px; height: 22px; background-color: green;"></div>
-  <div style="position: relative; right: 10px; margin-top: 1px; width: 22px; height: 22px; background-color: green;"></div>
-  <div style="position: relative; right: 10px; margin-top: 1px; width: 22px; height: 22px; background-color: green;"></div>
-  <div style="position: relative; right: 10px; margin-top: 1px; width: 22px; height: 22px; background-color: green;"></div>
+<div style="-webkit-writing-mode: vertical-lr; margin-top: 1px; position: relative; left: 10px; width: 20px; height: 20px; border: 1px solid green;">
+  <div class=fixed style="width: 20px; height: 20px; background-color: green;"></div>
+</div>
+
+<div style="position: relative; left: 10px; width: 20px; height: 20px; margin-top: 1px; border: 1px solid green;">
+  <div class=fixed style="width: 20px; height: 20px; background-color: green;"></div>
+</div>
+
+<div style="-webkit-writing-mode: vertical-lr; position: relative; left: 10px; width: 20px; height: 20px; margin-top: 1px; border: 1px solid green;">
+  <div class=fixed style="width: 20px; height: 20px; background-color: green;"></div>
+</div>
+
+<div style="position: absolute; left: 13px; margin-top: 1px;">
+  <div style="position: relative; left: 5px; width: 20px; height: 20px; border: 1px solid green;">
+    <div class=fixed style="width: 20px; height: 20px; background-color: green;"></div>
+  </div>
+</div>
+
+<div style="position: absolute; margin-top: 24px; left: 8px;">
+  <span style="position: relative; left: 10px;">
+    <div class=fixed style="width: 22px; height: 22px; background-color: green;"></div>
+  </span>
+  <span style="position: relative; left: 10px; margin: 1px;">
+    <div class=fixed style="width: 22px; height: 22px; background-color: green; margin-top: 5px;"></div>
+  </span>
+  <div style="position: absolute; left: 5px;">
+    <span style="position: relative; left: 5px;">
+      <div class=fixed style="width: 22px; height: 22px; margin-top: 10px; background-color: green;"></div>
+    </span>
+  </div>
+</div>
+
+<div dir=rtl>
+  <div style="position: relative; top: 0px; right: 10px; width: 20px; height: 20px; border: 1px solid green;">
+    <div class=fixed style="width: 20px; height: 20px; background-color: green;"></div>
+  </div>
+
+  <div style="position: relative; right: 10px; width: 20px; height: 20px; margin-top: 1px; border: 1px solid green;">
+    <div class=fixed style="width: 20px; height: 20px; background-color: green;"></div>
+  </div>
+
+  <div style="position: absolute; margin-top: 1px;">
+    <div style="position: relative; right: 10px; width: 20px; height: 20px; border: 1px solid green;">
+      <div class=fixed style="width: 20px; height: 20px; background-color: green;"></div>
+    </div>
+  </div>
+  <span style="position: relative; right: 10px; top: 24px;">
+      <div class=fixed style="width: 22px; height: 22px; background-color: green;"></div>
+  </span>
+
+  <span style="position: relative; right: 10px; top: 47px">
+      <div class=fixed style="width: 22px; height: 22px; background-color: green;"></div>
+  </span>
+
+  <div style="position: absolute; right: 13px;">
+    <span style="position: relative; right: 5px; top: 70px;">
+      <div class=fixed style="width: 22px; height: 22px; background-color: green;"></div>
+    </span>
+  </div>
 </div>
 </body>
 </html>

--- a/LayoutTests/fast/block/positioning/out-of-flow-continuation-rebuild-expected.html
+++ b/LayoutTests/fast/block/positioning/out-of-flow-continuation-rebuild-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<link rel="stylesheet" type="text/css" href="http://wpt.live/fonts/ahem.css" />
+<style>
+  .abs {
+    background-color: green;
+    width: 100px;
+    height: 100px;
+    position: absolute;
+  }
+</style>
+<body>
+    <span id="span" style="position: relative;">
+      <div id="absdiv" class="abs" ></div>
+    </span>
+</body>

--- a/LayoutTests/fast/block/positioning/out-of-flow-continuation-rebuild.html
+++ b/LayoutTests/fast/block/positioning/out-of-flow-continuation-rebuild.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<link rel="stylesheet" type="text/css" href="http://wpt.live/fonts/ahem.css" />
+<style>
+  body {
+    font: 100px/1 Ahem;
+    color: red;
+  }
+  .abs {
+    background-color: green;
+    width: 100px;
+    height: 100px;
+  }
+</style>
+<body>
+    <span id="span" style="position: relative;">
+      <div id="absdiv" class="abs" ></div>
+      x 
+    </span>
+</body>
+<script>
+  document.body.offsetHeight;
+  document.getElementById("absdiv").style.position = "absolute";
+</script>

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -141,9 +141,10 @@ void RenderTreeUpdater::updateRebuildRoots()
         auto* renderingAncestor = findRenderingAncestor(root);
         if (!renderingAncestor)
             return nullptr;
-        if (!RenderTreeBuilder::isRebuildRootForChildren(*renderingAncestor->renderer()))
-            return nullptr;
-        return renderingAncestor;
+        auto isInsideContinuation = root.renderer() && root.renderer()->parent()->isContinuation();
+        if (isInsideContinuation || RenderTreeBuilder::isRebuildRootForChildren(*renderingAncestor->renderer()))
+            return renderingAncestor;
+        return nullptr;
     };
 
     auto addForRebuild = [&](auto& element) {
@@ -160,7 +161,7 @@ void RenderTreeUpdater::updateRebuildRoots()
 
         auto* parent = composedTreeAncestors(element).first();
         m_styleUpdate->addElement(element, parent, Style::ElementUpdate {
-            RenderStyle::clonePtr(element.renderer()->style()),
+            makeUnique<RenderStyle>(RenderStyle::cloneIncludingPseudoElements(element.renderer()->style())),
             Style::Change::Renderer
         });
         return true;

--- a/Source/WebCore/style/StyleUpdate.cpp
+++ b/Source/WebCore/style/StyleUpdate.cpp
@@ -96,7 +96,7 @@ void Update::addElement(Element& element, Element* parent, ElementUpdate&& eleme
     m_roots.remove(&element);
     addPossibleRoot(parent);
 
-    if (elementUpdate.change == Change::Renderer)
+    if (elementUpdate.mayNeedRebuildRoot)
         addPossibleRebuildRoot(element, parent);
 
     m_elements.add(&element, WTFMove(elementUpdate));

--- a/Source/WebCore/style/StyleUpdate.h
+++ b/Source/WebCore/style/StyleUpdate.h
@@ -46,6 +46,7 @@ struct ElementUpdate {
     std::unique_ptr<RenderStyle> style;
     Change change { Change::None };
     bool recompositeLayer { false };
+    bool mayNeedRebuildRoot { false };
 };
 
 struct TextUpdate {


### PR DESCRIPTION
#### 235ae8a090b2798b982fa2737c5df7d65d26298b
<pre>
Rebuild continuations when position property changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=273137">https://bugs.webkit.org/show_bug.cgi?id=273137</a>
<a href="https://rdar.apple.com/124987637">rdar://124987637</a>

Reviewed by Alan Baradlay.

We fail to clear continuation renderers when a renderer becomes out-of-flow positioned.
In some cases this has painting or layout effects.

* LayoutTests/fast/block/positioning/fixed-container-with-relative-parent-expected.html:

Expectations of this tests were wrong and didn&apos;t match other browsers. Simply compare against the non-dynamic case.

* LayoutTests/fast/block/positioning/out-of-flow-continuation-rebuild-expected.html: Added.
* LayoutTests/fast/block/positioning/out-of-flow-continuation-rebuild.html: Added.
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::updateRebuildRoots):

Check if the rebuild root is inside a continuation. If so start the rebuild from the ancestor.
Also copy pseudo-elements.

* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):

If position property changes we need to check for different rebuild root.

* Source/WebCore/style/StyleUpdate.cpp:
(WebCore::Style::Update::addElement):

Collect potential rebuild roots based on a bit in Style::Update.

* Source/WebCore/style/StyleUpdate.h:

Canonical link: <a href="https://commits.webkit.org/277912@main">https://commits.webkit.org/277912@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e427c6f67006fe7d811f660ed21067f211a04c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48925 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51612 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44995 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51230 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34090 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25666 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39991 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25782 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21099 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23242 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6980 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53523 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23976 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20235 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47305 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25239 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42391 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10777 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26048 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24959 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->