### PR TITLE
[JSC] (Re-land 2) Add aligned label annotation to offlineasm

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -418,10 +418,9 @@ end
 end
 
 macro instructionLabel(instrname)
-    alignment()
-    unalignedglobal _ipint%instrname%_validate
-    _ipint%instrname%:
+    aligned _ipint%instrname%_validate 256
     _ipint%instrname%_validate:
+    _ipint%instrname%:
 end
 
 macro slowPathLabel(instrname)

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
@@ -567,17 +567,10 @@ JSValue CLoop::execute(OpcodeID entryOpcodeID, void* executableAddress, VM* vm, 
     ".thumb\n"                                   \
     ".thumb_func " THUMB_FUNC_PARAM(label) "\n"  \
     SYMBOL_STRING(label) ":\n"
-#elif CPU(ARM64)
-#define OFFLINE_ASM_GLOBAL_LABEL_IMPL(label, ALT_ENTRY, ALIGNMENT, VISIBILITY) \
-    OFFLINE_ASM_TEXT_SECTION                    \
-    ALIGNMENT                                   \
-    ALT_ENTRY(label)                            \
-    ".globl " SYMBOL_STRING(label) "\n"         \
-    VISIBILITY(label) "\n"                      \
-    SYMBOL_STRING(label) ":\n"
 #else
 #define OFFLINE_ASM_GLOBAL_LABEL_IMPL(label, ALT_ENTRY, ALIGNMENT, VISIBILITY) \
     OFFLINE_ASM_TEXT_SECTION                    \
+    ALIGNMENT                                   \
     ALT_ENTRY(label)                            \
     ".globl " SYMBOL_STRING(label) "\n"         \
     VISIBILITY(label) "\n"                      \
@@ -587,6 +580,14 @@ JSValue CLoop::execute(OpcodeID entryOpcodeID, void* executableAddress, VM* vm, 
 #define OFFLINE_ASM_ALIGN4B ".balign 4\n"
 #define OFFLINE_ASM_NOALIGN ""
 
+#if CPU(ARM64) || CPU(ARM64E)
+#define OFFLINE_ASM_ALIGN_TRAP(align) OFFLINE_ASM_BEGIN_SPACER "\n .balignl " #align ", 0xd4388e20\n" // pad with brk instructions
+#elif CPU(X86_64)
+#define OFFLINE_ASM_ALIGN_TRAP(align) OFFLINE_ASM_BEGIN_SPACER "\n .balign " #align ", 0xcc\n" // pad with int 3 instructions
+#elif CPU(ARM)
+#define OFFLINE_ASM_ALIGN_TRAP(align) OFFLINE_ASM_BEGIN_SPACER "\n .balignw " #align ", 0xde00\n" // pad with udf instructions
+#endif
+
 #define OFFLINE_ASM_EXPORT_SYMBOL(symbol)
 
 #if ENABLE(OFFLINE_ASM_ALT_ENTRY)
@@ -594,6 +595,8 @@ JSValue CLoop::execute(OpcodeID entryOpcodeID, void* executableAddress, VM* vm, 
     OFFLINE_ASM_GLOBAL_LABEL_IMPL(label, OFFLINE_ASM_ALT_ENTRY_DIRECTIVE, OFFLINE_ASM_ALIGN4B, HIDE_SYMBOL)
 #define OFFLINE_ASM_UNALIGNED_GLOBAL_LABEL(label) \
     OFFLINE_ASM_GLOBAL_LABEL_IMPL(label, OFFLINE_ASM_ALT_ENTRY_DIRECTIVE, OFFLINE_ASM_NOALIGN, HIDE_SYMBOL)
+#define OFFLINE_ASM_ALIGNED_GLOBAL_LABEL(label, align) \
+    OFFLINE_ASM_GLOBAL_LABEL_IMPL(label, OFFLINE_ASM_ALT_ENTRY_DIRECTIVE, OFFLINE_ASM_ALIGN_TRAP(align), HIDE_SYMBOL)
 #define OFFLINE_ASM_GLOBAL_EXPORT_LABEL(label) \
     OFFLINE_ASM_GLOBAL_LABEL_IMPL(label, OFFLINE_ASM_ALT_ENTRY_DIRECTIVE, OFFLINE_ASM_ALIGN4B, OFFLINE_ASM_EXPORT_SYMBOL)
 #define OFFLINE_ASM_UNALIGNED_GLOBAL_EXPORT_LABEL(label) \
@@ -603,6 +606,8 @@ JSValue CLoop::execute(OpcodeID entryOpcodeID, void* executableAddress, VM* vm, 
     OFFLINE_ASM_GLOBAL_LABEL_IMPL(label, OFFLINE_ASM_NO_ALT_ENTRY_DIRECTIVE, OFFLINE_ASM_ALIGN4B, HIDE_SYMBOL)
 #define OFFLINE_ASM_UNALIGNED_GLOBAL_LABEL(label) \
     OFFLINE_ASM_GLOBAL_LABEL_IMPL(label, OFFLINE_ASM_NO_ALT_ENTRY_DIRECTIVE, OFFLINE_ASM_NOALIGN, HIDE_SYMBOL)
+#define OFFLINE_ASM_ALIGNED_GLOBAL_LABEL(label, align) \
+    OFFLINE_ASM_GLOBAL_LABEL_IMPL(label, OFFLINE_ASM_NO_ALT_ENTRY_DIRECTIVE, OFFLINE_ASM_ALIGN_TRAP(align), HIDE_SYMBOL)
 #define OFFLINE_ASM_GLOBAL_EXPORT_LABEL(label) \
     OFFLINE_ASM_GLOBAL_LABEL_IMPL(label, OFFLINE_ASM_NO_ALT_ENTRY_DIRECTIVE, OFFLINE_ASM_ALIGN4B, OFFLINE_ASM_EXPORT_SYMBOL)
 #define OFFLINE_ASM_UNALIGNED_GLOBAL_EXPORT_LABEL(label) \

--- a/Source/JavaScriptCore/offlineasm/asm.rb
+++ b/Source/JavaScriptCore/offlineasm/asm.rb
@@ -226,7 +226,7 @@ class Assembler
         @lastlabel = ""
     end
 
-    def putsLabel(labelName, isGlobal, isExport, isAligned)
+    def putsLabel(labelName, isGlobal, isExport, isAligned, alignTo)
         raise unless @state == :asm
         @deferredNextLabelActions.each {
             | action |
@@ -242,6 +242,8 @@ class Assembler
                 if isAligned
                     if isExport
                         @outp.puts(formatDump("OFFLINE_ASM_GLOBAL_EXPORT_LABEL(#{labelName})", lastComment))
+                    elsif alignTo
+                        @outp.puts(formatDump("OFFLINE_ASM_ALIGNED_GLOBAL_LABEL(#{labelName}, #{alignTo})", lastComment))
                     else
                         @outp.puts(formatDump("OFFLINE_ASM_GLOBAL_LABEL(#{labelName})", lastComment))
                     end
@@ -263,6 +265,9 @@ class Assembler
                 @outp.puts(formatDump("  _#{label}::", lastComment))
             end            
         else
+            if alignTo
+                @outp.puts(formatDump("OFFLINE_ASM_ALIGN_TRAP(#{alignTo})", lastComment))
+            end
             if !$emitWinAsm
                 @outp.puts(formatDump("OFFLINE_ASM_GLUE_LABEL(#{labelName})", lastComment))
             else

--- a/Source/JavaScriptCore/offlineasm/ast.rb
+++ b/Source/JavaScriptCore/offlineasm/ast.rb
@@ -212,6 +212,10 @@ class Immediate < NoChildren
     def dump
         "#{value}"
     end
+
+    def name
+        "0x%x" % value
+    end
     
     def ==(other)
         other.is_a? Immediate and other.value == @value
@@ -1089,6 +1093,7 @@ class Label < NoChildren
         @extern = true
         @global = false
         @aligned = true
+        @alignTo = false
         @export = false
     end
     
@@ -1140,6 +1145,18 @@ class Label < NoChildren
         end
     end
 
+    def self.setAsAligned(codeOrigin, name, alignTo)
+        if $labelMapping[name]
+            label = $labelMapping[name]
+            raise "Label: #{name} declared aligned multiple times" unless not label.aligned?
+            label.setAligned(alignTo)
+        else
+            newLabel = Label.new(codeOrigin, name)
+            newLabel.setAligned(alignTo)
+            $labelMapping[name] = newLabel
+        end
+    end
+
     def self.setAsUnalignedGlobalExport(codeOrigin, name)
         if $labelMapping[name]
             label = $labelMapping[name]
@@ -1183,6 +1200,13 @@ class Label < NoChildren
     def setUnalignedGlobal
         @global = true
         @aligned = false
+    end
+
+    def setAligned(alignTo)
+        @aligned = true
+        @alignTo = alignTo
+        # You must use this from cpp for the alignment to work on all linkers
+        @global = true
     end
 
     def setUnalignedGlobalExport

--- a/Source/JavaScriptCore/offlineasm/backends.rb
+++ b/Source/JavaScriptCore/offlineasm/backends.rb
@@ -143,7 +143,7 @@ end
 class Label
     def lower(name)
         $asm.debugAnnotation codeOrigin.debugDirective if $enableDebugAnnotations
-        $asm.putsLabel(self.name[1..-1], @global, @export, @aligned)
+        $asm.putsLabel(self.name[1..-1], @global, @export, @aligned, @alignTo)
     end
 end
 

--- a/Source/JavaScriptCore/offlineasm/parser.rb
+++ b/Source/JavaScriptCore/offlineasm/parser.rb
@@ -749,6 +749,16 @@ class Parser
                 name = @tokens[@idx].string
                 @idx += 1
                 Label.setAsUnalignedGlobal(codeOrigin, name)
+            elsif @tokens[@idx] == "aligned"
+                codeOrigin = @tokens[@idx].codeOrigin
+                @idx += 1
+                skipNewLine
+                parseError unless isLabel(@tokens[@idx])
+                name = @tokens[@idx].string
+                @idx += 1
+                align = @tokens[@idx].string
+                @idx += 1
+                Label.setAsAligned(codeOrigin, name, align)
             elsif @tokens[@idx] == "unalignedglobalexport"
                 codeOrigin = @tokens[@idx].codeOrigin
                 @idx += 1

--- a/Source/JavaScriptCore/offlineasm/transform.rb
+++ b/Source/JavaScriptCore/offlineasm/transform.rb
@@ -268,6 +268,7 @@ class Label
             result = Label.forName(codeOrigin, name, @definedInFile)
             result.setGlobal() if global?
             result.setUnalignedGlobal() unless aligned?
+            result.setAligned(@alignTo) if aligned? and @alignTo
             result.clearExtern unless extern?
             result
         else
@@ -288,6 +289,7 @@ class Label
             result = Label.forName(codeOrigin, name, @definedInFile)
             result.setGlobal() if global?
             result.setUnalignedGlobal() unless aligned?
+            result.setAligned(@alignTo) if aligned? and @alignTo
             result.clearExtern unless extern?
             result
         else


### PR DESCRIPTION
#### 60f3e42f749884b3dad3d737097f5b3211bd870b
<pre>
[JSC] (Re-land 2) Add aligned label annotation to offlineasm
<a href="https://bugs.webkit.org/show_bug.cgi?id=273138">https://bugs.webkit.org/show_bug.cgi?id=273138</a>

Reviewed by Yusuke Suzuki.

In <a href="https://commits.webkit.org/277134@main">https://commits.webkit.org/277134@main</a>, I tried to re-land Max&apos;s patch to add aligned label annotations to offlineasm.
It also broke PGO+LTO Production macOS builds. This patch removes most of the uses of this new annotation, and hopefully won&apos;t
break things this time.

* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter.cpp:
* Source/JavaScriptCore/offlineasm/asm.rb:
* Source/JavaScriptCore/offlineasm/ast.rb:
* Source/JavaScriptCore/offlineasm/backends.rb:
* Source/JavaScriptCore/offlineasm/parser.rb:
* Source/JavaScriptCore/offlineasm/transform.rb:

Canonical link: <a href="https://commits.webkit.org/278753@main">https://commits.webkit.org/278753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/744ab8cb50a4ceb0fe64e2b926d826cab72929ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53118 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/552 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/119 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40691 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42924 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21815 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24174 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/140 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8245 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43197 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46239 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54699 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/49370 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24969 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/114 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-screenx-screeny.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48078 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26226 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43109 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47117 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11261 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27088 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56853 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25956 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11684 "Passed tests") | 
<!--EWS-Status-Bubble-End-->