### PR TITLE
MiniBrowser Build Fix w/ Release Builds

### DIFF
--- a/Tools/MiniBrowser/mac/AppDelegate.h
+++ b/Tools/MiniBrowser/mac/AppDelegate.h
@@ -24,6 +24,7 @@
  */
 
 #import <UserNotifications/UNUserNotificationCenter.h>
+#import <WebKit/WebKit.h>
 #import <WebKit/_WKWebsiteDataStoreDelegate.h>
 
 @class BrowserWindowController;

--- a/Tools/MiniBrowser/mac/MiniBrowser_Prefix.pch
+++ b/Tools/MiniBrowser/mac/MiniBrowser_Prefix.pch
@@ -25,7 +25,6 @@
 
 #ifdef __OBJC__
 #import <Cocoa/Cocoa.h>
-#import <WebKit/WebKit.h>
 #endif
 
 #define ENABLE_LOGGING 0

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.h
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.h
@@ -23,6 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <WebKit/WebKit.h>
 #import "BrowserWindowController.h"
 
 @interface WK2BrowserWindowController : BrowserWindowController


### PR DESCRIPTION
#### ba9d663c6686b5926899ff9897f597cea985a5f1
<pre>
MiniBrowser Build Fix w/ Release Builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=273140">https://bugs.webkit.org/show_bug.cgi?id=273140</a>

Reviewed by Elliott Williams.

MiniBrowser was seeing certain headers multiple times due to includes.
This was causing a build failure on certain SDKs.

From talking with Elliott, removing the #import webkit from the pch and moving
it to the select headers files resolved the problem.

* Tools/MiniBrowser/mac/AppDelegate.h:
* Tools/MiniBrowser/mac/MiniBrowser_Prefix.pch:
* Tools/MiniBrowser/mac/WK2BrowserWindowController.h:

Canonical link: <a href="https://commits.webkit.org/277909@main">https://commits.webkit.org/277909@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2410cca597891e75c2621470ac0de1263c126f87

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28085 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51559 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44938 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51177 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34037 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25613 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39953 "Found 1 new test failure: imported/w3c/web-platform-tests/webxr/xrSession_viewer_referenceSpace.https.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49454 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25737 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42138 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21056 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23198 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43312 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6927 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45130 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43808 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53470 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23923 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20190 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47257 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-visibility-hidden-child.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25186 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42347 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46217 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10776 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25995 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24906 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->