### PR TITLE
Unskip html/semantics/popover-light-dismiss.html WPT

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -743,6 +743,7 @@ webkit.org/b/250171 imported/w3c/web-platform-tests/html/semantics/popovers/popo
 webkit.org/b/250171 imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-display.tentative.html [ ImageOnlyFailure ]
 webkit.org/b/250171 imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-nested-display.tentative.html [ ImageOnlyFailure ]
 webkit.org/b/250171 imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-scroll-display.tentative.html [ ImageOnlyFailure ]
+webkit.org/b/250171 imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-scroll-within.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/charset-2.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/charset-bom.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/referrer-policies.sub.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
@@ -1,4 +1,4 @@
-Popover 1 Popover 1 Outside all popovers  Next control after popover1  Popover 3 - button 3   Popover 6  Popover8 invoker (no action)  Open convoluted popover  Example 2  Open popover 29  Popover 30 Open popover 30 Non-invoker
+Popover 1 Popover 1 Outside all popovers  Next control after popover1  Popover 3 - button 3  Popover8 invoker (no action)  Open convoluted popover  Example 2  Open popover 29  Popover 30 Open popover 30 Non-invoker
 
 PASS Clicking outside a popover will dismiss the popover
 PASS Canceling pointer events should not keep clicks from light dismissing popovers
@@ -16,7 +16,6 @@ PASS Clicking on popovertarget element, even if it wasn't used for activation, s
 PASS Dragging from an open popover outside an open popover should leave the popover open
 PASS A popover inside an invoking element doesn't participate in that invoker's ancestor chain
 PASS An invoking element that was not used to invoke the popover is not part of the ancestor chain
-PASS Scrolling within a popover should not close the popover
 PASS Clicking inside a shadow DOM popover does not close that popover
 PASS Clicking outside a shadow DOM popover should close that popover
 PASS Moving focus back to the invoker element should not dismiss the popover

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-scroll-within-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-scroll-within-expected.txt
@@ -1,0 +1,4 @@
+Popover
+
+PASS Scrolling within a popover should not close the popover
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-scroll-within.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-scroll-within.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Popover light dismiss behavior when scrolled within</title>
+<meta name="timeout" content="long">
+<link rel="author" href="mailto:masonf@chromium.org">
+<link rel=help href="https://open-ui.org/components/popover.research.explainer">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/popover-utils.js"></script>
+
+<style>
+  [popover] {
+    /* Position most popovers at the bottom-right, out of the way */
+    inset:auto;
+    bottom:0;
+    right:0;
+  }
+  [popover]::backdrop {
+    /* This should *not* affect anything: */
+    pointer-events: auto;
+  }
+</style>
+
+<div popover id=p>Inside popover
+  <div style="height:2000px;background:lightgreen"></div>
+  Bottom of popover6
+</div>
+<button popovertarget=p>Popover</button>
+<style>
+  #p6 {
+    width: 300px;
+    height: 300px;
+    overflow-y: scroll;
+  }
+</style>
+<script>
+  const popover = document.querySelector('#p');
+  promise_test(async () => {
+    popover.showPopover();
+    assert_equals(popover.scrollTop,0,'popover should start non-scrolled');
+    await new test_driver.Actions()
+       .scroll(0, 0, 0, 50, {origin: popover})
+       .send();
+    await waitForRender();
+    assert_true(popover.matches(':popover-open'),'popover should stay open');
+    assert_equals(popover.scrollTop,50,'popover should be scrolled');
+    popover.hidePopover();
+  },'Scrolling within a popover should not close the popover');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html
@@ -303,33 +303,6 @@
   },'An invoking element that was not used to invoke the popover is not part of the ancestor chain');
 </script>
 
-<div popover id=p6>Inside popover 6
-  <div style="height:2000px;background:lightgreen"></div>
-  Bottom of popover6
-</div>
-<button popovertarget=p6>Popover 6</button>
-<style>
-  #p6 {
-    width: 300px;
-    height: 300px;
-    overflow-y: scroll;
-  }
-</style>
-<script>
-  const popover6 = document.querySelector('#p6');
-  promise_test(async () => {
-    popover6.showPopover();
-    assert_equals(popover6.scrollTop,0,'popover6 should start non-scrolled');
-    await new test_driver.Actions()
-       .scroll(0, 0, 0, 50, {origin: popover6})
-       .send();
-    await waitForRender();
-    assert_true(popover6.matches(':popover-open'),'popover6 should stay open');
-    assert_equals(popover6.scrollTop,50,'popover6 should be scrolled');
-    popover6.hidePopover();
-  },'Scrolling within a popover should not close the popover');
-</script>
-
 <my-element id="myElement">
   <template shadowrootmode="open">
     <button id=b7 popovertarget=p7 popovertargetaction=show tabindex="0">Popover7</button>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3732,7 +3732,7 @@ imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-to-wi
 imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-for-user-scroll.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/abspos-dialog-layout.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/multiple-centered-dialogs.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-scroll-within.html [ Skip ]
 imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll.html [ Skip ]
 imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll_visible_descendant.html [ Skip ]
 imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-mouse.html [ Skip ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
@@ -1,4 +1,4 @@
-Popover 1 Popover 1 Popover1 anchor (no action) Outside all popovers  Next control after popover1 Popover 3 - button 3   Popover 6  Popover8 anchor (no action)  Open convoluted popover Example 2
+Popover 1 Popover 1 Outside all popovers  Next control after popover1  Popover 3 - button 3   Popover8 invoker (no action)  Open convoluted popover  Example 2  Open popover 29 Popover 30 Open popover 30 Non-invoker
 
 PASS Clicking outside a popover will dismiss the popover
 PASS Canceling pointer events should not keep clicks from light dismissing popovers
@@ -6,21 +6,19 @@ PASS Clicking inside a popover does not close that popover
 PASS Popovers close on pointerup, not pointerdown
 PASS Synthetic events can't close popovers
 PASS Moving focus outside the popover should not dismiss the popover
-FAIL Clicking inside a child popover shouldn't close either popover assert_true: popover1 should be open expected true got false
-FAIL Clicking inside a parent popover should close child popover assert_true: expected true got false
+PASS Clicking inside a child popover shouldn't close either popover
+PASS Clicking inside a parent popover should close child popover
 PASS Clicking on invoking element, after using it for activation, shouldn't close its popover
 PASS Clicking on invoking element, after using it for activation, shouldn't close its popover (nested case)
-FAIL Clicking on invoking element, after using it for activation, shouldn't close its popover (nested case, not used for invocation) assert_true: expected true got false
+PASS Clicking on invoking element, after using it for activation, shouldn't close its popover (nested case, not used for invocation)
 PASS Clicking on invoking element, even if it wasn't used for activation, shouldn't close its popover
 PASS Clicking on popovertarget element, even if it wasn't used for activation, should hide it exactly once
-PASS Clicking on anchor element (that isn't an invoking element) shouldn't prevent its popover from being closed
-FAIL Dragging from an open popover outside an open popover should leave the popover open assert_true: expected true got false
+PASS Dragging from an open popover outside an open popover should leave the popover open
 PASS A popover inside an invoking element doesn't participate in that invoker's ancestor chain
 PASS An invoking element that was not used to invoke the popover is not part of the ancestor chain
-FAIL Scrolling within a popover should not close the popover promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
 PASS Clicking inside a shadow DOM popover does not close that popover
 PASS Clicking outside a shadow DOM popover should close that popover
-PASS Moving focus back to the anchor element should not dismiss the popover
+PASS Moving focus back to the invoker element should not dismiss the popover
 PASS Ensure circular/convoluted ancestral relationships are functional
 PASS Ensure circular/convoluted ancestral relationships are functional, with a direct showPopover()
 PASS Hide the target popover during "hide all popovers until"
@@ -28,4 +26,6 @@ PASS Show a sibling popover during "hide all popovers until"
 PASS Show an unrelated popover during "hide popover"
 PASS Show other auto popover during "hide all popover until"
 PASS Nested showPopover
+PASS Pointer down in one document and pointer up in another document shouldn't dismiss popover
+PASS Pointer down inside invoker and up outside that invoker shouldn't dismiss popover
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4709,8 +4709,10 @@ imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-w
 imported/w3c/web-platform-tests/dom/events/scrolling/iframe-chains.html [ Skip ]
 imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-for-user-scroll.html [ Skip ]
 imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-not-fired-on-no-scroll.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-scroll-within.html [ Skip ]
 imported/w3c/web-platform-tests/uievents/order-of-events/mouse-events/wheel-scrolling.html [ Skip ]
+
+webkit.org/b/267688 imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html [ Failure ]
 
 #rdar://118015813 ([ iOS ]imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-main-frame-root.html is a flaky text failure (264281))
 imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-main-frame-root.html [ Pass Failure ]

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
@@ -1,4 +1,4 @@
-Popover 1 Popover 1 Popover1 anchor (no action) Outside all popovers  Next control after popover1  Popover 3 - button 3 Popover 6  Popover8 anchor (no action)  Open convoluted popover  Example 2
+Popover 1 Popover 1 Outside all popovers  Next control after popover1  Popover 3 - button 3   Popover 6  Popover8 invoker (no action)  Open convoluted popover  Example 2  Open popover 29  Popover 30 Open popover 30 Non-invoker
 
 FAIL Clicking outside a popover will dismiss the popover assert_false: expected false got true
 FAIL Canceling pointer events should not keep clicks from light dismissing popovers assert_false: expected false got true
@@ -6,21 +6,19 @@ FAIL Clicking inside a popover does not close that popover assert_false: expecte
 FAIL Popovers close on pointerup, not pointerdown assert_false: expected false got true
 FAIL Synthetic events can't close popovers assert_false: expected false got true
 FAIL Moving focus outside the popover should not dismiss the popover assert_equals: Focus should move to a button outside the popover expected Element node <button id="after_p1" tabindex="0">Next control after pop... but got Element node <body><button id="b1t" popovertarget="p1">Popover 1</butt...
-FAIL Clicking inside a child popover shouldn't close either popover assert_true: popover1 should be open expected true got false
-FAIL Clicking inside a parent popover should close child popover assert_true: expected true got false
-FAIL Clicking on invoking element, after using it for activation, shouldn't close its popover assert_true: expected true got false
+PASS Clicking inside a child popover shouldn't close either popover
+FAIL Clicking inside a parent popover should close child popover assert_false: expected false got true
+PASS Clicking on invoking element, after using it for activation, shouldn't close its popover
 FAIL Clicking on invoking element, after using it for activation, shouldn't close its popover (nested case) assert_true: button2 should activate popover2 expected true got false
-FAIL Clicking on invoking element, after using it for activation, shouldn't close its popover (nested case, not used for invocation) assert_true: expected true got false
+PASS Clicking on invoking element, after using it for activation, shouldn't close its popover (nested case, not used for invocation)
 PASS Clicking on invoking element, even if it wasn't used for activation, shouldn't close its popover
 FAIL Clicking on popovertarget element, even if it wasn't used for activation, should hide it exactly once assert_false: popover1 should be hidden by popovertarget expected false got true
-FAIL Clicking on anchor element (that isn't an invoking element) shouldn't prevent its popover from being closed assert_false: popover1 should close expected false got true
-FAIL Dragging from an open popover outside an open popover should leave the popover open assert_true: expected true got false
+PASS Dragging from an open popover outside an open popover should leave the popover open
 FAIL A popover inside an invoking element doesn't participate in that invoker's ancestor chain assert_true: invoking element should open popover expected true got false
 PASS An invoking element that was not used to invoke the popover is not part of the ancestor chain
-FAIL Scrolling within a popover should not close the popover promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
 PASS Clicking inside a shadow DOM popover does not close that popover
 FAIL Clicking outside a shadow DOM popover should close that popover assert_false: expected false got true
-FAIL Moving focus back to the anchor element should not dismiss the popover assert_equals: Focus should move to the anchor element expected Element node <button id="p8anchor" tabindex="0">Popover8 anchor (no ac... but got Element node <body><button id="b1t" popovertarget="p1">Popover 1</butt...
+FAIL Moving focus back to the invoker element should not dismiss the popover assert_equals: Focus should move to the invoker element expected Element node <button id="p8invoker" popovertarget="p8" tabindex="0">Po... but got Element node <body><button id="b1t" popovertarget="p1">Popover 1</butt...
 PASS Ensure circular/convoluted ancestral relationships are functional
 PASS Ensure circular/convoluted ancestral relationships are functional, with a direct showPopover()
 PASS Hide the target popover during "hide all popovers until"
@@ -28,4 +26,6 @@ PASS Show a sibling popover during "hide all popovers until"
 PASS Show an unrelated popover during "hide popover"
 PASS Show other auto popover during "hide all popover until"
 PASS Nested showPopover
+PASS Pointer down in one document and pointer up in another document shouldn't dismiss popover
+PASS Pointer down inside invoker and up outside that invoker shouldn't dismiss popover
 

--- a/LayoutTests/platform/mac-ventura-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-ventura-wk2/TestExpectations
@@ -49,5 +49,5 @@ imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passi
 imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-div.html [ Skip ]
 imported/w3c/web-platform-tests/dom/events/scrolling/iframe-chains.html [ Skip ]
 imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-for-user-scroll.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-scroll-within.html [ Skip ]
 imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-mouse.html [ Skip ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2744,7 +2744,7 @@ imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-w
 imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-div.html [ Skip ]
 imported/w3c/web-platform-tests/dom/events/scrolling/iframe-chains.html [ Skip ]
 imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-for-user-scroll.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-scroll-within.html [ Skip ]
 imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-mouse.html [ Skip ]
 
 imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting.html [ Failure ]


### PR DESCRIPTION
#### 2da25afcddf733555a446fc6851676dbe23dfea4
<pre>
Unskip html/semantics/popover-light-dismiss.html WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=273141">https://bugs.webkit.org/show_bug.cgi?id=273141</a>

Reviewed by Tim Nguyen.

This patch splits the &quot;Scrolling withing&quot; subtest from the popover-light-dismiss.html WPT into its own file.
It also unskips the main light dimiss test on all platforms.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-scroll-within-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-scroll-within.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt:
* LayoutTests/platform/mac-ventura-wk2/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:

* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt:

 LayoutTests/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/278325@main">https://commits.webkit.org/278325@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07d9092a8a52eb0b7d4d9a150469c2a9d6beaf45

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52935 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/369 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26598 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40546 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51793 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26516 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42785 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21667 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23957 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43987 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8064 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45867 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44496 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54516 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20944 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48182 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26047 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42937 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46948 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26895 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7255 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25772 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->