### PR TITLE
[JSC] Relax arraySpeciesWatchpointIsValid condition

### DIFF
--- a/JSTests/stress/array-splice-constructor.js
+++ b/JSTests/stress/array-splice-constructor.js
@@ -1,0 +1,30 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+{
+    let array = [0, 1, 2, 3, 4, 5];
+    array.deletedCount = 42;
+
+    array.splice(0, 3);
+    shouldBe(array.length, 3);
+    shouldBe(array[0], 3);
+    shouldBe(array[1], 4);
+    shouldBe(array[2], 5);
+}
+{
+    let object = null;
+    let array = [0, 1, 2, 3, 4, 5];
+    array.constructor = function () { object = this; };
+    array.constructor[Symbol.species] = array.constructor;
+    array.deletedCount = 42;
+
+    let result = array.splice(0, 3);
+    shouldBe(array.length, 3);
+    shouldBe(array[0], 3);
+    shouldBe(array[1], 4);
+    shouldBe(array[2], 5);
+
+    shouldBe(result, object);
+}

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -1730,7 +1730,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoPrivateFuncConcatMemcpy, (JSGlobalObject* glo
         return JSValue::encode(jsNull());
 
     // We need to check the species constructor here since checking it in the JS wrapper is too expensive for the non-optimizing tiers.
-    bool isValid = arraySpeciesWatchpointIsValid(firstArray);
+    bool isValid = arraySpeciesWatchpointIsValid(vm, firstArray);
     RETURN_IF_EXCEPTION(scope, { });
     if (UNLIKELY(!isValid))
         return JSValue::encode(jsNull());

--- a/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
@@ -40,16 +40,22 @@ enum class SpeciesConstructResult : uint8_t {
     CreatedObject
 };
 
-ALWAYS_INLINE bool arraySpeciesWatchpointIsValid(JSObject* thisObject)
+ALWAYS_INLINE bool arraySpeciesWatchpointIsValid(VM& vm, JSObject* thisObject)
 {
     JSGlobalObject* globalObject = thisObject->globalObject();
     ArrayPrototype* arrayPrototype = globalObject->arrayPrototype();
 
     ASSERT(globalObject->arraySpeciesWatchpointSet().state() != ClearWatchpoint);
+    if (arrayPrototype != thisObject->getPrototypeDirect())
+        return false;
 
-    return !thisObject->hasCustomProperties()
-        && arrayPrototype == thisObject->getPrototypeDirect()
-        && globalObject->arraySpeciesWatchpointSet().state() == IsWatched;
+    if (globalObject->arraySpeciesWatchpointSet().state() != IsWatched)
+        return false;
+
+    if (!thisObject->hasCustomProperties())
+        return true;
+
+    return thisObject->getDirectOffset(vm, vm.propertyNames->constructor) == invalidOffset;
 }
 
 ALWAYS_INLINE std::pair<SpeciesConstructResult, JSObject*> speciesConstructArray(JSGlobalObject* globalObject, JSObject* thisObject, uint64_t length)
@@ -66,7 +72,7 @@ ALWAYS_INLINE std::pair<SpeciesConstructResult, JSObject*> speciesConstructArray
     if (LIKELY(thisIsArray)) {
         // Fast path in the normal case where the user has not set an own constructor and the Array.prototype.constructor is normal.
         // We need prototype check for subclasses of Array, which are Array objects but have a different prototype by default.
-        bool isValid = arraySpeciesWatchpointIsValid(thisObject);
+        bool isValid = arraySpeciesWatchpointIsValid(vm, thisObject);
         RETURN_IF_EXCEPTION(scope, exceptionResult);
         if (LIKELY(isValid))
             return std::pair { SpeciesConstructResult::FastPath, nullptr };


### PR DESCRIPTION
#### 8b7b1a1b94a005149bbc517244ae80bbc87029b9
<pre>
[JSC] Relax arraySpeciesWatchpointIsValid condition
<a href="https://bugs.webkit.org/show_bug.cgi?id=273143">https://bugs.webkit.org/show_bug.cgi?id=273143</a>
<a href="https://rdar.apple.com/126938733">rdar://126938733</a>

Reviewed by Alexey Shvayka.

This patch relaxes arraySpeciesWatchpointIsValid condition so that we can accept Array with unrelated properties for the fast path.

* JSTests/stress/array-splice-constructor.js: Added.
(shouldBe):
(throw.new.Error):
(shouldBe.array):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h:
(JSC::arraySpeciesWatchpointIsValid):

Canonical link: <a href="https://commits.webkit.org/277900@main">https://commits.webkit.org/277900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38d259bd4e6de8515c2d4fa2f52af6e63698c117

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48876 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51563 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44942 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25617 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39954 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25739 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42140 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21057 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23200 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6931 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/42175 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45132 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43811 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53474 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/48367 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23927 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20192 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47261 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25190 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42349 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46212 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25999 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55862 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6986 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24910 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11499 "Passed tests") | 
<!--EWS-Status-Bubble-End-->