### PR TITLE
Add --js-builtin option to generate-sampling-profiler-flame-graph

### DIFF
--- a/Tools/Scripts/generate-sampling-profiler-flame-graph
+++ b/Tools/Scripts/generate-sampling-profiler-flame-graph
@@ -28,6 +28,9 @@ require 'getoptlong'
 
 $rootDirectory = File.expand_path(File.join(File.dirname(__FILE__), "..", ".."))
 
+$flameGraphTitle = ""
+$flameGraphJSBuiltin = false
+
 def render samples, title
     template = <<-RESULT
 <!DOCTYPE html>
@@ -188,15 +191,20 @@ def reconstruct database
         cursor = result
         next if stackTrace["frames"].empty?
         stackTrace["frames"].reverse.map do |frame|
+            jsbuiltin = ""
+            if $flameGraphJSBuiltin
+                flags = frame["flags"]
+                if !flags.nil? && flags & 0b1 != 0
+                    jsbuiltin = "/JSBUILTIN"
+                end
+            end
             hash, category, offset = frame["location"].split(":")
-            cursor = update(cursor, "#{frame["name"]}#{hash}")
+            cursor = update(cursor, "#{frame["name"]}#{hash}#{jsbuiltin}")
         end
         cursor["value"] += 1
     end
     result
 end
-
-$flameGraphTitle = ""
 
 def usage
     puts <<-HELP
@@ -212,24 +220,27 @@ end
 
 GetoptLong.new(
     ['--help', '-h', GetoptLong::NO_ARGUMENT],
-    ['--title', '-t', GetoptLong::REQUIRED_ARGUMENT]
+    ['--title', '-t', GetoptLong::REQUIRED_ARGUMENT],
+    ['--js-builtin', '-b', GetoptLong::NO_ARGUMENT],
 ).each do |opt, arg|
     case opt
     when '--help'
-      usage
+        usage
     when '--title'
-      $flameGraphTitle = arg
+        $flameGraphTitle = arg
+    when '--js-builtin'
+        $flameGraphJSBuiltin = true
     end
 end
 
 def main
-  json = nil
-  if ARGV.empty?
-      json = JSON.parse(STDIN.read)
-  else
-      json = JSON::parse(IO::read(ARGV[0]))
-  end
-  puts render(reconstruct(json), $flameGraphTitle)
+    json = nil
+    if ARGV.empty?
+        json = JSON.parse(STDIN.read)
+    else
+        json = JSON::parse(IO::read(ARGV[0]))
+    end
+    puts render(reconstruct(json), $flameGraphTitle)
 end
 
 main


### PR DESCRIPTION
#### ecd31acfa9f1371c758d65498b9f775ddb5e7736
<pre>
Add --js-builtin option to generate-sampling-profiler-flame-graph
<a href="https://bugs.webkit.org/show_bug.cgi?id=273147">https://bugs.webkit.org/show_bug.cgi?id=273147</a>
<a href="https://rdar.apple.com/126941714">rdar://126941714</a>

Reviewed by Keith Miller.

This is an option which annotate frame with `/JSBUILTIN` if it is JS builtin function in sampling profiler.

* Tools/Scripts/generate-sampling-profiler-flame-graph:

Canonical link: <a href="https://commits.webkit.org/277908@main">https://commits.webkit.org/277908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e361cca727e400692219342cedde3f99949d5745

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48886 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51573 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44952 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51191 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34051 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25627 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39963 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49468 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42151 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21066 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23212 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43325 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6941 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45144 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43823 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53484 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23937 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20200 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47270 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25200 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42360 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46222 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26009 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6992 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24920 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->