### PR TITLE
[WebGPU] Validate buffer length for bind group entries

### DIFF
--- a/LayoutTests/fast/webgpu/fuzz-126848520-auto-layout-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-126848520-auto-layout-expected.txt
@@ -1,0 +1,5 @@
+     0                0
+     8                0
+Buffer size is invalid
+done
+

--- a/LayoutTests/fast/webgpu/fuzz-126848520-auto-layout.html
+++ b/LayoutTests/fast/webgpu/fuzz-126848520-auto-layout.html
@@ -1,0 +1,69 @@
+<script src="../../resources/js-test-pre.js"></script>
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  onload = async () => {
+    let adapter0 = await navigator.gpu.requestAdapter();
+    let device = await adapter0.requestDevice();
+    try {
+      device.pushErrorScope('validation');
+      let code = `
+@group(0) @binding(0)
+var<storage, read_write> fixedSizeArray: array<u32, 0xfffffff>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+  fixedSizeArray[0x40] = 0x11223344;
+  fixedSizeArray[0x42] = 0xaabbccdd;
+}
+`;
+      let shaderModule = device.createShaderModule({code});
+      let bindGroupLayout0 = device.createBindGroupLayout({
+        entries: [
+          {binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: {type: 'storage'}},
+        ],
+      });
+      let pipelineLayout = device.createPipelineLayout({
+        bindGroupLayouts: [bindGroupLayout0],
+      });
+      let computePipeline = device.createComputePipeline({
+        layout: 'auto',
+        compute: {module: shaderModule, entryPoint: 'compute0'},
+      });
+      let compilationInfo = await shaderModule.getCompilationInfo();
+      for (let message of compilationInfo.messages) {
+        debug(message);
+      }
+      let buffer0 = device.createBuffer({size: 16, usage: GPUBufferUsage.STORAGE});
+      let bufferToDump = device.createBuffer({size: 16, usage: GPUBufferUsage.MAP_READ});
+      let bindGroup0 = device.createBindGroup({
+        layout: computePipeline.getBindGroupLayout(0),
+        entries: [
+          {binding: 0, resource: {buffer: buffer0, offset: 0, size: 16}},
+        ],
+      });
+      let commandEncoder = device.createCommandEncoder();
+      let computePassEncoder = commandEncoder.beginComputePass();
+      computePassEncoder.setBindGroup(0, bindGroup0);
+      computePassEncoder.setPipeline(computePipeline);
+      computePassEncoder.dispatchWorkgroups(1, 1, 1);
+      computePassEncoder.end();
+      let commandBuffer = commandEncoder.finish();
+      device.queue.submit([commandBuffer]);
+      await device.queue.onSubmittedWorkDone();
+      await bufferToDump.mapAsync(GPUMapMode.READ);
+      let dataView = new DataView(bufferToDump.getMappedRange());
+      for (let i = 0; i < dataView.byteLength; i += 8) {
+        let v = dataView.getBigUint64(i, true);
+        debug(`${i.toString(0x10).padStart(6)} ${v.toString(0x10).padStart(16)}`);
+      }
+    } catch (e) {
+      debug('error');
+      debug(e);
+    } finally {
+      let validationError = await device.popErrorScope();
+      debug(validationError?.message);
+    }
+    debug('done');
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/LayoutTests/fast/webgpu/fuzz-126848520-explicit-layout-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-126848520-explicit-layout-expected.txt
@@ -1,0 +1,5 @@
+     0                0
+     8                0
+Buffer size is invalid
+done
+

--- a/LayoutTests/fast/webgpu/fuzz-126848520-explicit-layout.html
+++ b/LayoutTests/fast/webgpu/fuzz-126848520-explicit-layout.html
@@ -1,0 +1,70 @@
+<script src="../../resources/js-test-pre.js"></script>
+<script>
+  globalThis.testRunner?.waitUntilDone();
+
+  onload = async () => {
+    let adapter0 = await navigator.gpu.requestAdapter();
+    let device = await adapter0.requestDevice();
+    try {
+      device.pushErrorScope('validation');
+      let code = `
+@group(0) @binding(0)
+var<storage, read_write> fixedSizeArray: array<u32, 0xfffffff>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+  fixedSizeArray[0x40] = 0x11223344;
+  fixedSizeArray[0x42] = 0xaabbccdd;
+}
+`;
+      let shaderModule = device.createShaderModule({code});
+      let bindGroupLayout0 = device.createBindGroupLayout({
+        entries: [
+          {binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: {type: 'storage'}},
+        ],
+      });
+      let pipelineLayout = device.createPipelineLayout({
+        bindGroupLayouts: [bindGroupLayout0],
+      });
+      let computePipeline = device.createComputePipeline({
+        layout: pipelineLayout,
+        compute: {module: shaderModule, entryPoint: 'compute0'},
+      });
+      let compilationInfo = await shaderModule.getCompilationInfo();
+      for (let message of compilationInfo.messages) {
+        debug(message);
+      }
+      let buffer0 = device.createBuffer({size: 16, usage: GPUBufferUsage.STORAGE});
+      let bufferToDump = device.createBuffer({size: 16, usage: GPUBufferUsage.MAP_READ});
+      let bindGroup0 = device.createBindGroup({
+        layout: bindGroupLayout0,
+        entries: [
+          {binding: 0, resource: {buffer: buffer0, offset: 0, size: 16}},
+        ],
+      });
+      let commandEncoder = device.createCommandEncoder();
+      let computePassEncoder = commandEncoder.beginComputePass();
+      computePassEncoder.setBindGroup(0, bindGroup0);
+      computePassEncoder.setPipeline(computePipeline);
+      computePassEncoder.dispatchWorkgroups(1, 1, 1);
+      computePassEncoder.end();
+      let commandBuffer = commandEncoder.finish();
+      device.queue.submit([commandBuffer]);
+      await device.queue.onSubmittedWorkDone();
+      await bufferToDump.mapAsync(GPUMapMode.READ);
+      let dataView = new DataView(bufferToDump.getMappedRange());
+      for (let i = 0; i < dataView.byteLength; i += 8) {
+        let v = dataView.getBigUint64(i, true);
+        debug(`${i.toString(0x10).padStart(6)} ${v.toString(0x10).padStart(16)}`);
+      }
+    } catch (e) {
+      debug('error');
+      debug(e);
+    } finally {
+      let validationError = await device.popErrorScope();
+      debug(validationError?.message);
+    }
+    debug('done');
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
@@ -196,6 +196,7 @@ RefPtr<BindGroupLayout> DeviceImpl::createBindGroupLayout(const BindGroupLayoutD
                 entry.buffer ? m_convertToBackingContext->convertToBacking(entry.buffer->type) : WGPUBufferBindingType_Undefined,
                 entry.buffer ? entry.buffer->hasDynamicOffset : false,
                 entry.buffer ? entry.buffer->minBindingSize : 0,
+                0,
             },
             .sampler = {
                 nullptr,

--- a/Source/WebGPU/WGSL/EntryPointRewriter.cpp
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.cpp
@@ -349,7 +349,7 @@ void EntryPointRewriter::appendBuiltins()
     }
 }
 
-void rewriteEntryPoints(ShaderModule& shaderModule, const HashMap<String, std::optional<PipelineLayout>>& pipelineLayouts)
+void rewriteEntryPoints(ShaderModule& shaderModule, const HashMap<String, PipelineLayout*>& pipelineLayouts)
 {
     for (auto& entryPoint : shaderModule.callGraph().entrypoints()) {
         if (!pipelineLayouts.contains(entryPoint.originalName))

--- a/Source/WebGPU/WGSL/EntryPointRewriter.h
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.h
@@ -32,6 +32,6 @@ namespace WGSL {
 class ShaderModule;
 struct PipelineLayout;
 
-void rewriteEntryPoints(ShaderModule&, const HashMap<String, std::optional<PipelineLayout>>&);
+void rewriteEntryPoints(ShaderModule&, const HashMap<String, PipelineLayout*>&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.h
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.h
@@ -38,6 +38,6 @@ namespace Reflection {
 struct EntryPointInformation;
 };
 
-std::optional<Error> rewriteGlobalVariables(ShaderModule&, const HashMap<String, std::optional<PipelineLayout>>&, HashMap<String, Reflection::EntryPointInformation>&);
+std::optional<Error> rewriteGlobalVariables(ShaderModule&, const HashMap<String, PipelineLayout*>&, HashMap<String, Reflection::EntryPointInformation>&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -92,7 +92,7 @@ SuccessfulCheck::SuccessfulCheck(Vector<Warning>&& messages, UniqueRef<ShaderMod
 
 SuccessfulCheck::~SuccessfulCheck() = default;
 
-inline std::variant<PrepareResult, Error> prepareImpl(ShaderModule& shaderModule, const HashMap<String, std::optional<PipelineLayout>>& pipelineLayouts)
+inline std::variant<PrepareResult, Error> prepareImpl(ShaderModule& shaderModule, const HashMap<String, PipelineLayout*>& pipelineLayouts)
 {
     CompilationScope compilationScope(shaderModule);
 
@@ -130,14 +130,14 @@ String generate(ShaderModule& shaderModule, PrepareResult& prepareResult, HashMa
     return result;
 }
 
-std::variant<PrepareResult, Error> prepare(ShaderModule& ast, const HashMap<String, std::optional<PipelineLayout>>& pipelineLayouts)
+std::variant<PrepareResult, Error> prepare(ShaderModule& ast, const HashMap<String, PipelineLayout*>& pipelineLayouts)
 {
     return prepareImpl(ast, pipelineLayouts);
 }
 
-std::variant<PrepareResult, Error> prepare(ShaderModule& ast, const String& entryPointName, const std::optional<PipelineLayout>& pipelineLayout)
+std::variant<PrepareResult, Error> prepare(ShaderModule& ast, const String& entryPointName, PipelineLayout* pipelineLayout)
 {
-    HashMap<String, std::optional<PipelineLayout>> pipelineLayouts;
+    HashMap<String, PipelineLayout*> pipelineLayouts;
     pipelineLayouts.add(entryPointName, pipelineLayout);
     return prepareImpl(ast, pipelineLayouts);
 }

--- a/Source/WebGPU/WGSL/WGSL.h
+++ b/Source/WebGPU/WGSL/WGSL.h
@@ -217,7 +217,6 @@ struct EntryPointInformation {
     String originalName;
     String mangledName;
     std::optional<PipelineLayout> defaultLayout; // If the input PipelineLayout is nullopt, the compiler computes a layout and returns it. https://gpuweb.github.io/gpuweb/#default-pipeline-layout
-    HashMap<std::pair<size_t, size_t>, size_t> bufferLengthLocations; // Metal buffer identity -> offset within helper buffer where its size needs to lie
     HashMap<String, SpecializationConstant> specializationConstants;
     std::variant<Vertex, Fragment, Compute> typedEntryPoint;
     size_t sizeForWorkgroupVariables { 0 };
@@ -230,8 +229,8 @@ struct PrepareResult {
     CompilationScope compilationScope;
 };
 
-std::variant<PrepareResult, Error> prepare(ShaderModule&, const HashMap<String, std::optional<PipelineLayout>>&);
-std::variant<PrepareResult, Error> prepare(ShaderModule&, const String& entryPointName, const std::optional<PipelineLayout>&);
+std::variant<PrepareResult, Error> prepare(ShaderModule&, const HashMap<String, PipelineLayout*>&);
+std::variant<PrepareResult, Error> prepare(ShaderModule&, const String& entryPointName, PipelineLayout*);
 
 String generate(ShaderModule&, PrepareResult&, HashMap<String, ConstantValue>&);
 

--- a/Source/WebGPU/WGSL/wgslc.cpp
+++ b/Source/WebGPU/WGSL/wgslc.cpp
@@ -131,7 +131,7 @@ static int runWGSL(const CommandLine& options)
         WGSL::AST::dumpAST(shaderModule);
 
     String entrypointName = String::fromLatin1(options.entrypoint());
-    auto prepareResult = WGSL::prepare(shaderModule, entrypointName, std::nullopt);
+    auto prepareResult = WGSL::prepare(shaderModule, entrypointName, nullptr);
 
     if (auto* error = std::get_if<WGSL::Error>(&prepareResult)) {
         dataLogLn(*error);

--- a/Source/WebGPU/WebGPU/BindGroupLayout.mm
+++ b/Source/WebGPU/WebGPU/BindGroupLayout.mm
@@ -59,7 +59,6 @@ static MTLArgumentDescriptor *createArgumentDescriptor(const WGPUBufferBindingLa
     } else
         descriptor.dataType = MTLDataTypePointer;
 
-    // FIXME: Handle minBindingSize.
     switch (bufferType) {
     case WGPUBufferBindingType_Uniform:
     case WGPUBufferBindingType_ReadOnlyStorage:
@@ -263,7 +262,7 @@ Ref<BindGroupLayout> Device::createBindGroupLayout(const WGPUBindGroupLayoutDesc
             descriptors[3] = createArgumentDescriptor(bufferLayout, *this, entry);
             bindingLayout = WGPUExternalTextureBindingLayout();
         } else if (entry.buffer.type == static_cast<WGPUBufferBindingType>(WGPUBufferBindingType_ArrayLength)) {
-            slotForEntry.set(entry.buffer.minBindingSize, entry.binding);
+            slotForEntry.set(entry.buffer.bufferSizeForBinding, entry.binding);
             hasCompilerGeneratedArrayLengths = true;
             continue;
         } else {
@@ -462,7 +461,7 @@ NSString* BindGroupLayout::errorValidatingDynamicOffsets(const uint32_t* dynamic
 
 static bool isEqual(const WGPUBufferBindingLayout& entry, const WGPUBufferBindingLayout& otherEntry)
 {
-    return entry.type == otherEntry.type && entry.hasDynamicOffset == otherEntry.hasDynamicOffset && entry.minBindingSize == otherEntry.minBindingSize;
+    return entry.type == otherEntry.type && entry.hasDynamicOffset == otherEntry.hasDynamicOffset && entry.minBindingSize == otherEntry.minBindingSize && entry.bufferSizeForBinding == otherEntry.bufferSizeForBinding;
 }
 static bool isEqual(const WGPUSamplerBindingLayout& entry, const WGPUSamplerBindingLayout& otherEntry)
 {

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -33,6 +33,7 @@
 #import "CommandEncoder.h"
 #import "ComputePipeline.h"
 #import "IsValidToUseWith.h"
+#import "Pipeline.h"
 #import "QuerySet.h"
 
 namespace WebGPU {
@@ -183,6 +184,10 @@ void ComputePassEncoder::executePreDispatchCommands(const Buffer* indirectBuffer
             return;
         }
         auto& group = *kvp.value.get();
+        if (!validateBindGroup(group)) {
+            makeInvalid(@"buffer is too small");
+            return;
+        }
         [m_computeCommandEncoder setBuffer:group.computeArgumentBuffer() offset:0 atIndex:bindGroupIndex];
     }
 

--- a/Source/WebGPU/WebGPU/Pipeline.h
+++ b/Source/WebGPU/WebGPU/Pipeline.h
@@ -28,6 +28,7 @@
 
 namespace WebGPU {
 
+class BindGroup;
 class ShaderModule;
 
 struct LibraryCreationResult {
@@ -36,8 +37,10 @@ struct LibraryCreationResult {
     HashMap<String, WGSL::ConstantValue> wgslConstantValues;
 };
 
-std::optional<LibraryCreationResult> createLibrary(id<MTLDevice>, const ShaderModule&, const PipelineLayout*, const String& entryPointName, NSString *label, uint32_t constantCount, const WGPUConstantEntry* constants, NSError **);
+std::optional<LibraryCreationResult> createLibrary(id<MTLDevice>, const ShaderModule&, PipelineLayout*, const String& entryPointName, NSString *label, uint32_t constantCount, const WGPUConstantEntry* constants, NSError **);
 
 id<MTLFunction> createFunction(id<MTLLibrary>, const WGSL::Reflection::EntryPointInformation&, NSString *label);
+
+bool validateBindGroup(BindGroup&);
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -33,6 +33,7 @@
 #import "CommandEncoder.h"
 #import "ExternalTexture.h"
 #import "IsValidToUseWith.h"
+#import "Pipeline.h"
 #import "QuerySet.h"
 #import "RenderBundle.h"
 #import "RenderPipeline.h"
@@ -460,6 +461,10 @@ bool RenderPassEncoder::executePreDrawCommands(const Buffer* indirectBuffer)
             return false;
         }
         auto& group = *weakBindGroup.get();
+        if (!validateBindGroup(group)) {
+            makeInvalid(@"buffer is too small");
+            return false;
+        }
         [m_renderCommandEncoder setVertexBuffer:group.vertexArgumentBuffer() offset:0 atIndex:m_device->vertexBufferIndexForBindGroup(groupIndex)];
         [m_renderCommandEncoder setFragmentBuffer:group.fragmentArgumentBuffer() offset:0 atIndex:groupIndex];
     }

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -803,14 +803,14 @@ NSString* Device::addPipelineLayouts(Vector<Vector<WGPUBindGroupLayoutEntry>>& p
                 continue;
             }
             WGPUBindGroupLayoutEntry newEntry = { };
-            uint64_t minBindingSize = 0;
+            uint64_t bufferSizeForBinding = 0;
             WGPUBufferBindingType bufferTypeOverride = WGPUBufferBindingType_Undefined;
             if (auto& entryName = entry.name; entryName.length()) {
                 if (entryName.endsWith("_ArrayLength"_s)) {
                     bufferTypeOverride = static_cast<WGPUBufferBindingType>(WGPUBufferBindingType_ArrayLength);
                     auto shortName = entryName.substring(2, entryName.length() - (sizeof("_ArrayLength") + 1));
                     if (auto it = entryMap.find(shortName); it != entryMap.end())
-                        minBindingSize = it->value;
+                        bufferSizeForBinding = it->value;
                 } else
                     entryMap.set(entryName, entry.webBinding);
             }
@@ -823,7 +823,8 @@ NSString* Device::addPipelineLayouts(Vector<Vector<WGPUBindGroupLayoutEntry>>& p
                     .nextInChain = nullptr,
                     .type = (bufferTypeOverride != WGPUBufferBindingType_Undefined) ? bufferTypeOverride : convertBindingType(bufferBinding.type),
                     .hasDynamicOffset = bufferBinding.hasDynamicOffset,
-                    .minBindingSize = minBindingSize ?: bufferBinding.minBindingSize,
+                    .minBindingSize = bufferBinding.minBindingSize,
+                    .bufferSizeForBinding = bufferSizeForBinding,
                 };
             }, [&](const WGSL::SamplerBindingLayout& sampler) {
                 newEntry.sampler = WGPUSamplerBindingLayout {
@@ -1285,7 +1286,7 @@ std::pair<Ref<RenderPipeline>, NSString*> Device::createRenderPipeline(const WGP
     mtlRenderPipelineDescriptor.supportIndirectCommandBuffers = YES;
     auto& deviceLimits = limits();
 
-    const PipelineLayout* pipelineLayout = nullptr;
+    PipelineLayout* pipelineLayout = nullptr;
     Vector<Vector<WGPUBindGroupLayoutEntry>> bindGroupEntries;
     if (descriptor.layout) {
         auto& layout = WebGPU::fromAPI(descriptor.layout);

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -787,6 +787,7 @@ typedef struct WGPUBufferBindingLayout {
     WGPUBufferBindingType type;
     WGPUBool hasDynamicOffset;
     uint64_t minBindingSize;
+    uint64_t bufferSizeForBinding;
 } WGPUBufferBindingLayout WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUBufferDescriptor {


### PR DESCRIPTION
#### ae36fffb790d1c33f548681ce46b41c007850418
<pre>
[WebGPU] Validate buffer length for bind group entries
<a href="https://bugs.webkit.org/show_bug.cgi?id=273151">https://bugs.webkit.org/show_bug.cgi?id=273151</a>
<a href="https://rdar.apple.com/126848520">rdar://126848520</a>

Reviewed by Mike Wyrzykowski.

We were missing a validation that the size of the buffer passed into a bind group
was big enough to fit the type of that entry. Most of the plumbing was already done,
but we never populated the `minBindingSize` in the compiler info. That works out of
the box for auto layouts, but for user-provided layouts we need to update the entries
with the computed size, and this later needs to be checked from draw/dispatch.

* LayoutTests/fast/webgpu/fuzz-126848520-auto-layout-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-126848520-auto-layout.html: Added.
* LayoutTests/fast/webgpu/fuzz-126848520-explicit-layout-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-126848520-explicit-layout.html: Added.
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::rewriteEntryPoints):
* Source/WebGPU/WGSL/EntryPointRewriter.h:
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::RewriteGlobalVariables):
(WGSL::RewriteGlobalVariables::visitEntryPoint):
(WGSL::bindingMemberForGlobal):
(WGSL::RewriteGlobalVariables::insertStructs):
(WGSL::rewriteGlobalVariables):
* Source/WebGPU/WGSL/GlobalVariableRewriter.h:
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::prepareImpl):
(WGSL::prepare):
* Source/WebGPU/WGSL/WGSL.h:
* Source/WebGPU/WGSL/wgslc.cpp:
(runWGSL):
* Source/WebGPU/WebGPU/BindGroupLayout.mm:
(WebGPU::createArgumentDescriptor):
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::executePreDispatchCommands):
* Source/WebGPU/WebGPU/Pipeline.h:
* Source/WebGPU/WebGPU/Pipeline.mm:
(WebGPU::createLibrary):
(WebGPU::validateBindGroup):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::executePreDrawCommands):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::earlyCompileShaderModule):

Canonical link: <a href="https://commits.webkit.org/278052@main">https://commits.webkit.org/278052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7476298cff6a502beb536f0bee003e08bf2e1b14

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49331 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52364 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/52202 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51635 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26233 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/52202 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51431 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26165 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42491 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/52202 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23619 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43674 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7699 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45530 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44178 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54082 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24412 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20601 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47625 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25684 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42698 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46618 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10843 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26523 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25408 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->