### PR TITLE
[WebGPU] IPC layer should be able to determine if a WebGPU object is valid

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPU.h
+++ b/Source/WebCore/Modules/WebGPU/GPU.h
@@ -63,7 +63,6 @@ public:
     RefPtr<GPUCompositorIntegration> createCompositorIntegration();
 
     void paintToCanvas(NativeImage&, const IntSize&, GraphicsContext&);
-
 private:
     GPU(Ref<WebGPU::GPU>&&);
 

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.cpp
@@ -122,6 +122,143 @@ void GPUImpl::paintToCanvas(WebCore::NativeImage& image, const WebCore::IntSize&
     context.drawNativeImage(image, canvasRect, FloatRect(FloatPoint(), imageSize), { CompositeOperator::Copy });
 }
 
+bool GPUImpl::isValid(const CompositorIntegration&) const
+{
+    return true;
+}
+
+bool GPUImpl::isValid(const Buffer& buffer) const
+{
+    WGPUBuffer wgpuBuffer = m_convertToBackingContext.get().convertToBacking(buffer);
+    return wgpuBufferIsValid(wgpuBuffer);
+}
+
+bool GPUImpl::isValid(const Adapter& adapter) const
+{
+    WGPUAdapter wgpuAdapter = m_convertToBackingContext.get().convertToBacking(adapter);
+    return wgpuAdapterIsValid(wgpuAdapter);
+}
+
+bool GPUImpl::isValid(const BindGroup& bindGroup) const
+{
+    WGPUBindGroup wgpuBindGroup = m_convertToBackingContext.get().convertToBacking(bindGroup);
+    return wgpuBindGroupIsValid(wgpuBindGroup);
+}
+
+bool GPUImpl::isValid(const BindGroupLayout& bindGroupLayout) const
+{
+    WGPUBindGroupLayout wgpuBindGroupLayout = m_convertToBackingContext.get().convertToBacking(bindGroupLayout);
+    return wgpuBindGroupLayoutIsValid(wgpuBindGroupLayout);
+}
+
+bool GPUImpl::isValid(const CommandBuffer& commandBuffer) const
+{
+    WGPUCommandBuffer wgpuCommandBuffer = m_convertToBackingContext.get().convertToBacking(commandBuffer);
+    return wgpuCommandBufferIsValid(wgpuCommandBuffer);
+}
+
+bool GPUImpl::isValid(const CommandEncoder& commandEncoder) const
+{
+    WGPUCommandEncoder wgpuCommandEncoder = m_convertToBackingContext.get().convertToBacking(commandEncoder);
+    return wgpuCommandEncoderIsValid(wgpuCommandEncoder);
+}
+
+bool GPUImpl::isValid(const ComputePassEncoder& computePassEncoder) const
+{
+    WGPUComputePassEncoder wgpuComputePassEncoder = m_convertToBackingContext.get().convertToBacking(computePassEncoder);
+    return wgpuComputePassEncoderIsValid(wgpuComputePassEncoder);
+}
+
+bool GPUImpl::isValid(const ComputePipeline& computePipeline) const
+{
+    WGPUComputePipeline wgpuComputePipeline = m_convertToBackingContext.get().convertToBacking(computePipeline);
+    return wgpuComputePipelineIsValid(wgpuComputePipeline);
+}
+
+bool GPUImpl::isValid(const Device& device) const
+{
+    WGPUDevice wgpuDevice = m_convertToBackingContext.get().convertToBacking(device);
+    return wgpuDeviceIsValid(wgpuDevice);
+}
+
+bool GPUImpl::isValid(const ExternalTexture& externalTexture) const
+{
+    WGPUExternalTexture wgpuExternalTexture = m_convertToBackingContext.get().convertToBacking(externalTexture);
+    return wgpuExternalTextureIsValid(wgpuExternalTexture);
+}
+
+bool GPUImpl::isValid(const PipelineLayout& pipelineLayout) const
+{
+    WGPUPipelineLayout wgpuPipelineLayout = m_convertToBackingContext.get().convertToBacking(pipelineLayout);
+    return wgpuPipelineLayoutIsValid(wgpuPipelineLayout);
+}
+
+bool GPUImpl::isValid(const PresentationContext& presentationContext) const
+{
+    WGPUSurface wgpuPresentationContext = m_convertToBackingContext.get().convertToBacking(presentationContext);
+    return wgpuPresentationContextIsValid(wgpuPresentationContext);
+}
+
+bool GPUImpl::isValid(const QuerySet& querySet) const
+{
+    WGPUQuerySet wgpuQuerySet = m_convertToBackingContext.get().convertToBacking(querySet);
+    return wgpuQuerySetIsValid(wgpuQuerySet);
+}
+
+bool GPUImpl::isValid(const Queue& queue) const
+{
+    WGPUQueue wgpuQueue = m_convertToBackingContext.get().convertToBacking(queue);
+    return wgpuQueueIsValid(wgpuQueue);
+}
+
+bool GPUImpl::isValid(const RenderBundleEncoder& renderBundleEncoder) const
+{
+    WGPURenderBundleEncoder wgpuRenderBundleEncoder = m_convertToBackingContext.get().convertToBacking(renderBundleEncoder);
+    return wgpuRenderBundleEncoderIsValid(wgpuRenderBundleEncoder);
+}
+
+bool GPUImpl::isValid(const RenderBundle& renderBundle) const
+{
+    WGPURenderBundle wgpuRenderBundle = m_convertToBackingContext.get().convertToBacking(renderBundle);
+    return wgpuRenderBundleIsValid(wgpuRenderBundle);
+}
+
+bool GPUImpl::isValid(const RenderPassEncoder& renderPassEncoder) const
+{
+    WGPURenderPassEncoder wgpuRenderPassEncoder = m_convertToBackingContext.get().convertToBacking(renderPassEncoder);
+    return wgpuRenderPassEncoderIsValid(wgpuRenderPassEncoder);
+}
+
+bool GPUImpl::isValid(const RenderPipeline& renderPipeline) const
+{
+    WGPURenderPipeline wgpuRenderPipeline = m_convertToBackingContext.get().convertToBacking(renderPipeline);
+    return wgpuRenderPipelineIsValid(wgpuRenderPipeline);
+}
+
+bool GPUImpl::isValid(const Sampler& sampler) const
+{
+    WGPUSampler wgpuSampler = m_convertToBackingContext.get().convertToBacking(sampler);
+    return wgpuSamplerIsValid(wgpuSampler);
+}
+
+bool GPUImpl::isValid(const ShaderModule& shaderModule) const
+{
+    WGPUShaderModule wgpuShaderModule = m_convertToBackingContext.get().convertToBacking(shaderModule);
+    return wgpuShaderModuleIsValid(wgpuShaderModule);
+}
+
+bool GPUImpl::isValid(const Texture& texture) const
+{
+    WGPUTexture wgpuTexture = m_convertToBackingContext.get().convertToBacking(texture);
+    return wgpuTextureIsValid(wgpuTexture);
+}
+
+bool GPUImpl::isValid(const TextureView& textureView) const
+{
+    WGPUTextureView wgpuTextureView = m_convertToBackingContext.get().convertToBacking(textureView);
+    return wgpuTextureViewIsValid(wgpuTextureView);
+}
+
 } // namespace WebCore::WebGPU
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.h
@@ -28,8 +28,10 @@
 #if HAVE(WEBGPU_IMPLEMENTATION)
 
 #include "WebGPU.h"
+#include "WebGPUConvertToBackingContext.h"
 #include "WebGPUPtr.h"
 #include <WebGPU/WebGPU.h>
+#include <WebGPU/WebGPUExt.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Deque.h>
 #include <wtf/Function.h>
@@ -42,7 +44,30 @@ class NativeImage;
 
 namespace WebCore::WebGPU {
 
+class Adapter;
+class Buffer;
+class BindGroup;
+class BindGroupLayout;
+class CompositorIntegration;
+class CommandBuffer;
+class CommandEncoder;
+class ComputePassEncoder;
+class ComputePipeline;
 class ConvertToBackingContext;
+class Device;
+class ExternalTexture;
+class PipelineLayout;
+class PresentationContext;
+class QuerySet;
+class Queue;
+class RenderBundleEncoder;
+class RenderBundle;
+class RenderPassEncoder;
+class RenderPipeline;
+class Sampler;
+class ShaderModule;
+class Texture;
+class TextureView;
 
 class GPUImpl final : public GPU, public RefCounted<GPUImpl> {
     WTF_MAKE_FAST_ALLOCATED;
@@ -76,6 +101,29 @@ private:
     RefPtr<PresentationContext> createPresentationContext(const PresentationContextDescriptor&) final;
 
     RefPtr<CompositorIntegration> createCompositorIntegration() final;
+    bool isValid(const CompositorIntegration&) const final;
+    bool isValid(const Buffer&) const final;
+    bool isValid(const Adapter&) const final;
+    bool isValid(const BindGroup&) const final;
+    bool isValid(const BindGroupLayout&) const final;
+    bool isValid(const CommandBuffer&) const final;
+    bool isValid(const CommandEncoder&) const final;
+    bool isValid(const ComputePassEncoder&) const final;
+    bool isValid(const ComputePipeline&) const final;
+    bool isValid(const Device&) const final;
+    bool isValid(const ExternalTexture&) const final;
+    bool isValid(const PipelineLayout&) const final;
+    bool isValid(const PresentationContext&) const final;
+    bool isValid(const QuerySet&) const final;
+    bool isValid(const Queue&) const final;
+    bool isValid(const RenderBundleEncoder&) const final;
+    bool isValid(const RenderBundle&) const final;
+    bool isValid(const RenderPassEncoder&) const final;
+    bool isValid(const RenderPipeline&) const final;
+    bool isValid(const Sampler&) const final;
+    bool isValid(const ShaderModule&) const final;
+    bool isValid(const Texture&) const final;
+    bool isValid(const TextureView&) const final;
 
     WebGPUPtr<WGPUInstance> m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.h
@@ -40,10 +40,33 @@ class GraphicsContext;
 namespace WebCore::WebGPU {
 
 class Adapter;
+class BindGroup;
+class BindGroupLayout;
+class Buffer;
+class CommandBuffer;
+class CommandEncoder;
 class CompositorIntegration;
+class ComputePassEncoder;
+class ComputePipeline;
+class Device;
+class ExternalTexture;
+class GPU;
+class GPUImpl;
 class GraphicsContext;
 class NativeImage;
+class PipelineLayout;
 class PresentationContext;
+class QuerySet;
+class Queue;
+class RenderBundleEncoder;
+class RenderBundle;
+class RenderPassEncoder;
+class RenderPipeline;
+class Sampler;
+class ShaderModule;
+class Texture;
+class TextureView;
+
 struct PresentationContextDescriptor;
 
 class GPU {
@@ -58,6 +81,29 @@ public:
 
     virtual RefPtr<CompositorIntegration> createCompositorIntegration() = 0;
     virtual void paintToCanvas(WebCore::NativeImage&, const WebCore::IntSize&, WebCore::GraphicsContext&) = 0;
+    virtual bool isValid(const CompositorIntegration&) const = 0;
+    virtual bool isValid(const Buffer&) const = 0;
+    virtual bool isValid(const Adapter&) const = 0;
+    virtual bool isValid(const BindGroup&) const = 0;
+    virtual bool isValid(const BindGroupLayout&) const = 0;
+    virtual bool isValid(const CommandBuffer&) const = 0;
+    virtual bool isValid(const CommandEncoder&) const = 0;
+    virtual bool isValid(const ComputePassEncoder&) const = 0;
+    virtual bool isValid(const ComputePipeline&) const = 0;
+    virtual bool isValid(const Device&) const = 0;
+    virtual bool isValid(const ExternalTexture&) const = 0;
+    virtual bool isValid(const PipelineLayout&) const = 0;
+    virtual bool isValid(const PresentationContext&) const = 0;
+    virtual bool isValid(const QuerySet&) const = 0;
+    virtual bool isValid(const Queue&) const = 0;
+    virtual bool isValid(const RenderBundleEncoder&) const = 0;
+    virtual bool isValid(const RenderBundle&) const = 0;
+    virtual bool isValid(const RenderPassEncoder&) const = 0;
+    virtual bool isValid(const RenderPipeline&) const = 0;
+    virtual bool isValid(const Sampler&) const = 0;
+    virtual bool isValid(const ShaderModule&) const = 0;
+    virtual bool isValid(const Texture&) const = 0;
+    virtual bool isValid(const TextureView&) const = 0;
 
 protected:
     GPU() = default;

--- a/Source/WebGPU/WebGPU/ExternalTexture.h
+++ b/Source/WebGPU/WebGPU/ExternalTexture.h
@@ -59,6 +59,8 @@ public:
     void setCommandEncoder(CommandEncoder&) const;
     bool isDestroyed() const;
 
+    bool isValid() const;
+
 private:
     ExternalTexture(CVPixelBufferRef, WGPUColorSpace, Device&);
     ExternalTexture(Device&);

--- a/Source/WebGPU/WebGPU/ExternalTexture.mm
+++ b/Source/WebGPU/WebGPU/ExternalTexture.mm
@@ -54,6 +54,11 @@ ExternalTexture::ExternalTexture(Device& device)
 {
 }
 
+bool ExternalTexture::isValid() const
+{
+    return m_pixelBuffer.get() || m_destroyed;
+}
+
 ExternalTexture::~ExternalTexture() = default;
 
 void ExternalTexture::destroy()

--- a/Source/WebGPU/WebGPU/Instance.mm
+++ b/Source/WebGPU/WebGPU/Instance.mm
@@ -250,3 +250,114 @@ void wgpuInstanceRequestAdapterWithBlock(WGPUInstance instance, WGPURequestAdapt
         callback(status, WebGPU::releaseToAPI(WTFMove(adapter)), message.utf8().data());
     });
 }
+
+// Fuzzer things
+bool wgpuBufferIsValid(WGPUBuffer buffer)
+{
+    return WebGPU::fromAPI(buffer).isValid();
+}
+
+bool wgpuAdapterIsValid(WGPUAdapter adapter)
+{
+    return WebGPU::fromAPI(adapter).isValid();
+}
+
+bool wgpuBindGroupIsValid(WGPUBindGroup bindGroup)
+{
+    return WebGPU::fromAPI(bindGroup).isValid();
+}
+
+bool wgpuBindGroupLayoutIsValid(WGPUBindGroupLayout bindGroupLayout)
+{
+    return WebGPU::fromAPI(bindGroupLayout).isValid();
+}
+
+bool wgpuCommandBufferIsValid(WGPUCommandBuffer commandBuffer)
+{
+    return WebGPU::fromAPI(commandBuffer).isValid();
+}
+
+bool wgpuCommandEncoderIsValid(WGPUCommandEncoder commandEncoder)
+{
+    return WebGPU::fromAPI(commandEncoder).isValid();
+}
+
+bool wgpuComputePassEncoderIsValid(WGPUComputePassEncoder computePassEncoder)
+{
+    return WebGPU::fromAPI(computePassEncoder).isValid();
+}
+
+bool wgpuComputePipelineIsValid(WGPUComputePipeline computePipeline)
+{
+    return WebGPU::fromAPI(computePipeline).isValid();
+}
+
+bool wgpuDeviceIsValid(WGPUDevice device)
+{
+    return WebGPU::fromAPI(device).isValid();
+}
+
+bool wgpuExternalTextureIsValid(WGPUExternalTexture externalTexture)
+{
+    return WebGPU::fromAPI(externalTexture).isValid();
+}
+
+bool wgpuPipelineLayoutIsValid(WGPUPipelineLayout pipelineLayout)
+{
+    return WebGPU::fromAPI(pipelineLayout).isValid();
+}
+
+bool wgpuPresentationContextIsValid(WGPUSurface presentationContext)
+{
+    return WebGPU::fromAPI(presentationContext).isValid();
+}
+
+bool wgpuQuerySetIsValid(WGPUQuerySet querySet)
+{
+    return WebGPU::fromAPI(querySet).isValid();
+}
+
+bool wgpuQueueIsValid(WGPUQueue queue)
+{
+    return WebGPU::fromAPI(queue).isValid();
+}
+
+bool wgpuRenderBundleEncoderIsValid(WGPURenderBundleEncoder renderBundleEncoder)
+{
+    return WebGPU::fromAPI(renderBundleEncoder).isValid();
+}
+
+bool wgpuRenderBundleIsValid(WGPURenderBundle renderBundle)
+{
+    return WebGPU::fromAPI(renderBundle).isValid();
+}
+
+bool wgpuRenderPassEncoderIsValid(WGPURenderPassEncoder renderPassEncoder)
+{
+    return WebGPU::fromAPI(renderPassEncoder).isValid();
+}
+
+bool wgpuRenderPipelineIsValid(WGPURenderPipeline renderPipeline)
+{
+    return WebGPU::fromAPI(renderPipeline).isValid();
+}
+
+bool wgpuSamplerIsValid(WGPUSampler sampler)
+{
+    return WebGPU::fromAPI(sampler).isValid();
+}
+
+bool wgpuShaderModuleIsValid(WGPUShaderModule shaderModule)
+{
+    return WebGPU::fromAPI(shaderModule).isValid();
+}
+
+bool wgpuTextureIsValid(WGPUTexture texture)
+{
+    return WebGPU::fromAPI(texture).isValid();
+}
+
+bool wgpuTextureViewIsValid(WGPUTextureView textureView)
+{
+    return WebGPU::fromAPI(textureView).isValid();
+}

--- a/Source/WebGPU/WebGPU/PresentationContext.h
+++ b/Source/WebGPU/WebGPU/PresentationContext.h
@@ -69,6 +69,7 @@ public:
     virtual bool isPresentationContextCoreAnimation() const { return false; }
     virtual RetainPtr<CGImageRef> getTextureAsNativeImage(uint32_t) { return nullptr; }
 
+    virtual bool isValid() { return false; }
 protected:
     explicit PresentationContext();
 };

--- a/Source/WebGPU/WebGPU/PresentationContextCoreAnimation.h
+++ b/Source/WebGPU/WebGPU/PresentationContextCoreAnimation.h
@@ -52,6 +52,8 @@ public:
 
     bool isPresentationContextCoreAnimation() const override { return true; }
 
+    bool isValid() override { return m_configuration != std::nullopt; }
+
 private:
     PresentationContextCoreAnimation(const WGPUSurfaceDescriptor&);
 

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
@@ -51,6 +51,7 @@ public:
 
     bool isPresentationContextIOSurface() const override { return true; }
 
+    bool isValid() override { return true; }
 private:
     PresentationContextIOSurface(const WGPUSurfaceDescriptor&, const Instance&);
 

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -1792,6 +1792,29 @@ WGPU_EXPORT void wgpuTextureViewSetLabel(WGPUTextureView textureView, char const
 WGPU_EXPORT void wgpuTextureViewReference(WGPUTextureView textureView) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuTextureViewRelease(WGPUTextureView textureView) WGPU_FUNCTION_ATTRIBUTE;
 
+// isValid checks
+WGPU_EXPORT bool wgpuBufferIsValid(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT bool wgpuAdapterIsValid(WGPUAdapter adapter) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT bool wgpuBindGroupIsValid(WGPUBindGroup bindGroup) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT bool wgpuBindGroupLayoutIsValid(WGPUBindGroupLayout bindGroupLayout) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT bool wgpuCommandBufferIsValid(WGPUCommandBuffer commandBuffer) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT bool wgpuCommandEncoderIsValid(WGPUCommandEncoder commandEncoder) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT bool wgpuComputePassEncoderIsValid(WGPUComputePassEncoder computePassEncoder) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT bool wgpuComputePipelineIsValid(WGPUComputePipeline computePipeline) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT bool wgpuDeviceIsValid(WGPUDevice device) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT bool wgpuPipelineLayoutIsValid(WGPUPipelineLayout pipelineLayout) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT bool wgpuPresentationContextIsValid(WGPUSurface presentationContext) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT bool wgpuQuerySetIsValid(WGPUQuerySet querySet) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT bool wgpuQueueIsValid(WGPUQueue queue) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT bool wgpuRenderBundleEncoderIsValid(WGPURenderBundleEncoder renderBundleEncoder) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT bool wgpuRenderBundleIsValid(WGPURenderBundle renderBundle) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT bool wgpuRenderPassEncoderIsValid(WGPURenderPassEncoder renderPassEncoder) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT bool wgpuRenderPipelineIsValid(WGPURenderPipeline renderPipeline) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT bool wgpuSamplerIsValid(WGPUSampler sampler) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT bool wgpuShaderModuleIsValid(WGPUShaderModule shaderModule) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT bool wgpuTextureIsValid(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT bool wgpuTextureViewIsValid(WGPUTextureView textureView) WGPU_FUNCTION_ATTRIBUTE;
+
 #endif  // !defined(WGPU_SKIP_DECLARATIONS)
 
 #ifdef __cplusplus

--- a/Source/WebGPU/WebGPU/WebGPUExt.h
+++ b/Source/WebGPU/WebGPU/WebGPUExt.h
@@ -135,6 +135,7 @@ WGPU_EXPORT void wgpuExternalTextureUndestroy(WGPUExternalTexture texture) WGPU_
 WGPU_EXPORT WGPULimits wgpuDefaultLimits() WGPU_FUNCTION_ATTRIBUTE;
 
 WGPU_EXPORT RetainPtr<CGImageRef> wgpuSwapChainGetTextureAsNativeImage(WGPUSwapChain swapChain, uint32_t bufferIndex);
+WGPU_EXPORT bool wgpuExternalTextureIsValid(WGPUExternalTexture externalTexture) WGPU_FUNCTION_ATTRIBUTE;
 
 #endif  // !defined(WGPU_SKIP_DECLARATIONS)
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
@@ -46,8 +46,8 @@
 #include <wtf/threads/BinarySemaphore.h>
 
 #if HAVE(WEBGPU_IMPLEMENTATION)
-#import <WebCore/WebGPUCreateImpl.h>
 #include <WebCore/ProcessIdentity.h>
+#include <WebCore/WebGPUCreateImpl.h>
 #endif
 
 #if PLATFORM(COCOA)
@@ -235,6 +235,19 @@ void RemoteGPU::paintNativeImageToImageBuffer(WebCore::NativeImage& nativeImage,
         semaphore.signal();
     });
     semaphore.wait();
+}
+
+void RemoteGPU::isValid(WebGPUIdentifier identifier, CompletionHandler<void(bool, bool)>&& completionHandler)
+{
+    assertIsCurrent(workQueue());
+    auto* gpu = static_cast<WebCore::WebGPU::GPU*>(m_backing.get());
+    if (!gpu) {
+        completionHandler(false, false);
+        return;
+    }
+
+    auto result = m_objectHeap->objectExistsAndValid(*gpu, identifier);
+    completionHandler(result.valid, result.exists);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
@@ -116,6 +116,8 @@ private:
 
     void createCompositorIntegration(WebGPUIdentifier);
 
+    void isValid(WebGPUIdentifier, CompletionHandler<void(bool, bool)>&&);
+
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
     Ref<IPC::StreamConnectionWorkQueue> m_workQueue;
     RefPtr<IPC::StreamServerConnection> m_streamConnection;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.messages.in
@@ -27,6 +27,8 @@ messages -> RemoteGPU NotRefCounted Stream {
     void RequestAdapter(WebKit::WebGPU::RequestAdapterOptions options, WebKit::WebGPUIdentifier identifier) -> (std::optional<WebKit::RemoteGPURequestAdapterResponse> response) Synchronous
     void CreatePresentationContext(WebKit::WebGPU::PresentationContextDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
     void CreateCompositorIntegration(WebKit::WebGPUIdentifier identifier)
+
+    void IsValid(WebKit::WebGPUIdentifier identifier) -> (bool isValid, bool exists) Synchronous
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/WebGPUObjectHeap.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/WebGPUObjectHeap.h
@@ -153,6 +153,11 @@ public:
     WebCore::WebGPU::Texture* convertTextureFromBacking(WebGPUIdentifier) final;
     WebCore::WebGPU::TextureView* convertTextureViewFromBacking(WebGPUIdentifier) final;
 
+    struct ExistsAndValid {
+        bool exists { false };
+        bool valid { false };
+    };
+    ExistsAndValid objectExistsAndValid(const WebCore::WebGPU::GPU&, WebGPUIdentifier) const;
 private:
     ObjectHeap();
 
@@ -182,6 +187,7 @@ private:
         IPC::ScopedActiveMessageReceiveQueue<RemoteTexture>,
         IPC::ScopedActiveMessageReceiveQueue<RemoteTextureView>
     >;
+
     HashMap<WebGPUIdentifier, Object> m_objects;
 };
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
@@ -221,6 +221,99 @@ void RemoteGPUProxy::paintToCanvas(WebCore::NativeImage&, const WebCore::IntSize
     ASSERT_NOT_REACHED();
 }
 
+bool RemoteGPUProxy::isValid(const WebCore::WebGPU::CompositorIntegration&) const
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+bool RemoteGPUProxy::isValid(const WebCore::WebGPU::Buffer&) const
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+bool RemoteGPUProxy::isValid(const WebCore::WebGPU::Adapter&) const
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+bool RemoteGPUProxy::isValid(const WebCore::WebGPU::BindGroup&) const
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+bool RemoteGPUProxy::isValid(const WebCore::WebGPU::BindGroupLayout&) const
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+bool RemoteGPUProxy::isValid(const WebCore::WebGPU::CommandBuffer&) const
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+bool RemoteGPUProxy::isValid(const WebCore::WebGPU::CommandEncoder&) const
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+bool RemoteGPUProxy::isValid(const WebCore::WebGPU::ComputePassEncoder&) const
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+bool RemoteGPUProxy::isValid(const WebCore::WebGPU::ComputePipeline&) const
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+bool RemoteGPUProxy::isValid(const WebCore::WebGPU::Device&) const
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+bool RemoteGPUProxy::isValid(const WebCore::WebGPU::ExternalTexture&) const
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+bool RemoteGPUProxy::isValid(const WebCore::WebGPU::PipelineLayout&) const
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+bool RemoteGPUProxy::isValid(const WebCore::WebGPU::PresentationContext&) const
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+bool RemoteGPUProxy::isValid(const WebCore::WebGPU::QuerySet&) const
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+bool RemoteGPUProxy::isValid(const WebCore::WebGPU::Queue&) const
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+bool RemoteGPUProxy::isValid(const WebCore::WebGPU::RenderBundleEncoder&) const
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+bool RemoteGPUProxy::isValid(const WebCore::WebGPU::RenderBundle&) const
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+bool RemoteGPUProxy::isValid(const WebCore::WebGPU::RenderPassEncoder&) const
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+bool RemoteGPUProxy::isValid(const WebCore::WebGPU::RenderPipeline&) const
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+bool RemoteGPUProxy::isValid(const WebCore::WebGPU::Sampler&) const
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+bool RemoteGPUProxy::isValid(const WebCore::WebGPU::ShaderModule&) const
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+bool RemoteGPUProxy::isValid(const WebCore::WebGPU::Texture&) const
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+bool RemoteGPUProxy::isValid(const WebCore::WebGPU::TextureView&) const
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
@@ -103,6 +103,29 @@ private:
     RefPtr<WebCore::WebGPU::PresentationContext> createPresentationContext(const WebCore::WebGPU::PresentationContextDescriptor&) final;
 
     RefPtr<WebCore::WebGPU::CompositorIntegration> createCompositorIntegration() final;
+    bool isValid(const WebCore::WebGPU::CompositorIntegration&) const final;
+    bool isValid(const WebCore::WebGPU::Buffer&) const final;
+    bool isValid(const WebCore::WebGPU::Adapter&) const final;
+    bool isValid(const WebCore::WebGPU::BindGroup&) const final;
+    bool isValid(const WebCore::WebGPU::BindGroupLayout&) const final;
+    bool isValid(const WebCore::WebGPU::CommandBuffer&) const final;
+    bool isValid(const WebCore::WebGPU::CommandEncoder&) const final;
+    bool isValid(const WebCore::WebGPU::ComputePassEncoder&) const final;
+    bool isValid(const WebCore::WebGPU::ComputePipeline&) const final;
+    bool isValid(const WebCore::WebGPU::Device&) const final;
+    bool isValid(const WebCore::WebGPU::ExternalTexture&) const final;
+    bool isValid(const WebCore::WebGPU::PipelineLayout&) const final;
+    bool isValid(const WebCore::WebGPU::PresentationContext&) const final;
+    bool isValid(const WebCore::WebGPU::QuerySet&) const final;
+    bool isValid(const WebCore::WebGPU::Queue&) const final;
+    bool isValid(const WebCore::WebGPU::RenderBundleEncoder&) const final;
+    bool isValid(const WebCore::WebGPU::RenderBundle&) const final;
+    bool isValid(const WebCore::WebGPU::RenderPassEncoder&) const final;
+    bool isValid(const WebCore::WebGPU::RenderPipeline&) const final;
+    bool isValid(const WebCore::WebGPU::Sampler&) const final;
+    bool isValid(const WebCore::WebGPU::ShaderModule&) const final;
+    bool isValid(const WebCore::WebGPU::Texture&) const final;
+    bool isValid(const WebCore::WebGPU::TextureView&) const final;
 
     void abandonGPUProcess();
     void disconnectGpuProcessIfNeeded();


### PR DESCRIPTION
#### 52b74baecbe4d4c3b8f3a1378de0ab0948f71f0b
<pre>
[WebGPU] IPC layer should be able to determine if a WebGPU object is valid
<a href="https://bugs.webkit.org/show_bug.cgi?id=272094">https://bugs.webkit.org/show_bug.cgi?id=272094</a>
&lt;radar://125853187&gt;

Reviewed by Tadeu Zagallo.

Patch from Nils with some minor cleanup to determine if an object
is valid from the IPC layer.

* Source/WebCore/Modules/WebGPU/GPU.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.cpp:
(WebCore::WebGPU::GPUImpl::isValid const):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebGPU/WebGPU/ExternalTexture.h:
* Source/WebGPU/WebGPU/ExternalTexture.mm:
(WebGPU::ExternalTexture::isValid const):
* Source/WebGPU/WebGPU/Instance.mm:
(wgpuBufferIsValid):
(wgpuAdapterIsValid):
(wgpuBindGroupIsValid):
(wgpuBindGroupLayoutIsValid):
(wgpuCommandBufferIsValid):
(wgpuCommandEncoderIsValid):
(wgpuComputePassEncoderIsValid):
(wgpuComputePipelineIsValid):
(wgpuDeviceIsValid):
(wgpuExternalTextureIsValid):
(wgpuPipelineLayoutIsValid):
(wgpuPresentationContextIsValid):
(wgpuQuerySetIsValid):
(wgpuQueueIsValid):
(wgpuRenderBundleEncoderIsValid):
(wgpuRenderBundleIsValid):
(wgpuRenderPassEncoderIsValid):
(wgpuRenderPipelineIsValid):
(wgpuSamplerIsValid):
(wgpuShaderModuleIsValid):
(wgpuTextureIsValid):
(wgpuTextureViewIsValid):
* Source/WebGPU/WebGPU/PresentationContext.h:
(WebGPU::PresentationContext::isValid):
* Source/WebGPU/WebGPU/PresentationContextCoreAnimation.h:
* Source/WebGPU/WebGPU/PresentationContextIOSurface.h:
* Source/WebGPU/WebGPU/WebGPU.h:
* Source/WebGPU/WebGPU/WebGPUExt.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::RemoteGPU::isValid):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/WebGPUObjectHeap.cpp:
(WebKit::WebGPU::ObjectHeap::objectExistsAndValid const):
* Source/WebKit/GPUProcess/graphics/WebGPU/WebGPUObjectHeap.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp:
(WebKit::RemoteGPUProxy::isValid const):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h:

Canonical link: <a href="https://commits.webkit.org/277948@main">https://commits.webkit.org/277948@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce9cd1c3d1c1866ee7e8a8bdf134aa26c39db80a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48995 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51683 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45065 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51300 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34176 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25736 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40052 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25853 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42244 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21160 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23311 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43414 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7050 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45237 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43919 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53593 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24046 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20300 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47366 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25309 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42453 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46336 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10790 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26118 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25029 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->