### PR TITLE
REGRESSION (277809@main): [ macOS wk1 ] imported/w3c/web-platform-tests/geolocation-API are consistent failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/geolocation-API/disabled-by-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/geolocation-API/disabled-by-permissions-policy.https.sub-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'Geolocation' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute ''.
+CONSOLE MESSAGE: Permission policy 'Geolocation' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute ''.
 
 
 FAIL Permissions-Policy header geolocation=() disallows the top-level document. promise_test: Unhandled rejection with value: object "[object GeolocationPosition]"

--- a/LayoutTests/imported/w3c/web-platform-tests/geolocation-API/enabled-by-permission-policy-attribute-redirect-on-load.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/geolocation-API/enabled-by-permission-policy-attribute-redirect-on-load.https.sub-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'Geolocation' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute ';geolocation'.
+CONSOLE MESSAGE: Permission policy 'Geolocation' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute ';geolocation'.
 
 
 PASS Permissions-Policy allow="geolocation" allows same-origin relocation

--- a/LayoutTests/imported/w3c/web-platform-tests/geolocation-API/enabled-by-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/geolocation-API/enabled-by-permissions-policy.https.sub-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'Geolocation' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute ''.
+CONSOLE MESSAGE: Permission policy 'Geolocation' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute ''.
 
 
 PASS Permissions-Policy header geolocation=* allows the top-level document.

--- a/LayoutTests/imported/w3c/web-platform-tests/geolocation-API/enabled-on-self-origin-by-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/geolocation-API/enabled-on-self-origin-by-permissions-policy.https.sub-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'Geolocation' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute ''.
+CONSOLE MESSAGE: Permission policy 'Geolocation' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute ''.
 
 PASS Permissions-Policy header geolocation=(self) allows the top-level document.
 PASS Permissions-Policy header geolocation=(self) allows same-origin iframes.

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/geolocation-API/disabled-by-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/geolocation-API/disabled-by-permissions-policy.https.sub-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'Geolocation' check failed for element with origin 'https://not-web-platform.test:9443' and allow attribute ''.
+CONSOLE MESSAGE: Permission policy 'Geolocation' check failed for element with origin 'https://not-web-platform.test:9443' and allow attribute ''.
 
 
 FAIL Permissions-Policy header geolocation=() disallows the top-level document. promise_test: Unhandled rejection with value: object "[object GeolocationPosition]"

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/geolocation-API/enabled-by-permission-policy-attribute-redirect-on-load.https.sub-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/geolocation-API/enabled-by-permission-policy-attribute-redirect-on-load.https.sub-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'Geolocation' check failed for element with origin 'https://not-web-platform.test:9443' and allow attribute ';geolocation'.
+CONSOLE MESSAGE: Permission policy 'Geolocation' check failed for element with origin 'https://not-web-platform.test:9443' and allow attribute ';geolocation'.
 
 
 PASS Permissions-Policy allow="geolocation" allows same-origin relocation

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/geolocation-API/enabled-by-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/geolocation-API/enabled-by-permissions-policy.https.sub-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'Geolocation' check failed for element with origin 'https://not-web-platform.test:9443' and allow attribute ''.
+CONSOLE MESSAGE: Permission policy 'Geolocation' check failed for element with origin 'https://not-web-platform.test:9443' and allow attribute ''.
 
 
 PASS Permissions-Policy header geolocation=* allows the top-level document.

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/geolocation-API/enabled-on-self-origin-by-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/geolocation-API/enabled-on-self-origin-by-permissions-policy.https.sub-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'Geolocation' check failed for element with origin 'https://not-web-platform.test:9443' and allow attribute ''.
+CONSOLE MESSAGE: Permission policy 'Geolocation' check failed for element with origin 'https://not-web-platform.test:9443' and allow attribute ''.
 
 PASS Permissions-Policy header geolocation=(self) allows the top-level document.
 PASS Permissions-Policy header geolocation=(self) allows same-origin iframes.

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2849,8 +2849,3 @@ fast/css/view-transitions-update-layer-lists-crash.html [ Skip ]
 
 webkit.org/b/272939 [ Ventura+ ] imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/referrer-strict-policies.sub.html [ Pass Failure ]
 
-# webkit.org/b/273083 REGRESSION (277809@main): [ macOS wk1 ] imported/w3c/web-platform-tests/geolocation-API are consistent failure
-imported/w3c/web-platform-tests/geolocation-API/disabled-by-permissions-policy.https.sub.html [ Failure ]
-imported/w3c/web-platform-tests/geolocation-API/enabled-by-permission-policy-attribute-redirect-on-load.https.sub.html [ Failure ]
-imported/w3c/web-platform-tests/geolocation-API/enabled-by-permissions-policy.https.sub.html [ Failure ]
-imported/w3c/web-platform-tests/geolocation-API/enabled-on-self-origin-by-permissions-policy.https.sub.html [ Failure ]

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/geolocation-API/disabled-by-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/geolocation-API/disabled-by-permissions-policy.https.sub-expected.txt
@@ -1,6 +1,6 @@
 CONSOLE MESSAGE: Blocked https://127.0.0.1:9443/resources/testdriver.js from asking for credentials because it is a cross-origin request.
 CONSOLE MESSAGE: Blocked https://127.0.0.1:9443/resources/testdriver-vendor.js from asking for credentials because it is a cross-origin request.
-CONSOLE MESSAGE: Feature policy 'Geolocation' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute ''.
+CONSOLE MESSAGE: Permission policy 'Geolocation' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute ''.
 
 
 FAIL Permissions-Policy header geolocation=() disallows the top-level document. promise_test: Unhandled rejection with value: object "[object GeolocationPosition]"

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/geolocation-API/enabled-by-permission-policy-attribute-redirect-on-load.https.sub-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/geolocation-API/enabled-by-permission-policy-attribute-redirect-on-load.https.sub-expected.txt
@@ -1,5 +1,5 @@
 CONSOLE MESSAGE: Blocked https://127.0.0.1:9443/resources/testdriver.js from asking for credentials because it is a cross-origin request.
-CONSOLE MESSAGE: Feature policy 'Geolocation' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute ';geolocation'.
+CONSOLE MESSAGE: Permission policy 'Geolocation' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute ';geolocation'.
 
 
 PASS Permissions-Policy allow="geolocation" allows same-origin relocation

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/geolocation-API/enabled-by-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/geolocation-API/enabled-by-permissions-policy.https.sub-expected.txt
@@ -1,5 +1,5 @@
 CONSOLE MESSAGE: Blocked https://127.0.0.1:9443/resources/testdriver.js from asking for credentials because it is a cross-origin request.
-CONSOLE MESSAGE: Feature policy 'Geolocation' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute ''.
+CONSOLE MESSAGE: Permission policy 'Geolocation' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute ''.
 
 
 PASS Permissions-Policy header geolocation=* allows the top-level document.

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/geolocation-API/enabled-on-self-origin-by-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/geolocation-API/enabled-on-self-origin-by-permissions-policy.https.sub-expected.txt
@@ -1,5 +1,5 @@
 CONSOLE MESSAGE: Blocked https://127.0.0.1:9443/resources/testdriver.js from asking for credentials because it is a cross-origin request.
-CONSOLE MESSAGE: Feature policy 'Geolocation' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute ''.
+CONSOLE MESSAGE: Permission policy 'Geolocation' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute ''.
 
 PASS Permissions-Policy header geolocation=(self) allows the top-level document.
 PASS Permissions-Policy header geolocation=(self) allows same-origin iframes.

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/geolocation-API/disabled-by-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/geolocation-API/disabled-by-permissions-policy.https.sub-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'Geolocation' check failed for element with origin 'https://not-web-platform.test:9443' and allow attribute ''.
+CONSOLE MESSAGE: Permission policy 'Geolocation' check failed for element with origin 'https://not-web-platform.test:9443' and allow attribute ''.
 
 
 FAIL Permissions-Policy header geolocation=() disallows the top-level document. promise_test: Unhandled rejection with value: object "[object GeolocationPosition]"

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/geolocation-API/enabled-by-permission-policy-attribute-redirect-on-load.https.sub-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/geolocation-API/enabled-by-permission-policy-attribute-redirect-on-load.https.sub-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'Geolocation' check failed for element with origin 'https://not-web-platform.test:9443' and allow attribute ';geolocation'.
+CONSOLE MESSAGE: Permission policy 'Geolocation' check failed for element with origin 'https://not-web-platform.test:9443' and allow attribute ';geolocation'.
 
 
 PASS Permissions-Policy allow="geolocation" allows same-origin relocation

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/geolocation-API/enabled-by-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/geolocation-API/enabled-by-permissions-policy.https.sub-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'Geolocation' check failed for element with origin 'https://not-web-platform.test:9443' and allow attribute ''.
+CONSOLE MESSAGE: Permission policy 'Geolocation' check failed for element with origin 'https://not-web-platform.test:9443' and allow attribute ''.
 
 
 PASS Permissions-Policy header geolocation=* allows the top-level document.

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/geolocation-API/enabled-on-self-origin-by-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/geolocation-API/enabled-on-self-origin-by-permissions-policy.https.sub-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'Geolocation' check failed for element with origin 'https://not-web-platform.test:9443' and allow attribute ''.
+CONSOLE MESSAGE: Permission policy 'Geolocation' check failed for element with origin 'https://not-web-platform.test:9443' and allow attribute ''.
 
 PASS Permissions-Policy header geolocation=(self) allows the top-level document.
 PASS Permissions-Policy header geolocation=(self) allows same-origin iframes.


### PR DESCRIPTION
#### b9413e6988be6d8cf97daf0a6cd5a8ca03b71585
<pre>
REGRESSION (277809@main): [ macOS wk1 ] imported/w3c/web-platform-tests/geolocation-API are consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=273083">https://bugs.webkit.org/show_bug.cgi?id=273083</a>
<a href="https://rdar.apple.com/126878399">rdar://126878399</a>

Reviewed by Simon Fraser.

Fixed console string in the test to match the expected result.

This happened because I landed the following patch without rebasing the geo tests that landed at the same time:
<a href="https://github.com/WebKit/WebKit/pull/27477">https://github.com/WebKit/WebKit/pull/27477</a>

* LayoutTests/imported/w3c/web-platform-tests/geolocation-API/disabled-by-permissions-policy.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/geolocation-API/enabled-by-permission-policy-attribute-redirect-on-load.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/geolocation-API/enabled-by-permissions-policy.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/geolocation-API/enabled-on-self-origin-by-permissions-policy.https.sub-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/geolocation-API/disabled-by-permissions-policy.https.sub-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/geolocation-API/enabled-by-permission-policy-attribute-redirect-on-load.https.sub-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/geolocation-API/enabled-by-permissions-policy.https.sub-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/geolocation-API/enabled-on-self-origin-by-permissions-policy.https.sub-expected.txt:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/geolocation-API/disabled-by-permissions-policy.https.sub-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/geolocation-API/enabled-by-permission-policy-attribute-redirect-on-load.https.sub-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/geolocation-API/enabled-by-permissions-policy.https.sub-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/geolocation-API/enabled-on-self-origin-by-permissions-policy.https.sub-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/geolocation-API/disabled-by-permissions-policy.https.sub-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/geolocation-API/enabled-by-permission-policy-attribute-redirect-on-load.https.sub-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/geolocation-API/enabled-by-permissions-policy.https.sub-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/geolocation-API/enabled-on-self-origin-by-permissions-policy.https.sub-expected.txt:

Canonical link: <a href="https://commits.webkit.org/277917@main">https://commits.webkit.org/277917@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da3970d8266595b757d221734b7cf09ff3bdf0c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51878 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51598 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44981 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34076 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25652 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39980 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42172 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21087 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23229 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43344 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6966 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45160 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43845 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53509 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23962 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20222 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47298 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25225 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42381 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46251 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10780 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26034 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24945 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->