### PR TITLE
Reduce use of mainFrame in WebKitTestRunner

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -128,7 +128,7 @@ interface TestRunner {
     undefined forceImmediateCompletion();
 
     // Printing
-    boolean isPageBoxVisible(long pageIndex);
+    [PassContext] boolean isPageBoxVisible(long pageIndex);
 
     undefined dumpAllHTTPRedirectedResponseHeaders();
 
@@ -150,7 +150,7 @@ interface TestRunner {
     // Text search testing.
     boolean findString(DOMString target, object optionsArray);
     undefined findStringMatchesInPage(DOMString target, object optionsArray);
-    undefined replaceFindMatchesAtIndices(object matchIndicesArray, DOMString replacementText, boolean selectionOnly);
+    [PassContext] undefined replaceFindMatchesAtIndices(object matchIndicesArray, DOMString replacementText, boolean selectionOnly);
 
     // Evaluating script in a special context.
     [PassContext] undefined evaluateScriptInIsolatedWorld(unsigned long worldID, DOMString script);
@@ -163,7 +163,7 @@ interface TestRunner {
 
     undefined setPOSIXLocale(DOMString locale);
 
-    undefined setTextDirection(DOMString direction);
+    [PassContext] undefined setTextDirection(DOMString direction);
 
     undefined setWillSendRequestReturnsNull(boolean flag);
     undefined setWillSendRequestReturnsNullOnRedirect(boolean flag);
@@ -246,7 +246,7 @@ interface TestRunner {
     // Audio testing.
     [PassContext] undefined setAudioResult(object data);
 
-    boolean callShouldCloseOnWebView();
+    [PassContext] boolean callShouldCloseOnWebView();
 
     // Work queue.
     undefined queueBackNavigation(unsigned long howFarBackward);
@@ -277,9 +277,9 @@ interface TestRunner {
     undefined setPluginSupportedMode(DOMString mode);
 
     // Hooks to the JSC compiler.
-    object failNextNewCodeBlock();
-    object numberOfDFGCompiles(object function);
-    object neverInlineFunction(object function);
+    [PassContext] object failNextNewCodeBlock();
+    [PassContext] object numberOfDFGCompiles(object function);
+    [PassContext] object neverInlineFunction(object function);
 
     // Swipe gestures
     undefined installDidBeginSwipeCallback(object callback);
@@ -377,7 +377,7 @@ interface TestRunner {
     undefined setRequestStorageAccessThrowsExceptionUntilReload(boolean enabled);
 
     // Open panel
-    undefined setOpenPanelFiles(object filesArray);
+    [PassContext] undefined setOpenPanelFiles(object filesArray);
     undefined setOpenPanelFilesMediaIcon(object mediaIcon);
 
     // Modal alerts
@@ -415,11 +415,11 @@ interface TestRunner {
 
     boolean hasAppBoundSession();
     undefined clearAppBoundSession();
-    undefined setAppBoundDomains(object originsArray, object callback);
+    [PassContext] undefined setAppBoundDomains(object originsArray, object callback);
     boolean didLoadAppInitiatedRequest();
     boolean didLoadNonAppInitiatedRequest();
 
-    undefined setManagedDomains(object originsArray, object callback);
+    [PassContext] undefined setManagedDomains(object originsArray, object callback);
 
     undefined injectUserScript(DOMString string);
     readonly attribute unsigned long userScriptInjectedCount;
@@ -456,7 +456,7 @@ interface TestRunner {
     undefined takeViewPortSnapshot(object callback);
 
     // Reporting API
-    undefined generateTestReport(DOMString message, DOMString group);
+    [PassContext] undefined generateTestReport(DOMString message, DOMString group);
 
     undefined getAndClearReportedWindowProxyAccessDomains(object callback);
     undefined flushConsoleLogs(object callback);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -159,7 +159,7 @@ public:
     // Text search testing.
     bool findString(JSStringRef, JSValueRef optionsArray);
     void findStringMatchesInPage(JSStringRef, JSValueRef optionsArray);
-    void replaceFindMatchesAtIndices(JSValueRef matchIndices, JSStringRef replacementText, bool selectionOnly);
+    void replaceFindMatchesAtIndices(JSContextRef, JSValueRef matchIndices, JSStringRef replacementText, bool selectionOnly);
 
     // Local storage
     void clearAllDatabases();
@@ -179,7 +179,7 @@ public:
     void forceImmediateCompletion();
 
     // Printing
-    bool isPageBoxVisible(int pageIndex);
+    bool isPageBoxVisible(JSContextRef, int pageIndex);
     bool isPrinting() { return m_isPrinting; }
     void setPrinting() { m_isPrinting = true; }
 
@@ -249,7 +249,7 @@ public:
     void setWillSendRequestAddsHTTPBody(JSStringRef body) { m_willSendRequestHTTPBody = toWTFString(body); }
     String willSendRequestHTTPBody() const { return m_willSendRequestHTTPBody; }
 
-    void setTextDirection(JSStringRef);
+    void setTextDirection(JSContextRef, JSStringRef);
 
     void setShouldStayOnPageAfterHandlingBeforeUnload(bool);
 
@@ -344,7 +344,7 @@ public:
     void setPageVisibility(JSStringRef state);
     void resetPageVisibility();
 
-    bool callShouldCloseOnWebView();
+    bool callShouldCloseOnWebView(JSContextRef);
 
     void setCustomTimeout(WTF::Seconds duration) { m_timeout = duration; }
 
@@ -360,9 +360,9 @@ public:
 
     bool secureEventInputIsEnabled() const;
 
-    JSValueRef failNextNewCodeBlock();
-    JSValueRef numberOfDFGCompiles(JSValueRef function);
-    JSValueRef neverInlineFunction(JSValueRef function);
+    JSValueRef failNextNewCodeBlock(JSContextRef);
+    JSValueRef numberOfDFGCompiles(JSContextRef, JSValueRef function);
+    JSValueRef neverInlineFunction(JSContextRef, JSValueRef function);
 
     bool shouldDecideNavigationPolicyAfterDelay() const { return m_shouldDecideNavigationPolicyAfterDelay; }
     void setShouldDecideNavigationPolicyAfterDelay(bool);
@@ -498,7 +498,7 @@ public:
     void setRequestStorageAccessThrowsExceptionUntilReload(bool enabled);
 
     // Open panel
-    void setOpenPanelFiles(JSValueRef);
+    void setOpenPanelFiles(JSContextRef, JSValueRef);
     void setOpenPanelFilesMediaIcon(JSValueRef);
 
     // Modal alerts
@@ -535,10 +535,10 @@ public:
 
     bool hasAppBoundSession();
     void clearAppBoundSession();
-    void setAppBoundDomains(JSValueRef originArray, JSValueRef callback);
+    void setAppBoundDomains(JSContextRef, JSValueRef originArray, JSValueRef callback);
     void didSetAppBoundDomainsCallback();
 
-    void setManagedDomains(JSValueRef originArray, JSValueRef callback);
+    void setManagedDomains(JSContextRef, JSValueRef originArray, JSValueRef callback);
     void didSetManagedDomainsCallback();
 
     bool didLoadAppInitiatedRequest();
@@ -582,7 +582,7 @@ public:
     void flushConsoleLogs(JSValueRef callback);
 
     // Reporting API
-    void generateTestReport(JSStringRef message, JSStringRef group);
+    void generateTestReport(JSContextRef, JSStringRef message, JSStringRef group);
 
     void getAndClearReportedWindowProxyAccessDomains(JSValueRef);
 


### PR DESCRIPTION
#### c5bc077e845e5db0074787179d7fb03de97952e9
<pre>
Reduce use of mainFrame in WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=273154">https://bugs.webkit.org/show_bug.cgi?id=273154</a>
<a href="https://rdar.apple.com/126952996">rdar://126952996</a>

Reviewed by Charlie Wolfe.

In many places we can just get the current frame.
Using the main frame is problematic with site isolation because it is often not in the current process.

* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::replaceFindMatchesAtIndices):
(WTR::TestRunner::isPageBoxVisible):
(WTR::TestRunner::evaluateScriptInIsolatedWorld):
(WTR::TestRunner::setTextDirection):
(WTR::TestRunner::callShouldCloseOnWebView):
(WTR::TestRunner::failNextNewCodeBlock):
(WTR::TestRunner::numberOfDFGCompiles):
(WTR::TestRunner::neverInlineFunction):
(WTR::TestRunner::setOpenPanelFiles):
(WTR::TestRunner::setAppBoundDomains):
(WTR::TestRunner::setManagedDomains):
(WTR::TestRunner::generateTestReport):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:

Canonical link: <a href="https://commits.webkit.org/277955@main">https://commits.webkit.org/277955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3dd5b4b91ca2328b4369bb09064c22382684909

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49043 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28261 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52013 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51761 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45114 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51347 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34237 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25795 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40083 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50308 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25889 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42273 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21191 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23348 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43443 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7158 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45283 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43948 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53670 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24105 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20337 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47399 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/25386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42481 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46369 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26175 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7025 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/25107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->