### PR TITLE
[webkitpy] Update cryptography and openssl dependencies

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/__init__.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/__init__.py
@@ -53,8 +53,16 @@ AutoInstall.register(Package('aenum', Version(2, 2, 6)))
 AutoInstall.register(Package('attrs', Version(21, 3, 0)))
 AutoInstall.register(Package('aioredis', Version(1, 3, 1)))
 AutoInstall.register(Package('async-timeout', Version(3, 0, 1)))
-AutoInstall.register(Package('boto3', Version(1, 16, 63), wheel=True))
-AutoInstall.register(Package('botocore', Version(1, 19, 63), wheel=True))
+
+if sys.version_info >= (3, 9):
+    AutoInstall.register(Package('boto3', Version(1, 33, 10), wheel=True))
+    AutoInstall.register(Package('botocore', Version(1, 34, 5), wheel=True))
+    AutoInstall.register(Package('jmespath', Version(1, 0, 1), wheel=True))
+else:
+    AutoInstall.register(Package('boto3', Version(1, 16, 63), wheel=True))
+    AutoInstall.register(Package('botocore', Version(1, 19, 63), wheel=True))
+    AutoInstall.register(Package('jmespath', Version(0, 10, 0), wheel=True))
+
 if platform.machine() == 'arm64':
     AutoInstall.register(Package('cassandra', Version(3, 25, 0), pypi_name='cassandra-driver', slow_install=True))
 else:
@@ -66,7 +74,6 @@ AutoInstall.register(Package('geomet', Version(0, 2, 1)))
 AutoInstall.register(Package('gremlinpython', Version(3, 4, 6)))
 AutoInstall.register(Package('hiredis', Version(1, 1, 0)))
 AutoInstall.register(Package('isodate', Version(0, 6, 0)))
-AutoInstall.register(Package('jmespath', Version(0, 10, 0), wheel=True))
 AutoInstall.register(Package('lupa', Version(1, 13)))
 AutoInstall.register(Package('pyasn1_modules', Version(0, 2, 8), pypi_name='pyasn1-modules'))
 AutoInstall.register(Package('redis', Version(3, 5, 3)))
@@ -79,6 +86,7 @@ AutoInstall.register(Package('sortedcontainers', Version(2, 4, 0)))
 AutoInstall.register(Package('tornado', Version(4, 5, 3)))
 AutoInstall.register(Package('twisted', Version(21, 2, 0), pypi_name='Twisted', implicit_deps=[
     Package('incremental', Version(21, 3, 0)),
+    'OpenSSL',
 ]))
 
 name = 'resultsdbpy'

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -101,15 +101,24 @@ AutoInstall.register(Package('whichcraft', Version(0, 6, 1)))
 AutoInstall.register(Package('cffi', Version(1, 15, 1)))
 
 if sys.version_info > (3, 0):
+    if sys.version_info >= (3, 9):
+        AutoInstall.register(Package('OpenSSL', Version(23, 2, 0), pypi_name='pyOpenSSL'))
+    else:
+        AutoInstall.register(Package('OpenSSL', Version(20, 0, 0), pypi_name='pyOpenSSL'))
+
     # There are no prebuilt binaries for arm-32 of 'cryptography' and building it requires cargo/rust
     # Since this dep is not really needed for the current arm-32 bots we skip it instead of
     # adding the overhead of a cargo/rust toolchain into the yocto-based image the bots run.
     if not (platform.machine().startswith('arm') and platform.architecture()[0] == '32bit'):
-        # This is synced with the logic for installing pyOpenSSL at Tools/Scripts/webkitpy/autoinstalled/twisted.py
         if sys.version_info >= (3, 11):
-            AutoInstall.register(Package('cryptography', Version(40, 0, 2), wheel=True, implicit_deps=['cffi']))
+            AutoInstall.register(Package('cryptography', Version(40, 0, 2), wheel=True, implicit_deps=['cffi', 'OpenSSL']))
+        elif sys.version_info >= (3, 9):
+            AutoInstall.register(Package('cryptography', Version(38, 0, 2), wheel=True, implicit_deps=['cffi', 'OpenSSL']))
         else:
-            AutoInstall.register(Package('cryptography', Version(36, 0, 2), wheel=True, implicit_deps=['cffi']))
+            AutoInstall.register(Package('cryptography', Version(36, 0, 2), wheel=True, implicit_deps=['cffi', 'OpenSSL']))
+
+else:
+    AutoInstall.register(Package('OpenSSL', Version(17, 2, 0), pypi_name='pyOpenSSL'))
 
 if sys.version_info >= (3, 6):
     if sys.platform == 'linux':

--- a/Tools/Scripts/webkitpy/autoinstalled/twisted.py
+++ b/Tools/Scripts/webkitpy/autoinstalled/twisted.py
@@ -33,10 +33,8 @@ if sys.version_info >= (3, 0):
 
     if sys.version_info >= (3, 11):
         AutoInstall.install(Package('twisted', Version(22, 10, 0), pypi_name='Twisted', implicit_deps=['pyparsing']))
-        AutoInstall.install(Package('OpenSSL', Version(23, 2, 0), pypi_name='pyOpenSSL'))
     else:
         AutoInstall.install(Package('twisted', Version(20, 3, 0), pypi_name='Twisted', implicit_deps=['pyparsing']))
-        AutoInstall.install(Package('OpenSSL', Version(20, 0, 0), pypi_name='pyOpenSSL'))
 
     # There are no prebuilt binaries for arm-32 of 'bcrypt' and building it requires cargo/rust
     # Since this dep is not really needed for the current arm-32 bots we skip it instead of
@@ -50,9 +48,7 @@ if sys.version_info >= (3, 0):
 else:
     AutoInstall.install(Package('hyperlink', Version(17, 3, 0), pypi_name='hyperlink'))
     AutoInstall.install(Package('incremental', Version(17, 5, 0), pypi_name='incremental'))
-    AutoInstall.install(Package('twisted', Version(17, 5, 0), pypi_name='Twisted', implicit_deps=['pyparsing']))
-
-    AutoInstall.install(Package('OpenSSL', Version(17, 2, 0), pypi_name='pyOpenSSL'))
+    AutoInstall.install(Package('twisted', Version(17, 5, 0), pypi_name='Twisted', implicit_deps=['OpenSSL', 'pyparsing']))
     AutoInstall.install(Package('pycparser', Version(2, 18)))
 
 sys.modules[__name__] = __import__('twisted')


### PR DESCRIPTION
#### b8390e24dbe69edce19760bc41b1a654d9dedc9b
<pre>
[webkitpy] Update cryptography and openssl dependencies
<a href="https://bugs.webkit.org/show_bug.cgi?id=268118">https://bugs.webkit.org/show_bug.cgi?id=268118</a>
<a href="https://rdar.apple.com/121462885">rdar://121462885</a>

Reviewed by Sam Sneddon and BJ Burg.

We need to update boto for testing. This requires updating cryptography,
which requires updating OpenSSL. Since cryptography is coupled to OpenSSL,
we should declare their dependencies in the same place.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/__init__.py: Update boto and dependencies.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py: Update cryptography on
newer version of Python, pair OpenSSL with cryptography definitions.
* Tools/Scripts/webkitpy/autoinstalled/twisted.py: Move OpenSSL dependency to webkitcorepy.

Canonical link: <a href="https://commits.webkit.org/277995@main">https://commits.webkit.org/277995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ec90f61668fa695e6238e4f3f46e4a7abe0d8ed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51606 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44989 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51224 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25660 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39987 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49658 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25776 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42178 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21094 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/48779 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23236 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43350 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6974 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45167 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43851 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53517 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23970 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20229 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47294 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/48948 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25233 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42387 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46248 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26042 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7048 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24953 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->