### PR TITLE
[git-webkit] Revert should include the identifier and hash

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py
@@ -50,7 +50,7 @@ class TestRevert(testing.PathTestCase):
             1: dict(
                 number=1,
                 opened=True,
-                title='Unreviewed, reverting 5@main',
+                title='Unreviewed, reverting 5@main (d8bce26)',
                 description='?',
                 creator=result.users.create(name='Tim Contributor', username='tcontributor'),
                 timestamp=1639536160,
@@ -61,7 +61,7 @@ class TestRevert(testing.PathTestCase):
         result.pull_requests = [dict(
             number=1,
             state='open',
-            title='Unreviewed, reverting 5@main',
+            title='Unreviewed, reverting 5@main (d8bce26)',
             user=dict(login='tcontributor'),
             body='''#### a5fe8afe9bf7d07158fcd9e9732ff02a712db2fd
     <pre>
@@ -102,7 +102,7 @@ class TestRevert(testing.PathTestCase):
             self.assertEqual(0, result)
             self.assertDictEqual(repo.modified, dict())
             self.assertDictEqual(repo.staged, dict())
-            self.assertEqual(True, 'Unreviewed, reverting 5@main' in repo.head.message)
+            self.assertEqual(True, 'Unreviewed, reverting 5@main (d8bce26)' in repo.head.message)
             self.assertEqual(local.Git(self.path).remote().pull_requests.get(1).draft, False)
 
         self.assertEqual(
@@ -110,7 +110,7 @@ class TestRevert(testing.PathTestCase):
             "This issue will track the revert and should not be the issue of the commit(s) to be reverted.\n"
             "Enter issue URL or title of new issue (reason for the revert): \n"
             "Created the local development branch 'eng/Example-feature-1'\n"
-            "Created 'PR 1 | Unreviewed, reverting 5@main'!\n"
+            "Created 'PR 1 | Unreviewed, reverting 5@main (d8bce26)'!\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n",
         )
         self.assertEqual(captured.stderr.getvalue(), '')
@@ -151,7 +151,7 @@ class TestRevert(testing.PathTestCase):
             self.assertEqual(0, result)
             self.assertDictEqual(repo.modified, dict())
             self.assertDictEqual(repo.staged, dict())
-            self.assertEqual(True, 'Unreviewed, reverting 5@main' in repo.head.message)
+            self.assertEqual(True, 'Unreviewed, reverting 5@main (d8bce26)' in repo.head.message)
             with MockTerminal.input('{}/show_bug.cgi?id=2'.format(self.BUGZILLA)):
                 result = program.main(args=('pull-request', '-v', '--no-history'), path=self.path)
             self.assertEqual(0, result)
@@ -162,7 +162,7 @@ class TestRevert(testing.PathTestCase):
             "This issue will track the revert and should not be the issue of the commit(s) to be reverted.\n"
             "Enter issue URL or title of new issue (reason for the revert): \n"
             "Created the local development branch 'eng/Example-feature-1'\n"
-            "Created 'PR 1 | Unreviewed, reverting 5@main'!\n"
+            "Created 'PR 1 | Unreviewed, reverting 5@main (d8bce26)'!\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n",
         )
         self.assertEqual(captured.stderr.getvalue(), '')
@@ -204,7 +204,7 @@ class TestRevert(testing.PathTestCase):
             self.assertEqual(0, result)
             self.assertDictEqual(repo.modified, dict())
             self.assertDictEqual(repo.staged, dict())
-            self.assertEqual(True, 'Unreviewed, reverting 5@main' in repo.head.message)
+            self.assertEqual(True, 'Unreviewed, reverting 5@main (d8bce26)' in repo.head.message)
             with MockTerminal.input('{}/show_bug.cgi?id=2'.format(self.BUGZILLA)):
                 result = program.main(args=('pull-request', '-v', '--no-history'), path=self.path)
             self.assertEqual(0, result)
@@ -213,7 +213,7 @@ class TestRevert(testing.PathTestCase):
         self.assertEqual(
             captured.stdout.getvalue(),
             "Created the local development branch 'eng/Example-feature-1'\n"
-            "Created 'PR 1 | Unreviewed, reverting 5@main'!\n"
+            "Created 'PR 1 | Unreviewed, reverting 5@main (d8bce26)'!\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n",
         )
         self.assertEqual(captured.stderr.getvalue(), '')
@@ -290,9 +290,9 @@ index 05e8751..0bf3c85 100644
             "This issue will track the revert and should not be the issue of the commit(s) to be reverted.\n"
             "Enter issue URL or title of new issue (reason for the revert): \n"
             "Created the local development branch 'eng/Example-feature-1'\n"
-            "Created 'PR 1 | Unreviewed, reverting 5@main'!\n"
+            "Created 'PR 1 | Unreviewed, reverting 5@main (d8bce26)'!\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n"
-            "Updated 'PR 1 | Unreviewed, reverting 5@main'!\n"
+            "Updated 'PR 1 | Unreviewed, reverting 5@main (d8bce26)'!\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n",
         )
         self.assertEqual(captured.stderr.getvalue(), '')
@@ -345,11 +345,11 @@ index 05e8751..0bf3c85 100644
             self.assertEqual(0, result)
             self.assertDictEqual(repo.modified, dict())
             self.assertDictEqual(repo.staged, dict())
-            self.assertEqual(True, 'Unreviewed, reverting 5@main' in repo.head.message)
+            self.assertEqual(True, 'Unreviewed, reverting 5@main (d8bce26)' in repo.head.message)
             self.assertEqual(
                 captured.stdout.getvalue(),
                 "Created the local development branch 'eng/Example-feature-1'\n"
-                "Created 'PR 1 | Unreviewed, reverting 5@main'!\n"
+                "Created 'PR 1 | Unreviewed, reverting 5@main (d8bce26)'!\n"
                 "https://github.example.com/WebKit/WebKit/pull/1\n"
             )
 
@@ -396,7 +396,7 @@ index 05e8751..0bf3c85 100644
                 "Pushing 'eng/Example-issue-1' to 'fork'...",
                 "Creating 'eng/Example-issue-1-1' as a reference branch",
                 "Creating pull-request for 'eng/Example-issue-1'...",
-                "Adding 'merge-queue' to 'PR 2 | Unreviewed, reverting 5@main'",
+                "Adding 'merge-queue' to 'PR 2 | Unreviewed, reverting 5@main (d8bce26)'",
             ],
         )
 
@@ -443,6 +443,6 @@ index 05e8751..0bf3c85 100644
                 "Pushing 'eng/Example-issue-1' to 'fork'...",
                 "Creating 'eng/Example-issue-1-1' as a reference branch",
                 "Creating pull-request for 'eng/Example-issue-1'...",
-                "Adding 'unsafe-merge-queue' to 'PR 2 | Unreviewed, reverting 5@main'",
+                "Adding 'unsafe-merge-queue' to 'PR 2 | Unreviewed, reverting 5@main (d8bce26)'",
             ],
         )


### PR DESCRIPTION
#### f65325499d4b21165de8fda96f404806bd13cc69
<pre>
[git-webkit] Revert should include the identifier and hash
<a href="https://bugs.webkit.org/show_bug.cgi?id=265594">https://bugs.webkit.org/show_bug.cgi?id=265594</a>
<a href="https://rdar.apple.com/119329882">rdar://119329882</a>

Reviewed by Jonathan Bedard.

Replaces <a href="https://commits.webkit.org/1234@main">https://commits.webkit.org/1234@main</a> with 1234@main (&lt;hash&gt;) in the commit message.
Also adds the hash to the commit title.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py:
(Revert.create_revert_commit_msg):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py:
(TestRevert.webserver):
(TestRevert):
(test_update):
(test_pr):
(test_land_safe):
(test_land_unsafe):

Canonical link: <a href="https://commits.webkit.org/277931@main">https://commits.webkit.org/277931@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aaa50c91abbcd600fdaf9487d34db6676daefe14

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28133 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/51887 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/51607 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/44990 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51225 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34085 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25661 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/51607 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/49666 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/25777 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/51887 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/51607 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/48780 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/23237 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/51887 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-skia~~](https://ews-build.webkit.org/#/builders/52/builds/6975 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45168 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/51887 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53518 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/23971 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20230 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47295 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/48949 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/25234 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/51887 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46249 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/26043 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7009 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/24954 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->