### PR TITLE
Expand use of WKBundlePagePostMessageWithAsyncReply

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
@@ -278,5 +278,6 @@ template<typename T> void postSynchronousPageMessage(const char* name, const WKR
 }
 
 void postMessageWithAsyncReply(const char* messageName, JSValueRef callback);
+void postMessageWithAsyncReply(const char* messageName, bool value, JSValueRef callback);
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -616,7 +616,6 @@ enum {
     WillEndSwipeCallbackID,
     DidEndSwipeCallbackID,
     DidRemoveSwipeSnapshotCallbackID,
-    SetStatisticsDebugModeCallbackID,
     SetStatisticsPrevalentResourceForDebugModeCallbackID,
     SetStatisticsLastSeenCallbackID,
     SetStatisticsMergeStatisticCallbackID,
@@ -1281,13 +1280,7 @@ bool TestRunner::isStatisticsEphemeral()
 
 void TestRunner::setStatisticsDebugMode(bool value, JSValueRef completionHandler)
 {
-    cacheTestRunnerCallback(SetStatisticsDebugModeCallbackID, completionHandler);
-    postMessage("SetStatisticsDebugMode", value);
-}
-
-void TestRunner::statisticsCallDidSetDebugModeCallback()
-{
-    callTestRunnerCallback(SetStatisticsDebugModeCallbackID);
+    postMessageWithAsyncReply("SetStatisticsDebugMode", value, completionHandler);
 }
 
 void TestRunner::setStatisticsPrevalentResourceForDebugMode(JSStringRef hostName, JSValueRef completionHandler)

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -420,7 +420,6 @@ public:
     void statisticsUpdateCookieBlocking(JSValueRef completionHandler);
     void statisticsCallDidSetBlockCookiesForHostCallback();
     void setStatisticsDebugMode(bool value, JSValueRef completionHandler);
-    void statisticsCallDidSetDebugModeCallback();
     void setStatisticsPrevalentResourceForDebugMode(JSStringRef hostName, JSValueRef completionHandler);
     void statisticsCallDidSetPrevalentResourceForDebugModeCallback();
     void setStatisticsLastSeen(JSStringRef hostName, double seconds, JSValueRef completionHandler);

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -220,7 +220,7 @@ public:
     bool doesStatisticsDomainIDExistInDatabase(unsigned domainID);
     void setStatisticsEnabled(bool value);
     bool isStatisticsEphemeral();
-    void setStatisticsDebugMode(bool value);
+    void setStatisticsDebugMode(bool value, CompletionHandler<void(WKTypeRef)>&&);
     void setStatisticsPrevalentResourceForDebugMode(WKStringRef hostName);
     void setStatisticsLastSeen(WKStringRef hostName, double seconds);
     void setStatisticsMergeStatistic(WKStringRef host, WKStringRef topFrameDomain1, WKStringRef topFrameDomain2, double lastSeen, bool hadUserInteraction, double mostRecentUserInteraction, bool isGrandfathered, bool isPrevalent, bool isVeryPrevalent, int dataRecordsRemoved);

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -716,11 +716,6 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         return;
     }
 
-    if (WKStringIsEqualToUTF8CString(messageName, "SetStatisticsDebugMode")) {
-        TestController::singleton().setStatisticsDebugMode(booleanValue(messageBody));
-        return;
-    }
-
     if (WKStringIsEqualToUTF8CString(messageName, "SetStatisticsPrevalentResourceForDebugMode")) {
         WKStringRef hostName = stringValue(messageBody);
         TestController::singleton().setStatisticsPrevalentResourceForDebugMode(hostName);
@@ -1713,11 +1708,6 @@ void TestInvocation::didResetStatisticsToConsistentState()
 void TestInvocation::didSetBlockCookiesForHost()
 {
     postPageMessage("CallDidSetBlockCookiesForHost");
-}
-
-void TestInvocation::didSetStatisticsDebugMode()
-{
-    postPageMessage("CallDidSetStatisticsDebugMode");
 }
 
 void TestInvocation::didSetPrevalentResourceForDebugMode()

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -82,7 +82,6 @@ public:
     void didSetThirdPartyCNAMEDomain();
     void didResetStatisticsToConsistentState();
     void didSetBlockCookiesForHost();
-    void didSetStatisticsDebugMode();
     void didSetPrevalentResourceForDebugMode();
     void didSetLastSeen();
     void didMergeStatistic();


### PR DESCRIPTION
#### a1e51b3692258c8c4643de82d12d06773f1069fa
<pre>
Expand use of WKBundlePagePostMessageWithAsyncReply
<a href="https://bugs.webkit.org/show_bug.cgi?id=273162">https://bugs.webkit.org/show_bug.cgi?id=273162</a>
<a href="https://rdar.apple.com/126956541">rdar://126956541</a>

Reviewed by Sihui Liu.

This helps site isolation testing by sending the reply to the sending process
instead of the main frame process.  This is covered by 2 tests:
http/tests/resourceLoadStatistics/set-custom-prevalent-resource-in-debug-mode.html
http/tests/resourceLoadStatistics/enable-debug-mode.html

* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::didReceiveMessageToPage):
(WTR::postMessageWithAsyncReplyImpl):
(WTR::postMessageWithAsyncReply):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::setStatisticsDebugMode):
(WTR::TestRunner::statisticsCallDidSetDebugModeCallback): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::didReceiveAsyncMessageFromInjectedBundle):
(WTR::TestController::setStatisticsDebugMode):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):
(WTR::TestInvocation::didSetStatisticsDebugMode): Deleted.
* Tools/WebKitTestRunner/TestInvocation.h:

Canonical link: <a href="https://commits.webkit.org/277933@main">https://commits.webkit.org/277933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae54563f38ad271a5e0ed95751a6cdfbb5d01fa0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48926 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51613 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44996 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51231 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25667 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39994 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49694 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25783 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42179 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21101 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23243 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43351 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6981 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45174 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43852 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53524 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23977 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20236 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47306 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-visibility-hidden-child.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25240 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42388 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46264 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26049 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7010 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24960 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->