### PR TITLE
Allow apps to set a custom inspection name for web extension background and popup web views

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.h
@@ -52,6 +52,7 @@ public:
 
     virtual String name() const { return String(); } // ITML JavaScript Page ServiceWorker WebPage
     virtual String url() const { return String(); } // Page ServiceWorker WebPage
+    virtual const String& nameOverride() const { return nullString(); }
     virtual bool hasLocalDebugger() const = 0;
 
     virtual void setIndicating(bool) { } // Default is to do nothing.

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspectorConstants.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspectorConstants.h
@@ -56,6 +56,7 @@
 #define WIRHasLocalDebuggerKey                  @"WIRHasLocalDebuggerKey"
 #define WIRTitleKey                             @"WIRTitleKey"
 #define WIRURLKey                               @"WIRURLKey"
+#define WIROverrideNameKey                      @"WIROverrideNameKey"
 #define WIRUserInfoKey                          @"WIRUserInfoKey"
 #define WIRApplicationDictionaryKey             @"WIRApplicationDictionaryKey"
 #define WIRMessageDataKey                       @"WIRMessageDataKey"

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
@@ -473,25 +473,30 @@ RetainPtr<NSDictionary> RemoteInspector::listingForInspectionTarget(const Remote
     switch (target.type()) {
     case RemoteInspectionTarget::Type::ITML:
         [listing setObject:target.name() forKey:WIRTitleKey];
+        [listing setObject:target.nameOverride() forKey:WIROverrideNameKey];
         [listing setObject:WIRTypeITML forKey:WIRTypeKey];
         break;
     case RemoteInspectionTarget::Type::JavaScript:
         [listing setObject:target.name() forKey:WIRTitleKey];
+        [listing setObject:target.nameOverride() forKey:WIROverrideNameKey];
         [listing setObject:WIRTypeJavaScript forKey:WIRTypeKey];
         break;
     case RemoteInspectionTarget::Type::Page:
         [listing setObject:target.url() forKey:WIRURLKey];
         [listing setObject:target.name() forKey:WIRTitleKey];
+        [listing setObject:target.nameOverride() forKey:WIROverrideNameKey];
         [listing setObject:WIRTypePage forKey:WIRTypeKey];
         break;
     case RemoteInspectionTarget::Type::ServiceWorker:
         [listing setObject:target.url() forKey:WIRURLKey];
         [listing setObject:target.name() forKey:WIRTitleKey];
+        [listing setObject:target.nameOverride() forKey:WIROverrideNameKey];
         [listing setObject:WIRTypeServiceWorker forKey:WIRTypeKey];
         break;
     case RemoteInspectionTarget::Type::WebPage:
         [listing setObject:target.url() forKey:WIRURLKey];
         [listing setObject:target.name() forKey:WIRTitleKey];
+        [listing setObject:target.nameOverride() forKey:WIROverrideNameKey];
         [listing setObject:WIRTypeWebPage forKey:WIRTypeKey];
         break;
     default:

--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -82,6 +82,9 @@
 /* Label for an inspectable Web Extension service worker */
 "%@ — Extension Service Worker" = "%@ — Extension Service Worker";
 
+/* Label for an inspectable Web Extension popup page */
+"%@ — Extension Popup Page" = "%@ — Extension Popup Page";
+
 /* Label to describe the number of files selected in a file upload control that allows multiple files */
 "%d files" = "%d files";
 

--- a/Source/WebCore/page/PageDebuggable.cpp
+++ b/Source/WebCore/page/PageDebuggable.cpp
@@ -46,9 +46,6 @@ PageDebuggable::PageDebuggable(Page& page)
 
 String PageDebuggable::name() const
 {
-    if (!m_nameOverride.isNull())
-        return m_nameOverride;
-
     RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
     if (!localMainFrame)
         return String();

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.h
@@ -41,6 +41,8 @@
 @class NSPopover;
 #endif
 
+#define HAVE_UPDATED_WEB_EXTENSION_ACTION_INSPECTION_OVERRIDE_NAME 1
+
 NS_ASSUME_NONNULL_BEGIN
 
 /*! @abstract This notification is sent whenever a @link WKWebExtensionAction has changed properties. */
@@ -96,6 +98,12 @@ NS_SWIFT_NAME(_WKWebExtension.Action)
  has been presented to the user. This property is useful for higher-level notification badges when extensions might be hidden behind an action sheet.
  */
 @property (nonatomic) BOOL hasUnreadBadgeText;
+
+/*!
+ @abstract The name shown when inspecting the popup web view.
+ @discussion This is the text that will appear when inspecting the popup web view.
+ */
+@property (nonatomic, nullable, copy) NSString *inspectionName;
 
 /*! @abstract A Boolean value indicating whether the action is enabled. */
 @property (nonatomic, readonly, getter=isEnabled) BOOL enabled;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -102,6 +102,16 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionAction, WebExtensionAction,
     return _webExtensionAction->setHasUnreadBadgeText(hasUnreadBadgeText);
 }
 
+- (NSString *)inspectionName
+{
+    return _webExtensionAction->popupWebViewInspectionName();
+}
+
+- (void)setInspectionName:(NSString *)name
+{
+    _webExtensionAction->setPopupWebViewInspectionName(name);
+}
+
 - (BOOL)isEnabled
 {
     return _webExtensionAction->isEnabled();
@@ -186,6 +196,15 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionAction, WebExtensionAction,
 }
 
 - (void)setHasUnreadBadgeText:(BOOL)hasUnreadBadgeText
+{
+}
+
+- (NSString *)inspectionName
+{
+    return nil;
+}
+
+- (void)setInspectionName:(NSString *)name
 {
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -44,6 +44,8 @@
 @class NSMenuItem;
 #endif
 
+#define HAVE_UPDATED_WEB_EXTENSION_CONTEXT_INSPECTION_OVERRIDE_NAME 1
+
 NS_ASSUME_NONNULL_BEGIN
 
 /*! @abstract Indicates a @link WKWebExtensionContext @/link error. */
@@ -184,6 +186,12 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
  You should set this to `YES` when needed for debugging purposes. The default value is `NO`.
 */
 @property (nonatomic, getter=isInspectable) BOOL inspectable;
+
+/*!
+ @abstract The name shown when inspecting the background web view.
+ @discussion This is the text that will appear when inspecting the background web view.
+ */
+@property (nonatomic, nullable, copy) NSString *inspectionName;
 
 /*!
  @abstract Specifies unsupported APIs for this extension, making them `undefined` in JavaScript.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -142,6 +142,16 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionContext, WebExtensionContex
 - (void)setInspectable:(BOOL)inspectable
 {
     _webExtensionContext->setInspectable(inspectable);
+}
+
+- (NSString *)inspectionName
+{
+    return _webExtensionContext->backgroundWebViewInspectionName();
+}
+
+- (void)setInspectionName:(NSString *)name
+{
+    _webExtensionContext->setBackgroundWebViewInspectionName(name);
 }
 
 - (NSSet<NSString *> *)unsupportedAPIs
@@ -877,6 +887,15 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(_WKWe
 }
 
 - (void)setInspectable:(BOOL)inspectable
+{
+}
+
+- (NSString *)inspectionName
+{
+    return nil;
+}
+
+- (void)setInspectionName:(NSString *)name
 {
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfigurationPrivate.h
@@ -25,9 +25,6 @@
 
 #import <WebKit/_WKWebExtensionControllerConfiguration.h>
 
-// FIXME: Remove once https://commits.webkit.org/275999@main is in the SDK.
-#define HAVE_UPDATED_WEB_EXTENSION_CONTROLLER_STORAGE_DIRECTORY_PATH 1
-
 NS_ASSUME_NONNULL_BEGIN
 
 @interface _WKWebExtensionControllerConfiguration ()

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionDataRecord.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionDataRecord.h
@@ -30,8 +30,6 @@
 
 #import <WebKit/_WKWebExtensionDataType.h>
 
-#define HAVE_UPDATED_WEB_EXTENSION_DATA_RECORD_ERROR_PROPERTIES 1
-
 NS_ASSUME_NONNULL_BEGIN
 
 /*! @abstract Indicates a `_WKWebExtensionDataRecord` error. */

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -645,6 +645,20 @@ void WebExtensionAction::setPopupPath(String path)
     propertiesDidChange();
 }
 
+NSString *WebExtensionAction::popupWebViewInspectionName()
+{
+    if (m_popupWebViewInspectionName.isEmpty())
+        m_popupWebViewInspectionName = WEB_UI_FORMAT_CFSTRING("%@ — Extension Popup Page", "Label for an inspectable Web Extension popup page", (__bridge CFStringRef)extensionContext()->extension().displayShortName());
+
+    return m_popupWebViewInspectionName;
+}
+
+void WebExtensionAction::setPopupWebViewInspectionName(const String& name)
+{
+    m_popupWebViewInspectionName = name;
+    m_popupWebView.get()._remoteInspectionNameOverride = name;
+}
+
 #if PLATFORM(IOS_FAMILY)
 UIViewController *WebExtensionAction::popupViewController()
 {
@@ -772,6 +786,7 @@ WKWebView *WebExtensionAction::popupWebView()
     m_popupWebView.get().UIDelegate = m_popupWebViewDelegate.get();
     m_popupWebView.get().inspectable = extensionContext()->isInspectable();
     m_popupWebView.get().accessibilityLabel = extensionContext()->extension().displayName();
+    m_popupWebView.get()._remoteInspectionNameOverride = popupWebViewInspectionName();
 
 #if PLATFORM(MAC)
     m_popupWebView.get()._sizeToContentAutoSizeMaximumSize = CGSizeMake(maximumPopoverWidth, maximumPopoverHeight);

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -3176,10 +3176,7 @@ void WebExtensionContext::loadBackgroundWebView()
     if ([delegate respondsToSelector:@selector(_webExtensionController:didCreateBackgroundWebView:forExtensionContext:)])
         [delegate _webExtensionController:m_extensionController->wrapper() didCreateBackgroundWebView:m_backgroundWebView.get() forExtensionContext:wrapper()];
 
-    if (extension().backgroundContentIsServiceWorker())
-        m_backgroundWebView.get()._remoteInspectionNameOverride = WEB_UI_FORMAT_CFSTRING("%@ — Extension Service Worker", "Label for an inspectable Web Extension service worker", (__bridge CFStringRef)extension().displayShortName());
-    else
-        m_backgroundWebView.get()._remoteInspectionNameOverride = WEB_UI_FORMAT_CFSTRING("%@ — Extension Background Page", "Label for an inspectable Web Extension background page", (__bridge CFStringRef)extension().displayShortName());
+    m_backgroundWebView.get()._remoteInspectionNameOverride = backgroundWebViewInspectionName();
 
     extension().removeError(WebExtension::Error::BackgroundContentFailedToLoad);
 
@@ -3210,6 +3207,25 @@ void WebExtensionContext::unloadBackgroundWebView()
 
     [m_backgroundWebView _close];
     m_backgroundWebView = nil;
+}
+
+NSString *WebExtensionContext::backgroundWebViewInspectionName()
+{
+    if (!m_backgroundWebViewInspectionName.isEmpty())
+        return m_backgroundWebViewInspectionName;
+
+    if (extension().backgroundContentIsServiceWorker())
+        m_backgroundWebViewInspectionName = WEB_UI_FORMAT_CFSTRING("%@ — Extension Service Worker", "Label for an inspectable Web Extension service worker", (__bridge CFStringRef)extension().displayShortName());
+    else
+        m_backgroundWebViewInspectionName = WEB_UI_FORMAT_CFSTRING("%@ — Extension Background Page", "Label for an inspectable Web Extension background page", (__bridge CFStringRef)extension().displayShortName());
+
+    return m_backgroundWebViewInspectionName;
+}
+
+void WebExtensionContext::setBackgroundWebViewInspectionName(const String& name)
+{
+    m_backgroundWebViewInspectionName = name;
+    m_backgroundWebView.get()._remoteInspectionNameOverride = name;
 }
 
 static inline bool isNotRunningInTestRunner()

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
@@ -110,6 +110,9 @@ public:
     String popupPath() const;
     void setPopupPath(String);
 
+    NSString *popupWebViewInspectionName();
+    void setPopupWebViewInspectionName(const String&);
+
 #if PLATFORM(IOS_FAMILY)
     UIViewController *popupViewController();
 #endif
@@ -162,6 +165,7 @@ private:
     RetainPtr<_WKWebExtensionActionWebView> m_popupWebView;
     RetainPtr<_WKWebExtensionActionWebViewDelegate> m_popupWebViewDelegate;
     String m_customPopupPath;
+    String m_popupWebViewInspectionName;
 
     RetainPtr<NSDictionary> m_customIcons;
     String m_customLabel;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -459,6 +459,9 @@ public:
     WKWebView *backgroundWebView() const { return m_backgroundWebView.get(); }
     bool safeToLoadBackgroundContent() const { return m_safeToLoadBackgroundContent; }
 
+    NSString *backgroundWebViewInspectionName();
+    void setBackgroundWebViewInspectionName(const String&);
+
     bool decidePolicyForNavigationAction(WKWebView *, WKNavigationAction *);
     void didFinishDocumentLoad(WKWebView *, WKNavigation *);
     void didFailNavigation(WKWebView *, WKNavigation *, NSError *);
@@ -887,6 +890,8 @@ private:
 
     RetainPtr<WKWebView> m_backgroundWebView;
     RetainPtr<_WKWebExtensionContextDelegate> m_delegate;
+
+    String m_backgroundWebViewInspectionName;
 
     std::unique_ptr<WebCore::Timer> m_unloadBackgroundWebViewTimer;
     MonotonicTime m_lastBackgroundPortActivityTime;

--- a/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.cpp
@@ -43,9 +43,6 @@ WebPageDebuggable::WebPageDebuggable(WebPageProxy& page)
 
 String WebPageDebuggable::name() const
 {
-    if (!m_nameOverride.isNull())
-        return m_nameOverride;
-
     if (!m_page.mainFrame())
         return String();
 

--- a/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.h
@@ -52,7 +52,7 @@ public:
     void dispatchMessageFromRemote(String&& message) final;
     void setIndicating(bool) final;
 
-    const String& nameOverride() const { return m_nameOverride; }
+    const String& nameOverride() const final { return m_nameOverride; }
     void setNameOverride(const String&);
 
 private:


### PR DESCRIPTION
#### e327d4468b6d6c0366404ed9e35dd215d4062610
<pre>
Allow apps to set a custom inspection name for web extension background and popup web views
<a href="https://bugs.webkit.org/show_bug.cgi?id=273161">https://bugs.webkit.org/show_bug.cgi?id=273161</a>
<a href="https://rdar.apple.com/125874004">rdar://125874004</a>

Reviewed by Timothy Hatcher.

Add API to allow apps to set a custom inspection name for background and popup web views.
Also, add a `nameOverride()` method to WebPageDebuggable. This will allow us to keep
track of overrides that are set for the web pages.

* Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.h:
* Source/JavaScriptCore/inspector/remote/RemoteInspectorConstants.h:
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm:
(Inspector::RemoteInspector::listingForInspectionTarget const):
Set the name override on the listing.

* Source/WebCore/en.lproj/Localizable.strings:
Add localized strings for text shown when inspecting the extension popup.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.mm:
(-[_WKWebExtensionAction inspectionName]):
(-[_WKWebExtensionAction setInspectionName:]):

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext inspectionName]):
(-[_WKWebExtensionContext setInspectionName:]):

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfigurationPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionDataRecord.h
Remove guards since _WKWebExtensionDataRecord.errors API has made it into the build.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::popupWebViewInspectionName):
(WebKit::WebExtensionAction::setPopupWebViewInspectionName):
(WebKit::WebExtensionAction::popupWebView):
Set the _remoteInspectionNameOverride for the popup web view.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::loadBackgroundWebView):
(WebKit::WebExtensionContext::backgroundWebViewInspectionName):
(WebKit::WebExtensionContext::setBackgroundWebViewInspectionName):

* Source/WebKit/UIProcess/Extensions/WebExtensionAction.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Inspector/WebPageDebuggable.cpp:

(WebKit::WebPageDebuggable::name const):
* Source/WebKit/UIProcess/Inspector/WebPageDebuggable.h:

Canonical link: <a href="https://commits.webkit.org/277937@main">https://commits.webkit.org/277937@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/112b9d95b3d8984c4a87063613cbdf4d18bb154f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49002 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51969 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51690 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45072 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51307 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25743 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/50047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/25858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/21164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/23316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7057 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/42301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53600 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/48493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24053 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/25316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26125 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55988 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7011 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/25036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11521 "Passed tests") | 
<!--EWS-Status-Bubble-End-->