### PR TITLE
REGRESSION (277633@main): [ MacOS iOS Debug ] TestWTF.WTF_CheckedPtr.CheckedRef is a consistent crash

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/CheckedPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CheckedPtr.cpp
@@ -51,70 +51,70 @@ class DerivedCheckedObject : public CheckedObject {
 TEST(WTF_CheckedPtr, Basic)
 {
     {
-        CheckedObject checkedObject;
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        auto checkedObject = makeUnique<CheckedObject>();
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
     }
 
     {
-        CheckedObject checkedObject;
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        auto checkedObject = makeUnique<CheckedObject>();
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
         {
-            CheckedPtr ptr { &checkedObject };
+            CheckedPtr ptr { checkedObject.get() };
             EXPECT_TRUE(!!ptr);
-            EXPECT_EQ(ptr.get(), &checkedObject);
+            EXPECT_EQ(ptr.get(), checkedObject.get());
             EXPECT_EQ(ptr->someFunction(), -7);
-            EXPECT_EQ(checkedObject.ptrCount(), 1u);
+            EXPECT_EQ(checkedObject->ptrCount(), 1u);
         }
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
     }
 
     {
-        CheckedObject checkedObject;
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        auto checkedObject = makeUnique<CheckedObject>();
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
 
-        CheckedPtr ptr = { &checkedObject };
+        CheckedPtr ptr = { checkedObject.get() };
         EXPECT_TRUE(!!ptr);
-        EXPECT_EQ(ptr.get(), &checkedObject);
+        EXPECT_EQ(ptr.get(), checkedObject.get());
         EXPECT_EQ(ptr->someFunction(), -7);
-        EXPECT_EQ(checkedObject.ptrCount(), 1u);
+        EXPECT_EQ(checkedObject->ptrCount(), 1u);
         ptr = nullptr;
 
         EXPECT_FALSE(!!ptr);
         EXPECT_EQ(ptr.get(), nullptr);
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
     }
 
     {
-        CheckedObject checkedObject;
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        auto checkedObject = makeUnique<CheckedObject>();
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
 
-        CheckedPtr ptr1 { &checkedObject };
+        CheckedPtr ptr1 { checkedObject.get() };
         EXPECT_TRUE(!!ptr1);
-        EXPECT_EQ(ptr1.get(), &checkedObject);
+        EXPECT_EQ(ptr1.get(), checkedObject.get());
         EXPECT_EQ(ptr1->someFunction(), -7);
-        EXPECT_EQ(checkedObject.ptrCount(), 1u);
+        EXPECT_EQ(checkedObject->ptrCount(), 1u);
 
-        const CheckedPtr ptr2 { &checkedObject };
+        const CheckedPtr ptr2 { checkedObject.get() };
         EXPECT_TRUE(!!ptr2);
-        EXPECT_EQ(ptr2.get(), &checkedObject);
+        EXPECT_EQ(ptr2.get(), checkedObject.get());
         EXPECT_EQ(ptr2->someFunction(), -7);
-        EXPECT_EQ(checkedObject.ptrCount(), 2u);
+        EXPECT_EQ(checkedObject->ptrCount(), 2u);
 
         CheckedPtr ptr3 = ptr2;
         EXPECT_TRUE(!!ptr3);
-        EXPECT_EQ(ptr3.get(), &checkedObject);
-        EXPECT_EQ(checkedObject.ptrCount(), 3u);
+        EXPECT_EQ(ptr3.get(), checkedObject.get());
+        EXPECT_EQ(checkedObject->ptrCount(), 3u);
 
         ptr1 = nullptr;
-        EXPECT_EQ(checkedObject.ptrCount(), 2u);
+        EXPECT_EQ(checkedObject->ptrCount(), 2u);
         EXPECT_EQ(ptr1.get(), nullptr);
-        EXPECT_EQ(ptr2.get(), &checkedObject);
-        EXPECT_EQ(ptr3.get(), &checkedObject);
+        EXPECT_EQ(ptr2.get(), checkedObject.get());
+        EXPECT_EQ(ptr3.get(), checkedObject.get());
 
         ptr1 = WTFMove(ptr3);
-        EXPECT_EQ(checkedObject.ptrCount(), 2u);
-        EXPECT_EQ(ptr1.get(), &checkedObject);
-        EXPECT_EQ(ptr2.get(), &checkedObject);
+        EXPECT_EQ(checkedObject->ptrCount(), 2u);
+        EXPECT_EQ(ptr1.get(), checkedObject.get());
+        EXPECT_EQ(ptr2.get(), checkedObject.get());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(ptr3.get(), nullptr);
     }
 }
@@ -122,204 +122,196 @@ TEST(WTF_CheckedPtr, Basic)
 TEST(WTF_CheckedPtr, CheckedRef)
 {
     {
-        CheckedObject checkedObject;
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        auto checkedObject = makeUnique<CheckedObject>();
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
         {
-            CheckedRef ref { checkedObject };
-            EXPECT_EQ(ref.ptr(), &checkedObject);
+            CheckedRef ref { *checkedObject };
+            EXPECT_EQ(ref.ptr(), checkedObject.get());
             EXPECT_EQ(ref->someFunction(), -7);
-            EXPECT_EQ(checkedObject.ptrCount(), 1u);
+            EXPECT_EQ(checkedObject->ptrCount(), 1u);
             CheckedPtr ptr { ref };
-            EXPECT_EQ(ref.ptr(), &checkedObject);
+            EXPECT_EQ(ref.ptr(), checkedObject.get());
             EXPECT_EQ(ref->someFunction(), -7);
-            EXPECT_EQ(ptr.get(), &checkedObject);
+            EXPECT_EQ(ptr.get(), checkedObject.get());
             EXPECT_EQ(ptr->someFunction(), -7);
-            EXPECT_EQ(checkedObject.ptrCount(), 2u);
+            EXPECT_EQ(checkedObject->ptrCount(), 2u);
         }
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
     }
 
     {
-        DerivedCheckedObject checkedObject;
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        auto checkedObject = makeUnique<DerivedCheckedObject>();
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
         {
-            CheckedRef<DerivedCheckedObject> ref { checkedObject };
-            EXPECT_EQ(ref.ptr(), &checkedObject);
+            CheckedRef<DerivedCheckedObject> ref { *checkedObject };
+            EXPECT_EQ(ref.ptr(), checkedObject.get());
             EXPECT_EQ(ref->someFunction(), -7);
-            EXPECT_EQ(checkedObject.ptrCount(), 1u);
+            EXPECT_EQ(checkedObject->ptrCount(), 1u);
             CheckedPtr<CheckedObject> ptr { ref };
-            EXPECT_EQ(ref.ptr(), &checkedObject);
+            EXPECT_EQ(ref.ptr(), checkedObject.get());
             EXPECT_EQ(ref->someFunction(), -7);
-            EXPECT_EQ(ptr.get(), &checkedObject);
+            EXPECT_EQ(ptr.get(), checkedObject.get());
             EXPECT_EQ(ptr->someFunction(), -7);
-            EXPECT_EQ(checkedObject.ptrCount(), 2u);
+            EXPECT_EQ(checkedObject->ptrCount(), 2u);
         }
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
     }
 
     {
-        CheckedObject checkedObject;
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        auto checkedObject = makeUnique<CheckedObject>();
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
         {
-            CheckedRef ref { checkedObject };
-            EXPECT_EQ(ref.ptr(), &checkedObject);
+            CheckedRef ref { *checkedObject };
+            EXPECT_EQ(ref.ptr(), checkedObject.get());
             EXPECT_EQ(ref->someFunction(), -7);
-            EXPECT_EQ(checkedObject.ptrCount(), 1u);
+            EXPECT_EQ(checkedObject->ptrCount(), 1u);
             CheckedPtr ptr { WTFMove(ref) };
-#if ASAN_ENABLED
-            __asan_unpoison_memory_region(&ref, sizeof(ref));
-#endif
-            EXPECT_EQ(ref.ptr(), nullptr);
-            EXPECT_EQ(ptr.get(), &checkedObject);
+            EXPECT_EQ(ptr.get(), checkedObject.get());
             EXPECT_EQ(ptr->someFunction(), -7);
-            EXPECT_EQ(checkedObject.ptrCount(), 1u);
+            EXPECT_EQ(checkedObject->ptrCount(), 1u);
         }
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
     }
 
     {
-        DerivedCheckedObject checkedObject;
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        auto checkedObject = makeUnique<DerivedCheckedObject>();
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
         {
-            CheckedRef<DerivedCheckedObject> ref { checkedObject };
-            EXPECT_EQ(ref.ptr(), &checkedObject);
+            CheckedRef<DerivedCheckedObject> ref { *checkedObject };
+            EXPECT_EQ(ref.ptr(), checkedObject.get());
             EXPECT_EQ(ref->someFunction(), -7);
-            EXPECT_EQ(checkedObject.ptrCount(), 1u);
+            EXPECT_EQ(checkedObject->ptrCount(), 1u);
             CheckedPtr<CheckedObject> ptr { WTFMove(ref) };
-#if ASAN_ENABLED
-            __asan_unpoison_memory_region(&ref, sizeof(ref));
-#endif
-            EXPECT_EQ(ref.ptr(), nullptr);
-            EXPECT_EQ(ptr.get(), &checkedObject);
+            EXPECT_EQ(ptr.get(), checkedObject.get());
             EXPECT_EQ(ptr->someFunction(), -7);
-            EXPECT_EQ(checkedObject.ptrCount(), 1u);
+            EXPECT_EQ(checkedObject->ptrCount(), 1u);
         }
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
     }
 }
 
 TEST(WTF_CheckedPtr, DerivedClass)
 {
     {
-        DerivedCheckedObject checkedObject;
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        auto checkedObject = makeUnique<DerivedCheckedObject>();
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
     }
 
     {
-        DerivedCheckedObject checkedObject;
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        auto checkedObject = makeUnique<DerivedCheckedObject>();
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
         {
-            CheckedPtr ptr = { &checkedObject };
+            CheckedPtr ptr = { checkedObject.get() };
             EXPECT_TRUE(!!ptr);
-            EXPECT_EQ(ptr.get(), &checkedObject);
+            EXPECT_EQ(ptr.get(), checkedObject.get());
             EXPECT_EQ(ptr->someFunction(), -7);
-            EXPECT_EQ(checkedObject.ptrCount(), 1u);
+            EXPECT_EQ(checkedObject->ptrCount(), 1u);
         }
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
     }
 
     {
-        CheckedObject checkedObject;
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        auto checkedObject = makeUnique<CheckedObject>();
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
 
-        CheckedPtr<CheckedObject> ptr { &checkedObject };
+        CheckedPtr<CheckedObject> ptr { checkedObject.get() };
         EXPECT_TRUE(!!ptr);
-        EXPECT_EQ(ptr.get(), &checkedObject);
+        EXPECT_EQ(ptr.get(), checkedObject.get());
         EXPECT_EQ(ptr->someFunction(), -7);
-        EXPECT_EQ(checkedObject.ptrCount(), 1u);
+        EXPECT_EQ(checkedObject->ptrCount(), 1u);
         ptr = nullptr;
 
         EXPECT_FALSE(!!ptr);
         EXPECT_EQ(ptr.get(), nullptr);
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
     }
 
     {
-        DerivedCheckedObject checkedObject;
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        auto checkedObject = makeUnique<DerivedCheckedObject>();
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
 
-        CheckedPtr<DerivedCheckedObject> ptr1 { &checkedObject };
+        CheckedPtr<DerivedCheckedObject> ptr1 { checkedObject.get() };
         EXPECT_TRUE(!!ptr1);
-        EXPECT_EQ(ptr1.get(), &checkedObject);
+        EXPECT_EQ(ptr1.get(), checkedObject.get());
         EXPECT_EQ(ptr1->someFunction(), -7);
-        EXPECT_EQ(checkedObject.ptrCount(), 1u);
+        EXPECT_EQ(checkedObject->ptrCount(), 1u);
 
         const CheckedPtr<CheckedObject> ptr2 = ptr1;
         EXPECT_TRUE(!!ptr2);
-        EXPECT_EQ(ptr2.get(), &checkedObject);
+        EXPECT_EQ(ptr2.get(), checkedObject.get());
         EXPECT_EQ(ptr2->someFunction(), -7);
-        EXPECT_EQ(checkedObject.ptrCount(), 2u);
+        EXPECT_EQ(checkedObject->ptrCount(), 2u);
 
         CheckedPtr<CheckedObject> ptr3 = ptr1;
         EXPECT_TRUE(!!ptr3);
-        EXPECT_EQ(ptr3.get(), &checkedObject);
-        EXPECT_EQ(checkedObject.ptrCount(), 3u);
+        EXPECT_EQ(ptr3.get(), checkedObject.get());
+        EXPECT_EQ(checkedObject->ptrCount(), 3u);
 
         ptr1 = nullptr;
-        EXPECT_EQ(checkedObject.ptrCount(), 2u);
+        EXPECT_EQ(checkedObject->ptrCount(), 2u);
         EXPECT_EQ(ptr1.get(), nullptr);
-        EXPECT_EQ(ptr2.get(), &checkedObject);
-        EXPECT_EQ(ptr3.get(), &checkedObject);
+        EXPECT_EQ(ptr2.get(), checkedObject.get());
+        EXPECT_EQ(ptr3.get(), checkedObject.get());
 
         CheckedPtr<CheckedObject> ptr4 = WTFMove(ptr3);
-        EXPECT_EQ(checkedObject.ptrCount(), 2u);
+        EXPECT_EQ(checkedObject->ptrCount(), 2u);
         EXPECT_EQ(ptr1.get(), nullptr);
-        EXPECT_EQ(ptr2.get(), &checkedObject);
+        EXPECT_EQ(ptr2.get(), checkedObject.get());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(ptr3.get(), nullptr);
-        EXPECT_EQ(ptr4.get(), &checkedObject);
+        EXPECT_EQ(ptr4.get(), checkedObject.get());
     }
 }
 
 TEST(WTF_CheckedPtr, HashSet)
 {
     {
-        CheckedObject checkedObject;
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        auto checkedObject = makeUnique<CheckedObject>();
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
 
-        CheckedPtr ptr = { &checkedObject };
-        EXPECT_EQ(ptr.get(), &checkedObject);
-        EXPECT_EQ(checkedObject.ptrCount(), 1u);
+        CheckedPtr ptr = { checkedObject.get() };
+        EXPECT_EQ(ptr.get(), checkedObject.get());
+        EXPECT_EQ(checkedObject->ptrCount(), 1u);
 
         HashSet<CheckedPtr<CheckedObject>> set;
         set.add(ptr);
-        EXPECT_EQ(checkedObject.ptrCount(), 2u);
+        EXPECT_EQ(checkedObject->ptrCount(), 2u);
 
         ptr = nullptr;
-        EXPECT_EQ(checkedObject.ptrCount(), 1u);
+        EXPECT_EQ(checkedObject->ptrCount(), 1u);
     }
 
     {
-        CheckedObject object1;
-        DerivedCheckedObject object2;
-        EXPECT_EQ(object1.ptrCount(), 0u);
-        EXPECT_EQ(object2.ptrCount(), 0u);
+        auto object1 = makeUnique<CheckedObject>();
+        auto object2 = makeUnique<DerivedCheckedObject>();
+        EXPECT_EQ(object1->ptrCount(), 0u);
+        EXPECT_EQ(object2->ptrCount(), 0u);
 
         HashSet<CheckedPtr<CheckedObject>> set;
-        set.add(&object1);
-        EXPECT_EQ(object1.ptrCount(), 1u);
-        EXPECT_EQ(object2.ptrCount(), 0u);
+        set.add(object1.get());
+        EXPECT_EQ(object1->ptrCount(), 1u);
+        EXPECT_EQ(object2->ptrCount(), 0u);
 
-        set.add(&object1);
-        EXPECT_EQ(object1.ptrCount(), 1u);
-        EXPECT_EQ(object2.ptrCount(), 0u);
+        set.add(object1.get());
+        EXPECT_EQ(object1->ptrCount(), 1u);
+        EXPECT_EQ(object2->ptrCount(), 0u);
 
-        CheckedPtr<DerivedCheckedObject> ptr { &object2 };
+        CheckedPtr<DerivedCheckedObject> ptr { object2.get() };
         set.add(ptr);
-        EXPECT_EQ(object1.ptrCount(), 1u);
-        EXPECT_EQ(object2.ptrCount(), 2u);
+        EXPECT_EQ(object1->ptrCount(), 1u);
+        EXPECT_EQ(object2->ptrCount(), 2u);
         ptr = nullptr;
 
-        EXPECT_EQ(object1.ptrCount(), 1u);
-        EXPECT_EQ(object2.ptrCount(), 1u);
+        EXPECT_EQ(object1->ptrCount(), 1u);
+        EXPECT_EQ(object2->ptrCount(), 1u);
 
-        set.remove(&object1);
-        EXPECT_EQ(object1.ptrCount(), 0u);
-        EXPECT_EQ(object2.ptrCount(), 1u);
+        set.remove(object1.get());
+        EXPECT_EQ(object1->ptrCount(), 0u);
+        EXPECT_EQ(object2->ptrCount(), 1u);
     }
 
     {
         Vector<std::unique_ptr<CheckedObject>> objects;
-        objects.append(makeUniqueWithoutFastMallocCheck<CheckedObject>());
+        objects.append(makeUnique<CheckedObject>());
         EXPECT_EQ(objects[0]->ptrCount(), 0u);
 
         HashSet<CheckedPtr<CheckedObject>> set;
@@ -328,9 +320,9 @@ TEST(WTF_CheckedPtr, HashSet)
 
         for (unsigned i = 0; set.capacity() == initialCapacity; ++i) {
             if (i % 2)
-                objects.append(makeUniqueWithoutFastMallocCheck<DerivedCheckedObject>());
+                objects.append(makeUnique<DerivedCheckedObject>());
             else
-                objects.append(makeUniqueWithoutFastMallocCheck<CheckedObject>());
+                objects.append(makeUnique<CheckedObject>());
             set.add(objects.last().get());
         }
 
@@ -346,11 +338,11 @@ TEST(WTF_CheckedPtr, HashSet)
 
 TEST(WTF_CheckedPtr, ReferenceCountLimit)
 {
-    CheckedObject object;
+    auto object = makeUnique<CheckedObject>();
     constexpr unsigned count = 256 * 1024;
     Vector<CheckedPtr<CheckedObject>> ptrs;
-    ptrs.fill(&object, count);
-    EXPECT_EQ(object.ptrCount(), count);
+    ptrs.fill(object.get(), count);
+    EXPECT_EQ(object->ptrCount(), count);
 }
 
 class ThreadSafeCheckedPtrObject final : public CanMakeThreadSafeCheckedPtr<ThreadSafeCheckedPtrObject> {
@@ -364,7 +356,7 @@ TEST(WTF_CheckedPtr, CanMakeThreadSafeCheckedPtr)
 {
     constexpr unsigned threadCount = 20;
     Vector<Ref<Thread>> threads;
-    ThreadSafeCheckedPtrObject object;
+    auto object = makeUnique<ThreadSafeCheckedPtrObject>();
 
     std::atomic<bool> allThreadsHaveStarted = false;
     Seconds startingTime;
@@ -372,7 +364,7 @@ TEST(WTF_CheckedPtr, CanMakeThreadSafeCheckedPtr)
     threads.reserveInitialCapacity(threadCount);
     for (unsigned i = 0; i < threadCount; ++i) {
         threads.append(Thread::create("CheckedPtr testing thread"_s, [&]() mutable {
-            CheckedPtr ptr = &object;
+            CheckedPtr ptr = object.get();
             do {
                 for (unsigned i = 0; i < 1000; ++i) {
                     CheckedRef ref { *ptr };

--- a/Tools/TestWebKitAPI/Tests/WTF/CheckedRef.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CheckedRef.cpp
@@ -64,227 +64,227 @@ public:
 TEST(WTF_CheckedRef, Basic)
 {
     {
-        CheckedObject checkedObject;
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        auto checkedObject = makeUnique<CheckedObject>();
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
     }
 
     {
-        CheckedObject checkedObject;
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        auto checkedObject = makeUnique<CheckedObject>();
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
         {
-            CheckedRef ref = checkedObject;
-            EXPECT_EQ(&ref.get(), &checkedObject);
-            EXPECT_EQ(ref.ptr(), &checkedObject);
+            CheckedRef ref = *checkedObject;
+            EXPECT_EQ(&ref.get(), checkedObject.get());
+            EXPECT_EQ(ref.ptr(), checkedObject.get());
             EXPECT_EQ(ref->someFunction(), -7);
             EXPECT_EQ(static_cast<CheckedObject&>(ref).someFunction(), -7);
-            EXPECT_EQ(checkedObject.ptrCount(), 1u);
+            EXPECT_EQ(checkedObject->ptrCount(), 1u);
         }
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
     }
 
     {
-        CheckedObject checkedObject;
-        CheckedObject anotherObject;
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        auto checkedObject = makeUnique<CheckedObject>();
+        auto anotherObject = makeUnique<CheckedObject>();
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
 
-        CheckedRef ref = checkedObject;
-        EXPECT_EQ(ref.ptr(), &checkedObject);
+        CheckedRef ref = *checkedObject;
+        EXPECT_EQ(ref.ptr(), checkedObject.get());
         EXPECT_EQ(ref->someFunction(), -7);
         EXPECT_EQ(static_cast<CheckedObject&>(ref).someFunction(), -7);
-        EXPECT_EQ(checkedObject.ptrCount(), 1u);
+        EXPECT_EQ(checkedObject->ptrCount(), 1u);
 
-        ref = anotherObject;
-        EXPECT_EQ(ref.ptr(), &anotherObject);
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
-        EXPECT_EQ(anotherObject.ptrCount(), 1u);
+        ref = *anotherObject;
+        EXPECT_EQ(ref.ptr(), anotherObject.get());
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(anotherObject->ptrCount(), 1u);
     }
 
     {
-        CheckedObject checkedObject;
-        CheckedObject anotherObject;
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        auto checkedObject = makeUnique<CheckedObject>();
+        auto anotherObject = makeUnique<CheckedObject>();
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
 
-        CheckedRef ref1 = checkedObject;
-        EXPECT_EQ(ref1.ptr(), &checkedObject);
+        CheckedRef ref1 = *checkedObject;
+        EXPECT_EQ(ref1.ptr(), checkedObject.get());
         EXPECT_EQ(ref1->someFunction(), -7);
         EXPECT_EQ(static_cast<CheckedObject&>(ref1).someFunction(), -7);
-        EXPECT_EQ(checkedObject.ptrCount(), 1u);
+        EXPECT_EQ(checkedObject->ptrCount(), 1u);
 
-        const CheckedRef ref2 = checkedObject;
-        EXPECT_EQ(ref2.ptr(), &checkedObject);
+        const CheckedRef ref2 = *checkedObject;
+        EXPECT_EQ(ref2.ptr(), checkedObject.get());
         EXPECT_EQ(ref2.get().someFunction(), -7);
         EXPECT_EQ(static_cast<const CheckedObject&>(ref2).someFunction(), -7);
-        EXPECT_EQ(checkedObject.ptrCount(), 2u);
+        EXPECT_EQ(checkedObject->ptrCount(), 2u);
 
         CheckedRef ref3 = ref2;
-        EXPECT_EQ(ref3.ptr(), &checkedObject);
-        EXPECT_EQ(checkedObject.ptrCount(), 3u);
+        EXPECT_EQ(ref3.ptr(), checkedObject.get());
+        EXPECT_EQ(checkedObject->ptrCount(), 3u);
 
-        ref1 = anotherObject;
-        EXPECT_EQ(checkedObject.ptrCount(), 2u);
-        EXPECT_EQ(anotherObject.ptrCount(), 1u);
-        EXPECT_EQ(ref1.ptr(), &anotherObject);
-        EXPECT_EQ(ref2.ptr(), &checkedObject);
-        EXPECT_EQ(ref3.ptr(), &checkedObject);
+        ref1 = *anotherObject;
+        EXPECT_EQ(checkedObject->ptrCount(), 2u);
+        EXPECT_EQ(anotherObject->ptrCount(), 1u);
+        EXPECT_EQ(ref1.ptr(), anotherObject.get());
+        EXPECT_EQ(ref2.ptr(), checkedObject.get());
+        EXPECT_EQ(ref3.ptr(), checkedObject.get());
 
         ref1 = WTFMove(ref3);
-        EXPECT_EQ(checkedObject.ptrCount(), 2u);
-        EXPECT_EQ(anotherObject.ptrCount(), 0u);
-        EXPECT_EQ(ref1.ptr(), &checkedObject);
-        EXPECT_EQ(ref2.ptr(), &checkedObject);
+        EXPECT_EQ(checkedObject->ptrCount(), 2u);
+        EXPECT_EQ(anotherObject->ptrCount(), 0u);
+        EXPECT_EQ(ref1.ptr(), checkedObject.get());
+        EXPECT_EQ(ref2.ptr(), checkedObject.get());
     }
 }
 
 TEST(WTF_CheckedRef, DerivedClass)
 {
     {
-        DerivedCheckedObject checkedObject;
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        auto checkedObject = makeUnique<DerivedCheckedObject>();
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
         {
-            CheckedRef ref = checkedObject;
-            EXPECT_EQ(&ref.get(), &checkedObject);
-            EXPECT_EQ(ref.ptr(), &checkedObject);
+            CheckedRef ref = *checkedObject;
+            EXPECT_EQ(&ref.get(), checkedObject.get());
+            EXPECT_EQ(ref.ptr(), checkedObject.get());
             EXPECT_EQ(static_cast<DerivedCheckedObject&>(ref).someFunction(), -11);
             EXPECT_EQ(ref->someFunction(), -11);
-            EXPECT_EQ(checkedObject.ptrCount(), 1u);
+            EXPECT_EQ(checkedObject->ptrCount(), 1u);
         }
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
     }
 
     {
-        DerivedCheckedObject checkedObject;
-        DerivedCheckedObject anotherObject;
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
-        EXPECT_EQ(anotherObject.ptrCount(), 0u);
+        auto checkedObject = makeUnique<DerivedCheckedObject>();
+        auto anotherObject = makeUnique<DerivedCheckedObject>();
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(anotherObject->ptrCount(), 0u);
 
-        CheckedRef<CheckedObject> ref = checkedObject;
-        EXPECT_EQ(ref.ptr(), &checkedObject);
+        CheckedRef<CheckedObject> ref = *checkedObject;
+        EXPECT_EQ(ref.ptr(), checkedObject.get());
         EXPECT_EQ(ref->someFunction(), -11);
         EXPECT_EQ(static_cast<CheckedObject&>(ref).someFunction(), -11);
-        EXPECT_EQ(checkedObject.ptrCount(), 1u);
-        EXPECT_EQ(anotherObject.ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->ptrCount(), 1u);
+        EXPECT_EQ(anotherObject->ptrCount(), 0u);
 
-        ref = anotherObject;
-        EXPECT_EQ(ref.ptr(), &anotherObject);
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
-        EXPECT_EQ(anotherObject.ptrCount(), 1u);
+        ref = *anotherObject;
+        EXPECT_EQ(ref.ptr(), anotherObject.get());
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(anotherObject->ptrCount(), 1u);
     }
 
     {
-        DerivedCheckedObject checkedObject { 10 };
-        DerivedCheckedObject anotherObject { 20 };
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
-        EXPECT_EQ(anotherObject.ptrCount(), 0u);
+        auto checkedObject = makeUnique<DerivedCheckedObject>(10);
+        auto anotherObject = makeUnique<DerivedCheckedObject>(20);
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
+        EXPECT_EQ(anotherObject->ptrCount(), 0u);
 
-        CheckedRef<DerivedCheckedObject> ref1 = checkedObject;
-        EXPECT_EQ(ref1.ptr(), &checkedObject);
+        CheckedRef<DerivedCheckedObject> ref1 = *checkedObject;
+        EXPECT_EQ(ref1.ptr(), checkedObject.get());
         EXPECT_EQ(ref1->someFunction(), 10);
         EXPECT_EQ(static_cast<CheckedObject&>(ref1).someFunction(), 10);
-        EXPECT_EQ(checkedObject.ptrCount(), 1u);
-        EXPECT_EQ(anotherObject.ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->ptrCount(), 1u);
+        EXPECT_EQ(anotherObject->ptrCount(), 0u);
 
         const CheckedRef<CheckedObject> ref2 = ref1;
-        EXPECT_EQ(ref2.ptr(), &checkedObject);
+        EXPECT_EQ(ref2.ptr(), checkedObject.get());
         EXPECT_EQ(ref2->someFunction(), 10);
         EXPECT_EQ(static_cast<const CheckedObject&>(ref2).someFunction(), 10);
-        EXPECT_EQ(checkedObject.ptrCount(), 2u);
-        EXPECT_EQ(anotherObject.ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->ptrCount(), 2u);
+        EXPECT_EQ(anotherObject->ptrCount(), 0u);
 
         CheckedRef<CheckedObject> ref3 = ref1;
-        EXPECT_EQ(ref3.ptr(), &checkedObject);
+        EXPECT_EQ(ref3.ptr(), checkedObject.get());
         EXPECT_EQ(static_cast<CheckedObject&>(ref3).someFunction(), 10);
-        EXPECT_EQ(checkedObject.ptrCount(), 3u);
-        EXPECT_EQ(anotherObject.ptrCount(), 0u);
+        EXPECT_EQ(checkedObject->ptrCount(), 3u);
+        EXPECT_EQ(anotherObject->ptrCount(), 0u);
 
-        ref1 = anotherObject;
-        EXPECT_EQ(checkedObject.ptrCount(), 2u);
-        EXPECT_EQ(anotherObject.ptrCount(), 1u);
-        EXPECT_EQ(ref1.ptr(), &anotherObject);
+        ref1 = *anotherObject;
+        EXPECT_EQ(checkedObject->ptrCount(), 2u);
+        EXPECT_EQ(anotherObject->ptrCount(), 1u);
+        EXPECT_EQ(ref1.ptr(), anotherObject.get());
         EXPECT_EQ(ref1->someFunction(), 20);
         EXPECT_EQ(static_cast<CheckedObject&>(ref1).someFunction(), 20);
-        EXPECT_EQ(ref2.ptr(), &checkedObject);
-        EXPECT_EQ(ref3.ptr(), &checkedObject);
+        EXPECT_EQ(ref2.ptr(), checkedObject.get());
+        EXPECT_EQ(ref3.ptr(), checkedObject.get());
 
         CheckedRef<CheckedObject> ref4 = WTFMove(ref1);
-        EXPECT_EQ(checkedObject.ptrCount(), 2u);
-        EXPECT_EQ(anotherObject.ptrCount(), 1u);
-        EXPECT_EQ(ref2.ptr(), &checkedObject);
-        EXPECT_EQ(ref3.ptr(), &checkedObject);
-        EXPECT_EQ(ref4.ptr(), &anotherObject);
+        EXPECT_EQ(checkedObject->ptrCount(), 2u);
+        EXPECT_EQ(anotherObject->ptrCount(), 1u);
+        EXPECT_EQ(ref2.ptr(), checkedObject.get());
+        EXPECT_EQ(ref3.ptr(), checkedObject.get());
+        EXPECT_EQ(ref4.ptr(), anotherObject.get());
         EXPECT_EQ(static_cast<CheckedObject&>(ref4).someFunction(), 20);
         EXPECT_EQ(ref4->someFunction(), 20);
 
-        ref1 = checkedObject;
-        EXPECT_EQ(checkedObject.ptrCount(), 3u);
-        EXPECT_EQ(anotherObject.ptrCount(), 1u);
-        EXPECT_EQ(ref1.ptr(), &checkedObject);
+        ref1 = *checkedObject;
+        EXPECT_EQ(checkedObject->ptrCount(), 3u);
+        EXPECT_EQ(anotherObject->ptrCount(), 1u);
+        EXPECT_EQ(ref1.ptr(), checkedObject.get());
         EXPECT_EQ(ref1->someFunction(), 10);
-        EXPECT_EQ(ref2.ptr(), &checkedObject);
-        EXPECT_EQ(ref3.ptr(), &checkedObject);
+        EXPECT_EQ(ref2.ptr(), checkedObject.get());
+        EXPECT_EQ(ref3.ptr(), checkedObject.get());
     }
 }
 
 TEST(WTF_CheckedRef, HashSet)
 {
     {
-        CheckedObject checkedObject;
-        EXPECT_EQ(checkedObject.ptrCount(), 0u);
+        auto checkedObject = makeUnique<CheckedObject>();
+        EXPECT_EQ(checkedObject->ptrCount(), 0u);
 
         HashSet<CheckedRef<CheckedObject>> set;
         {
-            CheckedRef ref = checkedObject;
-            EXPECT_EQ(ref.ptr(), &checkedObject);
-            EXPECT_EQ(checkedObject.ptrCount(), 1u);
+            CheckedRef ref = *checkedObject;
+            EXPECT_EQ(ref.ptr(), checkedObject.get());
+            EXPECT_EQ(checkedObject->ptrCount(), 1u);
 
             set.add(ref);
-            EXPECT_EQ(checkedObject.ptrCount(), 2u);
+            EXPECT_EQ(checkedObject->ptrCount(), 2u);
         }
-        EXPECT_EQ(checkedObject.ptrCount(), 1u);
+        EXPECT_EQ(checkedObject->ptrCount(), 1u);
     }
 
     {
-        CheckedObject object1;
-        DerivedCheckedObject object2;
-        EXPECT_EQ(object1.ptrCount(), 0u);
-        EXPECT_EQ(object2.ptrCount(), 0u);
+        auto object1 = makeUnique<CheckedObject>();
+        auto object2 = makeUnique<DerivedCheckedObject>();
+        EXPECT_EQ(object1->ptrCount(), 0u);
+        EXPECT_EQ(object2->ptrCount(), 0u);
 
         HashSet<CheckedRef<CheckedObject>> set;
-        set.add(object1);
-        EXPECT_EQ(object1.ptrCount(), 1u);
-        EXPECT_EQ(object2.ptrCount(), 0u);
-        EXPECT_TRUE(set.contains(object1));
-        EXPECT_FALSE(set.contains(object2));
+        set.add(*object1);
+        EXPECT_EQ(object1->ptrCount(), 1u);
+        EXPECT_EQ(object2->ptrCount(), 0u);
+        EXPECT_TRUE(set.contains(*object1));
+        EXPECT_FALSE(set.contains(*object2));
 
-        set.add(object1);
-        EXPECT_EQ(object1.ptrCount(), 1u);
-        EXPECT_EQ(object2.ptrCount(), 0u);
-        EXPECT_TRUE(set.contains(object1));
-        EXPECT_FALSE(set.contains(object2));
+        set.add(*object1);
+        EXPECT_EQ(object1->ptrCount(), 1u);
+        EXPECT_EQ(object2->ptrCount(), 0u);
+        EXPECT_TRUE(set.contains(*object1));
+        EXPECT_FALSE(set.contains(*object2));
 
         {
-            CheckedRef<DerivedCheckedObject> ref { object2 };
+            CheckedRef<DerivedCheckedObject> ref { *object2 };
             set.add(ref);
-            EXPECT_EQ(object1.ptrCount(), 1u);
-            EXPECT_EQ(object2.ptrCount(), 2u);
-            EXPECT_TRUE(set.contains(object1));
-            EXPECT_TRUE(set.contains(object2));
+            EXPECT_EQ(object1->ptrCount(), 1u);
+            EXPECT_EQ(object2->ptrCount(), 2u);
+            EXPECT_TRUE(set.contains(*object1));
+            EXPECT_TRUE(set.contains(*object2));
         }
 
-        EXPECT_EQ(object1.ptrCount(), 1u);
-        EXPECT_EQ(object2.ptrCount(), 1u);
-        EXPECT_TRUE(set.contains(object1));
-        EXPECT_TRUE(set.contains(object2));
+        EXPECT_EQ(object1->ptrCount(), 1u);
+        EXPECT_EQ(object2->ptrCount(), 1u);
+        EXPECT_TRUE(set.contains(*object1));
+        EXPECT_TRUE(set.contains(*object2));
 
-        set.remove(object1);
-        EXPECT_EQ(object1.ptrCount(), 0u);
-        EXPECT_EQ(object2.ptrCount(), 1u);
-        EXPECT_FALSE(set.contains(object1));
-        EXPECT_TRUE(set.contains(object2));
+        set.remove(*object1);
+        EXPECT_EQ(object1->ptrCount(), 0u);
+        EXPECT_EQ(object2->ptrCount(), 1u);
+        EXPECT_FALSE(set.contains(*object1));
+        EXPECT_TRUE(set.contains(*object2));
     }
 
     {
         Vector<std::unique_ptr<CheckedObject>> objects;
-        objects.append(makeUniqueWithoutFastMallocCheck<CheckedObject>(0));
+        objects.append(makeUnique<CheckedObject>(0));
         EXPECT_EQ(objects[0]->ptrCount(), 0u);
 
         HashSet<CheckedRef<CheckedObject>> set;
@@ -293,9 +293,9 @@ TEST(WTF_CheckedRef, HashSet)
 
         for (unsigned i = 0; set.capacity() == initialCapacity; ++i) {
             if (i % 2)
-                objects.append(makeUniqueWithoutFastMallocCheck<DerivedCheckedObject>(i + 1));
+                objects.append(makeUnique<DerivedCheckedObject>(i + 1));
             else
-                objects.append(makeUniqueWithoutFastMallocCheck<CheckedObject>(i + 1));
+                objects.append(makeUnique<CheckedObject>(i + 1));
             set.add(*objects.last());
         }
 


### PR DESCRIPTION
#### 4e0902cf80f621c0d596a179bf3c71f4765ebd61
<pre>
REGRESSION (277633@main): [ MacOS iOS Debug ] TestWTF.WTF_CheckedPtr.CheckedRef is a consistent crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=273158">https://bugs.webkit.org/show_bug.cgi?id=273158</a>
<a href="https://rdar.apple.com/126954078">rdar://126954078</a>

Unreviewed test fix.

Removed use after destruction test, since we assert when you do that now.

Changed test objects to be heap-allocated instead of stack-allocated. Stack
allocation wasn&apos;t the direct cause of the failure we saw, but CheckedPtr
requires heap allocation as of 277633@main, so let&apos;s do it right.

* Tools/TestWebKitAPI/Tests/WTF/CheckedPtr.cpp:
(TestWebKitAPI::TEST(WTF_CheckedPtr, Basic)):
(TestWebKitAPI::TEST(WTF_CheckedPtr, CheckedRef)):
(TestWebKitAPI::TEST(WTF_CheckedPtr, DerivedClass)):
(TestWebKitAPI::TEST(WTF_CheckedPtr, HashSet)):
(TestWebKitAPI::TEST(WTF_CheckedPtr, ReferenceCountLimit)):
(TestWebKitAPI::TEST(WTF_CheckedPtr, CanMakeThreadSafeCheckedPtr)):
* Tools/TestWebKitAPI/Tests/WTF/CheckedRef.cpp:

Canonical link: <a href="https://commits.webkit.org/277922@main">https://commits.webkit.org/277922@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09bcc93f6c117a2bb3b5662289337fa637d2a012

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28178 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51652 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45035 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51270 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25706 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40027 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49854 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/25826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21135 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/23287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7020 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53563 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24016 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47337 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25279 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46301 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26088 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7001 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24999 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->