### PR TITLE
[view-transitions] Pseudo elements can't be captured.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6939,7 +6939,6 @@ imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/locatio
 # Reftest failures:
 imported/w3c/web-platform-tests/css/css-view-transitions/content-with-clip-root.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/content-with-transform-old-image.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-top-layer-during-transition-new.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-new.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-old.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-with-overflow-children-old.html [ ImageOnlyFailure ]
@@ -6958,7 +6957,7 @@ imported/w3c/web-platform-tests/css/css-view-transitions/root-to-shared-animatio
 imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-absolute.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/span-with-overflowing-text.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/content-with-transform-new-image.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-top-layer-during-transition-old.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-rtl-iframe.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-with-overflow-children-new.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-offscreen-new.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-offscreen-old.html [ ImageOnlyFailure ]
@@ -6977,11 +6976,8 @@ imported/w3c/web-platform-tests/css/css-view-transitions/scroller.html [ ImageOn
 
 # Timeouts
 imported/w3c/web-platform-tests/css/css-view-transitions/iframe-transition.sub.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-computed-style-stays-in-sync-with-new-element.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-view-transitions/fragmented-during-transition-skips.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-view-transitions/root-element-display-none-during-transition-crash.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/iframe-transition-destroyed-document-crash.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-page.html [ Skip ]
 
 # Flakes

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5655,4 +5655,15 @@ void Element::setVisibilityAdjustment(OptionSet<VisibilityAdjustment> adjustment
     ensureElementRareData().setVisibilityAdjustment(adjustment);
 }
 
+TextStream& operator<<(TextStream& ts, ContentRelevancy relevancy)
+{
+    switch (relevancy) {
+    case ContentRelevancy::OnScreen: ts << "OnScreen"; break;
+    case ContentRelevancy::Focused: ts << "Focused"; break;
+    case ContentRelevancy::IsInTopLayer: ts << "IsInTopLayer"; break;
+    case ContentRelevancy::Selected: ts << "Selected"; break;
+    }
+    return ts;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -787,9 +787,6 @@ public:
     bool hasCustomState(const AtomString& state) const;
     CustomStateSet& ensureCustomStateSet();
 
-    bool capturedInViewTransition() const { return hasElementStateFlag(ElementStateFlag::CapturedInViewTransition); }
-    void setCapturedInViewTransition(bool captured) { setElementStateFlag(ElementStateFlag::CapturedInViewTransition, captured); }
-
 protected:
     Element(const QualifiedName&, Document&, OptionSet<TypeFlag>);
 
@@ -980,6 +977,8 @@ inline void Element::disconnectFromResizeObservers()
 
 void invalidateForSiblingCombinators(Element* sibling);
 inline bool isInTopLayerOrBackdrop(const RenderStyle&, const Element*);
+
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ContentRelevancy);
 
 } // namespace WebCore
 

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -652,11 +652,10 @@ protected:
         NeedsSVGRendererUpdate = 1 << 3,
         NeedsUpdateQueryContainerDependentStyle = 1 << 4,
         EverHadSmoothScroll = 1 << 5,
-        CapturedInViewTransition = 1 << 6,
 #if ENABLE(FULLSCREEN_API)
-        IsFullscreen = 1 << 7,
+        IsFullscreen = 1 << 6,
 #endif
-        // 8-bits free.
+        // 9-bits free.
     };
 
     enum class TabIndexState : uint8_t {

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -41,6 +41,7 @@
 #include "PseudoElementRequest.h"
 #include "RenderBox.h"
 #include "RenderLayer.h"
+#include "RenderLayerModelObject.h"
 #include "RenderView.h"
 #include "RenderViewTransitionCapture.h"
 #include "StyleResolver.h"
@@ -254,13 +255,11 @@ void ViewTransition::setupViewTransition()
     });
 }
 
-static AtomString effectiveViewTransitionName(Element& element)
+static AtomString effectiveViewTransitionName(RenderLayerModelObject& renderer)
 {
-    CheckVisibilityOptions visibilityOptions { .contentVisibilityAuto = true };
-    if (!element.checkVisibility(visibilityOptions))
+    if (renderer.isSkippedContent())
         return nullAtom();
-    ASSERT(element.computedStyle());
-    auto transitionName = element.computedStyle()->viewTransitionName();
+    auto transitionName = renderer.style().viewTransitionName();
     if (!transitionName)
         return nullAtom();
     return transitionName->name;
@@ -274,27 +273,23 @@ static ExceptionOr<void> checkDuplicateViewTransitionName(const AtomString& name
     return { };
 }
 
-static LayoutRect captureOverflowRect(Element& element)
+static LayoutRect captureOverflowRect(RenderLayerModelObject& renderer)
 {
-    CheckedPtr renderer = dynamicDowncast<RenderLayerModelObject>(element.renderer());
-    if (!renderer || !renderer->hasLayer())
+    if (!renderer.hasLayer())
         return { };
 
-    if (renderer->isDocumentElementRenderer()) {
-        auto& frameView = renderer->view().frameView();
+    if (renderer.isDocumentElementRenderer()) {
+        auto& frameView = renderer.view().frameView();
         return { { }, LayoutSize { frameView.frameRect().width(), frameView.frameRect().height() } };
     }
 
-    return renderer->layer()->calculateLayerBounds(renderer->layer(), LayoutSize(), { RenderLayer::IncludeFilterOutsets, RenderLayer::ExcludeHiddenDescendants, RenderLayer::IncludeCompositedDescendants, RenderLayer::PreserveAncestorFlags });
+    return renderer.layer()->calculateLayerBounds(renderer.layer(), LayoutSize(), { RenderLayer::IncludeFilterOutsets, RenderLayer::ExcludeHiddenDescendants, RenderLayer::IncludeCompositedDescendants, RenderLayer::PreserveAncestorFlags });
 }
 
-static RefPtr<ImageBuffer> snapshotElementVisualOverflowClippedToViewport(LocalFrame& frame, Element& element, const LayoutRect& snapshotRect)
+static RefPtr<ImageBuffer> snapshotElementVisualOverflowClippedToViewport(LocalFrame& frame, RenderLayerModelObject& renderer, const LayoutRect& snapshotRect)
 {
-    if (!element.renderer())
-        return nullptr;
-
-    ASSERT(element.renderer()->hasLayer());
-    CheckedPtr layerRenderer = downcast<RenderLayerModelObject>(element.renderer());
+    ASSERT(renderer.hasLayer());
+    CheckedRef layerRenderer = renderer;
 
     IntRect paintRect = snappedIntRect(snapshotRect);
 
@@ -322,30 +317,28 @@ static RefPtr<ImageBuffer> snapshotElementVisualOverflowClippedToViewport(LocalF
 }
 
 // This only iterates through elements with a RenderLayer, which is sufficient for View Transitions which force their creation.
-static ExceptionOr<void> forEachElementInPaintOrder(const std::function<ExceptionOr<void>(Element&)>& function, RenderLayer& layer)
+static ExceptionOr<void> forEachRendererInPaintOrder(const std::function<ExceptionOr<void>(RenderLayerModelObject&)>& function, RenderLayer& layer)
 {
-    if (RefPtr element = layer.renderer().element()) {
-        auto result = function(*element);
-        if (result.hasException())
-            return result.releaseException();
-    }
+    auto result = function(layer.renderer());
+    if (result.hasException())
+        return result.releaseException();
 
     layer.updateLayerListsIfNeeded();
 
     for (auto* child : layer.negativeZOrderLayers()) {
-        auto result = forEachElementInPaintOrder(function, *child);
+        auto result = forEachRendererInPaintOrder(function, *child);
         if (result.hasException())
             return result.releaseException();
     }
 
     for (auto* child : layer.normalFlowLayers()) {
-        auto result = forEachElementInPaintOrder(function, *child);
+        auto result = forEachRendererInPaintOrder(function, *child);
         if (result.hasException())
             return result.releaseException();
     }
 
     for (auto* child : layer.positiveZOrderLayers()) {
-        auto result = forEachElementInPaintOrder(function, *child);
+        auto result = forEachRendererInPaintOrder(function, *child);
         if (result.hasException())
             return result.releaseException();
     }
@@ -358,22 +351,26 @@ ExceptionOr<void> ViewTransition::captureOldState()
     if (!document())
         return { };
     ListHashSet<AtomString> usedTransitionNames;
-    Vector<Ref<Element>> captureElements;
+    Vector<CheckedRef<RenderLayerModelObject>> captureRenderers;
+
     // Ensure style & render tree are up-to-date.
     protectedDocument()->updateStyleIfNeeded();
 
     if (CheckedPtr view = document()->renderView()) {
         m_initialLargeViewportSize = view->sizeForCSSLargeViewportUnits();
 
-        auto result = forEachElementInPaintOrder([&](Element& element) -> ExceptionOr<void> {
-            if (auto name = effectiveViewTransitionName(element); !name.isNull()) {
+        auto result = forEachRendererInPaintOrder([&](RenderLayerModelObject& renderer) -> ExceptionOr<void> {
+            if (!Styleable::fromRenderer(renderer))
+                return { };
+
+            if (auto name = effectiveViewTransitionName(renderer); !name.isNull()) {
                 if (auto check = checkDuplicateViewTransitionName(name, usedTransitionNames); check.hasException())
                     return check.releaseException();
 
                 // FIXME: Skip fragmented content.
 
-                element.setCapturedInViewTransition(true);
-                captureElements.append(element);
+                renderer.setCapturedInViewTransition(true);
+                captureRenderers.append(renderer);
             }
             return { };
         }, *view->layer());
@@ -381,21 +378,20 @@ ExceptionOr<void> ViewTransition::captureOldState()
             return result.releaseException();
     }
 
-    for (auto& element : captureElements) {
+    for (auto& renderer : captureRenderers) {
         CapturedElement capture;
 
-        capture.oldProperties = copyElementBaseProperties(element, capture.oldSize);
-        capture.oldOverflowRect = captureOverflowRect(element);
+        capture.oldProperties = copyElementBaseProperties(renderer.get(), capture.oldSize);
+        capture.oldOverflowRect = captureOverflowRect(renderer.get());
         if (RefPtr frame = document()->frame())
-            capture.oldImage = snapshotElementVisualOverflowClippedToViewport(*frame, element, capture.oldOverflowRect);
+            capture.oldImage = snapshotElementVisualOverflowClippedToViewport(*frame, renderer.get(), capture.oldOverflowRect);
 
-        auto transitionName = element->computedStyle()->viewTransitionName();
+        auto transitionName = renderer->style().viewTransitionName();
         m_namedElements.add(transitionName->name, capture);
     }
 
-    for (auto& element : captureElements) {
-        element->setCapturedInViewTransition(false);
-        element->invalidateStyleAndLayerComposition();
+    for (auto& renderer : captureRenderers) {
+        renderer->setCapturedInViewTransition(false);
     }
 
     return { };
@@ -408,8 +404,12 @@ ExceptionOr<void> ViewTransition::captureNewState()
         return { };
     ListHashSet<AtomString> usedTransitionNames;
     if (CheckedPtr view = document()->renderView()) {
-        auto result = forEachElementInPaintOrder([&](Element& element) -> ExceptionOr<void> {
-            if (auto name = effectiveViewTransitionName(element); !name.isNull()) {
+        auto result = forEachRendererInPaintOrder([&](RenderLayerModelObject& renderer) -> ExceptionOr<void> {
+            std::optional<const Styleable> styleable = Styleable::fromRenderer(renderer);
+            if (!styleable)
+                return { };
+
+            if (auto name = effectiveViewTransitionName(renderer); !name.isNull()) {
                 if (auto check = checkDuplicateViewTransitionName(name, usedTransitionNames); check.hasException())
                     return check.releaseException();
 
@@ -417,7 +417,7 @@ ExceptionOr<void> ViewTransition::captureNewState()
                     CapturedElement capturedElement;
                     m_namedElements.add(name, capturedElement);
                 }
-                m_namedElements.find(name)->newElement = &element;
+                m_namedElements.find(name)->newElement = *styleable;
             }
             return { };
         }, *view->layer());
@@ -530,8 +530,10 @@ void ViewTransition::activateViewTransition()
     }
 
     for (auto& [name, capturedElement] : m_namedElements.map()) {
-        if (RefPtr newElement = capturedElement->newElement.get())
-            newElement->setCapturedInViewTransition(true);
+        if (auto newStyleable = capturedElement->newElement.styleable()) {
+            if (CheckedPtr renderer = newStyleable->renderer())
+                renderer->setCapturedInViewTransition(true);
+        }
     }
 
     setupTransitionPseudoElements();
@@ -616,8 +618,10 @@ void ViewTransition::clearViewTransition()
     }
 
     for (auto& [name, capturedElement] : m_namedElements.map()) {
-        if (RefPtr newElement = capturedElement->newElement.get())
-            newElement->setCapturedInViewTransition(false);
+        if (auto newStyleable = capturedElement->newElement.styleable()) {
+            if (CheckedPtr renderer = newStyleable->renderer())
+                renderer->setCapturedInViewTransition(false);
+        }
     }
 
     document->setHasViewTransitionPseudoElementTree(false);
@@ -628,9 +632,11 @@ void ViewTransition::clearViewTransition()
         documentElement->invalidateStyleInternal();
 }
 
-Ref<MutableStyleProperties> ViewTransition::copyElementBaseProperties(Element& element, LayoutSize& size)
+Ref<MutableStyleProperties> ViewTransition::copyElementBaseProperties(RenderLayerModelObject& renderer, LayoutSize& size)
 {
-    ComputedStyleExtractor styleExtractor(&element);
+    std::optional<const Styleable> styleable = Styleable::fromRenderer(renderer);
+    ASSERT(styleable);
+    ComputedStyleExtractor styleExtractor(&styleable->element, false, styleable->pseudoElementIdentifier);
 
     CSSPropertyID transitionProperties[] = {
         CSSPropertyWritingMode,
@@ -644,46 +650,41 @@ Ref<MutableStyleProperties> ViewTransition::copyElementBaseProperties(Element& e
     };
 
     Ref<MutableStyleProperties> props = styleExtractor.copyProperties(transitionProperties);
-    CheckedPtr renderer = element.renderer();
 
-    if (renderer && renderer->isDocumentElementRenderer()) {
-        auto& frameView = renderer->view().frameView();
+    if (renderer.isDocumentElementRenderer()) {
+        auto& frameView = renderer.view().frameView();
         size.setWidth(frameView.frameRect().width());
         size.setHeight(frameView.frameRect().height());
-    } else if (CheckedPtr renderBox = dynamicDowncast<RenderBoxModelObject>(element.renderer()))
+    } else if (CheckedPtr renderBox = dynamicDowncast<RenderBoxModelObject>(&renderer))
         size = renderBox->borderBoundingBox().size();
 
     props->setProperty(CSSPropertyWidth, CSSPrimitiveValue::create(size.width(), CSSUnitType::CSS_PX));
     props->setProperty(CSSPropertyHeight, CSSPrimitiveValue::create(size.height(), CSSUnitType::CSS_PX));
 
     TransformationMatrix transform;
-
+    RenderElement* current = &renderer;
     RenderElement* container = nullptr;
-    while (renderer && !renderer->isRenderView()) {
-        container = renderer->container();
+    while (current && !current->isRenderView()) {
+        container = current->container();
         if (!container)
             break;
-        LayoutSize containerOffset = renderer->offsetFromContainer(*container, LayoutPoint());
+        LayoutSize containerOffset = current->offsetFromContainer(*container, LayoutPoint());
         if (container->isRenderView()) {
-            auto frameView = renderer->view().protectedFrameView();
+            auto frameView = current->view().protectedFrameView();
             containerOffset -= toLayoutSize(frameView->scrollPositionRespectingCustomFixedPosition());
         }
         TransformationMatrix localTransform;
-        renderer->getTransformFromContainer(containerOffset, localTransform);
+        current->getTransformFromContainer(containerOffset, localTransform);
         transform = localTransform * transform;
-        renderer = container;
+        current = container;
     }
     // Apply the inverse of what will be added by the default value of 'transform-origin',
     // since the computed transform has already included it.
     transform.translate(size.width() / 2, size.height() / 2);
     transform.translateRight(-size.width() / 2, -size.height() / 2);
 
-    if (element.renderer()) {
-        Ref<CSSValue> transformListValue = CSSTransformListValue::create(ComputedStyleExtractor::matrixTransformValue(transform, element.renderer()->style()));
-        props->setProperty(CSSPropertyTransform, WTFMove(transformListValue));
-    } else
-        props->setProperty(CSSPropertyTransform, CSSPrimitiveValue::create(CSSValueID::CSSValueNone));
-
+    Ref<CSSValue> transformListValue = CSSTransformListValue::create(ComputedStyleExtractor::matrixTransformValue(transform, renderer.style()));
+    props->setProperty(CSSPropertyTransform, WTFMove(transformListValue));
     return props;
 }
 
@@ -694,26 +695,24 @@ ExceptionOr<void> ViewTransition::updatePseudoElementStyles()
 
     for (auto& [name, capturedElement] : m_namedElements.map()) {
         RefPtr<MutableStyleProperties> properties;
-        if (RefPtr newElement = capturedElement->newElement.get()) {
+        if (auto newStyleable = capturedElement->newElement.styleable()) {
             // FIXME: Also check fragmented content here.
-            CheckVisibilityOptions visibilityOptions { .contentVisibilityAuto = true };
-            if (!newElement->checkVisibility(visibilityOptions))
+            CheckedPtr renderer = dynamicDowncast<RenderBoxModelObject>(newStyleable->renderer());
+            if (!renderer || renderer->isSkippedContent())
                 return Exception { ExceptionCode::InvalidStateError, "One of the transitioned elements has become hidden."_s };
-            CheckedPtr renderBox = dynamicDowncast<RenderBoxModelObject>(newElement->renderer());
-            if (!renderBox)
-                continue;
 
             LayoutSize boxSize;
-            properties = copyElementBaseProperties(*newElement, boxSize);
-            LayoutRect overflowRect = captureOverflowRect(*newElement);
+            properties = copyElementBaseProperties(*renderer, boxSize);
+            LayoutRect overflowRect = captureOverflowRect(*renderer);
 
             if (RefPtr documentElement = document()->documentElement()) {
                 Styleable styleable(*documentElement, Style::PseudoElementIdentifier { PseudoId::ViewTransitionNew, name });
-                CheckedPtr renderer = styleable.renderer();
-                if (CheckedPtr viewTransitionCapture = dynamicDowncast<RenderViewTransitionCapture>(renderer.get())) {
+                if (CheckedPtr viewTransitionCapture = dynamicDowncast<RenderViewTransitionCapture>(styleable.renderer())) {
                     viewTransitionCapture->setSize(boxSize, overflowRect);
 
-                    RefPtr<ImageBuffer> image = viewTransitionCapture->canUseExistingLayers() ? nullptr : snapshotElementVisualOverflowClippedToViewport(*document()->frame(), *newElement, overflowRect);
+                    RefPtr<ImageBuffer> image;
+                    if (RefPtr frame = document()->frame(); !viewTransitionCapture->canUseExistingLayers())
+                        image = snapshotElementVisualOverflowClippedToViewport(*frame, *renderer, overflowRect);
                     viewTransitionCapture->setImage(image);
                 }
             }
@@ -734,12 +733,14 @@ ExceptionOr<void> ViewTransition::updatePseudoElementStyles()
     return { };
 }
 
-RenderViewTransitionCapture* ViewTransition::viewTransitionNewPseudoForCapturedElement(Element& element)
+RenderViewTransitionCapture* ViewTransition::viewTransitionNewPseudoForCapturedElement(RenderLayerModelObject& renderer)
 {
     for (auto& [name, capturedElement] : m_namedElements.map()) {
-        if (capturedElement->newElement == &element) {
-            Styleable styleable(*element.document().documentElement(), Style::PseudoElementIdentifier { PseudoId::ViewTransitionNew, name });
-            return dynamicDowncast<RenderViewTransitionCapture>(styleable.renderer());
+        if (auto newStyleable = capturedElement->newElement.styleable()) {
+            if (newStyleable->renderer() == &renderer) {
+                Styleable styleable(*renderer.document().documentElement(), Style::PseudoElementIdentifier { PseudoId::ViewTransitionNew, name });
+                return dynamicDowncast<RenderViewTransitionCapture>(styleable.renderer());
+            }
         }
     }
     return nullptr;

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -32,6 +32,7 @@
 #include "ImageBuffer.h"
 #include "JSValueInWrappedObject.h"
 #include "MutableStyleProperties.h"
+#include "Styleable.h"
 #include "ViewTransitionUpdateCallback.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/Ref.h>
@@ -41,6 +42,7 @@ namespace WebCore {
 
 class DOMPromise;
 class DeferredPromise;
+class RenderLayerModelObject;
 class RenderViewTransitionCapture;
 
 enum class ViewTransitionPhase : uint8_t {
@@ -60,7 +62,7 @@ public:
     LayoutRect oldOverflowRect;
     LayoutSize oldSize;
     RefPtr<MutableStyleProperties> oldProperties;
-    WeakPtr<Element, WeakPtrImplWithEventTargetData> newElement;
+    WeakStyleable newElement;
 
     RefPtr<MutableStyleProperties> groupStyleProperties;
 };
@@ -155,12 +157,12 @@ public:
     Document* document() const { return downcast<Document>(scriptExecutionContext()); }
     RefPtr<Document> protectedDocument() const { return document(); }
 
-    RenderViewTransitionCapture* viewTransitionNewPseudoForCapturedElement(Element&);
+    RenderViewTransitionCapture* viewTransitionNewPseudoForCapturedElement(RenderLayerModelObject&);
 
 private:
     ViewTransition(Document&, RefPtr<ViewTransitionUpdateCallback>&&);
 
-    Ref<MutableStyleProperties> copyElementBaseProperties(Element&, LayoutSize&);
+    Ref<MutableStyleProperties> copyElementBaseProperties(RenderLayerModelObject&, LayoutSize&);
 
     ExceptionOr<void> updatePseudoElementStyles();
     void setupDynamicStyleSheet(const AtomString&, const CapturedElement&);

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -508,6 +508,9 @@ void RenderElement::initializeStyle()
 
     // It would be nice to assert that !parent() here, but some RenderLayer subrenderers
     // have their parent set before getting a call to initializeStyle() :|
+
+    if (auto styleable = Styleable::fromRenderer(*this))
+        setCapturedInViewTransition(styleable->capturedInViewTransition());
 }
 
 void RenderElement::setStyle(RenderStyle&& style, StyleDifference minimalStyleDifference)
@@ -2069,11 +2072,6 @@ bool RenderElement::hasSelfPaintingLayer() const
         return false;
     auto& layerModelObject = downcast<RenderLayerModelObject>(*this);
     return layerModelObject.hasSelfPaintingLayer();
-}
-
-bool RenderElement::capturedInViewTransition() const
-{
-    return element() && element()->capturedInViewTransition();
 }
 
 bool RenderElement::hasViewTransitionName() const

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -191,7 +191,6 @@ public:
     inline bool hasClipOrNonVisibleOverflow() const;
     inline bool hasClipPath() const;
     inline bool hasHiddenBackface() const;
-    bool capturedInViewTransition() const;
     bool hasViewTransitionName() const;
     bool requiresRenderingConsolidationForViewTransition() const;
     bool hasOutlineAnnotation() const;

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -811,7 +811,13 @@ void RenderLayer::rebuildZOrderLists(std::unique_ptr<Vector<RenderLayer*>>& posZ
             if (!posZOrderList)
                 posZOrderList = makeUnique<Vector<RenderLayer*>>();
 
+            CheckedPtr<RenderLayer> viewTransitionLayer;
+            if (posZOrderList->size() && posZOrderList->last()->renderer().style().pseudoElementType() == PseudoId::ViewTransition)
+                viewTransitionLayer = posZOrderList->takeLast();
+
             posZOrderList->appendVector(topLayerLayers);
+            if (viewTransitionLayer)
+                posZOrderList->append(viewTransitionLayer.get());
         }
     }
 }
@@ -3508,7 +3514,7 @@ void RenderLayer::paintList(LayerList layerIterator, GraphicsContext& context, c
 #endif
 
     for (auto* childLayer : layerIterator) {
-        if (paintFlags.contains(PaintLayerFlag::PaintingSkipDescendantViewTransition) && childLayer->renderer().capturedInViewTransition())
+        if (paintFlags.contains(PaintLayerFlag::PaintingSkipDescendantViewTransition) && childLayer->renderer().capturedInViewTransition() && !childLayer->renderer().isDocumentElementRenderer())
             continue;
         childLayer->paintLayer(context, paintingInfo, paintFlags);
     }

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -660,7 +660,7 @@ void RenderLayerBacking::updateTransform(const RenderStyle& style)
     TransformationMatrix t;
     if (renderer().capturedInViewTransition() && renderer().element()) {
         if (RefPtr activeViewTransition = renderer().document().activeViewTransition()) {
-            if (CheckedPtr viewTransitionCapture = activeViewTransition->viewTransitionNewPseudoForCapturedElement(*renderer().element())) {
+            if (CheckedPtr viewTransitionCapture = activeViewTransition->viewTransitionNewPseudoForCapturedElement(renderer())) {
                 t.scaleNonUniform(viewTransitionCapture->scale().width(), viewTransitionCapture->scale().height());
                 t.translate(viewTransitionCapture->captureContentInset().x(), viewTransitionCapture->captureContentInset().y());
             }
@@ -1423,7 +1423,7 @@ void RenderLayerBacking::updateGeometry(const RenderLayer* compositedAncestor)
     // position so that layer positions are computed relative to our origin.
     if (renderer().capturedInViewTransition() && renderer().element()) {
         if (RefPtr activeViewTransition = renderer().document().activeViewTransition()) {
-            if (CheckedPtr viewTransitionCapture = activeViewTransition->viewTransitionNewPseudoForCapturedElement(*renderer().element())) {
+            if (CheckedPtr viewTransitionCapture = activeViewTransition->viewTransitionNewPseudoForCapturedElement(renderer())) {
                 ComputedOffsets computedOffsets(m_owningLayer, compositedAncestor, viewTransitionCapture->captureOverflowRect(), { }, { });
                 parentGraphicsLayerRect.move(computedOffsets.fromParentGraphicsLayer());
             }

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1409,10 +1409,14 @@ void RenderLayerCompositor::collectViewTransitionNewContentLayers(RenderLayer& l
         return;
 
     auto* capturedElement = activeViewTransition->namedElements().find(layer.renderer().style().pseudoElementNameArgument());
-    if (!capturedElement || !capturedElement->newElement)
+    if (!capturedElement)
         return;
 
-    auto* capturedRenderer = capturedElement->newElement->renderer();
+    auto newStyleable = capturedElement->newElement.styleable();
+    if (!newStyleable)
+        return;
+
+    auto* capturedRenderer = newStyleable->renderer();
     if (!capturedRenderer || !capturedRenderer->hasLayer())
         return;
 

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -718,6 +718,9 @@ public:
     inline bool isTransformed() const;
     inline bool hasTransformOrPerspective() const;
 
+    bool capturedInViewTransition() const { return m_stateBitfields.hasFlag(StateFlag::CapturedInViewTransition); }
+    void setCapturedInViewTransition(bool captured) { m_stateBitfields.setFlag(StateFlag::CapturedInViewTransition, captured); }
+
     inline bool preservesNewline() const;
 
     RenderView& view() const { return *document().renderView(); }
@@ -1215,6 +1218,7 @@ private:
         PaintContainmentApplies = 1 << 18,
         HasSVGTransform = 1 << 19,
         EverHadSkippedContentLayout = 1 << 20,
+        CapturedInViewTransition = 1 << 21
     };
 
     class StateBitfields {
@@ -1226,7 +1230,7 @@ private:
         };
 
     private:
-        uint32_t m_flags : 21 { 0 };
+        uint32_t m_flags : 22 { 0 };
         uint32_t m_positionedState : 2 { IsStaticallyPositioned }; // PositionedState
         uint32_t m_selectionState : 3 { enumToUnderlyingType(HighlightState::None) }; // HighlightState
         uint32_t m_fragmentedFlowState : 1 { enumToUnderlyingType(FragmentedFlowState::NotInsideFlow) }; // FragmentedFlowState

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -67,6 +67,7 @@
 #include "ShadowRoot.h"
 #include "StyleSelfAlignmentData.h"
 #include "StyleUpdate.h"
+#include "Styleable.h"
 #include "Text.h"
 #include "TouchAction.h"
 #include "TypedElementDescendantIterator.h"
@@ -88,7 +89,7 @@ namespace Style {
 
 using namespace HTMLNames;
 
-Adjuster::Adjuster(const Document& document, const RenderStyle& parentStyle, const RenderStyle* parentBoxStyle, const Element* element)
+Adjuster::Adjuster(const Document& document, const RenderStyle& parentStyle, const RenderStyle* parentBoxStyle, Element* element)
     : m_document(document)
     , m_parentStyle(parentStyle)
     , m_parentBoxStyle(parentBoxStyle ? *parentBoxStyle : m_parentStyle)
@@ -698,8 +699,11 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
             || style.hasMask()
             || style.hasBackdropFilter()
             || style.hasBlendMode()
-            || style.viewTransitionName()
-            || (m_element && m_element->capturedInViewTransition());
+            || style.viewTransitionName();
+        if (m_element) {
+            auto styleable = Styleable::fromElement(*m_element);
+            forceToFlat |= styleable.capturedInViewTransition();
+        }
         style.setTransformStyleForcedToFlat(forceToFlat);
     }
 

--- a/Source/WebCore/style/StyleAdjuster.h
+++ b/Source/WebCore/style/StyleAdjuster.h
@@ -46,7 +46,7 @@ class Update;
 
 class Adjuster {
 public:
-    Adjuster(const Document&, const RenderStyle& parentStyle, const RenderStyle* parentBoxStyle, const Element*);
+    Adjuster(const Document&, const RenderStyle& parentStyle, const RenderStyle* parentBoxStyle, Element*);
 
     void adjust(RenderStyle&, const RenderStyle* userAgentAppearanceStyle) const;
     void adjustAnimatedStyle(RenderStyle&, OptionSet<AnimationImpact>) const;
@@ -80,7 +80,7 @@ private:
     const Document& m_document;
     const RenderStyle& m_parentStyle;
     const RenderStyle& m_parentBoxStyle;
-    const Element* m_element;
+    Element* m_element;
 };
 
 }

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -248,7 +248,7 @@ BuilderContext Resolver::builderContext(const State& state)
     };
 }
 
-ResolvedStyle Resolver::styleForElement(const Element& element, const ResolutionContext& context, RuleMatchingBehavior matchingBehavior)
+ResolvedStyle Resolver::styleForElement(Element& element, const ResolutionContext& context, RuleMatchingBehavior matchingBehavior)
 {
     auto state = State(element, context.parentStyle, context.documentElementStyle);
 
@@ -307,7 +307,7 @@ ResolvedStyle Resolver::styleForElement(const Element& element, const Resolution
     return { state.takeStyle(), WTFMove(elementStyleRelations), collector.releaseMatchResult() };
 }
 
-std::unique_ptr<RenderStyle> Resolver::styleForKeyframe(const Element& element, const RenderStyle& elementStyle, const ResolutionContext& context, const StyleRuleKeyframe& keyframe, BlendingKeyframe& blendingKeyframe)
+std::unique_ptr<RenderStyle> Resolver::styleForKeyframe(Element& element, const RenderStyle& elementStyle, const ResolutionContext& context, const StyleRuleKeyframe& keyframe, BlendingKeyframe& blendingKeyframe)
 {
     // Add all the animating properties to the keyframe.
     bool hasRevert = false;
@@ -452,7 +452,7 @@ Vector<Ref<StyleRuleKeyframe>> Resolver::keyframeRulesForName(const AtomString& 
     return deduplicatedKeyframes;
 }
 
-void Resolver::keyframeStylesForAnimation(const Element& element, const RenderStyle& elementStyle, const ResolutionContext& context, BlendingKeyframes& list)
+void Resolver::keyframeStylesForAnimation(Element& element, const RenderStyle& elementStyle, const ResolutionContext& context, BlendingKeyframes& list)
 {
     list.clear();
 
@@ -479,7 +479,7 @@ void Resolver::keyframeStylesForAnimation(const Element& element, const RenderSt
     }
 }
 
-std::optional<ResolvedStyle> Resolver::styleForPseudoElement(const Element& element, const PseudoElementRequest& pseudoElementRequest, const ResolutionContext& context)
+std::optional<ResolvedStyle> Resolver::styleForPseudoElement(Element& element, const PseudoElementRequest& pseudoElementRequest, const ResolutionContext& context)
 {
     auto state = State(element, context.parentStyle, context.documentElementStyle);
 

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -91,11 +91,11 @@ public:
     static Ref<Resolver> create(Document&, ScopeType);
     ~Resolver();
 
-    ResolvedStyle styleForElement(const Element&, const ResolutionContext&, RuleMatchingBehavior = RuleMatchingBehavior::MatchAllRules);
+    ResolvedStyle styleForElement(Element&, const ResolutionContext&, RuleMatchingBehavior = RuleMatchingBehavior::MatchAllRules);
 
-    void keyframeStylesForAnimation(const Element&, const RenderStyle& elementStyle, const ResolutionContext&, BlendingKeyframes&);
+    void keyframeStylesForAnimation(Element&, const RenderStyle& elementStyle, const ResolutionContext&, BlendingKeyframes&);
 
-    WEBCORE_EXPORT std::optional<ResolvedStyle> styleForPseudoElement(const Element&, const PseudoElementRequest&, const ResolutionContext&);
+    WEBCORE_EXPORT std::optional<ResolvedStyle> styleForPseudoElement(Element&, const PseudoElementRequest&, const ResolutionContext&);
 
     std::unique_ptr<RenderStyle> styleForPage(int pageIndex);
     std::unique_ptr<RenderStyle> defaultStyleForElement(const Element*);
@@ -115,7 +115,7 @@ public:
 
     void addCurrentSVGFontFaceRules();
 
-    std::unique_ptr<RenderStyle> styleForKeyframe(const Element&, const RenderStyle& elementStyle, const ResolutionContext&, const StyleRuleKeyframe&, BlendingKeyframe&);
+    std::unique_ptr<RenderStyle> styleForKeyframe(Element&, const RenderStyle& elementStyle, const ResolutionContext&, const StyleRuleKeyframe&, BlendingKeyframe&);
     bool isAnimationNameValid(const String&);
 
     void setViewTransitionStyles(CSSSelector::PseudoElement, const AtomString&, Ref<MutableStyleProperties>);

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -54,6 +54,7 @@
 #include "StylePropertyShorthand.h"
 #include "StyleResolver.h"
 #include "StyleScope.h"
+#include "ViewTransition.h"
 #include "WebAnimation.h"
 #include "WebAnimationUtilities.h"
 #include "WillChangeData.h"
@@ -831,6 +832,22 @@ void Styleable::queryContainerDidChange() const
         if (keyframeEffect && keyframeEffect->blendingKeyframes().usesContainerUnits())
             cssAnimation->keyframesRuleDidChange();
     }
+}
+
+bool Styleable::capturedInViewTransition() const
+{
+    RefPtr activeViewTransition = element.document().activeViewTransition();
+    if (!activeViewTransition || activeViewTransition->phase() != ViewTransitionPhase::Animating)
+        return false;
+
+    for (auto& [name, capturedElement] : activeViewTransition->namedElements().map()) {
+        if (auto newStyleable = capturedElement->newElement.styleable()) {
+            if (*newStyleable == *this)
+                return true;
+        }
+    }
+
+    return false;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -80,6 +80,8 @@ struct Styleable {
 
     bool hasRunningAcceleratedAnimations() const;
 
+    bool capturedInViewTransition() const;
+
     KeyframeEffectStack* keyframeEffectStack() const
     {
         return element.keyframeEffectStack(pseudoElementIdentifier);
@@ -186,6 +188,31 @@ struct Styleable {
 
     void updateCSSAnimations(const RenderStyle* currentStyle, const RenderStyle& afterChangeStyle, const Style::ResolutionContext&, WeakStyleOriginatedAnimations&) const;
     void updateCSSTransitions(const RenderStyle& currentStyle, const RenderStyle& newStyle, WeakStyleOriginatedAnimations&) const;
+};
+
+class WeakStyleable {
+public:
+    WeakStyleable() = default;
+
+    explicit operator bool() const { return !!m_element; }
+
+    WeakStyleable& operator=(const Styleable& styleable)
+    {
+        m_element = styleable.element;
+        m_pseudoElementIdentifier = styleable.pseudoElementIdentifier;
+        return *this;
+    }
+
+    std::optional<Styleable> styleable() const
+    {
+        if (!m_element)
+            return std::nullopt;
+        return Styleable(*m_element, m_pseudoElementIdentifier);
+    }
+
+private:
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_element;
+    std::optional<Style::PseudoElementIdentifier> m_pseudoElementIdentifier;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 3ba31ee3b3d5e5a87e409978bc11eb8aa0c7f1c5
<pre>
[view-transitions] Pseudo elements can&apos;t be captured.
<a href="https://bugs.webkit.org/show_bug.cgi?id=273166">https://bugs.webkit.org/show_bug.cgi?id=273166</a>
&lt;<a href="https://rdar.apple.com/126964779">rdar://126964779</a>&gt;

Reviewed by Tim Nguyen.

Pseudo elements (like ::backdrop) don&apos;t have an associated Element, so can&apos;t
be found by ViewTransition&apos;s forEachElementInPaintOrder.

Rather than holding an Element in CapturedElement, hold a Styleable instead
which can represent these pseudo elements as well.

Since the normal Styleable class uses an Element reference, introduces a
WeakStyleable object which uses a WeakPtr to an Element and can (maybe) be
converted back into a Styleable when needed.

Changes most of the ViewTransition code to operator on the RenderElement
from the Styleable, instead of the Element.

Adds capturedInViewTransition to Styleable, so that we can look this up
in cases where the renderer hasn&apos;t yet been created.

* LayoutTests/TestExpectations:
* Source/WebCore/dom/Element.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/dom/Element.h:
(WebCore::Element::capturedInViewTransition const): Deleted.
(WebCore::Element::setCapturedInViewTransition): Deleted.
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::effectiveViewTransitionName):
(WebCore::captureOverflowRect):
(WebCore::snapshotElementVisualOverflowClippedToViewport):
(WebCore::forEachRendererInPaintOrder):
(WebCore::ViewTransition::captureOldState):
(WebCore::ViewTransition::captureNewState):
(WebCore::ViewTransition::activateViewTransition):
(WebCore::ViewTransition::clearViewTransition):
(WebCore::ViewTransition::copyElementBaseProperties):
(WebCore::ViewTransition::updatePseudoElementStyles):
(WebCore::ViewTransition::viewTransitionNewPseudoForCapturedElement):
(WebCore::forEachElementInPaintOrder): Deleted.
* Source/WebCore/dom/ViewTransition.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::initializeStyle):
(WebCore::RenderElement::capturedInViewTransition const): Deleted.
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::rebuildZOrderLists):
(WebCore::RenderLayer::paintList):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateTransform):
(WebCore::RenderLayerBacking::updateGeometry):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::collectViewTransitionNewContentLayers):
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::capturedInViewTransition const):
(WebCore::RenderObject::setCapturedInViewTransition):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::capturedInViewTransition const):
* Source/WebCore/style/Styleable.h:
(WebCore::WeakStyleable::operator bool const):
(WebCore::WeakStyleable::operator=):
(WebCore::WeakStyleable::styleable const):

Canonical link: <a href="https://commits.webkit.org/278123@main">https://commits.webkit.org/278123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/421a793ddaf88b9bc229e96a05f890026afb6dbd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49488 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52727 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/161 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51792 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26390 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40399 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51588 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26313 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42636 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21517 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23773 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43819 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7857 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45687 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44325 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54239 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24571 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20754 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47766 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25842 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46783 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10880 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26682 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25565 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->