### PR TITLE
Show passed output (if available) in ScriptError.

### DIFF
--- a/Tools/Scripts/webkitpy/common/system/executive.py
+++ b/Tools/Scripts/webkitpy/common/system/executive.py
@@ -56,9 +56,12 @@ class ScriptError(Exception):
         if not message:
             message = 'Failed to run "%s"' % repr(script_args)
             if exit_code:
-                message += " exit_code: %d" % exit_code
+                message += ", exit_code: %d" % exit_code
             if cwd:
-                message += " cwd: %s" % cwd
+                message += ", cwd: %s" % cwd
+            if output:
+                message += ", output: %s" % output
+        
 
         Exception.__init__(self, message)
         self.script_args = script_args  # 'args' is already used by Exception


### PR DESCRIPTION
#### d7ddfd1fe3be90b1f1f00a875422e77b9cb799e8
<pre>
Show passed output (if available) in ScriptError.
<a href="https://rdar.apple.com/126966101">rdar://126966101</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=273169">https://bugs.webkit.org/show_bug.cgi?id=273169</a>

Reviewed by NOBODY (OOPS!).

The constructor for webkitpy.common.system.executive.ScriptError takes an `output` parameter.
This should also be displayed if a custom error message isn&apos;t present, as it often contains
more information that may be useful to the user.

* Tools/Scripts/webkitpy/common/system/executive.py:
(ScriptError.__init__): Show `output` in addition to other already shown information when no message is specified.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7ddfd1fe3be90b1f1f00a875422e77b9cb799e8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48936 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51623 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45006 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25677 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40005 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25797 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42192 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21113 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/48796 "Found 2 webkitpy python3 test failures: webkitpy.common.system.executive_unittest.ScriptErrorTest.test_message_with_output, webkitpy.common.system.executive_unittest.ScriptErrorTest.test_message_with_tuple") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23257 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43364 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6991 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45186 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43866 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53534 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23987 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20246 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47314 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25250 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42401 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46272 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26059 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24970 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->