### PR TITLE
Remove and replace WKBundlePageSetTextZoomFactor/SetPageZoomFactor

### DIFF
--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -398,19 +398,9 @@ double WKBundlePageGetTextZoomFactor(WKBundlePageRef pageRef)
     return WebKit::toImpl(pageRef)->textZoomFactor();
 }
 
-void WKBundlePageSetTextZoomFactor(WKBundlePageRef pageRef, double zoomFactor)
-{
-    WebKit::toImpl(pageRef)->setTextZoomFactor(zoomFactor);
-}
-
 double WKBundlePageGetPageZoomFactor(WKBundlePageRef pageRef)
 {
     return WebKit::toImpl(pageRef)->pageZoomFactor();
-}
-
-void WKBundlePageSetPageZoomFactor(WKBundlePageRef pageRef, double zoomFactor)
-{
-    WebKit::toImpl(pageRef)->setPageZoomFactor(zoomFactor);
 }
 
 void WKBundlePageSetScaleAtOrigin(WKBundlePageRef pageRef, double scale, WKPoint origin)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePagePrivate.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePagePrivate.h
@@ -57,9 +57,7 @@ WK_EXPORT WKStringRef WKBundlePageCopyRenderTreeExternalRepresentationForPrintin
 WK_EXPORT void WKBundlePageExecuteEditingCommand(WKBundlePageRef page, WKStringRef commandName, WKStringRef argument);
 
 WK_EXPORT double WKBundlePageGetTextZoomFactor(WKBundlePageRef page);
-WK_EXPORT void WKBundlePageSetTextZoomFactor(WKBundlePageRef page, double zoomFactor);
 WK_EXPORT double WKBundlePageGetPageZoomFactor(WKBundlePageRef page);
-WK_EXPORT void WKBundlePageSetPageZoomFactor(WKBundlePageRef page, double zoomFactor);
 
 WK_EXPORT void WKBundlePageSetScaleAtOrigin(WKBundlePageRef page, double scale, WKPoint origin);
 

--- a/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
@@ -454,41 +454,45 @@ JSValueRef EventSendingController::contextClick(JSContextRef context)
 void EventSendingController::textZoomIn()
 {
     auto& injectedBundle = InjectedBundle::singleton();
-    // Ensure page zoom is reset.
-    WKBundlePageSetPageZoomFactor(injectedBundle.page()->page(), 1);
+    double zoomFactor = WKBundlePageGetTextZoomFactor(injectedBundle.page()->page()) * ZoomMultiplierRatio;
 
-    double zoomFactor = WKBundlePageGetTextZoomFactor(injectedBundle.page()->page());
-    WKBundlePageSetTextZoomFactor(injectedBundle.page()->page(), zoomFactor * ZoomMultiplierRatio);
+    auto body = adoptWK(WKMutableDictionaryCreate());
+    setValue(body, "SubMessage", "SetTextZoom");
+    setValue(body, "ZoomFactor", zoomFactor);
+    postSynchronousPageMessage("EventSender", body);
 }
 
 void EventSendingController::textZoomOut()
 {
     auto& injectedBundle = InjectedBundle::singleton();
-    // Ensure page zoom is reset.
-    WKBundlePageSetPageZoomFactor(injectedBundle.page()->page(), 1);
+    double zoomFactor = WKBundlePageGetTextZoomFactor(injectedBundle.page()->page()) / ZoomMultiplierRatio;
 
-    double zoomFactor = WKBundlePageGetTextZoomFactor(injectedBundle.page()->page());
-    WKBundlePageSetTextZoomFactor(injectedBundle.page()->page(), zoomFactor / ZoomMultiplierRatio);
+    auto body = adoptWK(WKMutableDictionaryCreate());
+    setValue(body, "SubMessage", "SetTextZoom");
+    setValue(body, "ZoomFactor", zoomFactor);
+    postSynchronousPageMessage("EventSender", body);
 }
 
 void EventSendingController::zoomPageIn()
 {
     auto& injectedBundle = InjectedBundle::singleton();
-    // Ensure text zoom is reset.
-    WKBundlePageSetTextZoomFactor(injectedBundle.page()->page(), 1);
+    double zoomFactor = WKBundlePageGetPageZoomFactor(injectedBundle.page()->page()) * ZoomMultiplierRatio;
 
-    double zoomFactor = WKBundlePageGetPageZoomFactor(injectedBundle.page()->page());
-    WKBundlePageSetPageZoomFactor(injectedBundle.page()->page(), zoomFactor * ZoomMultiplierRatio);
+    auto body = adoptWK(WKMutableDictionaryCreate());
+    setValue(body, "SubMessage", "SetPageZoom");
+    setValue(body, "ZoomFactor", zoomFactor);
+    postSynchronousPageMessage("EventSender", body);
 }
 
 void EventSendingController::zoomPageOut()
 {
     auto& injectedBundle = InjectedBundle::singleton();
-    // Ensure text zoom is reset.
-    WKBundlePageSetTextZoomFactor(injectedBundle.page()->page(), 1);
+    double zoomFactor = WKBundlePageGetPageZoomFactor(injectedBundle.page()->page()) / ZoomMultiplierRatio;
 
-    double zoomFactor = WKBundlePageGetPageZoomFactor(injectedBundle.page()->page());
-    WKBundlePageSetPageZoomFactor(injectedBundle.page()->page(), zoomFactor / ZoomMultiplierRatio);
+    auto body = adoptWK(WKMutableDictionaryCreate());
+    setValue(body, "SubMessage", "SetPageZoom");
+    setValue(body, "ZoomFactor", zoomFactor);
+    postSynchronousPageMessage("EventSender", body);
 }
 
 void EventSendingController::scalePageBy(double scale, double x, double y)

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -352,9 +352,6 @@ void InjectedBundlePage::prepare()
 {
     WKBundlePageClearMainFrameName(m_page);
 
-    WKBundlePageSetPageZoomFactor(m_page, 1);
-    WKBundlePageSetTextZoomFactor(m_page, 1);
-
     WKPoint origin = { 0, 0 };
     WKBundlePageSetScaleAtOrigin(m_page, 1, origin);
     

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -2304,6 +2304,20 @@ void TestController::didReceiveSynchronousMessageFromInjectedBundle(WKStringRef 
         }
 #endif // ENABLE(MAC_GESTURE_EVENTS)
 
+        if (WKStringIsEqualToUTF8CString(subMessageName, "SetPageZoom")) {
+            auto* page = mainWebView()->page();
+            WKPageSetTextZoomFactor(page, 1);
+            WKPageSetPageZoomFactor(page, doubleValue(dictionary, "ZoomFactor"));
+            return completionHandler(nullptr);
+        }
+
+        if (WKStringIsEqualToUTF8CString(subMessageName, "SetTextZoom")) {
+            auto* page = mainWebView()->page();
+            WKPageSetPageZoomFactor(page, 1);
+            WKPageSetTextZoomFactor(page, doubleValue(dictionary, "ZoomFactor"));
+            return completionHandler(nullptr);
+        }
+
         ASSERT_NOT_REACHED();
     }
 

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -176,6 +176,9 @@ void TestInvocation::invoke()
 
     // FIXME: We should clear out visited links here.
 
+    WKPageSetPageZoomFactor(TestController::singleton().mainWebView()->page(), 1);
+    WKPageSetTextZoomFactor(TestController::singleton().mainWebView()->page(), 1);
+
     postPageMessage("BeginTest", createTestSettingsDictionary());
 
     m_startedTesting = true;


### PR DESCRIPTION
#### a42f5c20a731b7d19a60187b3330cfb916dca7d9
<pre>
Remove and replace WKBundlePageSetTextZoomFactor/SetPageZoomFactor
<a href="https://rdar.apple.com/126969249">rdar://126969249</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=273170">https://bugs.webkit.org/show_bug.cgi?id=273170</a>

Reviewed by Sihui Liu.

Replace these functions with a synchronous message to the UI process. This is required because we will
need to have the UI process zoom all web processes with site isolation.

* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKBundlePageSetTextZoomFactor): Deleted.
(WKBundlePageSetPageZoomFactor): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePagePrivate.h:
* Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp:
(WTR::EventSendingController::textZoomIn):
(WTR::EventSendingController::textZoomOut):
(WTR::EventSendingController::zoomPageIn):
(WTR::EventSendingController::zoomPageOut):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp:
(WTR::InjectedBundlePage::prepare):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::didReceiveSynchronousMessageFromInjectedBundle):
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::invoke):

Canonical link: <a href="https://commits.webkit.org/277991@main">https://commits.webkit.org/277991@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12da23e6138553d14ee3712205b098789a73a2a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52085 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51836 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45171 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51393 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34301 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25865 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40113 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50595 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25931 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42314 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21227 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23386 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43490 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7296 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45318 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43993 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53751 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24165 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20371 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47433 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25445 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42520 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46402 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26233 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7046 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25164 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->