### PR TITLE
[visionOS] video goes blank and audio pauses when transitioning to LinearMediaKit fullscreen

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2589,3 +2589,5 @@ imported/w3c/web-platform-tests/fetch/metadata/generated/form-submission.sub.htm
 imported/w3c/web-platform-tests/fetch/metadata/generated/window-location.sub.html [ Skip ]
 
 [ Monterey Ventura ] imported/w3c/web-platform-tests/css/css-view-transitions/window-resize-aborts-transition.html [ Failure ]
+
+webkit.org/b/273308 http/tests/media/media-source/mediasource-rvfc.html [ Timeout ]

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -560,6 +560,9 @@ auto HTMLVideoElement::webkitPresentationMode() const -> VideoPresentationMode
 
 void HTMLVideoElement::didEnterFullscreenOrPictureInPicture(const FloatSize& size)
 {
+    if (RefPtr player = this->player())
+        player->setInFullscreenOrPictureInPicture(true);
+
     if (m_enteringPictureInPicture) {
         m_enteringPictureInPicture = false;
         setChangingVideoFullscreenMode(false);
@@ -586,6 +589,9 @@ void HTMLVideoElement::didEnterFullscreenOrPictureInPicture(const FloatSize& siz
 
 void HTMLVideoElement::didExitFullscreenOrPictureInPicture()
 {
+    if (RefPtr player = this->player())
+        player->setInFullscreenOrPictureInPicture(false);
+
     if (m_exitingPictureInPicture) {
         m_exitingPictureInPicture = false;
         setChangingVideoFullscreenMode(false);

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -1970,6 +1970,20 @@ void MediaPlayer::setSpatialTrackingLabel(const String& spatialTrackingLabel)
 }
 #endif
 
+void MediaPlayer::setInFullscreenOrPictureInPicture(bool isInFullscreenOrPictureInPicture)
+{
+    if (m_isInFullscreenOrPictureInPicture == isInFullscreenOrPictureInPicture)
+        return;
+
+    m_isInFullscreenOrPictureInPicture = isInFullscreenOrPictureInPicture;
+    m_private->isInFullscreenOrPictureInPictureChanged(isInFullscreenOrPictureInPicture);
+}
+
+bool MediaPlayer::isInFullscreenOrPictureInPicture() const
+{
+    return m_isInFullscreenOrPictureInPicture;
+}
+
 #if !RELEASE_LOG_DISABLED
 const Logger& MediaPlayer::mediaPlayerLogger()
 {

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -748,6 +748,9 @@ public:
     void setSpatialTrackingLabel(const String&);
 #endif
 
+    void setInFullscreenOrPictureInPicture(bool);
+    bool isInFullscreenOrPictureInPicture() const;
+
 private:
     MediaPlayer(MediaPlayerClient&);
     MediaPlayer(MediaPlayerClient&, MediaPlayerEnums::MediaEngineIdentifier);
@@ -800,6 +803,8 @@ private:
     String m_defaultSpatialTrackingLabel;
     String m_spatialTrackingLabel;
 #endif
+
+    bool m_isInFullscreenOrPictureInPicture { false };
 
     String m_lastErrorMessage;
     ProcessIdentity m_processIdentity;

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -367,6 +367,8 @@ public:
     virtual void setSpatialTrackingLabel(const String&) { }
 #endif
 
+    virtual void isInFullscreenOrPictureInPictureChanged(bool) { }
+
 protected:
     mutable PlatformTimeRanges m_seekable;
     bool m_shouldCheckHardwareSupport { false };

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -153,7 +153,7 @@ Vector<PlatformTimeRanges> SourceBufferPrivate::trackBuffersRanges() const
     });
 }
 
-void SourceBufferPrivate::reenqueSamples(TrackID trackID)
+void SourceBufferPrivate::reenqueSamples(TrackID trackID, NeedsFlush needsFlush)
 {
     RefPtr client = this->client();
     if (!client)
@@ -163,7 +163,7 @@ void SourceBufferPrivate::reenqueSamples(TrackID trackID)
     if (trackBuffer == m_trackBufferMap.end())
         return;
     trackBuffer->second->setNeedsReenqueueing(true);
-    reenqueueMediaForTime(trackBuffer->second, trackID, currentTime());
+    reenqueueMediaForTime(trackBuffer->second, trackID, currentTime(), needsFlush);
 }
 
 Ref<SourceBufferPrivate::ComputeSeekPromise> SourceBufferPrivate::computeSeekTime(const SeekTarget& target)
@@ -341,9 +341,10 @@ void SourceBufferPrivate::provideMediaData(TrackBuffer& trackBuffer, TrackID tra
     trySignalAllSamplesInTrackEnqueued(trackBuffer, trackID);
 }
 
-void SourceBufferPrivate::reenqueueMediaForTime(TrackBuffer& trackBuffer, TrackID trackID, const MediaTime& time)
+void SourceBufferPrivate::reenqueueMediaForTime(TrackBuffer& trackBuffer, TrackID trackID, const MediaTime& time, NeedsFlush needsFlush)
 {
-    flush(trackID);
+    if (needsFlush == NeedsFlush::Yes)
+        flush(trackID);
     if (trackBuffer.reenqueueMediaForTime(time, timeFudgeFactor()))
         provideMediaData(trackBuffer, trackID);
 }

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -192,7 +192,12 @@ protected:
     virtual void setMinimumUpcomingPresentationTime(TrackID, const MediaTime&) { }
     virtual void clearMinimumUpcomingPresentationTime(TrackID) { }
 
-    void reenqueSamples(TrackID);
+    enum class NeedsFlush: bool {
+        No = 0,
+        Yes
+    };
+
+    void reenqueSamples(TrackID, NeedsFlush = NeedsFlush::Yes);
 
     virtual bool precheckInitializationSegment(const InitializationSegment&) { return true; }
     virtual void processInitializationSegment(std::optional<InitializationSegment>&&) { }
@@ -218,7 +223,7 @@ private:
     Ref<MediaPromise> updateBuffered();
     void updateHighestPresentationTimestamp();
     void updateMinimumUpcomingPresentationTime(TrackBuffer&, TrackID);
-    void reenqueueMediaForTime(TrackBuffer&, TrackID, const MediaTime&);
+    void reenqueueMediaForTime(TrackBuffer&, TrackID, const MediaTime&, NeedsFlush = NeedsFlush::Yes);
     bool validateInitializationSegment(const InitializationSegment&);
     void provideMediaData(TrackBuffer&, TrackID);
     void setBufferedDirty(bool);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -88,7 +88,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     void addAudioRenderer(AVSampleBufferAudioRenderer*);
     void removeAudioRenderer(AVSampleBufferAudioRenderer*);
 ALLOW_NEW_API_WITHOUT_GUARDS_END
-    
+
     void removeAudioTrack(AudioTrackPrivate&);
     void removeVideoTrack(VideoTrackPrivate&);
     void removeTextTrack(InbandTextTrackPrivate&);
@@ -120,7 +120,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     bool timeIsProgressing() const final;
     AVSampleBufferDisplayLayer *sampleBufferDisplayLayer() const { return m_sampleBufferDisplayLayer.get(); }
     WebCoreDecompressionSession *decompressionSession() const { return m_decompressionSession.get(); }
-    WebSampleBufferVideoRendering *sampleBufferVideoRenderer() const;
+    WebSampleBufferVideoRendering *layerOrVideoRenderer() const;
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     RetainPtr<PlatformLayer> createVideoFullscreenLayer() override;
@@ -131,7 +131,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     bool requiresTextTrackRepresentation() const override;
     void setTextTrackRepresentation(TextTrackRepresentation*) override;
     void syncTextTrackBounds() override;
-    
+
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     void setCDMSession(LegacyCDMSession*) override;
     CDMSessionMediaSourceAVFObjC* cdmSession() const;
@@ -289,6 +289,10 @@ private:
     void ensureVideoRenderer();
     void destroyVideoRenderer();
 
+    void ensureLayerOrVideoRenderer();
+    void destroyLayerOrVideoRenderer();
+    void configureLayerOrVideoRenderer(WebSampleBufferVideoRendering *);
+
     bool shouldBePlaying() const;
 
     bool setCurrentTimeDidChangeCallback(MediaPlayer::CurrentTimeDidChangeCallback&&) final;
@@ -306,8 +310,7 @@ private:
     void checkNewVideoFrameMetadata(CMTime);
     MediaTime clampTimeToSensicalValue(const MediaTime&) const;
 
-    bool shouldEnsureLayer() const;
-    bool shouldEnsureVideoRenderer() const;
+    bool shouldEnsureLayerOrVideoRenderer() const;
 
     void setShouldDisableHDR(bool) final;
     void playerContentBoxRectChanged(const LayoutRect&) final;
@@ -321,8 +324,19 @@ private:
     void updateSpatialTrackingLabel();
 #endif
 
+    void isInFullscreenOrPictureInPictureChanged(bool) final;
+
     friend class MediaSourcePrivateAVFObjC;
     void bufferedChanged();
+
+    enum class AcceleratedVideoMode: uint8_t {
+        Layer = 0,
+        StagedVideoRenderer,
+        VideoRenderer,
+        StagedLayer
+    };
+
+    AcceleratedVideoMode acceleratedVideoMode() const;
 
     std::optional<SeekTarget> m_pendingSeek;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -300,7 +300,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::load(const URL&, const ContentType&, 
 
     m_mediaSourcePrivate = MediaSourcePrivateAVFObjC::create(*this, client);
     m_mediaSourcePrivate->setResourceOwner(m_resourceOwner);
-    m_mediaSourcePrivate->setVideoRenderer(sampleBufferVideoRenderer());
+    m_mediaSourcePrivate->setVideoRenderer(layerOrVideoRenderer());
     m_mediaSourcePrivate->setDecompressionSession(m_decompressionSession.get());
 
     acceleratedRenderingStateChanged();
@@ -744,7 +744,7 @@ bool MediaPlayerPrivateMediaSourceAVFObjC::updateLastPixelBuffer()
 {
 #if HAVE(AVSAMPLEBUFFERDISPLAYLAYER_COPYDISPLAYEDPIXELBUFFER)
     if (isCopyDisplayedPixelBufferAvailable()) {
-        if (auto pixelBuffer = adoptCF([sampleBufferVideoRenderer() copyDisplayedPixelBuffer])) {
+        if (auto pixelBuffer = adoptCF([layerOrVideoRenderer() copyDisplayedPixelBuffer])) {
             INFO_LOG(LOGIDENTIFIER, "displayed pixelbuffer copied for time ", currentTime());
             m_lastPixelBuffer = WTFMove(pixelBuffer);
             return true;
@@ -752,7 +752,7 @@ bool MediaPlayerPrivateMediaSourceAVFObjC::updateLastPixelBuffer()
     }
 #endif
 
-    if (sampleBufferVideoRenderer() || !m_decompressionSession)
+    if (layerOrVideoRenderer() || !m_decompressionSession)
         return false;
 
     auto flags = !m_lastPixelBuffer ? WebCoreDecompressionSession::AllowLater : WebCoreDecompressionSession::ExactTime;
@@ -850,7 +850,7 @@ bool MediaPlayerPrivateMediaSourceAVFObjC::supportsAcceleratedRendering() const
     return true;
 }
 
-bool MediaPlayerPrivateMediaSourceAVFObjC::shouldEnsureLayer() const
+bool MediaPlayerPrivateMediaSourceAVFObjC::shouldEnsureLayerOrVideoRenderer() const
 {
     // Decompression sessions do not support encrypted content; force layer
     // creation.
@@ -868,28 +868,15 @@ bool MediaPlayerPrivateMediaSourceAVFObjC::shouldEnsureLayer() const
 #endif
 }
 
-bool MediaPlayerPrivateMediaSourceAVFObjC::shouldEnsureVideoRenderer() const
-{
-    if (!shouldEnsureLayer())
-        return false;
-
-#if ENABLE(LINEAR_MEDIA_PLAYER)
-    if (m_videoTarget)
-        return true;
-#endif
-
-    return false;
-}
-
 void MediaPlayerPrivateMediaSourceAVFObjC::setPresentationSize(const IntSize& newSize)
 {
-    if (!sampleBufferVideoRenderer() && !newSize.isEmpty())
+    if (!layerOrVideoRenderer() && !newSize.isEmpty())
         updateDisplayLayerAndDecompressionSession();
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::setVideoLayerSizeFenced(const FloatSize& newSize, WTF::MachSendRight&&)
 {
-    if (!sampleBufferVideoRenderer() && !newSize.isEmpty())
+    if (!layerOrVideoRenderer() && !newSize.isEmpty())
         updateDisplayLayerAndDecompressionSession();
 }
 
@@ -900,22 +887,13 @@ void MediaPlayerPrivateMediaSourceAVFObjC::acceleratedRenderingStateChanged()
 
 void MediaPlayerPrivateMediaSourceAVFObjC::updateDisplayLayerAndDecompressionSession()
 {
-    if (shouldEnsureVideoRenderer()) {
+    if (shouldEnsureLayerOrVideoRenderer()) {
         destroyDecompressionSession();
-        destroyLayer();
-        ensureVideoRenderer();
+        ensureLayerOrVideoRenderer();
         return;
     }
 
-    if (shouldEnsureLayer()) {
-        destroyDecompressionSession();
-        destroyVideoRenderer();
-        ensureLayer();
-        return;
-    }
-
-    destroyLayer();
-    destroyVideoRenderer();
+    destroyLayerOrVideoRenderer();
     ensureDecompressionSession();
 }
 
@@ -964,7 +942,7 @@ std::optional<VideoPlaybackQualityMetrics> MediaPlayerPrivateMediaSourceAVFObjC:
         };
     }
 
-    auto metrics = [sampleBufferVideoRenderer() videoPerformanceMetrics];
+    auto metrics = [layerOrVideoRenderer() videoPerformanceMetrics];
     if (!metrics)
         return std::nullopt;
 
@@ -991,48 +969,24 @@ void MediaPlayerPrivateMediaSourceAVFObjC::ensureLayer()
     if (m_sampleBufferDisplayLayer)
         return;
 
+    ALWAYS_LOG(LOGIDENTIFIER);
+
     m_sampleBufferDisplayLayer = adoptNS([PAL::allocAVSampleBufferDisplayLayerInstance() init]);
+    if (!m_sampleBufferDisplayLayer)
+        return;
+
 #ifndef NDEBUG
     [m_sampleBufferDisplayLayer setName:@"MediaPlayerPrivateMediaSource AVSampleBufferDisplayLayer"];
 #endif
     [m_sampleBufferDisplayLayer setVideoGravity: (m_shouldMaintainAspectRatio ? AVLayerVideoGravityResizeAspect : AVLayerVideoGravityResize)];
 
-#if HAVE(SPATIAL_TRACKING_LABEL)
-    updateSpatialTrackingLabel();
-#endif
+    configureLayerOrVideoRenderer(m_sampleBufferDisplayLayer.get());
 
-    if (!m_sampleBufferDisplayLayer) {
-        ERROR_LOG(LOGIDENTIFIER, "Failed to create AVSampleBufferDisplayLayer");
-        if (m_mediaSourcePrivate)
-            m_mediaSourcePrivate->failedToCreateRenderer(MediaSourcePrivateAVFObjC::RendererType::Video);
-        setNetworkState(MediaPlayer::NetworkState::DecodeError);
-        return;
-    }
+    if (RefPtr player = m_player.get()) {
+        if ([m_sampleBufferDisplayLayer respondsToSelector:@selector(setToneMapToStandardDynamicRange:)])
+            [m_sampleBufferDisplayLayer setToneMapToStandardDynamicRange:player->shouldDisableHDR()];
 
-    [m_sampleBufferDisplayLayer setPreventsDisplaySleepDuringVideoPlayback:NO];
-
-    if ([m_sampleBufferDisplayLayer respondsToSelector:@selector(setPreventsAutomaticBackgroundingDuringVideoPlayback:)])
-        [m_sampleBufferDisplayLayer setPreventsAutomaticBackgroundingDuringVideoPlayback:NO];
-
-    @try {
-        [m_synchronizer addRenderer:m_sampleBufferDisplayLayer.get()];
-    } @catch(NSException *exception) {
-        ERROR_LOG(LOGIDENTIFIER, "-[AVSampleBufferRenderSynchronizer addRenderer:] threw an exception: ", exception.name, ", reason : ", exception.reason);
-        ASSERT_NOT_REACHED();
-
-        setNetworkState(MediaPlayer::NetworkState::DecodeError);
-        return;
-    }
-
-    auto player = m_player.get();
-    if (player && [m_sampleBufferDisplayLayer respondsToSelector:@selector(setToneMapToStandardDynamicRange:)])
-        [m_sampleBufferDisplayLayer setToneMapToStandardDynamicRange:player->shouldDisableHDR()];
-
-    if (m_mediaSourcePrivate)
-        m_mediaSourcePrivate->setVideoRenderer(m_sampleBufferDisplayLayer.get());
-    if (player) {
         m_videoLayerManager->setVideoLayer(m_sampleBufferDisplayLayer.get(), player->presentationSize());
-        player->renderingModeChanged();
     }
 }
 
@@ -1041,81 +995,54 @@ void MediaPlayerPrivateMediaSourceAVFObjC::destroyLayer()
     if (!m_sampleBufferDisplayLayer)
         return;
 
+    ALWAYS_LOG(LOGIDENTIFIER);
+
     CMTime currentTime = PAL::CMTimebaseGetTime([m_synchronizer timebase]);
     [m_synchronizer removeRenderer:m_sampleBufferDisplayLayer.get() atTime:currentTime completionHandler:nil];
 
-    if (m_mediaSourcePrivate)
-        m_mediaSourcePrivate->setVideoRenderer(nullptr);
     m_videoLayerManager->didDestroyVideoLayer();
     m_sampleBufferDisplayLayer = nullptr;
-    setHasAvailableVideoFrame(false);
-    if (auto player = m_player.get())
-        player->renderingModeChanged();
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::ensureVideoRenderer()
 {
-#if HAVE(AVSAMPLEBUFFERVIDEORENDERER)
+#if ENABLE(LINEAR_MEDIA_PLAYER)
     if (m_sampleBufferVideoRenderer)
         return;
 
+    ALWAYS_LOG(LOGIDENTIFIER);
+
     m_sampleBufferVideoRenderer = adoptNS([PAL::allocAVSampleBufferVideoRendererInstance() init]);
-
-    if (!m_sampleBufferVideoRenderer) {
-        ERROR_LOG(LOGIDENTIFIER, "Failed to create AVSampleBufferVideoRenderer");
-        if (m_mediaSourcePrivate)
-            m_mediaSourcePrivate->failedToCreateRenderer(MediaSourcePrivateAVFObjC::RendererType::Video);
-        setNetworkState(MediaPlayer::NetworkState::DecodeError);
+    if (!m_sampleBufferVideoRenderer)
         return;
-    }
 
-#if ENABLE(LINEAR_MEDIA_PLAYER)
     [m_sampleBufferVideoRenderer addVideoTarget:m_videoTarget.get()];
-#endif
 
-    [m_sampleBufferVideoRenderer setPreventsDisplaySleepDuringVideoPlayback:NO];
-    [m_sampleBufferVideoRenderer setPreventsAutomaticBackgroundingDuringVideoPlayback:NO];
-
-    @try {
-        [m_synchronizer addRenderer:m_sampleBufferVideoRenderer.get()];
-    } @catch(NSException *exception) {
-        ERROR_LOG(LOGIDENTIFIER, "-[AVSampleBufferRenderSynchronizer addRenderer:] threw an exception: ", exception.name, ", reason : ", exception.reason);
-        ASSERT_NOT_REACHED();
-
-        setNetworkState(MediaPlayer::NetworkState::DecodeError);
-        return;
-    }
-
-    if (m_mediaSourcePrivate)
-        m_mediaSourcePrivate->setVideoRenderer(m_sampleBufferVideoRenderer.get());
-    if (auto player = m_player.get())
-        player->renderingModeChanged();
-#endif // HAVE(AVSAMPLEBUFFERVIDEORENDERER)
+    configureLayerOrVideoRenderer(m_sampleBufferVideoRenderer.get());
+#endif // ENABLE(LINEAR_MEDIA_PLAYER)
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::destroyVideoRenderer()
 {
-#if HAVE(AVSAMPLEBUFFERVIDEORENDERER)
+#if ENABLE(LINEAR_MEDIA_PLAYER)
     if (!m_sampleBufferVideoRenderer)
         return;
+
+    ALWAYS_LOG(LOGIDENTIFIER);
 
     CMTime currentTime = PAL::CMTimebaseGetTime([m_synchronizer timebase]);
     [m_synchronizer removeRenderer:m_sampleBufferVideoRenderer.get() atTime:currentTime completionHandler:nil];
 
-    if (m_mediaSourcePrivate)
-        m_mediaSourcePrivate->setVideoRenderer(nullptr);
-    m_videoLayerManager->didDestroyVideoLayer();
     m_sampleBufferVideoRenderer = nullptr;
-    setHasAvailableVideoFrame(false);
-    if (auto player = m_player.get())
-        player->renderingModeChanged();
-#endif // HAVE(AVSAMPLEBUFFERVIDEORENDERER)
+#endif // ENABLE(LINEAR_MEDIA_PLAYER)
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::ensureDecompressionSession()
 {
     if (m_decompressionSession)
         return;
+
+    ALWAYS_LOG(LOGIDENTIFIER);
 
     m_decompressionSession = WebCoreDecompressionSession::createOpenGL();
     m_decompressionSession->setTimebase([m_synchronizer timebase]);
@@ -1133,12 +1060,122 @@ void MediaPlayerPrivateMediaSourceAVFObjC::destroyDecompressionSession()
     if (!m_decompressionSession)
         return;
 
+    ALWAYS_LOG(LOGIDENTIFIER);
+
     if (m_mediaSourcePrivate)
         m_mediaSourcePrivate->setDecompressionSession(nullptr);
 
     m_decompressionSession->invalidate();
     m_decompressionSession = nullptr;
     setHasAvailableVideoFrame(false);
+}
+
+void MediaPlayerPrivateMediaSourceAVFObjC::ensureLayerOrVideoRenderer()
+{
+    switch (acceleratedVideoMode()) {
+    case AcceleratedVideoMode::Layer:
+        destroyVideoRenderer();
+        FALLTHROUGH;
+    case AcceleratedVideoMode::StagedLayer:
+        if (m_sampleBufferDisplayLayer)
+            return;
+        ensureLayer();
+        break;
+    case AcceleratedVideoMode::VideoRenderer:
+        destroyLayer();
+        FALLTHROUGH;
+    case AcceleratedVideoMode::StagedVideoRenderer:
+        if (m_sampleBufferVideoRenderer)
+            return;
+        ensureVideoRenderer();
+        break;
+    }
+
+    RefPtr mediaSourcePrivate = m_mediaSourcePrivate;
+    RetainPtr renderer = layerOrVideoRenderer();
+
+    if (!renderer) {
+        ERROR_LOG(LOGIDENTIFIER, "Failed to create AVSampleBufferDisplayLayer or AVSampleBufferVideoRenderer");
+        if (mediaSourcePrivate)
+            mediaSourcePrivate->failedToCreateRenderer(MediaSourcePrivateAVFObjC::RendererType::Video);
+        setNetworkState(MediaPlayer::NetworkState::DecodeError);
+        return;
+    }
+
+    ALWAYS_LOG(LOGIDENTIFIER, acceleratedVideoMode(), ", renderer=", !!renderer);
+
+    bool needsRenderingModeChanged;
+    switch (acceleratedVideoMode()) {
+    case AcceleratedVideoMode::Layer:
+    case AcceleratedVideoMode::VideoRenderer:
+        needsRenderingModeChanged = true;
+        if (mediaSourcePrivate)
+            mediaSourcePrivate->setVideoRenderer(renderer.get());
+        break;
+    case AcceleratedVideoMode::StagedLayer:
+    case AcceleratedVideoMode::StagedVideoRenderer:
+        needsRenderingModeChanged = false;
+        if (mediaSourcePrivate)
+            mediaSourcePrivate->stageVideoRenderer(renderer.get());
+        break;
+    }
+
+    RefPtr player = m_player.get();
+    if (player && needsRenderingModeChanged)
+        player->renderingModeChanged();
+}
+
+void MediaPlayerPrivateMediaSourceAVFObjC::destroyLayerOrVideoRenderer()
+{
+    destroyLayer();
+    destroyVideoRenderer();
+
+    if (RefPtr mediaSourcePrivate = m_mediaSourcePrivate)
+        mediaSourcePrivate->setVideoRenderer(nil);
+
+    setHasAvailableVideoFrame(false);
+
+    if (RefPtr player = m_player.get())
+        player->renderingModeChanged();
+}
+
+void MediaPlayerPrivateMediaSourceAVFObjC::configureLayerOrVideoRenderer(WebSampleBufferVideoRendering *renderer)
+{
+#if HAVE(SPATIAL_TRACKING_LABEL)
+    updateSpatialTrackingLabel();
+#endif
+
+    renderer.preventsDisplaySleepDuringVideoPlayback = NO;
+
+    if ([renderer respondsToSelector:@selector(setPreventsAutomaticBackgroundingDuringVideoPlayback:)])
+        renderer.preventsAutomaticBackgroundingDuringVideoPlayback = NO;
+
+    @try {
+        [m_synchronizer addRenderer:renderer];
+    } @catch(NSException *exception) {
+        ERROR_LOG(LOGIDENTIFIER, "-[AVSampleBufferRenderSynchronizer addRenderer:] threw an exception: ", exception.name, ", reason : ", exception.reason);
+        ASSERT_NOT_REACHED();
+
+        setNetworkState(MediaPlayer::NetworkState::DecodeError);
+        return;
+    }
+}
+
+MediaPlayerPrivateMediaSourceAVFObjC::AcceleratedVideoMode MediaPlayerPrivateMediaSourceAVFObjC::acceleratedVideoMode() const
+{
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    RefPtr player = m_player.get();
+    if (player && player->isInFullscreenOrPictureInPicture()) {
+        if (m_videoTarget)
+            return AcceleratedVideoMode::VideoRenderer;
+        return AcceleratedVideoMode::StagedLayer;
+    }
+
+    if (m_videoTarget)
+        return AcceleratedVideoMode::StagedVideoRenderer;
+#endif // ENABLE(LINEAR_MEDIA_PLAYER)
+
+    return AcceleratedVideoMode::Layer;
 }
 
 bool MediaPlayerPrivateMediaSourceAVFObjC::shouldBePlaying() const
@@ -1653,7 +1690,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setShouldDisableHDR(bool shouldDisabl
 
 void MediaPlayerPrivateMediaSourceAVFObjC::playerContentBoxRectChanged(const LayoutRect& newRect)
 {
-    if (!sampleBufferVideoRenderer() && !newRect.isEmpty())
+    if (!layerOrVideoRenderer() && !newRect.isEmpty())
         updateDisplayLayerAndDecompressionSession();
 }
 
@@ -1736,18 +1773,26 @@ void MediaPlayerPrivateMediaSourceAVFObjC::updateSpatialTrackingLabel()
 }
 #endif
 
-WebSampleBufferVideoRendering *MediaPlayerPrivateMediaSourceAVFObjC::sampleBufferVideoRenderer() const
+WebSampleBufferVideoRendering *MediaPlayerPrivateMediaSourceAVFObjC::layerOrVideoRenderer() const
 {
 #if ENABLE(LINEAR_MEDIA_PLAYER)
-    if (m_videoTarget)
+    switch (acceleratedVideoMode()) {
+    case AcceleratedVideoMode::Layer:
+    case AcceleratedVideoMode::StagedLayer:
+        return m_sampleBufferDisplayLayer.get();
+    case AcceleratedVideoMode::VideoRenderer:
+    case AcceleratedVideoMode::StagedVideoRenderer:
         return m_sampleBufferVideoRenderer.get();
-#endif
+    }
+#else
     return m_sampleBufferDisplayLayer.get();
+#endif
 }
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
 void MediaPlayerPrivateMediaSourceAVFObjC::setVideoReceiverEndpoint(const VideoReceiverEndpoint& endpoint)
 {
+    ALWAYS_LOG(LOGIDENTIFIER, !!endpoint);
     if (!endpoint) {
         m_videoTarget = nullptr;
         updateDisplayLayerAndDecompressionSession();
@@ -1764,6 +1809,12 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setVideoReceiverEndpoint(const VideoR
 }
 #endif
 
+void MediaPlayerPrivateMediaSourceAVFObjC::isInFullscreenOrPictureInPictureChanged(bool isInFullscreenOrPictureInPicture)
+{
+    ALWAYS_LOG(LOGIDENTIFIER, isInFullscreenOrPictureInPicture);
+    updateDisplayLayerAndDecompressionSession();
 }
+
+} // namespace WebCore
 
 #endif

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
@@ -83,6 +83,7 @@ public:
 
     void hasSelectedVideoChanged(SourceBufferPrivateAVFObjC&);
     void setVideoRenderer(WebSampleBufferVideoRendering *);
+    void stageVideoRenderer(WebSampleBufferVideoRendering *);
     void setDecompressionSession(WebCoreDecompressionSession*);
 
     void flushActiveSourceBuffersIfNeeded();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
@@ -198,6 +198,12 @@ void MediaSourcePrivateAVFObjC::setVideoRenderer(WebSampleBufferVideoRendering *
         m_sourceBufferWithSelectedVideo->setVideoRenderer(renderer);
 }
 
+void MediaSourcePrivateAVFObjC::stageVideoRenderer(WebSampleBufferVideoRendering *renderer)
+{
+    if (m_sourceBufferWithSelectedVideo)
+        m_sourceBufferWithSelectedVideo->stageVideoRenderer(renderer);
+}
+
 void MediaSourcePrivateAVFObjC::setDecompressionSession(WebCoreDecompressionSession* decompressionSession)
 {
     if (m_sourceBufferWithSelectedVideo)
@@ -262,7 +268,7 @@ void MediaSourcePrivateAVFObjC::setSourceBufferWithSelectedVideo(SourceBufferPri
     m_sourceBufferWithSelectedVideo = sourceBuffer;
 
     if (auto player = platformPlayer(); m_sourceBufferWithSelectedVideo && player) {
-        m_sourceBufferWithSelectedVideo->setVideoRenderer(player->sampleBufferVideoRenderer());
+        m_sourceBufferWithSelectedVideo->setVideoRenderer(player->layerOrVideoRenderer());
         m_sourceBufferWithSelectedVideo->setDecompressionSession(player->decompressionSession());
     }
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -129,6 +129,8 @@ public:
     void unregisterForErrorNotifications(SourceBufferPrivateAVFObjCErrorClient*);
 
     void setVideoRenderer(WebSampleBufferVideoRendering *);
+    void stageVideoRenderer(WebSampleBufferVideoRendering *);
+
     void setDecompressionSession(WebCoreDecompressionSession*);
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
@@ -207,6 +209,9 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
     void setTrackChangeCallbacks(const InitializationSegment&, bool initialized);
 
+    void configureVideoRenderer(VideoMediaSampleRenderer&);
+    void invalidateVideoRenderer(VideoMediaSampleRenderer&);
+
     StdUnorderedMap<TrackID, RefPtr<VideoTrackPrivate>> m_videoTracks;
     StdUnorderedMap<TrackID, RefPtr<AudioTrackPrivate>> m_audioTracks;
     Vector<SourceBufferPrivateAVFObjCErrorClient*> m_errorClients;
@@ -216,6 +221,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     Deque<std::pair<TrackID, Ref<MediaSampleAVFObjC>>> m_blockedSamples;
 
     RefPtr<VideoMediaSampleRenderer> m_videoRenderer;
+    RefPtr<VideoMediaSampleRenderer> m_expiringVideoRenderer;
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     StdUnorderedMap<TrackID, RetainPtr<AVSampleBufferAudioRenderer>> m_audioRenderers;
 ALLOW_NEW_API_WITHOUT_GUARDS_END

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -893,6 +893,7 @@ void SourceBufferPrivateAVFObjC::videoRendererReadyForDisplayChanged(WebSampleBu
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER);
+
     if (RefPtr player = this->player())
         player->setHasAvailableVideoFrame(true);
 }
@@ -1122,8 +1123,13 @@ void SourceBufferPrivateAVFObjC::enqueueSampleBuffer(MediaSampleAVFObjC& sample)
             if (!protectedThis)
                 return;
 
-            if (!success || !m_videoRenderer) {
+            if (!success) {
                 ERROR_LOG(logSiteIdentifier, "prerollDecodeWithCompletionHandler failed");
+                return;
+            }
+
+            if (!m_videoRenderer) {
+                ERROR_LOG(logSiteIdentifier, "prerollDecodeWithCompletionHandler called after renderer destroyed");
                 return;
             }
 
@@ -1272,7 +1278,56 @@ bool SourceBufferPrivateAVFObjC::isSeeking() const
     return m_seeking;
 }
 
+void SourceBufferPrivateAVFObjC::configureVideoRenderer(VideoMediaSampleRenderer& videoRenderer)
+{
+    videoRenderer.setResourceOwner(m_resourceOwner);
+#if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
+    if (m_cdmInstance && shouldAddContentKeyRecipients())
+        [m_cdmInstance->contentKeySession() addContentKeyRecipient:videoRenderer.displayLayer()];
+#endif
+    videoRenderer.requestMediaDataWhenReady([weakThis = ThreadSafeWeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_enabledVideoTrackID)
+            protectedThis->didBecomeReadyForMoreSamples(*protectedThis->m_enabledVideoTrackID);
+    });
+    m_listener->beginObservingVideoRenderer(videoRenderer.renderer());
+}
+
+void SourceBufferPrivateAVFObjC::invalidateVideoRenderer(VideoMediaSampleRenderer& videoRenderer)
+{
+    videoRenderer.flush();
+    videoRenderer.stopRequestingMediaData();
+    m_listener->stopObservingVideoRenderer(videoRenderer.renderer());
+
+#if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
+    if (m_cdmInstance && shouldAddContentKeyRecipients())
+        [m_cdmInstance->contentKeySession() removeContentKeyRecipient:videoRenderer.displayLayer()];
+#endif
+}
+
 void SourceBufferPrivateAVFObjC::setVideoRenderer(WebSampleBufferVideoRendering *renderer)
+{
+    if (m_videoRenderer && renderer == m_videoRenderer->renderer()) {
+        if (RefPtr expiringVideoRenderer = std::exchange(m_expiringVideoRenderer, nullptr))
+            invalidateVideoRenderer(*expiringVideoRenderer);
+        return;
+    }
+
+    ALWAYS_LOG(LOGIDENTIFIER, "!!renderer = ", !!renderer);
+    ASSERT(!renderer || !m_decompressionSession || hasSelectedVideo());
+
+    if (m_videoRenderer)
+        invalidateVideoRenderer(*std::exchange(m_videoRenderer, nullptr));
+
+    if (!renderer)
+        return;
+
+    m_videoRenderer = VideoMediaSampleRenderer::create(renderer);
+    configureVideoRenderer(*m_videoRenderer);
+    if (m_enabledVideoTrackID)
+        reenqueSamples(*m_enabledVideoTrackID);
+}
+
+void SourceBufferPrivateAVFObjC::stageVideoRenderer(WebSampleBufferVideoRendering *renderer)
 {
     if (m_videoRenderer && renderer == m_videoRenderer->renderer())
         return;
@@ -1280,33 +1335,14 @@ void SourceBufferPrivateAVFObjC::setVideoRenderer(WebSampleBufferVideoRendering 
     ALWAYS_LOG(LOGIDENTIFIER, "!!renderer = ", !!renderer);
     ASSERT(!renderer || !m_decompressionSession || hasSelectedVideo());
 
-    if (m_videoRenderer) {
-        m_videoRenderer->flush();
-        m_videoRenderer->stopRequestingMediaData();
-        m_listener->stopObservingVideoRenderer(m_videoRenderer->renderer());
+    if (m_expiringVideoRenderer)
+        invalidateVideoRenderer(*std::exchange(m_expiringVideoRenderer, nullptr));
 
-#if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
-        if (m_cdmInstance && shouldAddContentKeyRecipients())
-            [m_cdmInstance->contentKeySession() removeContentKeyRecipient:m_videoRenderer->displayLayer()];
-#endif
-        m_videoRenderer = nullptr;
-    }
-
-    if (renderer) {
-        m_videoRenderer = VideoMediaSampleRenderer::create(renderer);
-        m_videoRenderer->setResourceOwner(m_resourceOwner);
-#if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
-        if (m_cdmInstance && shouldAddContentKeyRecipients())
-            [m_cdmInstance->contentKeySession() addContentKeyRecipient:m_videoRenderer->displayLayer()];
-#endif
-        m_videoRenderer->requestMediaDataWhenReady([weakThis = ThreadSafeWeakPtr { *this }] {
-            if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_enabledVideoTrackID)
-                protectedThis->didBecomeReadyForMoreSamples(*protectedThis->m_enabledVideoTrackID);
-        });
-        m_listener->beginObservingVideoRenderer(renderer);
-        if (m_enabledVideoTrackID)
-            reenqueSamples(*m_enabledVideoTrackID);
-    }
+    m_expiringVideoRenderer = WTFMove(m_videoRenderer);
+    m_videoRenderer = VideoMediaSampleRenderer::create(renderer);
+    configureVideoRenderer(*m_videoRenderer);
+    if (m_enabledVideoTrackID)
+        reenqueSamples(*m_enabledVideoTrackID, NeedsFlush::No);
 }
 
 void SourceBufferPrivateAVFObjC::setDecompressionSession(WebCoreDecompressionSession* decompressionSession)

--- a/Source/WebCore/platform/graphics/cocoa/WebSampleBufferVideoRendering.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebSampleBufferVideoRendering.h
@@ -33,6 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable CVPixelBufferRef)copyDisplayedPixelBuffer;
 - (void)prerollDecodeWithCompletionHandler:(void (^)(BOOL success))block;
 - (nullable AVVideoPerformanceMetrics *)videoPerformanceMetrics;
+@property BOOL preventsAutomaticBackgroundingDuringVideoPlayback;
+@property BOOL preventsDisplaySleepDuringVideoPlayback;
 @property (readonly) BOOL requiresFlushToResumeDecoding;
 @property (readonly) AVQueuedSampleBufferRenderingStatus status;
 @property (readonly, nullable) NSError *error;

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.h
@@ -76,6 +76,7 @@ private:
     void setContentDimensions(const FloatSize&) final;
     void setAllowsPictureInPicturePlayback(bool) final;
     bool isExternalPlaybackActive() const final;
+    bool willRenderToLayer() const final;
 
     RetainPtr<WebAVPlayerViewControllerDelegate> m_playerViewControllerDelegate;
     RetainPtr<WebAVPlayerViewController> m_playerViewController;

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.mm
@@ -897,6 +897,11 @@ bool VideoPresentationInterfaceAVKit::isExternalPlaybackActive() const
     return [playerController() isExternalPlaybackActive];
 }
 
+bool VideoPresentationInterfaceAVKit::willRenderToLayer() const
+{
+    return true;
+}
+
 static std::optional<bool> isPictureInPictureSupported;
 
 void setSupportsPictureInPicture(bool isSupported)

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -209,7 +209,7 @@ protected:
     RetainPtr<UIView> m_videoView;
     RetainPtr<WebAVPlayerLayerView> m_playerLayerView;
 
-    void finalizeSetup();
+    virtual void finalizeSetup();
     virtual void updateRouteSharingPolicy() = 0;
     virtual void setupPlayerViewController() = 0;
     virtual void invalidatePlayerViewController() = 0;
@@ -234,6 +234,7 @@ protected:
     virtual void setContentDimensions(const FloatSize&) = 0;
     virtual void setAllowsPictureInPicturePlayback(bool) = 0;
     virtual bool isExternalPlaybackActive() const = 0;
+    virtual bool willRenderToLayer() const = 0;
 
 #if PLATFORM(WATCHOS)
     bool m_waitingForPreparedToExit { false };

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
@@ -235,11 +235,13 @@ void VideoPresentationInterfaceIOS::doSetup()
         m_playerLayerView = adoptNS([allocWebAVPlayerLayerViewInstance() init]);
     [m_playerLayerView setHidden:isExternalPlaybackActive()];
     [m_playerLayerView setBackgroundColor:clearUIColor()];
-    [m_playerLayerView setVideoView:m_videoView.get()];
 
-    if (!m_currentMode.hasPictureInPicture() && !m_changingStandbyOnly) {
-        ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, "Moving videoView to fullscreen WebAVPlayerLayerView");
-        [m_playerLayerView addSubview:m_videoView.get()];
+    if (willRenderToLayer()) {
+        [m_playerLayerView setVideoView:m_videoView.get()];
+        if (!m_currentMode.hasPictureInPicture() && !m_changingStandbyOnly) {
+            ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, "Moving videoView to fullscreen WebAVPlayerLayerView");
+            [m_playerLayerView addSubview:m_videoView.get()];
+        }
     }
 
     WebAVPlayerLayer *playerLayer = (WebAVPlayerLayer *)[m_playerLayerView playerLayer];

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -1241,6 +1241,11 @@ void RemoteMediaPlayerProxy::setSpatialTrackingLabel(const String& spatialTracki
 }
 #endif
 
+void RemoteMediaPlayerProxy::isInFullscreenOrPictureInPictureChanged(bool isInFullscreenOrPictureInPicture)
+{
+    m_player->setInFullscreenOrPictureInPicture(isInFullscreenOrPictureInPicture);
+}
+
 #if !RELEASE_LOG_DISABLED
 WTFLogChannel& RemoteMediaPlayerProxy::logChannel() const
 {

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -372,6 +372,8 @@ private:
     void setSpatialTrackingLabel(const String&);
 #endif
 
+    void isInFullscreenOrPictureInPictureChanged(bool);
+
 #if !RELEASE_LOG_DISABLED
     const Logger& mediaPlayerLogger() final { return m_logger; }
     const void* mediaPlayerLogIdentifier() { return reinterpret_cast<const void*>(m_configuration.logIdentifier); }

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
@@ -149,6 +149,8 @@ messages -> RemoteMediaPlayerProxy {
     SetDefaultSpatialTrackingLabel(String defaultSpatialTrackingLabel);
     SetSpatialTrackingLabel(String spatialTrackingLabel);
 #endif
+
+    IsInFullscreenOrPictureInPictureChanged(bool value)
 }
 
 #endif

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
@@ -58,6 +58,7 @@ private:
     bool isPlayingVideoInEnhancedFullscreen() const final { return false; }
     void setupFullscreen(UIView&, const FloatRect&, const FloatSize&, UIView*, HTMLMediaElementEnums::VideoFullscreenMode, bool, bool, bool) final;
     void hasVideoChanged(bool) final { }
+    void finalizeSetup() final;
     void updateRouteSharingPolicy() final { }
     void setupPlayerViewController() final;
     void invalidatePlayerViewController() final;
@@ -70,6 +71,7 @@ private:
     void setContentDimensions(const FloatSize&) final;
     void setAllowsPictureInPicturePlayback(bool) final { }
     bool isExternalPlaybackActive() const final { return false; }
+    bool willRenderToLayer() const final { return false; }
     AVPlayerViewController *avPlayerViewController() const final { return nullptr; }
     void setupCaptionsLayer(CALayer *parent, const FloatSize&) final;
     LMPlayableViewController *playableViewController() final;

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
@@ -63,6 +63,14 @@ void VideoPresentationInterfaceLMK::setupFullscreen(UIView& videoView, const Flo
     VideoPresentationInterfaceIOS::setupFullscreen(videoView, initialRect, videoDimensions, parentView, mode, allowsPictureInPicturePlayback, standby, blocksReturnToFullscreenFromPictureInPicture);
 }
 
+void VideoPresentationInterfaceLMK::finalizeSetup()
+{
+    RunLoop::main().dispatch([protectedThis = Ref { *this }, this] {
+        if (RefPtr model = videoPresentationModel())
+            model->didSetupFullscreen();
+    });
+}
+
 void VideoPresentationInterfaceLMK::setupPlayerViewController()
 {
     linearMediaPlayer().captionLayer = captionsLayer();

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -1803,6 +1803,11 @@ void MediaPlayerPrivateRemote::setSpatialTrackingLabel(const String& spatialTrac
 }
 #endif
 
+void MediaPlayerPrivateRemote::isInFullscreenOrPictureInPictureChanged(bool isInFullscreenOrPictureInPicture)
+{
+    connection().send(Messages::RemoteMediaPlayerProxy::IsInFullscreenOrPictureInPictureChanged(isInFullscreenOrPictureInPicture), m_id);
+}
+
 void MediaPlayerPrivateRemote::commitAllTransactions(CompletionHandler<void()>&& completionHandler)
 {
     completionHandler();

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -471,6 +471,8 @@ private:
     void setSpatialTrackingLabel(const String&) final;
 #endif
 
+    void isInFullscreenOrPictureInPictureChanged(bool) final;
+
 #if PLATFORM(COCOA)
     void pushVideoFrameMetadata(WebCore::VideoFrameMetadata&&, RemoteVideoFrameProxy::Properties&&);
 #endif


### PR DESCRIPTION
#### f114890c78b5bb1de5d09d133a3b702618d02a06
<pre>
[visionOS] video goes blank and audio pauses when transitioning to LinearMediaKit fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=273171">https://bugs.webkit.org/show_bug.cgi?id=273171</a>
<a href="https://rdar.apple.com/125647233">rdar://125647233</a>

Reviewed by Jer Noble.

When transitioning to LinearMediaKit fullscreen, two issues cause the video to pause and show a
black frame in the WKWebView:
1. VideoPresentationInterfaceIOS moves the video view from the web view to a new WebAVPlayerView,
   even though this view is not used by LMPlayableViewController.
2. When MediaPlayerPrivateMediaSourceAVFObjC switches from an AVSampleBufferDisplayLayer to an
   AVSampleBufferVideoRenderer, it flushes the display layer and sets the synchronizer&apos;s rate to 0
   until the video render has an available frame.

Resolved (1) by keeping the video view in the WKWebView&apos;s hierarchy when
VideoPresentationInterfaceLMK is in use. This is OK since LMPLayableViewController will render to an
entity rather than a layer.

Resolved (2) by teaching MediaPlayerPrivateMediaSourceAVFObjC to stage the transition from
AVSampleBufferDisplayLayer to AVSampleBufferVideoRenderer (and vice versa). When a video receiver
endpoint is received an AVSampleBufferVideoRenderer is created, but the existing
AVSampleBufferDisplayLayer is kept alive. It isn&apos;t flushed, so it continues to render samples that
have been previously enqueued. Simultaneously, samples for the current time are enqueued to the
AVSampleBufferVideoRenderer, and only once the video render has an available frame the display layer
is destroyed. The synchronizer remains playing during this transition. A similar staged transition
occurs when switching back from a video renderer to a display layer.

* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::didEnterFullscreenOrPictureInPicture):
(WebCore::HTMLVideoElement::didExitFullscreenOrPictureInPicture):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::setInFullscreenOrPictureInPicture):
(WebCore::MediaPlayer::isInFullscreenOrPictureInPicture const):
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::isInFullscreenOrPictureInPictureChanged):
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::reenqueSamples):
(WebCore::SourceBufferPrivate::reenqueueMediaForTime):
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::load):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateLastPixelBuffer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::shouldEnsureLayerOrVideoRenderer const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setPresentationSize):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setVideoLayerSizeFenced):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateDisplayLayerAndDecompressionSession):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::videoPlaybackQualityMetrics):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureLayer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::destroyLayer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureVideoRenderer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::destroyVideoRenderer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureDecompressionSession):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::destroyDecompressionSession):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureLayerOrVideoRenderer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::destroyLayerOrVideoRenderer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::configureLayerOrVideoRenderer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::acceleratedVideoMode const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::playerContentBoxRectChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::layerOrVideoRenderer const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setVideoReceiverEndpoint):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::isInFullscreenOrPictureInPictureChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::shouldEnsureLayer const): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::shouldEnsureVideoRenderer const): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::sampleBufferVideoRenderer const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm:
(WebCore::MediaSourcePrivateAVFObjC::stageVideoRenderer):
(WebCore::MediaSourcePrivateAVFObjC::setSourceBufferWithSelectedVideo):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::videoRendererReadyForDisplayChanged):
(WebCore::SourceBufferPrivateAVFObjC::enqueueSampleBuffer):
(WebCore::SourceBufferPrivateAVFObjC::configureVideoRenderer):
(WebCore::SourceBufferPrivateAVFObjC::invalidateVideoRenderer):
(WebCore::SourceBufferPrivateAVFObjC::setVideoRenderer):
(WebCore::SourceBufferPrivateAVFObjC::stageVideoRenderer):
* Source/WebCore/platform/graphics/cocoa/WebSampleBufferVideoRendering.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.mm:
(WebCore::VideoPresentationInterfaceAVKit::willRenderToLayer const):
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm:
(WebCore::VideoPresentationInterfaceIOS::doSetup):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::isInFullscreenOrPictureInPictureChanged):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
(WebKit::VideoPresentationInterfaceLMK::finalizeSetup):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::isInFullscreenOrPictureInPictureChanged):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/278032@main">https://commits.webkit.org/278032@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc44a54bd94b3110ddf7aa46776ef05a56bb4ad5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28572 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52321 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52119 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45393 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51594 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26192 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40264 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26120 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21386 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23571 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43634 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7657 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/44138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54029 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24372 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20554 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47582 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25644 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42660 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46574 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10834 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26483 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25367 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->