### PR TITLE
Nested duplicate named capturing groups in regex is not syntax error

### DIFF
--- a/JSTests/stress/regexp-duplicate-named-captures.js
+++ b/JSTests/stress/regexp-duplicate-named-captures.js
@@ -143,14 +143,20 @@ function testRegExpSyntaxError(reString, flags, expError)
 {
     testNumber++;
 
+    let threw = false;
+
     try {
         let re = new RegExp(reString, flags);
     } catch (e) {
+        threw = true;
         if (e != expError)
             print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError + "\" got \"" + e + "\"");
         else if (verbose)
             print("/" + reString + "/" + flags + " passed, it threw \"" + expError + "\" as expected");
     }
+
+    if (!threw)
+        print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError + "\", but it didn't");
 }
 
 // Test 1
@@ -182,7 +188,7 @@ testRegExpSyntaxError("(?<A>123)(?<A>456)", "", "SyntaxError: Invalid regular ex
 testRegExpSyntaxError("(?<A>123)(?:(?<A>456)|(?<A>789))", "", "SyntaxError: Invalid regular expression: duplicate group specifier name");
 
 // Test 21
-testRegExpSyntaxError("(?<=\\k<a>a)x", "", "SyntaxError: Invalid regular expression: duplicate group specifier name");
+testRegExpSyntaxError("(?<=\\k<a>a)x", "u", "SyntaxError: Invalid regular expression: invalid \\k<> named backreference");
 testRegExp(/(?<b>.).\k<b>/u, "bab", ["bab", "b"]);
 testRegExp(/(?<b>.).\k<b>/u, "baa", null, null);
 testRegExp(/(?<a>\k<a>\w)../u, "bab", ["bab", "b"], { a: "b" });
@@ -192,9 +198,18 @@ testRegExp(/(?:(?<x>a)|(?<y>a)(?<x>b))(?:(?<z>c)|(?<z>d))/, "abc", ["abc", undef
 testRegExp(/(?<=(?:\1|b)(aa))./, "aaaax", ["x", "aa"]);
 testRegExp(/(?<=(?:\2|b)(?<=\1(a))(aa))./, "aaaax", ["x", "a", "aa"]);
 testRegExp(/(?<=((?:\3|b))(?<=\2(a))(aa))./, "aaaax", ["x", "aa", "a", "aa"]);
-testRegExp(/((?:(?<f>\w))(?<f>.)(a*c)?)*/, "aabbbccc", ["aabbbcc","bcc","b","c","c"], { f: "c" });
+testRegExpSyntaxError("((?:(?<f>\w))(?<f>.)(a*c)?)*", "", "SyntaxError: Invalid regular expression: duplicate group specifier name");
+//  &&&&  testRegExp(/((?:(?<f>\w))(?<f>.)(a*c)?)*/, "aabbbccc", ["aabbbcc","bcc","b","c","c"], { f: "c" });
 testRegExp(/(?<A>)|(?<A>)*\k<A>/, "", ["", "", undefined], { A: "" });
 
 // Test 31
 testRegExp(/(?:(?<A>a)|(?<A>b)*)\k<A>/, "bb", ["bb",undefined,"b"], { A: "b" });
 testRegExp(/((?<A>A+)(?<B>B+)(?<C>C+)(?<D>D+))+|((?<B>B+)(?<C>C+)(?<D>D+))+|((?<A>A+)(?<C>C+)(?<D>D+))+|((?<C>C+)(?<D>D+))+|((?<B>B+)(?<D>D+))+|((?<A>A+)(?<D>D+))+|((?<D>D+))/, "AAD", ["AAD", undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, "AAD", "AA", "D", undefined, undefined], { A: "AA", B: undefined, C: undefined, D: "D" });
+testRegExpSyntaxError("(?<x>c)(?:(?<x>a)|(?<x>b))", "", "SyntaxError: Invalid regular expression: duplicate group specifier name");
+testRegExpSyntaxError("(?:(?<x>a)|(?<x>b))(?<x>c)", "", "SyntaxError: Invalid regular expression: duplicate group specifier name");
+testRegExpSyntaxError("(?:(?<x>c)x)(?:(?<x>a)|(?<x>b))", "", "SyntaxError: Invalid regular expression: duplicate group specifier name");
+
+// Test 36
+testRegExpSyntaxError("(?:(?<x>a)|(?<x>b))(?:(?<x>c)x)", "", "SyntaxError: Invalid regular expression: duplicate group specifier name");
+testRegExpSyntaxError("(?:(?<x>c)x|(?<y>d))(?:(?<y>a)|(?<x>b))", "", "SyntaxError: Invalid regular expression: duplicate group specifier name");
+testRegExpSyntaxError("(?:(?<y>a)|(?<x>b))(?:(?<x>c)x|(?<y>d))", "", "SyntaxError: Invalid regular expression: duplicate group specifier name");


### PR DESCRIPTION
#### 93db8886b0d38f019b6504805d078e07662f93f1
<pre>
Nested duplicate named capturing groups in regex is not syntax error
<a href="https://bugs.webkit.org/show_bug.cgi?id=272659">https://bugs.webkit.org/show_bug.cgi?id=272659</a>
<a href="https://rdar.apple.com/126863735">rdar://126863735</a>

Reviewed by Alexey Shvayka.

Updated the record keeping of capture names in nested parenthesis and disjunctions.  Now we agregate all
group names seen in nested parenthesis and bubble them up to the cantaining disjunction.

Added new test cases.
Also updated the syntax error testing code to make sure that an expected error is actually thrown.
This change uncovered an unrelated test case that needed updating with the addition of a flag.

* JSTests/stress/regexp-duplicate-named-captures.js:
(testRegExpSyntaxError):
* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::Parser::NamedCaptureGroups::NamedCaptureGroups):
(JSC::Yarr::Parser::NamedCaptureGroups::reset):
(JSC::Yarr::Parser::NamedCaptureGroups::nextAlternative):
(JSC::Yarr::Parser::NamedCaptureGroups::pushParenthesis):
(JSC::Yarr::Parser::NamedCaptureGroups::popParenthesis):
(JSC::Yarr::Parser::NamedCaptureGroups::add):

Canonical link: <a href="https://commits.webkit.org/277928@main">https://commits.webkit.org/277928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16d3b9b000d0523b959670a323962c77f2c5c221

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48948 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51635 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45018 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25689 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40013 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49795 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25807 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42201 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21121 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23267 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43371 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7003 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/42247 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45195 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43875 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53546 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/48439 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23999 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20257 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47323 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25262 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42410 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46281 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10783 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26071 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55934 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24982 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11511 "Passed tests") | 
<!--EWS-Status-Bubble-End-->