### PR TITLE
[GTK][WPE] Don't allow depth test and stencil clipping if packed depth stencil is not supported

### DIFF
--- a/Source/WebCore/platform/graphics/egl/GLContext.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContext.cpp
@@ -541,6 +541,7 @@ const GLContext::GLExtensions& GLContext::glExtensions() const
         m_glExtensions.OES_texture_npot = isExtensionSupported(extensionsString, "GL_OES_texture_npot");
         m_glExtensions.EXT_unpack_subimage = isExtensionSupported(extensionsString, "GL_EXT_unpack_subimage");
         m_glExtensions.APPLE_sync = isExtensionSupported(extensionsString, "GL_APPLE_sync");
+        m_glExtensions.OES_packed_depth_stencil = isExtensionSupported(extensionsString, "GL_OES_packed_depth_stencil");
     });
     return m_glExtensions;
 }

--- a/Source/WebCore/platform/graphics/egl/GLContext.h
+++ b/Source/WebCore/platform/graphics/egl/GLContext.h
@@ -77,6 +77,7 @@ public:
         bool OES_texture_npot { false };
         bool EXT_unpack_subimage { false };
         bool APPLE_sync { false };
+        bool OES_packed_depth_stencil { false };
     };
     const GLExtensions& glExtensions() const;
 

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -51,7 +51,25 @@ static const GLenum s_pixelDataType = GL_UNSIGNED_INT_8_8_8_8_REV;
 static const GLenum s_pixelDataType = GL_UNSIGNED_BYTE;
 #endif
 
+// On GLES3, the format we want for packed depth stencil is GL_DEPTH24_STENCIL8, but when added through
+// the extension this format is called GL_DEPTH24_STENCIL8_OES. In any case they hold the same value 0x88F0
+// so we can just use the first one.
+// These definitions may not exist if this is a GLES1/2 context without the GL_OES_packed_depth_stencil
+// extension. We need to define the one we want to use in order to build on every case.
+#ifndef GL_DEPTH24_STENCIL8
+#define GL_DEPTH24_STENCIL8 0x88F0
+#endif
+
 namespace WebCore {
+
+GLenum depthBufferFormat()
+{
+    auto* glContext = GLContext::current();
+    if (glContext->version() >= 300 || glContext->glExtensions().OES_packed_depth_stencil)
+        return GL_DEPTH24_STENCIL8;
+
+    return GL_DEPTH_COMPONENT16;
+}
 
 BitmapTexture::BitmapTexture(const IntSize& size, OptionSet<Flags> flags, GLint internalFormat)
     : m_flags(flags)
@@ -186,18 +204,29 @@ void BitmapTexture::updateContents(GraphicsLayer* sourceLayer, const IntRect& ta
 
 void BitmapTexture::initializeStencil()
 {
-#if !USE(TEXMAP_DEPTH_STENCIL_BUFFER)
-    if (m_rbo)
+    if (m_flags.contains(Flags::DepthBuffer)) {
+        // We have a depth buffer and we're asked to have a stencil buffer as well. This is only
+        // possible if packed depth stencil is available. If that's the case, just bind the depth
+        // buffer as the stencil one if haven't done so. If packed depth stencil is not available
+        // don't do anything, which will cause stencil clips on this surface to fail.
+        if (depthBufferFormat() == GL_DEPTH24_STENCIL8 && !m_stencilBound) {
+            glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, m_depthBufferObject);
+            m_stencilBound = true;
+        }
+        return;
+    }
+
+    // We don't have a depth buffer. Use a stencil only buffer.
+    if (m_stencilBufferObject)
         return;
 
-    glGenRenderbuffers(1, &m_rbo);
-    glBindRenderbuffer(GL_RENDERBUFFER, m_rbo);
+    glGenRenderbuffers(1, &m_stencilBufferObject);
+    glBindRenderbuffer(GL_RENDERBUFFER, m_stencilBufferObject);
     glRenderbufferStorage(GL_RENDERBUFFER, GL_STENCIL_INDEX8, m_size.width(), m_size.height());
     glBindRenderbuffer(GL_RENDERBUFFER, 0);
-    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, m_rbo);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, m_stencilBufferObject);
     glClearStencil(0);
     glClear(GL_STENCIL_BUFFER_BIT);
-#endif
 }
 
 void BitmapTexture::initializeDepthBuffer()
@@ -205,15 +234,9 @@ void BitmapTexture::initializeDepthBuffer()
     if (m_depthBufferObject)
         return;
 
-#if USE(TEXMAP_DEPTH_STENCIL_BUFFER)
-    GLenum format = GL_DEPTH24_STENCIL8_OES;
-#else
-    GLenum format = GL_DEPTH_COMPONENT16;
-#endif
-
     glGenRenderbuffers(1, &m_depthBufferObject);
     glBindRenderbuffer(GL_RENDERBUFFER, m_depthBufferObject);
-    glRenderbufferStorage(GL_RENDERBUFFER, format, m_size.width(), m_size.height());
+    glRenderbufferStorage(GL_RENDERBUFFER, depthBufferFormat(), m_size.width(), m_size.height());
     glBindRenderbuffer(GL_RENDERBUFFER, 0);
     glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, m_depthBufferObject);
 }
@@ -265,13 +288,11 @@ BitmapTexture::~BitmapTexture()
     if (m_fbo)
         glDeleteFramebuffers(1, &m_fbo);
 
-#if !USE(TEXMAP_DEPTH_STENCIL_BUFFER)
-    if (m_rbo)
-        glDeleteRenderbuffers(1, &m_rbo);
-#endif
-
     if (m_depthBufferObject)
         glDeleteRenderbuffers(1, &m_depthBufferObject);
+
+    if (m_stencilBufferObject)
+        glDeleteRenderbuffers(1, &m_stencilBufferObject);
 }
 
 void BitmapTexture::copyFromExternalTexture(GLuint sourceTextureID)

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
@@ -43,12 +43,6 @@ class NativeImage;
 class TextureMapper;
 enum class TextureMapperFlags : uint16_t;
 
-#if OS(WINDOWS)
-#define USE_TEXMAP_DEPTH_STENCIL_BUFFER 1
-#else
-#define USE_TEXMAP_DEPTH_STENCIL_BUFFER 0
-#endif
-
 class BitmapTexture final : public ThreadSafeRefCounted<BitmapTexture> {
 public:
     enum class Flags : uint8_t {
@@ -102,10 +96,9 @@ private:
     IntSize m_size;
     GLuint m_id { 0 };
     GLuint m_fbo { 0 };
-#if !USE(TEXMAP_DEPTH_STENCIL_BUFFER)
-    GLuint m_rbo { 0 };
-#endif
     GLuint m_depthBufferObject { 0 };
+    GLuint m_stencilBufferObject { 0 };
+    bool m_stencilBound { false };
     bool m_shouldClear { true };
     ClipStack m_clipStack;
     OptionSet<TextureMapperFlags> m_colorConvertFlags;


### PR DESCRIPTION
#### ed286350cfd576f534f27200fa06d714fb14f8a9
<pre>
[GTK][WPE] Don&apos;t allow depth test and stencil clipping if packed depth stencil is not supported
<a href="https://bugs.webkit.org/show_bug.cgi?id=273177">https://bugs.webkit.org/show_bug.cgi?id=273177</a>

Reviewed by Carlos Garcia Campos.

Use a packed depth stencil format when available, which allows depth testing
and stencil clipping at the same time. If packed depth stencil is not
supported, use separate buffers for depth and stencil. In the latter case,
if both buffers are requested at the same time, the stencil buffer won&apos;t
be created.

* Source/WebCore/platform/graphics/egl/GLContext.cpp:
(WebCore::GLContext::glExtensions const):
* Source/WebCore/platform/graphics/egl/GLContext.h:
* Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp:
(WebCore::depthBufferFormat):
(WebCore::BitmapTexture::initializeStencil):
(WebCore::BitmapTexture::initializeDepthBuffer):
(WebCore::BitmapTexture::~BitmapTexture):
* Source/WebCore/platform/graphics/texmap/BitmapTexture.h:

Canonical link: <a href="https://commits.webkit.org/278159@main">https://commits.webkit.org/278159@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1b15109e2c31c310ffd388b10bd743aa6f5203c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28811 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52573 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52768 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/202 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51833 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26431 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40442 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51629 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42675 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21557 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23814 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43858 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7898 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45728 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44363 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54344 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24613 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20803 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47812 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25883 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46829 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26725 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7148 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25606 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->