### PR TITLE
[WPE] WPE Platform: Add input method context support for Wayland

### DIFF
--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -202,6 +202,7 @@ UIProcess/API/wpe/InputMethodFilterWPE.cpp @no-unify
 UIProcess/API/wpe/PageClientImpl.cpp @no-unify
 UIProcess/API/wpe/WebKitColor.cpp @no-unify
 UIProcess/API/wpe/WebKitInputMethodContextWPE.cpp @no-unify
+UIProcess/API/wpe/WebKitInputMethodContextImplWPE.cpp @no-unify
 UIProcess/API/wpe/WebKitPopupMenu.cpp @no-unify
 UIProcess/API/wpe/WebKitRectangle.cpp @no-unify
 UIProcess/API/wpe/WebKitScriptDialogWPE.cpp @no-unify

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -105,6 +105,9 @@
 #include "WebKitOptionMenuPrivate.h"
 #include "WebKitWebViewBackendPrivate.h"
 #include "WebKitWebViewClient.h"
+#if ENABLE(WPE_PLATFORM)
+#include "WebKitInputMethodContextImplWPE.h"
+#endif
 #endif
 
 #if ENABLE(2022_GLIB_API)
@@ -934,6 +937,12 @@ static void webkitWebViewConstructed(GObject* object)
     GRefPtr<WebKitInputMethodContext> imContext = adoptGRef(webkitInputMethodContextImplGtkNew());
     webkitInputMethodContextSetWebView(imContext.get(), webView);
     webkitWebViewBaseSetInputMethodContext(WEBKIT_WEB_VIEW_BASE(webView), imContext.get());
+#elif PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+    if (priv->display) {
+        GRefPtr<WebKitInputMethodContext> imContext = adoptGRef(webkitInputMethodContextImplWPENew(priv->view->wpeView()));
+        webkitInputMethodContextSetWebView(imContext.get(), webView);
+        priv->view->setInputMethodContext(imContext.get());
+    }
 #endif
 
 #if PLATFORM(WPE)

--- a/Source/WebKit/UIProcess/API/wpe/WebKitInputMethodContextImplWPE.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitInputMethodContextImplWPE.cpp
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "WebKitInputMethodContextImplWPE.h"
+
+#if ENABLE(WPE_PLATFORM)
+
+#include <wpe/wpe-platform.h>
+#include <wtf/MathExtras.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/WTFGType.h>
+
+struct _WebKitInputMethodContextImplWPEPrivate {
+    GRefPtr<WPEInputMethodContext> context;
+};
+
+WEBKIT_DEFINE_FINAL_TYPE(WebKitInputMethodContextImplWPE, webkit_input_method_context_impl_wpe, WEBKIT_TYPE_INPUT_METHOD_CONTEXT, WebKitInputMethodContext)
+
+static WPEInputPurpose toWPEInputPurpose(WebKitInputPurpose purpose)
+{
+    switch (purpose) {
+    case WEBKIT_INPUT_PURPOSE_FREE_FORM:
+        return WPE_INPUT_PURPOSE_FREE_FORM;
+    case WEBKIT_INPUT_PURPOSE_DIGITS:
+        return WPE_INPUT_PURPOSE_DIGITS;
+    case WEBKIT_INPUT_PURPOSE_NUMBER:
+        return WPE_INPUT_PURPOSE_NUMBER;
+    case WEBKIT_INPUT_PURPOSE_PHONE:
+        return WPE_INPUT_PURPOSE_PHONE;
+    case WEBKIT_INPUT_PURPOSE_URL:
+        return WPE_INPUT_PURPOSE_URL;
+    case WEBKIT_INPUT_PURPOSE_EMAIL:
+        return WPE_INPUT_PURPOSE_EMAIL;
+    case WEBKIT_INPUT_PURPOSE_PASSWORD:
+        return WPE_INPUT_PURPOSE_PASSWORD;
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+static WPEInputHints toWPEInputHints(WebKitInputHints hints)
+{
+    unsigned wpeHints = 0;
+    if (hints & WEBKIT_INPUT_HINT_SPELLCHECK)
+        wpeHints |= WPE_INPUT_HINT_SPELLCHECK;
+    if (hints & WEBKIT_INPUT_HINT_LOWERCASE)
+        wpeHints |= WPE_INPUT_HINT_LOWERCASE;
+    if (hints & WEBKIT_INPUT_HINT_UPPERCASE_CHARS)
+        wpeHints |= WPE_INPUT_HINT_UPPERCASE_CHARS;
+    if (hints & WEBKIT_INPUT_HINT_UPPERCASE_WORDS)
+        wpeHints |= WPE_INPUT_HINT_UPPERCASE_WORDS;
+    if (hints & WEBKIT_INPUT_HINT_UPPERCASE_SENTENCES)
+        wpeHints |= WPE_INPUT_HINT_UPPERCASE_SENTENCES;
+    if (hints & WEBKIT_INPUT_HINT_INHIBIT_OSK)
+        wpeHints |= WPE_INPUT_HINT_INHIBIT_OSK;
+    return static_cast<WPEInputHints>(wpeHints);
+}
+
+static void inputPurposeChangedCallback(WebKitInputMethodContextImplWPE* context)
+{
+    g_object_set(context->priv->context.get(), "input-purpose", toWPEInputPurpose(webkit_input_method_context_get_input_purpose(WEBKIT_INPUT_METHOD_CONTEXT(context))), nullptr);
+}
+
+static void inputHintsChangedCallback(WebKitInputMethodContextImplWPE* context)
+{
+    g_object_set(context->priv->context.get(), "input-hints", toWPEInputHints(webkit_input_method_context_get_input_hints(WEBKIT_INPUT_METHOD_CONTEXT(context))), nullptr);
+}
+
+static void wpeIMContextPreeditStartCallback(WebKitInputMethodContextImplWPE* context)
+{
+    g_signal_emit_by_name(context, "preedit-started", nullptr);
+}
+
+static void wpeIMContextPreeditChangedCallback(WebKitInputMethodContextImplWPE* context)
+{
+    g_signal_emit_by_name(context, "preedit-changed", nullptr);
+}
+
+static void wpeIMContextPreeditEndCallback(WebKitInputMethodContextImplWPE* context)
+{
+    g_signal_emit_by_name(context, "preedit-finished", nullptr);
+}
+
+static void wpeIMContextCommitCallback(WebKitInputMethodContextImplWPE* context, const char* text)
+{
+    g_signal_emit_by_name(context, "committed", text, nullptr);
+}
+
+static void wpeIMContextDeleteSurrounding(WebKitInputMethodContextImplWPE* context, gint offset, guint characterCount)
+{
+    g_signal_emit_by_name(context, "delete-surrounding", offset, characterCount, nullptr);
+}
+
+static void webkitInputMethodContextImplWPEGetPreedit(WebKitInputMethodContext* context, char** text, GList** underlines, guint* cursorOffset)
+{
+    auto* priv = WEBKIT_INPUT_METHOD_CONTEXT_IMPL_WPE(context)->priv;
+    GList* wpeUnderlines = nullptr;
+    guint offset;
+    wpe_input_method_context_get_preedit_string(priv->context.get(), text, underlines ? &wpeUnderlines : nullptr, &offset);
+
+    if (underlines) {
+        *underlines = nullptr;
+
+        if (wpeUnderlines) {
+            for (auto* it = wpeUnderlines; it; it = g_list_next(it)) {
+                auto* wpeUnderline = static_cast<WPEInputMethodUnderline*>(it->data);
+                auto* wpeColor = wpe_input_method_underline_get_color(wpeUnderline);
+                auto* underline = webkit_input_method_underline_new(
+                    clampTo<unsigned>(wpe_input_method_underline_get_start_offset(wpeUnderline)),
+                    clampTo<unsigned>(wpe_input_method_underline_get_end_offset(wpeUnderline)));
+                WebKitColor color = { wpeColor->red, wpeColor->green, wpeColor->blue, wpeColor->alpha };
+                webkit_input_method_underline_set_color(underline, &color);
+
+                *underlines = g_list_prepend(*underlines, underline);
+            }
+            g_list_free_full(wpeUnderlines, reinterpret_cast<GDestroyNotify>(wpe_input_method_underline_free));
+        }
+    }
+
+    if (cursorOffset)
+        *cursorOffset = clampTo<unsigned>(offset);
+}
+
+static void webkitInputMethodContextImplWPENotifyFocusIn(WebKitInputMethodContext* context)
+{
+    auto* priv = WEBKIT_INPUT_METHOD_CONTEXT_IMPL_WPE(context)->priv;
+    wpe_input_method_context_focus_in(priv->context.get());
+}
+
+static void webkitInputMethodContextImplWPENotifyFocusOut(WebKitInputMethodContext* context)
+{
+    auto* priv = WEBKIT_INPUT_METHOD_CONTEXT_IMPL_WPE(context)->priv;
+    wpe_input_method_context_focus_out(priv->context.get());
+}
+
+static void webkitInputMethodContextImplWPENotifyCursorArea(WebKitInputMethodContext* context, int x, int y, int width, int height)
+{
+    auto* priv = WEBKIT_INPUT_METHOD_CONTEXT_IMPL_WPE(context)->priv;
+    wpe_input_method_context_set_cursor_area(priv->context.get(), x, y, width, height);
+}
+
+static void webkitInputMethodContextImplWPENotifySurrounding(WebKitInputMethodContext* context, const gchar* text, unsigned length, unsigned cursorIndex, unsigned selectionIndex)
+{
+    auto* priv = WEBKIT_INPUT_METHOD_CONTEXT_IMPL_WPE(context)->priv;
+    wpe_input_method_context_set_surrounding(priv->context.get(), text, length, cursorIndex, selectionIndex);
+}
+
+static void webkitInputMethodContextImplWPEReset(WebKitInputMethodContext* context)
+{
+    auto* priv = WEBKIT_INPUT_METHOD_CONTEXT_IMPL_WPE(context)->priv;
+    wpe_input_method_context_reset(priv->context.get());
+}
+
+static void webkit_input_method_context_impl_wpe_class_init(WebKitInputMethodContextImplWPEClass* klass)
+{
+    auto* imClass = WEBKIT_INPUT_METHOD_CONTEXT_CLASS(klass);
+    imClass->get_preedit = webkitInputMethodContextImplWPEGetPreedit;
+    imClass->notify_focus_in = webkitInputMethodContextImplWPENotifyFocusIn;
+    imClass->notify_focus_out = webkitInputMethodContextImplWPENotifyFocusOut;
+    imClass->notify_cursor_area = webkitInputMethodContextImplWPENotifyCursorArea;
+    imClass->notify_surrounding = webkitInputMethodContextImplWPENotifySurrounding;
+    imClass->reset = webkitInputMethodContextImplWPEReset;
+}
+
+WebKitInputMethodContext* webkitInputMethodContextImplWPENew(WPEView *view)
+{
+    auto* context = WEBKIT_INPUT_METHOD_CONTEXT(g_object_new(WEBKIT_TYPE_INPUT_METHOD_CONTEXT_IMPL_WPE, nullptr));
+
+    g_signal_connect_swapped(context, "notify::input-purpose", G_CALLBACK(inputPurposeChangedCallback), context);
+    g_signal_connect_swapped(context, "notify::input-hints", G_CALLBACK(inputHintsChangedCallback), context);
+
+    auto* priv = WEBKIT_INPUT_METHOD_CONTEXT_IMPL_WPE(context)->priv;
+    priv->context = adoptGRef(wpe_input_method_context_new(view) );
+
+    g_signal_connect_object(priv->context.get(), "preedit-started", G_CALLBACK(wpeIMContextPreeditStartCallback), context, G_CONNECT_SWAPPED);
+    g_signal_connect_object(priv->context.get(), "preedit-changed", G_CALLBACK(wpeIMContextPreeditChangedCallback), context, G_CONNECT_SWAPPED);
+    g_signal_connect_object(priv->context.get(), "preedit-finished", G_CALLBACK(wpeIMContextPreeditEndCallback), context, G_CONNECT_SWAPPED);
+    g_signal_connect_object(priv->context.get(), "committed", G_CALLBACK(wpeIMContextCommitCallback), context, G_CONNECT_SWAPPED);
+    g_signal_connect_object(priv->context.get(), "delete-surrounding", G_CALLBACK(wpeIMContextDeleteSurrounding), context, G_CONNECT_SWAPPED);
+
+    return context;
+}
+
+#endif // ENABLE(WPE_PLATFORM)

--- a/Source/WebKit/UIProcess/API/wpe/WebKitInputMethodContextImplWPE.h
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitInputMethodContextImplWPE.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include "WebKitInputMethodContext.h"
+
+#if ENABLE(WPE_PLATFORM)
+
+#include <glib-object.h>
+
+typedef struct _WPEView WPEView;
+
+G_BEGIN_DECLS
+
+#define WEBKIT_TYPE_INPUT_METHOD_CONTEXT_IMPL_WPE (webkit_input_method_context_impl_wpe_get_type())
+G_DECLARE_FINAL_TYPE (WebKitInputMethodContextImplWPE, webkit_input_method_context_impl_wpe, WEBKIT, INPUT_METHOD_CONTEXT_IMPL_WPE, WebKitInputMethodContext)
+
+WebKitInputMethodContext* webkitInputMethodContextImplWPENew(WPEView *view);
+
+G_END_DECLS
+
+#endif // ENABLE(WPE_PLATFORM)

--- a/Source/WebKit/WPEPlatform/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/CMakeLists.txt
@@ -16,10 +16,12 @@ set(WPEPlatform_SOURCES
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferDMABuf.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferDMABufFormats.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferSHM.cpp
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEColor.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPECursorTheme.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEDisplay.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEEGLError.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEExtensions.cpp
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEInputMethodContext.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeyUnicode.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeymap.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeymapXKB.cpp
@@ -36,9 +38,11 @@ set(WPEPlatform_INSTALLED_HEADERS
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferDMABuf.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferDMABufFormats.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferSHM.h
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEColor.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEDefines.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEDisplay.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEEGLError.h
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEInputMethodContext.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeyUnicode.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeymap.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeymapXKB.h

--- a/Source/WebKit/WPEPlatform/wpe/WPEColor.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEColor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,17 +23,50 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "WPEColor.h"
 
-#include "WPEDisplayWayland.h"
-#include "WPEMonitor.h"
-#include "WPEWaylandCursor.h"
-#include "WPEWaylandSeat.h"
+/**
+ * WPEColor:
+ * @red: Red channel, between 0.0 and 1.0 inclusive
+ * @green: Green channel, between 0.0 and 1.0 inclusive
+ * @blue: Blue channel, between 0.0 and 1.0 inclusive
+ * @alpha: Alpha channel, between 0.0 and 1.0 inclusive
+ *
+ * Boxed type representing a RGBA color.
+ */
 
-struct xdg_wm_base* wpeDisplayWaylandGetXDGWMBase(WPEDisplayWayland*);
-WPE::WaylandSeat* wpeDisplayWaylandGetSeat(WPEDisplayWayland*);
-WPE::WaylandCursor* wpeDisplayWaylandGetCursor(WPEDisplayWayland*);
-WPEMonitor* wpeDisplayWaylandFindMonitor(WPEDisplayWayland*, struct wl_output*);
-struct zwp_linux_dmabuf_v1* wpeDisplayWaylandGetLinuxDMABuf(WPEDisplayWayland*);
-struct zwp_text_input_v1* wpeDisplayWaylandGetTextInputV1(WPEDisplayWayland*);
-struct zwp_text_input_v3* wpeDisplayWaylandGetTextInputV3(WPEDisplayWayland*);
+/**
+ * wpe_color_copy:
+ * @color: a #WPEColor
+ *
+ * Make a copy of @color.
+ *
+ * Returns: (transfer full): A copy of passed in #WPEColor.
+ */
+WPEColor* wpe_color_copy(WPEColor* color)
+{
+    g_return_val_if_fail(color, nullptr);
+
+    WPEColor* copy = static_cast<WPEColor*>(fastZeroedMalloc(sizeof(WPEColor)));
+    copy->red = color->red;
+    copy->green = color->green;
+    copy->blue = color->blue;
+    copy->alpha = color->alpha;
+    return copy;
+}
+
+/**
+ * wpe_color_free:
+ * @color: a #WPEColor
+ *
+ * Free the #WPEColor.
+ */
+void wpe_color_free(WPEColor* color)
+{
+    g_return_if_fail(color);
+
+    fastFree(color);
+}
+
+G_DEFINE_BOXED_TYPE(WPEColor, wpe_color, wpe_color_copy, wpe_color_free)

--- a/Source/WebKit/WPEPlatform/wpe/WPEColor.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEColor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,17 +23,31 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#ifndef WPEColor_h
+#define WPEColor_h
 
-#include "WPEDisplayWayland.h"
-#include "WPEMonitor.h"
-#include "WPEWaylandCursor.h"
-#include "WPEWaylandSeat.h"
+#if !defined(__WPE_PLATFORM_H_INSIDE__) && !defined(BUILDING_WEBKIT)
+#error "Only <wpe/wpe-platform.h> can be included directly."
+#endif
 
-struct xdg_wm_base* wpeDisplayWaylandGetXDGWMBase(WPEDisplayWayland*);
-WPE::WaylandSeat* wpeDisplayWaylandGetSeat(WPEDisplayWayland*);
-WPE::WaylandCursor* wpeDisplayWaylandGetCursor(WPEDisplayWayland*);
-WPEMonitor* wpeDisplayWaylandFindMonitor(WPEDisplayWayland*, struct wl_output*);
-struct zwp_linux_dmabuf_v1* wpeDisplayWaylandGetLinuxDMABuf(WPEDisplayWayland*);
-struct zwp_text_input_v1* wpeDisplayWaylandGetTextInputV1(WPEDisplayWayland*);
-struct zwp_text_input_v3* wpeDisplayWaylandGetTextInputV3(WPEDisplayWayland*);
+#include <glib-object.h>
+#include <wpe/WPEDefines.h>
+
+G_BEGIN_DECLS
+
+struct _WPEColor {
+    gdouble red;
+    gdouble green;
+    gdouble blue;
+    gdouble alpha;
+};
+
+typedef struct _WPEColor WPEColor;
+
+#define WPE_TYPE_COLOR (wpe_color_get_type())
+
+WPE_API GType wpe_color_get_type (void);
+
+G_END_DECLS
+
+#endif /* WPEColor_h */

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
@@ -523,3 +523,9 @@ const char* wpe_display_get_drm_render_node(WPEDisplay* display)
     auto* wpeDisplayClass = WPE_DISPLAY_GET_CLASS(display);
     return wpeDisplayClass->get_drm_render_node ? wpeDisplayClass->get_drm_render_node(display) : nullptr;
 }
+
+WPEInputMethodContext* wpeDisplayCreateInputMethodContext(WPEDisplay* display)
+{
+    auto* wpeDisplayClass = WPE_DISPLAY_GET_CLASS(display);
+    return wpeDisplayClass->create_input_method_context ? wpeDisplayClass->create_input_method_context(display) : nullptr;
+}

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
@@ -33,6 +33,7 @@
 #include <glib-object.h>
 #include <wpe/WPEBufferDMABufFormats.h>
 #include <wpe/WPEDefines.h>
+#include <wpe/WPEInputMethodContext.h>
 #include <wpe/WPEKeymap.h>
 #include <wpe/WPEMonitor.h>
 #include <wpe/WPEView.h>
@@ -61,6 +62,8 @@ struct _WPEDisplayClass
                                                                guint       index);
     const char             *(* get_drm_device)                (WPEDisplay *display);
     const char             *(* get_drm_render_node)           (WPEDisplay *display);
+
+    WPEInputMethodContext   *(* create_input_method_context)    (WPEDisplay *display);
 
     gpointer padding[32];
 };

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplayPrivate.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplayPrivate.h
@@ -29,3 +29,4 @@
 
 WPEView* wpeDisplayCreateView(WPEDisplay*);
 bool wpeDisplayCheckEGLExtension(WPEDisplay*, const char*);
+WPEInputMethodContext* wpeDisplayCreateInputMethodContext(WPEDisplay*);

--- a/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.cpp
@@ -1,0 +1,498 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEInputMethodContext.h"
+
+#include "WPEDisplayPrivate.h"
+#include "WPEEnumTypes.h"
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/WTFGType.h>
+
+struct _WPEInputMethodUnderline {
+    _WPEInputMethodUnderline(unsigned startOffset, unsigned endOffset)
+        : startOffset(startOffset)
+        , endOffset(endOffset)
+    {
+    }
+
+    guint startOffset { 0 };
+    guint endOffset { 0 };
+    WPEColor color { 0., 0., 0., 1. };
+};
+
+/**
+ * WPEInputMethodUnderline:
+ *
+ * Range of text in an preedit string to be shown underlined.
+ */
+
+G_DEFINE_BOXED_TYPE(WPEInputMethodUnderline, wpe_input_method_underline, wpe_input_method_underline_copy, wpe_input_method_underline_free)
+
+/**
+ * wpe_input_method_underline_new:
+ * @start_offset: the start offset in preedit string
+ * @end_offset: the end offset in preedit string
+ *
+ * Create a new #WPEInputMethodUnderline for the given range in preedit string
+ *
+ * Returns: (transfer full): A newly created #WPEInputMethodUnderline
+ */
+WPEInputMethodUnderline* wpe_input_method_underline_new(guint startOffset, guint endOffset)
+{
+    auto* underline = static_cast<WPEInputMethodUnderline*>(fastMalloc(sizeof(WPEInputMethodUnderline)));
+    new (underline) WPEInputMethodUnderline(startOffset, endOffset);
+    return underline;
+}
+
+/**
+ * wpe_input_method_underline_copy:
+ * @underline: a #WPEInputMethodUnderline
+ *
+ * Make a copy of the #WPEInputMethodUnderline.
+ *
+ * Returns: (transfer full): A copy of passed in #WPEInputMethodUnderline
+ */
+WPEInputMethodUnderline* wpe_input_method_underline_copy(WPEInputMethodUnderline* underline)
+{
+    g_return_val_if_fail(underline, nullptr);
+
+    auto* copyUnderline = static_cast<WPEInputMethodUnderline*>(fastMalloc(sizeof(WPEInputMethodUnderline)));
+    new (copyUnderline) WPEInputMethodUnderline(underline->startOffset, underline->endOffset);
+    return copyUnderline;
+}
+
+/**
+ * wpe_input_method_underline_free:
+ * @underline: A #WPEInputMethodUnderline
+ *
+ * Free the #WPEInputMethodUnderline.
+ */
+void wpe_input_method_underline_free(WPEInputMethodUnderline* underline)
+{
+    g_return_if_fail(underline);
+
+    underline->~WPEInputMethodUnderline();
+    fastFree(underline);
+}
+
+/**
+ * wpe_input_method_underline_get_start_offset:
+ * @underline: a #WPEInputMethodUnderline
+ *
+ * Returns: the underline start offset
+ */
+guint wpe_input_method_underline_get_start_offset(WPEInputMethodUnderline* underline)
+{
+    g_return_val_if_fail(underline, 0);
+
+    return underline->startOffset;
+}
+
+/**
+ * wpe_input_method_underline_get_end_offset:
+ * @underline: a #WPEInputMethodUnderline
+ *
+ * Returns: the underline end offset
+ */
+guint wpe_input_method_underline_get_end_offset(WPEInputMethodUnderline* underline)
+{
+    g_return_val_if_fail(underline, 0);
+
+    return underline->endOffset;
+}
+
+/**
+ * wpe_input_method_underline_set_color:
+ * @underline: a #WPEInputMethodUnderline
+ * @color: (nullable): a #WPEColor or %NULL
+ *
+ * Set the color of the underline. If @color is %NULL the foreground text color will be used
+ * for the underline too.
+ */
+void wpe_input_method_underline_set_color(WPEInputMethodUnderline* underline, const WPEColor* color)
+{
+    if (!color) {
+        underline->color.red = color->red;
+        underline->color.green = color->green;
+        underline->color.blue = color->blue;
+        underline->color.alpha = color->alpha;
+    }
+}
+
+/**
+ * wpe_input_method_underline_get_color:
+ * @underline: a #WPEInputMethodUnderline
+ *
+ * Returns: the underline color.
+ */
+const WPEColor* wpe_input_method_underline_get_color(WPEInputMethodUnderline* underline)
+{
+    g_return_val_if_fail(underline, nullptr);
+
+    return &underline->color;
+}
+
+struct _WPEInputMethodContextPrivate {
+    WPEView* view;
+    WPEInputPurpose purpose;
+    WPEInputHints hints;
+};
+
+WEBKIT_DEFINE_ABSTRACT_TYPE(WPEInputMethodContext, wpe_input_method_context, G_TYPE_OBJECT)
+
+enum {
+    PREEDIT_STARTED,
+    PREEDIT_CHANGED,
+    PREEDIT_FINISHED,
+    COMMITTED,
+    DELETE_SURROUNDING,
+    LAST_SIGNAL
+};
+
+enum {
+    PROP_0,
+    PROP_INPUT_PURPOSE,
+    PROP_INPUT_HINTS,
+    N_PROPERTIES
+};
+
+static guint signals[LAST_SIGNAL] = { 0, };
+static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
+
+static void wpeInputMethodContextSetProperty(GObject* object, guint propId, const GValue* value, GParamSpec* paramSpec)
+{
+    auto* ime = WPE_INPUT_METHOD_CONTEXT(object);
+
+    switch (propId) {
+    case PROP_INPUT_PURPOSE:
+        if (ime->priv->purpose != g_value_get_enum(value)) {
+            ime->priv->purpose = static_cast<WPEInputPurpose>(g_value_get_enum(value));
+            g_object_notify_by_pspec(object, paramSpec);
+        }
+        break;
+    case PROP_INPUT_HINTS:
+        if (ime->priv->hints != g_value_get_flags(value))  {
+            ime->priv->hints =  static_cast<WPEInputHints>(g_value_get_flags(value));
+            g_object_notify_by_pspec(object, paramSpec);
+        }
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
+    }
+}
+
+static void wpeInputMethodContextGetProperty(GObject* object, guint propId, GValue* value, GParamSpec* paramSpec)
+{
+    auto* ime = WPE_INPUT_METHOD_CONTEXT(object);
+
+    switch (propId) {
+    case PROP_INPUT_PURPOSE:
+        g_value_set_enum(value, ime->priv->purpose);
+        break;
+    case PROP_INPUT_HINTS:
+        g_value_set_flags(value, ime->priv->hints);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
+    }
+}
+
+static void wpe_input_method_context_class_init(WPEInputMethodContextClass* klass)
+{
+    GObjectClass* objectClass = G_OBJECT_CLASS(klass);
+    objectClass->set_property = wpeInputMethodContextSetProperty;
+    objectClass->get_property = wpeInputMethodContextGetProperty;
+
+    /**
+     * WPEInputMethodContext:input-purpose:
+     *
+     * The purpose of the text field that the #WPEInputMethodContext is connected to.
+     *
+     * This property can be used by on-screen keyboards and other input
+     * methods to adjust their behaviour.
+     */
+    sObjProperties[PROP_INPUT_PURPOSE] =
+        g_param_spec_enum(
+            "input-purpose",
+            nullptr, nullptr,
+            WPE_TYPE_INPUT_PURPOSE,
+            WPE_INPUT_PURPOSE_FREE_FORM,
+            static_cast<GParamFlags>(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY));
+
+    /**
+     * WPEInputMethodContext:input-hints:
+     *
+     * Additional hints that allow input methods to fine-tune
+     * their behaviour.
+     */
+    sObjProperties[PROP_INPUT_HINTS] =
+        g_param_spec_flags(
+            "input-hints",
+            nullptr, nullptr,
+            WPE_TYPE_INPUT_HINTS,
+            WPE_INPUT_HINT_NONE,
+            static_cast<GParamFlags>(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY));
+
+    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties);
+
+     /**
+     * WPEInputMethodContextClass::preedit-started:
+     * @context: the #WPEInputMethodContextClass on which the signal is emitted
+     *
+     * Emitted when a new preediting sequence starts.
+     */
+    signals[PREEDIT_STARTED] = g_signal_new(
+        "preedit-started",
+        G_TYPE_FROM_CLASS(klass),
+        G_SIGNAL_RUN_LAST,
+        0, nullptr, nullptr,
+        g_cclosure_marshal_generic,
+        G_TYPE_NONE, 0);
+
+    /**
+     * WPEInputMethodContext::preedit-changed:
+     * @context: the #WPEInputMethodContext on which the signal is emitted
+     *
+     * Emitted whenever the preedit sequence currently being entered has changed.
+     * It is also emitted at the end of a preedit sequence, in which case
+     * wpe_input_method_context_get_preedit() returns the empty string.
+     */
+    signals[PREEDIT_CHANGED] = g_signal_new(
+        "preedit-changed",
+        G_TYPE_FROM_CLASS(klass),
+        G_SIGNAL_RUN_LAST,
+        0, nullptr, nullptr,
+        g_cclosure_marshal_generic,
+        G_TYPE_NONE, 0);
+
+    /**
+     * WPEInputMethodContext::preedit-finished:
+     * @context: the #WPEInputMethodContext on which the signal is emitted
+     *
+     * Emitted when a preediting sequence has been completed or canceled.
+     */
+    signals[PREEDIT_FINISHED] = g_signal_new(
+        "preedit-finished",
+        G_TYPE_FROM_CLASS(klass),
+        G_SIGNAL_RUN_LAST,
+        0, nullptr, nullptr,
+        g_cclosure_marshal_generic,
+        G_TYPE_NONE, 0);
+
+    /**
+     * WPEInputMethodContext::committed:
+     * @context: the #WPEInputMethodContext on which the signal is emitted
+     * @text: the string result
+     *
+     * Emitted when a complete input sequence has been entered by the user.
+     * This can be a single character immediately after a key press or the
+     * final result of preediting.
+     */
+    signals[COMMITTED] = g_signal_new(
+        "committed",
+        G_TYPE_FROM_CLASS(klass),
+        G_SIGNAL_RUN_LAST,
+        0, nullptr, nullptr,
+        g_cclosure_marshal_generic,
+        G_TYPE_NONE, 1,
+        G_TYPE_STRING);
+
+    /**
+     * WPEInputMethodContext::delete-surrounding:
+     * @context: the #WPEInputMethodContext on which the signal is emitted
+     * @offset: the character offset from the cursor position of the text to be deleted.
+     * @n_chars: the number of characters to be deleted
+     *
+     * Emitted when the input method wants to delete the context surrounding the cursor.
+     * If @offset is a negative value, it means a position before the cursor.
+     */
+    signals[DELETE_SURROUNDING] = g_signal_new(
+        "delete-surrounding",
+        G_TYPE_FROM_CLASS(klass),
+        G_SIGNAL_RUN_LAST,
+        0, nullptr, nullptr,
+        g_cclosure_marshal_generic,
+        G_TYPE_NONE, 2,
+        G_TYPE_INT,
+        G_TYPE_UINT);
+}
+
+/**
+ * wpe_input_method_context_new:
+ * @view: a #WPEView
+ *
+ * Create a new #WPEInputMethodContext for @view
+ *
+ * Returns: (transfer full) (nullable): a #WPEInputMethodContext, or %NULL
+ */
+WPEInputMethodContext* wpe_input_method_context_new(WPEView* view)
+{
+    g_return_val_if_fail(WPE_IS_VIEW(view), nullptr);
+
+    auto display = wpe_view_get_display(view);
+    auto imeContext = wpeDisplayCreateInputMethodContext(display);
+    imeContext->priv->view = view;
+    return imeContext;
+}
+
+/**
+ * wpe_input_method_context_get_view:
+ * @context: a #WPEInputMethodContext
+ *
+ * Get the #WPEView of @context
+ *
+ * Returns: (transfer none): a #WPEView
+ */
+
+WPEView* wpe_input_method_context_get_view(WPEInputMethodContext   *context)
+{
+    g_return_val_if_fail(WPE_IS_INPUT_METHOD_CONTEXT(context), nullptr);
+
+    return context->priv->view;
+}
+
+/**
+ * wpe_input_method_context_get_display:
+ * @context: a #WPEInputMethodContext
+ *
+ * Get the #WPEDisplay of @context
+ *
+ * Returns: (transfer none): a #WPEDisplay
+ */
+WPEDisplay* wpe_input_method_context_get_display(WPEInputMethodContext* context)
+{
+    g_return_val_if_fail(WPE_IS_INPUT_METHOD_CONTEXT(context), nullptr);
+
+    return wpe_view_get_display(context->priv->view);
+}
+
+/**
+ * wpe_input_method_context_get_preedit_string:
+ * @context: a #WPEInputMethodContext
+ * @text: (out) (transfer full) (nullable): location to store the preedit string
+ * @underlines: (out) (transfer full) (nullable) (element-type WPEInputMethodUnderline): location to store the underlines as a #GList of #WPEInputMethodUnderline
+ * @cursor_offset: (out) (nullable): location to store the position of cursor in preedit string
+ *
+ * Get the pre-edit string and a list of WPEInputMethodUnderline.
+ *
+ * Get the current pre-edit string for the @context, and a list of WPEInputMethodUnderline to apply to the string.
+ * The string will be displayed inserted at @cursor_offset.
+ */
+void wpe_input_method_context_get_preedit_string(WPEInputMethodContext* context, char **text, GList** underlines, guint* cursorOffset)
+{
+    g_return_if_fail(WPE_IS_INPUT_METHOD_CONTEXT(context));
+
+    auto* imeClass = WPE_INPUT_METHOD_CONTEXT_GET_CLASS(context);
+    if (imeClass->get_preedit_string)
+        imeClass->get_preedit_string(context, text, underlines, cursorOffset);
+}
+
+/**
+ * wpe_input_method_context_focus_in:
+ * @context: a #WPEInputMethodContext
+ *
+ * Notify @context that input associated has gained focus.
+ */
+void wpe_input_method_context_focus_in(WPEInputMethodContext* context)
+{
+    g_return_if_fail(WPE_IS_INPUT_METHOD_CONTEXT(context));
+
+    auto* imeClass = WPE_INPUT_METHOD_CONTEXT_GET_CLASS(context);
+    if (imeClass->focus_in)
+        imeClass->focus_in(context);
+}
+
+/**
+ * wpe_input_method_context_focus_out:
+ * @context: a #WPEInputMethodContext
+ *
+ * Notify @context that input associated has lost focus.
+ */
+void wpe_input_method_context_focus_out(WPEInputMethodContext* context)
+{
+    g_return_if_fail(WPE_IS_INPUT_METHOD_CONTEXT(context));
+
+    auto* imeClass = WPE_INPUT_METHOD_CONTEXT_GET_CLASS(context);
+    if (imeClass->focus_out)
+        imeClass->focus_out(context);
+}
+
+/**
+ * wpe_input_method_context_set_cursor_area:
+ * @context: a #WPEInputMethodContext
+ * @x: the x coordinate of cursor location
+ * @y: the y coordinate of cursor location
+ * @width: the width of cursor area
+ * @height: the height of cursor area
+ *
+ * Notify @context that cursor area changed in input associated.
+ */
+void wpe_input_method_context_set_cursor_area(WPEInputMethodContext* context, int x, int y, int width, int height)
+{
+    g_return_if_fail(WPE_IS_INPUT_METHOD_CONTEXT(context));
+
+    auto* imeClass = WPE_INPUT_METHOD_CONTEXT_GET_CLASS(context);
+    if (imeClass->set_cursor_area)
+        imeClass->set_cursor_area(context, x, y, width, height);
+}
+
+/**
+ * wpe_input_method_context_set_surrounding:
+ * @context: a #WPEInputMethodContext
+ * @text: text surrounding the insertion point
+ * @length: the length of @text, or -1 if @text is nul-terminated
+ * @cursor_index: the byte index of the insertion cursor within @text.
+ * @selection_index: the byte index of the selection cursor within @text.
+ *
+ * Notify @context that the context surrounding the cursor has changed.
+ *
+ * If there's no selection @selection_index is the same as @cursor_index.
+ */
+void wpe_input_method_context_set_surrounding(WPEInputMethodContext* context, const char* text, guint length, guint cursorIndex, guint selectionIndex)
+{
+    g_return_if_fail(WPE_IS_INPUT_METHOD_CONTEXT(context));
+
+    auto* imeClass = WPE_INPUT_METHOD_CONTEXT_GET_CLASS(context);
+    if (imeClass->set_surrounding)
+        imeClass->set_surrounding(context, text, length, cursorIndex, selectionIndex);
+}
+
+/**
+ * wpe_input_method_context_reset:
+ * @context: a #WPEInputMethodContext
+ *
+ * Reset the @context.
+ *
+ * This will typically cause the input to clear the preedit state.
+ */
+void wpe_input_method_context_reset(WPEInputMethodContext* context)
+{
+    g_return_if_fail(WPE_IS_INPUT_METHOD_CONTEXT(context));
+
+    auto* imeClass = WPE_INPUT_METHOD_CONTEXT_GET_CLASS(context);
+    if (imeClass->reset)
+        imeClass->reset(context);
+}

--- a/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.h
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef WPEInputMethodContext_h
+#define WPEInputMethodContext_h
+
+#if !defined(__WPE_PLATFORM_H_INSIDE__) && !defined(BUILDING_WEBKIT)
+#error "Only <wpe/wpe-platform.h> can be included directly."
+#endif
+
+#include <glib-object.h>
+#include <wpe/WPEColor.h>
+#include <wpe/WPEDefines.h>
+
+G_BEGIN_DECLS
+
+#define WPE_TYPE_INPUT_METHOD_UNDERLINE (wpe_input_method_underline_get_type())
+#define WPE_TYPE_INPUT_METHOD_CONTEXT   (wpe_input_method_context_get_type())
+WPE_DECLARE_DERIVABLE_TYPE (WPEInputMethodContext, wpe_input_method_context, WPE, INPUT_METHOD_CONTEXT, GObject)
+
+typedef struct _WPEDisplay WPEDisplay;
+typedef struct _WPEView WPEView;
+
+/**
+ * WPEInputPurpose:
+ * @WPE_INPUT_PURPOSE_FREE_FORM: Allow any character
+ * @WPE_INPUT_PURPOSE_ALPHA: Allow only alphabetic characters
+ * @WPE_INPUT_PURPOSE_DIGITS: Allow only digits
+ * @WPE_INPUT_PURPOSE_NUMBER: Edited field expects numbers
+ * @WPE_INPUT_PURPOSE_PHONE: Edited field expects phone number
+ * @WPE_INPUT_PURPOSE_URL: Edited field expects URL
+ * @WPE_INPUT_PURPOSE_EMAIL: Edited field expects email address
+ * @WPE_INPUT_PURPOSE_NAME: Edited field expects the name of a person
+ * @WPE_INPUT_PURPOSE_PASSWORD: Like %WPE_INPUT_PURPOSE_FREE_FORM, but characters are hidden
+ * @WPE_INPUT_PURPOSE_PIN: Like %WPE_INPUT_PURPOSE_DIGITS, but characters are hidden
+ * @WPE_INPUT_PURPOSE_TERMINAL: Allow any character, in addition to control codes
+ *
+ * Describes primary purpose of the input widget.
+ *
+ * This information is useful for on-screen keyboards and similar input
+ * methods to decide which keys should be presented to the user.
+ */
+typedef enum
+{
+  WPE_INPUT_PURPOSE_FREE_FORM,
+  WPE_INPUT_PURPOSE_ALPHA,
+  WPE_INPUT_PURPOSE_DIGITS,
+  WPE_INPUT_PURPOSE_NUMBER,
+  WPE_INPUT_PURPOSE_PHONE,
+  WPE_INPUT_PURPOSE_URL,
+  WPE_INPUT_PURPOSE_EMAIL,
+  WPE_INPUT_PURPOSE_NAME,
+  WPE_INPUT_PURPOSE_PASSWORD,
+  WPE_INPUT_PURPOSE_PIN,
+  WPE_INPUT_PURPOSE_TERMINAL,
+} WPEInputPurpose;
+
+/**
+ * WPEInputHints:
+ * @WPE_INPUT_HINT_NONE: No special behaviour suggested
+ * @WPE_INPUT_HINT_SPELLCHECK: Suggest checking for typos
+ * @WPE_INPUT_HINT_NO_SPELLCHECK: Suggest not checking for typos
+ * @WPE_INPUT_HINT_WORD_COMPLETION: Suggest word completion
+ * @WPE_INPUT_HINT_LOWERCASE: Suggest to convert all text to lowercase
+ * @WPE_INPUT_HINT_UPPERCASE_CHARS: Suggest to capitalize all text
+ * @WPE_INPUT_HINT_UPPERCASE_WORDS: Suggest to capitalize the first
+ *   character of each word
+ * @WPE_INPUT_HINT_UPPERCASE_SENTENCES: Suggest to capitalize the
+ *   first word of each sentence
+ * @WPE_INPUT_HINT_INHIBIT_OSK: Suggest to not show an onscreen keyboard
+ *   (e.g for a calculator that already has all the keys).
+ * @WPE_INPUT_HINT_VERTICAL_WRITING: The text is vertical
+ * @WPE_INPUT_HINT_EMOJI: Suggest offering Emoji support
+ * @WPE_INPUT_HINT_NO_EMOJI: Suggest not offering Emoji support
+ * @WPE_INPUT_HINT_PRIVATE: Request that the input method should not
+ *    update personalized data (like typing history)
+ *
+ * Describes hints that might be taken into account by input methods
+ * or applications.
+ *
+ * Note that input methods may already tailor their behaviour according
+ * to the [enum@InputPurpose] of the entry.
+ *
+ * Some common sense is expected when using these flags - mixing
+ * %WPE_INPUT_HINT_LOWERCASE with any of the uppercase hints makes no sense.
+ */
+typedef enum
+{
+  WPE_INPUT_HINT_NONE                = 0,
+  WPE_INPUT_HINT_SPELLCHECK          = 1 << 0,
+  WPE_INPUT_HINT_NO_SPELLCHECK       = 1 << 1,
+  WPE_INPUT_HINT_WORD_COMPLETION     = 1 << 2,
+  WPE_INPUT_HINT_LOWERCASE           = 1 << 3,
+  WPE_INPUT_HINT_UPPERCASE_CHARS     = 1 << 4,
+  WPE_INPUT_HINT_UPPERCASE_WORDS     = 1 << 5,
+  WPE_INPUT_HINT_UPPERCASE_SENTENCES = 1 << 6,
+  WPE_INPUT_HINT_INHIBIT_OSK         = 1 << 7,
+  WPE_INPUT_HINT_VERTICAL_WRITING    = 1 << 8,
+  WPE_INPUT_HINT_EMOJI               = 1 << 9,
+  WPE_INPUT_HINT_NO_EMOJI            = 1 << 10,
+  WPE_INPUT_HINT_PRIVATE             = 1 << 11,
+} WPEInputHints;
+
+typedef struct _WPEInputMethodUnderline WPEInputMethodUnderline;
+
+struct _WPEInputMethodContextClass
+{
+    GObjectClass parent_class;
+
+    void     (* get_preedit_string) (WPEInputMethodContext *context,
+                                     gchar                 **text,
+                                     GList                 **underlines,
+                                     guint                 *cursor_offset);
+    void     (* focus_in)           (WPEInputMethodContext *context);
+    void     (* focus_out)          (WPEInputMethodContext *context);
+    void     (* set_cursor_area)    (WPEInputMethodContext *context,
+                                     int                    x,
+                                     int                    y,
+                                     int                    width,
+                                     int                    height);
+    void     (* set_surrounding)    (WPEInputMethodContext *context,
+                                     const gchar           *text,
+                                     guint                  length,
+                                     guint                  cursor_index,
+                                     guint                  selection_index);
+    void     (* reset)              (WPEInputMethodContext *context);
+
+    gpointer padding[32];
+};
+
+WPE_API WPEInputMethodContext   *wpe_input_method_context_new                (WPEView                 *view);
+WPE_API WPEView                 *wpe_input_method_context_get_view           (WPEInputMethodContext   *context);
+WPE_API WPEDisplay              *wpe_input_method_context_get_display        (WPEInputMethodContext   *context);
+WPE_API void                     wpe_input_method_context_get_preedit_string (WPEInputMethodContext   *context,
+                                                                              char                    **text,
+                                                                              GList                   **underlines,
+                                                                              guint                   *cursor_offset);
+WPE_API void                     wpe_input_method_context_focus_in           (WPEInputMethodContext   *context);
+WPE_API void                     wpe_input_method_context_focus_out          (WPEInputMethodContext   *context);
+WPE_API void                     wpe_input_method_context_set_cursor_area    (WPEInputMethodContext   *context,
+                                                                              int                      x,
+                                                                              int                      y,
+                                                                              int                      width,
+                                                                              int                      height);
+WPE_API void                     wpe_input_method_context_set_surrounding    (WPEInputMethodContext   *context,
+                                                                              const char              *text,
+                                                                              guint                    length,
+                                                                              guint                    cursor_index,
+                                                                              guint                    selection_index);
+WPE_API void                     wpe_input_method_context_reset              (WPEInputMethodContext   *context);
+
+WPE_API GType                    wpe_input_method_underline_get_type         (void);
+WPE_API WPEInputMethodUnderline *wpe_input_method_underline_new              (guint                    start_offset,
+                                                                              guint                    end_offset);
+WPE_API WPEInputMethodUnderline *wpe_input_method_underline_copy             (WPEInputMethodUnderline *underline);
+WPE_API void                     wpe_input_method_underline_free             (WPEInputMethodUnderline *underline);
+WPE_API guint                    wpe_input_method_underline_get_start_offset (WPEInputMethodUnderline *underline);
+WPE_API guint                    wpe_input_method_underline_get_end_offset   (WPEInputMethodUnderline *underline);
+WPE_API void                     wpe_input_method_underline_set_color        (WPEInputMethodUnderline *underline,
+                                                                              const WPEColor          *color);
+WPE_API const WPEColor          *wpe_input_method_underline_get_color        (WPEInputMethodUnderline *underline);
+
+G_END_DECLS
+
+#endif /* WPEInputMethodContext_h */

--- a/Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt
@@ -5,6 +5,8 @@ configure_file(wpe-platform-wayland-uninstalled.pc.in ${CMAKE_BINARY_DIR}/wpe-pl
 
 set(WPEPlatformWayland_SOURCES
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
+    ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV1.cpp
+    ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV3.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEMonitorWayland.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEWaylandCursor.cpp
@@ -12,6 +14,8 @@ set(WPEPlatformWayland_SOURCES
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEWaylandSHMPool.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/linux-dmabuf-unstable-v1-protocol.c
+    ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/text-input-unstable-v1-protocol.c
+    ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/text-input-unstable-v3-protocol.c
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/xdg-shell-protocol.c
 )
 
@@ -66,6 +70,32 @@ add_custom_command(
     OUTPUT ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/linux-dmabuf-unstable-v1-client-protocol.h
     MAIN_DEPENDENCY ${WAYLAND_PROTOCOLS_DATADIR}/unstable/linux-dmabuf/linux-dmabuf-unstable-v1.xml
     COMMAND ${WAYLAND_SCANNER} client-header ${WAYLAND_PROTOCOLS_DATADIR}/unstable/linux-dmabuf/linux-dmabuf-unstable-v1.xml ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/linux-dmabuf-unstable-v1-client-protocol.h
+    VERBATIM)
+
+add_custom_command(
+    OUTPUT ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/text-input-unstable-v1-protocol.c
+    MAIN_DEPENDENCY ${WAYLAND_PROTOCOLS_DATADIR}/unstable/text-input/text-input-unstable-v1.xml
+    DEPENDS ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/text-input-unstable-v1-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER} private-code ${WAYLAND_PROTOCOLS_DATADIR}/unstable/text-input/text-input-unstable-v1.xml ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/text-input-unstable-v1-protocol.c
+    VERBATIM)
+
+add_custom_command(
+    OUTPUT ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/text-input-unstable-v1-client-protocol.h
+    MAIN_DEPENDENCY ${WAYLAND_PROTOCOLS_DATADIR}/unstable/text-input/text-input-unstable-v1.xml
+    COMMAND ${WAYLAND_SCANNER} client-header ${WAYLAND_PROTOCOLS_DATADIR}/unstable/text-input/text-input-unstable-v1.xml ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/text-input-unstable-v1-client-protocol.h
+    VERBATIM)
+
+add_custom_command(
+    OUTPUT ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/text-input-unstable-v3-protocol.c
+    MAIN_DEPENDENCY ${WAYLAND_PROTOCOLS_DATADIR}/unstable/text-input/text-input-unstable-v3.xml
+    DEPENDS ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/text-input-unstable-v3-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER} private-code ${WAYLAND_PROTOCOLS_DATADIR}/unstable/text-input/text-input-unstable-v3.xml ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/text-input-unstable-v3-protocol.c
+    VERBATIM)
+
+add_custom_command(
+    OUTPUT ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/text-input-unstable-v3-client-protocol.h
+    MAIN_DEPENDENCY ${WAYLAND_PROTOCOLS_DATADIR}/unstable/text-input/text-input-unstable-v3.xml
+    COMMAND ${WAYLAND_SCANNER} client-header ${WAYLAND_PROTOCOLS_DATADIR}/unstable/text-input/text-input-unstable-v3.xml ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/text-input-unstable-v3-client-protocol.h
     VERBATIM)
 
 add_library(WPEPlatformWayland OBJECT ${WPEPlatformWayland_SOURCES})

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV1.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV1.cpp
@@ -1,0 +1,654 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEInputMethodContextWaylandV1.h"
+
+#include "WPEDisplayWaylandPrivate.h"
+#include "WPEViewWayland.h"
+
+#include "text-input-unstable-v1-client-protocol.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <wayland-client-protocol.h>
+#include <wtf/glib/GUniquePtr.h>
+#include <wtf/glib/WTFGType.h>
+#include <xkbcommon/xkbcommon.h>
+
+typedef struct _TextInputV1Global TextInputV1Global;
+
+struct _TextInputV1Global {
+    struct zwp_text_input_v1* textInput;
+
+    WPEInputMethodContext* current;
+
+    bool focused;
+
+    uint32_t serial;
+};
+
+struct _WPEIMContextWaylandV1Private {
+    struct {
+        GUniquePtr<char> text;
+        GList* underlines;
+        int32_t cursorIndex;
+    } preedit;
+
+    struct {
+        int32_t x;
+        int32_t y;
+        int32_t width;
+        int32_t height;
+    } cursorRect;
+
+    struct {
+        GUniquePtr<char> text;
+        uint32_t cursorIndex;
+        uint32_t anchorIndex;
+    } surrounding;
+
+    struct {
+        int32_t index;
+        uint32_t length;
+    } pendingSurroundingDelete;
+
+    struct {
+        xkb_mod_mask_t shiftMask;
+        xkb_mod_mask_t altMask;
+        xkb_mod_mask_t controlMask;
+    } modifiers;
+};
+
+WEBKIT_DEFINE_FINAL_TYPE(WPEIMContextWaylandV1, wpe_im_context_wayland_v1, WPE_TYPE_INPUT_METHOD_CONTEXT, WPEInputMethodContext)
+
+static TextInputV1Global* textInputV1GetGlobalByDisplay(WPEDisplayWayland* /*display*/);
+
+static TextInputV1Global* textInputV1GetGlobalByContext(WPEIMContextWaylandV1* self)
+{
+    if (wpe_input_method_context_get_view(WPE_INPUT_METHOD_CONTEXT(self)) == nullptr)
+        return nullptr;
+
+    auto* display = wpe_input_method_context_get_display(WPE_INPUT_METHOD_CONTEXT(self));
+    auto* global = textInputV1GetGlobalByDisplay(WPE_DISPLAY_WAYLAND(display));
+    if (global->current != WPE_INPUT_METHOD_CONTEXT(self))
+        return nullptr;
+    if (global->textInput == nullptr)
+        return nullptr;
+
+    return global;
+}
+
+static uint32_t toTextInputV1Hints(WPEInputHints inputHints, WPEInputPurpose purpose)
+{
+    uint32_t hints = 0;
+
+    if (inputHints & WPE_INPUT_HINT_WORD_COMPLETION)
+        hints |= ZWP_TEXT_INPUT_V1_CONTENT_HINT_AUTO_COMPLETION;
+    if (inputHints & WPE_INPUT_HINT_LOWERCASE)
+        hints |= ZWP_TEXT_INPUT_V1_CONTENT_HINT_LOWERCASE;
+    if (inputHints & WPE_INPUT_HINT_UPPERCASE_CHARS)
+        hints |= ZWP_TEXT_INPUT_V1_CONTENT_HINT_UPPERCASE;
+    if (inputHints & WPE_INPUT_HINT_UPPERCASE_WORDS)
+        hints |= ZWP_TEXT_INPUT_V1_CONTENT_HINT_TITLECASE;
+    if (inputHints & WPE_INPUT_HINT_UPPERCASE_SENTENCES)
+        hints |= ZWP_TEXT_INPUT_V1_CONTENT_HINT_AUTO_CAPITALIZATION;
+
+    if (purpose == WPE_INPUT_PURPOSE_PIN || purpose == WPE_INPUT_PURPOSE_PASSWORD)
+        hints |= (ZWP_TEXT_INPUT_V1_CONTENT_HINT_HIDDEN_TEXT | ZWP_TEXT_INPUT_V1_CONTENT_HINT_SENSITIVE_DATA);
+
+    return hints;
+}
+
+static uint32_t toTextInputV1Purpose(WPEInputPurpose purpose)
+{
+    switch (purpose) {
+    case WPE_INPUT_PURPOSE_FREE_FORM:
+        return ZWP_TEXT_INPUT_V1_CONTENT_PURPOSE_NORMAL;
+    case WPE_INPUT_PURPOSE_ALPHA:
+        return ZWP_TEXT_INPUT_V1_CONTENT_PURPOSE_ALPHA;
+    case WPE_INPUT_PURPOSE_DIGITS:
+        return ZWP_TEXT_INPUT_V1_CONTENT_PURPOSE_DIGITS;
+    case WPE_INPUT_PURPOSE_NUMBER:
+        return ZWP_TEXT_INPUT_V1_CONTENT_PURPOSE_NUMBER;
+    case WPE_INPUT_PURPOSE_PHONE:
+        return ZWP_TEXT_INPUT_V1_CONTENT_PURPOSE_PHONE;
+    case WPE_INPUT_PURPOSE_URL:
+        return ZWP_TEXT_INPUT_V1_CONTENT_PURPOSE_URL;
+    case WPE_INPUT_PURPOSE_EMAIL:
+        return ZWP_TEXT_INPUT_V1_CONTENT_PURPOSE_EMAIL;
+    case WPE_INPUT_PURPOSE_NAME:
+        return ZWP_TEXT_INPUT_V1_CONTENT_PURPOSE_NAME;
+    case WPE_INPUT_PURPOSE_PASSWORD:
+        return ZWP_TEXT_INPUT_V1_CONTENT_PURPOSE_PASSWORD;
+    case WPE_INPUT_PURPOSE_TERMINAL:
+        return ZWP_TEXT_INPUT_V1_CONTENT_PURPOSE_TERMINAL;
+    default:
+        g_assert_not_reached();
+    }
+
+    return ZWP_TEXT_INPUT_V1_CONTENT_PURPOSE_NORMAL;
+}
+
+static char* truncateSurroundingTextIfeeded(const char *text, uint32_t *cursorIndex, uint32_t *anchorIndex)
+{
+#define MAX_LEN 4000
+    unsigned len = strlen(text);
+
+    if (len < MAX_LEN)
+        return nullptr;
+
+    const char* start;
+    const char* end;
+    if (*cursorIndex < MAX_LEN && *anchorIndex < MAX_LEN) {
+        start = text;
+        end = &text[MAX_LEN];
+    } else if (*cursorIndex > len - MAX_LEN && *anchorIndex > len - MAX_LEN) {
+        start = &text[len - MAX_LEN];
+        end = &text[len];
+    } else {
+        unsigned selectionLen = std::abs(static_cast<int>(*cursorIndex - *anchorIndex));
+        if (selectionLen > MAX_LEN) {
+            /* This is unsupported, let's just ignore the selection. */
+            if (*cursorIndex < MAX_LEN) {
+                start = text;
+                end = &text[MAX_LEN];
+            } else if (*cursorIndex > len - MAX_LEN) {
+                start = &text[len - MAX_LEN];
+                end = &text[len];
+            } else {
+                start = &text[std::max(0u, *cursorIndex - (MAX_LEN / 2))];
+                end = &text[std::min(static_cast<unsigned>(MAX_LEN), *cursorIndex + (MAX_LEN / 2))];
+            }
+        } else {
+            unsigned mid = std::min(*cursorIndex, *anchorIndex) + (selectionLen / 2);
+            start = &text[std::max(0u, (mid - MAX_LEN) / 2)];
+            end = &text[std::min(static_cast<unsigned>(MAX_LEN), (mid + MAX_LEN / 2))];
+        }
+    }
+
+    if (start != text)
+        start = g_utf8_next_char(start);
+    if (end != &text[len])
+        end = g_utf8_find_prev_char(text, end);
+
+    *cursorIndex -= start - text;
+    *anchorIndex -= start - text;
+
+    return g_strndup(start, end - start);
+#undef MAX_LEN
+}
+
+static void textInputV1SetCursorRectangle(WPEIMContextWaylandV1* context)
+{
+    auto* global = textInputV1GetGlobalByContext(context);
+    if (global == nullptr)
+        return;
+
+    zwp_text_input_v1_set_cursor_rectangle(global->textInput,
+        context->priv->cursorRect.x,
+        context->priv->cursorRect.y,
+        context->priv->cursorRect.width,
+        context->priv->cursorRect.height);
+}
+
+static void textInputV1SetSurroundingText(WPEIMContextWaylandV1* context)
+{
+    auto* global = textInputV1GetGlobalByContext(context);
+    if (global == nullptr)
+        return;
+
+    if (!context->priv->surrounding.text)
+        return;
+
+    uint32_t cursorIndex = context->priv->surrounding.cursorIndex;
+    uint32_t anchorIndex = context->priv->surrounding.anchorIndex;
+    GUniquePtr<char> truncatedText(
+        truncateSurroundingTextIfeeded(context->priv->surrounding.text.get(),
+        &cursorIndex,
+        &anchorIndex));
+
+    zwp_text_input_v1_set_surrounding_text(global->textInput,
+        truncatedText ? truncatedText.get() : context->priv->surrounding.text.get(),
+        cursorIndex, anchorIndex);
+}
+
+static void textInputV1SetContentType(WPEIMContextWaylandV1* context)
+{
+    WPEInputHints hints;
+    WPEInputPurpose purpose;
+
+    auto* global = textInputV1GetGlobalByContext(context);
+    if (global == nullptr)
+        return;
+
+    g_object_get(context,
+        "input-hints", &hints,
+        "input-purpose", &purpose,
+        nullptr);
+
+    zwp_text_input_v1_set_content_type(global->textInput,
+        toTextInputV1Hints(hints, purpose),
+        toTextInputV1Purpose(purpose));
+}
+
+static void textInputV1CommitState(WPEIMContextWaylandV1* context)
+{
+    auto* global = textInputV1GetGlobalByContext(context);
+    if (global == nullptr)
+        return;
+
+    global->serial++;
+
+    zwp_text_input_v1_commit_state(global->textInput, global->serial);
+}
+
+static void textInputV1UpdateState(WPEIMContextWaylandV1* context)
+{
+    auto* global = textInputV1GetGlobalByContext(context);
+    if (global == nullptr)
+        return;
+
+    textInputV1SetSurroundingText(context);
+    textInputV1SetContentType(context);
+    textInputV1SetCursorRectangle(context);
+    textInputV1CommitState(context);
+}
+
+static xkb_mod_mask_t keysymModifiersGetMask(struct wl_array *map, const char *name)
+{
+    xkb_mod_index_t index = 0;
+    const char* p = static_cast<const char *>(map->data);
+
+    while (p < static_cast<const char *>(p + map->size)) {
+        if (!strcmp (p, name))
+            return 1 << index;
+
+        index++;
+        p += strlen(p) + 1;
+    }
+
+    return XKB_MOD_INVALID;
+}
+
+static const struct zwp_text_input_v1_listener textInputListenerV1 = {
+    // enter
+    [](void* data, struct zwp_text_input_v1* /*text_input*/, struct wl_surface* /*surface*/)
+    {
+        auto* global = static_cast<TextInputV1Global*>(data);
+
+        global->focused = true;
+
+        textInputV1UpdateState(WPE_IM_CONTEXT_WAYLAND_V1(global->current));
+    },
+    // leave
+    [](void *data, struct zwp_text_input_v1* /*text_input*/)
+    {
+        auto* global = static_cast<TextInputV1Global*>(data);
+
+        global->focused = false;
+    },
+    // modifiers_map
+    [](void* data, struct zwp_text_input_v1* /*text_input*/, struct wl_array* map)
+    {
+        auto* global = static_cast<TextInputV1Global*>(data);
+        if (global->current == nullptr)
+            return;
+
+        auto* priv = WPE_IM_CONTEXT_WAYLAND_V1(global->current)->priv;
+        priv->modifiers.shiftMask = keysymModifiersGetMask(map, XKB_MOD_NAME_SHIFT);
+        priv->modifiers.altMask = keysymModifiersGetMask(map, XKB_MOD_NAME_ALT);
+        priv->modifiers.controlMask = keysymModifiersGetMask(map, XKB_MOD_NAME_CTRL);
+    },
+    // input_panel_state
+    [](void* /*data*/, struct zwp_text_input_v1* /*text_input*/, uint32_t /*state*/)
+    {
+        // NOOP
+    },
+    // preedit_string
+    [](void* data, struct zwp_text_input_v1* /*text_input*/, uint32_t serial, const char* text, const char* /*commit*/)
+    {
+        auto* global = static_cast<TextInputV1Global*>(data);
+        if (global->current == nullptr)
+            return;
+
+        auto* priv = WPE_IM_CONTEXT_WAYLAND_V1(global->current)->priv;
+        bool valid = global->serial == serial;
+        if (valid && !priv->preedit.text)
+            g_signal_emit_by_name(global->current, "preedit-started");
+
+        priv->preedit.text.reset(g_strdup(text));
+        if (valid)
+            g_signal_emit_by_name(global->current, "preedit-changed");
+    },
+    // preedit_styling
+    [](void* data, struct zwp_text_input_v1* /*text_input*/, uint32_t index, uint32_t length, uint32_t style)
+    {
+        auto* global = static_cast<TextInputV1Global*>(data);
+        if (global->current == nullptr)
+            return;
+
+        if (style == ZWP_TEXT_INPUT_V1_PREEDIT_STYLE_NONE)
+            length = 0;
+
+        auto* underline = wpe_input_method_underline_new(index, index + length);
+        switch (style) {
+        case ZWP_TEXT_INPUT_V1_PREEDIT_STYLE_INCORRECT: {
+            WPEColor color = { 1., 0, 0, 1. };
+            wpe_input_method_underline_set_color(underline, &color);
+            break;
+        }
+        case ZWP_TEXT_INPUT_V1_PREEDIT_STYLE_HIGHLIGHT: {
+            WPEColor color = { 1., 1., 0., 1. };
+            wpe_input_method_underline_set_color(underline, &color);
+            break;
+        }
+        case ZWP_TEXT_INPUT_V1_PREEDIT_STYLE_ACTIVE: {
+            WPEColor color = { 0., 0., 1., 1. };
+            wpe_input_method_underline_set_color(underline, &color);
+            break;
+        }
+        case ZWP_TEXT_INPUT_V1_PREEDIT_STYLE_INACTIVE: {
+            WPEColor color = { 0.3, 0.3, 0.3, 1. };
+            wpe_input_method_underline_set_color(underline, &color);
+            break;
+        }
+        }
+
+        auto* priv = WPE_IM_CONTEXT_WAYLAND_V1(global->current)->priv;
+        priv->preedit.underlines = g_list_append(priv->preedit.underlines, underline);
+    },
+    // preedit_cursor
+    [](void* data, struct zwp_text_input_v1* /*text_input*/, int32_t index)
+    {
+        auto* global = static_cast<TextInputV1Global*>(data);
+        if (global->current == nullptr)
+            return;
+
+        auto* priv = WPE_IM_CONTEXT_WAYLAND_V1(global->current)->priv;
+        priv->preedit.cursorIndex = index;
+    },
+    // commit_string
+    [](void* data, struct zwp_text_input_v1* /*text_input*/, uint32_t serial, const char* text)
+    {
+        auto* global = static_cast<TextInputV1Global*>(data);
+        if (global->current == nullptr)
+            return;
+
+        auto* priv = WPE_IM_CONTEXT_WAYLAND_V1(global->current)->priv;
+        bool valid = global->serial == serial;
+        if (valid && priv->preedit.text) {
+            priv->preedit.text.reset(nullptr);
+            g_signal_emit_by_name(global->current, "preedit-changed");
+            g_signal_emit_by_name(global->current, "preedit-finished");
+        } else
+            priv->preedit.text.reset(nullptr);
+
+        if (valid && priv->surrounding.text && priv->pendingSurroundingDelete.length > 0) {
+            char* pos = priv->surrounding.text.get() + priv->surrounding.cursorIndex;
+            glong charIndex = g_utf8_pointer_to_offset(priv->surrounding.text.get(), pos);
+            pos += priv->pendingSurroundingDelete.index;
+            glong charStart = g_utf8_pointer_to_offset(priv->surrounding.text.get(), pos);
+            pos += priv->pendingSurroundingDelete.length;
+            glong charEnd = g_utf8_pointer_to_offset(priv->surrounding.text.get(), pos);
+
+            g_signal_emit_by_name(global->current, "delete-surrounding", charStart - charIndex, charEnd - charStart);
+        }
+        priv->pendingSurroundingDelete.index = 0;
+        priv->pendingSurroundingDelete.length = 0;
+
+        if (valid && text)
+            g_signal_emit_by_name(global->current, "committed", text);
+    },
+    // cursor_position
+    [](void* /*data*/, struct zwp_text_input_v1* /*text_input*/, int32_t /*index*/, int32_t /*anchor*/)
+    {
+        // NOOP
+    },
+    // delete_surrounding_text
+    [](void* data, struct zwp_text_input_v1* /*text_input*/, int32_t index, uint32_t length)
+    {
+        auto* global = static_cast<TextInputV1Global*>(data);
+        if (global->current == nullptr)
+            return;
+
+        auto* priv = WPE_IM_CONTEXT_WAYLAND_V1(global->current)->priv;
+        priv->pendingSurroundingDelete.index = index;
+        priv->pendingSurroundingDelete.length = length;
+    },
+    // keysym
+    [](void* data, struct zwp_text_input_v1* /*text_input*/, uint32_t /*serial*/, uint32_t time, uint32_t sym, uint32_t state, uint32_t modifiers)
+    {
+        auto* global = static_cast<TextInputV1Global*>(data);
+        if (global->current == nullptr)
+            return;
+
+        auto* priv = WPE_IM_CONTEXT_WAYLAND_V1(global->current)->priv;
+        auto* view = wpe_input_method_context_get_view(global->current);
+
+        uint32_t wpe_modifiers = 0;
+        if (modifiers & priv->modifiers.shiftMask)
+            wpe_modifiers |= WPE_MODIFIER_KEYBOARD_SHIFT;
+        if (modifiers & priv->modifiers.altMask)
+            wpe_modifiers |= WPE_MODIFIER_KEYBOARD_ALT;
+        if (modifiers & priv->modifiers.controlMask)
+            wpe_modifiers |= WPE_MODIFIER_KEYBOARD_CONTROL;
+
+        auto* event = wpe_event_keyboard_new(state ? WPE_EVENT_KEYBOARD_KEY_DOWN : WPE_EVENT_KEYBOARD_KEY_UP, view,
+            WPE_INPUT_SOURCE_KEYBOARD, time, static_cast<WPEModifiers>(wpe_modifiers), 0, sym);
+        wpe_view_event(view, event);
+        wpe_event_unref(event);
+    },
+    // language
+    [](void* /*data*/, struct zwp_text_input_v1* /*text_input*/, uint32_t /*serial*/, const char* /*language*/)
+    {
+        // NOOP
+    },
+    // text_direction
+    [](void* /*data*/, struct zwp_text_input_v1* /*text_input*/, uint32_t /*serial*/, uint32_t /*direction*/)
+    {
+        // NOOP
+    }
+};
+
+static void wpeIMContextWaylandV1GlobalFree(gpointer data)
+{
+    auto* global = static_cast<TextInputV1Global*>(data);
+    g_free(global);
+}
+
+static TextInputV1Global* textInputV1GetGlobalByDisplay(WPEDisplayWayland *display)
+{
+    auto* global = static_cast<TextInputV1Global*>(g_object_get_data(G_OBJECT(display), "text-input-v1-global"));
+    if (global != nullptr)
+        return global;
+
+    global = g_new0(TextInputV1Global, 1);
+    global->textInput = wpeDisplayWaylandGetTextInputV1(display);
+
+    if (global->textInput)
+        zwp_text_input_v1_add_listener(global->textInput, &textInputListenerV1, global);
+
+    g_object_set_data_full(G_OBJECT(display),
+        "text-input-v1-global",
+        global,
+        wpeIMContextWaylandV1GlobalFree);
+    return global;
+}
+
+static void wpeIMContextWaylandV1PurposeOrHintsChanged(WPEInputMethodContext *context)
+{
+    textInputV1SetContentType(WPE_IM_CONTEXT_WAYLAND_V1(context));
+    textInputV1CommitState(WPE_IM_CONTEXT_WAYLAND_V1(context));
+}
+
+static void wpeIMContextWaylandV1Constructed(GObject* object)
+{
+    G_OBJECT_CLASS(wpe_im_context_wayland_v1_parent_class)->constructed(object);
+
+    auto* context = WPE_INPUT_METHOD_CONTEXT(object);
+    auto* wpeContext = WPE_IM_CONTEXT_WAYLAND_V1(context);
+
+    g_signal_connect_swapped(context, "notify::input-purpose", G_CALLBACK(wpeIMContextWaylandV1PurposeOrHintsChanged), wpeContext);
+    g_signal_connect_swapped(context, "notify::input-hints", G_CALLBACK(wpeIMContextWaylandV1PurposeOrHintsChanged), wpeContext);
+}
+
+static void wpeIMContextWaylandV1Dispose(GObject* object)
+{
+    auto* self = WPE_IM_CONTEXT_WAYLAND_V1(object);
+
+    wpe_input_method_context_focus_out(WPE_INPUT_METHOD_CONTEXT(self));
+
+    G_OBJECT_CLASS(wpe_im_context_wayland_v1_parent_class)->dispose(object);
+}
+
+static void wpeIMContextWaylandV1GetPreeditString(WPEInputMethodContext* context, char** text, GList** underlines, guint* cursorOffset)
+{
+    auto* self = WPE_IM_CONTEXT_WAYLAND_V1(context);
+
+    if (text != nullptr)
+        *text = self->priv->preedit.text ? g_strdup(self->priv->preedit.text.get()) : g_strdup("");
+
+    if (underlines != nullptr)
+        *underlines = self->priv->preedit.underlines;
+    else
+        g_list_free_full(self->priv->preedit.underlines, g_object_unref);
+    self->priv->preedit.underlines = nullptr;
+
+    if (cursorOffset)
+        *cursorOffset = self->priv->preedit.cursorIndex;
+}
+
+static void wpeIMContextWaylandV1FocusIn(WPEInputMethodContext* context)
+{
+    auto* view = wpe_input_method_context_get_view(context);
+    auto* display = wpe_input_method_context_get_display(context);
+    auto* seat = wpeDisplayWaylandGetSeat(WPE_DISPLAY_WAYLAND(display));
+    auto* global = textInputV1GetGlobalByDisplay(WPE_DISPLAY_WAYLAND(display));
+    if (global->current == context)
+        return;
+
+    if (view == nullptr)
+        return;
+
+    global->current = context;
+    if (global->textInput == nullptr)
+        return;
+
+    WPEInputHints hints;
+    g_object_get(context, "input-hints", &hints, nullptr);
+    if (!(hints & WPE_INPUT_HINT_INHIBIT_OSK)) {
+        zwp_text_input_v1_show_input_panel(global->textInput);
+        zwp_text_input_v1_activate(global->textInput,
+            seat->seat(),
+            wpe_view_wayland_get_wl_surface(WPE_VIEW_WAYLAND(view)));
+    }
+}
+
+static void wpeIMContextWaylandV1FocusOut(WPEInputMethodContext *context)
+{
+    auto* self = WPE_IM_CONTEXT_WAYLAND_V1(context);
+    auto* display = wpe_input_method_context_get_display(context);
+    auto* seat = wpeDisplayWaylandGetSeat(WPE_DISPLAY_WAYLAND(display));
+    auto* global = textInputV1GetGlobalByContext(self);
+    if (global == nullptr)
+        return;
+
+    if (global->focused)
+        zwp_text_input_v1_deactivate(global->textInput, seat->seat());
+
+    global->current = nullptr;
+}
+
+static void wpeIMContextWaylandV1SetCursorArea(WPEInputMethodContext* context, int x, int y, int width, int height)
+{
+    auto* self = WPE_IM_CONTEXT_WAYLAND_V1(context);
+    auto* display = wpe_input_method_context_get_display(context);
+    auto* global = textInputV1GetGlobalByDisplay(WPE_DISPLAY_WAYLAND(display));
+    if (self->priv->cursorRect.x == x && self->priv->cursorRect.y == y && self->priv->cursorRect.width == width && self->priv->cursorRect.height == height)
+        return;
+
+    self->priv->cursorRect.x = x;
+    self->priv->cursorRect.y = y;
+    self->priv->cursorRect.width = width;
+    self->priv->cursorRect.height = height;
+
+    if (global->current == context) {
+        textInputV1SetCursorRectangle(self);
+        textInputV1CommitState(self);
+    }
+}
+
+static void wpeIMContextWaylandV1SetSurrounding(WPEInputMethodContext* context, const char* text, guint length, guint cursorIndex, guint selectionIndex)
+{
+    auto* self = WPE_IM_CONTEXT_WAYLAND_V1(context);
+    auto* display = wpe_input_method_context_get_display(context);
+    auto* global = textInputV1GetGlobalByDisplay(WPE_DISPLAY_WAYLAND(display));
+
+    self->priv->surrounding.text.reset(g_strndup(text, length));
+    self->priv->surrounding.cursorIndex = cursorIndex;
+    self->priv->surrounding.anchorIndex = selectionIndex;
+
+    if (global->current == context) {
+        textInputV1SetSurroundingText(self);
+        textInputV1CommitState(self);
+    }
+}
+
+static void wpeIMContextWaylandV1Reset(WPEInputMethodContext *context)
+{
+    auto* self = WPE_IM_CONTEXT_WAYLAND_V1(context);
+    auto* global = textInputV1GetGlobalByContext(self);
+    if (global->current == nullptr)
+        return;
+
+    if (global->current == context) {
+        zwp_text_input_v1_reset(global->textInput);
+        textInputV1UpdateState(self);
+    }
+}
+
+static void wpe_im_context_wayland_v1_class_init(WPEIMContextWaylandV1Class* klass)
+{
+    GObjectClass* objectClass = G_OBJECT_CLASS(klass);
+    objectClass->constructed = wpeIMContextWaylandV1Constructed;
+    objectClass->dispose = wpeIMContextWaylandV1Dispose;
+
+    WPEInputMethodContextClass* imContextClass = WPE_INPUT_METHOD_CONTEXT_CLASS(klass);
+    imContextClass->get_preedit_string = wpeIMContextWaylandV1GetPreeditString;
+    imContextClass->focus_in = wpeIMContextWaylandV1FocusIn;
+    imContextClass->focus_out = wpeIMContextWaylandV1FocusOut;
+    imContextClass->set_cursor_area = wpeIMContextWaylandV1SetCursorArea;
+    imContextClass->set_surrounding = wpeIMContextWaylandV1SetSurrounding;
+    imContextClass->reset = wpeIMContextWaylandV1Reset;
+}
+
+WPEInputMethodContext* wpe_im_context_wayland_v1_new(WPEDisplayWayland* display)
+{
+    g_return_val_if_fail(WPE_IS_DISPLAY_WAYLAND(display), nullptr);
+
+    textInputV1GetGlobalByDisplay(display); // ensure creation of listener
+    return WPE_INPUT_METHOD_CONTEXT(g_object_new(WPE_TYPE_IM_CONTEXT_WAYLAND_V1, nullptr));
+}

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV1.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV1.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,17 +23,20 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#ifndef WPEInputMethodContextWaylandV1_h
+#define WPEInputMethodContextWaylandV1_h
 
-#include "WPEDisplayWayland.h"
-#include "WPEMonitor.h"
-#include "WPEWaylandCursor.h"
-#include "WPEWaylandSeat.h"
+#include <glib-object.h>
+#include <wpe/wpe-platform.h>
+#include <wpe/wayland/WPEDisplayWayland.h>
 
-struct xdg_wm_base* wpeDisplayWaylandGetXDGWMBase(WPEDisplayWayland*);
-WPE::WaylandSeat* wpeDisplayWaylandGetSeat(WPEDisplayWayland*);
-WPE::WaylandCursor* wpeDisplayWaylandGetCursor(WPEDisplayWayland*);
-WPEMonitor* wpeDisplayWaylandFindMonitor(WPEDisplayWayland*, struct wl_output*);
-struct zwp_linux_dmabuf_v1* wpeDisplayWaylandGetLinuxDMABuf(WPEDisplayWayland*);
-struct zwp_text_input_v1* wpeDisplayWaylandGetTextInputV1(WPEDisplayWayland*);
-struct zwp_text_input_v3* wpeDisplayWaylandGetTextInputV3(WPEDisplayWayland*);
+G_BEGIN_DECLS
+
+#define WPE_TYPE_IM_CONTEXT_WAYLAND_V1 (wpe_im_context_wayland_v1_get_type())
+G_DECLARE_FINAL_TYPE (WPEIMContextWaylandV1, wpe_im_context_wayland_v1, WPE, IM_CONTEXT_WAYLAND_V1, WPEInputMethodContext)
+
+WPEInputMethodContext   *wpe_im_context_wayland_v1_new (WPEDisplayWayland *display);
+
+G_END_DECLS
+
+#endif /* WPEInputMethodContextWaylandV1_h */

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV3.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV3.cpp
@@ -1,0 +1,611 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEInputMethodContextWaylandV3.h"
+
+#include "WPEDisplayWaylandPrivate.h"
+#include "WPEViewWayland.h"
+
+#include "text-input-unstable-v3-client-protocol.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <wayland-client-protocol.h>
+#include <wtf/glib/WTFGType.h>
+#include <xkbcommon/xkbcommon.h>
+
+typedef struct _TextInputV3Global TextInputV3Global;
+typedef struct _Preedit Preedit;
+
+struct _TextInputV3Global {
+    struct zwp_text_input_v3* textInput;
+
+    WPEInputMethodContext* current;
+
+    bool focused;
+
+    uint32_t serial;
+};
+
+struct _Preedit {
+    GUniquePtr<char> text;
+    int32_t cursorBegin;
+    int32_t cursorEnd;
+
+    _Preedit& operator=(Preedit& other)
+    {
+        if (this != &other) {
+            text.reset(g_strdup(other.text.get()));
+            cursorBegin = other.cursorBegin;
+            cursorEnd = other.cursorEnd;
+        }
+        return *this;
+    }
+};
+
+struct _WPEIMContextWaylandV3Private {
+    Preedit pendingPreedit;
+    Preedit currentPreedit;
+
+    GUniquePtr<char> pendingCommit;
+
+    struct {
+        int32_t x;
+        int32_t y;
+        int32_t width;
+        int32_t height;
+    } cursorRect;
+
+    struct {
+        GUniquePtr<char> text;
+        int32_t cursorIndex;
+        int32_t anchorIndex;
+    } surrounding;
+
+    enum zwp_text_input_v3_change_cause textChangeCause;
+
+    struct {
+        uint32_t beforeLength;
+        uint32_t afterLength;
+    } pendingSurroundingDelete;
+};
+
+WEBKIT_DEFINE_FINAL_TYPE(WPEIMContextWaylandV3, wpe_im_context_wayland_v3, WPE_TYPE_INPUT_METHOD_CONTEXT, WPEInputMethodContext)
+
+static TextInputV3Global* textInputV3GetGlobalByDisplay(WPEDisplayWayland*);
+
+static TextInputV3Global* textInputV3GetGlobalByContext(WPEIMContextWaylandV3* self)
+{
+    if (wpe_input_method_context_get_view(WPE_INPUT_METHOD_CONTEXT(self)) == nullptr)
+        return nullptr;
+
+    auto* display = wpe_input_method_context_get_display(WPE_INPUT_METHOD_CONTEXT(self));
+    auto* global = textInputV3GetGlobalByDisplay(WPE_DISPLAY_WAYLAND(display));
+    if (global->current != WPE_INPUT_METHOD_CONTEXT(self))
+        return nullptr;
+    if (global->textInput == nullptr)
+        return nullptr;
+
+    return global;
+}
+
+static uint32_t toTextInputV3Hints(WPEInputHints inputHints, WPEInputPurpose purpose)
+{
+    uint32_t hints = 0;
+
+    if (inputHints & WPE_INPUT_HINT_SPELLCHECK)
+        hints |= ZWP_TEXT_INPUT_V3_CONTENT_HINT_SPELLCHECK;
+    if (inputHints & WPE_INPUT_HINT_WORD_COMPLETION)
+        hints |= ZWP_TEXT_INPUT_V3_CONTENT_HINT_COMPLETION;
+    if (inputHints & WPE_INPUT_HINT_LOWERCASE)
+        hints |= ZWP_TEXT_INPUT_V3_CONTENT_HINT_LOWERCASE;
+    if (inputHints & WPE_INPUT_HINT_UPPERCASE_CHARS)
+        hints |= ZWP_TEXT_INPUT_V3_CONTENT_HINT_UPPERCASE;
+    if (inputHints & WPE_INPUT_HINT_UPPERCASE_WORDS)
+        hints |= ZWP_TEXT_INPUT_V3_CONTENT_HINT_TITLECASE;
+    if (inputHints & WPE_INPUT_HINT_UPPERCASE_SENTENCES)
+        hints |= ZWP_TEXT_INPUT_V3_CONTENT_HINT_AUTO_CAPITALIZATION;
+
+    if (purpose == WPE_INPUT_PURPOSE_PIN || purpose == WPE_INPUT_PURPOSE_PASSWORD)
+        hints |= (ZWP_TEXT_INPUT_V3_CONTENT_HINT_HIDDEN_TEXT | ZWP_TEXT_INPUT_V3_CONTENT_HINT_SENSITIVE_DATA);
+
+    return hints;
+}
+
+static uint32_t toTextInputV3Purpose(WPEInputPurpose purpose)
+{
+    switch (purpose) {
+    case WPE_INPUT_PURPOSE_FREE_FORM:
+        return ZWP_TEXT_INPUT_V3_CONTENT_PURPOSE_NORMAL;
+    case WPE_INPUT_PURPOSE_ALPHA:
+        return ZWP_TEXT_INPUT_V3_CONTENT_PURPOSE_ALPHA;
+    case WPE_INPUT_PURPOSE_DIGITS:
+        return ZWP_TEXT_INPUT_V3_CONTENT_PURPOSE_DIGITS;
+    case WPE_INPUT_PURPOSE_NUMBER:
+        return ZWP_TEXT_INPUT_V3_CONTENT_PURPOSE_NUMBER;
+    case WPE_INPUT_PURPOSE_PHONE:
+        return ZWP_TEXT_INPUT_V3_CONTENT_PURPOSE_PHONE;
+    case WPE_INPUT_PURPOSE_URL:
+        return ZWP_TEXT_INPUT_V3_CONTENT_PURPOSE_URL;
+    case WPE_INPUT_PURPOSE_EMAIL:
+        return ZWP_TEXT_INPUT_V3_CONTENT_PURPOSE_EMAIL;
+    case WPE_INPUT_PURPOSE_NAME:
+        return ZWP_TEXT_INPUT_V3_CONTENT_PURPOSE_NAME;
+    case WPE_INPUT_PURPOSE_PASSWORD:
+        return ZWP_TEXT_INPUT_V3_CONTENT_PURPOSE_PASSWORD;
+    case WPE_INPUT_PURPOSE_PIN:
+        return ZWP_TEXT_INPUT_V3_CONTENT_PURPOSE_PIN;
+    case WPE_INPUT_PURPOSE_TERMINAL:
+        return ZWP_TEXT_INPUT_V3_CONTENT_PURPOSE_TERMINAL;
+    default:
+        g_assert_not_reached();
+    }
+
+    return ZWP_TEXT_INPUT_V3_CONTENT_PURPOSE_NORMAL;
+}
+
+static char* truncateSurroundingTextIfeeded(const char *text, uint32_t *cursorIndex, uint32_t *anchorIndex)
+{
+#define MAX_LEN 4000
+    unsigned len = strlen(text);
+
+    if (len < MAX_LEN)
+        return nullptr;
+
+    const char* start;
+    const char* end;
+    if (*cursorIndex < MAX_LEN && *anchorIndex < MAX_LEN) {
+        start = text;
+        end = &text[MAX_LEN];
+    } else if (*cursorIndex > len - MAX_LEN && *anchorIndex > len - MAX_LEN) {
+        start = &text[len - MAX_LEN];
+        end = &text[len];
+    } else {
+        unsigned selectionLen = std::abs(static_cast<int>(*cursorIndex - *anchorIndex));
+        if (selectionLen > MAX_LEN) {
+            /* This is unsupported, let's just ignore the selection. */
+            if (*cursorIndex < MAX_LEN) {
+                start = text;
+                end = &text[MAX_LEN];
+            } else if (*cursorIndex > len - MAX_LEN) {
+                start = &text[len - MAX_LEN];
+                end = &text[len];
+            } else {
+                start = &text[std::max(0u, *cursorIndex - (MAX_LEN / 2))];
+                end = &text[std::min(static_cast<unsigned>(MAX_LEN), *cursorIndex + (MAX_LEN / 2))];
+            }
+        } else {
+            unsigned mid = std::min(*cursorIndex, *anchorIndex) + (selectionLen / 2);
+            start = &text[std::max(0u, (mid - MAX_LEN) / 2)];
+            end = &text[std::min(static_cast<unsigned>(MAX_LEN), (mid + MAX_LEN / 2))];
+        }
+    }
+
+    if (start != text)
+        start = g_utf8_next_char(start);
+    if (end != &text[len])
+        end = g_utf8_find_prev_char(text, end);
+
+    *cursorIndex -= start - text;
+    *anchorIndex -= start - text;
+
+    return g_strndup(start, end - start);
+#undef MAX_LEN
+}
+
+static void textInputV3SetCursorRectangle(WPEIMContextWaylandV3* context)
+{
+    auto* global = textInputV3GetGlobalByContext(context);
+    if (global == nullptr)
+        return;
+
+    zwp_text_input_v3_set_cursor_rectangle(global->textInput,
+        context->priv->cursorRect.x,
+        context->priv->cursorRect.y,
+        context->priv->cursorRect.width,
+        context->priv->cursorRect.height);
+}
+
+static void textInputV3SetSurroundingText(WPEIMContextWaylandV3* context)
+{
+    auto* global = textInputV3GetGlobalByContext(context);
+    if (global == nullptr)
+        return;
+
+    if (!context->priv->surrounding.text)
+        return;
+
+    uint32_t cursorIndex = context->priv->surrounding.cursorIndex;
+    uint32_t anchorIndex = context->priv->surrounding.anchorIndex;
+    GUniquePtr<char> truncatedText(
+        truncateSurroundingTextIfeeded(context->priv->surrounding.text.get(),
+        &cursorIndex,
+        &anchorIndex));
+
+    zwp_text_input_v3_set_surrounding_text(global->textInput,
+        truncatedText ? truncatedText.get() : context->priv->surrounding.text.get(),
+        cursorIndex, anchorIndex);
+    zwp_text_input_v3_set_text_change_cause(global->textInput,
+        context->priv->textChangeCause);
+}
+
+static void textInputV3SetContentType(WPEIMContextWaylandV3* context)
+{
+    WPEInputHints hints;
+    WPEInputPurpose purpose;
+
+    auto* global = textInputV3GetGlobalByContext(context);
+    if (global == nullptr)
+        return;
+
+    g_object_get(context,
+        "input-hints", &hints,
+        "input-purpose", &purpose,
+        nullptr);
+
+    zwp_text_input_v3_set_content_type(global->textInput,
+        toTextInputV3Hints(hints, purpose),
+        toTextInputV3Purpose(purpose));
+}
+
+static void textInputV3CommitState(WPEIMContextWaylandV3* context)
+{
+    auto* global = textInputV3GetGlobalByContext(context);
+    if (global == nullptr)
+        return;
+
+    global->serial++;
+    zwp_text_input_v3_commit(global->textInput);
+    context->priv->textChangeCause = ZWP_TEXT_INPUT_V3_CHANGE_CAUSE_INPUT_METHOD;
+}
+
+static void textInputV3UpdateState(WPEIMContextWaylandV3* context, enum zwp_text_input_v3_change_cause cause)
+{
+    auto* global = textInputV3GetGlobalByContext(context);
+    if (global == nullptr)
+        return;
+
+    context->priv->textChangeCause = cause;
+
+    textInputV3SetSurroundingText(context);
+    textInputV3SetContentType(context);
+    textInputV3SetCursorRectangle(context);
+    textInputV3CommitState(context);
+}
+
+static void textInputV3PreeditApply(TextInputV3Global* global, uint32_t serial)
+{
+    auto* priv = WPE_IM_CONTEXT_WAYLAND_V3(global->current)->priv;
+
+    bool valid = global->serial == serial;
+    bool stateChanged = (priv->currentPreedit.text != nullptr) != (priv->pendingPreedit.text != nullptr);
+    if (valid && stateChanged && !priv->currentPreedit.text)
+        g_signal_emit_by_name(global->current, "preedit-started");
+
+    priv->currentPreedit = priv->pendingPreedit;
+    priv->pendingPreedit.text.reset(nullptr);
+    priv->pendingPreedit.cursorBegin = priv->pendingPreedit.cursorEnd = 0;
+
+    if (valid)
+        g_signal_emit_by_name(global->current, "preedit-changed");
+
+    if (valid && stateChanged && !priv->currentPreedit.text)
+        g_signal_emit_by_name(global->current, "preedit-finished");
+}
+
+static void textInputV3CommitApply(TextInputV3Global* global, uint32_t serial)
+{
+    auto* priv = WPE_IM_CONTEXT_WAYLAND_V3(global->current)->priv;
+
+    bool valid = global->serial == serial;
+    if (valid && priv->pendingCommit)
+        g_signal_emit_by_name(global->current, "committed", priv->pendingCommit.get());
+    g_clear_pointer(&priv->pendingCommit, g_free);
+}
+
+static void textInputV3DeleteSurroundingTextApply(TextInputV3Global* global, uint32_t serial)
+{
+    auto* priv = WPE_IM_CONTEXT_WAYLAND_V3(global->current)->priv;
+
+    bool valid = global->serial == serial;
+    if ((valid && priv->pendingSurroundingDelete.beforeLength) || priv->pendingSurroundingDelete.afterLength) {
+        g_signal_emit_by_name(global->current,
+            "delete-surrounding",
+            -priv->pendingSurroundingDelete.beforeLength,
+            priv->pendingSurroundingDelete.beforeLength +
+            priv->pendingSurroundingDelete.afterLength);
+    }
+    priv->pendingSurroundingDelete.beforeLength = 0;
+    priv->pendingSurroundingDelete.afterLength = 0;
+}
+
+static void textInputV3Enable(WPEIMContextWaylandV3* context, TextInputV3Global* global)
+{
+    zwp_text_input_v3_enable(global->textInput);
+    textInputV3UpdateState(context, ZWP_TEXT_INPUT_V3_CHANGE_CAUSE_OTHER);
+
+    // Mutter only pops up the OSK on >1 consecutive zwp_text_input_v3_enable() calls
+    WPEInputHints hints;
+    g_object_get(context, "input-hints", &hints, nullptr);
+    if (!(hints & WPE_INPUT_HINT_INHIBIT_OSK)) {
+        zwp_text_input_v3_enable(global->textInput);
+        textInputV3CommitState(context);
+    }
+}
+
+static void textInputV3Disable(WPEIMContextWaylandV3* context, TextInputV3Global* global)
+{
+    zwp_text_input_v3_disable(global->textInput);
+    textInputV3CommitState(context);
+}
+
+
+static const struct zwp_text_input_v3_listener textInputListenerV3 = {
+    // enter
+    [](void* data, struct zwp_text_input_v3* /*zwp_text_input_v3*/, struct wl_surface* /*surface*/)
+    {
+        auto* global = static_cast<TextInputV3Global*>(data);
+
+        global->focused = true;
+
+        if (global->current)
+            textInputV3Enable(WPE_IM_CONTEXT_WAYLAND_V3(global->current), global);
+    },
+    // leave
+    [](void* data, struct zwp_text_input_v3* /*zwp_text_input_v3*/, struct wl_surface* /*surface*/)
+    {
+        auto* global = static_cast<TextInputV3Global*>(data);
+
+        global->focused = false;
+
+        if (global->current)
+            textInputV3Disable(WPE_IM_CONTEXT_WAYLAND_V3(global->current), global);
+    },
+    // preedit_string
+    [](void* data, struct zwp_text_input_v3* /*zwp_text_input_v3*/, const char* text, int32_t cursorBegin, int32_t cursorEnd)
+    {
+        auto* global = static_cast<TextInputV3Global*>(data);
+        if (global->current == nullptr)
+            return;
+
+        auto* priv = WPE_IM_CONTEXT_WAYLAND_V3(global->current)->priv;
+        Preedit* pendingPreedit = &priv->pendingPreedit;
+        g_clear_pointer(&pendingPreedit->text, g_free);
+        pendingPreedit->text.reset(g_strdup(text));
+        pendingPreedit->cursorBegin = cursorBegin;
+        pendingPreedit->cursorEnd = cursorEnd;
+    },
+    // commit_string
+    [](void* data, struct zwp_text_input_v3* /*zwp_text_input_v3*/, const char* text)
+    {
+        auto* global = static_cast<TextInputV3Global*>(data);
+        if (global->current == nullptr)
+            return;
+
+        auto* priv = WPE_IM_CONTEXT_WAYLAND_V3(global->current)->priv;
+        g_clear_pointer(&priv->pendingCommit, g_free);
+        priv->pendingCommit.reset(g_strdup(text));
+    },
+    // delete_surrounding_text
+    [](void* data, struct zwp_text_input_v3* /*zwp_text_input_v3*/, uint32_t beforeLength, uint32_t afterLength)
+    {
+        auto* global = static_cast<TextInputV3Global*>(data);
+        if (global->current == nullptr)
+            return;
+
+        auto* priv = WPE_IM_CONTEXT_WAYLAND_V3(global->current)->priv;
+        priv->pendingSurroundingDelete.beforeLength = beforeLength;
+        priv->pendingSurroundingDelete.afterLength = afterLength;
+    },
+    // done
+    [](void* data, struct zwp_text_input_v3* /*zwp_text_input_v3*/, uint32_t serial)
+    {
+        auto* global = static_cast<TextInputV3Global*>(data);
+        if (global->current == nullptr)
+            return;
+
+        auto* context = WPE_IM_CONTEXT_WAYLAND_V3(global->current);
+
+        bool hasPendingPreedit = g_strcmp0(context->priv->pendingPreedit.text.get(), context->priv->currentPreedit.text.get());
+        bool hasPendingCommit = context->priv->pendingCommit != nullptr;
+        bool updateIm = (hasPendingPreedit || hasPendingCommit);
+
+        textInputV3DeleteSurroundingTextApply(global, serial);
+        textInputV3CommitApply(global, serial);
+        textInputV3PreeditApply(global, serial);
+
+        if (updateIm && global->serial == serial)
+            textInputV3UpdateState(context, ZWP_TEXT_INPUT_V3_CHANGE_CAUSE_INPUT_METHOD);
+    }
+};
+
+static void wpeIMContextWaylandV3GlobalFree(gpointer data)
+{
+    auto* global = static_cast<TextInputV3Global*>(data);
+    g_free(global);
+}
+
+static TextInputV3Global* textInputV3GetGlobalByDisplay(WPEDisplayWayland *display)
+{
+    auto* global = static_cast<TextInputV3Global*>(g_object_get_data(G_OBJECT(display), "text-input-v3-global"));
+    if (global != nullptr)
+        return global;
+
+    global = g_new0(TextInputV3Global, 1);
+    global->textInput = wpeDisplayWaylandGetTextInputV3(display);
+
+    if (global->textInput)
+        zwp_text_input_v3_add_listener(global->textInput, &textInputListenerV3, global);
+
+    g_object_set_data_full(G_OBJECT(display),
+        "text-input-v3-global",
+        global,
+        wpeIMContextWaylandV3GlobalFree);
+    return global;
+}
+
+static void wpeIMContextWaylandV3PurposeOrHintsChanged(WPEInputMethodContext *context)
+{
+    textInputV3SetContentType(WPE_IM_CONTEXT_WAYLAND_V3(context));
+    textInputV3CommitState(WPE_IM_CONTEXT_WAYLAND_V3(context));
+}
+
+static void wpeIMContextWaylandV3Constructed(GObject* object)
+{
+    G_OBJECT_CLASS(wpe_im_context_wayland_v3_parent_class)->constructed(object);
+
+    auto* context = WPE_INPUT_METHOD_CONTEXT(object);
+    auto* wpeContext = WPE_IM_CONTEXT_WAYLAND_V3(context);
+
+    g_signal_connect_swapped(context, "notify::input-purpose", G_CALLBACK(wpeIMContextWaylandV3PurposeOrHintsChanged), wpeContext);
+    g_signal_connect_swapped(context, "notify::input-hints", G_CALLBACK(wpeIMContextWaylandV3PurposeOrHintsChanged), wpeContext);
+}
+
+static void wpeIMContextWaylandV3Dispose(GObject* object)
+{
+    auto* self = WPE_IM_CONTEXT_WAYLAND_V3(object);
+
+    wpe_input_method_context_focus_out(WPE_INPUT_METHOD_CONTEXT(self));
+
+    G_OBJECT_CLASS(wpe_im_context_wayland_v3_parent_class)->dispose(object);
+}
+
+static void wpeIMContextWaylandV3GetPreeditString(WPEInputMethodContext* context, char** text, GList** underlines, guint* cursorOffset)
+{
+    auto* self = WPE_IM_CONTEXT_WAYLAND_V3(context);
+
+    if (text != nullptr)
+        *text = self->priv->currentPreedit.text ? g_strdup(self->priv->currentPreedit.text.get()) : g_strdup("");
+
+    if (underlines != nullptr) {
+        *underlines = nullptr;
+        if (self->priv->currentPreedit.cursorBegin != self->priv->currentPreedit.cursorEnd) {
+            *underlines =
+                g_list_prepend(*underlines, wpe_input_method_underline_new(self->priv->currentPreedit.cursorBegin,
+                    self->priv->currentPreedit.cursorEnd));
+        }
+    };
+
+    if (cursorOffset)
+        *cursorOffset = self->priv->currentPreedit.cursorBegin;
+}
+
+static void wpeIMContextWaylandV3FocusIn(WPEInputMethodContext* context)
+{
+    auto* self = WPE_IM_CONTEXT_WAYLAND_V3(context);
+    auto* display = wpe_input_method_context_get_display(context);
+    auto* global = textInputV3GetGlobalByDisplay(WPE_DISPLAY_WAYLAND(display));
+    if (global->current == context)
+        return;
+
+    if (wpe_input_method_context_get_view(context) == nullptr)
+        return;
+
+    global->current = context;
+    if (global->textInput == nullptr)
+        return;
+
+    if (global->focused)
+        textInputV3Enable(self, global);
+}
+
+static void wpeIMContextWaylandV3FocusOut(WPEInputMethodContext *context)
+{
+    auto* self = WPE_IM_CONTEXT_WAYLAND_V3(context);
+    auto* global = textInputV3GetGlobalByContext(self);
+    if (global == nullptr)
+        return;
+
+    if (global->focused)
+        textInputV3Disable(self, global);
+
+    global->current = nullptr;
+}
+
+static void wpeIMContextWaylandV3SetCursorArea(WPEInputMethodContext* context, int x, int y, int width, int height)
+{
+    auto* self = WPE_IM_CONTEXT_WAYLAND_V3(context);
+    auto* display = wpe_input_method_context_get_display(context);
+    auto* global = textInputV3GetGlobalByDisplay(WPE_DISPLAY_WAYLAND(display));
+
+    if (self->priv->cursorRect.x == x && self->priv->cursorRect.y == y && self->priv->cursorRect.width == width && self->priv->cursorRect.height == height)
+        return;
+
+    self->priv->cursorRect.x = x;
+    self->priv->cursorRect.y = y;
+    self->priv->cursorRect.width = width;
+    self->priv->cursorRect.height = height;
+
+    if (global->current == context) {
+        textInputV3SetCursorRectangle(self);
+        textInputV3CommitState(self);
+    }
+}
+
+static void wpeIMContextWaylandV3SetSurrounding(WPEInputMethodContext* context, const char* text, guint length, guint cursorIndex, guint selectionIndex)
+{
+    auto* self = WPE_IM_CONTEXT_WAYLAND_V3(context);
+    auto* display = wpe_input_method_context_get_display(context);
+    auto* global = textInputV3GetGlobalByDisplay(WPE_DISPLAY_WAYLAND(display));
+
+    g_clear_pointer(&self->priv->surrounding.text, g_free);
+    self->priv->surrounding.text.reset(g_strndup(text, length));
+    self->priv->surrounding.cursorIndex = cursorIndex;
+    self->priv->surrounding.anchorIndex = selectionIndex;
+
+    if (global->current == context) {
+        textInputV3SetSurroundingText(self);
+        textInputV3CommitState(self);
+    }
+}
+
+static void wpeIMContextWaylandV3Reset(WPEInputMethodContext *context)
+{
+    textInputV3UpdateState(WPE_IM_CONTEXT_WAYLAND_V3(context), ZWP_TEXT_INPUT_V3_CHANGE_CAUSE_OTHER);
+}
+
+static void wpe_im_context_wayland_v3_class_init(WPEIMContextWaylandV3Class* klass)
+{
+    GObjectClass* objectClass = G_OBJECT_CLASS(klass);
+    objectClass->constructed = wpeIMContextWaylandV3Constructed;
+    objectClass->dispose = wpeIMContextWaylandV3Dispose;
+
+    WPEInputMethodContextClass* imContextClass = WPE_INPUT_METHOD_CONTEXT_CLASS(klass);
+    imContextClass->get_preedit_string = wpeIMContextWaylandV3GetPreeditString;
+    imContextClass->focus_in = wpeIMContextWaylandV3FocusIn;
+    imContextClass->focus_out = wpeIMContextWaylandV3FocusOut;
+    imContextClass->set_cursor_area = wpeIMContextWaylandV3SetCursorArea;
+    imContextClass->set_surrounding = wpeIMContextWaylandV3SetSurrounding;
+    imContextClass->reset = wpeIMContextWaylandV3Reset;
+}
+
+WPEInputMethodContext* wpe_im_context_wayland_v3_new(WPEDisplayWayland* display)
+{
+    g_return_val_if_fail(WPE_IS_DISPLAY_WAYLAND(display), nullptr);
+
+    textInputV3GetGlobalByDisplay(display); // ensure creation of listener
+    return WPE_INPUT_METHOD_CONTEXT(g_object_new(WPE_TYPE_IM_CONTEXT_WAYLAND_V3, nullptr));
+}

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV3.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV3.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,17 +23,20 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#ifndef WPEInputMethodContextWaylandV3_h
+#define WPEInputMethodContextWaylandV3_h
 
-#include "WPEDisplayWayland.h"
-#include "WPEMonitor.h"
-#include "WPEWaylandCursor.h"
-#include "WPEWaylandSeat.h"
+#include <glib-object.h>
+#include <wpe/wpe-platform.h>
+#include <wpe/wayland/WPEDisplayWayland.h>
 
-struct xdg_wm_base* wpeDisplayWaylandGetXDGWMBase(WPEDisplayWayland*);
-WPE::WaylandSeat* wpeDisplayWaylandGetSeat(WPEDisplayWayland*);
-WPE::WaylandCursor* wpeDisplayWaylandGetCursor(WPEDisplayWayland*);
-WPEMonitor* wpeDisplayWaylandFindMonitor(WPEDisplayWayland*, struct wl_output*);
-struct zwp_linux_dmabuf_v1* wpeDisplayWaylandGetLinuxDMABuf(WPEDisplayWayland*);
-struct zwp_text_input_v1* wpeDisplayWaylandGetTextInputV1(WPEDisplayWayland*);
-struct zwp_text_input_v3* wpeDisplayWaylandGetTextInputV3(WPEDisplayWayland*);
+G_BEGIN_DECLS
+
+#define WPE_TYPE_IM_CONTEXT_WAYLAND_V3 (wpe_im_context_wayland_v3_get_type())
+G_DECLARE_FINAL_TYPE (WPEIMContextWaylandV3, wpe_im_context_wayland_v3, WPE, IM_CONTEXT_WAYLAND_V3, WPEInputMethodContext)
+
+WPEInputMethodContext   *wpe_im_context_wayland_v3_new (WPEDisplayWayland *display);
+
+G_END_DECLS
+
+#endif /* WPEInputMethodContextWaylandV3_h */

--- a/Source/WebKit/WPEPlatform/wpe/wpe-platform.h
+++ b/Source/WebKit/WPEPlatform/wpe/wpe-platform.h
@@ -33,10 +33,12 @@
 #include <wpe/WPEBufferDMABuf.h>
 #include <wpe/WPEBufferDMABufFormats.h>
 #include <wpe/WPEBufferSHM.h>
+#include <wpe/WPEColor.h>
 #include <wpe/WPEConfig.h>
 #include <wpe/WPEDefines.h>
 #include <wpe/WPEDisplay.h>
 #include <wpe/WPEEGLError.h>
+#include <wpe/WPEInputMethodContext.h>
 #include <wpe/WPEKeymap.h>
 #include <wpe/WPEKeyUnicode.h>
 #include <wpe/WPEKeymapXKB.h>


### PR DESCRIPTION
#### 77db03823160b5bc32d0088dcabd873449f77b7f
<pre>
[WPE] WPE Platform: Add input method context support for Wayland
<a href="https://bugs.webkit.org/show_bug.cgi?id=265649">https://bugs.webkit.org/show_bug.cgi?id=265649</a>

Reviewed by Carlos Garcia Campos.

Add WPE Platfrom default input method context support for wayland
text input v1 and v3.

* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewConstructed):
* Source/WebKit/UIProcess/API/wpe/WebKitInputMethodContextImplWPE.cpp: Added.
(toWPEInputPurpose):
(toWPEInputHints):
(inputPurposeChangedCallback):
(inputHintsChangedCallback):
(wpeIMContextPreeditStartCallback):
(wpeIMContextPreeditChangedCallback):
(wpeIMContextPreeditEndCallback):
(wpeIMContextCommitCallback):
(wpeIMContextDeleteSurrounding):
(webkitInputMethodContextImplWPEGetPreedit):
(webkitInputMethodContextImplWPENotifyFocusIn):
(webkitInputMethodContextImplWPENotifyFocusOut):
(webkitInputMethodContextImplWPENotifyCursorArea):
(webkitInputMethodContextImplWPENotifySurrounding):
(webkitInputMethodContextImplWPEReset):
(webkit_input_method_context_impl_wpe_class_init):
(webkitInputMethodContextImplWPENew):
* Source/WebKit/UIProcess/API/wpe/WebKitInputMethodContextImplWPE.h: Added.
* Source/WebKit/WPEPlatform/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/WPEColor.cpp: Copied from Source/WebKit/WPEPlatform/wpe/wpe-platform.h.
(wpe_color_copy):
(wpe_color_free):
* Source/WebKit/WPEPlatform/wpe/WPEColor.h: Copied from Source/WebKit/WPEPlatform/wpe/WPEDisplayPrivate.h.
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp:
(wpeDisplayCreateInputMethodContext):
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.h:
* Source/WebKit/WPEPlatform/wpe/WPEDisplayPrivate.h:
* Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.cpp: Added.
(_WPEInputMethodUnderline::_WPEInputMethodUnderline):
(wpe_input_method_underline_new):
(wpe_input_method_underline_copy):
(wpe_input_method_underline_free):
(wpe_input_method_underline_get_start_offset):
(wpe_input_method_underline_get_end_offset):
(wpe_input_method_underline_set_color):
(wpe_input_method_underline_get_color):
(wpeInputMethodContextGetProperty):
(wpe_input_method_context_class_init):
(wpe_input_method_context_new):
(wpe_input_method_context_get_view):
(wpe_input_method_context_get_display):
(wpe_input_method_context_get_preedit_string):
(wpe_input_method_context_focus_in):
(wpe_input_method_context_focus_out):
(wpe_input_method_context_set_cursor_area):
(wpe_input_method_context_set_surrounding):
(wpe_input_method_context_reset):
* Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.h: Added.
* Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp:
(wpeDisplayWaylandDispose):
(wpeDisplayWaylandCreateInputMethodContext):
(wpeDisplayWaylandGetTextInputV1):
(wpeDisplayWaylandGetTextInputV3):
(wpe_display_wayland_class_init):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWaylandPrivate.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV1.cpp: Added.
(textInputV1GetGlobalByContext):
(toTextInputV1Hints):
(toTextInputV1Purpose):
(truncateSurroundingTextIfeeded):
(textInputV1SetCursorRectangle):
(textInputV1SetSurroundingText):
(textInputV1SetContentType):
(textInputV1CommitState):
(textInputV1UpdateState):
(keysymModifiersGetMask):
(textInputV1GetGlobalByDisplay):
(wpeIMContextWaylandV1PurposeOrHintsChanged):
(wpeIMContextWaylandV1Constructed):
(wpeIMContextWaylandV1Dispose):
(wpeIMContextWaylandV1GetPreeditString):
(wpeIMContextWaylandV1FocusIn):
(wpeIMContextWaylandV1FocusOut):
(wpeIMContextWaylandV1SetCursorArea):
(wpeIMContextWaylandV1SetSurrounding):
(wpeIMContextWaylandV1Reset):
(wpe_im_context_wayland_v1_class_init):
(wpe_im_context_wayland_v1_new):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV1.h: Copied from Source/WebKit/WPEPlatform/wpe/WPEDisplayPrivate.h.
* Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV3.cpp: Added.
(_Preedit::operator=):
(textInputV3GetGlobalByContext):
(toTextInputV3Hints):
(toTextInputV3Purpose):
(truncateSurroundingTextIfeeded):
(textInputV3SetCursorRectangle):
(textInputV3SetSurroundingText):
(textInputV3SetContentType):
(textInputV3CommitState):
(textInputV3UpdateState):
(textInputV3PreeditApply):
(textInputV3CommitApply):
(textInputV3DeleteSurroundingTextApply):
(textInputV3Enable):
(textInputV3Disable):
(textInputV3GetGlobalByDisplay):
(wpeIMContextWaylandV3PurposeOrHintsChanged):
(wpeIMContextWaylandV3Constructed):
(wpeIMContextWaylandV3Dispose):
(wpeIMContextWaylandV3GetPreeditString):
(wpeIMContextWaylandV3FocusIn):
(wpeIMContextWaylandV3FocusOut):
(wpeIMContextWaylandV3SetCursorArea):
(wpeIMContextWaylandV3SetSurrounding):
(wpeIMContextWaylandV3Reset):
(wpe_im_context_wayland_v3_class_init):
(wpe_im_context_wayland_v3_new):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV3.h: Copied from Source/WebKit/WPEPlatform/wpe/WPEDisplayPrivate.h.
* Source/WebKit/WPEPlatform/wpe/wpe-platform.h:

Canonical link: <a href="https://commits.webkit.org/279725@main">https://commits.webkit.org/279725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f815cae637b5f81c2f0632945affa4d611f83828

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54206 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57482 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4930 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41120 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4881 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43909 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3305 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31857 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46947 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25050 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28667 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3079 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50367 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4480 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59075 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4648 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51332 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30583 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47055 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50692 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31553 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8046 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30369 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->