### PR TITLE
[GTK][WPE] DRMDeviceManager: fallback to primary device if render node is asked but there isn't any

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/DRMDeviceManager.cpp
+++ b/Source/WebCore/platform/graphics/gbm/DRMDeviceManager.cpp
@@ -46,6 +46,22 @@ DRMDeviceManager& DRMDeviceManager::singleton()
 
 DRMDeviceManager::~DRMDeviceManager() = default;
 
+static void drmForeachDevice(Function<bool(drmDevice*)>&& functor)
+{
+    drmDevicePtr devices[64];
+    memset(devices, 0, sizeof(devices));
+
+    int numDevices = drmGetDevices2(0, devices, std::size(devices));
+    if (numDevices <= 0)
+        return;
+
+    for (int i = 0; i < numDevices; ++i) {
+        if (!functor(devices[i]))
+            break;
+    }
+    drmFreeDevices(devices, numDevices);
+}
+
 void DRMDeviceManager::initializeMainDevice(const String& deviceFile)
 {
     RELEASE_ASSERT(!m_mainDevice.isInitialized);
@@ -53,45 +69,36 @@ void DRMDeviceManager::initializeMainDevice(const String& deviceFile)
     if (deviceFile.isEmpty())
         return;
 
-    drmDevicePtr devices[64];
-    memset(devices, 0, sizeof(devices));
-
-    int numDevices = drmGetDevices2(0, devices, std::size(devices));
-    if (numDevices <= 0) {
-        WTFLogAlways("No DRM devices found");
-        return;
-    }
-
-    drmDevice* device = nullptr;
-    for (int i = 0; i < numDevices && !device; ++i) {
-        for (int j = 0; j < DRM_NODE_MAX && !device; ++j) {
-            if (!(devices[i]->available_nodes & (1 << j)))
+    drmForeachDevice([&](drmDevice* device) {
+        for (int i = 0; i < DRM_NODE_MAX; ++i) {
+            if (!(device->available_nodes & (1 << i)))
                 continue;
 
-            if (String::fromUTF8(devices[i]->nodes[j]) == deviceFile)
-                device = devices[i];
+            if (String::fromUTF8(device->nodes[i]) == deviceFile) {
+                RELEASE_ASSERT(device->available_nodes & (1 << DRM_NODE_PRIMARY));
+                if (device->available_nodes & (1 << DRM_NODE_RENDER)) {
+                    m_mainDevice.primaryNode = DRMDeviceNode::create(CString { device->nodes[DRM_NODE_PRIMARY] });
+                    m_mainDevice.renderNode = DRMDeviceNode::create(CString { device->nodes[DRM_NODE_RENDER] });
+                } else
+                    m_mainDevice.primaryNode = DRMDeviceNode::create(CString { device->nodes[DRM_NODE_PRIMARY] });
+                return false;
+            }
         }
-    }
+        return true;
+    });
 
-    if (device) {
-        RELEASE_ASSERT(device->available_nodes & (1 << DRM_NODE_PRIMARY));
-
-        if (device->available_nodes & (1 << DRM_NODE_RENDER)) {
-            m_mainDevice.primaryNode = DRMDeviceNode::create(CString { device->nodes[DRM_NODE_PRIMARY] });
-            m_mainDevice.renderNode = DRMDeviceNode::create(CString { device->nodes[DRM_NODE_RENDER] });
-        } else
-            m_mainDevice.primaryNode = DRMDeviceNode::create(CString { device->nodes[DRM_NODE_PRIMARY] });
-    } else
+    if (!m_mainDevice.primaryNode)
         WTFLogAlways("Failed to find DRM device for %s", deviceFile.utf8().data());
-
-    drmFreeDevices(devices, numDevices);
 }
 
 RefPtr<DRMDeviceNode> DRMDeviceManager::mainDeviceNode(DRMDeviceManager::NodeType nodeType) const
 {
     RELEASE_ASSERT(m_mainDevice.isInitialized);
 
-    return nodeType == NodeType::Primary ? m_mainDevice.primaryNode : m_mainDevice.renderNode;
+    if (nodeType == NodeType::Render)
+        return m_mainDevice.renderNode ? m_mainDevice.renderNode : m_mainDevice.primaryNode;
+
+    return m_mainDevice.primaryNode ? m_mainDevice.primaryNode : m_mainDevice.renderNode;
 }
 
 #if USE(GBM)


### PR DESCRIPTION
#### 53d24706292c592556c5991a08e75e3066495105
<pre>
[GTK][WPE] DRMDeviceManager: fallback to primary device if render node is asked but there isn&apos;t any
<a href="https://bugs.webkit.org/show_bug.cgi?id=273181">https://bugs.webkit.org/show_bug.cgi?id=273181</a>

Reviewed by Alejandro G. Castro.

* Source/WebCore/platform/graphics/gbm/DRMDeviceManager.cpp:
(WebCore::drmForeachDevice):
(WebCore::DRMDeviceManager::initializeMainDevice):
(WebCore::DRMDeviceManager::mainDeviceNode const):

Canonical link: <a href="https://commits.webkit.org/277971@main">https://commits.webkit.org/277971@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98b182477edb9fe7fd9f52be1145b78fe70f27ee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28173 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51927 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51647 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45030 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51265 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34131 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25701 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40023 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49844 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25817 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42210 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21131 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23277 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43380 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7015 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45205 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43885 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53558 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24011 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20268 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47332 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25274 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42419 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46294 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26083 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7035 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24994 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->