### PR TITLE
[Skia] Use SkScalarToDouble when creating a TransformationMatrix from SkM44

### DIFF
--- a/Source/WebCore/platform/graphics/skia/TransformationMatrixSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/TransformationMatrixSkia.cpp
@@ -33,14 +33,15 @@
 namespace WebCore {
 
 TransformationMatrix::TransformationMatrix(const SkM44& t)
+    : TransformationMatrix(SkScalarToDouble(t.rc(0, 0)), SkScalarToDouble(t.rc(0, 1)), SkScalarToDouble(t.rc(0, 2)), SkScalarToDouble(t.rc(0, 3)),
+        SkScalarToDouble(t.rc(1, 0)), SkScalarToDouble(t.rc(1, 1)), SkScalarToDouble(t.rc(1, 2)), SkScalarToDouble(t.rc(1, 3)),
+        SkScalarToDouble(t.rc(2, 0)), SkScalarToDouble(t.rc(2, 1)), SkScalarToDouble(t.rc(2, 2)), SkScalarToDouble(t.rc(2, 3)),
+        SkScalarToDouble(t.rc(3, 0)), SkScalarToDouble(t.rc(3, 1)), SkScalarToDouble(t.rc(3, 2)), SkScalarToDouble(t.rc(3, 3)))
 {
-    // FIXME: Check convention.
-    setMatrix(t.rc(0, 0), t.rc(0, 1), t.rc(0, 2), t.rc(0, 3), t.rc(1, 0), t.rc(1, 1), t.rc(1, 2), t.rc(1, 3), t.rc(2, 0), t.rc(2, 1), t.rc(2, 2), t.rc(2, 3), t.rc(3, 0), t.rc(3, 1), t.rc(3, 2), t.rc(3, 3));
 }
 
 TransformationMatrix::operator SkM44() const
 {
-    // FIXME: Check convention.
     return SkM44 {
         SkDoubleToScalar(m11()),
         SkDoubleToScalar(m12()),
@@ -62,9 +63,9 @@ TransformationMatrix::operator SkM44() const
 }
 
 AffineTransform::AffineTransform(const SkMatrix& t)
+    : AffineTransform(SkScalarToDouble(t[SkMatrix::kMScaleX]), SkScalarToDouble(t[SkMatrix::kMSkewY]), SkScalarToDouble(t[SkMatrix::kMSkewX]),  SkScalarToDouble(t[SkMatrix::kMScaleY]),
+        SkScalarToDouble(t[SkMatrix::kMTransX]), SkScalarToDouble(t[SkMatrix::kMTransY]))
 {
-    setMatrix(SkScalarToDouble(t[SkMatrix::kMScaleX]), SkScalarToDouble(t[SkMatrix::kMSkewY]), SkScalarToDouble(t[SkMatrix::kMSkewX]),  SkScalarToDouble(t[SkMatrix::kMScaleY]),
-        SkScalarToDouble(t[SkMatrix::kMTransX]), SkScalarToDouble(t[SkMatrix::kMTransY]));
 }
 
 AffineTransform::operator SkMatrix() const


### PR DESCRIPTION
#### 26805fa9a852a7398ec4002871e4e85bf6e5f953
<pre>
[Skia] Use SkScalarToDouble when creating a TransformationMatrix from SkM44
<a href="https://bugs.webkit.org/show_bug.cgi?id=273182">https://bugs.webkit.org/show_bug.cgi?id=273182</a>

Reviewed by Alejandro G. Castro.

* Source/WebCore/platform/graphics/skia/TransformationMatrixSkia.cpp:
(WebCore::TransformationMatrix::TransformationMatrix):
(WebCore::TransformationMatrix::operator SkM44 const):
(WebCore::AffineTransform::AffineTransform):

Canonical link: <a href="https://commits.webkit.org/278029@main">https://commits.webkit.org/278029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94b5bf5f57db81312251241cc7f23bf6b910a3b0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48961 "Build is in progress. Recent messages:OS: Unknown (10.15.7), Xcode: 11.7; Skipping applying patch since patch_id isn't provided; Checked out pull request; 4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51648 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45031 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51266 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25702 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40024 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25819 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42215 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21132 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23279 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43385 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7016 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45207 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43890 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53559 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24012 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20269 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47334 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25275 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42424 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46297 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26084 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7069 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24995 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->