### PR TITLE
Spurious assertion after direct call data ic on 32 bits

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -925,7 +925,7 @@ void SpeculativeJIT::emitCall(Node* node)
     }
 
     if (isDirect) {
-        auto* callLinkInfo = jitCode()->common.m_directCallLinkInfos.add(m_currentNode->origin.semantic, DirectCallLinkInfo::UseDataIC::No, m_graph.m_codeBlock, executable);
+        auto* callLinkInfo = jitCode()->common.m_directCallLinkInfos.add(m_currentNode->origin.semantic, DirectCallLinkInfo::UseDataIC::Yes, m_graph.m_codeBlock, executable);
         callLinkInfo->setCallType(callType);
         callLinkInfo->setMaxArgumentCountIncludingThis(numAllocatedArgs);
 

--- a/Source/JavaScriptCore/jit/CallFrameShuffler.h
+++ b/Source/JavaScriptCore/jit/CallFrameShuffler.h
@@ -682,9 +682,12 @@ private:
     {
         ASSERT(gpr != InvalidGPRReg && !m_newRegisters[gpr]);
         ASSERT(recovery.technique() == Int32DisplacedInJSStack
-            || recovery.technique() == Int32TagDisplacedInJSStack);
+            || recovery.technique() == Int32TagDisplacedInJSStack
+            || recovery.technique() == UnboxedInt32InGPR);
         CachedRecovery* cachedRecovery = addCachedRecovery(recovery);
         if (JSValueRegs oldRegs { cachedRecovery->wantedJSValueRegs() }) {
+            ASSERT(recovery.technique() == Int32DisplacedInJSStack
+            || recovery.technique() == Int32TagDisplacedInJSStack);
             // Combine with the other CSR in the same virtual register slot
             ASSERT(oldRegs.tagGPR() == InvalidGPRReg);
             ASSERT(oldRegs.payloadGPR() != InvalidGPRReg && oldRegs.payloadGPR() != gpr);


### PR DESCRIPTION
#### 7f93c606efccc5df180d461167efe78f1824ffb8
<pre>
Spurious assertion after direct call data ic on 32 bits
<a href="https://bugs.webkit.org/show_bug.cgi?id=273183">https://bugs.webkit.org/show_bug.cgi?id=273183</a>

Reviewed by Yusuke Suzuki.

This assertion made sense before DataIC. It is asserting that we only see boxed ints,
because unboxed ints should use the other version of the addNew method that takes JSValueRegs.

Essentially, on 32-bit, we may have separate Tag and Payload recoveries that should map to the same
cachedRecovery. When we iterate over each register in CallFrameShuffler(), we lose this information, so
addNew really becomes addNew (or update the tag register).

Now though, recent DataIC changes mean the CallLinkInfo* needs to be mainained
by the call frame shuffler in the DirectTailCall case, unboxed. So, we just move the assertion to
the case where it actually matters.

* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::emitCall):
* Source/JavaScriptCore/jit/CallFrameShuffler.h:
(JSC::CallFrameShuffler::addNew):

Canonical link: <a href="https://commits.webkit.org/277977@main">https://commits.webkit.org/277977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5779b8637eef8ef9d061e3a8be9f1edff0603c68

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48963 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28176 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51650 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45033 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34137 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40025 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25822 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42213 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21133 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23283 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43383 "Found 1 new test failure: imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-dom.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7018 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/42262 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45210 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43888 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53561 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/48454 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24014 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20270 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47335 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25277 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42422 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46299 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10804 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26086 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55949 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24997 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11513 "Found 9 new JSC stress test failures: stress/proxy-is-array.js.bytecode-cache, stress/proxy-is-array.js.default, stress/proxy-is-array.js.dfg-eager, stress/proxy-is-array.js.dfg-eager-no-cjit-validate, stress/proxy-is-array.js.eager-jettison-no-cjit, stress/proxy-is-array.js.mini-mode, stress/proxy-is-array.js.no-cjit-collect-continuously, stress/proxy-is-array.js.no-cjit-validate-phases, stress/proxy-is-array.js.no-llint (failure)") | 
<!--EWS-Status-Bubble-End-->