### PR TITLE
[visionOS] Fix build issue and re-baseline layer based tests

### DIFF
--- a/LayoutTests/interaction-region/interaction-layers-culling-expected.txt
+++ b/LayoutTests/interaction-region/interaction-layers-culling-expected.txt
@@ -75,7 +75,7 @@
                               (layer position [x: 400 y: 400])
                               (layer cornerRadius 8))))))))))))))
     (
-      (layer bounds [x: 0 y: 0 width: 800 height: 86050])
+      (layer bounds [x: 0 y: 0 width: 0 height: 0])
       (layer position [x: 400 y: 400]))
     (
       (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/interaction-region/interaction-layers-culling-layer-type-change-expected.txt
+++ b/LayoutTests/interaction-region/interaction-layers-culling-layer-type-change-expected.txt
@@ -60,7 +60,7 @@
                                       (layer position [x: 400 y: 400])
                                       (layer cornerRadius 8))))))))))))))))))
     (
-      (layer bounds [x: 0 y: 0 width: 800 height: 713])
+      (layer bounds [x: 0 y: 0 width: 0 height: 0])
       (layer position [x: 400 y: 400]))
     (
       (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/interaction-region/layer-tree-expected.txt
+++ b/LayoutTests/interaction-region/layer-tree-expected.txt
@@ -119,7 +119,7 @@
                                   (layer bounds [x: 0 y: 0 width: 800 height: 20])
                                   (layer position [x: 400 y: 400]))))))))))))))))
     (
-      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer bounds [x: 0 y: 0 width: 0 height: 0])
       (layer position [x: 400 y: 400]))
     (
       (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/interaction-region/layer-tree-shape-reset-expected.txt
+++ b/LayoutTests/interaction-region/layer-tree-shape-reset-expected.txt
@@ -52,7 +52,7 @@
                               (layer bounds [x: 0 y: 0 width: 100 height: 100])
                               (layer position [x: 350 y: 350]))))))))))))))
     (
-      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer bounds [x: 0 y: 0 width: 0 height: 0])
       (layer position [x: 400 y: 400]))
     (
       (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/overlay-region/fixed-node-updates-expected.txt
+++ b/LayoutTests/overlay-region/fixed-node-updates-expected.txt
@@ -54,7 +54,7 @@
                                           (layer bounds [x: 0 y: 0 width: 800 height: 50])
                                           (layer position [x: 400 y: 400]))))))))))))))))
             (view [class: UIView]
-              (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+              (layer bounds [x: 0 y: 0 width: 0 height: 0])
               (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/overlay-region/full-page-dynamic-expected.txt
+++ b/LayoutTests/overlay-region/full-page-dynamic-expected.txt
@@ -69,7 +69,7 @@
                                           (layer bounds [x: 0 y: 0 width: 800 height: 50])
                                           (layer position [x: 400 y: 400]))))))))))))))))
             (view [class: UIView]
-              (layer bounds [x: 0 y: 0 width: 800 height: 7113])
+              (layer bounds [x: 0 y: 0 width: 0 height: 0])
               (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/overlay-region/full-page-expected.txt
+++ b/LayoutTests/overlay-region/full-page-expected.txt
@@ -69,7 +69,7 @@
                                           (layer bounds [x: 0 y: 0 width: 800 height: 50])
                                           (layer position [x: 400 y: 400]))))))))))))))))
             (view [class: UIView]
-              (layer bounds [x: 0 y: 0 width: 800 height: 7113])
+              (layer bounds [x: 0 y: 0 width: 0 height: 0])
               (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/overlay-region/full-page-horizontal-expected.txt
+++ b/LayoutTests/overlay-region/full-page-horizontal-expected.txt
@@ -50,7 +50,7 @@
                                               (layer bounds [x: 0 y: 0 width: 50 height: 600])
                                               (layer anchorPoint [x: 0 y: 0]))))))))))))))))))
             (view [class: UIView]
-              (layer bounds [x: 0 y: 0 width: 3000 height: 600])
+              (layer bounds [x: 0 y: 0 width: 0 height: 0])
               (layer position [x: 1500 y: 1500]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/overlay-region/full-page-overflow-expected.txt
+++ b/LayoutTests/overlay-region/full-page-overflow-expected.txt
@@ -142,7 +142,7 @@
                                           (layer bounds [x: 0 y: 0 width: 800 height: 50])
                                           (layer position [x: 400 y: 400]))))))))))))))))
             (view [class: UIView]
-              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer bounds [x: 0 y: 0 width: 0 height: 0])
               (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/overlay-region/full-page-overflow-scrolling-expected.txt
+++ b/LayoutTests/overlay-region/full-page-overflow-scrolling-expected.txt
@@ -142,7 +142,7 @@
                                           (layer bounds [x: 0 y: 0 width: 800 height: 50])
                                           (layer position [x: 400 y: 400]))))))))))))))))
             (view [class: UIView]
-              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer bounds [x: 0 y: 0 width: 0 height: 0])
               (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/overlay-region/full-page-overflow-snapping-expected.txt
+++ b/LayoutTests/overlay-region/full-page-overflow-snapping-expected.txt
@@ -139,7 +139,7 @@
                                           (layer bounds [x: 0 y: 0 width: 800 height: 50])
                                           (layer position [x: 400 y: 400]))))))))))))))))
             (view [class: UIView]
-              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer bounds [x: 0 y: 0 width: 0 height: 0])
               (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/overlay-region/full-page-scrolling-expected.txt
+++ b/LayoutTests/overlay-region/full-page-scrolling-expected.txt
@@ -70,7 +70,7 @@
                                           (layer bounds [x: 0 y: 0 width: 800 height: 50])
                                           (layer position [x: 400 y: 400]))))))))))))))))
             (view [class: UIView]
-              (layer bounds [x: 0 y: 0 width: 800 height: 7113])
+              (layer bounds [x: 0 y: 0 width: 0 height: 0])
               (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/overlay-region/many-candidates-expected.txt
+++ b/LayoutTests/overlay-region/many-candidates-expected.txt
@@ -270,7 +270,7 @@
                                                               (layer bounds [x: 0 y: 0 width: 90 height: 6])
                                                               (layer position [x: 48 y: 48]))))))))))))))))))))))))))
             (view [class: UIView]
-              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer bounds [x: 0 y: 0 width: 0 height: 0])
               (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/overlay-region/map-expected.txt
+++ b/LayoutTests/overlay-region/map-expected.txt
@@ -98,7 +98,7 @@
                                                           (layer bounds [x: 0 y: 0 width: 28 height: 6])
                                                           (layer position [x: 17 y: 17]))))))))))))))))))))))))
             (view [class: UIView]
-              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer bounds [x: 0 y: 0 width: 0 height: 0])
               (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/overlay-region/map-small-expected.txt
+++ b/LayoutTests/overlay-region/map-small-expected.txt
@@ -95,7 +95,7 @@
                                                           (layer bounds [x: 0 y: 0 width: 28 height: 6])
                                                           (layer position [x: 17 y: 17]))))))))))))))))))))))))
             (view [class: UIView]
-              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer bounds [x: 0 y: 0 width: 0 height: 0])
               (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/overlay-region/overlay-element-expected.txt
+++ b/LayoutTests/overlay-region/overlay-element-expected.txt
@@ -47,7 +47,7 @@
                                           (layer bounds [x: 0 y: 0 width: 800 height: 600])
                                           (layer position [x: 400 y: 400]))))))))))))))))
             (view [class: UIView]
-              (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+              (layer bounds [x: 0 y: 0 width: 0 height: 0])
               (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/overlay-region/overlay-element-overflow-expected.txt
+++ b/LayoutTests/overlay-region/overlay-element-overflow-expected.txt
@@ -105,7 +105,7 @@
                                           (layer bounds [x: 0 y: 0 width: 800 height: 600])
                                           (layer position [x: 400 y: 400]))))))))))))))))
             (view [class: UIView]
-              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer bounds [x: 0 y: 0 width: 0 height: 0])
               (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/overlay-region/snapping-expected.txt
+++ b/LayoutTests/overlay-region/snapping-expected.txt
@@ -175,7 +175,7 @@
                                               (layer bounds [x: 0 y: 0 width: 50 height: 50])
                                               (layer anchorPoint [x: 0 y: 0]))))))))))))))))))
             (view [class: UIView]
-              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer bounds [x: 0 y: 0 width: 0 height: 0])
               (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/overlay-region/split-scrollers-expected.txt
+++ b/LayoutTests/overlay-region/split-scrollers-expected.txt
@@ -195,7 +195,7 @@
                                       (layer bounds [x: 0 y: 0 width: 0 height: 0])
                                       (layer position [x: 0 y: 0]))))))))))))))
             (view [class: UIView]
-              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer bounds [x: 0 y: 0 width: 0 height: 0])
               (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -28,6 +28,7 @@
 #include "AffineTransform.h"
 #include "FloatRoundedRect.h"
 #include "IntRect.h"
+#include "IntRectHash.h"
 #include "InteractionRegion.h"
 #include "Node.h"
 #include "Region.h"


### PR DESCRIPTION
#### 9706f30b429bdf90adfa92bcf6305e41cc03a6db
<pre>
[visionOS] Fix build issue and re-baseline layer based tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=273186">https://bugs.webkit.org/show_bug.cgi?id=273186</a>
<a href="https://rdar.apple.com/126984383">rdar://126984383</a>

Reviewed by Mike Wyrzykowski.

Add the missing include to fix the build failure and re-baseline layer
tests (again).

* Source/WebCore/rendering/EventRegion.h:
Unified sources fun, prevent `explicit specialization after instantiation`
error on IntRect hashes.

* LayoutTests/interaction-region/interaction-layers-culling-expected.txt:
* LayoutTests/interaction-region/interaction-layers-culling-layer-type-change-expected.txt:
* LayoutTests/interaction-region/layer-tree-expected.txt:
* LayoutTests/interaction-region/layer-tree-shape-reset-expected.txt:
* LayoutTests/overlay-region/fixed-node-updates-expected.txt:
* LayoutTests/overlay-region/full-page-dynamic-expected.txt:
* LayoutTests/overlay-region/full-page-expected.txt:
* LayoutTests/overlay-region/full-page-horizontal-expected.txt:
* LayoutTests/overlay-region/full-page-overflow-expected.txt:
* LayoutTests/overlay-region/full-page-overflow-scrolling-expected.txt:
* LayoutTests/overlay-region/full-page-overflow-snapping-expected.txt:
* LayoutTests/overlay-region/full-page-scrolling-expected.txt:
* LayoutTests/overlay-region/many-candidates-expected.txt:
* LayoutTests/overlay-region/map-expected.txt:
* LayoutTests/overlay-region/map-small-expected.txt:
* LayoutTests/overlay-region/overlay-element-expected.txt:
* LayoutTests/overlay-region/overlay-element-overflow-expected.txt:
* LayoutTests/overlay-region/snapping-expected.txt:
* LayoutTests/overlay-region/split-scrollers-expected.txt:
Re-baseline tests.

Canonical link: <a href="https://commits.webkit.org/277927@main">https://commits.webkit.org/277927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89ecabb84f21d4538b0c8bf1d9ac3e80a8edaca7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51651 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45034 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51269 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25705 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40028 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49853 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25825 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42216 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21136 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23286 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43386 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7019 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45213 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43891 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53562 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20272 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47338 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25278 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42425 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46302 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10782 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26087 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24998 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->