### PR TITLE
Implement eval support for TrustedScript objects

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5510,13 +5510,13 @@ webkit.org/b/261849 imported/w3c/web-platform-tests/css/css-scroll-anchoring/sta
 
 # Trusted Types aren't fully implemented yet
 webkit.org/b/272196 imported/w3c/web-platform-tests/trusted-types/trusted-types-createHTMLDocument.html [ Pass Failure ]
-webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-eval.html [ Skip ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting.html [ Skip ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html [ Skip ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-report-only.html [ Skip ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-importScripts.html [ Pass Failure ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-navigation.html [ Pass Failure ]
 webkit.org/b/274088 imported/w3c/web-platform-tests/trusted-types/Element-setAttribute-respects-Elements-node-documents-globals-CSP.html [ Pass Failure ]
+webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-eval.html [ Pass Failure ]
 
 # Close watchers aren't implemented yet
 webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/n-activate-preventDefault.html?dialog [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-eval-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-eval-expected.txt
@@ -1,13 +1,20 @@
-CONSOLE MESSAGE: Unrecognized Content-Security-Policy directive 'require-trusted-types-for'.
-
 
 FAIL eval(string) in dedicated worker assert_throws_js: function "_ => eval("2")" did not throw
-FAIL eval(TrustedScript) in dedicated worker assert_equals: expected (number) 7 but got (object) object "2"
+FAIL indirect eval(string) in dedicated worker assert_throws_js: function "_ => eval?.("2")" did not throw
+PASS eval(TrustedScript) in dedicated worker
+PASS indirect eval(TrustedScript) in dedicated worker
 FAIL eval(string) with default policy in dedicated worker assert_equals: expected 5 but got 2
-FAIL eval(string) in shared worker assert_throws_js: function "_ => eval("2")" did not throw
-FAIL eval(TrustedScript) in shared worker assert_equals: expected (number) 7 but got (object) object "2"
-FAIL eval(string) with default policy in shared worker assert_equals: expected 5 but got 2
+FAIL indirect eval(string) with default policy in dedicated worker assert_equals: expected 5 but got 2
 FAIL eval(string) in service worker assert_throws_js: function "_ => eval("2")" did not throw
-FAIL eval(TrustedScript) in service worker assert_equals: expected (number) 7 but got (object) object "2"
+FAIL indirect eval(string) in service worker assert_throws_js: function "_ => eval?.("2")" did not throw
+PASS eval(TrustedScript) in service worker
+PASS indirect eval(TrustedScript) in service worker
 FAIL eval(string) with default policy in service worker assert_equals: expected 5 but got 2
+FAIL eval(string) in shared worker assert_throws_js: function "_ => eval("2")" did not throw
+FAIL indirect eval(string) with default policy in service worker assert_equals: expected 5 but got 2
+FAIL indirect eval(string) in shared worker assert_throws_js: function "_ => eval?.("2")" did not throw
+PASS eval(TrustedScript) in shared worker
+PASS indirect eval(TrustedScript) in shared worker
+FAIL eval(string) with default policy in shared worker assert_equals: expected 5 but got 2
+FAIL indirect eval(string) with default policy in shared worker assert_equals: expected 5 but got 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-eval.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-eval.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
 <html>
 <head>
   <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script';">

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/csp-block-eval-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/csp-block-eval-expected.txt
@@ -1,6 +1,4 @@
 
 PASS eval with plain string throws (both block).
-FAIL eval with TrustedScript throws (script-src blocks). assert_throws_js: function "_ => {
-      eval(p.createScript('a="Hello transformed string"'));
-    }" did not throw
+PASS eval with TrustedScript throws (script-src blocks).
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/csp-block-eval.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/csp-block-eval.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
 <html>
 <head>
   <script nonce="abc" src="/resources/testharness.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-no-tt-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-no-tt-expected.txt
@@ -1,6 +1,8 @@
 
-FAIL eval of TrustedScript works. assert_equals: expected (number) 2 but got (object) object "1+1"
+PASS eval of TrustedScript works.
+PASS indirect eval of TrustedScript works.
 PASS eval of string works.
+PASS indirect eval of string works.
 PASS eval of !TrustedScript and !string works.
 PASS Function constructor of TrustedScript works.
 PASS Function constructor of string works.

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-no-tt.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-no-tt.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
 <html>
 <head>
   <script nonce="abc" src="/resources/testharness.js"></script>
@@ -15,8 +15,16 @@
   }, "eval of TrustedScript works.");
 
   test(t => {
+    assert_equals(eval?.(p.createScript("1+1")), 2);
+  }, "indirect eval of TrustedScript works.");
+
+  test(t => {
     assert_equals(eval('1+1'), 2);
   }, "eval of string works.");
+
+  test(t => {
+    assert_equals(eval?.('1+1'), 2);
+  }, "indirect eval of string works.");
 
   test(t => {
     assert_equals(eval(42), 42);

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy-expected.txt
@@ -1,5 +1,6 @@
 
-FAIL eval of TrustedScript works. assert_equals: expected (number) 2 but got (object) object "1+1"
+PASS eval of TrustedScript works.
+PASS indirect eval of TrustedScript works.
 FAIL eval of string works. assert_equals: expected 5 but got 2
 PASS eval of !TrustedScript and !string works.
 PASS Function constructor of TrustedScript works.

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
 <html>
 <head>
   <script nonce="abc" src="/resources/testharness.js"></script>
@@ -14,6 +14,10 @@
   test(t => {
     assert_equals(eval(p.createScript('1+1')), 2);
   }, "eval of TrustedScript works.");
+
+  test(t => {
+    assert_equals(eval?.(p.createScript('1+1')), 2);
+  }, "indirect eval of TrustedScript works.");
 
   test(t => {
     assert_equals(eval('1+1'), 5); // '1+1' becomes '4+1'.

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-no-default-policy-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-no-default-policy-expected.txt
@@ -1,6 +1,8 @@
 
-FAIL eval of TrustedScript works. assert_equals: expected (number) 2 but got (object) object "1+1"
+PASS eval of TrustedScript works.
+PASS indirect eval of TrustedScript works.
 FAIL eval of string fails. assert_throws_js: function "_ => eval('1+1')" did not throw
+FAIL indirect eval of string fails. assert_throws_js: function "_ => eval?.('1+1')" did not throw
 PASS eval of !TrustedScript and !string works.
 PASS Function constructor of TrustedScript works.
 FAIL Function constructor of string fails. assert_throws_js: function "_ => new Function('return 1+1')()" did not throw

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-no-default-policy.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-no-default-policy.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
 <html>
 <head>
   <script nonce="abc" src="/resources/testharness.js"></script>
@@ -15,8 +15,16 @@
   }, "eval of TrustedScript works.");
 
   test(t => {
+    assert_equals(eval?.(p.createScript('1+1')), 2);
+  }, "indirect eval of TrustedScript works.");
+
+  test(t => {
     assert_throws_js(EvalError, _ => eval('1+1'));
   }, "eval of string fails.");
+
+  test(t => {
+    assert_throws_js(EvalError, _ => eval?.('1+1'));
+  }, "indirect eval of string fails.");
 
   test(t => {
     assert_equals(eval(42), 42);

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-no-csp-no-tt-default-policy-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-no-csp-no-tt-default-policy-expected.txt
@@ -1,6 +1,8 @@
 
-FAIL eval of TrustedScript works. assert_equals: expected (number) 2 but got (object) object "1+1"
+PASS eval of TrustedScript works.
+PASS indirect eval of TrustedScript works.
 PASS eval of string works and does not call a default policy.
+PASS indirect eval of string works and does not call a default policy.
 PASS eval of !TrustedScript and !string works.
 PASS Function constructor of TrustedScript works.
 PASS Function constructor of string works and does not call a default policy.

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-no-csp-no-tt-default-policy.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-no-csp-no-tt-default-policy.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
 <html>
 <head>
   <script nonce="abc" src="/resources/testharness.js"></script>
@@ -16,8 +16,16 @@
   }, "eval of TrustedScript works.");
 
   test(t => {
+    assert_equals(eval?.(p.createScript('1+1')), 2);
+  }, "indirect eval of TrustedScript works.");
+
+  test(t => {
     assert_equals(eval('1+1'), 2);
   }, "eval of string works and does not call a default policy.");
+
+  test(t => {
+    assert_equals(eval?.('1+1'), 2);
+  }, "indirect eval of string works and does not call a default policy.");
 
   test(t => {
     assert_equals(eval(42), 42);

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-no-csp-no-tt-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-no-csp-no-tt-expected.txt
@@ -1,6 +1,8 @@
 
-FAIL eval of TrustedScript works. assert_equals: expected (number) 2 but got (object) object "1+1"
+PASS eval of TrustedScript works.
+PASS indirect eval of TrustedScript works.
 PASS eval of string works.
+PASS indirect eval of string works.
 PASS eval of !TrustedScript and !string works.
 PASS Function constructor of TrustedScript works.
 PASS Function constructor of string works.

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-no-csp-no-tt.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-no-csp-no-tt.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
 <html>
 <head>
   <script nonce="abc" src="/resources/testharness.js"></script>
@@ -15,8 +15,16 @@
   }, "eval of TrustedScript works.");
 
   test(t => {
+    assert_equals(eval?.(p.createScript('1+1')), 2);
+  }, "indirect eval of TrustedScript works.");
+
+  test(t => {
     assert_equals(eval('1+1'), 2);
   }, "eval of string works.");
+
+  test(t => {
+    assert_equals(eval?.('1+1'), 2);
+  }, "indirect eval of string works.");
 
   test(t => {
     assert_equals(eval(42), 42);

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-permissive-csp-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-permissive-csp-expected.txt
@@ -2,11 +2,16 @@
 FAIL eval with plain string with Trusted Types and permissive CSP throws (no type). assert_throws_js: function "_ => {
       eval('a="hello there"');
     }" did not throw
+FAIL indirect eval with plain string with Trusted Types and permissive CSP throws (no type). assert_throws_js: function "_ => {
+      eval?.('a="hello there"');
+    }" did not throw
 FAIL Function constructor with plain string with Trusted Types and permissive CSP throws (no type). assert_throws_js: function "_ => {
       new Function('a="hello there"');
     }" did not throw
-FAIL eval with TrustedScript and permissive CSP works. assert_equals: expected "Hello a cat string" but got "\"Hello a cat string\""
+PASS eval with TrustedScript and permissive CSP works.
+PASS indirect eval with TrustedScript and permissive CSP works.
 PASS new Function with TrustedScript and permissive CSP works.
 FAIL eval with default policy and permissive CSP still obeys default policy. assert_equals: expected "Hello a cat untrusted string" but got "Hello transformed untrusted string"
+FAIL indirect eval with default policy and permissive CSP still obeys default policy. assert_equals: expected "Hello a cat untrusted string" but got "Hello transformed untrusted string"
 FAIL new Function with default policy and permissive CSP still obeys default policy. assert_equals: expected "Hello a cat untrusted string" but got "Hello transformed untrusted string"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-permissive-csp.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-permissive-csp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
 <html>
 <head>
   <script nonce="abc" src="/resources/testharness.js"></script>
@@ -23,6 +23,14 @@
   test(t => {
     let a = 0;
     assert_throws_js(EvalError, _ => {
+      eval?.('a="hello there"');
+    });
+    assert_equals(a, 0);
+  }, "indirect eval with plain string with Trusted Types and permissive CSP throws (no type).");
+
+  test(t => {
+    let a = 0;
+    assert_throws_js(EvalError, _ => {
       new Function('a="hello there"');
     });
     assert_equals(a, 0);
@@ -34,6 +42,11 @@
   }, "eval with TrustedScript and permissive CSP works.");
 
   test(t => {
+    let s = eval?.(p.createScript('"Hello transformed string"'));
+    assert_equals("" + s, "Hello a cat string");
+  }, "indirect eval with TrustedScript and permissive CSP works.");
+
+  test(t => {
     let s = new Function(p.createScript('return "Hello transformed string"'))();
     assert_equals(s, "Hello a cat string");
   }, "new Function with TrustedScript and permissive CSP works.");
@@ -43,6 +56,11 @@
     let s = eval('"Hello transformed untrusted string"');
     assert_equals(s, "Hello a cat untrusted string");
   }, "eval with default policy and permissive CSP still obeys default policy.");
+
+  test(t => {
+    let s = eval?.('"Hello transformed untrusted string"');
+    assert_equals(s, "Hello a cat untrusted string");
+  }, "indirect eval with default policy and permissive CSP still obeys default policy.");
 
   test(t => {
     let s = new Function('return "Hello transformed untrusted string"')();

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/support/WorkerGlobalScope-eval.https.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/support/WorkerGlobalScope-eval.https.js
@@ -18,6 +18,10 @@ test(t => {
   assert_throws_js(EvalError, _ => eval("2"));
 }, "eval(string) in " + worker_type);
 
+test(t => {
+  assert_throws_js(EvalError, _ => eval?.("2"));
+}, "indirect eval(string) in " + worker_type);
+
 // Test eval(TrustedScript)
 let test_policy = trustedTypes.createPolicy("xxx", {
   createScript: x => x.replace("2", "7")
@@ -26,6 +30,10 @@ test(t => {
   assert_equals(eval(test_policy.createScript("2")), 7);
 }, "eval(TrustedScript) in " + worker_type);
 
+test(t => {
+  assert_equals(eval?.(test_policy.createScript("2")), 7);
+}, "indirect eval(TrustedScript) in " + worker_type);
+
 // Test eval(String) with default policy
 trustedTypes.createPolicy("default", {
   createScript: x => x.replace("2", "5")
@@ -33,5 +41,8 @@ trustedTypes.createPolicy("default", {
 test(t => {
   assert_equals(eval("2"), 5);
 }, "eval(string) with default policy in " + worker_type);
+test(t => {
+  assert_equals(eval?.("2"), 5);
+}, "indirect eval(string) with default policy in " + worker_type);
 
 done();

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-expected.txt
@@ -1,5 +1,7 @@
+CONSOLE MESSAGE: Refused to load because it does not appear in the object-src directive of the Content Security Policy.
+
 
 FAIL Trusted Type violation report: evaluating a string. assert_throws_js: function "_ => eval('beacon="should not run"')" did not throw
-FAIL Trusted Type violation report: evaluating a Trusted Script. assert_equals: expected "i ran" but got "never_overwritten2"
+PASS Trusted Type violation report: evaluating a Trusted Script.
 FAIL Trusted Type violation report: default policy transforms the script before CSP checks runs. assert_equals: expected "default policy" but got "payload"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
 <head>
   <script nonce="123" src="/resources/testharness.js"></script>
   <script nonce="123" src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -3270,6 +3270,7 @@ webkit.org/b/271223 fast/events/wheel/redispatched-wheel-event.html [ Skip ] # T
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting.html [ Skip ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-report-only.html [ Skip ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html [ Skip ]
+webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting.html [ Skip ]
 
 # testRunner.dontForceRepaint
 compositing/repaint/copy-forward-dirty-region-purged-backbuffer.html [ Skip ]

--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.cpp
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.cpp
@@ -58,6 +58,7 @@ const GlobalObjectMethodTable* JSAPIGlobalObject::globalObjectMethodTable()
         nullptr, // compileStreaming
         nullptr, // instantiateStreaming
         nullptr, // deriveShadowRealmGlobalObject
+        &codeForEval,
     };
     return &table;
 }

--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
@@ -77,6 +77,7 @@ const GlobalObjectMethodTable* JSAPIGlobalObject::globalObjectMethodTable()
         nullptr, // compileStreaming
         nullptr, // instantiateStreaming
         &deriveShadowRealmGlobalObject,
+        &codeForEval,
     };
     return &table;
 };

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -943,7 +943,8 @@ const GlobalObjectMethodTable GlobalObject::s_globalObjectMethodTable = {
     nullptr, // defaultLanguage
     nullptr, // compileStreaming
     nullptr, // instantinateStreaming
-    &deriveShadowRealmGlobalObject
+    &deriveShadowRealmGlobalObject,
+    &codeForEval
 };
 
 GlobalObject::GlobalObject(VM& vm, Structure* structure)

--- a/Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h
+++ b/Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h
@@ -70,6 +70,7 @@ struct GlobalObjectMethodTable {
     JSPromise* (*compileStreaming)(JSGlobalObject*, JSValue);
     JSPromise* (*instantiateStreaming)(JSGlobalObject*, JSValue, JSObject*);
     JSGlobalObject* (*deriveShadowRealmGlobalObject)(JSGlobalObject*);
+    String (*codeForEval)(JSGlobalObject*, JSValue);
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -610,7 +610,8 @@ const GlobalObjectMethodTable* JSGlobalObject::baseGlobalObjectMethodTable()
         nullptr, // defaultLanguage
         nullptr, // compileStreaming
         nullptr, // instantiateStreaming
-        &deriveShadowRealmGlobalObject
+        &deriveShadowRealmGlobalObject,
+        &codeForEval
     };
     return &table;
 };

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -922,6 +922,7 @@ public:
     static JSObject* currentScriptExecutionOwner(JSGlobalObject* global) { return global; }
     static ScriptExecutionStatus scriptExecutionStatus(JSGlobalObject*, JSObject*) { return ScriptExecutionStatus::Running; }
     static void reportViolationForUnsafeEval(JSGlobalObject*, JSString*) { }
+    static String codeForEval(JSGlobalObject*, JSValue) { return nullString(); }
 
     inline JSObject* arrayBufferPrototype(ArrayBufferSharingMode) const;
     inline Structure* arrayBufferStructure(ArrayBufferSharingMode) const;
@@ -1018,6 +1019,7 @@ public:
     JS_EXPORT_PRIVATE void queueMicrotask(JSValue job, JSValue, JSValue, JSValue, JSValue);
 
     static void reportViolationForUnsafeEval(const JSGlobalObject*, JSString*) { }
+    static String codeForEval(const JSGlobalObject*, JSValue) { return nullString(); }
 
     bool evalEnabled() const { return m_evalEnabled; }
     bool webAssemblyEnabled() const { return m_webAssemblyEnabled; }

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -599,6 +599,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useShadowRealm, false, Normal, "Expose the ShadowRealm object."_s) \
     v(Bool, useStringWellFormed, true, Normal, "Expose the String well-formed methods."_s) \
     v(Bool, useTemporal, false, Normal, "Expose the Temporal object."_s) \
+    v(Bool, useTrustedTypes, false, Normal, "Enable trusted types eval protection feature."_s) \
     v(Bool, useWebAssemblyThreading, true, Normal, "Allow instructions from the wasm threading spec."_s) \
     v(Bool, useWebAssemblyTypedFunctionReferences, true, Normal, "Allow function types from the wasm typed function references spec."_s) \
     v(Bool, useWebAssemblyGC, false, Normal, "Allow gc types from the wasm gc proposal."_s) \

--- a/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
@@ -41,6 +41,7 @@
 #include "JSFetchResponse.h"
 #include "JSMicrotaskCallback.h"
 #include "JSNode.h"
+#include "JSTrustedScript.h"
 #include "LocalFrame.h"
 #include "Logging.h"
 #include "Page.h"
@@ -103,7 +104,8 @@ const GlobalObjectMethodTable* JSDOMWindowBase::globalObjectMethodTable()
         nullptr,
         nullptr,
 #endif
-        deriveShadowRealmGlobalObject
+        deriveShadowRealmGlobalObject,
+        codeForEval
     };
     return &table;
 };
@@ -295,6 +297,16 @@ void JSDOMWindowBase::reportViolationForUnsafeEval(JSGlobalObject* object, JSStr
     if (source)
         sourceString = source->tryGetValue();
     contentSecurityPolicy->allowEval(object, LogToConsole::No, sourceString);
+}
+
+String JSDOMWindowBase::codeForEval(JSGlobalObject* globalObject, JSValue value)
+{
+    VM& vm = globalObject->vm();
+
+    if (auto* script = JSTrustedScript::toWrapped(vm, value))
+        return script->toString();
+
+    return nullString();
 }
 
 void JSDOMWindowBase::willRemoveFromWindowProxy()

--- a/Source/WebCore/bindings/js/JSDOMWindowBase.h
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.h
@@ -80,7 +80,8 @@ public:
     static JSC::JSObject* currentScriptExecutionOwner(JSC::JSGlobalObject*);
     static JSC::ScriptExecutionStatus scriptExecutionStatus(JSC::JSGlobalObject*, JSC::JSObject*);
     static void reportViolationForUnsafeEval(JSC::JSGlobalObject*, JSC::JSString*);
-    
+    static String codeForEval(JSC::JSGlobalObject*, JSC::JSValue);
+
     void printErrorMessage(const String&) const;
 
     JSWindowProxy& proxy() const;

--- a/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.cpp
+++ b/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.cpp
@@ -71,6 +71,7 @@ const GlobalObjectMethodTable* JSShadowRealmGlobalScopeBase::globalObjectMethodT
         nullptr,
 #endif
         &deriveShadowRealmGlobalObject,
+        &codeForEval,
     };
     return &table;
 };
@@ -151,6 +152,11 @@ void JSShadowRealmGlobalScopeBase::reportViolationForUnsafeEval(JSC::JSGlobalObj
 {
     auto incubating = jsCast<JSShadowRealmGlobalScopeBase*>(globalObject)->incubatingRealm();
     incubating->globalObjectMethodTable()->reportViolationForUnsafeEval(incubating, msg);
+}
+
+String JSShadowRealmGlobalScopeBase::codeForEval(JSC::JSGlobalObject* globalObject, JSC::JSValue value)
+{
+    return JSGlobalObject::codeForEval(globalObject, value);
 }
 
 void JSShadowRealmGlobalScopeBase::queueMicrotaskToEventLoop(JSGlobalObject& object, Ref<JSC::Microtask>&& task)

--- a/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.h
+++ b/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.h
@@ -55,6 +55,7 @@ private:
     static JSC::ScriptExecutionStatus scriptExecutionStatus(JSC::JSGlobalObject*, JSC::JSObject*);
     static void queueMicrotaskToEventLoop(JSC::JSGlobalObject&, Ref<JSC::Microtask>&&);
     static void reportViolationForUnsafeEval(JSC::JSGlobalObject*, JSC::JSString*);
+    static String codeForEval(JSC::JSGlobalObject*, JSC::JSValue);
 
 protected:
     JSShadowRealmGlobalScopeBase(JSC::VM&, JSC::Structure*, RefPtr<ShadowRealmGlobalScope>&&);

--- a/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.h
+++ b/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.h
@@ -58,6 +58,7 @@ public:
     static JSC::ScriptExecutionStatus scriptExecutionStatus(JSC::JSGlobalObject*, JSC::JSObject*);
     static void queueMicrotaskToEventLoop(JSC::JSGlobalObject&, Ref<JSC::Microtask>&&);
     static void reportViolationForUnsafeEval(JSC::JSGlobalObject*, JSC::JSString*);
+    static String codeForEval(JSC::JSGlobalObject*, JSC::JSValue);
 
 protected:
     JSWorkerGlobalScopeBase(JSC::VM&, JSC::Structure*, RefPtr<WorkerGlobalScope>&&);

--- a/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.cpp
+++ b/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.cpp
@@ -69,6 +69,7 @@ const GlobalObjectMethodTable* JSWorkletGlobalScopeBase::globalObjectMethodTable
         nullptr,
 #endif
         deriveShadowRealmGlobalObject,
+        codeForEval,
     };
     return &table;
 };
@@ -117,6 +118,11 @@ JSC::ScriptExecutionStatus JSWorkletGlobalScopeBase::scriptExecutionStatus(JSC::
 void JSWorkletGlobalScopeBase::reportViolationForUnsafeEval(JSC::JSGlobalObject* globalObject, JSC::JSString* source)
 {
     return JSGlobalObject::reportViolationForUnsafeEval(globalObject, source);
+}
+
+String JSWorkletGlobalScopeBase::codeForEval(JSC::JSGlobalObject* globalObject, JSC::JSValue value)
+{
+    return JSGlobalObject::codeForEval(globalObject, value);
 }
 
 bool JSWorkletGlobalScopeBase::supportsRichSourceInfo(const JSGlobalObject* object)

--- a/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.h
+++ b/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.h
@@ -59,6 +59,7 @@ public:
     static JSC::ScriptExecutionStatus scriptExecutionStatus(JSC::JSGlobalObject*, JSC::JSObject*);
     static void queueMicrotaskToEventLoop(JSC::JSGlobalObject&, Ref<JSC::Microtask>&&);
     static void reportViolationForUnsafeEval(JSC::JSGlobalObject*, JSC::JSString*);
+    static String codeForEval(JSC::JSGlobalObject*, JSC::JSValue);
 
 protected:
     JSWorkletGlobalScopeBase(JSC::VM&, JSC::Structure*, RefPtr<WorkletGlobalScope>&&);


### PR DESCRIPTION
#### 5e0f9b3cfb2b1ec21b3481b9c09ba763aa32a119
<pre>
Implement eval support for TrustedScript objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=273184">https://bugs.webkit.org/show_bug.cgi?id=273184</a>

Reviewed by Ryosuke Niwa and Justin Michaud.

This patch introduces a new codeForEval function to the global object method table.
The eval code is updated to check if an object has associated code instead of always returning the object.
Add test coverage for indirect evals.

See <a href="https://tc39.es/proposal-dynamic-code-brand-checks/">https://tc39.es/proposal-dynamic-code-brand-checks/</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-eval-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-eval.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/csp-block-eval-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/csp-block-eval.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-no-tt-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-no-tt.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-no-default-policy-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-no-default-policy.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-no-csp-no-tt-default-policy-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-no-csp-no-tt-default-policy.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-no-csp-no-tt-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-no-csp-no-tt.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-permissive-csp-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-permissive-csp.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/support/WorkerGlobalScope-eval.https.js:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting.html:
* Source/JavaScriptCore/API/JSAPIGlobalObject.cpp:
(JSC::JSAPIGlobalObject::globalObjectMethodTable):
* Source/JavaScriptCore/API/JSAPIGlobalObject.mm:
(JSC::JSAPIGlobalObject::globalObjectMethodTable):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::eval):
* Source/JavaScriptCore/jsc.cpp:
* Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::baseGlobalObjectMethodTable):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::codeForEval):
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/WebCore/bindings/js/JSDOMWindowBase.cpp:
(WebCore::JSDOMWindowBase::globalObjectMethodTable):
(WebCore::JSDOMWindowBase::codeForEval):
* Source/WebCore/bindings/js/JSDOMWindowBase.h:
* Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.cpp:
(WebCore::JSShadowRealmGlobalScopeBase::globalObjectMethodTable):
(WebCore::JSShadowRealmGlobalScopeBase::codeForEval):
* Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.h:
* Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp:
(WebCore::JSWorkerGlobalScopeBase::globalObjectMethodTable):
(WebCore::JSWorkerGlobalScopeBase::codeForEval):
* Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.h:
* Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.cpp:
(WebCore::JSWorkletGlobalScopeBase::globalObjectMethodTable):
(WebCore::JSWorkletGlobalScopeBase::codeForEval):
* Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.h:
* LayoutTests/platform/wincairo/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/279194@main">https://commits.webkit.org/279194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef56c24aafcc6983158131eb7a97e5467fd114d4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55844 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3293 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54875 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2994 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42712 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2101 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54668 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29574 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45368 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23804 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26727 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2649 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1452 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45921 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48614 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2803 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57440 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52080 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27705 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2819 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50110 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28931 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45485 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49376 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11529 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29843 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64386 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28681 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12203 "Passed tests") | 
<!--EWS-Status-Bubble-End-->