### PR TITLE
[IPC] Cleanup DaemonCoders.h

### DIFF
--- a/Source/WebKit/Platform/IPC/DaemonCoders.cpp
+++ b/Source/WebKit/Platform/IPC/DaemonCoders.cpp
@@ -29,11 +29,9 @@
 #include "DaemonDecoder.h"
 #include "DaemonEncoder.h"
 #include <WebCore/CertificateInfo.h>
-#include <WebCore/ExceptionData.h>
 #include <WebCore/PrivateClickMeasurement.h>
 #include <WebCore/PushSubscriptionData.h>
 #include <WebCore/RegistrableDomain.h>
-#include <WebCore/SecurityOriginData.h>
 
 #if PLATFORM(COCOA)
 #include <CoreFoundation/CoreFoundation.h>
@@ -41,58 +39,6 @@
 #endif
 
 namespace WebKit::Daemon {
-
-void Coder<WebCore::PushSubscriptionData>::encode(Encoder& encoder, const WebCore::PushSubscriptionData& instance)
-{
-    encoder << instance.identifier;
-    encoder << instance.endpoint;
-    encoder << instance.expirationTime;
-    encoder << instance.serverVAPIDPublicKey;
-    encoder << instance.clientECDHPublicKey;
-    encoder << instance.sharedAuthenticationSecret;
-}
-
-std::optional<WebCore::PushSubscriptionData> Coder<WebCore::PushSubscriptionData>::decode(Decoder& decoder)
-{
-    std::optional<WebCore::PushSubscriptionIdentifier> identifier;
-    decoder >> identifier;
-    if (!identifier)
-        return std::nullopt;
-
-    std::optional<String> endpoint;
-    decoder >> endpoint;
-    if (!endpoint)
-        return std::nullopt;
-
-    std::optional<std::optional<WebCore::EpochTimeStamp>> expirationTime;
-    decoder >> expirationTime;
-    if (!expirationTime)
-        return std::nullopt;
-
-    std::optional<Vector<uint8_t>> serverVAPIDPublicKey;
-    decoder >> serverVAPIDPublicKey;
-    if (!serverVAPIDPublicKey)
-        return std::nullopt;
-
-    std::optional<Vector<uint8_t>> clientECDHPublicKey;
-    decoder >> clientECDHPublicKey;
-    if (!clientECDHPublicKey)
-        return std::nullopt;
-
-    std::optional<Vector<uint8_t>> sharedAuthenticationSecret;
-    decoder >> sharedAuthenticationSecret;
-    if (!sharedAuthenticationSecret)
-        return std::nullopt;
-
-    return { {
-        WTFMove(*identifier),
-        WTFMove(*endpoint),
-        WTFMove(*expirationTime),
-        WTFMove(*serverVAPIDPublicKey),
-        WTFMove(*clientECDHPublicKey),
-        WTFMove(*sharedAuthenticationSecret),
-    } };
-}
 
 void Coder<WTF::WallTime>::encode(Encoder& encoder, const WTF::WallTime& instance)
 {
@@ -348,58 +294,6 @@ std::optional<WebCore::PCM::AttributionTriggerData> Coder<WebCore::PCM::Attribut
     } };
 }
 
-void Coder<WebCore::ExceptionData, void>::encode(Encoder& encoder, const WebCore::ExceptionData& instance)
-{
-    encoder << instance.code;
-    encoder << instance.message;
-}
-
-std::optional<WebCore::ExceptionData> Coder<WebCore::ExceptionData, void>::decode(Decoder& decoder)
-{
-    std::optional<WebCore::ExceptionCode> code;
-    decoder >> code;
-    if (!code)
-        return std::nullopt;
-
-    std::optional<String> message;
-    decoder >> message;
-    if (!message)
-        return std::nullopt;
-
-    return WebCore::ExceptionData { WTFMove(*code), WTFMove(*message) };
-}
-
-void Coder<WebCore::SecurityOriginData, void>::encode(Encoder& encoder, const WebCore::SecurityOriginData& instance)
-{
-    encoder << instance.protocol();
-    encoder << instance.host();
-    encoder << instance.port();
-}
-
-std::optional<WebCore::SecurityOriginData> Coder<WebCore::SecurityOriginData, void>::decode(Decoder& decoder)
-{
-    std::optional<String> protocol;
-    decoder >> protocol;
-    if (!protocol)
-        return std::nullopt;
-    
-    std::optional<String> host;
-    decoder >> host;
-    if (!host)
-        return std::nullopt;
-    
-    std::optional<std::optional<uint16_t>> port;
-    decoder >> port;
-    if (!port)
-        return std::nullopt;
-    
-    WebCore::SecurityOriginData data { WTFMove(*protocol), WTFMove(*host), WTFMove(*port) };
-    if (data.isHashTableDeletedValue())
-        return std::nullopt;
-
-    return data;
-}
-
 void Coder<WebCore::RegistrableDomain, void>::encode(Encoder& encoder, const WebCore::RegistrableDomain& instance)
 {
     encoder << instance.string();
@@ -413,21 +307,6 @@ std::optional<WebCore::RegistrableDomain> Coder<WebCore::RegistrableDomain, void
         return std::nullopt;
 
     return { WebCore::RegistrableDomain::fromRawString(WTFMove(*host)) };
-}
-
-void Coder<WebCore::PushSubscriptionIdentifier>::encode(Encoder& encoder, const WebCore::PushSubscriptionIdentifier& instance)
-{
-    encoder << instance.toUInt64();
-}
-
-std::optional<WebCore::PushSubscriptionIdentifier> Coder<WebCore::PushSubscriptionIdentifier>::decode(Decoder& decoder)
-{
-    std::optional<uint64_t> rawID;
-    decoder >> rawID;
-    if (!rawID)
-        return std::nullopt;
-
-    return { WebCore::PushSubscriptionIdentifier(*rawID) };
 }
 
 }

--- a/Source/WebKit/Platform/IPC/DaemonCoders.h
+++ b/Source/WebKit/Platform/IPC/DaemonCoders.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "ArgumentCoders.h"
-#include <WebCore/PushSubscriptionIdentifier.h>
 #include <optional>
 #include <wtf/Forward.h>
 #include <wtf/StdLibExtras.h>
@@ -37,9 +36,7 @@
 namespace WebCore {
 struct ExceptionData;
 class CertificateInfo;
-struct PushSubscriptionData;
 class PrivateClickMeasurement;
-class SecurityOriginData;
 class RegistrableDomain;
 namespace PCM {
 struct AttributionTimeToSendData;
@@ -49,10 +46,6 @@ struct EphemeralNonce;
 }
 
 namespace WebKit {
-
-namespace WebPushD {
-struct WebPushDaemonConnectionConfiguration;
-}
 
 namespace Daemon {
 
@@ -113,14 +106,9 @@ template<> struct Coder<class> { \
 }
 
 DECLARE_CODER(WebCore::CertificateInfo);
-DECLARE_CODER(WebCore::ExceptionData);
 DECLARE_CODER(WebCore::PrivateClickMeasurement);
 DECLARE_CODER(WebCore::PCM::AttributionTriggerData);
-DECLARE_CODER(WebCore::PushSubscriptionData);
-DECLARE_CODER(WebCore::PushSubscriptionIdentifier);
 DECLARE_CODER(WebCore::RegistrableDomain);
-DECLARE_CODER(WebCore::SecurityOriginData);
-DECLARE_CODER(WebPushD::WebPushDaemonConnectionConfiguration);
 DECLARE_CODER(WTF::WallTime);
 
 #undef DECLARE_CODER
@@ -139,33 +127,6 @@ template<> struct Coder<WTF::URL> {
         if (!string)
             return std::nullopt;
         return { WTF::URL(WTFMove(*string)) };
-    }
-};
-
-template<> struct Coder<WTF::UUID> {
-    template<typename Encoder>
-    static void encode(Encoder& encoder, const WTF::UUID& instance)
-    {
-        encoder << static_cast<uint64_t>(instance.data() >> 64) << static_cast<uint64_t>(instance.data());
-    }
-    template<typename Decoder>
-    static std::optional<WTF::UUID> decode(Decoder& decoder)
-    {
-        std::optional<uint64_t> high;
-        decoder >> high;
-        if (!high)
-            return std::nullopt;
-
-        std::optional<uint64_t> low;
-        decoder >> low;
-        if (!low)
-            return std::nullopt;
-
-        auto result = (static_cast<UInt128>(*high) << 64) | *low;
-        if (result == WTF::UUID::deletedValue)
-            return { };
-
-        return WTF::UUID { result };
     }
 };
 


### PR DESCRIPTION
#### 6ca8653a03e3863ac614b15f1a59ac6b271031f9
<pre>
[IPC] Cleanup DaemonCoders.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=273198">https://bugs.webkit.org/show_bug.cgi?id=273198</a>

Reviewed by Ben Nham.

Removed unused IPC code from DaemonCoders

* Source/WebKit/Platform/IPC/DaemonCoders.cpp:
(WebKit::Daemon::Coder&lt;WebCore::PushSubscriptionData&gt;::encode): Deleted.
(WebKit::Daemon::Coder&lt;WebCore::PushSubscriptionData&gt;::decode): Deleted.
(WebKit::Daemon::Coder&lt;WebCore::PushSubscriptionIdentifier&gt;::encode): Deleted.
(WebKit::Daemon::Coder&lt;WebCore::PushSubscriptionIdentifier&gt;::decode): Deleted.
* Source/WebKit/Platform/IPC/DaemonCoders.h:
(WebKit::Daemon::Coder&lt;WTF::UUID&gt;::encode): Deleted.
(WebKit::Daemon::Coder&lt;WTF::UUID&gt;::decode): Deleted.

Canonical link: <a href="https://commits.webkit.org/278695@main">https://commits.webkit.org/278695@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5096adec7f5550ddc7c8240d061a6e481e053634

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28610 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52560 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26230 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40303 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42486 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21419 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23612 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7697 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45523 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44173 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54077 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24410 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20599 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47623 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25682 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46638 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11229 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26521 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25405 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->