### PR TITLE
[WebGPU] mapAsync shouldn't be calling getMappedRange on the entire buffer

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1782,6 +1782,18 @@ webkit.org/b/261356 [ Debug ] fast/mediastream/device-change-event-2.html [ Pass
 webkit.org/b/263396 css3/color/text.html [ Skip ]
 
 # WebGPU
+
+[ Release ] http/tests/webgpu/webgpu/api/operation/buffers/map.html [ Pass ]
+[ Release ] http/tests/webgpu/webgpu/api/operation/buffers/map_ArrayBuffer.html [ Pass ]
+[ Release ] http/tests/webgpu/webgpu/api/operation/buffers/map_detach.html [ Pass ]
+[ Release ] http/tests/webgpu/webgpu/api/operation/buffers/map_oom.html [ Pass ]
+[ Release ] http/tests/webgpu/webgpu/api/operation/buffers/threading.html [ Pass ]
+
+[ Release ] http/tests/webgpu/webgpu/api/validation/buffer/create.html [ Pass ]
+[ Release ] http/tests/webgpu/webgpu/api/validation/buffer/destroy.html [ Pass ]
+[ Release ] http/tests/webgpu/webgpu/api/validation/buffer/mapping.html [ Pass ]
+
+# Skip tests until they can be validated to consistently pass in EWS
 http/tests/webgpu/webgpu/idl/constructable.html [ Skip ]
 http/tests/webgpu/webgpu/idl/constants/flags.html [ Skip ]
 

--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.h
@@ -80,7 +80,7 @@ private:
     Ref<WebGPU::Buffer> m_backing;
     struct ArrayBufferWithOffset {
         RefPtr<JSC::ArrayBuffer> buffer;
-        uint8_t* source;
+        size_t offset { 0 };
     };
     Vector<ArrayBufferWithOffset> m_arrayBuffers;
     size_t m_bufferSize { 0 };

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.cpp
@@ -83,6 +83,21 @@ auto BufferImpl::getMappedRange(Size64 offset, std::optional<Size64> size) -> Ma
     return { static_cast<uint8_t*>(pointer) - actualOffset, actualSize };
 }
 
+auto BufferImpl::getBufferContents() -> MappedRange
+{
+    if (!m_backing.get())
+        return { nullptr, 0 };
+
+    auto* pointer = wgpuBufferGetBufferContents(m_backing.get());
+    auto bufferSize = wgpuBufferGetSize(m_backing.get());
+    return { static_cast<uint8_t*>(pointer), static_cast<size_t>(bufferSize) };
+}
+
+void BufferImpl::copy(Vector<uint8_t>&&, size_t)
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
 void BufferImpl::unmap()
 {
     wgpuBufferUnmap(m_backing.get());

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.h
@@ -60,7 +60,9 @@ private:
 
     void mapAsync(MapModeFlags, Size64 offset, std::optional<Size64> sizeForMap, CompletionHandler<void(bool)>&&) final;
     MappedRange getMappedRange(Size64 offset, std::optional<Size64>) final;
+    MappedRange getBufferContents() final;
     void unmap() final;
+    void copy(Vector<uint8_t>&&, size_t) final;
 
     void destroy() final;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h
@@ -58,7 +58,8 @@ public:
     virtual void unmap() = 0;
 
     virtual void destroy() = 0;
-
+    virtual MappedRange getBufferContents() = 0;
+    virtual void copy(Vector<uint8_t>&&, size_t offset) = 0;
 protected:
     Buffer() = default;
 

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -91,6 +91,7 @@ public:
     bool isDestroyed() const;
     void setCommandEncoder(CommandEncoder&, bool mayModifyBuffer = false) const;
     uint32_t maxIndex(MTLIndexType) const;
+    uint8_t* getBufferContents();
 
 private:
     Buffer(id<MTLBuffer>, uint64_t initialSize, WGPUBufferUsageFlags, State initialState, MappingRange initialMappingRange, Device&);

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -240,6 +240,11 @@ void* Buffer::getMappedRange(size_t offset, size_t size)
     return static_cast<char*>(m_buffer.contents) + offset;
 }
 
+uint8_t* Buffer::getBufferContents()
+{
+    return static_cast<uint8_t*>(m_buffer.contents);
+}
+
 NSString* Buffer::errorValidatingMapAsync(WGPUMapModeFlags mode, size_t offset, size_t rangeSize) const
 {
 #define ERROR_STRING(x) (@"GPUBuffer.mapAsync: " x)
@@ -443,6 +448,11 @@ WGPUBufferMapState wgpuBufferGetMapState(WGPUBuffer buffer)
 void* wgpuBufferGetMappedRange(WGPUBuffer buffer, size_t offset, size_t size)
 {
     return WebGPU::fromAPI(buffer).getMappedRange(offset, size);
+}
+
+void* wgpuBufferGetBufferContents(WGPUBuffer buffer)
+{
+    return WebGPU::fromAPI(buffer).getBufferContents();
 }
 
 uint64_t wgpuBufferGetSize(WGPUBuffer buffer)

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -1597,6 +1597,7 @@ WGPU_EXPORT void wgpuBufferDestroy(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void const * wgpuBufferGetConstMappedRange(WGPUBuffer buffer, size_t offset, size_t size) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUBufferMapState wgpuBufferGetMapState(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void * wgpuBufferGetMappedRange(WGPUBuffer buffer, size_t offset, size_t size) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void * wgpuBufferGetBufferContents(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT uint64_t wgpuBufferGetSize(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUBufferUsageFlags wgpuBufferGetUsage(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuBufferMapAsync(WGPUBuffer buffer, WGPUMapModeFlags mode, size_t offset, size_t size, WGPUBufferMapCallback callback, void * userdata) WGPU_FUNCTION_ATTRIBUTE;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
@@ -32,6 +32,8 @@
 #include "StreamServerConnection.h"
 #include "WebGPUObjectHeap.h"
 
+#include <wtf/CheckedArithmetic.h>
+
 namespace WebKit {
 
 RemoteBuffer::RemoteBuffer(WebCore::WebGPU::Buffer& buffer, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, bool mappedAtCreation, WebGPUIdentifier identifier)
@@ -52,47 +54,57 @@ void RemoteBuffer::stopListeningForIPC()
     m_streamConnection->stopReceivingMessages(Messages::RemoteBuffer::messageReceiverName(), m_identifier.toUInt64());
 }
 
-void RemoteBuffer::mapAsync(WebCore::WebGPU::MapModeFlags mapModeFlags, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&& callback)
+void RemoteBuffer::mapAsync(WebCore::WebGPU::MapModeFlags mapModeFlags, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size, CompletionHandler<void(bool)>&& callback)
 {
     m_isMapped = true;
     m_mapModeFlags = mapModeFlags;
 
     m_backing->mapAsync(mapModeFlags, offset, size, [protectedThis = Ref<RemoteBuffer>(*this), callback = WTFMove(callback)] (bool success) mutable {
         if (!success) {
-            callback(std::nullopt);
+            callback(false);
             return;
         }
 
-        auto mappedRange = protectedThis->m_backing->getMappedRange(0, std::nullopt);
-        protectedThis->m_mappedRange = mappedRange;
-        callback(Vector(std::span { static_cast<const uint8_t*>(mappedRange.source), mappedRange.byteLength }));
+        callback(true);
     });
 }
 
 void RemoteBuffer::getMappedRange(WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&& callback)
 {
     auto mappedRange = m_backing->getMappedRange(offset, size);
-    m_mappedRange = mappedRange;
     m_isMapped = true;
 
     callback(Vector(std::span { static_cast<const uint8_t*>(mappedRange.source), mappedRange.byteLength }));
 }
 
-void RemoteBuffer::unmap(Vector<uint8_t>&& data)
+void RemoteBuffer::unmap()
 {
-    if (m_isMapped && m_mappedRange && m_mappedRange->byteLength >= data.size() && m_mapModeFlags.contains(WebCore::WebGPU::MapMode::Write))
-        memcpy(m_mappedRange->source, data.data(), data.size());
-
     if (m_isMapped)
         m_backing->unmap();
     m_isMapped = false;
-    m_mappedRange = std::nullopt;
     m_mapModeFlags = { };
+}
+
+void RemoteBuffer::copy(Vector<uint8_t>&& data, size_t offset)
+{
+    if (!m_isMapped || !m_mapModeFlags.contains(WebCore::WebGPU::MapMode::Write))
+        return;
+
+    auto [buffer, bufferLength] = m_backing->getBufferContents();
+    if (!buffer || !bufferLength)
+        return;
+
+    auto dataSize = data.size();
+    auto endOffset = checkedSum<size_t>(offset, dataSize);
+    if (endOffset.hasOverflowed() || endOffset.value() > bufferLength)
+        return;
+
+    memcpy(buffer + offset, data.data(), data.size());
 }
 
 void RemoteBuffer::destroy()
 {
-    unmap(Vector<uint8_t>());
+    unmap();
     m_backing->destroy();
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
@@ -79,8 +79,9 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void getMappedRange(WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> sizeForMap, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
-    void mapAsync(WebCore::WebGPU::MapModeFlags, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> sizeForMap, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
-    void unmap(Vector<uint8_t>&&);
+    void mapAsync(WebCore::WebGPU::MapModeFlags, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> sizeForMap, CompletionHandler<void(bool)>&&);
+    void copy(Vector<uint8_t>&&, size_t offset);
+    void unmap();
 
     void destroy();
     void destruct();
@@ -92,7 +93,6 @@ private:
     Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
     bool m_isMapped { false };
-    std::optional<WebCore::WebGPU::Buffer::MappedRange> m_mappedRange;
     WebCore::WebGPU::MapModeFlags m_mapModeFlags;
 };
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.messages.in
@@ -25,8 +25,9 @@
 
 messages -> RemoteBuffer NotRefCounted Stream {
     void GetMappedRange(WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size) -> (std::optional<Vector<uint8_t>> data) Synchronous
-    void MapAsync(WebCore::WebGPU::MapModeFlags mapModeFlags, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size) -> (std::optional<Vector<uint8_t>> data)
-    void Unmap(Vector<uint8_t> data)
+    void MapAsync(WebCore::WebGPU::MapModeFlags mapModeFlags, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size) -> (bool success)
+    void Copy(Vector<uint8_t> data, size_t offset)
+    void Unmap()
     void Destroy()
     void Destruct()
     void SetLabel(String label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
@@ -49,10 +49,9 @@ RemoteBufferProxy::~RemoteBufferProxy()
 
 void RemoteBufferProxy::mapAsync(WebCore::WebGPU::MapModeFlags mapModeFlags, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size, CompletionHandler<void(bool)>&& callback)
 {
-    auto sendResult = sendWithAsyncReply(Messages::RemoteBuffer::MapAsync(mapModeFlags, offset, size), [callback = WTFMove(callback), mapModeFlags, protectedThis = Ref { *this }](auto data) mutable {
-        if (!data)
+    auto sendResult = sendWithAsyncReply(Messages::RemoteBuffer::MapAsync(mapModeFlags, offset, size), [callback = WTFMove(callback), mapModeFlags, protectedThis = Ref { *this }](auto success) mutable {
+        if (!success)
             return callback(false);
-        protectedThis->m_data = WTFMove(data);
         protectedThis->m_mapModeFlags = mapModeFlags;
         callback(true);
     });
@@ -66,13 +65,6 @@ static bool offsetOrSizeExceedsBounds(size_t dataSize, WebCore::WebGPU::Size64 o
 
 auto RemoteBufferProxy::getMappedRange(WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size) -> MappedRange
 {
-    if (m_data.has_value() && m_data->data()) {
-        if (offsetOrSizeExceedsBounds(m_data->size(), offset, size))
-            return { };
-
-        return { m_data->data() + offset, static_cast<size_t>(size.value_or(m_data->size() - offset)) };
-    }
-
     // FIXME: Implement error handling.
     auto sendResult = sendSync(Messages::RemoteBuffer::GetMappedRange(offset, size));
     auto [data] = sendResult.takeReplyOr(std::nullopt);
@@ -80,19 +72,28 @@ auto RemoteBufferProxy::getMappedRange(WebCore::WebGPU::Size64 offset, std::opti
     if (!data || !data->data() || offsetOrSizeExceedsBounds(data->size(), offset, size))
         return { };
 
-    m_data = WTFMove(data);
-    return { m_data->data() + offset, static_cast<size_t>(size.value_or(m_data->size() - offset)) };
+    return { data->data() + offset, static_cast<size_t>(size.value_or(data->size() - offset)) };
+}
+
+auto RemoteBufferProxy::getBufferContents() -> MappedRange
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+void RemoteBufferProxy::copy(Vector<uint8_t>&& data, size_t offset)
+{
+    if (!m_mapModeFlags.contains(WebCore::WebGPU::MapMode::Write))
+        return;
+
+    auto sendResult = send(Messages::RemoteBuffer::Copy(WTFMove(data), offset));
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteBufferProxy::unmap()
 {
-    Vector<uint8_t> data;
-    if (m_data && m_mapModeFlags.contains(WebCore::WebGPU::MapMode::Write))
-        data = WTFMove(*m_data);
-    auto sendResult = send(Messages::RemoteBuffer::Unmap(WTFMove(data)));
+    auto sendResult = send(Messages::RemoteBuffer::Unmap());
     UNUSED_VARIABLE(sendResult);
 
-    m_data = std::nullopt;
     m_mapModeFlags = { };
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
@@ -80,7 +80,9 @@ private:
 
     void mapAsync(WebCore::WebGPU::MapModeFlags, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> sizeForMap, CompletionHandler<void(bool)>&&) final;
     MappedRange getMappedRange(WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64>) final;
+    MappedRange getBufferContents() final;
     void unmap() final;
+    void copy(Vector<uint8_t>&&, size_t offset) final;
 
     void destroy() final;
 
@@ -91,7 +93,6 @@ private:
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
     Ref<RemoteDeviceProxy> m_parent;
-    std::optional<Vector<uint8_t>> m_data;
     WebCore::WebGPU::MapModeFlags m_mapModeFlags;
 };
 


### PR DESCRIPTION
#### 065a0ff443f85ce620cad22f7cb7eab4bea62ca0
<pre>
[WebGPU] mapAsync shouldn&apos;t be calling getMappedRange on the entire buffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=273028">https://bugs.webkit.org/show_bug.cgi?id=273028</a>
&lt;radar://126800249&gt;

Reviewed by Tadeu Zagallo.

Simplify buffer mapping so we don&apos;t pass a copy of the entire buffer from the
GPU process to the web process when it is not needed.

* LayoutTests/platform/mac-wk2/TestExpectations:
Add passing expectations for api,operation,buffers,* and
api,validation,buffer,* tests.

Passing expectations already exist, tests were still marked Skipped.

* Source/WebCore/Modules/WebGPU/GPUBuffer.cpp:
(WebCore::makeArrayBuffer):
(WebCore::GPUBuffer::getMappedRange):
(WebCore::GPUBuffer::internalUnmap):
* Source/WebCore/Modules/WebGPU/GPUBuffer.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.cpp:
(WebCore::WebGPU::BufferImpl::getBufferContents):
(WebCore::WebGPU::BufferImpl::copy):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h:
* Source/WebGPU/WebGPU/Buffer.h:
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::getBufferContents):
(wgpuBufferGetBufferContents):
* Source/WebGPU/WebGPU/WebGPU.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp:
(WebKit::RemoteBuffer::mapAsync):
(WebKit::RemoteBuffer::getMappedRange):
(WebKit::RemoteBuffer::unmap):
(WebKit::RemoteBuffer::copy):
(WebKit::RemoteBuffer::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp:
(WebKit::WebGPU::RemoteBufferProxy::mapAsync):
(WebKit::WebGPU::RemoteBufferProxy::getMappedRange):
(WebKit::WebGPU::RemoteBufferProxy::getBufferContents):
(WebKit::WebGPU::RemoteBufferProxy::copy):
(WebKit::WebGPU::RemoteBufferProxy::unmap):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h:
Simplify buffer mapping by storing fewer state variables refering to the same
data and remove copies.

Canonical link: <a href="https://commits.webkit.org/278286@main">https://commits.webkit.org/278286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ec58710983dede935bb63fd9d94a5bea91289e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28225 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51700 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45082 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51317 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34196 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25753 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40067 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50141 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25868 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42256 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21175 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23327 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43426 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7071 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45251 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43931 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53611 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24063 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20315 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47380 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25326 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42465 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46349 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10982 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26135 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25046 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->