### PR TITLE
Use smart pointers with WebCore::CachedResourceLoader in libxml2/libxslt code

### DIFF
--- a/Source/WebCore/xml/parser/XMLDocumentParserScope.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParserScope.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,28 +33,29 @@
 
 namespace WebCore {
 
-    class CachedResourceLoader;
+class CachedResourceLoader;
 
-    class XMLDocumentParserScope {
-        WTF_MAKE_NONCOPYABLE(XMLDocumentParserScope);
-    public:
-        explicit XMLDocumentParserScope(CachedResourceLoader*);
-        ~XMLDocumentParserScope();
+class XMLDocumentParserScope {
+    WTF_MAKE_NONCOPYABLE(XMLDocumentParserScope);
+public:
+    XMLDocumentParserScope() = delete;
+    explicit XMLDocumentParserScope(CachedResourceLoader*);
+    ~XMLDocumentParserScope();
 
-        static CachedResourceLoader* currentCachedResourceLoader;
-
-#if ENABLE(XSLT)
-        XMLDocumentParserScope(CachedResourceLoader*, xmlGenericErrorFunc, xmlStructuredErrorFunc structuredErrorFunc = 0, void* errorContext = nullptr);
-#endif
-
-    private:
-        CachedResourceLoader* m_oldCachedResourceLoader;
+    static WeakPtr<CachedResourceLoader>& currentCachedResourceLoader();
 
 #if ENABLE(XSLT)
-        xmlGenericErrorFunc m_oldGenericErrorFunc;
-        xmlStructuredErrorFunc m_oldStructuredErrorFunc;
-        void* m_oldErrorContext;
+    XMLDocumentParserScope(CachedResourceLoader*, xmlGenericErrorFunc, xmlStructuredErrorFunc = nullptr, void* errorContext = nullptr);
 #endif
-    };
+
+private:
+    WeakPtr<CachedResourceLoader> m_oldCachedResourceLoader;
+
+#if ENABLE(XSLT)
+    xmlGenericErrorFunc m_oldGenericErrorFunc { nullptr };
+    xmlStructuredErrorFunc m_oldStructuredErrorFunc { nullptr };
+    void* m_oldErrorContext { nullptr };
+#endif
+};
 
 } // namespace WebCore


### PR DESCRIPTION
#### 49e16e9ddcee72f8f19370735909ca1a677a8b14
<pre>
Use smart pointers with WebCore::CachedResourceLoader in libxml2/libxslt code
<a href="https://bugs.webkit.org/show_bug.cgi?id=273204">https://bugs.webkit.org/show_bug.cgi?id=273204</a>
&lt;<a href="https://rdar.apple.com/126997686">rdar://126997686</a>&gt;

Reviewed by Chris Dumez and Alex Christensen.

Deploy smart pointers for CachedResourceLoader objects used in
libxml2/libxslt integration code.  Use WeakPtr&lt;&gt; for storing temporary
references.  Use RefPtr&lt;&gt; when used multiple times in a method.

Also change 0 to nullptr functions that were modified.

* Source/WebCore/xml/XSLTProcessorLibxslt.cpp:
(WebCore::globalCachedResourceLoader): Add.
(WebCore::docLoaderFunc):
- Add early return when there is no data to parse.  This also simplifies
  the arguments to xmlReadMemory().
(WebCore::setXSLTLoadCallBack):
(WebCore::XSLTProcessor::transformToString):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::matchFunc):
(WebCore::shouldAllowExternalLoad):
(WebCore::openFunc):
- Add early return when
  XMLDocumentParserScope::currentCachedResourceLoader() is nullptr.
- Store Document in a RefPtr.
(WebCore::XMLDocumentParser::doEnd):
* Source/WebCore/xml/parser/XMLDocumentParserScope.cpp:
(WebCore::XMLDocumentParserScope::currentCachedResourceLoader): Add.
(WebCore::XMLDocumentParserScope::XMLDocumentParserScope):
(WebCore::XMLDocumentParserScope::~XMLDocumentParserScope):
* Source/WebCore/xml/parser/XMLDocumentParserScope.h:
- Fix old-style indentation of class declaration.
- Delete unused default constructor.
- Provide default initializers for instance variables.

Canonical link: <a href="https://commits.webkit.org/277956@main">https://commits.webkit.org/277956@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02d6e013b5adc87f17307f95fe35149338b60cc5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51760 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45113 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51346 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34236 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25793 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40082 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50293 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42272 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21190 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23354 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43442 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7156 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45285 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43947 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53668 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24104 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20345 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47397 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/25385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42480 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46372 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26172 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7026 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/25106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->