### PR TITLE
[webkitscmpy] Add merged flag to pull request

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py
@@ -171,7 +171,8 @@ class PullRequest(object):
         self, number, title=None,
         body=None, author=None,
         head=None, base=None,
-        opened=None, generator=None, metadata=None,
+        opened=None, merged=None,
+        generator=None, metadata=None,
         url=None, draft=None, hash=None,
     ):
         self.number = number
@@ -183,6 +184,7 @@ class PullRequest(object):
         self.draft = draft
         self.hash = hash
         self._opened = opened
+        self._merged = merged
         self._reviewers = None
         self._approvers = None
         self._blockers = None
@@ -229,6 +231,10 @@ class PullRequest(object):
         if not self.generator:
             raise self.Exception('No associated pull-request generator')
         return self.generator.update(self, opened=False)
+
+    @property
+    def merged(self):
+        return self._merged
 
     def comment(self, content):
         if not self.generator:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
@@ -58,6 +58,7 @@ class BitBucket(Scm):
                 hash=data['fromRef'].get('latestCommit', None),
                 base=data['toRef']['displayId'],
                 opened=True if data.get('open') else (False if data.get('closed') else None),
+                merged=data.get('state', '') == 'MERGED',
                 generator=self,
                 url='{}/pull-requests/{}/overview'.format(self.repository.url, data['id']),
                 draft=False,

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
@@ -73,6 +73,7 @@ class GitHub(Scm):
                     closed=False,
                     merged=False,
                 ).get(data.get('state').lower(), None),
+                merged=data.get('merged', False),
                 generator=self,
                 metadata=dict(
                     issue=issue,

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -1991,6 +1991,7 @@ class TestNetworkPullRequestGitHub(unittest.TestCase):
         result.pull_requests = [dict(
             number=1,
             state='open',
+            merged=False,
             title='Example Change',
             user=dict(login='tcontributor'),
             body='''#### 95507e3a1a4a919d1a156abbc279fdf6d24b13f5
@@ -2101,10 +2102,22 @@ Reviewed by NOBODY (OOPS!).
             repo = remote.GitHub(self.remote)
             pr = repo.pull_requests.get(1)
             self.assertTrue(pr.opened)
+            self.assertFalse(pr.merged)
             pr.close()
             self.assertFalse(pr.opened)
+            self.assertFalse(pr.merged)
             pr.open()
             self.assertTrue(pr.opened)
+            self.assertFalse(pr.merged)
+
+    def test_merged(self):
+        with self.webserver() as server:
+            server.pull_requests[0]['state'] = 'closed'
+            server.pull_requests[0]['merged'] = True
+
+            repo = remote.GitHub(self.remote)
+            pr = repo.pull_requests.get(1)
+            self.assertTrue(pr.merged)
 
     def test_review(self):
         with self.webserver():
@@ -2368,10 +2381,23 @@ Reviewed by NOBODY (OOPS!).
             repo = remote.BitBucket(self.remote)
             pr = repo.pull_requests.get(1)
             self.assertTrue(pr.opened)
+            self.assertFalse(pr.merged)
             pr.close()
             self.assertFalse(pr.opened)
+            self.assertFalse(pr.merged)
             pr.open()
             self.assertTrue(pr.opened)
+            self.assertFalse(pr.merged)
+
+    def test_merged(self):
+        with self.webserver() as server:
+            server.pull_requests[0]['open'] = False
+            server.pull_requests[0]['closed'] = True
+            server.pull_requests[0]['state'] = 'MERGED'
+
+            repo = remote.BitBucket(self.remote)
+            pr = repo.pull_requests.get(1)
+            self.assertTrue(pr.merged)
 
     def test_whoami(self):
         with self.webserver():


### PR DESCRIPTION
#### 2b7d70e43797fadce195ec70e5c57227b8a64080
<pre>
[webkitscmpy] Add merged flag to pull request
<a href="https://bugs.webkit.org/show_bug.cgi?id=273207">https://bugs.webkit.org/show_bug.cgi?id=273207</a>
<a href="https://rdar.apple.com/127002247">rdar://127002247</a>

Reviewed by Sam Sneddon.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py:
(PullRequest.__init__): Add &apos;merged&apos; option.
(PullRequest.merged): Return &apos;False&apos; if the pull request is open, otherwise,
consult the _merged value and return it&apos;s state.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py:
(BitBucket.PRGenerator.PullRequest): Extract &apos;merged&apos; from the state.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:
(GitHub.PRGenerator.PullRequest): Extract &apos;merged&apos; flag from data.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:

Canonical link: <a href="https://commits.webkit.org/278165@main">https://commits.webkit.org/278165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/646fb2c7354467bcd53f52ac13ce4a63294e5dbd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49607 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52849 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/283 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51912 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34912 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40491 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51707 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26432 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42725 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21606 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/49463 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23891 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43914 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7978 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45795 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44420 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54426 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20865 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47865 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/49633 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25961 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46906 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26807 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7150 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25686 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->