### PR TITLE
Drop TextRun::characters8() / characters16()

### DIFF
--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -238,7 +238,7 @@ static Vector<unsigned, 128> offsetMapping(const String& text)
         return { };
 
     Vector<unsigned, 128> offsets;
-    SurrogatePairAwareTextIterator iterator(text.characters16(), 0, text.length(), text.length());
+    SurrogatePairAwareTextIterator iterator(text.span16(), 0, text.length());
     char32_t character;
     unsigned clusterLength = 0;
     unsigned i;

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -170,11 +170,11 @@ TextUtil::FallbackFontList TextUtil::fallbackFontsForText(StringView textContent
             return;
 
         if (textRun.is8Bit()) {
-            auto textIterator = Latin1TextIterator { textRun.data8(0), 0, textRun.length(), textRun.length() };
+            Latin1TextIterator textIterator { textRun.span8(), 0, textRun.length() };
             fallbackFontsForRunWithIterator(fallbackFonts, style.fontCascade(), textRun, textIterator);
             return;
         }
-        auto textIterator = SurrogatePairAwareTextIterator { textRun.data16(0), 0, textRun.length(), textRun.length() };
+        SurrogatePairAwareTextIterator textIterator { textRun.span16(), 0, textRun.length() };
         fallbackFontsForRunWithIterator(fallbackFonts, style.fontCascade(), textRun, textIterator);
     };
 
@@ -220,10 +220,10 @@ TextUtil::EnclosingAscentDescent TextUtil::enclosingGlyphBoundsForText(StringVie
         return { };
 
     if (textContent.is8Bit()) {
-        auto textIterator = Latin1TextIterator { textContent.span8().data(), 0, textContent.length(), textContent.length() };
+        Latin1TextIterator textIterator { textContent.span8(), 0, textContent.length() };
         return enclosingGlyphBoundsForRunWithIterator(style.fontCascade(), !style.isLeftToRightDirection(), textIterator);
     }
-    auto textIterator = SurrogatePairAwareTextIterator { textContent.span16().data(), 0, textContent.length(), textContent.length() };
+    SurrogatePairAwareTextIterator textIterator { textContent.span16(), 0, textContent.length() };
     return enclosingGlyphBoundsForRunWithIterator(style.fontCascade(), !style.isLeftToRightDirection(), textIterator);
 }
 

--- a/Source/WebCore/platform/graphics/ComplexTextController.h
+++ b/Source/WebCore/platform/graphics/ComplexTextController.h
@@ -154,7 +154,7 @@ private:
 
     void collectComplexTextRuns();
 
-    void collectComplexTextRunsForCharacters(const UChar*, unsigned length, unsigned stringLocation, const Font*);
+    void collectComplexTextRunsForCharacters(std::span<const UChar>, unsigned stringLocation, const Font*);
     void adjustGlyphsAndAdvances();
 
     unsigned indexOfCurrentRun(unsigned& leftmostGlyph);

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -1268,10 +1268,11 @@ static GlyphUnderlineType computeUnderlineType(const TextRun& textRun, const Gly
         return GlyphUnderlineType::SkipDescenders;
     
     if (textRun.is8Bit())
-        baseCharacter = textRun.characters8()[offsetInString.value()];
-    else
-        U16_GET(textRun.characters16(), 0, static_cast<unsigned>(offsetInString.value()), textRun.length(), baseCharacter);
-    
+        baseCharacter = textRun.span8()[offsetInString.value()];
+    else {
+        auto characters = textRun.span16();
+        U16_GET(characters, 0, static_cast<unsigned>(offsetInString.value()), characters.size(), baseCharacter);
+    }
     // u_getIntPropertyValue with UCHAR_IDEOGRAPHIC doesn't return true for Japanese or Korean codepoints.
     // Instead, we can use the "Unicode allocation block" for the character.
     UBlockCode blockCode = ublock_getCode(baseCharacter);

--- a/Source/WebCore/platform/graphics/Latin1TextIterator.h
+++ b/Source/WebCore/platform/graphics/Latin1TextIterator.h
@@ -29,8 +29,8 @@ class Latin1TextIterator {
 public:
     // The passed in LChar pointer starts at 'currentIndex'. The iterator operates on the range [currentIndex, lastIndex].
     // 'endCharacter' denotes the maximum length of the UChar array, which might exceed 'lastIndex'.
-    Latin1TextIterator(const LChar* characters, unsigned currentIndex, unsigned lastIndex, unsigned /*endCharacter*/)
-        : m_characters(characters)
+    Latin1TextIterator(std::span<const LChar> characters, unsigned currentIndex, unsigned lastIndex)
+        : m_characters(characters.data())
         , m_currentIndex(currentIndex)
         , m_originalIndex(currentIndex)
         , m_lastIndex(lastIndex)

--- a/Source/WebCore/platform/graphics/SurrogatePairAwareTextIterator.h
+++ b/Source/WebCore/platform/graphics/SurrogatePairAwareTextIterator.h
@@ -29,12 +29,12 @@ class SurrogatePairAwareTextIterator {
 public:
     // The passed in UChar pointer starts at 'currentIndex'. The iterator operates on the range [currentIndex, lastIndex].
     // 'endIndex' denotes the maximum length of the UChar array, which might exceed 'lastIndex'.
-    SurrogatePairAwareTextIterator(const UChar* characters, unsigned currentIndex, unsigned lastIndex, unsigned endIndex)
-        : m_characters(characters)
+    SurrogatePairAwareTextIterator(std::span<const UChar> characters, unsigned currentIndex, unsigned lastIndex)
+        : m_characters(characters.data())
         , m_currentIndex(currentIndex)
         , m_originalIndex(currentIndex)
         , m_lastIndex(lastIndex)
-        , m_endIndex(endIndex)
+        , m_endIndex(characters.size() + currentIndex)
     {
     }
 

--- a/Source/WebCore/platform/graphics/TextRun.h
+++ b/Source/WebCore/platform/graphics/TextRun.h
@@ -110,28 +110,21 @@ public:
         auto result { *this };
 
         if (is8Bit())
-            result.setText(data8(startOffset), length);
+            result.setText(subspan8(startOffset).first(length));
         else
-            result.setText(data16(startOffset), length);
+            result.setText(subspan16(startOffset).first(length));
         return result;
     }
 
     UChar operator[](unsigned i) const { RELEASE_ASSERT(i < m_text.length()); return m_text[i]; }
-    const LChar* data8(unsigned i) const { ASSERT_WITH_SECURITY_IMPLICATION(i < m_text.length()); ASSERT(is8Bit()); return &m_text.characters8()[i]; }
-    const UChar* data16(unsigned i) const { ASSERT_WITH_SECURITY_IMPLICATION(i < m_text.length()); ASSERT(!is8Bit()); return &m_text.characters16()[i]; }
     std::span<const LChar> span8() const { ASSERT(is8Bit()); return m_text.span8(); }
     std::span<const UChar> span16() const { ASSERT(!is8Bit()); return m_text.span16(); }
     std::span<const LChar> subspan8(unsigned i) const { return span8().subspan(i); }
     std::span<const UChar> subspan16(unsigned i) const { return span16().subspan(i); }
 
-    const LChar* characters8() const { ASSERT(is8Bit()); return m_text.characters8(); }
-    const UChar* characters16() const { ASSERT(!is8Bit()); return m_text.characters16(); }
-
     bool is8Bit() const { return m_text.is8Bit(); }
     unsigned length() const { return m_text.length(); }
 
-    void setText(const LChar* text, unsigned length) { setText(std::span { text, length }); }
-    void setText(const UChar* text, unsigned length) { setText(std::span { text, length }); }
     void setText(StringView text) { ASSERT(!text.isNull()); m_text = text.toStringWithoutCopying(); }
 
     float horizontalGlyphStretch() const { return m_horizontalGlyphStretch; }

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -801,13 +801,13 @@ void WidthIterator::advance(unsigned offset, GlyphBuffer& glyphBuffer)
     float startingRunWidth = m_runWidthSoFar;
 
     if (m_run->is8Bit()) {
-        Latin1TextIterator textIterator(m_run->data8(m_currentCharacterIndex), m_currentCharacterIndex, offset, length);
+        Latin1TextIterator textIterator(m_run->subspan8(m_currentCharacterIndex), m_currentCharacterIndex, offset);
         advanceInternal(textIterator, glyphBuffer);
     } else {
 #if USE(CLUSTER_AWARE_WIDTH_ITERATOR)
-        ComposedCharacterClusterTextIterator textIterator(m_run->span16(m_currentCharacterIndex), m_currentCharacterIndex, offset);
+        ComposedCharacterClusterTextIterator textIterator(m_run->subspan16(m_currentCharacterIndex), m_currentCharacterIndex, offset);
 #else
-        SurrogatePairAwareTextIterator textIterator(m_run->data16(m_currentCharacterIndex), m_currentCharacterIndex, offset, length);
+        SurrogatePairAwareTextIterator textIterator(m_run->subspan16(m_currentCharacterIndex), m_currentCharacterIndex, offset);
 #endif
         advanceInternal(textIterator, glyphBuffer);
     }

--- a/Source/WebCore/platform/graphics/cairo/FontCairoHarfbuzzNG.cpp
+++ b/Source/WebCore/platform/graphics/cairo/FontCairoHarfbuzzNG.cpp
@@ -110,7 +110,7 @@ const Font* FontCascade::fontForCombiningCharacterSequence(StringView stringView
 
     char32_t character;
     unsigned clusterLength = 0;
-    SurrogatePairAwareTextIterator iterator(characters.data(), 0, length, length);
+    SurrogatePairAwareTextIterator iterator(characters, 0, length);
     if (!iterator.consume(character, clusterLength))
         return nullptr;
 

--- a/Source/WebCore/platform/graphics/harfbuzz/ComplexTextControllerHarfBuzz.cpp
+++ b/Source/WebCore/platform/graphics/harfbuzz/ComplexTextControllerHarfBuzz.cpp
@@ -239,9 +239,9 @@ struct HBRun {
     UScriptCode script;
 };
 
-static std::optional<HBRun> findNextRun(const UChar* characters, unsigned length, unsigned offset)
+static std::optional<HBRun> findNextRun(std::span<const UChar> characters, unsigned offset)
 {
-    SurrogatePairAwareTextIterator textIterator(characters + offset, offset, length, length);
+    SurrogatePairAwareTextIterator textIterator(characters.subspan(offset), offset, characters.size());
     char32_t character;
     unsigned clusterLength = 0;
     if (!textIterator.consume(character, clusterLength))
@@ -306,18 +306,18 @@ static hb_script_t findScriptForVerticalGlyphSubstitution(hb_face_t* face)
     return HB_SCRIPT_INVALID;
 }
 
-void ComplexTextController::collectComplexTextRunsForCharacters(const UChar* characters, unsigned length, unsigned stringLocation, const Font* font)
+void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const UChar> characters, unsigned stringLocation, const Font* font)
 {
     if (!font) {
         // Create a run of missing glyphs from the primary font.
-        m_complexTextRuns.append(ComplexTextRun::create(m_font.primaryFont(), characters, stringLocation, length, 0, length, m_run.ltr()));
+        m_complexTextRuns.append(ComplexTextRun::create(m_font.primaryFont(), characters.data(), stringLocation, characters.size(), 0, characters.size(), m_run.ltr()));
         return;
     }
 
     Vector<HBRun> runList;
     unsigned offset = 0;
-    while (offset < length) {
-        auto run = findNextRun(characters, length, offset);
+    while (offset < characters.size()) {
+        auto run = findNextRun(characters, offset);
         if (!run)
             break;
         runList.append(run.value());
@@ -379,10 +379,10 @@ void ComplexTextController::collectComplexTextRunsForCharacters(const UChar* cha
             // Leaving direction to HarfBuzz to guess is *really* bad, but will do for now.
             hb_buffer_guess_segment_properties(buffer.get());
         }
-        hb_buffer_add_utf16(buffer.get(), reinterpret_cast<const uint16_t*>(characters), length, run.startIndex, run.endIndex - run.startIndex);
+        hb_buffer_add_utf16(buffer.get(), reinterpret_cast<const uint16_t*>(characters.data()), characters.size(), run.startIndex, run.endIndex - run.startIndex);
 
         hb_shape(harfBuzzFont.get(), buffer.get(), features.isEmpty() ? nullptr : features.data(), features.size());
-        m_complexTextRuns.append(ComplexTextRun::create(buffer.get(), *font, characters, stringLocation, length, run.startIndex, run.endIndex));
+        m_complexTextRuns.append(ComplexTextRun::create(buffer.get(), *font, characters.data(), stringLocation, characters.size(), run.startIndex, run.endIndex));
         hb_buffer_reset(buffer.get());
     }
 }

--- a/Source/WebCore/platform/graphics/mac/ComplexTextControllerCoreText.mm
+++ b/Source/WebCore/platform/graphics/mac/ComplexTextControllerCoreText.mm
@@ -118,20 +118,19 @@ ComplexTextController::ComplexTextRun::ComplexTextRun(CTRunRef ctRun, const Font
 }
 
 struct ProviderInfo {
-    const UChar* cp;
-    unsigned length;
+    std::span<const UChar> cp;
     CFDictionaryRef attributes;
 };
 
 static const UniChar* provideStringAndAttributes(CFIndex stringIndex, CFIndex* charCount, CFDictionaryRef* attributes, void* refCon)
 {
     ProviderInfo* info = static_cast<struct ProviderInfo*>(refCon);
-    if (stringIndex < 0 || static_cast<unsigned>(stringIndex) >= info->length)
+    if (stringIndex < 0 || static_cast<size_t>(stringIndex) >= info->cp.size())
         return 0;
 
-    *charCount = info->length - stringIndex;
+    *charCount = info->cp.size() - stringIndex;
     *attributes = info->attributes;
-    return reinterpret_cast<const UniChar*>(info->cp + stringIndex);
+    return reinterpret_cast<const UniChar*>(info->cp.data() + stringIndex);
 }
 
 template<bool isLTR>
@@ -148,11 +147,11 @@ static CFDictionaryRef typesetterOptions()
     return options.get().get();
 }
 
-void ComplexTextController::collectComplexTextRunsForCharacters(const UChar* cp, unsigned length, unsigned stringLocation, const Font* font)
+void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const UChar> cp, unsigned stringLocation, const Font* font)
 {
     if (!font) {
         // Create a run of missing glyphs from the primary font.
-        m_complexTextRuns.append(ComplexTextRun::create(m_font.primaryFont(), cp, stringLocation, length, 0, length, m_run.ltr()));
+        m_complexTextRuns.append(ComplexTextRun::create(m_font.primaryFont(), cp.data(), stringLocation, cp.size(), 0, cp.size(), m_run.ltr()));
         return;
     }
 
@@ -164,7 +163,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(const UChar* cp,
         // FIXME: This code path does not support small caps.
         isSystemFallback = true;
 
-        U16_GET(cp, 0, 0, length, baseCharacter);
+        U16_GET(cp, 0, 0, cp.size(), baseCharacter);
         font = m_font.fallbackRangesAt(0).fontForCharacter(baseCharacter);
         if (!font)
             font = &m_font.fallbackRangesAt(0).fontForFirstRange();
@@ -177,16 +176,16 @@ void ComplexTextController::collectComplexTextRunsForCharacters(const UChar* cp,
     RetainPtr<CTLineRef> line;
 
     LOG_WITH_STREAM(TextShaping,
-        stream << "Complex shaping " << length << " code units with info " << String(adoptCF(CFCopyDescription(stringAttributes.get())).get()) << ".\n";
+        stream << "Complex shaping " << cp.size() << " code units with info " << String(adoptCF(CFCopyDescription(stringAttributes.get())).get()) << ".\n";
         stream << "Font attributes: " << String(adoptCF(CFCopyDescription(adoptCF(CTFontDescriptorCopyAttributes(adoptCF(CTFontCopyFontDescriptor(font->platformData().ctFont())).get())).get())).get()) << "\n";
         stream << "Code Units:";
-        for (unsigned i = 0; i < length; ++i)
-            stream << " " << cp[i];
+        for (auto codePoint : cp)
+            stream << " " << codePoint;
         stream << "\n";
     );
 
     if (!m_mayUseNaturalWritingDirection || m_run.directionalOverride()) {
-        ProviderInfo info = { cp, length, stringAttributes.get() };
+        ProviderInfo info { cp, stringAttributes.get() };
         // FIXME: Some SDKs complain that the second parameter below cannot be null.
         IGNORE_NULL_CHECK_WARNINGS_BEGIN
         auto typesetter = adoptCF(CTTypesetterCreateWithUniCharProviderAndOptions(&provideStringAndAttributes, 0, &info, m_run.ltr() ? typesetterOptions<true>() : typesetterOptions<false>()));
@@ -201,7 +200,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(const UChar* cp,
     } else {
         LOG_WITH_STREAM(TextShaping, stream << "Not forcing direction");
 
-        ProviderInfo info = { cp, length, stringAttributes.get() };
+        ProviderInfo info { cp, stringAttributes.get() };
 
         line = adoptCF(CTLineCreateWithUniCharProvider(&provideStringAndAttributes, nullptr, &info));
     }
@@ -245,7 +244,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(const UChar* cp,
                 if (!runFont) {
                     RetainPtr<CFStringRef> fontName = adoptCF(CTFontCopyPostScriptName(runCTFont));
                     if (CFEqual(fontName.get(), CFSTR("LastResort"))) {
-                        m_complexTextRuns.append(ComplexTextRun::create(m_font.primaryFont(), cp, stringLocation, length, runRange.location, runRange.location + runRange.length, m_run.ltr()));
+                        m_complexTextRuns.append(ComplexTextRun::create(m_font.primaryFont(), cp.data(), stringLocation, cp.size(), runRange.location, runRange.location + runRange.length, m_run.ltr()));
                         continue;
                     }
                     FontPlatformData runFontPlatformData(runCTFont, CTFontGetSize(runCTFont));
@@ -260,7 +259,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(const UChar* cp,
 
         LOG_WITH_STREAM(TextShaping, stream << "Run " << r << ":");
 
-        m_complexTextRuns.append(ComplexTextRun::create(ctRun, *runFont, cp, stringLocation, length, runRange.location, runRange.location + runRange.length));
+        m_complexTextRuns.append(ComplexTextRun::create(ctRun, *runFont, cp.data(), stringLocation, cp.size(), runRange.location, runRange.location + runRange.length));
     }
 }
 

--- a/Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp
@@ -102,9 +102,9 @@ struct HBRun {
     UScriptCode script;
 };
 
-static std::optional<HBRun> findNextRun(const UChar* characters, unsigned length, unsigned offset)
+static std::optional<HBRun> findNextRun(std::span<const UChar> characters, unsigned offset)
 {
-    SurrogatePairAwareTextIterator textIterator(characters + offset, offset, length, length);
+    SurrogatePairAwareTextIterator textIterator(characters.subspan(offset), offset, characters.size());
     char32_t character;
     unsigned clusterLength = 0;
     if (!textIterator.consume(character, clusterLength))
@@ -148,18 +148,18 @@ static std::optional<HBRun> findNextRun(const UChar* characters, unsigned length
     return std::optional<HBRun>({ startIndex, textIterator.currentIndex(), currentScript.value() });
 }
 
-void ComplexTextController::collectComplexTextRunsForCharacters(const UChar* characters, unsigned length, unsigned stringLocation, const Font* font)
+void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const UChar> characters, unsigned stringLocation, const Font* font)
 {
     if (!font) {
         // Create a run of missing glyphs from the primary font.
-        m_complexTextRuns.append(ComplexTextRun::create(m_font.primaryFont(), characters, stringLocation, length, 0, length, m_run.ltr()));
+        m_complexTextRuns.append(ComplexTextRun::create(m_font.primaryFont(), characters.data(), stringLocation, characters.size(), 0, characters.size(), m_run.ltr()));
         return;
     }
 
     Vector<HBRun> runList;
-    unsigned offset = 0;
-    while (offset < length) {
-        auto run = findNextRun(characters, length, offset);
+    size_t offset = 0;
+    while (offset < characters.size()) {
+        auto run = findNextRun(characters, offset);
         if (!run)
             break;
         runList.append(run.value());
@@ -202,10 +202,10 @@ void ComplexTextController::collectComplexTextRunsForCharacters(const UChar* cha
             // Leaving direction to HarfBuzz to guess is *really* bad, but will do for now.
             hb_buffer_guess_segment_properties(buffer.get());
         }
-        hb_buffer_add_utf16(buffer.get(), reinterpret_cast<const uint16_t*>(characters), length, run.startIndex, run.endIndex - run.startIndex);
+        hb_buffer_add_utf16(buffer.get(), reinterpret_cast<const uint16_t*>(characters.data()), characters.size(), run.startIndex, run.endIndex - run.startIndex);
 
         hb_shape(hbFont, buffer.get(), featuresData, featuresSize);
-        m_complexTextRuns.append(ComplexTextRun::create(buffer.get(), *font, characters, stringLocation, length, run.startIndex, run.endIndex));
+        m_complexTextRuns.append(ComplexTextRun::create(buffer.get(), *font, characters.data(), stringLocation, characters.size(), run.startIndex, run.endIndex));
         hb_buffer_reset(buffer.get());
     }
 }


### PR DESCRIPTION
#### f74abf65a72c20f20ac736065a7467643de06652
<pre>
Drop TextRun::characters8() / characters16()
<a href="https://bugs.webkit.org/show_bug.cgi?id=273199">https://bugs.webkit.org/show_bug.cgi?id=273199</a>

Reviewed by Darin Adler.

Drop TextRun::characters8() / characters16() in favor of span versions.

* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::fallbackFontsForText):
* Source/WebCore/platform/graphics/ComplexTextController.cpp:
(WebCore::ComplexTextController::collectComplexTextRuns):
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::computeUnderlineType):
* Source/WebCore/platform/graphics/TextRun.h:
* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::WidthIterator::advance):

Canonical link: <a href="https://commits.webkit.org/277986@main">https://commits.webkit.org/277986@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3663d6236fbb782f326338b25558a83206fef6d2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49138 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51936 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45232 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51442 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34397 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25988 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40162 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50779 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25979 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42357 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21275 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23435 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43531 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7462 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45363 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44038 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53845 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24216 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20421 "Found 1 new test failure: media/video-pause-immediately.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47481 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25494 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46467 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26308 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7042 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25213 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->