### PR TITLE
[view-transitions] Clear view transition on navigation

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2833,10 +2833,6 @@ imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties
 [ Sonoma+ ] imported/w3c/web-platform-tests/web-animations/animation-model/side-effects-of-animations-current.html [ ImageOnlyFailure ]
 [ Sonoma+ ] imported/w3c/web-platform-tests/web-animations/animation-model/side-effects-of-animations-in-effect.html [ ImageOnlyFailure ]
 
-# webkit.org/b/272792 REGRESSION (277521@main): [ MacOS WK1 ] fast/css/viewport-height-border.html is a flaky crash 
-fast/css/view-transitions-update-pseudo-element-crash.html [ Skip ]
-fast/css/view-transitions-update-layer-lists-crash.html [ Skip ]
-
 # webkit.org/b/272926 [ Ventura wk1 ] 8 tests in imported/w3c/web-platform-tests/workers are flaky failures
 [ Ventura ] imported/w3c/web-platform-tests/worklets/animation-worklet-credentials.https.html [ Pass Failure ]
 [ Ventura ] imported/w3c/web-platform-tests/worklets/audio-worklet-credentials.https.html [ Pass Failure ]

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ActiveDOMObject.h"
 #include "Document.h"
 #include "Element.h"
 #include "ExceptionOr.h"
@@ -127,7 +128,7 @@ private:
     HashMap<AtomString, UniqueRef<CapturedElement>> m_map;
 };
 
-class ViewTransition : public RefCounted<ViewTransition>, public CanMakeWeakPtr<ViewTransition> {
+class ViewTransition : public RefCounted<ViewTransition>, public CanMakeWeakPtr<ViewTransition>, public ActiveDOMObject {
 public:
     static Ref<ViewTransition> create(Document&, RefPtr<ViewTransitionUpdateCallback>&&);
     ~ViewTransition();
@@ -151,7 +152,8 @@ public:
     ViewTransitionPhase phase() const { return m_phase; }
     const OrderedNamedElementsMap& namedElements() const { return m_namedElements; };
 
-    RefPtr<Document> protectedDocument() const { return m_document.get(); }
+    Document* document() const { return downcast<Document>(scriptExecutionContext()); }
+    RefPtr<Document> protectedDocument() const { return document(); }
 
     RenderViewTransitionCapture* viewTransitionNewPseudoForCapturedElement(Element&);
 
@@ -163,7 +165,7 @@ private:
     ExceptionOr<void> updatePseudoElementStyles();
     void setupDynamicStyleSheet(const AtomString&, const CapturedElement&);
 
-    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
+    void stop() final;
 
     OrderedNamedElementsMap m_namedElements;
     ViewTransitionPhase m_phase { ViewTransitionPhase::PendingCapture };

--- a/Source/WebCore/dom/ViewTransition.idl
+++ b/Source/WebCore/dom/ViewTransition.idl
@@ -24,6 +24,7 @@
  */
 
 [
+    ActiveDOMObject,
     EnabledBySetting=ViewTransitionsEnabled,
     Exposed=Window
 ]


### PR DESCRIPTION
#### f6ed29f91fc8f5d7fbde9c3d4a825b07dd6111fb
<pre>
[view-transitions] Clear view transition on navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=272792">https://bugs.webkit.org/show_bug.cgi?id=272792</a>
<a href="https://rdar.apple.com/126590072">rdar://126590072</a>

Reviewed by Chris Dumez.

The VT crashtests were causing the following test to flakily crash. To fix this, clear the view transition when the user navigates by
using ActiveDOMObject and defining a stop method.

Also protect the document in `ViewTransition::callUpdateCallback`.

* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::ViewTransition):
(WebCore::ViewTransition::create):
(WebCore::ViewTransition::skipViewTransition):
(WebCore::ViewTransition::callUpdateCallback):
(WebCore::ViewTransition::setupViewTransition):
(WebCore::ViewTransition::captureOldState):
(WebCore::ViewTransition::captureNewState):
(WebCore::ViewTransition::setupTransitionPseudoElements):
(WebCore::ViewTransition::handleTransitionFrame):
(WebCore::ViewTransition::clearViewTransition):
(WebCore::ViewTransition::updatePseudoElementStyles):
(WebCore::ViewTransition::stop):
* Source/WebCore/dom/ViewTransition.h:
(WebCore::ViewTransition::document const):
(WebCore::ViewTransition::protectedDocument const):
* Source/WebCore/dom/ViewTransition.idl:

Canonical link: <a href="https://commits.webkit.org/277958@main">https://commits.webkit.org/277958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/334edf997416e14f4865cc5e56ff05ea0c282081

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51769 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45121 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51353 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25802 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40085 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50323 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25902 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42289 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21194 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23353 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43462 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7169 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45288 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43967 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53678 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24112 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20340 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47401 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/25392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42495 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46371 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10793 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26181 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/25113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->