### PR TITLE
Adopt smart pointers in ApplicationStateTracker

### DIFF
--- a/Source/WebKit/UIProcess/ApplicationStateTracker.h
+++ b/Source/WebKit/UIProcess/ApplicationStateTracker.h
@@ -83,10 +83,10 @@ private:
 
     bool m_isInBackground;
 
-    id m_didEnterBackgroundObserver;
-    id m_willEnterForegroundObserver;
-    id m_willBeginSnapshotSequenceObserver;
-    id m_didCompleteSnapshotSequenceObserver;
+    WeakObjCPtr<NSObject> m_didEnterBackgroundObserver;
+    WeakObjCPtr<NSObject> m_willEnterForegroundObserver;
+    WeakObjCPtr<NSObject> m_willBeginSnapshotSequenceObserver;
+    WeakObjCPtr<NSObject> m_didCompleteSnapshotSequenceObserver;
 };
 
 ApplicationType applicationType(UIWindow *);

--- a/Source/WebKit/UIProcess/ApplicationStateTracker.mm
+++ b/Source/WebKit/UIProcess/ApplicationStateTracker.mm
@@ -164,8 +164,6 @@ ApplicationStateTracker::ApplicationStateTracker(UIView *view, SEL didEnterBackg
     , m_willBeginSnapshotSequenceSelector(willBeginSnapshotSequenceSelector)
     , m_didCompleteSnapshotSequenceSelector(didCompleteSnapshotSequenceSelector)
     , m_isInBackground(true)
-    , m_didEnterBackgroundObserver(nullptr)
-    , m_willEnterForegroundObserver(nullptr)
 {
     ASSERT([m_view.get() respondsToSelector:m_didEnterBackgroundSelector]);
     ASSERT([m_view.get() respondsToSelector:m_willEnterForegroundSelector]);
@@ -191,19 +189,19 @@ void ApplicationStateTracker::removeAllObservers()
 {
     NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
     if (m_didEnterBackgroundObserver) {
-        [notificationCenter removeObserver:m_didEnterBackgroundObserver];
+        [notificationCenter removeObserver:m_didEnterBackgroundObserver.get().get()];
         m_didEnterBackgroundObserver = nil;
     }
     if (m_willEnterForegroundObserver) {
-        [notificationCenter removeObserver:m_willEnterForegroundObserver];
+        [notificationCenter removeObserver:m_willEnterForegroundObserver.get().get()];
         m_willEnterForegroundObserver = nil;
     }
     if (m_willBeginSnapshotSequenceObserver) {
-        [notificationCenter removeObserver:m_willBeginSnapshotSequenceObserver];
+        [notificationCenter removeObserver:m_willBeginSnapshotSequenceObserver.get().get()];
         m_willBeginSnapshotSequenceObserver = nil;
     }
     if (m_didCompleteSnapshotSequenceObserver) {
-        [notificationCenter removeObserver:m_didCompleteSnapshotSequenceObserver];
+        [notificationCenter removeObserver:m_didCompleteSnapshotSequenceObserver.get().get()];
         m_didCompleteSnapshotSequenceObserver = nil;
     }
 }


### PR DESCRIPTION
#### 6c333c99a9a77e7f985b532002f6f2f8f7e05a07
<pre>
Adopt smart pointers in ApplicationStateTracker
<a href="https://bugs.webkit.org/show_bug.cgi?id=273218">https://bugs.webkit.org/show_bug.cgi?id=273218</a>
&lt;<a href="https://rdar.apple.com/126764684">rdar://126764684</a>&gt;

Reviewed by David Kilzer.

The ApplicationStateTracker uses `id` values to remember observers that it
Registers and unregisters at various points in the display of a view. It&apos;s
possible that some framework could decide to unregistered an observer outside
of this flow, causing us to request an observer to be removed a second time,
which triggers a release assert.

* Source/WebKit/UIProcess/ApplicationStateTracker.h:
* Source/WebKit/UIProcess/ApplicationStateTracker.mm:
(WebKit::m_isInBackground):
(WebKit::ApplicationStateTracker::removeAllObservers):
(WebKit::m_willEnterForegroundObserver): Deleted.

Canonical link: <a href="https://commits.webkit.org/278022@main">https://commits.webkit.org/278022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9355f1a551bc60f7888ee16ceffd66faace25007

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52212 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51982 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45285 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40194 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51129 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42389 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21309 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23482 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7508 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45406 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44071 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53893 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24267 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20468 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25540 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42593 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10830 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26371 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25261 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->