### PR TITLE
Reduce use of WKBundlePageGetMainFrame in WebKitTestRunner

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/EventSendingController.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/EventSendingController.idl
@@ -28,8 +28,8 @@ dictionary MonitorWheelEventsOptions {
 };
 
 interface EventSendingController {
-    undefined mouseDown(long buttonNumber, object modifierArray, optional DOMString pointerType);
-    undefined mouseUp(long buttonNumber, object modifierArray, optional DOMString pointerType);
+    [PassContext] undefined mouseDown(long buttonNumber, object modifierArray, optional DOMString pointerType);
+    [PassContext] undefined mouseUp(long buttonNumber, object modifierArray, optional DOMString pointerType);
     undefined mouseMoveTo(long x, long y, optional DOMString pointerType);
     undefined mouseForceClick();
     undefined startAndCancelMouseForceClick();
@@ -40,16 +40,16 @@ interface EventSendingController {
     undefined mouseScrollByWithWheelAndMomentumPhases(long x, long y, DOMString phase, DOMString momentum);
     undefined setWheelHasPreciseDeltas(boolean hasPreciseDeltas);
     undefined continuousMouseScrollBy(long x, long y, optional boolean paged);
-    object contextClick();
+    [PassContext] object contextClick();
     undefined scheduleAsynchronousClick();
 
     undefined leapForward(long milliseconds);
 
     // keyDown is really keyUpAndDown, and perhaps should be renamed to reflect that.
     // rawKeyDown is just the keyDown, and rawKeyUp is just the keyUp
-    undefined keyDown(DOMString key, object modifierArray, long location);
-    undefined rawKeyDown(DOMString key, object modifierArray, long location);
-    undefined rawKeyUp(DOMString key, object modifierArray, long location);
+    [PassContext] undefined keyDown(DOMString key, object modifierArray, long location);
+    [PassContext] undefined rawKeyDown(DOMString key, object modifierArray, long location);
+    [PassContext] undefined rawKeyUp(DOMString key, object modifierArray, long location);
     undefined scheduleAsynchronousKeyDown(DOMString key);
 
     // Zoom functions.
@@ -60,7 +60,7 @@ interface EventSendingController {
     undefined scalePageBy(double scale, double x, double y);
 
     undefined monitorWheelEvents(optional MonitorWheelEventsOptions options);
-    undefined callAfterScrollingCompletes(object functionCallback);
+    [PassContext] undefined callAfterScrollingCompletes(object functionCallback);
 
 #if defined(ENABLE_TOUCH_EVENTS) && ENABLE_TOUCH_EVENTS
     // Touch events.

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TextInputController.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TextInputController.idl
@@ -24,7 +24,7 @@
  */
 
 interface TextInputController {
-    undefined setMarkedText(DOMString string, long from, long length, boolean suppressUnderline, object highlights);
+    [PassContext] undefined setMarkedText(DOMString string, long from, long length, boolean suppressUnderline, object highlights);
     boolean hasMarkedText();
     undefined unmarkText();
     undefined insertText(DOMString string);

--- a/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
@@ -191,11 +191,6 @@ static WKEventModifiers parseModifierArray(JSContextRef context, JSValueRef arra
     return modifiers;
 }
 
-static WKEventModifiers parseModifierArray(JSValueRef arrayValue)
-{
-    return parseModifierArray(WKBundleFrameGetJavaScriptContext(WKBundlePageGetMainFrame(InjectedBundle::singleton().page()->page())), arrayValue);
-}
-
 Ref<EventSendingController> EventSendingController::create()
 {
     return adoptRef(*new EventSendingController);
@@ -219,14 +214,14 @@ static WKRetainPtr<WKDictionaryRef> createMouseMessageBody(MouseState state, int
     return body;
 }
 
-void EventSendingController::mouseDown(int button, JSValueRef modifierArray, JSStringRef pointerType)
+void EventSendingController::mouseDown(JSContextRef context, int button, JSValueRef modifierArray, JSStringRef pointerType)
 {
-    postSynchronousPageMessage("EventSender", createMouseMessageBody(MouseDown, button, parseModifierArray(modifierArray), pointerType));
+    postSynchronousPageMessage("EventSender", createMouseMessageBody(MouseDown, button, parseModifierArray(context, modifierArray), pointerType));
 }
 
-void EventSendingController::mouseUp(int button, JSValueRef modifierArray, JSStringRef pointerType)
+void EventSendingController::mouseUp(JSContextRef context, int button, JSValueRef modifierArray, JSStringRef pointerType)
 {
-    postSynchronousPageMessage("EventSender", createMouseMessageBody(MouseUp, button, parseModifierArray(modifierArray), pointerType));
+    postSynchronousPageMessage("EventSender", createMouseMessageBody(MouseUp, button, parseModifierArray(context, modifierArray), pointerType));
 }
 
 void EventSendingController::mouseMoveTo(int x, int y, JSStringRef pointerType)
@@ -326,19 +321,19 @@ static WKRetainPtr<WKMutableDictionaryRef> createRawKeyUpMessageBody(JSStringRef
     return body;
 }
 
-void EventSendingController::keyDown(JSStringRef key, JSValueRef modifierArray, int location)
+void EventSendingController::keyDown(JSContextRef context, JSStringRef key, JSValueRef modifierArray, int location)
 {
-    postSynchronousPageMessage("EventSender", createKeyDownMessageBody(key, parseModifierArray(modifierArray), location));
+    postSynchronousPageMessage("EventSender", createKeyDownMessageBody(key, parseModifierArray(context, modifierArray), location));
 }
 
-void EventSendingController::rawKeyDown(JSStringRef key, JSValueRef modifierArray, int location)
+void EventSendingController::rawKeyDown(JSContextRef context, JSStringRef key, JSValueRef modifierArray, int location)
 {
-    postSynchronousPageMessage("EventSender", createRawKeyDownMessageBody(key, parseModifierArray(modifierArray), location));
+    postSynchronousPageMessage("EventSender", createRawKeyDownMessageBody(key, parseModifierArray(context, modifierArray), location));
 }
 
-void EventSendingController::rawKeyUp(JSStringRef key, JSValueRef modifierArray, int location)
+void EventSendingController::rawKeyUp(JSContextRef context, JSStringRef key, JSValueRef modifierArray, int location)
 {
-    postSynchronousPageMessage("EventSender", createRawKeyUpMessageBody(key, parseModifierArray(modifierArray), location));
+    postSynchronousPageMessage("EventSender", createRawKeyUpMessageBody(key, parseModifierArray(context, modifierArray), location));
 }
 
 void EventSendingController::scheduleAsynchronousKeyDown(JSStringRef key)
@@ -432,12 +427,10 @@ void EventSendingController::continuousMouseScrollBy(int x, int y, bool paged)
     postSynchronousPageMessage("EventSender", body);
 }
 
-JSValueRef EventSendingController::contextClick()
+JSValueRef EventSendingController::contextClick(JSContextRef context)
 {
-    auto page = InjectedBundle::singleton().page()->page();
-    WKBundleFrameRef mainFrame = WKBundlePageGetMainFrame(page);
-    JSContextRef context = WKBundleFrameGetJavaScriptContext(mainFrame);
 #if ENABLE(CONTEXT_MENUS)
+    auto page = InjectedBundle::singleton().page()->page();
     auto menuEntries = adoptWK(WKBundlePageCopyContextMenuAtPointInWindow(page, m_position));
     auto array = JSObjectMakeArray(context, 0, 0, 0);
     if (!menuEntries)
@@ -545,14 +538,12 @@ static void executeCallback(void* context)
     JSValueUnprotect(callbackData->m_context, callbackData->m_function);
 }
 
-void EventSendingController::callAfterScrollingCompletes(JSValueRef functionCallback)
+void EventSendingController::callAfterScrollingCompletes(JSContextRef context, JSValueRef functionCallback)
 {
     if (!functionCallback)
         return;
 
     auto page = InjectedBundle::singleton().page()->page();
-    WKBundleFrameRef mainFrame = WKBundlePageGetMainFrame(page);
-    JSContextRef context = WKBundleFrameGetJavaScriptContext(mainFrame);
     
     JSObjectRef functionCallbackObject = JSValueToObject(context, functionCallback, nullptr);
     if (!functionCallbackObject)

--- a/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.h
@@ -48,8 +48,8 @@ public:
 
     void makeWindowObject(JSContextRef);
 
-    void mouseDown(int button, JSValueRef modifierArray, JSStringRef pointerType);
-    void mouseUp(int button, JSValueRef modifierArray, JSStringRef pointerType);
+    void mouseDown(JSContextRef, int button, JSValueRef modifierArray, JSStringRef pointerType);
+    void mouseUp(JSContextRef, int button, JSValueRef modifierArray, JSStringRef pointerType);
     void mouseMoveTo(int x, int y, JSStringRef pointerType);
     void mouseForceClick();
     void startAndCancelMouseForceClick();
@@ -60,19 +60,19 @@ public:
     void mouseScrollByWithWheelAndMomentumPhases(int x, int y, JSStringRef phase, JSStringRef momentum);
     void setWheelHasPreciseDeltas(bool);
     void continuousMouseScrollBy(int x, int y, bool paged);
-    JSValueRef contextClick();
+    JSValueRef contextClick(JSContextRef);
     void leapForward(int milliseconds);
     void scheduleAsynchronousClick();
 
     void monitorWheelEvents(MonitorWheelEventsOptions*);
-    void callAfterScrollingCompletes(JSValueRef functionCallback);
+    void callAfterScrollingCompletes(JSContextRef, JSValueRef functionCallback);
     
     void sentWheelPhaseEndOrCancel() { m_sentWheelPhaseEndOrCancel = true; }
     void sentWheelMomentumPhaseEnd() { m_sentWheelMomentumPhaseEnd = true; }
 
-    void keyDown(JSStringRef key, JSValueRef modifierArray, int location);
-    void rawKeyDown(JSStringRef key, JSValueRef modifierArray, int location);
-    void rawKeyUp(JSStringRef key, JSValueRef modifierArray, int location);
+    void keyDown(JSContextRef, JSStringRef key, JSValueRef modifierArray, int location);
+    void rawKeyDown(JSContextRef, JSStringRef key, JSValueRef modifierArray, int location);
+    void rawKeyUp(JSContextRef, JSStringRef key, JSValueRef modifierArray, int location);
     void scheduleAsynchronousKeyDown(JSStringRef key);
 
     void textZoomIn();

--- a/Tools/WebKitTestRunner/InjectedBundle/TextInputController.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TextInputController.cpp
@@ -79,10 +79,9 @@ static WKArrayRef createCompositionHighlightData(JSContextRef context, JSValueRe
     return result;
 }
 
-void TextInputController::setMarkedText(JSStringRef text, int from, int length, bool suppressUnderline, JSValueRef jsHighlightsValue)
+void TextInputController::setMarkedText(JSContextRef context, JSStringRef text, int from, int length, bool suppressUnderline, JSValueRef jsHighlightsValue)
 {
     auto page = InjectedBundle::singleton().page()->page();
-    auto context = WKBundleFrameGetJavaScriptContext(WKBundlePageGetMainFrame(page));
     auto highlights = adoptWK(createCompositionHighlightData(context, jsHighlightsValue));
     WKBundlePageSetComposition(page, toWK(text).get(), from, length, suppressUnderline, highlights.get());
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/TextInputController.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TextInputController.h
@@ -40,7 +40,7 @@ public:
 
     void makeWindowObject(JSContextRef);
 
-    void setMarkedText(JSStringRef text, int from, int length, bool suppressUnderline, JSValueRef highlights);
+    void setMarkedText(JSContextRef, JSStringRef text, int from, int length, bool suppressUnderline, JSValueRef highlights);
     bool hasMarkedText();
     void unmarkText();
     void insertText(JSStringRef text);


### PR DESCRIPTION
#### 4d615268b408e70bbdbab4670ef69439c98bd2af
<pre>
Reduce use of WKBundlePageGetMainFrame in WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=273223">https://bugs.webkit.org/show_bug.cgi?id=273223</a>
<a href="https://rdar.apple.com/127020492">rdar://127020492</a>

Reviewed by Pascoe.

The main frame, and the main frame JS context, might not be in the current process
with site isolation enabled.  What we want is the current context.

This PR fixes fast/events/key-events-in-frame.html with --site-isolation, among other tests.

* Tools/WebKitTestRunner/InjectedBundle/Bindings/EventSendingController.idl:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TextInputController.idl:
* Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp:
(WTR::EventSendingController::mouseDown):
(WTR::EventSendingController::mouseUp):
(WTR::EventSendingController::keyDown):
(WTR::EventSendingController::rawKeyDown):
(WTR::EventSendingController::rawKeyUp):
(WTR::EventSendingController::contextClick):
(WTR::EventSendingController::callAfterScrollingCompletes):
* Tools/WebKitTestRunner/InjectedBundle/EventSendingController.h:
* Tools/WebKitTestRunner/InjectedBundle/TextInputController.cpp:
(WTR::TextInputController::setMarkedText):
* Tools/WebKitTestRunner/InjectedBundle/TextInputController.h:

Canonical link: <a href="https://commits.webkit.org/277960@main">https://commits.webkit.org/277960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1c3b297bc4942ffd9b1379f85b91dd9d2b4fcdf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51807 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45149 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51379 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34279 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25839 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40100 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50489 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25920 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42298 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21213 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23373 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43471 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7245 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43976 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53721 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24146 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20360 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47420 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/25428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42504 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46390 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26214 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7028 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/25150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->