### PR TITLE
[Remote Inspection] Add the ability to search for target elements by text

### DIFF
--- a/Source/WebCore/page/ElementTargetingController.h
+++ b/Source/WebCore/page/ElementTargetingController.h
@@ -44,6 +44,7 @@ namespace WebCore {
 
 class Element;
 class Document;
+class Node;
 class Page;
 
 class ElementTargetingController final : public CanMakeCheckedPtr<ElementTargetingController> {
@@ -65,6 +66,11 @@ public:
 private:
     void cleanUpAdjustmentClientRects();
     void applyVisibilityAdjustmentFromSelectors(Document&);
+
+    std::pair<Vector<Ref<Node>>, RefPtr<Element>> findNodes(FloatPoint location);
+    std::pair<Vector<Ref<Node>>, RefPtr<Element>> findNodes(const String& searchText);
+
+    Vector<TargetedElementInfo> extractTargets(Vector<Ref<Node>>&&, RefPtr<Element>&& innerElement, bool canIncludeNearbyElements);
 
     SingleThreadWeakPtr<Page> m_page;
     DeferrableOneShotTimer m_recentAdjustmentClientRectsCleanUpTimer;

--- a/Source/WebCore/page/ElementTargetingTypes.h
+++ b/Source/WebCore/page/ElementTargetingTypes.h
@@ -38,7 +38,7 @@
 namespace WebCore {
 
 struct TargetedElementRequest {
-    FloatPoint pointInRootView;
+    std::variant<FloatPoint, String> data;
     bool canIncludeNearbyElements { true };
 };
 
@@ -47,12 +47,13 @@ struct TargetedElementInfo {
     ScriptExecutionContextIdentifier documentIdentifier;
     RectEdges<bool> offsetEdges;
     String renderedText;
+    String searchableText;
     Vector<Vector<String>> selectors;
     FloatRect boundsInRootView;
     FloatRect boundsInClientCoordinates;
     PositionType positionType { PositionType::Static };
     Vector<FrameIdentifier> childFrameIdentifiers;
-    bool isUnderPoint { true };
+    bool isNearbyTarget { true };
     bool isPseudoElement { false };
     bool isInShadowTree { false };
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -886,7 +886,7 @@ enum class WebCore::ShareDataOriginator : bool
 
 header: <WebCore/ElementTargetingTypes.h>
 [CustomHeader] struct WebCore::TargetedElementRequest {
-    WebCore::FloatPoint pointInRootView
+    std::variant<WebCore::FloatPoint, String> data
     bool canIncludeNearbyElements
 };
 
@@ -896,12 +896,13 @@ header: <WebCore/ElementTargetingTypes.h>
     WebCore::ScriptExecutionContextIdentifier documentIdentifier
     WebCore::RectEdges<bool> offsetEdges
     String renderedText
+    String searchableText
     Vector<Vector<String>> selectors
     WebCore::FloatRect boundsInRootView
     WebCore::FloatRect boundsInClientCoordinates
     WebCore::PositionType positionType
     Vector<WebCore::FrameIdentifier> childFrameIdentifiers
-    bool isUnderPoint
+    bool isNearbyTarget
     bool isPseudoElement
     bool isInShadowTree
 };

--- a/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
@@ -51,13 +51,14 @@ public:
     WebCore::RectEdges<bool> offsetEdges() const { return m_info.offsetEdges; }
 
     const WTF::String& renderedText() const { return m_info.renderedText; }
+    const WTF::String& searchableText() const { return m_info.searchableText; }
     const Vector<Vector<WTF::String>>& selectors() const { return m_info.selectors; }
     WebCore::PositionType positionType() const { return m_info.positionType; }
     WebCore::FloatRect boundsInRootView() const { return m_info.boundsInRootView; }
     WebCore::FloatRect boundsInWebView() const;
     WebCore::FloatRect boundsInClientCoordinates() const { return m_info.boundsInClientCoordinates; }
 
-    bool isUnderPoint() const { return m_info.isUnderPoint; }
+    bool isNearbyTarget() const { return m_info.isNearbyTarget; }
     bool isPseudoElement() const { return m_info.isPseudoElement; }
     bool isInShadowTree() const { return m_info.isInShadowTree; }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2842,14 +2842,17 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
 
 - (void)_requestTargetedElementInfo:(_WKTargetedElementRequest *)request completionHandler:(void(^)(NSArray<_WKTargetedElementInfo *> *))completion
 {
-    WebCore::TargetedElementRequest coreRequest {
+    WebCore::TargetedElementRequest coreRequest;
+    if (request.searchText)
+        coreRequest.data = String { request.searchText };
+    else {
 #if PLATFORM(IOS_FAMILY)
-        [self convertPoint:request.point toView:_contentView.get()],
+        coreRequest.data = [self convertPoint:request.point toView:_contentView.get()];
 #else
-        request.point,
+        coreRequest.data = request.point;
 #endif
-        static_cast<bool>(request.canIncludeNearbyElements)
-    };
+    }
+    coreRequest.canIncludeNearbyElements = !!request.canIncludeNearbyElements;
     _page->requestTargetedElement(WTFMove(coreRequest), [completion = makeBlockPtr(completion)](auto& elements) {
         completion(createNSArray(elements, [](auto& element) {
             return wrapper(element);

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h
@@ -43,13 +43,14 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @property (nonatomic, readonly) _WKTargetedElementPosition positionType;
 @property (nonatomic, readonly) CGRect boundsInWebView; // In WKWebView's coordinate space.
 @property (nonatomic, readonly) CGRect boundsInClientCoordinates;
-@property (nonatomic, readonly, getter=isUnderPoint) BOOL underPoint;
+@property (nonatomic, readonly, getter=isNearbyTarget) BOOL nearbyTarget;
 @property (nonatomic, readonly, getter=isPseudoElement) BOOL pseudoElement;
 @property (nonatomic, readonly, getter=isInShadowTree) BOOL inShadowTree;
 
 @property (nonatomic, readonly, copy) NSArray<NSString *> *selectors;
 @property (nonatomic, readonly, copy) NSArray<NSArray<NSString *> *> *selectorsIncludingShadowHosts;
 @property (nonatomic, readonly, copy) NSString *renderedText;
+@property (nonatomic, readonly, copy) NSString *searchableText;
 @property (nonatomic, readonly) _WKRectEdge offsetEdges;
 
 // In root view coordinates. To be deprecated and removed, once clients adopt the more explicit bounds properties above.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
@@ -109,6 +109,11 @@
     return _info->renderedText();
 }
 
+- (NSString *)searchableText
+{
+    return _info->searchableText();
+}
+
 - (_WKRectEdge)offsetEdges
 {
     _WKRectEdge edges = _WKRectEdgeNone;
@@ -138,9 +143,9 @@
     return _info->isSameElement(*other->_info);
 }
 
-- (BOOL)isUnderPoint
+- (BOOL)isNearbyTarget
 {
-    return _info->isUnderPoint();
+    return _info->isNearbyTarget();
 }
 
 - (BOOL)isPseudoElement

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.h
@@ -29,10 +29,19 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @interface _WKTargetedElementRequest : NSObject
 
-@property (nonatomic) CGPoint point;
+- (instancetype)initWithPoint:(CGPoint)point;
+- (instancetype)initWithSearchText:(NSString *)searchText;
+
+@property (nonatomic) CGPoint point; // This should become readonly, once no internal client relies on the setter.
+@property (nonatomic, readonly, nullable, copy) NSString *searchText;
+
 @property (nonatomic) BOOL canIncludeNearbyElements;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.mm
@@ -26,15 +26,33 @@
 #import "config.h"
 #import "_WKTargetedElementRequest.h"
 
-@implementation _WKTargetedElementRequest
+@implementation _WKTargetedElementRequest {
+    RetainPtr<NSString> _searchText;
+}
 
-- (instancetype)init
+- (instancetype)initWithSearchText:(NSString *)searchText
 {
     if (!(self = [super init]))
         return nil;
 
+    _searchText = adoptNS(searchText.copy);
     _canIncludeNearbyElements = YES;
     return self;
+}
+
+- (instancetype)initWithPoint:(CGPoint)point
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _point = point;
+    _canIncludeNearbyElements = YES;
+    return self;
+}
+
+- (NSString *)searchText
+{
+    return adoptNS([_searchText copy]).autorelease();
 }
 
 @end

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-7.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-7.html
@@ -37,7 +37,7 @@ img {
 </head>
 <body>
     <div class="fixed">
-        <h2>Sunset</h2>
+        <div>Image of a sunset over the 4th floor of Infinite Loop 2</div>
         <img src="sunset-in-cupertino-200px.png" />
     </div>
     <p>Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo. You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them. Because they change things. They push the human race forward. And while some may see them as the crazy ones, we see genius. Because the people who are crazy enough to think they can change the world, are the ones who do.</p>

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -346,8 +346,7 @@ void UIScriptControllerCocoa::requestTextExtraction(JSValueRef callback, TextExt
 void UIScriptControllerCocoa::requestRenderedTextForFrontmostTarget(int x, int y, JSValueRef callback)
 {
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
-    auto request = adoptNS([_WKTargetedElementRequest new]);
-    [request setPoint:CGPointMake(x, y)];
+    auto request = adoptNS([[_WKTargetedElementRequest alloc] initWithPoint:CGPointMake(x, y)]);
     [webView() _requestTargetedElementInfo:request.get() completionHandler:^(NSArray<_WKTargetedElementInfo *> *elements) {
         if (!m_context)
             return;
@@ -360,8 +359,7 @@ void UIScriptControllerCocoa::requestRenderedTextForFrontmostTarget(int x, int y
 void UIScriptControllerCocoa::adjustVisibilityForFrontmostTarget(int x, int y, JSValueRef callback)
 {
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
-    auto request = adoptNS([_WKTargetedElementRequest new]);
-    [request setPoint:CGPointMake(x, y)];
+    auto request = adoptNS([[_WKTargetedElementRequest alloc] initWithPoint:CGPointMake(x, y)]);
     [webView() _requestTargetedElementInfo:request.get() completionHandler:[callbackID, this](NSArray<_WKTargetedElementInfo *> *elements) {
         if (!elements.count) {
             m_context->asyncTaskComplete(callbackID);


### PR DESCRIPTION
#### edca530205c5e76991b0cf709322fb121f8b575d
<pre>
[Remote Inspection] Add the ability to search for target elements by text
<a href="https://bugs.webkit.org/show_bug.cgi?id=273222">https://bugs.webkit.org/show_bug.cgi?id=273222</a>
<a href="https://rdar.apple.com/126991300">rdar://126991300</a>

Reviewed by Abrar Protyasha and Aditya Keerthi.

Add support for:

1.  A `-searchableText` property on `_WKTargetedElementInfo`, which exposes the first 100 characters
    of the longest contiguous text run in the targeted element.

2.  A way to initialize `_WKTargetedElementRequest` with a `searchText` string instead of a `point`,
    which retrieves a targeted element by searching in the document (and recursively in any
    subframes) for the first range that matches the text.

See below for more details.

* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::collectDocumentElementsFromChildFrames):
(WebCore::searchableTextForTarget):
(WebCore::targetedElementInfo):
(WebCore::ElementTargetingController::findTargets):
(WebCore::ElementTargetingController::findNodes):

Refactor the element targeting logic to work with both hit-testing (based on a point in root view
space) or text search (based on a search string). To do this, we split the logic out into two parts:

1.  The first part computes a list of potential candidates (`Vector&lt;Ref&lt;Node&gt;&gt;`), using one of two
    strategies: hit-testing or text search.

2.  The second part takes the list of potential candiates from (1) and resolves the final list of
    targeted elements.

The new text search codepath hooks into the existing targeting code by searching the DOM for ranges
that match the given text and surfacing the ancestor chain as potential candidates, which the rest
of the targeting heuristic pipeline consumes.

(WebCore::searchForElementContainingText):
(WebCore::ElementTargetingController::extractTargets):
* Source/WebCore/page/ElementTargetingController.h:
* Source/WebCore/page/ElementTargetingTypes.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Back `TargetedElementRequest` with a variant of `FloatPoint, String` instead of just a `FloatPoint`.
The `FloatPoint` represents a hit-testing location in root view coordinates, while the `String`
represents a search string.

* Source/WebKit/UIProcess/API/APITargetedElementInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _requestTargetedElementInfo:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm:
(-[_WKTargetedElementInfo searchableText]):
(-[_WKTargetedElementInfo isNearbyTarget]):
(-[_WKTargetedElementInfo isUnderPoint]): Deleted.

Rename this property to `isNearbyTarget`, since `isUnderPoint` doesn&apos;t make sense in the case where
the targeted element was requested via text search.

* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.mm:
(-[_WKTargetedElementRequest initWithSearchText:]):
(-[_WKTargetedElementRequest initWithPoint:]):
(-[_WKTargetedElementRequest searchText]):
(-[_WKTargetedElementRequest init]): Deleted.

Instead of having clients use `-init` and then set a point on the request, we add initializer
methods to take either a string (for the search text) or a point in web view coordinates, and then
expose the point or search text as readonly properties only. (For now, we need to keep exposing
`-setPoint:` for source compatibility, but this should become readonly shortly).

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm:
(-[WKWebView _targetedElementInfo:]):
(-[WKWebView targetedElementInfoAt:]):
(-[WKWebView targetedElementInfoWithText:]):
(TestWebKitAPI::TEST(ElementTargeting, NearbyOutOfFlowElements)):
(TestWebKitAPI::TEST(ElementTargeting, RequestTargetedElementsBySearchableText)):

Add a new API test to exercise both SPIs.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-7.html:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::requestRenderedTextForFrontmostTarget):
(WTR::UIScriptControllerCocoa::adjustVisibilityForFrontmostTarget):

Canonical link: <a href="https://commits.webkit.org/278027@main">https://commits.webkit.org/278027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/476afa100ed68e9c462003dddb5d39708bf612d8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52282 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52047 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45354 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51555 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26153 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40235 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26085 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42429 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21356 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23538 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43604 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7573 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/42551 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45461 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/44112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53958 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20518 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47553 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25605 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42631 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10832 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26443 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25327 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->