### PR TITLE
Cleanup hardened mach exceptions and formalize fallback

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -3522,9 +3522,6 @@ int main(int argc, char** argv WTF_TZONE_EXTRA_MAIN_ARGS)
 
 #if OS(UNIX)
     if (getenv("JS_SHELL_WAIT_FOR_SIGUSR2_TO_EXIT")) {
-        uint32_t key = 0;
-        int mask = 0;
-        initializeSignalHandling(key, mask);
         addSignalHandler(Signal::Usr, SignalHandler([&] (Signal, SigInfo&, PlatformRegisters&) {
             dataLogLn("Signal handler hit, we can exit now.");
             waitToExit.signal();
@@ -3998,20 +3995,6 @@ void CommandLine::parseArguments(int argc, char** argv)
         }
         if (!strcmp(arg, "-s")) {
 #if OS(UNIX)
-            uint32_t key = 0;
-            int mask = 0;
-#if HAVE(MACH_EXCEPTIONS)
-            mask |= toMachMask(Signal::IllegalInstruction);
-            mask |= toMachMask(Signal::AccessFault);
-            mask |= toMachMask(Signal::FloatingPoint);
-            mask |= toMachMask(Signal::Breakpoint);
-#if !OS(DARWIN)
-            mask |= toMachMask(Signal::Abort);
-#endif // !OS(DARWIN)
-#endif // HAVE(MACH_EXCEPTIONS)
-
-            initializeSignalHandling(key, mask);
-
             SignalAction (*exit)(Signal, SigInfo&, PlatformRegisters&) = [] (Signal, SigInfo&, PlatformRegisters&) {
                 dataLogLn("Signal handler hit. Exiting with status 0");
                 // Deliberate exit with a SIGKILL code greater than 130.
@@ -4034,7 +4017,6 @@ void CommandLine::parseArguments(int argc, char** argv)
             addSignalHandler(Signal::Abort, SignalHandler(exit));
             activateSignalHandlersFor(Signal::Abort);
 #endif
-            finalizeSignalHandlers();
 #endif
             continue;
         }

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -136,23 +136,11 @@ void initialize()
             WTF::fastEnableMiniMode();
 
         if (Wasm::isSupported() || !Options::usePollingTraps()) {
-            // JSLock::lock() can call registerThreadForMachExceptionHandling() which crashes if this has not been called first.
-            int mask = 0;
-#if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
-            JSC::Wasm::MachExceptionSigningKey keygen;
-            uint32_t signingKey = keygen.randomSigningKey;
-            mask |= toMachMask(Signal::AccessFault);
-#else
-            uint32_t signingKey = 0;
-#endif // CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
-            initializeSignalHandling(signingKey, mask);
-
             if (!Options::usePollingTraps())
                 VMTraps::initializeSignals();
             if (Wasm::isSupported())
                 Wasm::prepareSignalingMemory();
-        } else
-            disableSignalHandling();
+        }
 
         WTF::compilerFence();
         RELEASE_ASSERT(!g_jscConfig.initializeHasBeenCalled);

--- a/Source/JavaScriptCore/runtime/JSCConfig.cpp
+++ b/Source/JavaScriptCore/runtime/JSCConfig.cpp
@@ -42,12 +42,6 @@ Config& Config::singleton()
     return g_jscConfig;
 }
 
-void Config::disableFreezingForTesting()
-{
-    RELEASE_ASSERT(!g_jscConfig.isPermanentlyFrozen());
-    g_jscConfig.disabledFreezingForTesting = true;
-}
-
 void Config::enableRestrictedOptions()
 {
     RELEASE_ASSERT(!g_jscConfig.isPermanentlyFrozen());

--- a/Source/JavaScriptCore/runtime/JSCConfig.h
+++ b/Source/JavaScriptCore/runtime/JSCConfig.h
@@ -44,9 +44,9 @@ using JITWriteSeparateHeapsFunction = void (*)(off_t, const void*, size_t);
 struct Config {
     static Config& singleton();
 
-    JS_EXPORT_PRIVATE static void disableFreezingForTesting();
+    static void disableFreezingForTesting() { g_wtfConfig.disableFreezingForTesting(); }
     JS_EXPORT_PRIVATE static void enableRestrictedOptions();
-    static void permanentlyFreeze() { WTF::Config::permanentlyFreeze(); }
+    static void finalize() { WTF::Config::finalize(); }
 
     static void configureForTesting()
     {
@@ -60,8 +60,8 @@ struct Config {
     // All the fields in this struct should be chosen such that their
     // initial value is 0 / null / falsy because Config is instantiated
     // as a global singleton.
+    // FIXME: We should use a placement new constructor from JSC::initialize so we can use default initializers.
 
-    bool disabledFreezingForTesting;
     bool restrictedOptionsEnabled;
     bool jitDisabled;
     bool vmCreationDisallowed;

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -434,8 +434,7 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
         jitSizeStatistics = makeUnique<JITSizeStatistics>();
 #endif
 
-    if (!g_jscConfig.disabledFreezingForTesting)
-        Config::permanentlyFreeze();
+    Config::finalize();
 
     // We must set this at the end only after the VM is fully initialized.
     WTF::storeStoreFence();

--- a/Source/JavaScriptCore/runtime/VMEntryScope.cpp
+++ b/Source/JavaScriptCore/runtime/VMEntryScope.cpp
@@ -48,8 +48,7 @@ void VMEntryScope::setUpSlow()
         if (Wasm::isSupported())
             Wasm::startTrackingCurrentThread();
 #if HAVE(MACH_EXCEPTIONS)
-        if (g_wtfConfig.signalHandlers.initState == WTF::SignalHandlers::InitState::AddedHandlers)
-            registerThreadForMachExceptionHandling(thread);
+        registerThreadForMachExceptionHandling(thread);
 #endif
     }
 

--- a/Source/JavaScriptCore/runtime/VMTraps.cpp
+++ b/Source/JavaScriptCore/runtime/VMTraps.cpp
@@ -201,7 +201,6 @@ public:
         , m_vm(vm)
     {
         activateSignalHandlersFor(Signal::AccessFault);
-        finalizeSignalHandlers();
     }
 
     static void initializeSignals()

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -2922,7 +2922,7 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(functionCallWithStackSize, SUPPRESS_ASA
         return throwVMError(globalObject, throwScope, "Not supported for this platform"_s);
 
 #if ENABLE(ASSEMBLER)
-    if (g_jscConfig.isPermanentlyFrozen() || !g_jscConfig.disabledFreezingForTesting)
+    if (g_jscConfig.isPermanentlyFrozen() || !g_wtfConfig.disabledFreezingForTesting)
         return throwVMError(globalObject, throwScope, "Options are frozen"_s);
 
     if (callFrame->argumentCount() < 2)

--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
@@ -39,7 +39,6 @@
 #include "WasmMemory.h"
 #include "WasmThunks.h"
 #include <wtf/CodePtr.h>
-#include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/threads/Signals.h>
@@ -49,18 +48,8 @@ namespace JSC { namespace Wasm {
 using WTF::CodePtr;
 
 #if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
-void* presignedTrampoline = { };
-
-MachExceptionSigningKey::MachExceptionSigningKey()
-{
-    // Sign the trampoline pointer using a random diversifier and stash it away before webcontent has started so that
-    // even a PAC signing gadget cannot fake this random diversifier
-    randomSigningKey = WTF::cryptographicallyRandomNumber<uint32_t>() & __DARWIN_ARM_THREAD_STATE64_USER_DIVERSIFIER_MASK;
-    uint64_t diversifier = ptrauth_blend_discriminator((void *)(unsigned long)randomSigningKey, ptrauth_string_discriminator("pc"));
-    presignedTrampoline = JSC::LLInt::getCodePtr<CFunctionPtrTag>(wasm_throw_from_fault_handler_trampoline_reg_instance).untaggedPtr();
-    presignedTrampoline = ptrauth_sign_unauthenticated(presignedTrampoline, ptrauth_key_function_pointer, diversifier);
-}
-#endif // CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
+void* presignedTrampoline { nullptr };
+#endif
 
 namespace {
 namespace WasmFaultSignalHandlerInternal {
@@ -115,7 +104,7 @@ static SignalAction trapHandler(Signal signal, SigInfo& sigInfo, PlatformRegiste
 
             if (didFaultInWasm(faultingInstruction)) {
 #if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
-                if (!WTF::fallbackToOldExceptions.load()) {
+                if (g_wtfConfig.signalHandlers.useHardenedHandler) {
                     MachineContext::setInstructionPointer(context, presignedTrampoline);
                     return SignalAction::Handled;
                 }
@@ -139,7 +128,6 @@ void activateSignalingMemory()
             return;
 
         activateSignalHandlersFor(Signal::AccessFault);
-        WTF::finalizeSignalHandlers();
     });
 }
 
@@ -153,6 +141,9 @@ void prepareSignalingMemory()
         if (!Options::useWasmFaultSignalHandler())
             return;
 
+#if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
+        presignedTrampoline = g_wtfConfig.signalHandlers.presignReturnPCForHandler(LLInt::getCodePtr<NoPtrTag>(wasm_throw_from_fault_handler_trampoline_reg_instance));
+#endif
         addSignalHandler(Signal::AccessFault, [] (Signal signal, SigInfo& sigInfo, PlatformRegisters& ucontext) {
             return trapHandler(signal, sigInfo, ucontext);
         });

--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h
@@ -36,12 +36,4 @@ inline void activateSignalingMemory() { }
 inline void prepareSignalingMemory() { }
 #endif // ENABLE(WEBASSEMBLY)
 
-#if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
-class MachExceptionSigningKey {
-public:
-    uint32_t randomSigningKey = { };
-    MachExceptionSigningKey();
-};
-#endif // CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
-
 } } // namespace JSC::Wasm

--- a/Source/WTF/wtf/CryptographicallyRandomNumber.cpp
+++ b/Source/WTF/wtf/CryptographicallyRandomNumber.cpp
@@ -57,15 +57,15 @@ class ARC4RandomNumberGenerator {
 public:
     ARC4RandomNumberGenerator() = default;
 
-    uint32_t randomNumber();
+    template<typename IntegerType>
+    IntegerType randomNumber();
     void randomValues(std::span<uint8_t>);
 
 private:
     inline void addRandomData(std::span<const uint8_t, 128>);
     void stir() WTF_REQUIRES_LOCK(m_lock);
     void stirIfNeeded() WTF_REQUIRES_LOCK(m_lock);
-    inline uint8_t getByte();
-    inline uint32_t getWord();
+    inline uint8_t getByte() WTF_REQUIRES_LOCK(m_lock);
 
     Lock m_lock;
     ARC4Stream m_stream;
@@ -121,30 +121,25 @@ uint8_t ARC4RandomNumberGenerator::getByte()
     return (m_stream.s[(si + sj) & 0xff]);
 }
 
-uint32_t ARC4RandomNumberGenerator::getWord()
-{
-    uint32_t val;
-    val = getByte() << 24;
-    val |= getByte() << 16;
-    val |= getByte() << 8;
-    val |= getByte();
-    return val;
-}
-
-uint32_t ARC4RandomNumberGenerator::randomNumber()
+template<typename IntegerType>
+IntegerType ARC4RandomNumberGenerator::randomNumber()
 {
     Locker locker { m_lock };
 
-    m_count -= 4;
-    stirIfNeeded();
-    return getWord();
+    IntegerType val = 0;
+    for (unsigned i = 0; i < sizeof(IntegerType); ++i) {
+        m_count--;
+        stirIfNeeded();
+        val = (val << 8) | getByte();
+    }
+
+    return val;
 }
 
 void ARC4RandomNumberGenerator::randomValues(std::span<uint8_t> buffer)
 {
     Locker locker { m_lock };
 
-    stirIfNeeded();
     for (auto& byte : WTF::makeReversedRange(buffer)) {
         m_count--;
         stirIfNeeded();
@@ -167,9 +162,14 @@ ARC4RandomNumberGenerator& sharedRandomNumberGenerator()
 
 }
 
+template<> uint8_t cryptographicallyRandomNumber<uint8_t>()
+{
+    return sharedRandomNumberGenerator().randomNumber<uint8_t>();
+}
+
 template<> unsigned cryptographicallyRandomNumber<unsigned>()
 {
-    return sharedRandomNumberGenerator().randomNumber();
+    return sharedRandomNumberGenerator().randomNumber<unsigned>();
 }
 
 void cryptographicallyRandomValues(std::span<uint8_t> buffer)
@@ -179,8 +179,7 @@ void cryptographicallyRandomValues(std::span<uint8_t> buffer)
 
 template<> uint64_t cryptographicallyRandomNumber<uint64_t>()
 {
-    uint64_t high = cryptographicallyRandomNumber<unsigned>();
-    return (high << 32) | cryptographicallyRandomNumber<unsigned>();
+    return sharedRandomNumberGenerator().randomNumber<uint64_t>();
 }
 
 double cryptographicallyRandomUnitInterval()

--- a/Source/WTF/wtf/CryptographicallyRandomNumber.h
+++ b/Source/WTF/wtf/CryptographicallyRandomNumber.h
@@ -32,6 +32,8 @@ namespace WTF {
 
 template<typename IntegerType> IntegerType cryptographicallyRandomNumber() = delete;
 
+template<> WTF_EXPORT_PRIVATE uint8_t cryptographicallyRandomNumber<uint8_t>();
+
 // Returns a cryptographically secure pseudo-random number in the range [0, UINT_MAX].
 template<> WTF_EXPORT_PRIVATE unsigned cryptographicallyRandomNumber<unsigned>();
 

--- a/Source/WTF/wtf/PlatformRegisters.cpp
+++ b/Source/WTF/wtf/PlatformRegisters.cpp
@@ -54,8 +54,8 @@ void* threadStateLRInternal(PlatformRegisters& regs)
 void* threadStatePCInternal(PlatformRegisters& regs)
 {
 #if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
-    // If userspace has modified the PC and set it to the presignedTrampoline,
-    // we want to avoid authing the value as it is using a custom ptrauth signing scheme.
+    // If we have modified the PC and set it to a presigned function we want to avoid
+    // authing the value as it is using a custom ptrauth signing scheme.
     _STRUCT_ARM_THREAD_STATE64* ts = &(regs);
     if (!(ts->__opaque_flags & __DARWIN_ARM_THREAD_STATE64_FLAGS_KERNEL_SIGNED_PC))
         return nullptr;

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -501,9 +501,6 @@ void initialize()
 #endif
         initializeDates();
         Thread::initializePlatformThreading();
-#if USE(PTHREADS) && HAVE(MACHINE_CONTEXT)
-        SignalHandlers::initialize();
-#endif
 #if PLATFORM(COCOA)
         initializeLibraryPathDiagnostics();
 #endif

--- a/Source/WTF/wtf/WTFConfig.cpp
+++ b/Source/WTF/wtf/WTFConfig.cpp
@@ -100,6 +100,7 @@ void setPermissionsOfConfigPage()
 
 void Config::initialize()
 {
+    // FIXME: We should do a placement new for Config so we can use default initializers.
     []() -> void {
         uintptr_t onePage = pageSize(); // At least, first one page must be unmapped.
 #if OS(DARWIN)
@@ -124,14 +125,23 @@ void Config::initialize()
         g_wtfConfig.lowestAccessibleAddress = onePage;
     }();
     g_wtfConfig.highestAccessibleAddress = static_cast<uintptr_t>((1ULL << OS_CONSTANT(EFFECTIVE_ADDRESS_WIDTH)) - 1);
+    SignalHandlers::initialize();
+}
+
+void Config::finalize()
+{
+    static std::once_flag once;
+    std::call_once(once, [] {
+        SignalHandlers::finalize();
+        if (!g_wtfConfig.disabledFreezingForTesting)
+            Config::permanentlyFreeze();
+    });
 }
 
 void Config::permanentlyFreeze()
 {
-    static Lock configLock;
-    Locker locker { configLock };
-
     RELEASE_ASSERT(roundUpToMultipleOf(pageSize(), ConfigSizeToProtect) == ConfigSizeToProtect);
+    ASSERT(!g_wtfConfig.disabledFreezingForTesting);
 
     if (!g_wtfConfig.isPermanentlyFrozen) {
         g_wtfConfig.isPermanentlyFrozen = true;
@@ -165,6 +175,12 @@ void Config::permanentlyFreeze()
 
     RELEASE_ASSERT(!result);
     RELEASE_ASSERT(g_wtfConfig.isPermanentlyFrozen);
+}
+
+void Config::disableFreezingForTesting()
+{
+    RELEASE_ASSERT(!g_wtfConfig.isPermanentlyFrozen);
+    g_wtfConfig.disabledFreezingForTesting = true;
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/WTFConfig.h
+++ b/Source/WTF/wtf/WTFConfig.h
@@ -69,6 +69,8 @@ constexpr size_t ConfigSizeToProtect = std::max(CeilingOnPageSize, 16 * KB);
 struct Config {
     WTF_EXPORT_PRIVATE static void permanentlyFreeze();
     WTF_EXPORT_PRIVATE static void initialize();
+    WTF_EXPORT_PRIVATE static void finalize();
+    WTF_EXPORT_PRIVATE static void disableFreezingForTesting();
 
     struct AssertNotFrozenScope {
         AssertNotFrozenScope();
@@ -83,6 +85,7 @@ struct Config {
     uintptr_t highestAccessibleAddress;
 
     bool isPermanentlyFrozen;
+    bool disabledFreezingForTesting;
     bool useSpecialAbortForExtraSecurityImplications;
 #if PLATFORM(COCOA)
     bool disableForwardingVPrintfStdErrToOSLog;

--- a/Source/WTF/wtf/threads/Signals.cpp
+++ b/Source/WTF/wtf/threads/Signals.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -53,6 +53,7 @@ extern "C" {
 
 #include <unistd.h>
 #include <wtf/Atomics.h>
+#include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/DataLog.h>
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
@@ -63,20 +64,19 @@ extern "C" {
 #include <wtf/TranslatedProcess.h>
 #include <wtf/WTFConfig.h>
 
-#if CPU(ARM64) && HAVE(HARDENED_MACH_EXCEPTIONS)
-#include <wtf/spi/darwin/SandboxSPI.h>
-#endif
-
-
 namespace WTF {
 
-Atomic<bool> fallbackToOldExceptions { false };
+#if HAVE(MACH_EXCEPTIONS)
+static exception_mask_t toMachMask(Signal);
+#endif
 
 void SignalHandlers::add(Signal signal, SignalHandler&& handler)
 {
     Config::AssertNotFrozenScope assertScope;
-    static Lock lock;
-    Locker locker { lock };
+
+    ASSERT(signal < Signal::NumberOfSignals);
+    ASSERT(!useMach || signal != Signal::Usr);
+    RELEASE_ASSERT(initState == SignalHandlers::InitState::Initializing);
 
     size_t signalIndex = static_cast<size_t>(signal);
     size_t nextFree = numberOfHandlers[signalIndex];
@@ -88,16 +88,7 @@ void SignalHandlers::add(Signal signal, SignalHandler&& handler)
     SignalHandlerMemory* memory = &handlers[signalIndex][nextFree];
     new (memory) SignalHandler(WTFMove(handler));
 
-    // We deliberately do not want to increment the count until after we've
-    // fully initialized the memory. This way, forEachHandler() won't see a
-    // partially initialized handler.
-    storeStoreFence();
     numberOfHandlers[signalIndex]++;
-#if HAVE(MACH_EXCEPTIONS)
-    RELEASE_ASSERT(initState >= InitState::InitializedHandlerThread);
-    initState = InitState::AddedHandlers;
-#endif
-    loadLoadFence();
 }
 
 template<typename Func>
@@ -118,76 +109,101 @@ inline void SignalHandlers::forEachHandler(Signal signal, const Func& func) cons
 // and the Mach interface Generator (MiG) here:
 // http://www.cs.cmu.edu/afs/cs/project/mach/public/doc/unpublished/mig.ps
 
-static constexpr size_t maxMessageSize = 1 * KB;
-uint32_t randomSigningKey = 0;
+#if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
+// Our secret key which we use as random diversifier when signing our return PC in the handler callbacks.
+// Be VERY careful to clear this before any web content is loaded.
+static uint32_t secretSigningKey;
 
-void initMachExceptionHandlerThread(bool enable, uint32_t signingKey, exception_mask_t mask)
+void* SignalHandlers::presignReturnPCForHandler(CodePtr<NoPtrTag> returnPC)
 {
-    static std::once_flag once;
-    std::call_once(once, [=] {
-        RELEASE_ASSERT(g_wtfConfig.signalHandlers.initState == SignalHandlers::InitState::Uninitialized);
-        g_wtfConfig.signalHandlers.initState = SignalHandlers::InitState::InitializedHandlerThread;
+    ASSERT(initState < SignalHandlers::InitState::Finalized);
+    uint64_t diversifier = ptrauth_blend_discriminator(reinterpret_cast<void*>(secretSigningKey), ptrauth_string_discriminator("pc"));
+    return ptrauth_sign_unauthenticated(returnPC.untaggedPtr(), ptrauth_key_function_pointer, diversifier);
+}
+#endif
 
-        if (!enable || !g_wtfConfig.signalHandlers.useMach)
-            return;
+static constexpr size_t maxMessageSize = 1 * KB;
 
-        Config::AssertNotFrozenScope assertScope;
-        SignalHandlers& handlers = g_wtfConfig.signalHandlers;
+static void initMachExceptionHandlerThread()
+{
+    Config::AssertNotFrozenScope assertScope;
+    SignalHandlers& handlers = g_wtfConfig.signalHandlers;
+    RELEASE_ASSERT_WITH_MESSAGE(!handlers.exceptionPort, "Mach exception handler thread was already created");
+    ASSERT(handlers.useMach);
 
-        uint16_t flags = MPO_INSERT_SEND_RIGHT;
+    // We need this because some processes (e.g. WebKit's GPU process) don't allow signal handling in their
+    // sandbox profiles. We don't use them there so there's no point in setting up a dispatch queue we're
+    // never going to use.
+    if (!handlers.addedExceptions)
+        return;
 
-// This provisional flag can be removed once macos sonoma is no longer supported
+    uint16_t flags = MPO_INSERT_SEND_RIGHT;
+
+    // This provisional flag can be removed once macos sonoma is no longer supported
 #ifdef MPO_PROVISIONAL_ID_PROT_OPTOUT
-        flags |= MPO_PROVISIONAL_ID_PROT_OPTOUT;
+    flags |= MPO_PROVISIONAL_ID_PROT_OPTOUT;
 #endif
 
 #if CPU(ARM64) && HAVE(HARDENED_MACH_EXCEPTIONS)
-        flags |= MPO_EXCEPTION_PORT;
+    flags |= MPO_EXCEPTION_PORT;
 #endif
-        mach_port_options_t options;
-        memset(&options, 0, sizeof(options));
-        options.flags = flags;
 
-        kern_return_t kr = mach_port_construct(mach_task_self(), &options, 0, &handlers.exceptionPort);
+    mach_port_options_t options { };
+    options.flags = flags;
+
+    kern_return_t kr = mach_port_construct(mach_task_self(), &options, 0, &handlers.exceptionPort);
+    RELEASE_ASSERT(kr == KERN_SUCCESS);
+
+#if CPU(ARM64) && HAVE(HARDENED_MACH_EXCEPTIONS)
+#if !CPU(ARM64E)
+    uint32_t secretSigningKey = 0;
+#endif
+    uint64_t exceptionsAllowed = handlers.addedExceptions;
+    uint64_t behaviorsAllowed = EXCEPTION_STATE_IDENTITY_PROTECTED | MACH_EXCEPTION_CODES;
+    uint64_t flavorsAllowed = MACHINE_THREAD_STATE;
+
+    kr = task_register_hardened_exception_handler(current_task(), secretSigningKey, exceptionsAllowed,
+        behaviorsAllowed, flavorsAllowed, handlers.exceptionPort);
+    if (kr == KERN_SUCCESS)
+        handlers.useHardenedHandler = true;
+    else {
+        dataLog("Failed to register hardened exception handler due to ", mach_error_string(kr));
+        if (kr == KERN_DENIED)
+            dataLog(" consider adding `task_register_hardened_exception_handler` and `thread_adopt_exception_handler` to your sandbox");
+        dataLogLn();
+    }
+
+    // Clear the key since we no longer need it anymore and we don't want an attacker to find it.
+    secretSigningKey = 0;
+#endif
+
+    dispatch_source_t source = dispatch_source_create(
+        DISPATCH_SOURCE_TYPE_MACH_RECV, handlers.exceptionPort, 0, DISPATCH_TARGET_QUEUE_DEFAULT);
+    RELEASE_ASSERT(source);
+
+    dispatch_source_set_event_handler(source, ^{
+        UNUSED_PARAM(source); // Capture a pointer to source in user space to silence the leaks tool.
+
+        kern_return_t kr = mach_msg_server_once(
+            mach_exc_server, maxMessageSize, handlers.exceptionPort, MACH_MSG_TIMEOUT_NONE);
         RELEASE_ASSERT(kr == KERN_SUCCESS);
-
-#if CPU(ARM64) && HAVE(HARDENED_MACH_EXCEPTIONS)
-        uint64_t exceptionsAllowed = mask;
-        uint64_t behaviorsAllowed = EXCEPTION_STATE_IDENTITY_PROTECTED | MACH_EXCEPTION_CODES;
-        uint64_t flavorsAllowed = MACHINE_THREAD_STATE;
-
-        int ret = sandbox_check(getpid(), "user-preference-read", static_cast<sandbox_filter_type>(SANDBOX_CHECK_NO_REPORT | SANDBOX_FILTER_PREFERENCE_DOMAIN), "com.apple.webkit-new-sandbox-test");
-        if (ret == 1) {
-            fallbackToOldExceptions.store(true);
-        } else if (!ret) {
-            kr = task_register_hardened_exception_handler(current_task(), signingKey, exceptionsAllowed,
-                behaviorsAllowed, flavorsAllowed, handlers.exceptionPort);
-            if (kr != KERN_SUCCESS)
-                fallbackToOldExceptions.store(true);
-        } else
-            RELEASE_ASSERT_NOT_REACHED(ret);
-
-#else
-        UNUSED_PARAM(signingKey);
-        UNUSED_PARAM(mask);
-#endif
-
-        dispatch_source_t source = dispatch_source_create(
-            DISPATCH_SOURCE_TYPE_MACH_RECV, handlers.exceptionPort, 0, DISPATCH_TARGET_QUEUE_DEFAULT);
-        RELEASE_ASSERT(source);
-
-        dispatch_source_set_event_handler(source, ^{
-            UNUSED_PARAM(source); // Capture a pointer to source in user space to silence the leaks tool.
-
-            kern_return_t kr = mach_msg_server_once(
-                mach_exc_server, maxMessageSize, handlers.exceptionPort, MACH_MSG_TIMEOUT_NONE);
-            RELEASE_ASSERT(kr == KERN_SUCCESS);
-        });
-
-        // No need for a cancel handler because we never destroy exceptionPort.
-
-        dispatch_resume(source);
     });
+
+    // No need for a cancel handler because we never destroy exceptionPort.
+
+    dispatch_resume(source);
+}
+
+static exception_mask_t toMachMask(Signal signal)
+{
+    switch (signal) {
+    case Signal::AccessFault: return EXC_MASK_BAD_ACCESS;
+    case Signal::IllegalInstruction: return EXC_MASK_BAD_INSTRUCTION;
+    case Signal::FloatingPoint: return EXC_MASK_ARITHMETIC;
+    case Signal::Breakpoint: return EXC_MASK_BREAKPOINT;
+    default: break;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 static Signal fromMachException(exception_type_t type)
@@ -245,7 +261,7 @@ kern_return_t catch_mach_exception_raise_state_identity(mach_port_t, mach_port_t
     return KERN_FAILURE;
 }
 
-static kern_return_t runSignalHandlers(Signal &signal, PlatformRegisters& registers, bool &didHandle, mach_msg_type_number_t dataCount, mach_exception_data_t exceptionData)
+static kern_return_t runSignalHandlers(Signal signal, PlatformRegisters& registers, mach_msg_type_number_t dataCount, mach_exception_data_t exceptionData)
 {
     SigInfo info;
     SignalHandlers& handlers = g_wtfConfig.signalHandlers;
@@ -262,11 +278,12 @@ static kern_return_t runSignalHandlers(Signal &signal, PlatformRegisters& regist
 #endif
     }
 
+    bool didHandle = false;
     handlers.forEachHandler(signal, [&] (const SignalHandler& handler) {
         SignalAction handlerResult = handler(signal, info, registers);
         didHandle |= handlerResult == SignalAction::Handled;
     });
-    return KERN_SUCCESS;
+    return didHandle ? KERN_SUCCESS : KERN_FAILURE;
 }
 
 #if defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
@@ -303,6 +320,7 @@ kern_return_t catch_mach_exception_raise_state(
     thread_state_t outState,
     mach_msg_type_number_t* outStateCount)
 {
+    ASSERT(g_wtfConfig.isPermanentlyFrozen || g_wtfConfig.disabledFreezingForTesting);
     SignalHandlers& handlers = g_wtfConfig.signalHandlers;
     RELEASE_ASSERT(port == handlers.exceptionPort);
     // If we wanted to distinguish between SIGBUS and SIGSEGV for EXC_BAD_ACCESS on Darwin we could do:
@@ -312,6 +330,10 @@ kern_return_t catch_mach_exception_raise_state(
     //    signal = SIGBUS;
     Signal signal = fromMachException(exceptionType);
     RELEASE_ASSERT(signal != Signal::Unknown);
+
+#if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
+    ASSERT_WITH_MESSAGE(!secretSigningKey, "The secret key should have been cleared before any exception handlers are run");
+#endif
 
 #if CPU(ARM64E) && OS(DARWIN)
     ptrauth_generic_signature_t inStateHash = hashThreadState(inState);
@@ -333,20 +355,15 @@ kern_return_t catch_mach_exception_raise_state(
     PlatformRegisters& registers = reinterpret_cast<arm_unified_thread_state*>(outState)->ts_32;
 #endif
 
-    bool didHandle = false;
-    kern_return_t kr = runSignalHandlers(signal, registers, didHandle, dataCount, exceptionData);
+    kern_return_t kr = runSignalHandlers(signal, registers, dataCount, exceptionData);
     if (kr != KERN_SUCCESS)
         return kr;
 
-    if (didHandle) {
 #if CPU(ARM64E) && OS(DARWIN)
-        RELEASE_ASSERT(inStateHash == hashThreadState(outState));
+    RELEASE_ASSERT(inStateHash == hashThreadState(outState));
 #endif
-        *outStateCount = inStateCount;
-        return KERN_SUCCESS;
-    }
-
-    return KERN_FAILURE;
+    *outStateCount = inStateCount;
+    return KERN_SUCCESS;
 }
 
 }; // extern "C"
@@ -364,16 +381,13 @@ inline void setExceptionPorts(const AbstractLocker& threadGroupLocker, Thread& t
     SignalHandlers& handlers = g_wtfConfig.signalHandlers;
 
 #if CPU(ARM64) && HAVE(HARDENED_MACH_EXCEPTIONS)
-    // If we are a translated process in rosetta or failed to set up a hardened handler, use the old exception style
-    if (!WTF::isX86BinaryRunningOnARM() && !fallbackToOldExceptions.loadRelaxed()) {
-        // Otherwise use the new style
+    if (handlers.useHardenedHandler) {
         const exception_behavior_t newBehavior = MACH_EXCEPTION_CODES | EXCEPTION_STATE_IDENTITY_PROTECTED;
         kern_return_t result = thread_adopt_exception_handler(thread.machThread(), handlers.exceptionPort, handlers.addedExceptions & activeExceptions, newBehavior, MACHINE_THREAD_STATE);
         RELEASE_ASSERT(result == KERN_SUCCESS, result, handlers.exceptionPort, handlers.addedExceptions, activeExceptions);
         return;
     }
 #endif // CPU(ARM64) && HAVE(HARDENED_MACH_EXCEPTIONS)
-
     const exception_behavior_t newBehavior = MACH_EXCEPTION_CODES | EXCEPTION_STATE;
     kern_return_t result = thread_set_exception_ports(thread.machThread(), handlers.addedExceptions & activeExceptions, handlers.exceptionPort, newBehavior, MACHINE_THREAD_STATE);
     RELEASE_ASSERT(result == KERN_SUCCESS, result, handlers.exceptionPort, handlers.addedExceptions, activeExceptions);
@@ -384,7 +398,6 @@ static ThreadGroup& activeThreads()
     static LazyNeverDestroyed<std::shared_ptr<ThreadGroup>> activeThreads;
     static std::once_flag initializeKey;
     std::call_once(initializeKey, [&] {
-        Config::AssertNotFrozenScope assertScope;
         activeThreads.construct(ThreadGroup::create());
     });
     return (*activeThreads.get());
@@ -392,7 +405,11 @@ static ThreadGroup& activeThreads()
 
 void registerThreadForMachExceptionHandling(Thread& thread)
 {
-    RELEASE_ASSERT(g_wtfConfig.signalHandlers.initState == SignalHandlers::InitState::AddedHandlers, g_wtfConfig.signalHandlers.initState);
+    const SignalHandlers& signalHandlers = g_wtfConfig.signalHandlers;
+    RELEASE_ASSERT(signalHandlers.initState >= SignalHandlers::InitState::Initializing, signalHandlers.initState);
+    if (!signalHandlers.useMach || !signalHandlers.addedExceptions)
+        return;
+
     Locker locker { activeThreads().getLock() };
     if (activeThreads().add(locker, thread) == ThreadGroupAddResult::NewlyAdded)
         setExceptionPorts(locker, thread);
@@ -438,72 +455,36 @@ inline size_t offsetForSystemSignal(int sig)
     return static_cast<size_t>(signal) + (sig == SIGBUS);
 }
 
-static void jscSignalHandler(int, siginfo_t*, void*);
-
-void addSignalHandler(Signal signal, SignalHandler&& handler)
-{
-    Config::AssertNotFrozenScope assertScope;
-    SignalHandlers& handlers = g_wtfConfig.signalHandlers;
-    ASSERT(signal < Signal::Unknown);
-    ASSERT(!handlers.useMach || signal != Signal::Usr);
-#if HAVE(MACH_EXCEPTIONS)
-    RELEASE_ASSERT(handlers.initState >= SignalHandlers::InitState::InitializedHandlerThread);
-#endif
-
-    static std::once_flag initializeOnceFlags[static_cast<size_t>(Signal::NumberOfSignals)];
-    std::call_once(initializeOnceFlags[static_cast<size_t>(signal)], [&] {
-        Config::AssertNotFrozenScope assertScope;
-        if (!handlers.useMach) {
-            struct sigaction action;
-            action.sa_sigaction = jscSignalHandler;
-            auto result = sigfillset(&action.sa_mask);
-            RELEASE_ASSERT(!result);
-            // Do not block this signal since it is used on non-Darwin systems to suspend and resume threads.
-            RELEASE_ASSERT(g_wtfConfig.isThreadSuspendResumeSignalConfigured);
-            result = sigdelset(&action.sa_mask, g_wtfConfig.sigThreadSuspendResume);
-            RELEASE_ASSERT(!result);
-            action.sa_flags = SA_SIGINFO;
-            auto systemSignals = toSystemSignal(signal);
-            result = sigaction(std::get<0>(systemSignals), &action, &handlers.oldActions[offsetForSystemSignal(std::get<0>(systemSignals))]);
-            if (std::get<1>(systemSignals))
-                result |= sigaction(*std::get<1>(systemSignals), &action, &handlers.oldActions[offsetForSystemSignal(*std::get<1>(systemSignals))]);
-            RELEASE_ASSERT(!result);
-        }
-    });
-
-    handlers.add(signal, WTFMove(handler));
-}
-
 void activateSignalHandlersFor(Signal signal)
 {
-    UNUSED_PARAM(signal);
-#if HAVE(MACH_EXCEPTIONS)
     const SignalHandlers& handlers = g_wtfConfig.signalHandlers;
-    RELEASE_ASSERT(handlers.initState >= SignalHandlers::InitState::InitializedHandlerThread);
-    ASSERT(signal < Signal::Unknown);
-    ASSERT(!handlers.useMach || signal != Signal::Usr);
+    RELEASE_ASSERT(handlers.initState >= SignalHandlers::InitState::Initializing);
+    ASSERT_UNUSED(signal, signal < Signal::Unknown);
 
-    if (handlers.useMach)
-        activeExceptions |= toMachMask(signal);
-#endif
-}
-
-
-void finalizeSignalHandlers()
-{
 #if HAVE(MACH_EXCEPTIONS)
-    const SignalHandlers& handlers = g_wtfConfig.signalHandlers;
-    RELEASE_ASSERT(handlers.initState >= SignalHandlers::InitState::InitializedHandlerThread);
-
-    Locker locker { activeThreads().getLock() };
     if (handlers.useMach) {
+        ASSERT(signal != Signal::Usr);
+        Locker locker { activeThreads().getLock() };
+        if (activeExceptions & toMachMask(signal))
+            return;
+
+        ASSERT(handlers.numberOfHandlers[static_cast<uint8_t>(signal)]);
+        activeExceptions |= toMachMask(signal);
+        // activeExceptions should be a subset of addedExceptions.
+        ASSERT(!(activeExceptions & ~handlers.addedExceptions));
         for (auto& thread : activeThreads().threads(locker))
             setExceptionPorts(locker, thread.get());
+        return;
     }
 #endif
 }
 
-void jscSignalHandler(int sig, siginfo_t* info, void* ucontext)
+void addSignalHandler(Signal signal, SignalHandler&& handler)
+{
+    g_wtfConfig.signalHandlers.add(signal, WTFMove(handler));
+}
+
+static void jscSignalHandler(int sig, siginfo_t* info, void* ucontext)
 {
     Signal signal = fromSystemSignal(sig);
     SignalHandlers& handlers = g_wtfConfig.signalHandlers;
@@ -575,14 +556,55 @@ void jscSignalHandler(int sig, siginfo_t* info, void* ucontext)
 
 void SignalHandlers::initialize()
 {
-#if HAVE(MACH_EXCEPTIONS)
-    // In production configurations, this does not matter because signal handler
-    // installations will always trigger this initialization. However, in debugging
-    // configurations, we may end up disabling the use of all signal handlers but
-    // we still need this to be initialized. Hence, we need to initialize it
-    // eagerly to ensure that it is done before we freeze the WTF::Config.
-    activeThreads();
+    SignalHandlers& handlers = g_wtfConfig.signalHandlers;
+    RELEASE_ASSERT(handlers.initState == SignalHandlers::InitState::Uninitialized);
+    handlers.initState = SignalHandlers::InitState::Initializing;
+
+#if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
+    // Set up our secret key which we use as random diversifier when signing our return PC in the handler callbacks.
+    // According to the ARM64 ABI ptrauth_blend_discriminator can't take zero as the first argument.
+    static_assert(__DARWIN_ARM_THREAD_STATE64_USER_DIVERSIFIER_MASK == 0xff000000);
+    do {
+        secretSigningKey = static_cast<uint32_t>(WTF::cryptographicallyRandomNumber<uint8_t>()) << 24;
+    } while (!secretSigningKey);
+    ASSERT(secretSigningKey == (secretSigningKey & __DARWIN_ARM_THREAD_STATE64_USER_DIVERSIFIER_MASK));
 #endif
+}
+
+void SignalHandlers::finalize()
+{
+    Config::AssertNotFrozenScope assertScope;
+    SignalHandlers& handlers = g_wtfConfig.signalHandlers;
+    RELEASE_ASSERT(handlers.initState == SignalHandlers::InitState::Initializing);
+    handlers.initState = SignalHandlers::InitState::Finalized;
+
+#if HAVE(MACH_EXCEPTIONS)
+    if (handlers.useMach)
+        initMachExceptionHandlerThread();
+#endif
+
+    if (!handlers.useMach) {
+        for (unsigned i = 0; i < numberOfSignals; ++i) {
+            if (!handlers.numberOfHandlers[i])
+                continue;
+
+            Signal signal = static_cast<Signal>(i);
+            struct sigaction action;
+            action.sa_sigaction = jscSignalHandler;
+            auto result = sigfillset(&action.sa_mask);
+            RELEASE_ASSERT(!result);
+            // Do not block this signal since it is used on non-Darwin systems to suspend and resume threads.
+            RELEASE_ASSERT(g_wtfConfig.isThreadSuspendResumeSignalConfigured);
+            result = sigdelset(&action.sa_mask, g_wtfConfig.sigThreadSuspendResume);
+            RELEASE_ASSERT(!result);
+            action.sa_flags = SA_SIGINFO;
+            auto systemSignals = toSystemSignal(signal);
+            result = sigaction(std::get<0>(systemSignals), &action, &handlers.oldActions[offsetForSystemSignal(std::get<0>(systemSignals))]);
+            if (std::get<1>(systemSignals))
+                result |= sigaction(*std::get<1>(systemSignals), &action, &handlers.oldActions[offsetForSystemSignal(*std::get<1>(systemSignals))]);
+            RELEASE_ASSERT(!result);
+        }
+    }
 }
 
 } // namespace WTF

--- a/Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm
+++ b/Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm
@@ -66,5 +66,5 @@ void GPU_SERVICE_INITIALIZER(xpc_connection_t connection, xpc_object_t initializ
     WebKit::XPCServiceInitializer<WebKit::GPUProcess, WebKit::GPUServiceInitializerDelegate>(connection, initializerMessage);
 #endif // ENABLE(GPU_PROCESS)
 
-    JSC::Config::permanentlyFreeze();
+    JSC::Config::finalize();
 }

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -1396,10 +1396,6 @@
     io_service_get_matching_service_bin
     io_service_get_matching_services_bin))
 
-; This rule is only temporary and should be removed shortly
-; See: rdar://125256111.
-(mobile-preferences-read "com.apple.webkit-new-sandbox-test")
-    
 (allow mach-kernel-endpoint
     (apply-message-filter
         (deny mach-message-send (with telemetry))
@@ -1440,25 +1436,12 @@
 #if HAVE(HARDENED_MACH_EXCEPTIONS)
         (with-filter (require-not (lockdown-mode))
             (allow mach-message-send (kernel-mig-routine thread_adopt_exception_handler))
-#if ENABLE(BLOCK_SET_EXCEPTION_PORTS)
             (with-filter (require-not (webcontent-process-launched))
-                (allow mach-message-send (kernel-mig-routine task_register_hardened_exception_handler)))
-#else
-            (allow mach-message-send (kernel-mig-routine task_register_hardened_exception_handler))
-#endif ;; ENABLE(BLOCK_SET_EXCEPTION_PORTS)
-        )
+                (allow mach-message-send (kernel-mig-routine task_register_hardened_exception_handler))))
 #else
         (with-filter (require-not (lockdown-mode))
-#if ENABLE(BLOCK_SET_EXCEPTION_PORTS)
-            (with-filter (require-not (webcontent-process-launched))
-                (allow mach-message-send (kernel-mig-routine thread_set_exception_ports)))
-#else
-            (allow mach-message-send (kernel-mig-routine thread_set_exception_ports))
-#endif ;; ENABLE(BLOCK_SET_EXCEPTION_PORTS)
-        )
+            (allow mach-message-send (kernel-mig-routine thread_set_exception_ports)))
 #endif ;; HAVE(HARDENED_MACH_EXCEPTIONS)
-
-
 
         (with-filter (lockdown-mode)
             (deny mach-message-send (with telemetry) (with message "Lockdown mode")

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -1901,7 +1901,10 @@ static NSURL *computeTestURL(NSString *pathOrURLString, NSString **relativeTestP
 static WTR::TestOptions testOptionsForTest(const WTR::TestCommand& command)
 {
     // hack for cases when useDollarVM will be reset before injectInternalsObject is called in DRT
-    JSC::Options::useDollarVM() = true;
+    {
+        JSC::Options::AllowUnfinalizedAccessScope scope;
+        JSC::Options::useDollarVM() = true;
+    }
     WTR::TestFeatures features = WTR::TestOptions::defaults();
     WTR::merge(features, WTR::hardcodedFeaturesBasedOnPathForTest(command));
     WTR::merge(features, WTR::featureDefaultsFromTestHeaderForTest(command, WTR::TestOptions::keyTypeMapping()));

--- a/Tools/TestWebKitAPI/Tests/WTF/Signals.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Signals.cpp
@@ -28,7 +28,7 @@
 #include <type_traits>
 #include <wtf/DataLog.h>
 #include <wtf/Threading.h>
-#include <wtf/threads/Signals.h>
+#include <wtf/WTFConfig.h>
 #if OS(UNIX)
 #include <signal.h>
 #else
@@ -47,18 +47,14 @@ public:
 TEST(Signals, SignalsWorkOnExit)
 {
     static bool handlerRan = false;
-    uint32_t key = 0;
-    int mask = 0;
-    initializeSignalHandling(key, mask);
     addSignalHandler(Signal::Usr, [] (Signal signal, SigInfo&, PlatformRegisters&) -> SignalAction {
         RELEASE_ASSERT(signal == Signal::Usr);
 
-        dataLogLn("here");
         handlerRan = true;
         return SignalAction::Handled;
     });
     activateSignalHandlersFor(Signal::Usr);
-    finalizeSignalHandlers();
+    WTF::Config::finalize();
 
     Atomic<bool> receiverShouldKeepRunning(true);
     Ref<Thread> receiverThread = (Thread::create("ThreadMessage receiver"_s,
@@ -82,12 +78,6 @@ TEST(Signals, SignalsWorkOnExit)
 TEST(Signals, SignalsAccessFault)
 {
     static bool handlerRan = false;
-    uint32_t key = 0;
-    int mask = 0;
-#if HAVE(MACH_EXCEPTIONS)
-    mask |= toMachMask(Signal::AccessFault);
-#endif // HAVE(MACH_EXCEPTIONS)
-    initializeSignalHandling(key, mask);
     addSignalHandler(Signal::AccessFault, [] (Signal signal, SigInfo& sigInfo, PlatformRegisters& context) -> SignalAction {
         RELEASE_ASSERT(signal == Signal::AccessFault);
 
@@ -105,7 +95,7 @@ TEST(Signals, SignalsAccessFault)
         return SignalAction::Handled;
     });
     activateSignalHandlersFor(Signal::AccessFault);
-    finalizeSignalHandlers();
+    WTF::Config::finalize();
 
     // Allocate a page of memory
     char* ptr = bitwise_cast<char*>(Gigacage::tryAllocateZeroedVirtualPages(Gigacage::Primitive, 4096));


### PR DESCRIPTION
#### 7a6fd55b43d76cbfeacf8a55c39005c081bd03f2
<pre>
Cleanup hardened mach exceptions and formalize fallback
<a href="https://bugs.webkit.org/show_bug.cgi?id=272839">https://bugs.webkit.org/show_bug.cgi?id=272839</a>
<a href="https://rdar.apple.com/126634499">rdar://126634499</a>

Reviewed by Yusuke Suzuki.

This version adds a check in registerThreadForMachExceptionHandling that we&apos;re actually using mach exceptions
and have some registered. Not checking mostly worked, as the OS would happly accept garbage parameters, except
when our sandbox blocked `thread_set_exception_ports` in the WebContentProcess. In that case we would trip our
ASSERT and crash.

* Source/JavaScriptCore/jsc.cpp:
(main):
(CommandLine::parseArguments):
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):
* Source/JavaScriptCore/runtime/JSCConfig.cpp:
(JSC::Config::disableFreezingForTesting): Deleted.
* Source/JavaScriptCore/runtime/JSCConfig.h:
(JSC::Config::disableFreezingForTesting):
(JSC::Config::finalize):
(JSC::Config::permanentlyFreeze): Deleted.
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
* Source/JavaScriptCore/runtime/VMEntryScope.cpp:
(JSC::VMEntryScope::setUpSlow):
* Source/JavaScriptCore/runtime/VMTraps.cpp:
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES):
* Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp:
(JSC::Wasm::trapHandler):
(JSC::Wasm::activateSignalingMemory):
(JSC::Wasm::prepareSignalingMemory):
(JSC::Wasm::MachExceptionSigningKey::MachExceptionSigningKey): Deleted.
* Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h:
* Source/WTF/wtf/CryptographicallyRandomNumber.cpp:
(WTF::cryptographicallyRandomNumber&lt;uint8_t&gt;):
(WTF::cryptographicallyRandomNumber&lt;unsigned&gt;):
(WTF::cryptographicallyRandomNumber&lt;uint64_t&gt;):
* Source/WTF/wtf/CryptographicallyRandomNumber.h:
* Source/WTF/wtf/PlatformRegisters.cpp:
(WTF::threadStatePCInternal):
* Source/WTF/wtf/Threading.cpp:
(WTF::initialize):
* Source/WTF/wtf/WTFConfig.cpp:
(WTF::Config::initialize):
(WTF::Config::finalize):
(WTF::Config::permanentlyFreeze):
(WTF::Config::disableFreezingForTesting):
* Source/WTF/wtf/WTFConfig.h:
* Source/WTF/wtf/threads/Signals.cpp:
(WTF::SignalHandlers::add):
(WTF::SignalHandlers::presignReturnPCForHandler):
(WTF::initMachExceptionHandlerThread):
(WTF::toMachMask):
(WTF::setExceptionPorts):
(WTF::activeThreads):
(WTF::registerThreadForMachExceptionHandling):
(WTF::activateSignalHandlersFor):
(WTF::addSignalHandler):
(WTF::jscSignalHandler):
(WTF::SignalHandlers::initialize):
(WTF::SignalHandlers::finalize):
(WTF::finalizeSignalHandlers): Deleted.
* Source/WTF/wtf/threads/Signals.h:
(WTF::toMachMask): Deleted.
(WTF::initializeSignalHandling): Deleted.
(WTF::disableSignalHandling): Deleted.
* Source/WTF/wtf/win/SignalsWin.cpp:
(WTF::SignalHandlers::add):
(WTF::addSignalHandler):
(WTF::activateSignalHandlersFor):
(WTF::SignalHandlers::initialize):
(WTF::SignalHandlers::finalize):
(WTF::finalizeSignalHandlers): Deleted.
* Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm:
(GPU_SERVICE_INITIALIZER):
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(testOptionsForTest):
* Tools/TestWebKitAPI/Tests/WTF/Signals.cpp:
(TEST(Signals, SignalsWorkOnExit)):
(TEST(Signals, SignalsAccessFault)):

Canonical link: <a href="https://commits.webkit.org/277994@main">https://commits.webkit.org/277994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2446d7a4a1c1684d585ac6dff557c507767a26ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49083 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52063 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51826 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45159 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51387 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25854 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40117 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50587 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42310 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21225 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23382 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43483 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7277 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/42382 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45312 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53740 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/48573 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24159 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20367 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47435 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25438 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46409 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10814 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26227 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56068 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25158 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11530 "Passed tests") | 
<!--EWS-Status-Bubble-End-->