### PR TITLE
[webkitpy] Fix detection of existing/uninitialized simulated devices.

### DIFF
--- a/Tools/Scripts/webkitpy/xcode/simulated_device.py
+++ b/Tools/Scripts/webkitpy/xcode/simulated_device.py
@@ -180,7 +180,14 @@ class SimulatedDeviceManager(object):
         return result
 
     @staticmethod
-    def _find_exisiting_device_for_request(request):
+    def _find_existing_uninitialized_device_for_request(request):
+        # type: (DeviceRequest) -> DeviceRequest | None
+        '''Finds an existing, eligible, and uninitialized device that satisfies the passed request.
+
+        Arguments:
+            request (`DeviceRequest`): The details of the device request.
+        '''
+
         if not request.use_existing_simulator:
             return None
         for device in SimulatedDeviceManager.AVAILABLE_DEVICES:
@@ -189,7 +196,7 @@ class SimulatedDeviceManager(object):
                 if isinstance(initialized_device, Device) and device == initialized_device:
                     device = None
                     break
-            if device and request.device_type == device.device_type:
+            if device and request.device_type == device.device_type and not device.platform_device.is_booted_or_booting():
                 return device
         return None
 
@@ -277,7 +284,7 @@ class SimulatedDeviceManager(object):
         assert isinstance(request, DeviceRequest)
         host = host or SystemHost.get_default()
 
-        device = cls._find_exisiting_device_for_request(request)
+        device = cls._find_existing_uninitialized_device_for_request(request)
         if device:
             return device
 


### PR DESCRIPTION
#### 4ce23ce267cf9ed93e79a4678caec89cb2b04e7a
<pre>
[webkitpy] Fix detection of existing/uninitialized simulated devices.
<a href="https://bugs.webkit.org/show_bug.cgi?id=273226">https://bugs.webkit.org/show_bug.cgi?id=273226</a>
<a href="https://rdar.apple.com/127028481">rdar://127028481</a>

Reviewed by Jonathan Bedard.

As part of the DeviceRequest fulfillment flow, webkitpy will first determine if it needs
to create a new simulated device on the machine. One of the steps it takes is to check
all existing/available simulated devices to determine if any can be used.

Currently, there is no check to make sure the device isn&apos;t currently booted. This causes
already booted devices to be identified as eligible candidates to fulfill the request.
This will cause a fatal error to be thrown when `xcrun simctl boot &lt;UDID&gt;` is run, as
the device is already booted.

This change:
- Adds detection for if each device in the available devices list is booted/booting.
- Changes the name of the method `SimulatedDeviceManager._find_exisiting_device_for_request`
    to `SimulatedDeviceManager._find_existing_uninitialized_device_for_request` and add
    documentation, so as to disambiguate its purpose (and fix the typo!).

* Tools/Scripts/webkitpy/xcode/simulated_device.py:
(SimulatedDeviceManager._find_exisiting_device_for_request): Renamed to _find_existing_uninitialized_device_for_request.
(SimulatedDeviceManager._create_or_find_device_for_request): Changed call to old method to use new method name.
(SimulatedDeviceManager._find_existing_uninitialized_device_for_request): Added check for device not already booted/booting.

Canonical link: <a href="https://commits.webkit.org/277984@main">https://commits.webkit.org/277984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/558a32607a8c96efaad170d861fff7a9bbffe0b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51854 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45173 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51397 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34314 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25881 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40119 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25935 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42325 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21232 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/48953 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23390 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43485 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7330 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45322 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43990 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53767 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24169 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20375 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47438 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25449 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46410 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10812 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26238 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25168 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->