### PR TITLE
Re-import css/css-view-transitions WPT

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6949,9 +6949,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-left-of
 imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-of-viewport-offscreen-old.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-right-of-viewport-offscreen-old.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-right-of-viewport-partially-onscreen-new.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/new-content-with-object-view-box.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/object-view-box-new-image.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/object-view-box-old-image.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/old-content-with-overflow-zoomed.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/root-style-change-during-animation.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/root-to-shared-animation-incoming.html [ ImageOnlyFailure ]
@@ -6970,11 +6967,33 @@ imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-right-o
 imported/w3c/web-platform-tests/css/css-view-transitions/new-content-captures-different-size.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/new-content-captures-root.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/new-content-with-overflow-zoomed.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/old-content-with-object-view-box.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-static.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/fractional-translation-from-position.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/scroller-child.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/scroller.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/content-with-clip.html [ ImageOnlyFailure ]
+
+# Timeouts
+imported/w3c/web-platform-tests/css/css-view-transitions/iframe-transition.sub.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-computed-style-stays-in-sync-with-new-element.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-view-transitions/fragmented-during-transition-skips.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-view-transitions/root-element-display-none-during-transition-crash.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-view-transitions/iframe-transition-destroyed-document-crash.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-page.html [ Skip ]
+
+# Flakes
+imported/w3c/web-platform-tests/css/css-view-transitions/synchronous-callback-skipped-before-run.html [ Failure Pass ]
+
+# Reftests with variants are not supported
+imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api-parse-pseudo-argument.html?first-pseudo=::view-transition-group(%20%20%20%20%20%20first%20) [ Skip ]
+imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api-parse-pseudo-argument.html?first-pseudo=::view-transition-group(%20first [ Skip ]
+imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api-parse-pseudo-argument.html?first-pseudo=::view-transition-group(%20first) [ Skip ]
+imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api-parse-pseudo-argument.html?first-pseudo=::view-transition-group(first [ Skip ]
+imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api-parse-pseudo-argument.html?first-pseudo=::view-transition-group(first%20) [ Skip ]
+imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api-parse-pseudo-argument.html?first-pseudo=::view-transition-group(first) [ Skip ]
+
+# View transitions Level 2 - classes.
 imported/w3c/web-platform-tests/css/css-view-transitions/class-specificity.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-entry.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-exit.html [ ImageOnlyFailure ]
@@ -6987,27 +7006,12 @@ imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-mul
 imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-new-with-class-old-without.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-view-transition-group.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-view-transition-image-pair.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/content-with-clip.html [ ImageOnlyFailure ]
 
-# Timeouts
-imported/w3c/web-platform-tests/css/css-view-transitions/iframe-transition.sub.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-computed-style-stays-in-sync-with-new-element.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/fragmented-during-transition-skips.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/root-element-display-none-during-transition-crash.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/iframe-transition-destroyed-document-crash.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-page.html [ Skip ]
-
-# Reftests with variants are not supported
-imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api-parse-pseudo-argument.html?first-pseudo=::view-transition-group(%20%20%20%20%20%20first%20) [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api-parse-pseudo-argument.html?first-pseudo=::view-transition-group(%20first [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api-parse-pseudo-argument.html?first-pseudo=::view-transition-group(%20first) [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api-parse-pseudo-argument.html?first-pseudo=::view-transition-group(first [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api-parse-pseudo-argument.html?first-pseudo=::view-transition-group(first%20) [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api-parse-pseudo-argument.html?first-pseudo=::view-transition-group(first) [ Skip ]
-
-# Flakes
-imported/w3c/web-platform-tests/css/css-view-transitions/synchronous-callback-skipped-before-run.html [ Failure Pass ]
+# Depends on object-view-box (unimplemented).
+imported/w3c/web-platform-tests/css/css-view-transitions/old-content-with-object-view-box.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/object-view-box-new-image.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/object-view-box-old-image.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/new-content-with-object-view-box.html [ ImageOnlyFailure ]
 
 # -- END: View transitions -- #
 

--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -4470,6 +4470,8 @@
         "web-platform-tests/css/css-view-transitions/old-content-object-view-box-clip-path-reference-ref.html",
         "web-platform-tests/css/css-view-transitions/old-content-object-view-box-overflow-ref.html",
         "web-platform-tests/css/css-view-transitions/old-root-vertical-writing-mode-ref.html",
+        "web-platform-tests/css/css-view-transitions/pseudo-element-overflow-hidden-ref.html",
+        "web-platform-tests/css/css-view-transitions/pseudo-element-preserve-3d-ref.html",
         "web-platform-tests/css/css-view-transitions/pseudo-rendering-invalidation-ref.html",
         "web-platform-tests/css/css-view-transitions/pseudo-with-classes-ref.html",
         "web-platform-tests/css/css-view-transitions/root-captured-as-different-tag-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/3d-transform-incoming.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/3d-transform-incoming.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="3d-transform-incoming-ref.html">
-<meta name=fuzzy content="3d-transform-incoming-expected.html:0-255;0-515">
+<meta name=fuzzy content="maxDifference=0-255; totalPixels=0-515">
 <script src="/common/reftest-wait.js"></script>
 <style>
 div { box-sizing: border-box; will-change: transform }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/3d-transform-outgoing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/3d-transform-outgoing.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="3d-transform-outgoing-ref.html">
-<meta name=fuzzy content="3d-transform-outgoing-expected.html:0-255;0-1200">
+<meta name=fuzzy content="maxDifference=0-255; totalPixels=0-1200">
 <script src="/common/reftest-wait.js"></script>
 
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/block-with-overflowing-text.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/block-with-overflowing-text.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="block-with-overflowing-text-ref.html">
-<meta name="fuzzy" content="block-with-overflowing-text-expected.html:maxDifference=0-2;totalPixels=0-1200">
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-1200">
 
 
 <script src="/common/reftest-wait.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/break-inside-avoid-child.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/break-inside-avoid-child.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="break-inside-avoid-child-ref.html">
-<meta name="fuzzy" content="break-inside-avoid-child-expected.html:0-5;0-1600">
+<meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-1600">
 <script src="/common/reftest-wait.js"></script>
 
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-offscreen-child.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-offscreen-child.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="capture-with-offscreen-child-ref.html">
-<meta name="fuzzy" content="capture-with-offscreen-child-expected.html:0-5;0-200">
+<meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-200">
 <script src="/common/reftest-wait.js"></script>
 
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-opacity-zero-child.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-opacity-zero-child.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="capture-with-visibility-hidden-child-ref.html">
-<meta name="fuzzy" content="capture-with-opacity-zero-child-expected.html:0-5;0-300">
+<meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-300">
 <script src="/common/reftest-wait.js"></script>
 
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-visibility-mixed-descendants.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-visibility-mixed-descendants.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="capture-with-visibility-mixed-descendants-ref.html">
-<meta name=fuzzy content="capture-with-visibility-mixed-descendants-expected.html:0-5;0-500">
+<meta name=fuzzy content="maxDifference=0-5; totalPixels=0-500">
 <script src="/common/reftest-wait.js"></script>
 
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/clip-path-larger-than-border-box-on-child-of-named-element.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/clip-path-larger-than-border-box-on-child-of-named-element.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="clip-path-larger-than-border-box-on-child-of-named-element-ref.html">
-<meta name="fuzzy" content="clip-path-larger-than-border-box-on-child-of-named-element-expected.html:maxDifference=0-255;totalPixels=0-400">
+<meta name="fuzzy" content="maxDifference=0-255;totalPixels=0-400">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .target {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/content-with-transform-new-image.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/content-with-transform-new-image.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="content-with-transform-ref.html">
-<meta name="fuzzy" content="content-with-transform-new-image-expected.html:0-1;0-500">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-500">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/content-with-transform-old-image.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/content-with-transform-old-image.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="content-with-transform-ref.html">
-<meta name="fuzzy" content="content-with-transform-old-image-expected.html:0-1;0-400">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-400">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/css-tags-paint-order-with-entry.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/css-tags-paint-order-with-entry.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="css-tags-paint-order-with-entry-ref.html">
-<meta name="fuzzy" content="css-tags-paint-order-with-entry-expected.html:0-120;0-300">
+<meta name="fuzzy" content="maxDifference=0-120; totalPixels=0-300">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-rtl-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-rtl-iframe.html
@@ -5,7 +5,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
   <link rel="author" href="mailto:bokan@chromium.org">
   <link rel="match" href="dialog-in-rtl-iframe-ref.html">
-  <meta name=fuzzy content="dialog-in-rtl-iframe-expected.html:0-80;0-500">
+  <meta name=fuzzy content="maxDifference=0-80; totalPixels=0-500">
   <script src="/common/reftest-wait.js"></script>
   <style>
     iframe {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/far-away-capture.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/far-away-capture.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="far-away-capture-ref.html">
-<meta name="fuzzy" content="far-away-capture-expected.html:0-1;0-5">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-5">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .flex {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-with-overflow-children-new.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-with-overflow-children-new.html
@@ -6,7 +6,7 @@
 <link rel="match" href="fractional-box-with-overflow-children-ref.html">
 <!-- subpixel differences are ok in this test (in highdpi), but channel difference
      should not be perceptible -->
-<meta name=fuzzy content="fractional-box-with-overflow-children-new-expected.html:0-3;0-100">
+<meta name=fuzzy content="maxDifference=0-3; totalPixels=0-100">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .box {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-with-overflow-children-old.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-with-overflow-children-old.html
@@ -6,7 +6,7 @@
 <link rel="match" href="fractional-box-with-overflow-children-ref.html">
 <!-- subpixel differences are ok in this test (in highdpi), but channel difference
      should not be perceptible -->
-<meta name=fuzzy content="fractional-box-with-overflow-children-old-expected.html:0-3;0-100">
+<meta name=fuzzy content="maxDifference=0-3; totalPixels=0-100">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .box {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/iframe-new-has-scrollbar.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/iframe-new-has-scrollbar.html
@@ -5,7 +5,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
   <link rel="author" href="mailto:bokan@chromium.org">
   <link rel="match" href="iframe-new-has-scrollbar-ref.html">
-  <meta name=fuzzy content="iframe-new-has-scrollbar-expected.html:0-80;0-500">
+  <meta name=fuzzy content="maxDifference=0-80; totalPixels=0-500">
   <script src="/common/reftest-wait.js"></script>
   <style>
     iframe {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/iframe-old-has-scrollbar.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/iframe-old-has-scrollbar.html
@@ -5,7 +5,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
   <link rel="author" href="mailto:bokan@chromium.org">
   <link rel="match" href="iframe-old-has-scrollbar-ref.html">
-  <meta name=fuzzy content="iframe-old-has-scrollbar-expected.html:0-80;0-500">
+  <meta name=fuzzy content="maxDifference=0-80; totalPixels=0-500">
   <script src="/common/reftest-wait.js"></script>
   <style>
     iframe {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/iframe-transition.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/iframe-transition.sub.html
@@ -6,7 +6,7 @@
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="iframe-transition-ref.html">
 <meta name="assert" content="Ensure that iframe root capture is sized and displayed correctly">
-<meta name=fuzzy content="iframe-transition.sub-expected.html:0-200;0-200">
+<meta name=fuzzy content="maxDifference=0-200; totalPixels=0-200">
 <script src="/common/reftest-wait.js"></script>
 <style>
 iframe { width: 500px; height: 500px }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/inline-with-offset-from-containing-block.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/inline-with-offset-from-containing-block.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="inline-with-offset-from-containing-block-ref.html">
-<meta name="fuzzy" content="inline-with-offset-from-containing-block-expected.html:0-255;0-1400">
+<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-1400">
 
 <script src="/common/reftest-wait.js"></script>
 <script src="/common/rendering-utils.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-and-on-top-of-viewport-partially-onscreen-new.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-and-on-top-of-viewport-partially-onscreen-new.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-below-and-on-top-of-viewport-partially-onscreen-ref.html">
-<meta name="fuzzy" content="massive-element-below-and-on-top-of-viewport-partially-onscreen-new-expected.html:maxDifference=0-2;totalPixels=0-330">
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-330">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-offscreen-new.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-offscreen-new.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-below-viewport-offscreen-ref.html">
-<meta name="fuzzy" content="massive-element-below-viewport-offscreen-new-expected.html:maxDifference=0-3;totalPixels=0-950">
+<meta name="fuzzy" content="maxDifference=0-3;totalPixels=0-950">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-offscreen-old.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-offscreen-old.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-below-viewport-offscreen-ref.html">
-<meta name="fuzzy" content="massive-element-below-viewport-offscreen-old-expected.html:maxDifference=0-2;totalPixels=0-445">
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-445">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-new.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-new.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-below-viewport-partially-onscreen-ref.html">
-<meta name="fuzzy" content="massive-element-below-viewport-partially-onscreen-new-expected.html:maxDifference=0-2;totalPixels=0-330">
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-330">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-left-of-viewport-offscreen-new.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-left-of-viewport-offscreen-new.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-left-of-viewport-offscreen-ref.html">
-<meta name="fuzzy" content="massive-element-left-of-viewport-offscreen-new-expected.html:maxDifference=0-2;totalPixels=0-330">
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-330">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-left-of-viewport-offscreen-old.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-left-of-viewport-offscreen-old.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-left-of-viewport-offscreen-ref.html">
-<meta name="fuzzy" content="massive-element-left-of-viewport-offscreen-old-expected.html:maxDifference=0-3;totalPixels=0-330">
+<meta name="fuzzy" content="maxDifference=0-3;totalPixels=0-330">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-left-of-viewport-partially-onscreen-new.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-left-of-viewport-partially-onscreen-new.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-left-of-viewport-partially-onscreen-ref.html">
-<meta name="fuzzy" content="massive-element-left-of-viewport-partially-onscreen-new-expected.html:maxDifference=0-2;totalPixels=0-330">
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-330">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-left-of-viewport-partially-onscreen-old.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-left-of-viewport-partially-onscreen-old.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-left-of-viewport-partially-onscreen-ref.html">
-<meta name="fuzzy" content="massive-element-left-of-viewport-partially-onscreen-old-expected.html:maxDifference=0-3;totalPixels=0-330">
+<meta name="fuzzy" content="maxDifference=0-3;totalPixels=0-330">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-of-viewport-offscreen-new.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-of-viewport-offscreen-new.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-on-top-of-viewport-offscreen-ref.html">
-<meta name="fuzzy" content="massive-element-on-top-of-viewport-offscreen-new-expected.html:maxDifference=0-6;totalPixels=0-920">
+<meta name="fuzzy" content="maxDifference=0-6;totalPixels=0-920">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-of-viewport-offscreen-old.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-of-viewport-offscreen-old.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-on-top-of-viewport-offscreen-ref.html">
-<meta name="fuzzy" content="massive-element-on-top-of-viewport-offscreen-old-expected.html:maxDifference=0-3;totalPixels=0-330">
+<meta name="fuzzy" content="maxDifference=0-3;totalPixels=0-330">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-of-viewport-partially-onscreen-new.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-of-viewport-partially-onscreen-new.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-on-top-of-viewport-partially-onscreen-ref.html">
-<meta name="fuzzy" content="massive-element-on-top-of-viewport-partially-onscreen-new-expected.html:maxDifference=0-2;totalPixels=0-330">
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-330">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-of-viewport-partially-onscreen-old.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-of-viewport-partially-onscreen-old.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-on-top-of-viewport-partially-onscreen-ref.html">
-<meta name="fuzzy" content="massive-element-on-top-of-viewport-partially-onscreen-old-expected.html:maxDifference=0-3;totalPixels=0-330">
+<meta name="fuzzy" content="maxDifference=0-3;totalPixels=0-330">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-right-and-left-of-viewport-partially-onscreen-new.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-right-and-left-of-viewport-partially-onscreen-new.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-right-and-left-of-viewport-partially-onscreen-ref.html">
-<meta name="fuzzy" content="massive-element-right-and-left-of-viewport-partially-onscreen-new-expected.html:maxDifference=0-2;totalPixels=0-330">
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-330">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-right-of-viewport-offscreen-new.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-right-of-viewport-offscreen-new.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-right-of-viewport-offscreen-ref.html">
-<meta name="fuzzy" content="massive-element-right-of-viewport-offscreen-new-expected.html:maxDifference=0-2;totalPixels=0-445">
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-445">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-right-of-viewport-offscreen-old.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-right-of-viewport-offscreen-old.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-right-of-viewport-offscreen-ref.html">
-<meta name="fuzzy" content="massive-element-right-of-viewport-offscreen-old-expected.html:maxDifference=0-3;totalPixels=0-445">
+<meta name="fuzzy" content="maxDifference=0-3;totalPixels=0-445">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-right-of-viewport-partially-onscreen-new.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-right-of-viewport-partially-onscreen-new.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-right-of-viewport-partially-onscreen-ref.html">
-<meta name="fuzzy" content="massive-element-right-of-viewport-partially-onscreen-new-expected.html:maxDifference=0-2;totalPixels=0-330">
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-330">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-right-of-viewport-partially-onscreen-old.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-right-of-viewport-partially-onscreen-old.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-right-of-viewport-partially-onscreen-ref.html">
-<meta name="fuzzy" content="massive-element-right-of-viewport-partially-onscreen-old-expected.html:maxDifference=0-3;totalPixels=0-445">
+<meta name="fuzzy" content="maxDifference=0-3;totalPixels=0-445">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/multiline-span-with-overflowing-text-and-box-decorations.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/multiline-span-with-overflowing-text-and-box-decorations.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="multiline-span-with-overflowing-text-and-box-decorations-ref.html">
-<meta name="fuzzy" content="multiline-span-with-overflowing-text-and-box-decorations-expected.html:maxDifference=0-3;totalPixels=0-4900">
+<meta name="fuzzy" content="maxDifference=0-3; totalPixels=0-4900">
 
 
 <script src="/common/reftest-wait.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-and-old-sizes-match.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-and-old-sizes-match.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="new-and-old-sizes-match-ref.html">
-<meta name="fuzzy" content="new-and-old-sizes-match-expected.html:0-1;0-300">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-300">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .box {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-captures-clip-path.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-captures-clip-path.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="new-content-captures-clip-path-ref.html">
-<meta name="fuzzy" content="new-content-captures-clip-path-expected.html:0-1;0-500">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-500">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .box {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-captures-different-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-captures-different-size.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="new-content-captures-different-size-ref.html">
-<meta name=fuzzy content="new-content-captures-different-size-expected.html:0-40;0-30000">
+<meta name=fuzzy content="maxDifference=0-40; totalPixels=0-30000">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .box {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-has-scrollbars.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-has-scrollbars.html
@@ -6,7 +6,7 @@
 <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/7859">
 <link rel="author" href="mailto:bokan@chromium.org">
 <link rel="match" href="new-content-has-scrollbars-ref.html">
-<meta name=fuzzy content="new-content-has-scrollbars-expected.html:0-40;0-30000">
+<meta name=fuzzy content="maxDifference=0-40; totalPixels=0-30000">
 <script src="/common/reftest-wait.js"></script>
 <style>
   html, body {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-is-inline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-is-inline.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:bokan@chromium.org">
 <link rel="match" href="new-content-is-inline-ref.html">
-<meta name="fuzzy" content="new-content-is-inline-expected.html:0-255;0-1000">
+<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-1000">
 <script src="/common/reftest-wait.js"></script>
 
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-object-fit-fill.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-object-fit-fill.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="content-object-fit-fill-ref.html">
-<meta name="fuzzy" content="new-content-object-fit-fill-expected.html:0-60;0-20">
+<meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-20">
 <script src="/common/reftest-wait.js"></script>
 <style>
 #target {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-scaling.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-scaling.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="new-content-scaling-ref.html">
-<meta name="fuzzy" content="new-content-scaling-expected.html:maxDifference=0-16;totalPixels=0-400">
+<meta name="fuzzy" content="maxDifference=0-16; totalPixels=0-400">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .shared {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/object-view-box-old-image.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/object-view-box-old-image.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="object-view-box-ref.html">
-<meta name="fuzzy" content="object-view-box-old-image-expected.html:0-1;0-300">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-300">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-captures-clip-path.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-captures-clip-path.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="old-content-captures-clip-path-ref.html">
-<meta name="fuzzy" content="old-content-captures-clip-path-expected.html:0-1;0-500">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-500">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .box {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-captures-different-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-captures-different-size.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="old-content-captures-different-size-ref.html">
-<meta name=fuzzy content="old-content-captures-different-size-expected.html:0-40;0-30000">
+<meta name=fuzzy content="maxDifference=0-40; totalPixels=0-30000">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .box {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-captures-opacity.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-captures-opacity.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="old-content-captures-opacity-ref.html">
-<meta name=fuzzy content="old-content-captures-opacity-expected.html:0-1;0-50000">
+<meta name=fuzzy content="maxDifference=0-1; totalPixels=0-50000">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-captures-root.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-captures-root.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="old-content-captures-root-ref.html">
-<meta name="fuzzy" content="old-content-captures-root-expected.html:0-1;0-500">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-500">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .box {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-has-scrollbars.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-has-scrollbars.html
@@ -6,7 +6,7 @@
 <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/7859">
 <link rel="author" href="mailto:bokan@chromium.org">
 <link rel="match" href="old-content-has-scrollbars-ref.html">
-<meta name=fuzzy content="old-content-has-scrollbars-expected.html:0-40;0-30000">
+<meta name=fuzzy content="maxDifference=0-40; totalPixels=0-30000">
 <script src="/common/reftest-wait.js"></script>
 <style>
   html, body {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-is-inline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-is-inline.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:bokan@chromium.org">
 <link rel="match" href="old-content-is-inline-ref.html">
-<meta name="fuzzy" content="old-content-is-inline-expected.html:0-255;0-500">
+<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-500">
 <script src="/common/reftest-wait.js"></script>
 
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-object-fit-fill.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-object-fit-fill.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="content-object-fit-fill-ref.html">
-<meta name="fuzzy" content="old-content-object-fit-fill-expected.html:0-60;0-20">
+<meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-20">
 <script src="/common/reftest-wait.js"></script>
 <style>
 #target {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-object-view-box-clip-path-reference.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-object-view-box-clip-path-reference.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="old-content-object-view-box-clip-path-reference-ref.html">
-<meta name="fuzzy" content="old-content-object-view-box-clip-path-reference-expected.html:0-1;0-100">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-100">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .target {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-object-view-box-clip-path.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-object-view-box-clip-path.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="old-content-object-view-box-clip-path-ref.html">
-<meta name="fuzzy" content="old-content-object-view-box-clip-path-expected.html:0-1;0-30">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-30">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .target {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-rendering-invalidation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-rendering-invalidation.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:bokan@chromium.org">
 <link rel="match" href="pseudo-rendering-invalidation-ref.html">
-<meta name="fuzzy" content="pseudo-rendering-invalidation-expected.html:0-20;0-300">
+<meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-300">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/root-captured-as-different-tag.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/root-captured-as-different-tag.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="old-content-captures-root-ref.html">
-<meta name="fuzzy" content="root-captured-as-different-tag-expected.html:0-1;0-500">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-500">
 <script src="/common/reftest-wait.js"></script>
 <style>
 :root { view-transition-name: another-root; }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/scroller-child-abspos.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/scroller-child-abspos.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="scroller-child-abspos-ref.html">
-<meta name="fuzzy" content="scroller-child-abspos-expected.html:0-5;0-800">
+<meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-800">
 <script src="/common/reftest-wait.js"></script>
 
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/scroller-child.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/scroller-child.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="scroller-child-ref.html">
-<meta name="fuzzy" content="scroller-child-expected.html:0-5;0-800">
+<meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-800">
 <script src="/common/reftest-wait.js"></script>
 
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/scroller.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/scroller.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="scroller-ref.html">
-<meta name="fuzzy" content="scroller-expected.html:0-5;0-10">
+<meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-10">
 <script src="/common/reftest-wait.js"></script>
 
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/set-current-time.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/set-current-time.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="set-current-time-ref.html">
-<meta name="fuzzy" content="set-current-time-expected.html:0-2;0-40000">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-40000">
 <script src="/common/reftest-wait.js"></script>
 <style>
 :root { view-transition-name: unset; }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-absolute.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-absolute.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:bokan@chromium.org">
 <link rel="match" href="snapshot-containing-block-absolute-ref.html">
-<meta name="fuzzy" content="snapshot-containing-block-absolute-expected.html:0-20;0-100">
+<meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-100">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-includes-scrollbar-gutter.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-includes-scrollbar-gutter.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:bokan@chromium.org">
 <link rel="match" href="snapshot-containing-block-includes-scrollbar-gutter-ref.html">
-<meta name="fuzzy" content="snapshot-containing-block-includes-scrollbar-gutter-expected.html:0-20;0-100">
+<meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-100">
 <script src="/common/reftest-wait.js"></script>
 <style>
   :root {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-static.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-static.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:bokan@chromium.org">
 <link rel="match" href="snapshot-containing-block-static-ref.html">
-<meta name="fuzzy" content="snapshot-containing-block-static-expected.html:0-20;0-100">
+<meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-100">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/span-with-overflowing-text-and-box-decorations.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/span-with-overflowing-text-and-box-decorations.html
@@ -4,8 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="span-with-overflowing-text-and-box-decorations-ref.html">
-<meta name="fuzzy" content="span-with-overflowing-text-and-box-decorations-expected.html:maxDifference=0-3;totalPixels=0-4900">
-
+<meta name="fuzzy" content="maxDifference=0-3;totalPixels=0-4900">
 
 <script src="/common/reftest-wait.js"></script>
 <script src="/common/rendering-utils.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/span-with-overflowing-text.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/span-with-overflowing-text.html
@@ -4,8 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="span-with-overflowing-text-ref.html">
-<meta name="fuzzy" content="span-with-overflowing-text-expected.html:maxDifference=0-3;totalPixels=0-1100">
-
+<meta name="fuzzy" content="maxDifference=0-3;totalPixels=0-1100">
 
 <script src="/common/reftest-wait.js"></script>
 <script src="/common/rendering-utils.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-empty-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-empty-iframe.html
@@ -5,7 +5,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
   <link rel="author" href="mailto:bokan@chromium.org">
   <link rel="match" href="transition-in-empty-iframe-ref.html">
-  <meta name=fuzzy content="transition-in-empty-iframe-expected.html:0-80;0-1000">
+  <meta name=fuzzy content="maxDifference=0-80; totalPixels=0-1000">
   <script src="/common/reftest-wait.js"></script>
   <style>
     iframe {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/w3c-import.log
@@ -410,6 +410,12 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/paused-animation-at-end.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-computed-style-stays-in-sync-with-new-element.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-animations.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-overflow-hidden-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-overflow-hidden-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-overflow-hidden.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-preserve-3d-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-preserve-3d-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-preserve-3d.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-rendering-invalidation-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-rendering-invalidation-ref.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api-parse-pseudo-argument.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api-parse-pseudo-argument.html
@@ -3,7 +3,7 @@
 <title>View transitions with web-animation API: full parsing of argument</title>
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="match" href="web-animations-api-ref.html">
-<meta name="fuzzy" content="web-animations-api-parse-pseudo-argument-expected.html:0-2;0-500">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-500">
 <meta name="variant" content="?first-pseudo=::view-transition-group( first)">
 <meta name="variant" content="?first-pseudo=::view-transition-group(first)">
 <meta name="variant" content="?first-pseudo=::view-transition-group( first">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="web-animations-api-ref.html">
-<meta name="fuzzy" content="web-animations-api-expected.html:0-2;0-500">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-500">
 
 <script src="/common/reftest-wait.js"></script>
 <style>


### PR DESCRIPTION
#### c260b2daba967cdd051caf9f706517684a2cffdb
<pre>
Re-import css/css-view-transitions WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=273230">https://bugs.webkit.org/show_bug.cgi?id=273230</a>
<a href="https://rdar.apple.com/127030231">rdar://127030231</a>

Reviewed by Matthieu Dubet.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/e4c6343bd35b1cce398883d0c32c04d597f15f60">https://github.com/web-platform-tests/wpt/commit/e4c6343bd35b1cce398883d0c32c04d597f15f60</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/3d-transform-incoming.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/3d-transform-outgoing.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/block-with-overflowing-text.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/break-inside-avoid-child.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-offscreen-child.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-opacity-zero-child.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-visibility-mixed-descendants.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/clip-path-larger-than-border-box-on-child-of-named-element.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/content-with-transform-new-image.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/content-with-transform-old-image.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/css-tags-paint-order-with-entry.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-rtl-iframe.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/far-away-capture.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-with-overflow-children-new.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-with-overflow-children-old.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/iframe-new-has-scrollbar.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/iframe-old-has-scrollbar.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/iframe-transition.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/inline-with-offset-from-containing-block.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-and-on-top-of-viewport-partially-onscreen-new.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-offscreen-new.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-offscreen-old.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-new.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-left-of-viewport-offscreen-new.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-left-of-viewport-offscreen-old.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-left-of-viewport-partially-onscreen-new.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-left-of-viewport-partially-onscreen-old.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-of-viewport-offscreen-new.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-of-viewport-offscreen-old.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-of-viewport-partially-onscreen-new.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-of-viewport-partially-onscreen-old.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-right-and-left-of-viewport-partially-onscreen-new.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-right-of-viewport-offscreen-new.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-right-of-viewport-offscreen-old.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-right-of-viewport-partially-onscreen-new.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-right-of-viewport-partially-onscreen-old.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/multiline-span-with-overflowing-text-and-box-decorations.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-and-old-sizes-match.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-captures-clip-path.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-captures-different-size.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-has-scrollbars.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-is-inline.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-object-fit-fill.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-scaling.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/object-view-box-old-image.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-captures-clip-path.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-captures-different-size.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-captures-opacity.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-captures-root.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-has-scrollbars.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-is-inline.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-object-fit-fill.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-object-view-box-clip-path-reference.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-object-view-box-clip-path.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-rendering-invalidation.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/root-captured-as-different-tag.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/scroller-child-abspos.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/scroller-child.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/scroller.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/set-current-time.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-absolute.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-includes-scrollbar-gutter.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-static.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/span-with-overflowing-text-and-box-decorations.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/span-with-overflowing-text.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-empty-iframe.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api-parse-pseudo-argument.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api.html:

Canonical link: <a href="https://commits.webkit.org/277968@main">https://commits.webkit.org/277968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cae5dcb1ec62da07547623b1060de3d1d5a4279c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49096 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28349 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51863 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45177 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25889 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40123 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50647 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25937 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21236 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23400 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7349 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/44001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53776 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24174 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20383 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47440 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/25452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46413 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10800 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26241 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/25171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->