### PR TITLE
Crash observed in running webxr layout test from WebCore::WebXRSession::~WebXRSession()

### DIFF
--- a/Source/WebCore/testing/WebFakeXRDevice.cpp
+++ b/Source/WebCore/testing/WebFakeXRDevice.cpp
@@ -221,7 +221,10 @@ Vector<PlatformXR::Device::ViewData> SimulatedXRDevice::views(PlatformXR::Sessio
     return { { .active = true, .eye = PlatformXR::Eye::None } };
 }
 
-WebFakeXRDevice::WebFakeXRDevice() = default;
+WebFakeXRDevice::WebFakeXRDevice()
+    : m_device(adoptRef(*new SimulatedXRDevice()))
+{
+}
 
 void WebFakeXRDevice::setViews(const Vector<FakeXRViewInit>& views)
 {
@@ -242,7 +245,7 @@ void WebFakeXRDevice::setViews(const Vector<FakeXRViewInit>& views)
         }
     }
 
-    m_device.setViews(WTFMove(deviceViews));
+    m_device->setViews(WTFMove(deviceViews));
 }
 
 void WebFakeXRDevice::disconnect(DOMPromiseDeferred<void>&& promise)
@@ -256,13 +259,13 @@ void WebFakeXRDevice::setViewerOrigin(FakeXRRigidTransformInit origin, bool emul
     if (pose.hasException())
         return;
 
-    m_device.setViewerOrigin(pose.releaseReturnValue());
-    m_device.setEmulatedPosition(emulatedPosition);
+    m_device->setViewerOrigin(pose.releaseReturnValue());
+    m_device->setEmulatedPosition(emulatedPosition);
 }
 
 void WebFakeXRDevice::simulateVisibilityChange(XRVisibilityState visibilityState)
 {
-    m_device.setVisibilityState(visibilityState);
+    m_device->setVisibilityState(visibilityState);
 }
 
 void WebFakeXRDevice::setFloorOrigin(FakeXRRigidTransformInit origin)
@@ -271,7 +274,7 @@ void WebFakeXRDevice::setFloorOrigin(FakeXRRigidTransformInit origin)
     if (pose.hasException())
         return;
 
-    m_device.setFloorOrigin(pose.releaseReturnValue());
+    m_device->setFloorOrigin(pose.releaseReturnValue());
 }
 
 void WebFakeXRDevice::simulateResetPose()
@@ -282,7 +285,7 @@ Ref<WebFakeXRInputController> WebFakeXRDevice::simulateInputSourceConnection(con
 {
     auto handle = ++mInputSourceHandleIndex;
     auto input = WebFakeXRInputController::create(handle, init);
-    m_device.addInputConnection(input.copyRef());
+    m_device->addInputConnection(input.copyRef());
     return input;
 }
 
@@ -323,12 +326,12 @@ ExceptionOr<Ref<FakeXRView>> WebFakeXRDevice::parseView(const FakeXRViewInit& in
 
 void WebFakeXRDevice::setSupportsShutdownNotification()
 {
-    m_device.setSupportsShutdownNotification(true);
+    m_device->setSupportsShutdownNotification(true);
 }
 
 void WebFakeXRDevice::simulateShutdown()
 {
-    m_device.simulateShutdownCompleted();
+    m_device->simulateShutdownCompleted();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/testing/WebFakeXRDevice.h
+++ b/Source/WebCore/testing/WebFakeXRDevice.h
@@ -116,11 +116,11 @@ public:
     void setViews(const Vector<FakeXRViewInit>&);
     void disconnect(DOMPromiseDeferred<void>&&);
     void setViewerOrigin(FakeXRRigidTransformInit origin, bool emulatedPosition = false);
-    void clearViewerOrigin() { m_device.setViewerOrigin(std::nullopt); }
+    void clearViewerOrigin() { m_device->setViewerOrigin(std::nullopt); }
     void simulateVisibilityChange(XRVisibilityState);
-    void setBoundsGeometry(Vector<FakeXRBoundsPoint>&& bounds) { m_device.setNativeBoundsGeometry(WTFMove(bounds)); }
+    void setBoundsGeometry(Vector<FakeXRBoundsPoint>&& bounds) { m_device->setNativeBoundsGeometry(WTFMove(bounds)); }
     void setFloorOrigin(FakeXRRigidTransformInit);
-    void clearFloorOrigin() { m_device.setFloorOrigin(std::nullopt); }
+    void clearFloorOrigin() { m_device->setFloorOrigin(std::nullopt); }
     void simulateResetPose();
     Ref<WebFakeXRInputController> simulateInputSourceConnection(const FakeXRInputSourceInit&);
     static ExceptionOr<Ref<FakeXRView>> parseView(const FakeXRViewInit&);
@@ -133,7 +133,7 @@ public:
 private:
     WebFakeXRDevice();
 
-    SimulatedXRDevice m_device;
+    Ref<SimulatedXRDevice> m_device;
     PlatformXR::InputSourceHandle mInputSourceHandleIndex { 0 };
 };
 


### PR DESCRIPTION
#### 75f9692054bd633dfbc9768ba682d9ce43953760
<pre>
Crash observed in running webxr layout test from WebCore::WebXRSession::~WebXRSession()
<a href="https://bugs.webkit.org/show_bug.cgi?id=272426">https://bugs.webkit.org/show_bug.cgi?id=272426</a>

Reviewed by Mike Wyrzykowski.

Since `SimulatedXRDevice` inherits from `PlatformXR::Device` which is
reference counted, `WebFakeXRDevice::m_device` should be a `Ref`.

* Source/WebCore/testing/WebFakeXRDevice.cpp:
(WebCore::WebFakeXRDevice::WebFakeXRDevice):
(WebCore::WebFakeXRDevice::setViews):
(WebCore::WebFakeXRDevice::setViewerOrigin):
(WebCore::WebFakeXRDevice::simulateVisibilityChange):
(WebCore::WebFakeXRDevice::setFloorOrigin):
(WebCore::WebFakeXRDevice::simulateInputSourceConnection):
(WebCore::WebFakeXRDevice::setSupportsShutdownNotification):
(WebCore::WebFakeXRDevice::simulateShutdown):
* Source/WebCore/testing/WebFakeXRDevice.h:

Canonical link: <a href="https://commits.webkit.org/277983@main">https://commits.webkit.org/277983@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67d14975bc877ed5758e640b76598d284bb5a999

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28376 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52110 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51907 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45196 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51414 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25925 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40134 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25952 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42327 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21247 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23409 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43501 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7431 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45337 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53817 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24188 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20394 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47452 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25466 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46441 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10810 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26264 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25185 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->