### PR TITLE
REGRESSION (276098@main): [ iOS ] Broken test fast/css/line-height-determined-by-primary-font.html

### DIFF
--- a/LayoutTests/platform/ios/fast/css/line-height-determined-by-primary-font-expected.txt
+++ b/LayoutTests/platform/ios/fast/css/line-height-determined-by-primary-font-expected.txt
@@ -1,0 +1,62 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x270
+  RenderBlock {HTML} at (0,0) size 800x270
+    RenderBody {BODY} at (8,12) size 784x246
+      RenderBlock {P} at (0,0) size 784x28
+        RenderText {#text} at (0,0) size 779x28
+          text run at (0,0) width 779: "This test verifies that line height is determined solely by a box's primary font, not by its fallback fonts. The following two lines should have a solid, unbroken red line"
+          text run at (0,14) width 58: "below them:"
+      RenderBlock {DIV} at (0,40) size 784x97
+        RenderBlock {UL} at (0,0) size 567x97
+          RenderBlock (floating) {LI} at (40,0) size 52x31 [border: none (1px solid #FF0000) none]
+            RenderInline {A} at (0,0) size 30x15
+              RenderText {#text} at (12,7) size 30x15
+                text run at (12,7) width 30: "\x{6EE8}\x{5D0E}\x{6B65}"
+          RenderBlock (floating) {LI} at (92,0) size 76x31 [border: none (1px solid #FF0000) none]
+            RenderInline {A} at (0,0) size 54x20
+              RenderText {#text} at (12,5) size 54x20
+                text run at (12,5) width 54: "\x{8521}\x{4F9D}\x{6797}"
+          RenderBlock (floating) {LI} at (168,0) size 64x31 [border: none (1px solid #FF0000) none]
+            RenderInline {A} at (0,0) size 42x26
+              RenderText {#text} at (12,2) size 42x26
+                text run at (12,2) width 42: "\x{9648}\x{7EEE}\x{8D1E}"
+          RenderBlock (floating) {LI} at (232,0) size 69x31 [border: none (1px solid #FF0000) none]
+            RenderInline {A} at (0,0) size 47x20
+              RenderText {#text} at (12,5) size 47x20
+                text run at (12,5) width 47: "\x{9648}\x{5955}\x{8FC5}"
+          RenderBlock (floating) {LI} at (301,0) size 48x31 [border: none (1px solid #FF0000) none]
+            RenderInline {A} at (0,0) size 26x14
+              RenderText {#text} at (12,8) size 26x14
+                text run at (12,8) width 26: "\x{9ED1}\x{9E2D}\x{5B50}"
+          RenderBlock (floating) {LI} at (349,0) size 64x31 [border: none (1px solid #FF0000) none]
+            RenderInline {A} at (0,0) size 42x15
+              RenderText {#text} at (12,7) size 42x15
+                text run at (12,7) width 42: "\x{674E}\x{5B87}\x{6625}"
+          RenderBlock (floating) {LI} at (413,0) size 64x31 [border: none (1px solid #FF0000) none]
+            RenderInline {A} at (0,0) size 42x15
+              RenderText {#text} at (12,7) size 42x15
+                text run at (12,7) width 42: "\x{6881}\x{9759}\x{8339}"
+      RenderBlock {DIV} at (0,149) size 784x97
+        RenderBlock {UL} at (0,0) size 567x97
+          RenderBlock (floating) {LI} at (40,0) size 52x31 [border: none (1px solid #FF0000) none]
+            RenderText {#text} at (12,7) size 30x15
+              text run at (12,7) width 30: "\x{6EE8}\x{5D0E}\x{6B65}"
+          RenderBlock (floating) {LI} at (92,0) size 76x31 [border: none (1px solid #FF0000) none]
+            RenderText {#text} at (12,5) size 54x20
+              text run at (12,5) width 54: "\x{8521}\x{4F9D}\x{6797}"
+          RenderBlock (floating) {LI} at (168,0) size 64x31 [border: none (1px solid #FF0000) none]
+            RenderText {#text} at (12,2) size 42x26
+              text run at (12,2) width 42: "\x{9648}\x{7EEE}\x{8D1E}"
+          RenderBlock (floating) {LI} at (232,0) size 69x31 [border: none (1px solid #FF0000) none]
+            RenderText {#text} at (12,5) size 47x20
+              text run at (12,5) width 47: "\x{9648}\x{5955}\x{8FC5}"
+          RenderBlock (floating) {LI} at (301,0) size 48x31 [border: none (1px solid #FF0000) none]
+            RenderText {#text} at (12,8) size 26x14
+              text run at (12,8) width 26: "\x{9ED1}\x{9E2D}\x{5B50}"
+          RenderBlock (floating) {LI} at (349,0) size 64x31 [border: none (1px solid #FF0000) none]
+            RenderText {#text} at (12,7) size 42x15
+              text run at (12,7) width 42: "\x{674E}\x{5B87}\x{6625}"
+          RenderBlock (floating) {LI} at (413,0) size 64x31 [border: none (1px solid #FF0000) none]
+            RenderText {#text} at (12,7) size 42x15
+              text run at (12,7) width 42: "\x{6881}\x{9759}\x{8339}"


### PR DESCRIPTION
#### 0b6899a9f363868f596dbe6f3205df46fba56292
<pre>
REGRESSION (276098@main): [ iOS ] Broken test fast/css/line-height-determined-by-primary-font.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=271867">https://bugs.webkit.org/show_bug.cgi?id=271867</a>

Unreviewed test gardening.

* LayoutTests/platform/ios/fast/css/line-height-determined-by-primary-font-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/277976@main">https://commits.webkit.org/277976@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a883ac536e3ace696244c04638aa26ad76e4fa47

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52119 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51915 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45204 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34357 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25938 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40142 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25956 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42338 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21255 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23413 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43512 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7441 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45341 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44019 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53824 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20403 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47460 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/25473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42543 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46440 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26275 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7039 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/25192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->