### PR TITLE
Reduce use of mainFrameJSContext in WebKitTestRunner

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -3040,20 +3040,18 @@ ProcessID WKPageGetGPUProcessIdentifier(WKPageRef page)
 #endif
 }
 
-#ifdef __BLOCKS__
-void WKPageGetApplicationManifest_b(WKPageRef pageRef, WKPageGetApplicationManifestBlock block)
+void WKPageGetApplicationManifest(WKPageRef pageRef, void* context, WKPageGetApplicationManifestFunction function)
 {
     CRASH_IF_SUSPENDED;
 #if ENABLE(APPLICATION_MANIFEST)
-    toImpl(pageRef)->getApplicationManifest([block](const std::optional<WebCore::ApplicationManifest>& manifest) {
-        block();
+    toImpl(pageRef)->getApplicationManifest([function, context](const std::optional<WebCore::ApplicationManifest>& manifest) {
+        function(context);
     });
-#else // ENABLE(APPLICATION_MANIFEST)
+#else
     UNUSED_PARAM(pageRef);
-    block();
-#endif // not ENABLE(APPLICATION_MANIFEST)
-}
+    function(context);
 #endif
+}
 
 void WKPageDumpPrivateClickMeasurement(WKPageRef pageRef, WKPageDumpPrivateClickMeasurementFunction callback, void* callbackContext)
 {

--- a/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
@@ -169,10 +169,8 @@ WK_EXPORT void WKPageSetIgnoresViewportScaleLimits(WKPageRef page, bool ignoresV
 WK_EXPORT WKProcessID WKPageGetProcessIdentifier(WKPageRef page);
 WK_EXPORT WKProcessID WKPageGetGPUProcessIdentifier(WKPageRef page);
 
-#ifdef __BLOCKS__
-typedef void (^WKPageGetApplicationManifestBlock)(void);
-WK_EXPORT void WKPageGetApplicationManifest_b(WKPageRef page, WKPageGetApplicationManifestBlock block);
-#endif
+typedef void (*WKPageGetApplicationManifestFunction)(void* functionContext);
+WK_EXPORT void WKPageGetApplicationManifest(WKPageRef page, void* context, WKPageGetApplicationManifestFunction block);
 
 typedef void (*WKPageDumpPrivateClickMeasurementFunction)(WKStringRef privateClickMeasurementRepresentation, void* functionContext);
 WK_EXPORT void WKPageDumpPrivateClickMeasurement(WKPageRef, WKPageDumpPrivateClickMeasurementFunction, void* callbackContext);

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -378,7 +378,7 @@ interface TestRunner {
 
     // Open panel
     [PassContext] undefined setOpenPanelFiles(object filesArray);
-    undefined setOpenPanelFilesMediaIcon(object mediaIcon);
+    [PassContext] undefined setOpenPanelFilesMediaIcon(object mediaIcon);
 
     // Modal alerts
     undefined setShouldDismissJavaScriptAlertsAsynchronously(boolean value);

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -246,36 +246,8 @@ void InjectedBundle::didReceiveMessageToPage(WKBundlePageRef page, WKStringRef m
         return;
     }
 
-    if (WKStringIsEqualToUTF8CString(messageName, "CallAddChromeInputFieldCallback")) {
-        m_testRunner->callAddChromeInputFieldCallback();
-        return;
-    }
-
     if (WKStringIsEqualToUTF8CString(messageName, "CallRemoveChromeInputFieldCallback")) {
         m_testRunner->callRemoveChromeInputFieldCallback();
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "CallSetTextInChromeInputFieldCallback")) {
-        m_testRunner->callSetTextInChromeInputFieldCallback();
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "CallSelectChromeInputFieldCallback")) {
-        m_testRunner->callSelectChromeInputFieldCallback();
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "CallGetSelectedTextInChromeInputFieldCallback")) {
-        ASSERT(messageBody);
-        ASSERT(WKGetTypeID(messageBody) == WKStringGetTypeID());
-        auto jsString = toJS(static_cast<WKStringRef>(messageBody));
-        m_testRunner->callGetSelectedTextInChromeInputFieldCallback(jsString.get());
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "CallFocusWebViewCallback")) {
-        m_testRunner->callFocusWebViewCallback();
         return;
     }
 
@@ -301,24 +273,6 @@ void InjectedBundle::didReceiveMessageToPage(WKBundlePageRef page, WKStringRef m
 
     if (WKStringIsEqualToUTF8CString(messageName, "CallDidRemoveSwipeSnapshotCallback")) {
         m_testRunner->callDidRemoveSwipeSnapshotCallback();
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "CallDidReceiveLoadedSubresourceDomains")) {
-        ASSERT(messageBody);
-        ASSERT(WKGetTypeID(messageBody) == WKArrayGetTypeID());
-
-        WKArrayRef domainsArray = static_cast<WKArrayRef>(messageBody);
-        auto size = WKArrayGetSize(domainsArray);
-        Vector<String> domains;
-        domains.reserveInitialCapacity(size);
-        for (size_t i = 0; i < size; ++i) {
-            auto item = WKArrayGetItemAtIndex(domainsArray, i);
-            if (item && WKGetTypeID(item) == WKStringGetTypeID())
-                domains.append(toWTFString(static_cast<WKStringRef>(item)));
-        }
-
-        m_testRunner->callDidReceiveLoadedSubresourceDomainsCallback(WTFMove(domains));
         return;
     }
 
@@ -359,11 +313,6 @@ void InjectedBundle::didReceiveMessageToPage(WKBundlePageRef page, WKStringRef m
 
     if (WKStringIsEqualToUTF8CString(messageName, "WebsiteDataScanForRegistrableDomainsFinished")) {
         m_testRunner->statisticsDidScanDataRecordsCallback();
-        return;
-    }
-    
-    if (WKStringIsEqualToUTF8CString(messageName, "DidGetApplicationManifest")) {
-        m_testRunner->didGetApplicationManifest();
         return;
     }
 
@@ -549,35 +498,9 @@ void InjectedBundle::postNewBeforeUnloadReturnValue(bool value)
     postPageMessage("BeforeUnloadReturnValue", value);
 }
 
-void InjectedBundle::postAddChromeInputField()
-{
-    postPageMessage("AddChromeInputField");
-}
-
 void InjectedBundle::postRemoveChromeInputField()
 {
     postPageMessage("RemoveChromeInputField");
-}
-
-void InjectedBundle::postSetTextInChromeInputField(const String& text)
-{
-    auto wkText = toWK(text);
-    postPageMessage("SetTextInChromeInputField", wkText.get());
-}
-
-void InjectedBundle::postSelectChromeInputField()
-{
-    postPageMessage("SelectChromeInputField");
-}
-
-void InjectedBundle::postGetSelectedTextInChromeInputField()
-{
-    postPageMessage("GetSelectedTextInChromeInputField");
-}
-
-void InjectedBundle::postFocusWebView()
-{
-    postPageMessage("FocusWebView");
 }
 
 void InjectedBundle::postSetBackingScaleFactor(double backingScaleFactor)

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
@@ -82,12 +82,7 @@ public:
     void outputText(StringView, IsFinalTestOutput = IsFinalTestOutput::No);
     void dumpToStdErr(const String&);
     void postNewBeforeUnloadReturnValue(bool);
-    void postAddChromeInputField();
     void postRemoveChromeInputField();
-    void postSetTextInChromeInputField(const String&);
-    void postSelectChromeInputField();
-    void postGetSelectedTextInChromeInputField();
-    void postFocusWebView();
     void postSetBackingScaleFactor(double);
     void postSetWindowIsKey(bool);
     void postSetViewSize(double width, double height);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -279,14 +279,8 @@ public:
 
     void setViewSize(double width, double height);
 
-    void callAddChromeInputFieldCallback();
     void callRemoveChromeInputFieldCallback();
-    void callFocusWebViewCallback();
     void callSetBackingScaleFactorCallback();
-
-    void callSetTextInChromeInputFieldCallback();
-    void callSelectChromeInputFieldCallback();
-    void callGetSelectedTextInChromeInputFieldCallback(JSStringRef);
 
     static void overridePreference(JSStringRef preference, JSStringRef value);
 
@@ -466,7 +460,6 @@ public:
     void statisticsSetThirdPartyCNAMEDomain(JSStringRef cnameURLString, JSValueRef completionHandler);
     void statisticsResetToConsistentState(JSValueRef completionHandler);
     void loadedSubresourceDomains(JSValueRef callback);
-    void callDidReceiveLoadedSubresourceDomainsCallback(Vector<String>&& domains);
 
     // Injected bundle form client.
     void installTextDidChangeInTextFieldCallback(JSValueRef callback);
@@ -482,7 +475,7 @@ public:
 
     // Open panel
     void setOpenPanelFiles(JSContextRef, JSValueRef);
-    void setOpenPanelFilesMediaIcon(JSValueRef);
+    void setOpenPanelFilesMediaIcon(JSContextRef, JSValueRef);
 
     // Modal alerts
     void setShouldDismissJavaScriptAlertsAsynchronously(bool);
@@ -497,7 +490,6 @@ public:
     void callDidRemoveAllSessionCredentialsCallback();
     
     void getApplicationManifestThen(JSValueRef);
-    void didGetApplicationManifest();
 
     void installFakeHelvetica(JSStringRef configuration);
 

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -281,7 +281,7 @@ public:
 
     void getAllStorageAccessEntries(CompletionHandler<void(WKTypeRef)>&&);
     void setRequestStorageAccessThrowsExceptionUntilReload(bool enabled);
-    void loadedSubresourceDomains();
+    void loadedSubresourceDomains(CompletionHandler<void(WKTypeRef)>&&);
     void clearLoadedSubresourceDomains();
     void clearAppBoundSession();
     void reinitializeAppBoundDomains();

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -383,40 +383,10 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         TestController::singleton().setBeforeUnloadReturnValue(booleanValue(messageBody));
         return;
     }
-    
-    if (WKStringIsEqualToUTF8CString(messageName, "AddChromeInputField")) {
-        TestController::singleton().mainWebView()->addChromeInputField();
-        postPageMessage("CallAddChromeInputFieldCallback");
-        return;
-    }
 
     if (WKStringIsEqualToUTF8CString(messageName, "RemoveChromeInputField")) {
         TestController::singleton().mainWebView()->removeChromeInputField();
         postPageMessage("CallRemoveChromeInputFieldCallback");
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "SetTextInChromeInputField")) {
-        TestController::singleton().mainWebView()->setTextInChromeInputField(toWTFString(stringValue(messageBody)));
-        postPageMessage("CallSetTextInChromeInputFieldCallback");
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "SelectChromeInputField")) {
-        TestController::singleton().mainWebView()->selectChromeInputField();
-        postPageMessage("CallSelectChromeInputFieldCallback");
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "GetSelectedTextInChromeInputField")) {
-        auto selectedText = TestController::singleton().mainWebView()->getSelectedTextInChromeInputField();
-        postPageMessage("CallGetSelectedTextInChromeInputFieldCallback", toWK(selectedText));
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "FocusWebView")) {
-        TestController::singleton().mainWebView()->makeWebViewFirstResponder();
-        postPageMessage("CallFocusWebViewCallback");
         return;
     }
 
@@ -701,11 +671,6 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         return;
     }
 #endif
-    
-    if (WKStringIsEqualToUTF8CString(messageName, "LoadedSubresourceDomains")) {
-        TestController::singleton().loadedSubresourceDomains();
-        return;
-    }
 
     if (WKStringIsEqualToUTF8CString(messageName, "ReloadFromOrigin")) {
         TestController::singleton().reloadFromOrigin();
@@ -719,18 +684,6 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
 
     if (WKStringIsEqualToUTF8CString(messageName, "RemoveAllSessionCredentials")) {
         TestController::singleton().removeAllSessionCredentials();
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "GetApplicationManifest")) {
-#ifdef __BLOCKS__
-        WKPageGetApplicationManifest_b(TestController::singleton().mainWebView()->page(), ^{
-            postPageMessage("DidGetApplicationManifest");
-        });
-#else
-        // FIXME: Add API for loading the manifest on non-__BLOCKS__ ports.
-        ASSERT_NOT_REACHED();
-#endif
         return;
     }
 
@@ -1534,14 +1487,6 @@ void TestInvocation::didRemoveSwipeSnapshot()
 void TestInvocation::notifyDownloadDone()
 {
     postPageMessage("NotifyDownloadDone");
-}
-
-void TestInvocation::didReceiveLoadedSubresourceDomains(Vector<String>&& domains)
-{
-    auto messageBody = adoptWK(WKMutableArrayCreate());
-    for (auto& domain : domains)
-        WKArrayAppendItem(messageBody.get(), toWK(domain).get());
-    postPageMessage("CallDidReceiveLoadedSubresourceDomains", messageBody);
 }
 
 void TestInvocation::didRemoveAllSessionCredentials()

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -72,8 +72,6 @@ public:
 
     void notifyDownloadDone();
 
-    void didReceiveLoadedSubresourceDomains(Vector<String>&& domains);
-
     void didRemoveAllSessionCredentials();
 
     void didSetAppBoundDomains();

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -512,26 +512,6 @@ void TestController::removeAllSessionCredentials()
     }];
 }
 
-void TestController::loadedSubresourceDomains()
-{
-    auto* parentView = mainWebView();
-    if (!parentView)
-        return;
-    
-    [[globalWebViewConfiguration() websiteDataStore] _loadedSubresourceDomainsFor:parentView->platformView() completionHandler:^(NSArray<NSString *> *domains) {
-        m_currentInvocation->didReceiveLoadedSubresourceDomains(makeVector<String>(domains));
-    }];
-}
-
-void TestController::clearLoadedSubresourceDomains()
-{
-    auto* parentView = mainWebView();
-    if (!parentView)
-        return;
-
-    [[globalWebViewConfiguration() websiteDataStore] _clearLoadedSubresourceDomainsFor:parentView->platformView()];
-}
-
 bool TestController::didLoadAppInitiatedRequest()
 {
     auto* parentView = mainWebView();


### PR DESCRIPTION
#### b05ec723eb45d12d5df692990551d89cce4dc919
<pre>
Reduce use of mainFrameJSContext in WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=273246">https://bugs.webkit.org/show_bug.cgi?id=273246</a>

Reviewed by Sihui Liu and Charlie Wolfe.

With site isolation the main frame might be in another process.

* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageGetApplicationManifest):
(WKPageGetApplicationManifest_b): Deleted.
* Source/WebKit/UIProcess/API/C/WKPagePrivate.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::didReceiveMessageToPage):
(WTR::InjectedBundle::postAddChromeInputField): Deleted.
(WTR::InjectedBundle::postSetTextInChromeInputField): Deleted.
(WTR::InjectedBundle::postSelectChromeInputField): Deleted.
(WTR::InjectedBundle::postGetSelectedTextInChromeInputField): Deleted.
(WTR::InjectedBundle::postFocusWebView): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::addChromeInputField):
(WTR::TestRunner::setTextInChromeInputField):
(WTR::TestRunner::selectChromeInputField):
(WTR::TestRunner::getSelectedTextInChromeInputField):
(WTR::TestRunner::focusWebView):
(WTR::TestRunner::loadedSubresourceDomains):
(WTR::TestRunner::setOpenPanelFilesMediaIcon):
(WTR::TestRunner::getApplicationManifestThen):
(WTR::TestRunner::callAddChromeInputFieldCallback): Deleted.
(WTR::TestRunner::callSetTextInChromeInputFieldCallback): Deleted.
(WTR::TestRunner::callSelectChromeInputFieldCallback): Deleted.
(WTR::TestRunner::callGetSelectedTextInChromeInputFieldCallback): Deleted.
(WTR::TestRunner::callFocusWebViewCallback): Deleted.
(WTR::makeDomainsValue): Deleted.
(WTR::TestRunner::callDidReceiveLoadedSubresourceDomainsCallback): Deleted.
(WTR::TestRunner::didGetApplicationManifest): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::adoptAndCallCompletionHandler):
(WTR::TestController::didReceiveAsyncMessageFromInjectedBundle):
(WTR::TestController::loadedSubresourceDomains):
(WTR::LoadedSubresourceDomainsCallbackContext::LoadedSubresourceDomainsCallbackContext): Deleted.
(WTR::loadedSubresourceDomainsCallback): Deleted.
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):
(WTR::TestInvocation::didReceiveLoadedSubresourceDomains): Deleted.
* Tools/WebKitTestRunner/TestInvocation.h:
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::loadedSubresourceDomains): Deleted.
(WTR::TestController::clearLoadedSubresourceDomains): Deleted.

Canonical link: <a href="https://commits.webkit.org/277990@main">https://commits.webkit.org/277990@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afcac613cae06394d1e44c476a3662d0113844fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52154 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51939 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45236 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51445 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25995 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40164 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50795 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25982 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42360 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21277 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23438 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43534 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7465 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45366 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53848 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24219 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20425 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47482 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25497 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46466 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26313 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7045 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25216 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->