### PR TITLE
Select primary font for missing glyph for PUA characters

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7454,5 +7454,3 @@ webkit.org/b/272417 imported/w3c/web-platform-tests/svg/path/property/priority.s
 
 # re-import css/css-align WPT failure
 webkit.org/b/271692 imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-break-overflow-020.html [ ImageOnlyFailure ]
-
-webkit.org/b/273233 imported/w3c/web-platform-tests/css/css-fonts/matching/font-unicode-PUA-primary-font.html [ Skip ]

--- a/LayoutTests/platform/mac/fast/text/softbank-emoji-expected.txt
+++ b/LayoutTests/platform/mac/fast/text/softbank-emoji-expected.txt
@@ -5,8 +5,8 @@ layer at (0,0) size 800x246
     RenderBody {BODY} at (8,8) size 784x230
       RenderBlock {DIV} at (0,0) size 784x230
         RenderBlock {DIV} at (0,0) size 784x115
-          RenderText {#text} at (0,0) size 256x115
-            text run at (0,0) width 256: "\x{E001} a \x{E001}"
+          RenderText {#text} at (0,0) size 238x115
+            text run at (0,0) width 238: "\x{E001} a \x{E001}"
         RenderBlock {DIV} at (0,115) size 784x115
-          RenderText {#text} at (0,0) size 73x115
-            text run at (0,0) width 73: "\x{E001}"
+          RenderText {#text} at (0,0) size 64x115
+            text run at (0,0) width 64: "\x{E001}"

--- a/LayoutTests/platform/wpe/fast/text/softbank-emoji-expected.txt
+++ b/LayoutTests/platform/wpe/fast/text/softbank-emoji-expected.txt
@@ -5,8 +5,8 @@ layer at (0,0) size 800x246
     RenderBody {BODY} at (8,8) size 784x230
       RenderBlock {DIV} at (0,0) size 784x230
         RenderBlock {DIV} at (0,0) size 784x115
-          RenderText {#text} at (0,1) size 268x112
-            text run at (0,1) width 268: "\x{E001} a \x{E001}"
+          RenderText {#text} at (0,1) size 262x112
+            text run at (0,1) width 262: "\x{E001} a \x{E001}"
         RenderBlock {DIV} at (0,115) size 784x115
-          RenderText {#text} at (0,1) size 78x112
-            text run at (0,1) width 78: "\x{E001}"
+          RenderText {#text} at (0,1) size 75x112
+            text run at (0,1) width 75: "\x{E001}"

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -485,12 +485,8 @@ GlyphData FontCascadeFonts::glyphDataForVariant(char32_t character, const FontCa
     // http://www.unicode.org/Public/MAPPINGS/VENDORS/APPLE/CORPCHAR.TXT
     shouldCheckForPrivateUseAreaCharacters = character != 0xF8FF;
 #endif
-    if (shouldCheckForPrivateUseAreaCharacters && isPrivateUseAreaCharacter(character)) {
-        auto font = FontCache::forCurrentThread().lastResortFallbackFont(description);
-        GlyphData glyphData(0, font.ptr());
-        m_systemFallbackFontSet.add(WTFMove(font));
-        return glyphData; // 0 is the font's reserved .notdef glyph
-    }
+    if (shouldCheckForPrivateUseAreaCharacters && isPrivateUseAreaCharacter(character))
+        return { 0, &primaryFont(description) }; // 0 is the font's reserved .notdef glyph
 
     return glyphDataForSystemFallback(character, description, variant, resolvedEmojiPolicy, fallbackVisibility == FallbackVisibility::Invisible);
 }


### PR DESCRIPTION
#### df0f17533ab4c17991214087049e647a68754ce5
<pre>
Select primary font for missing glyph for PUA characters
<a href="https://bugs.webkit.org/show_bug.cgi?id=273233">https://bugs.webkit.org/show_bug.cgi?id=273233</a>
<a href="https://rdar.apple.com/124036223">rdar://124036223</a>

Reviewed by Antti Koivisto.

We used to render the missing glyph for PUA characters (see [1])
with the lastResortFontFallback, instead of the primary font.
This is done by FontCascadeFonts::glyphDataForVariant(...)
producing a GlyphData object with such font for the missing glyph (glyph 0).

The ComplexTextController, which handles complex text, would always
use the primary font for getting metrics for the missing glyph. When rendering
PUA characters we would use the simple path (WidthIterator is used instead
of ComplexTextController), selecting the last resort font both for layout and painting.

However, when computing the caret position, we still use the ComplexTextController
because WidthIterator can&apos;t handle partial runs with ligatures (for example).

This would result in WidthIterator being used for layout/painting and selecting the
lastResortFont, and ComplexTextController being used for calculating the caret position,
selecting the primary font.

We are fixing it by updating the special case for PUA character and selecting
the primary font for such case, instead of the lastResortFont. This also has
the benefit of enforcing interoperability with other browser, as Blink
and Gecko seem to also use the primary font selected by the author.

[1] <a href="https://commits.webkit.org/269524@main">https://commits.webkit.org/269524@main</a>

* LayoutTests/platform/mac/fast/text/softbank-emoji-expected.txt:
* LayoutTests/platform/wpe/fast/text/softbank-emoji-expected.txt:
- Rebasing this test since they contain PUA characters and font will change.

* LayoutTests/TestExpectations:
- We should pass this test now.

* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::FontCascadeFonts::glyphDataForVariant):
- Using primary font instead of last resort font for glyph 0 when PUA characters can&apos;t be mapped by selected fonts.

Canonical link: <a href="https://commits.webkit.org/278221@main">https://commits.webkit.org/278221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d420261bb3d173133d808c52455c8434e76ae6ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52860 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/294 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51923 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26523 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40496 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51718 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26478 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42733 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21611 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23920 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43927 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7989 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45828 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54437 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24704 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20876 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47871 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25972 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42870 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46899 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10943 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26823 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25697 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->