### PR TITLE
[JSC] Ensure canonicalizing "GMT" to "UTC"

### DIFF
--- a/JSTests/stress/intl-canonical-gmt.js
+++ b/JSTests/stress/intl-canonical-gmt.js
@@ -1,0 +1,6 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+shouldBe(new Intl.DateTimeFormat('en', { timeZone: "GMT" }).resolvedOptions().timeZone, "UTC")

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -139,7 +139,7 @@ static String canonicalizeTimeZoneName(const String& timeZoneName)
     } while (canonical.isNull());
     uenum_close(timeZones);
 
-    // 3. If ianaTimeZone is "Etc/UTC" or "Etc/GMT", then return "UTC".
+    // 3. If ianaTimeZone is "Etc/UTC", "Etc/GMT", or "GMT", then return "UTC".
     if (isUTCEquivalent(canonical))
         return "UTC"_s;
 

--- a/Source/JavaScriptCore/runtime/JSDateMath.h
+++ b/Source/JavaScriptCore/runtime/JSDateMath.h
@@ -200,7 +200,7 @@ private:
 
 ALWAYS_INLINE bool isUTCEquivalent(StringView timeZone)
 {
-    return timeZone == "Etc/UTC"_s || timeZone == "Etc/GMT"_s;
+    return timeZone == "Etc/UTC"_s || timeZone == "Etc/GMT"_s || timeZone == "GMT"_s;
 }
 
 } // namespace JSC


### PR DESCRIPTION
#### 9f6d74bdbaeab77242278678e9802625370247ea
<pre>
[JSC] Ensure canonicalizing &quot;GMT&quot; to &quot;UTC&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=273258">https://bugs.webkit.org/show_bug.cgi?id=273258</a>
<a href="https://rdar.apple.com/127061600">rdar://127061600</a>

Reviewed by Mark Lam and Keith Miller.

Update Intl implementation to ensure canonicalizing &quot;GMT&quot; to &quot;UTC&quot; based on the spec update[1].

[1]: <a href="https://github.com/tc39/ecma402/commit/50eb4138d5e0f994dfd08bb664cab16c8998d76f">https://github.com/tc39/ecma402/commit/50eb4138d5e0f994dfd08bb664cab16c8998d76f</a>

* JSTests/stress/intl-canonical-gmt.js: Added.
(shouldBe):
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::canonicalizeTimeZoneName):
* Source/JavaScriptCore/runtime/JSDateMath.h:
(JSC::isUTCEquivalent):

Canonical link: <a href="https://commits.webkit.org/277997@main">https://commits.webkit.org/277997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29b628c8abb1946059d4cb76cd6e718eabd6e2a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28442 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/52194 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51963 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45265 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26035 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40188 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50984 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26006 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/52194 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21301 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23462 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/52194 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7489 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/42481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45391 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/52194 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53872 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/48656 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24244 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20451 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25521 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/52194 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/26348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56150 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7049 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/25243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11540 "Passed tests") | 
<!--EWS-Status-Bubble-End-->