### PR TITLE
Add script to boot simulators using webkitpy.

### DIFF
--- a/Tools/Scripts/boot-simulators
+++ b/Tools/Scripts/boot-simulators
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 Apple Inc.  All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import webkitpy
+
+import argparse
+import logging
+import os
+import sys
+
+from webkitcorepy import arguments
+
+from webkitpy.common.system.executive import ScriptError
+
+from webkitpy.port.ios_simulator import IPhoneSimulatorPort, IPadSimulatorPort
+from webkitpy.port.visionos_simulator import VisionOSSimulatorPort
+from webkitpy.port.watch_simulator import WatchSimulatorPort
+
+from webkitpy.xcode.simulated_device import DeviceRequest, SimulatedDeviceManager
+
+
+def init():
+    parser = argparse.ArgumentParser(description='Boots a specified number of simulators of the default device type.')
+
+    parser.add_argument('number_of_simulators', help='The number of simulators to boot.', type=int)
+
+    sim_type = parser.add_argument_group(title='Simulator Type', description='Specifies which type of simulator(s) to boot.').add_mutually_exclusive_group(required=True)
+    sim_type.add_argument('--ios-simulator', '--iphone-simulator', help='Boot an iOS simulator.', action='store_const', const=IPhoneSimulatorPort)
+    sim_type.add_argument('--ipados-simulator', '--ipad-simulator', help='Boot an iPadOS simulator.', action='store_const', const=IPadSimulatorPort)
+    sim_type.add_argument('--visionos-simulator', '--vision-simulator', help='Boot a visionOS simulator.', action='store_const', const=VisionOSSimulatorPort)
+    sim_type.add_argument('--watchos-simulator', '--watch-simulator', help='Boot a watchOS simulator.', action='store_const', const=WatchSimulatorPort)
+    # FIXME: add tvOS simulator support if/when the port is added to webkitpy.port. (webkit.org/b/273261)
+
+    opt_args = parser.add_argument_group(title='Optional Arguments', description='Optional arguments affecting specific boot behaviors.')
+    opt_args.add_argument('--use-booted',
+                          help='Count booted simulators towards the specified number. Default is to boot the desired number of simulators regardless of if any are already booted.',
+                          action='store_true')
+
+    arguments.LoggingGroup(parser, loggers=[logging.getLogger()])
+    logging.basicConfig(format='%(asctime)s: %(message)s')
+
+    return parser.parse_args()
+
+
+def main():
+    args = init()
+
+    if args.number_of_simulators <= 0:
+        raise ScriptError('Invalid number of simulators to boot.')
+
+    port = args.ios_simulator or args.ipados_simulator or args.visionos_simulator or args.watchos_simulator
+    request = DeviceRequest(device_type=port.DEFAULT_DEVICE_TYPES[0], use_booted_simulator=args.use_booted)
+
+    manager = SimulatedDeviceManager()
+    manager.initialize_devices([request] * args.number_of_simulators, keep_alive=True)
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
#### c261cf90ec3f34f85a7fc1ee3c898d82a76c17eb
<pre>
Add script to boot simulators using webkitpy.
<a href="https://rdar.apple.com/127062283">rdar://127062283</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=273260">https://bugs.webkit.org/show_bug.cgi?id=273260</a>

Reviewed by Jonathan Bedard.

This PR adds a script that is able to tie into `webkitpy.xcode.simulated_device.SimulatedDeviceManager`
to boot simulated devices.

* Tools/Scripts/boot-simulators: Added.
(init): Sets up script arguments and logging.
(main): Determines the appropriate port to use and generates/satisfies corresponding requests.

Canonical link: <a href="https://commits.webkit.org/278179@main">https://commits.webkit.org/278179@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d95b7cc9883251e1b65b87c4e1b322de302307a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29029 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/52792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/52983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52046 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35050 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26646 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/52983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51841 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/26557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/52792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/52983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/23998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/52792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8113 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/52792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/54565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/24829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/54565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/26095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/52792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/54565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/26943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7159 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/25820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->