### PR TITLE
[Remote Inspection] Element targeting should try :has() before falling back to relative selectors

### DIFF
--- a/LayoutTests/fast/element-targeting/target-container-with-link-expected.txt
+++ b/LayoutTests/fast/element-targeting/target-container-with-link-expected.txt
@@ -1,0 +1,11 @@
+PASS targetSelector is "SECTION:has(A[href='https://webkit.org'])"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+WebKit Homepage
+
+WebKit
+Apple Homepage
+
+Apple
+This test requires WebKitTestRunner

--- a/LayoutTests/fast/element-targeting/target-container-with-link.html
+++ b/LayoutTests/fast/element-targeting/target-container-with-link.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+body, html {
+    margin: 0;
+}
+
+section {
+    width: 300px;
+    height: 150px;
+    border: 1px solid gray;
+    box-sizing: border-box;
+    background: lightgray;
+    color: white;
+    text-align: center;
+    display: inline-block;
+}
+</style>
+</head>
+<body>
+    <main>
+        <section>
+            <p>WebKit Homepage</p>
+            <a href="https://webkit.org">WebKit</a>
+        </section>
+        <section>
+            <p>Apple Homepage</p>
+            <a href="https://apple.com">Apple</a>
+        </section>
+        <footer>
+            <p>This test requires WebKitTestRunner</p>
+        </footer>
+    </main>
+</body>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async event => {
+    const firstSection = document.querySelector("section");
+    targetSelector = await UIHelper.adjustVisibilityForFrontmostTarget(firstSection);
+    shouldBeEqualToString("targetSelector", "SECTION:has(A[href='https://webkit.org'])");
+    finishJSTest();
+});
+</script>
+</html>


### PR DESCRIPTION
#### 048d68a2ee2a1517b2f8bc4006b5d73ebb22c159
<pre>
[Remote Inspection] Element targeting should try :has() before falling back to relative selectors
<a href="https://bugs.webkit.org/show_bug.cgi?id=273265">https://bugs.webkit.org/show_bug.cgi?id=273265</a>
<a href="https://rdar.apple.com/127065936">rdar://127065936</a>

Reviewed by Abrar Protyasha.

Currently, when finding suitable selectors for a given target element, we first check the target&apos;s
class, ID, and other DOM attributes to see if we can find anything unique. Failing this, we then
fall back to a recursive selector, assembled using either `nth-child` (if relative to the parent) or
`+` (if relative to a sibling). This can lead to unstable targeting behaviors in some cases.

Instead, implement another strategy based around using `:has(…)` on any child element with unique
attributes, and add ancestor selectors (`… &gt; …`) until the selector uniquely identifies the target.
Prefer this strategy, before falling back to parent or sibling selectors.

* LayoutTests/fast/element-targeting/target-container-with-link-expected.txt: Added.
* LayoutTests/fast/element-targeting/target-container-with-link.html: Added.

Add a layout test to exercise the change.

* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::computeTagAndAttributeSelector):
(WebCore::computeHasChildSelector):
(WebCore::selectorsForTarget):

Canonical link: <a href="https://commits.webkit.org/278020@main">https://commits.webkit.org/278020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e68b2539d921846b5bc80ae0401abbab0b8e1fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49194 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51991 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45295 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51497 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26081 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40200 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51175 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42394 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21317 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43570 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7517 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44076 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53902 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24276 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20475 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47517 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25549 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42598 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46504 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10827 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26382 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25270 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->