### PR TITLE
Creating ImageBitmap out of WebGPU OffscreenCanvas context crashes

### DIFF
--- a/LayoutTests/fast/webgpu/image-bitmap-no-crash-expected.html
+++ b/LayoutTests/fast/webgpu/image-bitmap-no-crash-expected.html
@@ -1,0 +1,3 @@
+<body style="margin:0">
+<div style="position:absolute; width: 10px; height: 10px; background: lime;"></div>
+</body>

--- a/LayoutTests/fast/webgpu/image-bitmap-no-crash.html
+++ b/LayoutTests/fast/webgpu/image-bitmap-no-crash.html
@@ -1,0 +1,19 @@
+<body style="margin:0">
+<canvas id="c"></canvas>
+<script>
+onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter();
+    let device = await adapter.requestDevice();
+    let canvas = new OffscreenCanvas(10, 10); // Would reliably crash with this size.
+    let context = canvas.getContext('webgpu');
+    const format = "rgba8unorm";
+    context.configure({ device, format });
+    const encoder = device.createCommandEncoder({});
+    const pass = encoder.beginRenderPass({colorAttachments: [{clearValue: [0.0, 1.0, 0.0, 1], loadOp: 'clear', storeOp: 'store', view: context.getCurrentTexture().createView()}]});
+    pass.end();
+    device.queue.submit([encoder.finish()]);
+    let b = await createImageBitmap(canvas);
+    c.getContext("2d").drawImage(b, 0, 0);
+};
+</script>
+</body>


### PR DESCRIPTION
#### f6c16b9ea729135fc08ec21179373f59014c2901
<pre>
Creating ImageBitmap out of WebGPU OffscreenCanvas context crashes
<a href="https://bugs.webkit.org/show_bug.cgi?id=273255">https://bugs.webkit.org/show_bug.cgi?id=273255</a>
<a href="https://rdar.apple.com/126761479">rdar://126761479</a>

Reviewed by Mike Wyrzykowski.

Transfer the CGImage malloc buffer ownership to the CGDataProvider.

* LayoutTests/fast/webgpu/image-bitmap-no-crash-expected.html: Added.
* LayoutTests/fast/webgpu/image-bitmap-no-crash.html: Added.
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::getTextureAsNativeImage):

Canonical link: <a href="https://commits.webkit.org/278058@main">https://commits.webkit.org/278058@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/460a0126df3f5a73c9d0fcb36f1ac40e98d35567

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49199 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52229 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51996 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45301 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34486 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26088 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40204 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26039 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42393 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21322 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23493 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43569 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7522 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45416 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44075 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53907 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24281 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20479 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47521 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25554 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42597 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46508 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10847 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26389 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25275 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->