### PR TITLE
Use SFINAE instead of an IDL attribute to pass a JSContextRef to WebKitTestRunner JS callbacks

### DIFF
--- a/Source/WebCore/bindings/scripts/IDLAttributes.json
+++ b/Source/WebCore/bindings/scripts/IDLAttributes.json
@@ -399,10 +399,6 @@
         "BypassDocumentFullyActiveCheck": {
             "contextsAllowed": ["type"]
         },
-        "PassContext": {
-            "contextsAllowed": ["operation"],
-            "notes" : "Only used by WebKitTestRunner and DumpRenderTree"
-        },
         "Plugin": {
             "contextsAllowed": ["interface"],
             "notes" : "Should only be used by elements that forward to Netscape plug-ins"

--- a/Tools/DumpRenderTree/Bindings/CodeGeneratorDumpRenderTree.pm
+++ b/Tools/DumpRenderTree/Bindings/CodeGeneratorDumpRenderTree.pm
@@ -286,10 +286,6 @@ EOF
 
                 $self->_includeHeaders(\%contentsIncludes, $operation->type);
 
-                if ($operation->extendedAttributes->{"PassContext"}) {
-                    push(@arguments, "context");
-                }
-
                 if (!@specifiedArguments) {
                     push(@contents, "    UNUSED_VARIABLE(argumentCount);\n");
                     push(@contents, "    UNUSED_VARIABLE(arguments);\n");

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
@@ -424,10 +424,10 @@ private:
     RetainPtr<id> attributeValueForParameter(NSString *, id) const;
     unsigned arrayAttributeCount(NSString *) const;
     RetainPtr<NSString> descriptionOfValue(id valueObject) const;
-    bool boolAttributeValue(NSString *attribute) const;
-    JSRetainPtr<JSStringRef> stringAttributeValue(NSString *attribute) const;
-    double numberAttributeValue(NSString *attribute) const;
-    bool isAttributeSettable(NSString *) const;
+    bool boolAttributeValueNS(NSString *attribute) const;
+    JSRetainPtr<JSStringRef> stringAttributeValueNS(NSString *attribute) const;
+    double numberAttributeValueNS(NSString *attribute) const;
+    bool isAttributeSettableNS(NSString *) const;
 #endif
 
 #if !PLATFORM(COCOA) && !USE(ATSPI)

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
@@ -213,10 +213,10 @@ interface AccessibilityUIElement {
     DOMString attributedStringForRange(unsigned long location, unsigned long length);
     DOMString attributedStringForElement();
     boolean attributedStringRangeIsMisspelled(unsigned long location, unsigned long length);
-    [PassContext] unsigned long uiElementCountForSearchPredicate(AccessibilityUIElement startElement, boolean isDirectionNext, object searchKey, DOMString searchText, boolean visibleOnly, boolean immediateDescendantsOnly);
-    [PassContext] AccessibilityUIElement uiElementForSearchPredicate(AccessibilityUIElement startElement, boolean isDirectionNext, object searchKey, DOMString searchText, boolean visibleOnly, boolean immediateDescendantsOnly);
-    [PassContext] DOMString selectTextWithCriteria(DOMString ambiguityResolution, object searchStrings, DOMString replacementString, DOMString activity);
-    [PassContext] object searchTextWithCriteria(object searchStrings, DOMString startFrom, DOMString direction);
+    unsigned long uiElementCountForSearchPredicate(AccessibilityUIElement startElement, boolean isDirectionNext, object searchKey, DOMString searchText, boolean visibleOnly, boolean immediateDescendantsOnly);
+    AccessibilityUIElement uiElementForSearchPredicate(AccessibilityUIElement startElement, boolean isDirectionNext, object searchKey, DOMString searchText, boolean visibleOnly, boolean immediateDescendantsOnly);
+    DOMString selectTextWithCriteria(DOMString ambiguityResolution, object searchStrings, DOMString replacementString, DOMString activity);
+    object searchTextWithCriteria(object searchStrings, DOMString startFrom, DOMString direction);
     boolean setSelectedTextRange(unsigned long location, unsigned long length);
 
     // Scroll area attributes.

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/EventSendingController.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/EventSendingController.idl
@@ -28,8 +28,8 @@ dictionary MonitorWheelEventsOptions {
 };
 
 interface EventSendingController {
-    [PassContext] undefined mouseDown(long buttonNumber, object modifierArray, optional DOMString pointerType);
-    [PassContext] undefined mouseUp(long buttonNumber, object modifierArray, optional DOMString pointerType);
+    undefined mouseDown(long buttonNumber, object modifierArray, optional DOMString pointerType);
+    undefined mouseUp(long buttonNumber, object modifierArray, optional DOMString pointerType);
     undefined mouseMoveTo(long x, long y, optional DOMString pointerType);
     undefined mouseForceClick();
     undefined startAndCancelMouseForceClick();
@@ -40,16 +40,16 @@ interface EventSendingController {
     undefined mouseScrollByWithWheelAndMomentumPhases(long x, long y, DOMString phase, DOMString momentum);
     undefined setWheelHasPreciseDeltas(boolean hasPreciseDeltas);
     undefined continuousMouseScrollBy(long x, long y, optional boolean paged);
-    [PassContext] object contextClick();
+    object contextClick();
     undefined scheduleAsynchronousClick();
 
     undefined leapForward(long milliseconds);
 
     // keyDown is really keyUpAndDown, and perhaps should be renamed to reflect that.
     // rawKeyDown is just the keyDown, and rawKeyUp is just the keyUp
-    [PassContext] undefined keyDown(DOMString key, object modifierArray, long location);
-    [PassContext] undefined rawKeyDown(DOMString key, object modifierArray, long location);
-    [PassContext] undefined rawKeyUp(DOMString key, object modifierArray, long location);
+    undefined keyDown(DOMString key, object modifierArray, long location);
+    undefined rawKeyDown(DOMString key, object modifierArray, long location);
+    undefined rawKeyUp(DOMString key, object modifierArray, long location);
     undefined scheduleAsynchronousKeyDown(DOMString key);
 
     // Zoom functions.
@@ -60,7 +60,7 @@ interface EventSendingController {
     undefined scalePageBy(double scale, double x, double y);
 
     undefined monitorWheelEvents(optional MonitorWheelEventsOptions options);
-    [PassContext] undefined callAfterScrollingCompletes(object functionCallback);
+    undefined callAfterScrollingCompletes(object functionCallback);
 
 #if defined(ENABLE_TOUCH_EVENTS) && ENABLE_TOUCH_EVENTS
     // Touch events.

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -128,11 +128,11 @@ interface TestRunner {
     undefined forceImmediateCompletion();
 
     // Printing
-    [PassContext] boolean isPageBoxVisible(long pageIndex);
+    boolean isPageBoxVisible(long pageIndex);
 
     undefined dumpAllHTTPRedirectedResponseHeaders();
 
-    [PassContext] undefined setValueForUser(object element, DOMString value);
+    undefined setValueForUser(object element, DOMString value);
 
     // UserContent testing.
     undefined addUserScript(DOMString source, boolean runAtStart, boolean allFrames);
@@ -150,10 +150,10 @@ interface TestRunner {
     // Text search testing.
     boolean findString(DOMString target, object optionsArray);
     undefined findStringMatchesInPage(DOMString target, object optionsArray);
-    [PassContext] undefined replaceFindMatchesAtIndices(object matchIndicesArray, DOMString replacementText, boolean selectionOnly);
+    undefined replaceFindMatchesAtIndices(object matchIndicesArray, DOMString replacementText, boolean selectionOnly);
 
     // Evaluating script in a special context.
-    [PassContext] undefined evaluateScriptInIsolatedWorld(unsigned long worldID, DOMString script);
+    undefined evaluateScriptInIsolatedWorld(unsigned long worldID, DOMString script);
 
     // For Web Inspector tests
     undefined showWebInspector();
@@ -163,7 +163,7 @@ interface TestRunner {
 
     undefined setPOSIXLocale(DOMString locale);
 
-    [PassContext] undefined setTextDirection(DOMString direction);
+    undefined setTextDirection(DOMString direction);
 
     undefined setWillSendRequestReturnsNull(boolean flag);
     undefined setWillSendRequestReturnsNullOnRedirect(boolean flag);
@@ -244,9 +244,9 @@ interface TestRunner {
     readonly attribute boolean isDoingMediaCapture;
 
     // Audio testing.
-    [PassContext] undefined setAudioResult(object data);
+    undefined setAudioResult(object data);
 
-    [PassContext] boolean callShouldCloseOnWebView();
+    boolean callShouldCloseOnWebView();
 
     // Work queue.
     undefined queueBackNavigation(unsigned long howFarBackward);
@@ -277,9 +277,9 @@ interface TestRunner {
     undefined setPluginSupportedMode(DOMString mode);
 
     // Hooks to the JSC compiler.
-    [PassContext] object failNextNewCodeBlock();
-    [PassContext] object numberOfDFGCompiles(object function);
-    [PassContext] object neverInlineFunction(object function);
+    object failNextNewCodeBlock();
+    object numberOfDFGCompiles(object function);
+    object neverInlineFunction(object function);
 
     // Swipe gestures
     undefined installDidBeginSwipeCallback(object callback);
@@ -377,8 +377,8 @@ interface TestRunner {
     undefined setRequestStorageAccessThrowsExceptionUntilReload(boolean enabled);
 
     // Open panel
-    [PassContext] undefined setOpenPanelFiles(object filesArray);
-    [PassContext] undefined setOpenPanelFilesMediaIcon(object mediaIcon);
+    undefined setOpenPanelFiles(object filesArray);
+    undefined setOpenPanelFilesMediaIcon(object mediaIcon);
 
     // Modal alerts
     undefined setShouldDismissJavaScriptAlertsAsynchronously(boolean value);
@@ -415,11 +415,11 @@ interface TestRunner {
 
     boolean hasAppBoundSession();
     undefined clearAppBoundSession();
-    [PassContext] undefined setAppBoundDomains(object originsArray, object callback);
+    undefined setAppBoundDomains(object originsArray, object callback);
     boolean didLoadAppInitiatedRequest();
     boolean didLoadNonAppInitiatedRequest();
 
-    [PassContext] undefined setManagedDomains(object originsArray, object callback);
+    undefined setManagedDomains(object originsArray, object callback);
 
     undefined injectUserScript(DOMString string);
     readonly attribute unsigned long userScriptInjectedCount;
@@ -456,7 +456,7 @@ interface TestRunner {
     undefined takeViewPortSnapshot(object callback);
 
     // Reporting API
-    [PassContext] undefined generateTestReport(DOMString message, DOMString group);
+    undefined generateTestReport(DOMString message, DOMString group);
 
     undefined getAndClearReportedWindowProxyAccessDomains(object callback);
     undefined flushConsoleLogs(object callback);

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TextInputController.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TextInputController.idl
@@ -24,7 +24,7 @@
  */
 
 interface TextInputController {
-    [PassContext] undefined setMarkedText(DOMString string, long from, long length, boolean suppressUnderline, object highlights);
+    undefined setMarkedText(DOMString string, long from, long length, boolean suppressUnderline, object highlights);
     boolean hasMarkedText();
     undefined unmarkText();
     undefined insertText(DOMString string);

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -225,7 +225,7 @@ void InjectedBundle::didReceiveMessageToPage(WKBundlePageRef page, WKStringRef m
             InjectedBundle::page()->stopLoading();
 
             setlocale(LC_ALL, "");
-            TestRunner::removeAllWebNotificationPermissions();
+            InjectedBundle::singleton().testRunner()->removeAllWebNotificationPermissions();
 
             InjectedBundle::page()->resetAfterTest();
         }

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -298,12 +298,12 @@ public:
     void callExitFullscreenForElementCallback();
 
     // Web notifications.
-    static void grantWebNotificationPermission(JSStringRef origin);
-    static void denyWebNotificationPermission(JSStringRef origin);
-    static void denyWebNotificationPermissionOnPrompt(JSStringRef origin);
-    static void removeAllWebNotificationPermissions();
-    static void simulateWebNotificationClick(JSValueRef notification);
-    static void simulateWebNotificationClickForServiceWorkerNotifications();
+    void grantWebNotificationPermission(JSStringRef origin);
+    void denyWebNotificationPermission(JSStringRef origin);
+    void denyWebNotificationPermissionOnPrompt(JSStringRef origin);
+    void removeAllWebNotificationPermissions();
+    void simulateWebNotificationClick(JSValueRef notification);
+    void simulateWebNotificationClickForServiceWorkerNotifications();
 
     JSRetainPtr<JSStringRef> getBackgroundFetchIdentifier();
     void abortBackgroundFetch(JSStringRef);

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -397,7 +397,7 @@ unsigned AccessibilityUIElement::arrayAttributeCount(NSString *attributeName) co
 
 JSRetainPtr<JSStringRef> AccessibilityUIElement::domIdentifier() const
 {
-    return stringAttributeValue(NSAccessibilityDOMIdentifierAttribute);
+    return stringAttributeValueNS(NSAccessibilityDOMIdentifierAttribute);
 }
 
 void AccessibilityUIElement::getLinkedUIElements(Vector<RefPtr<AccessibilityUIElement>>& elementVector)
@@ -731,10 +731,10 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::stringDescriptionOfAttributeVal
 
 JSRetainPtr<JSStringRef> AccessibilityUIElement::stringAttributeValue(JSStringRef attribute)
 {
-    return stringAttributeValue([NSString stringWithJSStringRef:attribute]);
+    return stringAttributeValueNS([NSString stringWithJSStringRef:attribute]);
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::stringAttributeValue(NSString *attribute) const
+JSRetainPtr<JSStringRef> AccessibilityUIElement::stringAttributeValueNS(NSString *attribute) const
 {
     BEGIN_AX_OBJC_EXCEPTIONS
     auto value = attributeValue(attribute);
@@ -747,10 +747,10 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::stringAttributeValue(NSString *
 
 double AccessibilityUIElement::numberAttributeValue(JSStringRef attribute)
 {
-    return numberAttributeValue([NSString stringWithJSStringRef:attribute]);
+    return numberAttributeValueNS([NSString stringWithJSStringRef:attribute]);
 }
 
-double AccessibilityUIElement::numberAttributeValue(NSString *attribute) const
+double AccessibilityUIElement::numberAttributeValueNS(NSString *attribute) const
 {
     BEGIN_AX_OBJC_EXCEPTIONS
     auto value = attributeValue(attribute);
@@ -775,7 +775,7 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::uiElementAttributeValue(J
     return nullptr;
 }
 
-bool AccessibilityUIElement::boolAttributeValue(NSString *attribute) const
+bool AccessibilityUIElement::boolAttributeValueNS(NSString *attribute) const
 {
     BEGIN_AX_OBJC_EXCEPTIONS
     auto value = attributeValue(attribute);
@@ -788,7 +788,7 @@ bool AccessibilityUIElement::boolAttributeValue(NSString *attribute) const
 
 bool AccessibilityUIElement::boolAttributeValue(JSStringRef attribute)
 {
-    return boolAttributeValue([NSString stringWithJSStringRef:attribute]);
+    return boolAttributeValueNS([NSString stringWithJSStringRef:attribute]);
 }
 
 void AccessibilityUIElement::attributeValueAsync(JSStringRef attribute, JSValueRef callback)
@@ -826,10 +826,10 @@ void AccessibilityUIElement::setValue(JSStringRef value)
 
 bool AccessibilityUIElement::isAttributeSettable(JSStringRef attribute)
 {
-    return isAttributeSettable([NSString stringWithJSStringRef:attribute]);
+    return isAttributeSettableNS([NSString stringWithJSStringRef:attribute]);
 }
 
-bool AccessibilityUIElement::isAttributeSettable(NSString *attribute) const
+bool AccessibilityUIElement::isAttributeSettableNS(NSString *attribute) const
 {
     bool value = false;
 
@@ -949,12 +949,12 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::brailleRoleDescription() const
 
 JSRetainPtr<JSStringRef> AccessibilityUIElement::liveRegionStatus() const
 {
-    return stringAttributeValue(@"AXARIALive");
+    return stringAttributeValueNS(@"AXARIALive");
 }
 
 JSRetainPtr<JSStringRef> AccessibilityUIElement::liveRegionRelevant() const
 {
-    return stringAttributeValue(@"AXARIARelevant");
+    return stringAttributeValueNS(@"AXARIARelevant");
 }
 
 JSRetainPtr<JSStringRef> AccessibilityUIElement::orientation() const
@@ -1098,17 +1098,17 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::lineRectsAndText() const
 
 double AccessibilityUIElement::intValue() const
 {
-    return numberAttributeValue(NSAccessibilityValueAttribute);
+    return numberAttributeValueNS(NSAccessibilityValueAttribute);
 }
 
 double AccessibilityUIElement::minValue()
 {
-    return numberAttributeValue(NSAccessibilityMinValueAttribute);
+    return numberAttributeValueNS(NSAccessibilityMinValueAttribute);
 }
 
 double AccessibilityUIElement::maxValue()
 {
-    return numberAttributeValue(NSAccessibilityMaxValueAttribute);
+    return numberAttributeValueNS(NSAccessibilityMaxValueAttribute);
 }
 
 JSRetainPtr<JSStringRef> AccessibilityUIElement::valueDescription()
@@ -1172,22 +1172,22 @@ bool AccessibilityUIElement::isDecrementActionSupported()
 
 bool AccessibilityUIElement::isAtomicLiveRegion() const
 {
-    return boolAttributeValue(@"AXARIAAtomic");
+    return boolAttributeValueNS(@"AXARIAAtomic");
 }
 
 bool AccessibilityUIElement::isBusy() const
 {
-    return boolAttributeValue(@"AXElementBusy");
+    return boolAttributeValueNS(@"AXElementBusy");
 }
 
 bool AccessibilityUIElement::isEnabled()
 {
-    return boolAttributeValue(NSAccessibilityEnabledAttribute);
+    return boolAttributeValueNS(NSAccessibilityEnabledAttribute);
 }
 
 bool AccessibilityUIElement::isRequired() const
 {
-    return boolAttributeValue(@"AXRequired");
+    return boolAttributeValueNS(@"AXRequired");
 }
 
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::focusedElement() const
@@ -1202,7 +1202,7 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::focusedElement() const
 
 bool AccessibilityUIElement::isFocused() const
 {
-    return boolAttributeValue(NSAccessibilityFocusedAttribute);
+    return boolAttributeValueNS(NSAccessibilityFocusedAttribute);
 }
 
 bool AccessibilityUIElement::isSelected() const
@@ -1220,12 +1220,12 @@ bool AccessibilityUIElement::isSelectedOptionActive() const
 
 bool AccessibilityUIElement::isIndeterminate() const
 {
-    return boolAttributeValue(@"AXIsIndeterminate");
+    return boolAttributeValueNS(@"AXIsIndeterminate");
 }
 
 bool AccessibilityUIElement::isExpanded() const
 {
-    return boolAttributeValue(NSAccessibilityExpandedAttribute);
+    return boolAttributeValueNS(NSAccessibilityExpandedAttribute);
 }
 
 bool AccessibilityUIElement::isChecked() const
@@ -1236,12 +1236,12 @@ bool AccessibilityUIElement::isChecked() const
 
 JSRetainPtr<JSStringRef> AccessibilityUIElement::currentStateValue() const
 {
-    return stringAttributeValue(NSAccessibilityARIACurrentAttribute);
+    return stringAttributeValueNS(NSAccessibilityARIACurrentAttribute);
 }
 
 JSRetainPtr<JSStringRef> AccessibilityUIElement::sortDirection() const
 {
-    return stringAttributeValue(NSAccessibilitySortDirectionAttribute);
+    return stringAttributeValueNS(NSAccessibilitySortDirectionAttribute);
 }
 
 int AccessibilityUIElement::hierarchicalLevel() const
@@ -1289,7 +1289,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::speakAs()
 
 bool AccessibilityUIElement::ariaIsGrabbed() const
 {
-    return boolAttributeValue(NSAccessibilityGrabbedAttribute);
+    return boolAttributeValueNS(NSAccessibilityGrabbedAttribute);
 }
 
 JSRetainPtr<JSStringRef> AccessibilityUIElement::ariaDropEffects() const
@@ -1836,12 +1836,12 @@ bool AccessibilityUIElement::removeNotificationListener()
 
 bool AccessibilityUIElement::isFocusable() const
 {
-    return isAttributeSettable(NSAccessibilityFocusedAttribute);
+    return isAttributeSettableNS(NSAccessibilityFocusedAttribute);
 }
 
 bool AccessibilityUIElement::isSelectable() const
 {
-    return isAttributeSettable(NSAccessibilitySelectedAttribute);
+    return isAttributeSettableNS(NSAccessibilitySelectedAttribute);
 }
 
 bool AccessibilityUIElement::isMultiSelectable() const
@@ -1918,12 +1918,12 @@ bool AccessibilityUIElement::isMultiLine() const
 
 bool AccessibilityUIElement::hasPopup() const
 {
-    return boolAttributeValue(@"AXHasPopup");
+    return boolAttributeValueNS(@"AXHasPopup");
 }
 
 JSRetainPtr<JSStringRef> AccessibilityUIElement::popupValue() const
 {
-    if (auto result = stringAttributeValue(@"AXPopupValue"))
+    if (auto result = stringAttributeValueNS(@"AXPopupValue"))
         return result;
 
     return [@"false" createJSStringRef];
@@ -1931,12 +1931,12 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::popupValue() const
 
 bool AccessibilityUIElement::hasDocumentRoleAncestor() const
 {
-    return boolAttributeValue(@"AXHasDocumentRoleAncestor");
+    return boolAttributeValueNS(@"AXHasDocumentRoleAncestor");
 }
 
 bool AccessibilityUIElement::hasWebApplicationAncestor() const
 {
-    return boolAttributeValue(@"AXHasWebApplicationAncestor");
+    return boolAttributeValueNS(@"AXHasWebApplicationAncestor");
 }
 
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::focusableAncestor()
@@ -1971,17 +1971,17 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::highestEditableAncestor()
 
 bool AccessibilityUIElement::isInDescriptionListDetail() const
 {
-    return boolAttributeValue(@"AXIsInDescriptionListDetail");
+    return boolAttributeValueNS(@"AXIsInDescriptionListDetail");
 }
 
 bool AccessibilityUIElement::isInDescriptionListTerm() const
 {
-    return boolAttributeValue(@"AXIsInDescriptionListTerm");
+    return boolAttributeValueNS(@"AXIsInDescriptionListTerm");
 }
 
 bool AccessibilityUIElement::isInCell() const
 {
-    return boolAttributeValue(@"AXIsInCell");
+    return boolAttributeValueNS(@"AXIsInCell");
 }
 
 void AccessibilityUIElement::takeFocus()


### PR DESCRIPTION
#### baea2b903e06bf405e36c9858713553a8fa9fc52
<pre>
Use SFINAE instead of an IDL attribute to pass a JSContextRef to WebKitTestRunner JS callbacks
<a href="https://bugs.webkit.org/show_bug.cgi?id=273267">https://bugs.webkit.org/show_bug.cgi?id=273267</a>
<a href="https://rdar.apple.com/127068455">rdar://127068455</a>

Reviewed by Charlie Wolfe.

This will make it easier to add JSContextRef to more functions.
This is similar to how we add a Connection parameter to functions called by IPC in HandleMessage.h
It doesn&apos;t work well with static functions or functions with multiple sets of parameters,
so tweaked a few functions to get it to work.

* Source/WebCore/bindings/scripts/IDLAttributes.json:
* Tools/DumpRenderTree/Bindings/CodeGeneratorDumpRenderTree.pm:
(_generateImplementationFile):
* Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm:
(AccessibilityUIElement::stringAttributeValue):
(AccessibilityUIElement::domIdentifier const):
(AccessibilityUIElement::liveRegionRelevant const):
(AccessibilityUIElement::liveRegionStatus const):
(AccessibilityUIElement::popupValue const):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/CodeGeneratorTestRunner.pm:
(_generateImplementationFile):
* Tools/WebKitTestRunner/InjectedBundle/Bindings/EventSendingController.idl:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TextInputController.idl:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::didReceiveMessageToPage):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::AccessibilityUIElement::domIdentifier const):
(WTR::AccessibilityUIElement::stringAttributeValue):
(WTR::AccessibilityUIElement::stringAttributeValueNS const):
(WTR::AccessibilityUIElement::numberAttributeValue):
(WTR::AccessibilityUIElement::numberAttributeValueNS const):
(WTR::AccessibilityUIElement::boolAttributeValueNS const):
(WTR::AccessibilityUIElement::boolAttributeValue):
(WTR::AccessibilityUIElement::isAttributeSettable):
(WTR::AccessibilityUIElement::isAttributeSettableNS const):
(WTR::AccessibilityUIElement::liveRegionStatus const):
(WTR::AccessibilityUIElement::liveRegionRelevant const):
(WTR::AccessibilityUIElement::intValue const):
(WTR::AccessibilityUIElement::minValue):
(WTR::AccessibilityUIElement::maxValue):
(WTR::AccessibilityUIElement::isAtomicLiveRegion const):
(WTR::AccessibilityUIElement::isBusy const):
(WTR::AccessibilityUIElement::isEnabled):
(WTR::AccessibilityUIElement::isRequired const):
(WTR::AccessibilityUIElement::isFocused const):
(WTR::AccessibilityUIElement::isIndeterminate const):
(WTR::AccessibilityUIElement::isExpanded const):
(WTR::AccessibilityUIElement::currentStateValue const):
(WTR::AccessibilityUIElement::sortDirection const):
(WTR::AccessibilityUIElement::ariaIsGrabbed const):
(WTR::AccessibilityUIElement::isFocusable const):
(WTR::AccessibilityUIElement::isSelectable const):
(WTR::AccessibilityUIElement::hasPopup const):
(WTR::AccessibilityUIElement::popupValue const):
(WTR::AccessibilityUIElement::hasDocumentRoleAncestor const):
(WTR::AccessibilityUIElement::hasWebApplicationAncestor const):
(WTR::AccessibilityUIElement::isInDescriptionListDetail const):
(WTR::AccessibilityUIElement::isInDescriptionListTerm const):
(WTR::AccessibilityUIElement::isInCell const):
(WTR::AccessibilityUIElement::stringAttributeValue const): Deleted.
(WTR::AccessibilityUIElement::numberAttributeValue const): Deleted.
(WTR::AccessibilityUIElement::boolAttributeValue const): Deleted.
(WTR::AccessibilityUIElement::isAttributeSettable const): Deleted.

Canonical link: <a href="https://commits.webkit.org/278012@main">https://commits.webkit.org/278012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/338b0fa0ba5e0a3122c4c7f657d2e8e1491366ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49195 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28477 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51992 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45296 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51498 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26082 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40201 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51192 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42395 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21318 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23490 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43571 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7518 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45413 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44077 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53903 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20476 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47516 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25550 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42599 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26383 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7062 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25271 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->