### PR TITLE
Add support for loading the background content for a _WKWebExtensionContext.

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -79,11 +79,11 @@
 /* Label for an inspectable Web Extension background page */
 "%@ — Extension Background Page" = "%@ — Extension Background Page";
 
-/* Label for an inspectable Web Extension service worker */
-"%@ — Extension Service Worker" = "%@ — Extension Service Worker";
-
 /* Label for an inspectable Web Extension popup page */
 "%@ — Extension Popup Page" = "%@ — Extension Popup Page";
+
+/* Label for an inspectable Web Extension service worker */
+"%@ — Extension Service Worker" = "%@ — Extension Service Worker";
 
 /* Label to describe the number of files selected in a file upload control that allows multiple files */
 "%d files" = "%d files";
@@ -1030,6 +1030,9 @@
 /* Empty select list */
 "No Options Select Popover" = "No Options";
 
+/* WKWebExtensionContextErrorNoBackgroundContent description */
+"No background content is available to load." = "No background content is available to load.";
+
 /* Label for only item in menu that appears when clicking on the search field image, when no searches have been performed */
 "No recent searches" = "No recent searches";
 
@@ -1441,7 +1444,7 @@
 /* WKErrorWebContentProcessTerminated description */
 "The Web Content process was terminated" = "The Web Content process was terminated";
 
-/* WKWebExtensionErrorBackgroundContentFailedToLoad description */
+/* WKWebExtensionContextErrorBackgroundContentFailedToLoad description */
 "The background content failed to load due to an error." = "The background content failed to load due to an error.";
 
 /* WebKitErrorGeolocationLocationUnknown description */

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
@@ -51,7 +51,6 @@ WK_EXTERN NSErrorDomain const _WKWebExtensionErrorDomain NS_SWIFT_NAME(_WKWebExt
  @constant WKWebExtensionErrorInvalidManifestEntry  Indicates that an invalid manifest entry was encountered.
  @constant WKWebExtensionErrorInvalidDeclarativeNetRequestEntry  Indicates that an invalid declarative net request entry was encountered.
  @constant WKWebExtensionErrorInvalidBackgroundPersistence  Indicates that the extension specified background persistence that was not compatible with the platform or features requested.
- @constant WKWebExtensionErrorBackgroundContentFailedToLoad  Indicates that an error occurred loading the background content.
  */
 typedef NS_ERROR_ENUM(_WKWebExtensionErrorDomain, _WKWebExtensionError) {
     _WKWebExtensionErrorUnknown = 1,
@@ -62,7 +61,6 @@ typedef NS_ERROR_ENUM(_WKWebExtensionErrorDomain, _WKWebExtensionError) {
     _WKWebExtensionErrorInvalidManifestEntry,
     _WKWebExtensionErrorInvalidDeclarativeNetRequestEntry,
     _WKWebExtensionErrorInvalidBackgroundPersistence,
-    _WKWebExtensionErrorBackgroundContentFailedToLoad,
 } NS_SWIFT_NAME(_WKWebExtension.Error) WK_API_AVAILABLE(macos(13.3), ios(16.4));
 
 /*! @abstract This notification is sent whenever a @link WKWebExtension @/link has new errors or errors were cleared. */

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -57,12 +57,16 @@ WK_EXTERN NSErrorDomain const _WKWebExtensionContextErrorDomain NS_SWIFT_NAME(_W
  @constant WKWebExtensionContextErrorAlreadyLoaded  Indicates that the context is already loaded by a @link WKWebExtensionController @/link.
  @constant WKWebExtensionContextErrorNotLoaded  Indicates that the context is not loaded by a @link WKWebExtensionController @/link.
  @constant WKWebExtensionContextErrorBaseURLAlreadyInUse  Indicates that another context is already using the specified base URL.
+ @constant WKWebExtensionContextErrorNoBackgroundContent  Indicates that the extension does not have background content.
+ @constant WKWebExtensionContextErrorBackgroundContentFailedToLoad  Indicates that an error occurred loading the background content.
  */
 typedef NS_ERROR_ENUM(_WKWebExtensionContextErrorDomain, _WKWebExtensionContextError) {
     _WKWebExtensionContextErrorUnknown = 1,
     _WKWebExtensionContextErrorAlreadyLoaded,
     _WKWebExtensionContextErrorNotLoaded,
     _WKWebExtensionContextErrorBaseURLAlreadyInUse,
+    _WKWebExtensionContextErrorNoBackgroundContent,
+    _WKWebExtensionContextErrorBackgroundContentFailedToLoad,
 } NS_SWIFT_NAME(_WKWebExtensionContext.Error) WK_API_AVAILABLE(macos(13.3), ios(16.4));
 
 /*!
@@ -523,6 +527,15 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
  @seealso setPermissionStatus:forMatchPattern:inTab:
 */
 - (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forMatchPattern:(_WKWebExtensionMatchPattern *)pattern expirationDate:(nullable NSDate *)expirationDate NS_SWIFT_NAME(setPermissionStatus(_:for:expirationDate:));
+
+/*!
+ @abstract Loads the background content if needed for the extension.
+ @param completionHandler A block to be called upon completion of the loading process, with an optional error object.
+ @discussion This method forces the loading of the background content for the extension that will otherwise be loaded on-demand during specific events.
+ It is useful when the app requires the background content to be loaded for other reasons. If the background content is already loaded, the completion handler
+ will be called immediately. An error will occur if the extension does not have any background content to load or loading fails.
+ */
+- (void)loadBackgroundContentWithCompletionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
 /*!
  @abstract Retrieves the extension action for a given tab, or the default action if `nil` is passed.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -42,6 +42,7 @@
 #import "_WKWebExtensionInternal.h"
 #import "_WKWebExtensionMatchPatternInternal.h"
 #import "_WKWebExtensionTab.h"
+#import <wtf/BlockPtr.h>
 #import <wtf/URLParser.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
@@ -535,6 +536,11 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
 - (BOOL)hasContentModificationRules
 {
     return _webExtensionContext->hasContentModificationRules();
+}
+
+- (void)loadBackgroundContentWithCompletionHandler:(void (^)(NSError *error))completionHandler
+{
+    _webExtensionContext->loadBackgroundContent(makeBlockPtr(completionHandler));
 }
 
 - (_WKWebExtensionAction *)actionForTab:(id<_WKWebExtensionTab>)tab
@@ -1084,6 +1090,10 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(_WKWe
 - (BOOL)hasContentModificationRules
 {
     return NO;
+}
+
+- (void)loadBackgroundContentWithCompletionHandler:(void (^)(NSError *error))completionHandler
+{
 }
 
 - (_WKWebExtensionAction *)actionForTab:(id<_WKWebExtensionTab>)tab NS_SWIFT_NAME(action(for:))

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -641,8 +641,6 @@ static _WKWebExtensionError toAPI(WebExtension::Error error)
         return _WKWebExtensionErrorInvalidManifestEntry;
     case WebExtension::Error::InvalidBackgroundPersistence:
         return _WKWebExtensionErrorInvalidBackgroundPersistence;
-    case WebExtension::Error::BackgroundContentFailedToLoad:
-        return _WKWebExtensionErrorBackgroundContentFailedToLoad;
     case WebExtension::Error::InvalidResourceCodeSignature:
         return _WKWebExtensionErrorInvalidResourceCodeSignature;
     }
@@ -754,10 +752,6 @@ ALLOW_NONLITERAL_FORMAT_END
 
     case Error::InvalidBackgroundPersistence:
         localizedDescription = WEB_UI_STRING("Invalid `persistent` manifest entry.", "WKWebExtensionErrorInvalidBackgroundPersistence description");
-        break;
-
-    case Error::BackgroundContentFailedToLoad:
-        localizedDescription = WEB_UI_STRING("The background content failed to load due to an error.", "WKWebExtensionErrorBackgroundContentFailedToLoad description");
         break;
 
     case Error::InvalidResourceCodeSignature:

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -106,7 +106,6 @@ public:
         InvalidURLOverrides,
         InvalidVersion,
         InvalidWebAccessibleResources,
-        BackgroundContentFailedToLoad,
     };
 
     enum class InjectionTime : uint8_t {

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -227,6 +227,8 @@ public:
         AlreadyLoaded,
         NotLoaded,
         BaseURLAlreadyInUse,
+        NoBackgroundContent,
+        BackgroundContentFailedToLoad,
     };
 
     enum class PermissionState : int8_t {
@@ -459,6 +461,8 @@ public:
     WKWebView *backgroundWebView() const { return m_backgroundWebView.get(); }
     bool safeToLoadBackgroundContent() const { return m_safeToLoadBackgroundContent; }
 
+    NSError *backgroundContentLoadError() const { return m_backgroundContentLoadError.get(); }
+
     NSString *backgroundWebViewInspectionName();
     void setBackgroundWebViewInspectionName(const String&);
 
@@ -499,6 +503,8 @@ public:
     WebsiteDataStore* websiteDataStore(std::optional<PAL::SessionID> = std::nullopt) const;
 
     void cookiesDidChange(API::HTTPCookieStore&);
+
+    void loadBackgroundContent(CompletionHandler<void(NSError *)>&&);
 
     void wakeUpBackgroundContentIfNecessary(CompletionHandler<void()>&&);
     void wakeUpBackgroundContentIfNecessaryToFireEvents(EventListenerTypeSet&&, CompletionHandler<void()>&&);
@@ -889,6 +895,7 @@ private:
     String m_previousVersion;
 
     RetainPtr<WKWebView> m_backgroundWebView;
+    RetainPtr<NSError> m_backgroundContentLoadError;
     RetainPtr<_WKWebExtensionContextDelegate> m_delegate;
 
     String m_backgroundWebViewInspectionName;


### PR DESCRIPTION
#### 10d19200a9d72b72e9d2a0a149dc35da825df3aa
<pre>
Add support for loading the background content for a _WKWebExtensionContext.
<a href="https://webkit.org/b/273269">https://webkit.org/b/273269</a>
<a href="https://rdar.apple.com/126994428">rdar://126994428</a>

Reviewed by Brian Weinstein.

Added a loadBackgroundContentWithCompletionHandler: method, and changed how the background
load errors are created. This is a step in the direction of having WebExtensionContext
track runtime errors separate from WebExtension (see bug 270580).

* Source/WebCore/en.lproj/Localizable.strings: Updated with update-webkit-localizable-strings.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h:
(NS_ERROR_ENUM): Removed _WKWebExtensionErrorBackgroundContentFailedToLoad.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h:
(NS_ERROR_ENUM): Added _WKWebExtensionContextErrorNoBackgroundContent and
_WKWebExtensionContextErrorBackgroundContentFailedToLoad.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext loadBackgroundContentWithCompletionHandler:]): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::toAPI): Removed BackgroundContentFailedToLoad.
(WebKit::WebExtension::createError): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::toAPI): Added new error codes.
(WebKit::WebExtensionContext::createError): Ditto.
(WebKit::WebExtensionContext::loadBackgroundContent): Added.
(WebKit::WebExtensionContext::loadBackgroundWebView): Set m_backgroundContentLoadError
instead of recording it on the WebExtension.
(WebKit::WebExtensionContext::didFailNavigation): Ditto.
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::backgroundContentLoadError const): Added.

Canonical link: <a href="https://commits.webkit.org/277998@main">https://commits.webkit.org/277998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5bbcd19a985ed048831909545cb80fdeae4b6bfc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49190 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28472 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/52217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51987 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/45290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26075 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51186 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26032 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/52217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21312 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/23486 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/52217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7513 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/52217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53898 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24272 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/25545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/52217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/26376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7050 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/25266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->