### PR TITLE
Add a way to exclude certain game controllers from Gamepad API

### DIFF
--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm
@@ -39,6 +39,19 @@
 
 #import "GameControllerSoftLink.h"
 
+#if USE(APPLE_INTERNAL_SDK)
+#import <WebKitAdditions/GameControllerAdditions.mm>
+#else
+namespace WebCore {
+
+static bool shouldExcludeGameController(GCController *)
+{
+    return false;
+}
+
+}
+#endif
+
 namespace WebCore {
 
 #if !HAVE(GCCONTROLLER_HID_DEVICE_CHECK)
@@ -108,6 +121,8 @@ void GameControllerGamepadProvider::controllerDidConnect(GCController *controlle
     }
 #endif // HAVE(MULTIGAMEPADPROVIDER_SUPPORT) && !HAVE(GCCONTROLLER_HID_DEVICE_CHECK)
 
+    if (shouldExcludeGameController(controller))
+        return;
 
     // When initially starting up the GameController framework machinery,
     // we might get the connection notification for an already-connected controller.


### PR DESCRIPTION
#### c8371eaa79e62ee1f18df46b5c5450e1e8d31e27
<pre>
Add a way to exclude certain game controllers from Gamepad API
<a href="https://bugs.webkit.org/show_bug.cgi?id=273274">https://bugs.webkit.org/show_bug.cgi?id=273274</a>
<a href="https://rdar.apple.com/127075441">rdar://127075441</a>

Reviewed by Brady Eidson.

* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm:
(WebCore::shouldExcludeGameController):
(WebCore::GameControllerGamepadProvider::controllerDidConnect):

Canonical link: <a href="https://commits.webkit.org/278040@main">https://commits.webkit.org/278040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5665db13599523b85e066b74067398ba45131f91

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52303 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52075 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45375 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51576 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26174 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40256 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51373 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26102 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42440 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21373 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23554 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43616 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7617 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45476 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44124 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53984 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24354 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20540 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47567 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25626 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42642 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46558 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10836 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26465 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25348 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->