### PR TITLE
[JSC] Remove use of Committed / Primordial state of AccessCase and cloning cases only when it is Generated and having CallLinkInfo

### DIFF
--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -317,7 +317,6 @@ Vector<WatchpointSet*, 2> AccessCase::commit(VM& vm)
     // It's fine to commit something that is already committed. That arises when we switch to using
     // newly allocated watchpoints. When it happens, it's not efficient - but we think that's OK
     // because most AccessCases have no extra watchpoints anyway.
-    RELEASE_ASSERT(m_state == Primordial || m_state == Committed);
 
     Vector<WatchpointSet*, 2> result;
     Structure* structure = this->structure();

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -682,6 +682,128 @@ static bool isMegamorphicById(AccessCase::AccessType type)
     return false;
 }
 
+static bool doesJSCalls(AccessCase::AccessType type)
+{
+    switch (type) {
+    case AccessCase::Getter:
+    case AccessCase::Setter:
+    case AccessCase::ProxyObjectHas:
+    case AccessCase::ProxyObjectLoad:
+    case AccessCase::ProxyObjectStore:
+    case AccessCase::IndexedProxyObjectLoad:
+        return true;
+
+    case AccessCase::LoadMegamorphic:
+    case AccessCase::StoreMegamorphic:
+    case AccessCase::InMegamorphic:
+    case AccessCase::Load:
+    case AccessCase::Transition:
+    case AccessCase::Delete:
+    case AccessCase::DeleteNonConfigurable:
+    case AccessCase::DeleteMiss:
+    case AccessCase::Replace:
+    case AccessCase::Miss:
+    case AccessCase::GetGetter:
+    case AccessCase::CheckPrivateBrand:
+    case AccessCase::SetPrivateBrand:
+    case AccessCase::IndexedNoIndexingMiss:
+    case AccessCase::CustomValueGetter:
+    case AccessCase::CustomAccessorGetter:
+    case AccessCase::CustomValueSetter:
+    case AccessCase::CustomAccessorSetter:
+    case AccessCase::IntrinsicGetter:
+    case AccessCase::ModuleNamespaceLoad:
+    case AccessCase::InstanceOfHit:
+    case AccessCase::InstanceOfMiss:
+    case AccessCase::InHit:
+    case AccessCase::InMiss:
+    case AccessCase::IndexedNoIndexingInMiss:
+    case AccessCase::ArrayLength:
+    case AccessCase::StringLength:
+    case AccessCase::DirectArgumentsLength:
+    case AccessCase::ScopedArgumentsLength:
+    case AccessCase::IndexedMegamorphicLoad:
+    case AccessCase::IndexedMegamorphicStore:
+    case AccessCase::IndexedInt32Load:
+    case AccessCase::IndexedDoubleLoad:
+    case AccessCase::IndexedContiguousLoad:
+    case AccessCase::IndexedArrayStorageLoad:
+    case AccessCase::IndexedScopedArgumentsLoad:
+    case AccessCase::IndexedDirectArgumentsLoad:
+    case AccessCase::IndexedTypedArrayInt8Load:
+    case AccessCase::IndexedTypedArrayUint8Load:
+    case AccessCase::IndexedTypedArrayUint8ClampedLoad:
+    case AccessCase::IndexedTypedArrayInt16Load:
+    case AccessCase::IndexedTypedArrayUint16Load:
+    case AccessCase::IndexedTypedArrayInt32Load:
+    case AccessCase::IndexedTypedArrayUint32Load:
+    case AccessCase::IndexedTypedArrayFloat32Load:
+    case AccessCase::IndexedTypedArrayFloat64Load:
+    case AccessCase::IndexedResizableTypedArrayInt8Load:
+    case AccessCase::IndexedResizableTypedArrayUint8Load:
+    case AccessCase::IndexedResizableTypedArrayUint8ClampedLoad:
+    case AccessCase::IndexedResizableTypedArrayInt16Load:
+    case AccessCase::IndexedResizableTypedArrayUint16Load:
+    case AccessCase::IndexedResizableTypedArrayInt32Load:
+    case AccessCase::IndexedResizableTypedArrayUint32Load:
+    case AccessCase::IndexedResizableTypedArrayFloat32Load:
+    case AccessCase::IndexedResizableTypedArrayFloat64Load:
+    case AccessCase::IndexedInt32Store:
+    case AccessCase::IndexedDoubleStore:
+    case AccessCase::IndexedContiguousStore:
+    case AccessCase::IndexedArrayStorageStore:
+    case AccessCase::IndexedTypedArrayInt8Store:
+    case AccessCase::IndexedTypedArrayUint8Store:
+    case AccessCase::IndexedTypedArrayUint8ClampedStore:
+    case AccessCase::IndexedTypedArrayInt16Store:
+    case AccessCase::IndexedTypedArrayUint16Store:
+    case AccessCase::IndexedTypedArrayInt32Store:
+    case AccessCase::IndexedTypedArrayUint32Store:
+    case AccessCase::IndexedTypedArrayFloat32Store:
+    case AccessCase::IndexedTypedArrayFloat64Store:
+    case AccessCase::IndexedResizableTypedArrayInt8Store:
+    case AccessCase::IndexedResizableTypedArrayUint8Store:
+    case AccessCase::IndexedResizableTypedArrayUint8ClampedStore:
+    case AccessCase::IndexedResizableTypedArrayInt16Store:
+    case AccessCase::IndexedResizableTypedArrayUint16Store:
+    case AccessCase::IndexedResizableTypedArrayInt32Store:
+    case AccessCase::IndexedResizableTypedArrayUint32Store:
+    case AccessCase::IndexedResizableTypedArrayFloat32Store:
+    case AccessCase::IndexedResizableTypedArrayFloat64Store:
+    case AccessCase::IndexedStringLoad:
+    case AccessCase::IndexedInt32InHit:
+    case AccessCase::IndexedDoubleInHit:
+    case AccessCase::IndexedContiguousInHit:
+    case AccessCase::IndexedArrayStorageInHit:
+    case AccessCase::IndexedScopedArgumentsInHit:
+    case AccessCase::IndexedDirectArgumentsInHit:
+    case AccessCase::IndexedTypedArrayInt8InHit:
+    case AccessCase::IndexedTypedArrayUint8InHit:
+    case AccessCase::IndexedTypedArrayUint8ClampedInHit:
+    case AccessCase::IndexedTypedArrayInt16InHit:
+    case AccessCase::IndexedTypedArrayUint16InHit:
+    case AccessCase::IndexedTypedArrayInt32InHit:
+    case AccessCase::IndexedTypedArrayUint32InHit:
+    case AccessCase::IndexedTypedArrayFloat32InHit:
+    case AccessCase::IndexedTypedArrayFloat64InHit:
+    case AccessCase::IndexedResizableTypedArrayInt8InHit:
+    case AccessCase::IndexedResizableTypedArrayUint8InHit:
+    case AccessCase::IndexedResizableTypedArrayUint8ClampedInHit:
+    case AccessCase::IndexedResizableTypedArrayInt16InHit:
+    case AccessCase::IndexedResizableTypedArrayUint16InHit:
+    case AccessCase::IndexedResizableTypedArrayInt32InHit:
+    case AccessCase::IndexedResizableTypedArrayUint32InHit:
+    case AccessCase::IndexedResizableTypedArrayFloat32InHit:
+    case AccessCase::IndexedResizableTypedArrayFloat64InHit:
+    case AccessCase::IndexedStringInHit:
+    case AccessCase::IndexedMegamorphicIn:
+    case AccessCase::InstanceOfGeneric:
+        return false;
+    }
+
+    return false;
+}
+
 void InlineCacheCompiler::installWatchpoint(CodeBlock* codeBlock, const ObjectPropertyCondition& condition)
 {
     WatchpointsOnStructureStubInfo::ensureReferenceAndInstallWatchpoint(m_watchpoints, codeBlock, m_stubInfo, condition);
@@ -1408,7 +1530,6 @@ void InlineCacheCompiler::generateWithGuard(AccessCase& accessCase, CCallHelpers
 
     accessCase.checkConsistency(*m_stubInfo);
 
-    RELEASE_ASSERT(accessCase.m_state == AccessCase::Committed);
     accessCase.m_state = AccessCase::Generated;
 
     JSGlobalObject* globalObject = m_globalObject;
@@ -2605,7 +2726,6 @@ void InlineCacheCompiler::generateWithGuard(AccessCase& accessCase, CCallHelpers
 
 void InlineCacheCompiler::generate(AccessCase& accessCase)
 {
-    RELEASE_ASSERT(accessCase.state() == AccessCase::Committed);
     RELEASE_ASSERT(m_stubInfo->hasConstantIdentifier);
     accessCase.m_state = AccessCase::Generated;
 
@@ -3960,16 +4080,9 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
     // to be unmutated. For sure, we want it to hang onto any data structures that may be referenced
     // from the code of the current stub (aka previous).
     PolymorphicAccess::ListType cases;
+    cases.reserveInitialCapacity(poly.m_list.size());
     unsigned srcIndex = 0;
-    unsigned dstIndex = 0;
-    while (srcIndex < poly.m_list.size()) {
-        RefPtr<AccessCase> someCase = WTFMove(poly.m_list[srcIndex++]);
-
-        // If the case had been generated, then we have to keep the original in m_list in case we
-        // fail to regenerate. That case may have data structures that are used by the code that it
-        // had generated. If the case had not been generated, then we want to remove it from m_list.
-        bool isGenerated = someCase->state() == AccessCase::Generated;
-
+    for (auto& someCase : poly.m_list) {
         [&] () {
             if (!someCase->couldStillSucceed())
                 return;
@@ -3991,16 +4104,17 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
                     return;
             }
 
-            if (isGenerated)
+            // If the case had been generated, then we have to keep the original in m_list in case we
+            // fail to regenerate. That case may have data structures that are used by the code that it
+            // had generated. If the case had not been generated, then we want to remove it from m_list.
+            bool isGeneratedAndDoesJSCalls = someCase->state() == AccessCase::Generated && doesJSCalls(someCase->type());
+            if (isGeneratedAndDoesJSCalls)
                 cases.append(someCase->clone());
             else
-                cases.append(WTFMove(someCase));
+                cases.append(someCase);
         }();
-
-        if (isGenerated)
-            poly.m_list[dstIndex++] = WTFMove(someCase);
+        ++srcIndex;
     }
-    poly.m_list.shrink(dstIndex);
 
     bool generatedMegamorphicCode = false;
 
@@ -4009,8 +4123,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
     if (cases.size() >= Options::maxAccessVariantListSize() || m_stubInfo->canBeMegamorphic) {
         switch (m_stubInfo->accessType) {
         case AccessType::InstanceOf: {
-            while (!cases.isEmpty())
-                poly.m_list.append(cases.takeLast());
+            cases.shrink(0);
             cases.append(AccessCase::create(vm(), codeBlock, AccessCase::InstanceOfGeneric, nullptr));
             generatedMegamorphicCode = true;
             break;
@@ -4043,8 +4156,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
 #endif
 
             if (allAreSimpleLoadOrMiss) {
-                while (!cases.isEmpty())
-                    poly.m_list.append(cases.takeLast());
+                cases.shrink(0);
                 cases.append(AccessCase::create(vm(), codeBlock, AccessCase::LoadMegamorphic, identifier));
                 generatedMegamorphicCode = true;
             }
@@ -4075,8 +4187,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
                 allAreSimpleLoadOrMiss = false;
 
             if (allAreSimpleLoadOrMiss) {
-                while (!cases.isEmpty())
-                    poly.m_list.append(cases.takeLast());
+                cases.shrink(0);
                 cases.append(AccessCase::create(vm(), codeBlock, AccessCase::IndexedMegamorphicLoad, nullptr));
                 generatedMegamorphicCode = true;
             }
@@ -4114,8 +4225,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
 #endif
 
             if (allAreSimpleReplaceOrTransition) {
-                while (!cases.isEmpty())
-                    poly.m_list.append(cases.takeLast());
+                cases.shrink(0);
                 cases.append(AccessCase::create(vm(), codeBlock, AccessCase::StoreMegamorphic, identifier));
                 generatedMegamorphicCode = true;
             }
@@ -4148,8 +4258,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
 #endif
 
             if (allAreSimpleReplaceOrTransition) {
-                while (!cases.isEmpty())
-                    poly.m_list.append(cases.takeLast());
+                cases.shrink(0);
                 cases.append(AccessCase::create(vm(), codeBlock, AccessCase::IndexedMegamorphicStore, nullptr));
                 generatedMegamorphicCode = true;
             }
@@ -4182,8 +4291,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
 #endif
 
             if (allAreSimpleHitOrMiss) {
-                while (!cases.isEmpty())
-                    poly.m_list.append(cases.takeLast());
+                cases.shrink(0);
                 cases.append(AccessCase::create(vm(), codeBlock, AccessCase::InMegamorphic, identifier));
                 generatedMegamorphicCode = true;
             }
@@ -4211,8 +4319,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
 #endif
 
             if (allAreSimpleHitOrMiss) {
-                while (!cases.isEmpty())
-                    poly.m_list.append(cases.takeLast());
+                cases.shrink(0);
                 cases.append(AccessCase::create(vm(), codeBlock, AccessCase::IndexedMegamorphicIn, nullptr));
                 generatedMegamorphicCode = true;
             }
@@ -4297,17 +4404,8 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
             scratchFPR = allocator.allocateScratchFPR();
 
         doesCalls |= entry->doesCalls(vm(), &cellsToMark);
+        doesJSCalls |= JSC::doesJSCalls(entry->type());
         switch (entry->type()) {
-        case AccessCase::Getter:
-        case AccessCase::Setter:
-        case AccessCase::ProxyObjectHas:
-        case AccessCase::ProxyObjectLoad:
-        case AccessCase::ProxyObjectStore:
-        case AccessCase::IndexedProxyObjectLoad:
-            // Getter / Setter / ProxyObjectLoad / ProxyObjectStore / IndexedProxyObjectLoad rely on stack-pointer adjustment, which is tied to the linked CodeBlock, which makes this code unshareable.
-            canBeShared = false;
-            doesJSCalls = true;
-            break;
         case AccessCase::CustomValueGetter:
         case AccessCase::CustomAccessorGetter:
         case AccessCase::CustomValueSetter:
@@ -4343,7 +4441,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
     m_scratchFPR = scratchFPR.value_or(InvalidFPRReg);
     m_doesCalls = doesCalls;
     m_doesJSCalls = doesJSCalls;
-    if (needsSymbolPropertyCheck || needsStringPropertyCheck || needsInt32PropertyCheck)
+    if (needsSymbolPropertyCheck || needsStringPropertyCheck || needsInt32PropertyCheck || doesJSCalls)
         canBeShared = false;
 
     CCallHelpers jit(codeBlock);


### PR DESCRIPTION
#### 103f05d044f0b05b0497833dba83a642526c229a
<pre>
[JSC] Remove use of Committed / Primordial state of AccessCase and cloning cases only when it is Generated and having CallLinkInfo
<a href="https://bugs.webkit.org/show_bug.cgi?id=273276">https://bugs.webkit.org/show_bug.cgi?id=273276</a>
<a href="https://rdar.apple.com/127076206">rdar://127076206</a>

Reviewed by Keith Miller.

This is a change towards making AccessCase just a constant feedback information instead of having mutating state.
This patch removes effective use of Committed / Primordial state since we do not care about them. Right now CallLinkInfo is tied to
AccessCase so we still need to know about Generated state and we need to clone it. But we don&apos;t need to clone AccessCase when it doesn&apos;t
have CallLinkInfo inside it. So this patch removes this cloning for AccessCases not holding CallLinkInfo*.

This is paving a path towards <a href="https://bugs.webkit.org/show_bug.cgi?id=156456.">https://bugs.webkit.org/show_bug.cgi?id=156456.</a> Once CallLinkInfo* gets wiped from AccessCase, we can completely
remove (1) Generated state since AccessCase now just becomes immutable data and (2) cloning feature since we no longer need this.

* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::commit):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::doesJSCalls):
(JSC::InlineCacheCompiler::generateWithGuard):
(JSC::InlineCacheCompiler::generate):
(JSC::InlineCacheCompiler::regenerate):

Canonical link: <a href="https://commits.webkit.org/278051@main">https://commits.webkit.org/278051@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/518aeaca5604c3bdf4b3d741b4d8f676a57ad876

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49261 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52057 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45364 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34556 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26163 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40238 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26087 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42435 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21361 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23540 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43611 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7583 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/42563 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45463 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44118 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53968 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/48750 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); jscore-tests (cancelled)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24342 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20529 "Found 1 new test failure: imported/w3c/web-platform-tests/html/canvas/offscreen/manual/filter/offscreencanvas.filter.w.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47558 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25615 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42637 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46560 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26453 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56244 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7087 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25337 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11552 "Found 4 new JSC stress test failures: microbenchmarks/delete-property-keeps-cacheable-structure.js.dfg-eager, microbenchmarks/delete-property-keeps-cacheable-structure.js.dfg-eager-no-cjit-validate, microbenchmarks/getter-richards.js.default, microbenchmarks/getter-richards.js.no-cjit (failure)") | 
<!--EWS-Status-Bubble-End-->