### PR TITLE
Reduce use of `const char*` in the code base

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerCodeRef.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerCodeRef.h
@@ -152,7 +152,7 @@ public:
     
     void dump(PrintStream& out) const
     {
-        m_codePtr.dumpWithName("CodeRef", out);
+        m_codePtr.dumpWithName("CodeRef"_s, out);
     }
 
     static ptrdiff_t offsetOfCodePtr() { return OBJECT_OFFSETOF(MacroAssemblerCodeRef, m_codePtr); }

--- a/Source/JavaScriptCore/ftl/FTLCompile.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCompile.cpp
@@ -232,7 +232,7 @@ void compile(State& state, Safepoint::Result& safepointResult)
         graph.ensureSSADominators();
         graph.ensureSSANaturalLoops();
 
-        const char* prefix = "    ";
+        constexpr auto prefix = "    "_s;
 
         DumpContext dumpContext;
         StringPrintStream out;

--- a/Source/WTF/wtf/CodePtr.cpp
+++ b/Source/WTF/wtf/CodePtr.cpp
@@ -30,17 +30,17 @@
 
 namespace WTF {
 
-void CodePtrBase::dumpWithName(void* executableAddress, void* dataLocation, const char* name, PrintStream& out)
+void CodePtrBase::dumpWithName(void* executableAddress, void* dataLocation, ASCIILiteral name, PrintStream& out)
 {
     if (!executableAddress) {
-        out.print(name, "(null)");
+        out.print(name, "(null)"_s);
         return;
     }
     if (executableAddress == dataLocation) {
-        out.print(name, "(", RawPointer(executableAddress), ")");
+        out.print(name, "("_s, RawPointer(executableAddress), ")"_s);
         return;
     }
-    out.print(name, "(executable = ", RawPointer(executableAddress), ", dataLocation = ", RawPointer(dataLocation), ")");
+    out.print(name, "(executable = "_s, RawPointer(executableAddress), ", dataLocation = "_s, RawPointer(dataLocation), ")"_s);
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/CodePtr.h
+++ b/Source/WTF/wtf/CodePtr.h
@@ -58,7 +58,7 @@ public:
     friend bool operator==(CodePtrBase, CodePtrBase) = default;
 
 protected:
-    WTF_EXPORT_PRIVATE static void dumpWithName(void* executableAddress, void* dataLocation, const char* name, PrintStream& out);
+    WTF_EXPORT_PRIVATE static void dumpWithName(void* executableAddress, void* dataLocation, ASCIILiteral name, PrintStream& out);
 };
 
 template<PtrTag tag, FunctionAttributes attr = FunctionAttributes::None>
@@ -204,7 +204,7 @@ public:
     CodePtr& operator+=(size_t sizeInBytes) { return *this = *this + sizeInBytes; }
     CodePtr& operator-=(size_t sizeInBytes) { return *this = *this - sizeInBytes; }
 
-    void dumpWithName(const char* name, PrintStream& out) const
+    void dumpWithName(ASCIILiteral name, PrintStream& out) const
     {
         if (m_value)
             CodePtrBase::dumpWithName(taggedPtr(), dataLocation(), name, out);
@@ -212,7 +212,7 @@ public:
             CodePtrBase::dumpWithName(nullptr, nullptr, name, out);
     }
 
-    void dump(PrintStream& out) const { dumpWithName("CodePtr", out); }
+    void dump(PrintStream& out) const { dumpWithName("CodePtr"_s, out); }
 
     enum EmptyValueTag { EmptyValue };
     enum DeletedValueTag { DeletedValue };

--- a/Source/WTF/wtf/Dominators.h
+++ b/Source/WTF/wtf/Dominators.h
@@ -104,9 +104,9 @@ public:
                         continue;
                 
                     if (dominates(fromBlock, toBlock) != naiveDominates(fromBlock, toBlock))
-                        context.reportError(fromBlock, toBlock, "Range-based domination check is broken");
+                        context.reportError(fromBlock, toBlock, "Range-based domination check is broken"_s);
                     if (dominates(fromBlock, toBlock) != context.naiveDominators.dominates(fromBlock, toBlock))
-                        context.reportError(fromBlock, toBlock, "Lengauer-Tarjan domination is broken");
+                        context.reportError(fromBlock, toBlock, "Lengauer-Tarjan domination is broken"_s);
                 }
             }
         
@@ -620,7 +620,7 @@ private:
         {
         }
     
-        void reportError(typename Graph::Node from, typename Graph::Node to, const char* message)
+        void reportError(typename Graph::Node from, typename Graph::Node to, ASCIILiteral message)
         {
             Error error;
             error.from = from;
@@ -681,7 +681,7 @@ private:
 
             typename Graph::Node from;
             typename Graph::Node to;
-            const char* message;
+            ASCIILiteral message;
         };
     
         Vector<Error> errors;

--- a/Source/WTF/wtf/Gigacage.h
+++ b/Source/WTF/wtf/Gigacage.h
@@ -27,6 +27,7 @@
 
 #include <wtf/FastMalloc.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/text/ASCIILiteral.h>
 
 #if USE(SYSTEM_MALLOC)
 #define GIGACAGE_ENABLED 0
@@ -51,16 +52,16 @@ inline void removePrimitiveDisableCallback(void (*)(void*), void*) { }
 
 inline void forbidDisablingPrimitiveGigacage() { }
 
-ALWAYS_INLINE const char* name(Kind kind)
+ALWAYS_INLINE ASCIILiteral name(Kind kind)
 {
     switch (kind) {
     case Primitive:
-        return "Primitive";
+        return "Primitive"_s;
     case NumberOfKinds:
         break;
     }
     RELEASE_ASSERT_NOT_REACHED();
-    return nullptr;
+    return { };
 }
 
 ALWAYS_INLINE bool contains(const void*) { return false; }

--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -99,15 +99,15 @@ void MemoryPressureHandler::setShouldUsePeriodicMemoryMonitor(bool use)
 }
 
 #if !RELEASE_LOG_DISABLED
-static const char* toString(MemoryUsagePolicy policy)
+static ASCIILiteral toString(MemoryUsagePolicy policy)
 {
     switch (policy) {
-    case MemoryUsagePolicy::Unrestricted: return "Unrestricted";
-    case MemoryUsagePolicy::Conservative: return "Conservative";
-    case MemoryUsagePolicy::Strict: return "Strict";
+    case MemoryUsagePolicy::Unrestricted: return "Unrestricted"_s;
+    case MemoryUsagePolicy::Conservative: return "Conservative"_s;
+    case MemoryUsagePolicy::Strict: return "Strict"_s;
     }
     ASSERT_NOT_REACHED();
-    return "";
+    return ""_s;
 }
 #endif
 
@@ -211,7 +211,7 @@ void MemoryPressureHandler::setMemoryUsagePolicyBasedOnFootprint(size_t footprin
     if (newPolicy == m_memoryUsagePolicy)
         return;
 
-    RELEASE_LOG(MemoryPressure, "Memory usage policy changed: %s -> %s", toString(m_memoryUsagePolicy), toString(newPolicy));
+    RELEASE_LOG(MemoryPressure, "Memory usage policy changed: %s -> %s", toString(m_memoryUsagePolicy).characters(), toString(newPolicy).characters());
     m_memoryUsagePolicy = newPolicy;
     memoryPressureStatusChanged();
 }

--- a/Source/WTF/wtf/SingleRootGraph.h
+++ b/Source/WTF/wtf/SingleRootGraph.h
@@ -39,7 +39,7 @@ class SingleRootGraphNode {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     // We use "#root" to refer to the synthetic root we have created.
-    static const char* rootName() { return "#root"; };
+    static ASCIILiteral rootName() { return "#root"_s; };
 
     SingleRootGraphNode(typename Graph::Node node = typename Graph::Node())
         : m_node(node)
@@ -105,7 +105,7 @@ public:
     void dump(PrintStream& out) const
     {
         if (m_hasRoot)
-            out.print(Node::rootName(), " ");
+            out.print(Node::rootName(), " "_s);
         out.print(m_set);
     }
     

--- a/Source/WTF/wtf/StringHashDumpContext.h
+++ b/Source/WTF/wtf/StringHashDumpContext.h
@@ -76,7 +76,7 @@ public:
     {
         out.print(prefix);
         T::dumpContextHeader(out);
-        out.print("\n");
+        out.print("\n"_s);
         
         Vector<CString> keys;
         unsigned maxKeySize = 0;
@@ -92,12 +92,12 @@ public:
         
         for (unsigned i = 0; i < keys.size(); ++i) {
             const T* value = m_backwardMap.get(keys[i]);
-            out.print(prefix, "    ");
+            out.print(prefix, "    "_s);
             CString briefString = brief(value, keys[i]);
             out.print(briefString);
             for (unsigned n = briefString.length(); n < maxKeySize; ++n)
-                out.print(" ");
-            out.print(" = ", *value, "\n");
+                out.print(" "_s);
+            out.print(" = "_s, *value, "\n"_s);
         }
     }
     

--- a/Source/WTF/wtf/SuspendableWorkQueue.cpp
+++ b/Source/WTF/wtf/SuspendableWorkQueue.cpp
@@ -42,19 +42,19 @@ SuspendableWorkQueue::SuspendableWorkQueue(ASCIILiteral name, QOS qos, ShouldLog
     ASSERT(isMainThread());
 }
 
-const char* SuspendableWorkQueue::stateString(State state)
+ASCIILiteral SuspendableWorkQueue::stateString(State state)
 {
     switch (state) {
     case State::Running:
-        return "Running";
+        return "Running"_s;
     case State::WillSuspend:
-        return "WillSuspend";
+        return "WillSuspend"_s;
     case State::Suspended:
-        return "Suspended";
+        return "Suspended"_s;
     }
 
     ASSERT_NOT_REACHED();
-    return nullptr;
+    return { };
 }
 
 void SuspendableWorkQueue::suspend(Function<void()>&& suspendFunction, CompletionHandler<void()>&& completionHandler)
@@ -62,7 +62,7 @@ void SuspendableWorkQueue::suspend(Function<void()>&& suspendFunction, Completio
     ASSERT(isMainThread());
     Locker suspensionLocker { m_suspensionLock };
 
-    RELEASE_LOG_IF(m_shouldLog, SuspendableWorkQueue, "%p - SuspendableWorkQueue::suspend current state %" PUBLIC_LOG_STRING, this, stateString(m_state));
+    RELEASE_LOG_IF(m_shouldLog, SuspendableWorkQueue, "%p - SuspendableWorkQueue::suspend current state %" PUBLIC_LOG_STRING, this, stateString(m_state).characters());
     if (m_state == State::Suspended)
         return completionHandler();
 
@@ -84,7 +84,7 @@ void SuspendableWorkQueue::resume()
     ASSERT(isMainThread());
     Locker suspensionLocker { m_suspensionLock };
 
-    RELEASE_LOG_IF(m_shouldLog, SuspendableWorkQueue, "%p - SuspendableWorkQueue::resume current state %" PUBLIC_LOG_STRING, this, stateString(m_state));
+    RELEASE_LOG_IF(m_shouldLog, SuspendableWorkQueue, "%p - SuspendableWorkQueue::resume current state %" PUBLIC_LOG_STRING, this, stateString(m_state).characters());
     if (m_state == State::Running)
         return;
 

--- a/Source/WTF/wtf/SuspendableWorkQueue.h
+++ b/Source/WTF/wtf/SuspendableWorkQueue.h
@@ -54,7 +54,7 @@ private:
     using WorkQueue::runLoop;
 #endif
     enum class State : uint8_t { Running, WillSuspend, Suspended };
-    static const char* stateString(State);
+    static ASCIILiteral stateString(State);
 
     Lock m_suspensionLock;
     Condition m_suspensionCondition;

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -2925,9 +2925,7 @@ std::optional<KeyValuePair<String, String>> URLParser::parseQueryNameAndValue(St
 static void serializeURLEncodedForm(const String& input, Vector<LChar>& output)
 {
     auto utf8 = input.utf8(StrictConversion);
-    const char* data = utf8.data();
-    for (size_t i = 0; i < utf8.length(); ++i) {
-        const char byte = data[i];
+    for (char byte : utf8.span()) {
         if (byte == 0x20)
             output.append(0x2B);
         else if (byte == 0x2A

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
@@ -181,9 +181,9 @@ void UniqueIDBDatabase::openDatabaseConnection(IDBConnectionToClient& connection
     handleDatabaseOperations();
 }
 
-static inline String quotaErrorMessageName(const char* taskName)
+static inline String quotaErrorMessageName(ASCIILiteral taskName)
 {
-    return makeString("Failed to ", taskName, " in database because not enough space for domain");
+    return makeString("Failed to "_s, taskName, " in database because not enough space for domain"_s);
 }
 
 void UniqueIDBDatabase::performCurrentOpenOperation()
@@ -226,7 +226,7 @@ void UniqueIDBDatabase::performCurrentOpenOperationAfterSpaceCheck(bool isGrante
         if (!m_manager)
             backingStoreOpenError = IDBError { ExceptionCode::InvalidStateError };
         else if (!isGranted)
-            backingStoreOpenError = IDBError { ExceptionCode::QuotaExceededError, quotaErrorMessageName("OpenBackingStore") };
+            backingStoreOpenError = IDBError { ExceptionCode::QuotaExceededError, quotaErrorMessageName("OpenBackingStore"_s) };
         else {
             m_backingStore = m_manager->createBackingStore(m_identifier);
             IDBDatabaseInfo databaseInfo;
@@ -598,7 +598,7 @@ void UniqueIDBDatabase::createObjectStore(UniqueIDBDatabaseTransaction& transact
     }
 
     if (spaceCheckResult != SpaceCheckResult::Pass) {
-        callback(IDBError { ExceptionCode::QuotaExceededError, quotaErrorMessageName("CreateObjectStore") });
+        callback(IDBError { ExceptionCode::QuotaExceededError, quotaErrorMessageName("CreateObjectStore"_s) });
         return;
     }
 
@@ -667,7 +667,7 @@ void UniqueIDBDatabase::renameObjectStore(UniqueIDBDatabaseTransaction& transact
     }
 
     if (spaceCheckResult != SpaceCheckResult::Pass) {
-        callback(IDBError(ExceptionCode::QuotaExceededError, quotaErrorMessageName("RenameObjectStore")));
+        callback(IDBError(ExceptionCode::QuotaExceededError, quotaErrorMessageName("RenameObjectStore"_s)));
         return;
     }
 
@@ -733,7 +733,7 @@ void UniqueIDBDatabase::createIndex(UniqueIDBDatabaseTransaction& transaction, c
     }
 
     if (spaceCheckResult != SpaceCheckResult::Pass) {
-        callback(IDBError { ExceptionCode::QuotaExceededError, quotaErrorMessageName("CreateIndex") });
+        callback(IDBError { ExceptionCode::QuotaExceededError, quotaErrorMessageName("CreateIndex"_s) });
         return;
     }
 
@@ -814,7 +814,7 @@ void UniqueIDBDatabase::renameIndex(UniqueIDBDatabaseTransaction& transaction, u
     }
 
     if (spaceCheckResult != SpaceCheckResult::Pass) {
-        callback(IDBError { ExceptionCode::QuotaExceededError, quotaErrorMessageName("RenameIndex") });
+        callback(IDBError { ExceptionCode::QuotaExceededError, quotaErrorMessageName("RenameIndex"_s) });
         return;
     }
 
@@ -926,7 +926,7 @@ void UniqueIDBDatabase::putOrAddAfterSpaceCheck(const IDBRequestData& requestDat
     });
 
     if (spaceCheckResult != SpaceCheckResult::Pass)
-        return callback(IDBError { ExceptionCode::QuotaExceededError, quotaErrorMessageName("PutOrAdd") }, keyData);
+        return callback(IDBError { ExceptionCode::QuotaExceededError, quotaErrorMessageName("PutOrAdd"_s) }, keyData);
     // If a record already exists in store, then remove the record from store using the steps for deleting records from an object store.
     // This is important because formally deleting it from the object store also removes it from the appropriate indexes.
     IDBError error = m_backingStore->deleteRange(transactionIdentifier, objectStoreIdentifier, keyData);

--- a/Source/WebCore/Modules/push-api/PushDatabase.h
+++ b/Source/WebCore/Modules/push-api/PushDatabase.h
@@ -114,7 +114,7 @@ private:
 
     Ref<WorkQueue> m_queue;
     UniqueRef<WebCore::SQLiteDatabase> m_db;
-    HashMap<const char*, UniqueRef<WebCore::SQLiteStatement>> m_statements;
+    HashMap<ASCIILiteral, UniqueRef<WebCore::SQLiteStatement>> m_statements;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webauthn/cbor/CBORReader.cpp
+++ b/Source/WebCore/Modules/webauthn/cbor/CBORReader.cpp
@@ -51,20 +51,20 @@ uint8_t getAdditionalInfo(uint8_t initialDataByte)
 }
 
 // Error messages that correspond to each of the error codes.
-const char kNoError[] = "Successfully deserialized to a CBOR value.";
-const char kUnsupportedMajorType[] = "Unsupported major type.";
-const char kUnknownAdditionalInfo[] = "Unknown additional info format in the first byte.";
-const char kIncompleteCBORData[] = "Prematurely terminated CBOR data byte array.";
-const char kIncorrectMapKeyType[] = "Map keys other than utf-8 encoded strings are not allowed.";
-const char kTooMuchNesting[] = "Too much nesting.";
-const char kInvalidUTF8[] = "String encoding other than utf8 are not allowed.";
-const char kExtraneousData[] = "Trailing data bytes are not allowed.";
-const char kDuplicateKey[] = "Duplicate map keys are not allowed.";
-const char kMapKeyOutOfOrder[] = "Map keys must be sorted by byte length and then by byte-wise lexical order.";
-const char kNonMinimalCBOREncoding[] = "Unsigned integers must be encoded with minimum number of bytes.";
-const char kUnsupportedSimpleValue[] = "Unsupported or unassigned simple value.";
-const char kUnsupportedFloatingPointValue[] = "Floating point numbers are not supported.";
-const char kOutOfRangeIntegerValue[] = "Integer values must be between INT64_MIN and INT64_MAX.";
+constexpr auto kNoError = "Successfully deserialized to a CBOR value."_s;
+constexpr auto kUnsupportedMajorType = "Unsupported major type."_s;
+constexpr auto kUnknownAdditionalInfo = "Unknown additional info format in the first byte."_s;
+constexpr auto kIncompleteCBORData = "Prematurely terminated CBOR data byte array."_s;
+constexpr auto kIncorrectMapKeyType = "Map keys other than utf-8 encoded strings are not allowed."_s;
+constexpr auto kTooMuchNesting = "Too much nesting."_s;
+constexpr auto kInvalidUTF8 = "String encoding other than utf8 are not allowed."_s;
+constexpr auto kExtraneousData = "Trailing data bytes are not allowed."_s;
+constexpr auto kDuplicateKey = "Duplicate map keys are not allowed."_s;
+constexpr auto kMapKeyOutOfOrder = "Map keys must be sorted by byte length and then by byte-wise lexical order."_s;
+constexpr auto kNonMinimalCBOREncoding = "Unsigned integers must be encoded with minimum number of bytes."_s;
+constexpr auto kUnsupportedSimpleValue = "Unsupported or unassigned simple value."_s;
+constexpr auto kUnsupportedFloatingPointValue = "Floating point numbers are not supported."_s;
+constexpr auto kOutOfRangeIntegerValue = "Integer values must be between INT64_MIN and INT64_MAX."_s;
 
 } // namespace
 
@@ -337,7 +337,7 @@ CBORReader::DecoderError CBORReader::getErrorCode()
 }
 
 // static
-const char* CBORReader::errorCodeToString(DecoderError error)
+ASCIILiteral CBORReader::errorCodeToString(DecoderError error)
 {
     switch (error) {
     case DecoderError::CBORNoError:
@@ -370,7 +370,7 @@ const char* CBORReader::errorCodeToString(DecoderError error)
         return kOutOfRangeIntegerValue;
     default:
         ASSERT_NOT_REACHED();
-        return "Unknown error code.";
+        return "Unknown error code."_s;
     }
 }
 

--- a/Source/WebCore/Modules/webauthn/cbor/CBORReader.h
+++ b/Source/WebCore/Modules/webauthn/cbor/CBORReader.h
@@ -104,7 +104,7 @@ public:
     WEBCORE_EXPORT static std::optional<CBORValue> read(const Bytes&, DecoderError* errorCodeOut = nullptr, int maxNestingLevel = kCBORMaxDepth);
 
     // Translates errors to human-readable error messages.
-    static const char* errorCodeToString(DecoderError errorCode);
+    static ASCIILiteral errorCodeToString(DecoderError errorCode);
 
 private:
     explicit CBORReader(const Bytes&);

--- a/Source/WebCore/Modules/webauthn/fido/FidoConstants.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/FidoConstants.cpp
@@ -113,7 +113,7 @@ bool isFidoHidDeviceCommand(FidoHidDeviceCommand cmd)
     }
 }
 
-const char* publicKeyCredentialTypeToString(PublicKeyCredentialType type)
+ASCIILiteral publicKeyCredentialTypeToString(PublicKeyCredentialType type)
 {
     switch (type) {
     case PublicKeyCredentialType::PublicKey:

--- a/Source/WebCore/Modules/webauthn/fido/FidoConstants.h
+++ b/Source/WebCore/Modules/webauthn/fido/FidoConstants.h
@@ -142,20 +142,20 @@ const uint8_t kBogusChallenge[] = {
 
 // String key values for CTAP request optional parameters and
 // AuthenticatorGetInfo response.
-const char kResidentKeyMapKey[] = "rk";
-const char kUserVerificationMapKey[] = "uv";
-const char kUserPresenceMapKey[] = "up";
-const char kClientPinMapKey[] = "clientPin";
-const char kPlatformDeviceMapKey[] = "plat";
-const char kEntityIdMapKey[] = "id";
+constexpr auto kResidentKeyMapKey = "rk"_s;
+constexpr auto kUserVerificationMapKey = "uv"_s;
+constexpr auto kUserPresenceMapKey = "up"_s;
+constexpr auto kClientPinMapKey = "clientPin"_s;
+constexpr auto kPlatformDeviceMapKey = "plat"_s;
+constexpr auto kEntityIdMapKey = "id"_s;
 constexpr auto kEntityNameMapKey = "name"_s;
 constexpr auto kDisplayNameMapKey = "displayName"_s;
-const char kIconUrlMapKey[] = "icon";
-const char kCredentialTypeMapKey[] = "type";
-const char kCredentialAlgorithmMapKey[] = "alg";
+constexpr auto kIconUrlMapKey = "icon"_s;
+constexpr auto kCredentialTypeMapKey = "type"_s;
+constexpr auto kCredentialAlgorithmMapKey = "alg"_s;
 // Keys for storing credential descriptor information in CBOR map.
-const char kCredentialIdKey[] = "id";
-const char kCredentialTypeKey[] = "type";
+constexpr auto kCredentialIdKey = "id"_s;
+constexpr auto kCredentialTypeKey = "type"_s;
 
 // HID transport specific constants.
 const size_t kHidPacketSize = 64;
@@ -208,15 +208,15 @@ enum class U2fApduInstruction : uint8_t {
 
 // String key values for attestation object as a response to MakeCredential
 // request.
-const char kFormatKey[] = "fmt";
-const char kAttestationStatementKey[] = "attStmt";
-const char kAuthDataKey[] = "authData";
+constexpr auto kFormatKey = "fmt"_s;
+constexpr auto kAttestationStatementKey = "attStmt"_s;
+constexpr auto kAuthDataKey = "authData"_s;
 
 // String representation of public key credential enum.
 // https://w3c.github.io/webauthn/#credentialType
-const char kPublicKey[] = "public-key";
+constexpr auto kPublicKey = "public-key"_s;
 
-const char* publicKeyCredentialTypeToString(WebCore::PublicKeyCredentialType);
+ASCIILiteral publicKeyCredentialTypeToString(WebCore::PublicKeyCredentialType);
 
 // FIXME: Add url to the official spec once it's standardized.
 constexpr auto kCtap2Version = "FIDO_2_0"_s;

--- a/Source/WebCore/Modules/webdatabase/DatabaseTask.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseTask.cpp
@@ -69,7 +69,7 @@ void DatabaseTask::performTask()
     // Database tasks are meant to be used only once, so make sure this one hasn't been performed before.
     ASSERT(!m_complete);
 
-    LOG(StorageAPI, "Performing %s %p\n", debugTaskName(), this);
+    LOG(StorageAPI, "Performing %s %p\n", debugTaskName().characters(), this);
 
     m_database.resetAuthorizer();
 
@@ -100,9 +100,9 @@ void DatabaseOpenTask::doPerformTask()
 
 #if !LOG_DISABLED
 
-const char* DatabaseOpenTask::debugTaskName() const
+ASCIILiteral DatabaseOpenTask::debugTaskName() const
 {
-    return "DatabaseOpenTask";
+    return "DatabaseOpenTask"_s;
 }
 
 #endif
@@ -122,9 +122,9 @@ void DatabaseCloseTask::doPerformTask()
 
 #if !LOG_DISABLED
 
-const char* DatabaseCloseTask::debugTaskName() const
+ASCIILiteral DatabaseCloseTask::debugTaskName() const
 {
-    return "DatabaseCloseTask";
+    return "DatabaseCloseTask"_s;
 }
 
 #endif
@@ -161,9 +161,9 @@ void DatabaseTransactionTask::doPerformTask()
 
 #if !LOG_DISABLED
 
-const char* DatabaseTransactionTask::debugTaskName() const
+ASCIILiteral DatabaseTransactionTask::debugTaskName() const
 {
-    return "DatabaseTransactionTask";
+    return "DatabaseTransactionTask"_s;
 }
 
 #endif
@@ -185,9 +185,9 @@ void DatabaseTableNamesTask::doPerformTask()
 
 #if !LOG_DISABLED
 
-const char* DatabaseTableNamesTask::debugTaskName() const
+ASCIILiteral DatabaseTableNamesTask::debugTaskName() const
 {
-    return "DatabaseTableNamesTask";
+    return "DatabaseTableNamesTask"_s;
 }
 
 #endif

--- a/Source/WebCore/Modules/webdatabase/DatabaseTask.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseTask.h
@@ -89,7 +89,7 @@ private:
     DatabaseTaskSynchronizer* m_synchronizer;
 
 #if !LOG_DISABLED
-    virtual const char* debugTaskName() const = 0;
+    virtual ASCIILiteral debugTaskName() const = 0;
 #endif
 
 #if ASSERT_ENABLED
@@ -105,7 +105,7 @@ private:
     void doPerformTask() final;
 
 #if !LOG_DISABLED
-    const char* debugTaskName() const final;
+    ASCIILiteral debugTaskName() const final;
 #endif
 
     bool m_setVersionInNewDatabase;
@@ -120,7 +120,7 @@ private:
     void doPerformTask() final;
 
 #if !LOG_DISABLED
-    const char* debugTaskName() const final;
+    ASCIILiteral debugTaskName() const final;
 #endif
 };
 
@@ -135,7 +135,7 @@ private:
     void doPerformTask() final;
 
 #if !LOG_DISABLED
-    const char* debugTaskName() const final;
+    ASCIILiteral debugTaskName() const final;
 #endif
 
     RefPtr<SQLTransaction> m_transaction;
@@ -150,7 +150,7 @@ private:
     void doPerformTask() final;
 
 #if !LOG_DISABLED
-    const char* debugTaskName() const override;
+    ASCIILiteral debugTaskName() const override;
 #endif
 
     Vector<String>& m_result;

--- a/Source/WebCore/Modules/webdatabase/SQLTransaction.cpp
+++ b/Source/WebCore/Modules/webdatabase/SQLTransaction.cpp
@@ -110,7 +110,7 @@ void SQLTransaction::performNextStep()
 void SQLTransaction::performPendingCallback()
 {
     ASSERT(isMainThread());
-    LOG(StorageAPI, "Callback %s\n", debugStepName(m_nextStep));
+    LOG(StorageAPI, "Callback %s\n", debugStepName(m_nextStep).characters());
 
     ASSERT(m_nextStep == &SQLTransaction::deliverTransactionCallback
            || m_nextStep == &SQLTransaction::deliverTransactionErrorCallback
@@ -176,7 +176,7 @@ SQLTransaction::StateFunction SQLTransaction::stateFunctionFor(SQLTransactionSta
 // modify is m_requestedState which is meant for this purpose.
 void SQLTransaction::requestTransitToState(SQLTransactionState nextState)
 {
-    LOG(StorageAPI, "Scheduling %s for transaction %p\n", nameForSQLTransactionState(nextState), this);
+    LOG(StorageAPI, "Scheduling %s for transaction %p\n", nameForSQLTransactionState(nextState).characters(), this);
     m_requestedState = nextState;
     m_database->scheduleTransactionCallback(this);
 }
@@ -218,7 +218,7 @@ void SQLTransaction::scheduleCallback(void (SQLTransaction::*step)())
 {
     m_nextStep = step;
 
-    LOG(StorageAPI, "Scheduling %s for transaction %p\n", debugStepName(step), this);
+    LOG(StorageAPI, "Scheduling %s for transaction %p\n", debugStepName(step).characters(), this);
     m_database->scheduleTransactionCallback(this);
 }
 
@@ -494,7 +494,7 @@ void SQLTransaction::computeNextStateAndCleanupIfNeeded()
             || m_nextState == SQLTransactionState::DeliverQuotaIncreaseCallback
             || m_nextState == SQLTransactionState::DeliverSuccessCallback);
 
-        LOG(StorageAPI, "Callback %s\n", nameForSQLTransactionState(m_nextState));
+        LOG(StorageAPI, "Callback %s\n", nameForSQLTransactionState(m_nextState).characters());
         return;
     } else
         callErrorCallbackDueToInterruption();
@@ -647,31 +647,31 @@ void SQLTransaction::releaseOriginLockIfNeeded()
 }
 
 #if !LOG_DISABLED
-const char* SQLTransaction::debugStepName(void (SQLTransaction::*step)())
+ASCIILiteral SQLTransaction::debugStepName(void (SQLTransaction::*step)())
 {
     if (step == &SQLTransaction::acquireLock)
-        return "acquireLock";
+        return "acquireLock"_s;
     if (step == &SQLTransaction::openTransactionAndPreflight)
-        return "openTransactionAndPreflight";
+        return "openTransactionAndPreflight"_s;
     if (step == &SQLTransaction::runStatements)
-        return "runStatements";
+        return "runStatements"_s;
     if (step == &SQLTransaction::postflightAndCommit)
-        return "postflightAndCommit";
+        return "postflightAndCommit"_s;
     if (step == &SQLTransaction::cleanupAfterTransactionErrorCallback)
-        return "cleanupAfterTransactionErrorCallback";
+        return "cleanupAfterTransactionErrorCallback"_s;
     if (step == &SQLTransaction::deliverTransactionCallback)
-        return "deliverTransactionCallback";
+        return "deliverTransactionCallback"_s;
     if (step == &SQLTransaction::deliverTransactionErrorCallback)
-        return "deliverTransactionErrorCallback";
+        return "deliverTransactionErrorCallback"_s;
     if (step == &SQLTransaction::deliverStatementCallback)
-        return "deliverStatementCallback";
+        return "deliverStatementCallback"_s;
     if (step == &SQLTransaction::deliverQuotaIncreaseCallback)
-        return "deliverQuotaIncreaseCallback";
+        return "deliverQuotaIncreaseCallback"_s;
     if (step == &SQLTransaction::deliverSuccessCallback)
-        return "deliverSuccessCallback";
+        return "deliverSuccessCallback"_s;
 
     ASSERT_NOT_REACHED();
-    return "UNKNOWN";
+    return "UNKNOWN"_s;
 }
 #endif
 

--- a/Source/WebCore/Modules/webdatabase/SQLTransaction.h
+++ b/Source/WebCore/Modules/webdatabase/SQLTransaction.h
@@ -117,7 +117,7 @@ private:
     void releaseOriginLockIfNeeded();
 
 #if !LOG_DISABLED
-    static const char* debugStepName(void (SQLTransaction::*)());
+    static ASCIILiteral debugStepName(void (SQLTransaction::*)());
 #endif
 
     Ref<Database> m_database;

--- a/Source/WebCore/Modules/webdatabase/SQLTransactionBackend.cpp
+++ b/Source/WebCore/Modules/webdatabase/SQLTransactionBackend.cpp
@@ -436,7 +436,7 @@ void SQLTransactionBackend::computeNextStateAndCleanupIfNeeded()
             || m_nextState == SQLTransactionState::CleanupAndTerminate
             || m_nextState == SQLTransactionState::CleanupAfterTransactionErrorCallback);
 
-        LOG(StorageAPI, "State %s\n", nameForSQLTransactionState(m_nextState));
+        LOG(StorageAPI, "State %s\n", nameForSQLTransactionState(m_nextState).characters());
         return;
     }
 
@@ -505,7 +505,7 @@ void SQLTransactionBackend::cleanupAfterTransactionErrorCallback()
 // modify is m_requestedState which is meant for this purpose.
 void SQLTransactionBackend::requestTransitToState(SQLTransactionState nextState)
 {
-    LOG(StorageAPI, "Scheduling %s for transaction %p\n", nameForSQLTransactionState(nextState), this);
+    LOG(StorageAPI, "Scheduling %s for transaction %p\n", nameForSQLTransactionState(nextState).characters(), this);
     m_requestedState = nextState;
     ASSERT(m_requestedState != SQLTransactionState::End);
     m_frontend.m_database->scheduleTransactionStep(m_frontend);

--- a/Source/WebCore/Modules/webdatabase/SQLTransactionStateMachine.cpp
+++ b/Source/WebCore/Modules/webdatabase/SQLTransactionStateMachine.cpp
@@ -32,37 +32,37 @@
 namespace WebCore {
 
 #if !LOG_DISABLED
-const char* nameForSQLTransactionState(SQLTransactionState state)
+ASCIILiteral nameForSQLTransactionState(SQLTransactionState state)
 {
     switch (state) {
     case SQLTransactionState::End:
-        return "end";
+        return "end"_s;
     case SQLTransactionState::Idle:
-        return "idle";
+        return "idle"_s;
     case SQLTransactionState::AcquireLock:
-        return "acquireLock";
+        return "acquireLock"_s;
     case SQLTransactionState::OpenTransactionAndPreflight:
-        return "openTransactionAndPreflight";
+        return "openTransactionAndPreflight"_s;
     case SQLTransactionState::RunStatements:
-        return "runStatements";
+        return "runStatements"_s;
     case SQLTransactionState::PostflightAndCommit:
-        return "postflightAndCommit";
+        return "postflightAndCommit"_s;
     case SQLTransactionState::CleanupAndTerminate:
-        return "cleanupAndTerminate";
+        return "cleanupAndTerminate"_s;
     case SQLTransactionState::CleanupAfterTransactionErrorCallback:
-        return "cleanupAfterTransactionErrorCallback";
+        return "cleanupAfterTransactionErrorCallback"_s;
     case SQLTransactionState::DeliverTransactionCallback:
-        return "deliverTransactionCallback";
+        return "deliverTransactionCallback"_s;
     case SQLTransactionState::DeliverTransactionErrorCallback:
-        return "deliverTransactionErrorCallback";
+        return "deliverTransactionErrorCallback"_s;
     case SQLTransactionState::DeliverStatementCallback:
-        return "deliverStatementCallback";
+        return "deliverStatementCallback"_s;
     case SQLTransactionState::DeliverQuotaIncreaseCallback:
-        return "deliverQuotaIncreaseCallback";
+        return "deliverQuotaIncreaseCallback"_s;
     case SQLTransactionState::DeliverSuccessCallback:
-        return "deliverSuccessCallback";
+        return "deliverSuccessCallback"_s;
     default:
-        return "UNKNOWN";
+        return "UNKNOWN"_s;
     }
 }
 #endif

--- a/Source/WebCore/Modules/webdatabase/SQLTransactionStateMachine.h
+++ b/Source/WebCore/Modules/webdatabase/SQLTransactionStateMachine.h
@@ -58,7 +58,7 @@ protected:
 };
 
 #if !LOG_DISABLED
-extern const char* nameForSQLTransactionState(SQLTransactionState);
+extern ASCIILiteral nameForSQLTransactionState(SQLTransactionState);
 #endif
 
 template<typename T>

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -120,7 +120,7 @@ static String encodeProtocolString(const String& protocol)
     return builder.toString();
 }
 
-static String joinStrings(const Vector<String>& strings, const char* separator)
+static String joinStrings(const Vector<String>& strings, ASCIILiteral separator)
 {
     StringBuilder builder;
     for (size_t i = 0; i < strings.size(); ++i) {

--- a/Source/WebCore/Modules/websockets/WebSocketExtensionParser.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketExtensionParser.cpp
@@ -49,8 +49,8 @@ bool WebSocketExtensionParser::parsedSuccessfully()
 
 static bool isSeparator(char character)
 {
-    static const char* separatorCharacters = "()<>@,;:\\\"/[]?={} \t";
-    const char* p = strchr(separatorCharacters, character);
+    static constexpr auto separatorCharacters = "()<>@,;:\\\"/[]?={} \t"_s;
+    const char* p = strchr(separatorCharacters.characters(), character);
     return p && *p;
 }
 

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -266,93 +266,93 @@ enum ArrayBufferViewSubtag {
     BigUint64ArrayTag = 11,
 };
 
-static const char* name(SerializationTag tag)
+static ASCIILiteral name(SerializationTag tag)
 {
     switch (tag) {
-    case ArrayTag: return "ArrayTag";
-    case ObjectTag: return "ObjectTag";
-    case UndefinedTag: return "UndefinedTag";
-    case NullTag: return "NullTag";
-    case IntTag: return "IntTag";
-    case ZeroTag: return "ZeroTag";
-    case OneTag: return "OneTag";
-    case FalseTag: return "FalseTag";
-    case TrueTag: return "TrueTag";
-    case DoubleTag: return "DoubleTag";
-    case DateTag: return "DateTag";
-    case FileTag: return "FileTag";
-    case FileListTag: return "FileListTag";
-    case ImageDataTag: return "ImageDataTag";
-    case BlobTag: return "BlobTag";
-    case StringTag: return "StringTag";
-    case EmptyStringTag: return "EmptyStringTag";
-    case RegExpTag: return "RegExpTag";
-    case ObjectReferenceTag: return "ObjectReferenceTag";
-    case MessagePortReferenceTag: return "MessagePortReferenceTag";
-    case ArrayBufferTag: return "ArrayBufferTag";
-    case ArrayBufferViewTag: return "ArrayBufferViewTag";
-    case ArrayBufferTransferTag: return "ArrayBufferTransferTag";
-    case TrueObjectTag: return "TrueObjectTag";
-    case FalseObjectTag: return "FalseObjectTag";
-    case StringObjectTag: return "StringObjectTag";
-    case EmptyStringObjectTag: return "EmptyStringObjectTag";
-    case NumberObjectTag: return "NumberObjectTag";
-    case SetObjectTag: return "SetObjectTag";
-    case MapObjectTag: return "MapObjectTag";
-    case NonMapPropertiesTag: return "NonMapPropertiesTag";
-    case NonSetPropertiesTag: return "NonSetPropertiesTag";
-    case CryptoKeyTag: return "CryptoKeyTag";
-    case SharedArrayBufferTag: return "SharedArrayBufferTag";
+    case ArrayTag: return "ArrayTag"_s;
+    case ObjectTag: return "ObjectTag"_s;
+    case UndefinedTag: return "UndefinedTag"_s;
+    case NullTag: return "NullTag"_s;
+    case IntTag: return "IntTag"_s;
+    case ZeroTag: return "ZeroTag"_s;
+    case OneTag: return "OneTag"_s;
+    case FalseTag: return "FalseTag"_s;
+    case TrueTag: return "TrueTag"_s;
+    case DoubleTag: return "DoubleTag"_s;
+    case DateTag: return "DateTag"_s;
+    case FileTag: return "FileTag"_s;
+    case FileListTag: return "FileListTag"_s;
+    case ImageDataTag: return "ImageDataTag"_s;
+    case BlobTag: return "BlobTag"_s;
+    case StringTag: return "StringTag"_s;
+    case EmptyStringTag: return "EmptyStringTag"_s;
+    case RegExpTag: return "RegExpTag"_s;
+    case ObjectReferenceTag: return "ObjectReferenceTag"_s;
+    case MessagePortReferenceTag: return "MessagePortReferenceTag"_s;
+    case ArrayBufferTag: return "ArrayBufferTag"_s;
+    case ArrayBufferViewTag: return "ArrayBufferViewTag"_s;
+    case ArrayBufferTransferTag: return "ArrayBufferTransferTag"_s;
+    case TrueObjectTag: return "TrueObjectTag"_s;
+    case FalseObjectTag: return "FalseObjectTag"_s;
+    case StringObjectTag: return "StringObjectTag"_s;
+    case EmptyStringObjectTag: return "EmptyStringObjectTag"_s;
+    case NumberObjectTag: return "NumberObjectTag"_s;
+    case SetObjectTag: return "SetObjectTag"_s;
+    case MapObjectTag: return "MapObjectTag"_s;
+    case NonMapPropertiesTag: return "NonMapPropertiesTag"_s;
+    case NonSetPropertiesTag: return "NonSetPropertiesTag"_s;
+    case CryptoKeyTag: return "CryptoKeyTag"_s;
+    case SharedArrayBufferTag: return "SharedArrayBufferTag"_s;
 #if ENABLE(WEBASSEMBLY)
-    case WasmModuleTag: return "WasmModuleTag";
+    case WasmModuleTag: return "WasmModuleTag"_s;
 #endif
-    case DOMPointReadOnlyTag: return "DOMPointReadOnlyTag";
-    case DOMPointTag: return "DOMPointTag";
-    case DOMRectReadOnlyTag: return "DOMRectReadOnlyTag";
-    case DOMRectTag: return "DOMRectTag";
-    case DOMMatrixReadOnlyTag: return "DOMMatrixReadOnlyTag";
-    case DOMMatrixTag: return "DOMMatrixTag";
-    case DOMQuadTag: return "DOMQuadTag";
-    case ImageBitmapTransferTag: return "ImageBitmapTransferTag";
+    case DOMPointReadOnlyTag: return "DOMPointReadOnlyTag"_s;
+    case DOMPointTag: return "DOMPointTag"_s;
+    case DOMRectReadOnlyTag: return "DOMRectReadOnlyTag"_s;
+    case DOMRectTag: return "DOMRectTag"_s;
+    case DOMMatrixReadOnlyTag: return "DOMMatrixReadOnlyTag"_s;
+    case DOMMatrixTag: return "DOMMatrixTag"_s;
+    case DOMQuadTag: return "DOMQuadTag"_s;
+    case ImageBitmapTransferTag: return "ImageBitmapTransferTag"_s;
 #if ENABLE(WEB_RTC)
-    case RTCCertificateTag: return "RTCCertificateTag";
+    case RTCCertificateTag: return "RTCCertificateTag"_s;
 #endif
-    case ImageBitmapTag: return "ImageBitmapTag";
+    case ImageBitmapTag: return "ImageBitmapTag"_s;
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
-    case OffscreenCanvasTransferTag: return "OffscreenCanvasTransferTag";
+    case OffscreenCanvasTransferTag: return "OffscreenCanvasTransferTag"_s;
 #endif
-    case BigIntTag: return "BigIntTag";
-    case BigIntObjectTag: return "BigIntObjectTag";
+    case BigIntTag: return "BigIntTag"_s;
+    case BigIntObjectTag: return "BigIntObjectTag"_s;
 #if ENABLE(WEBASSEMBLY)
-    case WasmMemoryTag: return "WasmMemoryTag";
+    case WasmMemoryTag: return "WasmMemoryTag"_s;
 #endif
 #if ENABLE(WEB_RTC)
-    case RTCDataChannelTransferTag: return "RTCDataChannelTransferTag";
+    case RTCDataChannelTransferTag: return "RTCDataChannelTransferTag"_s;
 #endif
-    case DOMExceptionTag: return "DOMExceptionTag";
+    case DOMExceptionTag: return "DOMExceptionTag"_s;
 #if ENABLE(WEB_CODECS)
-    case WebCodecsEncodedVideoChunkTag: return "WebCodecsEncodedVideoChunkTag";
-    case WebCodecsVideoFrameTag: return "WebCodecsVideoFrameTag";
+    case WebCodecsEncodedVideoChunkTag: return "WebCodecsEncodedVideoChunkTag"_s;
+    case WebCodecsVideoFrameTag: return "WebCodecsVideoFrameTag"_s;
 #endif
-    case ResizableArrayBufferTag: return "ResizableArrayBufferTag";
-    case ErrorInstanceTag: return "ErrorInstanceTag";
+    case ResizableArrayBufferTag: return "ResizableArrayBufferTag"_s;
+    case ErrorInstanceTag: return "ErrorInstanceTag"_s;
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
-    case InMemoryOffscreenCanvasTag: return "InMemoryOffscreenCanvasTag";
+    case InMemoryOffscreenCanvasTag: return "InMemoryOffscreenCanvasTag"_s;
 #endif
-    case InMemoryMessagePortTag: return "InMemoryMessagePortTag";
+    case InMemoryMessagePortTag: return "InMemoryMessagePortTag"_s;
 #if ENABLE(WEB_CODECS)
-    case WebCodecsEncodedAudioChunkTag: return "WebCodecsEncodedAudioChunkTag";
-    case WebCodecsAudioDataTag: return "WebCodecsAudioDataTag";
+    case WebCodecsEncodedAudioChunkTag: return "WebCodecsEncodedAudioChunkTag"_s;
+    case WebCodecsAudioDataTag: return "WebCodecsAudioDataTag"_s;
 #endif
 #if ENABLE(MEDIA_STREAM)
-    case MediaStreamTrackTag: return "MediaStreamTrackTag";
+    case MediaStreamTrackTag: return "MediaStreamTrackTag"_s;
 #endif
 #if ENABLE(MEDIA_SOURCE_IN_WORKERS)
-    case MediaSourceHandleTransferTag: return "MediaSourceHandleTransferTag";
+    case MediaSourceHandleTransferTag: return "MediaSourceHandleTransferTag"_s;
 #endif
-    case ErrorTag: return "ErrorTag";
+    case ErrorTag: return "ErrorTag"_s;
     }
-    return "<unknown tag>";
+    return "<unknown tag>"_s;
 }
 
 } // namespace WebCore
@@ -363,11 +363,11 @@ void printInternal(PrintStream&, WebCore::SerializationTag);
 
 void printInternal(PrintStream& out, WebCore::SerializationTag tag)
 {
-    const char* tagName = WebCore::name(tag);
+    auto tagName = WebCore::name(tag);
     if (tagName[0] != '<')
         out.print(tagName);
     else
-        out.print("<unknown tag ", static_cast<unsigned>(tag), ">");
+        out.print("<unknown tag "_s, static_cast<unsigned>(tag), ">"_s);
 }
 
 } // namespace WTF

--- a/Source/WebCore/contentextensions/ContentExtensionActions.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionActions.cpp
@@ -413,14 +413,14 @@ auto RedirectAction::RegexSubstitutionAction::deserialize(std::span<const uint8_
     return { WTFMove(regexSubstitution), WTFMove(regexFilter) };
 }
 
-static JSRetainPtr<JSStringRef> makeJSString(const char* utf8)
+static JSRetainPtr<JSStringRef> makeJSString(ASCIILiteral literal)
 {
-    return adopt(JSStringCreateWithUTF8CString(utf8));
+    return adopt(JSStringCreateWithUTF8CString(literal));
 }
 
 static JSRetainPtr<JSStringRef> makeJSString(const String& string)
 {
-    return makeJSString(string.utf8().data());
+    return adopt(JSStringCreateWithUTF8CString(string.utf8().data()));
 }
 
 void RedirectAction::RegexSubstitutionAction::applyToURL(URL& url) const
@@ -435,7 +435,7 @@ void RedirectAction::RegexSubstitutionAction::applyToURL(URL& url) const
     auto toObject = [&] (JSValueRef value) {
         return JSValueToObject(context, value, nullptr);
     };
-    auto getProperty = [&] (JSValueRef value, const char* name) {
+    auto getProperty = [&] (JSValueRef value, ASCIILiteral name) {
         return JSObjectGetProperty(context, toObject(value), makeJSString(name).get(), nullptr);
     };
     auto getArrayValue = [&] (JSValueRef value, size_t index) {
@@ -455,13 +455,13 @@ void RedirectAction::RegexSubstitutionAction::applyToURL(URL& url) const
     JSValueRef regexFilterValue = JSValueMakeString(context, makeJSString(regexFilter).get());
     JSObjectRef regexp = JSObjectMakeRegExp(context, 1, &regexFilterValue, nullptr);
     JSValueRef urlValue = JSValueMakeString(context, makeJSString(url.string()).get());
-    JSObjectRef matchFunction = JSValueToObject(context, getProperty(urlValue, "match"), nullptr);
+    JSObjectRef matchFunction = JSValueToObject(context, getProperty(urlValue, "match"_s), nullptr);
     JSValueRef result = JSObjectCallAsFunction(context, matchFunction, toObject(urlValue), 1, &regexp, nullptr);
     if (!JSValueIsArray(context, result))
         return;
 
     String substitution = regexSubstitution;
-    size_t resultLength = JSValueToNumber(context, getProperty(result, "length"), nullptr);
+    size_t resultLength = JSValueToNumber(context, getProperty(result, "length"_s), nullptr);
     for (size_t i = 0; i < std::min<size_t>(10, resultLength); i++)
         substitution = makeStringByReplacingAll(substitution, makeString('\\', i), valueToWTFString(getArrayValue(result, i)));
 

--- a/Source/WebCore/contentextensions/ContentExtensionParser.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionParser.cpp
@@ -97,9 +97,9 @@ static Expected<Vector<String>, std::error_code> getDomainList(const JSON::Array
         for (auto& pair : escapeTable)
             domain = makeStringByReplacingAll(domain, pair.first, pair.second);
 
-        const char* protocolRegex = "[a-z][a-z+.-]*:\\/\\/";
-        const char* allowSubdomainsRegex = "([^/]*\\.)*";
-        regexes.append(makeString(protocolRegex, allowSubdomains ? allowSubdomainsRegex : "", domain, "[:/]"));
+        constexpr auto protocolRegex = "[a-z][a-z+.-]*:\\/\\/"_s;
+        constexpr auto allowSubdomainsRegex = "([^/]*\\.)*"_s;
+        regexes.append(makeString(protocolRegex, allowSubdomains ? allowSubdomainsRegex : ""_s, domain, "[:/]"_s));
     }
     return regexes;
 }

--- a/Source/WebCore/contentextensions/DFABytecodeInterpreter.cpp
+++ b/Source/WebCore/contentextensions/DFABytecodeInterpreter.cpp
@@ -203,7 +203,7 @@ void DFABytecodeInterpreter::interpretTestFlagsAndAppendAction(uint32_t& program
 }
 
 template<bool caseSensitive>
-inline void DFABytecodeInterpreter::interpetJumpTable(std::span<const char> url, uint32_t& urlIndex, uint32_t& programCounter)
+inline void DFABytecodeInterpreter::interpretJumpTable(std::span<const LChar> url, uint32_t& urlIndex, uint32_t& programCounter)
 {
     DFABytecodeJumpSize jumpSize = getJumpSize(m_bytecode, programCounter);
 
@@ -245,12 +245,12 @@ auto DFABytecodeInterpreter::actionsMatchingEverything() -> Actions
 auto DFABytecodeInterpreter::interpret(const String& urlString, ResourceFlags flags) -> Actions
 {
     CString urlCString;
-    std::span<const char> url;
+    std::span<const LChar> url;
     if (LIKELY(urlString.is8Bit()))
-        url = { reinterpret_cast<const char*>(urlString.characters8()), urlString.length() };
+        url = urlString.span8();
     else {
         urlCString = urlString.utf8();
-        url = { urlCString.data(), urlCString.length() };
+        url = urlCString.span();
     }
     ASSERT(url.data());
     
@@ -330,13 +330,13 @@ auto DFABytecodeInterpreter::interpret(const String& urlString, ResourceFlags fl
                 if (urlIndex > url.size())
                     goto nextDFA;
 
-                interpetJumpTable<false>(url, urlIndex, programCounter);
+                interpretJumpTable<false>(url, urlIndex, programCounter);
                 break;
             case DFABytecodeInstruction::JumpTableCaseSensitive:
                 if (urlIndex > url.size())
                     goto nextDFA;
 
-                interpetJumpTable<true>(url, urlIndex, programCounter);
+                interpretJumpTable<true>(url, urlIndex, programCounter);
                 break;
                     
             case DFABytecodeInstruction::CheckValueRangeCaseSensitive: {

--- a/Source/WebCore/contentextensions/DFABytecodeInterpreter.h
+++ b/Source/WebCore/contentextensions/DFABytecodeInterpreter.h
@@ -50,7 +50,7 @@ private:
     void interpretTestFlagsAndAppendAction(unsigned& programCounter, ResourceFlags, Actions&);
 
     template<bool caseSensitive>
-    void interpetJumpTable(std::span<const char> url, uint32_t& urlIndex, uint32_t& programCounter);
+    void interpretJumpTable(std::span<const LChar> url, uint32_t& urlIndex, uint32_t& programCounter);
 
     const std::span<const uint8_t> m_bytecode;
 };

--- a/Source/WebCore/crypto/SubtleCrypto.cpp
+++ b/Source/WebCore/crypto/SubtleCrypto.cpp
@@ -80,7 +80,7 @@ enum class Operations : uint8_t {
     GetKeyLength
 };
 
-static const char* const AESCFBDeprecation = "AES-CFB support is deprecated";
+constexpr auto AESCFBDeprecation = "AES-CFB support is deprecated"_s;
 
 static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAlgorithmParameters(JSGlobalObject&, WebCore::SubtleCrypto::AlgorithmIdentifier, Operations);
 
@@ -164,7 +164,7 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
         }
         case CryptoAlgorithmIdentifier::AES_CFB:
             if (isAESCFBWebCryptoDeprecated(state))
-                return Exception { ExceptionCode::NotSupportedError, String::fromUTF8(AESCFBDeprecation) };
+                return Exception { ExceptionCode::NotSupportedError, AESCFBDeprecation };
             [[fallthrough]];
         case CryptoAlgorithmIdentifier::AES_CBC: {
             auto params = convertDictionary<CryptoAlgorithmAesCbcCfbParams>(state, value.get());
@@ -253,7 +253,7 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
         }
         case CryptoAlgorithmIdentifier::AES_CFB:
             if (isAESCFBWebCryptoDeprecated(state))
-                return Exception { ExceptionCode::NotSupportedError, String::fromUTF8(AESCFBDeprecation) };
+                return Exception { ExceptionCode::NotSupportedError, AESCFBDeprecation };
             [[fallthrough]];
         case CryptoAlgorithmIdentifier::AES_CTR:
         case CryptoAlgorithmIdentifier::AES_CBC:
@@ -366,7 +366,7 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
         }
         case CryptoAlgorithmIdentifier::AES_CFB:
             if (isAESCFBWebCryptoDeprecated(state))
-                return Exception { ExceptionCode::NotSupportedError, String::fromUTF8(AESCFBDeprecation) };
+                return Exception { ExceptionCode::NotSupportedError, AESCFBDeprecation };
             [[fallthrough]];
         case CryptoAlgorithmIdentifier::AES_CTR:
         case CryptoAlgorithmIdentifier::AES_CBC:
@@ -423,7 +423,7 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
         switch (*identifier) {
         case CryptoAlgorithmIdentifier::AES_CFB:
             if (isAESCFBWebCryptoDeprecated(state))
-                return Exception { ExceptionCode::NotSupportedError, String::fromUTF8(AESCFBDeprecation) };
+                return Exception { ExceptionCode::NotSupportedError, AESCFBDeprecation };
             [[fallthrough]];
         case CryptoAlgorithmIdentifier::AES_CTR:
         case CryptoAlgorithmIdentifier::AES_CBC:

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDSAGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDSAGCrypt.cpp
@@ -35,7 +35,7 @@
 
 namespace WebCore {
 
-static bool extractECDSASignatureInteger(Vector<uint8_t>& signature, gcry_sexp_t signatureSexp, const char* integerName, size_t keySizeInBytes)
+static bool extractECDSASignatureInteger(Vector<uint8_t>& signature, gcry_sexp_t signatureSexp, ASCIILiteral integerName, size_t keySizeInBytes)
 {
     // Retrieve byte data of the specified integer.
     PAL::GCrypt::Handle<gcry_sexp_t> integerSexp(gcry_sexp_find_token(signatureSexp, integerName, 0));
@@ -109,8 +109,8 @@ static std::optional<Vector<uint8_t>> gcryptSign(gcry_sexp_t keySexp, const Vect
     Vector<uint8_t> signature;
     signature.reserveInitialCapacity(keySizeInBytes * 2);
 
-    if (!extractECDSASignatureInteger(signature, signatureSexp, "r", keySizeInBytes)
-        || !extractECDSASignatureInteger(signature, signatureSexp, "s", keySizeInBytes))
+    if (!extractECDSASignatureInteger(signature, signatureSexp, "r"_s, keySizeInBytes)
+        || !extractECDSASignatureInteger(signature, signatureSexp, "s"_s, keySizeInBytes))
         return std::nullopt;
 
     return signature;

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp
@@ -25,7 +25,7 @@
 
 namespace WebCore {
 
-static bool extractEDDSASignatureInteger(Vector<uint8_t>& signature, gcry_sexp_t signatureSexp, const char* integerName, size_t keySizeInBytes)
+static bool extractEDDSASignatureInteger(Vector<uint8_t>& signature, gcry_sexp_t signatureSexp, ASCIILiteral integerName, size_t keySizeInBytes)
 {
     // Retrieve byte data of the specified integer.
     PAL::GCrypt::Handle<gcry_sexp_t> integerSexp(gcry_sexp_find_token(signatureSexp, integerName, 0));
@@ -91,8 +91,8 @@ static ExceptionOr<Vector<uint8_t>> signEd25519(const Vector<uint8_t>& sk, size_
     Vector<uint8_t> signature;
     signature.reserveInitialCapacity(64);
 
-    if (!extractEDDSASignatureInteger(signature, signatureSexp, "r", keySizeInBytes)
-        || !extractEDDSASignatureInteger(signature, signatureSexp, "s", keySizeInBytes))
+    if (!extractEDDSASignatureInteger(signature, signatureSexp, "r"_s, keySizeInBytes)
+        || !extractEDDSASignatureInteger(signature, signatureSexp, "s"_s, keySizeInBytes))
         return Exception { ExceptionCode::OperationError };
 
     return signature;

--- a/Source/WebCore/crypto/gcrypt/CryptoKeyECGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoKeyECGCrypt.cpp
@@ -34,19 +34,20 @@
 #include <wtf/text/Base64.h>
 
 namespace WebCore {
-static const char* curveName(CryptoKeyEC::NamedCurve curve)
+
+static ASCIILiteral curveName(CryptoKeyEC::NamedCurve curve)
 {
     switch (curve) {
     case CryptoKeyEC::NamedCurve::P256:
-        return "NIST P-256";
+        return "NIST P-256"_s;
     case CryptoKeyEC::NamedCurve::P384:
-        return "NIST P-384";
+        return "NIST P-384"_s;
     case CryptoKeyEC::NamedCurve::P521:
-        return "NIST P-521";
+        return "NIST P-521"_s;
     }
 
     ASSERT_NOT_REACHED();
-    return nullptr;
+    return { };
 }
 
 static const uint8_t* curveIdentifier(CryptoKeyEC::NamedCurve curve)
@@ -114,7 +115,7 @@ bool CryptoKeyEC::platformSupportedCurve(NamedCurve curve)
 std::optional<CryptoKeyPair> CryptoKeyEC::platformGeneratePair(CryptoAlgorithmIdentifier identifier, NamedCurve curve, bool extractable, CryptoKeyUsageBitmap usages, UseCryptoKit)
 {
     PAL::GCrypt::Handle<gcry_sexp_t> genkeySexp;
-    gcry_error_t error = gcry_sexp_build(&genkeySexp, nullptr, "(genkey(ecc(curve %s)))", curveName(curve));
+    gcry_error_t error = gcry_sexp_build(&genkeySexp, nullptr, "(genkey(ecc(curve %s)))", curveName(curve).characters());
     if (error != GPG_ERR_NO_ERROR) {
         PAL::GCrypt::logError(error);
         return std::nullopt;
@@ -144,7 +145,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportRaw(CryptoAlgorithmIdentifier ide
 
     PAL::GCrypt::Handle<gcry_sexp_t> platformKey;
     gcry_error_t error = gcry_sexp_build(&platformKey, nullptr, "(public-key(ecc(curve %s)(q %b)))",
-        curveName(curve), keyData.size(), keyData.data());
+        curveName(curve).characters(), keyData.size(), keyData.data());
     if (error != GPG_ERR_NO_ERROR) {
         PAL::GCrypt::logError(error);
         return nullptr;
@@ -168,7 +169,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPublic(CryptoAlgorithmIdentifi
 
     PAL::GCrypt::Handle<gcry_sexp_t> platformKey;
     gcry_error_t error = gcry_sexp_build(&platformKey, nullptr, "(public-key(ecc(curve %s)(q %b)))",
-        curveName(curve), q.size(), q.data());
+        curveName(curve).characters(), q.size(), q.data());
     if (error != GPG_ERR_NO_ERROR) {
         PAL::GCrypt::logError(error);
         return nullptr;
@@ -192,7 +193,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPrivate(CryptoAlgorithmIdentif
 
     PAL::GCrypt::Handle<gcry_sexp_t> platformKey;
     gcry_error_t error = gcry_sexp_build(&platformKey, nullptr, "(private-key(ecc(curve %s)(q %b)(d %b)))",
-        curveName(curve), q.size(), q.data(), d.size(), d.data());
+        curveName(curve).characters(), q.size(), q.data(), d.size(), d.data());
     if (error != GPG_ERR_NO_ERROR) {
         PAL::GCrypt::logError(error);
         return nullptr;
@@ -316,7 +317,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportSpki(CryptoAlgorithmIdentifier id
 
         // Create an EC context for the specified curve.
         PAL::GCrypt::Handle<gcry_ctx_t> context;
-        gcry_error_t error = gcry_mpi_ec_new(&context, nullptr, curveName(curve));
+        gcry_error_t error = gcry_mpi_ec_new(&context, nullptr, curveName(curve).characters());
         if (error != GPG_ERR_NO_ERROR) {
             PAL::GCrypt::logError(error);
             return nullptr;
@@ -327,7 +328,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportSpki(CryptoAlgorithmIdentifier id
             return nullptr;
 
         error = gcry_sexp_build(&platformKey, nullptr, "(public-key(ecc(curve %s)(q %b)))",
-            curveName(curve), subjectPublicKey->size(), subjectPublicKey->data());
+            curveName(curve).characters(), subjectPublicKey->size(), subjectPublicKey->data());
         if (error != GPG_ERR_NO_ERROR) {
             PAL::GCrypt::logError(error);
             return nullptr;
@@ -445,7 +446,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportPkcs8(CryptoAlgorithmIdentifier i
 
         // Construct the `private-key` expression that will also be used for the EC context.
         gcry_error_t error = gcry_sexp_build(&platformKey, nullptr, "(private-key(ecc(curve %s)(d %b)))",
-            curveName(curve), privateKey->size(), privateKey->data());
+            curveName(curve).characters(), privateKey->size(), privateKey->data());
         if (error != GPG_ERR_NO_ERROR) {
             PAL::GCrypt::logError(error);
             return nullptr;

--- a/Source/WebCore/css/CSSCounterStyleRule.cpp
+++ b/Source/WebCore/css/CSSCounterStyleRule.cpp
@@ -112,46 +112,46 @@ CSSCounterStyleRule::~CSSCounterStyleRule() = default;
 String CSSCounterStyleRule::cssText() const
 {
     String systemText = system();
-    const char* systemPrefix = systemText.isEmpty() ? "" : " system: ";
-    const char* systemSuffix = systemText.isEmpty() ? "" : ";";
+    const auto systemPrefix = systemText.isEmpty() ? ""_s : " system: "_s;
+    const auto systemSuffix = systemText.isEmpty() ? ""_s : ";"_s;
 
     String symbolsText = symbols();
-    const char* symbolsPrefix = symbolsText.isEmpty() ? "" : " symbols: ";
-    const char* symbolsSuffix = symbolsText.isEmpty() ? "" : ";";
+    const auto symbolsPrefix = symbolsText.isEmpty() ? ""_s : " symbols: "_s;
+    const auto symbolsSuffix = symbolsText.isEmpty() ? ""_s : ";"_s;
 
     String additiveSymbolsText = additiveSymbols();
-    const char* additiveSymbolsPrefix = additiveSymbolsText.isEmpty() ? "" : " additive-symbols: ";
-    const char* additiveSymbolsSuffix = additiveSymbolsText.isEmpty() ? "" : ";";
+    const auto additiveSymbolsPrefix = additiveSymbolsText.isEmpty() ? ""_s : " additive-symbols: "_s;
+    const auto additiveSymbolsSuffix = additiveSymbolsText.isEmpty() ? ""_s : ";"_s;
 
     String negativeText = negative();
-    const char* negativePrefix = negativeText.isEmpty() ? "" : " negative: ";
-    const char* negativeSuffix = negativeText.isEmpty() ? "" : ";";
+    const auto negativePrefix = negativeText.isEmpty() ? ""_s : " negative: "_s;
+    const auto negativeSuffix = negativeText.isEmpty() ? ""_s : ";"_s;
 
     String prefixText = prefix();
-    const char* prefixTextPrefix = prefixText.isEmpty() ? "" : " prefix: ";
-    const char* prefixTextSuffix = prefixText.isEmpty() ? "" : ";";
+    const auto prefixTextPrefix = prefixText.isEmpty() ? ""_s : " prefix: "_s;
+    const auto prefixTextSuffix = prefixText.isEmpty() ? ""_s : ";"_s;
 
     String suffixText = suffix();
-    const char* suffixTextPrefix = suffixText.isEmpty() ? "" : " suffix: ";
-    const char* suffixTextSuffix = suffixText.isEmpty() ? "" : ";";
+    const auto suffixTextPrefix = suffixText.isEmpty() ? ""_s : " suffix: "_s;
+    const auto suffixTextSuffix = suffixText.isEmpty() ? ""_s : ";"_s;
 
     String padText = pad();
-    const char* padPrefix = padText.isEmpty() ? "" : " pad: ";
-    const char* padSuffix = padText.isEmpty() ? "" : ";";
+    const auto padPrefix = padText.isEmpty() ? ""_s : " pad: "_s;
+    const auto padSuffix = padText.isEmpty() ? ""_s : ";"_s;
 
     String rangeText = range();
-    const char* rangePrefix = rangeText.isEmpty() ? "" : " range: ";
-    const char* rangeSuffix = rangeText.isEmpty() ? "" : ";";
+    const auto rangePrefix = rangeText.isEmpty() ? ""_s : " range: "_s;
+    const auto rangeSuffix = rangeText.isEmpty() ? ""_s : ";"_s;
 
     String fallbackText = fallback();
-    const char* fallbackPrefix = fallbackText.isEmpty() ? "" : " fallback: ";
-    const char* fallbackSuffix = fallbackText.isEmpty() ? "" : ";";
+    const auto fallbackPrefix = fallbackText.isEmpty() ? ""_s : " fallback: "_s;
+    const auto fallbackSuffix = fallbackText.isEmpty() ? ""_s : ";"_s;
 
     String speakAsText = speakAs();
-    const char* speakAsPrefix = speakAsText.isEmpty() ? "" : " speak-as: ";
-    const char* speakAsSuffix = speakAsText.isEmpty() ? "" : ";";
+    const auto speakAsPrefix = speakAsText.isEmpty() ? ""_s : " speak-as: "_s;
+    const auto speakAsSuffix = speakAsText.isEmpty() ? ""_s : ";"_s;
 
-    return makeString("@counter-style ", name(), " {",
+    return makeString("@counter-style "_s, name(), " {"_s,
         systemPrefix, systemText, systemSuffix,
         symbolsPrefix, symbolsText, symbolsSuffix,
         additiveSymbolsPrefix, additiveSymbolsText, additiveSymbolsSuffix,
@@ -162,7 +162,7 @@ String CSSCounterStyleRule::cssText() const
         rangePrefix, rangeText, rangeSuffix,
         fallbackPrefix, fallbackText, fallbackSuffix,
         speakAsPrefix, speakAsText, speakAsSuffix,
-    " }");
+    " }"_s);
 }
 
 void CSSCounterStyleRule::reattach(StyleRuleBase& rule)

--- a/Source/WebCore/css/CSSTimingFunctionValue.cpp
+++ b/Source/WebCore/css/CSSTimingFunctionValue.cpp
@@ -66,27 +66,27 @@ bool CSSCubicBezierTimingFunctionValue::equals(const CSSCubicBezierTimingFunctio
 
 String CSSStepsTimingFunctionValue::customCSSText() const
 {
-    const char* position = "";
+    ASCIILiteral position = ""_s;
     if (m_stepPosition) {
         switch (m_stepPosition.value()) {
         case StepsTimingFunction::StepPosition::JumpStart:
-            position = ", jump-start";
+            position = ", jump-start"_s;
             break;
         case StepsTimingFunction::StepPosition::JumpNone:
-            position = ", jump-none";
+            position = ", jump-none"_s;
             break;
         case StepsTimingFunction::StepPosition::JumpBoth:
-            position = ", jump-both";
+            position = ", jump-both"_s;
             break;
         case StepsTimingFunction::StepPosition::Start:
-            position = ", start";
+            position = ", start"_s;
             break;
         case StepsTimingFunction::StepPosition::JumpEnd:
         case StepsTimingFunction::StepPosition::End:
             break;
         }
     }
-    return makeString("steps(", m_steps, position, ')');
+    return makeString("steps("_s, m_steps, position, ')');
 }
 
 bool CSSStepsTimingFunctionValue::equals(const CSSStepsTimingFunctionValue& other) const

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -99,9 +99,9 @@ private:
     bool commonSerializationChecks(const StyleProperties&);
 
     String serializeLonghands() const;
-    String serializeLonghands(unsigned lengthLimit, const char* separator = " ") const;
+    String serializeLonghands(unsigned lengthLimit, ASCIILiteral separator = " "_s) const;
     String serializeLonghandsOmittingInitialValues() const;
-    String serializeLonghandsOmittingTrailingInitialValue(const char* separator = " ") const;
+    String serializeLonghandsOmittingTrailingInitialValue(ASCIILiteral separator = " "_s) const;
 
     String serializeCommonValue() const;
     String serializeCommonValue(unsigned startIndex, unsigned count) const;
@@ -362,7 +362,7 @@ String ShorthandSerializer::serialize()
     case CSSPropertyWebkitBorderRadius:
         return serializeBorderRadius();
     case CSSPropertyContainer:
-        return serializeLonghandsOmittingTrailingInitialValue(" / ");
+        return serializeLonghandsOmittingTrailingInitialValue(" / "_s);
     case CSSPropertyFlex:
     case CSSPropertyPerspectiveOrigin:
         return serializeLonghands();
@@ -420,7 +420,7 @@ String ShorthandSerializer::serializeLonghands() const
     return serializeLonghands(length());
 }
 
-String ShorthandSerializer::serializeLonghands(unsigned lengthLimit, const char* separator) const
+String ShorthandSerializer::serializeLonghands(unsigned lengthLimit, ASCIILiteral separator) const
 {
     ASSERT(lengthLimit <= length());
     switch (lengthLimit) {
@@ -434,7 +434,7 @@ String ShorthandSerializer::serializeLonghands(unsigned lengthLimit, const char*
         return makeString(serializeLonghandValue(0), separator, serializeLonghandValue(1), separator, serializeLonghandValue(2), separator, serializeLonghandValue(3));
     default:
         StringBuilder result;
-        auto prefix = "";
+        auto prefix = ""_s;
         for (unsigned i = 0; i < lengthLimit; ++i)
             result.append(std::exchange(prefix, separator), serializeLonghandValue(i));
         return result.toString();
@@ -452,7 +452,7 @@ String ShorthandSerializer::serializeLonghandsOmittingInitialValues() const
     return result.isEmpty() ? serializeLonghandValue(0) : result.toString();
 }
 
-String ShorthandSerializer::serializeLonghandsOmittingTrailingInitialValue(const char* separator) const
+String ShorthandSerializer::serializeLonghandsOmittingTrailingInitialValue(ASCIILiteral separator) const
 {
     ASSERT(length() >= 2);
     return serializeLonghands(length() - isLonghandInitialValue(length() - 1), separator);
@@ -1119,13 +1119,13 @@ String ShorthandSerializer::serializeGridArea() const
                 --longhandsToSerialize;
         }
     }
-    return serializeLonghands(longhandsToSerialize, " / ");
+    return serializeLonghands(longhandsToSerialize, " / "_s);
 }
 
 String ShorthandSerializer::serializeGridRowColumn() const
 {
     ASSERT(length() == 2);
-    return serializeLonghands(canOmitTrailingGridAreaValue(longhandValue(0), longhandValue(1)) ? 1 : 2, " / ");
+    return serializeLonghands(canOmitTrailingGridAreaValue(longhandValue(0), longhandValue(1)) ? 1 : 2, " / "_s);
 }
 
 String ShorthandSerializer::serializeGridTemplate() const
@@ -1140,7 +1140,7 @@ String ShorthandSerializer::serializeGridTemplate() const
     if (!areasValue) {
         if (isLonghandValueNone(rowsIndex) && isLonghandValueNone(columnsIndex))
             return nameString(CSSValueNone);
-        return serializeLonghands(2, " / ");
+        return serializeLonghands(2, " / "_s);
     }
 
     // Depending on the values of grid-template-rows and grid-template-columns, we may not

--- a/Source/WebCore/css/StyleColor.cpp
+++ b/Source/WebCore/css/StyleColor.cpp
@@ -67,8 +67,8 @@ Color StyleColor::colorFromAbsoluteKeyword(CSSValueID keyword)
 {
     // TODO: maybe it should be a constexpr map for performance.
     ASSERT(StyleColor::isAbsoluteColorKeyword(keyword));
-    if (const char* valueName = nameLiteral(keyword)) {
-        if (auto namedColor = findColor(valueName, strlen(valueName)))
+    if (auto valueName = nameLiteral(keyword)) {
+        if (auto namedColor = findColor(valueName.characters(), valueName.length()))
             return asSRGBA(PackedColor::ARGB { namedColor->ARGBValue });
     }
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/css/typedom/numeric/CSSNumericBaseType.h
+++ b/Source/WebCore/css/typedom/numeric/CSSNumericBaseType.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <array>
+#include <wtf/text/ASCIILiteral.h>
 
 namespace WebCore {
 
@@ -52,25 +53,25 @@ constexpr std::array<CSSNumericBaseType, 7> eachBaseType()
     };
 }
 
-constexpr const char* debugString(CSSNumericBaseType type)
+constexpr ASCIILiteral debugString(CSSNumericBaseType type)
 {
     switch (type) {
     case CSSNumericBaseType::Length:
-        return "length";
+        return "length"_s;
     case CSSNumericBaseType::Angle:
-        return "angle";
+        return "angle"_s;
     case CSSNumericBaseType::Time:
-        return "time";
+        return "time"_s;
     case CSSNumericBaseType::Frequency:
-        return "frequency";
+        return "frequency"_s;
     case CSSNumericBaseType::Resolution:
-        return "resolution";
+        return "resolution"_s;
     case CSSNumericBaseType::Flex:
-        return "flex";
+        return "flex"_s;
     case CSSNumericBaseType::Percent:
-        return "percent";
+        return "percent"_s;
     }
-    return "invalid";
+    return "invalid"_s;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -134,65 +134,65 @@ static WeakHashSet<Node>& liveNodeSet()
     return liveNodes;
 }
 
-static const char* stringForRareDataUseType(NodeRareData::UseType useType)
+static ASCIILiteral stringForRareDataUseType(NodeRareData::UseType useType)
 {
     switch (useType) {
     case NodeRareData::UseType::TabIndex:
-        return "TabIndex";
+        return "TabIndex"_s;
     case NodeRareData::UseType::ChildIndex:
-        return "ChildIndex";
+        return "ChildIndex"_s;
     case NodeRareData::UseType::NodeList:
-        return "NodeList";
+        return "NodeList"_s;
     case NodeRareData::UseType::MutationObserver:
-        return "MutationObserver";
+        return "MutationObserver"_s;
     case NodeRareData::UseType::ManuallyAssignedSlot:
-        return "ManuallyAssignedSlot";
+        return "ManuallyAssignedSlot"_s;
     case NodeRareData::UseType::ScrollingPosition:
-        return "ScrollingPosition";
+        return "ScrollingPosition"_s;
     case NodeRareData::UseType::ComputedStyle:
-        return "ComputedStyle";
+        return "ComputedStyle"_s;
     case NodeRareData::UseType::DisplayContentsOrNoneStyle:
-        return "DisplayContentsOrNoneStyle";
+        return "DisplayContentsOrNoneStyle"_s;
     case NodeRareData::UseType::EffectiveLang:
-        return "EffectiveLang";
+        return "EffectiveLang"_s;
     case NodeRareData::UseType::Dataset:
-        return "Dataset";
+        return "Dataset"_s;
     case NodeRareData::UseType::ClassList:
-        return "ClassList";
+        return "ClassList"_s;
     case NodeRareData::UseType::ShadowRoot:
-        return "ShadowRoot";
+        return "ShadowRoot"_s;
     case NodeRareData::UseType::CustomElementReactionQueue:
-        return "CustomElementReactionQueue";
+        return "CustomElementReactionQueue"_s;
     case NodeRareData::UseType::CustomElementDefaultARIA:
-        return "CustomElementDefaultARIA";
+        return "CustomElementDefaultARIA"_s;
     case NodeRareData::UseType::FormAssociatedCustomElement:
-        return "FormAssociatedCustomElement";
+        return "FormAssociatedCustomElement"_s;
     case NodeRareData::UseType::AttributeMap:
-        return "AttributeMap";
+        return "AttributeMap"_s;
     case NodeRareData::UseType::InteractionObserver:
-        return "InteractionObserver";
+        return "InteractionObserver"_s;
     case NodeRareData::UseType::ResizeObserver:
-        return "ResizeObserver";
+        return "ResizeObserver"_s;
     case NodeRareData::UseType::Animations:
-        return "Animations";
+        return "Animations"_s;
     case NodeRareData::UseType::PseudoElements:
-        return "PseudoElements";
+        return "PseudoElements"_s;
     case NodeRareData::UseType::AttributeStyleMap:
-        return "AttributeStyleMap";
+        return "AttributeStyleMap"_s;
     case NodeRareData::UseType::ComputedStyleMap:
-        return "ComputedStyleMap";
+        return "ComputedStyleMap"_s;
     case NodeRareData::UseType::PartList:
-        return "PartList";
+        return "PartList"_s;
     case NodeRareData::UseType::PartNames:
-        return "PartNames";
+        return "PartNames"_s;
     case NodeRareData::UseType::Nonce:
-        return "Nonce";
+        return "Nonce"_s;
     case NodeRareData::UseType::ExplicitlySetAttrElementsMap:
-        return "ExplicitlySetAttrElementsMap";
+        return "ExplicitlySetAttrElementsMap"_s;
     case NodeRareData::UseType::Popover:
-        return "Popover";
+        return "Popover"_s;
     }
-    return nullptr;
+    return { };
 }
 
 #endif
@@ -310,7 +310,7 @@ void Node::dumpStatistics()
     printf("Number of Nodes with RareData: %zu\n", nodesWithRareData);
     printf("  Mixed use: %zu\n", mixedRareDataUseCount);
     for (auto it : rareDataSingleUseTypeCounts)
-        printf("  %s: %zu\n", stringForRareDataUseType(static_cast<NodeRareData::UseType>(it.key)), it.value);
+        printf("  %s: %zu\n", stringForRareDataUseType(static_cast<NodeRareData::UseType>(it.key)).characters(), it.value);
     printf("\n");
 
 
@@ -1988,7 +1988,7 @@ String Node::debugDescription() const
 
 #if ENABLE(TREE_DEBUGGING)
 
-static void appendAttributeDesc(const Node* node, StringBuilder& stringBuilder, const QualifiedName& name, const char* attrDesc)
+static void appendAttributeDesc(const Node* node, StringBuilder& stringBuilder, const QualifiedName& name, ASCIILiteral attrDesc)
 {
     auto* element = dynamicDowncast<Element>(*node);
     if (!element)
@@ -2002,19 +2002,19 @@ static void appendAttributeDesc(const Node* node, StringBuilder& stringBuilder, 
     stringBuilder.append(attr);
 }
 
-void Node::showNode(const char* prefix) const
+void Node::showNode(ASCIILiteral prefix) const
 {
-    if (!prefix)
-        prefix = "";
+    if (prefix.isNull())
+        prefix = ""_s;
     if (isTextNode()) {
         String value = makeStringByReplacingAll(nodeValue(), '\\', "\\\\"_s);
         value = makeStringByReplacingAll(value, '\n', "\\n"_s);
-        fprintf(stderr, "%s%s\t%p \"%s\"\n", prefix, nodeName().utf8().data(), this, value.utf8().data());
+        fprintf(stderr, "%s%s\t%p \"%s\"\n", prefix.characters(), nodeName().utf8().data(), this, value.utf8().data());
     } else {
         StringBuilder attrs;
-        appendAttributeDesc(this, attrs, classAttr, " CLASS=");
-        appendAttributeDesc(this, attrs, styleAttr, " STYLE=");
-        fprintf(stderr, "%s%s\t%p (renderer %p) %s%s%s\n", prefix, nodeName().utf8().data(), this, renderer(), attrs.toString().utf8().data(), needsStyleRecalc() ? " (needs style recalc)" : "", childNeedsStyleRecalc() ? " (child needs style recalc)" : "");
+        appendAttributeDesc(this, attrs, classAttr, " CLASS="_s);
+        appendAttributeDesc(this, attrs, styleAttr, " STYLE="_s);
+        fprintf(stderr, "%s%s\t%p (renderer %p) %s%s%s\n", prefix.characters(), nodeName().utf8().data(), this, renderer(), attrs.toString().utf8().data(), needsStyleRecalc() ? " (needs style recalc)" : "", childNeedsStyleRecalc() ? " (child needs style recalc)" : "");
     }
 }
 

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -496,7 +496,7 @@ public:
     virtual String debugDescription() const;
 
 #if ENABLE(TREE_DEBUGGING)
-    void showNode(const char* prefix = "") const;
+    void showNode(ASCIILiteral prefix = ""_s) const;
     WEBCORE_EXPORT void showTreeForThis() const;
     void showNodePathForThis() const;
     void showTreeAndMark(const Node* markedNode1, const char* markedLabel1, const Node* markedNode2 = nullptr, const char* markedLabel2 = nullptr) const;

--- a/Source/WebCore/html/FTPDirectoryDocument.cpp
+++ b/Source/WebCore/html/FTPDirectoryDocument.cpp
@@ -239,7 +239,7 @@ static String processFileDateString(const FTPTime& fileTime)
     if (fileTime.tm_year == now.year() - 1 && fileTime.tm_mon == 12 && fileTime.tm_mday == 31 && now.month() == 1 && now.monthDay() == 1)
         return "Yesterday" + timeOfDay;
 
-    static const char* months[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", "???" };
+    static constexpr std::array months = { "Jan"_s, "Feb"_s, "Mar"_s, "Apr"_s, "May"_s, "Jun"_s, "Jul"_s, "Aug"_s, "Sep"_s, "Oct"_s, "Nov"_s, "Dec"_s, "???"_s };
 
     int month = fileTime.tm_mon;
     if (month < 0 || month > 11)

--- a/Source/WebCore/html/PermissionsPolicy.cpp
+++ b/Source/WebCore/html/PermissionsPolicy.cpp
@@ -39,52 +39,52 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-static const char* policyTypeName(PermissionsPolicy::Type type)
+static ASCIILiteral policyTypeName(PermissionsPolicy::Type type)
 {
     switch (type) {
     case PermissionsPolicy::Type::Camera:
-        return "Camera";
+        return "Camera"_s;
     case PermissionsPolicy::Type::Microphone:
-        return "Microphone";
+        return "Microphone"_s;
     case PermissionsPolicy::Type::SpeakerSelection:
-        return "SpeakerSelection";
+        return "SpeakerSelection"_s;
     case PermissionsPolicy::Type::DisplayCapture:
-        return "DisplayCapture";
+        return "DisplayCapture"_s;
     case PermissionsPolicy::Type::Gamepad:
-        return "Gamepad";
+        return "Gamepad"_s;
     case PermissionsPolicy::Type::Geolocation:
-        return "Geolocation";
+        return "Geolocation"_s;
     case PermissionsPolicy::Type::Payment:
-        return "Payment";
+        return "Payment"_s;
     case PermissionsPolicy::Type::ScreenWakeLock:
-        return "ScreenWakeLock";
+        return "ScreenWakeLock"_s;
     case PermissionsPolicy::Type::SyncXHR:
-        return "SyncXHR";
+        return "SyncXHR"_s;
     case PermissionsPolicy::Type::Fullscreen:
-        return "Fullscreen";
+        return "Fullscreen"_s;
     case PermissionsPolicy::Type::WebShare:
-        return "WebShare";
+        return "WebShare"_s;
 #if ENABLE(DEVICE_ORIENTATION)
     case PermissionsPolicy::Type::Gyroscope:
-        return "Gyroscope";
+        return "Gyroscope"_s;
     case PermissionsPolicy::Type::Accelerometer:
-        return "Accelerometer";
+        return "Accelerometer"_s;
     case PermissionsPolicy::Type::Magnetometer:
-        return "Magnetometer";
+        return "Magnetometer"_s;
 #endif
 #if ENABLE(WEB_AUTHN)
     case PermissionsPolicy::Type::PublickeyCredentialsGetRule:
-        return "PublickeyCredentialsGet";
+        return "PublickeyCredentialsGet"_s;
 #endif
 #if ENABLE(WEBXR)
     case PermissionsPolicy::Type::XRSpatialTracking:
-        return "XRSpatialTracking";
+        return "XRSpatialTracking"_s;
 #endif
     case PermissionsPolicy::Type::PrivateToken:
-        return "PrivateToken";
+        return "PrivateToken"_s;
     }
     ASSERT_NOT_REACHED();
-    return "";
+    return ""_s;
 }
 
 bool isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type type, const Document& document, LogPermissionsPolicyFailure logFailure)

--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -84,23 +84,23 @@ static bool foundMixedContentInFrameTree(const LocalFrame& frame, const URL& url
 
 static void logConsoleWarning(const LocalFrame& frame, bool allowed, ASCIILiteral action, const URL& target)
 {
-    const char* errorString = allowed ? " was allowed to " : " was not allowed to ";
-    auto message = makeString((allowed ? "" : "[blocked] "), "The page at ", frame.document()->url().stringCenterEllipsizedToLength(), errorString, action, " insecure content from ", target.stringCenterEllipsizedToLength(), ".\n");
+    auto errorString = allowed ? " was allowed to "_s : " was not allowed to "_s;
+    auto message = makeString((allowed ? ""_s : "[blocked] "_s), "The page at "_s, frame.document()->url().stringCenterEllipsizedToLength(), errorString, action, " insecure content from "_s, target.stringCenterEllipsizedToLength(), ".\n"_s);
     frame.protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Warning, message);
 }
 
 static void logConsoleWarningForUpgrade(const LocalFrame& frame, bool blocked, const URL& target, bool isUpgradingIPAddressAndLocalhostEnabled)
 {
     auto isUpgradingLocalhostDisabled = !isUpgradingIPAddressAndLocalhostEnabled && SecurityOrigin::isLocalhostAddress(target.host());
-    const char* errorString;
+    ASCIILiteral errorString = [&] {
     if (blocked)
-        errorString = "blocked and must";
-    else if (isUpgradingLocalhostDisabled)
-        errorString = "not upgraded to HTTPS and must be served from the local host.";
-    else
-        errorString = "automatically upgraded and should";
+        return "blocked and must"_s;
+    if (isUpgradingLocalhostDisabled)
+        return "not upgraded to HTTPS and must be served from the local host."_s;
+    return "automatically upgraded and should"_s;
+    }();
 
-    auto message = makeString((!blocked ? "" : "[blocked] "), "The page at ", frame.document()->url().stringCenterEllipsizedToLength(), " requested insecure content from ", target.stringCenterEllipsizedToLength(), ". This content was ", errorString, !isUpgradingLocalhostDisabled ? " be served over HTTPS.\n" : "\n"_s);
+    auto message = makeString((!blocked ? ""_s : "[blocked] "_s), "The page at "_s, frame.document()->url().stringCenterEllipsizedToLength(), " requested insecure content from "_s, target.stringCenterEllipsizedToLength(), ". This content was "_s, errorString, !isUpgradingLocalhostDisabled ? " be served over HTTPS.\n"_s : "\n"_s);
     frame.document()->addConsoleMessage(MessageSource::Security, MessageLevel::Warning, message);
 }
 

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -221,7 +221,7 @@ void logMemoryStatistics(LogMemoryStatisticsReason reason)
     RELEASE_LOG(MemoryPressure, "Websam state: %" PUBLIC_LOG_STRING, MemoryPressureHandler::processStateDescription().characters());
     auto stats = PerformanceLogging::memoryUsageStatistics(ShouldIncludeExpensiveComputations::Yes);
     for (auto& [key, val] : stats)
-        RELEASE_LOG(MemoryPressure, "%" PUBLIC_LOG_STRING ": %zu", key, val);
+        RELEASE_LOG(MemoryPressure, "%" PUBLIC_LOG_STRING ": %zu", key.characters(), val);
 
 #if PLATFORM(COCOA)
     auto pageSize = vmPageSize();

--- a/Source/WebCore/page/PerformanceLogging.h
+++ b/Source/WebCore/page/PerformanceLogging.h
@@ -48,11 +48,11 @@ public:
     void didReachPointOfInterest(PointOfInterest);
 
     WEBCORE_EXPORT static HashCountedSet<const char*> javaScriptObjectCounts();
-    WEBCORE_EXPORT static HashMap<const char*, size_t> memoryUsageStatistics(ShouldIncludeExpensiveComputations);
+    WEBCORE_EXPORT static Vector<std::pair<ASCIILiteral, size_t>> memoryUsageStatistics(ShouldIncludeExpensiveComputations);
     WEBCORE_EXPORT static std::optional<uint64_t> physicalFootprint();
 
 private:
-    static void getPlatformMemoryUsageStatistics(HashMap<const char*, size_t>&);
+    static void getPlatformMemoryUsageStatistics(Vector<std::pair<ASCIILiteral, size_t>>&);
 
     Page& m_page;
 };

--- a/Source/WebCore/page/cocoa/PerformanceLoggingCocoa.mm
+++ b/Source/WebCore/page/cocoa/PerformanceLoggingCocoa.mm
@@ -41,18 +41,18 @@ std::optional<uint64_t> PerformanceLogging::physicalFootprint()
     return vmInfo.phys_footprint;
 }
 
-void PerformanceLogging::getPlatformMemoryUsageStatistics(HashMap<const char*, size_t>& stats)
+void PerformanceLogging::getPlatformMemoryUsageStatistics(Vector<std::pair<ASCIILiteral, size_t>>& stats)
 {
     task_vm_info_data_t vmInfo;
     mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
     kern_return_t err = task_info(mach_task_self(), TASK_VM_INFO, (task_info_t) &vmInfo, &count);
     if (err != KERN_SUCCESS)
         return;
-    stats.add("internal_mb", static_cast<size_t>(vmInfo.internal >> 20));
-    stats.add("compressed_mb", static_cast<size_t>(vmInfo.compressed >> 20));
-    stats.add("phys_footprint_mb", static_cast<size_t>(vmInfo.phys_footprint >> 20));
-    stats.add("resident_size_mb", static_cast<size_t>(vmInfo.resident_size >> 20));
-    stats.add("virtual_size_mb", static_cast<size_t>(vmInfo.virtual_size >> 20));
+    stats.append(std::pair { "internal_mb"_s, static_cast<size_t>(vmInfo.internal >> 20) });
+    stats.append(std::pair { "compressed_mb"_s, static_cast<size_t>(vmInfo.compressed >> 20) });
+    stats.append(std::pair { "phys_footprint_mb"_s, static_cast<size_t>(vmInfo.phys_footprint >> 20) });
+    stats.append(std::pair { "resident_size_mb"_s, static_cast<size_t>(vmInfo.resident_size >> 20) });
+    stats.append(std::pair { "virtual_size_mb"_s, static_cast<size_t>(vmInfo.virtual_size >> 20) });
 }
 
 }

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -1051,12 +1051,12 @@ void ContentSecurityPolicy::reportInvalidPathCharacter(const String& directiveNa
 {
     ASSERT(invalidChar == '#' || invalidChar == '?');
 
-    const char* ignoring;
-    if (invalidChar == '?')
-        ignoring = "The query component, including the '?', will be ignored.";
-    else
-        ignoring = "The fragment identifier, including the '#', will be ignored.";
-    logToConsole(makeString("The source list for Content Security Policy directive '", directiveName, "' contains a source with an invalid path: '", value, "'. ", ignoring));
+    ASCIILiteral ignoring = [&] {
+        if (invalidChar == '?')
+            return "The query component, including the '?', will be ignored."_s;
+        return "The fragment identifier, including the '#', will be ignored."_s;
+    }();
+    logToConsole(makeString("The source list for Content Security Policy directive '"_s, directiveName, "' contains a source with an invalid path: '"_s, value, "'. "_s, ignoring));
 }
 
 void ContentSecurityPolicy::reportInvalidSourceExpression(const String& directiveName, const String& source) const

--- a/Source/WebCore/platform/RuntimeApplicationChecks.cpp
+++ b/Source/WebCore/platform/RuntimeApplicationChecks.cpp
@@ -93,28 +93,28 @@ std::optional<AuxiliaryProcessType> processType()
     return auxiliaryProcessType();
 }
 
-const char* processTypeDescription(std::optional<AuxiliaryProcessType> type)
+ASCIILiteral processTypeDescription(std::optional<AuxiliaryProcessType> type)
 {
     if (!type)
-        return "UI";
+        return "UI"_s;
 
     switch (*type) {
     case AuxiliaryProcessType::WebContent:
-        return "Web";
+        return "Web"_s;
     case AuxiliaryProcessType::Network:
-        return "Network";
+        return "Network"_s;
     case AuxiliaryProcessType::Plugin:
-        return "Plugin";
+        return "Plugin"_s;
 #if ENABLE(GPU_PROCESS)
     case AuxiliaryProcessType::GPU:
-        return "GPU";
+        return "GPU"_s;
 #endif
 #if ENABLE(MODEL_PROCESS)
     case AuxiliaryProcessType::Model:
-        return "Model";
+        return "Model"_s;
 #endif
     }
-    return "Unknown";
+    return "Unknown"_s;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/RuntimeApplicationChecks.h
+++ b/Source/WebCore/platform/RuntimeApplicationChecks.h
@@ -49,7 +49,7 @@ WEBCORE_EXPORT void setAuxiliaryProcessType(AuxiliaryProcessType);
 WEBCORE_EXPORT void setAuxiliaryProcessTypeForTesting(std::optional<AuxiliaryProcessType>);
 WEBCORE_EXPORT bool checkAuxiliaryProcessType(AuxiliaryProcessType);
 WEBCORE_EXPORT std::optional<AuxiliaryProcessType> processType();
-WEBCORE_EXPORT const char* processTypeDescription(std::optional<AuxiliaryProcessType>);
+WEBCORE_EXPORT ASCIILiteral processTypeDescription(std::optional<AuxiliaryProcessType>);
 
 WEBCORE_EXPORT bool isInAuxiliaryProcess();
 inline bool isInWebProcess() { return checkAuxiliaryProcessType(AuxiliaryProcessType::WebContent); }

--- a/Source/WebCore/platform/graphics/GraphicsContextState.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.cpp
@@ -196,60 +196,60 @@ void GraphicsContextState::mergeAllChanges(const GraphicsContextState& state)
 #endif
 }
 
-static const char* stateChangeName(GraphicsContextState::Change change)
+static ASCIILiteral stateChangeName(GraphicsContextState::Change change)
 {
     switch (change) {
     case GraphicsContextState::Change::FillBrush:
-        return "fill-brush";
+        return "fill-brush"_s;
 
     case GraphicsContextState::Change::FillRule:
-        return "fill-rule";
+        return "fill-rule"_s;
 
     case GraphicsContextState::Change::StrokeBrush:
-        return "stroke-brush";
+        return "stroke-brush"_s;
 
     case GraphicsContextState::Change::StrokeThickness:
-        return "stroke-thickness";
+        return "stroke-thickness"_s;
 
     case GraphicsContextState::Change::StrokeStyle:
-        return "stroke-style";
+        return "stroke-style"_s;
 
     case GraphicsContextState::Change::CompositeMode:
-        return "composite-mode";
+        return "composite-mode"_s;
 
     case GraphicsContextState::Change::DropShadow:
-        return "drop-shadow";
+        return "drop-shadow"_s;
 
     case GraphicsContextState::Change::Style:
-        return "style";
+        return "style"_s;
 
     case GraphicsContextState::Change::Alpha:
-        return "alpha";
+        return "alpha"_s;
 
     case GraphicsContextState::Change::ImageInterpolationQuality:
-        return "image-interpolation-quality";
+        return "image-interpolation-quality"_s;
 
     case GraphicsContextState::Change::TextDrawingMode:
-        return "text-drawing-mode";
+        return "text-drawing-mode"_s;
 
     case GraphicsContextState::Change::ShouldAntialias:
-        return "should-antialias";
+        return "should-antialias"_s;
 
     case GraphicsContextState::Change::ShouldSmoothFonts:
-        return "should-smooth-fonts";
+        return "should-smooth-fonts"_s;
 
     case GraphicsContextState::Change::ShouldSubpixelQuantizeFonts:
-        return "should-subpixel-quantize-fonts";
+        return "should-subpixel-quantize-fonts"_s;
 
     case GraphicsContextState::Change::ShadowsIgnoreTransforms:
-        return "shadows-ignore-transforms";
+        return "shadows-ignore-transforms"_s;
 
     case GraphicsContextState::Change::DrawLuminanceMask:
-        return "draw-luminance-mask";
+        return "draw-luminance-mask"_s;
 
 #if HAVE(OS_DARK_MODE_SUPPORT)
     case GraphicsContextState::Change::UseDarkAppearance:
-        return "use-dark-appearance";
+        return "use-dark-appearance"_s;
 #endif
     }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
@@ -217,10 +217,10 @@ void CDMSessionAVContentKeySession::releaseKeys()
     }
 }
 
-static bool isEqual(Uint8Array* data, const char* literal)
+static bool isEqual(Uint8Array* data, ASCIILiteral literal)
 {
     ASSERT(data);
-    ASSERT(literal);
+    ASSERT(!literal.isNull());
     unsigned length = data->length();
 
     for (unsigned i = 0; i < length; ++i) {
@@ -237,7 +237,7 @@ bool CDMSessionAVContentKeySession::update(Uint8Array* key, RefPtr<Uint8Array>& 
 {
     UNUSED_PARAM(nextMessage);
 
-    if (isEqual(key, "acknowledged")) {
+    if (isEqual(key, "acknowledged"_s)) {
         ALWAYS_LOG(LOGIDENTIFIER, "acknowleding secure stop message");
 
         String storagePath = this->storagePath();
@@ -259,7 +259,7 @@ bool CDMSessionAVContentKeySession::update(Uint8Array* key, RefPtr<Uint8Array>& 
         return false;
     }
 
-    bool shouldGenerateKeyRequest = !m_certificate || isEqual(key, "renew");
+    bool shouldGenerateKeyRequest = !m_certificate || isEqual(key, "renew"_s);
     if (!m_certificate) {
         ALWAYS_LOG(LOGIDENTIFIER, "certificate data");
 

--- a/Source/WebCore/platform/sql/SQLiteDatabase.cpp
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.cpp
@@ -316,18 +316,18 @@ void SQLiteDatabase::close()
 
 void SQLiteDatabase::overrideUnauthorizedFunctions()
 {
-    static const std::pair<const char*, int> functionParameters[] = {
-        { "rtreenode", 2 },
-        { "rtreedepth", 1 },
-        { "eval", 1 },
-        { "eval", 2 },
-        { "printf", -1 },
-        { "fts3_tokenizer", 1 },
-        { "fts3_tokenizer", 2 },
+    static const std::pair<ASCIILiteral, int> functionParameters[] = {
+        { "rtreenode"_s, 2 },
+        { "rtreedepth"_s, 1 },
+        { "eval"_s, 1 },
+        { "eval"_s, 2 },
+        { "printf"_s, -1 },
+        { "fts3_tokenizer"_s, 1 },
+        { "fts3_tokenizer"_s, 2 },
     };
 
     for (auto& functionParameter : functionParameters)
-        sqlite3_create_function(m_db, functionParameter.first, functionParameter.second, SQLITE_UTF8, const_cast<char*>(functionParameter.first), unauthorizedSQLFunction, 0, 0);
+        sqlite3_create_function(m_db, functionParameter.first, functionParameter.second, SQLITE_UTF8, const_cast<char*>(functionParameter.first.characters()), unauthorizedSQLFunction, 0, 0);
 }
 
 void SQLiteDatabase::setFullsync(bool fsync)

--- a/Source/WebCore/rendering/RenderCounter.cpp
+++ b/Source/WebCore/rendering/RenderCounter.cpp
@@ -606,7 +606,7 @@ RefPtr<CSSCounterStyle> RenderCounter::counterStyle() const
 
 #if ENABLE(TREE_DEBUGGING)
 
-void showCounterRendererTree(const WebCore::RenderObject* renderer, const char* counterName)
+void showCounterRendererTree(const WebCore::RenderObject* renderer, ASCIILiteral counterName)
 {
     if (!renderer)
         return;
@@ -614,7 +614,7 @@ void showCounterRendererTree(const WebCore::RenderObject* renderer, const char* 
     while (root->parent())
         root = root->parent();
 
-    auto identifier = AtomString::fromLatin1(counterName);
+    AtomString identifier { counterName };
     for (auto* current = root; current; current = current->nextInPreOrder()) {
         auto* element = dynamicDowncast<WebCore::RenderElement>(*current);
         if (!element)
@@ -625,7 +625,7 @@ void showCounterRendererTree(const WebCore::RenderObject* renderer, const char* 
         fprintf(stderr, "%p N:%p P:%p PS:%p NS:%p C:%p\n",
             current, current->node(), current->parent(), current->previousSibling(),
             current->nextSibling(), element->hasCounterNodeMap() ?
-            counterName ? WebCore::counterMaps().find(*downcast<WebCore::RenderElement>(current))->value->get(identifier) : (WebCore::CounterNode*)1 : (WebCore::CounterNode*)0);
+            !counterName.isNull() ? WebCore::counterMaps().find(*downcast<WebCore::RenderElement>(current))->value->get(identifier) : (WebCore::CounterNode*)1 : (WebCore::CounterNode*)0);
     }
     fflush(stderr);
 }

--- a/Source/WebCore/rendering/RenderCounter.h
+++ b/Source/WebCore/rendering/RenderCounter.h
@@ -65,5 +65,5 @@ SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderCounter, isRenderCounter())
 
 #if ENABLE(TREE_DEBUGGING)
 // Outside the WebCore namespace for ease of invocation from the debugger.
-void showCounterRendererTree(const WebCore::RenderObject*, const char* counterName = nullptr);
+void showCounterRendererTree(const WebCore::RenderObject*, ASCIILiteral counterName = { });
 #endif

--- a/Source/WebKit/Platform/IPC/HandleMessage.h
+++ b/Source/WebKit/Platform/IPC/HandleMessage.h
@@ -64,10 +64,10 @@ inline TextStream textStreamForLogging(const Connection& connection, MessageName
 
     switch (forReply) {
     case ForReply::No:
-        stream << "-> " << WebCore::processTypeDescription(WebCore::processType()) << ' ' << getCurrentProcessID() << " receiver " << object << "] " << description(messageName);
+        stream << "-> "_s << WebCore::processTypeDescription(WebCore::processType()) << ' ' << getCurrentProcessID() << " receiver "_s << object << "] "_s << description(messageName);
         break;
     case ForReply::Yes:
-        stream << "<- " << WebCore::processTypeDescription(WebCore::processType()) << ' ' << getCurrentProcessID() << "] " << description(messageName) << " Reply";
+        stream << "<- "_s << WebCore::processTypeDescription(WebCore::processType()) << ' ' << getCurrentProcessID() << "] "_s << description(messageName) << " Reply"_s;
         break;
     }
 

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -746,9 +746,9 @@ RetainPtr<NSDictionary> WebProcess::additionalStateForDiagnosticReport() const
     auto stateDictionary = adoptNS([[NSMutableDictionary alloc] init]);
     {
         auto memoryUsageStats = adoptNS([[NSMutableDictionary alloc] init]);
-        for (auto& it : PerformanceLogging::memoryUsageStatistics(ShouldIncludeExpensiveComputations::Yes)) {
-            auto keyString = adoptNS([[NSString alloc] initWithUTF8String:it.key]);
-            [memoryUsageStats setObject:@(it.value) forKey:keyString.get()];
+        for (auto& [key, value] : PerformanceLogging::memoryUsageStatistics(ShouldIncludeExpensiveComputations::Yes)) {
+            auto keyString = adoptNS([[NSString alloc] initWithUTF8String:key]);
+            [memoryUsageStats setObject:@(value) forKey:keyString.get()];
         }
         [stateDictionary setObject:memoryUsageStats.get() forKey:@"Memory Usage Stats"];
     }


### PR DESCRIPTION
#### cb33335735a96497d668430668716a1b8f694e29
<pre>
Reduce use of `const char*` in the code base
<a href="https://bugs.webkit.org/show_bug.cgi?id=273277">https://bugs.webkit.org/show_bug.cgi?id=273277</a>

Reviewed by Darin Adler.

Reduce use of `const char*` in the code base by leveraging ASCIILiteral.

* Source/JavaScriptCore/assembler/MacroAssemblerCodeRef.h:
(JSC::MacroAssemblerCodeRef::dump const):
* Source/JavaScriptCore/ftl/FTLCompile.cpp:
(JSC::FTL::compile):
* Source/WTF/wtf/CodePtr.cpp:
(WTF::CodePtrBase::dumpWithName):
* Source/WTF/wtf/CodePtr.h:
(WTF::CodePtr::dumpWithName const):
(WTF::CodePtr::dump const):
* Source/WTF/wtf/Dominators.h:
(WTF::Dominators::Dominators):
(WTF::Dominators::ValidationContext::reportError):
* Source/WTF/wtf/Gigacage.h:
(Gigacage::name):
* Source/WTF/wtf/MemoryPressureHandler.cpp:
(WTF::toString):
(WTF::MemoryPressureHandler::setMemoryUsagePolicyBasedOnFootprint):
* Source/WTF/wtf/SingleRootGraph.h:
(WTF::SingleRootGraphNode::rootName):
(WTF::SingleRootGraphSet::dump const):
* Source/WTF/wtf/StringHashDumpContext.h:
(WTF::StringHashDumpContext::dump const):
* Source/WTF/wtf/SuspendableWorkQueue.cpp:
(WTF::SuspendableWorkQueue::stateString):
(WTF::SuspendableWorkQueue::suspend):
(WTF::SuspendableWorkQueue::resume):
* Source/WTF/wtf/SuspendableWorkQueue.h:
* Source/WTF/wtf/URLParser.cpp:
(WTF::serializeURLEncodedForm):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp:
(WebCore::IDBServer::quotaErrorMessageName):
(WebCore::IDBServer::UniqueIDBDatabase::performCurrentOpenOperationAfterSpaceCheck):
(WebCore::IDBServer::UniqueIDBDatabase::createObjectStore):
(WebCore::IDBServer::UniqueIDBDatabase::renameObjectStore):
(WebCore::IDBServer::UniqueIDBDatabase::createIndex):
(WebCore::IDBServer::UniqueIDBDatabase::renameIndex):
(WebCore::IDBServer::UniqueIDBDatabase::putOrAddAfterSpaceCheck):
* Source/WebCore/Modules/push-api/PushDatabase.h:
* Source/WebCore/Modules/webauthn/cbor/CBORReader.cpp:
(cbor::CBORReader::errorCodeToString):
* Source/WebCore/Modules/webauthn/cbor/CBORReader.h:
* Source/WebCore/Modules/webauthn/fido/FidoConstants.cpp:
(fido::publicKeyCredentialTypeToString):
* Source/WebCore/Modules/webauthn/fido/FidoConstants.h:
* Source/WebCore/Modules/webdatabase/Database.cpp:
(WebCore::formatErrorMessage):
(WebCore::Database::performOpenAndVerify):
(WebCore::Database::incrementalVacuumIfNeeded):
* Source/WebCore/Modules/webdatabase/DatabaseTask.cpp:
(WebCore::DatabaseTask::performTask):
(WebCore::DatabaseOpenTask::debugTaskName const):
(WebCore::DatabaseCloseTask::debugTaskName const):
(WebCore::DatabaseTransactionTask::debugTaskName const):
(WebCore::DatabaseTableNamesTask::debugTaskName const):
* Source/WebCore/Modules/webdatabase/DatabaseTask.h:
* Source/WebCore/Modules/webdatabase/SQLTransaction.cpp:
(WebCore::SQLTransaction::performPendingCallback):
(WebCore::SQLTransaction::requestTransitToState):
(WebCore::SQLTransaction::scheduleCallback):
(WebCore::SQLTransaction::computeNextStateAndCleanupIfNeeded):
(WebCore::SQLTransaction::debugStepName):
* Source/WebCore/Modules/webdatabase/SQLTransaction.h:
* Source/WebCore/Modules/webdatabase/SQLTransactionBackend.cpp:
(WebCore::SQLTransactionBackend::computeNextStateAndCleanupIfNeeded):
(WebCore::SQLTransactionBackend::requestTransitToState):
* Source/WebCore/Modules/webdatabase/SQLTransactionStateMachine.cpp:
(WebCore::nameForSQLTransactionState):
* Source/WebCore/Modules/webdatabase/SQLTransactionStateMachine.h:
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::joinStrings):
* Source/WebCore/Modules/websockets/WebSocketExtensionParser.cpp:
(WebCore::isSeparator):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::name):
(WTF::printInternal):
* Source/WebCore/contentextensions/ContentExtensionActions.cpp:
(WebCore::ContentExtensions::makeJSString):
(WebCore::ContentExtensions::RedirectAction::RegexSubstitutionAction::applyToURL const):
* Source/WebCore/contentextensions/ContentExtensionParser.cpp:
(WebCore::ContentExtensions::getDomainList):
* Source/WebCore/contentextensions/DFABytecodeInterpreter.cpp:
(WebCore::ContentExtensions::DFABytecodeInterpreter::interpret):
* Source/WebCore/crypto/SubtleCrypto.cpp:
(WebCore::normalizeCryptoAlgorithmParameters):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDSAGCrypt.cpp:
(WebCore::extractECDSASignatureInteger):
(WebCore::gcryptSign):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp:
(WebCore::extractEDDSASignatureInteger):
(WebCore::signEd25519):
* Source/WebCore/crypto/gcrypt/CryptoKeyECGCrypt.cpp:
(WebCore::curveName):
(WebCore::CryptoKeyEC::platformGeneratePair):
* Source/WebCore/crypto/gcrypt/CryptoKeyRSAGCrypt.cpp:
(WebCore::getRSAKeyParameter):
(WebCore::CryptoKeyRSA::algorithm const):
(WebCore::CryptoKeyRSA::exportData const):
* Source/WebCore/css/CSSCounterStyleRule.cpp:
(WebCore::CSSCounterStyleRule::cssText const):
* Source/WebCore/css/CSSTimingFunctionValue.cpp:
(WebCore::CSSStepsTimingFunctionValue::customCSSText const):
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::serialize):
(WebCore::ShorthandSerializer::serializeLonghands const):
(WebCore::ShorthandSerializer::serializeLonghandsOmittingTrailingInitialValue const):
(WebCore::ShorthandSerializer::serializeGridArea const):
(WebCore::ShorthandSerializer::serializeGridRowColumn const):
(WebCore::ShorthandSerializer::serializeGridTemplate const):
* Source/WebCore/css/StyleColor.cpp:
(WebCore::StyleColor::colorFromAbsoluteKeyword):
* Source/WebCore/css/typedom/numeric/CSSNumericBaseType.h:
(WebCore::debugString):
* Source/WebCore/dom/Node.cpp:
(WebCore::stringForRareDataUseType):
(WebCore::Node::dumpStatistics):
(WebCore::appendAttributeDesc):
(WebCore::Node::showNode const):
* Source/WebCore/dom/Node.h:
* Source/WebCore/html/FTPDirectoryDocument.cpp:
(WebCore::processFileDateString):
* Source/WebCore/html/PermissionsPolicy.cpp:
(WebCore::policyTypeName):
* Source/WebCore/loader/MixedContentChecker.cpp:
(WebCore::logConsoleWarning):
(WebCore::logConsoleWarningForUpgrade):
* Source/WebCore/page/PerformanceLogging.cpp:
(WebCore::toString):
(WebCore::PerformanceLogging::memoryUsageStatistics):
(WebCore::PerformanceLogging::didReachPointOfInterest):
(WebCore::PerformanceLogging::getPlatformMemoryUsageStatistics):
* Source/WebCore/page/PerformanceLogging.h:
* Source/WebCore/page/cocoa/PerformanceLoggingCocoa.mm:
(WebCore::PerformanceLogging::getPlatformMemoryUsageStatistics):
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::reportInvalidPathCharacter const):
* Source/WebCore/platform/RuntimeApplicationChecks.cpp:
(WebCore::processTypeDescription):
* Source/WebCore/platform/RuntimeApplicationChecks.h:
* Source/WebCore/platform/graphics/GraphicsContextState.cpp:
(WebCore::stateChangeName):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm:
(WebCore::isEqual):
(WebCore::CDMSessionAVContentKeySession::update):
* Source/WebCore/platform/sql/SQLiteDatabase.cpp:
(WebCore::SQLiteDatabase::overrideUnauthorizedFunctions):
* Source/WebCore/rendering/RenderCounter.cpp:
(showCounterRendererTree):
* Source/WebCore/rendering/RenderCounter.h:
(showCounterRendererTree):
* Source/WebKit/Platform/IPC/HandleMessage.h:
(IPC::textStreamForLogging):

Canonical link: <a href="https://commits.webkit.org/278045@main">https://commits.webkit.org/278045@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec7f61490f48624e53d03125b96b1dede85d514d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52343 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52157 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45415 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51616 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34608 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26214 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40287 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51413 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26141 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42478 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; 3 api tests failed or timed out; re-run-api-tests (cancelled)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21408 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23592 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43659 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7679 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/42614 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Compiled JSC (warnings); jscore-tests (cancelled)") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45509 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; 5 api tests failed or timed out; re-run-api-tests (cancelled)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44162 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54060 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/48801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24394 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20577 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47609 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25666 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42686 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46612 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (failure); re-run-api-tests (cancelled)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26505 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56296 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7080 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25389 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11563 "Passed tests") | 
<!--EWS-Status-Bubble-End-->