### PR TITLE
[JSC] Avoid allocations in BinarySwitch

### DIFF
--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -4491,11 +4491,11 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
             CCallHelpers::Address(m_stubInfo->m_baseGPR, JSCell::structureIDOffset()),
             m_scratchGPR);
 
-        Vector<int64_t> caseValues(cases.size());
+        Vector<int64_t, 16> caseValues(cases.size());
         for (unsigned i = 0; i < cases.size(); ++i)
             caseValues[i] = bitwise_cast<int32_t>(cases[i]->structure()->id());
 
-        BinarySwitch binarySwitch(m_scratchGPR, caseValues, BinarySwitch::Int32);
+        BinarySwitch binarySwitch(m_scratchGPR, caseValues.span(), BinarySwitch::Int32);
         while (binarySwitch.advance(jit))
             generate(*cases[binarySwitch.caseIndex()]);
         m_failAndRepatch.append(binarySwitch.fallThrough());

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -1940,7 +1940,7 @@ void linkPolymorphicCall(VM& vm, JSCell* owner, CallFrame* callFrame, CallLinkIn
         memset(fastCounts.get(), 0, callSlots.size() * sizeof(uint32_t));
     }
 
-    Vector<int64_t> caseValues;
+    Vector<int64_t, 16> caseValues;
     caseValues.reserveInitialCapacity(callSlots.size());
     for (auto& slot : callSlots) {
         int64_t caseValue = bitwise_cast<intptr_t>(slot.m_calleeOrExecutable);
@@ -1989,7 +1989,7 @@ void linkPolymorphicCall(VM& vm, JSCell* owner, CallFrame* callFrame, CallLinkIn
         hasExecutable.link(&jit);
     }
 
-    BinarySwitch binarySwitch(comparisonValueGPR, caseValues, BinarySwitch::IntPtr);
+    BinarySwitch binarySwitch(comparisonValueGPR, caseValues.span(), BinarySwitch::IntPtr);
     while (binarySwitch.advance(jit)) {
         size_t caseIndex = binarySwitch.caseIndex();
         auto& slot = callSlots[caseIndex];

--- a/Source/JavaScriptCore/jit/BinarySwitch.h
+++ b/Source/JavaScriptCore/jit/BinarySwitch.h
@@ -65,7 +65,7 @@ public:
         IntPtr
     };
     
-    BinarySwitch(GPRReg value, const Vector<int64_t>& cases, Type);
+    BinarySwitch(GPRReg value, std::span<const int64_t> cases, Type);
     ~BinarySwitch();
     
     unsigned caseIndex() const { return m_cases[m_caseIndex].index; }
@@ -77,9 +77,6 @@ public:
     
 private:
     void build(unsigned start, bool hardStart, unsigned end);
-    
-    Type m_type;
-    GPRReg m_value;
     
     struct Case {
         Case() { }
@@ -100,8 +97,6 @@ private:
         int64_t value;
         unsigned index;
     };
-    
-    Vector<Case> m_cases;
     
     enum BranchKind {
         NotEqualToFallThrough,
@@ -125,16 +120,16 @@ private:
         BranchKind kind;
         unsigned index;
     };
-    
-    WeakRandom m_weakRandom;
-    
-    Vector<BranchCode> m_branches;
 
-    unsigned m_index;
-    unsigned m_caseIndex;
-    Vector<MacroAssembler::Jump> m_jumpStack;
-    
+    WeakRandom m_weakRandom;
+    Vector<Case, 16> m_cases;
+    Vector<BranchCode, 32> m_branches;
+    Vector<MacroAssembler::Jump, 32> m_jumpStack;
     MacroAssembler::JumpList m_fallThrough;
+    Type m_type;
+    GPRReg m_value;
+    unsigned m_index { 0 };
+    unsigned m_caseIndex { UINT_MAX };
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -3680,9 +3680,9 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addSwitch(Value condition, const Vector
 
         fallThrough.link(&m_jit);
     } else {
-        Vector<int64_t> cases(targets.size(), [](size_t i) { return i; });
+        Vector<int64_t, 16> cases(targets.size(), [](size_t i) { return i; });
 
-        BinarySwitch binarySwitch(wasmScratchGPR, cases, BinarySwitch::Int32);
+        BinarySwitch binarySwitch(wasmScratchGPR, cases.span(), BinarySwitch::Int32);
         while (binarySwitch.advance(m_jit)) {
             unsigned value = binarySwitch.caseValue();
             unsigned index = binarySwitch.caseIndex();


### PR DESCRIPTION
#### 3df15f02c1078c2c1257c865e1772f21d61d3a8d
<pre>
[JSC] Avoid allocations in BinarySwitch
<a href="https://bugs.webkit.org/show_bug.cgi?id=273291">https://bugs.webkit.org/show_bug.cgi?id=273291</a>
<a href="https://rdar.apple.com/127081651">rdar://127081651</a>

Reviewed by Keith Miller.

This patch adds some initial capacity to the Vector of BinarySwitch so that we can cover most of cases without allocations.

* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::regenerate):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::linkPolymorphicCall):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/jit/BinarySwitch.cpp:
(JSC::BinarySwitch::BinarySwitch):
(JSC::BinarySwitch::build):
(JSC::BinarySwitch::~BinarySwitch): Deleted.
* Source/JavaScriptCore/jit/BinarySwitch.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addSwitch):

Canonical link: <a href="https://commits.webkit.org/278049@main">https://commits.webkit.org/278049@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31670f72bcf8ee37e687273490715f66ef6478c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49237 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28518 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52033 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45340 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26135 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40223 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26068 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42414 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21343 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23521 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43590 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7559 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/42537 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45456 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44097 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53944 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/48726 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24318 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20507 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47540 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25591 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42618 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46534 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26429 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56220 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7084 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25313 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11546 "Found 9 new JSC stress test failures: stress/proxy-is-array.js.bytecode-cache, stress/proxy-is-array.js.default, stress/proxy-is-array.js.dfg-eager, stress/proxy-is-array.js.dfg-eager-no-cjit-validate, stress/proxy-is-array.js.eager-jettison-no-cjit, stress/proxy-is-array.js.mini-mode, stress/proxy-is-array.js.no-cjit-collect-continuously, stress/proxy-is-array.js.no-cjit-validate-phases, stress/proxy-is-array.js.no-llint (failure)") | 
<!--EWS-Status-Bubble-End-->