### PR TITLE
[WebGPU] WebGPU spec updated to support SharedWorkers and ServiceWorkers from only DedicatedWorkers

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPU.idl
+++ b/Source/WebCore/Modules/WebGPU/GPU.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPU {

--- a/Source/WebCore/Modules/WebGPU/GPUAdapter.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapter.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUAdapter {

--- a/Source/WebCore/Modules/WebGPU/GPUAdapterInfo.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapterInfo.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUAdapterInfo {

--- a/Source/WebCore/Modules/WebGPU/GPUBindGroup.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBindGroup.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUBindGroup {

--- a/Source/WebCore/Modules/WebGPU/GPUBindGroupLayout.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBindGroupLayout.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUBindGroupLayout {

--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.idl
@@ -32,7 +32,7 @@ typedef [EnforceRange] unsigned long GPUBufferUsageFlags;
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUBuffer {

--- a/Source/WebCore/Modules/WebGPU/GPUBufferUsage.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBufferUsage.idl
@@ -28,7 +28,7 @@
 typedef [EnforceRange] unsigned long GPUBufferUsageFlags;
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUBufferUsage {

--- a/Source/WebCore/Modules/WebGPU/GPUColorWrite.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUColorWrite.idl
@@ -28,7 +28,7 @@
 typedef [EnforceRange] unsigned long GPUColorWriteFlags;
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUColorWrite {

--- a/Source/WebCore/Modules/WebGPU/GPUCommandBuffer.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandBuffer.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUCommandBuffer {

--- a/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.idl
@@ -33,7 +33,7 @@ typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUCommandEncoder {

--- a/Source/WebCore/Modules/WebGPU/GPUCompilationInfo.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCompilationInfo.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     Serializable,
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUCompilationMessage.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCompilationMessage.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     Serializable,
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.idl
@@ -31,7 +31,7 @@ typedef [EnforceRange] unsigned long long GPUSize64;
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUComputePassEncoder {

--- a/Source/WebCore/Modules/WebGPU/GPUComputePipeline.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePipeline.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUComputePipeline {

--- a/Source/WebCore/Modules/WebGPU/GPUDeviceLostInfo.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUDeviceLostInfo.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUDeviceLostInfo {

--- a/Source/WebCore/Modules/WebGPU/GPUExternalTexture.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUExternalTexture.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUExternalTexture {

--- a/Source/WebCore/Modules/WebGPU/GPUInternalError.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUInternalError.idl
@@ -25,7 +25,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUInternalError {

--- a/Source/WebCore/Modules/WebGPU/GPUMapMode.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUMapMode.idl
@@ -28,7 +28,7 @@
 typedef [EnforceRange] unsigned long GPUMapModeFlags;
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUMapMode {

--- a/Source/WebCore/Modules/WebGPU/GPUOutOfMemoryError.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUOutOfMemoryError.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUOutOfMemoryError {

--- a/Source/WebCore/Modules/WebGPU/GPUPipelineLayout.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUPipelineLayout.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUPipelineLayout {

--- a/Source/WebCore/Modules/WebGPU/GPUQuerySet.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUQuerySet.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUQuerySet {

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.idl
@@ -33,7 +33,7 @@ typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUQueue {

--- a/Source/WebCore/Modules/WebGPU/GPURenderBundle.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderBundle.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPURenderBundle {

--- a/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPURenderBundleEncoder {

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.idl
@@ -33,7 +33,7 @@ typedef (sequence<double> or GPUColorDict) GPUColor;
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPURenderPassEncoder {

--- a/Source/WebCore/Modules/WebGPU/GPURenderPipeline.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPipeline.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPURenderPipeline {

--- a/Source/WebCore/Modules/WebGPU/GPUSampler.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUSampler.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUSampler {

--- a/Source/WebCore/Modules/WebGPU/GPUShaderModule.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUShaderModule.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUShaderModule {

--- a/Source/WebCore/Modules/WebGPU/GPUShaderStage.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUShaderStage.idl
@@ -28,7 +28,7 @@
 typedef [EnforceRange] unsigned long GPUShaderStageFlags;
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUShaderStage {

--- a/Source/WebCore/Modules/WebGPU/GPUSupportedFeatures.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUSupportedFeatures.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUSupportedFeatures {

--- a/Source/WebCore/Modules/WebGPU/GPUSupportedLimits.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUSupportedLimits.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUSupportedLimits {

--- a/Source/WebCore/Modules/WebGPU/GPUTexture.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTexture.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUTexture {

--- a/Source/WebCore/Modules/WebGPU/GPUTextureUsage.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureUsage.idl
@@ -28,7 +28,7 @@
 typedef [EnforceRange] unsigned long GPUTextureUsageFlags;
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUTextureUsage {

--- a/Source/WebCore/Modules/WebGPU/GPUTextureView.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureView.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUTextureView {

--- a/Source/WebCore/Modules/WebGPU/GPUUncapturedErrorEvent.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUUncapturedErrorEvent.idl
@@ -31,7 +31,7 @@ typedef (GPUOutOfMemoryError or GPUValidationError or GPUInternalError) GPUError
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUUncapturedErrorEvent : Event {

--- a/Source/WebCore/Modules/WebGPU/GPUValidationError.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUValidationError.idl
@@ -25,7 +25,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface GPUValidationError {

--- a/Source/WebCore/Modules/WebGPU/WGSLLanguageFeatures.idl
+++ b/Source/WebCore/Modules/WebGPU/WGSLLanguageFeatures.idl
@@ -25,7 +25,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext
 ]
 interface WGSLLanguageFeatures {

--- a/Source/WebCore/html/canvas/GPUCanvasContext.idl
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.idl
@@ -28,7 +28,7 @@
 [
     ActiveDOMObject,
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window,DedicatedWorker),
+    Exposed=(Window,Worker),
     SecureContext,
     SkipVTableValidation,
 ]

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
@@ -53,17 +53,17 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(ServiceWorkerGlobalScope);
 
-Ref<ServiceWorkerGlobalScope> ServiceWorkerGlobalScope::create(ServiceWorkerContextData&& contextData, ServiceWorkerData&& workerData, const WorkerParameters& params, Ref<SecurityOrigin>&& origin, ServiceWorkerThread& thread, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy* connectionProxy, SocketProvider* socketProvider, std::unique_ptr<NotificationClient>&& notificationClient)
+Ref<ServiceWorkerGlobalScope> ServiceWorkerGlobalScope::create(ServiceWorkerContextData&& contextData, ServiceWorkerData&& workerData, const WorkerParameters& params, Ref<SecurityOrigin>&& origin, ServiceWorkerThread& thread, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy* connectionProxy, SocketProvider* socketProvider, std::unique_ptr<NotificationClient>&& notificationClient, std::unique_ptr<WorkerClient>&& workerClient)
 {
-    auto scope = adoptRef(*new ServiceWorkerGlobalScope { WTFMove(contextData), WTFMove(workerData), params, WTFMove(origin), thread, WTFMove(topOrigin), connectionProxy, socketProvider, WTFMove(notificationClient) });
+    auto scope = adoptRef(*new ServiceWorkerGlobalScope { WTFMove(contextData), WTFMove(workerData), params, WTFMove(origin), thread, WTFMove(topOrigin), connectionProxy, socketProvider, WTFMove(notificationClient), WTFMove(workerClient) });
     scope->addToContextsMap();
     scope->applyContentSecurityPolicyResponseHeaders(params.contentSecurityPolicyResponseHeaders);
     scope->notifyServiceWorkerPageOfCreationIfNecessary();
     return scope;
 }
 
-ServiceWorkerGlobalScope::ServiceWorkerGlobalScope(ServiceWorkerContextData&& contextData, ServiceWorkerData&& workerData, const WorkerParameters& params, Ref<SecurityOrigin>&& origin, ServiceWorkerThread& thread, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy* connectionProxy, SocketProvider* socketProvider, std::unique_ptr<NotificationClient>&& notificationClient)
-    : WorkerGlobalScope(WorkerThreadType::ServiceWorker, params, WTFMove(origin), thread, WTFMove(topOrigin), connectionProxy, socketProvider, nullptr)
+ServiceWorkerGlobalScope::ServiceWorkerGlobalScope(ServiceWorkerContextData&& contextData, ServiceWorkerData&& workerData, const WorkerParameters& params, Ref<SecurityOrigin>&& origin, ServiceWorkerThread& thread, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy* connectionProxy, SocketProvider* socketProvider, std::unique_ptr<NotificationClient>&& notificationClient, std::unique_ptr<WorkerClient>&& workerClient)
+    : WorkerGlobalScope(WorkerThreadType::ServiceWorker, params, WTFMove(origin), thread, WTFMove(topOrigin), connectionProxy, socketProvider, WTFMove(workerClient))
     , m_contextData(WTFMove(contextData))
     , m_registration(ServiceWorkerRegistration::getOrCreate(*this, navigator().serviceWorker(), WTFMove(m_contextData.registration)))
     , m_serviceWorker(ServiceWorker::getOrCreate(*this, WTFMove(workerData)))

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.h
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.h
@@ -43,6 +43,7 @@ class PushEvent;
 class ServiceWorkerClient;
 class ServiceWorkerClients;
 class ServiceWorkerThread;
+class WorkerClient;
 
 #if ENABLE(DECLARATIVE_WEB_PUSH)
 class PushNotificationEvent;
@@ -55,7 +56,7 @@ struct ServiceWorkerClientData;
 class ServiceWorkerGlobalScope final : public WorkerGlobalScope {
     WTF_MAKE_ISO_ALLOCATED(ServiceWorkerGlobalScope);
 public:
-    static Ref<ServiceWorkerGlobalScope> create(ServiceWorkerContextData&&, ServiceWorkerData&&, const WorkerParameters&, Ref<SecurityOrigin>&&, ServiceWorkerThread&, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, std::unique_ptr<NotificationClient>&&);
+    static Ref<ServiceWorkerGlobalScope> create(ServiceWorkerContextData&&, ServiceWorkerData&&, const WorkerParameters&, Ref<SecurityOrigin>&&, ServiceWorkerThread&, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, std::unique_ptr<NotificationClient>&&, std::unique_ptr<WorkerClient>&&);
 
     ~ServiceWorkerGlobalScope();
 
@@ -110,7 +111,7 @@ public:
     CookieStore& cookieStore();
 
 private:
-    ServiceWorkerGlobalScope(ServiceWorkerContextData&&, ServiceWorkerData&&, const WorkerParameters&, Ref<SecurityOrigin>&&, ServiceWorkerThread&, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, std::unique_ptr<NotificationClient>&&);
+    ServiceWorkerGlobalScope(ServiceWorkerContextData&&, ServiceWorkerData&&, const WorkerParameters&, Ref<SecurityOrigin>&&, ServiceWorkerThread&, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, std::unique_ptr<NotificationClient>&&, std::unique_ptr<WorkerClient>&&);
     void notifyServiceWorkerPageOfCreationIfNecessary();
 
     void prepareForDestruction() final;

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
@@ -128,7 +128,7 @@ ServiceWorkerThread::~ServiceWorkerThread() = default;
 Ref<WorkerGlobalScope> ServiceWorkerThread::createWorkerGlobalScope(const WorkerParameters& params, Ref<SecurityOrigin>&& origin, Ref<SecurityOrigin>&& topOrigin)
 {
     RELEASE_ASSERT(m_contextData);
-    return ServiceWorkerGlobalScope::create(*std::exchange(m_contextData, std::nullopt), *std::exchange(m_workerData, std::nullopt), params, WTFMove(origin), *this, WTFMove(topOrigin), idbConnectionProxy(), socketProvider(), WTFMove(m_notificationClient));
+    return ServiceWorkerGlobalScope::create(*std::exchange(m_contextData, std::nullopt), *std::exchange(m_workerData, std::nullopt), params, WTFMove(origin), *this, WTFMove(topOrigin), idbConnectionProxy(), socketProvider(), WTFMove(m_notificationClient), WTFMove(m_workerClient));
 }
 
 void ServiceWorkerThread::runEventLoop()

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -57,6 +57,7 @@
 #include "WebSocketProvider.h"
 #include "WebStorageProvider.h"
 #include "WebUserContentController.h"
+#include "WebWorkerClient.h"
 #include <WebCore/EditorClient.h>
 #include <WebCore/EmptyClients.h>
 #include <WebCore/MessageWithMessagePorts.h>
@@ -206,7 +207,11 @@ void WebSWContextManagerConnection::installServiceWorker(ServiceWorkerContextDat
         notificationClient = makeUnique<WebNotificationClient>(nullptr);
 #endif
 
+        auto& corePage = page.get();
         auto serviceWorkerThreadProxy = ServiceWorkerThreadProxy::create(WTFMove(page), WTFMove(contextData), WTFMove(workerData), WTFMove(effectiveUserAgent), workerThreadMode, WebProcess::singleton().cacheStorageProvider(), WTFMove(notificationClient));
+
+        auto workerClient = WebWorkerClient::create(corePage, serviceWorkerThreadProxy->thread());
+        serviceWorkerThreadProxy->thread().setWorkerClient(workerClient.moveToUniquePtr());
 
         if (lastNavigationWasAppInitiated)
             serviceWorkerThreadProxy->setLastNavigationWasAppInitiated(lastNavigationWasAppInitiated == WebCore::LastNavigationWasAppInitiated::Yes);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -995,7 +995,7 @@ RefPtr<ImageBuffer> WebChromeClient::sinkIntoImageBuffer(std::unique_ptr<Seriali
 
 std::unique_ptr<WebCore::WorkerClient> WebChromeClient::createWorkerClient(SerialFunctionDispatcher& dispatcher)
 {
-    return WebWorkerClient::create(protectedPage(), dispatcher).moveToUniquePtr();
+    return WebWorkerClient::create(*protectedPage()->corePage(), dispatcher).moveToUniquePtr();
 }
 
 #if ENABLE(WEBGL)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
@@ -115,13 +115,13 @@ RefPtr<WebCore::WebGPU::GPU> GPUProcessWebWorkerClient::createGPUForWebGPU() con
 
 #endif
 
-UniqueRef<WebWorkerClient> WebWorkerClient::create(WebPage& page, SerialFunctionDispatcher& dispatcher)
+UniqueRef<WebWorkerClient> WebWorkerClient::create(Page& page, SerialFunctionDispatcher& dispatcher)
 {
     ASSERT(isMainRunLoop());
 #if ENABLE(GPU_PROCESS)
-    return UniqueRef<GPUProcessWebWorkerClient> { *new GPUProcessWebWorkerClient { dispatcher, page.corePage()->displayID() } };
+    return UniqueRef<GPUProcessWebWorkerClient> { *new GPUProcessWebWorkerClient { dispatcher, page.displayID() } };
 #else
-    return UniqueRef<WebWorkerClient> { *new WebWorkerClient { dispatcher, page.corePage()->displayID() } };
+    return UniqueRef<WebWorkerClient> { *new WebWorkerClient { dispatcher, page.displayID() } };
 #endif
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h
@@ -30,6 +30,10 @@
 #include "WebGPUIdentifier.h"
 #include <WebCore/WorkerClient.h>
 
+namespace WebCore {
+class Page;
+}
+
 namespace WebCore::WebGPU {
 class GPU;
 }
@@ -47,7 +51,7 @@ public:
     // happen on the worker.
     // Any details needed from the page must be copied at this
     // point, but can't hold references to any main-thread objects.
-    static UniqueRef<WebWorkerClient> create(WebPage&, SerialFunctionDispatcher&);
+    static UniqueRef<WebWorkerClient> create(WebCore::Page&, SerialFunctionDispatcher&);
 
     UniqueRef<WorkerClient> createNestedWorkerClient(SerialFunctionDispatcher&) override;
 


### PR DESCRIPTION
#### da1878500441aeae9a3c5683e883f4531b7ec132
<pre>
[WebGPU] WebGPU spec updated to support SharedWorkers and ServiceWorkers from only DedicatedWorkers
<a href="https://bugs.webkit.org/show_bug.cgi?id=273195">https://bugs.webkit.org/show_bug.cgi?id=273195</a>
&lt;radar://126990546&gt;

Reviewed by Tadeu Zagallo.

Add support for SharedWorkers and ServiceWorkers as the spec
requires it now.

* Source/WebCore/Modules/WebGPU/GPU.idl:
* Source/WebCore/Modules/WebGPU/GPUAdapter.idl:
* Source/WebCore/Modules/WebGPU/GPUAdapterInfo.idl:
* Source/WebCore/Modules/WebGPU/GPUBindGroup.idl:
* Source/WebCore/Modules/WebGPU/GPUBindGroupLayout.idl:
* Source/WebCore/Modules/WebGPU/GPUBuffer.idl:
* Source/WebCore/Modules/WebGPU/GPUBufferUsage.idl:
* Source/WebCore/Modules/WebGPU/GPUColorWrite.idl:
* Source/WebCore/Modules/WebGPU/GPUCommandBuffer.idl:
* Source/WebCore/Modules/WebGPU/GPUCommandEncoder.idl:
* Source/WebCore/Modules/WebGPU/GPUCompilationInfo.idl:
* Source/WebCore/Modules/WebGPU/GPUCompilationMessage.idl:
* Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.idl:
* Source/WebCore/Modules/WebGPU/GPUComputePipeline.idl:
* Source/WebCore/Modules/WebGPU/GPUDeviceLostInfo.idl:
* Source/WebCore/Modules/WebGPU/GPUExternalTexture.idl:
* Source/WebCore/Modules/WebGPU/GPUInternalError.idl:
* Source/WebCore/Modules/WebGPU/GPUMapMode.idl:
* Source/WebCore/Modules/WebGPU/GPUOutOfMemoryError.idl:
* Source/WebCore/Modules/WebGPU/GPUPipelineLayout.idl:
* Source/WebCore/Modules/WebGPU/GPUQuerySet.idl:
* Source/WebCore/Modules/WebGPU/GPUQueue.idl:
* Source/WebCore/Modules/WebGPU/GPURenderBundle.idl:
* Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.idl:
* Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.idl:
* Source/WebCore/Modules/WebGPU/GPURenderPipeline.idl:
* Source/WebCore/Modules/WebGPU/GPUSampler.idl:
* Source/WebCore/Modules/WebGPU/GPUShaderModule.idl:
* Source/WebCore/Modules/WebGPU/GPUShaderStage.idl:
* Source/WebCore/Modules/WebGPU/GPUSupportedFeatures.idl:
* Source/WebCore/Modules/WebGPU/GPUSupportedLimits.idl:
* Source/WebCore/Modules/WebGPU/GPUTexture.idl:
* Source/WebCore/Modules/WebGPU/GPUTextureUsage.idl:
* Source/WebCore/Modules/WebGPU/GPUTextureView.idl:
* Source/WebCore/Modules/WebGPU/GPUUncapturedErrorEvent.idl:
* Source/WebCore/Modules/WebGPU/GPUValidationError.idl:
* Source/WebCore/Modules/WebGPU/WGSLLanguageFeatures.idl:
* Source/WebCore/html/canvas/GPUCanvasContext.idl:
Update idl files

* Source/WebCore/workers/WorkerGlobalScope.h:
* Source/WebCore/workers/WorkerLoaderProxy.h:
* Source/WebCore/workers/WorkerMessagingProxy.h:
* Source/WebCore/workers/WorkerThread.h:
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp:
(WebCore::ServiceWorkerGlobalScope::create):
(WebCore::ServiceWorkerGlobalScope::ServiceWorkerGlobalScope):
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.h:
* Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
(WebCore::ServiceWorkerThread::createWorkerGlobalScope):
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h:
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::installServiceWorker):
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h:
* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp:
(WebKit::WebSharedWorkerContextManagerConnection::launchSharedWorker):
* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createWorkerClient):
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp:
(WebKit::WebWorkerClient::create):
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h:

Canonical link: <a href="https://commits.webkit.org/279984@main">https://commits.webkit.org/279984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be06cc92b4c4f2f4ed9a1c0ddea8a3738e1fb6cb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55062 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58344 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5794 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42087 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5831 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44581 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3958 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57157 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47709 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25705 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29385 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5053 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3938 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51244 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5288 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59934 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30341 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5440 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52011 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31465 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47777 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51495 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12261 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32491 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31255 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->