### PR TITLE
[Mac] Scrolling should be determined by the frontmost interactive layer

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll_background-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll_background-expected.txt
@@ -1,0 +1,9 @@
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+pointer-events: none
+
+Scrolling here should scroll the scroller behind
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+PASS pointer-events: none foreground should not prevent background to be scrolled.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll_background.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll_background.html
@@ -1,0 +1,63 @@
+<!doctype html>
+
+<meta charset=utf-8>
+<title>pointer-events: auto descendant correctly targets scrolls</title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+
+    <style>
+        .scroller {
+            width: 400px;
+            height: 400px;
+            border: 1px solid black;
+            padding: 10px;
+            overflow: scroll;
+            font-size: 16pt;
+            background-color: rgba(255, 255, 255, 0.75);
+            margin-bottom: 100px;
+        }
+
+        h1 {
+            font-size: 24pt;
+        }
+
+        .contents {
+            height: 400%;
+        }
+    </style>
+
+<body id="body">
+    <div id="background" class="scroller">
+        <div class="contents">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</div>
+    </div>
+
+    <div id="foreground" class="scroller" style="left: 100px; top: 100px; pointer-events: none; position:absolute ">
+        <h1>pointer-events: none</h1>
+        <p>Scrolling here should scroll the scroller behind</p>
+        <div class="contents">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</div>
+    </div>
+</body>
+
+<script>
+  promise_test(async (t) => {
+    let scrolled = new Promise((resolve) => {
+      let scrollers = [window, document.getElementById("background"), document.getElementById("foreground")];
+      let onscroll = (evt) => {
+        for (const scroller of scrollers) {
+          scroller.removeEventListener("scroll", onscroll);
+        }
+        resolve(evt.target.id || "root");
+      }
+      for (const scroller of scrollers) {
+        scroller.addEventListener("scroll", onscroll);
+      }
+    });
+    const actions = new test_driver.Actions().scroll(200, 200, 0, 50, { duration: 50 });
+    actions.send();
+    assert_equals(await scrolled, "background", "Incorrect element scrolled");
+  }, "pointer-events: none foreground should not prevent background to be scrolled.");
+</script>

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
@@ -150,12 +150,15 @@ RefPtr<ScrollingTreeNode> ScrollingTreeMac::scrollingNodeForPoint(FloatPoint poi
 #endif
 
     if (layersAtPoint.size()) {
-        auto* frontmostLayer = layersAtPoint.first().first;
+        RetainPtr<CALayer> frontmostInteractiveLayer;
         for (size_t i = 0 ; i < layersAtPoint.size() ; i++) {
             auto [layer, point] = layersAtPoint[i];
 
             if (!layerEventRegionContainsPoint(layer, point))
                 continue;
+
+            if (!frontmostInteractiveLayer)
+                frontmostInteractiveLayer = layer;
 
             auto scrollingNodeForLayer = [&] (auto layer, auto point) -> RefPtr<ScrollingTreeNode> {
                 UNUSED_PARAM(point);
@@ -163,7 +166,8 @@ RefPtr<ScrollingTreeNode> ScrollingTreeMac::scrollingNodeForPoint(FloatPoint poi
                 RefPtr scrollingNode = nodeForID(nodeID);
                 if (!is<ScrollingTreeScrollingNode>(scrollingNode))
                     return nullptr;
-                if (isScrolledBy(*this, nodeID, frontmostLayer)) {
+                ASSERT(frontmostInteractiveLayer);
+                if (isScrolledBy(*this, nodeID, frontmostInteractiveLayer.get())) {
                     LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeMac " << this << " scrollingNodeForPoint " << point << " found scrolling node " << nodeID);
                     return scrollingNode;
                 }


### PR DESCRIPTION
#### 34e7db744efe67b25854294b0afc5b5717585286
<pre>
[Mac] Scrolling should be determined by the frontmost interactive layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=273031">https://bugs.webkit.org/show_bug.cgi?id=273031</a>
<a href="https://rdar.apple.com/126865799">rdar://126865799</a>

Reviewed by Simon Fraser.

<a href="https://commits.webkit.org/270094@main">https://commits.webkit.org/270094@main</a> has introduced a regression
where the frontmost interactive or scroll container (even non interactive)
layer was considered as the scrolling hit layer.

* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll_background-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll_background.html: Added.
* Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm:
(ScrollingTreeMac::scrollingNodeForPoint):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::handleWheelEventAfterDefaultHandling):
(WebKit::RemoteScrollingTreeMac::scrollingNodeForPoint):

Canonical link: <a href="https://commits.webkit.org/278084@main">https://commits.webkit.org/278084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8dd26f3e9f6b73c614fe5188a7699d99ae371221

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49352 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52385 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52604 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/24 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51656 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34649 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26254 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40311 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26180 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42509 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21427 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23635 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43692 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7720 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45547 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44196 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54103 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24433 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20619 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47642 "Found 1 new test failure: imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll_background.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25705 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42716 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46635 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10860 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26544 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25429 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->