### PR TITLE
[SVG] Known properties should avoid going through an hashmap

### DIFF
--- a/Source/WebCore/svg/SVGAElement.cpp
+++ b/Source/WebCore/svg/SVGAElement.cpp
@@ -44,6 +44,8 @@
 #include "SVGNames.h"
 #include "SVGSMILElement.h"
 #include "XLinkNames.h"
+#include "svg/SVGGraphicsElement.h"
+#include "svg/SVGURIReference.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -76,6 +78,15 @@ String SVGAElement::title() const
 
     // Otherwise, use the title of this element.
     return SVGElement::title();
+}
+
+SVGAnimatedProperty* SVGAElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::targetAttr)
+        return m_target.ptr();
+    if (auto* property = SVGGraphicsElement::propertyForAttribute(name))
+        return property;
+    return SVGURIReference::propertyForAttribute(name);
 }
 
 void SVGAElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGAElement.h
+++ b/Source/WebCore/svg/SVGAElement.h
@@ -46,6 +46,9 @@ private:
     SVGAElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGAElement, SVGGraphicsElement, SVGURIReference>;
+    friend PropertyRegistry;
+
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
@@ -56,7 +59,7 @@ private:
     bool isValid() const final { return SVGTests::isValid(); }
     String title() const final;
     void defaultEventHandler(Event&) final;
-    
+
     bool supportsFocus() const final;
     bool isMouseFocusable() const final;
     bool isKeyboardFocusable(KeyboardEvent*) const final;

--- a/Source/WebCore/svg/SVGAltGlyphElement.cpp
+++ b/Source/WebCore/svg/SVGAltGlyphElement.cpp
@@ -49,6 +49,13 @@ Ref<SVGAltGlyphElement> SVGAltGlyphElement::create(const QualifiedName& tagName,
     return adoptRef(*new SVGAltGlyphElement(tagName, document));
 }
 
+SVGAnimatedProperty* SVGAltGlyphElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (auto* property = SVGTextPositioningElement::propertyForAttribute(name))
+        return property;
+    return SVGURIReference::propertyForAttribute(name);
+}
+
 ExceptionOr<void> SVGAltGlyphElement::setGlyphRef(const AtomString&)
 {
     return Exception { ExceptionCode::NoModificationAllowedError };
@@ -88,7 +95,7 @@ bool SVGAltGlyphElement::hasValidGlyphElements(Vector<String>& glyphNames) const
         glyphNames.append(target.identifier);
         return true;
     }
-    
+
     RefPtr altGlyphDefElement = downcast<SVGAltGlyphDefElement>(target.element.get());
     return altGlyphDefElement && altGlyphDefElement->hasValidGlyphElements(glyphNames);
 }

--- a/Source/WebCore/svg/SVGAltGlyphElement.h
+++ b/Source/WebCore/svg/SVGAltGlyphElement.h
@@ -44,7 +44,9 @@ private:
     SVGAltGlyphElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGAltGlyphElement, SVGTextPositioningElement, SVGURIReference>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
     bool childShouldCreateRenderer(const Node&) const override;
 };

--- a/Source/WebCore/svg/SVGAnimateTransformElement.cpp
+++ b/Source/WebCore/svg/SVGAnimateTransformElement.cpp
@@ -54,6 +54,8 @@ bool SVGAnimateTransformElement::hasValidAttributeType() const
     return SVGAnimateElementBase::hasValidAttributeType();
 }
 
+
+
 void SVGAnimateTransformElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     if (name == SVGNames::typeAttr) {

--- a/Source/WebCore/svg/SVGAnimateTransformElement.h
+++ b/Source/WebCore/svg/SVGAnimateTransformElement.h
@@ -38,8 +38,9 @@ public:
 
 private:
     SVGAnimateTransformElement(const QualifiedName&, Document&);
-    
+
     bool hasValidAttributeType() const final;
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override { return nullptr; };
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     String animateRangeString(const String&) const final;
 

--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -57,6 +57,13 @@ SVGAnimationElement::SVGAnimationElement(const QualifiedName& tagName, Document&
 {
 }
 
+SVGAnimatedProperty* SVGAnimationElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (auto* property = SVGSMILElement::propertyForAttribute(name))
+        return property;
+    return SVGTests::propertyForAttribute(name);
+}
+
 static Vector<float> parseKeyTimes(StringView value, bool verifyOrder)
 {
     auto keyTimes = value.split(';');
@@ -246,8 +253,8 @@ ExceptionOr<float> SVGAnimationElement::getSimpleDuration() const
     if (!simpleDuration.isFinite())
         return Exception { ExceptionCode::NotSupportedError, "The simple duration is not determined on the given element."_s };
     return narrowPrecisionToFloat(simpleDuration.value());
-}    
-    
+}
+
 void SVGAnimationElement::beginElement()
 {
     beginElementAt(0);
@@ -318,17 +325,17 @@ void SVGAnimationElement::setAttributeType(const AtomString& attributeType)
 }
 
 String SVGAnimationElement::toValue() const
-{    
+{
     return attributeWithoutSynchronization(SVGNames::toAttr);
 }
 
 String SVGAnimationElement::byValue() const
-{    
+{
     return attributeWithoutSynchronization(SVGNames::byAttr);
 }
 
 String SVGAnimationElement::fromValue() const
-{    
+{
     return attributeWithoutSynchronization(SVGNames::fromAttr);
 }
 
@@ -438,16 +445,16 @@ float SVGAnimationElement::calculatePercentFromKeyPoints(float percent) const
 
     unsigned index = calculateKeyTimesIndex(percent);
     float fromKeyPoint = m_keyPoints[index];
-    
+
     if (calcMode() == CalcMode::Discrete)
         return fromKeyPoint;
-    
+
     ASSERT(index + 1 < keyTimes.size());
     float fromPercent = keyTimes[index];
     float toPercent = keyTimes[index + 1];
     float toKeyPoint = m_keyPoints[index + 1];
     float keyPointPercent = (percent - fromPercent) / (toPercent - fromPercent);
-    
+
     if (calcMode() == CalcMode::Spline) {
         ASSERT(m_keySplines.size() == m_keyPoints.size() - 1);
         keyPointPercent = calculatePercentForSpline(keyPointPercent, index);
@@ -463,7 +470,7 @@ float SVGAnimationElement::calculatePercentForFromTo(float percent) const
 
     return percent;
 }
-    
+
 void SVGAnimationElement::currentValuesFromKeyPoints(float percent, float& effectivePercent, String& from, String& to) const
 {
     ASSERT(!m_keyPoints.isEmpty());
@@ -474,7 +481,7 @@ void SVGAnimationElement::currentValuesFromKeyPoints(float percent, float& effec
     from = m_values[index];
     to = m_values[index + 1];
 }
-    
+
 void SVGAnimationElement::currentValuesForValuesAnimation(float percent, float& effectivePercent, String& from, String& to)
 {
     unsigned valuesCount = m_values.size();
@@ -496,7 +503,7 @@ void SVGAnimationElement::currentValuesForValuesAnimation(float percent, float& 
     }
     if (!m_keyPoints.isEmpty() && calcMode != CalcMode::Paced)
         return currentValuesFromKeyPoints(percent, effectivePercent, from, to);
-    
+
     const auto& keyTimes = this->keyTimes();
     unsigned keyTimesCount = keyTimes.size();
     ASSERT(!keyTimesCount || valuesCount == keyTimesCount);
@@ -504,25 +511,25 @@ void SVGAnimationElement::currentValuesForValuesAnimation(float percent, float& 
 
     unsigned index = calculateKeyTimesIndex(percent);
     if (calcMode == CalcMode::Discrete) {
-        if (!keyTimesCount) 
+        if (!keyTimesCount)
             index = static_cast<unsigned>(percent * valuesCount);
         from = m_values[index];
         to = m_values[index];
         effectivePercent = 0;
         return;
     }
-    
+
     float fromPercent;
     float toPercent;
     if (keyTimesCount) {
         fromPercent = keyTimes[index];
         toPercent = keyTimes[index + 1];
-    } else {        
+    } else {
         index = static_cast<unsigned>(floorf(percent * (valuesCount - 1)));
         fromPercent =  static_cast<float>(index) / (valuesCount - 1);
         toPercent =  static_cast<float>(index + 1) / (valuesCount - 1);
     }
-    
+
     if (index == valuesCount - 1)
         --index;
     from = m_values[index];
@@ -535,7 +542,7 @@ void SVGAnimationElement::currentValuesForValuesAnimation(float percent, float& 
         effectivePercent = calculatePercentForSpline(effectivePercent, index);
     }
 }
-    
+
 void SVGAnimationElement::startedActiveInterval()
 {
     m_animationValid = false;
@@ -593,7 +600,7 @@ void SVGAnimationElement::startedActiveInterval()
 }
 
 void SVGAnimationElement::updateAnimation(float percent, unsigned repeatCount)
-{    
+{
     if (!m_animationValid)
         return;
 

--- a/Source/WebCore/svg/SVGAnimationElement.h
+++ b/Source/WebCore/svg/SVGAnimationElement.h
@@ -83,6 +83,9 @@ protected:
     SVGAnimationElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGAnimationElement, SVGElement, SVGTests>;
+    friend PropertyRegistry;
+
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
 
     virtual void resetAnimation();
 

--- a/Source/WebCore/svg/SVGCircleElement.cpp
+++ b/Source/WebCore/svg/SVGCircleElement.cpp
@@ -51,6 +51,17 @@ Ref<SVGCircleElement> SVGCircleElement::create(const QualifiedName& tagName, Doc
     return adoptRef(*new SVGCircleElement(tagName, document));
 }
 
+SVGAnimatedProperty* SVGCircleElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name.matches(SVGNames::cxAttr))
+        return m_cx.ptr();
+    if (name.matches(SVGNames::cyAttr))
+        return m_cy.ptr();
+    if (name.matches(SVGNames::rAttr))
+        return m_r.ptr();
+    return SVGGeometryElement::propertyForAttribute(name);
+}
+
 void SVGCircleElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGParsingError parseError = NoError;

--- a/Source/WebCore/svg/SVGCircleElement.h
+++ b/Source/WebCore/svg/SVGCircleElement.h
@@ -43,7 +43,9 @@ private:
     SVGCircleElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGCircleElement, SVGGeometryElement>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 

--- a/Source/WebCore/svg/SVGClipPathElement.cpp
+++ b/Source/WebCore/svg/SVGClipPathElement.cpp
@@ -58,6 +58,13 @@ Ref<SVGClipPathElement> SVGClipPathElement::create(const QualifiedName& tagName,
     return adoptRef(*new SVGClipPathElement(tagName, document));
 }
 
+SVGAnimatedProperty* SVGClipPathElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::clipPathUnitsAttr)
+        return m_clipPathUnits.ptr();
+    return SVGGraphicsElement::propertyForAttribute(name);
+}
+
 void SVGClipPathElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     if (name == SVGNames::clipPathUnitsAttr) {

--- a/Source/WebCore/svg/SVGClipPathElement.h
+++ b/Source/WebCore/svg/SVGClipPathElement.h
@@ -46,7 +46,9 @@ private:
     SVGClipPathElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGClipPathElement, SVGGraphicsElement>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
     void childrenChanged(const ChildChange&) final;

--- a/Source/WebCore/svg/SVGComponentTransferFunctionElement.h
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElement.h
@@ -93,12 +93,14 @@ protected:
     SVGComponentTransferFunctionElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGComponentTransferFunctionElement, SVGElement>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override { return nullptr; }; // FIXME: implement
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 
     bool rendererIsNeeded(const RenderStyle&) override { return false; }
-    
+
 private:
     Ref<SVGAnimatedEnumeration> m_type { SVGAnimatedEnumeration::create(this, ComponentTransferType::FECOMPONENTTRANSFER_TYPE_IDENTITY) };
     Ref<SVGAnimatedNumberList> m_tableValues { SVGAnimatedNumberList::create(this) };

--- a/Source/WebCore/svg/SVGCursorElement.cpp
+++ b/Source/WebCore/svg/SVGCursorElement.cpp
@@ -58,6 +58,19 @@ SVGCursorElement::~SVGCursorElement()
         client.cursorElementRemoved(*this);
 }
 
+SVGAnimatedProperty* SVGCursorElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::xAttr)
+        return m_x.ptr();
+    if (name == SVGNames::yAttr)
+        return m_y.ptr();
+    if (auto* property = SVGURIReference::propertyForAttribute(name))
+        return property;
+    if (auto* property = SVGTests::propertyForAttribute(name))
+        return property;
+    return SVGElement::propertyForAttribute(name);
+}
+
 void SVGCursorElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGParsingError parseError = NoError;

--- a/Source/WebCore/svg/SVGCursorElement.h
+++ b/Source/WebCore/svg/SVGCursorElement.h
@@ -49,7 +49,9 @@ private:
     SVGCursorElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGCursorElement, SVGElement, SVGTests, SVGURIReference>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 

--- a/Source/WebCore/svg/SVGDefsElement.h
+++ b/Source/WebCore/svg/SVGDefsElement.h
@@ -34,6 +34,7 @@ private:
     SVGDefsElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGDefsElement, SVGGraphicsElement>;
+    friend PropertyRegistry;
 
     bool isValid() const final;
     bool supportsFocus() const final { return false; }

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -543,6 +543,15 @@ void SVGElement::attributeChanged(const QualifiedName& name, const AtomString& o
 
 void SVGElement::synchronizeAttribute(const QualifiedName& name)
 {
+    /*
+    // Fast known property access, if not found we fallback to the hashmap property registry.
+    if (auto* property = propertyForAttribute(name)) {
+        if (auto value = property->synchronize())
+            setSynchronizedLazyAttribute(name, AtomString { *value });
+        return;
+    }
+    */
+
     // If the value of the property has changed, serialize the new value to the attribute.
     if (auto value = propertyRegistry().synchronize(name))
         setSynchronizedLazyAttribute(name, AtomString { *value });

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -136,6 +136,7 @@ public:
     class InstanceInvalidationGuard;
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGElement>;
+    friend PropertyRegistry;
     const SVGPropertyRegistry& propertyRegistry() const { return m_propertyRegistry.get(); }
     void detachAllProperties() { propertyRegistry().detachAllProperties(); }
 
@@ -171,6 +172,8 @@ public:
 protected:
     SVGElement(const QualifiedName&, Document&, UniqueRef<SVGPropertyRegistry>&&, OptionSet<TypeFlag> = { });
     virtual ~SVGElement();
+
+    virtual SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) { return nullptr; };
 
     bool rendererIsNeeded(const RenderStyle&) override;
 
@@ -265,4 +268,3 @@ SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGElement)
     static bool isType(const WebCore::EventTarget& eventTarget) { return eventTarget.isNode() && static_cast<const WebCore::Node&>(eventTarget).isSVGElement(); }
     static bool isType(const WebCore::Node& node) { return node.isSVGElement(); }
 SPECIALIZE_TYPE_TRAITS_END()
-

--- a/Source/WebCore/svg/SVGEllipseElement.cpp
+++ b/Source/WebCore/svg/SVGEllipseElement.cpp
@@ -27,6 +27,7 @@
 #include "NodeName.h"
 #include "RenderSVGEllipse.h"
 #include "SVGElementInlines.h"
+#include "SVGNames.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -50,6 +51,19 @@ inline SVGEllipseElement::SVGEllipseElement(const QualifiedName& tagName, Docume
 Ref<SVGEllipseElement> SVGEllipseElement::create(const QualifiedName& tagName, Document& document)
 {
     return adoptRef(*new SVGEllipseElement(tagName, document));
+}
+
+SVGAnimatedProperty* SVGEllipseElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::cxAttr)
+        return m_cx.ptr();
+    if (name == SVGNames::cyAttr)
+        return m_cy.ptr();
+    if (name == SVGNames::rxAttr)
+        return m_rx.ptr();
+    if (name == SVGNames::ryAttr)
+        return m_ry.ptr();
+    return SVGGeometryElement::propertyForAttribute(name);
 }
 
 void SVGEllipseElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGEllipseElement.h
+++ b/Source/WebCore/svg/SVGEllipseElement.h
@@ -45,7 +45,9 @@ private:
     SVGEllipseElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGEllipseElement, SVGGeometryElement>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 

--- a/Source/WebCore/svg/SVGFEBlendElement.cpp
+++ b/Source/WebCore/svg/SVGFEBlendElement.cpp
@@ -36,7 +36,7 @@ inline SVGFEBlendElement::SVGFEBlendElement(const QualifiedName& tagName, Docume
     : SVGFilterPrimitiveStandardAttributes(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
 {
     ASSERT(hasTagName(SVGNames::feBlendTag));
-    
+
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
         PropertyRegistry::registerProperty<SVGNames::modeAttr, BlendMode, &SVGFEBlendElement::m_mode>();
@@ -48,6 +48,17 @@ inline SVGFEBlendElement::SVGFEBlendElement(const QualifiedName& tagName, Docume
 Ref<SVGFEBlendElement> SVGFEBlendElement::create(const QualifiedName& tagName, Document& document)
 {
     return adoptRef(*new SVGFEBlendElement(tagName, document));
+}
+
+SVGAnimatedProperty* SVGFEBlendElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::modeAttr)
+        return m_mode.ptr();
+    if (name == SVGNames::inAttr)
+        return m_in1.ptr();
+    if (name == SVGNames::in2Attr)
+        return m_in2.ptr();
+    return SVGFilterPrimitiveStandardAttributes::propertyForAttribute(name);
 }
 
 void SVGFEBlendElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGFEBlendElement.h
+++ b/Source/WebCore/svg/SVGFEBlendElement.h
@@ -64,7 +64,9 @@ private:
     SVGFEBlendElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEBlendElement, SVGFilterPrimitiveStandardAttributes>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGFEColorMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEColorMatrixElement.cpp
@@ -59,6 +59,17 @@ bool SVGFEColorMatrixElement::isInvalidValuesLength() const
         || (filterType == ColorMatrixType::FECOLORMATRIX_TYPE_SATURATE  && size != 1);
 }
 
+SVGAnimatedProperty* SVGFEColorMatrixElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::inAttr)
+        return m_in1.ptr();
+    if (name == SVGNames::typeAttr)
+        return m_type.ptr();
+    if (name == SVGNames::valuesAttr)
+        return m_values.ptr();
+    return SVGFilterPrimitiveStandardAttributes::propertyForAttribute(name);
+}
+
 void SVGFEColorMatrixElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     switch (name.nodeName()) {

--- a/Source/WebCore/svg/SVGFEColorMatrixElement.h
+++ b/Source/WebCore/svg/SVGFEColorMatrixElement.h
@@ -80,9 +80,11 @@ private:
     SVGFEColorMatrixElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEColorMatrixElement, SVGFilterPrimitiveStandardAttributes>;
+    friend PropertyRegistry;
 
     bool isInvalidValuesLength() const;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGFEComponentTransferElement.h
+++ b/Source/WebCore/svg/SVGFEComponentTransferElement.h
@@ -45,6 +45,7 @@ private:
     SVGFEComponentTransferElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEComponentTransferElement, SVGFilterPrimitiveStandardAttributes>;
+    friend PropertyRegistry;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFECompositeElement.cpp
+++ b/Source/WebCore/svg/SVGFECompositeElement.cpp
@@ -48,6 +48,25 @@ inline SVGFECompositeElement::SVGFECompositeElement(const QualifiedName& tagName
     });
 }
 
+SVGAnimatedProperty* SVGFECompositeElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::inAttr)
+        return m_in1.ptr();
+    if (name == SVGNames::in2Attr)
+        return m_in2.ptr();
+    if (name == SVGNames::operatorAttr)
+        return m_svgOperator.ptr();
+    if (name == SVGNames::k1Attr)
+        return m_k1.ptr();
+    if (name == SVGNames::k2Attr)
+        return m_k2.ptr();
+    if (name == SVGNames::k3Attr)
+        return m_k3.ptr();
+    if (name == SVGNames::k4Attr)
+        return m_k4.ptr();
+    return SVGFilterPrimitiveStandardAttributes::propertyForAttribute(name);
+}
+
 Ref<SVGFECompositeElement> SVGFECompositeElement::create(const QualifiedName& tagName, Document& document)
 {
     return adoptRef(*new SVGFECompositeElement(tagName, document));

--- a/Source/WebCore/svg/SVGFECompositeElement.h
+++ b/Source/WebCore/svg/SVGFECompositeElement.h
@@ -100,7 +100,9 @@ private:
     SVGFECompositeElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFECompositeElement, SVGFilterPrimitiveStandardAttributes>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
@@ -27,6 +27,7 @@
 #include "NodeName.h"
 #include "SVGNames.h"
 #include "SVGParserUtilities.h"
+#include "svg/SVGFilterPrimitiveStandardAttributes.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
@@ -57,6 +58,29 @@ inline SVGFEConvolveMatrixElement::SVGFEConvolveMatrixElement(const QualifiedNam
 Ref<SVGFEConvolveMatrixElement> SVGFEConvolveMatrixElement::create(const QualifiedName& tagName, Document& document)
 {
     return adoptRef(*new SVGFEConvolveMatrixElement(tagName, document));
+}
+
+SVGAnimatedProperty* SVGFEConvolveMatrixElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::inAttr)
+        return m_in1.ptr();
+    // FIXME: handle order
+    if (name == SVGNames::kernelMatrixAttr)
+        return m_kernelMatrix.ptr();
+    if (name == SVGNames::divisorAttr)
+        return m_divisor.ptr();
+    if (name == SVGNames::biasAttr)
+        return m_bias.ptr();
+    if (name == SVGNames::targetXAttr)
+        return m_targetX.ptr();
+    if (name == SVGNames::targetYAttr)
+        return m_targetY.ptr();
+    if (name == SVGNames::edgeModeAttr)
+        return m_edgeMode.ptr();
+    // FIXME: handle kernelUnit
+    if (name == SVGNames::preserveAlphaAttr)
+        return m_preserveAlpha.ptr();
+    return SVGFilterPrimitiveStandardAttributes::propertyForAttribute(name);
 }
 
 void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.h
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.h
@@ -98,7 +98,9 @@ private:
     SVGFEConvolveMatrixElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEConvolveMatrixElement, SVGFilterPrimitiveStandardAttributes>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGFEDiffuseLightingElement.h
+++ b/Source/WebCore/svg/SVGFEDiffuseLightingElement.h
@@ -52,7 +52,9 @@ private:
     SVGFEDiffuseLightingElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEDiffuseLightingElement, SVGFilterPrimitiveStandardAttributes>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override { return nullptr; }; // FIXME: implement
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGFEDisplacementMapElement.h
+++ b/Source/WebCore/svg/SVGFEDisplacementMapElement.h
@@ -24,7 +24,7 @@
 #include "SVGFilterPrimitiveStandardAttributes.h"
 
 namespace WebCore {
- 
+
 template<>
 struct SVGPropertyTraits<ChannelSelectorType> {
     static unsigned highestEnumValue() { return enumToUnderlyingType(ChannelSelectorType::CHANNEL_A); }
@@ -85,7 +85,9 @@ private:
     SVGFEDisplacementMapElement(const QualifiedName& tagName, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEDisplacementMapElement, SVGFilterPrimitiveStandardAttributes>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override { return nullptr; }; // FIXME: implement
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGFEDropShadowElement.cpp
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.cpp
@@ -36,7 +36,7 @@ inline SVGFEDropShadowElement::SVGFEDropShadowElement(const QualifiedName& tagNa
     : SVGFilterPrimitiveStandardAttributes(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
 {
     ASSERT(hasTagName(SVGNames::feDropShadowTag));
-    
+
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
         PropertyRegistry::registerProperty<SVGNames::inAttr, &SVGFEDropShadowElement::m_in1>();
@@ -56,6 +56,17 @@ void SVGFEDropShadowElement::setStdDeviation(float x, float y)
     Ref { m_stdDeviationX }->setBaseValInternal(x);
     Ref { m_stdDeviationY }->setBaseValInternal(y);
     updateSVGRendererForElementChange();
+}
+
+SVGAnimatedProperty* SVGFEDropShadowElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::inAttr)
+        return m_in1.ptr();
+    if (name == SVGNames::dxAttr)
+        return m_dx.ptr();
+    if (name == SVGNames::dyAttr)
+        return m_dy.ptr();
+    return SVGFilterPrimitiveStandardAttributes::propertyForAttribute(name);
 }
 
 void SVGFEDropShadowElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
@@ -157,7 +168,7 @@ RefPtr<FilterEffect> SVGFEDropShadowElement::createFilterEffect(const FilterEffe
 
     auto& style = renderer->style();
     const SVGRenderStyle& svgStyle = style.svgStyle();
-    
+
     Color color = style.colorWithColorFilter(svgStyle.floodColor());
     float opacity = svgStyle.floodOpacity();
 

--- a/Source/WebCore/svg/SVGFEDropShadowElement.h
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.h
@@ -29,7 +29,7 @@ class SVGFEDropShadowElement final : public SVGFilterPrimitiveStandardAttributes
     WTF_MAKE_ISO_ALLOCATED(SVGFEDropShadowElement);
 public:
     static Ref<SVGFEDropShadowElement> create(const QualifiedName&, Document&);
-    
+
     void setStdDeviation(float stdDeviationX, float stdDeviationY);
 
     String in1() const { return m_in1->currentValue(); }
@@ -48,7 +48,8 @@ private:
     SVGFEDropShadowElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEDropShadowElement, SVGFilterPrimitiveStandardAttributes>;
-
+    friend PropertyRegistry;
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 
@@ -64,5 +65,5 @@ private:
     Ref<SVGAnimatedNumber> m_stdDeviationX { SVGAnimatedNumber::create(this, 2) };
     Ref<SVGAnimatedNumber> m_stdDeviationY { SVGAnimatedNumber::create(this, 2) };
 };
-    
+
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGFEFloodElement.h
+++ b/Source/WebCore/svg/SVGFEFloodElement.h
@@ -34,6 +34,7 @@ private:
     SVGFEFloodElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEFloodElement, SVGFilterPrimitiveStandardAttributes>;
+    friend PropertyRegistry;
 
     bool setFilterEffectAttribute(FilterEffect&, const QualifiedName& attrName) override;
     RefPtr<FilterEffect> createFilterEffect(const FilterEffectVector&, const GraphicsContext& destinationContext) const override;

--- a/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
+++ b/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
@@ -58,6 +58,16 @@ void SVGFEGaussianBlurElement::setStdDeviation(float x, float y)
     updateSVGRendererForElementChange();
 }
 
+SVGAnimatedProperty* SVGFEGaussianBlurElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::inAttr)
+        return m_in1.ptr();
+    // FIXME: stdDeviationAttr
+    if (name == SVGNames::edgeModeAttr)
+        return m_edgeMode.ptr();
+    return SVGFilterPrimitiveStandardAttributes::propertyForAttribute(name);
+}
+
 void SVGFEGaussianBlurElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     switch (name.nodeName()) {

--- a/Source/WebCore/svg/SVGFEGaussianBlurElement.h
+++ b/Source/WebCore/svg/SVGFEGaussianBlurElement.h
@@ -48,7 +48,9 @@ private:
     SVGFEGaussianBlurElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEGaussianBlurElement, SVGFilterPrimitiveStandardAttributes>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGFEImageElement.cpp
+++ b/Source/WebCore/svg/SVGFEImageElement.cpp
@@ -112,6 +112,15 @@ void SVGFEImageElement::buildPendingResource()
     updateSVGRendererForElementChange();
 }
 
+SVGAnimatedProperty* SVGFEImageElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::preserveAspectRatioAttr)
+        return m_preserveAspectRatio.ptr();
+    if (auto* property = SVGURIReference::propertyForAttribute(name))
+        return property;
+    return SVGFilterPrimitiveStandardAttributes::propertyForAttribute(name);
+}
+
 void SVGFEImageElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     if (name == SVGNames::preserveAspectRatioAttr)

--- a/Source/WebCore/svg/SVGFEImageElement.h
+++ b/Source/WebCore/svg/SVGFEImageElement.h
@@ -44,7 +44,9 @@ private:
     SVGFEImageElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEImageElement, SVGFilterPrimitiveStandardAttributes, SVGURIReference>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGFELightElement.cpp
+++ b/Source/WebCore/svg/SVGFELightElement.cpp
@@ -69,6 +69,31 @@ SVGFELightElement* SVGFELightElement::findLightElement(const SVGElement* svgElem
     return nullptr;
 }
 
+SVGAnimatedProperty* SVGFELightElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::azimuthAttr)
+        return m_azimuth.ptr();
+    if (name == SVGNames::elevationAttr)
+        return m_elevation.ptr();
+    if (name == SVGNames::xAttr)
+        return m_x.ptr();
+    if (name == SVGNames::yAttr)
+        return m_y.ptr();
+    if (name == SVGNames::zAttr)
+        return m_z.ptr();
+    if (name == SVGNames::pointsAtXAttr)
+        return m_pointsAtX.ptr();
+    if (name == SVGNames::pointsAtYAttr)
+        return m_pointsAtY.ptr();
+    if (name == SVGNames::pointsAtZAttr)
+        return m_pointsAtZ.ptr();
+    if (name == SVGNames::specularExponentAttr)
+        return m_specularExponent.ptr();
+    if (name == SVGNames::limitingConeAngleAttr)
+        return m_limitingConeAngle.ptr();
+    return SVGElement::propertyForAttribute(name);
+}
+
 void SVGFELightElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     switch (name.nodeName()) {

--- a/Source/WebCore/svg/SVGFELightElement.h
+++ b/Source/WebCore/svg/SVGFELightElement.h
@@ -64,7 +64,9 @@ protected:
 
 private:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFELightElement, SVGElement>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
     void childrenChanged(const ChildChange&) override;

--- a/Source/WebCore/svg/SVGFEMergeElement.h
+++ b/Source/WebCore/svg/SVGFEMergeElement.h
@@ -34,6 +34,7 @@ private:
     SVGFEMergeElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEMergeElement, SVGFilterPrimitiveStandardAttributes>;
+    friend PropertyRegistry;
 
     void childrenChanged(const ChildChange&) override;
 

--- a/Source/WebCore/svg/SVGFEMergeNodeElement.cpp
+++ b/Source/WebCore/svg/SVGFEMergeNodeElement.cpp
@@ -36,11 +36,18 @@ inline SVGFEMergeNodeElement::SVGFEMergeNodeElement(const QualifiedName& tagName
     : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
 {
     ASSERT(hasTagName(SVGNames::feMergeNodeTag));
-    
+
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
         PropertyRegistry::registerProperty<SVGNames::inAttr, &SVGFEMergeNodeElement::m_in1>();
     });
+}
+
+SVGAnimatedProperty* SVGFEMergeNodeElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::inAttr)
+        return m_in1.ptr();
+    return SVGElement::propertyForAttribute(name);
 }
 
 Ref<SVGFEMergeNodeElement> SVGFEMergeNodeElement::create(const QualifiedName& tagName, Document& document)

--- a/Source/WebCore/svg/SVGFEMergeNodeElement.h
+++ b/Source/WebCore/svg/SVGFEMergeNodeElement.h
@@ -37,7 +37,9 @@ private:
     SVGFEMergeNodeElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEMergeNodeElement, SVGElement>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 

--- a/Source/WebCore/svg/SVGFEMorphologyElement.cpp
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.cpp
@@ -36,7 +36,7 @@ inline SVGFEMorphologyElement::SVGFEMorphologyElement(const QualifiedName& tagNa
     : SVGFilterPrimitiveStandardAttributes(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
 {
     ASSERT(hasTagName(SVGNames::feMorphologyTag));
-    
+
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
         PropertyRegistry::registerProperty<SVGNames::inAttr, &SVGFEMorphologyElement::m_in1>();
@@ -48,6 +48,17 @@ inline SVGFEMorphologyElement::SVGFEMorphologyElement(const QualifiedName& tagNa
 Ref<SVGFEMorphologyElement> SVGFEMorphologyElement::create(const QualifiedName& tagName, Document& document)
 {
     return adoptRef(*new SVGFEMorphologyElement(tagName, document));
+}
+
+SVGAnimatedProperty* SVGFEMorphologyElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::inAttr)
+        return m_in1.ptr();
+    if (name == SVGNames::operatorAttr)
+        return m_svgOperator.ptr();
+    if (name == SVGNames::radiusAttr)
+        return m_radiusY.ptr();
+    return SVGFilterPrimitiveStandardAttributes::propertyForAttribute(name);
 }
 
 void SVGFEMorphologyElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGFEMorphologyElement.h
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.h
@@ -74,7 +74,9 @@ private:
     SVGFEMorphologyElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEMorphologyElement, SVGFilterPrimitiveStandardAttributes>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGFEOffsetElement.cpp
+++ b/Source/WebCore/svg/SVGFEOffsetElement.cpp
@@ -35,7 +35,7 @@ inline SVGFEOffsetElement::SVGFEOffsetElement(const QualifiedName& tagName, Docu
     : SVGFilterPrimitiveStandardAttributes(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
 {
     ASSERT(hasTagName(SVGNames::feOffsetTag));
-    
+
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
         PropertyRegistry::registerProperty<SVGNames::inAttr, &SVGFEOffsetElement::m_in1>();
@@ -49,6 +49,16 @@ Ref<SVGFEOffsetElement> SVGFEOffsetElement::create(const QualifiedName& tagName,
     return adoptRef(*new SVGFEOffsetElement(tagName, document));
 }
 
+SVGAnimatedProperty* SVGFEOffsetElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::inAttr)
+        return m_in1.ptr();
+    if (name == SVGNames::dxAttr)
+        return m_dx.ptr();
+    if (name == SVGNames::dyAttr)
+        return m_dy.ptr();
+    return SVGFilterPrimitiveStandardAttributes::propertyForAttribute(name);
+}
 void SVGFEOffsetElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     switch (name.nodeName()) {

--- a/Source/WebCore/svg/SVGFEOffsetElement.h
+++ b/Source/WebCore/svg/SVGFEOffsetElement.h
@@ -42,7 +42,9 @@ private:
     SVGFEOffsetElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEOffsetElement, SVGFilterPrimitiveStandardAttributes>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGFESpecularLightingElement.h
+++ b/Source/WebCore/svg/SVGFESpecularLightingElement.h
@@ -52,7 +52,9 @@ private:
     SVGFESpecularLightingElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFESpecularLightingElement, SVGFilterPrimitiveStandardAttributes>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override { return nullptr; }; // FIXME: implement
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGFETileElement.cpp
+++ b/Source/WebCore/svg/SVGFETileElement.cpp
@@ -46,6 +46,13 @@ Ref<SVGFETileElement> SVGFETileElement::create(const QualifiedName& tagName, Doc
     return adoptRef(*new SVGFETileElement(tagName, document));
 }
 
+SVGAnimatedProperty* SVGFETileElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::inAttr)
+        return m_in1.ptr();
+    return SVGFilterPrimitiveStandardAttributes::propertyForAttribute(name);
+}
+
 void SVGFETileElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     if (name == SVGNames::inAttr)

--- a/Source/WebCore/svg/SVGFETileElement.h
+++ b/Source/WebCore/svg/SVGFETileElement.h
@@ -37,7 +37,9 @@ private:
     SVGFETileElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFETileElement, SVGFilterPrimitiveStandardAttributes>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGFETurbulenceElement.cpp
+++ b/Source/WebCore/svg/SVGFETurbulenceElement.cpp
@@ -52,6 +52,20 @@ Ref<SVGFETurbulenceElement> SVGFETurbulenceElement::create(const QualifiedName& 
     return adoptRef(*new SVGFETurbulenceElement(tagName, document));
 }
 
+SVGAnimatedProperty* SVGFETurbulenceElement::propertyForAttribute(const QualifiedName& name)
+{
+    // FIXME: implement for base frequency
+    if (name == SVGNames::numOctavesAttr)
+        return m_numOctaves.ptr();
+    if (name == SVGNames::seedAttr)
+        return m_seed.ptr();
+    if (name == SVGNames::stitchTilesAttr)
+        return m_stitchTiles.ptr();
+    if (name == SVGNames::typeAttr)
+        return m_type.ptr();
+    return SVGFilterPrimitiveStandardAttributes::propertyForAttribute(name);
+}
+
 void SVGFETurbulenceElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     switch (name.nodeName()) {

--- a/Source/WebCore/svg/SVGFETurbulenceElement.h
+++ b/Source/WebCore/svg/SVGFETurbulenceElement.h
@@ -113,7 +113,9 @@ private:
     SVGFETurbulenceElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFETurbulenceElement, SVGFilterPrimitiveStandardAttributes>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGFilterElement.cpp
+++ b/Source/WebCore/svg/SVGFilterElement.cpp
@@ -63,6 +63,21 @@ Ref<SVGFilterElement> SVGFilterElement::create(const QualifiedName& tagName, Doc
     return adoptRef(*new SVGFilterElement(tagName, document));
 }
 
+SVGAnimatedProperty* SVGFilterElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::xAttr)
+        return m_x.ptr();
+    if (name == SVGNames::yAttr)
+        return m_y.ptr();
+    if (name == SVGNames::widthAttr)
+        return m_width.ptr();
+    if (name == SVGNames::heightAttr)
+        return m_height.ptr();
+    if (auto* property = SVGURIReference::propertyForAttribute(name))
+        return property;
+    return SVGElement::propertyForAttribute(name);
+}
+
 void SVGFilterElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGParsingError parseError = NoError;

--- a/Source/WebCore/svg/SVGFilterElement.h
+++ b/Source/WebCore/svg/SVGFilterElement.h
@@ -52,7 +52,9 @@ private:
     SVGFilterElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFilterElement, SVGElement, SVGURIReference>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
     void childrenChanged(const ChildChange&) final;

--- a/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp
+++ b/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp
@@ -26,6 +26,7 @@
 #include "FilterEffect.h"
 #include "NodeName.h"
 #include "SVGElementInlines.h"
+#include "SVGNames.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/NeverDestroyed.h>
 
@@ -44,6 +45,21 @@ SVGFilterPrimitiveStandardAttributes::SVGFilterPrimitiveStandardAttributes(const
         PropertyRegistry::registerProperty<SVGNames::heightAttr, &SVGFilterPrimitiveStandardAttributes::m_height>();
         PropertyRegistry::registerProperty<SVGNames::resultAttr, &SVGFilterPrimitiveStandardAttributes::m_result>();
     });
+}
+
+SVGAnimatedProperty* SVGFilterPrimitiveStandardAttributes::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::xAttr)
+        return m_x.ptr();
+    if (name == SVGNames::yAttr)
+        return m_y.ptr();
+    if (name == SVGNames::widthAttr)
+        return m_width.ptr();
+    if (name == SVGNames::heightAttr)
+        return m_height.ptr();
+    if (name == SVGNames::restartAttr)
+        return m_result.ptr();
+    return SVGElement::propertyForAttribute(name);
 }
 
 void SVGFilterPrimitiveStandardAttributes::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h
+++ b/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h
@@ -38,6 +38,7 @@ class SVGFilterPrimitiveStandardAttributes : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGFilterPrimitiveStandardAttributes);
 public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFilterPrimitiveStandardAttributes, SVGElement>;
+    friend PropertyRegistry;
 
     const SVGLengthValue& x() const { return m_x->currentValue(); }
     const SVGLengthValue& y() const { return m_y->currentValue(); }
@@ -66,6 +67,7 @@ public:
 protected:
     SVGFilterPrimitiveStandardAttributes(const QualifiedName&, Document&, UniqueRef<SVGPropertyRegistry>&&);
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
     void childrenChanged(const ChildChange&) override;

--- a/Source/WebCore/svg/SVGFitToViewBox.cpp
+++ b/Source/WebCore/svg/SVGFitToViewBox.cpp
@@ -46,6 +46,15 @@ SVGFitToViewBox::SVGFitToViewBox(SVGElement* contextElement, SVGPropertyAccess a
     });
 }
 
+SVGAnimatedProperty* SVGFitToViewBox::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::viewBoxAttr)
+        return m_viewBox.ptr();
+    if (name == SVGNames::preserveAspectRatioAttr)
+        return m_preserveAspectRatio.ptr();
+    return nullptr;
+}
+
 void SVGFitToViewBox::setViewBox(const FloatRect& viewBox)
 {
     Ref { m_viewBox }->setBaseValInternal(viewBox);

--- a/Source/WebCore/svg/SVGFitToViewBox.h
+++ b/Source/WebCore/svg/SVGFitToViewBox.h
@@ -60,6 +60,7 @@ public:
 protected:
     SVGFitToViewBox(SVGElement* contextElement, SVGPropertyAccess = SVGPropertyAccess::ReadWrite);
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&);
     static bool isKnownAttribute(const QualifiedName& attributeName) { return PropertyRegistry::isKnownAttribute(attributeName); }
 
     void reset();

--- a/Source/WebCore/svg/SVGFontElement.h
+++ b/Source/WebCore/svg/SVGFontElement.h
@@ -50,6 +50,7 @@ private:
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFontElement, SVGElement>;
+    friend PropertyRegistry;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGForeignObjectElement.cpp
+++ b/Source/WebCore/svg/SVGForeignObjectElement.cpp
@@ -56,6 +56,19 @@ Ref<SVGForeignObjectElement> SVGForeignObjectElement::create(const QualifiedName
     return adoptRef(*new SVGForeignObjectElement(tagName, document));
 }
 
+SVGAnimatedProperty* SVGForeignObjectElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::xAttr)
+        return m_x.ptr();
+    if (name == SVGNames::yAttr)
+        return m_y.ptr();
+    if (name == SVGNames::widthAttr)
+        return m_width.ptr();
+    if (name == SVGNames::heightAttr)
+        return m_height.ptr();
+    return SVGGraphicsElement::propertyForAttribute(name);
+}
+
 void SVGForeignObjectElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGParsingError parseError = NoError;

--- a/Source/WebCore/svg/SVGForeignObjectElement.h
+++ b/Source/WebCore/svg/SVGForeignObjectElement.h
@@ -44,7 +44,9 @@ private:
     SVGForeignObjectElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGForeignObjectElement, SVGGraphicsElement>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 

--- a/Source/WebCore/svg/SVGGElement.h
+++ b/Source/WebCore/svg/SVGGElement.h
@@ -37,6 +37,7 @@ private:
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGGElement, SVGGraphicsElement>;
+    friend PropertyRegistry;
 
     bool isValid() const final { return SVGTests::isValid(); }
     bool rendererIsNeeded(const RenderStyle&) final;

--- a/Source/WebCore/svg/SVGGeometryElement.cpp
+++ b/Source/WebCore/svg/SVGGeometryElement.cpp
@@ -29,8 +29,10 @@
 #include "LegacyRenderSVGShape.h"
 #include "RenderSVGShape.h"
 #include "SVGDocumentExtensions.h"
+#include "SVGNames.h"
 #include "SVGPathUtilities.h"
 #include "SVGPoint.h"
+#include "svg/SVGGraphicsElement.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -62,6 +64,13 @@ float SVGGeometryElement::getTotalLength() const
 
     ASSERT_NOT_REACHED();
     return 0;
+}
+
+SVGAnimatedProperty* SVGGeometryElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::pathLengthAttr)
+        return m_pathLength.ptr();
+    return SVGGraphicsElement::propertyForAttribute(name);
 }
 
 ExceptionOr<Ref<SVGPoint>> SVGGeometryElement::getPointAtLength(float distance) const

--- a/Source/WebCore/svg/SVGGeometryElement.h
+++ b/Source/WebCore/svg/SVGGeometryElement.h
@@ -41,6 +41,7 @@ public:
     bool isPointInStroke(DOMPointInit&&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGGeometryElement, SVGGraphicsElement>;
+    friend PropertyRegistry;
 
     float pathLength() const { return m_pathLength->currentValue(); }
     SVGAnimatedNumber& pathLengthAnimated() { return m_pathLength; }
@@ -48,6 +49,7 @@ public:
 protected:
     SVGGeometryElement(const QualifiedName&, Document&, UniqueRef<SVGPropertyRegistry>&&);
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGGlyphRefElement.cpp
+++ b/Source/WebCore/svg/SVGGlyphRefElement.cpp
@@ -61,6 +61,13 @@ static float parseFloat(const AtomString& value)
     return parseNumber(value).value_or(0);
 }
 
+SVGAnimatedProperty* SVGGlyphRefElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (auto* property = SVGURIReference::propertyForAttribute(name))
+        return property;
+    return SVGElement::propertyForAttribute(name);
+}
+
 void SVGGlyphRefElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     // FIXME: Is the error handling in parseFloat correct for these attributes?

--- a/Source/WebCore/svg/SVGGlyphRefElement.h
+++ b/Source/WebCore/svg/SVGGlyphRefElement.h
@@ -45,7 +45,9 @@ private:
     SVGGlyphRefElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGGlyphRefElement, SVGElement, SVGURIReference>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
 

--- a/Source/WebCore/svg/SVGGradientElement.h
+++ b/Source/WebCore/svg/SVGGradientElement.h
@@ -82,6 +82,7 @@ public:
     GradientColorStops buildStops();
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGGradientElement, SVGElement, SVGURIReference>;
+    friend PropertyRegistry;
 
     SVGSpreadMethodType spreadMethod() const { return m_spreadMethod->currentValue<SVGSpreadMethodType>(); }
     SVGUnitTypes::SVGUnitType gradientUnits() const { return m_gradientUnits->currentValue<SVGUnitTypes::SVGUnitType>(); }
@@ -94,6 +95,7 @@ public:
 protected:
     SVGGradientElement(const QualifiedName&, Document&, UniqueRef<SVGPropertyRegistry>&&);
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override { return nullptr; }; // FIXME: implement
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGGraphicsElement.cpp
+++ b/Source/WebCore/svg/SVGGraphicsElement.cpp
@@ -58,6 +58,15 @@ SVGGraphicsElement::SVGGraphicsElement(const QualifiedName& tagName, Document& d
     });
 }
 
+SVGAnimatedProperty* SVGGraphicsElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::transformAttr)
+        return m_transform.ptr();
+    if (auto* property = SVGTests::propertyForAttribute(name))
+        return property;
+    return SVGElement::propertyForAttribute(name);
+}
+
 SVGGraphicsElement::~SVGGraphicsElement() = default;
 
 Ref<SVGMatrix> SVGGraphicsElement::getCTMForBindings()

--- a/Source/WebCore/svg/SVGGraphicsElement.h
+++ b/Source/WebCore/svg/SVGGraphicsElement.h
@@ -66,6 +66,7 @@ public:
     size_t approximateMemoryCost() const override { return sizeof(*this); }
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGGraphicsElement, SVGElement, SVGTests>;
+    friend PropertyRegistry;
 
     const SVGTransformList& transform() const { return m_transform->currentValue(); }
     Ref<const SVGTransformList> protectedTransform() const;
@@ -74,6 +75,7 @@ public:
 protected:
     SVGGraphicsElement(const QualifiedName&, Document&, UniqueRef<SVGPropertyRegistry>&&, OptionSet<TypeFlag> = { });
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
     void didAttachRenderers() override;

--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -87,6 +87,23 @@ bool SVGImageElement::renderingTaintsOrigin() const
     return cachedImage->isCORSCrossOrigin();
 }
 
+SVGAnimatedProperty* SVGImageElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::xAttr)
+        return m_x.ptr();
+    if (name == SVGNames::yAttr)
+        return m_y.ptr();
+    if (name == SVGNames::widthAttr)
+        return m_width.ptr();
+    if (name == SVGNames::heightAttr)
+        return m_height.ptr();
+    if (name == SVGNames::preserveAspectRatioAttr)
+        return m_preserveAspectRatio.ptr();
+    if (auto* property = SVGGraphicsElement::propertyForAttribute(name))
+        return property;
+    return SVGURIReference::propertyForAttribute(name);
+}
+
 void SVGImageElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGParsingError parseError = NoError;

--- a/Source/WebCore/svg/SVGImageElement.h
+++ b/Source/WebCore/svg/SVGImageElement.h
@@ -55,7 +55,9 @@ private:
     SVGImageElement(const QualifiedName&, Document&);
     
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGImageElement, SVGGraphicsElement, SVGURIReference>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 

--- a/Source/WebCore/svg/SVGLineElement.cpp
+++ b/Source/WebCore/svg/SVGLineElement.cpp
@@ -52,22 +52,35 @@ Ref<SVGLineElement> SVGLineElement::create(const QualifiedName& tagName, Documen
     return adoptRef(*new SVGLineElement(tagName, document));
 }
 
+SVGAnimatedProperty* SVGLineElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::x1Attr)
+        return m_x1.ptr();
+    if (name == SVGNames::x2Attr)
+        return m_x2.ptr();
+    if (name == SVGNames::y1Attr)
+        return m_y1.ptr();
+    if (name == SVGNames::y2Attr)
+        return m_y2.ptr();
+    return SVGGeometryElement::propertyForAttribute(name);
+}
+
 void SVGLineElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGParsingError parseError = NoError;
 
     switch (name.nodeName()) {
     case AttributeNames::x1Attr:
-        Ref { m_x1 }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_x1 } -> setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
         break;
     case AttributeNames::y1Attr:
-        Ref { m_y1 }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_y1 } -> setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
     case AttributeNames::x2Attr:
-        Ref { m_x2 }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_x2 } -> setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
         break;
     case AttributeNames::y2Attr:
-        Ref { m_y2 }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_y2 } -> setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGLineElement.h
+++ b/Source/WebCore/svg/SVGLineElement.h
@@ -45,7 +45,9 @@ private:
     SVGLineElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGLineElement, SVGGeometryElement>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 

--- a/Source/WebCore/svg/SVGLinearGradientElement.cpp
+++ b/Source/WebCore/svg/SVGLinearGradientElement.cpp
@@ -62,6 +62,19 @@ Ref<SVGLinearGradientElement> SVGLinearGradientElement::create(const QualifiedNa
     return adoptRef(*new SVGLinearGradientElement(tagName, document));
 }
 
+SVGAnimatedProperty* SVGLinearGradientElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::x1Attr)
+        return m_x1.ptr();
+    if (name == SVGNames::y1Attr)
+        return m_y1.ptr();
+    if (name == SVGNames::x2Attr)
+        return m_x2.ptr();
+    if (name == SVGNames::y2Attr)
+        return m_y2.ptr();
+    return SVGGradientElement::propertyForAttribute(name);
+}
+
 void SVGLinearGradientElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGParsingError parseError = NoError;

--- a/Source/WebCore/svg/SVGLinearGradientElement.h
+++ b/Source/WebCore/svg/SVGLinearGradientElement.h
@@ -49,7 +49,9 @@ private:
     SVGLinearGradientElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGLinearGradientElement, SVGGradientElement>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGMPathElement.cpp
+++ b/Source/WebCore/svg/SVGMPathElement.cpp
@@ -50,6 +50,13 @@ SVGMPathElement::~SVGMPathElement()
     clearResourceReferences();
 }
 
+SVGAnimatedProperty* SVGMPathElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (auto* property = SVGURIReference::propertyForAttribute(name))
+        return property;
+    return SVGElement::propertyForAttribute(name);
+}
+
 void SVGMPathElement::buildPendingResource()
 {
     clearResourceReferences();

--- a/Source/WebCore/svg/SVGMPathElement.h
+++ b/Source/WebCore/svg/SVGMPathElement.h
@@ -25,7 +25,7 @@
 #include "SVGURIReference.h"
 
 namespace WebCore {
-    
+
 class SVGPathElement;
 
 class SVGMPathElement final : public SVGElement, public SVGURIReference {
@@ -43,7 +43,9 @@ private:
     SVGMPathElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGMPathElement, SVGElement, SVGURIReference>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 

--- a/Source/WebCore/svg/SVGMarkerElement.cpp
+++ b/Source/WebCore/svg/SVGMarkerElement.cpp
@@ -62,6 +62,24 @@ AffineTransform SVGMarkerElement::viewBoxToViewTransform(float viewWidth, float 
     return SVGFitToViewBox::viewBoxToViewTransform(viewBox(), preserveAspectRatio(), viewWidth, viewHeight);
 }
 
+SVGAnimatedProperty* SVGMarkerElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::refXAttr)
+        return m_refX.ptr();
+    if (name == SVGNames::refYAttr)
+        return m_refY.ptr();
+    if (name == SVGNames::markerWidthAttr)
+        return m_markerWidth.ptr();
+    if (name == SVGNames::markerHeightAttr)
+        return m_markerHeight.ptr();
+    if (name == SVGNames::markerUnitsAttr)
+        return m_markerUnits.ptr();
+    // FIXME: orientAttr
+    if (auto* property = SVGFitToViewBox::propertyForAttribute(name))
+        return property;
+    return SVGElement::propertyForAttribute(name);
+}
+
 void SVGMarkerElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGParsingError parseError = NoError;
@@ -123,7 +141,7 @@ void SVGMarkerElement::svgAttributeChanged(const QualifiedName& attrName)
             invalidateMarkerResource();
         return;
     }
-    
+
     if (SVGFitToViewBox::isKnownAttribute(attrName)) {
         updateSVGRendererForElementChange();
         return;

--- a/Source/WebCore/svg/SVGMarkerElement.h
+++ b/Source/WebCore/svg/SVGMarkerElement.h
@@ -73,7 +73,9 @@ private:
     SVGMarkerElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGMarkerElement, SVGElement, SVGFitToViewBox>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
     void childrenChanged(const ChildChange&) override;

--- a/Source/WebCore/svg/SVGMaskElement.cpp
+++ b/Source/WebCore/svg/SVGMaskElement.cpp
@@ -68,6 +68,19 @@ Ref<SVGMaskElement> SVGMaskElement::create(const QualifiedName& tagName, Documen
     return adoptRef(*new SVGMaskElement(tagName, document));
 }
 
+SVGAnimatedProperty* SVGMaskElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::xAttr)
+        return m_x.ptr();
+    if (name == SVGNames::yAttr)
+        return m_y.ptr();
+    if (name == SVGNames::widthAttr)
+        return m_width.ptr();
+    if (name == SVGNames::heightAttr)
+        return m_height.ptr();
+    return SVGElement::propertyForAttribute(name);
+}
+
 void SVGMaskElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGParsingError parseError = NoError;

--- a/Source/WebCore/svg/SVGMaskElement.h
+++ b/Source/WebCore/svg/SVGMaskElement.h
@@ -54,7 +54,9 @@ private:
     SVGMaskElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGMaskElement, SVGElement, SVGTests>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
     void childrenChanged(const ChildChange&) final;

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -107,6 +107,13 @@ Ref<SVGPathElement> SVGPathElement::create(const QualifiedName& tagName, Documen
     return adoptRef(*new SVGPathElement(tagName, document));
 }
 
+SVGAnimatedProperty* SVGPathElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::dAttr)
+        return m_pathSegList.ptr();
+    return SVGGeometryElement::propertyForAttribute(name);
+}
+
 void SVGPathElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     if (name == SVGNames::dAttr) {

--- a/Source/WebCore/svg/SVGPathElement.h
+++ b/Source/WebCore/svg/SVGPathElement.h
@@ -36,7 +36,7 @@ class SVGPathElement final : public SVGGeometryElement {
     WTF_MAKE_ISO_ALLOCATED(SVGPathElement);
 public:
     static Ref<SVGPathElement> create(const QualifiedName&, Document&);
-    
+
     static Ref<SVGPathSegClosePath> createSVGPathSegClosePath() { return SVGPathSegClosePath::create(); }
     static Ref<SVGPathSegMovetoAbs> createSVGPathSegMovetoAbs(float x, float y) { return SVGPathSegMovetoAbs::create(x, y); }
     static Ref<SVGPathSegMovetoRel> createSVGPathSegMovetoRel(float x, float y) { return SVGPathSegMovetoRel::create(x, y); }
@@ -106,7 +106,9 @@ private:
     SVGPathElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGPathElement, SVGGeometryElement>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 

--- a/Source/WebCore/svg/SVGPatternElement.cpp
+++ b/Source/WebCore/svg/SVGPatternElement.cpp
@@ -72,6 +72,31 @@ Ref<SVGPatternElement> SVGPatternElement::create(const QualifiedName& tagName, D
     return adoptRef(*new SVGPatternElement(tagName, document));
 }
 
+SVGAnimatedProperty* SVGPatternElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::xAttr)
+        return m_x.ptr();
+    if (name == SVGNames::yAttr)
+        return m_y.ptr();
+    if (name == SVGNames::widthsAttr)
+        return m_width.ptr();
+    if (name == SVGNames::heightAttr)
+        return m_height.ptr();
+    if (name == SVGNames::patternUnitsAttr)
+        return m_patternUnits.ptr();
+    if (name == SVGNames::patternContentUnitsAttr)
+        return m_patternContentUnits.ptr();
+    if (name == SVGNames::patternTransformAttr)
+        return m_patternTransform.ptr();
+    if (auto* property = SVGFitToViewBox::propertyForAttribute(name))
+        return property;
+    if (auto* property = SVGTests::propertyForAttribute(name))
+        return property;
+    if (auto* property = SVGURIReference::propertyForAttribute(name))
+        return property;
+    return SVGElement::propertyForAttribute(name);
+}
+
 void SVGPatternElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGParsingError parseError = NoError;

--- a/Source/WebCore/svg/SVGPatternElement.h
+++ b/Source/WebCore/svg/SVGPatternElement.h
@@ -31,7 +31,7 @@
 namespace WebCore {
 
 struct PatternAttributes;
- 
+
 class SVGPatternElement final : public SVGElement, public SVGFitToViewBox, public SVGTests, public SVGURIReference {
     WTF_MAKE_ISO_ALLOCATED(SVGPatternElement);
 public:
@@ -62,7 +62,9 @@ private:
     SVGPatternElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGPatternElement, SVGElement, SVGFitToViewBox, SVGTests, SVGURIReference>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
     void childrenChanged(const ChildChange&) final;

--- a/Source/WebCore/svg/SVGPolyElement.cpp
+++ b/Source/WebCore/svg/SVGPolyElement.cpp
@@ -42,6 +42,12 @@ SVGPolyElement::SVGPolyElement(const QualifiedName& tagName, Document& document)
         PropertyRegistry::registerProperty<SVGNames::pointsAttr, &SVGPolyElement::m_points>();
     });
 }
+SVGAnimatedProperty* SVGPolyElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::pointsAttr)
+        return m_points.ptr();
+    return SVGGeometryElement::propertyForAttribute(name);
+}
 
 void SVGPolyElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {

--- a/Source/WebCore/svg/SVGPolyElement.h
+++ b/Source/WebCore/svg/SVGPolyElement.h
@@ -41,7 +41,9 @@ protected:
 
 private:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGPolyElement, SVGGeometryElement>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGRadialGradientElement.cpp
+++ b/Source/WebCore/svg/SVGRadialGradientElement.cpp
@@ -64,6 +64,23 @@ Ref<SVGRadialGradientElement> SVGRadialGradientElement::create(const QualifiedNa
     return adoptRef(*new SVGRadialGradientElement(tagName, document));
 }
 
+SVGAnimatedProperty* SVGRadialGradientElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::cxAttr)
+        return m_cx.ptr();
+    if (name == SVGNames::cyAttr)
+        return m_cy.ptr();
+    if (name == SVGNames::rAttr)
+        return m_r.ptr();
+    if (name == SVGNames::fxAttr)
+        return m_fx.ptr();
+    if (name == SVGNames::fyAttr)
+        return m_fy.ptr();
+    if (name == SVGNames::frAttr)
+        return m_fr.ptr();
+    return SVGGradientElement::propertyForAttribute(name);
+}
+
 void SVGRadialGradientElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGParsingError parseError = NoError;

--- a/Source/WebCore/svg/SVGRadialGradientElement.h
+++ b/Source/WebCore/svg/SVGRadialGradientElement.h
@@ -53,7 +53,9 @@ private:
     SVGRadialGradientElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGRadialGradientElement, SVGGradientElement>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGRectElement.cpp
+++ b/Source/WebCore/svg/SVGRectElement.cpp
@@ -28,6 +28,7 @@
 #include "NodeName.h"
 #include "RenderSVGRect.h"
 #include "SVGElementInlines.h"
+#include "SVGNames.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -53,6 +54,23 @@ inline SVGRectElement::SVGRectElement(const QualifiedName& tagName, Document& do
 Ref<SVGRectElement> SVGRectElement::create(const QualifiedName& tagName, Document& document)
 {
     return adoptRef(*new SVGRectElement(tagName, document));
+}
+
+SVGAnimatedProperty* SVGRectElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::xAttr)
+        return m_x.ptr();
+    if (name == SVGNames::yAttr)
+        return m_y.ptr();
+    if (name == SVGNames::widthAttr)
+        return m_width.ptr();
+    if (name == SVGNames::heightAttr)
+        return m_height.ptr();
+    if (name == SVGNames::rxAttr)
+        return m_rx.ptr();
+    if (name == SVGNames::ryAttr)
+        return m_ry.ptr();
+    return SVGGeometryElement::propertyForAttribute(name);
 }
 
 void SVGRectElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGRectElement.h
+++ b/Source/WebCore/svg/SVGRectElement.h
@@ -49,7 +49,9 @@ private:
     SVGRectElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGRectElement, SVGGeometryElement>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -45,6 +45,7 @@
 #include "SVGElementTypeHelpers.h"
 #include "SVGLength.h"
 #include "SVGMatrix.h"
+#include "SVGNames.h"
 #include "SVGNumber.h"
 #include "SVGPoint.h"
 #include "SVGRect.h"
@@ -54,6 +55,8 @@
 #include "StaticNodeList.h"
 #include "TreeScopeInlines.h"
 #include "TypedElementDescendantIteratorInlines.h"
+#include "svg/SVGFitToViewBox.h"
+#include "svg/SVGGraphicsElement.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -75,6 +78,22 @@ inline SVGSVGElement::SVGSVGElement(const QualifiedName& tagName, Document& docu
         PropertyRegistry::registerProperty<SVGNames::widthAttr, &SVGSVGElement::m_width>();
         PropertyRegistry::registerProperty<SVGNames::heightAttr, &SVGSVGElement::m_height>();
     });
+}
+
+
+SVGAnimatedProperty* SVGSVGElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::xAttr)
+        return m_x.ptr();
+    if (name == SVGNames::yAttr)
+        return m_y.ptr();
+    if (name == SVGNames::widthAttr)
+        return m_x.ptr();
+    if (name == SVGNames::heightAttr)
+        return m_height.ptr();
+    if (auto* property = SVGGraphicsElement::propertyForAttribute(name))
+        return property;
+    return SVGFitToViewBox::propertyForAttribute(name);
 }
 
 Ref<SVGSVGElement> SVGSVGElement::create(const QualifiedName& tagName, Document& document)

--- a/Source/WebCore/svg/SVGSVGElement.h
+++ b/Source/WebCore/svg/SVGSVGElement.h
@@ -125,7 +125,9 @@ private:
     virtual ~SVGSVGElement();
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGSVGElement, SVGGraphicsElement, SVGFitToViewBox>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
     bool selfHasRelativeLengths() const override;

--- a/Source/WebCore/svg/SVGScriptElement.cpp
+++ b/Source/WebCore/svg/SVGScriptElement.cpp
@@ -44,6 +44,13 @@ Ref<SVGScriptElement> SVGScriptElement::create(const QualifiedName& tagName, Doc
     return adoptRef(*new SVGScriptElement(tagName, document, insertedByParser, false));
 }
 
+SVGAnimatedProperty* SVGScriptElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (auto* property = SVGURIReference::propertyForAttribute(name))
+        return property;
+    return SVGElement::propertyForAttribute(name);
+}
+
 void SVGScriptElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGURIReference::parseAttribute(name, newValue);

--- a/Source/WebCore/svg/SVGScriptElement.h
+++ b/Source/WebCore/svg/SVGScriptElement.h
@@ -40,7 +40,9 @@ private:
     SVGScriptElement(const QualifiedName&, Document&, bool wasInsertedByParser, bool alreadyStarted);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGScriptElement, SVGElement, SVGURIReference>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 

--- a/Source/WebCore/svg/SVGStopElement.cpp
+++ b/Source/WebCore/svg/SVGStopElement.cpp
@@ -50,6 +50,13 @@ Ref<SVGStopElement> SVGStopElement::create(const QualifiedName& tagName, Documen
     return adoptRef(*new SVGStopElement(tagName, document));
 }
 
+SVGAnimatedProperty* SVGStopElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::offsetAttr)
+        return m_offset.ptr();
+    return SVGElement::propertyForAttribute(name);
+}
+
 void SVGStopElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     if (name == SVGNames::offsetAttr) {

--- a/Source/WebCore/svg/SVGStopElement.h
+++ b/Source/WebCore/svg/SVGStopElement.h
@@ -39,7 +39,9 @@ private:
     SVGStopElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGStopElement, SVGElement>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 

--- a/Source/WebCore/svg/SVGSwitchElement.h
+++ b/Source/WebCore/svg/SVGSwitchElement.h
@@ -34,6 +34,7 @@ private:
     SVGSwitchElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGSwitchElement, SVGGraphicsElement>;
+    friend PropertyRegistry;
 
     bool isValid() const final { return SVGTests::isValid(); }
 

--- a/Source/WebCore/svg/SVGSymbolElement.cpp
+++ b/Source/WebCore/svg/SVGSymbolElement.cpp
@@ -44,6 +44,13 @@ Ref<SVGSymbolElement> SVGSymbolElement::create(const QualifiedName& tagName, Doc
     return adoptRef(*new SVGSymbolElement(tagName, document));
 }
 
+SVGAnimatedProperty* SVGSymbolElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (auto* property = SVGFitToViewBox::propertyForAttribute(name))
+        return property;
+    return SVGGraphicsElement::propertyForAttribute(name);
+}
+
 void SVGSymbolElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGFitToViewBox::parseAttribute(name, newValue);

--- a/Source/WebCore/svg/SVGSymbolElement.h
+++ b/Source/WebCore/svg/SVGSymbolElement.h
@@ -35,7 +35,9 @@ private:
     SVGSymbolElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGSymbolElement, SVGGraphicsElement, SVGFitToViewBox>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
 

--- a/Source/WebCore/svg/SVGTRefElement.cpp
+++ b/Source/WebCore/svg/SVGTRefElement.cpp
@@ -179,6 +179,13 @@ void SVGTRefElement::detachTarget()
         treeScopeForSVGReferences().addPendingSVGResource(target.identifier, *this);
 }
 
+SVGAnimatedProperty* SVGTRefElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (auto* property = SVGTextPositioningElement::propertyForAttribute(name))
+        return property;
+    return SVGURIReference::propertyForAttribute(name);
+}
+
 void SVGTRefElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGURIReference::parseAttribute(name, newValue);

--- a/Source/WebCore/svg/SVGTRefElement.h
+++ b/Source/WebCore/svg/SVGTRefElement.h
@@ -40,9 +40,11 @@ private:
     virtual ~SVGTRefElement();
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGTRefElement, SVGTextPositioningElement, SVGURIReference>;
+    friend PropertyRegistry;
 
     Ref<SVGTRefTargetEventListener> protectedTargetListener() const;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGTests.h
+++ b/Source/WebCore/svg/SVGTests.h
@@ -36,6 +36,7 @@ template<typename OwnerType, typename... BaseTypes>
 class SVGPropertyOwnerRegistry;
 
 class SVGTests;
+class SVGAnimatedProperty;
 
 class SVGConditionalProcessingAttributes {
     WTF_MAKE_NONCOPYABLE(SVGConditionalProcessingAttributes); WTF_MAKE_FAST_ALLOCATED;
@@ -59,7 +60,9 @@ public:
     bool isValid() const;
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGTests>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) { return nullptr; };
     void parseAttribute(const QualifiedName&, const AtomString&);
     void svgAttributeChanged(const QualifiedName&);
 

--- a/Source/WebCore/svg/SVGTextContentElement.cpp
+++ b/Source/WebCore/svg/SVGTextContentElement.cpp
@@ -43,7 +43,7 @@
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(SVGTextContentElement);
- 
+
 SVGTextContentElement::SVGTextContentElement(const QualifiedName& tagName, Document& document, UniqueRef<SVGPropertyRegistry>&& propertyRegistry)
     : SVGGraphicsElement(tagName, document, WTFMove(propertyRegistry))
 {
@@ -52,6 +52,15 @@ SVGTextContentElement::SVGTextContentElement(const QualifiedName& tagName, Docum
         PropertyRegistry::registerProperty<SVGNames::textLengthAttr, &SVGTextContentElement::m_textLength>();
         PropertyRegistry::registerProperty<SVGNames::lengthAdjustAttr, SVGLengthAdjustType, &SVGTextContentElement::m_lengthAdjust>();
     });
+}
+
+SVGAnimatedProperty* SVGTextContentElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::textLengthAttr)
+        return m_textLength.ptr();
+    if (name == SVGNames::lengthAdjustAttr)
+        return m_lengthAdjust.ptr();
+    return SVGGraphicsElement::propertyForAttribute(name);
 }
 
 unsigned SVGTextContentElement::getNumberOfChars()

--- a/Source/WebCore/svg/SVGTextContentElement.h
+++ b/Source/WebCore/svg/SVGTextContentElement.h
@@ -83,6 +83,7 @@ public:
     static SVGTextContentElement* elementFromRenderer(RenderObject*);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGTextContentElement, SVGGraphicsElement>;
+    friend PropertyRegistry;
 
     const SVGLengthValue& specifiedTextLength() const { return m_specifiedTextLength; }
     const SVGLengthValue& textLength() const { return m_textLength->currentValue(); }
@@ -96,6 +97,7 @@ protected:
 
     bool isValid() const override { return SVGTests::isValid(); }
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const override;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) override;

--- a/Source/WebCore/svg/SVGTextPathElement.cpp
+++ b/Source/WebCore/svg/SVGTextPathElement.cpp
@@ -66,6 +66,19 @@ void SVGTextPathElement::clearResourceReferences()
     removeElementReference();
 }
 
+SVGAnimatedProperty* SVGTextPathElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::startOffsetAttr)
+        return m_startOffset.ptr();
+    if (name == SVGNames::methodAttr)
+        return m_method.ptr();
+    if (name == SVGNames::spacingAttr)
+        return m_spacing.ptr();
+    if (auto* property = SVGURIReference::propertyForAttribute(name))
+        return property;
+    return SVGTextContentElement::propertyForAttribute(name);
+}
+
 void SVGTextPathElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGParsingError parseError = NoError;

--- a/Source/WebCore/svg/SVGTextPathElement.h
+++ b/Source/WebCore/svg/SVGTextPathElement.h
@@ -53,7 +53,7 @@ struct SVGPropertyTraits<SVGTextPathMethodType> {
         case SVGTextPathMethodStretch:
             return "stretch"_s;
         }
-    
+
         ASSERT_NOT_REACHED();
         return emptyString();
     }
@@ -127,7 +127,9 @@ private:
     void didFinishInsertingNode() override;
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGTextPathElement, SVGTextContentElement, SVGURIReference>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGTextPositioningElement.cpp
+++ b/Source/WebCore/svg/SVGTextPositioningElement.cpp
@@ -52,6 +52,21 @@ SVGTextPositioningElement::SVGTextPositioningElement(const QualifiedName& tagNam
     });
 }
 
+SVGAnimatedProperty* SVGTextPositioningElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::xAttr)
+        return m_x.ptr();
+    if (name == SVGNames::yAttr)
+        return m_y.ptr();
+    if (name == SVGNames::dxAttr)
+        return m_dx.ptr();
+    if (name == SVGNames::dyAttr)
+        return m_dy.ptr();
+    if (name == SVGNames::rotateAttr)
+        return m_rotate.ptr();
+    return SVGTextContentElement::propertyForAttribute(name);
+}
+
 void SVGTextPositioningElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     switch (name.nodeName()) {

--- a/Source/WebCore/svg/SVGTextPositioningElement.h
+++ b/Source/WebCore/svg/SVGTextPositioningElement.h
@@ -31,6 +31,7 @@ public:
     static SVGTextPositioningElement* elementFromRenderer(RenderBoxModelObject&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGTextPositioningElement, SVGTextContentElement>;
+    friend PropertyRegistry;
 
     const SVGLengthList& x() const { return m_x->currentValue(); }
     const SVGLengthList& y() const { return m_y->currentValue(); }
@@ -47,6 +48,7 @@ public:
 protected:
     SVGTextPositioningElement(const QualifiedName&, Document&, UniqueRef<SVGPropertyRegistry>&&);
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGURIReference.cpp
+++ b/Source/WebCore/svg/SVGURIReference.cpp
@@ -42,6 +42,14 @@ SVGURIReference::SVGURIReference(SVGElement* contextElement)
     });
 }
 
+SVGAnimatedProperty* SVGURIReference::propertyForAttribute(const QualifiedName& name)
+{
+    if (name.matches(SVGNames::hrefAttr))
+        return m_href.ptr();
+    // FIXME: fast path for xlink href
+    return nullptr;
+}
+
 bool SVGURIReference::isKnownAttribute(const QualifiedName& attributeName)
 {
     return PropertyRegistry::isKnownAttribute(attributeName);

--- a/Source/WebCore/svg/SVGURIReference.h
+++ b/Source/WebCore/svg/SVGURIReference.h
@@ -24,10 +24,12 @@
 #include "Document.h"
 #include "QualifiedName.h"
 #include "SVGPropertyOwnerRegistry.h"
+#include "svg/SVGTests.h"
 
 namespace WebCore {
 
 class SVGElement;
+class SVGAnimatedProperty;
 
 class SVGURIReference {
     WTF_MAKE_NONCOPYABLE(SVGURIReference);
@@ -57,6 +59,7 @@ public:
     }
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGURIReference>;
+    friend PropertyRegistry;
 
     String href() const { return m_href->currentValue(); }
     SVGAnimatedString& hrefAnimated() { return m_href; }
@@ -64,6 +67,7 @@ public:
 protected:
     SVGURIReference(SVGElement* contextElement);
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&);
     static bool isKnownAttribute(const QualifiedName& attributeName);
 
     virtual bool haveFiredLoadEvent() const { return false; }

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -40,12 +40,14 @@
 #include "SVGDocumentExtensions.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGGElement.h"
+#include "SVGNames.h"
 #include "SVGSVGElement.h"
 #include "SVGSymbolElement.h"
 #include "ScriptDisallowedScope.h"
 #include "ShadowRoot.h"
 #include "TypedElementDescendantIteratorInlines.h"
 #include "XLinkNames.h"
+#include "svg/SVGURIReference.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/RobinHoodHashSet.h>
 
@@ -79,6 +81,21 @@ SVGUseElement::~SVGUseElement()
 {
     if (CachedResourceHandle externalDocument = m_externalDocument)
         externalDocument->removeClient(*this);
+}
+
+SVGAnimatedProperty* SVGUseElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (name == SVGNames::xAttr)
+        return m_x.ptr();
+    if (name == SVGNames::yAttr)
+        return m_y.ptr();
+    if (name == SVGNames::widthAttr)
+        return m_width.ptr();
+    if (name == SVGNames::heightAttr)
+        return m_height.ptr();
+    if (auto* property = SVGGraphicsElement::propertyForAttribute(name))
+        return property;
+    return SVGURIReference::propertyForAttribute(name);
 }
 
 void SVGUseElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGUseElement.h
+++ b/Source/WebCore/svg/SVGUseElement.h
@@ -61,7 +61,9 @@ private:
     void buildPendingResource() override;
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGUseElement, SVGGraphicsElement, SVGURIReference>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGViewElement.cpp
+++ b/Source/WebCore/svg/SVGViewElement.cpp
@@ -45,6 +45,14 @@ Ref<SVGViewElement> SVGViewElement::create(const QualifiedName& tagName, Documen
     return adoptRef(*new SVGViewElement(tagName, document));
 }
 
+SVGAnimatedProperty* SVGViewElement::propertyForAttribute(const QualifiedName& name)
+{
+    if (auto* property = SVGElement::propertyForAttribute(name))
+        return property;
+    return SVGFitToViewBox::propertyForAttribute(name);
+}
+
+
 void SVGViewElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGFitToViewBox::parseAttribute(name, newValue);

--- a/Source/WebCore/svg/SVGViewElement.h
+++ b/Source/WebCore/svg/SVGViewElement.h
@@ -45,7 +45,9 @@ private:
     SVGViewElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGViewElement, SVGElement, SVGFitToViewBox>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) override;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;
 


### PR DESCRIPTION
#### e7392dc906754668df3b9b2e4b1ea073fd6311a4
<pre>
[SVG] Known properties should avoid going through an hashmap
<a href="https://bugs.webkit.org/show_bug.cgi?id=273293">https://bugs.webkit.org/show_bug.cgi?id=273293</a>
<a href="https://rdar.apple.com/127085305">rdar://127085305</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/svg/SVGAElement.cpp:
(WebCore::SVGAElement::propertyForAttribute):
* Source/WebCore/svg/SVGAElement.h:
* Source/WebCore/svg/SVGAltGlyphElement.cpp:
(WebCore::SVGAltGlyphElement::propertyForAttribute):
(WebCore::SVGAltGlyphElement::hasValidGlyphElements const):
* Source/WebCore/svg/SVGAltGlyphElement.h:
* Source/WebCore/svg/SVGAnimateTransformElement.cpp:
* Source/WebCore/svg/SVGAnimateTransformElement.h:
* Source/WebCore/svg/SVGAnimationElement.cpp:
(WebCore::SVGAnimationElement::propertyForAttribute):
(WebCore::SVGAnimationElement::getSimpleDuration const):
(WebCore::SVGAnimationElement::toValue const):
(WebCore::SVGAnimationElement::byValue const):
(WebCore::SVGAnimationElement::fromValue const):
(WebCore::SVGAnimationElement::calculatePercentFromKeyPoints const):
(WebCore::SVGAnimationElement::currentValuesForValuesAnimation):
(WebCore::SVGAnimationElement::updateAnimation):
* Source/WebCore/svg/SVGAnimationElement.h:
* Source/WebCore/svg/SVGCircleElement.cpp:
(WebCore::SVGCircleElement::propertyForAttribute):
* Source/WebCore/svg/SVGCircleElement.h:
* Source/WebCore/svg/SVGClipPathElement.cpp:
(WebCore::SVGClipPathElement::propertyForAttribute):
* Source/WebCore/svg/SVGClipPathElement.h:
* Source/WebCore/svg/SVGComponentTransferFunctionElement.h:
* Source/WebCore/svg/SVGCursorElement.cpp:
(WebCore::SVGCursorElement::propertyForAttribute):
* Source/WebCore/svg/SVGCursorElement.h:
* Source/WebCore/svg/SVGDefsElement.h:
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::synchronizeAttribute):
* Source/WebCore/svg/SVGElement.h:
(WebCore::SVGElement::propertyForAttribute):
* Source/WebCore/svg/SVGEllipseElement.cpp:
(WebCore::SVGEllipseElement::propertyForAttribute):
* Source/WebCore/svg/SVGEllipseElement.h:
* Source/WebCore/svg/SVGFEBlendElement.cpp:
(WebCore::SVGFEBlendElement::SVGFEBlendElement):
(WebCore::SVGFEBlendElement::propertyForAttribute):
* Source/WebCore/svg/SVGFEBlendElement.h:
* Source/WebCore/svg/SVGFEColorMatrixElement.cpp:
(WebCore::SVGFEColorMatrixElement::propertyForAttribute):
* Source/WebCore/svg/SVGFEColorMatrixElement.h:
* Source/WebCore/svg/SVGFEComponentTransferElement.h:
* Source/WebCore/svg/SVGFECompositeElement.cpp:
(WebCore::SVGFECompositeElement::propertyForAttribute):
* Source/WebCore/svg/SVGFECompositeElement.h:
* Source/WebCore/svg/SVGFEConvolveMatrixElement.h:
* Source/WebCore/svg/SVGFEDiffuseLightingElement.h:
* Source/WebCore/svg/SVGFEDisplacementMapElement.h:
* Source/WebCore/svg/SVGFEDropShadowElement.cpp:
(WebCore::SVGFEDropShadowElement::SVGFEDropShadowElement):
(WebCore::SVGFEDropShadowElement::propertyForAttribute):
(WebCore::SVGFEDropShadowElement::createFilterEffect const):
* Source/WebCore/svg/SVGFEDropShadowElement.h:
* Source/WebCore/svg/SVGFEFloodElement.h:
* Source/WebCore/svg/SVGFEGaussianBlurElement.cpp:
(WebCore::SVGFEGaussianBlurElement::propertyForAttribute):
* Source/WebCore/svg/SVGFEGaussianBlurElement.h:
* Source/WebCore/svg/SVGFEImageElement.cpp:
(WebCore::SVGFEImageElement::propertyForAttribute):
* Source/WebCore/svg/SVGFEImageElement.h:
* Source/WebCore/svg/SVGFELightElement.cpp:
(WebCore::SVGFELightElement::propertyForAttribute):
* Source/WebCore/svg/SVGFELightElement.h:
* Source/WebCore/svg/SVGFEMergeElement.h:
* Source/WebCore/svg/SVGFEMergeNodeElement.cpp:
(WebCore::SVGFEMergeNodeElement::SVGFEMergeNodeElement):
(WebCore::SVGFEMergeNodeElement::propertyForAttribute):
* Source/WebCore/svg/SVGFEMergeNodeElement.h:
* Source/WebCore/svg/SVGFEMorphologyElement.cpp:
(WebCore::SVGFEMorphologyElement::SVGFEMorphologyElement):
(WebCore::SVGFEMorphologyElement::propertyForAttribute):
* Source/WebCore/svg/SVGFEMorphologyElement.h:
* Source/WebCore/svg/SVGFEOffsetElement.cpp:
(WebCore::SVGFEOffsetElement::SVGFEOffsetElement):
(WebCore::SVGFEOffsetElement::propertyForAttribute):
* Source/WebCore/svg/SVGFEOffsetElement.h:
* Source/WebCore/svg/SVGFESpecularLightingElement.h:
* Source/WebCore/svg/SVGFETileElement.cpp:
(WebCore::SVGFETileElement::propertyForAttribute):
* Source/WebCore/svg/SVGFETileElement.h:
* Source/WebCore/svg/SVGFETurbulenceElement.cpp:
(WebCore::SVGFETurbulenceElement::propertyForAttribute):
* Source/WebCore/svg/SVGFETurbulenceElement.h:
* Source/WebCore/svg/SVGFilterElement.cpp:
(WebCore::SVGFilterElement::propertyForAttribute):
* Source/WebCore/svg/SVGFilterElement.h:
* Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp:
(WebCore::SVGFilterPrimitiveStandardAttributes::propertyForAttribute):
* Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h:
* Source/WebCore/svg/SVGFitToViewBox.cpp:
(WebCore::SVGFitToViewBox::propertyForAttribute):
* Source/WebCore/svg/SVGFitToViewBox.h:
* Source/WebCore/svg/SVGFontElement.h:
* Source/WebCore/svg/SVGForeignObjectElement.cpp:
(WebCore::SVGForeignObjectElement::propertyForAttribute):
* Source/WebCore/svg/SVGForeignObjectElement.h:
* Source/WebCore/svg/SVGGElement.h:
* Source/WebCore/svg/SVGGeometryElement.cpp:
(WebCore::SVGGeometryElement::propertyForAttribute):
* Source/WebCore/svg/SVGGeometryElement.h:
* Source/WebCore/svg/SVGGlyphRefElement.cpp:
(WebCore::SVGGlyphRefElement::propertyForAttribute):
* Source/WebCore/svg/SVGGlyphRefElement.h:
* Source/WebCore/svg/SVGGradientElement.h:
* Source/WebCore/svg/SVGGraphicsElement.cpp:
(WebCore::SVGGraphicsElement::propertyForAttribute):
* Source/WebCore/svg/SVGGraphicsElement.h:
* Source/WebCore/svg/SVGImageElement.cpp:
(WebCore::SVGImageElement::propertyForAttribute):
* Source/WebCore/svg/SVGImageElement.h:
* Source/WebCore/svg/SVGLineElement.cpp:
(WebCore::SVGLineElement::propertyForAttribute):
(WebCore::SVGLineElement::attributeChanged):
* Source/WebCore/svg/SVGLineElement.h:
* Source/WebCore/svg/SVGLinearGradientElement.cpp:
(WebCore::SVGLinearGradientElement::propertyForAttribute):
* Source/WebCore/svg/SVGLinearGradientElement.h:
* Source/WebCore/svg/SVGMPathElement.cpp:
(WebCore::SVGMPathElement::propertyForAttribute):
* Source/WebCore/svg/SVGMPathElement.h:
* Source/WebCore/svg/SVGMarkerElement.cpp:
(WebCore::SVGMarkerElement::propertyForAttribute):
(WebCore::SVGMarkerElement::svgAttributeChanged):
* Source/WebCore/svg/SVGMarkerElement.h:
* Source/WebCore/svg/SVGMaskElement.cpp:
(WebCore::SVGMaskElement::propertyForAttribute):
* Source/WebCore/svg/SVGMaskElement.h:
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::propertyForAttribute):
* Source/WebCore/svg/SVGPathElement.h:
* Source/WebCore/svg/SVGPatternElement.cpp:
(WebCore::SVGPatternElement::propertyForAttribute):
* Source/WebCore/svg/SVGPatternElement.h:
* Source/WebCore/svg/SVGPolyElement.cpp:
(WebCore::SVGPolyElement::propertyForAttribute):
* Source/WebCore/svg/SVGPolyElement.h:
* Source/WebCore/svg/SVGRadialGradientElement.cpp:
(WebCore::SVGRadialGradientElement::propertyForAttribute):
* Source/WebCore/svg/SVGRadialGradientElement.h:
* Source/WebCore/svg/SVGRectElement.cpp:
(WebCore::SVGRectElement::propertyForAttribute):
* Source/WebCore/svg/SVGRectElement.h:
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::propertyForAttribute):
* Source/WebCore/svg/SVGSVGElement.h:
* Source/WebCore/svg/SVGScriptElement.cpp:
(WebCore::SVGScriptElement::propertyForAttribute):
* Source/WebCore/svg/SVGScriptElement.h:
* Source/WebCore/svg/SVGStopElement.cpp:
(WebCore::SVGStopElement::propertyForAttribute):
* Source/WebCore/svg/SVGStopElement.h:
* Source/WebCore/svg/SVGSwitchElement.h:
* Source/WebCore/svg/SVGSymbolElement.cpp:
(WebCore::SVGSymbolElement::propertyForAttribute):
* Source/WebCore/svg/SVGSymbolElement.h:
* Source/WebCore/svg/SVGTRefElement.cpp:
(WebCore::SVGTRefElement::propertyForAttribute):
* Source/WebCore/svg/SVGTRefElement.h:
* Source/WebCore/svg/SVGTests.h:
(WebCore::SVGTests::propertyForAttribute):
* Source/WebCore/svg/SVGTextContentElement.cpp:
(WebCore::SVGTextContentElement::propertyForAttribute):
* Source/WebCore/svg/SVGTextContentElement.h:
* Source/WebCore/svg/SVGTextPathElement.cpp:
(WebCore::SVGTextPathElement::propertyForAttribute):
* Source/WebCore/svg/SVGTextPathElement.h:
(WebCore::SVGPropertyTraits&lt;SVGTextPathMethodType&gt;::toString):
* Source/WebCore/svg/SVGTextPositioningElement.cpp:
(WebCore::SVGTextPositioningElement::propertyForAttribute):
* Source/WebCore/svg/SVGTextPositioningElement.h:
* Source/WebCore/svg/SVGURIReference.cpp:
(WebCore::SVGURIReference::propertyForAttribute):
* Source/WebCore/svg/SVGURIReference.h:
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::propertyForAttribute):
* Source/WebCore/svg/SVGUseElement.h:
* Source/WebCore/svg/SVGViewElement.cpp:
(WebCore::SVGViewElement::propertyForAttribute):
* Source/WebCore/svg/SVGViewElement.h:
* Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h:
(WebCore::SVGPropertyOwnerRegistry::fastAnimatedPropertyLookup):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7392dc906754668df3b9b2e4b1ea073fd6311a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30759 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54716 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2142 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53752 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1822 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41894 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53548 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44367 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23019 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25703 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1626 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47672 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56308 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26568 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1589 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49289 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27808 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44428 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48468 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28701 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27543 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->