### PR TITLE
When running jsc test, redirect dyld output to a file for better debug purpose

### DIFF
--- a/Tools/Scripts/run-javascriptcore-tests
+++ b/Tools/Scripts/run-javascriptcore-tests
@@ -111,6 +111,8 @@ my $forceCollectContinuously = 0;
 my $envVars = "";
 my $gmallocPath = undef;
 my $gmallocDefaultPath = "/usr/lib/libgmalloc.dylib";
+my $dyldLogPath = undef;
+my $dyldLogDefaultPath = "dyld.log";
 
 my $createTarball = 0;
 my $remoteHost = 0;
@@ -305,6 +307,7 @@ Usage: $programName [options] [options to pass to build system]
                                 Each environment variable should be separated by a space.
                                 e.g. \"foo=bar x=y\" (no quotes).
   --gmalloc:                    Run tests with Guard Malloc enabled (if no path is given: $gmallocDefaultPath is used)
+  --dyld-log:                   Dyld log file path (if no path is given: dyld.log is used)
   --verbose:                    Verbose output (specify more than once to increase verbosity).
 
   --report:                     Results database url to report results to.
@@ -377,6 +380,7 @@ GetOptions(
     'help' => \$showHelp,
     'env-vars=s' => \$envVars,
     'gmalloc:s' => \$gmallocPath,
+    'dyld-log:s' => \$dyldLogPath,
     'verbose+' => \$verbose,
     'report=s' => \$report,
     'buildbot-master=s' => \$buildbotMaster,
@@ -596,6 +600,16 @@ if (defined($gmallocPath)) {
     } else {
         $envVars .= " DYLD_INSERT_LIBRARIES=" . $gmallocPath;
     }
+}
+
+if (defined($dyldLogPath)) {
+    if ($gmallocPath eq "") {
+        $envVars .= " DYLD_PRINT_TO_FILE=" . $dyldLogDefaultPath;
+    } else {
+        $envVars .= " DYLD_PRINT_TO_FILE=" . $dyldLogPath;
+    }
+} else {
+    $envVars .= " DYLD_PRINT_TO_FILE=" . $dyldLogDefaultPath;
 }
 
 my $htmlDir;


### PR DESCRIPTION
#### b7f482474ccb0ee712cf39afc87172d4a0a4fbc3
<pre>
When running jsc test, redirect dyld output to a file for better debug purpose
<a href="https://bugs.webkit.org/show_bug.cgi?id=273294">https://bugs.webkit.org/show_bug.cgi?id=273294</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Tools/Scripts/run-javascriptcore-tests:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7f482474ccb0ee712cf39afc87172d4a0a4fbc3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49248 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52044 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45351 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51552 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34543 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26150 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40240 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51349 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26082 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42427 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21363 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23535 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43605 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7570 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/42548 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45459 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44110 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53955 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/48737 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24329 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20524 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47552 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25602 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42629 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46541 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26440 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56231 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25324 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11548 "Passed tests") | 
<!--EWS-Status-Bubble-End-->