### PR TITLE
Stop using mainFrameJSContext and firstRootFrameJSContext in WebKitTestRunner

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
@@ -272,7 +272,7 @@ template<typename T> void postSynchronousPageMessage(const char* name, const WKR
     }
 }
 
-void postMessageWithAsyncReply(const char* messageName, JSValueRef callback);
-void postMessageWithAsyncReply(const char* messageName, WKRetainPtr<WKTypeRef> value, JSValueRef callback);
+void postMessageWithAsyncReply(JSContextRef, const char* messageName, JSValueRef callback);
+void postMessageWithAsyncReply(JSContextRef, const char* messageName, WKRetainPtr<WKTypeRef> value, JSValueRef callback);
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -157,8 +157,8 @@ public:
     void addUserStyleSheet(JSStringRef source, bool allFrames);
 
     // Text search testing.
-    bool findString(JSStringRef, JSValueRef optionsArray);
-    void findStringMatchesInPage(JSStringRef, JSValueRef optionsArray);
+    bool findString(JSContextRef, JSStringRef, JSValueRef optionsArray);
+    void findStringMatchesInPage(JSContextRef, JSStringRef, JSValueRef optionsArray);
     void replaceFindMatchesAtIndices(JSContextRef, JSValueRef matchIndices, JSStringRef replacementText, bool selectionOnly);
 
     // Local storage
@@ -265,15 +265,15 @@ public:
     double databaseMaxQuota() const { return m_databaseMaxQuota; }
     void setDatabaseMaxQuota(double quota) { m_databaseMaxQuota = quota; }
 
-    void addChromeInputField(JSValueRef);
-    void removeChromeInputField(JSValueRef);
-    void focusWebView(JSValueRef);
+    void addChromeInputField(JSContextRef, JSValueRef);
+    void removeChromeInputField(JSContextRef, JSValueRef);
+    void focusWebView(JSContextRef, JSValueRef);
 
-    void setTextInChromeInputField(JSStringRef text, JSValueRef callback);
-    void selectChromeInputField(JSValueRef callback);
-    void getSelectedTextInChromeInputField(JSValueRef callback);
+    void setTextInChromeInputField(JSContextRef, JSStringRef text, JSValueRef callback);
+    void selectChromeInputField(JSContextRef, JSValueRef callback);
+    void getSelectedTextInChromeInputField(JSContextRef, JSValueRef callback);
 
-    void setBackingScaleFactor(double, JSValueRef);
+    void setBackingScaleFactor(JSContextRef, double, JSValueRef);
 
     void setWindowIsKey(bool);
 
@@ -287,14 +287,14 @@ public:
     // Cookies testing
     void setAlwaysAcceptCookies(bool);
     void setOnlyAcceptFirstPartyCookies(bool);
-    void removeAllCookies(JSValueRef callback);
+    void removeAllCookies(JSContextRef, JSValueRef callback);
 
     // Custom full screen behavior.
     void setHasCustomFullScreenBehavior(bool value) { m_customFullScreenBehavior = value; }
     bool hasCustomFullScreenBehavior() const { return m_customFullScreenBehavior; }
-    void setEnterFullscreenForElementCallback(JSValueRef);
+    void setEnterFullscreenForElementCallback(JSContextRef, JSValueRef);
     void callEnterFullscreenForElementCallback();
-    void setExitFullscreenForElementCallback(JSValueRef);
+    void setExitFullscreenForElementCallback(JSContextRef, JSValueRef);
     void callExitFullscreenForElementCallback();
 
     // Web notifications.
@@ -302,7 +302,7 @@ public:
     void denyWebNotificationPermission(JSStringRef origin);
     void denyWebNotificationPermissionOnPrompt(JSStringRef origin);
     void removeAllWebNotificationPermissions();
-    void simulateWebNotificationClick(JSValueRef notification);
+    void simulateWebNotificationClick(JSContextRef, JSValueRef notification);
     void simulateWebNotificationClickForServiceWorkerNotifications();
 
     JSRetainPtr<JSStringRef> getBackgroundFetchIdentifier();
@@ -371,17 +371,17 @@ public:
     bool didCancelClientRedirect() const { return m_didCancelClientRedirect; }
     void setDidCancelClientRedirect(bool value) { m_didCancelClientRedirect = value; }
 
-    void runUIScript(JSStringRef script, JSValueRef callback);
-    void runUIScriptImmediately(JSStringRef script, JSValueRef callback);
+    void runUIScript(JSContextRef, JSStringRef script, JSValueRef callback);
+    void runUIScriptImmediately(JSContextRef, JSStringRef script, JSValueRef callback);
     void runUIScriptCallback(unsigned callbackID, JSStringRef result);
 
     // Contextual menu actions
-    void setAllowedMenuActions(JSValueRef);
+    void setAllowedMenuActions(JSContextRef, JSValueRef);
 
-    void installDidBeginSwipeCallback(JSValueRef);
-    void installWillEndSwipeCallback(JSValueRef);
-    void installDidEndSwipeCallback(JSValueRef);
-    void installDidRemoveSwipeSnapshotCallback(JSValueRef);
+    void installDidBeginSwipeCallback(JSContextRef, JSValueRef);
+    void installWillEndSwipeCallback(JSContextRef, JSValueRef);
+    void installDidEndSwipeCallback(JSContextRef, JSValueRef);
+    void installDidRemoveSwipeSnapshotCallback(JSContextRef, JSValueRef);
     void callDidBeginSwipeCallback();
     void callWillEndSwipeCallback();
     void callDidEndSwipeCallback();
@@ -405,26 +405,26 @@ public:
     bool doesStatisticsDomainIDExistInDatabase(unsigned domainID);
     void setStatisticsEnabled(bool value);
     bool isStatisticsEphemeral();
-    void installStatisticsDidModifyDataRecordsCallback(JSValueRef callback);
-    void installStatisticsDidScanDataRecordsCallback(JSValueRef callback);
+    void installStatisticsDidModifyDataRecordsCallback(JSContextRef, JSValueRef callback);
+    void installStatisticsDidScanDataRecordsCallback(JSContextRef, JSValueRef callback);
     void statisticsDidModifyDataRecordsCallback();
     void statisticsDidScanDataRecordsCallback();
     bool statisticsNotifyObserver();
     void statisticsProcessStatisticsAndDataRecords();
-    void statisticsUpdateCookieBlocking(JSValueRef completionHandler);
-    void setStatisticsDebugMode(bool value, JSValueRef completionHandler);
-    void setStatisticsPrevalentResourceForDebugMode(JSStringRef hostName, JSValueRef completionHandler);
-    void setStatisticsLastSeen(JSStringRef hostName, double seconds, JSValueRef completionHandler);
-    void setStatisticsMergeStatistic(JSStringRef hostName, JSStringRef topFrameDomain1, JSStringRef topFrameDomain2, double lastSeen, bool hadUserInteraction, double mostRecentUserInteraction, bool isGrandfathered, bool isPrevalent, bool isVeryPrevalent, unsigned dataRecordsRemoved, JSValueRef completionHandler);
-    void setStatisticsExpiredStatistic(JSStringRef hostName, unsigned numberOfOperatingDaysPassed, bool hadUserInteraction, bool isScheduledForAllButCookieDataRemoval, bool isPrevalent, JSValueRef completionHandler);
-    void setStatisticsPrevalentResource(JSStringRef hostName, bool value, JSValueRef completionHandler);
-    void setStatisticsVeryPrevalentResource(JSStringRef hostName, bool value, JSValueRef completionHandler);
+    void statisticsUpdateCookieBlocking(JSContextRef, JSValueRef completionHandler);
+    void setStatisticsDebugMode(JSContextRef, bool value, JSValueRef completionHandler);
+    void setStatisticsPrevalentResourceForDebugMode(JSContextRef, JSStringRef hostName, JSValueRef completionHandler);
+    void setStatisticsLastSeen(JSContextRef, JSStringRef hostName, double seconds, JSValueRef completionHandler);
+    void setStatisticsMergeStatistic(JSContextRef, JSStringRef hostName, JSStringRef topFrameDomain1, JSStringRef topFrameDomain2, double lastSeen, bool hadUserInteraction, double mostRecentUserInteraction, bool isGrandfathered, bool isPrevalent, bool isVeryPrevalent, unsigned dataRecordsRemoved, JSValueRef completionHandler);
+    void setStatisticsExpiredStatistic(JSContextRef, JSStringRef hostName, unsigned numberOfOperatingDaysPassed, bool hadUserInteraction, bool isScheduledForAllButCookieDataRemoval, bool isPrevalent, JSValueRef completionHandler);
+    void setStatisticsPrevalentResource(JSContextRef, JSStringRef hostName, bool value, JSValueRef completionHandler);
+    void setStatisticsVeryPrevalentResource(JSContextRef, JSStringRef hostName, bool value, JSValueRef completionHandler);
     bool isStatisticsPrevalentResource(JSStringRef hostName);
     bool isStatisticsVeryPrevalentResource(JSStringRef hostName);
     bool isStatisticsRegisteredAsSubresourceUnder(JSStringRef subresourceHost, JSStringRef topFrameHost);
     bool isStatisticsRegisteredAsSubFrameUnder(JSStringRef subFrameHost, JSStringRef topFrameHost);
     bool isStatisticsRegisteredAsRedirectingTo(JSStringRef hostRedirectedFrom, JSStringRef hostRedirectedTo);
-    void setStatisticsHasHadUserInteraction(JSStringRef hostName, bool value, JSValueRef completionHandler);
+    void setStatisticsHasHadUserInteraction(JSContextRef, JSStringRef hostName, bool value, JSValueRef completionHandler);
     bool isStatisticsHasHadUserInteraction(JSStringRef hostName);
     bool isStatisticsOnlyInDatabaseOnce(JSStringRef subHost, JSStringRef topHost);
     void setStatisticsGrandfathered(JSStringRef hostName, bool value);
@@ -445,32 +445,32 @@ public:
     void setStatisticsGrandfatheringTime(double seconds);
     void setStatisticsMaxStatisticsEntries(unsigned);
     void setStatisticsPruneEntriesDownTo(unsigned);
-    void statisticsClearInMemoryAndPersistentStore(JSValueRef callback);
-    void statisticsClearInMemoryAndPersistentStoreModifiedSinceHours(unsigned hours, JSValueRef callback);
-    void statisticsClearThroughWebsiteDataRemoval(JSValueRef callback);
+    void statisticsClearInMemoryAndPersistentStore(JSContextRef, JSValueRef callback);
+    void statisticsClearInMemoryAndPersistentStoreModifiedSinceHours(JSContextRef, unsigned hours, JSValueRef callback);
+    void statisticsClearThroughWebsiteDataRemoval(JSContextRef, JSValueRef callback);
     void statisticsDeleteCookiesForHost(JSStringRef hostName, bool includeHttpOnlyCookies);
     bool isStatisticsHasLocalStorage(JSStringRef hostName);
     void setStatisticsCacheMaxAgeCap(double seconds);
     bool hasStatisticsIsolatedSession(JSStringRef hostName);
-    void setStatisticsShouldDowngradeReferrer(bool, JSValueRef callback);
-    void setStatisticsShouldBlockThirdPartyCookies(bool value, JSValueRef callback, bool onlyOnSitesWithoutUserInteraction);
-    void setStatisticsFirstPartyWebsiteDataRemovalMode(bool value, JSValueRef callback);
-    void statisticsSetToSameSiteStrictCookies(JSStringRef hostName, JSValueRef callback);
-    void statisticsSetFirstPartyHostCNAMEDomain(JSStringRef firstPartyURLString, JSStringRef cnameURLString, JSValueRef completionHandler);
-    void statisticsSetThirdPartyCNAMEDomain(JSStringRef cnameURLString, JSValueRef completionHandler);
-    void statisticsResetToConsistentState(JSValueRef completionHandler);
-    void loadedSubresourceDomains(JSValueRef callback);
+    void setStatisticsShouldDowngradeReferrer(JSContextRef, bool, JSValueRef callback);
+    void setStatisticsShouldBlockThirdPartyCookies(JSContextRef, bool value, JSValueRef callback, bool onlyOnSitesWithoutUserInteraction);
+    void setStatisticsFirstPartyWebsiteDataRemovalMode(JSContextRef, bool value, JSValueRef callback);
+    void statisticsSetToSameSiteStrictCookies(JSContextRef, JSStringRef hostName, JSValueRef callback);
+    void statisticsSetFirstPartyHostCNAMEDomain(JSContextRef, JSStringRef firstPartyURLString, JSStringRef cnameURLString, JSValueRef completionHandler);
+    void statisticsSetThirdPartyCNAMEDomain(JSContextRef, JSStringRef cnameURLString, JSValueRef completionHandler);
+    void statisticsResetToConsistentState(JSContextRef, JSValueRef completionHandler);
+    void loadedSubresourceDomains(JSContextRef, JSValueRef callback);
 
     // Injected bundle form client.
-    void installTextDidChangeInTextFieldCallback(JSValueRef callback);
+    void installTextDidChangeInTextFieldCallback(JSContextRef, JSValueRef callback);
     void textDidChangeInTextFieldCallback();
-    void installTextFieldDidBeginEditingCallback(JSValueRef callback);
+    void installTextFieldDidBeginEditingCallback(JSContextRef, JSValueRef callback);
     void textFieldDidBeginEditingCallback();
-    void installTextFieldDidEndEditingCallback(JSValueRef callback);
+    void installTextFieldDidEndEditingCallback(JSContextRef, JSValueRef callback);
     void textFieldDidEndEditingCallback();
 
     // Storage Access API
-    void getAllStorageAccessEntries(JSValueRef callback);
+    void getAllStorageAccessEntries(JSContextRef, JSValueRef callback);
     void setRequestStorageAccessThrowsExceptionUntilReload(bool enabled);
 
     // Open panel
@@ -486,18 +486,18 @@ public:
     void terminateServiceWorkers();
     void setUseSeparateServiceWorkerProcess(bool);
 
-    void removeAllSessionCredentials(JSValueRef);
+    void removeAllSessionCredentials(JSContextRef, JSValueRef);
     void callDidRemoveAllSessionCredentialsCallback();
     
-    void getApplicationManifestThen(JSValueRef);
+    void getApplicationManifestThen(JSContextRef, JSValueRef);
 
     void installFakeHelvetica(JSStringRef configuration);
 
     void dumpAllHTTPRedirectedResponseHeaders() { m_dumpAllHTTPRedirectedResponseHeaders = true; }
     bool shouldDumpAllHTTPRedirectedResponseHeaders() const { return m_dumpAllHTTPRedirectedResponseHeaders; }
 
-    void addMockCameraDevice(JSStringRef persistentId, JSStringRef label, JSValueRef properties);
-    void addMockMicrophoneDevice(JSStringRef persistentId, JSStringRef label, JSValueRef propertie);
+    void addMockCameraDevice(JSContextRef, JSStringRef persistentId, JSStringRef label, JSValueRef properties);
+    void addMockMicrophoneDevice(JSContextRef, JSStringRef persistentId, JSStringRef label, JSValueRef propertie);
     void addMockScreenDevice(JSStringRef persistentId, JSStringRef label);
     void clearMockMediaDevices();
     void removeMockMediaDevice(JSStringRef persistentId);
@@ -552,14 +552,14 @@ public:
 
     void setIsMediaKeySystemPermissionGranted(bool);
 
-    void takeViewPortSnapshot(JSValueRef callback);
+    void takeViewPortSnapshot(JSContextRef, JSValueRef callback);
 
-    void flushConsoleLogs(JSValueRef callback);
+    void flushConsoleLogs(JSContextRef, JSValueRef callback);
 
     // Reporting API
     void generateTestReport(JSContextRef, JSStringRef message, JSStringRef group);
 
-    void getAndClearReportedWindowProxyAccessDomains(JSValueRef);
+    void getAndClearReportedWindowProxyAccessDomains(JSContextRef, JSValueRef);
 
 private:
     TestRunner();


### PR DESCRIPTION
#### 4deeedaacec92708589899707d067bc335bc048b
<pre>
Stop using mainFrameJSContext and firstRootFrameJSContext in WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=273298">https://bugs.webkit.org/show_bug.cgi?id=273298</a>
<a href="https://rdar.apple.com/127093020">rdar://127093020</a>

Reviewed by Charlie Wolfe.

We need a JSContextRef to do things with JavaScript.  It&apos;s easy to use a globally accessible
function to get one that&apos;s always there, but with site isolation the main frame JS context
is no longer always there.  Instead, get the JSContextRef from the originating JS function
call.  For callbacks, store a JSRetainPtr&lt;JSGlobalContextRef&gt; and use it again when the
callback happens.

* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::postMessageWithAsyncReply):
(WTR::firstRootFrame): Deleted.
(WTR::firstRootFrameJSContext): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::findOptionsFromArray):
(WTR::TestRunner::findString):
(WTR::TestRunner::findStringMatchesInPage):
(WTR::cacheTestRunnerCallback):
(WTR::callTestRunnerCallback):
(WTR::TestRunner::clearTestRunnerCallbacks):
(WTR::TestRunner::addChromeInputField):
(WTR::TestRunner::removeChromeInputField):
(WTR::TestRunner::setTextInChromeInputField):
(WTR::TestRunner::selectChromeInputField):
(WTR::TestRunner::getSelectedTextInChromeInputField):
(WTR::TestRunner::focusWebView):
(WTR::TestRunner::setBackingScaleFactor):
(WTR::TestRunner::removeAllCookies):
(WTR::TestRunner::setEnterFullscreenForElementCallback):
(WTR::TestRunner::setExitFullscreenForElementCallback):
(WTR::TestRunner::simulateWebNotificationClick):
(WTR::TestRunner::runUIScript):
(WTR::TestRunner::runUIScriptImmediately):
(WTR::TestRunner::runUIScriptCallback):
(WTR::TestRunner::setAllowedMenuActions):
(WTR::TestRunner::installDidBeginSwipeCallback):
(WTR::TestRunner::installWillEndSwipeCallback):
(WTR::TestRunner::installDidEndSwipeCallback):
(WTR::TestRunner::installDidRemoveSwipeSnapshotCallback):
(WTR::TestRunner::setStatisticsDebugMode):
(WTR::TestRunner::setStatisticsPrevalentResourceForDebugMode):
(WTR::TestRunner::setStatisticsLastSeen):
(WTR::TestRunner::setStatisticsMergeStatistic):
(WTR::TestRunner::setStatisticsExpiredStatistic):
(WTR::TestRunner::setStatisticsPrevalentResource):
(WTR::TestRunner::setStatisticsVeryPrevalentResource):
(WTR::TestRunner::setStatisticsHasHadUserInteraction):
(WTR::TestRunner::installStatisticsDidModifyDataRecordsCallback):
(WTR::TestRunner::installStatisticsDidScanDataRecordsCallback):
(WTR::TestRunner::statisticsUpdateCookieBlocking):
(WTR::TestRunner::statisticsClearInMemoryAndPersistentStoreModifiedSinceHours):
(WTR::TestRunner::statisticsClearInMemoryAndPersistentStore):
(WTR::TestRunner::statisticsClearThroughWebsiteDataRemoval):
(WTR::TestRunner::setStatisticsShouldDowngradeReferrer):
(WTR::TestRunner::setStatisticsShouldBlockThirdPartyCookies):
(WTR::TestRunner::setStatisticsFirstPartyWebsiteDataRemovalMode):
(WTR::TestRunner::statisticsSetToSameSiteStrictCookies):
(WTR::TestRunner::statisticsSetFirstPartyHostCNAMEDomain):
(WTR::TestRunner::statisticsSetThirdPartyCNAMEDomain):
(WTR::TestRunner::statisticsResetToConsistentState):
(WTR::TestRunner::installTextDidChangeInTextFieldCallback):
(WTR::TestRunner::installTextFieldDidBeginEditingCallback):
(WTR::TestRunner::installTextFieldDidEndEditingCallback):
(WTR::TestRunner::getAllStorageAccessEntries):
(WTR::TestRunner::loadedSubresourceDomains):
(WTR::captureDeviceProperties):
(WTR::TestRunner::addMockCameraDevice):
(WTR::TestRunner::addMockMicrophoneDevice):
(WTR::TestRunner::removeAllSessionCredentials):
(WTR::TestRunner::getApplicationManifestThen):
(WTR::TestRunner::setAppBoundDomains):
(WTR::TestRunner::setManagedDomains):
(WTR::TestRunner::takeViewPortSnapshot):
(WTR::TestRunner::flushConsoleLogs):
(WTR::TestRunner::getAndClearReportedWindowProxyAccessDomains):
(WTR::mainFrame): Deleted.
(WTR::mainFrameJSContext): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:

Canonical link: <a href="https://commits.webkit.org/278038@main">https://commits.webkit.org/278038@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/641d91dfb4073be18f6251113ef76ef9b1988601

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49269 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52067 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45372 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51573 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26171 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40246 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42437 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21369 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23551 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43613 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7598 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45474 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44121 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53978 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24351 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20536 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47564 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25623 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42639 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46556 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26462 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7074 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25345 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->