### PR TITLE
Password entry visible during Clone Mirroring after switching origins in the same tab.

### DIFF
--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -554,6 +554,7 @@ public:
 
     virtual WebCore::Color contentViewBackgroundColor() = 0;
     virtual WebCore::Color insertionPointColor() = 0;
+    virtual bool isScreenBeingCaptured() = 0;
 
     virtual String sceneID() = 0;
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -322,6 +322,7 @@ private:
 
     WebCore::Color contentViewBackgroundColor() final;
     WebCore::Color insertionPointColor() final;
+    bool isScreenBeingCaptured() final;
 
     String sceneID() final;
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -1160,6 +1160,11 @@ Color PageClientImpl::insertionPointColor()
     return roundAndClampToSRGBALossy([webView() _insertionPointColor].CGColor);
 }
 
+bool PageClientImpl::isScreenBeingCaptured()
+{
+    return [contentView() screenIsBeingCaptured];
+}
+
 void PageClientImpl::requestScrollToRect(const FloatRect& targetRect, const FloatPoint& origin)
 {
     [contentView() _scrollToRect:targetRect withOrigin:origin minimumScrollDistance:0];

--- a/Source/WebKit/UIProcess/ios/WKContentView.h
+++ b/Source/WebKit/UIProcess/ios/WKContentView.h
@@ -93,6 +93,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)didInterruptScrolling;
 - (void)didZoomToScale:(CGFloat)scale;
 - (void)willStartZoomOrScroll;
+- (BOOL)screenIsBeingCaptured;
 
 - (void)_webViewDestroyed;
 

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -231,7 +231,7 @@ static NSArray *keyCommandsPlaceholderHackForEvernote(id self, SEL _cmd)
 
     _page->setIntrinsicDeviceScaleFactor(WebCore::screenScaleFactor([UIScreen mainScreen]));
     _page->setUseFixedLayout(true);
-    _page->setScreenIsBeingCaptured([[[self window] screen] isCaptured]);
+    _page->setScreenIsBeingCaptured([self screenIsBeingCaptured]);
 
     _page->windowScreenDidChange(_page->generateDisplayIDFromPageID());
 
@@ -533,8 +533,10 @@ static NSArray *keyCommandsPlaceholderHackForEvernote(id self, SEL _cmd)
 
     _cachedHasCustomTintColor = std::nullopt;
 
-    if (self.window)
+    if (self.window) {
         [self setUpInteraction];
+        _page->setScreenIsBeingCaptured([self screenIsBeingCaptured]);
+    }
     else
         [self cleanUpInteractionPreviewContainers];
 }
@@ -712,6 +714,11 @@ static WebCore::FloatBoxExtent floatBoxExtent(UIEdgeInsets insets)
 - (void)didZoomToScale:(CGFloat)scale
 {
     [self _didEndScrollingOrZooming];
+}
+
+- (BOOL)screenIsBeingCaptured
+{
+    return [[[self window] screen] isCaptured];
 }
 
 - (NSUndoManager *)undoManagerForWebView
@@ -1058,7 +1065,7 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
 
 - (void)_screenCapturedDidChange:(NSNotification *)notification
 {
-    _page->setScreenIsBeingCaptured([[[self window] screen] isCaptured]);
+    _page->setScreenIsBeingCaptured([self screenIsBeingCaptured]);
 }
 
 @end

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -1415,7 +1415,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _autocorrectionContextNeedsUpdate = YES;
 
     _page->process().updateTextCheckerState();
-    _page->setScreenIsBeingCaptured([[[self window] screen] isCaptured]);
+    _page->setScreenIsBeingCaptured([self screenIsBeingCaptured]);
 
 #if ENABLE(IMAGE_ANALYSIS)
     [self _setUpImageAnalysis];

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -583,6 +583,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     , m_forceAlwaysUserScalable(parameters.ignoresViewportScaleLimits)
 #endif
 #if PLATFORM(IOS_FAMILY)
+    , m_screenIsBeingCaptured(parameters.isCapturingScreen)
     , m_screenSize(parameters.screenSize)
     , m_availableScreenSize(parameters.availableScreenSize)
     , m_overrideScreenSize(parameters.overrideScreenSize)


### PR DESCRIPTION
#### bc318704d271bcf5e75428dd6f56e22c8a7d3792
<pre>
Password entry visible during Clone Mirroring after switching origins in the same tab.
<a href="https://bugs.webkit.org/show_bug.cgi?id=273290">https://bugs.webkit.org/show_bug.cgi?id=273290</a>
<a href="https://rdar.apple.com/126586657">rdar://126586657</a>

Reviewed by Abrar Rahman Protyasha and Wenson Hsieh.

The state of screen capturing isn&apos;t be persisted between
swapping processes in the same tab. Make sure that the
state of screen capture is set on every new origin and process
creation.

* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::isScreenBeingCaptured):
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView didMoveToWindow]):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:

Canonical link: <a href="https://commits.webkit.org/278053@main">https://commits.webkit.org/278053@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9adbcbdaf2fcc068ada5a7343ea88b446150e0d4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52369 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52213 "Failed to checkout and rebase branch from PR 27787") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34633 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26238 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/52213 "Failed to checkout and rebase branch from PR 27787") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51436 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26162 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42490 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/52213 "Failed to checkout and rebase branch from PR 27787") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23616 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7704 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45527 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44177 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54087 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24417 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20603 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47628 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25689 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42697 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46621 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10844 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26528 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25413 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->