### PR TITLE
[WebCore] Optimize text layout building

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.h
@@ -44,14 +44,14 @@ public:
     static bool isEligibleForSimplifiedInlineLayoutByStyle(const RenderStyle&);
 
 private:
-    InlineItemPosition placeInlineTextContent(const InlineItemRange&);
-    InlineItemPosition placeNonWrappingInlineTextContent(const InlineItemRange&);
-    TextOnlyLineBreakResult handleOverflowingTextContent(const InlineContentBreaker::ContinuousContent&, const InlineItemRange&);
-    TextOnlyLineBreakResult commitCandidateContent(const CandidateTextContent&, const InlineItemRange&);
+    InlineItemPosition placeInlineTextContent(const RenderStyle&, const InlineItemRange&);
+    InlineItemPosition placeNonWrappingInlineTextContent(const RenderStyle&, const InlineItemRange&);
+    TextOnlyLineBreakResult handleOverflowingTextContent(const RenderStyle&, const InlineContentBreaker::ContinuousContent&, const InlineItemRange&);
+    TextOnlyLineBreakResult commitCandidateContent(const RenderStyle&, const CandidateTextContent&, const InlineItemRange&);
     void initialize(const InlineItemRange&, const InlineRect& initialLogicalRect, const std::optional<PreviousLine>&);
-    void handleLineEnding(InlineItemPosition, size_t layoutRangeEndIndex);
-    size_t revertToTrailingItem(const InlineItemRange&, const InlineTextItem&);
-    size_t revertToLastNonOverflowingItem(const InlineItemRange&);
+    void handleLineEnding(const RenderStyle&, InlineItemPosition, size_t layoutRangeEndIndex);
+    size_t revertToTrailingItem(const RenderStyle&, const InlineItemRange&, const InlineTextItem&);
+    size_t revertToLastNonOverflowingItem(const RenderStyle&, const InlineItemRange&);
     InlineLayoutUnit availableWidth() const;
     bool isWrappingAllowed() const { return m_isWrappingAllowed; }
 

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -457,11 +457,7 @@ bool TextUtil::containsStrongDirectionalityText(StringView text)
     if (text.is8Bit())
         return false;
 
-    auto length = text.length();
-    for (size_t position = 0; position < length;) {
-        char32_t character;
-        auto characters = text.span16();
-        U16_NEXT(characters, position, length, character);
+    for (char32_t character : text.codePoints()) {
         if (isStrongDirectionalityCharacter(character))
             return true;
     }

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -645,7 +645,7 @@ FontCascade::CodePath FontCascade::codePath(const TextRun& run, std::optional<un
     return characterRangeCodePath(run.span16());
 }
 
-FontCascade::CodePath FontCascade::characterRangeCodePath(std::span<const UChar> characters)
+FontCascade::CodePath FontCascade::characterRangeCodePath(std::span<const UChar> span)
 {
     // FIXME: Should use a UnicodeSet in ports where ICU is used. Note that we 
     // can't simply use UnicodeCharacter Property/class because some characters
@@ -654,7 +654,9 @@ FontCascade::CodePath FontCascade::characterRangeCodePath(std::span<const UChar>
     // list of ranges.
     CodePath result = CodePath::Simple;
     bool previousCharacterIsEmojiGroupCandidate = false;
-    for (size_t i = 0; i < characters.size(); ++i) {
+    size_t size = span.size();
+    auto* characters = span.data();
+    for (size_t i = 0; i < size; ++i) {
         auto c = characters[i];
         if (c == zeroWidthJoiner && previousCharacterIsEmojiGroupCandidate)
             return CodePath::Complex;
@@ -776,7 +778,7 @@ FontCascade::CodePath FontCascade::characterRangeCodePath(std::span<const UChar>
         if (c <= 0xDBFF) {
             // High surrogate
 
-            if (i == characters.size() - 1)
+            if (i + 1 == size)
                 continue;
 
             UChar next = characters[++i];


### PR DESCRIPTION
#### c310b02276953cd72ce53b9c8ec72d5d8a977d45
<pre>
[WebCore] Optimize text layout building
<a href="https://bugs.webkit.org/show_bug.cgi?id=273301">https://bugs.webkit.org/show_bug.cgi?id=273301</a>
<a href="https://rdar.apple.com/127095998">rdar://127095998</a>

Reviewed by Alan Baradlay.

This does micro-optimizations for Text Layout.

1. TextUtil::containsStrongDirectionalityText should use StringView::codePoints.
2. FontCascade::characterRangeCodePath should first take size and data from span.
3. TextOnlySimpleLineBuilder should take rootStyle and threading it through line building code.
4. InlineItemsBuilder should appropriately expand the Vector capacity before appending items in loop.

* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::InlineItemsBuilder::buildInlineItemListForTextFromBreakingPositionsCache):
(WebCore::Layout::InlineItemsBuilder::handleTextContent):
* Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp:
(WebCore::Layout::TextOnlySimpleLineBuilder::layoutInlineContent):
(WebCore::Layout::TextOnlySimpleLineBuilder::placeInlineTextContent):
(WebCore::Layout::TextOnlySimpleLineBuilder::placeNonWrappingInlineTextContent):
(WebCore::Layout::TextOnlySimpleLineBuilder::commitCandidateContent):
(WebCore::Layout::TextOnlySimpleLineBuilder::handleOverflowingTextContent):
(WebCore::Layout::TextOnlySimpleLineBuilder::handleLineEnding):
(WebCore::Layout::TextOnlySimpleLineBuilder::revertToTrailingItem):
(WebCore::Layout::TextOnlySimpleLineBuilder::revertToLastNonOverflowingItem):
* Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.h:
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::containsStrongDirectionalityText):

Canonical link: <a href="https://commits.webkit.org/278044@main">https://commits.webkit.org/278044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5cf5f530d922a41a79b1820831b6973a5308918a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49314 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52345 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52159 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45417 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51618 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26216 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40285 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26143 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42476 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21406 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23594 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43657 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7681 "Built successfully") | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45511 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; 6 api tests failed or timed out; re-run-api-tests (cancelled)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44160 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54062 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24396 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20579 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47605 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25668 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42683 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46602 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26507 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7079 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25391 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->