### PR TITLE
Reduce use of WKBundlePageGetMainFrame in WebKitTestRunner

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
@@ -127,11 +127,11 @@ void AccessibilityUIElement::setBoolAttributeValue(JSStringRef, bool) { }
 void AccessibilityUIElement::setValue(JSStringRef) { }
 JSValueRef AccessibilityUIElement::searchTextWithCriteria(JSContextRef, JSValueRef, JSStringRef, JSStringRef) { return nullptr; }
 bool AccessibilityUIElement::isOnScreen() const { return true; }
-JSValueRef AccessibilityUIElement::mathRootRadicand() const { return { }; }
+JSValueRef AccessibilityUIElement::mathRootRadicand(JSContextRef) { return { }; }
 unsigned AccessibilityUIElement::numberOfCharacters() const { return 0; }
-JSValueRef AccessibilityUIElement::columns() { return { }; }
+JSValueRef AccessibilityUIElement::columns(JSContextRef) { return { }; }
 JSRetainPtr<JSStringRef> AccessibilityUIElement::dateValue() { return nullptr; }
-#endif // !PLATFORM(MAC))
+#endif // !PLATFORM(MAC)
 
 #if !PLATFORM(COCOA)
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::focusedElement() const { return nullptr; }
@@ -159,8 +159,8 @@ RefPtr<AccessibilityTextMarker> AccessibilityUIElement::nextSentenceEndTextMarke
 RefPtr<AccessibilityTextMarker> AccessibilityUIElement::previousSentenceStartTextMarkerForTextMarker(AccessibilityTextMarker*) { return nullptr; }
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::misspellingTextMarkerRange(AccessibilityTextMarkerRange*, bool) { return nullptr; }
 void AccessibilityUIElement::dismiss() { }
-JSValueRef AccessibilityUIElement::children() const { return { }; }
-JSValueRef AccessibilityUIElement::imageOverlayElements() const { return { }; }
+JSValueRef AccessibilityUIElement::children(JSContextRef) { return { }; }
+JSValueRef AccessibilityUIElement::imageOverlayElements(JSContextRef) { return { }; }
 JSRetainPtr<JSStringRef> AccessibilityUIElement::embeddedImageDescription() const { return nullptr; }
 #endif // !PLATFORM(COCOA)
 
@@ -175,17 +175,17 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaLabelledByElementAtIn
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::labelForElementAtIndex(unsigned) { return nullptr; }
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::ownerElementAtIndex(unsigned) { return nullptr; }
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::activeElement() const { return nullptr; }
-JSValueRef AccessibilityUIElement::selectedChildren() const { return { }; }
+JSValueRef AccessibilityUIElement::selectedChildren(JSContextRef) { return { }; }
 #endif // PLATFORM(IOS_FAMILY)
 
 #if PLATFORM(WIN) || PLATFORM(PLAYSTATION)
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::controllerElementAtIndex(unsigned) { return nullptr; }
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaDescribedByElementAtIndex(unsigned) { return nullptr; }
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::descriptionForElementAtIndex(unsigned) { return nullptr; }
-JSValueRef AccessibilityUIElement::detailsElements() const { return nullptr; }
+JSValueRef AccessibilityUIElement::detailsElements(JSContextRef) { return nullptr; }
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaDetailsElementAtIndex(unsigned) { return nullptr; }
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::detailsForElementAtIndex(unsigned) { return nullptr; }
-JSValueRef AccessibilityUIElement::errorMessageElements() const { return nullptr; }
+JSValueRef AccessibilityUIElement::errorMessageElements(JSContextRef) { return nullptr; }
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaErrorMessageElementAtIndex(unsigned) { return nullptr; }
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::errorMessageForElementAtIndex(unsigned) { return nullptr; }
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::flowFromElementAtIndex(unsigned) { return nullptr; }
@@ -193,7 +193,7 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaLabelledByElementAtIn
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::labelForElementAtIndex(unsigned) { return nullptr; }
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::ownerElementAtIndex(unsigned) { return nullptr; }
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::activeElement() const { return nullptr; }
-JSValueRef AccessibilityUIElement::selectedChildren() const { return { }; }
+JSValueRef AccessibilityUIElement::selectedChildren(JSContextRef) { return { }; }
 #endif // PLATFORM(WIN) || PLATFORM(PLAYSTATION)
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
@@ -89,7 +89,7 @@ public:
     JSRetainPtr<JSStringRef> domIdentifier() const;
 
     RefPtr<AccessibilityUIElement> elementAtPoint(int x, int y);
-    JSValueRef children() const;
+    JSValueRef children(JSContextRef);
     RefPtr<AccessibilityUIElement> childAtIndex(unsigned);
     unsigned indexOfChild(AccessibilityUIElement*);
     unsigned childrenCount();
@@ -134,16 +134,16 @@ public:
     JSRetainPtr<JSStringRef> stringDescriptionOfAttributeValue(JSStringRef attribute);
     JSRetainPtr<JSStringRef> stringAttributeValue(JSStringRef attribute);
     double numberAttributeValue(JSStringRef attribute);
-    JSValueRef uiElementArrayAttributeValue(JSStringRef attribute) const;
+    JSValueRef uiElementArrayAttributeValue(JSContextRef, JSStringRef attribute);
     RefPtr<AccessibilityUIElement> uiElementAttributeValue(JSStringRef attribute) const;
     bool boolAttributeValue(JSStringRef attribute);
 #if PLATFORM(MAC)
     RetainPtr<id> attributeValue(NSString *) const;
-    void attributeValueAsync(JSStringRef attribute, JSValueRef callback);
+    void attributeValueAsync(JSContextRef, JSStringRef attribute, JSValueRef callback);
     NSArray *actionNames() const;
     void performAction(NSString *) const;
 #else
-    void attributeValueAsync(JSStringRef attribute, JSValueRef callback) { }
+    void attributeValueAsync(JSContextRef, JSStringRef attribute, JSValueRef callback) { }
 #endif
     void setBoolAttributeValue(JSStringRef attribute, bool value);
     bool isAttributeSupported(JSStringRef attribute);
@@ -200,7 +200,7 @@ public:
     void removeSelectionAtIndex(unsigned) const;
     void clearSelectedChildren() const;
     RefPtr<AccessibilityUIElement> activeElement() const;
-    JSValueRef selectedChildren() const;
+    JSValueRef selectedChildren(JSContextRef);
     unsigned selectedChildrenCount() const;
     RefPtr<AccessibilityUIElement> selectedChildAtIndex(unsigned) const;
 
@@ -226,7 +226,7 @@ public:
     JSRetainPtr<JSStringRef> url();
     JSRetainPtr<JSStringRef> classList() const;
     JSRetainPtr<JSStringRef> embeddedImageDescription() const;
-    JSValueRef imageOverlayElements() const;
+    JSValueRef imageOverlayElements(JSContextRef);
 
     // CSS3-speech properties.
     JSRetainPtr<JSStringRef> speakAs();
@@ -235,7 +235,7 @@ public:
     JSRetainPtr<JSStringRef> attributesOfColumnHeaders();
     JSRetainPtr<JSStringRef> attributesOfRowHeaders();
     JSRetainPtr<JSStringRef> attributesOfColumns();
-    JSValueRef columns();
+    JSValueRef columns(JSContextRef);
     JSRetainPtr<JSStringRef> attributesOfRows();
     JSRetainPtr<JSStringRef> attributesOfVisibleCells();
     JSRetainPtr<JSStringRef> attributesOfHeader();
@@ -248,10 +248,10 @@ public:
     JSRetainPtr<JSStringRef> columnIndexRange();
     int rowCount();
     int columnCount();
-    JSValueRef rowHeaders() const;
-    JSValueRef columnHeaders() const;
+    JSValueRef rowHeaders(JSContextRef);
+    JSValueRef columnHeaders(JSContextRef);
     JSRetainPtr<JSStringRef> customContent() const;
-    JSValueRef selectedCells() const;
+    JSValueRef selectedCells(JSContextRef);
 
     // Tree/Outline specific attributes
     RefPtr<AccessibilityUIElement> selectedRowAtIndex(unsigned);
@@ -265,10 +265,10 @@ public:
     RefPtr<AccessibilityUIElement> ariaControlsElementAtIndex(unsigned);
     RefPtr<AccessibilityUIElement> ariaDescribedByElementAtIndex(unsigned);
     RefPtr<AccessibilityUIElement> descriptionForElementAtIndex(unsigned);
-    JSValueRef detailsElements() const;
+    JSValueRef detailsElements(JSContextRef);
     RefPtr<AccessibilityUIElement> ariaDetailsElementAtIndex(unsigned);
     RefPtr<AccessibilityUIElement> detailsForElementAtIndex(unsigned);
-    JSValueRef errorMessageElements() const;
+    JSValueRef errorMessageElements(JSContextRef);
     RefPtr<AccessibilityUIElement> ariaErrorMessageElementAtIndex(unsigned);
     RefPtr<AccessibilityUIElement> errorMessageForElementAtIndex(unsigned);
     RefPtr<AccessibilityUIElement> flowFromElementAtIndex(unsigned);
@@ -370,7 +370,7 @@ public:
     JSRetainPtr<JSStringRef> supportedActions() const;
     JSRetainPtr<JSStringRef> mathPostscriptsDescription() const;
     JSRetainPtr<JSStringRef> mathPrescriptsDescription() const;
-    JSValueRef mathRootRadicand() const;
+    JSValueRef mathRootRadicand(JSContextRef);
 
     JSRetainPtr<JSStringRef> pathDescription() const;
     
@@ -461,15 +461,12 @@ private:
 #ifdef __OBJC__
 inline std::optional<RefPtr<AccessibilityUIElement>> makeVectorElement(const RefPtr<AccessibilityUIElement>*, id element) { return { { AccessibilityUIElement::create(element) } }; }
 
-JSObjectRef makeJSArray(NSArray *);
+JSObjectRef makeJSArray(JSContextRef, NSArray *);
 #endif
 
 template<typename T>
-JSObjectRef makeJSArray(const Vector<T>& elements)
+JSObjectRef makeJSArray(JSContextRef context, const Vector<T>& elements)
 {
-    WKBundleFrameRef mainFrame = WKBundlePageGetMainFrame(InjectedBundle::singleton().page()->page());
-    JSContextRef context = WKBundleFrameGetJavaScriptContext(mainFrame);
-
     auto array = JSObjectMakeArray(context, 0, nullptr, nullptr);
     size_t size = elements.size();
     for (size_t i = 0; i < size; ++i)

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/CodeGeneratorTestRunner.pm
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/CodeGeneratorTestRunner.pm
@@ -328,7 +328,7 @@ EOF
             $self->_includeHeaders(\%contentsIncludes, $constant->type);
 
             my $getterName = _constantGetterFunctionName($self->_getterName($constant));
-            my $getterExpression = "impl->${getterName}()";
+            my $getterExpression = "callFunction(context, impl, &${implementationClassName}::${getterName})";
             my $value = $constant->value;
 
             push(@contents, <<EOF);
@@ -391,7 +391,7 @@ EOF
             $self->_includeHeaders(\%contentsIncludes, $attribute->type);
 
             my $getterName = $self->_getterName($attribute);
-            my $getterExpression = "impl->${getterName}()";
+            my $getterExpression = "callFunction(context, impl, &${implementationClassName}::${getterName})";
 
             push(@contents, <<EOF);
 

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
@@ -479,16 +479,13 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::domIdentifier() const
     return OpaqueJSString::tryCreate(m_element->attributes().get("id"_s)).leakRef();
 }
 
-JSValueRef AccessibilityUIElement::uiElementArrayAttributeValue(JSStringRef attribute) const
+JSValueRef AccessibilityUIElement::uiElementArrayAttributeValue(JSContextRef, JSStringRef attribute)
 {
     return nullptr;
 }
 
-static JSValueRef makeJSArray(const Vector<RefPtr<AccessibilityUIElement>>& elements)
+static JSValueRef makeJSArray(JSContextRef context, const Vector<RefPtr<AccessibilityUIElement>>& elements)
 {
-    WKBundleFrameRef mainFrame = WKBundlePageGetMainFrame(InjectedBundle::singleton().page()->page());
-    JSContextRef context = WKBundleFrameGetJavaScriptContext(mainFrame);
-
     size_t elementCount = elements.size();
     auto valueElements = makeUniqueArray<JSValueRef>(elementCount);
     for (size_t i = 0; i < elementCount; i++)
@@ -497,42 +494,42 @@ static JSValueRef makeJSArray(const Vector<RefPtr<AccessibilityUIElement>>& elem
     return JSObjectMakeArray(context, elementCount, valueElements.get(), nullptr);
 }
 
-JSValueRef AccessibilityUIElement::rowHeaders() const
+JSValueRef AccessibilityUIElement::rowHeaders(JSContextRef context)
 {
     if (m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Table)) {
         m_element->updateBackingStore();
-        return makeJSArray(elementsVector(m_element->rowHeaders()));
+        return makeJSArray(context, elementsVector(m_element->rowHeaders()));
     }
 
     if (m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::TableCell)) {
         m_element->updateBackingStore();
-        return makeJSArray(elementsVector(m_element->cellRowHeaders()));
+        return makeJSArray(context, elementsVector(m_element->cellRowHeaders()));
     }
 
-    return makeJSArray({ });
+    return makeJSArray(context, { });
 }
 
-JSValueRef AccessibilityUIElement::columnHeaders() const
+JSValueRef AccessibilityUIElement::columnHeaders(JSContextRef context)
 {
     if (m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Table)) {
         m_element->updateBackingStore();
-        return makeJSArray(elementsVector(m_element->columnHeaders()));
+        return makeJSArray(context, elementsVector(m_element->columnHeaders()));
     }
 
     if (m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::TableCell)) {
         m_element->updateBackingStore();
-        return makeJSArray(elementsVector(m_element->cellColumnHeaders()));
+        return makeJSArray(context, elementsVector(m_element->cellColumnHeaders()));
     }
 
-    return makeJSArray({ });
+    return makeJSArray(context, { });
 }
 
-JSValueRef AccessibilityUIElement::selectedCells() const
+JSValueRef AccessibilityUIElement::selectedCells(JSContextRef context)
 {
-    return makeJSArray({ });
+    return makeJSArray(context, { });
 }
 
-static JSValueRef elementsForRelation(WebCore::AccessibilityObjectAtspi* element, WebCore::Atspi::Relation relation)
+static JSValueRef elementsForRelation(JSContextRef context, WebCore::AccessibilityObjectAtspi* element, WebCore::Atspi::Relation relation)
 {
     element->updateBackingStore();
     auto relationMap = element->relationMap();
@@ -540,17 +537,17 @@ static JSValueRef elementsForRelation(WebCore::AccessibilityObjectAtspi* element
     if (targets.isEmpty())
         return { };
 
-    return makeJSArray(elementsVector(targets));
+    return makeJSArray(context, elementsVector(targets));
 }
 
-JSValueRef AccessibilityUIElement::detailsElements() const
+JSValueRef AccessibilityUIElement::detailsElements(JSContextRef context)
 {
-    return elementsForRelation(m_element.get(), WebCore::Atspi::Relation::Details);
+    return elementsForRelation(context, m_element.get(), WebCore::Atspi::Relation::Details);
 }
 
-JSValueRef AccessibilityUIElement::errorMessageElements() const
+JSValueRef AccessibilityUIElement::errorMessageElements(JSContextRef context)
 {
-    return elementsForRelation(m_element.get(), WebCore::Atspi::Relation::ErrorMessage);
+    return elementsForRelation(context, m_element.get(), WebCore::Atspi::Relation::ErrorMessage);
 }
 
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::uiElementAttributeValue(JSStringRef attribute) const
@@ -1516,13 +1513,13 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::activeElement() const
     return nullptr;
 }
 
-JSValueRef AccessibilityUIElement::selectedChildren() const
+JSValueRef AccessibilityUIElement::selectedChildren(JSContextRef context)
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Selection))
-        makeJSArray({ });
+        return makeJSArray(context, { });
 
     m_element->updateBackingStore();
-    return makeJSArray(elementsVector(m_element->selectedChildren()));
+    return makeJSArray(context, elementsVector(m_element->selectedChildren()));
 }
 
 JSRetainPtr<JSStringRef> AccessibilityUIElement::accessibilityValue() const

--- a/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm
@@ -63,20 +63,13 @@ Class webAccessibilityObjectWrapperClass()
     return cls;
 }
 
-static JSObjectRef makeJSArray(JSContextRef context, NSArray *array)
+JSObjectRef makeJSArray(JSContextRef context, NSArray *array)
 {
     NSUInteger count = array.count;
     JSValueRef arguments[count];
     for (NSUInteger i = 0; i < count; i++)
         arguments[i] = makeValueRefForValue(context, [array objectAtIndex:i]);
     return JSObjectMakeArray(context, count, arguments, nullptr);
-}
-
-JSObjectRef makeJSArray(NSArray *array)
-{
-    WKBundleFrameRef mainFrame = WKBundlePageGetMainFrame(InjectedBundle::singleton().page()->page());
-    JSContextRef context = WKBundleFrameGetJavaScriptContext(mainFrame);
-    return makeJSArray(context, array);
 }
 
 static JSObjectRef makeJSObject(JSContextRef context, NSDictionary *dictionary)

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
@@ -228,9 +228,9 @@ void AccessibilityUIElement::getDocumentLinks(Vector<RefPtr<AccessibilityUIEleme
 {
 }
 
-JSValueRef AccessibilityUIElement::children() const
+JSValueRef AccessibilityUIElement::children(JSContextRef context)
 {
-    return makeJSArray(makeVector<RefPtr<AccessibilityUIElement>>([m_element accessibilityElements]));
+    return makeJSArray(context, makeVector<RefPtr<AccessibilityUIElement>>([m_element accessibilityElements]));
 }
 
 Vector<RefPtr<AccessibilityUIElement>> AccessibilityUIElement::getChildren() const
@@ -268,19 +268,19 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::linkedUIElementAtIndex(un
     return nullptr;
 }
 
-JSValueRef AccessibilityUIElement::detailsElements() const
+JSValueRef AccessibilityUIElement::detailsElements(JSContextRef context)
 {
     NSArray *elements = [m_element accessibilityDetailsElements];
     if ([elements isKindOfClass:NSArray.class])
-        return makeJSArray(makeVector<RefPtr<AccessibilityUIElement>>(elements));
+        return makeJSArray(context, makeVector<RefPtr<AccessibilityUIElement>>(elements));
     return { };
 }
 
-JSValueRef AccessibilityUIElement::errorMessageElements() const
+JSValueRef AccessibilityUIElement::errorMessageElements(JSContextRef context)
 {
     NSArray *elements = [m_element accessibilityErrorMessageElements];
     if ([elements isKindOfClass:NSArray.class])
-        return makeJSArray(makeVector<RefPtr<AccessibilityUIElement>>(elements));
+        return makeJSArray(context, makeVector<RefPtr<AccessibilityUIElement>>(elements));
     return { };
 }
 
@@ -438,22 +438,22 @@ double AccessibilityUIElement::numberAttributeValue(JSStringRef attribute)
     return 0;
 }
 
-JSValueRef AccessibilityUIElement::uiElementArrayAttributeValue(JSStringRef attribute) const
+JSValueRef AccessibilityUIElement::uiElementArrayAttributeValue(JSContextRef, JSStringRef attribute)
 {
     return nullptr;
 }
 
-JSValueRef AccessibilityUIElement::rowHeaders() const
+JSValueRef AccessibilityUIElement::rowHeaders(JSContextRef)
 {
     return nullptr;
 }
 
-JSValueRef AccessibilityUIElement::selectedCells() const
+JSValueRef AccessibilityUIElement::selectedCells(JSContextRef)
 {
     return nullptr;
 }
 
-JSValueRef AccessibilityUIElement::columnHeaders() const
+JSValueRef AccessibilityUIElement::columnHeaders(JSContextRef)
 {
     return nullptr;
 }
@@ -1169,9 +1169,9 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::embeddedImageDescription() cons
     return concatenateAttributeAndValue(@"AXEmbeddedImageDescription", [m_element _accessibilityPhotoDescription]);
 }
 
-JSValueRef AccessibilityUIElement::imageOverlayElements() const
+JSValueRef AccessibilityUIElement::imageOverlayElements(JSContextRef context)
 {
-    return makeJSArray(makeVector<RefPtr<AccessibilityUIElement>>([m_element accessibilityImageOverlayElements]));
+    return makeJSArray(context, makeVector<RefPtr<AccessibilityUIElement>>([m_element accessibilityImageOverlayElements]));
 }
 
 bool AccessibilityUIElement::isCollapsed() const

--- a/Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp
@@ -214,25 +214,25 @@ double AccessibilityUIElement::numberAttributeValue(JSStringRef attribute)
     return 0;
 }
 
-JSValueRef AccessibilityUIElement::uiElementArrayAttributeValue(JSStringRef attribute) const
+JSValueRef AccessibilityUIElement::uiElementArrayAttributeValue(JSContextRef, JSStringRef attribute)
 {
     notImplemented();
     return nullptr;
 }
 
-JSValueRef AccessibilityUIElement::rowHeaders() const
+JSValueRef AccessibilityUIElement::rowHeaders(JSContextRef)
 {
     notImplemented();
     return nullptr;
 }
 
-JSValueRef AccessibilityUIElement::columnHeaders() const
+JSValueRef AccessibilityUIElement::columnHeaders(JSContextRef)
 {
     notImplemented();
     return nullptr;
 }
 
-JSValueRef AccessibilityUIElement::selectedCells() const
+JSValueRef AccessibilityUIElement::selectedCells(JSContextRef)
 {
     notImplemented();
     return nullptr;


### PR DESCRIPTION
#### f8803aadf9e780393cb65c6a67caf33f182886e9
<pre>
Reduce use of WKBundlePageGetMainFrame in WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=273302">https://bugs.webkit.org/show_bug.cgi?id=273302</a>

Reviewed by Wenson Hsieh.

With site isolation, the main frame might be in another process.
Use the current JSContextRef instead.

* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp:
(WTR::AccessibilityUIElement::mathRootRadicand):
(WTR::AccessibilityUIElement::children):
(WTR::AccessibilityUIElement::imageOverlayElements):
(WTR::AccessibilityUIElement::selectedChildren):
(WTR::AccessibilityUIElement::detailsElements):
(WTR::AccessibilityUIElement::mathRootRadicand const): Deleted.
(WTR::AccessibilityUIElement::children const): Deleted.
(WTR::AccessibilityUIElement::imageOverlayElements const): Deleted.
(WTR::AccessibilityUIElement::selectedChildren const): Deleted.
(WTR::AccessibilityUIElement::detailsElements const): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h:
(WTR::AccessibilityUIElement::attributeValueAsync):
(WTR::makeJSArray):
* Tools/WebKitTestRunner/InjectedBundle/Bindings/CodeGeneratorTestRunner.pm:
(_generateImplementationFile):
* Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm:
(WTR::makeJSArray):
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm:
(WTR::AccessibilityUIElement::children):
(WTR::AccessibilityUIElement::detailsElements):
(WTR::AccessibilityUIElement::errorMessageElements):
(WTR::AccessibilityUIElement::uiElementArrayAttributeValue):
(WTR::AccessibilityUIElement::rowHeaders):
(WTR::AccessibilityUIElement::selectedCells):
(WTR::AccessibilityUIElement::columnHeaders):
(WTR::AccessibilityUIElement::imageOverlayElements):
(WTR::AccessibilityUIElement::children const): Deleted.
(WTR::AccessibilityUIElement::detailsElements const): Deleted.
(WTR::AccessibilityUIElement::errorMessageElements const): Deleted.
(WTR::AccessibilityUIElement::uiElementArrayAttributeValue const): Deleted.
(WTR::AccessibilityUIElement::rowHeaders const): Deleted.
(WTR::AccessibilityUIElement::selectedCells const): Deleted.
(WTR::AccessibilityUIElement::columnHeaders const): Deleted.
(WTR::AccessibilityUIElement::imageOverlayElements const): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::AccessibilityUIElement::children):
(WTR::AccessibilityUIElement::rowHeaders):
(WTR::AccessibilityUIElement::selectedCells):
(WTR::AccessibilityUIElement::columnHeaders):
(WTR::AccessibilityUIElement::detailsElements):
(WTR::AccessibilityUIElement::errorMessageElements):
(WTR::AccessibilityUIElement::selectedChildren):
(WTR::AccessibilityUIElement::uiElementArrayAttributeValue):
(WTR::AccessibilityUIElement::attributeValueAsync):
(WTR::AccessibilityUIElement::searchTextWithCriteria):
(WTR::AccessibilityUIElement::columns):
(WTR::AccessibilityUIElement::imageOverlayElements):
(WTR::AccessibilityUIElement::mathRootRadicand):
(WTR::AccessibilityUIElement::children const): Deleted.
(WTR::AccessibilityUIElement::rowHeaders const): Deleted.
(WTR::AccessibilityUIElement::selectedCells const): Deleted.
(WTR::AccessibilityUIElement::columnHeaders const): Deleted.
(WTR::AccessibilityUIElement::detailsElements const): Deleted.
(WTR::AccessibilityUIElement::errorMessageElements const): Deleted.
(WTR::AccessibilityUIElement::selectedChildren const): Deleted.
(WTR::AccessibilityUIElement::uiElementArrayAttributeValue const): Deleted.
(WTR::AccessibilityUIElement::imageOverlayElements const): Deleted.
(WTR::AccessibilityUIElement::mathRootRadicand const): Deleted.

Canonical link: <a href="https://commits.webkit.org/278039@main">https://commits.webkit.org/278039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/459494c8f9eabb4eebd4f321d00c0425da345b02

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52316 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52101 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45388 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51589 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26187 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40259 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26114 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21381 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23566 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7652 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45484 "Passed tests") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54011 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24367 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20549 "Found 1 new test failure: media/video-pause-immediately.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47575 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25639 "Built successfully") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Release-WK2-Stress-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46566 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26478 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7075 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25362 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->