### PR TITLE
[macOS] REGRESSION(275831@main): Netflix can error out while scrubbing

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -165,6 +165,13 @@ private:
         });
     }
 
+    void seeked(const MediaTime& time)
+    {
+        ensureWeakOnDispatcher([time = time](MediaSource& parent) {
+            parent.seeked(time);
+        });
+    }
+
 #if !RELEASE_LOG_DISABLED
     void setLogIdentifier(const void* identifier)
     {
@@ -1472,6 +1479,12 @@ void MediaSource::failedToCreateRenderer(RendererType type)
 {
     if (auto context = scriptExecutionContext())
         context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("MediaSource ", type == RendererType::Video ? "video" : "audio", " renderer creation failed."));
+}
+
+void MediaSource::seeked(const MediaTime& time)
+{
+    ALWAYS_LOG(LOGIDENTIFIER, time);
+    monitorSourceBuffers();
 }
 
 void MediaSource::sourceBufferReceivedFirstInitializationSegmentChanged()

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -198,6 +198,7 @@ private:
     Ref<MediaPromise> seekToTime(const MediaTime&);
     using RendererType = MediaSourcePrivateClient::RendererType;
     void failedToCreateRenderer(RendererType);
+    void seeked(const MediaTime&);
 
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -109,6 +109,12 @@ Ref<MediaPromise> MediaSourcePrivate::seekToTime(const MediaTime& time)
     return MediaPromise::createAndReject(PlatformMediaError::ClientDisconnected);
 }
 
+void MediaSourcePrivate::seeked(const MediaTime& time)
+{
+    if (RefPtr client = this->client())
+        return client->seeked(time);
+}
+
 void MediaSourcePrivate::removeSourceBuffer(SourceBufferPrivate& sourceBuffer)
 {
     assertIsCurrent(m_dispatcher);

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -98,6 +98,7 @@ public:
 
     Ref<MediaTimePromise> waitForTarget(const SeekTarget&);
     Ref<MediaPromise> seekToTime(const MediaTime&);
+    void seeked(const MediaTime&);
 
     virtual void setTimeFudgeFactor(const MediaTime& fudgeFactor) { m_timeFudgeFactor = fudgeFactor; }
     MediaTime timeFudgeFactor() const { return m_timeFudgeFactor; }

--- a/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
@@ -45,6 +45,7 @@ public:
     virtual void setPrivateAndOpen(Ref<MediaSourcePrivate>&&) = 0;
     virtual Ref<MediaTimePromise> waitForTarget(const SeekTarget&) = 0;
     virtual Ref<MediaPromise> seekToTime(const MediaTime&) = 0;
+    virtual void seeked(const MediaTime&) = 0;
 
 #if !RELEASE_LOG_DISABLED
     virtual void setLogIdentifier(const void*) = 0;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
@@ -78,6 +78,7 @@ public:
     bool hasSelectedVideo() const;
 
     void willSeek();
+    void seeked(const MediaTime&);
 
     FloatSize naturalSize() const;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
@@ -173,6 +173,12 @@ void MediaSourcePrivateAVFObjC::willSeek()
         downcast<SourceBufferPrivateAVFObjC>(sourceBuffer)->willSeek();
 }
 
+void MediaSourcePrivateAVFObjC::seeked(const MediaTime& time)
+{
+    if (RefPtr client = this->client())
+        client->seeked(time);
+}
+
 FloatSize MediaSourcePrivateAVFObjC::naturalSize() const
 {
     FloatSize result;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
@@ -66,6 +66,9 @@ public:
     Ref<WebCore::MediaTimePromise> waitForTarget(const WebCore::SeekTarget&) final;
     Ref<WebCore::MediaPromise> seekToTime(const MediaTime&) final;
 
+    // Handled by MediaPlayerPrivateRemote:
+    void seeked(const MediaTime&) final { };
+
 #if !RELEASE_LOG_DISABLED
     void setLogIdentifier(const void*) final;
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -508,6 +508,12 @@ void MediaPlayerPrivateRemote::seeked(MediaTimeUpdateData&& timeData)
     m_currentTimeEstimator.setTime(timeData);
     if (auto player = m_player.get())
         player->seeked(timeData.currentTime);
+#if ENABLE(MEDIA_SOURCE)
+    // This message may well have been handled by the MediaSource object before
+    // theis message, which would result in the wrong
+    if (RefPtr mediaSourcePrivate = m_mediaSourcePrivate)
+        return mediaSourcePrivate->seeked(timeData.currentTime);
+#endif
 }
 
 void MediaPlayerPrivateRemote::timeChanged(RemoteMediaPlayerState&& state, MediaTimeUpdateData&& timeData)


### PR DESCRIPTION
#### c7be93fa40d309506d29618823d9b181e558e481
<pre>
[macOS] REGRESSION(275831@main): Netflix can error out while scrubbing
<a href="https://bugs.webkit.org/show_bug.cgi?id=273306">https://bugs.webkit.org/show_bug.cgi?id=273306</a>
<a href="https://rdar.apple.com/126654352">rdar://126654352</a>

Reviewed by Eric Carlson.

A race condition can occur where the MediaSource object in the WebContent process
does not check the buffered ranges for the new currentTime after a seek, which leads
to the readyState remaining at HAVE_METADATA, and the seeked event failing to fire.

Ensure that the MediaSource checks its buffered ranges after a seek by adding an
explicit &quot;seeked()&quot; method to MediaSourcePrivateClient to be used when a seek completes
in a MediaPlayerPrivate, to notify the MediaSource to revalidate its buffered ranges.

To avaid adding a new race condition, call this new &quot;seeked()&quot; method from
MediaPlayerPrivateRemote, rather than from MediaSourcePrivateRemote, to ensure that
the &quot;official&quot; time is fully updated before the MediaSource monitiors its source buffers.

* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::failedToCreateRenderer):
(WebCore::MediaSource::seeked):
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::seeked):
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/MediaSourcePrivateClient.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm:
(WebCore::MediaSourcePrivateAVFObjC::seeked):
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::seeked):

Canonical link: <a href="https://commits.webkit.org/278060@main">https://commits.webkit.org/278060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02a26a173a7f4084447e1ed6207c919e0e6e6bd5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52392 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/52592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/31 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51663 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26261 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/52592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26184 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42511 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/52592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23639 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43694 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7727 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45551 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44198 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54110 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24440 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20624 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47648 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25712 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42718 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46642 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10848 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/26551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25436 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->