### PR TITLE
[Skia] Handle font style when finding fallback fonts

### DIFF
--- a/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
@@ -53,6 +53,43 @@ SkFontMgr& FontCache::fontManager() const
     return *m_fontManager.get();
 }
 
+static SkFontStyle skiaFontStyle(const FontDescription& fontDescription)
+{
+    int skWeight = SkFontStyle::kNormal_Weight;
+    auto weight = fontDescription.weight();
+    if (weight > FontSelectionValue(SkFontStyle::kInvisible_Weight) && weight <= FontSelectionValue(SkFontStyle::kExtraBlack_Weight))
+        skWeight = static_cast<int>(weight);
+
+    int skWidth = SkFontStyle::kNormal_Width;
+    auto stretch = fontDescription.stretch();
+    if (stretch <= ultraCondensedStretchValue())
+        skWidth = SkFontStyle::kUltraCondensed_Width;
+    else if (stretch <= extraCondensedStretchValue())
+        skWidth = SkFontStyle::kExtraCondensed_Width;
+    else if (stretch <= condensedStretchValue())
+        skWidth = SkFontStyle::kCondensed_Width;
+    else if (stretch <= semiCondensedStretchValue())
+        skWidth = SkFontStyle::kSemiCondensed_Width;
+    else if (stretch >= semiExpandedStretchValue())
+        skWidth = SkFontStyle::kSemiExpanded_Width;
+    else if (stretch >= expandedStretchValue())
+        skWidth = SkFontStyle::kExpanded_Width;
+    if (stretch >= extraExpandedStretchValue())
+        skWidth = SkFontStyle::kExtraExpanded_Width;
+    if (stretch >= ultraExpandedStretchValue())
+        skWidth = SkFontStyle::kUltraExpanded_Width;
+
+    SkFontStyle::Slant skSlant = SkFontStyle::kUpright_Slant;
+    if (auto italic = fontDescription.italic()) {
+        if (italic.value() > normalItalicValue() && italic.value() <= italicThreshold())
+            skSlant = SkFontStyle::kItalic_Slant;
+        else if (italic.value() > italicThreshold())
+            skSlant = SkFontStyle::kOblique_Slant;
+    }
+
+    return SkFontStyle(skWeight, skWidth, skSlant);
+}
+
 RefPtr<Font> FontCache::systemFallbackForCharacterCluster(const FontDescription& description, const Font&, IsForPlatformFont, PreferColoredFont, StringView stringView)
 {
     // FIXME: matchFamilyStyleCharacter is slow, we need a cache here, see https://bugs.webkit.org/show_bug.cgi?id=203544.
@@ -72,7 +109,7 @@ RefPtr<Font> FontCache::systemFallbackForCharacterCluster(const FontDescription&
 
     // FIXME: handle synthetic properties.
     auto features = computeFeatures(description, { });
-    auto typeface = fontManager().matchFamilyStyleCharacter(nullptr, { }, bcp47.data(), bcp47.size(), baseCharacter);
+    auto typeface = fontManager().matchFamilyStyleCharacter(nullptr, skiaFontStyle(description), bcp47.data(), bcp47.size(), baseCharacter);
     FontPlatformData alternateFontData(WTFMove(typeface), description.computedSize(), false /* syntheticBold */, false /* syntheticOblique */, description.orientation(), description.widthVariant(), description.textRenderingMode(), WTFMove(features));
     return fontForPlatformData(alternateFontData);
 }
@@ -294,43 +331,6 @@ Vector<hb_feature_t> FontCache::computeFeatures(const FontDescription& fontDescr
     for (const auto& iter : featuresToBeApplied)
         features.append({ HB_TAG(iter.key[0], iter.key[1], iter.key[2], iter.key[3]), static_cast<uint32_t>(iter.value), 0, static_cast<unsigned>(-1) });
     return features;
-}
-
-static SkFontStyle skiaFontStyle(const FontDescription& fontDescription)
-{
-    int skWeight = SkFontStyle::kNormal_Weight;
-    auto weight = fontDescription.weight();
-    if (weight > FontSelectionValue(SkFontStyle::kInvisible_Weight) && weight <= FontSelectionValue(SkFontStyle::kExtraBlack_Weight))
-        skWeight = static_cast<int>(weight);
-
-    int skWidth = SkFontStyle::kNormal_Width;
-    auto stretch = fontDescription.stretch();
-    if (stretch <= ultraCondensedStretchValue())
-        skWidth = SkFontStyle::kUltraCondensed_Width;
-    else if (stretch <= extraCondensedStretchValue())
-        skWidth = SkFontStyle::kExtraCondensed_Width;
-    else if (stretch <= condensedStretchValue())
-        skWidth = SkFontStyle::kCondensed_Width;
-    else if (stretch <= semiCondensedStretchValue())
-        skWidth = SkFontStyle::kSemiCondensed_Width;
-    else if (stretch >= semiExpandedStretchValue())
-        skWidth = SkFontStyle::kSemiExpanded_Width;
-    else if (stretch >= expandedStretchValue())
-        skWidth = SkFontStyle::kExpanded_Width;
-    if (stretch >= extraExpandedStretchValue())
-        skWidth = SkFontStyle::kExtraExpanded_Width;
-    if (stretch >= ultraExpandedStretchValue())
-        skWidth = SkFontStyle::kUltraExpanded_Width;
-
-    SkFontStyle::Slant skSlant = SkFontStyle::kUpright_Slant;
-    if (auto italic = fontDescription.italic()) {
-        if (italic.value() > normalItalicValue() && italic.value() <= italicThreshold())
-            skSlant = SkFontStyle::kItalic_Slant;
-        else if (italic.value() > italicThreshold())
-            skSlant = SkFontStyle::kOblique_Slant;
-    }
-
-    return SkFontStyle(skWeight, skWidth, skSlant);
 }
 
 std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDescription& fontDescription, const AtomString& family, const FontCreationContext& fontCreationContext)


### PR DESCRIPTION
#### 1ade9b72a383daa2aee2e964d15c42877b9fb999
<pre>
[Skia] Handle font style when finding fallback fonts
<a href="https://bugs.webkit.org/show_bug.cgi?id=273310">https://bugs.webkit.org/show_bug.cgi?id=273310</a>

Reviewed by Alejandro G. Castro.

* Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp:
(WebCore::skiaFontStyle):
(WebCore::FontCache::systemFallbackForCharacterCluster):

Canonical link: <a href="https://commits.webkit.org/278031@main">https://commits.webkit.org/278031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7678750bfafa3ea8bd10a2fd74b077cfddc5b576

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28573 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52126 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45394 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51595 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26193 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40265 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51392 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26121 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21387 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23572 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43635 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7658 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/44139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54035 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24373 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20555 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47583 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25645 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42661 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26484 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7071 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25368 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->