### PR TITLE
Picture-in-Picture from canvas-sourced video turns black when canvas is resized

### DIFF
--- a/LayoutTests/media/picture-in-picture/video-resize-requestPictureInPicture-crash-expected.txt
+++ b/LayoutTests/media/picture-in-picture/video-resize-requestPictureInPicture-crash-expected.txt
@@ -1,0 +1,5 @@
+
+This test passes if it does not crash.
+
+EVENT(resize)
+

--- a/LayoutTests/media/picture-in-picture/video-resize-requestPictureInPicture-crash.html
+++ b/LayoutTests/media/picture-in-picture/video-resize-requestPictureInPicture-crash.html
@@ -1,0 +1,50 @@
+<html>
+<head>
+    <script src="../video-test.js"></script>
+    <script src="../utilities.js"></script>
+    <script>
+    let canvas = null;
+
+    internals.settings.setAllowsPictureInPictureMediaPlayback(true);
+
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.dumpAsText();
+    }
+
+    async function load() {
+        canvas = document.getElementById('canvas');
+        findMediaElement();
+        video.srcObject = canvas.captureStream();
+
+        const ctx = canvas.getContext('2d');
+        setInterval(() => {
+            ctx.fillStyle = 'red';
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+        }, 33);
+
+        await once(video, 'canplaythrough');
+        runWithKeyDown(async () => {
+            await video.requestPictureInPicture();
+            canvas.width = Math.round(Math.random() * 100) + 100;
+            canvas.height = Math.round(Math.random() * 100) + 100;
+
+            video.width = canvas.width;
+            video.height = canvas.height;
+            await waitFor(video, 'resize');
+
+            await document.exitPictureInPicture();
+            
+            if (window.testRunner)
+                testRunner.notifyDone();
+        });
+    }
+    </script>
+    <style type="text/css"></style>
+</head>
+<body onload="load()">
+    <canvas id="canvas" width="100" height="100"></canvas>
+    <video id="video" width="100" height="100" autoplay></video>
+    <p>This test passes if it does not crash.</p>
+</body>
+</html>

--- a/LayoutTests/platform/ipad/TestExpectations
+++ b/LayoutTests/platform/ipad/TestExpectations
@@ -84,6 +84,7 @@ webkit.org/b/203264 editing/pasteboard/smart-paste-paragraph-001.html [ Pass ]
 webkit.org/b/231635 [ Release ] editing/selection/ios/scroll-to-reveal-selection-when-showing-software-keyboard.html [ Timeout ]
 
 media/picture-in-picture [ Pass ]
+media/picture-in-picture/video-resize-requestPictureInPicture-crash.html [ Pass Timeout ]
 media/remove-video-element-in-pip-from-document.html [ Pass ]
 
 http/tests/media/media-source/mediasource-rvfc.html [ Pass ]

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -59,8 +59,6 @@ class ShareableBitmapHandle;
 
 namespace WebKit {
 
-using LayerHostingContextID = uint32_t;
-
 class LayerHostingContext;
 class WebPage;
 class PlaybackSessionInterfaceContext;
@@ -220,7 +218,6 @@ protected:
     HashMap<PlaybackSessionContextIdentifier, int> m_clientCounts;
     WeakPtr<WebCore::HTMLVideoElement> m_videoElementInPictureInPicture;
     bool m_currentlyInFullscreen { false };
-    WTF::Function<void(LayerHostingContextID, const WebCore::FloatSize&)> m_setupFullscreenHandler;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -400,11 +400,10 @@ void VideoPresentationManager::enterVideoFullscreenForVideoElement(HTMLVideoElem
     if (blockMediaLayerRehosting) {
         contextID = videoElement.layerHostingContextID();
         if (!contextID) {
-            m_setupFullscreenHandler = WTFMove(setupFullscreen);
-            videoElement.requestHostingContextID([this, protectedThis = Ref { *this }, videoElement = Ref { videoElement }] (auto contextID) {
-                if (!contextID || !m_setupFullscreenHandler)
+            videoElement.requestHostingContextID([protectedThis = Ref { *this }, videoElement = Ref { videoElement }, setupFullscreenHandler = WTFMove(setupFullscreen)] (auto contextID) {
+                if (!contextID)
                     return;
-                m_setupFullscreenHandler(contextID, FloatSize(videoElement->videoWidth(), videoElement->videoHeight()));
+                setupFullscreenHandler(contextID, FloatSize(videoElement->videoWidth(), videoElement->videoHeight()));
             });
             return;
         }
@@ -524,15 +523,6 @@ void VideoPresentationManager::hasVideoChanged(PlaybackSessionContextIdentifier 
 
 void VideoPresentationManager::videoDimensionsChanged(PlaybackSessionContextIdentifier contextId, const FloatSize& videoDimensions)
 {
-    if (m_setupFullscreenHandler) {
-        auto [model, interface] = ensureModelAndInterface(contextId);
-        RefPtr videoElement = model->videoElement();
-        auto layerHostingContextID = videoElement ? videoElement->layerHostingContextID() : 0;
-        if (layerHostingContextID) {
-            m_setupFullscreenHandler(layerHostingContextID, videoDimensions);
-            m_setupFullscreenHandler = nullptr;
-        }
-    }
     if (m_page)
         m_page->send(Messages::VideoPresentationManagerProxy::SetVideoDimensions(contextId, videoDimensions));
 }


### PR DESCRIPTION
#### c610bd1cd7c7c41aad043fc2527683cf4ee6e044
<pre>
Picture-in-Picture from canvas-sourced video turns black when canvas is resized
<a href="https://bugs.webkit.org/show_bug.cgi?id=270859">https://bugs.webkit.org/show_bug.cgi?id=270859</a>
<a href="https://rdar.apple.com/124479880">rdar://124479880</a>

Reviewed by Jer Noble.

In 262654@main, a workaround was added waiting for the element size to change, assuming that
when the size changed, the HostingContextID would always be known.
In 262654@main, a proper solution was added that asynchronously waited for the context ID to
be available before continuing setting up fullscreen PiP, however it didn&apos;t remove the workaround
set in 262654@main and as it incorrectly didn&apos;t clear the callback it allowed for it to be called
multiple times.
When used with a MediaStream, there&apos;s no initial size change as the size is known upon
creation of the canvas.
So when the video element was resized, it would attempt to enter fullscreen when we were
already in fullscreen.
This caused an assertion in debug build and an Obj-C exception would also be thrown when exiting PiP
due to the ViewController having already been deleted.

This change is in effect a revert of 262654@main.
Added test.

* LayoutTests/platform/ipad/TestExpectations: On EWS, tests intermittently timeout, works fine locally
* LayoutTests/media/picture-in-picture/video-resize-requestPictureInPicture-crash-expected.txt: Added.
* LayoutTests/media/picture-in-picture/video-resize-requestPictureInPicture-crash.html: Added.
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::enterVideoFullscreenForVideoElement):
(WebKit::VideoPresentationManager::videoDimensionsChanged):

Canonical link: <a href="https://commits.webkit.org/278075@main">https://commits.webkit.org/278075@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6e214a9a80ed89d2af6097b65086b628c5a31a3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28694 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52447 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/52651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/85 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34710 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26314 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/52651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51512 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26241 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42567 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/52651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23697 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43750 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7781 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45614 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44253 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54163 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24494 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20683 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47695 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-visibility-hidden-child.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25766 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42771 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46700 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/non-editable (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10858 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26605 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25489 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->