### PR TITLE
[CMake] Skia headers symlink is sometimes not created before it is needed

### DIFF
--- a/Source/ThirdParty/skia/CMakeLists.txt
+++ b/Source/ThirdParty/skia/CMakeLists.txt
@@ -926,24 +926,15 @@ WEBKIT_ADD_TARGET_CXX_FLAGS(Skia
     -Wno-unused-parameter
 )
 
-add_custom_command(
-    TARGET Skia
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E create_symlink
-        "${CMAKE_CURRENT_SOURCE_DIR}/include"
-        "${Skia_FRAMEWORK_HEADERS_DIR}/skia"
-    BYPRODUCTS
-        "${Skia_FRAMEWORK_HEADERS_DIR}/skia"
-    COMMENT "Link Skia headers"
-    VERBATIM
+target_include_directories(Skia
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}"
+    INTERFACE "${Skia_FRAMEWORK_HEADERS_DIR}"
 )
 
-target_include_directories(Skia PRIVATE
-    "${CMAKE_CURRENT_SOURCE_DIR}"
-)
-target_include_directories(Skia INTERFACE
-    "${CMAKE_CURRENT_SOURCE_DIR}"
-    "${Skia_FRAMEWORK_HEADERS_DIR}"
+file(CREATE_LINK
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${Skia_FRAMEWORK_HEADERS_DIR}/skia"
+    SYMBOLIC
 )
 
 target_compile_definitions(Skia PRIVATE


### PR DESCRIPTION
#### 6f3cd5542cb2f418a5f146e2565834f106008046
<pre>
[CMake] Skia headers symlink is sometimes not created before it is needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=273315">https://bugs.webkit.org/show_bug.cgi?id=273315</a>

Reviewed by Carlos Garcia Campos.

* Source/ThirdParty/skia/CMakeLists.txt: Ensure that the symlink to the
  headers location is created while CMake, with file(CREATE_SYMLINK).
  This makes the symlink always available during the build and avoids
  using complicated dependency chains on interface targets or using
  custom_target(), which would that cause some targets to be considered
  always outdated.

Canonical link: <a href="https://commits.webkit.org/278034@main">https://commits.webkit.org/278034@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5fa8252bf6298a6ecc4ee0a3cb7e2a916c3b23b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49300 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52145 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45403 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26202 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40272 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51401 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/26130 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42462 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/21394 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23581 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43643 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7667 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44146 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54047 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24382 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25654 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42669 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26493 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7072 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25377 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->