### PR TITLE
[GTK][WPE] Main thread can't start rendering the next frame until the previous one is composited

### DIFF
--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
@@ -232,6 +232,7 @@ void ThreadedCompositor::renderLayerTree()
     WebCore::IntPoint scrollPosition;
     float scaleFactor;
     bool needsResize;
+    uint32_t compositionRequestID;
 
     Vector<RefPtr<Nicosia::Scene>> states;
 
@@ -241,6 +242,7 @@ void ThreadedCompositor::renderLayerTree()
         scrollPosition = m_attributes.scrollPosition;
         scaleFactor = m_attributes.scaleFactor;
         needsResize = m_attributes.needsResize;
+        compositionRequestID = m_attributes.compositionRequestID;
 
         states = WTFMove(m_attributes.states);
 
@@ -278,7 +280,7 @@ void ThreadedCompositor::renderLayerTree()
     m_context->swapBuffers();
 
     if (m_scene->isActive())
-        m_client.didRenderFrame();
+        m_client.didRenderFrame(compositionRequestID);
 }
 
 void ThreadedCompositor::sceneUpdateFinished()
@@ -310,10 +312,12 @@ void ThreadedCompositor::sceneUpdateFinished()
     m_compositingRunLoop->updateCompleted(stateLocker);
 }
 
-void ThreadedCompositor::updateSceneState(const RefPtr<Nicosia::Scene>& state)
+void ThreadedCompositor::updateSceneState(const RefPtr<Nicosia::Scene>& state, uint32_t compositionRequestID)
 {
     Locker locker { m_attributes.lock };
-    m_attributes.states.append(state);
+    if (state)
+        m_attributes.states.append(state);
+    m_attributes.compositionRequestID = compositionRequestID;
     m_compositingRunLoop->scheduleUpdate();
 }
 

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h
@@ -57,7 +57,7 @@ public:
         virtual void resize(const WebCore::IntSize&) = 0;
         virtual void willRenderFrame() = 0;
         virtual void clearIfNeeded() = 0;
-        virtual void didRenderFrame() = 0;
+        virtual void didRenderFrame(uint32_t) = 0;
         virtual void displayDidRefresh(WebCore::PlatformDisplayID) = 0;
     };
 
@@ -71,7 +71,7 @@ public:
     void setScrollPosition(const WebCore::IntPoint&, float scale);
     void setViewportSize(const WebCore::IntSize&, float scale);
 
-    void updateSceneState(const RefPtr<Nicosia::Scene>&);
+    void updateSceneState(const RefPtr<Nicosia::Scene>&, uint32_t);
     void updateScene();
     void updateSceneWithoutRendering();
 
@@ -128,6 +128,7 @@ private:
         Vector<RefPtr<Nicosia::Scene>> states;
 
         bool clientRendersNextFrame { false };
+        uint32_t compositionRequestID { 0 };
     } m_attributes;
 
 #if !HAVE(DISPLAY_LINK)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
@@ -216,7 +216,7 @@ bool CompositingCoordinator::flushPendingLayerChanges(OptionSet<FinalizeRenderin
     }
 #if HAVE(DISPLAY_LINK)
     else
-        m_client.updateScene();
+        m_client.commitSceneState(nullptr);
 #endif
 
     m_page.didUpdateRendering();

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -355,7 +355,7 @@ void LayerTreeHost::didFlushRootLayer(const FloatRect& visibleContentRect)
 void LayerTreeHost::commitSceneState(const RefPtr<Nicosia::Scene>& state)
 {
     m_isWaitingForRenderer = true;
-    m_compositor->updateSceneState(state);
+    m_compositor->updateSceneState(state, ++m_compositionRequestID);
 }
 
 void LayerTreeHost::updateScene()
@@ -408,10 +408,11 @@ void LayerTreeHost::clearIfNeeded()
     m_surface->clearIfNeeded();
 }
 
-void LayerTreeHost::didRenderFrame()
+void LayerTreeHost::didRenderFrame(uint32_t compositionResponseID)
 {
     m_surface->didRenderFrame();
 #if HAVE(DISPLAY_LINK)
+    m_compositionResponseID = compositionResponseID;
     if (!m_didRenderFrameTimer.isActive())
         m_didRenderFrameTimer.startOneShot(0_s);
 #endif
@@ -424,7 +425,8 @@ void LayerTreeHost::didRenderFrame()
 #if HAVE(DISPLAY_LINK)
 void LayerTreeHost::didRenderFrameTimerFired()
 {
-    renderNextFrame(false);
+    if (!m_isWaitingForRenderer || (m_isWaitingForRenderer && m_compositionRequestID == m_compositionResponseID))
+        renderNextFrame(false);
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -140,7 +140,7 @@ private:
     void resize(const WebCore::IntSize&) override;
     void willRenderFrame() override;
     void clearIfNeeded() override;
-    void didRenderFrame() override;
+    void didRenderFrame(uint32_t) override;
     void displayDidRefresh(WebCore::PlatformDisplayID) override;
 
 #if !HAVE(DISPLAY_LINK)
@@ -189,6 +189,9 @@ private:
     double m_transientZoomScale { 1 };
     WebCore::FloatPoint m_transientZoomOrigin;
 #endif
+
+    uint32_t m_compositionRequestID { 0 };
+    uint32_t m_compositionResponseID { 0 };
 };
 
 #if !USE(COORDINATED_GRAPHICS)


### PR DESCRIPTION
#### 9191148390c27310fbe868ded361a7e7f45fba14
<pre>
[GTK][WPE] Main thread can&apos;t start rendering the next frame until the previous one is composited
<a href="https://bugs.webkit.org/show_bug.cgi?id=273317">https://bugs.webkit.org/show_bug.cgi?id=273317</a>

Reviewed by Carlos Garcia Campos.

All the content rendered by the main thread is sent to the compositor thread
using commitSceneState, which adds a requestID parameter. The compositor will
send in the didRenderFrame call the last requestID it processed. This way
the LayerTreeHost can check whether each request was composed to allow
rendering new frames.

* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::renderLayerTree):
(WebKit::ThreadedCompositor::updateSceneState):
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp:
(WebKit::CompositingCoordinator::flushPendingLayerChanges):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::commitSceneState):
(WebKit::LayerTreeHost::didRenderFrame):
(WebKit::LayerTreeHost::didRenderFrameTimerFired):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:

Canonical link: <a href="https://commits.webkit.org/278399@main">https://commits.webkit.org/278399@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5e4592f3801f680c7db2767a5e445e993bd1f5d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49306 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52151 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45409 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26208 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40276 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42469 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21398 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23586 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7673 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45502 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44153 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54053 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24388 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20570 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47596 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25660 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42676 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46590 "Found 4 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/menulist, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/listbox, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/value/basic (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26499 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7288 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25383 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->