### PR TITLE
[WebRTC][GStreamer] Missing media in SDP if setConfiguration() is called after createDataChannel() or addTransceiver()

### DIFF
--- a/LayoutTests/webrtc/setConfiguration-after-createDataChannel-or-addTransceiver-expected.txt
+++ b/LayoutTests/webrtc/setConfiguration-after-createDataChannel-or-addTransceiver-expected.txt
@@ -1,0 +1,5 @@
+
+PASS setConfiguration after data channel is created
+PASS setConfiguration after video transceiver is added
+PASS setConfiguration after audio transceiver is added
+

--- a/LayoutTests/webrtc/setConfiguration-after-createDataChannel-or-addTransceiver.html
+++ b/LayoutTests/webrtc/setConfiguration-after-createDataChannel-or-addTransceiver.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Testing media fields in SDP when setConfiguration comes after createDataChannel/addTransceiver</title>
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <script src ="routines.js"></script>
+        <script>
+function testMediaInSDP(addTransceiverOrDataChannel, regex) {
+    return async (test) => {
+        const pc = new RTCPeerConnection();
+        addTransceiverOrDataChannel(pc);
+        pc.setConfiguration({});
+        await pc.setLocalDescription();
+        const sdp = pc.localDescription.sdp;
+        assert_true(regex.test(sdp));
+    }
+}
+
+promise_test(testMediaInSDP(
+        pc => pc.createDataChannel("data-channel"),
+        /\r\nm=application.*webrtc-datachannel\r\n/),
+    'setConfiguration after data channel is created');
+
+promise_test(testMediaInSDP(
+        pc => pc.addTransceiver("video"),
+        /\r\nm=video.*\r\n/),
+    'setConfiguration after video transceiver is added');
+
+promise_test(testMediaInSDP(
+        pc => pc.addTransceiver("audio"),
+        /\r\nm=audio.*\r\n/),
+    'setConfiguration after audio transceiver is added');
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -80,6 +80,8 @@ GStreamerMediaEndpoint::GStreamerMediaEndpoint(GStreamerPeerConnectionBackend& p
     std::call_once(debugRegisteredFlag, [] {
         GST_DEBUG_CATEGORY_INIT(webkit_webrtc_endpoint_debug, "webkitwebrtcendpoint", 0, "WebKit WebRTC end-point");
     });
+
+    initializePipeline();
 }
 
 GStreamerMediaEndpoint::~GStreamerMediaEndpoint()
@@ -244,12 +246,6 @@ void GStreamerMediaEndpoint::disposeElementChain(GstElement* element)
 
 bool GStreamerMediaEndpoint::setConfiguration(MediaEndpointConfiguration& configuration)
 {
-    if (m_pipeline)
-        teardownPipeline();
-
-    if (!initializePipeline())
-        return false;
-
     auto bundlePolicy = bundlePolicyFromConfiguration(configuration);
     auto iceTransportPolicy = iceTransportPolicyFromConfiguration(configuration);
     g_object_set(m_webrtcBin.get(), "bundle-policy", bundlePolicy, "ice-transport-policy", iceTransportPolicy, nullptr);


### PR DESCRIPTION
#### 1bc81c31ff6c5f2b535b70b44de1ebc5e0389725
<pre>
[WebRTC][GStreamer] Missing media in SDP if setConfiguration() is called after createDataChannel() or addTransceiver()
<a href="https://bugs.webkit.org/show_bug.cgi?id=273318">https://bugs.webkit.org/show_bug.cgi?id=273318</a>

Reviewed by Xabier Rodriguez-Calvar.

GStreamerMediaEndpoint::setConfiguration() was tearing down the pipeline
if one already existed and creating a new one, which is an issue if any data channels
or transceivers are created before RTCPeerConnection.setConfiguration().

The issue is fixed by creating the pipeline earlier in GStreamerMediaEndpoint&apos;s contructor,
so that data channels or transceivers aren&apos;t discarded if created/added before setConfiguration().

Credit to Philippe Normand &lt;philn@igalia.com&gt; for finding the issue and fixing it.
I wrote the layout test, which fails without his fix.

* LayoutTests/webrtc/setConfiguration-after-createDataChannel-or-addTransceiver-expected.txt: Added.
* LayoutTests/webrtc/setConfiguration-after-createDataChannel-or-addTransceiver.html: Added.
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::GStreamerMediaEndpoint):
(WebCore::GStreamerMediaEndpoint::setConfiguration):

Canonical link: <a href="https://commits.webkit.org/278099@main">https://commits.webkit.org/278099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a7a47fa19054fb8a58808f9b3368ced59bb2002

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52342 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52156 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45414 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51615 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34607 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40289 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51412 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26140 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42475 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21410 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23591 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43656 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7678 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45508 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44159 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54059 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24393 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20574 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47603 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25665 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42682 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46599 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10869 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26504 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25388 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->