### PR TITLE
Reduce use of WKBundlePageGetMainFrame in WebKitTestRunner

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.h
@@ -78,7 +78,7 @@ public:
     void executeOnMainThread(Function<void()>&&);
 #endif
 
-    bool addNotificationListener(JSValueRef functionCallback);
+    bool addNotificationListener(JSContextRef, JSValueRef functionCallback);
     bool removeNotificationListener();
     void injectAccessibilityPreference(JSStringRef domain, JSStringRef key, JSStringRef value);
 

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
@@ -376,7 +376,7 @@ public:
     
     // Notifications
     // Function callback should take one argument, the name of the notification.
-    bool addNotificationListener(JSValueRef functionCallback);
+    bool addNotificationListener(JSContextRef, JSValueRef functionCallback);
     // Make sure you call remove, because you can't rely on objects being deallocated in a timely fashion.
     bool removeNotificationListener();
     

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityControllerAtspi.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityControllerAtspi.cpp
@@ -101,7 +101,7 @@ RefPtr<AccessibilityUIElement> AccessibilityController::focusedElement()
     return nullptr;
 }
 
-bool AccessibilityController::addNotificationListener(JSValueRef functionCallback)
+bool AccessibilityController::addNotificationListener(JSContextRef, JSValueRef functionCallback)
 {
     if (!functionCallback)
         return false;

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
@@ -1547,7 +1547,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::url()
     return OpaqueJSString::tryCreate(makeString("AXURL: ", stringURL)).leakRef();
 }
 
-bool AccessibilityUIElement::addNotificationListener(JSValueRef functionCallback)
+bool AccessibilityUIElement::addNotificationListener(JSContextRef, JSValueRef functionCallback)
 {
     if (!functionCallback)
         return false;

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityControllerIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityControllerIOS.mm
@@ -46,7 +46,7 @@ RefPtr<AccessibilityUIElement> AccessibilityController::focusedElement()
     return rootElement->focusedElement();
 }
 
-bool AccessibilityController::addNotificationListener(JSValueRef functionCallback)
+bool AccessibilityController::addNotificationListener(JSContextRef context, JSValueRef functionCallback)
 {
     if (!functionCallback)
         return false;
@@ -56,7 +56,7 @@ bool AccessibilityController::addNotificationListener(JSValueRef functionCallbac
     if (m_globalNotificationHandler)
         return false;
 
-    m_globalNotificationHandler = adoptNS([[AccessibilityNotificationHandler alloc] init]);
+    m_globalNotificationHandler = adoptNS([[AccessibilityNotificationHandler alloc] initWithContext:context]);
     [m_globalNotificationHandler setCallback:functionCallback];
     [m_globalNotificationHandler startObserving];
     

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityNotificationHandler.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityNotificationHandler.h
@@ -28,22 +28,21 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef AccessibilityNotificationHandler_h
-#define AccessibilityNotificationHandler_h
+#pragma once
 
 #import <JavaScriptCore/JSObjectRef.h>
+#import <JavaScriptCore/JSRetainPtr.h>
 
 @interface AccessibilityNotificationHandler : NSObject {
     id m_platformElement;
     JSValueRef m_notificationFunctionCallback;
+    JSRetainPtr<JSGlobalContextRef> m_context;
 }
 
-- (id)init;
+- (id)initWithContext:(JSContextRef)context;
 - (void)setPlatformElement:(id)platformElement;
 - (void)setCallback:(JSValueRef)callback;
 - (void)startObserving;
 - (void)stopObserving;
 
 @end
-
-#endif // AccessibilityNotificationHandler_h

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
@@ -1110,7 +1110,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::url()
     return [[url absoluteString] createJSStringRef];
 }
 
-bool AccessibilityUIElement::addNotificationListener(JSValueRef functionCallback)
+bool AccessibilityUIElement::addNotificationListener(JSContextRef context, JSValueRef functionCallback)
 {
     if (!functionCallback)
         return false;
@@ -1120,7 +1120,7 @@ bool AccessibilityUIElement::addNotificationListener(JSValueRef functionCallback
     if (m_notificationHandler)
         return false;
 
-    m_notificationHandler = adoptNS([[AccessibilityNotificationHandler alloc] init]);
+    m_notificationHandler = adoptNS([[AccessibilityNotificationHandler alloc] initWithContext:context]);
     [m_notificationHandler setPlatformElement:platformUIElement()];
     [m_notificationHandler setCallback:functionCallback];
     [m_notificationHandler startObserving];

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm
@@ -71,7 +71,7 @@ RefPtr<AccessibilityUIElement> AccessibilityController::focusedElement()
     return nullptr;
 }
 
-bool AccessibilityController::addNotificationListener(JSValueRef functionCallback)
+bool AccessibilityController::addNotificationListener(JSContextRef context, JSValueRef functionCallback)
 {
     if (!functionCallback)
         return false;
@@ -79,7 +79,7 @@ bool AccessibilityController::addNotificationListener(JSValueRef functionCallbac
     if (m_globalNotificationHandler)
         return false;
 
-    m_globalNotificationHandler = adoptNS([[AccessibilityNotificationHandler alloc] init]);
+    m_globalNotificationHandler = adoptNS([[AccessibilityNotificationHandler alloc] initWithContext:context]);
     [m_globalNotificationHandler.get() setCallback:functionCallback];
     [m_globalNotificationHandler.get() startObserving];
 

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityNotificationHandler.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityNotificationHandler.h
@@ -28,22 +28,21 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef AccessibilityNotificationHandler_h
-#define AccessibilityNotificationHandler_h
+#pragma once
 
 #import <JavaScriptCore/JSObjectRef.h>
+#import <JavaScriptCore/JSRetainPtr.h>
 
 @interface AccessibilityNotificationHandler : NSObject {
     id m_platformElement;
     JSValueRef m_notificationFunctionCallback;
+    JSRetainPtr<JSGlobalContextRef> m_context;
 }
 
-- (id)init;
+- (id)initWithContext:(JSContextRef)context;
 - (void)setPlatformElement:(id)platformElement;
 - (void)setCallback:(JSValueRef)callback;
 - (void)startObserving;
 - (void)stopObserving;
 
 @end
-
-#endif // AccessibilityNotificationHandler_h

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -1801,7 +1801,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::url()
     return nullptr;
 }
 
-bool AccessibilityUIElement::addNotificationListener(JSValueRef functionCallback)
+bool AccessibilityUIElement::addNotificationListener(JSContextRef context, JSValueRef functionCallback)
 {
     if (!functionCallback)
         return false;
@@ -1811,7 +1811,7 @@ bool AccessibilityUIElement::addNotificationListener(JSValueRef functionCallback
     if (m_notificationHandler)
         return false;
 
-    m_notificationHandler = adoptNS([[AccessibilityNotificationHandler alloc] init]);
+    m_notificationHandler = adoptNS([[AccessibilityNotificationHandler alloc] initWithContext:context]);
     [m_notificationHandler setPlatformElement:platformUIElement()];
     [m_notificationHandler setCallback:functionCallback];
     [m_notificationHandler startObserving];

--- a/Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityControllerPlayStation.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityControllerPlayStation.cpp
@@ -65,7 +65,7 @@ RefPtr<AccessibilityUIElement> AccessibilityController::focusedElement()
     return nullptr;
 }
 
-bool AccessibilityController::addNotificationListener(JSValueRef)
+bool AccessibilityController::addNotificationListener(JSContextRef, JSValueRef)
 {
     notImplemented();
     return false;

--- a/Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityUIElementPlayStation.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityUIElementPlayStation.cpp
@@ -728,7 +728,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::url()
     return nullptr;
 }
 
-bool AccessibilityUIElement::addNotificationListener(JSValueRef functionCallback)
+bool AccessibilityUIElement::addNotificationListener(JSContextRef, JSValueRef functionCallback)
 {
     notImplemented();
     return false;

--- a/Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityControllerWin.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityControllerWin.cpp
@@ -65,7 +65,7 @@ RefPtr<AccessibilityUIElement> AccessibilityController::focusedElement()
     return nullptr;
 }
 
-bool AccessibilityController::addNotificationListener(JSValueRef)
+bool AccessibilityController::addNotificationListener(JSContextRef, JSValueRef)
 {
     notImplemented();
     return false;

--- a/Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp
@@ -728,7 +728,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::url()
     return nullptr;
 }
 
-bool AccessibilityUIElement::addNotificationListener(JSValueRef functionCallback)
+bool AccessibilityUIElement::addNotificationListener(JSContextRef, JSValueRef functionCallback)
 {
     notImplemented();
     return false;


### PR DESCRIPTION
#### 7b15896c8c44d9f7982a6123799b7f8495b5e86a
<pre>
Reduce use of WKBundlePageGetMainFrame in WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=273322">https://bugs.webkit.org/show_bug.cgi?id=273322</a>
<a href="https://rdar.apple.com/127117771">rdar://127117771</a>

Reviewed by Pascoe.

With site isolation the main frame is not necessarily in the current process.
Use the current JSContextRef instead.

* Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.h:
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h:
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityControllerIOS.mm:
(WTR::AccessibilityController::addNotificationListener):
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityNotificationHandler.h:
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm:
(WTR::AccessibilityUIElement::addNotificationListener):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm:
(WTR::AccessibilityController::addNotificationListener):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityNotificationHandler.h:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityNotificationHandler.mm:
(-[AccessibilityNotificationHandler initWithContext:]):
(-[AccessibilityNotificationHandler dealloc]):
(-[AccessibilityNotificationHandler setCallback:]):
(-[AccessibilityNotificationHandler _notificationReceived:]):
(-[AccessibilityNotificationHandler init]): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::AccessibilityUIElement::addNotificationListener):

Canonical link: <a href="https://commits.webkit.org/278048@main">https://commits.webkit.org/278048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42a66c207f88eea5f5ff8cb00a69a67bfb2c4055

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28605 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52168 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45426 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51627 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34619 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26225 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40299 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51424 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26155 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42483 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21415 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23609 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43667 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7690 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45520 "Build was cancelled. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44170 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54071 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24405 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20596 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47619 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25677 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42691 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46610 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26516 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7083 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25400 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->