### PR TITLE
[WebGPU] Destroyed texture should not be used as depth stencil attachments

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2106,6 +2106,10 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-273505.html [ Pass Failure Timeout ]
 [ Debug ] fast/webgpu/fuzz-273566.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-273566.html [ Pass Failure Timeout ]
+[ Debug ] fast/webgpu/fuzz-273323.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-273323.html [ Pass Failure Timeout ]
+[ Debug ] fast/webgpu/fuzz-273573.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-273573.html [ Pass Failure Timeout ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/fuzz-273323-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-273323-expected.txt
@@ -1,0 +1,799 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 873x7523
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x7523
+  RenderBlock {HTML} at (0,0) size 785x7523 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x7507
+      RenderText {#text} at (0,6) size 116x17
+        text run at (0,6) width 61: "\x{E311}\x{1B}\x{D83F}\x{DF87}\x{399}\x{D2A}\x{DE1}"
+        text run at (60,6) width 11 RTL: "\x{8BD}"
+        text run at (70,6) width 46: "\x{B71}\x{AA1}\x{3CD8}\x{3C6F}"
+      RenderText {#text} at (131,6) size 130x17
+        text run at (131,6) width 104: "\x{D83E}\x{DFFB}\x{244}\x{65AD}\x{BDFC}\x{5F4E}\x{772F}\x{3FE}\x{E8A}"
+        text run at (234,6) width 5 RTL: "\x{719}"
+        text run at (238,6) width 23: "\x{E62}\x{D83E}\x{DE69}"
+      RenderText {#text} at (260,6) size 106x17
+        text run at (260,6) width 64: "\x{D83E}\x{DE03}\x{6F01}\x{D83E}\x{DC85}\x{D83F}\x{DD0B}\x{3606}"
+        text run at (323,6) width 13 RTL: "\x{804}"
+        text run at (335,6) width 31: "\x{FE18}\x{6623}"
+      RenderText {#text} at (365,6) size 94x17
+        text run at (365,6) width 71: "\x{931}\x{D83E}\x{DD29}\x{1DF}\x{D83F}\x{DC56}\x{D83D}\x{DF50}\x{5B7}\x{D83F}\x{DFCF}"
+        text run at (435,6) width 9 RTL: "\x{677}"
+        text run at (443,6) width 16: "\x{61E3}"
+      RenderText {#text} at (458,6) size 129x17
+        text run at (458,6) width 129: "\x{919E}\x{6EF6}\x{41E9}\x{A4BB}\x{D83F}\x{DFAA}\x{34D}\x{D83D}\x{DF6E}\x{D83D}\x{DEB4}\x{8D60}\x{434}"
+      RenderText {#text} at (586,6) size 30x17
+        text run at (586,6) width 30: "\x{D83F}\x{DF71}\x{1F5}\x{D83F}\x{DD2F}"
+      RenderText {#text} at (300,164) size 84x17
+        text run at (300,164) width 48: "\x{7F94}\x{D83F}\x{DFC3}\x{B5A}\x{EE8}"
+        text run at (347,164) width 5 RTL: "\x{7CA}"
+        text run at (351,164) width 33: "\x{19E7}\x{D83E}\x{DD9E}"
+      RenderText {#text} at (399,164) size 78x17
+        text run at (399,164) width 58: "\x{640B}\x{9BB0}\x{DF}\x{D83E}\x{DD65}"
+        text run at (456,164) width 21 RTL: "\x{635}\x{68E}"
+      RenderText {#text} at (476,164) size 107x17
+        text run at (476,164) width 28: "\x{7FBA}\x{C26}"
+        text run at (503,164) width 14 RTL: "\x{804}"
+        text run at (516,164) width 67: "\x{13F9}\x{D83F}\x{DEFB}\x{3B7}\x{D83E}\x{DFEF}\x{D83F}\x{DCF8}\x{466A}"
+      RenderText {#text} at (582,164) size 89x17
+        text run at (582,164) width 89: "\x{418C}\x{A84}\x{8AAA}\x{D42}\x{D83D}\x{DE9F}\x{482D}"
+      RenderImage {IMG} at (670,107) size 44x70
+      RenderText {#text} at (0,164) size 729x179
+        text run at (713,164) width 16: "\x{D55D}"
+        text run at (0,326) width 28: "\x{1F8E}\x{F1EB}"
+        text run at (27,326) width 9 RTL: "\x{78D}"
+        text run at (35,326) width 80: "\x{1B41}\x{18A}\x{BE6}\x{CDEE}\x{48A}\x{1D8}"
+      RenderText {#text} at (114,326) size 126x17
+        text run at (114,326) width 7 RTL: "\x{68D}"
+        text run at (120,326) width 120: "\x{D83E}\x{DFB8}\x{D83F}\x{DCA0}\x{5DDA}\x{58C0}\x{541}\x{4BC6}\x{D83E}\x{DCE8}G\x{154}\x{FA76}"
+      RenderText {#text} at (239,326) size 95x17
+        text run at (239,326) width 95: "\x{D83D}\x{DFFE}\x{D83E}\x{DC02}\x{93D}\x{51D}\x{7F9B}\x{A7B2}\x{9662}\x{B206}\x{323}"
+      RenderText {#text} at (333,326) size 106x17
+        text run at (333,326) width 106: "\x{4D00}\x{D83F}\x{DCD9}\x{BF1}\x{D83E}\x{DEDA}\x{70AD}\x{D83E}\x{DFD9}\x{E7F3}\x{F846}"
+      RenderText {#text} at (738,326) size 31x17
+        text run at (738,326) width 31: "\x{72D9}\x{5978}\x{817}"
+      RenderText {#text} at (0,487) size 40x17
+        text run at (0,487) width 40: "\x{A8A}\x{32D}\x{8613}\x{D83F}\x{DFD4}"
+      RenderText {#text} at (455,487) size 30x17
+        text run at (455,487) width 30: "\x{8FB2}\x{D83D}\x{DF60}"
+      RenderText {#text} at (484,487) size 140x17
+        text run at (484,487) width 140: "\x{50B}\x{F003}\x{DAC}\x{F2FA}\x{939C}\x{8D26}\x{D83D}\x{DF08}\x{A4DE}\x{D83E}\x{DF94}\x{C9E}\x{D83E}\x{DD95}"
+      RenderText {#text} at (623,487) size 42x17
+        text run at (623,487) width 42: "\x{AA1E}\x{DA2}\x{D83F}\x{DCF3}"
+      RenderText {#text} at (0,487) size 752x187
+        text run at (664,487) width 12 RTL: "\x{61D}"
+        text run at (675,487) width 77: "\x{1535}\x{B7A5}\x{4D5}\x{946A}\x{823F}\x{302B}\x{936}"
+        text run at (0,657) width 15: "\x{B10A}"
+      RenderText {#text} at (14,657) size 86x17
+        text run at (14,657) width 15: "\x{A3F}"
+        text run at (28,657) width 11 RTL: "\x{7DA}"
+        text run at (38,657) width 62: "\x{52E}\x{D83D}\x{DF28}\x{F707}\x{3B7}\x{D83F}\x{DEF5}\x{3E3}"
+      RenderText {#text} at (99,657) size 79x17
+        text run at (99,657) width 79: "\x{C28}\x{84F4}\x{99}\x{DC6}\x{5322}\x{C4BB}"
+      RenderText {#text} at (177,657) size 46x17
+        text run at (177,657) width 46: "\x{7790}\x{7812}\x{31ED}f"
+      RenderText {#text} at (222,657) size 52x17
+        text run at (222,657) width 52: "\x{D83F}\x{DE16}\x{DB7F}\x{F14}\x{8107}\x{15A}"
+      RenderText {#text} at (273,657) size 109x17
+        text run at (273,657) width 109: "\x{3FE7}\x{22F}\x{83D1}\x{BE84}\x{D83E}\x{DFAD}\x{7AA1}\x{D83F}\x{DE92}\x{A35E}\x{E6F}"
+      RenderImage {IMG} at (381,507) size 162x163
+      RenderText {#text} at (543,657) size 83x17
+        text run at (543,657) width 83: "\x{72AB}\x{10}\x{D83E}\x{DDE3}\x{76BB}\x{D83D}\x{DF84}\x{D83F}\x{DE09}"
+      RenderText {#text} at (625,657) size 103x17
+        text run at (625,657) width 69: "\x{D83F}\x{DE6A}\x{8645}\x{1F91}\x{E811}\x{1432}\x{D83E}\x{DE02}"
+        text run at (693,657) width 10 RTL: "\x{6FC}"
+        text run at (702,657) width 26: "B\x{CFDA}"
+      RenderText {#text} at (0,657) size 762x725
+        text run at (743,657) width 19: "\x{2E1}\x{B373}"
+        text run at (0,1365) width 30: "\x{8EB4}\x{C41E}"
+      RenderText {#text} at (29,1365) size 36x17
+        text run at (29,1365) width 36: "\x{D83F}\x{DE82}\x{D41F}\x{2E16}"
+      RenderText {#text} at (364,1365) size 46x17
+        text run at (364,1365) width 46: "\x{4E50}\x{D294}\x{320D}"
+      RenderText {#text} at (409,1365) size 103x17
+        text run at (409,1365) width 75: "\x{4375}\x{C96}\x{E568}\x{D4EB}\x{994}\x{D83F}\x{DFA9}"
+        text run at (483,1365) width 14 RTL: "\x{833}"
+        text run at (496,1365) width 16: "\x{CB52}"
+      RenderText {#text} at (527,1365) size 108x17
+        text run at (527,1365) width 108: "\x{110E}S\x{D83F}\x{DE78}\x{D83F}\x{DEA9}\x{4285}\x{D83E}\x{DEE5}\x{5190}\x{2DF}\x{A023}"
+      RenderText {#text} at (634,1365) size 119x17
+        text run at (634,1365) width 11: "\x{141}"
+        text run at (644,1365) width 11 RTL: "\x{7CB}"
+        text run at (654,1365) width 60: "\x{3D72}\x{D83D}\x{DEE8}\x{379}\x{A3E1}\x{91C7}"
+        text run at (713,1365) width 14 RTL: "\x{77E}"
+        text run at (726,1365) width 27: "\x{E642}\x{6861}"
+      RenderText {#text} at (0,1612) size 41x17
+        text run at (0,1612) width 32: "\x{D06}\x{D83E}\x{DC6A}"
+        text run at (31,1612) width 10 RTL: "\x{792}"
+      RenderText {#text} at (40,1612) size 38x17
+        text run at (40,1612) width 38: "\x{D83F}\x{DE0C}\x{AD4}\x{67CE}"
+      RenderText {#text} at (77,1612) size 36x17
+        text run at (77,1612) width 36: "\x{DCD}\x{1FC}\x{D83F}\x{DE47}"
+      RenderText {#text} at (112,1612) size 128x17
+        text run at (112,1612) width 128: "\x{538}\x{A45}\x{2BD0}\x{F52}\x{53BD}\x{38C7}\x{D83E}\x{DFA4}\x{56A}\x{DBC9}\x{17}\x{5EF4}"
+      RenderText {#text} at (239,1612) size 97x17
+        text run at (239,1612) width 65: "\x{A574}\x{2919}\x{21A9}\x{6ED}\x{4AA}\x{D83F}\x{DE31}\x{2ED}"
+        text run at (303,1612) width 9 RTL: "\x{5D1}"
+        text run at (311,1612) width 25: "\x{3873}\x{A194}"
+      RenderImage {IMG} at (335,1384) size 288x241
+      RenderText {#text} at (622,1612) size 130x17
+        text run at (622,1612) width 130: "\x{8805}\x{C9A9}\x{1FB}\x{1E}\x{4803}\x{F52A}\x{8F3C}\x{1F}\x{11C3}\x{6A7B}"
+      RenderText {#text} at (600,1850) size 56x17
+        text run at (600,1850) width 56: "\x{C105}\x{D83E}\x{DCF0}\x{73A7}\x{9121}"
+      RenderImage {IMG} at (655,1634) size 55x229
+      RenderText {#text} at (0,1850) size 739x42
+        text run at (709,1850) width 12: "\x{EC5}"
+        text run at (720,1850) width 11 RTL: "\x{7D2}"
+        text run at (730,1850) width 9: "\x{666}"
+        text run at (0,1875) width 15: "\x{8949}"
+      RenderText {#text} at (15,1875) size 109x17
+        text run at (15,1875) width 45: "\x{309C}\x{232A}\x{715B}"
+        text run at (60,1875) width 10 RTL: "\x{6CC}"
+        text run at (69,1875) width 55: "\x{8EDF}\x{18B}\x{3E7C}\x{4008}"
+      RenderText {#text} at (123,1875) size 79x17
+        text run at (123,1875) width 79: "\x{FF9}\x{8E5}\x{9F6}\x{1C1}\x{6243}\x{57CF}\x{D83F}\x{DCB8}"
+      RenderText {#text} at (201,1875) size 127x17
+        text run at (201,1875) width 12: "\x{A7CF}"
+        text run at (212,1875) width 14 RTL: "\x{75C}"
+        text run at (225,1875) width 73: "\x{5E03}\x{D83F}\x{DFE6}\x{380}\x{D83D}\x{DEA7}\x{9821}"
+        text run at (297,1875) width 9: "\x{667}"
+        text run at (305,1875) width 23: "\x{4D27}\x{22D}"
+      RenderText {#text} at (327,1875) size 127x17
+        text run at (327,1875) width 127: "\x{D83F}\x{DDC0}\x{7}\x{D83E}\x{DF90}\x{CBC}\x{2DA}\x{8C65}\x{88B1}\x{D83E}\x{DE11}\x{303}\x{8702}\x{D83F}\x{DC7D}"
+      RenderText {#text} at (453,1875) size 20x17
+        text run at (453,1875) width 12: "\x{54D}"
+        text run at (464,1875) width 9 RTL: "\x{5DC}"
+      RenderText {#text} at (300,2590) size 86x17
+        text run at (300,2590) width 86: "\x{AABF}\x{2800}\x{C20}\x{D83E}\x{DFF5}\x{D83F}\x{DD02}\x{86FF}\x{D83D}\x{DEFC}"
+      RenderText {#text} at (385,2590) size 117x17
+        text run at (385,2590) width 117: "\x{D83E}\x{DFAD}\x{D83D}\x{DE6F}\x{6C35}\x{C958}\x{419E}\x{25D5}\x{D83F}\x{DC3C}\x{5A86}\x{4DB6}"
+      RenderText {#text} at (664,2590) size 21x17
+        text run at (664,2590) width 21: "\x{494}\x{963}"
+      RenderText {#text} at (684,2590) size 63x17
+        text run at (684,2590) width 63: "\x{7429}\x{D83D}\x{DF8E}\x{AA31}\x{EC5F}\x{699F}"
+      RenderImage {IMG} at (226,3107) size 155x232
+      RenderText {#text} at (381,3326) size 87x17
+        text run at (381,3326) width 87: "\x{D83E}\x{DC02}\x{3258}\x{D83F}\x{DCBD}\x{B46D}\x{82B}\x{BA08}\x{E7DA}\x{1CB9}"
+      RenderText {#text} at (467,3326) size 113x17
+        text run at (467,3326) width 113: "\x{DAE6}\x{B88E}\x{653}\x{661F}\x{D83E}\x{DE61}\x{C9A5}\x{33B5}\x{8000}\x{238D}"
+      RenderText {#text} at (579,3326) size 83x17
+        text run at (579,3326) width 83: "\x{D83D}\x{DE5A}\x{8930}\x{B4C8}\x{64D1}\x{1854}\x{F6A4}\x{1EA4}"
+      RenderText {#text} at (585,3852) size 102x17
+        text run at (585,3852) width 102: "\x{85}\x{EC1}\x{DD94}\x{5371}\x{3963}\x{4C2}\x{5B0C}\x{8D72}"
+      RenderText {#text} at (0,3852) size 762x322
+        text run at (686,3852) width 76: "\x{4F0D}\x{28BF}\x{5F14}\x{F33D}\x{D83D}\x{DF1D}\x{2F0A}"
+        text run at (0,4157) width 15: "\x{9306}"
+        text run at (15,4157) width 10 RTL: "\x{63D}"
+        text run at (24,4157) width 34: "\x{D83D}\x{DF88}\x{D83D}\x{DF0B}\x{AB6}"
+      RenderText {#text} at (57,4157) size 84x17
+        text run at (57,4157) width 84: "\x{D83E}\x{DC6E}\x{D83D}\x{DF23}\x{3CBC}\x{F3C6}\x{62D9}\x{CBC}\x{5C4B}"
+      RenderText {#text} at (140,4157) size 102x17
+        text run at (140,4157) width 33: "\x{D83F}\x{DE2B}\x{AAF8}\x{D83F}\x{DC38}"
+        text run at (172,4157) width 11 RTL: "\x{78B}"
+        text run at (182,4157) width 60: "\x{E7D}\x{DA79}\x{5414}\x{A69}\x{C06E}"
+      RenderText {#text} at (241,4157) size 107x17
+        text run at (241,4157) width 107: "\x{D83D}\x{DFE7}\x{C3BE}\x{D83F}\x{DDBE}\x{D83F}\x{DD59}\x{D83E}\x{DCA9}\x{9A2}\x{D83D}\x{DFD7}\x{D82}\x{2E82}"
+      RenderText {#text} at (347,4157) size 37x17
+        text run at (347,4157) width 23: "\x{D83F}\x{DC5E}\x{D83F}\x{DE50}"
+        text run at (369,4157) width 8 RTL: "\x{842}"
+        text run at (376,4157) width 8: "\x{29FF}"
+      RenderImage {IMG} at (383,3873) size 120x297
+      RenderText {#text} at (502,4157) size 134x17
+        text run at (502,4157) width 72: "\x{B0AA}\x{2B16}\x{DC36}\x{211F}\x{D83F}\x{DECD}\x{66C2}"
+        text run at (573,4157) width 12 RTL: "\x{864}"
+        text run at (584,4157) width 52: "\x{DB5}\x{D83F}\x{DE67}\x{7ACB}\x{5C9C}"
+      RenderText {#text} at (635,4157) size 99x17
+        text run at (635,4157) width 50: "\x{A0D7}\x{C68A}\x{D83F}\x{DCFD}\x{895D}"
+        text run at (684,4157) width 15 RTL: "\x{69A}"
+        text run at (698,4157) width 36: "\x{31CE}\x{D83E}\x{DE83}"
+      RenderText {#text} at (0,4157) size 755x275
+        text run at (733,4157) width 22: "\x{A04}\x{D83E}\x{DF0A}"
+        text run at (0,4415) width 68: "\x{C1FF}\x{CB55}\x{A6C5}\x{D83E}\x{DC51}\x{D83F}\x{DC4A}\x{2C3B}"
+      RenderImage {IMG} at (67,4178) size 234x250
+      RenderText {#text} at (300,4415) size 26x17
+        text run at (300,4415) width 26: "\x{25D2}\x{1025}"
+      RenderText {#text} at (325,4415) size 31x17
+        text run at (325,4415) width 31: "\x{58FE}\x{394F}"
+      RenderText {#text} at (0,4815) size 33x17
+        text run at (0,4815) width 33: "\x{D83E}\x{DC7C}\x{AB5A}\x{256A}"
+      RenderText {#text} at (97,4815) size 18x17
+        text run at (97,4815) width 18: "\x{EEF8}\x{2F5}"
+      RenderImage {IMG} at (414,4726) size 56x102
+      RenderText {#text} at (308,4970) size 107x17
+        text run at (308,4970) width 107: "\x{2FC9}\x{E28F}\x{3F3}\x{220}\x{81F9}\x{ACD}\x{AD6F}\x{CAE}\x{902}\x{34F}"
+      RenderText {#text} at (414,4970) size 71x17
+        text run at (414,4970) width 71: "\x{F66}\x{357}\x{F57}\x{FA75}\x{1CE}\x{D83D}\x{DE2E}\x{B10C}"
+      RenderText {#text} at (484,4970) size 119x17
+        text run at (484,4970) width 119: "\x{D83E}\x{DC56}\x{D83F}\x{DC4C}\x{28D}\x{EC0}\x{6E54}\x{6248}\x{58D9}\x{D83E}\x{DD17}\x{B910}"
+      RenderText {#text} at (602,4970) size 78x17
+        text run at (602,4970) width 78: "\x{E639}\x{BB4F}\x{E234}\x{4D95}\x{D83F}\x{DD4E}\x{8937}"
+      RenderText {#text} at (0,4970) size 766x43
+        text run at (679,4970) width 87: "\x{8102}\x{CF7F}\x{6776}\x{D83E}\x{DF9A}\x{65FF}\x{431A}"
+        text run at (0,4996) width 59: "\x{456B}\x{9AA}\x{9587}\x{E4C}\x{E8EC}"
+      RenderText {#text} at (58,4996) size 115x17
+        text run at (58,4996) width 115: "\x{9A73}\x{2669}\x{D83D}\x{DF76}\x{E94B}\x{8233}\x{D83F}\x{DE54}\x{D83F}\x{DC5A}\x{D83E}\x{DC4B}\x{B471}"
+      RenderImage {IMG} at (172,4999) size 247x10
+      RenderText {#text} at (418,4996) size 112x17
+        text run at (418,4996) width 60: "\x{B600}\x{C6B}\x{D83F}\x{DC84}\x{43EC}\x{C87}"
+        text run at (477,4996) width 8 RTL: "\x{FEA9}"
+        text run at (484,4996) width 46: "\x{6ABA}\x{9301}\x{5878}"
+      RenderText {#text} at (529,4996) size 87x17
+        text run at (529,4996) width 16: "\x{911E}"
+        text run at (544,4996) width 14 RTL: "\x{854}"
+        text run at (557,4996) width 59: "\x{585F}\x{DF32}\x{4F7}\x{BCB}"
+      RenderText {#text} at (615,4996) size 27x17
+        text run at (615,4996) width 27: "\x{8974}\x{D83F}\x{DD6E}"
+      RenderText {#text} at (641,4996) size 21x17
+        text run at (641,4996) width 21: "\x{E328}\x{BAA}"
+      RenderText {#text} at (661,4996) size 49x17
+        text run at (661,4996) width 22: "\x{DC5}\x{D83F}\x{DDDC}"
+        text run at (682,4996) width 8 RTL: "\x{765}"
+        text run at (689,4996) width 21: "\x{128}\x{327}\x{9B91}"
+      RenderText {#text} at (714,4996) size 19x17
+        text run at (714,4996) width 19: "\x{EB28}\x{F1B}"
+      RenderText {#text} at (732,4996) size 23x17
+        text run at (732,4996) width 23: "\x{4194}\x{1899}"
+      RenderText {#text} at (0,4996) size 766x224
+        text run at (754,4996) width 12: "\x{EDBE}"
+        text run at (0,5203) width 20: "\x{D83E}\x{DD94}"
+        text run at (20,5203) width 20 RTL: "\x{FCCC}\x{80F}"
+        text run at (39,5203) width 41: "\x{8EDF}\x{39C2}\x{D83F}\x{DD03}"
+      RenderImage {IMG} at (79,5018) size 217x198
+      RenderText {#text} at (295,5203) size 61x17
+        text run at (295,5203) width 61: "\x{B002}\x{3FA7}\x{C8EF}\x{4B0C}"
+      RenderImage {IMG} at (355,5026) size 140x190
+      RenderText {#text} at (494,5203) size 44x17
+        text run at (494,5203) width 9 RTL: "\x{FEA6}"
+        text run at (502,5203) width 36: "\x{B85}\x{D83E}\x{DE61}\x{94F}"
+      RenderText {#text} at (537,5203) size 107x17
+        text run at (537,5203) width 107: "\x{1126}\x{605C}\x{667A}\x{5D95}\x{51FD}\x{D83F}\x{DC4A}\x{D83E}\x{DDD6}"
+      RenderText {#text} at (643,5203) size 46x17
+        text run at (643,5203) width 46: "\x{4ED5}\x{78BE}\x{B9D5}"
+      RenderText {#text} at (0,5203) size 760x1001
+        text run at (688,5203) width 72: "\x{73A4}\x{D83F}\x{DC61}\x{FA5}\x{A351}\x{D83E}\x{DFDD}\x{B12B}"
+        text run at (0,6187) width 15: "\x{BC41}"
+      RenderText {#text} at (14,6187) size 63x17
+        text run at (14,6187) width 63: "\x{818E}\x{D83E}\x{DC51}\x{DF9}\x{3165}\x{944}"
+      RenderHTMLCanvas {CANVAS} at (76,5225) size 301x975
+      RenderText {#text} at (471,6343) size 69x17
+        text run at (471,6343) width 69: "\x{A25C}\x{5315}\x{416}\x{956}\x{F53}\x{4884}"
+      RenderText {#text} at (539,6343) size 16x17
+        text run at (539,6343) width 16: "\x{658}\x{C017}"
+      RenderText {#text} at (554,6343) size 32x17
+        text run at (554,6343) width 32: "\x{D83E}\x{DFFA}\x{D83E}\x{DE7A}"
+      RenderText {#text} at (585,6343) size 55x17
+        text run at (585,6343) width 55: "\x{A4BC}\x{D83F}\x{DE97}\x{E9FC}\x{2ABB}\x{D83F}\x{DCBA}"
+      RenderText {#text} at (639,6343) size 45x17
+        text run at (639,6343) width 16: "\x{F944}"
+        text run at (654,6343) width 7 RTL: "\x{6C6}"
+        text run at (660,6343) width 24: "\x{D1E6}\x{AA2}"
+      RenderText {#text} at (683,6343) size 49x17
+        text run at (683,6343) width 49: "\x{928}\x{E241}\x{D83D}\x{DE23}\x{BC0}"
+      RenderText {#text} at (0,6343) size 739x107
+        text run at (731,6343) width 8: "_"
+        text run at (0,6433) width 109: "\x{D83E}\x{DDB1}\x{FE5E}\x{D68}\x{175F}\x{D83F}\x{DF37}\x{8B77}\x{BE52}\x{F089}"
+      RenderText {#text} at (108,6433) size 131x17
+        text run at (108,6433) width 131: "\x{2FA}\x{6125}\x{11E3}\x{C1E}\x{CEB}\x{FC7}\x{28C}\x{D83F}\x{DF7E}\x{548C}\x{D83D}\x{DFD3}\x{7013}"
+      RenderText {#text} at (238,6433) size 70x17
+        text run at (238,6433) width 70: "\x{C261}\x{D83D}\x{DE25}\x{D6A2}\x{EED}\x{A008}"
+      RenderText {#text} at (307,6433) size 93x17
+        text run at (307,6433) width 93: "\x{869E}\x{D83F}\x{DC5C}\x{88BC}\x{CAA}\x{10D6}\x{D83E}\x{DEE3}\x{D83D}\x{DF85}"
+      RenderText {#text} at (399,6433) size 93x17
+        text run at (399,6433) width 12 RTL: "\x{FCEF}"
+        text run at (410,6433) width 71: "\x{D83E}\x{DECB}\x{D83F}\x{DC09}\x{B05}\x{D83E}\x{DE00}\x{E034}\x{2D53}\x{E0D}"
+        text run at (480,6433) width 12 RTL: "\x{FC12}"
+      RenderText {#text} at (491,6433) size 20x17
+        text run at (491,6433) width 20: "\x{471}\x{2697}"
+      RenderText {#text} at (510,6433) size 161x17
+        text run at (510,6433) width 161: "\x{B2A6}\x{4366}\x{D64A}\x{9E1B}\x{E4FD}\x{CAE9}\x{D516}\x{87F1}\x{1FC}\x{D83D}\x{DFE2}\x{2AE3}"
+      RenderText {#text} at (0,6433) size 756x252
+        text run at (734,6433) width 22: "\x{D83F}\x{DF01}\x{D83F}\x{DD7B}"
+        text run at (0,6668) width 24 RTL: "\x{FD24}"
+        text run at (23,6668) width 68: "\x{D83F}\x{DF47}\x{A8E}\x{B776}\x{B94A}\x{1D68}\x{1692}"
+      RenderText {#text} at (90,6668) size 41x17
+        text run at (90,6668) width 36: "\x{5A7B}\x{D83E}\x{DE97}"
+        text run at (125,6668) width 6 RTL: "\x{773}"
+      RenderText {#text} at (130,6668) size 93x17
+        text run at (130,6668) width 93: "\x{2EF2}\x{E025}\x{865E}\x{1A7}\x{56E}\x{267A}\x{E6BD}\x{980}"
+      RenderText {#text} at (222,6668) size 108x17
+        text run at (222,6668) width 108: "\x{CCF}\x{7706}\x{5B61}\x{B30B}\x{D83F}\x{DC9D}\x{4A90}\x{5E97}\x{1C0D}"
+      RenderText {#text} at (329,6668) size 147x17
+        text run at (329,6668) width 147: "\x{D83F}\x{DCEB}\x{CE92}\x{9F0}\x{D83E}\x{DD42}\x{568}\x{106D}\x{908F}\x{7465}\x{D83D}\x{DEE7}\x{7204}\x{18D3}"
+      RenderImage {IMG} at (475,6620) size 31x61
+      RenderText {#text} at (662,6668) size 70x17
+        text run at (662,6668) width 43: "\x{8EC9}\x{19E2}\x{9C36}"
+        text run at (704,6668) width 23 RTL: "\x{86B}\x{20DC}"
+        text run at (726,6668) width 6: "\x{EC4}"
+      RenderText {#text} at (731,6668) size 20x17
+        text run at (731,6668) width 20: "\x{A217}\x{16}"
+      RenderText {#text} at (0,6668) size 766x335
+        text run at (750,6668) width 16: "\x{711A}"
+        text run at (0,6986) width 10: "\x{29B}"
+      RenderText {#text} at (9,6986) size 134x17
+        text run at (9,6986) width 134: "\x{D83E}\x{DEE5}\x{1AE}\x{49F}\x{E378}\x{D10}\x{2353}\x{2E3}\x{D83F}\x{DCA4}\x{D83D}\x{DF79}\x{505}\x{E57}"
+      RenderText {#text} at (142,6986) size 69x17
+        text run at (142,6986) width 7: "\x{2E8}"
+        text run at (148,6986) width 11 RTL: "\x{754}"
+        text run at (158,6986) width 53: "\x{897B}\x{D83E}\x{DCA5}\x{AA0C}\x{C35}"
+      RenderText {#text} at (210,6986) size 60x17
+        text run at (210,6986) width 37: "\x{F01E}\x{8944}\x{EA26}"
+        text run at (246,6986) width 9 RTL: "\x{7DE}"
+        text run at (254,6986) width 16: "\x{B51E}"
+      RenderText {#text} at (269,6986) size 39x17
+        text run at (269,6986) width 39: "\x{AFE1}\x{E8A6}\x{C38}"
+      RenderImage {IMG} at (307,6700) size 156x299
+      RenderText {#text} at (462,6986) size 67x17
+        text run at (462,6986) width 67: "\x{FA31}\x{69D6}\x{E706}\x{A981}\x{5604}"
+      RenderText {#text} at (528,6986) size 108x17
+        text run at (528,6986) width 27: "\x{F3D5}\x{74D5}"
+        text run at (554,6986) width 9 RTL: "\x{716}"
+        text run at (562,6986) width 27: "\x{42A}\x{9195}"
+        text run at (588,6986) width 11 RTL: "\x{718}"
+        text run at (598,6986) width 38: "\x{3916}\x{607}\x{D83D}\x{DF21}"
+      RenderText {#text} at (635,6986) size 94x17
+        text run at (635,6986) width 94: "\x{8550}\x{3C92}\x{E75A}\x{6E4}\x{4F72}\x{B1C1}\x{E694}"
+      RenderText {#text} at (728,6986) size 36x17
+        text run at (728,6986) width 36: "\x{1D9C}\x{C707}\x{EA0}"
+      RenderText {#text} at (0,7019) size 51x17
+        text run at (0,7019) width 40: "\x{7AF7}\x{501}\x{7965}"
+        text run at (39,7019) width 12 RTL: "\x{5CB}"
+      RenderText {#text} at (50,7019) size 107x17
+        text run at (50,7019) width 107: "\x{BBF}\x{DEF2}\x{D6E1}\x{33D}\x{9C4C}\x{1}\x{17C9}\x{D83E}\x{DE74}\x{D68}"
+      RenderText {#text} at (156,7019) size 33x17
+        text run at (156,7019) width 33: "\x{E65C}\x{983}\x{E247}"
+      RenderText {#text} at (188,7019) size 56x17
+        text run at (188,7019) width 16: "\x{3B2B}"
+        text run at (203,7019) width 15 RTL: "\x{8A1}"
+        text run at (217,7019) width 27: "\x{59B4}\x{5BD}\x{D83F}\x{DF00}"
+      RenderText {#text} at (243,7019) size 28x17
+        text run at (243,7019) width 28: "\x{D83E}\x{DF70}\x{1079}"
+      RenderText {#text} at (270,7019) size 77x17
+        text run at (270,7019) width 77: "\x{D83F}\x{DFCA}\x{310}\x{A04}\x{D83D}\x{DF87}\x{A1DC}\x{36A2}\x{D942}"
+      RenderText {#text} at (346,7019) size 89x17
+        text run at (346,7019) width 89: "\x{11B3}\x{C51F}\x{D80}\x{D83F}\x{DEFC}\x{D83E}\x{DE3A}\x{5FF6}\x{E223}"
+      RenderText {#text} at (434,7019) size 139x17
+        text run at (434,7019) width 139: "\x{52A2}\x{EF2B}\x{EDBA}\x{D83E}\x{DD60}\x{E19}\x{D26}\x{6558}\x{126}\x{2A8D}\x{1B33}\x{D4F}"
+      RenderText {#text} at (572,7019) size 57x17
+        text run at (572,7019) width 57: "\x{FA85}\x{D83F}\x{DDE0}\x{D83E}\x{DD89}\x{CE2F}"
+      RenderText {#text} at (628,7019) size 118x17
+        text run at (628,7019) width 118: "\x{443C}\x{D83D}\x{DEBA}\x{D23}\x{D83F}\x{DDD9}\x{5093}\x{4203}\x{D83E}\x{DFFF}\x{4EA}"
+      RenderText {#text} at (0,7019) size 757x55
+        text run at (745,7019) width 12: "\x{4F4}"
+        text run at (0,7057) width 72: "\x{82E2}\x{1B3}\x{F091}\x{D83F}\x{DF1E}\x{B6C1}\x{10E}"
+      RenderText {#text} at (71,7057) size 94x17
+        text run at (71,7057) width 94: "\x{D83D}\x{DEDA}\x{A4F4}\x{5BFF}\x{4F3}\x{CDA5}\x{32F2}\x{124F}\x{22FE}"
+      RenderText {#text} at (164,7057) size 60x17
+        text run at (164,7057) width 60: "\x{D83D}\x{DEB5}\x{38F6}\x{88D6}\x{EA5}"
+      RenderText {#text} at (223,7057) size 57x17
+        text run at (223,7057) width 57: "\x{3A02}\x{B53}\x{5FA6}\x{81F7}"
+      RenderText {#text} at (279,7057) size 135x17
+        text run at (279,7057) width 135: "\x{35E5}\x{E53F}\x{13D6}\x{A885}\x{1022}\x{EDAE}\x{901A}\x{5DA3}\x{41F}\x{D83E}\x{DEE1}"
+      RenderText {#text} at (413,7057) size 107x17
+        text run at (413,7057) width 75: "\x{B38}\x{D83F}\x{DD67}\x{CE3E}\x{BB97}\x{5F37}\x{26E}"
+        text run at (487,7057) width 14 RTL: "\x{8B6}\x{DD4}"
+        text run at (500,7057) width 20: "\x{575}\x{D117}"
+      RenderText {#text} at (519,7057) size 53x17
+        text run at (519,7057) width 53: "\x{C45}\x{D83D}\x{DF71}\x{662B}\x{C834}"
+      RenderText {#text} at (571,7057) size 111x17
+        text run at (571,7057) width 111: "\x{1F2B}\x{539E}\x{D83D}\x{DE86}\x{D83F}\x{DD9B}\x{89E}\x{B5F}\x{13E3}\x{55C4}"
+      RenderText {#text} at (0,7057) size 762x55
+        text run at (681,7057) width 23: "\x{FF08}\x{969}\x{654}"
+        text run at (703,7057) width 14 RTL: "\x{841}"
+        text run at (716,7057) width 46: "\x{35DF}\x{D0BC}\x{482A}"
+        text run at (0,7095) width 25: "\x{267E}\x{87AD}"
+      RenderText {#text} at (24,7095) size 79x17
+        text run at (24,7095) width 79: "\x{CE9E}\x{A910}\x{4ABC}\x{88DB}\x{2F29}\x{442}"
+      RenderText {#text} at (102,7095) size 43x17
+        text run at (102,7095) width 43: "\x{EF55}\x{D83D}\x{DE17}\x{D83E}\x{DF61}"
+      RenderText {#text} at (144,7095) size 75x17
+        text run at (144,7095) width 75: "\x{4C3C}\x{D83D}\x{DE89}\x{FAE5}\x{3ABE}\x{2A37}"
+      RenderText {#text} at (218,7095) size 127x17
+        text run at (218,7095) width 90: "\x{8546}\x{43A5}\x{9E6}\x{51C}\x{29E2}\x{D83E}\x{DDD0}\x{90A}"
+        text run at (307,7095) width 23 RTL: "\x{FC2D}\x{85E}"
+        text run at (329,7095) width 16: "\x{C1B1}"
+      RenderText {#text} at (344,7095) size 103x17
+        text run at (344,7095) width 103: "\x{ECDF}\x{7D93}\x{D83F}\x{DE94}\x{2010}\x{3567}\x{D83E}\x{DF94}\x{17B}\x{39B5}\x{DA8}"
+      RenderText {#text} at (446,7095) size 38x17
+        text run at (446,7095) width 38: "\x{6F7C}\x{2EF}\x{2AE0}\x{E0A}"
+      RenderText {#text} at (483,7095) size 90x17
+        text run at (483,7095) width 90: "\x{F9A4}\x{D83F}\x{DDB2}\x{2B59}\x{D83E}\x{DFB3}\x{4EB2}\x{ECF4}\x{328C}"
+      RenderText {#text} at (572,7095) size 49x17
+        text run at (572,7095) width 16: "\x{573D}"
+        text run at (587,7095) width 12 RTL: "\x{8A3}"
+        text run at (598,7095) width 23: "\x{D83F}\x{DCB3}\x{ADC}"
+      RenderText {#text} at (620,7095) size 121x17
+        text run at (620,7095) width 121: "\x{D83F}\x{DCE5}\x{585D}\x{D83E}\x{DFBA}\x{2462}\x{D83D}\x{DE18}\x{1E66}\x{F397}\x{5CC5}\x{3875}"
+      RenderText {#text} at (0,7095) size 767x41
+        text run at (740,7095) width 12 RTL: "\x{784}"
+        text run at (751,7095) width 16: "\x{2662}"
+        text run at (0,7119) width 30: "\x{8081}\x{89F5}"
+      RenderText {#text} at (30,7119) size 148x17
+        text run at (30,7119) width 128: "\x{5253}\x{FFF}\x{72CB}\x{5973}\x{DC65}\x{6BF3}\x{C8E6}\x{D83F}\x{DCD8}\x{FB4}\x{3D9}"
+        text run at (157,7119) width 21 RTL: "\x{FD2D}"
+      RenderText {#text} at (177,7119) size 87x17
+        text run at (177,7119) width 87: "\x{5972}\x{6846}\x{D83D}\x{DF0E}\x{D83F}\x{DF80}\x{B98D}\x{D83E}\x{DCDD}\x{ECD0}"
+      RenderText {#text} at (263,7119) size 121x17
+        text run at (263,7119) width 121: "\x{D83F}\x{DD65}\x{F317}\x{3C72}\x{7414}\x{F0BD}\x{3A99}\x{49B}\x{D83E}\x{DE44}\x{D83D}\x{DF0E}\x{326C}"
+      RenderText {#text} at (383,7119) size 63x17
+        text run at (383,7119) width 63: "\x{D83E}\x{DF4E}\x{F13}\x{D83F}\x{DEA0}\x{980}\x{D7}\x{D289}"
+      RenderText {#text} at (445,7119) size 86x17
+        text run at (445,7119) width 86: "\x{2A6F}\x{8396}\x{2DF3}\x{D83F}\x{DD11}\x{4977}\x{AAD0}\x{F2B4}\x{BEE}"
+      RenderText {#text} at (530,7119) size 26x17
+        text run at (530,7119) width 26: "\x{481}\x{D83E}\x{DF33}\x{1E9}"
+      RenderText {#text} at (555,7119) size 24x17
+        text run at (555,7119) width 24: "\x{2AC9}\x{30FB}"
+      RenderText {#text} at (578,7119) size 99x17
+        text run at (578,7119) width 99: "\x{BC84}\x{92B}\x{D83F}\x{DECF}\x{365}\x{D83D}\x{DFD8}\x{94C1}\x{DD2}\x{75A0}"
+      RenderText {#text} at (676,7119) size 31x17
+        text run at (676,7119) width 31: "\x{BBE1}\x{596}\x{26D}\x{F75B}"
+      RenderText {#text} at (0,7119) size 763x45
+        text run at (706,7119) width 57: "\x{7444}\x{D83F}\x{DF2E}\x{A850}]\x{B69F}"
+        text run at (0,7147) width 69: "\x{A440}\x{D83E}\x{DEE1}\x{DB5F}\x{656A}\x{C9F7}"
+      RenderText {#text} at (68,7147) size 52x17
+        text run at (68,7147) width 52: "\x{2BA6}\x{1D5D}\x{1F6C}\x{F7AC}\x{D83D}\x{DF42}"
+      RenderText {#text} at (119,7147) size 26x17
+        text run at (119,7147) width 26: "\x{278F}\x{4DC6}"
+      RenderText {#text} at (144,7147) size 56x17
+        text run at (144,7147) width 56: "\x{173F}\x{F02}\x{D83F}\x{DD19}\x{193}\x{A07D}"
+      RenderText {#text} at (199,7147) size 130x17
+        text run at (199,7147) width 7 RTL: "\x{778}"
+        text run at (205,7147) width 124: "\x{5AA0}\x{10E}\x{D83F}\x{DD91}\x{D83F}\x{DECD}\x{631E}\x{5907}\x{D83E}\x{DD4A}\x{5A7D}\x{D83F}\x{DFC5}"
+      RenderText {#text} at (328,7147) size 57x17
+        text run at (328,7147) width 57: "\x{1C30}\x{36A2}\x{A127}\x{D83E}\x{DC62}\x{9613}"
+      RenderText {#text} at (384,7147) size 84x17
+        text run at (384,7147) width 61: "\x{FA94}\x{61DE}\x{6551}\x{A806}\x{F31}\x{D83F}\x{DDEE}"
+        text run at (444,7147) width 9 RTL: "\x{639}"
+        text run at (452,7147) width 16: "\x{5CB9}"
+      RenderText {#text} at (467,7147) size 123x17
+        text run at (467,7147) width 105: "\x{60D0}\x{6DB6}\x{D95C}\x{522D}\x{2A0}\x{B3}\x{7EE}\x{8405}\x{4E1}"
+        text run at (571,7147) width 8: "\x{663}"
+        text run at (578,7147) width 12: "\x{E675}"
+      RenderText {#text} at (589,7147) size 127x17
+        text run at (589,7147) width 46: "\x{4D1B}\x{C2E4}\x{5114}"
+        text run at (634,7147) width 11 RTL: "\x{62B}"
+        text run at (644,7147) width 72: "\x{C2AB}\x{94FF}\x{D83F}\x{DCE2}\x{82F6}\x{5BA9}\x{81E}"
+      RenderText {#text} at (0,7147) size 765x45
+        text run at (715,7147) width 50: "\x{46EE}\x{A414}\x{A45}\x{AFE1}"
+        text run at (0,7175) width 15: "\x{B18C}"
+      RenderText {#text} at (14,7175) size 32x17
+        text run at (14,7175) width 32: "\x{D83E}\x{DED6}\x{E6B1}"
+      RenderText {#text} at (45,7175) size 64x17
+        text run at (45,7175) width 27: "\x{9CB3}\x{B5A}"
+        text run at (71,7175) width 12: "\x{D83E}\x{DFF6}"
+        text run at (82,7175) width 12 RTL: "\x{6CD}"
+        text run at (93,7175) width 16: "\x{53E4}"
+      RenderText {#text} at (108,7175) size 33x17
+        text run at (108,7175) width 33: "\x{F5BE}\x{A5F}\x{D83E}\x{DC76}"
+      RenderText {#text} at (140,7175) size 127x17
+        text run at (140,7175) width 106: "\x{EFDB}\x{FF2}\x{408}\x{EB97}\x{F1C3}\x{93BE}\x{D83E}\x{DF1D}\x{6A1E}\x{4B63}"
+        text run at (245,7175) width 11 RTL: "\x{5D0}"
+        text run at (255,7175) width 12: "\x{A7D}"
+      RenderText {#text} at (266,7175) size 149x17
+        text run at (266,7175) width 149: "\x{BD5E}\x{4AE}\x{D05}\x{D83E}\x{DEC1}\x{5883}\x{A07}\x{D83F}\x{DC88}\x{1AC0}\x{52F9}\x{6223}\x{2DB}"
+      RenderText {#text} at (414,7175) size 30x17
+        text run at (414,7175) width 30: "\x{24F}\x{2273}\x{D931}"
+      RenderText {#text} at (443,7175) size 77x17
+        text run at (443,7175) width 77: "\x{8C4B}\x{5088}\x{1C05}\x{E266}\x{AFA5}\x{312C}"
+      RenderText {#text} at (519,7175) size 24x17
+        text run at (519,7175) width 24: "\x{B39E}\x{463}"
+      RenderText {#text} at (542,7175) size 53x17
+        text run at (542,7175) width 53: "\x{70CE}X\x{40BD}\x{D83F}\x{DC97}"
+      RenderText {#text} at (594,7175) size 66x17
+        text run at (594,7175) width 66: "\x{2E8}\x{D6AF}\x{917}\x{D83F}\x{DD2C}\x{7513}\x{D83E}\x{DCD3}"
+      RenderText {#text} at (659,7175) size 36x17
+        text run at (659,7175) width 36: "\x{A0F4}\x{6A47}\x{1BFB}"
+      RenderText {#text} at (0,7175) size 764x45
+        text run at (694,7175) width 70: "\x{1CCF}\x{F78}\x{E12B}\x{B48}\x{EC7}\x{9B42}"
+        text run at (0,7203) width 66: "\x{C894}\x{C25}\x{9CE}\x{6B51}\x{5BD0}"
+      RenderText {#text} at (65,7203) size 111x17
+        text run at (65,7203) width 26: "\x{5300}\x{D64}"
+        text run at (90,7203) width 12 RTL: "\x{887}"
+        text run at (101,7203) width 53: "\x{D83E}\x{DC4A}\x{13E6}\x{F28}\x{EA3}\x{7037}"
+        text run at (153,7203) width 12 RTL: "\x{80A}"
+        text run at (164,7203) width 12: "\x{D83F}\x{DF0D}"
+      RenderText {#text} at (175,7203) size 31x17
+        text run at (175,7203) width 31: "r\x{36D6}\x{EB6}\x{A4B}"
+      RenderText {#text} at (205,7203) size 53x17
+        text run at (205,7203) width 53: "\x{D83E}\x{DCEA}\x{D83E}\x{DC89}\x{B86E}\x{4D2D}"
+      RenderText {#text} at (257,7203) size 79x17
+        text run at (257,7203) width 49: "\x{9FA9}\x{EC0C}\x{3165}9"
+        text run at (305,7203) width 9 RTL: "\x{7D1}"
+        text run at (313,7203) width 23: "\x{F701}\x{619}"
+      RenderText {#text} at (335,7203) size 123x17
+        text run at (335,7203) width 42: "\x{5E54}\x{DF9C}\x{5EBE}"
+        text run at (376,7203) width 11 RTL: "\x{887}"
+        text run at (386,7203) width 72: "\x{C3}\x{D83F}\x{DD25}\x{D83F}\x{DEBD}\x{C26}\x{5272}\x{D83D}\x{DEE7}"
+      RenderText {#text} at (457,7203) size 126x17
+        text run at (457,7203) width 126: "\x{7E4A}\x{8E32}\x{E6}\x{549E}\x{D83E}\x{DFFF}\x{DF85}\x{70FC}\x{30FA}\x{A4F}\x{2CD0}"
+      RenderText {#text} at (582,7203) size 61x17
+        text run at (582,7203) width 61: "\x{D83F}\x{DCA1}\x{7D06}\x{96B}\x{F25D}\x{CB3E}"
+      RenderText {#text} at (0,7203) size 766x45
+        text run at (642,7203) width 124: "\x{D83E}\x{DCEA}\x{D83F}\x{DE52}\x{1128}\x{B29}\x{D83E}\x{DD9F}\x{D83E}\x{DCA8}\x{BF60}\x{854F}\x{735B}"
+        text run at (0,7231) width 10: "\x{259A}"
+      RenderText {#text} at (9,7231) size 115x17
+        text run at (9,7231) width 115: "\x{F75B}\x{1C68}\x{379}\x{CC03}\x{49B}\x{D83F}\x{DCE1}\x{1979}\x{C0C}\x{E031}\x{D40E}"
+      RenderText {#text} at (123,7231) size 41x17
+        text run at (123,7231) width 41: "\x{D83E}\x{DE9F}\x{D83D}\x{DE2E}"
+      RenderText {#text} at (163,7231) size 115x17
+        text run at (163,7231) width 115: "\x{D83F}\x{DE10}\x{D83F}\x{DD14}\x{D643}\x{A23}\x{D83D}\x{DE22}\x{A477}\x{34F}\x{D16F}\x{D83F}\x{DC20}\x{43F5}"
+      RenderText {#text} at (277,7231) size 127x17
+        text run at (277,7231) width 116: "\x{CAF9}\x{D3E}\x{998}\x{A33}\x{D83E}\x{DC19}\x{D83E}\x{DE3C}\x{E7E5}\x{F6DC}\x{D83E}\x{DD01}\x{D83F}\x{DFC9}"
+        text run at (392,7231) width 12 RTL: "\x{7B6}"
+      RenderText {#text} at (403,7231) size 132x17
+        text run at (403,7231) width 132: "\x{4A3E}\x{D83F}\x{DD04}\x{AC54}\x{AF6}\x{50C}\x{B80}\x{AFB}\x{3798}\x{2FA}\x{AC53}\x{D83D}\x{DF1B}"
+      RenderText {#text} at (534,7231) size 86x17
+        text run at (534,7231) width 21: "\x{D83D}\x{DF48}\x{196}"
+        text run at (554,7231) width 15 RTL: "\x{815}"
+        text run at (568,7231) width 52: "\x{AE08}\x{F0DE}\x{316}\x{3575}"
+      RenderText {#text} at (619,7231) size 118x17
+        text run at (619,7231) width 118: "\x{4898}\x{CCB1}\x{606F}\x{E7ED}\x{8BAA}\x{D83F}\x{DD60}\x{CD54}\x{D83D}\x{DEE5}"
+      RenderText {#text} at (736,7231) size 27x17
+        text run at (736,7231) width 27: "\x{5669}\x{F70F}"
+      RenderText {#text} at (0,7258) size 128x17
+        text run at (0,7258) width 128: "\x{CCDB}\x{7183}\x{22F4}\x{B721}\x{E7AD}\x{7B64}\x{CD8}>\x{E19}\x{D83E}\x{DE92}"
+      RenderText {#text} at (127,7258) size 33x17
+        text run at (127,7258) width 33: "\x{DECC}\x{D7D7}\x{1937}"
+      RenderText {#text} at (159,7258) size 121x17
+        text run at (159,7258) width 121: "\x{1418}\x{D83E}\x{DE74}\x{89DA}\x{C43}\x{D014}\x{C130}\x{E22C}\x{AE80}"
+      RenderText {#text} at (279,7258) size 110x17
+        text run at (279,7258) width 110: "\x{8465}\x{D83F}\x{DFEE}\x{667E}\x{850C}\x{454E}\x{D88}\x{3F19}\x{35F}\x{D83E}\x{DC3C}"
+      RenderText {#text} at (388,7258) size 84x17
+        text run at (388,7258) width 16: "\x{574C}"
+        text run at (403,7258) width 15 RTL: "\x{69A}"
+        text run at (417,7258) width 55: "\x{D83F}\x{DDA7}\x{A4BF}\x{95B}\x{A46}\x{3470}"
+      RenderText {#text} at (471,7258) size 31x17
+        text run at (471,7258) width 31: "\x{300C}\x{9CFB}"
+      RenderText {#text} at (501,7258) size 89x17
+        text run at (501,7258) width 17 RTL: "\x{79D}"
+        text run at (517,7258) width 73: "\x{581}\x{C45}\x{6B36}\x{D19}\x{4D5F}\x{BA}\x{387}"
+      RenderText {#text} at (589,7258) size 86x17
+        text run at (589,7258) width 86: "\x{D83F}\x{DC9F}\x{D83D}\x{DE75}\x{31D}\x{929}\x{2556}\x{D83E}\x{DDBC}\x{38F2}"
+      RenderText {#text} at (674,7258) size 85x17
+        text run at (674,7258) width 85: "\x{D83E}\x{DF17}\x{D83F}\x{DEC6}\x{D83E}\x{DC31}\x{D83E}\x{DDD1}\x{D83E}\x{DF08}\x{D83E}\x{DD96}"
+      RenderText {#text} at (0,7283) size 87x17
+        text run at (0,7283) width 87: "\x{D83F}\x{DE20}\x{A9B}\x{52A9}\x{D83D}\x{DE30}\x{F51}\x{87D1}\x{2078}"
+      RenderText {#text} at (86,7283) size 76x17
+        text run at (86,7283) width 76: "\x{BC5}\x{D83D}\x{DF7C}\x{7ADA}\x{D83D}\x{DF1F}\x{5F57}\x{4807}"
+      RenderText {#text} at (161,7283) size 49x17
+        text run at (161,7283) width 49: "\x{B1A}\x{583}\x{28D3}\x{8951}"
+      RenderText {#text} at (209,7283) size 128x17
+        text run at (209,7283) width 92: "\x{399C}\x{2942}\x{96E0}\x{2568}\x{375}\x{9548}\x{D83E}\x{DD1A}"
+        text run at (300,7283) width 10 RTL: "\x{FB4E}"
+        text run at (309,7283) width 28: "\x{BB6E}\x{D83D}\x{DF5C}"
+      RenderText {#text} at (336,7283) size 67x17
+        text run at (336,7283) width 67: "\x{7EC0}\x{D83E}\x{DDE5}\x{A7D5}\x{D83E}\x{DDD1}"
+      RenderText {#text} at (402,7283) size 29x17
+        text run at (402,7283) width 21: "\x{C2D}\x{FF9B}"
+        text run at (422,7283) width 9 RTL: "\x{716}"
+      RenderText {#text} at (430,7283) size 77x17
+        text run at (430,7283) width 77: "\x{8268}\x{CD47}\x{D83E}\x{DDE9}\x{C7A3}\x{D83F}\x{DF95}"
+      RenderText {#text} at (506,7283) size 83x17
+        text run at (506,7283) width 40: "\x{7741}\x{336}\x{705A}\x{18B}\x{364}"
+        text run at (545,7283) width 9 RTL: "\x{840}"
+        text run at (553,7283) width 36: "\x{CF3}\x{CE2F}\x{7F0}"
+      RenderText {#text} at (588,7283) size 33x17
+        text run at (588,7283) width 33: "\x{F30}\x{ECA}\x{4780}\x{F2}"
+      RenderText {#text} at (620,7283) size 121x17
+        text run at (620,7283) width 27: "\x{DA9D}\x{CBB7}"
+        text run at (646,7283) width 12 RTL: "\x{897}"
+        text run at (657,7283) width 84: "\x{D83E}\x{DC9B}\x{37C0}\x{DE0}\x{DB10}\x{AFD}\x{6018}\x{F30}"
+      RenderText {#text} at (0,7283) size 750x45
+        text run at (740,7283) width 10: "\x{918}"
+        text run at (0,7311) width 135: "\x{D83E}\x{DD55}\x{EBD0}\x{E0B0}\x{AA31}\x{6925}\x{8780}\x{3102}\x{9048}\x{D83F}\x{DDCC}\x{50E7}"
+      RenderText {#text} at (134,7311) size 41x17
+        text run at (134,7311) width 41: "\x{A8D9}\x{D83F}\x{DF66}\x{D83E}\x{DC15}\x{ED64}"
+      RenderText {#text} at (174,7311) size 17x17
+        text run at (174,7311) width 17: "\x{E6E3}\x{2D1}"
+      RenderText {#text} at (190,7311) size 144x17
+        text run at (190,7311) width 144: "\x{9131}\x{FCB}\x{BFAD}\x{E2D3}\x{D83F}\x{DE59}\x{E2C6}\x{5ECC}\x{CF59}\x{D83E}\x{DECC}\x{3E99}\x{A016}"
+      RenderText {#text} at (333,7311) size 27x17
+        text run at (333,7311) width 27: "\x{4445}\x{D83E}\x{DE48}"
+      RenderText {#text} at (359,7311) size 102x17
+        text run at (359,7311) width 102: "\x{D83F}\x{DD09}\x{D83E}\x{DDB1}\x{60C0}\x{B82A}\x{C487}\x{D83D}\x{DEEE}\x{F29}\x{A76B}"
+      RenderText {#text} at (460,7311) size 58x17
+        text run at (460,7311) width 27: "\x{601}"
+        text run at (486,7311) width 32: "\x{41D4}\x{2B5}\x{D83F}\x{DE16}"
+      RenderText {#text} at (517,7311) size 81x17
+        text run at (517,7311) width 81: "\x{D83D}\x{DE41}\x{2FB6}\x{50D1}\x{B18F}\x{61AA}"
+      RenderText {#text} at (597,7311) size 26x17
+        text run at (597,7311) width 26: "\x{DF5B}\x{913F}"
+      RenderText {#text} at (622,7311) size 66x17
+        text run at (622,7311) width 66: "\x{A77D}\x{D83F}\x{DDA2}\x{34F}\x{6A84}\x{B2E0}\x{9088}"
+      RenderText {#text} at (0,7311) size 758x45
+        text run at (687,7311) width 64: "\x{62BA}\x{2A5}\x{37F5}\x{D3DB}"
+        text run at (750,7311) width 8 RTL: "\x{84B}"
+        text run at (0,7339) width 60: "\x{BA54}\x{D83F}\x{DD26}\x{A344}\x{1CC4}"
+      RenderText {#text} at (59,7339) size 74x17
+        text run at (59,7339) width 74: "\x{4DD8}\x{BC1}\x{6D2D}\x{59D9}\x{99E}"
+      RenderText {#text} at (132,7339) size 115x17
+        text run at (132,7339) width 23: "\x{EF27}\x{D83E}\x{DC87}"
+        text run at (154,7339) width 11 RTL: "\x{877}"
+        text run at (164,7339) width 83: "\x{43A2}\x{EAEC}\x{FA3}\x{D13D}\x{823D}\x{8A33}"
+      RenderText {#text} at (246,7339) size 48x17
+        text run at (246,7339) width 48: "\x{C016}\x{D83F}\x{DFB1}\x{D83F}\x{DE82}\x{D83F}\x{DFF4}"
+      RenderText {#text} at (293,7339) size 125x17
+        text run at (293,7339) width 125: "\x{F451}\x{142D}\x{D83D}\x{DE0E}\x{D83E}\x{DFA6}\x{E255}\x{D83D}\x{DF66}\x{D83E}\x{DD25}\x{FAC4}\x{55F3}"
+      RenderText {#text} at (683,7339) size 86x17
+        text run at (683,7339) width 86 RTL: "\x{69B}\x{6BC}\x{202E}\x{CC07}\x{67E}\x{E35B}\x{B7EB}\x{8F7C}"
+      RenderText {#text} at (587,7339) size 97x17
+        text run at (587,7339) width 97 RTL: "\x{203}\x{4153}\x{F18}\x{8AA8}\x{35A2}\x{D83F}\x{DE2B}\x{CA4D}\x{D4F}"
+      RenderText {#text} at (444,7339) size 144x17
+        text run at (444,7339) width 144 RTL: "\x{6EA2}\x{D83E}\x{DD54}\x{7032}\x{D83E}\x{DFD2}\x{D83D}\x{DE8B}\x{588}\x{565}\x{D83D}\x{DE17}\x{7FC}\x{AE}"
+      RenderText {#text} at (417,7339) size 352x45
+        text run at (417,7339) width 28 RTL: "\x{38A2}\x{A96}"
+        text run at (738,7367) width 31 RTL: "\x{41D0}\x{D013}"
+      RenderText {#text} at (656,7367) size 83x17
+        text run at (656,7367) width 83 RTL: "\x{D83F}\x{DEAC}\x{603C}\x{9B39}\x{C4AA}\x{D83F}\x{DF7B}\x{98FE}"
+      RenderText {#text} at (636,7367) size 21x17
+        text run at (636,7367) width 21 RTL: "\x{D83F}\x{DDFE}\x{3D1}"
+      RenderText {#text} at (547,7367) size 90x17
+        text run at (547,7367) width 90 RTL: "\x{D83E}\x{DDEE}\x{4A72}\x{6D37}\x{FD91}\x{D83F}\x{DC37}\x{23A0}\x{271C}"
+      RenderText {#text} at (446,7367) size 102x17
+        text run at (446,7367) width 102 RTL: "\x{F9C4}\x{85DB}\x{130}\x{5F74}\x{171}\x{AB7A}\x{9599}\x{17B}\x{D83E}\x{DECA}"
+      RenderText {#text} at (327,7367) size 120x17
+        text run at (327,7367) width 120 RTL: "\x{76FE}\x{2775}\x{C23}\x{D83F}\x{DE0B}\x{C012}\x{D83E}\x{DCD5}\x{D83E}\x{DD2A}\x{9E24}\x{9E2B}"
+      RenderText {#text} at (292,7367) size 36x17
+        text run at (292,7367) width 36 RTL: "\x{DDE}\x{8E9}\x{4745}"
+      RenderText {#text} at (199,7367) size 94x17
+        text run at (199,7367) width 94 RTL: "\x{5A92}\x{D83D}\x{DE0D}\x{BBD}\x{A85}\x{9842}\x{D8E1}\x{E36}"
+      RenderText {#text} at (109,7367) size 91x17
+        text run at (109,7367) width 91 RTL: "\x{9C76}\x{A628}\x{668}\x{D83F}\x{DF85}\x{D83E}\x{DFC4}\x{88E}\x{7A90}\x{E777}"
+      RenderText {#text} at (15,7367) size 95x17
+        text run at (15,7367) width 95 RTL: "\x{14D}\x{9DE9}\x{774}\x{CF8}\x{E564}\x{D83E}\x{DE93}\x{EED}\x{49D4}"
+      RenderText {#text} at (0,7367) size 763x43
+        text run at (0,7367) width 15 RTL: "\x{11E8}"
+        text run at (718,7393) width 45 RTL: "\x{675}\x{BACC}\x{F8B}\x{90C}"
+      RenderText {#text} at (677,7393) size 42x17
+        text run at (677,7393) width 42 RTL: "\x{683E}\x{D83F}\x{DEF3}\x{3C93}"
+      RenderText {#text} at (637,7393) size 41x17
+        text run at (637,7393) width 41 RTL: "\x{78F5}\x{7F78}\x{D83F}\x{DF83}"
+      RenderText {#text} at (518,7393) size 120x17
+        text run at (518,7393) width 120 RTL: "\x{D83D}\x{DE09}\x{796}\x{D83F}\x{DCBC}D\x{19C2}\x{6A17}\x{7B70}\x{D83D}\x{DEEB}\x{A174}\x{34C}"
+      RenderText {#text} at (488,7393) size 31x17
+        text run at (488,7393) width 31 RTL: "\x{56F3}\x{6FCC}"
+      RenderText {#text} at (418,7393) size 71x17
+        text run at (418,7393) width 71 RTL: "\x{FE70}\x{521C}\x{AA06}\x{84E8}\x{D83E}\x{DF45}\x{D83F}\x{DE37}"
+      RenderText {#text} at (294,7393) size 125x17
+        text run at (294,7393) width 125 RTL: "\x{8CD}\x{B3D3}\x{D80F}\x{16B}\x{E08}\x{232}\x{B97}\x{D83E}\x{DE69}\x{1F3C}\x{488B}\x{8A11}"
+      RenderText {#text} at (198,7393) size 97x17
+        text run at (198,7393) width 97 RTL: "\x{4A5}\x{E74}\x{CAF4}\x{D34}\x{D83E}\x{DF1B}\x{4B6}\x{2BD}\x{9A45}\x{D83F}\x{DE1D}"
+      RenderText {#text} at (85,7393) size 114x17
+        text run at (85,7393) width 114 RTL: "\x{BAF5}\x{5E12}\x{B80}\x{89BF}\x{B118}\x{63C}\x{A084}\x{F6D}\x{63D}\x{77C}"
+      RenderText {#text} at (0,7393) size 728x45
+        text run at (0,7393) width 86 RTL: "\x{7EA2}\x{5644}\x{BE3F}\x{556}\x{181E}\x{7889}"
+        text run at (662,7421) width 66 RTL: "\x{CF5}\x{887E}\x{C83}\x{93F9}\x{D83E}\x{DE2E}"
+      RenderText {#text} at (542,7421) size 121x17
+        text run at (542,7421) width 121 RTL: "\x{D83F}\x{DFEC}\x{CEA0}\x{D83E}\x{DF45}\x{CFC}\x{5A89}\x{D83F}\x{DEC3}\x{7A7C}\x{54A4}\x{E65}\x{9F2}"
+      RenderText {#text} at (498,7421) size 45x17
+        text run at (498,7421) width 45 RTL: "\x{FDF3}\x{9EA}\x{9412}"
+      RenderText {#text} at (442,7421) size 57x17
+        text run at (442,7421) width 57 RTL: "\x{44B}\x{3CB2}\x{D83F}\x{DF31}\x{DE4E}\x{E2E}"
+      RenderText {#text} at (325,7421) size 118x17
+        text run at (325,7421) width 118 RTL: "\x{5144}\x{8AB}\x{196}\x{D83F}\x{DDBD}\x{D83E}\x{DEB9}\x{F091}\x{A9E}\x{D83F}\x{DFC5}\x{D83F}\x{DCE9}\x{8787}"
+      RenderText {#text} at (208,7421) size 118x17
+        text run at (208,7421) width 118 RTL: "\x{C2A5}\x{800}\x{9F46}\x{CF1}\x{F21}\x{66E7}\x{BF55}\x{A0FF}\x{BD8}\x{15}"
+      RenderText {#text} at (123,7421) size 86x17
+        text run at (123,7421) width 86 RTL: "\x{87F3}\x{A73D}\x{5D3C}\x{9312}\x{F4DD}\x{BA3}"
+      RenderText {#text} at (25,7421) size 99x17
+        text run at (25,7421) width 99 RTL: "\x{D83F}\x{DEE2}\x{46D}\x{4AD}\x{841}\x{6ECB}\x{7C9E}\x{E5CD}\x{82F}"
+      RenderText {#text} at (0,7421) size 26x17
+        text run at (0,7421) width 26 RTL: "\x{1AEB}\x{3AAB}"
+      RenderText {#text} at (665,7449) size 95x17
+        text run at (665,7449) width 95 RTL: "\x{2959}\x{1942}\x{D9F}\x{BCD}\x{A4B}\x{8BB5}\x{D83D}\x{DE88}\x{D83E}\x{DF26}"
+      RenderText {#text} at (592,7449) size 74x17
+        text run at (592,7449) width 74 RTL: "\x{3DFB}\x{E853}\x{902F}\x{784}\x{13E}\x{3133}"
+      RenderText {#text} at (557,7449) size 36x17
+        text run at (557,7449) width 36 RTL: "\x{FB8}\x{7912}\x{EC9E}"
+      RenderText {#text} at (523,7449) size 35x17
+        text run at (523,7449) width 35 RTL: "\x{504B}\x{D91A}\x{236}"
+      RenderText {#text} at (462,7449) size 62x17
+        text run at (462,7449) width 62 RTL: "\x{AAA}\x{F7DF}\x{384}\x{B4EC}\x{C45}\x{DC4}\x{E05E}"
+      RenderText {#text} at (365,7449) size 98x17
+        text run at (365,7449) width 98 RTL: "\x{D83D}\x{DE6C}\x{6645}\x{453}\x{D83F}\x{DF03}\x{F67}\x{FA0}\x{D83F}\x{DF1E}\x{D83E}\x{DF2C}\x{7162}"
+      RenderText {#text} at (336,7449) size 30x17
+        text run at (336,7449) width 30 RTL: "\x{89E5}\x{A3E}"
+      RenderText {#text} at (213,7449) size 124x17
+        text run at (213,7449) width 124 RTL: "\x{C8B8}\x{D04F}\x{4599}\x{3FFD}\x{61AF}\x{8B27}\x{D291}\x{EE6}\x{769}"
+      RenderText {#text} at (156,7449) size 58x17
+        text run at (156,7449) width 58 RTL: "\x{E85A}\x{9E6}\x{B96}\x{CC8}\x{541C}"
+      RenderText {#text} at (71,7449) size 86x17
+        text run at (71,7449) width 86 RTL: "\x{902}\x{E280}\x{4174}\x{F7E4}\x{7D6E}\x{2F9B}\x{687}"
+      RenderText {#text} at (0,7449) size 507x53
+        text run at (0,7449) width 72 RTL: "\x{C66}\x{C57C}\x{F094}\x{AA6F}\x{19B}\x{D150}"
+        text run at (466,7485) width 41 RTL: "\x{D83D}\x{DFEE}\x{645}\x{443}\x{C2B5}"
+      RenderText {#text} at (368,7485) size 99x17
+        text run at (368,7485) width 99 RTL: "\x{F89}\x{20D}\x{545C}\x{CDE9}\x{6ACF}\x{F15F}\x{D83F}\x{DF0F}\x{30A7}"
+      RenderText {#text} at (289,7485) size 80x17
+        text run at (289,7485) width 80 RTL: "\x{93EA}\x{329D}\x{9F1}\x{484}\x{A2E0}\x{D83F}\x{DD32}\x{DB2C}\x{F512}"
+      RenderText {#text} at (209,7485) size 81x17
+        text run at (209,7485) width 81 RTL: "\x{851D}\x{11BD}\x{D83F}\x{DDAF}\x{47B7}\x{3D2A}\x{A86D}"
+      RenderText {#text} at (83,7485) size 127x17
+        text run at (83,7485) width 127 RTL: "\x{E1F2}\x{4E8}\x{FA6}\x{D83F}\x{DE0B}\x{501B}\x{405D}\x{981}\x{492}\x{54B8}\x{D83E}\x{DE64}\x{313}"
+      RenderText {#text} at (67,7485) size 17x17
+        text run at (67,7485) width 17 RTL: "\x{F680}\x{1D6A}"
+      RenderText {#text} at (0,7485) size 68x17
+        text run at (0,7485) width 68 RTL: "\x{E09}\x{F66F}\x{684}\x{EC1}\x{717D}\x{CD50}\x{8D5}"
+layer at (124,11) size 16x16
+  RenderVideo {VIDEO} at (115,3) size 17x16
+layer at (8,35) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,27) size 300x150
+layer at (391,169) size 16x16
+  RenderVideo {VIDEO} at (383,161) size 17x16
+layer at (446,197) size 300x150
+  RenderHTMLCanvas {CANVAS} at (438,189) size 301x150
+layer at (47,492) size 16x16
+  RenderVideo {VIDEO} at (39,484) size 17x16
+layer at (63,358) size 100x150
+  RenderHTMLCanvas {CANVAS} at (55,350) size 101x150
+layer at (163,358) size 300x150
+  RenderHTMLCanvas {CANVAS} at (155,350) size 301x150
+layer at (736,662) size 16x16
+  RenderVideo {VIDEO} at (727,654) size 17x16
+layer at (73,687) size 300x699
+  RenderHTMLCanvas {CANVAS} at (64,679) size 301x699
+layer at (520,1370) size 16x16
+  RenderVideo {VIDEO} at (511,1362) size 17x16
+layer at (8,1721) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,1713) size 300x150
+layer at (308,1721) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,1713) size 300x150
+layer at (8,1903) size 300x708
+  RenderHTMLCanvas {CANVAS} at (0,1895) size 300x708
+layer at (510,2448) size 163x163
+  RenderVideo {VIDEO} at (501,2440) size 164x163
+layer at (8,2617) size 210x730
+  RenderHTMLCanvas {CANVAS} at (0,2609) size 210x730
+layer at (218,3331) size 16x16
+  RenderVideo {VIDEO} at (210,3323) size 16x16
+layer at (8,3354) size 585x519
+  RenderHTMLCanvas {CANVAS} at (0,3346) size 585x519
+layer at (8,4455) size 865x150
+  RenderHTMLCanvas {CANVAS} at (0,4447) size 865x150
+layer at (40,4605) size 65x231
+  RenderVideo {VIDEO} at (32,4597) size 66x231
+layer at (123,4686) size 300x150
+  RenderHTMLCanvas {CANVAS} at (114,4678) size 301x150
+layer at (8,4841) size 308x150
+  RenderHTMLCanvas {CANVAS} at (0,4833) size 308x150
+layer at (717,5012) size 5x5
+  RenderVideo {VIDEO} at (709,5004) size 6x5
+layer at (8,6214) size 471x150
+  RenderHTMLCanvas {CANVAS} at (0,6206) size 471x150
+layer at (678,6373) size 64x81
+  RenderVideo {VIDEO} at (670,6365) size 65x81
+layer at (514,6463) size 157x226
+  RenderVideo {VIDEO} at (505,6455) size 158x226

--- a/LayoutTests/fast/webgpu/fuzz-273323.html
+++ b/LayoutTests/fast/webgpu/fuzz-273323.html
@@ -1,0 +1,17844 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUCommandEncoder} commandEncoder
+ */
+function pseudoSubmit(device, commandEncoder) {
+  device.pushErrorScope('validation');
+  commandEncoder.clearBuffer(device.createBuffer({size: 0, usage: 0}), 0, 0);
+  device.popErrorScope().then(() => {});
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let device0 = await adapter0.requestDevice({
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 4,
+maxColorAttachmentBytesPerSample: 57,
+maxVertexAttributes: 22,
+maxVertexBufferArrayStride: 41093,
+maxStorageTexturesPerShaderStage: 44,
+maxStorageBuffersPerShaderStage: 35,
+maxDynamicStorageBuffersPerPipelineLayout: 9462,
+maxBindingsPerBindGroup: 2153,
+maxTextureDimension1D: 10480,
+maxTextureDimension2D: 13445,
+maxVertexBuffers: 12,
+minUniformBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 24866923,
+maxUniformBuffersPerShaderStage: 30,
+maxInterStageShaderVariables: 82,
+maxInterStageShaderComponents: 92,
+maxSamplersPerShaderStage: 22,
+},
+});
+let texture0 = device0.createTexture(
+{
+label: '\u077c\u717d\u0daf\u{1fe85}\u{1fcca}\uce5a\u0702\u0075\u0ec6',
+size: [2811],
+sampleCount: 1,
+dimension: '1d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb'
+],
+}
+);
+let renderBundleEncoder0 = device0.createRenderBundleEncoder(
+{
+label: '\u0031\u{1f807}\u{1f889}\u260a\u2bff\ub703\u9441\u2793\ud3ed\u7204',
+colorFormats: [
+undefined,
+'rg16uint',
+'rg11b10ufloat',
+'rg8uint'
+],
+sampleCount: 641,
+stencilReadOnly: true,
+}
+);
+let canvas0 = document.createElement('canvas');
+let texture1 = device0.createTexture(
+{
+label: '\u3965\uc6c2\u0ef3\ua3af',
+size: {width: 561, height: 1, depthOrArrayLayers: 69},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rg16sint',
+'rg16sint',
+'rg16sint'
+],
+}
+);
+let renderBundle0 = renderBundleEncoder0.finish(
+{
+label: '\u{1ffa7}\uc15b'
+}
+);
+let renderBundleEncoder1 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba32uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 40,
+stencilReadOnly: false,
+}
+);
+let imageBitmap0 = await createImageBitmap(canvas0);
+let querySet0 = device0.createQuerySet({
+type: 'occlusion',
+count: 428,
+});
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas0);
+canvas0.width = 489;
+let videoFrame0 = new VideoFrame(canvas0, {timestamp: 0});
+let commandEncoder0 = device0.createCommandEncoder(
+{
+}
+);
+let texture2 = device0.createTexture(
+{
+label: '\u784e\u5c78\u174d\ua274\u057e\uea34\u8ed8\u08cd\u{1f75a}\u09b3\ufaa0',
+size: {width: 10306, height: 45, depthOrArrayLayers: 44},
+mipLevelCount: 3,
+format: 'rg8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let offscreenCanvas0 = new OffscreenCanvas(808, 121);
+let img0 = await imageWithData(128, 118, '#58b79216', '#12f08c9d');
+let imageBitmap1 = await createImageBitmap(canvas0);
+try {
+renderBundleEncoder1.setVertexBuffer(
+86,
+undefined,
+3840574286
+);
+} catch {}
+let querySet1 = device0.createQuerySet({
+label: '\u{1fe9c}\u6c7e\ua8ba\u{1f8f5}\u32e6\ube48\u{1f97e}',
+type: 'occlusion',
+count: 2316,
+});
+let textureView0 = texture1.createView(
+{
+label: '\u{1f81f}\u0c16\u09fe\u108f\u490e\u{1fd7b}\u02d3\u0f10',
+aspect: 'all',
+baseMipLevel: 1,
+}
+);
+let renderBundleEncoder2 = device0.createRenderBundleEncoder(
+{
+label: '\u0289\u05b7\ud84f\u7cac\ud01d\u2494\uaf65\u{1f629}\u{1fb99}\ucd03\u{1f951}',
+colorFormats: [
+undefined,
+'rgb10a2unorm',
+'rgba8uint',
+'bgra8unorm',
+'rgb10a2uint',
+'r32float',
+'rg8sint',
+'r16sint'
+],
+sampleCount: 989,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+let querySet2 = device0.createQuerySet({
+type: 'occlusion',
+count: 1597,
+});
+let computePassEncoder0 = commandEncoder0.beginComputePass(
+{
+
+}
+);
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+gc();
+let adapter1 = await navigator.gpu.requestAdapter();
+pseudoSubmit(device0, commandEncoder0);
+let sampler0 = device0.createSampler(
+{
+label: '\ue6ac\ud42c',
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 93.043,
+lodMaxClamp: 93.250,
+maxAnisotropy: 1,
+}
+);
+let sampler1 = device0.createSampler(
+{
+label: '\ua9d6\ua977\u{1ff86}\u{1fdd8}\uddff',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 85.629,
+lodMaxClamp: 90.777,
+maxAnisotropy: 17,
+}
+);
+try {
+renderBundleEncoder2.setVertexBuffer(
+86,
+undefined,
+1680654657
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture3 = device0.createTexture(
+{
+label: '\u59af\u0db8\u{1fd5c}\ub5bc\u5fbe\u063e\u{1fd48}',
+size: [689, 1, 207],
+mipLevelCount: 10,
+dimension: '3d',
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32sint',
+'r32sint',
+'r32sint'
+],
+}
+);
+let renderBundle1 = renderBundleEncoder2.finish(
+{
+label: '\u{1ff3d}\u45d7\uc776\ub5bc\u{1faef}\u{1fb4a}\u0f02\u0526\uda50\u0a76'
+}
+);
+let imageData0 = new ImageData(140, 168);
+try {
+offscreenCanvas0.getContext('webgl2');
+} catch {}
+let bindGroupLayout0 = device0.createBindGroupLayout(
+{
+label: '\ud9a8\u{1f923}\u456e\ud0ce\u{1fb14}\u{1f95c}\u{1fb46}\u{1f9dd}',
+entries: [
+{
+binding: 1287,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'filtering' },
+},
+{
+binding: 1264,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 619,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+}
+],
+}
+);
+let pipelineLayout0 = device0.createPipelineLayout(
+{
+label: '\u00a5\u{1f916}\uecf4\ue42d\u{1fdb2}\u0f9d\u{1fb3e}\u05c1\ub392\u{1f91e}\uf6be',
+bindGroupLayouts: [
+bindGroupLayout0
+]
+}
+);
+let querySet3 = device0.createQuerySet({
+label: '\u6d95\u0636\ufbd4\u{1fbb9}\uf07a\u3015\u0438\ub8a9\u54c8\ue4d5',
+type: 'occlusion',
+count: 53,
+});
+let renderBundle2 = renderBundleEncoder0.finish(
+{
+
+}
+);
+let sampler2 = device0.createSampler(
+{
+label: '\u6c35\u4c4a\u0e8f\u0396\u0466\u0902\u{1fb63}',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 92.955,
+lodMaxClamp: 93.609,
+compare: 'never',
+}
+);
+let externalTexture0 = device0.importExternalTexture(
+{
+label: '\ufabe\u03fd',
+source: videoFrame0,
+colorSpace: 'srgb',
+}
+);
+document.body.prepend(canvas0);
+let shaderModule0 = device0.createShaderModule(
+{
+code: `@group(0) @binding(1287)
+var<storage, read_write> global0: array<u32>;
+@group(0) @binding(619)
+var<storage, read_write> parameter0: array<u32>;
+@group(0) @binding(1264)
+var<storage, read_write> global1: array<u32>;
+
+@compute @workgroup_size(5, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S1 {
+@location(65) f0: vec3<i32>,
+@location(4) f1: i32,
+@location(40) f2: vec4<u32>,
+@location(24) f3: f16,
+@location(20) f4: vec4<f32>,
+@location(61) f5: f16,
+@location(11) f6: vec4<i32>,
+@location(17) f7: f32,
+@location(75) f8: f32,
+@location(43) f9: vec4<f16>,
+@location(19) f10: vec4<i32>,
+@builtin(sample_index) f11: u32,
+@location(69) f12: f16,
+@location(80) f13: i32,
+@location(67) f14: vec3<f16>,
+@location(23) f15: vec2<f16>,
+@location(14) f16: u32,
+@builtin(front_facing) f17: bool,
+@location(34) f18: f32,
+@location(27) f19: vec2<f32>,
+@location(12) f20: vec3<u32>,
+@location(16) f21: vec2<u32>,
+@location(13) f22: i32,
+@builtin(sample_mask) f23: u32,
+@location(42) f24: u32,
+@location(74) f25: vec3<i32>,
+@location(57) f26: vec3<i32>,
+@location(22) f27: vec2<i32>,
+@location(45) f28: vec2<f16>,
+@location(7) f29: vec2<f16>,
+@builtin(position) f30: vec4<f32>,
+@location(9) f31: vec4<u32>,
+@location(54) f32: vec3<u32>,
+@location(37) f33: vec3<u32>
+}
+struct FragmentOutput0 {
+@location(5) f0: vec2<i32>,
+@location(6) f1: vec3<u32>
+}
+
+@fragment
+fn fragment0(a0: S1, @location(26) a1: vec3<f16>, @location(53) a2: vec4<f32>, @location(50) a3: vec2<u32>, @location(48) a4: vec3<u32>, @location(66) a5: vec3<u32>, @location(18) a6: i32, @location(35) a7: vec2<u32>, @location(63) a8: f32, @location(60) a9: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S0 {
+@builtin(instance_index) f0: u32,
+@location(16) f1: f32,
+@location(7) f2: vec3<f16>,
+@location(15) f3: f16,
+@location(21) f4: vec3<f32>,
+@location(18) f5: vec4<i32>
+}
+struct VertexOutput0 {
+@location(60) f0: vec4<f32>,
+@location(24) f1: f16,
+@location(80) f2: i32,
+@location(43) f3: vec4<f16>,
+@location(35) f4: vec2<u32>,
+@location(57) f5: vec3<i32>,
+@location(20) f6: vec4<f32>,
+@location(11) f7: vec4<i32>,
+@location(63) f8: f32,
+@location(19) f9: vec4<i32>,
+@location(12) f10: vec3<u32>,
+@location(54) f11: vec3<u32>,
+@location(37) f12: vec3<u32>,
+@location(65) f13: vec3<i32>,
+@location(69) f14: f16,
+@location(40) f15: vec4<u32>,
+@builtin(position) f16: vec4<f32>,
+@location(16) f17: vec2<u32>,
+@location(14) f18: u32,
+@location(22) f19: vec2<i32>,
+@location(45) f20: vec2<f16>,
+@location(27) f21: vec2<f32>,
+@location(7) f22: vec2<f16>,
+@location(23) f23: vec2<f16>,
+@location(61) f24: f16,
+@location(13) f25: i32,
+@location(42) f26: u32,
+@location(4) f27: i32,
+@location(53) f28: vec4<f32>,
+@location(66) f29: vec3<u32>,
+@location(48) f30: vec3<u32>,
+@location(67) f31: vec3<f16>,
+@location(34) f32: f32,
+@location(17) f33: f32,
+@location(9) f34: vec4<u32>,
+@location(50) f35: vec2<u32>,
+@location(74) f36: vec3<i32>,
+@location(18) f37: i32,
+@location(26) f38: vec3<f16>,
+@location(75) f39: f32
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec2<u32>, @location(4) a1: vec2<f16>, a2: S0, @location(0) a3: vec2<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let renderBundle3 = renderBundleEncoder2.finish(
+{
+label: '\u{1f703}\u06c7\u3b3f\uaa86\u04ff\u0163\u{1f6df}\u0939\u5d11'
+}
+);
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let canvas1 = document.createElement('canvas');
+let pipelineLayout1 = device0.createPipelineLayout(
+{
+label: '\u{1f6da}\u0e7d\u38af\u0f58\u37ea\u2847',
+bindGroupLayouts: [
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0
+]
+}
+);
+let texture4 = device0.createTexture(
+{
+size: {width: 132, height: 211, depthOrArrayLayers: 245},
+mipLevelCount: 5,
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'bgra8unorm',
+'bgra8unorm',
+'bgra8unorm-srgb'
+],
+}
+);
+let textureView1 = texture0.createView(
+{
+format: 'bgra8unorm-srgb',
+}
+);
+let renderBundleEncoder3 = device0.createRenderBundleEncoder(
+{
+label: '\u{1fa97}\u{1fa86}\uf9a5\u0ddc\ud8a1\u6b2c',
+colorFormats: [
+'rgba32uint',
+'bgra8unorm',
+'rg8sint',
+'rgba8unorm',
+'r32sint',
+'r32uint'
+],
+sampleCount: 416,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle4 = renderBundleEncoder0.finish(
+{
+label: '\u{1f84a}\u047b\uae81\u6aa5\ud9ad\u0add\u7fd3\uf472\ue2dc'
+}
+);
+let sampler3 = device0.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 44.923,
+}
+);
+try {
+renderBundleEncoder1.setVertexBuffer(
+66,
+undefined,
+735869037,
+479321587
+);
+} catch {}
+let shaderModule1 = device0.createShaderModule(
+{
+label: '\uaed7\u0a4c\u48b4\u{1ffcd}\u{1fe27}\u{1f763}\u57e5\u4db9\u{1feeb}\u1e01',
+code: `@group(0) @binding(619)
+var<storage, read_write> global2: array<u32>;
+@group(0) @binding(1264)
+var<storage, read_write> field0: array<u32>;
+@group(0) @binding(1287)
+var<storage, read_write> function0: array<u32>;
+
+@compute @workgroup_size(5, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: vec2<u32>,
+@location(0) f1: vec3<f32>,
+@location(2) f2: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S2 {
+@location(6) f0: u32,
+@location(17) f1: vec2<f32>,
+@location(2) f2: vec4<u32>,
+@location(0) f3: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec3<f16>, @location(16) a1: u32, @location(7) a2: vec3<f16>, @location(20) a3: vec2<u32>, @location(19) a4: vec4<f32>, @location(3) a5: vec2<f16>, @location(10) a6: u32, a7: S2, @location(11) a8: vec2<i32>, @location(14) a9: i32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let sampler4 = device0.createSampler(
+{
+label: '\ud64c\u0dff\u016a',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 78.997,
+lodMaxClamp: 89.584,
+compare: 'greater',
+}
+);
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'eac-rg11unorm',
+'rgba8unorm'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+let promise0 = device0.createRenderPipelineAsync(
+{
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x3',
+offset: 22468,
+shaderLocation: 2,
+},
+{
+format: 'uint8x2',
+offset: 12876,
+shaderLocation: 10,
+},
+{
+format: 'float32x2',
+offset: 12320,
+shaderLocation: 3,
+},
+{
+format: 'uint32',
+offset: 33396,
+shaderLocation: 20,
+},
+{
+format: 'snorm16x2',
+offset: 36288,
+shaderLocation: 8,
+},
+{
+format: 'unorm8x4',
+offset: 20632,
+shaderLocation: 19,
+},
+{
+format: 'float32',
+offset: 36124,
+shaderLocation: 7,
+},
+{
+format: 'sint8x4',
+offset: 35872,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 3604,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 2312,
+shaderLocation: 6,
+},
+{
+format: 'sint32x2',
+offset: 2928,
+shaderLocation: 11,
+},
+{
+format: 'unorm8x4',
+offset: 516,
+shaderLocation: 17,
+},
+{
+format: 'sint32x3',
+offset: 2564,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 2640,
+attributes: [
+
+],
+},
+{
+arrayStride: 27932,
+attributes: [
+
+],
+},
+{
+arrayStride: 25740,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 14564,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rg16float',
+}
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'zero',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilReadMask: 1525,
+stencilWriteMask: 1804,
+depthBiasSlopeScale: 13,
+depthBiasClamp: 69,
+},
+}
+);
+let img1 = await imageWithData(111, 49, '#e547a6d9', '#45a3c9b0');
+let renderBundleEncoder4 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8unorm',
+'rgb10a2uint',
+'rgba16sint',
+'rg8uint',
+undefined
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 190,
+stencilReadOnly: false,
+}
+);
+try {
+renderBundleEncoder3.setVertexBuffer(
+22,
+undefined
+);
+} catch {}
+let commandEncoder1 = device0.createCommandEncoder(
+{
+label: '\ue5bf\u2c92\u7d51\u0b8b\u{1fcc8}\ud8c2\u1674\ue577\u{1fdc6}\u5497\u3c06',
+}
+);
+let computePassEncoder1 = commandEncoder1.beginComputePass(
+{
+label: '\u0562\u{1f93b}\u9c96\u{1fc44}\u{1ffe7}\u4524\u369b\u0597'
+}
+);
+try {
+renderBundleEncoder3.setVertexBuffer(
+75,
+undefined,
+1414454643,
+2016163141
+);
+} catch {}
+let pipeline0 = device0.createRenderPipeline(
+{
+label: '\uef85\u{1ffeb}\u{1fbf8}\u{1f782}',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 8496,
+attributes: [
+{
+format: 'sint32x2',
+offset: 1464,
+shaderLocation: 0,
+},
+{
+format: 'uint32x4',
+offset: 5008,
+shaderLocation: 16,
+},
+{
+format: 'float16x2',
+offset: 144,
+shaderLocation: 19,
+},
+{
+format: 'snorm8x2',
+offset: 7174,
+shaderLocation: 7,
+},
+{
+format: 'uint16x4',
+offset: 7832,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 18804,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 5078,
+shaderLocation: 17,
+},
+{
+format: 'uint8x2',
+offset: 11020,
+shaderLocation: 10,
+},
+{
+format: 'sint16x2',
+offset: 9020,
+shaderLocation: 11,
+},
+{
+format: 'float32x3',
+offset: 9152,
+shaderLocation: 8,
+},
+{
+format: 'uint16x4',
+offset: 12120,
+shaderLocation: 20,
+},
+{
+format: 'unorm16x2',
+offset: 10844,
+shaderLocation: 3,
+},
+{
+format: 'sint8x2',
+offset: 2572,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 17624,
+attributes: [
+
+],
+},
+{
+arrayStride: 27016,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 36512,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 2336,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'stencil8',
+stencilFront: {
+compare: 'equal',
+failOp: 'invert',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilWriteMask: 678,
+depthBias: 64,
+depthBiasSlopeScale: 3,
+depthBiasClamp: 27,
+},
+}
+);
+gc();
+let pipelineLayout2 = device0.createPipelineLayout(
+{
+label: '\u170d\u{1fba6}\u08f1\uad10\u03ab\uf915\u232d\u0636\uc945\u0050\u08cd',
+bindGroupLayouts: [
+bindGroupLayout0
+]
+}
+);
+let querySet4 = device0.createQuerySet({
+label: '\u0542\ued5a\u{1f8b6}\u41c0\u68de\u0a65\u{1f64c}\u8764\u{1fe69}\u054c',
+type: 'occlusion',
+count: 2629,
+});
+let renderBundle5 = renderBundleEncoder1.finish(
+{
+label: '\u0bc4\u84dc\u7eb7\u0ea0\u086c\u{1fb6c}\uc56c\u{1ff56}\ufccc'
+}
+);
+try {
+renderBundleEncoder4.setVertexBuffer(
+8,
+undefined,
+852779166,
+2119715626
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 1026, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Float64Array(new ArrayBuffer(8)),
+/* required buffer size: 500 */{
+offset: 500,
+},
+{width: 1581, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let canvas2 = document.createElement('canvas');
+let texture5 = device0.createTexture(
+{
+size: {width: 7506, height: 235, depthOrArrayLayers: 180},
+mipLevelCount: 11,
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+let renderBundleEncoder5 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba16sint',
+'r32float',
+'r16float',
+'rg32float',
+'r16float',
+'rgba32sint'
+],
+sampleCount: 838,
+depthReadOnly: true,
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 1940, y: 0, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(48),
+/* required buffer size: 958 */{
+offset: 958,
+},
+{width: 136, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let bindGroupLayout1 = device0.createBindGroupLayout(
+{
+label: '\u8b65\u{1f7c6}\u{1fa45}\u9cb2\u0b09\ue452\u7abf',
+entries: [
+{
+binding: 1032,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba16sint', access: 'write-only', viewDimension: '2d' },
+},
+{
+binding: 1192,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+}
+],
+}
+);
+pseudoSubmit(device0, commandEncoder1);
+let pipeline1 = device0.createComputePipeline(
+{
+label: '\u06d2\u0d33\u{1fb90}',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let adapter2 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let texture6 = device0.createTexture(
+{
+label: '\u76bf\u9c82\u08ef\u{1f63d}\u{1f8d1}\u057c',
+size: [18, 115, 1],
+mipLevelCount: 5,
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb10a2unorm'
+],
+}
+);
+let sampler5 = device0.createSampler(
+{
+label: '\u0983\u0b0d\u0b68\u8aa5\u{1f601}\u{1fe47}\ud3c4\ua340\u0ae0\u{1fc8c}\u{1fc44}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 4.744,
+lodMaxClamp: 20.139,
+compare: 'never',
+maxAnisotropy: 2,
+}
+);
+let gpuCanvasContext1 = canvas1.getContext('webgpu');
+let imageBitmap2 = await createImageBitmap(canvas0);
+let renderBundle6 = renderBundleEncoder3.finish(
+{
+label: '\u{1f9e1}\u011b\u{1feea}\u0537\u74ed\uf589\u09a0\u0967\u0787'
+}
+);
+let promise1 = device0.popErrorScope();
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-12x10-unorm'
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let gpuCanvasContext2 = canvas2.getContext('webgpu');
+let buffer0 = device0.createBuffer(
+{
+label: '\uc823\u{1f917}\u{1fa41}\ucccd\u{1f8c7}\u0b31\u02a0\u3229\ub025\u0e56\u2d7b',
+size: 47584,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8snorm',
+'eac-rg11snorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let shaderModule2 = device0.createShaderModule(
+{
+label: '\u{1faaf}\u3370\u86bd\ue182\u0e2e\ue5e5\u{1f77f}\u{1febb}\ud2ad\u{1fc96}',
+code: `@group(0) @binding(1264)
+var<storage, read_write> local0: array<u32>;
+@group(0) @binding(619)
+var<storage, read_write> i0: array<u32>;
+@group(0) @binding(1287)
+var<storage, read_write> i1: array<u32>;
+
+@compute @workgroup_size(5, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(5) f0: vec4<i32>,
+@location(2) f1: vec3<i32>,
+@location(1) f2: vec3<u32>,
+@location(0) f3: vec3<i32>,
+@location(6) f4: vec3<u32>,
+@location(3) f5: u32,
+@location(4) f6: vec2<u32>,
+@builtin(sample_mask) f7: u32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S3 {
+@location(15) f0: f16,
+@location(12) f1: vec3<u32>,
+@location(2) f2: u32,
+@location(6) f3: vec3<i32>,
+@location(18) f4: vec4<u32>,
+@location(8) f5: vec4<u32>
+}
+struct VertexOutput0 {
+@location(72) f40: vec2<f32>,
+@location(46) f41: vec2<f16>,
+@location(68) f42: vec4<i32>,
+@location(56) f43: i32,
+@location(23) f44: u32,
+@location(6) f45: vec3<f32>,
+@location(70) f46: vec4<f16>,
+@location(24) f47: vec2<u32>,
+@location(73) f48: vec2<f32>,
+@builtin(position) f49: vec4<f32>,
+@location(37) f50: vec3<f16>,
+@location(0) f51: vec4<f32>,
+@location(3) f52: i32,
+@location(14) f53: vec2<u32>,
+@location(66) f54: vec2<u32>,
+@location(5) f55: i32,
+@location(80) f56: i32,
+@location(8) f57: vec3<i32>,
+@location(17) f58: u32,
+@location(52) f59: i32,
+@location(7) f60: vec3<i32>,
+@location(13) f61: vec2<f16>,
+@location(78) f62: vec2<u32>,
+@location(40) f63: i32,
+@location(42) f64: vec4<f32>,
+@location(38) f65: vec2<u32>,
+@location(48) f66: f16,
+@location(9) f67: vec2<f16>,
+@location(2) f68: vec3<f16>,
+@location(49) f69: vec2<i32>,
+@location(58) f70: vec2<f32>,
+@location(65) f71: u32,
+@location(76) f72: vec3<i32>,
+@location(11) f73: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(19) a0: vec4<f16>, @location(0) a1: vec2<u32>, @location(5) a2: vec3<i32>, @location(4) a3: vec4<i32>, @location(17) a4: vec3<f16>, a5: S3, @builtin(vertex_index) a6: u32, @location(20) a7: vec3<f32>, @location(7) a8: vec4<f32>, @location(13) a9: vec4<f16>, @builtin(instance_index) a10: u32, @location(21) a11: f32, @location(16) a12: vec2<f32>, @location(11) a13: i32, @location(1) a14: vec3<f32>, @location(3) a15: vec4<i32>, @location(10) a16: vec4<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let texture7 = device0.createTexture(
+{
+label: '\u0594\u743e\u5121\u552d',
+size: {width: 234, height: 1, depthOrArrayLayers: 944},
+mipLevelCount: 6,
+dimension: '3d',
+format: 'r32float',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let sampler6 = device0.createSampler(
+{
+label: '\u8de7\u5094\u4748',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 25.524,
+lodMaxClamp: 43.371,
+}
+);
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let videoFrame1 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+let bindGroupLayout2 = pipeline0.getBindGroupLayout(0);
+let texture8 = device0.createTexture(
+{
+label: '\u{1fd2e}\u{1f9dc}\u04f6\u96ce',
+size: [9257, 233, 1],
+mipLevelCount: 4,
+dimension: '2d',
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+buffer0.unmap();
+} catch {}
+try {
+adapter1.label = '\ub76f\u{1f935}\u0ac7\udd10\u{1fc24}\u{1fb74}\u0d70';
+} catch {}
+let sampler7 = device0.createSampler(
+{
+label: '\u0d82\u{1f646}\u982e\ub2f1\u444d\u06dd',
+addressModeU: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 68.789,
+}
+);
+try {
+renderBundleEncoder4.setVertexBuffer(
+10,
+undefined,
+1521712523
+);
+} catch {}
+try {
+renderBundleEncoder5.pushDebugGroup(
+'\u0eb0'
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+gc();
+let videoFrame2 = new VideoFrame(imageBitmap0, {timestamp: 0});
+let shaderModule3 = device0.createShaderModule(
+{
+label: '\u{1f724}\u5bce',
+code: `@group(0) @binding(1264)
+var<storage, read_write> local1: array<u32>;
+@group(0) @binding(1287)
+var<storage, read_write> field1: array<u32>;
+
+@compute @workgroup_size(8, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S5 {
+@builtin(sample_index) f0: u32
+}
+struct FragmentOutput0 {
+@builtin(sample_mask) f0: u32,
+@location(1) f1: vec4<i32>,
+@location(3) f2: vec4<u32>,
+@location(4) f3: vec2<f32>,
+@location(2) f4: vec3<f32>,
+@location(0) f5: vec3<f32>,
+@location(7) f6: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(position) a1: vec4<f32>, @builtin(sample_mask) a2: u32, a3: S5) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S4 {
+@location(16) f0: i32,
+@location(5) f1: u32,
+@location(11) f2: vec4<i32>,
+@location(13) f3: u32,
+@location(2) f4: vec2<f16>,
+@location(14) f5: vec3<u32>,
+@location(7) f6: f32,
+@location(12) f7: vec3<f32>,
+@location(3) f8: vec3<i32>,
+@location(9) f9: vec4<i32>,
+@location(10) f10: i32,
+@location(1) f11: vec4<f32>,
+@builtin(instance_index) f12: u32,
+@location(19) f13: vec2<f32>,
+@location(4) f14: vec4<f16>,
+@location(15) f15: vec2<i32>,
+@builtin(vertex_index) f16: u32,
+@location(18) f17: u32,
+@location(21) f18: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(17) a0: vec3<f32>, a1: S4, @location(8) a2: u32, @location(0) a3: vec3<f16>, @location(6) a4: i32, @location(20) a5: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let sampler8 = device0.createSampler(
+{
+label: '\u0216\ud233',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+compare: 'always',
+}
+);
+try {
+buffer0.unmap();
+} catch {}
+try {
+renderBundleEncoder4.insertDebugMarker(
+'\u6227'
+);
+} catch {}
+let pipeline2 = await device0.createRenderPipelineAsync(
+{
+label: '\u{1fd88}\u{1f7d6}\u0a69\ud5a6\u0db6\u{1f95a}\u4534',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 9448,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 7892,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x4',
+offset: 2812,
+shaderLocation: 16,
+},
+{
+format: 'sint32x3',
+offset: 2068,
+shaderLocation: 18,
+},
+{
+format: 'float32x3',
+offset: 6592,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x2',
+offset: 9126,
+shaderLocation: 15,
+},
+{
+format: 'snorm16x4',
+offset: 952,
+shaderLocation: 21,
+}
+],
+},
+{
+arrayStride: 34652,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 8396,
+shaderLocation: 0,
+},
+{
+format: 'float32',
+offset: 15368,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilWriteMask: 3295,
+depthBias: 93,
+depthBiasClamp: 5,
+},
+}
+);
+try {
+await promise1;
+} catch {}
+let texture9 = device0.createTexture(
+{
+label: '\u5eb0\u3961\u2dc1\u4873\u{1fd22}\u0495\u0fa5\u3575\ub076\u{1fc9e}',
+size: {width: 130, height: 1, depthOrArrayLayers: 589},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg8sint',
+'rg8sint',
+'rg8sint'
+],
+}
+);
+let textureView2 = texture7.createView(
+{
+label: '\u530f\u{1f7cd}\u{1fab8}',
+baseMipLevel: 1,
+mipLevelCount: 1,
+}
+);
+let renderBundleEncoder6 = device0.createRenderBundleEncoder(
+{
+label: '\u04b5\uc146\u07e4\u{1fac0}\u79fe\u7b72\u{1f8c1}',
+colorFormats: [
+'rgba8unorm',
+'rgba8unorm',
+'rg16sint',
+'rg16sint'
+],
+sampleCount: 313,
+}
+);
+try {
+texture2.destroy();
+} catch {}
+let buffer1 = device0.createBuffer(
+{
+label: '\udf6b\u{1f7d9}',
+size: 47576,
+usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+}
+);
+let renderBundleEncoder7 = device0.createRenderBundleEncoder(
+{
+label: '\u0a50\u0fc4\u{1f94c}\u{1fa1c}',
+colorFormats: [
+'rg11b10ufloat'
+],
+sampleCount: 862,
+depthReadOnly: true,
+}
+);
+let renderBundle7 = renderBundleEncoder1.finish(
+{
+label: '\u09cf\u9ff0\u0ec8\u0aa1\u51d6\u08d2\u9fe0\ubea4'
+}
+);
+try {
+await buffer0.mapAsync(
+GPUMapMode.READ
+);
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+let pipeline3 = device0.createComputePipeline(
+{
+label: '\u{1f764}\u238a\u9437\u{1f622}\u0da5\u0b39\u6efd\u7294\u3cd6\u{1f9c3}',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline4 = device0.createRenderPipeline(
+{
+label: '\u6e8a\u{1f6a1}\ua9e7',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 37764,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 2204,
+attributes: [
+{
+format: 'unorm8x4',
+offset: 1252,
+shaderLocation: 0,
+},
+{
+format: 'unorm8x4',
+offset: 220,
+shaderLocation: 4,
+},
+{
+format: 'sint32x4',
+offset: 1176,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 26040,
+attributes: [
+{
+format: 'unorm16x4',
+offset: 17848,
+shaderLocation: 21,
+},
+{
+format: 'uint8x2',
+offset: 7790,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 6492,
+attributes: [
+{
+format: 'float32',
+offset: 1364,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 5076,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 1408,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x2',
+offset: 612,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0xd3b843e,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'rg16uint',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'equal',
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilBack: {
+failOp: 'increment-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 1770,
+stencilWriteMask: 2589,
+depthBiasSlopeScale: 19,
+},
+}
+);
+let commandEncoder2 = device0.createCommandEncoder(
+{
+label: '\u822b\ua380\u8479\u6d3e\u1298\uaf4a',
+}
+);
+let sampler9 = device0.createSampler(
+{
+label: '\u830c\u{1f6d5}\u06bb\u{1ffef}\u9d0b\u0fde\u{1f60b}\ufddb',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 25.228,
+lodMaxClamp: 41.937,
+compare: 'less',
+maxAnisotropy: 18,
+}
+);
+try {
+commandEncoder2.copyTextureToTexture(
+{
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 2291, y: 92, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 3,
+  origin: { x: 0, y: 2, z: 0 },
+  aspect: 'all',
+},
+{width: 1157, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder2.clearBuffer(
+buffer0
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture3,
+  mipLevel: 9,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(0),
+/* required buffer size: 564 */{
+offset: 560,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline5 = device0.createRenderPipeline(
+{
+label: '\u390a\ub7e9',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 13428,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 4168,
+shaderLocation: 2,
+},
+{
+format: 'uint32x2',
+offset: 4788,
+shaderLocation: 13,
+},
+{
+format: 'snorm8x4',
+offset: 2040,
+shaderLocation: 1,
+},
+{
+format: 'sint32x4',
+offset: 2280,
+shaderLocation: 20,
+},
+{
+format: 'sint32',
+offset: 12136,
+shaderLocation: 11,
+},
+{
+format: 'sint32',
+offset: 9952,
+shaderLocation: 3,
+},
+{
+format: 'float32x3',
+offset: 9268,
+shaderLocation: 0,
+},
+{
+format: 'float16x2',
+offset: 9560,
+shaderLocation: 7,
+},
+{
+format: 'sint8x2',
+offset: 9704,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x4',
+offset: 1296,
+shaderLocation: 12,
+},
+{
+format: 'unorm16x4',
+offset: 10396,
+shaderLocation: 17,
+},
+{
+format: 'uint32x4',
+offset: 7976,
+shaderLocation: 8,
+},
+{
+format: 'uint32x4',
+offset: 2740,
+shaderLocation: 14,
+},
+{
+format: 'float32',
+offset: 9376,
+shaderLocation: 21,
+},
+{
+format: 'snorm8x4',
+offset: 8648,
+shaderLocation: 4,
+},
+{
+format: 'sint32x4',
+offset: 436,
+shaderLocation: 10,
+},
+{
+format: 'sint16x2',
+offset: 4244,
+shaderLocation: 15,
+},
+{
+format: 'sint16x4',
+offset: 8576,
+shaderLocation: 6,
+},
+{
+format: 'sint8x2',
+offset: 8104,
+shaderLocation: 16,
+},
+{
+format: 'uint16x4',
+offset: 10256,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 24016,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 31512,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 30800,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 19468,
+shaderLocation: 5,
+},
+{
+format: 'float16x2',
+offset: 7672,
+shaderLocation: 19,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 1,
+},
+fragment: {
+module: shaderModule3,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+document.body.prepend(img0);
+let renderBundleEncoder8 = device0.createRenderBundleEncoder(
+{
+label: '\u02f4\uf0a0\u973b\u3416\u0955\u4247',
+colorFormats: [
+'rg32float',
+'r8uint',
+'rg8uint',
+'rg32float',
+'r8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 842,
+depthReadOnly: true,
+}
+);
+let renderBundle8 = renderBundleEncoder3.finish(
+{
+label: '\ue235\u860e\u9c11\u{1f7b0}\u5e75\u0b8b\ufa3a\u2bef\u{1fddc}\u90bb\ueb35'
+}
+);
+let canvas3 = document.createElement('canvas');
+let img2 = await imageWithData(33, 28, '#fc6d013f', '#bbe53883');
+try {
+window.someLabel = pipeline5.label;
+} catch {}
+let commandEncoder3 = device0.createCommandEncoder(
+{
+}
+);
+let textureView3 = texture1.createView(
+{
+label: '\u0a00\u{1ff38}\u0574\uf0ae\u{1f69d}\u2837\uea39',
+mipLevelCount: 1,
+}
+);
+let renderBundle9 = renderBundleEncoder8.finish(
+{
+
+}
+);
+let pipeline6 = device0.createRenderPipeline(
+{
+label: '\u0372\u779a\u0e49\u{1f6d9}\ub481\ub6b5\u20c0',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 22300,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 1612,
+shaderLocation: 0,
+},
+{
+format: 'uint16x4',
+offset: 19380,
+shaderLocation: 10,
+},
+{
+format: 'sint16x2',
+offset: 9376,
+shaderLocation: 3,
+},
+{
+format: 'snorm16x2',
+offset: 14272,
+shaderLocation: 16,
+},
+{
+format: 'sint16x2',
+offset: 16124,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 8220,
+shaderLocation: 21,
+},
+{
+format: 'uint8x2',
+offset: 11692,
+shaderLocation: 18,
+},
+{
+format: 'unorm16x2',
+offset: 40344,
+shaderLocation: 13,
+},
+{
+format: 'uint32',
+offset: 9528,
+shaderLocation: 12,
+},
+{
+format: 'sint32',
+offset: 232,
+shaderLocation: 4,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 8684,
+shaderLocation: 15,
+},
+{
+format: 'snorm16x2',
+offset: 3788,
+shaderLocation: 19,
+},
+{
+format: 'uint32x2',
+offset: 13304,
+shaderLocation: 8,
+},
+{
+format: 'unorm16x2',
+offset: 37824,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 37096,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x4',
+offset: 37968,
+shaderLocation: 2,
+},
+{
+format: 'snorm8x4',
+offset: 20224,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 5288,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 1042,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'sint16x4',
+offset: 26508,
+shaderLocation: 6,
+},
+{
+format: 'sint32',
+offset: 10404,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 1548,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x2',
+offset: 1308,
+shaderLocation: 20,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32sint',
+},
+{
+format: 'r8uint',
+writeMask: 0,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater-equal',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilWriteMask: 3698,
+depthBias: 3,
+depthBiasSlopeScale: 21,
+},
+}
+);
+document.body.prepend(img1);
+try {
+canvas3.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder4 = device0.createCommandEncoder(
+{
+label: '\ub81f\u{1f94a}\u38fc\uf9e5\u{1f92a}',
+}
+);
+let texture10 = device0.createTexture(
+{
+label: '\u5fcd\u0645\ub259',
+size: {width: 744, height: 137, depthOrArrayLayers: 211},
+mipLevelCount: 6,
+dimension: '2d',
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16uint',
+'r16uint',
+'r16uint'
+],
+}
+);
+let sampler10 = device0.createSampler(
+{
+label: '\u0619\u0d92\u{1f727}\u03c5\u0e36\u0bd6\u2c35\ua13a\u8c0a\u03db\u080f',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 73.660,
+lodMaxClamp: 78.011,
+}
+);
+try {
+renderBundleEncoder7.setVertexBuffer(
+29,
+undefined,
+2852743007,
+106371616
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture1,
+  mipLevel: 1,
+  origin: { x: 17, y: 0, z: 4 },
+  aspect: 'all',
+},
+new Int32Array(new ArrayBuffer(72)),
+/* required buffer size: 369220 */{
+offset: 264,
+bytesPerRow: 944,
+rowsPerImage: 15,
+},
+{width: 199, height: 1, depthOrArrayLayers: 27}
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline7 = device0.createComputePipeline(
+{
+label: '\uae65\u0206\u03e5',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let commandEncoder5 = device0.createCommandEncoder(
+{
+label: '\u27cf\u{1fb47}\u8ddf\u9d74\u075e\udcfb\u0116\ue6e2\u0de6',
+}
+);
+let textureView4 = texture0.createView(
+{
+label: '\u{1f7ae}\u6b01\uaa41\u0da1\u0c37\u{1f6cf}\u0a4c\u76dd\u56f6\u41a2\u0ef6',
+aspect: 'all',
+format: 'bgra8unorm-srgb',
+}
+);
+try {
+renderBundleEncoder6.setVertexBuffer(
+10,
+undefined,
+3779349023,
+370274507
+);
+} catch {}
+let pipeline8 = device0.createRenderPipeline(
+{
+label: '\u{1f828}\u775b\u0faf',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 20812,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x2',
+offset: 19232,
+shaderLocation: 18,
+},
+{
+format: 'float32x3',
+offset: 9032,
+shaderLocation: 21,
+}
+],
+},
+{
+arrayStride: 27728,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x4',
+offset: 20484,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x2',
+offset: 6564,
+shaderLocation: 1,
+},
+{
+format: 'sint32x2',
+offset: 7392,
+shaderLocation: 3,
+},
+{
+format: 'float32x3',
+offset: 9032,
+shaderLocation: 19,
+},
+{
+format: 'uint32x2',
+offset: 19584,
+shaderLocation: 5,
+},
+{
+format: 'sint8x2',
+offset: 11582,
+shaderLocation: 16,
+},
+{
+format: 'sint8x4',
+offset: 21456,
+shaderLocation: 15,
+},
+{
+format: 'uint32x2',
+offset: 19508,
+shaderLocation: 13,
+},
+{
+format: 'snorm8x4',
+offset: 10764,
+shaderLocation: 0,
+},
+{
+format: 'float16x4',
+offset: 25624,
+shaderLocation: 2,
+},
+{
+format: 'sint16x2',
+offset: 17408,
+shaderLocation: 11,
+},
+{
+format: 'sint32',
+offset: 21404,
+shaderLocation: 6,
+},
+{
+format: 'uint16x4',
+offset: 21380,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 2132,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 1076,
+shaderLocation: 4,
+},
+{
+format: 'float32x4',
+offset: 1364,
+shaderLocation: 17,
+},
+{
+format: 'sint16x4',
+offset: 700,
+shaderLocation: 20,
+},
+{
+format: 'snorm8x4',
+offset: 964,
+shaderLocation: 12,
+},
+{
+format: 'uint16x4',
+offset: 384,
+shaderLocation: 14,
+},
+{
+format: 'unorm16x4',
+offset: 1052,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 26684,
+attributes: [
+
+],
+},
+{
+arrayStride: 22484,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x4',
+offset: 14380,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule3,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16float',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'keep',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'zero',
+depthFailOp: 'replace',
+},
+stencilReadMask: 1530,
+stencilWriteMask: 2146,
+depthBiasSlopeScale: 57,
+depthBiasClamp: 4,
+},
+}
+);
+document.body.prepend(canvas0);
+try {
+device0.label = '\u6274\u{1f668}\u0802\u{1fdb4}\u{1f860}';
+} catch {}
+let shaderModule4 = device0.createShaderModule(
+{
+label: '\uacf0\u{1fe08}\u266b\ucc14\u0645\u00aa',
+code: `@group(1) @binding(619)
+var<storage, read_write> parameter1: array<u32>;
+@group(0) @binding(1264)
+var<storage, read_write> global3: array<u32>;
+@group(1) @binding(1264)
+var<storage, read_write> i2: array<u32>;
+@group(1) @binding(1287)
+var<storage, read_write> parameter2: array<u32>;
+@group(0) @binding(1287)
+var<storage, read_write> function1: array<u32>;
+
+@compute @workgroup_size(4, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S7 {
+@builtin(sample_mask) f0: u32,
+@builtin(sample_index) f1: u32
+}
+struct FragmentOutput0 {
+@location(2) f0: vec3<i32>,
+@location(4) f1: i32
+}
+
+@fragment
+fn fragment0(a0: S7, @builtin(front_facing) a1: bool, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S6 {
+@builtin(instance_index) f0: u32,
+@builtin(vertex_index) f1: u32,
+@location(17) f2: vec2<i32>,
+@location(20) f3: vec4<u32>,
+@location(4) f4: vec3<i32>,
+@location(7) f5: vec3<i32>,
+@location(19) f6: vec3<u32>,
+@location(12) f7: vec2<i32>,
+@location(8) f8: vec3<u32>,
+@location(10) f9: vec4<f32>,
+@location(16) f10: vec4<u32>,
+@location(15) f11: vec4<u32>,
+@location(5) f12: vec3<f32>,
+@location(9) f13: f32,
+@location(21) f14: vec4<i32>,
+@location(13) f15: vec3<f16>,
+@location(0) f16: vec4<u32>,
+@location(1) f17: f32,
+@location(11) f18: vec2<i32>,
+@location(14) f19: vec3<i32>,
+@location(2) f20: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(18) a0: vec2<f32>, a1: S6, @location(6) a2: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+}
+);
+let texture11 = device0.createTexture(
+{
+label: '\u{1ff4a}\ud7e9\u{1fd91}\u0e9f',
+size: [56, 24, 1],
+format: 'astc-8x6-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-8x6-unorm-srgb',
+'astc-8x6-unorm-srgb',
+'astc-8x6-unorm-srgb'
+],
+}
+);
+let renderBundleEncoder9 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg16sint',
+'r32sint',
+'rgb10a2unorm',
+'r8uint',
+'rgba32float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 696,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+let externalTexture1 = device0.importExternalTexture(
+{
+label: '\u0229\u{1fe1c}\u{1f654}\ud1b9',
+source: videoFrame1,
+colorSpace: 'srgb',
+}
+);
+try {
+commandEncoder3.clearBuffer(
+buffer0
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline9 = device0.createComputePipeline(
+{
+label: '\u{1f8aa}\ud854\u9b31\u4866',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageData1 = new ImageData(204, 16);
+let querySet5 = device0.createQuerySet({
+label: '\u{1f9a6}\u4189',
+type: 'occlusion',
+count: 4064,
+});
+let commandEncoder6 = device0.createCommandEncoder();
+let commandBuffer0 = commandEncoder2.finish(
+{
+}
+);
+let renderBundleEncoder10 = device0.createRenderBundleEncoder(
+{
+label: '\u{1fd9b}\ue1d0\u03b9\u24f7',
+colorFormats: [
+'rgb10a2uint'
+],
+sampleCount: 844,
+}
+);
+try {
+renderBundleEncoder4.setVertexBuffer(
+55,
+undefined,
+2448845835
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture1,
+  mipLevel: 1,
+  origin: { x: 48, y: 0, z: 16 },
+  aspect: 'all',
+},
+new Int16Array(new ArrayBuffer(48)),
+/* required buffer size: 991516 */{
+offset: 796,
+bytesPerRow: 1152,
+rowsPerImage: 172,
+},
+{width: 218, height: 0, depthOrArrayLayers: 6}
+);
+} catch {}
+let texture12 = device0.createTexture(
+{
+label: '\u7729\u{1fe2f}\u0294\udbe1',
+size: [8129],
+dimension: '1d',
+format: 'r8sint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'r8sint',
+'r8sint'
+],
+}
+);
+let textureView5 = texture6.createView(
+{
+label: '\u{1f895}\u{1f78c}\ud935\u5774\u{1fe90}\u0750\u7ac4\u4c6f\u75f2\u5c92',
+dimension: '2d-array',
+baseMipLevel: 3,
+mipLevelCount: 1,
+}
+);
+try {
+renderBundleEncoder6.setVertexBuffer(
+60,
+undefined,
+3222400463,
+373876601
+);
+} catch {}
+let pipeline10 = device0.createRenderPipeline(
+{
+label: '\u0a2e\udbb8\u5745\u72d9\u{1fdde}\u0b17\u{1f701}\u{1fd40}\u0952\u00b8',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 18052,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x4',
+offset: 7872,
+shaderLocation: 18,
+},
+{
+format: 'unorm16x4',
+offset: 17464,
+shaderLocation: 16,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 2948,
+shaderLocation: 0,
+},
+{
+format: 'float32x4',
+offset: 14488,
+shaderLocation: 21,
+}
+],
+},
+{
+arrayStride: 28808,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 28700,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x4',
+offset: 24864,
+shaderLocation: 15,
+},
+{
+format: 'float16x4',
+offset: 15728,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 6204,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 4316,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 3055,
+depthBias: 31,
+depthBiasSlopeScale: 51,
+depthBiasClamp: 45,
+},
+}
+);
+let bindGroupLayout3 = pipeline4.getBindGroupLayout(0);
+let renderBundleEncoder11 = device0.createRenderBundleEncoder(
+{
+label: '\ucacf\u09a0',
+colorFormats: [
+'rgba16sint',
+'rgba8sint',
+undefined
+],
+sampleCount: 217,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder5.setVertexBuffer(
+19,
+undefined,
+1331799770
+);
+} catch {}
+try {
+commandEncoder5.copyTextureToTexture(
+{
+  texture: texture4,
+  mipLevel: 4,
+  origin: { x: 4, y: 1, z: 185 },
+  aspect: 'all',
+},
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 1615, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 3, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let canvas4 = document.createElement('canvas');
+let texture13 = device0.createTexture(
+{
+label: '\u{1fddf}\u7db0\u7cd0\u{1ff61}\uce80\u{1f617}\ue5a2\u7ab3\u{1fb09}\u{1f6b1}\u5a39',
+size: {width: 142, height: 1, depthOrArrayLayers: 196},
+mipLevelCount: 8,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+commandEncoder3.clearBuffer(
+buffer0,
+2912
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let promise2 = adapter1.requestDevice({
+label: '\u23b2\u9088\u17c6\u{1fee1}\ubd3a\uf8cd\u05dc\u1db2\u0022\u0fc9\uca0f',
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 9,
+maxColorAttachmentBytesPerSample: 53,
+maxVertexAttributes: 19,
+maxVertexBufferArrayStride: 65242,
+maxStorageTexturesPerShaderStage: 40,
+maxStorageBuffersPerShaderStage: 25,
+maxDynamicStorageBuffersPerPipelineLayout: 17172,
+maxBindingsPerBindGroup: 3749,
+maxTextureArrayLayers: 256,
+maxTextureDimension1D: 11208,
+maxTextureDimension2D: 15930,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 21732000,
+maxUniformBuffersPerShaderStage: 20,
+maxInterStageShaderVariables: 94,
+maxInterStageShaderComponents: 100,
+maxSamplersPerShaderStage: 19,
+},
+});
+let commandEncoder7 = device0.createCommandEncoder(
+{
+label: '\uc7bc\ub8c9\u4255\u{1f668}\ue4a5\u74ed\u0a5e\u0983\udb44',
+}
+);
+let commandBuffer1 = commandEncoder6.finish(
+{
+}
+);
+let renderPassEncoder0 = commandEncoder5.beginRenderPass(
+{
+label: '\u97a3\u008f\u08c4\u0be7\u{1f81c}\u881d\ud29e',
+colorAttachments: [
+{
+view: textureView5,
+clearValue: { r: 33.92, g: 385.1, b: -85.06, a: -748.4, },
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet1,
+maxDrawCount: 39456,
+}
+);
+try {
+buffer1.unmap();
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder();
+let sampler11 = device0.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 92.689,
+lodMaxClamp: 93.372,
+maxAnisotropy: 12,
+}
+);
+let externalTexture2 = device0.importExternalTexture(
+{
+label: '\u8701\u8236\u0395\u09c4\ua54b\u641a\u9cfe\u4caf\u0081\u0d90',
+source: videoFrame2,
+colorSpace: 'srgb',
+}
+);
+let promise3 = device0.createComputePipelineAsync(
+{
+label: '\u{1fb42}\u0fd1\u0120\u{1f640}\u{1f79a}\u6f2d\uf285\u0216\ue2fd\u0be5\u1dcf',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let bindGroupLayout4 = device0.createBindGroupLayout(
+{
+label: '\u4349\u22ee\u2e9c\u4438\u182c\uccea\u6971\uce28',
+entries: [
+{
+binding: 1025,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+try {
+renderPassEncoder0.setStencilReference(
+1888
+);
+} catch {}
+try {
+commandEncoder4.clearBuffer(
+buffer0
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 3490, y: 1, z: 1 },
+  aspect: 'all',
+},
+new BigUint64Array(new ArrayBuffer(80)),
+/* required buffer size: 500 */{
+offset: 500,
+rowsPerImage: 276,
+},
+{width: 2349, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let canvas5 = document.createElement('canvas');
+try {
+canvas4.getContext('bitmaprenderer');
+} catch {}
+try {
+renderBundle4.label = '\u2585\u0fdd\u035e\u5d24\u{1f6e6}\uda96';
+} catch {}
+let querySet6 = device0.createQuerySet({
+label: '\u0cd0\u79c5\u0c61\u2c87\u7f22\u97c5\ufa74\u071f\u1fe8\u1c4f',
+type: 'occlusion',
+count: 2952,
+});
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(
+1658
+);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(
+4,
+undefined
+);
+} catch {}
+try {
+commandEncoder3.copyTextureToTexture(
+{
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 453, y: 19, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 2,
+  origin: { x: 0, y: 40, z: 0 },
+  aspect: 'all',
+},
+{width: 2314, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 656, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Float32Array(new ArrayBuffer(56)),
+/* required buffer size: 361 */{
+offset: 361,
+},
+{width: 1956, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline11 = device0.createRenderPipeline(
+{
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 20476,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 20232,
+shaderLocation: 20,
+},
+{
+format: 'float32x3',
+offset: 11024,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 9980,
+attributes: [
+{
+format: 'unorm16x4',
+offset: 9588,
+shaderLocation: 17,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 5016,
+shaderLocation: 19,
+},
+{
+format: 'uint8x4',
+offset: 1800,
+shaderLocation: 6,
+},
+{
+format: 'sint32x2',
+offset: 6912,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 24340,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x2',
+offset: 2470,
+shaderLocation: 0,
+},
+{
+format: 'uint16x2',
+offset: 18244,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 3116,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 1388,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 8192,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 1376,
+shaderLocation: 7,
+},
+{
+format: 'uint16x4',
+offset: 5184,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 34720,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 880,
+shaderLocation: 10,
+},
+{
+format: 'sint8x2',
+offset: 8530,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 17044,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 4294,
+shaderLocation: 3,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+}
+],
+},
+}
+);
+let renderBundle10 = renderBundleEncoder11.finish(
+{
+label: '\u0714\u0cc1'
+}
+);
+let sampler12 = device0.createSampler(
+{
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 73.629,
+lodMaxClamp: 84.414,
+}
+);
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(
+47,
+undefined,
+1621990566
+);
+} catch {}
+try {
+computePassEncoder0.pushDebugGroup(
+'\u7b60'
+);
+} catch {}
+let bindGroupLayout5 = device0.createBindGroupLayout(
+{
+label: '\u65c1\u{1fd10}\ube68\ud8cc\u{1f96b}\u5fe0\u{1fb23}\ua738',
+entries: [
+{
+binding: 644,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+},
+{
+binding: 636,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba32float', access: 'read-only', viewDimension: '2d-array' },
+},
+{
+binding: 1467,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32sint', access: 'write-only', viewDimension: '1d' },
+}
+],
+}
+);
+let bindGroup0 = device0.createBindGroup({
+label: '\u0212\uc2c9\u5a1b',
+layout: bindGroupLayout4,
+entries: [
+{
+binding: 1025,
+resource: externalTexture0
+}
+],
+});
+let querySet7 = device0.createQuerySet({
+label: '\u4ff8\u4314',
+type: 'occlusion',
+count: 3459,
+});
+let texture14 = device0.createTexture(
+{
+size: {width: 62, height: 1, depthOrArrayLayers: 255},
+dimension: '3d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16sint',
+'rgba16sint'
+],
+}
+);
+try {
+renderBundleEncoder5.setVertexBuffer(
+62,
+undefined,
+3124137207
+);
+} catch {}
+try {
+commandEncoder4.clearBuffer(
+buffer0
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer1,
+commandBuffer0,
+]);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule5 = device0.createShaderModule(
+{
+label: '\uf66a\ud457\u326a\u{1f82f}\u6f4d\u476c\ue0a4\u{1fdf7}\u5705\ue539',
+code: `@group(0) @binding(1287)
+var<storage, read_write> type0: array<u32>;
+@group(0) @binding(1264)
+var<storage, read_write> function2: array<u32>;
+@group(0) @binding(619)
+var<storage, read_write> parameter3: array<u32>;
+
+@compute @workgroup_size(6, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(3) f0: vec3<u32>,
+@builtin(sample_mask) f1: u32,
+@location(6) f2: vec3<i32>,
+@location(0) f3: vec2<f32>,
+@builtin(frag_depth) f4: f32,
+@location(4) f5: i32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(sample_mask) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(12) a0: vec3<u32>, @location(15) a1: vec3<i32>, @location(3) a2: vec4<u32>, @location(6) a3: vec4<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder9 = device0.createCommandEncoder();
+try {
+commandEncoder4.clearBuffer(
+buffer0
+);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let commandBuffer2 = commandEncoder8.finish(
+{
+label: '\u7abc\u8d22',
+}
+);
+let textureView6 = texture11.createView(
+{
+label: '\u95c0\ud938\u{1fe6b}\u{1fd83}',
+format: 'astc-8x6-unorm-srgb',
+baseMipLevel: 0,
+}
+);
+let renderBundleEncoder12 = device0.createRenderBundleEncoder(
+{
+label: '\u{1f8a6}\u0442\u8b48',
+colorFormats: [
+'r16sint',
+'bgra8unorm-srgb',
+'rg32uint',
+'rg16sint',
+'rgb10a2uint',
+'rgb10a2unorm',
+'rgba32sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 391,
+stencilReadOnly: false,
+}
+);
+let renderBundle11 = renderBundleEncoder11.finish(
+{
+label: '\u0dbb\u{1fc34}\uf638'
+}
+);
+try {
+renderBundleEncoder12.setBindGroup(
+0,
+bindGroup0,
+new Uint32Array(1536),
+1286,
+0
+);
+} catch {}
+try {
+adapter1.label = '\u0c3b\uda5f';
+} catch {}
+let bindGroupLayout6 = device0.createBindGroupLayout(
+{
+label: '\u{1fd59}\u795e\u{1fd11}\u36fc\u{1fe72}\u2ba6\u{1fc1c}',
+entries: [
+{
+binding: 344,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+let bindGroup1 = device0.createBindGroup({
+label: '\u{1fbb3}\u03ed\u0885\u862d\u391f\ua8ec',
+layout: bindGroupLayout4,
+entries: [
+{
+binding: 1025,
+resource: externalTexture1
+}
+],
+});
+let querySet8 = device0.createQuerySet({
+label: '\u{1fb43}\u0c87\u0ef3\ubbbb\u{1f6e1}',
+type: 'occlusion',
+count: 1871,
+});
+let renderBundle12 = renderBundleEncoder4.finish(
+{
+label: '\uc648\u{1ffd1}\u08a5\u076a\ucc52\u66d6\u08c9\ue1a2'
+}
+);
+try {
+renderBundleEncoder10.setBindGroup(
+1,
+bindGroup0
+);
+} catch {}
+let imageData2 = new ImageData(248, 212);
+try {
+canvas5.getContext('webgl2');
+} catch {}
+let textureView7 = texture13.createView(
+{
+dimension: '2d',
+baseMipLevel: 7,
+mipLevelCount: 1,
+baseArrayLayer: 99,
+}
+);
+let arrayBuffer0 = buffer0.getMappedRange(
+0,
+12448
+);
+let commandBuffer3 = commandEncoder9.finish(
+{
+}
+);
+let computePassEncoder2 = commandEncoder7.beginComputePass();
+let renderPassEncoder1 = commandEncoder4.beginRenderPass(
+{
+label: '\u04f8\u136d\u{1f875}\u8376\u0474\ufad5\u{1f75c}\u{1fd70}\u{1fab0}\ub507\u03e5',
+colorAttachments: [
+undefined,
+{
+view: textureView5,
+clearValue: { r: 349.0, g: 162.2, b: -855.1, a: -517.0, },
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet7,
+maxDrawCount: 11160,
+}
+);
+let renderBundleEncoder13 = device0.createRenderBundleEncoder(
+{
+label: '\u97b4\u035d\u{1fef8}\u57bd\u0a6e\ub146\u95e1',
+colorFormats: [
+'r8unorm'
+],
+sampleCount: 321,
+stencilReadOnly: true,
+}
+);
+let renderBundle13 = renderBundleEncoder12.finish();
+let sampler13 = device0.createSampler(
+{
+label: '\ud9e4\u{1f8bd}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 75.117,
+lodMaxClamp: 95.060,
+}
+);
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(
+2,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(3173);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(
+96,
+undefined,
+1490224732,
+290200025
+);
+} catch {}
+let arrayBuffer1 = buffer0.getMappedRange(
+12448,
+96
+);
+let pipeline12 = device0.createComputePipeline(
+{
+label: '\uce2a\ud649\u{1f7e3}\udb7d\u0614',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let device1 = await adapter2.requestDevice({
+label: '\uf67f\u40db\u0e9f\u0a2c\ud37d\u083c\u024d\u1731\u594d\u{1ffba}',
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 51,
+maxVertexAttributes: 20,
+maxVertexBufferArrayStride: 7601,
+maxStorageTexturesPerShaderStage: 8,
+maxStorageBuffersPerShaderStage: 9,
+maxDynamicStorageBuffersPerPipelineLayout: 51878,
+maxBindingsPerBindGroup: 8679,
+maxTextureDimension1D: 15753,
+maxTextureDimension2D: 15584,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 128700188,
+maxUniformBuffersPerShaderStage: 21,
+maxInterStageShaderVariables: 73,
+maxInterStageShaderComponents: 76,
+maxSamplersPerShaderStage: 18,
+},
+});
+let buffer2 = device0.createBuffer(
+{
+size: 24374,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let commandEncoder10 = device0.createCommandEncoder(
+{
+}
+);
+let querySet9 = device0.createQuerySet({
+label: '\u6fa1\u{1fc5f}\ua69b\u0e1c\u388a\u{1fc92}\u13c5\ua068\u0d63',
+type: 'occlusion',
+count: 3263,
+});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder(
+{
+label: '\u0426\u0973\u2008\ucdc2\u{1fe4f}\u{1ff35}\u9be7\u014d\u1ec8\u015c',
+colorFormats: [
+'rg16float',
+'rg16sint',
+'rgba32uint',
+'rg8uint',
+'rg32sint',
+'rg32uint',
+'r32uint'
+],
+sampleCount: 513,
+stencilReadOnly: true,
+}
+);
+let sampler14 = device0.createSampler(
+{
+label: '\u41b3\u0de0\u025a\u053c\u63ee\u2155\ufe17',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 71.659,
+lodMaxClamp: 82.053,
+}
+);
+try {
+renderPassEncoder1.setViewport(
+0.6724,
+10.85,
+0.3148,
+1.482,
+0.1486,
+0.5206
+);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(
+3,
+bindGroup1
+);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let textureView8 = texture1.createView(
+{
+format: 'rg16sint',
+}
+);
+let renderBundle14 = renderBundleEncoder14.finish(
+{
+label: '\u5d68\u2505\u{1f841}\u9db9\u0229\u0e36'
+}
+);
+try {
+renderBundleEncoder13.setBindGroup(
+0,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(
+54,
+undefined,
+2015933850,
+1784634238
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8uint',
+'r32uint'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let pipeline13 = await promise3;
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let querySet10 = device1.createQuerySet({
+label: '\ud553\u0736\u8cc5\ucf2f',
+type: 'occlusion',
+count: 2308,
+});
+let video0 = await videoWithData();
+let sampler15 = device1.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+lodMaxClamp: 85.582,
+}
+);
+canvas2.height = 395;
+let commandEncoder11 = device1.createCommandEncoder();
+let computePassEncoder3 = commandEncoder11.beginComputePass();
+let canvas6 = document.createElement('canvas');
+let computePassEncoder4 = commandEncoder7.beginComputePass(
+{
+
+}
+);
+try {
+renderPassEncoder1.setStencilReference(
+760
+);
+} catch {}
+try {
+texture3.destroy();
+} catch {}
+try {
+await buffer2.mapAsync(
+GPUMapMode.READ,
+18760,
+4316
+);
+} catch {}
+try {
+commandEncoder10.copyTextureToTexture(
+{
+  texture: texture4,
+  mipLevel: 2,
+  origin: { x: 5, y: 28, z: 156 },
+  aspect: 'all',
+},
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 90, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 6, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture11,
+  mipLevel: 0,
+  origin: { x: 0, y: 6, z: 1 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer0),
+/* required buffer size: 74 */{
+offset: 74,
+rowsPerImage: 159,
+},
+{width: 48, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline14 = await device0.createRenderPipelineAsync(
+{
+label: '\u054d\ud4c0\u0464\u{1fe93}\u8c1d\u862f\u33da',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule4,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 4188,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x2',
+offset: 1710,
+shaderLocation: 21,
+},
+{
+format: 'uint8x4',
+offset: 2200,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 4792,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 4380,
+shaderLocation: 10,
+},
+{
+format: 'sint8x4',
+offset: 484,
+shaderLocation: 17,
+},
+{
+format: 'unorm16x2',
+offset: 2412,
+shaderLocation: 2,
+},
+{
+format: 'sint16x2',
+offset: 3584,
+shaderLocation: 12,
+},
+{
+format: 'float32x3',
+offset: 2560,
+shaderLocation: 6,
+},
+{
+format: 'uint32x3',
+offset: 2040,
+shaderLocation: 8,
+},
+{
+format: 'float32x2',
+offset: 1124,
+shaderLocation: 1,
+},
+{
+format: 'snorm8x4',
+offset: 2072,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 304,
+attributes: [
+{
+format: 'sint8x4',
+offset: 40,
+shaderLocation: 4,
+},
+{
+format: 'uint8x4',
+offset: 28,
+shaderLocation: 20,
+},
+{
+format: 'sint32x4',
+offset: 144,
+shaderLocation: 7,
+},
+{
+format: 'uint32x2',
+offset: 272,
+shaderLocation: 19,
+},
+{
+format: 'uint8x4',
+offset: 104,
+shaderLocation: 15,
+},
+{
+format: 'float16x2',
+offset: 204,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 18428,
+attributes: [
+{
+format: 'snorm8x2',
+offset: 14330,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 18880,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 32,
+shaderLocation: 0,
+},
+{
+format: 'unorm16x4',
+offset: 6804,
+shaderLocation: 5,
+},
+{
+format: 'sint16x2',
+offset: 5876,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 4304,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 2988,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 708,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule4,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+undefined,
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+undefined,
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.BLUE,
+},
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'invert',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-wrap',
+passOp: 'invert',
+},
+stencilWriteMask: 3605,
+depthBias: 31,
+depthBiasSlopeScale: 51,
+depthBiasClamp: 45,
+},
+}
+);
+let gpuCanvasContext3 = canvas6.getContext('webgpu');
+let bindGroupLayout7 = device0.createBindGroupLayout(
+{
+label: '\u{1fe88}\u0e6f\u{1f673}\u05a8\u9338\u{1f7da}\u{1f8e8}\u0db7\u6663\u{1f948}\u026d',
+entries: [
+
+],
+}
+);
+let commandEncoder12 = device0.createCommandEncoder(
+{
+label: '\u{1fe6c}\u{1fd11}\u072d',
+}
+);
+let querySet11 = device0.createQuerySet({
+label: '\u{1ff4a}\u6941\u9293\u2e90\u9d93\u9ae2\ud93e\u82f3\u0269\u{1fb35}\u0584',
+type: 'occlusion',
+count: 1939,
+});
+try {
+renderPassEncoder1.setScissorRect(
+2,
+6,
+0,
+4
+);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(
+683
+);
+} catch {}
+gc();
+let adapter3 = await navigator.gpu.requestAdapter(
+{
+powerPreference: 'high-performance',
+}
+);
+let renderPassEncoder2 = commandEncoder3.beginRenderPass(
+{
+label: '\ufff9\u0c2d',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+{
+view: textureView5,
+clearValue: { r: -451.5, g: 739.3, b: -157.0, a: -197.2, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+undefined
+],
+occlusionQuerySet: querySet1,
+maxDrawCount: 41600,
+}
+);
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+0,
+1,
+1,
+9
+);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(
+0,
+bindGroup0,
+new Uint32Array(2947),
+1640,
+0
+);
+} catch {}
+let device2 = await promise2;
+let texture15 = device0.createTexture(
+{
+label: '\u{1fc09}\u0c78\u817f\udb22',
+size: [240, 100, 1],
+mipLevelCount: 2,
+format: 'astc-5x5-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-5x5-unorm-srgb',
+'astc-5x5-unorm-srgb'
+],
+}
+);
+let renderBundleEncoder15 = device0.createRenderBundleEncoder(
+{
+label: '\ufb60\u28ae\u040c\u2519\u082e\uf2ad\u02d1\uf108\u{1f84f}',
+colorFormats: [
+'rg32uint',
+'rg16float',
+'rgb10a2unorm',
+'r8unorm',
+'rgba8unorm-srgb',
+'rgba8unorm',
+'rgba8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 537,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle15 = renderBundleEncoder4.finish();
+try {
+renderBundleEncoder13.setVertexBuffer(
+13,
+undefined
+);
+} catch {}
+try {
+computePassEncoder4.insertDebugMarker(
+'\u5f09'
+);
+} catch {}
+try {
+gpuCanvasContext3.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8snorm',
+'astc-5x4-unorm-srgb',
+'rgba16float'
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 413, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint8Array(arrayBuffer0),
+/* required buffer size: 292 */{
+offset: 292,
+},
+{width: 342, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let commandEncoder13 = device0.createCommandEncoder(
+{
+label: '\u{1f681}\u{1fd9e}\ud0c2\ud02c\u5eaa\u{1fbc1}\u{1fde8}\u294b\u8a40\u{1fdaf}\uf79d',
+}
+);
+let sampler16 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 38.592,
+lodMaxClamp: 41.025,
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder2.setScissorRect(
+2,
+12,
+0,
+2
+);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(
+1584
+);
+} catch {}
+try {
+renderPassEncoder1.setViewport(
+0.1154,
+7.296,
+0.5509,
+6.144,
+0.9968,
+0.9975
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+texture1.destroy();
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 1989, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Float32Array(arrayBuffer1),
+/* required buffer size: 705 */{
+offset: 705,
+},
+{width: 120, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline15 = await device0.createComputePipelineAsync(
+{
+label: '\u0bd1\u{1f627}\u0dbb\u{1fbe0}\u02e4\u0a30\u0fde\u3143\ueb7b\u3549\u10f8',
+layout: 'auto',
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(508, 496);
+let textureView9 = texture14.createView(
+{
+label: '\ua9e8\ua0c3',
+}
+);
+let sampler17 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 82.561,
+lodMaxClamp: 95.217,
+maxAnisotropy: 20,
+}
+);
+try {
+computePassEncoder4.setBindGroup(
+3,
+bindGroup1,
+new Uint32Array(2251),
+2106,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+2,
+5,
+0,
+1
+);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(
+58,
+undefined,
+1766124617,
+1681347829
+);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer2,
+]);
+} catch {}
+try {
+offscreenCanvas1.getContext('webgl');
+} catch {}
+let video1 = await videoWithData();
+let bindGroupLayout8 = device2.createBindGroupLayout(
+{
+label: '\u{1f973}\ub519\u2dfa\ued84\u07a0\u0c93\u0542\u0718\u0469\u{1f6a2}\u068e',
+entries: [
+{
+binding: 2768,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+},
+{
+binding: 175,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+}
+],
+}
+);
+let texture16 = device1.createTexture(
+{
+label: '\u{1ff46}\u{1fe54}\ua5df\u8d86\u0a9f\u30e4',
+size: [9815],
+dimension: '1d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+let textureView10 = texture16.createView(
+{
+mipLevelCount: 1,
+}
+);
+let renderBundleEncoder16 = device1.createRenderBundleEncoder(
+{
+label: '\u96d8\u{1f9c5}\u01f1\u4d21\udb4a',
+colorFormats: [
+'rgb10a2uint',
+'rgba16float',
+'r16uint',
+undefined
+],
+sampleCount: 387,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder16.setVertexBuffer(
+2,
+undefined
+);
+} catch {}
+let buffer3 = device1.createBuffer(
+{
+label: '\u{1fc83}\ubc78\u0fdf\u85f0\u774b\u8210\u0e2e\ua2ee\ua3b4\u59d2\u97ba',
+size: 39787,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let texture17 = device1.createTexture(
+{
+label: '\u3886\u0f9d\ua1cb\u56ab\u5905\ub558',
+size: {width: 1615, height: 1, depthOrArrayLayers: 1009},
+mipLevelCount: 11,
+dimension: '3d',
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+try {
+renderBundleEncoder16.setVertexBuffer(
+2,
+undefined,
+879735905,
+2665254086
+);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let canvas7 = document.createElement('canvas');
+let commandEncoder14 = device1.createCommandEncoder(
+{
+}
+);
+let querySet12 = device1.createQuerySet({
+label: '\u{1f656}\u{1f990}\u{1fd1f}\u{1fab9}',
+type: 'occlusion',
+count: 15,
+});
+let texture18 = device1.createTexture(
+{
+size: {width: 3969},
+dimension: '1d',
+format: 'rg32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32float'
+],
+}
+);
+let computePassEncoder5 = commandEncoder14.beginComputePass(
+{
+label: '\u7202\u54dd\u033e'
+}
+);
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let adapter4 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let commandEncoder15 = device2.createCommandEncoder(
+{
+label: '\u7ab7\u4ec1\u0960',
+}
+);
+let querySet13 = device2.createQuerySet({
+label: '\u{1ff40}\u0906\u{1f6cb}\u9025\uf7c9\u8123\u530c\u0413\udc35',
+type: 'occlusion',
+count: 1703,
+});
+let texture19 = device2.createTexture(
+{
+size: [180, 28, 1],
+mipLevelCount: 8,
+format: 'etc2-rgb8a1unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'etc2-rgb8a1unorm-srgb',
+'etc2-rgb8a1unorm'
+],
+}
+);
+let textureView11 = texture19.createView(
+{
+label: '\u48cf\u26a2\u0dae\u70e1\u0b76',
+format: 'etc2-rgb8a1unorm-srgb',
+}
+);
+let computePassEncoder6 = commandEncoder15.beginComputePass(
+{
+
+}
+);
+gc();
+let commandEncoder16 = device0.createCommandEncoder(
+{
+label: '\u004c\u159c\ua380',
+}
+);
+try {
+renderPassEncoder1.setBindGroup(
+3,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(
+2979
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+await adapter3.requestAdapterInfo();
+} catch {}
+let texture20 = device1.createTexture(
+{
+label: '\u0929\uedcf\u0cef\ua76b\u44d2\u{1f63c}',
+size: [94, 185, 89],
+mipLevelCount: 3,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'depth24plus',
+'depth24plus'
+],
+}
+);
+try {
+await buffer3.mapAsync(
+GPUMapMode.WRITE,
+0,
+3596
+);
+} catch {}
+let canvas8 = document.createElement('canvas');
+let bindGroupLayout9 = device1.createBindGroupLayout(
+{
+entries: [
+{
+binding: 1832,
+visibility: 0,
+sampler: { type: 'filtering' },
+},
+{
+binding: 1199,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+let texture21 = device1.createTexture(
+{
+label: '\u835d\u{1f6a5}\u{1f7ac}\ub624\u69ca\u{1fa8b}\uf244',
+size: {width: 202, height: 249, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView12 = texture20.createView(
+{
+label: '\u63ca\u06d9\ucdea\u06b4\u22d1',
+dimension: '2d',
+baseMipLevel: 2,
+baseArrayLayer: 13,
+arrayLayerCount: 1,
+}
+);
+let renderBundle16 = renderBundleEncoder16.finish(
+{
+label: '\u{1fb4e}\u{1f699}\u3927\uc696\u8a77\u7ee7\u{1f6eb}\u{1fec9}'
+}
+);
+try {
+texture20.destroy();
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture17,
+  mipLevel: 9,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 774 */{
+offset: 766,
+rowsPerImage: 54,
+},
+{width: 2, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let bindGroupLayout10 = device0.createBindGroupLayout(
+{
+entries: [
+
+],
+}
+);
+let buffer4 = device0.createBuffer(
+{
+size: 53793,
+usage: GPUBufferUsage.INDIRECT,
+mappedAtCreation: false,
+}
+);
+let commandBuffer4 = commandEncoder16.finish(
+{
+label: '\u56f0\u33e2\u{1fe3d}\u0d11\u{1fb83}\u0c71\u7347\u{1f92d}\u524d',
+}
+);
+let texture22 = device0.createTexture(
+{
+size: {width: 9565},
+dimension: '1d',
+format: 'rg32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32uint',
+'rg32uint',
+'rg32uint'
+],
+}
+);
+let textureView13 = texture10.createView(
+{
+baseMipLevel: 5,
+baseArrayLayer: 32,
+arrayLayerCount: 49,
+}
+);
+let renderBundleEncoder17 = device0.createRenderBundleEncoder(
+{
+label: '\u{1f657}\u06d1\u38c9\u47c3\ua110',
+colorFormats: [
+'r32uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 198,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle17 = renderBundleEncoder4.finish();
+try {
+renderBundleEncoder5.setVertexBuffer(
+57,
+undefined,
+684891188,
+3139171500
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let renderBundleEncoder18 = device2.createRenderBundleEncoder(
+{
+label: '\u63f0\u9e8a\ue9f1\u063f\u801a\u8690\u550e\ub978',
+colorFormats: [
+'rgba8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 101,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle18 = renderBundleEncoder18.finish(
+{
+label: '\u36e3\u6d8f\u75d7\u0236\u012a\u04da\u8ebd\u4121\u{1f83b}'
+}
+);
+try {
+device2.queue.writeTexture(
+{
+  texture: texture19,
+  mipLevel: 6,
+  origin: { x: 4, y: 4, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 859 */{
+offset: 859,
+rowsPerImage: 23,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let video2 = await videoWithData();
+try {
+sampler15.label = '\u079b\u6935\udca9\u{1fd12}\u7246\u0270\u0cbc\uf369\u3b39\u2186';
+} catch {}
+let pipelineLayout3 = device1.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout9,
+bindGroupLayout9,
+bindGroupLayout9,
+bindGroupLayout9,
+bindGroupLayout9,
+bindGroupLayout9,
+bindGroupLayout9,
+bindGroupLayout9
+]
+}
+);
+let commandEncoder17 = device1.createCommandEncoder(
+{
+label: '\u{1fda5}\u2498\u7edf\u5c8c\uab36\uc736\u1dcb\ubd0e\u02b1',
+}
+);
+let texture23 = device1.createTexture(
+{
+size: {width: 1501, height: 1, depthOrArrayLayers: 216},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+let renderPassEncoder3 = commandEncoder17.beginRenderPass(
+{
+label: '\u65aa\u052e',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView12,
+depthClearValue: -2.3715811295008855,
+depthLoadOp: 'load',
+depthStoreOp: 'discard',
+stencilClearValue: 39448,
+},
+occlusionQuerySet: querySet10,
+maxDrawCount: 190600,
+}
+);
+let renderBundleEncoder19 = device1.createRenderBundleEncoder(
+{
+label: '\u{1fd93}\ua64e\u1e81\u2e91\u6007',
+colorFormats: [
+'rg16uint',
+'rgba32sint'
+],
+sampleCount: 831,
+stencilReadOnly: false,
+}
+);
+let renderBundle19 = renderBundleEncoder19.finish(
+{
+label: '\uc23c\u0c08\u0220\ub19f\u0aa2\u98f4\u06c3'
+}
+);
+try {
+renderPassEncoder3.setStencilReference(
+1678
+);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+computePassEncoder3.insertDebugMarker(
+'\ucf66'
+);
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+colorSpace: 'srgb',
+}
+);
+} catch {}
+let gpuCanvasContext4 = canvas8.getContext('webgpu');
+video2.height = 230;
+let pipelineLayout4 = device2.createPipelineLayout(
+{
+label: '\ua7a9\u{1f802}\u{1faee}\u{1fbfb}\u{1ff66}\u{1fe2c}\u{1fc27}\uf2f8',
+bindGroupLayouts: [
+bindGroupLayout8,
+bindGroupLayout8,
+bindGroupLayout8,
+bindGroupLayout8,
+bindGroupLayout8
+]
+}
+);
+let renderBundle20 = renderBundleEncoder18.finish(
+{
+label: '\u0435\u09f4\u4e62\u49ce\u5ce4\u708c\u0ddf\u0597'
+}
+);
+let sampler18 = device2.createSampler(
+{
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 76.580,
+lodMaxClamp: 81.148,
+}
+);
+let offscreenCanvas2 = new OffscreenCanvas(942, 176);
+let texture24 = device2.createTexture(
+{
+label: '\u0bfc\u{1fdf6}\u0b6f\ubf89\u026a',
+size: [15111, 122, 14],
+mipLevelCount: 6,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'stencil8',
+'stencil8'
+],
+}
+);
+try {
+device2.queue.writeTexture(
+{
+  texture: texture19,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 429 */{
+offset: 429,
+bytesPerRow: 130,
+},
+{width: 4, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+canvas8.height = 892;
+try {
+computePassEncoder4.setBindGroup(
+2,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(2097);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+0.9693,
+9.360,
+0.4791,
+3.205,
+0.07005,
+0.9627
+);
+} catch {}
+try {
+commandEncoder12.clearBuffer(
+buffer2,
+2592,
+20136
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+renderBundleEncoder17.insertDebugMarker(
+'\u842d'
+);
+} catch {}
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(
+3467
+);
+} catch {}
+try {
+renderPassEncoder3.insertDebugMarker(
+'\u024e'
+);
+} catch {}
+let gpuCanvasContext5 = offscreenCanvas2.getContext('webgpu');
+let querySet14 = device0.createQuerySet({
+type: 'occlusion',
+count: 1509,
+});
+let textureView14 = texture4.createView(
+{
+label: '\u702d\u{1fcfe}\uf836\u02e6\u01ba\ub9e5\u{1feeb}\u{1f9b8}\uce6d',
+dimension: '2d',
+baseMipLevel: 4,
+baseArrayLayer: 85,
+}
+);
+let renderBundleEncoder20 = device0.createRenderBundleEncoder(
+{
+label: '\uafb7\ub712\ubbaf\u8532\u0258',
+colorFormats: [
+'rgba32uint',
+undefined
+],
+sampleCount: 89,
+}
+);
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+let pipeline16 = device0.createComputePipeline(
+{
+label: '\u{1fe1f}\u6d90\u{1fb09}\u050e\u0ddc\uab3c\u0664\u{1fffd}\u5343\ue95b\u432a',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+}
+);
+try {
+device0.destroy();
+} catch {}
+let shaderModule6 = device1.createShaderModule(
+{
+label: '\u0ee6\uaf62\u00db\u{1fa85}\u0a4e\u0a89\ua651\u0440\ud10c\u0045\u{1ffcd}',
+code: `@group(5) @binding(1832)
+var<storage, read_write> type1: array<u32>;
+@group(6) @binding(1199)
+var<storage, read_write> global4: array<u32>;
+@group(0) @binding(1199)
+var<storage, read_write> i3: array<u32>;
+@group(7) @binding(1832)
+var<storage, read_write> field2: array<u32>;
+@group(3) @binding(1199)
+var<storage, read_write> function3: array<u32>;
+@group(4) @binding(1199)
+var<storage, read_write> function4: array<u32>;
+@group(5) @binding(1199)
+var<storage, read_write> type2: array<u32>;
+@group(3) @binding(1832)
+var<storage, read_write> parameter4: array<u32>;
+
+@compute @workgroup_size(1, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(7) f0: vec3<f32>,
+@location(0) f1: vec3<i32>,
+@location(1) f2: u32,
+@location(6) f3: vec4<i32>,
+@location(4) f4: vec3<i32>,
+@location(3) f5: vec2<u32>,
+@location(5) f6: vec2<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S8 {
+@location(6) f0: vec3<i32>,
+@location(1) f1: vec4<f16>,
+@location(2) f2: vec2<f32>,
+@location(19) f3: vec3<u32>,
+@location(14) f4: vec2<f16>,
+@location(5) f5: vec4<i32>,
+@location(8) f6: f32,
+@location(10) f7: vec4<f16>,
+@location(12) f8: u32,
+@location(15) f9: vec2<f32>
+}
+struct VertexOutput0 {
+@location(50) f74: u32,
+@location(53) f75: vec4<f32>,
+@location(0) f76: vec4<u32>,
+@location(47) f77: vec4<i32>,
+@location(12) f78: vec4<u32>,
+@location(3) f79: u32,
+@location(25) f80: vec2<u32>,
+@location(18) f81: vec4<i32>,
+@location(9) f82: vec3<f16>,
+@location(17) f83: i32,
+@location(71) f84: vec2<i32>,
+@location(49) f85: vec3<f32>,
+@location(30) f86: vec4<f32>,
+@location(57) f87: vec3<f16>,
+@location(61) f88: f16,
+@location(15) f89: vec4<u32>,
+@location(38) f90: vec3<u32>,
+@location(26) f91: vec4<f32>,
+@location(29) f92: vec2<i32>,
+@location(7) f93: f16,
+@location(31) f94: vec3<f32>,
+@location(13) f95: f16,
+@builtin(position) f96: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(16) a0: vec4<f16>, @location(13) a1: vec2<f16>, @location(17) a2: vec4<f16>, @location(4) a3: f32, @builtin(instance_index) a4: u32, @builtin(vertex_index) a5: u32, @location(0) a6: f32, a7: S8, @location(7) a8: vec4<i32>, @location(3) a9: vec3<i32>, @location(11) a10: vec4<u32>, @location(9) a11: vec2<f32>, @location(18) a12: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let computePassEncoder7 = commandEncoder11.beginComputePass();
+let renderBundle21 = renderBundleEncoder16.finish(
+{
+label: '\ued3b\udb07\u61a7\u0d90\u6553\u{1fe59}\u135a\u{1f675}'
+}
+);
+try {
+renderPassEncoder3.setScissorRect(
+6,
+11,
+5,
+1
+);
+} catch {}
+let gpuCanvasContext6 = canvas7.getContext('webgpu');
+gc();
+let buffer5 = device2.createBuffer(
+{
+label: '\u0472\u06e3\u{1f67c}\uc039\uaa0c\ub257\u00bd\u5924\u{1f7b4}\u021c\u0490',
+size: 722,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: false,
+}
+);
+let commandEncoder18 = device2.createCommandEncoder(
+{
+label: '\uf24f\u0e26\u0679\ub587\u6f69\u077d\u0f27\u{1fa4e}\u0cfe\ub59c',
+}
+);
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+texture21.label = '\u{1ffbe}\uea77\u0fc1';
+} catch {}
+let bindGroupLayout11 = device1.createBindGroupLayout(
+{
+label: '\ud1d7\u0b70\u{1f694}\u{1fa0c}\ue17d\u6c58\u3888\ub5e6',
+entries: [
+{
+binding: 5363,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+},
+{
+binding: 7532,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+let querySet15 = device1.createQuerySet({
+label: '\ub4d2\ua4f7\ubc2f',
+type: 'occlusion',
+count: 2802,
+});
+try {
+renderPassEncoder3.beginOcclusionQuery(1019);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+buffer3.destroy();
+} catch {}
+pseudoSubmit(device1, commandEncoder17);
+let texture25 = device1.createTexture(
+{
+label: '\u10f6\uc4a5\ue4d6\uef8a\u{1f8b5}\u7b06\u{1fc53}\u08ba\u4aee',
+size: {width: 15048},
+dimension: '1d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'r8uint',
+'r8uint'
+],
+}
+);
+let renderBundleEncoder21 = device1.createRenderBundleEncoder(
+{
+label: '\u0185\u43e6\uf739\ub008',
+colorFormats: [
+'rg16float',
+'rg32sint',
+'rgba8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 520,
+stencilReadOnly: true,
+}
+);
+let renderBundle22 = renderBundleEncoder21.finish(
+{
+label: '\u7ddc\u436c\u5f31\u{1fa78}\ufd85\ud661\u0ef6\u01cd\u62e2\u0244\u{1f927}'
+}
+);
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+device1.pushErrorScope('validation');
+} catch {}
+let pipeline17 = await device1.createComputePipelineAsync(
+{
+label: '\u{1ffcb}\ub537\u066c\u{1f9cd}\u{1f6b9}',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+},
+}
+);
+gc();
+let videoFrame3 = new VideoFrame(canvas3, {timestamp: 0});
+let commandEncoder19 = device2.createCommandEncoder(
+{
+label: '\u252f\ub712\ub94e\u9174\u3dca\u{1fcf7}\u026b\u{1fc61}\u0762',
+}
+);
+let commandBuffer5 = commandEncoder19.finish(
+{
+label: '\udd9b\u4cf4\u9d1f\u0300\u{1f8c5}\uabcb\u0865',
+}
+);
+let texture26 = device2.createTexture(
+{
+label: '\u{1fbbf}\u010a\u6222\udb08\u0f0c\u246f\u{1fab8}\u{1fc39}',
+size: [15315, 246, 1],
+mipLevelCount: 1,
+sampleCount: 4,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let computePassEncoder8 = commandEncoder18.beginComputePass(
+{
+label: '\u3c3a\u3c01\u01b6\u{1f606}\ub665\ucb38\u46f4'
+}
+);
+let renderBundleEncoder22 = device2.createRenderBundleEncoder(
+{
+label: '\u21ce\u26d9\ufcf2\u0203\u0d48\u{1febe}\u2cdd',
+colorFormats: [
+'r16sint',
+'rg8sint',
+undefined,
+'rg11b10ufloat',
+'rgba32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 399,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder22.setVertexBuffer(
+34,
+undefined,
+3551239995
+);
+} catch {}
+let imageData3 = new ImageData(224, 136);
+let bindGroupLayout12 = device2.createBindGroupLayout(
+{
+entries: [
+{
+binding: 1393,
+visibility: 0,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 1303,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+},
+{
+binding: 3670,
+visibility: GPUShaderStage.FRAGMENT,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+let bindGroup2 = device2.createBindGroup({
+layout: bindGroupLayout8,
+entries: [
+{
+binding: 175,
+resource: sampler18
+},
+{
+binding: 2768,
+resource: sampler18
+}
+],
+});
+let renderBundleEncoder23 = device2.createRenderBundleEncoder(
+{
+label: '\u{1f6ec}\ubb76\u6c26\ub08d\uac55\u861b\u497e\u{1f95f}\u4ca4\u37c3',
+colorFormats: [
+'r16float',
+'r16sint',
+'rgba8sint',
+'rgb10a2unorm',
+'r8unorm',
+'r32uint',
+'rg32sint',
+'rg32uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 825,
+depthReadOnly: true,
+}
+);
+let renderBundle23 = renderBundleEncoder23.finish(
+{
+label: '\u{1f906}\u03ab\u{1f9ad}'
+}
+);
+try {
+renderBundleEncoder22.setBindGroup(
+4,
+bindGroup2
+);
+} catch {}
+let pipelineLayout5 = device1.createPipelineLayout(
+{
+label: '\uc3c9\u{1fa56}\u00fb',
+bindGroupLayouts: [
+bindGroupLayout11,
+bindGroupLayout9,
+bindGroupLayout9,
+bindGroupLayout11,
+bindGroupLayout11,
+bindGroupLayout11
+]
+}
+);
+let commandEncoder20 = device1.createCommandEncoder(
+{
+label: '\u3679\ufc1c\u90eb\ud307',
+}
+);
+let querySet16 = device1.createQuerySet({
+label: '\u35f5\u09c0\u0cf6\u{1fd5c}\uce0f\u1aab\u0333\u03f0\u{1fe0c}',
+type: 'occlusion',
+count: 1349,
+});
+let texture27 = device1.createTexture(
+{
+label: '\u0726\u{1fc7b}\u221b\uf2f8\u{1f6de}\u{1f789}\u{1f919}',
+size: {width: 14473, height: 177, depthOrArrayLayers: 24},
+mipLevelCount: 5,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+try {
+computePassEncoder5.setPipeline(
+pipeline17
+);
+} catch {}
+canvas5.width = 21;
+let pipelineLayout6 = device1.createPipelineLayout(
+{
+label: '\u257d\u0b3b\u04c6\uc8f4',
+bindGroupLayouts: [
+bindGroupLayout9,
+bindGroupLayout11,
+bindGroupLayout11,
+bindGroupLayout9,
+bindGroupLayout11,
+bindGroupLayout11
+]
+}
+);
+let renderPassEncoder4 = commandEncoder20.beginRenderPass(
+{
+label: '\u0fc2\u{1fa19}\ud0ed\u0578\u{1fe0e}\u54d8',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView12,
+depthClearValue: 0.2387826659529393,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+depthReadOnly: false,
+stencilClearValue: 65389,
+},
+occlusionQuerySet: querySet15,
+maxDrawCount: 48616,
+}
+);
+let sampler19 = device1.createSampler(
+{
+label: '\uec92\uf4fd\u70f1\u2d3b\ue693\u049b\u{1fb23}\ueac6\u{1f655}\ubc6b',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 99.225,
+lodMaxClamp: 99.581,
+}
+);
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(
+49,
+undefined,
+3199817043,
+766908855
+);
+} catch {}
+document.body.prepend(img0);
+let textureView15 = texture26.createView(
+{
+}
+);
+try {
+computePassEncoder7.setPipeline(
+pipeline17
+);
+} catch {}
+try {
+renderPassEncoder4.end();
+} catch {}
+try {
+computePassEncoder5.pushDebugGroup(
+'\u91bf'
+);
+} catch {}
+let pipeline18 = device1.createComputePipeline(
+{
+label: '\u10da\u{1fe75}\u{1febc}\u0ae4\u2925',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+},
+}
+);
+let img3 = await imageWithData(222, 134, '#8944fcce', '#0ea83fcd');
+let video3 = await videoWithData();
+let shaderModule7 = device2.createShaderModule(
+{
+label: '\u0321\uea19\u{1fa94}\u0262\u0530\u82d2\u10f8\u00b9',
+code: `@group(3) @binding(175)
+var<storage, read_write> i4: array<u32>;
+@group(4) @binding(2768)
+var<storage, read_write> function5: array<u32>;
+@group(2) @binding(175)
+var<storage, read_write> type3: array<u32>;
+@group(3) @binding(2768)
+var<storage, read_write> global5: array<u32>;
+@group(1) @binding(175)
+var<storage, read_write> type4: array<u32>;
+@group(1) @binding(2768)
+var<storage, read_write> global6: array<u32>;
+@group(0) @binding(2768)
+var<storage, read_write> parameter5: array<u32>;
+@group(4) @binding(175)
+var<storage, read_write> i5: array<u32>;
+
+@compute @workgroup_size(2, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(5) f0: vec2<f32>,
+@location(2) f1: vec3<u32>,
+@location(0) f2: vec3<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder21 = device2.createCommandEncoder(
+{
+label: '\u0e60\uc08b\u{1fd59}\u26a6',
+}
+);
+let querySet17 = device2.createQuerySet({
+label: '\u{1f835}\u{1ff59}\u64c9\u0b78\u0249\ue1a3\u07a1',
+type: 'occlusion',
+count: 3782,
+});
+let renderPassEncoder5 = commandEncoder21.beginRenderPass(
+{
+label: '\ud78b\u131a',
+colorAttachments: [
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView15,
+depthLoadOp: 'load',
+depthStoreOp: 'discard',
+depthReadOnly: false,
+stencilLoadOp: 'load',
+stencilStoreOp: 'store',
+},
+occlusionQuerySet: querySet13,
+}
+);
+try {
+renderPassEncoder5.beginOcclusionQuery(797);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(
+3,
+bindGroup2
+);
+} catch {}
+let pipeline19 = await device2.createComputePipelineAsync(
+{
+label: '\u0864\u0c4f\u85f1\u{1fa99}\u548c\u{1f9b8}\u39d4\u09de\u025c',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let bindGroupLayout13 = device1.createBindGroupLayout(
+{
+label: '\u9346\ud590\u00ac\u{1fc36}',
+entries: [
+{
+binding: 5301,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 3079,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32uint', access: 'write-only', viewDimension: '3d' },
+}
+],
+}
+);
+let querySet18 = device1.createQuerySet({
+type: 'occlusion',
+count: 3572,
+});
+pseudoSubmit(device1, commandEncoder11);
+let texture28 = device1.createTexture(
+{
+label: '\u07e9\u0a6f\u7c0b\u0970\u{1f890}',
+size: [12973],
+dimension: '1d',
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView16 = texture27.createView(
+{
+label: '\u938a\u{1fbc2}\u08b6\u0bc4\ud108\u0102\u{1f670}\u055f\u{1f6b2}\u{1ff7a}\u0d10',
+dimension: '2d',
+aspect: 'depth-only',
+baseMipLevel: 2,
+mipLevelCount: 2,
+baseArrayLayer: 3,
+}
+);
+let promise4 = device1.popErrorScope();
+let video4 = await videoWithData();
+let shaderModule8 = device2.createShaderModule(
+{
+label: '\u0522\ub6ee\u{1fb30}\u{1fc99}\u0679\u{1fe75}\u06c9\u03b9\u040d\ud616\u0de1',
+code: `@group(0) @binding(175)
+var<storage, read_write> i6: array<u32>;
+@group(1) @binding(175)
+var<storage, read_write> field3: array<u32>;
+@group(4) @binding(2768)
+var<storage, read_write> parameter6: array<u32>;
+@group(2) @binding(2768)
+var<storage, read_write> field4: array<u32>;
+@group(3) @binding(175)
+var<storage, read_write> global7: array<u32>;
+@group(2) @binding(175)
+var<storage, read_write> function6: array<u32>;
+@group(3) @binding(2768)
+var<storage, read_write> field5: array<u32>;
+@group(1) @binding(2768)
+var<storage, read_write> local2: array<u32>;
+
+@compute @workgroup_size(4, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S10 {
+@location(57) f0: u32,
+@location(19) f1: vec4<i32>,
+@location(48) f2: vec4<f32>,
+@location(89) f3: vec3<f16>,
+@location(50) f4: f32,
+@location(54) f5: vec3<f16>,
+@location(80) f6: f32,
+@builtin(sample_index) f7: u32,
+@location(36) f8: vec4<i32>,
+@location(58) f9: vec3<i32>,
+@location(41) f10: vec2<f32>,
+@location(84) f11: vec4<f32>,
+@location(93) f12: vec2<u32>,
+@location(90) f13: vec4<f32>,
+@location(33) f14: vec2<f16>,
+@location(62) f15: vec4<u32>,
+@location(77) f16: vec4<f16>,
+@location(13) f17: vec2<f16>,
+@builtin(front_facing) f18: bool,
+@location(0) f19: vec2<u32>,
+@location(49) f20: vec2<f32>,
+@location(67) f21: i32
+}
+struct FragmentOutput0 {
+@location(0) f0: vec4<u32>,
+@location(5) f1: vec2<u32>
+}
+
+@fragment
+fn fragment0(@location(91) a0: vec3<f32>, @location(44) a1: vec4<u32>, @location(30) a2: u32, @location(56) a3: vec2<f16>, a4: S10, @location(1) a5: vec4<f16>, @location(68) a6: vec4<i32>, @location(86) a7: vec4<f32>, @builtin(position) a8: vec4<f32>, @location(10) a9: u32, @location(18) a10: i32, @location(34) a11: vec3<i32>, @location(45) a12: vec3<u32>, @location(46) a13: vec4<f32>, @location(39) a14: vec4<u32>, @location(71) a15: vec4<f16>, @location(63) a16: vec4<i32>, @builtin(sample_mask) a17: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S9 {
+@location(10) f0: vec2<u32>,
+@location(1) f1: vec4<f32>,
+@location(0) f2: vec3<i32>,
+@location(9) f3: u32,
+@location(15) f4: vec4<f32>,
+@location(7) f5: vec2<i32>,
+@location(16) f6: vec2<u32>,
+@location(4) f7: vec4<i32>,
+@location(2) f8: f16,
+@location(6) f9: vec3<f16>,
+@location(11) f10: vec2<u32>,
+@location(18) f11: vec2<i32>,
+@location(12) f12: vec2<u32>,
+@location(3) f13: vec3<f16>,
+@location(17) f14: i32,
+@location(5) f15: vec4<f16>
+}
+struct VertexOutput0 {
+@location(36) f97: vec4<i32>,
+@location(33) f98: vec2<f16>,
+@builtin(position) f99: vec4<f32>,
+@location(67) f100: i32,
+@location(50) f101: f32,
+@location(62) f102: vec4<u32>,
+@location(44) f103: vec4<u32>,
+@location(84) f104: vec4<f32>,
+@location(56) f105: vec2<f16>,
+@location(39) f106: vec4<u32>,
+@location(89) f107: vec3<f16>,
+@location(41) f108: vec2<f32>,
+@location(86) f109: vec4<f32>,
+@location(1) f110: vec4<f16>,
+@location(58) f111: vec3<i32>,
+@location(63) f112: vec4<i32>,
+@location(45) f113: vec3<u32>,
+@location(30) f114: u32,
+@location(93) f115: vec2<u32>,
+@location(77) f116: vec4<f16>,
+@location(49) f117: vec2<f32>,
+@location(46) f118: vec4<f32>,
+@location(57) f119: u32,
+@location(10) f120: u32,
+@location(13) f121: vec2<f16>,
+@location(90) f122: vec4<f32>,
+@location(18) f123: i32,
+@location(68) f124: vec4<i32>,
+@location(54) f125: vec3<f16>,
+@location(19) f126: vec4<i32>,
+@location(48) f127: vec4<f32>,
+@location(34) f128: vec3<i32>,
+@location(0) f129: vec2<u32>,
+@location(71) f130: vec4<f16>,
+@location(91) f131: vec3<f32>,
+@location(80) f132: f32
+}
+
+@vertex
+fn vertex0(@location(13) a0: f16, a1: S9, @location(14) a2: vec3<f32>, @builtin(vertex_index) a3: u32, @location(8) a4: vec4<u32>, @builtin(instance_index) a5: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let textureView17 = texture26.createView(
+{
+label: '\ue67e\uc6a5\ufc4e\u05a9\uf24f\u5d4b\u0f95\u0496',
+aspect: 'stencil-only',
+baseArrayLayer: 0,
+}
+);
+try {
+computePassEncoder6.setBindGroup(
+1,
+bindGroup2,
+new Uint32Array(200),
+136,
+0
+);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(
+2,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder22.insertDebugMarker(
+'\uae2d'
+);
+} catch {}
+let pipeline20 = await device2.createRenderPipelineAsync(
+{
+label: '\u{1fbd9}\u0d5d\u84f7\u{1f9af}\u0820\ue6d0\u09d3',
+layout: 'auto',
+vertex: {
+module: shaderModule8,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 49048,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 53480,
+shaderLocation: 12,
+},
+{
+format: 'sint32x3',
+offset: 32700,
+shaderLocation: 4,
+},
+{
+format: 'uint8x2',
+offset: 25010,
+shaderLocation: 10,
+},
+{
+format: 'float32x3',
+offset: 10800,
+shaderLocation: 3,
+},
+{
+format: 'uint32x4',
+offset: 33716,
+shaderLocation: 11,
+},
+{
+format: 'uint32x4',
+offset: 48520,
+shaderLocation: 9,
+},
+{
+format: 'sint32x3',
+offset: 8712,
+shaderLocation: 18,
+},
+{
+format: 'snorm8x4',
+offset: 33836,
+shaderLocation: 15,
+},
+{
+format: 'float32x4',
+offset: 47476,
+shaderLocation: 5,
+},
+{
+format: 'float32x4',
+offset: 700,
+shaderLocation: 13,
+},
+{
+format: 'unorm8x2',
+offset: 51058,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 37760,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x4',
+offset: 17824,
+shaderLocation: 0,
+},
+{
+format: 'sint8x4',
+offset: 604,
+shaderLocation: 7,
+},
+{
+format: 'sint32x3',
+offset: 28488,
+shaderLocation: 17,
+},
+{
+format: 'uint16x2',
+offset: 33764,
+shaderLocation: 8,
+},
+{
+format: 'float32x2',
+offset: 24756,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 44708,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 40600,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 26912,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 25852,
+shaderLocation: 2,
+},
+{
+format: 'uint32x4',
+offset: 12732,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule8,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+undefined,
+undefined,
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.GREEN,
+},
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilWriteMask: 2248,
+depthBias: 16,
+depthBiasSlopeScale: 45,
+},
+}
+);
+try {
+device2.destroy();
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(139, 690);
+let imageBitmap3 = await createImageBitmap(canvas2);
+canvas0.height = 251;
+try {
+adapter3.label = '\u{1ff3f}\u1484\uc2e5\u{1ffdd}\u0aac\u4553\u026e\u{1ffe0}\u0fee';
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let video5 = await videoWithData();
+try {
+offscreenCanvas3.getContext('webgl');
+} catch {}
+try {
+adapter2.label = '\udc83\u400c\u54b8\ude6c\u07b9\u0167';
+} catch {}
+let commandEncoder22 = device1.createCommandEncoder(
+{
+label: '\ud238\u0caf\u{1face}',
+}
+);
+let texture29 = device1.createTexture(
+{
+label: '\u0f54\uaf2e\u3efc\u{1f737}\u1eff\u582d\u0c4b\u1c5f\u{1f883}',
+size: [5024, 171, 1],
+mipLevelCount: 12,
+sampleCount: 1,
+format: 'rg8sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+let textureView18 = texture25.createView(
+{
+label: '\u03a9\u8a83\u0955\u0d2d\ud5b5\u0e83\u21a5\ue788\uda57',
+mipLevelCount: 1,
+}
+);
+let renderPassEncoder6 = commandEncoder22.beginRenderPass(
+{
+label: '\u1cd3\u0c84',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView12,
+depthReadOnly: true,
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet18,
+maxDrawCount: 75328,
+}
+);
+try {
+renderPassEncoder6.setBlendConstant({ r: -564.1, g: 606.5, b: 216.9, a: 839.7, });
+} catch {}
+try {
+renderPassEncoder6.setViewport(
+6.371,
+42.48,
+2.575,
+0.7367,
+0.9892,
+0.9955
+);
+} catch {}
+let pipeline21 = device1.createRenderPipeline(
+{
+label: '\u94bf\udafd\u0047\u0957\u5ad3\u0f5e\u80ec\u0a4c\u03f0\u06b7',
+layout: 'auto',
+vertex: {
+module: shaderModule6,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 3788,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 3132,
+shaderLocation: 18,
+},
+{
+format: 'uint32x2',
+offset: 2844,
+shaderLocation: 12,
+},
+{
+format: 'snorm16x2',
+offset: 2128,
+shaderLocation: 14,
+},
+{
+format: 'float16x4',
+offset: 1904,
+shaderLocation: 4,
+},
+{
+format: 'float32',
+offset: 1464,
+shaderLocation: 0,
+},
+{
+format: 'sint32x4',
+offset: 3044,
+shaderLocation: 3,
+},
+{
+format: 'uint32x3',
+offset: 940,
+shaderLocation: 19,
+},
+{
+format: 'sint8x2',
+offset: 376,
+shaderLocation: 7,
+},
+{
+format: 'float32',
+offset: 3240,
+shaderLocation: 16,
+},
+{
+format: 'sint8x4',
+offset: 2880,
+shaderLocation: 5,
+},
+{
+format: 'float32x2',
+offset: 1152,
+shaderLocation: 17,
+},
+{
+format: 'snorm16x4',
+offset: 2848,
+shaderLocation: 13,
+},
+{
+format: 'snorm16x4',
+offset: 3048,
+shaderLocation: 1,
+},
+{
+format: 'snorm16x2',
+offset: 2772,
+shaderLocation: 8,
+},
+{
+format: 'float16x2',
+offset: 1716,
+shaderLocation: 9,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 788,
+shaderLocation: 15,
+},
+{
+format: 'uint8x4',
+offset: 3292,
+shaderLocation: 11,
+},
+{
+format: 'sint16x4',
+offset: 3288,
+shaderLocation: 6,
+},
+{
+format: 'unorm16x4',
+offset: 3064,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 644,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 5276,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 2784,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+multisample: {
+mask: 0x1d8235c3,
+},
+fragment: {
+module: shaderModule6,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.GREEN,
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r8sint',
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'one-minus-dst',
+dstFactor: 'dst-alpha'
+},
+},
+format: 'rg8unorm',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-wrap',
+},
+stencilWriteMask: 3233,
+depthBias: 1,
+depthBiasSlopeScale: 27,
+depthBiasClamp: 74,
+},
+}
+);
+let offscreenCanvas4 = new OffscreenCanvas(91, 321);
+let imageData4 = new ImageData(12, 140);
+video1.height = 174;
+gc();
+document.body.prepend(img3);
+try {
+offscreenCanvas4.getContext('webgl2');
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+commandEncoder19.label = '\u{1fe85}\u97ba\u0396\u04d4\ue252\u0686\u{1f902}\u482a\u0bd8\u649d\u94c6';
+} catch {}
+let imageBitmap4 = await createImageBitmap(video4);
+gc();
+let imageBitmap5 = await createImageBitmap(video5);
+document.body.prepend(canvas1);
+let imageData5 = new ImageData(112, 148);
+let videoFrame4 = new VideoFrame(video1, {timestamp: 0});
+let offscreenCanvas5 = new OffscreenCanvas(946, 323);
+let querySet19 = device1.createQuerySet({
+label: '\u50e7\u08d3\u0226\u0dce\u3f6b\u{1fdfe}\uefff\uec62\u{1fafb}\u0321',
+type: 'occlusion',
+count: 1477,
+});
+canvas0.height = 384;
+let imageBitmap6 = await createImageBitmap(canvas3);
+let imageData6 = new ImageData(116, 40);
+let video6 = await videoWithData();
+let texture30 = device1.createTexture(
+{
+label: '\u01e9\u{1fdb3}\ua05f\u5a08\u049a\u{1ffbe}\ub1fc\ud32c\u0b54',
+size: {width: 3371, height: 223, depthOrArrayLayers: 50},
+mipLevelCount: 11,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+let promise5 = device1.queue.onSubmittedWorkDone();
+let offscreenCanvas6 = new OffscreenCanvas(188, 398);
+let img4 = await imageWithData(201, 70, '#0434943d', '#72c0a642');
+let offscreenCanvas7 = new OffscreenCanvas(806, 363);
+try {
+await promise4;
+} catch {}
+document.body.prepend(canvas3);
+try {
+adapter2.label = '\ua2f4\u6854\u{1f79f}\u72f8\ud87c\u74a0';
+} catch {}
+let offscreenCanvas8 = new OffscreenCanvas(658, 379);
+let adapter5 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let gpuCanvasContext7 = offscreenCanvas8.getContext('webgpu');
+let bindGroupLayout14 = device1.createBindGroupLayout(
+{
+label: '\uad6b\u7b4f\uc039\u03a0\u{1fe15}\u90b0\u{1f94e}\u0d31',
+entries: [
+{
+binding: 5460,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rg32sint', access: 'write-only', viewDimension: '1d' },
+},
+{
+binding: 6961,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '3d' },
+}
+],
+}
+);
+let querySet20 = device1.createQuerySet({
+type: 'occlusion',
+count: 2432,
+});
+let externalTexture3 = device1.importExternalTexture(
+{
+label: '\u0659\u{1fb07}\u604a\u8125\u{1fbc0}\u09a9\u99f5\u0820\u074f\u{1ff04}\u{1f617}',
+source: video0,
+colorSpace: 'srgb',
+}
+);
+try {
+renderPassEncoder6.setStencilReference(
+490
+);
+} catch {}
+try {
+gpuCanvasContext6.configure(
+{
+device: device1,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let pipeline22 = device1.createComputePipeline(
+{
+label: '\u2107\u9462',
+layout: 'auto',
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+},
+}
+);
+let video7 = await videoWithData();
+try {
+offscreenCanvas7.getContext('2d');
+} catch {}
+let shaderModule9 = device1.createShaderModule(
+{
+label: '\u5249\uf8e0\u0903\u0d74\u47b7\ua8fa\u008f\u0942',
+code: `@group(1) @binding(1199)
+var<storage, read_write> global8: array<u32>;
+@group(4) @binding(7532)
+var<storage, read_write> type5: array<u32>;
+@group(4) @binding(5363)
+var<storage, read_write> global9: array<u32>;
+@group(5) @binding(5363)
+var<storage, read_write> function7: array<u32>;
+@group(0) @binding(5363)
+var<storage, read_write> function8: array<u32>;
+@group(3) @binding(7532)
+var<storage, read_write> type6: array<u32>;
+@group(2) @binding(1199)
+var<storage, read_write> function9: array<u32>;
+@group(1) @binding(1832)
+var<storage, read_write> function10: array<u32>;
+@group(5) @binding(7532)
+var<storage, read_write> global10: array<u32>;
+@group(0) @binding(7532)
+var<storage, read_write> function11: array<u32>;
+@group(3) @binding(5363)
+var<storage, read_write> global11: array<u32>;
+@group(2) @binding(1832)
+var<storage, read_write> field6: array<u32>;
+
+@compute @workgroup_size(2, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(2) f0: i32,
+@location(6) f1: vec3<i32>,
+@location(3) f2: vec2<i32>,
+@location(5) f3: vec4<f32>,
+@location(7) f4: f32,
+@builtin(frag_depth) f5: f32,
+@location(0) f6: vec2<f32>,
+@location(1) f7: vec2<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(4) a0: i32, @location(10) a1: u32, @location(2) a2: f16, @location(9) a3: vec3<f32>, @location(13) a4: vec3<f32>, @location(6) a5: vec3<f16>, @location(1) a6: vec2<u32>, @location(16) a7: vec2<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let buffer6 = device1.createBuffer(
+{
+label: '\u2461\u{1fea8}\u497f\u1edc\uc13e\u0a75\ub1b7\u025d\u{1fd0c}',
+size: 2340,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+try {
+renderPassEncoder6.beginOcclusionQuery(3126);
+} catch {}
+try {
+renderPassEncoder6.setViewport(
+6.271,
+17.24,
+10.11,
+22.49,
+0.1419,
+0.4708
+);
+} catch {}
+let pipeline23 = await device1.createComputePipelineAsync(
+{
+label: '\ub5a2\u{1f90e}\u{1fa2f}\u628d\u8685\u0568\u{1ffac}\u0f8d\u27c2',
+layout: 'auto',
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+},
+}
+);
+let pipeline24 = device1.createRenderPipeline(
+{
+label: '\u0771\u0612\u02a0\ud434\u{1fa3c}\u7a63\uf7cf\ua7a6\ucea6\u01fb',
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule6,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 7224,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x3',
+offset: 3024,
+shaderLocation: 7,
+},
+{
+format: 'uint16x4',
+offset: 1036,
+shaderLocation: 12,
+},
+{
+format: 'sint32x2',
+offset: 5088,
+shaderLocation: 3,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 3912,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x4',
+offset: 1780,
+shaderLocation: 15,
+},
+{
+format: 'float32',
+offset: 4424,
+shaderLocation: 1,
+},
+{
+format: 'uint32',
+offset: 2080,
+shaderLocation: 11,
+},
+{
+format: 'float16x4',
+offset: 24,
+shaderLocation: 0,
+},
+{
+format: 'unorm8x4',
+offset: 1840,
+shaderLocation: 13,
+},
+{
+format: 'uint8x4',
+offset: 2904,
+shaderLocation: 19,
+},
+{
+format: 'sint32x2',
+offset: 5860,
+shaderLocation: 5,
+},
+{
+format: 'snorm16x2',
+offset: 264,
+shaderLocation: 18,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 6112,
+shaderLocation: 2,
+},
+{
+format: 'float32',
+offset: 2148,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 3576,
+shaderLocation: 17,
+},
+{
+format: 'snorm8x2',
+offset: 2086,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x4',
+offset: 988,
+shaderLocation: 9,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 6304,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 5944,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 7376,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x2',
+offset: 6232,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 6836,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 5396,
+shaderLocation: 14,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: false,
+},
+fragment: {
+module: shaderModule6,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r16sint',
+},
+{
+format: 'r16uint',
+},
+undefined,
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.GREEN,
+},
+{
+format: 'rg8unorm',
+writeMask: GPUColorWrite.RED,
+},
+{
+format: 'rgba32sint',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-wrap',
+depthFailOp: 'zero',
+passOp: 'replace',
+},
+stencilReadMask: 620,
+stencilWriteMask: 2586,
+depthBias: 28,
+depthBiasSlopeScale: 79,
+depthBiasClamp: 9,
+},
+}
+);
+let gpuCanvasContext8 = offscreenCanvas6.getContext('webgpu');
+let videoFrame5 = new VideoFrame(imageBitmap3, {timestamp: 0});
+try {
+offscreenCanvas5.getContext('2d');
+} catch {}
+let texture31 = device1.createTexture(
+{
+label: '\u{1fa94}\u1bd8\u829a\u09da\u5221',
+size: [13018, 172, 1],
+mipLevelCount: 9,
+sampleCount: 1,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundle24 = renderBundleEncoder16.finish(
+{
+label: '\u{1fdc8}\u{1fb82}\u0ae3\uf46a\ud762\u013e\u06f9\u0fe3\u0404'
+}
+);
+try {
+gpuCanvasContext7.configure(
+{
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let pipeline25 = device1.createComputePipeline(
+{
+label: '\u034c\u0dfe\u09b9\u{1fe72}\u4827\u{1febf}\u0dd9\u{1fc39}',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline26 = device1.createRenderPipeline(
+{
+label: '\u{1f6c1}\u1528\u03b3',
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule6,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 2692,
+shaderLocation: 12,
+},
+{
+format: 'sint16x2',
+offset: 1652,
+shaderLocation: 6,
+},
+{
+format: 'float32x2',
+offset: 732,
+shaderLocation: 10,
+},
+{
+format: 'sint8x4',
+offset: 4688,
+shaderLocation: 7,
+},
+{
+format: 'float16x4',
+offset: 4584,
+shaderLocation: 13,
+},
+{
+format: 'float32x3',
+offset: 420,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 4556,
+attributes: [
+{
+format: 'float32x4',
+offset: 1264,
+shaderLocation: 2,
+},
+{
+format: 'uint32',
+offset: 1704,
+shaderLocation: 11,
+},
+{
+format: 'snorm8x4',
+offset: 4516,
+shaderLocation: 0,
+},
+{
+format: 'unorm8x4',
+offset: 656,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x4',
+offset: 4504,
+shaderLocation: 14,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 828,
+shaderLocation: 17,
+},
+{
+format: 'float32x4',
+offset: 2908,
+shaderLocation: 4,
+},
+{
+format: 'unorm16x4',
+offset: 196,
+shaderLocation: 15,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 3084,
+shaderLocation: 1,
+},
+{
+format: 'uint8x2',
+offset: 1872,
+shaderLocation: 19,
+},
+{
+format: 'float16x4',
+offset: 2556,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 2152,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32',
+offset: 2144,
+shaderLocation: 3,
+},
+{
+format: 'float32x2',
+offset: 1244,
+shaderLocation: 16,
+},
+{
+format: 'sint8x4',
+offset: 1168,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'back',
+unclippedDepth: false,
+},
+multisample: {
+count: 4,
+mask: 0x43532948,
+},
+fragment: {
+module: shaderModule6,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.BLUE,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'equal',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+passOp: 'increment-wrap',
+},
+stencilWriteMask: 1299,
+depthBias: 30,
+depthBiasSlopeScale: 78,
+depthBiasClamp: 23,
+},
+}
+);
+let img5 = await imageWithData(51, 43, '#4fd65f6e', '#22a1bb02');
+let canvas9 = document.createElement('canvas');
+let gpuCanvasContext9 = canvas9.getContext('webgpu');
+gc();
+let buffer7 = device1.createBuffer(
+{
+size: 49205,
+usage: GPUBufferUsage.QUERY_RESOLVE,
+}
+);
+let texture32 = device1.createTexture(
+{
+label: '\u0d9f\u2b5d\u59f1\u10c7\ue2bd',
+size: [8121],
+dimension: '1d',
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundle25 = renderBundleEncoder19.finish(
+{
+label: '\u021c\u{1ff76}\u{1f85e}'
+}
+);
+try {
+computePassEncoder5.setPipeline(
+pipeline25
+);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(
+82,
+undefined
+);
+} catch {}
+try {
+computePassEncoder5.popDebugGroup();
+} catch {}
+let promise6 = navigator.gpu.requestAdapter(
+{
+}
+);
+let querySet21 = device0.createQuerySet({
+label: '\u0ac4\ubb20\u{1fb0c}',
+type: 'occlusion',
+count: 3733,
+});
+let commandBuffer6 = commandEncoder10.finish(
+{
+}
+);
+let texture33 = device0.createTexture(
+{
+size: [110, 68, 188],
+mipLevelCount: 7,
+sampleCount: 1,
+format: 'astc-5x4-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-5x4-unorm',
+'astc-5x4-unorm-srgb'
+],
+}
+);
+let textureView19 = texture11.createView(
+{
+label: '\u5b55\u002a\u07ba\ud864\u0d7b\u0842\uf2bf\u0183',
+dimension: '2d-array',
+}
+);
+try {
+renderPassEncoder1.setBlendConstant({ r: 740.5, g: -296.4, b: 360.7, a: 223.3, });
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+1,
+3,
+1,
+3
+);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(
+95,
+undefined,
+222608422
+);
+} catch {}
+try {
+await promise5;
+} catch {}
+let video8 = await videoWithData();
+try {
+window.someLabel = device0.label;
+} catch {}
+let buffer8 = device1.createBuffer(
+{
+size: 46432,
+usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+mappedAtCreation: true,
+}
+);
+let querySet22 = device1.createQuerySet({
+label: '\u7915\u7336\u3737\u6093\u0921\u0861\u035f\u209d\ue7b2\u0e11',
+type: 'occlusion',
+count: 3728,
+});
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setViewport(
+18.57,
+8.094,
+2.112,
+22.53,
+0.7056,
+0.8573
+);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+offscreenCanvas1.width = 763;
+try {
+adapter5.label = '\u0453\ua579\u{1fa6e}';
+} catch {}
+let shaderModule10 = device1.createShaderModule(
+{
+label: '\u{1f9d8}\uf4bc\ueb2d\uc6a3\ue946\u5878\u0c74\u{1fee8}\ucd00\u{1ff6b}\u5854',
+code: `@group(3) @binding(1832)
+var<storage, read_write> field7: array<u32>;
+@group(5) @binding(1832)
+var<storage, read_write> parameter7: array<u32>;
+@group(6) @binding(1832)
+var<storage, read_write> function12: array<u32>;
+@group(1) @binding(1199)
+var<storage, read_write> i7: array<u32>;
+@group(0) @binding(1199)
+var<storage, read_write> type7: array<u32>;
+@group(1) @binding(1832)
+var<storage, read_write> parameter8: array<u32>;
+@group(2) @binding(1199)
+var<storage, read_write> global12: array<u32>;
+@group(7) @binding(1199)
+var<storage, read_write> global13: array<u32>;
+@group(6) @binding(1199)
+var<storage, read_write> local3: array<u32>;
+@group(5) @binding(1199)
+var<storage, read_write> global14: array<u32>;
+@group(0) @binding(1832)
+var<storage, read_write> global15: array<u32>;
+@group(4) @binding(1199)
+var<storage, read_write> i8: array<u32>;
+@group(3) @binding(1199)
+var<storage, read_write> i9: array<u32>;
+@group(7) @binding(1832)
+var<storage, read_write> i10: array<u32>;
+@group(2) @binding(1832)
+var<storage, read_write> i11: array<u32>;
+
+@compute @workgroup_size(4, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S12 {
+@builtin(position) f0: vec4<f32>,
+@location(69) f1: f16,
+@location(44) f2: vec4<i32>,
+@location(64) f3: u32,
+@location(8) f4: vec2<i32>,
+@location(35) f5: vec4<f16>,
+@builtin(sample_mask) f6: u32,
+@location(4) f7: vec2<f32>,
+@builtin(sample_index) f8: u32,
+@location(22) f9: vec3<i32>
+}
+struct FragmentOutput0 {
+@location(6) f0: vec3<i32>,
+@location(4) f1: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(43) a0: vec4<u32>, @location(41) a1: vec4<f32>, @location(59) a2: vec3<i32>, @location(23) a3: f16, @location(34) a4: vec2<u32>, @location(25) a5: vec2<f16>, a6: S12, @location(30) a7: vec2<f16>, @location(14) a8: i32, @location(11) a9: u32, @location(16) a10: i32, @location(51) a11: vec4<f16>, @location(55) a12: vec2<f16>, @location(29) a13: vec2<u32>, @location(47) a14: i32, @location(48) a15: vec2<u32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S11 {
+@location(2) f0: vec2<i32>,
+@location(11) f1: vec4<f32>,
+@location(9) f2: vec2<i32>,
+@location(10) f3: f16,
+@location(16) f4: vec4<i32>,
+@builtin(instance_index) f5: u32,
+@location(6) f6: vec4<f16>,
+@location(3) f7: u32,
+@location(17) f8: vec3<f32>,
+@location(7) f9: vec2<i32>
+}
+struct VertexOutput0 {
+@location(44) f133: vec4<i32>,
+@location(29) f134: vec2<u32>,
+@location(58) f135: u32,
+@location(16) f136: i32,
+@location(59) f137: vec3<i32>,
+@location(48) f138: vec2<u32>,
+@location(4) f139: vec2<f32>,
+@location(47) f140: i32,
+@location(51) f141: vec4<f16>,
+@builtin(position) f142: vec4<f32>,
+@location(23) f143: f16,
+@location(64) f144: u32,
+@location(14) f145: i32,
+@location(34) f146: vec2<u32>,
+@location(30) f147: vec2<f16>,
+@location(41) f148: vec4<f32>,
+@location(11) f149: u32,
+@location(25) f150: vec2<f16>,
+@location(55) f151: vec2<f16>,
+@location(22) f152: vec3<i32>,
+@location(43) f153: vec4<u32>,
+@location(21) f154: f16,
+@location(6) f155: vec4<f16>,
+@location(8) f156: vec2<i32>,
+@location(35) f157: vec4<f16>,
+@location(69) f158: f16
+}
+
+@vertex
+fn vertex0(@location(19) a0: f16, @location(15) a1: vec4<f16>, @location(4) a2: i32, @location(12) a3: f16, @location(8) a4: vec4<u32>, @location(18) a5: vec3<u32>, @location(5) a6: f32, @location(1) a7: vec2<f16>, @location(0) a8: vec3<f16>, a9: S11) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+try {
+computePassEncoder5.setPipeline(
+pipeline18
+);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(1715);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(
+3,
+31,
+8,
+6
+);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(
+buffer8,
+'uint32'
+);
+} catch {}
+try {
+computePassEncoder7.pushDebugGroup(
+'\ub952'
+);
+} catch {}
+let shaderModule11 = device1.createShaderModule(
+{
+label: '\u1fcc\u352c\u04bd\ubc6a\u{1fbdc}\u03a5\u{1fa2d}\u9828\u84ff\u51b3',
+code: `@group(2) @binding(1199)
+var<storage, read_write> field8: array<u32>;
+@group(5) @binding(5363)
+var<storage, read_write> field9: array<u32>;
+@group(5) @binding(7532)
+var<storage, read_write> i12: array<u32>;
+@group(1) @binding(1832)
+var<storage, read_write> field10: array<u32>;
+@group(3) @binding(7532)
+var<storage, read_write> type8: array<u32>;
+@group(2) @binding(1832)
+var<storage, read_write> i13: array<u32>;
+@group(4) @binding(5363)
+var<storage, read_write> function13: array<u32>;
+@group(0) @binding(7532)
+var<storage, read_write> type9: array<u32>;
+@group(4) @binding(7532)
+var<storage, read_write> i14: array<u32>;
+@group(3) @binding(5363)
+var<storage, read_write> local4: array<u32>;
+
+@compute @workgroup_size(7, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S14 {
+@location(15) f0: f32,
+@location(39) f1: u32,
+@location(16) f2: vec2<i32>,
+@location(14) f3: vec4<f32>,
+@location(1) f4: u32,
+@location(31) f5: f32,
+@location(41) f6: f16,
+@location(63) f7: i32,
+@location(4) f8: f32,
+@location(59) f9: f32,
+@location(28) f10: vec2<f16>,
+@location(70) f11: vec3<u32>
+}
+struct FragmentOutput0 {
+@location(1) f0: vec2<u32>,
+@builtin(frag_depth) f1: f32,
+@location(7) f2: f32,
+@location(6) f3: i32,
+@location(4) f4: f32,
+@location(2) f5: vec4<f32>,
+@builtin(sample_mask) f6: u32,
+@location(0) f7: vec2<f32>,
+@location(5) f8: i32,
+@location(3) f9: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, a1: S14, @location(2) a2: vec3<f32>, @location(56) a3: vec2<u32>, @location(11) a4: f32, @location(66) a5: vec2<i32>, @location(48) a6: vec3<u32>, @location(22) a7: i32, @location(0) a8: f32, @location(36) a9: vec2<u32>, @location(33) a10: vec3<f16>, @location(7) a11: vec2<f32>, @location(34) a12: vec3<f16>, @location(40) a13: vec4<i32>, @location(23) a14: vec2<f16>, @builtin(position) a15: vec4<f32>, @builtin(sample_index) a16: u32, @builtin(sample_mask) a17: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S13 {
+@location(0) f0: i32
+}
+struct VertexOutput0 {
+@location(31) f159: f32,
+@location(28) f160: vec2<f16>,
+@location(14) f161: vec4<f32>,
+@location(7) f162: vec2<f32>,
+@location(70) f163: vec3<u32>,
+@location(4) f164: f32,
+@location(2) f165: vec3<f32>,
+@location(48) f166: vec3<u32>,
+@location(66) f167: vec2<i32>,
+@location(15) f168: f32,
+@location(16) f169: vec2<i32>,
+@builtin(position) f170: vec4<f32>,
+@location(0) f171: f32,
+@location(41) f172: f16,
+@location(59) f173: f32,
+@location(1) f174: u32,
+@location(36) f175: vec2<u32>,
+@location(63) f176: i32,
+@location(23) f177: vec2<f16>,
+@location(56) f178: vec2<u32>,
+@location(11) f179: f32,
+@location(22) f180: i32,
+@location(34) f181: vec3<f16>,
+@location(39) f182: u32,
+@location(40) f183: vec4<i32>,
+@location(33) f184: vec3<f16>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(4) a1: vec4<f32>, @location(6) a2: vec2<i32>, @builtin(instance_index) a3: u32, @location(8) a4: vec3<f16>, @location(7) a5: f16, @location(10) a6: vec4<i32>, @location(5) a7: vec4<f16>, @location(1) a8: f32, @location(9) a9: u32, @location(17) a10: vec2<f32>, a11: S13, @location(15) a12: u32, @location(13) a13: u32, @location(3) a14: vec2<f32>, @location(18) a15: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let renderBundle26 = renderBundleEncoder19.finish(
+{
+label: '\u08d3\u7664\ud3a5\u{1fe52}\u0781'
+}
+);
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.insertDebugMarker(
+'\ue8b1'
+);
+} catch {}
+canvas9.width = 263;
+let device3 = await adapter5.requestDevice({
+label: '\u8042\u3f1c\u2428\u30cf\u85a1\ua0b4\u3548\u33cc\u5a01\ud22a',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 6,
+maxColorAttachmentBytesPerSample: 40,
+maxVertexAttributes: 18,
+maxVertexBufferArrayStride: 52590,
+maxStorageTexturesPerShaderStage: 16,
+maxStorageBuffersPerShaderStage: 32,
+maxDynamicStorageBuffersPerPipelineLayout: 5718,
+maxBindingsPerBindGroup: 4259,
+maxTextureArrayLayers: 256,
+maxTextureDimension1D: 12144,
+maxTextureDimension2D: 8817,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 3884253,
+maxUniformBuffersPerShaderStage: 29,
+maxInterStageShaderVariables: 95,
+maxInterStageShaderComponents: 70,
+maxSamplersPerShaderStage: 21,
+},
+});
+let commandEncoder23 = device3.createCommandEncoder(
+{
+label: '\u1408\u{1fc8b}\u08af\u{1f8c4}\u50af\u6820\u02e3',
+}
+);
+let promise7 = device3.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let video9 = await videoWithData();
+video9.height = 294;
+document.body.prepend(canvas1);
+let offscreenCanvas9 = new OffscreenCanvas(324, 905);
+let texture34 = device3.createTexture(
+{
+size: [62, 1, 1141],
+mipLevelCount: 10,
+dimension: '3d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16sint'
+],
+}
+);
+let gpuCanvasContext10 = offscreenCanvas9.getContext('webgpu');
+let texture35 = device0.createTexture(
+{
+label: '\u113b\u{1f93c}\u0462\u3676',
+size: {width: 11058, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8snorm'
+],
+}
+);
+let renderBundle27 = renderBundleEncoder21.finish(
+{
+label: '\u0084\u0ee5\u013f\u{1fff0}'
+}
+);
+try {
+renderPassEncoder6.beginOcclusionQuery(1866);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+let video10 = await videoWithData();
+try {
+device3.queue.label = '\u5962\ue98d\ue358\u{1ffab}\u3683';
+} catch {}
+let commandEncoder24 = device3.createCommandEncoder(
+{
+label: '\u76a4\u1969\u0784\u0394\u834f\u2774\u0a59\u06ec',
+}
+);
+let textureView20 = texture34.createView(
+{
+label: '\u0186\uca8f\u1f03\uf1f7\ubf94\u03ab\ubd13\u1945\u07fb\u3fd1',
+baseMipLevel: 7,
+mipLevelCount: 2,
+}
+);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let bindGroupLayout15 = pipeline18.getBindGroupLayout(2);
+let texture36 = device1.createTexture(
+{
+size: {width: 8192, height: 1, depthOrArrayLayers: 93},
+mipLevelCount: 3,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth24plus-stencil8',
+'depth24plus-stencil8'
+],
+}
+);
+try {
+computePassEncoder5.setPipeline(
+pipeline23
+);
+} catch {}
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+gpuCanvasContext7.configure(
+{
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'bgra8unorm-srgb',
+'rgba8unorm-srgb',
+'rgba8unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let querySet23 = device3.createQuerySet({
+label: '\ua28e\u8fc0\u0a6a\u7a54\u7428\u0e96\ue043\u09f1\u3228',
+type: 'occlusion',
+count: 1187,
+});
+let texture37 = device3.createTexture(
+{
+label: '\u{1fbb9}\u{1fdc3}\u0403\u9f12\u9713',
+size: {width: 204, height: 200, depthOrArrayLayers: 1},
+format: 'etc2-rgb8a1unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'etc2-rgb8a1unorm',
+'etc2-rgb8a1unorm',
+'etc2-rgb8a1unorm'
+],
+}
+);
+let textureView21 = texture37.createView(
+{
+label: '\u0cb5\ua6a9',
+}
+);
+try {
+device3.queue.writeTexture(
+{
+  texture: texture34,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 161 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 52697803 */{
+offset: 647,
+bytesPerRow: 700,
+rowsPerImage: 83,
+},
+{width: 57, height: 1, depthOrArrayLayers: 908}
+);
+} catch {}
+let bindGroupLayout16 = device1.createBindGroupLayout(
+{
+label: '\u04ba\u{1f984}\u{1f95e}\uaefa\u09bc\udfe6\u{1ff6d}',
+entries: [
+{
+binding: 1495,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 7164,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+pseudoSubmit(device1, commandEncoder22);
+let sampler20 = device1.createSampler(
+{
+label: '\u{1fdcb}\udd79\uc03a\u{1f80b}\ua410\u91a2\u0096\u7989\u{1ff8c}\u2e13\ue6f4',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 30.189,
+maxAnisotropy: 19,
+}
+);
+let pipeline27 = device1.createRenderPipeline(
+{
+label: '\uaaf7\ufd1c\u{1f9d6}\ue62e\uc081\ue4b7\u7709\u{1f802}\u47d7\u992d',
+layout: pipelineLayout6,
+vertex: {
+module: shaderModule9,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 44,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 36,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x4',
+offset: 20,
+shaderLocation: 6,
+},
+{
+format: 'uint8x4',
+offset: 28,
+shaderLocation: 1,
+},
+{
+format: 'snorm16x2',
+offset: 8,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 4912,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 152,
+shaderLocation: 13,
+},
+{
+format: 'uint16x4',
+offset: 4624,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 4208,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 4112,
+shaderLocation: 4,
+},
+{
+format: 'uint32',
+offset: 980,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+cullMode: 'back',
+},
+multisample: {
+count: 4,
+mask: 0x3da1de93,
+},
+fragment: {
+module: shaderModule9,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+depthFailOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilWriteMask: 2459,
+depthBiasClamp: 79,
+},
+}
+);
+let imageData7 = new ImageData(212, 40);
+let textureView22 = texture34.createView(
+{
+label: '\u{1fdc0}\ud209\u0de6\u011b\u8d64\u2412\u0a8c\ub873\u7d15\u4bab',
+baseMipLevel: 4,
+mipLevelCount: 1,
+}
+);
+let computePassEncoder9 = commandEncoder24.beginComputePass(
+{
+
+}
+);
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame6 = new VideoFrame(video2, {timestamp: 0});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let videoFrame7 = videoFrame5.clone();
+let commandEncoder25 = device1.createCommandEncoder(
+{
+label: '\udffc\u7d05',
+}
+);
+let computePassEncoder10 = commandEncoder25.beginComputePass(
+{
+label: '\u09f5\u0d96\uc47e\u12ed\u89bf\u{1fcac}\ua0f5'
+}
+);
+let renderBundleEncoder24 = device1.createRenderBundleEncoder(
+{
+label: '\uecb7\u06eb\u{1fc97}\u0162',
+colorFormats: [
+'rgba16sint',
+'rgb10a2uint',
+'r16sint',
+'rg16float',
+'rgba32uint',
+'rg8sint',
+'rgba8sint',
+'r8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 704,
+}
+);
+let renderBundle28 = renderBundleEncoder19.finish(
+{
+label: '\u{1f836}\u0ffe\u922e\u2654\u0305'
+}
+);
+try {
+computePassEncoder10.setPipeline(
+pipeline17
+);
+} catch {}
+let pipeline28 = await device1.createRenderPipelineAsync(
+{
+label: '\uebb7\u{1fbbd}\u{1f9f9}\u{1ff3d}\ub321\u5021',
+layout: pipelineLayout5,
+vertex: {
+module: shaderModule6,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1504,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 452,
+shaderLocation: 5,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 448,
+shaderLocation: 10,
+},
+{
+format: 'float32x4',
+offset: 940,
+shaderLocation: 16,
+},
+{
+format: 'sint32',
+offset: 180,
+shaderLocation: 7,
+},
+{
+format: 'unorm16x4',
+offset: 340,
+shaderLocation: 1,
+},
+{
+format: 'sint16x4',
+offset: 348,
+shaderLocation: 3,
+},
+{
+format: 'unorm16x2',
+offset: 196,
+shaderLocation: 18,
+},
+{
+format: 'sint16x4',
+offset: 1292,
+shaderLocation: 6,
+},
+{
+format: 'float16x4',
+offset: 920,
+shaderLocation: 13,
+},
+{
+format: 'float32x3',
+offset: 16,
+shaderLocation: 14,
+},
+{
+format: 'uint16x2',
+offset: 1496,
+shaderLocation: 11,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 1204,
+shaderLocation: 9,
+},
+{
+format: 'float32x2',
+offset: 448,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x4',
+offset: 1168,
+shaderLocation: 8,
+},
+{
+format: 'uint16x4',
+offset: 892,
+shaderLocation: 12,
+},
+{
+format: 'unorm16x4',
+offset: 360,
+shaderLocation: 0,
+},
+{
+format: 'uint8x2',
+offset: 698,
+shaderLocation: 19,
+},
+{
+format: 'float32',
+offset: 1080,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 4992,
+attributes: [
+
+],
+},
+{
+arrayStride: 5248,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 2300,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 1020,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x2',
+offset: 928,
+shaderLocation: 15,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0x43cbb4ee,
+},
+fragment: {
+module: shaderModule6,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+let commandEncoder26 = device2.createCommandEncoder();
+try {
+renderPassEncoder5.setScissorRect(
+14312,
+76,
+349,
+15
+);
+} catch {}
+let imageBitmap7 = await createImageBitmap(imageBitmap4);
+let texture38 = device3.createTexture(
+{
+label: '\ufc7f\u{1ff23}\u0fdc\u9aea\u0636',
+size: [40, 212, 1],
+mipLevelCount: 2,
+format: 'etc2-rgba8unorm-srgb',
+usage: 0,
+}
+);
+let renderBundleEncoder25 = device3.createRenderBundleEncoder(
+{
+label: '\u0686\ua25d\u{1f8c2}\u{1fb4c}\u09ef',
+colorFormats: [
+'rg32float'
+],
+sampleCount: 164,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+document.body.prepend(video3);
+document.body.prepend(video0);
+let imageData8 = new ImageData(56, 20);
+let pipeline29 = device1.createRenderPipeline(
+{
+label: '\u{1fb3c}\u0a13\u815d\u5b83\u{1fca9}\u0a0e\u7fd2\ub9c8\u67ac\u0685',
+layout: pipelineLayout5,
+vertex: {
+module: shaderModule10,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 2204,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 1980,
+shaderLocation: 5,
+},
+{
+format: 'snorm8x4',
+offset: 1768,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 2044,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32',
+offset: 360,
+shaderLocation: 19,
+},
+{
+format: 'sint32',
+offset: 944,
+shaderLocation: 9,
+},
+{
+format: 'float32x4',
+offset: 400,
+shaderLocation: 17,
+},
+{
+format: 'float16x4',
+offset: 600,
+shaderLocation: 12,
+},
+{
+format: 'sint16x4',
+offset: 536,
+shaderLocation: 4,
+},
+{
+format: 'uint16x2',
+offset: 244,
+shaderLocation: 8,
+},
+{
+format: 'float32x2',
+offset: 1468,
+shaderLocation: 0,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 1036,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x4',
+offset: 160,
+shaderLocation: 6,
+},
+{
+format: 'uint32x4',
+offset: 64,
+shaderLocation: 18,
+},
+{
+format: 'sint8x4',
+offset: 416,
+shaderLocation: 2,
+},
+{
+format: 'sint32',
+offset: 864,
+shaderLocation: 7,
+},
+{
+format: 'float32x4',
+offset: 1732,
+shaderLocation: 10,
+},
+{
+format: 'uint32x2',
+offset: 760,
+shaderLocation: 3,
+},
+{
+format: 'snorm8x4',
+offset: 576,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 6500,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'sint32x3',
+offset: 2216,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+cullMode: 'front',
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+failOp: 'increment-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 3977,
+stencilWriteMask: 1844,
+depthBias: 19,
+depthBiasSlopeScale: 32,
+depthBiasClamp: 93,
+},
+}
+);
+document.body.prepend(img3);
+try {
+adapter5.label = '\u{1f627}\u0f7c\u0a0d\ud230\u0e07\u9146\u{1fdf2}\ua3dc\ub99d\u0c0e\u059e';
+} catch {}
+let offscreenCanvas10 = new OffscreenCanvas(909, 683);
+let textureView23 = texture38.createView(
+{
+label: '\u{1fb70}\u08e3\u7d5a\ue4dd\u0a9e\u{1fcbc}',
+mipLevelCount: 1,
+}
+);
+try {
+computePassEncoder9.end();
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(
+72,
+undefined,
+1496753704,
+2140911860
+);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+offscreenCanvas10.getContext('webgl');
+} catch {}
+let textureView24 = texture37.createView(
+{
+}
+);
+let renderPassEncoder7 = commandEncoder23.beginRenderPass(
+{
+label: '\u{1f623}\u7815\uc118\u{1f7cd}',
+colorAttachments: [
+undefined,
+{
+view: textureView22,
+depthSlice: 26,
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined,
+{
+view: textureView22,
+depthSlice: 17,
+clearValue: { r: -222.3, g: 815.5, b: -87.10, a: 405.8, },
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined
+],
+occlusionQuerySet: querySet23,
+maxDrawCount: 9472,
+}
+);
+try {
+renderBundleEncoder25.insertDebugMarker(
+'\u397e'
+);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(
+2549
+);
+} catch {}
+try {
+renderPassEncoder7.setViewport(
+2.857,
+0.4905,
+0.00868,
+0.4150,
+0.6781,
+0.9780
+);
+} catch {}
+try {
+await device3.popErrorScope();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let buffer9 = device3.createBuffer(
+{
+label: '\u0207\u3ceb\u1d35\ucbbc\uc7f7',
+size: 33886,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let commandEncoder27 = device3.createCommandEncoder();
+let querySet24 = device3.createQuerySet({
+label: '\u{1f93b}\u{1f870}\u277c\u66ec\uf351\u187e\u6053\u1f9b\uff55',
+type: 'occlusion',
+count: 2548,
+});
+try {
+renderPassEncoder7.setScissorRect(
+0,
+0,
+0,
+0
+);
+} catch {}
+try {
+gpuCanvasContext3.configure(
+{
+device: device3,
+format: 'rgba8sint',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+}
+);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+try {
+await promise7;
+} catch {}
+let texture39 = device3.createTexture(
+{
+label: '\u{1fc22}\u1087',
+size: [73, 73, 1],
+mipLevelCount: 4,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'stencil8',
+'stencil8',
+'stencil8'
+],
+}
+);
+let computePassEncoder11 = commandEncoder24.beginComputePass(
+{
+label: '\u0f46\u001f\u615a\ud547\u0201\u0381\u33da\u0632\u{1fc38}\u9362\u0f6e'
+}
+);
+try {
+renderPassEncoder7.setScissorRect(
+1,
+0,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder7.setViewport(
+1.502,
+0.03908,
+0.5562,
+0.6331,
+0.2745,
+0.9805
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture34,
+  mipLevel: 8,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 145268 */{
+offset: 46,
+bytesPerRow: 253,
+rowsPerImage: 287,
+},
+{width: 0, height: 1, depthOrArrayLayers: 3}
+);
+} catch {}
+let offscreenCanvas11 = new OffscreenCanvas(40, 243);
+let imageData9 = new ImageData(4, 148);
+let commandEncoder28 = device1.createCommandEncoder();
+let querySet25 = device1.createQuerySet({
+label: '\ub728\u4fdf\udf8f\u{1f889}\u06d2\u1e7f\u3289\u4e4b\u{1f6e6}\uf0c5\u0f4d',
+type: 'occlusion',
+count: 461,
+});
+try {
+commandEncoder28.copyBufferToBuffer(
+buffer3,
+18212,
+buffer6,
+1328,
+100
+);
+dissociateBuffer(device1, buffer3);
+dissociateBuffer(device1, buffer6);
+} catch {}
+document.body.prepend(canvas7);
+try {
+adapter4.label = '\u{1fc05}\u3ef0\u{1fac7}';
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(
+75,
+undefined,
+2462618553,
+838490477
+);
+} catch {}
+let arrayBuffer2 = buffer6.getMappedRange(
+0,
+492
+);
+try {
+computePassEncoder7.insertDebugMarker(
+'\u8d15'
+);
+} catch {}
+let adapter6 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let offscreenCanvas12 = new OffscreenCanvas(507, 173);
+let imageData10 = new ImageData(224, 212);
+let commandEncoder29 = device3.createCommandEncoder(
+{
+}
+);
+let textureView25 = texture38.createView(
+{
+label: '\u4d58\u9677\u0615\u{1faa7}\uea08\u{1fc1c}',
+dimension: '2d',
+}
+);
+let computePassEncoder12 = commandEncoder29.beginComputePass();
+let renderBundleEncoder26 = device3.createRenderBundleEncoder(
+{
+label: '\u{1ff34}\u35d5\uad20\u1b42\ua9ea\u03f2\ue27a\u0c4d\u{1f981}\u{1fe1e}',
+colorFormats: [
+'rg32sint',
+'r32sint',
+'r32uint',
+undefined,
+'rgba16uint',
+undefined,
+'rg32uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 530,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder7.beginOcclusionQuery(99);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(
+11,
+undefined,
+3215388387,
+16773556
+);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(
+17,
+undefined,
+2587575995,
+121555032
+);
+} catch {}
+gc();
+video7.width = 149;
+try {
+adapter6.label = '\u57c5\u{1fcfd}\u{1f650}\ua236\u06ba\u405b\u9623\u883d';
+} catch {}
+let video11 = await videoWithData();
+let commandEncoder30 = device3.createCommandEncoder(
+{
+}
+);
+try {
+gpuCanvasContext6.configure(
+{
+device: device3,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16float'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture34,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 3 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(arrayBuffer2),
+/* required buffer size: 128 */{
+offset: 128,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let img6 = await imageWithData(119, 212, '#18600389', '#ca14bbab');
+let bindGroupLayout17 = device3.createBindGroupLayout(
+{
+label: '\u0014\u8cbe\u0976\u065b\u{1f777}\u{1f8f0}\u{1f67c}',
+entries: [
+
+],
+}
+);
+let commandEncoder31 = device3.createCommandEncoder(
+{
+}
+);
+let querySet26 = device3.createQuerySet({
+label: '\u153c\u506c\u{1feea}\u4ec4\u0d2a',
+type: 'occlusion',
+count: 2245,
+});
+let renderPassEncoder8 = commandEncoder27.beginRenderPass(
+{
+label: '\u0a08\u{1fa46}\u9650\uf765\uc352\u027d\u{1f7c1}\u{1fe70}\ud522\u0a95',
+colorAttachments: [
+undefined,
+{
+view: textureView22,
+depthSlice: 20,
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined,
+{
+view: textureView22,
+depthSlice: 61,
+clearValue: { r: -962.5, g: 231.6, b: 496.7, a: 78.55, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView22,
+depthSlice: 39,
+clearValue: { r: -805.2, g: 898.6, b: -639.0, a: -863.6, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView22,
+depthSlice: 6,
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView22,
+depthSlice: 53,
+clearValue: { r: -235.8, g: -361.4, b: 576.2, a: 648.8, },
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet26,
+maxDrawCount: 58728,
+}
+);
+let renderBundleEncoder27 = device3.createRenderBundleEncoder(
+{
+label: '\u0269\ud74c\u{1fba2}\u0a8a\u8edb',
+colorFormats: [
+'rg8unorm',
+'rg16float',
+'rg16sint',
+'rg16float',
+'r32uint',
+'r16sint'
+],
+sampleCount: 88,
+stencilReadOnly: true,
+}
+);
+let renderBundle29 = renderBundleEncoder25.finish(
+{
+label: '\u8e26\u{1f896}\u84d4\ue0b0'
+}
+);
+try {
+renderPassEncoder7.setStencilReference(
+1730
+);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout18 = device1.createBindGroupLayout(
+{
+label: '\u25cb\ub9a9\u{1f919}\u241b\u082b\u5264',
+entries: [
+{
+binding: 490,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'filtering' },
+},
+{
+binding: 2202,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+}
+],
+}
+);
+let commandEncoder32 = device1.createCommandEncoder(
+{
+}
+);
+let renderPassEncoder9 = commandEncoder28.beginRenderPass(
+{
+label: '\u{1fe8d}\u{1fb50}\u4a82\u0c30\u9953\u{1fa30}\ub116\u04d2\u8f71',
+colorAttachments: [
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView12,
+depthClearValue: -8.558060447596398,
+depthReadOnly: true,
+stencilClearValue: 5861,
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet15,
+}
+);
+let sampler21 = device1.createSampler(
+{
+label: '\u0d4d\u49d8\u{1fe79}\u{1fd54}\uf2ed\ube9c\u0eca',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 41.321,
+lodMaxClamp: 72.741,
+maxAnisotropy: 3,
+}
+);
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(
+16,
+7,
+5,
+18
+);
+} catch {}
+try {
+commandEncoder32.clearBuffer(
+buffer6
+);
+dissociateBuffer(device1, buffer6);
+} catch {}
+let imageData11 = new ImageData(20, 132);
+let querySet27 = device1.createQuerySet({
+label: '\u{1fee1}\u0995\u5f01\uf829\u0bc1\u0aaa\u{1f746}\uae3c',
+type: 'occlusion',
+count: 4070,
+});
+let renderPassEncoder10 = commandEncoder32.beginRenderPass(
+{
+label: '\u34c7\u01f3\u{1febb}\u3fd8\ue4f0\u0fb0\ued1f\u0cb5\u0dd1\u4691',
+colorAttachments: [
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView12,
+depthClearValue: -0.23973528284528633,
+depthReadOnly: true,
+stencilClearValue: 44227,
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet19,
+maxDrawCount: 61296,
+}
+);
+try {
+computePassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(
+buffer8,
+'uint16',
+31008,
+1887
+);
+} catch {}
+let promise8 = device1.queue.onSubmittedWorkDone();
+let pipeline30 = await device1.createComputePipelineAsync(
+{
+label: '\u979e\u4bb0',
+layout: 'auto',
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline31 = await device1.createRenderPipelineAsync(
+{
+label: '\u3e89\u83f3\u6ab5\u{1fc4f}\u83d1\u0ee9',
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule9,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 596,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x4',
+offset: 296,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 1616,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 1044,
+shaderLocation: 10,
+},
+{
+format: 'float32x4',
+offset: 1060,
+shaderLocation: 13,
+},
+{
+format: 'sint32x4',
+offset: 284,
+shaderLocation: 4,
+},
+{
+format: 'uint32x4',
+offset: 968,
+shaderLocation: 16,
+},
+{
+format: 'uint16x4',
+offset: 1204,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 4120,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 4436,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 5036,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 1120,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 520,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+attributes: [
+
+],
+},
+{
+arrayStride: 2900,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 1468,
+shaderLocation: 6,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0x7b511cf2,
+},
+fragment: {
+module: shaderModule9,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'dst',
+dstFactor: 'src'
+},
+},
+format: 'rg8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'always',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'replace',
+},
+stencilReadMask: 739,
+stencilWriteMask: 1464,
+depthBias: 65,
+depthBiasSlopeScale: 12,
+depthBiasClamp: 16,
+},
+}
+);
+let video12 = await videoWithData();
+try {
+offscreenCanvas11.getContext('webgl');
+} catch {}
+try {
+await promise8;
+} catch {}
+offscreenCanvas8.width = 27;
+let videoFrame8 = new VideoFrame(videoFrame0, {timestamp: 0});
+let shaderModule12 = device1.createShaderModule(
+{
+label: '\u{1f6d2}\uae08\u69ef\u3f71\u4e9b\u9220\u0038\u7938',
+code: `@group(3) @binding(7532)
+var<storage, read_write> field11: array<u32>;
+@group(1) @binding(1199)
+var<storage, read_write> type10: array<u32>;
+@group(5) @binding(7532)
+var<storage, read_write> field12: array<u32>;
+@group(5) @binding(5363)
+var<storage, read_write> local5: array<u32>;
+@group(2) @binding(1832)
+var<storage, read_write> parameter9: array<u32>;
+@group(0) @binding(5363)
+var<storage, read_write> function14: array<u32>;
+@group(4) @binding(7532)
+var<storage, read_write> global16: array<u32>;
+@group(2) @binding(1199)
+var<storage, read_write> function15: array<u32>;
+
+@compute @workgroup_size(2, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: vec4<u32>,
+@builtin(frag_depth) f1: f32,
+@builtin(sample_mask) f2: u32,
+@location(2) f3: u32,
+@location(7) f4: vec2<i32>,
+@location(5) f5: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool, @builtin(position) a3: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S15 {
+@location(13) f0: vec4<f32>,
+@location(10) f1: i32,
+@location(8) f2: vec2<i32>,
+@location(18) f3: u32,
+@location(15) f4: vec2<f32>,
+@builtin(vertex_index) f5: u32,
+@location(17) f6: vec4<f32>,
+@location(1) f7: vec2<f32>,
+@location(7) f8: vec2<i32>,
+@location(0) f9: vec3<f32>,
+@location(5) f10: vec2<i32>,
+@location(14) f11: vec4<i32>,
+@location(2) f12: u32
+}
+
+@vertex
+fn vertex0(@location(19) a0: vec3<i32>, @location(6) a1: vec2<f32>, @builtin(instance_index) a2: u32, @location(4) a3: vec3<u32>, a4: S15, @location(11) a5: vec3<i32>, @location(3) a6: vec2<f32>, @location(16) a7: vec4<i32>, @location(12) a8: i32, @location(9) a9: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroupLayout19 = device1.createBindGroupLayout(
+{
+entries: [
+{
+binding: 3926,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '1d' },
+},
+{
+binding: 5558,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '3d' },
+}
+],
+}
+);
+let renderBundleEncoder28 = device1.createRenderBundleEncoder(
+{
+label: '\u7263\u5fca\udbc6\u12d1\u0608\ucfde\u431e\u01df',
+colorFormats: [
+'rg16float',
+'rg16uint',
+'rgba16uint',
+'rgba32sint',
+'r32uint',
+'r32float'
+],
+sampleCount: 908,
+depthReadOnly: true,
+stencilReadOnly: false,
+}
+);
+try {
+renderPassEncoder10.setBlendConstant({ r: -229.0, g: -198.0, b: 179.1, a: 611.1, });
+} catch {}
+let pipeline32 = await device1.createComputePipelineAsync(
+{
+label: '\ucc62\ua9e1\u{1fdb0}\ua00f\u0990\u33e3\ufeb3\u78f9\u0753\u{1fb53}',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let gpuCanvasContext11 = offscreenCanvas12.getContext('webgpu');
+try {
+querySet5.label = '\ufbf4\u{1fbe7}\uf82c\u181c\u0fb2\ud052\u{1fc67}\u0bf4\u1803';
+} catch {}
+let buffer10 = device0.createBuffer(
+{
+label: '\u247a\u09d0\u0653\ubd68\uc7a4\ubdc6',
+size: 4840,
+usage: GPUBufferUsage.VERTEX,
+mappedAtCreation: true,
+}
+);
+let renderPassEncoder11 = commandEncoder13.beginRenderPass(
+{
+label: '\u093d\u2760\u0b4e\u{1f88a}',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+{
+view: textureView5,
+clearValue: { r: 426.0, g: 950.5, b: 427.5, a: -366.9, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined
+],
+occlusionQuerySet: querySet5,
+maxDrawCount: 67536,
+}
+);
+let renderBundle30 = renderBundleEncoder9.finish(
+{
+label: '\uff1a\u7c3b\u{1fc72}\u{1ffaf}\u9b0e\u{1fd1e}\u{1fab7}\u{1f8f7}\u092f'
+}
+);
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(
+1,
+10,
+0,
+2
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+5,
+buffer10
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+7,
+buffer10,
+2112,
+2170
+);
+} catch {}
+let offscreenCanvas13 = new OffscreenCanvas(246, 147);
+let pipelineLayout7 = device3.createPipelineLayout(
+{
+label: '\u0e31\u0834\u3343\u0404\u{1fc89}\u4a85\u0093\u{1f7c9}\u1814',
+bindGroupLayouts: [
+bindGroupLayout17,
+bindGroupLayout17,
+bindGroupLayout17,
+bindGroupLayout17
+]
+}
+);
+let computePassEncoder13 = commandEncoder31.beginComputePass(
+{
+label: '\u9916\u8f16\u0e9b\u4721\uddea\u0b1c'
+}
+);
+let renderBundle31 = renderBundleEncoder27.finish();
+try {
+renderPassEncoder8.beginOcclusionQuery(131);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(
+36,
+undefined
+);
+} catch {}
+try {
+renderPassEncoder8.insertDebugMarker(
+'\u0c93'
+);
+} catch {}
+try {
+device3.destroy();
+} catch {}
+video10.width = 202;
+let imageData12 = new ImageData(84, 228);
+try {
+await adapter5.requestAdapterInfo();
+} catch {}
+let buffer11 = device1.createBuffer(
+{
+size: 13660,
+usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+mappedAtCreation: false,
+}
+);
+let querySet28 = device1.createQuerySet({
+label: '\u0d05\u1cef\u2bd6\ue7ea',
+type: 'occlusion',
+count: 434,
+});
+let texture40 = device1.createTexture(
+{
+label: '\u{1fbe1}\u0a80',
+size: [1000, 1, 1821],
+mipLevelCount: 11,
+sampleCount: 1,
+dimension: '3d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgba32float',
+'rgba32float',
+'rgba32float'
+],
+}
+);
+let renderBundle32 = renderBundleEncoder16.finish(
+{
+
+}
+);
+try {
+computePassEncoder10.setPipeline(
+pipeline25
+);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder9.setViewport(
+5.959,
+34.20,
+13.71,
+1.569,
+0.6755,
+0.9800
+);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(
+buffer8,
+'uint32',
+24892,
+5283
+);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+computePassEncoder7.popDebugGroup();
+} catch {}
+let promise9 = device1.queue.onSubmittedWorkDone();
+document.body.prepend(canvas9);
+try {
+await promise9;
+} catch {}
+let offscreenCanvas14 = new OffscreenCanvas(678, 9);
+try {
+offscreenCanvas13.getContext('webgpu');
+} catch {}
+let device4 = await adapter4.requestDevice({
+label: '\udee5\u{1f73a}\ue197\u{1fdd4}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+});
+try {
+renderPassEncoder10.end();
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(996);
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant({ r: -508.7, g: 992.4, b: -184.8, a: 173.6, });
+} catch {}
+try {
+renderPassEncoder9.setViewport(
+10.41,
+40.99,
+10.01,
+2.083,
+0.07882,
+0.7586
+);
+} catch {}
+try {
+commandEncoder14.clearBuffer(
+buffer6
+);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+commandEncoder14.insertDebugMarker(
+'\uf547'
+);
+} catch {}
+try {
+gpuCanvasContext4.configure(
+{
+device: device1,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg16uint',
+'bgra8unorm'
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+window.someLabel = texture20.label;
+} catch {}
+let bindGroupLayout20 = device1.createBindGroupLayout(
+{
+label: '\u{1fea9}\ud803\uc981\u7e95\u0a3b',
+entries: [
+
+],
+}
+);
+let pipelineLayout8 = device1.createPipelineLayout(
+{
+label: '\u05b9\ube58',
+bindGroupLayouts: [
+bindGroupLayout20,
+bindGroupLayout14
+]
+}
+);
+let querySet29 = device1.createQuerySet({
+label: '\u1ae0\uaecc\uca12\u2a18\u05bb\u042e',
+type: 'occlusion',
+count: 1788,
+});
+pseudoSubmit(device1, commandEncoder32);
+let renderPassEncoder12 = commandEncoder14.beginRenderPass(
+{
+label: '\u9ac8\ubeed\u{1f942}\u0dee',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView12,
+depthClearValue: -5.469348585567133,
+depthLoadOp: 'load',
+depthStoreOp: 'discard',
+depthReadOnly: false,
+stencilClearValue: 4064,
+},
+occlusionQuerySet: querySet18,
+}
+);
+let renderBundleEncoder29 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba16sint',
+'r8unorm',
+undefined,
+'rgba32uint',
+'r16uint',
+'rgba16sint'
+],
+sampleCount: 496,
+}
+);
+try {
+computePassEncoder10.setPipeline(
+pipeline23
+);
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(
+512
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 1420, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 269 */{
+offset: 269,
+rowsPerImage: 29,
+},
+{width: 10979, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let buffer12 = device1.createBuffer(
+{
+label: '\u0742\u04b4\u{1fc51}\u56fc\u0336\u{1f81b}\u{1fef6}\u{1faa4}\u{1fc6c}\uf78d',
+size: 57608,
+usage: GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let renderBundleEncoder30 = device1.createRenderBundleEncoder(
+{
+label: '\u0c13\u0162\u{1f9fe}\u01f1\u0e84',
+colorFormats: [
+'r8uint',
+'rgba32sint'
+],
+sampleCount: 990,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.setViewport(
+2.912,
+31.57,
+6.281,
+1.586,
+0.4682,
+0.4801
+);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture17,
+  mipLevel: 5,
+  origin: { x: 13, y: 0, z: 0 },
+  aspect: 'all',
+},
+new DataView(new ArrayBuffer(80)),
+/* required buffer size: 449545 */{
+offset: 725,
+bytesPerRow: 88,
+rowsPerImage: 204,
+},
+{width: 5, height: 1, depthOrArrayLayers: 26}
+);
+} catch {}
+let commandEncoder33 = device4.createCommandEncoder(
+{
+label: '\u031b\ud902\u73c5\u{1f8e3}\u{1f7d3}',
+}
+);
+let texture41 = device4.createTexture(
+{
+size: {width: 164, height: 1, depthOrArrayLayers: 11},
+mipLevelCount: 7,
+format: 'stencil8',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'stencil8',
+'stencil8',
+'stencil8'
+],
+}
+);
+let videoFrame9 = new VideoFrame(canvas8, {timestamp: 0});
+gc();
+try {
+offscreenCanvas14.getContext('webgpu');
+} catch {}
+let canvas10 = document.createElement('canvas');
+try {
+device3.label = '\u49cb\u{1ff72}';
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let imageBitmap8 = await createImageBitmap(offscreenCanvas0);
+try {
+canvas10.getContext('webgpu');
+} catch {}
+let canvas11 = document.createElement('canvas');
+let shaderModule13 = device1.createShaderModule(
+{
+label: '\u0e68\ud6fc\u{1f88d}\u050b',
+code: `@group(5) @binding(7532)
+var<storage, read_write> function16: array<u32>;
+@group(0) @binding(1199)
+var<storage, read_write> global17: array<u32>;
+@group(3) @binding(1832)
+var<storage, read_write> i15: array<u32>;
+@group(1) @binding(5363)
+var<storage, read_write> local6: array<u32>;
+@group(4) @binding(5363)
+var<storage, read_write> i16: array<u32>;
+@group(2) @binding(7532)
+var<storage, read_write> local7: array<u32>;
+@group(2) @binding(5363)
+var<storage, read_write> type11: array<u32>;
+@group(1) @binding(7532)
+var<storage, read_write> i17: array<u32>;
+@group(4) @binding(7532)
+var<storage, read_write> local8: array<u32>;
+@group(0) @binding(1832)
+var<storage, read_write> parameter10: array<u32>;
+
+@compute @workgroup_size(6, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(7) f0: vec4<f32>,
+@location(3) f1: vec2<f32>,
+@location(0) f2: u32,
+@builtin(sample_mask) f3: u32,
+@location(2) f4: vec4<f32>,
+@location(4) f5: vec4<f32>,
+@builtin(frag_depth) f6: f32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let renderBundleEncoder31 = device1.createRenderBundleEncoder(
+{
+label: '\ude85\u0564\ue4e2\u61ca',
+colorFormats: [
+'r32uint',
+'rgba8uint',
+'rgba32sint',
+'rgba8unorm',
+'rgba16sint'
+],
+sampleCount: 793,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+let promise10 = device1.queue.onSubmittedWorkDone();
+let pipeline33 = await device1.createComputePipelineAsync(
+{
+label: '\u4457\u1bba\u0978\u0695\u4d8a\u{1f99b}\u{1ffe4}\u04b7\u691d\u{1feb2}',
+layout: 'auto',
+compute: {
+module: shaderModule13,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let device5 = await adapter6.requestDevice({
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+});
+let imageBitmap9 = await createImageBitmap(canvas3);
+let bindGroupLayout21 = device5.createBindGroupLayout(
+{
+entries: [
+{
+binding: 167,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba32float', access: 'read-only', viewDimension: '2d' },
+}
+],
+}
+);
+let buffer13 = device5.createBuffer(
+{
+size: 46348,
+usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let commandEncoder34 = device5.createCommandEncoder(
+{
+label: '\u029d\u813a\uad7c\uef26\u06db',
+}
+);
+let texture42 = gpuCanvasContext7.getCurrentTexture();
+let textureView26 = texture42.createView(
+{
+label: '\u80a4\u47b2\ub711\u79fe\u54dc\u5930',
+dimension: '2d',
+format: 'rgba8unorm-srgb',
+}
+);
+let imageData13 = new ImageData(48, 96);
+let textureView27 = texture41.createView(
+{
+baseMipLevel: 2,
+mipLevelCount: 1,
+baseArrayLayer: 10,
+}
+);
+let sampler22 = device4.createSampler(
+{
+label: '\u0e76\u3d9f',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 27.579,
+lodMaxClamp: 61.012,
+}
+);
+video7.height = 228;
+offscreenCanvas8.height = 499;
+gc();
+let querySet30 = device1.createQuerySet({
+label: '\u0fe8\u81d0\u1748\uc99e',
+type: 'occlusion',
+count: 2291,
+});
+let texture43 = device1.createTexture(
+{
+size: {width: 184, height: 1, depthOrArrayLayers: 136},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+renderPassEncoder12.setScissorRect(
+15,
+2,
+7,
+42
+);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(
+buffer11,
+'uint32',
+8996,
+1043
+);
+} catch {}
+try {
+canvas11.getContext('webgl');
+} catch {}
+try {
+await adapter6.requestAdapterInfo();
+} catch {}
+let canvas12 = document.createElement('canvas');
+let videoFrame10 = new VideoFrame(img6, {timestamp: 0});
+try {
+canvas12.getContext('webgl');
+} catch {}
+offscreenCanvas12.height = 969;
+let video13 = await videoWithData();
+let pipelineLayout9 = device5.createPipelineLayout(
+{
+label: '\u33e6\u{1fd64}\u0cf8\u2524\uff6e\u{1fc2a}\u{1fd1a}',
+bindGroupLayouts: [
+bindGroupLayout21,
+bindGroupLayout21,
+bindGroupLayout21,
+bindGroupLayout21
+]
+}
+);
+let commandEncoder35 = device5.createCommandEncoder();
+let texture44 = gpuCanvasContext2.getCurrentTexture();
+let computePassEncoder14 = commandEncoder34.beginComputePass(
+{
+label: '\u5931\u0131\u0be1\u27ab\u7c2c\u13f4\ud160'
+}
+);
+try {
+await device5.popErrorScope();
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture44,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+},
+new BigUint64Array(new ArrayBuffer(24)),
+/* required buffer size: 379 */{
+offset: 379,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let canvas13 = document.createElement('canvas');
+let imageBitmap10 = await createImageBitmap(imageBitmap5);
+let imageData14 = new ImageData(28, 20);
+try {
+computePassEncoder10.label = '\u0a2a\u0c4a\u4b06\u{1feea}\u0967';
+} catch {}
+let renderBundle33 = renderBundleEncoder19.finish(
+{
+label: '\ue72c\u{1fbd4}\u0298\u{1f75a}\u4271\u{1fc41}\u7d12'
+}
+);
+let sampler23 = device1.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 67.065,
+lodMaxClamp: 93.278,
+maxAnisotropy: 11,
+}
+);
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant({ r: 918.6, g: -268.7, b: 429.7, a: -661.9, });
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(
+1205
+);
+} catch {}
+canvas5.width = 435;
+let textureView28 = texture42.createView(
+{
+dimension: '2d',
+format: 'rgba8unorm-srgb',
+}
+);
+try {
+device5.queue.writeTexture(
+{
+  texture: texture44,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 751 */{
+offset: 751,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let offscreenCanvas15 = new OffscreenCanvas(1011, 494);
+let shaderModule14 = device1.createShaderModule(
+{
+code: `@group(6) @binding(1832)
+var<storage, read_write> function17: array<u32>;
+@group(6) @binding(1199)
+var<storage, read_write> local9: array<u32>;
+@group(5) @binding(1199)
+var<storage, read_write> parameter11: array<u32>;
+@group(7) @binding(1832)
+var<storage, read_write> function18: array<u32>;
+@group(1) @binding(1199)
+var<storage, read_write> function19: array<u32>;
+@group(0) @binding(1199)
+var<storage, read_write> function20: array<u32>;
+@group(2) @binding(1199)
+var<storage, read_write> function21: array<u32>;
+@group(3) @binding(1832)
+var<storage, read_write> parameter12: array<u32>;
+@group(4) @binding(1832)
+var<storage, read_write> i18: array<u32>;
+@group(5) @binding(1832)
+var<storage, read_write> type12: array<u32>;
+@group(7) @binding(1199)
+var<storage, read_write> type13: array<u32>;
+@group(2) @binding(1832)
+var<storage, read_write> local10: array<u32>;
+
+@compute @workgroup_size(7, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(1) f0: i32,
+@location(7) f1: vec4<f32>,
+@location(0) f2: vec4<u32>,
+@location(5) f3: vec2<f32>,
+@builtin(sample_mask) f4: u32,
+@location(2) f5: vec3<i32>,
+@location(6) f6: vec4<f32>,
+@location(4) f7: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(16) a0: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+pseudoSubmit(device1, commandEncoder14);
+try {
+renderPassEncoder12.beginOcclusionQuery(1806);
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(
+1254
+);
+} catch {}
+try {
+renderPassEncoder9.setViewport(
+21.98,
+42.51,
+0.02973,
+2.854,
+0.7819,
+0.8028
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 5224, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint8Array(arrayBuffer0),
+/* required buffer size: 4196 */{
+offset: 476,
+bytesPerRow: 3997,
+rowsPerImage: 39,
+},
+{width: 465, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline34 = await device1.createComputePipelineAsync(
+{
+layout: pipelineLayout6,
+compute: {
+module: shaderModule10,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+offscreenCanvas15.getContext('webgl2');
+} catch {}
+let shaderModule15 = device5.createShaderModule(
+{
+code: `@group(1) @binding(167)
+var<storage, read_write> type14: array<u32>;
+@group(3) @binding(167)
+var<storage, read_write> function22: array<u32>;
+@group(0) @binding(167)
+var<storage, read_write> parameter13: array<u32>;
+@group(2) @binding(167)
+var<storage, read_write> field13: array<u32>;
+
+@compute @workgroup_size(5, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S17 {
+@builtin(front_facing) f0: bool,
+@location(14) f1: vec3<f32>,
+@location(6) f2: vec2<f32>,
+@location(12) f3: vec4<i32>,
+@location(15) f4: vec3<u32>,
+@location(11) f5: vec2<i32>,
+@location(9) f6: vec3<u32>,
+@location(13) f7: f16,
+@location(2) f8: vec4<i32>,
+@location(8) f9: vec3<u32>
+}
+struct FragmentOutput0 {
+@location(0) f0: vec2<f32>,
+@location(6) f1: vec3<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(sample_mask) a1: u32, @location(7) a2: u32, @location(4) a3: vec4<i32>, @location(3) a4: f16, @location(10) a5: vec3<u32>, a6: S17) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S16 {
+@location(13) f0: vec3<f16>,
+@location(15) f1: vec2<u32>,
+@location(11) f2: vec3<u32>,
+@builtin(vertex_index) f3: u32
+}
+struct VertexOutput0 {
+@location(0) f185: vec4<f16>,
+@location(7) f186: u32,
+@location(2) f187: vec4<i32>,
+@location(6) f188: vec2<f32>,
+@builtin(position) f189: vec4<f32>,
+@location(4) f190: vec4<i32>,
+@location(10) f191: vec3<u32>,
+@location(13) f192: f16,
+@location(8) f193: vec3<u32>,
+@location(15) f194: vec3<u32>,
+@location(3) f195: f16,
+@location(12) f196: vec4<i32>,
+@location(9) f197: vec3<u32>,
+@location(11) f198: vec2<i32>,
+@location(14) f199: vec3<f32>
+}
+
+@vertex
+fn vertex0(a0: S16, @location(9) a1: vec3<u32>, @location(8) a2: u32, @builtin(instance_index) a3: u32, @location(14) a4: f16, @location(0) a5: f16, @location(5) a6: f32, @location(3) a7: vec3<f32>, @location(7) a8: f16, @location(2) a9: vec4<i32>, @location(12) a10: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroupLayout22 = device5.createBindGroupLayout(
+{
+label: '\u0d49\u{1f765}\u39ed\u381e\u06e0\u{1fad8}',
+entries: [
+{
+binding: 704,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+pseudoSubmit(device5, commandEncoder34);
+let texture45 = gpuCanvasContext3.getCurrentTexture();
+try {
+texture42.destroy();
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture44,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Float64Array(new ArrayBuffer(40)),
+/* required buffer size: 858 */{
+offset: 858,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline35 = await device5.createComputePipelineAsync(
+{
+layout: pipelineLayout9,
+compute: {
+module: shaderModule15,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let renderBundle34 = renderBundleEncoder28.finish(
+{
+label: '\u0d49\ud854\u09d3\u0baa\u0ee0'
+}
+);
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+let renderBundleEncoder32 = device5.createRenderBundleEncoder(
+{
+label: '\u{1f920}\u6a5d',
+colorFormats: [
+'rg32float',
+'rg32sint',
+'r16uint',
+'rgb10a2unorm',
+'rg16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 912,
+}
+);
+let sampler24 = device5.createSampler(
+{
+label: '\u04f0\u50db\u002a\ud72c\u0c29\u1120\u{1fbcf}',
+addressModeU: 'clamp-to-edge',
+lodMinClamp: 35.392,
+lodMaxClamp: 77.432,
+}
+);
+document.body.prepend(img5);
+offscreenCanvas10.height = 512;
+let img7 = await imageWithData(105, 44, '#4c6d36b3', '#aba62771');
+let imageData15 = new ImageData(188, 160);
+let querySet31 = device4.createQuerySet({
+label: '\u05d5\u{1ff3f}\u{1fc11}\u14a0\u15de\u6226\u{1fce6}\ue66e',
+type: 'occlusion',
+count: 1276,
+});
+let offscreenCanvas16 = new OffscreenCanvas(36, 407);
+let video14 = await videoWithData();
+let imageBitmap11 = await createImageBitmap(canvas4);
+let gpuCanvasContext12 = canvas13.getContext('webgpu');
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let shaderModule16 = device5.createShaderModule(
+{
+label: '\ufe6a\u050f\u{1f629}\u5faa\u1e6d\u0827\ua41c\u6c19',
+code: `@group(1) @binding(167)
+var<storage, read_write> i19: array<u32>;
+@group(3) @binding(167)
+var<storage, read_write> parameter14: array<u32>;
+@group(2) @binding(167)
+var<storage, read_write> function23: array<u32>;
+@group(0) @binding(167)
+var<storage, read_write> field14: array<u32>;
+
+@compute @workgroup_size(3, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S18 {
+@builtin(sample_index) f0: u32
+}
+struct FragmentOutput0 {
+@builtin(sample_mask) f0: u32,
+@location(4) f1: vec3<u32>,
+@location(6) f2: vec3<u32>,
+@builtin(frag_depth) f3: f32,
+@location(0) f4: f32,
+@location(7) f5: vec2<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>, a2: S18, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(1) a0: vec4<f16>, @location(8) a1: vec3<u32>, @location(3) a2: i32, @location(7) a3: vec3<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+}
+);
+let buffer14 = device5.createBuffer(
+{
+label: '\ud6eb\u{1ff31}\u0b95\ucdf7',
+size: 6346,
+usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+}
+);
+let commandBuffer7 = commandEncoder35.finish();
+let texture46 = device5.createTexture(
+{
+label: '\u0805\u05ba\u{1fc67}\u{1fa7f}\u3f7b\u06f8\u{1f813}',
+size: [168, 78, 198],
+mipLevelCount: 4,
+format: 'astc-8x6-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+
+],
+}
+);
+let promise11 = device5.createRenderPipelineAsync(
+{
+label: '\u0c3d\u0591\u011e\ua98e\u{1fa2a}\u5bc4\ua527\u{1f608}\u0d4d\ua04d\ud4f9',
+layout: pipelineLayout9,
+vertex: {
+module: shaderModule15,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 16,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 0,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x2',
+offset: 4,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x2',
+offset: 10,
+shaderLocation: 7,
+},
+{
+format: 'float16x2',
+offset: 4,
+shaderLocation: 13,
+},
+{
+format: 'float32x4',
+offset: 0,
+shaderLocation: 0,
+},
+{
+format: 'sint8x4',
+offset: 8,
+shaderLocation: 2,
+},
+{
+format: 'float32x4',
+offset: 0,
+shaderLocation: 14,
+},
+{
+format: 'uint32x4',
+offset: 0,
+shaderLocation: 8,
+},
+{
+format: 'uint8x2',
+offset: 12,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 1332,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 360,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 1524,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 1044,
+shaderLocation: 15,
+},
+{
+format: 'snorm8x4',
+offset: 712,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule15,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'one-minus-src',
+dstFactor: 'one-minus-src'
+},
+},
+format: 'rg8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+}
+);
+try {
+await promise10;
+} catch {}
+let adapter7 = await promise6;
+let img8 = await imageWithData(121, 214, '#c38a8b58', '#3a912d9f');
+let sampler25 = device5.createSampler(
+{
+label: '\u51ec\ubd4a\u0232\u6948\u23cd\u04ac\u96ad\u0df3\u{1f720}\u{1fcaa}\u6eae',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMaxClamp: 42.350,
+maxAnisotropy: 1,
+}
+);
+try {
+gpuCanvasContext5.configure(
+{
+device: device5,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'etc2-rgba8unorm',
+'r32sint',
+'rgba16float'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let pipeline36 = await device5.createComputePipelineAsync(
+{
+label: '\u0e81\u{1ff96}\u1506',
+layout: pipelineLayout9,
+compute: {
+module: shaderModule16,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageData16 = new ImageData(144, 180);
+let texture47 = device4.createTexture(
+{
+label: '\ue9ce\u3f98\u0d3a\u{1f7da}\u01e4\u21e4',
+size: [1714, 1, 28],
+mipLevelCount: 9,
+dimension: '3d',
+format: 'rgba32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32uint',
+'rgba32uint',
+'rgba32uint'
+],
+}
+);
+try {
+device4.queue.writeTexture(
+{
+  texture: texture47,
+  mipLevel: 3,
+  origin: { x: 127, y: 0, z: 0 },
+  aspect: 'all',
+},
+new DataView(new ArrayBuffer(16)),
+/* required buffer size: 121650 */{
+offset: 220,
+bytesPerRow: 665,
+rowsPerImage: 182,
+},
+{width: 25, height: 1, depthOrArrayLayers: 2}
+);
+} catch {}
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder36 = device4.createCommandEncoder(
+{
+label: '\u0244\u61e6\u4d9d\u0c4b\uef42\u0098\u1a49\u{1f622}\u{1f6e4}\ue7e0\u{1fe54}',
+}
+);
+let sampler26 = device4.createSampler(
+{
+label: '\uf56f\ubb0e\u0ddf\u{1ff27}\u098a\u388a\u4879\uf021\ufa77\ua814\ua874',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 91.543,
+lodMaxClamp: 97.347,
+maxAnisotropy: 18,
+}
+);
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+let img9 = await imageWithData(123, 213, '#1dc727e8', '#a3e51227');
+let shaderModule17 = device1.createShaderModule(
+{
+label: '\u01ca\u8d13\u7399',
+code: `@group(1) @binding(1832)
+var<storage, read_write> field15: array<u32>;
+@group(3) @binding(1199)
+var<storage, read_write> function24: array<u32>;
+@group(0) @binding(1199)
+var<storage, read_write> type15: array<u32>;
+@group(4) @binding(1832)
+var<storage, read_write> i20: array<u32>;
+@group(5) @binding(1199)
+var<storage, read_write> i21: array<u32>;
+@group(7) @binding(1199)
+var<storage, read_write> field16: array<u32>;
+@group(6) @binding(1832)
+var<storage, read_write> i22: array<u32>;
+@group(2) @binding(1832)
+var<storage, read_write> type16: array<u32>;
+@group(7) @binding(1832)
+var<storage, read_write> field17: array<u32>;
+@group(5) @binding(1832)
+var<storage, read_write> i23: array<u32>;
+@group(0) @binding(1832)
+var<storage, read_write> local11: array<u32>;
+@group(1) @binding(1199)
+var<storage, read_write> local12: array<u32>;
+@group(2) @binding(1199)
+var<storage, read_write> local13: array<u32>;
+@group(3) @binding(1832)
+var<storage, read_write> global18: array<u32>;
+
+@compute @workgroup_size(8, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S19 {
+@location(60) f0: vec4<i32>,
+@location(15) f1: vec4<u32>,
+@location(32) f2: u32,
+@location(25) f3: vec4<i32>,
+@location(6) f4: vec4<f32>,
+@location(11) f5: vec4<u32>,
+@builtin(position) f6: vec4<f32>,
+@location(17) f7: i32,
+@location(36) f8: f16,
+@builtin(sample_mask) f9: u32,
+@location(68) f10: u32,
+@location(0) f11: vec3<u32>,
+@location(56) f12: f32,
+@location(63) f13: vec4<f32>
+}
+struct FragmentOutput0 {
+@location(4) f0: vec2<i32>,
+@location(7) f1: vec2<i32>,
+@location(3) f2: u32,
+@location(2) f3: f32,
+@location(1) f4: vec4<u32>,
+@location(0) f5: vec3<f32>,
+@location(6) f6: vec2<f32>,
+@location(5) f7: vec2<u32>,
+@builtin(frag_depth) f8: f32
+}
+
+@fragment
+fn fragment0(@location(50) a0: vec4<f32>, @location(10) a1: vec4<f16>, @location(59) a2: vec3<i32>, @location(67) a3: u32, @location(9) a4: vec2<f32>, @location(52) a5: vec3<i32>, @location(19) a6: vec3<f32>, @location(41) a7: vec4<f16>, @location(7) a8: vec3<u32>, @location(46) a9: vec2<i32>, a10: S19) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(50) f200: vec4<f32>,
+@location(6) f201: vec4<f32>,
+@location(35) f202: vec3<i32>,
+@location(39) f203: vec3<f32>,
+@location(55) f204: i32,
+@location(0) f205: vec3<u32>,
+@builtin(position) f206: vec4<f32>,
+@location(10) f207: vec4<f16>,
+@location(20) f208: f32,
+@location(59) f209: vec3<i32>,
+@location(7) f210: vec3<u32>,
+@location(17) f211: i32,
+@location(36) f212: f16,
+@location(19) f213: vec3<f32>,
+@location(52) f214: vec3<i32>,
+@location(56) f215: f32,
+@location(15) f216: vec4<u32>,
+@location(45) f217: vec3<i32>,
+@location(60) f218: vec4<i32>,
+@location(63) f219: vec4<f32>,
+@location(41) f220: vec4<f16>,
+@location(47) f221: u32,
+@location(9) f222: vec2<f32>,
+@location(25) f223: vec4<i32>,
+@location(46) f224: vec2<i32>,
+@location(67) f225: u32,
+@location(68) f226: u32,
+@location(64) f227: vec2<f16>,
+@location(32) f228: u32,
+@location(11) f229: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(13) a0: u32, @location(1) a1: vec3<u32>, @location(10) a2: vec3<i32>, @location(12) a3: vec4<f16>, @location(4) a4: vec4<i32>, @location(5) a5: vec2<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+}
+);
+try {
+renderPassEncoder9.setBlendConstant({ r: -664.5, g: 801.9, b: 390.9, a: 699.6, });
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(
+18,
+39,
+0,
+5
+);
+} catch {}
+let offscreenCanvas17 = new OffscreenCanvas(536, 147);
+let querySet32 = device1.createQuerySet({
+label: '\u0d3e\u04e0\u5b8e\ud87f\u899e\u{1fc88}\u426d\u1f87',
+type: 'occlusion',
+count: 1658,
+});
+try {
+computePassEncoder10.setPipeline(
+pipeline34
+);
+} catch {}
+try {
+renderPassEncoder9.setViewport(
+18.99,
+34.40,
+3.231,
+1.358,
+0.7317,
+0.9495
+);
+} catch {}
+let pipeline37 = await device1.createRenderPipelineAsync(
+{
+label: '\u{1fa51}\uccac\u047a\ua0dc\uf7b8\u0ff7',
+layout: pipelineLayout5,
+vertex: {
+module: shaderModule17,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'sint8x4',
+offset: 1020,
+shaderLocation: 10,
+},
+{
+format: 'sint8x4',
+offset: 1368,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 900,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 540,
+shaderLocation: 13,
+},
+{
+format: 'float32x2',
+offset: 268,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 516,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 2528,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 1380,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 3824,
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 2688,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'back',
+},
+multisample: {
+count: 4,
+mask: 0x803a2c0b,
+},
+fragment: {
+module: shaderModule17,
+entryPoint: 'fragment0',
+targets: [
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'one-minus-src',
+dstFactor: 'src'
+},
+},
+format: 'rg8unorm',
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r16uint',
+},
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+format: 'rg8uint',
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'src',
+dstFactor: 'one-minus-src'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilWriteMask: 1851,
+depthBias: 42,
+depthBiasSlopeScale: 90,
+depthBiasClamp: 59,
+},
+}
+);
+let imageData17 = new ImageData(252, 60);
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+let commandEncoder37 = device0.createCommandEncoder(
+{
+label: '\u{1fcab}\u064c\u2087\u{1f78c}\u3329\u3ecf\u26eb\u0d79\u802e\u6e40\u9790',
+}
+);
+let querySet33 = device0.createQuerySet({
+label: '\uabd4\u3433\u{1f9d2}',
+type: 'occlusion',
+count: 2929,
+});
+let renderBundleEncoder33 = device0.createRenderBundleEncoder(
+{
+label: '\ue2c0\u61e6\u0f1e\u578c\uf30a',
+colorFormats: [
+'r8uint',
+'rg32uint',
+undefined,
+'rg8uint'
+],
+sampleCount: 617,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle35 = renderBundleEncoder13.finish(
+{
+label: '\u587b\u{1fd33}\u02f5\u0860'
+}
+);
+try {
+computePassEncoder4.setBindGroup(
+0,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(
+2328
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+1,
+buffer10
+);
+} catch {}
+let promise12 = device0.popErrorScope();
+try {
+device0.queue.writeTexture(
+{
+  texture: texture33,
+  mipLevel: 0,
+  origin: { x: 10, y: 44, z: 2 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 10025271 */{
+offset: 140,
+bytesPerRow: 315,
+rowsPerImage: 221,
+},
+{width: 80, height: 8, depthOrArrayLayers: 145}
+);
+} catch {}
+let device6 = await adapter7.requestDevice({
+label: '\uc2e3\u8337\u0e4e\u6cba\uee73\u0b76\u43d4\ucd68\u0722\ubedc',
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+});
+try {
+offscreenCanvas16.getContext('2d');
+} catch {}
+let buffer15 = device5.createBuffer(
+{
+label: '\u4b0b\u0d8d\u{1f6bd}\u10fd',
+size: 33442,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let texture48 = device5.createTexture(
+{
+label: '\uf1e9\u544e\u{1f891}\u3c11\u0ead\u0c7a\uca48\u{1ff13}\u{1fd9a}',
+size: {width: 1240, height: 252, depthOrArrayLayers: 29},
+mipLevelCount: 8,
+format: 'etc2-rgb8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'etc2-rgb8unorm',
+'etc2-rgb8unorm-srgb'
+],
+}
+);
+try {
+renderBundleEncoder32.setVertexBuffer(
+3,
+buffer13,
+42164,
+954
+);
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 24, y: 147 },
+  flipY: true,
+},
+{
+  texture: texture44,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline38 = await device5.createRenderPipelineAsync(
+{
+label: '\u05f2\u0044\u42de\u0e74\u0976\u{1ff48}\u0a68\uf2ec\u77cd',
+layout: pipelineLayout9,
+vertex: {
+module: shaderModule16,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1996,
+attributes: [
+{
+format: 'unorm16x2',
+offset: 660,
+shaderLocation: 1,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 32,
+shaderLocation: 7,
+},
+{
+format: 'sint16x2',
+offset: 972,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+
+],
+},
+{
+arrayStride: 940,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 192,
+shaderLocation: 8,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: false,
+},
+multisample: {
+count: 4,
+},
+fragment: {
+module: shaderModule16,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+failOp: 'replace',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilBack: {
+failOp: 'decrement-wrap',
+depthFailOp: 'zero',
+passOp: 'replace',
+},
+stencilReadMask: 3345,
+stencilWriteMask: 103,
+depthBias: 100,
+depthBiasSlopeScale: 16,
+depthBiasClamp: 37,
+},
+}
+);
+let querySet34 = device4.createQuerySet({
+label: '\u{1fd89}\u{1fca3}\ue8e0\u51e5\uc0ee\ud73d\ue190\u4604\ub41e\u{1f6b3}',
+type: 'occlusion',
+count: 899,
+});
+let computePassEncoder15 = commandEncoder33.beginComputePass(
+{
+label: '\u{1fe25}\ue997\u0efd\u0305\u230d\u{1f9ec}\u0371'
+}
+);
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img0);
+let commandEncoder38 = device6.createCommandEncoder(
+{
+}
+);
+try {
+commandEncoder38.insertDebugMarker(
+'\ufc18'
+);
+} catch {}
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+try {
+await promise12;
+} catch {}
+gc();
+let img10 = await imageWithData(185, 28, '#d8dad2b8', '#6e777316');
+let videoFrame11 = new VideoFrame(canvas10, {timestamp: 0});
+let commandEncoder39 = device4.createCommandEncoder(
+{
+label: '\u2f87\u{1f846}\uc5e4\u0667\u4cd1\u9562\ue31d\u08d3\u23b3\uaa4a',
+}
+);
+let querySet35 = device4.createQuerySet({
+label: '\u7591\u7080\u{1fa64}\ub2db\u{1f95c}\u1b05\uf00c\u5d30\ubbad\u14ab',
+type: 'occlusion',
+count: 459,
+});
+let texture49 = device4.createTexture(
+{
+size: {width: 3660, height: 4, depthOrArrayLayers: 170},
+sampleCount: 1,
+format: 'eac-r11snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'eac-r11snorm'
+],
+}
+);
+let computePassEncoder16 = commandEncoder39.beginComputePass(
+{
+
+}
+);
+let sampler27 = device4.createSampler(
+{
+label: '\u7f64\ua5a7\u00c8\uefb6',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 94.449,
+lodMaxClamp: 95.073,
+compare: 'always',
+}
+);
+try {
+device4.queue.writeTexture(
+{
+  texture: texture47,
+  mipLevel: 5,
+  origin: { x: 5, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Int8Array(arrayBuffer2),
+/* required buffer size: 978 */{
+offset: 274,
+},
+{width: 44, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+gc();
+try {
+buffer3.label = '\u00a9\u{1fd9b}\u073c\u0bcd\ud2eb\u{1f79d}\u0792\u{1fd99}';
+} catch {}
+let texture50 = device1.createTexture(
+{
+label: '\u0ea1\u0403\u0638\u7219\ud8ff\u8e52',
+size: {width: 7075},
+dimension: '1d',
+format: 'rgba32sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32sint',
+'rgba32sint',
+'rgba32sint'
+],
+}
+);
+let sampler28 = device1.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 48.059,
+lodMaxClamp: 90.595,
+compare: 'not-equal',
+maxAnisotropy: 16,
+}
+);
+try {
+computePassEncoder10.setPipeline(
+pipeline25
+);
+} catch {}
+try {
+renderPassEncoder12.beginOcclusionQuery(857);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(
+5,
+undefined,
+3460399357
+);
+} catch {}
+let arrayBuffer3 = buffer12.getMappedRange(
+49800,
+1076
+);
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let imageBitmap12 = await createImageBitmap(video10);
+let querySet36 = device4.createQuerySet({
+label: '\u33df\ub244\u0046\u01ea\u0338\u869f\u{1fcc4}\u0b6d\u0c4e\u7502\u6f57',
+type: 'occlusion',
+count: 3009,
+});
+let sampler29 = device4.createSampler(
+{
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 97.563,
+lodMaxClamp: 99.368,
+}
+);
+let gpuCanvasContext13 = offscreenCanvas17.getContext('webgpu');
+let shaderModule18 = device1.createShaderModule(
+{
+label: '\ufbf7\udd55\u0064\u832f\u{1feed}\u0d8b\u097e\u0a09\u6aec\u0896',
+code: `@group(0) @binding(1199)
+var<storage, read_write> field18: array<u32>;
+@group(0) @binding(1832)
+var<storage, read_write> i24: array<u32>;
+@group(4) @binding(7532)
+var<storage, read_write> function25: array<u32>;
+@group(1) @binding(5363)
+var<storage, read_write> function26: array<u32>;
+@group(2) @binding(5363)
+var<storage, read_write> parameter15: array<u32>;
+@group(5) @binding(7532)
+var<storage, read_write> field19: array<u32>;
+@group(3) @binding(1199)
+var<storage, read_write> field20: array<u32>;
+@group(5) @binding(5363)
+var<storage, read_write> i25: array<u32>;
+@group(2) @binding(7532)
+var<storage, read_write> field21: array<u32>;
+@group(4) @binding(5363)
+var<storage, read_write> global19: array<u32>;
+@group(1) @binding(7532)
+var<storage, read_write> global20: array<u32>;
+@group(3) @binding(1832)
+var<storage, read_write> type17: array<u32>;
+
+@compute @workgroup_size(6, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S21 {
+@location(27) f0: vec3<i32>,
+@builtin(sample_mask) f1: u32,
+@location(50) f2: vec3<u32>,
+@builtin(sample_index) f3: u32,
+@builtin(position) f4: vec4<f32>,
+@location(38) f5: vec3<u32>,
+@location(62) f6: vec2<i32>,
+@location(71) f7: vec4<i32>,
+@location(55) f8: u32,
+@location(14) f9: f16,
+@location(12) f10: vec4<u32>,
+@location(41) f11: vec3<f32>,
+@location(1) f12: vec4<f32>,
+@location(42) f13: vec3<f16>,
+@builtin(front_facing) f14: bool,
+@location(72) f15: f16,
+@location(35) f16: vec4<u32>,
+@location(31) f17: vec3<f32>,
+@location(34) f18: vec4<f32>,
+@location(6) f19: vec2<u32>,
+@location(40) f20: vec3<i32>,
+@location(68) f21: i32,
+@location(0) f22: vec2<f32>,
+@location(60) f23: vec3<u32>,
+@location(16) f24: vec4<u32>,
+@location(33) f25: vec4<i32>,
+@location(59) f26: vec2<i32>,
+@location(47) f27: vec4<f32>
+}
+struct FragmentOutput0 {
+@location(0) f0: vec4<u32>,
+@location(6) f1: vec4<u32>,
+@location(1) f2: f32,
+@location(3) f3: vec2<f32>,
+@location(2) f4: vec4<i32>,
+@location(5) f5: vec4<f32>,
+@location(7) f6: vec2<u32>,
+@location(4) f7: vec2<u32>
+}
+
+@fragment
+fn fragment0(@location(8) a0: vec2<f32>, @location(13) a1: vec3<f32>, @location(4) a2: vec2<u32>, a3: S21) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S20 {
+@location(15) f0: vec2<i32>,
+@builtin(vertex_index) f1: u32,
+@location(3) f2: vec3<f16>,
+@location(7) f3: vec3<f32>,
+@location(19) f4: vec2<f16>,
+@location(5) f5: vec4<u32>,
+@builtin(instance_index) f6: u32,
+@location(8) f7: vec2<i32>,
+@location(1) f8: vec3<i32>,
+@location(4) f9: vec2<f32>,
+@location(12) f10: f16
+}
+struct VertexOutput0 {
+@location(62) f230: vec2<i32>,
+@location(60) f231: vec3<u32>,
+@location(55) f232: u32,
+@location(27) f233: vec3<i32>,
+@location(71) f234: vec4<i32>,
+@location(35) f235: vec4<u32>,
+@location(50) f236: vec3<u32>,
+@location(72) f237: f16,
+@location(59) f238: vec2<i32>,
+@location(0) f239: vec2<f32>,
+@location(42) f240: vec3<f16>,
+@location(41) f241: vec3<f32>,
+@location(6) f242: vec2<u32>,
+@location(13) f243: vec3<f32>,
+@location(12) f244: vec4<u32>,
+@location(16) f245: vec4<u32>,
+@location(14) f246: f16,
+@location(1) f247: vec4<f32>,
+@location(8) f248: vec2<f32>,
+@location(33) f249: vec4<i32>,
+@location(68) f250: i32,
+@location(31) f251: vec3<f32>,
+@builtin(position) f252: vec4<f32>,
+@location(34) f253: vec4<f32>,
+@location(47) f254: vec4<f32>,
+@location(38) f255: vec3<u32>,
+@location(40) f256: vec3<i32>,
+@location(4) f257: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec2<i32>, @location(14) a1: vec3<f16>, @location(6) a2: vec2<f32>, a3: S20, @location(10) a4: vec4<i32>, @location(18) a5: vec4<i32>, @location(13) a6: vec4<f16>, @location(2) a7: vec3<u32>, @location(17) a8: vec3<i32>, @location(0) a9: vec2<i32>, @location(16) a10: vec3<i32>, @location(9) a11: f16) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let renderBundle36 = renderBundleEncoder21.finish(
+{
+label: '\u0e98\u0da9\u{1fccc}\u{1ffdf}\u068a\u{1f7d6}\ubbc0\u0bfe\ub88f'
+}
+);
+let sampler30 = device1.createSampler(
+{
+label: '\ub3c8\u{1fb2d}\uee19\ufeac',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 52.450,
+lodMaxClamp: 86.194,
+maxAnisotropy: 4,
+}
+);
+try {
+renderPassEncoder12.setBlendConstant({ r: -546.0, g: 90.10, b: -715.1, a: 489.6, });
+} catch {}
+try {
+renderPassEncoder9.setViewport(
+9.388,
+11.15,
+10.35,
+16.27,
+0.3097,
+0.3761
+);
+} catch {}
+try {
+buffer7.destroy();
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder40 = device6.createCommandEncoder();
+let computePassEncoder17 = commandEncoder38.beginComputePass(
+{
+label: '\u0368\u15b4\u4242\u0827\u02cb\u{1f720}\u8da9\u0d5a\u917f\uc099'
+}
+);
+let buffer16 = device1.createBuffer(
+{
+label: '\u06f8\ue0d2\u0217\u6710\ue49b\u{1f8e6}\u82cd',
+size: 10929,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let sampler31 = device1.createSampler(
+{
+label: '\ue2af\u9975\u1c8b\u{1feb5}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 11.222,
+lodMaxClamp: 34.813,
+}
+);
+try {
+renderPassEncoder12.setIndexBuffer(
+buffer11,
+'uint32',
+2360,
+4751
+);
+} catch {}
+try {
+computePassEncoder7.insertDebugMarker(
+'\u02aa'
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer16,
+1800,
+new DataView(new ArrayBuffer(48501)),
+43739,
+3088
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture31,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(arrayBuffer2),
+/* required buffer size: 794 */{
+offset: 794,
+rowsPerImage: 151,
+},
+{width: 101, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let promise13 = device1.createComputePipelineAsync(
+{
+label: '\u{1fe5c}\u7e24\u1624\u{1faa6}\u069a\u5472\u7f62\u3a11',
+layout: 'auto',
+compute: {
+module: shaderModule17,
+entryPoint: 'compute0',
+},
+}
+);
+let pipeline39 = device1.createRenderPipeline(
+{
+label: '\u0b08\u2b72\u0b61\u0c6b',
+layout: pipelineLayout8,
+vertex: {
+module: shaderModule14,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 704,
+attributes: [
+
+],
+},
+{
+arrayStride: 1088,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 1424,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32',
+offset: 648,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+},
+multisample: {
+count: 1,
+mask: 0x1279579f,
+},
+fragment: {
+module: shaderModule14,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16uint',
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'one-minus-dst-alpha',
+dstFactor: 'one-minus-src'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'one-minus-src-alpha',
+dstFactor: 'dst-alpha'
+},
+},
+format: 'rg8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'invert',
+depthFailOp: 'zero',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 582,
+stencilWriteMask: 1504,
+depthBias: 79,
+depthBiasClamp: 67,
+},
+}
+);
+let videoFrame12 = new VideoFrame(offscreenCanvas12, {timestamp: 0});
+let img11 = await imageWithData(211, 176, '#270150f2', '#4be511cf');
+let bindGroupLayout23 = device6.createBindGroupLayout(
+{
+label: '\u04d7\u9f18\u{1fd84}\uf9ca\u0caf\uab50\u{1fe88}\u2df1\u01d8',
+entries: [
+{
+binding: 432,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 536,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+}
+],
+}
+);
+let pipelineLayout10 = device6.createPipelineLayout(
+{
+label: '\u05ff\u0940\u0682\u{1fd6d}\u{1fbb2}',
+bindGroupLayouts: [
+
+]
+}
+);
+let commandEncoder41 = device6.createCommandEncoder(
+{
+label: '\u0640\uacd1\u0be5\ua985',
+}
+);
+let querySet37 = device6.createQuerySet({
+label: '\u2cf3\uf946\u0aa1\u4cc9\u{1fd94}\u0084',
+type: 'occlusion',
+count: 1866,
+});
+let computePassEncoder18 = commandEncoder40.beginComputePass(
+{
+label: '\u0978\uab81\u{1fc3e}\ueb6c\ud86c\ucce0\u25fc'
+}
+);
+let canvas14 = document.createElement('canvas');
+try {
+await adapter4.requestAdapterInfo();
+} catch {}
+let texture51 = device5.createTexture(
+{
+label: '\u0929\u{1fcd4}\u0a06\u{1f7ed}\u68fe\u0572\u0a0a\u0228\u0040\ue923\u3766',
+size: {width: 7720, height: 20, depthOrArrayLayers: 71},
+format: 'astc-10x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x10-unorm',
+'astc-10x10-unorm-srgb'
+],
+}
+);
+let textureView29 = texture46.createView(
+{
+label: '\ud1f6\u651a\u0784\ue0c6\u1d31\u4812\u0d0d',
+dimension: '2d',
+baseMipLevel: 1,
+baseArrayLayer: 42,
+}
+);
+let sampler32 = device5.createSampler(
+{
+label: '\ub8db\u{1fcca}\u{1f6b0}\u{1f7ae}',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 49.505,
+lodMaxClamp: 58.834,
+compare: 'greater-equal',
+maxAnisotropy: 4,
+}
+);
+try {
+await device5.popErrorScope();
+} catch {}
+let imageData18 = new ImageData(32, 256);
+try {
+renderPassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(
+14,
+undefined,
+1023455973,
+2181389070
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer16,
+3208,
+new Float32Array(43769),
+35495,
+180
+);
+} catch {}
+let imageBitmap13 = await createImageBitmap(imageData14);
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let video15 = await videoWithData();
+let commandEncoder42 = device1.createCommandEncoder(
+{
+label: '\u849c\uc6cb\u37d1\u{1fe18}',
+}
+);
+let texture52 = device1.createTexture(
+{
+size: [859, 1, 184],
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm',
+'rgba8unorm-srgb',
+'rgba8unorm'
+],
+}
+);
+let renderBundle37 = renderBundleEncoder19.finish();
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(
+13,
+37,
+0,
+3
+);
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(
+3129
+);
+} catch {}
+let pipeline40 = device1.createRenderPipeline(
+{
+label: '\uebc1\ucb4a\u{1f8a6}\u0895',
+layout: pipelineLayout8,
+vertex: {
+module: shaderModule17,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 3408,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 2252,
+shaderLocation: 12,
+},
+{
+format: 'sint16x4',
+offset: 1212,
+shaderLocation: 10,
+},
+{
+format: 'uint8x2',
+offset: 2386,
+shaderLocation: 5,
+},
+{
+format: 'uint32x3',
+offset: 1692,
+shaderLocation: 1,
+},
+{
+format: 'uint32x4',
+offset: 1972,
+shaderLocation: 13,
+},
+{
+format: 'sint8x2',
+offset: 3254,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0x5a79b5b6,
+},
+fragment: {
+module: shaderModule17,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'rgba8uint',
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rg16uint',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-wrap',
+depthFailOp: 'invert',
+passOp: 'zero',
+},
+stencilWriteMask: 1789,
+depthBias: 33,
+depthBiasClamp: 20,
+},
+}
+);
+offscreenCanvas14.width = 710;
+let commandEncoder43 = device4.createCommandEncoder();
+let texture53 = device4.createTexture(
+{
+label: '\u2efe\ua17f\u59cd\ucbdf\u974e\ua6b5\ub5d4\ubfb9\ua4fd\u{1ff36}\u{1fe25}',
+size: [60, 10, 153],
+mipLevelCount: 3,
+format: 'astc-12x10-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-12x10-unorm-srgb',
+'astc-12x10-unorm'
+],
+}
+);
+let renderBundleEncoder34 = device4.createRenderBundleEncoder(
+{
+label: '\u{1f7f3}\u4e3d\u646c\uc00c\u4616\u2f14\u{1fd2f}',
+colorFormats: [
+'rgba32uint'
+],
+sampleCount: 333,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle38 = renderBundleEncoder34.finish(
+{
+label: '\u00d2\u{1ff32}\u049f\u0550\u{1f7d1}\ue82c\u{1fd50}\u{1f90c}'
+}
+);
+let pipelineLayout11 = device1.createPipelineLayout(
+{
+label: '\u{1fd84}\u{1ffb5}\uec37\u{1fabd}\u01ab\u9fd4\u7a63\u5fb4\u71c5\ufbe8\u{1f8af}',
+bindGroupLayouts: [
+bindGroupLayout13,
+bindGroupLayout16,
+bindGroupLayout18,
+bindGroupLayout9,
+bindGroupLayout15,
+bindGroupLayout11,
+bindGroupLayout11,
+bindGroupLayout14,
+bindGroupLayout11,
+bindGroupLayout14,
+bindGroupLayout18
+]
+}
+);
+let commandEncoder44 = device1.createCommandEncoder(
+{
+label: '\u14cd\u{1fc13}\u80cb\u5c20\u{1fdad}\u4316\u7d0f\uccf7\u82fd',
+}
+);
+let textureView30 = texture43.createView(
+{
+label: '\u{1fe01}\u8a13\u0442\uc925\uad7f\u0756\u{1f900}\u37f8\u9a4d\u0992',
+baseMipLevel: 1,
+}
+);
+let renderPassEncoder13 = commandEncoder42.beginRenderPass(
+{
+label: '\u44f2\ufc07\ube66\u{1f6e3}',
+colorAttachments: [
+undefined
+],
+depthStencilAttachment: {
+view: textureView12,
+depthClearValue: 0.4372405103974264,
+depthLoadOp: 'clear',
+depthStoreOp: 'discard',
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet15,
+maxDrawCount: 5032,
+}
+);
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.setViewport(
+13.25,
+4.713,
+7.352,
+18.55,
+0.4304,
+0.9837
+);
+} catch {}
+try {
+commandEncoder44.clearBuffer(
+buffer6
+);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture31,
+  mipLevel: 1,
+  origin: { x: 0, y: 32, z: 1 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(new ArrayBuffer(16)),
+/* required buffer size: 492 */{
+offset: 492,
+},
+{width: 6509, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let promise14 = device1.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let adapter8 = await navigator.gpu.requestAdapter();
+let img12 = await imageWithData(181, 16, '#8b145ea8', '#014f105f');
+let shaderModule19 = device5.createShaderModule(
+{
+code: `@group(3) @binding(167)
+var<storage, read_write> function27: array<u32>;
+@group(2) @binding(167)
+var<storage, read_write> local14: array<u32>;
+@group(1) @binding(167)
+var<storage, read_write> parameter16: array<u32>;
+@group(0) @binding(167)
+var<storage, read_write> field22: array<u32>;
+
+@compute @workgroup_size(1, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@location(15) a0: vec2<u32>, @location(1) a1: vec2<u32>, @location(7) a2: vec4<u32>, @location(2) a3: vec2<f16>, @location(12) a4: vec3<u32>, @location(6) a5: vec4<u32>, @location(9) a6: vec3<i32>, @location(3) a7: i32, @location(4) a8: vec2<f32>, @location(10) a9: vec4<u32>, @builtin(sample_index) a10: u32, @builtin(position) a11: vec4<f32>, @location(0) a12: u32, @location(11) a13: vec4<i32>, @builtin(sample_mask) a14: u32) -> @location(0) u32 {
+return u32();
+}
+
+struct VertexOutput0 {
+@location(10) f258: vec4<u32>,
+@location(11) f259: vec4<i32>,
+@location(6) f260: vec4<u32>,
+@location(1) f261: vec2<u32>,
+@location(12) f262: vec3<u32>,
+@location(4) f263: vec2<f32>,
+@location(7) f264: vec4<u32>,
+@location(15) f265: vec2<u32>,
+@location(3) f266: i32,
+@location(0) f267: u32,
+@location(9) f268: vec3<i32>,
+@location(2) f269: vec2<f16>,
+@builtin(position) f270: vec4<f32>
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let sampler33 = device5.createSampler(
+{
+label: '\ub341\ud1f2\u39ba\u0a0e\uea7c\u7054\u1c89\u41f7\u0bed',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 77.103,
+lodMaxClamp: 81.757,
+maxAnisotropy: 2,
+}
+);
+let promise15 = device5.createRenderPipelineAsync(
+{
+label: '\u1687\u0c7b\u257b\u5dcf\u8e01\u6abe\u0403\udec3\u0000\ue3e0\ue2d3',
+layout: pipelineLayout9,
+vertex: {
+module: shaderModule16,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 396,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x2',
+offset: 252,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 1596,
+shaderLocation: 8,
+},
+{
+format: 'sint16x2',
+offset: 1948,
+shaderLocation: 3,
+},
+{
+format: 'snorm8x2',
+offset: 910,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule16,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'dst-alpha',
+dstFactor: 'dst'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.BLUE,
+},
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'greater',
+depthFailOp: 'invert',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'replace',
+depthFailOp: 'decrement-clamp',
+},
+stencilReadMask: 2092,
+stencilWriteMask: 540,
+depthBias: 8,
+depthBiasSlopeScale: 68,
+depthBiasClamp: 95,
+},
+}
+);
+canvas8.height = 692;
+let imageData19 = new ImageData(128, 28);
+document.body.prepend(canvas11);
+let computePassEncoder19 = commandEncoder44.beginComputePass(
+{
+
+}
+);
+let renderBundleEncoder35 = device1.createRenderBundleEncoder(
+{
+label: '\uf585\ud2e8\u0ff0\u0459',
+colorFormats: [
+'r32float',
+undefined,
+'rg8uint',
+'r16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 153,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder9.setBlendConstant({ r: 257.9, g: 798.5, b: -484.3, a: 469.3, });
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(
+1,
+46,
+13,
+0
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer16,
+2432,
+new DataView(new ArrayBuffer(28575)),
+8356,
+148
+);
+} catch {}
+gc();
+let texture54 = device4.createTexture(
+{
+label: '\u{1f95a}\u{1f88c}\u04ee\u1a2e\u165c\ue6fa',
+size: [4, 4, 240],
+mipLevelCount: 3,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+computePassEncoder16.insertDebugMarker(
+'\u084a'
+);
+} catch {}
+let imageBitmap14 = await createImageBitmap(videoFrame10);
+let texture55 = device1.createTexture(
+{
+label: '\u0e77\u0a70',
+size: [25, 6, 109],
+mipLevelCount: 7,
+dimension: '3d',
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let sampler34 = device1.createSampler(
+{
+label: '\u5a44\u4b4e\u94f4\u3ab8\u0f53',
+addressModeU: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 14.860,
+lodMaxClamp: 85.088,
+}
+);
+try {
+renderPassEncoder9.setIndexBuffer(
+buffer11,
+'uint16',
+11814,
+302
+);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(
+21,
+undefined,
+2623610581,
+587562855
+);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(
+buffer8,
+'uint32'
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer16,
+4216,
+new DataView(new ArrayBuffer(191)),
+109,
+40
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture55,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 5 },
+  aspect: 'all',
+},
+new ArrayBuffer(32832),
+/* required buffer size: 32832 */{
+offset: 860,
+bytesPerRow: 122,
+rowsPerImage: 131,
+},
+{width: 2, height: 1, depthOrArrayLayers: 3}
+);
+} catch {}
+let querySet38 = device5.createQuerySet({
+label: '\u{1fa0b}\u0d8a\u{1fed4}\u06bd\u{1f976}',
+type: 'occlusion',
+count: 3733,
+});
+let pipeline41 = await device5.createComputePipelineAsync(
+{
+label: '\u9631\u0eb0\u{1f9f1}',
+layout: pipelineLayout9,
+compute: {
+module: shaderModule15,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let gpuCanvasContext14 = canvas14.getContext('webgpu');
+let offscreenCanvas18 = new OffscreenCanvas(108, 415);
+let sampler35 = device6.createSampler(
+{
+label: '\u7b45\u3172\u{1fdd4}\u7f8d\u0b00\u0391',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 58.470,
+lodMaxClamp: 64.563,
+maxAnisotropy: 17,
+}
+);
+try {
+commandEncoder41.insertDebugMarker(
+'\ud162'
+);
+} catch {}
+canvas3.height = 976;
+let imageData20 = new ImageData(120, 152);
+let querySet39 = device4.createQuerySet({
+label: '\u{1faa2}\u{1ff04}\u1582\u0452\u{1f81c}\u0d92\u{1f79b}\u79a5',
+type: 'occlusion',
+count: 1848,
+});
+let textureView31 = texture49.createView(
+{
+label: '\u2019\u142f\u6553\ue6a5\u91f2',
+dimension: '2d',
+baseArrayLayer: 39,
+}
+);
+let renderBundle39 = renderBundleEncoder34.finish(
+{
+label: '\u0915\ub699\u815c'
+}
+);
+try {
+device4.pushErrorScope('internal');
+} catch {}
+let imageBitmap15 = await createImageBitmap(img10);
+let commandEncoder45 = device4.createCommandEncoder(
+{
+}
+);
+let textureView32 = texture54.createView(
+{
+label: '\u7d10\u{1fbbe}\udb0b',
+baseMipLevel: 2,
+baseArrayLayer: 157,
+arrayLayerCount: 8,
+}
+);
+let promise16 = device4.queue.onSubmittedWorkDone();
+try {
+offscreenCanvas18.getContext('webgl2');
+} catch {}
+let bindGroupLayout24 = device6.createBindGroupLayout(
+{
+label: '\ue38e\u0706\u0a44\u2db0\u{1f957}\u0bd5\u01d5\uc813',
+entries: [
+{
+binding: 108,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d-array', sampleType: 'depth', multisampled: false },
+},
+{
+binding: 111,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+}
+],
+}
+);
+let renderBundleEncoder36 = device6.createRenderBundleEncoder(
+{
+label: '\u0bc8\u010a\ubf23\u5ca3\ubde3',
+colorFormats: [
+'rgba32sint',
+'r16sint',
+'r32uint',
+'r16uint',
+'rg16float',
+'rg8uint'
+],
+sampleCount: 751,
+depthReadOnly: true,
+}
+);
+let renderBundle40 = renderBundleEncoder36.finish(
+{
+label: '\u0d2c\u600d\u{1ff7c}\u0b96'
+}
+);
+let sampler36 = device6.createSampler(
+{
+label: '\u{1f7ce}\u4b8a\u77a3\u{1f788}\u7185\u1923\u{1f796}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 73.808,
+lodMaxClamp: 93.117,
+}
+);
+try {
+gpuCanvasContext1.configure(
+{
+device: device6,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8uint'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device5.queue.label = '\u094a\u0464\u3244\u5a25\u{1f830}\u{1fc1e}\u{1f8f9}\u49f2';
+} catch {}
+let bindGroupLayout25 = device5.createBindGroupLayout(
+{
+label: '\u0c9a\u{1fd99}\u780a\u650e\u8733\u0ce3\uae01\u{1fa15}\u0134',
+entries: [
+{
+binding: 378,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 59,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let buffer17 = device5.createBuffer(
+{
+size: 43534,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+}
+);
+let textureView33 = texture45.createView(
+{
+}
+);
+let renderBundleEncoder37 = device5.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg16float',
+'rg32sint',
+'r32uint',
+'rgba8unorm-srgb',
+'rg32uint'
+],
+sampleCount: 174,
+stencilReadOnly: true,
+}
+);
+let pipeline42 = device5.createComputePipeline(
+{
+label: '\ubbe4\ubeae\u{1f684}\ub489\udc05\u{1fb59}\u5e17',
+layout: pipelineLayout9,
+compute: {
+module: shaderModule16,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline43 = await promise15;
+let renderBundleEncoder38 = device5.createRenderBundleEncoder(
+{
+label: '\u0aad\u081f\u93bd\uf82e',
+colorFormats: [
+'rgba32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 461,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder32.setVertexBuffer(
+1,
+buffer13,
+20256,
+21989
+);
+} catch {}
+let pipeline44 = device5.createComputePipeline(
+{
+label: '\u99b3\u{1fffe}',
+layout: pipelineLayout9,
+compute: {
+module: shaderModule16,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let commandEncoder46 = device6.createCommandEncoder(
+{
+label: '\u3da5\u{1fdce}\u0b48\u68c3\u011a\u{1fa15}\u{1fdf3}\u8093\u469a\u{1fda8}\u{1f975}',
+}
+);
+let renderBundleEncoder39 = device6.createRenderBundleEncoder(
+{
+label: '\u599c\u1330\u{1fe63}\u{1face}\ua9da\u3982\u7468\ud200\ube08\u0b05',
+colorFormats: [
+'r8sint',
+undefined,
+'rg32float',
+undefined,
+'r32float',
+'r8unorm',
+'rgb10a2unorm'
+],
+sampleCount: 620,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let externalTexture4 = device6.importExternalTexture(
+{
+label: '\u{1fb38}\u{1fc57}\u6834\u0d4e',
+source: videoFrame1,
+colorSpace: 'srgb',
+}
+);
+try {
+gpuCanvasContext4.configure(
+{
+device: device6,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+gc();
+try {
+renderBundleEncoder18.label = '\u3911\u0a36\u0e60\u0a41\u0acc\u0fb8\u06f9\u40aa\u0517\u0c0c';
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(
+3780,
+142,
+9889,
+68
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let video16 = await videoWithData();
+let imageData21 = new ImageData(52, 112);
+offscreenCanvas1.width = 156;
+let texture56 = device4.createTexture(
+{
+label: '\u07f2\u8f0d\ua7fa',
+size: {width: 766},
+dimension: '1d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg16float',
+'rg16float',
+'rg16float'
+],
+}
+);
+try {
+computePassEncoder15.end();
+} catch {}
+let querySet40 = device1.createQuerySet({
+label: '\u{1f72d}\u{1f634}\u1d39\u33de\u0691\u{1fb6f}\u6e13',
+type: 'occlusion',
+count: 1441,
+});
+try {
+renderPassEncoder13.setBlendConstant({ r: -741.9, g: 505.1, b: 539.8, a: 371.7, });
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(
+buffer8,
+'uint32',
+44968,
+162
+);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(
+82,
+undefined,
+1262650262,
+978898828
+);
+} catch {}
+let arrayBuffer4 = buffer6.getMappedRange(
+496,
+944
+);
+try {
+device1.queue.writeTexture(
+{
+  texture: texture43,
+  mipLevel: 0,
+  origin: { x: 8, y: 0, z: 74 },
+  aspect: 'all',
+},
+new Int8Array(arrayBuffer4),
+/* required buffer size: 1007122 */{
+offset: 280,
+bytesPerRow: 842,
+rowsPerImage: 239,
+},
+{width: 163, height: 1, depthOrArrayLayers: 6}
+);
+} catch {}
+let imageBitmap16 = await createImageBitmap(imageBitmap15);
+let renderBundleEncoder40 = device1.createRenderBundleEncoder(
+{
+label: '\u90d3\u{1fa2e}\u{1fe2f}\u{1fcb6}\ue923\u0296\u8e82\u9092\u9aa6\u{1ff1d}',
+colorFormats: [
+'r16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 118,
+stencilReadOnly: false,
+}
+);
+try {
+renderPassEncoder13.beginOcclusionQuery(1922);
+} catch {}
+try {
+renderPassEncoder13.setViewport(
+17.24,
+2.748,
+3.697,
+20.10,
+0.5865,
+0.7506
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer16,
+1828,
+new Float32Array(54293),
+45538,
+1512
+);
+} catch {}
+let renderBundleEncoder41 = device4.createRenderBundleEncoder(
+{
+label: '\u0bbe\u3621\u0b9e\uf95b\uab8b',
+colorFormats: [
+'rgba32float',
+undefined,
+'r16float',
+undefined,
+'rg8sint',
+'r32float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 886,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let externalTexture5 = device4.importExternalTexture(
+{
+label: '\u24be\u{1f847}\u69ab\u0146\ub312\u6b11\ua841\u09d2\u{1f65f}\u0860\u03ee',
+source: videoFrame9,
+colorSpace: 'display-p3',
+}
+);
+try {
+computePassEncoder16.insertDebugMarker(
+'\u3c4f'
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture53,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 42 },
+  aspect: 'all',
+},
+new Int8Array(arrayBuffer1),
+/* required buffer size: 2367113 */{
+offset: 833,
+bytesPerRow: 313,
+rowsPerImage: 90,
+},
+{width: 12, height: 0, depthOrArrayLayers: 85}
+);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let renderBundleEncoder42 = device1.createRenderBundleEncoder(
+{
+label: '\u00a8\u05c8\u8892\u{1f864}\uf079\u4139\u0629\uadf1',
+colorFormats: [
+'r32sint',
+'r32sint',
+'rgba8uint',
+'rgba8unorm-srgb',
+'rgba32float',
+'r8unorm',
+'r8sint',
+'rgba8unorm-srgb'
+],
+sampleCount: 282,
+depthReadOnly: true,
+}
+);
+let sampler37 = device1.createSampler(
+{
+label: '\u9b81\u03d8',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 23.510,
+lodMaxClamp: 35.971,
+}
+);
+try {
+renderPassEncoder13.setViewport(
+22.72,
+12.32,
+0.1750,
+26.42,
+0.3538,
+0.9757
+);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(
+88,
+undefined,
+2572415750,
+930914353
+);
+} catch {}
+try {
+gpuCanvasContext13.configure(
+{
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'bgra8unorm',
+'r8sint'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer16,
+1836,
+new Float32Array(63492),
+29387,
+1932
+);
+} catch {}
+let imageData22 = new ImageData(32, 204);
+try {
+await adapter8.requestAdapterInfo();
+} catch {}
+let imageData23 = new ImageData(168, 172);
+let texture57 = device6.createTexture(
+{
+size: {width: 562},
+dimension: '1d',
+format: 'rgba8sint',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8sint',
+'rgba8sint',
+'rgba8sint'
+],
+}
+);
+let renderBundleEncoder43 = device6.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg32float',
+'r16sint',
+'rg16uint'
+],
+sampleCount: 449,
+stencilReadOnly: true,
+}
+);
+let commandBuffer8 = commandEncoder36.finish(
+{
+label: '\ubf4d\u20e3',
+}
+);
+let texture58 = device4.createTexture(
+{
+label: '\u02df\uc660',
+size: [7160],
+dimension: '1d',
+format: 'rg32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let sampler38 = device4.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 67.716,
+lodMaxClamp: 92.330,
+}
+);
+try {
+renderBundleEncoder41.setVertexBuffer(
+12,
+undefined,
+4183070401,
+865251
+);
+} catch {}
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+try {
+await promise16;
+} catch {}
+let bindGroup3 = device5.createBindGroup({
+label: '\u{1f979}\u{1f90f}\u7e0d\uf37a\u{1ff94}\u{1ffae}',
+layout: bindGroupLayout22,
+entries: [
+{
+binding: 704,
+resource: sampler32
+}
+],
+});
+let renderBundleEncoder44 = device5.createRenderBundleEncoder(
+{
+label: '\u0fd3\u0888\ua2e8\u0edb\u{1ff3f}\u8b5d\u078c\u{1fbf9}\u03db\u{1fbf0}',
+colorFormats: [
+'r8uint',
+'rg32float',
+'rgba32uint',
+'rg16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 649,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder32.setVertexBuffer(
+4,
+buffer13,
+36248,
+7539
+);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture46,
+  mipLevel: 2,
+  origin: { x: 0, y: 6, z: 17 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 2014064 */{
+offset: 180,
+bytesPerRow: 124,
+rowsPerImage: 149,
+},
+{width: 40, height: 0, depthOrArrayLayers: 110}
+);
+} catch {}
+let videoFrame13 = new VideoFrame(imageBitmap16, {timestamp: 0});
+try {
+computePassEncoder16.insertDebugMarker(
+'\u11d1'
+);
+} catch {}
+let querySet41 = device4.createQuerySet({
+type: 'occlusion',
+count: 3707,
+});
+let textureView34 = texture54.createView(
+{
+label: '\u2d14\u4f7f\u6805\ud8dd',
+baseMipLevel: 1,
+mipLevelCount: 1,
+baseArrayLayer: 79,
+arrayLayerCount: 140,
+}
+);
+let sampler39 = device4.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 50.677,
+lodMaxClamp: 61.405,
+compare: 'never',
+}
+);
+try {
+renderBundleEncoder41.setVertexBuffer(
+38,
+undefined
+);
+} catch {}
+let texture59 = device1.createTexture(
+{
+label: '\u0d54\u0d14\u2980\u{1ffa5}\u242b\u{1fb43}\u81b3\u0c30\u3441\u0a02',
+size: [185, 1, 166],
+mipLevelCount: 5,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+}
+);
+let renderBundle41 = renderBundleEncoder28.finish(
+{
+label: '\u020b\u6424\u0a68\u2115'
+}
+);
+try {
+renderPassEncoder9.setStencilReference(
+2132
+);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(
+buffer11,
+'uint16',
+13050,
+515
+);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let commandEncoder47 = device1.createCommandEncoder(
+{
+label: '\u45dd\u02f0\u7864\u{1f918}\uf7ea',
+}
+);
+let querySet42 = device1.createQuerySet({
+label: '\u0e20\u2d8e\ucb2c',
+type: 'occlusion',
+count: 330,
+});
+let textureView35 = texture29.createView(
+{
+label: '\u0854\u{1fb0a}\u0787\u42b7\u019d',
+baseMipLevel: 6,
+mipLevelCount: 2,
+}
+);
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline45 = await promise13;
+let device7 = await adapter8.requestDevice({
+label: '\u3d3e\ud2a6\u026e\u4ea7',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 60,
+maxVertexAttributes: 25,
+maxVertexBufferArrayStride: 34530,
+maxStorageTexturesPerShaderStage: 16,
+maxStorageBuffersPerShaderStage: 22,
+maxDynamicStorageBuffersPerPipelineLayout: 39150,
+maxBindingsPerBindGroup: 9269,
+maxTextureDimension1D: 14890,
+maxTextureDimension2D: 10866,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 185746955,
+maxUniformBuffersPerShaderStage: 43,
+maxInterStageShaderVariables: 63,
+maxInterStageShaderComponents: 116,
+maxSamplersPerShaderStage: 17,
+},
+});
+try {
+renderBundleEncoder43.setVertexBuffer(
+17,
+undefined,
+4207557307
+);
+} catch {}
+try {
+device6.pushErrorScope('internal');
+} catch {}
+try {
+await promise14;
+} catch {}
+let video17 = await videoWithData();
+let commandBuffer9 = commandEncoder33.finish(
+{
+label: '\u01cf\u1819\ub4ac\u8589\uf299\u9a78\u4a8a\u{1fc62}',
+}
+);
+let textureView36 = texture49.createView(
+{
+label: '\u418e\u05e8\ua892\u{1fa80}',
+baseMipLevel: 0,
+baseArrayLayer: 4,
+arrayLayerCount: 158,
+}
+);
+let renderBundle42 = renderBundleEncoder41.finish(
+{
+
+}
+);
+try {
+computePassEncoder16.end();
+} catch {}
+let commandEncoder48 = device5.createCommandEncoder();
+let querySet43 = device5.createQuerySet({
+label: '\u83f7\ue704\u3a11\u1e49\ue3ed\ua8c8\u0fcb\u79e4\u06f6\u840f\u103d',
+type: 'occlusion',
+count: 2304,
+});
+try {
+buffer15.unmap();
+} catch {}
+try {
+commandEncoder48.copyTextureToTexture(
+{
+  texture: texture48,
+  mipLevel: 5,
+  origin: { x: 4, y: 0, z: 7 },
+  aspect: 'all',
+},
+{
+  texture: texture48,
+  mipLevel: 3,
+  origin: { x: 112, y: 24, z: 0 },
+  aspect: 'all',
+},
+{width: 28, height: 0, depthOrArrayLayers: 22}
+);
+} catch {}
+try {
+commandEncoder48.resolveQuerySet(
+querySet43,
+1196,
+157,
+buffer14,
+2048
+);
+} catch {}
+try {
+computePassEncoder14.insertDebugMarker(
+'\u0b24'
+);
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData22,
+  origin: { x: 27, y: 20 },
+  flipY: true,
+},
+{
+  texture: texture44,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+offscreenCanvas14.width = 909;
+gc();
+let querySet44 = device5.createQuerySet({
+label: '\u5174\u8bf5\u0512\u{1f783}\u32e2\uacaa',
+type: 'occlusion',
+count: 1634,
+});
+let sampler40 = device5.createSampler(
+{
+label: '\ud291\u8ed2\u32ba\u9df6\u043b\u9882\u0c7f\u{1fd8a}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 92.873,
+lodMaxClamp: 94.818,
+maxAnisotropy: 8,
+}
+);
+try {
+renderBundleEncoder37.setVertexBuffer(
+2,
+buffer13
+);
+} catch {}
+try {
+device5.addEventListener('uncapturederror', e => { log('device5.uncapturederror'); log(e); e.label = device5.label; });
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture44,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new BigInt64Array(new ArrayBuffer(8)),
+/* required buffer size: 357 */{
+offset: 357,
+bytesPerRow: 133,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline46 = await promise11;
+gc();
+let renderBundle43 = renderBundleEncoder41.finish(
+{
+label: '\u58d7\u0d4c\u108e'
+}
+);
+let sampler41 = device4.createSampler(
+{
+label: '\ucd61\u{1f7bf}\u{1f70d}\ufbdb\u8b7e\u0cc1\u8463\u05cc\uc9f7\u53b6\u54cd',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 49.232,
+}
+);
+document.body.prepend(canvas0);
+try {
+window.someLabel = textureView24.label;
+} catch {}
+let img13 = await imageWithData(183, 205, '#279a39f0', '#ec522a27');
+let imageData24 = new ImageData(96, 188);
+try {
+device7.destroy();
+} catch {}
+video3.width = 67;
+let bindGroupLayout26 = device6.createBindGroupLayout(
+{
+entries: [
+
+],
+}
+);
+let pipelineLayout12 = device6.createPipelineLayout(
+{
+label: '\u44c1\u0906\u53b2',
+bindGroupLayouts: [
+bindGroupLayout26
+]
+}
+);
+let commandEncoder49 = device6.createCommandEncoder(
+{
+label: '\u001e\ubd0d\u{1f93b}\u{1f8e5}',
+}
+);
+pseudoSubmit(device6, commandEncoder40);
+let renderBundle44 = renderBundleEncoder43.finish();
+let sampler42 = device6.createSampler(
+{
+label: '\u51e0\u0fa3\u{1feec}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMaxClamp: 95.008,
+compare: 'always',
+}
+);
+let textureView37 = texture57.createView(
+{
+}
+);
+let offscreenCanvas19 = new OffscreenCanvas(624, 751);
+let gpuCanvasContext15 = offscreenCanvas19.getContext('webgpu');
+document.body.prepend(canvas6);
+canvas1.width = 339;
+video13.height = 86;
+let img14 = await imageWithData(68, 154, '#9dbb81c4', '#e5c2a2ed');
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let buffer18 = device4.createBuffer(
+{
+label: '\u4c6b\u3dc2\ue4b4\u{1fba9}',
+size: 12412,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let commandEncoder50 = device4.createCommandEncoder(
+{
+label: '\u{1fa4c}\ue00f\u01d6\ucce8\u5de8',
+}
+);
+let querySet45 = device4.createQuerySet({
+type: 'occlusion',
+count: 630,
+});
+let renderBundle45 = renderBundleEncoder41.finish(
+{
+label: '\u0675\uddb4\u0edc\u017b\u85d2\u{1fa36}\ucd68\u057b\u{1fc72}\u0e2a\u{1ff89}'
+}
+);
+try {
+gpuCanvasContext7.configure(
+{
+device: device4,
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture49,
+  mipLevel: 0,
+  origin: { x: 896, y: 0, z: 149 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 641444 */{
+offset: 87,
+bytesPerRow: 3865,
+rowsPerImage: 165,
+},
+{width: 1816, height: 4, depthOrArrayLayers: 2}
+);
+} catch {}
+let imageData25 = new ImageData(144, 96);
+pseudoSubmit(device5, commandEncoder48);
+let texture60 = device5.createTexture(
+{
+label: '\u04c0\u0c32\u{1fd61}\u{1fb0b}\u{1f9d8}\uc5d0\u060d\ua971\u51ec\u2d76\u9564',
+size: {width: 2440, height: 120, depthOrArrayLayers: 1},
+mipLevelCount: 12,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+}
+);
+let sampler43 = device5.createSampler(
+{
+label: '\u02d3\uc48c',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 77.642,
+lodMaxClamp: 83.366,
+}
+);
+try {
+device5.queue.writeBuffer(
+buffer17,
+14036,
+new Float32Array(26367),
+4877,
+1680
+);
+} catch {}
+canvas9.width = 764;
+let bindGroupLayout27 = device1.createBindGroupLayout(
+{
+label: '\u9f1b\u{1ff79}',
+entries: [
+{
+binding: 5887,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba32float', access: 'write-only', viewDimension: '2d-array' },
+},
+{
+binding: 5765,
+visibility: 0,
+externalTexture: {},
+}
+],
+}
+);
+let commandEncoder51 = device1.createCommandEncoder(
+{
+label: '\u4da4\u{1f954}\u{1f66a}\u0d91',
+}
+);
+let textureView38 = texture28.createView(
+{
+label: '\u007c\u0cca\u1716\u5bc0\u643a\ue0eb\u3ed8\ue3b7',
+}
+);
+let computePassEncoder20 = commandEncoder51.beginComputePass(
+{
+label: '\u098f\udec4\u42c4\u{1f62f}'
+}
+);
+let renderBundleEncoder45 = device1.createRenderBundleEncoder(
+{
+label: '\u0282\u{1f6ac}\u07e7\u{1fe0a}\u0d50',
+colorFormats: [
+undefined,
+'rgba16float',
+'bgra8unorm',
+'r8unorm',
+'rg16sint',
+'rgba32uint',
+'rgba16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 124,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder13.setBlendConstant({ r: 378.1, g: 838.9, b: 440.5, a: 899.5, });
+} catch {}
+try {
+commandEncoder47.copyBufferToBuffer(
+buffer3,
+7476,
+buffer16,
+9396,
+948
+);
+dissociateBuffer(device1, buffer3);
+dissociateBuffer(device1, buffer16);
+} catch {}
+let bindGroupLayout28 = device5.createBindGroupLayout(
+{
+label: '\u8278\ud5ea\uf294\ua5c8\u9196\u{1fd44}',
+entries: [
+{
+binding: 736,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '3d' },
+}
+],
+}
+);
+try {
+renderBundleEncoder32.insertDebugMarker(
+'\u6177'
+);
+} catch {}
+try {
+device5.queue.writeBuffer(
+buffer17,
+7344,
+new BigUint64Array(50921),
+41086,
+3820
+);
+} catch {}
+let pipeline47 = await device5.createComputePipelineAsync(
+{
+label: '\u{1f789}\u{1fc3d}\u9ebe\u3719\u0a4d',
+layout: pipelineLayout9,
+compute: {
+module: shaderModule15,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let buffer19 = device5.createBuffer(
+{
+label: '\u1392\u{1f8c9}\u0227\u9921\ua6f0\uc720\u0d68',
+size: 53440,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let commandEncoder52 = device5.createCommandEncoder(
+{
+label: '\uf21f\uf698\u4924\u{1fae2}\u{1f7a6}\u093c\u4a35\u0e95\u0295',
+}
+);
+let renderBundle46 = renderBundleEncoder44.finish(
+{
+
+}
+);
+let sampler44 = device5.createSampler(
+{
+label: '\u{1f71d}\u{1ff61}\u6961\u9486\u{1f988}\udac8\u7b4b',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMaxClamp: 87.702,
+compare: 'not-equal',
+}
+);
+try {
+device5.queue.writeTexture(
+{
+  texture: texture46,
+  mipLevel: 1,
+  origin: { x: 40, y: 18, z: 31 },
+  aspect: 'all',
+},
+new BigUint64Array(arrayBuffer4),
+/* required buffer size: 1010545 */{
+offset: 91,
+bytesPerRow: 230,
+rowsPerImage: 244,
+},
+{width: 32, height: 12, depthOrArrayLayers: 19}
+);
+} catch {}
+let buffer20 = device5.createBuffer(
+{
+size: 45594,
+usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+}
+);
+pseudoSubmit(device5, commandEncoder52);
+try {
+renderBundleEncoder38.setBindGroup(
+3,
+bindGroup3,
+[]
+);
+} catch {}
+try {
+await device5.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+pseudoSubmit(device6, commandEncoder46);
+let textureView39 = texture57.createView(
+{
+}
+);
+let sampler45 = device6.createSampler(
+{
+label: '\uff6d\u0a59\uac54\ua2ed\u7df5\ueee7\u{1f76e}\u0eea\u0f5e\u93b7\u0c01',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 76.660,
+lodMaxClamp: 87.361,
+}
+);
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let offscreenCanvas20 = new OffscreenCanvas(255, 687);
+let imageData26 = new ImageData(256, 20);
+let texture61 = device5.createTexture(
+{
+size: [163, 1, 215],
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba32float',
+'rgba32float',
+'rgba32float'
+],
+}
+);
+let textureView40 = texture45.createView(
+{
+label: '\u23fd\uff75\u92c3',
+dimension: '2d-array',
+}
+);
+let img15 = await imageWithData(173, 177, '#5a220a3c', '#0e49c02a');
+let pipelineLayout13 = device6.createPipelineLayout(
+{
+label: '\ue125\uc27f\u771b\u{1fedf}\u08e1\u98b4\u{1fcb7}\u88e1\u1a87',
+bindGroupLayouts: [
+bindGroupLayout24,
+bindGroupLayout24,
+bindGroupLayout24
+]
+}
+);
+let externalTexture6 = device6.importExternalTexture(
+{
+label: '\u4e48\u{1f71f}\u0f47',
+source: video16,
+colorSpace: 'srgb',
+}
+);
+document.body.prepend(canvas5);
+let videoFrame14 = new VideoFrame(offscreenCanvas20, {timestamp: 0});
+let shaderModule20 = device2.createShaderModule(
+{
+label: '\uc182\ub029',
+code: `@group(0) @binding(2768)
+var<storage, read_write> type18: array<u32>;
+@group(4) @binding(2768)
+var<storage, read_write> i26: array<u32>;
+@group(4) @binding(175)
+var<storage, read_write> i27: array<u32>;
+@group(2) @binding(2768)
+var<storage, read_write> parameter17: array<u32>;
+@group(3) @binding(175)
+var<storage, read_write> parameter18: array<u32>;
+@group(2) @binding(175)
+var<storage, read_write> type19: array<u32>;
+
+@compute @workgroup_size(8, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S22 {
+@location(11) f0: vec3<i32>,
+@location(58) f1: vec2<f32>,
+@location(4) f2: vec3<f16>,
+@location(80) f3: vec4<f16>,
+@location(43) f4: vec3<u32>,
+@location(49) f5: vec2<u32>,
+@location(57) f6: vec3<f16>,
+@builtin(position) f7: vec4<f32>,
+@location(85) f8: vec2<f32>,
+@location(18) f9: vec3<f32>,
+@location(88) f10: f32,
+@location(55) f11: vec3<f32>,
+@location(48) f12: u32,
+@location(65) f13: vec2<f32>,
+@location(51) f14: vec3<i32>,
+@location(9) f15: vec3<f32>,
+@location(15) f16: vec2<f16>,
+@location(34) f17: vec3<i32>
+}
+struct FragmentOutput0 {
+@location(3) f0: vec3<f32>,
+@location(5) f1: vec4<f32>,
+@location(2) f2: f32,
+@builtin(sample_mask) f3: u32,
+@location(6) f4: vec4<i32>,
+@location(4) f5: i32
+}
+
+@fragment
+fn fragment0(@location(7) a0: vec2<i32>, @location(12) a1: f32, @location(38) a2: vec4<f32>, @location(75) a3: vec3<f32>, @location(59) a4: vec2<f16>, @builtin(front_facing) a5: bool, @location(37) a6: vec3<u32>, @location(82) a7: vec3<i32>, @location(52) a8: vec4<f16>, a9: S22, @location(76) a10: vec2<f32>, @location(78) a11: i32, @builtin(sample_mask) a12: u32, @location(92) a13: vec2<i32>, @location(30) a14: vec3<i32>, @location(56) a15: vec3<u32>, @location(28) a16: vec4<f32>, @location(40) a17: vec4<i32>, @location(27) a18: u32, @location(41) a19: vec2<i32>, @location(47) a20: vec4<u32>, @location(61) a21: vec4<i32>, @location(93) a22: f32, @location(68) a23: vec3<u32>, @builtin(sample_index) a24: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@builtin(position) f271: vec4<f32>,
+@location(93) f272: f32,
+@location(41) f273: vec2<i32>,
+@location(59) f274: vec2<f16>,
+@location(30) f275: vec3<i32>,
+@location(37) f276: vec3<u32>,
+@location(88) f277: f32,
+@location(38) f278: vec4<f32>,
+@location(92) f279: vec2<i32>,
+@location(55) f280: vec3<f32>,
+@location(7) f281: vec2<i32>,
+@location(27) f282: u32,
+@location(68) f283: vec3<u32>,
+@location(82) f284: vec3<i32>,
+@location(52) f285: vec4<f16>,
+@location(11) f286: vec3<i32>,
+@location(9) f287: vec3<f32>,
+@location(56) f288: vec3<u32>,
+@location(85) f289: vec2<f32>,
+@location(4) f290: vec3<f16>,
+@location(15) f291: vec2<f16>,
+@location(51) f292: vec3<i32>,
+@location(49) f293: vec2<u32>,
+@location(61) f294: vec4<i32>,
+@location(80) f295: vec4<f16>,
+@location(65) f296: vec2<f32>,
+@location(43) f297: vec3<u32>,
+@location(76) f298: vec2<f32>,
+@location(12) f299: f32,
+@location(47) f300: vec4<u32>,
+@location(78) f301: i32,
+@location(48) f302: u32,
+@location(34) f303: vec3<i32>,
+@location(18) f304: vec3<f32>,
+@location(40) f305: vec4<i32>,
+@location(75) f306: vec3<f32>,
+@location(28) f307: vec4<f32>,
+@location(58) f308: vec2<f32>,
+@location(57) f309: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec2<u32>, @location(3) a1: vec3<f16>, @location(12) a2: vec3<i32>, @location(2) a3: vec3<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder53 = device2.createCommandEncoder(
+{
+label: '\u068f\u0d70\u1d2e\u0dd4\u{1f9de}\u06dd',
+}
+);
+let computePassEncoder21 = commandEncoder26.beginComputePass(
+{
+
+}
+);
+let sampler46 = device2.createSampler(
+{
+label: '\udb2e\u9c1a\ub530\u071f\u703a\ua94c\uf6f1',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 20.998,
+maxAnisotropy: 14,
+}
+);
+try {
+renderPassEncoder5.setBindGroup(
+6,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(
+5521,
+152,
+3491,
+0
+);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(
+27,
+undefined,
+2300277329,
+896016286
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline48 = await device2.createRenderPipelineAsync(
+{
+label: '\u0411\u0741\u0317',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule8,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 2396,
+shaderLocation: 1,
+},
+{
+format: 'unorm16x2',
+offset: 8396,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 9868,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32',
+offset: 292,
+shaderLocation: 17,
+},
+{
+format: 'unorm16x4',
+offset: 8656,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 38492,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32',
+offset: 2728,
+shaderLocation: 18,
+},
+{
+format: 'uint32',
+offset: 14708,
+shaderLocation: 11,
+},
+{
+format: 'snorm8x4',
+offset: 28296,
+shaderLocation: 13,
+},
+{
+format: 'float16x4',
+offset: 18940,
+shaderLocation: 6,
+},
+{
+format: 'uint16x4',
+offset: 4944,
+shaderLocation: 9,
+},
+{
+format: 'uint16x4',
+offset: 32368,
+shaderLocation: 16,
+},
+{
+format: 'uint32x3',
+offset: 19288,
+shaderLocation: 10,
+},
+{
+format: 'float16x4',
+offset: 12292,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 38728,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 8624,
+shaderLocation: 8,
+},
+{
+format: 'sint8x4',
+offset: 24452,
+shaderLocation: 0,
+},
+{
+format: 'sint32x4',
+offset: 14444,
+shaderLocation: 4,
+},
+{
+format: 'uint8x4',
+offset: 30296,
+shaderLocation: 12,
+},
+{
+format: 'unorm8x2',
+offset: 35146,
+shaderLocation: 14,
+},
+{
+format: 'sint16x4',
+offset: 18848,
+shaderLocation: 7,
+},
+{
+format: 'float16x2',
+offset: 3124,
+shaderLocation: 15,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+unclippedDepth: false,
+},
+fragment: {
+module: shaderModule8,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rgb10a2uint',
+},
+undefined,
+undefined,
+undefined,
+undefined,
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+undefined
+],
+},
+}
+);
+let gpuCanvasContext16 = offscreenCanvas20.getContext('webgpu');
+let renderBundleEncoder46 = device4.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba32uint',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 271,
+depthReadOnly: true,
+}
+);
+try {
+buffer18.unmap();
+} catch {}
+try {
+device4.queue.submit([
+commandBuffer9,
+commandBuffer8,
+]);
+} catch {}
+document.body.prepend(video3);
+let adapter9 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let canvas15 = document.createElement('canvas');
+canvas5.width = 935;
+let imageData27 = new ImageData(204, 236);
+let textureView41 = texture49.createView(
+{
+label: '\u{1f723}\u4aec\u5194\u0c40\u06da\u0f8d\u52a2\u813a\u88a4',
+baseArrayLayer: 25,
+arrayLayerCount: 48,
+}
+);
+let renderBundle47 = renderBundleEncoder46.finish(
+{
+label: '\u5a52\u477a'
+}
+);
+try {
+commandEncoder39.pushDebugGroup(
+'\u5aed'
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture58,
+  mipLevel: 0,
+  origin: { x: 1075, y: 1, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(172),
+/* required buffer size: 172 */{
+offset: 172,
+},
+{width: 5399, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let commandEncoder54 = device5.createCommandEncoder(
+{
+label: '\u3cc0\u44b7\ubf09\u0f85\u07b3\uc428\ue2c1\u07a0\u0853',
+}
+);
+let querySet46 = device5.createQuerySet({
+label: '\uc5b7\u8407\u{1f755}\ue9fd\u0e08',
+type: 'occlusion',
+count: 344,
+});
+let textureView42 = texture51.createView(
+{
+dimension: '2d',
+format: 'astc-10x10-unorm',
+baseArrayLayer: 62,
+}
+);
+try {
+renderBundleEncoder37.setBindGroup(
+1,
+bindGroup3
+);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(
+0,
+bindGroup3,
+new Uint32Array(8700),
+8279,
+0
+);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(
+2,
+buffer13
+);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture48,
+  mipLevel: 5,
+  origin: { x: 8, y: 0, z: 2 },
+  aspect: 'all',
+},
+new ArrayBuffer(72),
+/* required buffer size: 44245 */{
+offset: 149,
+bytesPerRow: 136,
+rowsPerImage: 81,
+},
+{width: 16, height: 4, depthOrArrayLayers: 5}
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+offscreenCanvas2.width = 347;
+let video18 = await videoWithData();
+document.body.prepend(canvas14);
+let offscreenCanvas21 = new OffscreenCanvas(969, 947);
+let video19 = await videoWithData();
+let video20 = await videoWithData();
+let bindGroupLayout29 = device1.createBindGroupLayout(
+{
+label: '\u{1ff66}\u6440\u02b3\u8df9\u{1f90c}\u9bdd',
+entries: [
+{
+binding: 1803,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+},
+{
+binding: 1997,
+visibility: 0,
+externalTexture: {},
+},
+{
+binding: 1570,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+}
+],
+}
+);
+let texture62 = device1.createTexture(
+{
+label: '\u0450\udf68\u0c27\u068b',
+size: {width: 6164},
+dimension: '1d',
+format: 'rg8sint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundleEncoder47 = device1.createRenderBundleEncoder(
+{
+label: '\u0695\u55ef',
+colorFormats: [
+'rgba8unorm',
+'rgba32sint',
+'r8sint',
+undefined,
+'rg16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 78,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle48 = renderBundleEncoder30.finish(
+{
+label: '\u5708\ud060\u0e3e\u4fb3\u6db1\udc4b\u337a\u039e'
+}
+);
+try {
+renderPassEncoder13.setScissorRect(
+19,
+36,
+3,
+6
+);
+} catch {}
+try {
+commandEncoder47.resolveQuerySet(
+querySet16,
+174,
+784,
+buffer7,
+11520
+);
+} catch {}
+let texture63 = device4.createTexture(
+{
+size: {width: 1830},
+dimension: '1d',
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float',
+'rgba16float'
+],
+}
+);
+canvas4.width = 657;
+let img16 = await imageWithData(266, 27, '#9d8878ff', '#a5450169');
+let bindGroup4 = device5.createBindGroup({
+label: '\u274c\u0fdf\u0835\u{1fd1f}\u{1f9f3}\u046c\u{1f77a}\u{1f703}\u0f66',
+layout: bindGroupLayout22,
+entries: [
+{
+binding: 704,
+resource: sampler32
+}
+],
+});
+let renderBundleEncoder48 = device5.createRenderBundleEncoder(
+{
+label: '\u62d3\u{1f6b9}\u990a',
+colorFormats: [
+'r16float',
+'rg8uint',
+undefined,
+'rg16float',
+'rg32float'
+],
+sampleCount: 265,
+depthReadOnly: true,
+}
+);
+let sampler47 = device5.createSampler(
+{
+label: '\u05d2\u{1fdff}\u035c\uae4b\u50f0',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 99.178,
+maxAnisotropy: 12,
+}
+);
+try {
+device5.queue.submit([
+]);
+} catch {}
+try {
+device5.queue.writeBuffer(
+buffer17,
+26264,
+new BigUint64Array(9395),
+1689,
+1112
+);
+} catch {}
+let pipeline49 = device5.createComputePipeline(
+{
+label: '\ue9d3\u0432\u7c8f\u78ca\u1996\u0ca5\u1ae7\u58fa\u{1fca0}',
+layout: pipelineLayout9,
+compute: {
+module: shaderModule16,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline50 = await device5.createRenderPipelineAsync(
+{
+label: '\u0121\u6924',
+layout: pipelineLayout9,
+vertex: {
+module: shaderModule19,
+entryPoint: 'vertex0',
+buffers: [
+
+]
+},
+fragment: {
+module: shaderModule19,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+let offscreenCanvas22 = new OffscreenCanvas(740, 973);
+let imageData28 = new ImageData(152, 120);
+let buffer21 = device1.createBuffer(
+{
+label: '\u0031\u3546\u3e82\u1d63\u0a42\ufdf4\u0cae\u03ac\u0086\u0fe0\uf30e',
+size: 22200,
+usage: GPUBufferUsage.STORAGE,
+mappedAtCreation: true,
+}
+);
+let texture64 = device1.createTexture(
+{
+label: '\u0602\u08e7\u5b03\u524e\u{1fd78}',
+size: [175, 1, 1723],
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgb10a2uint',
+'rgb10a2uint',
+'rgb10a2uint'
+],
+}
+);
+let renderBundleEncoder49 = device1.createRenderBundleEncoder(
+{
+label: '\u1087\u{1f8b2}\u1f27\u8ae9\u778d\u38de\u9018\u0790',
+colorFormats: [
+'rg32sint',
+'rg32float',
+'r16float',
+'r8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 745,
+depthReadOnly: true,
+}
+);
+try {
+computePassEncoder10.setPipeline(
+pipeline30
+);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(
+buffer8,
+'uint16',
+29768,
+6664
+);
+} catch {}
+try {
+commandEncoder47.copyTextureToTexture(
+{
+  texture: texture30,
+  mipLevel: 5,
+  origin: { x: 0, y: 2, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture59,
+  mipLevel: 0,
+  origin: { x: 22, y: 0, z: 32 },
+  aspect: 'depth-only',
+},
+{width: 105, height: 0, depthOrArrayLayers: 32}
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture23,
+  mipLevel: 4,
+  origin: { x: 28, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 451309 */{
+offset: 453,
+bytesPerRow: 313,
+rowsPerImage: 120,
+},
+{width: 34, height: 1, depthOrArrayLayers: 13}
+);
+} catch {}
+let pipeline51 = device1.createComputePipeline(
+{
+label: '\u25e3\u022c\uc0f4\ua1d9\u80fc\ucd9d\u9580\u9089\uc31f\u0555\u{1fae2}',
+layout: pipelineLayout6,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline52 = device1.createRenderPipeline(
+{
+layout: pipelineLayout8,
+vertex: {
+module: shaderModule18,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 368,
+attributes: [
+{
+format: 'uint32x4',
+offset: 48,
+shaderLocation: 2,
+},
+{
+format: 'snorm8x2',
+offset: 24,
+shaderLocation: 7,
+},
+{
+format: 'sint32',
+offset: 80,
+shaderLocation: 15,
+},
+{
+format: 'float16x4',
+offset: 20,
+shaderLocation: 4,
+},
+{
+format: 'sint8x2',
+offset: 356,
+shaderLocation: 17,
+},
+{
+format: 'sint32',
+offset: 232,
+shaderLocation: 16,
+},
+{
+format: 'snorm16x2',
+offset: 8,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x4',
+offset: 148,
+shaderLocation: 6,
+},
+{
+format: 'sint32x4',
+offset: 44,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x2',
+offset: 312,
+shaderLocation: 12,
+},
+{
+format: 'sint8x4',
+offset: 156,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x4',
+offset: 44,
+shaderLocation: 13,
+},
+{
+format: 'unorm16x4',
+offset: 112,
+shaderLocation: 14,
+},
+{
+format: 'uint32',
+offset: 212,
+shaderLocation: 5,
+},
+{
+format: 'sint32',
+offset: 352,
+shaderLocation: 1,
+},
+{
+format: 'sint32x3',
+offset: 40,
+shaderLocation: 10,
+},
+{
+format: 'float32x2',
+offset: 64,
+shaderLocation: 19,
+},
+{
+format: 'sint8x4',
+offset: 0,
+shaderLocation: 18,
+},
+{
+format: 'sint32x3',
+offset: 292,
+shaderLocation: 11,
+},
+{
+format: 'snorm8x2',
+offset: 330,
+shaderLocation: 3,
+}
+],
+}
+]
+},
+multisample: {
+mask: 0xf0d3a902,
+},
+fragment: {
+module: shaderModule18,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rgba32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rg16sint',
+},
+{
+format: 'rg16float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+format: 'rg32float',
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+},
+{
+format: 'rg8uint',
+writeMask: 0,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'replace',
+depthFailOp: 'replace',
+passOp: 'decrement-clamp',
+},
+stencilWriteMask: 210,
+depthBias: 84,
+depthBiasSlopeScale: 64,
+depthBiasClamp: 5,
+},
+}
+);
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+try {
+canvas15.getContext('2d');
+} catch {}
+try {
+adapter5.label = '\u{1f662}\ufb3a\u079e';
+} catch {}
+let device8 = await adapter9.requestDevice({
+label: '\u{1f782}\u{1fddf}\u5c09\u0f25\ua97d\u{1fb7a}',
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 35,
+maxVertexAttributes: 21,
+maxVertexBufferArrayStride: 12115,
+maxStorageTexturesPerShaderStage: 13,
+maxStorageBuffersPerShaderStage: 42,
+maxDynamicStorageBuffersPerPipelineLayout: 41229,
+maxBindingsPerBindGroup: 1420,
+maxTextureDimension1D: 14875,
+maxTextureDimension2D: 9789,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 263204759,
+maxUniformBuffersPerShaderStage: 42,
+maxInterStageShaderVariables: 124,
+maxInterStageShaderComponents: 84,
+maxSamplersPerShaderStage: 21,
+},
+});
+let offscreenCanvas23 = new OffscreenCanvas(174, 217);
+let gpuCanvasContext17 = offscreenCanvas22.getContext('webgpu');
+offscreenCanvas10.height = 931;
+let img17 = await imageWithData(258, 40, '#0c13af87', '#55a8c25b');
+let buffer22 = device8.createBuffer(
+{
+label: '\u620f\u{1ff7a}\ueee3\u15da\ud54a\u{1ffbb}\ua3d7\u601e\u0beb\u02fe',
+size: 55283,
+usage: GPUBufferUsage.COPY_SRC,
+}
+);
+let renderBundleEncoder50 = device8.createRenderBundleEncoder(
+{
+colorFormats: [
+'bgra8unorm-srgb',
+'rgba8sint',
+'rg16float',
+'rg32sint',
+'r32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 786,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+await device8.queue.onSubmittedWorkDone();
+} catch {}
+let imageData29 = new ImageData(156, 112);
+let gpuCanvasContext18 = offscreenCanvas21.getContext('webgpu');
+let imageBitmap17 = await createImageBitmap(videoFrame4);
+let buffer23 = device6.createBuffer(
+{
+label: '\u0ac1\ua6f4\u6d9a\u{1f95a}\u9f02\u5187\u0aa4\u05ef\u0f6a\ud1ee\ufcd6',
+size: 31986,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+pseudoSubmit(device6, commandEncoder38);
+let textureView43 = texture57.createView(
+{
+label: '\u{1ffb6}\u0dbb\u00e3\u0900\u9820\u6035\u4230\u82a5\ua478\u{1ff90}\u03b6',
+baseMipLevel: 0,
+mipLevelCount: 1,
+baseArrayLayer: 0,
+}
+);
+let videoFrame15 = new VideoFrame(video18, {timestamp: 0});
+let commandEncoder55 = device4.createCommandEncoder(
+{
+label: '\u0dbd\u{1f661}\ued06\u8147\u{1fc07}\u06d7\ub80b\u0616\uc04e\u977c\u{1fec3}',
+}
+);
+let querySet47 = device4.createQuerySet({
+label: '\u0fee\u9b1a\u8629\u3a9b\u0f11\u6396\u{1f803}\u{1fc02}\u0a57',
+type: 'occlusion',
+count: 3451,
+});
+let textureView44 = texture56.createView(
+{
+baseArrayLayer: 0,
+}
+);
+let renderBundleEncoder51 = device4.createRenderBundleEncoder(
+{
+label: '\u{1fcbd}\u0bad\u{1f889}\uc24f\u361e\ua27a\u685d\u04e0\ua365\uf2a4\u274f',
+colorFormats: [
+undefined,
+undefined,
+'rg11b10ufloat',
+'rgba8unorm-srgb',
+'rg8uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 9,
+stencilReadOnly: true,
+}
+);
+let promise17 = adapter3.requestAdapterInfo();
+try {
+await promise17;
+} catch {}
+let adapter10 = await navigator.gpu.requestAdapter(
+{
+powerPreference: 'low-power',
+}
+);
+let offscreenCanvas24 = new OffscreenCanvas(629, 138);
+try {
+offscreenCanvas24.getContext('webgl2');
+} catch {}
+let textureView45 = texture57.createView(
+{
+label: '\u{1f97b}\u{1f8bb}\u7f25\u0848\u2f6c\u1de6',
+aspect: 'all',
+}
+);
+let computePassEncoder22 = commandEncoder49.beginComputePass(
+{
+
+}
+);
+let renderBundle49 = renderBundleEncoder39.finish(
+{
+label: '\u0b24\u{1f916}\u0ed7\u572f'
+}
+);
+let bindGroupLayout30 = device8.createBindGroupLayout(
+{
+label: '\u6c64\u75bb\u8528\u{1f8c0}\u858c\ue0b8\u06af\u0737',
+entries: [
+
+],
+}
+);
+let querySet48 = device8.createQuerySet({
+label: '\ua8cc\u{1fe3f}\u{1ff54}\u8ea9\uac7b\uaa6a\uc238\u494d\u{1fcfa}',
+type: 'occlusion',
+count: 3020,
+});
+let renderBundleEncoder52 = device8.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba32float',
+'rgba8uint',
+'r32float',
+'r32sint',
+undefined,
+'r8sint'
+],
+sampleCount: 447,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder50.setVertexBuffer(
+40,
+undefined,
+3464583727,
+440002951
+);
+} catch {}
+let promise18 = device8.queue.onSubmittedWorkDone();
+try {
+offscreenCanvas23.getContext('webgl');
+} catch {}
+let texture65 = device1.createTexture(
+{
+label: '\uc5b7\u0788\u{1f968}\u45a7\u{1fdcb}\u{1fe2d}',
+size: {width: 102, height: 1, depthOrArrayLayers: 157},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundle50 = renderBundleEncoder29.finish();
+try {
+renderPassEncoder13.setScissorRect(
+12,
+3,
+5,
+10
+);
+} catch {}
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+let commandEncoder56 = device5.createCommandEncoder(
+{
+}
+);
+let computePassEncoder23 = commandEncoder56.beginComputePass(
+{
+label: '\u0d19\ub0bf\uc431\u31ee\u3e67\u0bd0\u0848'
+}
+);
+let renderBundleEncoder53 = device5.createRenderBundleEncoder(
+{
+label: '\u9c39\u{1f61b}\u{1fea3}\ud478\uff25\ud8ec\ud0fd\u6cf5\u{1f929}\u02b9\u0760',
+colorFormats: [
+'rgba16uint',
+'rgba8unorm',
+'rg16uint',
+'rgba16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 163,
+depthReadOnly: true,
+}
+);
+let externalTexture7 = device5.importExternalTexture(
+{
+label: '\u0630\u6e36\u3aa9',
+source: videoFrame12,
+colorSpace: 'display-p3',
+}
+);
+try {
+computePassEncoder23.setPipeline(
+pipeline49
+);
+} catch {}
+try {
+renderBundleEncoder53.setBindGroup(
+2,
+bindGroup4
+);
+} catch {}
+let pipeline53 = device5.createComputePipeline(
+{
+layout: pipelineLayout9,
+compute: {
+module: shaderModule19,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageData30 = new ImageData(108, 44);
+try {
+computePassEncoder23.setPipeline(
+pipeline41
+);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(
+1,
+buffer13
+);
+} catch {}
+try {
+texture48.destroy();
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData18,
+  origin: { x: 8, y: 181 },
+  flipY: true,
+},
+{
+  texture: texture44,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline54 = device5.createComputePipeline(
+{
+label: '\u5292\ufda3\u4267\u0185\u660d\ubaad\u08eb\uf213\u9073\u09e7',
+layout: pipelineLayout9,
+compute: {
+module: shaderModule19,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let computePassEncoder24 = commandEncoder41.beginComputePass(
+{
+label: '\u0647\u0c4a\u02ba\u0f4e\ub8dd'
+}
+);
+let renderBundleEncoder54 = device6.createRenderBundleEncoder(
+{
+label: '\u0f34\u22a7\u47bf\u2681\u9211\u084a',
+colorFormats: [
+'rg16uint',
+undefined,
+'rg16sint',
+'rgba32sint',
+'rg32float',
+undefined
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 446,
+}
+);
+let videoFrame16 = new VideoFrame(img1, {timestamp: 0});
+let querySet49 = device6.createQuerySet({
+label: '\u000e\u77fb\ua1ad',
+type: 'occlusion',
+count: 593,
+});
+try {
+renderBundleEncoder54.setVertexBuffer(
+42,
+undefined,
+1973689288,
+1888392382
+);
+} catch {}
+try {
+device6.pushErrorScope('out-of-memory');
+} catch {}
+try {
+gpuCanvasContext10.configure(
+{
+device: device6,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let promise19 = device6.queue.onSubmittedWorkDone();
+canvas2.width = 810;
+let canvas16 = document.createElement('canvas');
+let bindGroupLayout31 = device8.createBindGroupLayout(
+{
+entries: [
+{
+binding: 1170,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+}
+],
+}
+);
+let querySet50 = device8.createQuerySet({
+label: '\u3532\u{1f74c}\uf841\u{1f6ad}\u0767\u94e6\uc88e\ua720\u8ff8',
+type: 'occlusion',
+count: 1462,
+});
+let texture66 = device8.createTexture(
+{
+size: [128, 176, 1],
+mipLevelCount: 3,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-8x8-unorm-srgb'
+],
+}
+);
+let sampler48 = device8.createSampler(
+{
+label: '\u3d7d\uf5da\u27e2\u{1f99b}\u796e\u9f69\u0748\u041b\u1e2f\ubb81',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+lodMinClamp: 3.121,
+lodMaxClamp: 72.716,
+}
+);
+try {
+renderBundleEncoder50.setVertexBuffer(
+50,
+undefined,
+3496702864,
+437527625
+);
+} catch {}
+let renderBundleEncoder55 = device4.createRenderBundleEncoder(
+{
+label: '\u01e8\u06dd\u{1f98a}\u081d\u08b2\u5fa4\ue5e6\u42d7\u0e39\u{1f6a4}',
+colorFormats: [
+'r32uint',
+'rgba32sint',
+'r8uint',
+'rg16uint'
+],
+sampleCount: 650,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle51 = renderBundleEncoder34.finish();
+let sampler49 = device4.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 22.113,
+lodMaxClamp: 68.903,
+maxAnisotropy: 1,
+}
+);
+let promise20 = device4.queue.onSubmittedWorkDone();
+try {
+await promise18;
+} catch {}
+let commandEncoder57 = device1.createCommandEncoder(
+{
+}
+);
+let commandBuffer10 = commandEncoder57.finish(
+{
+}
+);
+let renderPassEncoder14 = commandEncoder47.beginRenderPass(
+{
+label: '\u8551\uc69f\u37fd',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView12,
+depthClearValue: 0.8249143241193726,
+depthLoadOp: 'clear',
+depthStoreOp: 'discard',
+},
+occlusionQuerySet: querySet30,
+maxDrawCount: 66472,
+}
+);
+let renderBundle52 = renderBundleEncoder30.finish();
+let sampler50 = device1.createSampler(
+{
+label: '\uc7ad\u770b\uc4dd\u8717\u{1fc46}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 91.312,
+lodMaxClamp: 98.233,
+}
+);
+try {
+renderPassEncoder9.setScissorRect(
+19,
+46,
+4,
+0
+);
+} catch {}
+try {
+renderPassEncoder13.setStencilReference(
+3609
+);
+} catch {}
+try {
+renderPassEncoder9.setViewport(
+11.97,
+12.48,
+5.286,
+29.49,
+0.6957,
+0.9298
+);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(
+buffer11,
+'uint16'
+);
+} catch {}
+let buffer24 = device4.createBuffer(
+{
+label: '\u{1ff2e}\u41b7',
+size: 58123,
+usage: GPUBufferUsage.COPY_SRC,
+}
+);
+let texture67 = device4.createTexture(
+{
+size: [12, 192, 1],
+mipLevelCount: 2,
+format: 'astc-12x12-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+let renderBundle53 = renderBundleEncoder55.finish(
+{
+
+}
+);
+try {
+renderBundleEncoder51.setVertexBuffer(
+60,
+undefined,
+943636274,
+3253006056
+);
+} catch {}
+try {
+commandEncoder39.popDebugGroup();
+} catch {}
+let gpuCanvasContext19 = canvas16.getContext('webgpu');
+let pipelineLayout14 = device8.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout31,
+bindGroupLayout30,
+bindGroupLayout31,
+bindGroupLayout30,
+bindGroupLayout30
+]
+}
+);
+let textureView46 = texture66.createView(
+{
+label: '\u{1fc9a}\u004c\u03eb\ufb3c\u0317\u6bb0\u{1fdcf}\u0fab',
+baseMipLevel: 2,
+}
+);
+let sampler51 = device8.createSampler(
+{
+label: '\u0e52\u0b74\u43b1\u{1fb1b}\u0440\u{1fcbe}\u89b0\uf8fb',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 38.909,
+lodMaxClamp: 39.235,
+compare: 'less-equal',
+maxAnisotropy: 11,
+}
+);
+try {
+renderBundleEncoder52.setVertexBuffer(
+52,
+undefined
+);
+} catch {}
+try {
+device8.pushErrorScope('internal');
+} catch {}
+try {
+await device8.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let video21 = await videoWithData();
+let adapter11 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let imageBitmap18 = await createImageBitmap(offscreenCanvas9);
+let offscreenCanvas25 = new OffscreenCanvas(950, 207);
+try {
+await promise19;
+} catch {}
+try {
+adapter8.label = '\u{1f661}\ua203\u{1f8e0}\u04e8\uc3d8\u{1ffa5}\u8577\udcc5';
+} catch {}
+let texture68 = device1.createTexture(
+{
+label: '\u4ed3\u{1f714}\u0727\u6223\u06e8\u297b\uf9d7\uf739\u9015\u0aaf\u76e6',
+size: [192, 1, 47],
+mipLevelCount: 4,
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+let renderBundle54 = renderBundleEncoder21.finish(
+{
+label: '\u697c\u5b4e\u{1f673}'
+}
+);
+try {
+renderPassEncoder14.setScissorRect(
+17,
+1,
+1,
+39
+);
+} catch {}
+try {
+renderPassEncoder14.setViewport(
+1.371,
+18.89,
+6.446,
+5.713,
+0.4803,
+0.9976
+);
+} catch {}
+try {
+texture21.destroy();
+} catch {}
+let gpuCanvasContext20 = offscreenCanvas25.getContext('webgpu');
+let bindGroup5 = device8.createBindGroup({
+label: '\u2eca\ufb7f',
+layout: bindGroupLayout30,
+entries: [
+
+],
+});
+let commandEncoder58 = device8.createCommandEncoder(
+{
+label: '\u{1f9d8}\u9ce4\u094b\u{1fb92}\u9463\u2a57\ubd9e\u0f7b',
+}
+);
+let querySet51 = device8.createQuerySet({
+type: 'occlusion',
+count: 497,
+});
+let renderBundleEncoder56 = device8.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgb10a2unorm',
+'rgba8unorm-srgb',
+'rgba16sint',
+'r32uint',
+'r8uint',
+undefined
+],
+sampleCount: 685,
+}
+);
+let offscreenCanvas26 = new OffscreenCanvas(341, 450);
+try {
+offscreenCanvas26.getContext('2d');
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(
+2,
+bindGroup3,
+[]
+);
+} catch {}
+try {
+buffer20.destroy();
+} catch {}
+try {
+commandEncoder54.clearBuffer(
+buffer15,
+2924,
+26924
+);
+dissociateBuffer(device5, buffer15);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture46,
+  mipLevel: 0,
+  origin: { x: 0, y: 42, z: 99 },
+  aspect: 'all',
+},
+new ArrayBuffer(1193664),
+/* required buffer size: 1193664 */{
+offset: 208,
+bytesPerRow: 424,
+rowsPerImage: 281,
+},
+{width: 160, height: 30, depthOrArrayLayers: 11}
+);
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video16,
+  origin: { x: 12, y: 15 },
+  flipY: true,
+},
+{
+  texture: texture44,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await promise20;
+} catch {}
+gc();
+let bindGroupLayout32 = device8.createBindGroupLayout(
+{
+entries: [
+
+],
+}
+);
+let commandEncoder59 = device8.createCommandEncoder(
+{
+label: '\u{1f89a}\u003c\u{1fac7}\uddd1\u07d8',
+}
+);
+let querySet52 = device8.createQuerySet({
+label: '\u9d4d\u{1fdd8}\u697b\u09dc\u80ca\u0fab\uc08b\u{1fee9}\ue848',
+type: 'occlusion',
+count: 2719,
+});
+let textureView47 = texture66.createView(
+{
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+let sampler52 = device8.createSampler(
+{
+label: '\u1815\u1832\u0545\u{1fd2f}\u01bb\u2130\u5f5e\u5ece\udda5\u{1f812}\u0d1d',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 61.986,
+lodMaxClamp: 77.316,
+maxAnisotropy: 3,
+}
+);
+try {
+device8.queue.writeTexture(
+{
+  texture: texture66,
+  mipLevel: 2,
+  origin: { x: 16, y: 8, z: 1 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(arrayBuffer0),
+/* required buffer size: 806 */{
+offset: 806,
+bytesPerRow: 221,
+rowsPerImage: 177,
+},
+{width: 0, height: 24, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+window.someLabel = textureView10.label;
+} catch {}
+let commandEncoder60 = device1.createCommandEncoder();
+let texture69 = device1.createTexture(
+{
+label: '\u09e1\u0cc6\u0938\u4fd2\u0a4e\u20b6',
+size: [4299],
+dimension: '1d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg8snorm'
+],
+}
+);
+let computePassEncoder25 = commandEncoder60.beginComputePass(
+{
+
+}
+);
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.setViewport(
+14.93,
+7.896,
+4.636,
+9.794,
+0.9158,
+0.9290
+);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let computePassEncoder26 = commandEncoder54.beginComputePass(
+{
+
+}
+);
+let renderBundleEncoder57 = device5.createRenderBundleEncoder(
+{
+label: '\u{1f9ac}\u{1f953}\u04a8\u{1f8b9}\uf578\u0b82',
+colorFormats: [
+'rgba16float',
+'rgba8uint',
+'rg16float',
+'rg8sint',
+'r8uint'
+],
+sampleCount: 823,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder38.setVertexBuffer(
+5,
+buffer13,
+42632,
+2265
+);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture44,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer4),
+/* required buffer size: 977 */{
+offset: 977,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline55 = await device5.createRenderPipelineAsync(
+{
+layout: pipelineLayout9,
+vertex: {
+module: shaderModule16,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 908,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x2',
+offset: 88,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 832,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32',
+offset: 112,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 1408,
+attributes: [
+{
+format: 'float32x3',
+offset: 716,
+shaderLocation: 7,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 292,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0xc6f43171,
+},
+fragment: {
+module: shaderModule16,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater-equal',
+depthFailOp: 'replace',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'invert',
+},
+stencilReadMask: 1283,
+depthBias: 64,
+depthBiasSlopeScale: 14,
+},
+}
+);
+offscreenCanvas16.height = 544;
+let renderBundle55 = renderBundleEncoder51.finish(
+{
+label: '\u02cf\uf1d8\ua8c3\u0044\u7ada\u0690\u0467\u{1ff6d}'
+}
+);
+let sampler53 = device4.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 67.947,
+maxAnisotropy: 1,
+}
+);
+try {
+commandEncoder39.copyBufferToTexture(
+{
+/* bytesInLastRow: 2912 widthInBlocks: 364 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 34808 */
+offset: 34808,
+bytesPerRow: 3072,
+buffer: buffer24,
+},
+{
+  texture: texture58,
+  mipLevel: 0,
+  origin: { x: 4008, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 364, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device4, buffer24);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let imageData31 = new ImageData(176, 52);
+let bindGroup6 = device8.createBindGroup({
+label: '\u034f\u{1fcf5}\u0c85\u{1ffe9}\ue903',
+layout: bindGroupLayout30,
+entries: [
+
+],
+});
+let computePassEncoder27 = commandEncoder58.beginComputePass(
+{
+label: '\u1c66\u453a\u039f\u0882\u{1f8db}\u{1f835}\ue425\u{1fa59}\u{1f949}\u50c0\ufa73'
+}
+);
+try {
+renderBundleEncoder52.setVertexBuffer(
+27,
+undefined,
+1892312023
+);
+} catch {}
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+let device9 = await adapter10.requestDevice({
+label: '\u97ff\u{1fa8c}\u05ff\u09f4\ub2fc\uc477\u{1fe0a}\uc9d4\uaf46\u{1fbb6}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 8,
+maxColorAttachmentBytesPerSample: 54,
+maxVertexAttributes: 17,
+maxVertexBufferArrayStride: 65370,
+maxStorageBuffersPerShaderStage: 24,
+maxDynamicStorageBuffersPerPipelineLayout: 58660,
+maxBindingsPerBindGroup: 5478,
+maxTextureDimension1D: 11548,
+maxTextureDimension2D: 8934,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 17016132,
+maxUniformBuffersPerShaderStage: 23,
+maxInterStageShaderVariables: 93,
+maxInterStageShaderComponents: 99,
+maxSamplersPerShaderStage: 19,
+},
+});
+offscreenCanvas12.height = 531;
+let imageData32 = new ImageData(232, 64);
+let commandEncoder61 = device7.createCommandEncoder(
+{
+label: '\uc18c\u9f91\ub575\ube55\u0c89\u61c0\ua25e\u0d66\u0cde\u0f81',
+}
+);
+let texture70 = device7.createTexture(
+{
+label: '\uf1e8\uf579\uf65e\u3bb7\u0378\uebc1\u430e\u{1fa17}\uc965',
+size: {width: 6360, height: 6, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'astc-10x6-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let computePassEncoder28 = commandEncoder61.beginComputePass(
+{
+label: '\u0baf\u0f97\ufc0e\u{1fe44}\u01f5\u{1f905}\u03b2'
+}
+);
+let videoFrame17 = new VideoFrame(offscreenCanvas10, {timestamp: 0});
+let bindGroupLayout33 = device5.createBindGroupLayout(
+{
+label: '\u{1ff83}\u{1fbce}\uc017\u{1f87d}\u{1fb1d}',
+entries: [
+{
+binding: 820,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '2d' },
+},
+{
+binding: 555,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+},
+{
+binding: 634,
+visibility: 0,
+texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+}
+],
+}
+);
+let buffer25 = device5.createBuffer(
+{
+label: '\u011d\ue7f1\u2ed2\u6eb7\u0c7e\u044f',
+size: 18949,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let texture71 = device5.createTexture(
+{
+label: '\u{1fdb7}\u002c',
+size: {width: 6794},
+mipLevelCount: 1,
+dimension: '1d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg16float',
+'rg16float'
+],
+}
+);
+let sampler54 = device5.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 96.128,
+lodMaxClamp: 97.067,
+compare: 'equal',
+}
+);
+try {
+renderBundleEncoder37.setBindGroup(
+2,
+bindGroup3
+);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(
+3,
+buffer13,
+18672,
+17376
+);
+} catch {}
+let commandEncoder62 = device5.createCommandEncoder(
+{
+label: '\u0c58\u03e8\u6461\u555d\u67df\ubf8b\u3339\u5c18',
+}
+);
+let textureView48 = texture61.createView(
+{
+baseMipLevel: 5,
+}
+);
+let computePassEncoder29 = commandEncoder62.beginComputePass(
+{
+label: '\u2838\u7488\u05e7\u0dc8\uc656\ue3d1\u{1fb26}\uaecc'
+}
+);
+try {
+computePassEncoder26.setPipeline(
+pipeline35
+);
+} catch {}
+let renderBundleEncoder58 = device6.createRenderBundleEncoder(
+{
+label: '\u{1f9df}\u7d3f\u{1fabf}',
+colorFormats: [
+'rgb10a2unorm',
+undefined,
+undefined
+],
+sampleCount: 422,
+depthReadOnly: true,
+}
+);
+gc();
+let querySet53 = device9.createQuerySet({
+label: '\u{1fb46}\u4b39\u013c\u9ceb\u{1fb3a}\u3428\u0d2b\u23b7\uefc7\u09ba\uc041',
+type: 'occlusion',
+count: 3725,
+});
+let sampler55 = device9.createSampler(
+{
+label: '\u{1ffe1}\ua244\u3240',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMaxClamp: 93.540,
+}
+);
+try {
+gpuCanvasContext20.configure(
+{
+device: device9,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg16uint',
+'rgba16float',
+'rgb9e5ufloat'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+let offscreenCanvas27 = new OffscreenCanvas(617, 1023);
+let texture72 = device4.createTexture(
+{
+label: '\ue6fa\u7f49\u1cf4',
+size: {width: 8037, height: 194, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+sampleCount: 1,
+dimension: '2d',
+format: 'rgba32sint',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32sint',
+'rgba32sint',
+'rgba32sint'
+],
+}
+);
+try {
+device4.queue.writeTexture(
+{
+  texture: texture47,
+  mipLevel: 7,
+  origin: { x: 3, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer2),
+/* required buffer size: 290 */{
+offset: 290,
+bytesPerRow: 325,
+},
+{width: 2, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let gpuCanvasContext21 = offscreenCanvas27.getContext('webgpu');
+let shaderModule21 = device8.createShaderModule(
+{
+label: '\u062e\u{1fc81}\uf8d4\u65c7\u{1fa92}\u89dc',
+code: `@group(0) @binding(1170)
+var<storage, read_write> global21: array<u32>;
+
+@compute @workgroup_size(3, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(0) f0: vec3<i32>,
+@location(7) f1: vec4<i32>,
+@location(3) f2: vec4<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S23 {
+@location(11) f0: u32,
+@location(1) f1: f16,
+@location(18) f2: f32,
+@location(15) f3: vec2<i32>,
+@location(16) f4: vec2<f16>,
+@location(10) f5: vec3<f32>,
+@location(9) f6: f16
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec2<f16>, @location(14) a1: vec2<f32>, @location(2) a2: vec4<f32>, @location(0) a3: vec3<f16>, @location(13) a4: u32, @location(6) a5: vec3<u32>, @location(8) a6: vec2<f32>, @builtin(instance_index) a7: u32, @location(5) a8: vec2<u32>, @location(12) a9: vec4<f16>, @location(19) a10: vec4<u32>, @location(4) a11: vec2<i32>, a12: S23) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let renderBundle56 = renderBundleEncoder52.finish(
+{
+label: '\u9c2c\u3d77\uf0fe\u{1fa4a}\u04ed'
+}
+);
+try {
+adapter4.label = '\u{1f6d5}\u{1ffb6}\u1ba6\u3fa0\u0860\ubc0d\u5335\u14d2\ub5c3';
+} catch {}
+let querySet54 = device5.createQuerySet({
+label: '\u6bbb\u0efa\uba45\u91ec\uc45b\uc5b9\u5d17\u9184\ud633\ud293',
+type: 'occlusion',
+count: 872,
+});
+let textureView49 = texture61.createView(
+{
+label: '\u{1f70c}\u0fe4\u8319',
+baseMipLevel: 4,
+}
+);
+let sampler56 = device5.createSampler(
+{
+label: '\u5608\u014b\u8c07',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 69.750,
+lodMaxClamp: 99.730,
+}
+);
+try {
+renderBundleEncoder37.setBindGroup(
+0,
+bindGroup3
+);
+} catch {}
+try {
+device5.queue.submit([
+commandBuffer7,
+]);
+} catch {}
+try {
+device5.queue.writeBuffer(
+buffer17,
+19196,
+new Int16Array(991),
+480,
+372
+);
+} catch {}
+try {
+adapter1.label = '\ubeed\u5adc\u2526\uf455\u0c55\u0c95\u2d0f\u0454\u0062\u{1fb50}\u4893';
+} catch {}
+let buffer26 = device9.createBuffer(
+{
+label: '\u3e15\ue719\ubc5c\u3c6f\ua2c3\ucd7f\uc6b9\u0c76',
+size: 920,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let bindGroup7 = device8.createBindGroup({
+label: '\u6479\u{1f977}',
+layout: bindGroupLayout32,
+entries: [
+
+],
+});
+let textureView50 = texture66.createView(
+{
+label: '\u066f\uc196\ucfe8\u0d15\u0bc7\u{1f9a4}',
+aspect: 'all',
+baseMipLevel: 0,
+mipLevelCount: 1,
+}
+);
+try {
+renderBundleEncoder50.setBindGroup(
+2,
+bindGroup7
+);
+} catch {}
+try {
+commandEncoder59.copyBufferToTexture(
+{
+/* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 54320 */
+offset: 54320,
+bytesPerRow: 256,
+buffer: buffer22,
+},
+{
+  texture: texture66,
+  mipLevel: 2,
+  origin: { x: 16, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 8, height: 40, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device8, buffer22);
+} catch {}
+try {
+device8.queue.writeTexture(
+{
+  texture: texture66,
+  mipLevel: 1,
+  origin: { x: 8, y: 16, z: 1 },
+  aspect: 'all',
+},
+new Float64Array(new ArrayBuffer(0)),
+/* required buffer size: 115 */{
+offset: 115,
+bytesPerRow: 18,
+},
+{width: 8, height: 56, depthOrArrayLayers: 0}
+);
+} catch {}
+let bindGroup8 = device8.createBindGroup({
+label: '\u{1f815}\u3f50\u5aed\u{1ffb7}\u{1f802}\u2f62\u6ce8\u{1f9f1}\u3c79\ue623',
+layout: bindGroupLayout30,
+entries: [
+
+],
+});
+let device10 = await adapter11.requestDevice({
+label: '\u8f5e\u{1fdda}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxBindGroups: 9,
+maxColorAttachmentBytesPerSample: 60,
+maxVertexAttributes: 21,
+maxVertexBufferArrayStride: 38213,
+maxStorageTexturesPerShaderStage: 29,
+maxStorageBuffersPerShaderStage: 10,
+maxDynamicStorageBuffersPerPipelineLayout: 13260,
+maxBindingsPerBindGroup: 4218,
+maxTextureDimension1D: 8398,
+maxTextureDimension2D: 14953,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 99204218,
+maxUniformBuffersPerShaderStage: 40,
+maxInterStageShaderVariables: 87,
+maxInterStageShaderComponents: 68,
+maxSamplersPerShaderStage: 20,
+},
+});
+try {
+buffer22.destroy();
+} catch {}
+let texture73 = gpuCanvasContext7.getCurrentTexture();
+let textureView51 = texture47.createView(
+{
+label: '\u24eb\u1a8f\ud91d',
+baseMipLevel: 5,
+mipLevelCount: 2,
+baseArrayLayer: 0,
+}
+);
+try {
+commandEncoder55.copyBufferToTexture(
+{
+/* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 41072 */
+offset: 41072,
+buffer: buffer24,
+},
+{
+  texture: texture73,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device4, buffer24);
+} catch {}
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let commandEncoder63 = device1.createCommandEncoder(
+{
+label: '\u8f50\u05d0\u{1fb4b}\u1e97\u9776\u52ca',
+}
+);
+let renderBundleEncoder59 = device1.createRenderBundleEncoder(
+{
+label: '\u{1fab0}\uccf6\u9c4d',
+colorFormats: [
+'rg32float',
+'r16uint',
+'r16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 145,
+stencilReadOnly: false,
+}
+);
+try {
+commandEncoder63.clearBuffer(
+buffer16,
+1176,
+4456
+);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+device1.queue.submit([
+]);
+} catch {}
+let imageBitmap19 = await createImageBitmap(offscreenCanvas15);
+let videoFrame18 = new VideoFrame(videoFrame8, {timestamp: 0});
+let textureView52 = texture46.createView(
+{
+label: '\uef58\u{1f984}\u0a01\ud1f3\u7571\u09f8\u086e\u0e94\u423a\u{1fd4f}',
+baseMipLevel: 1,
+mipLevelCount: 2,
+baseArrayLayer: 92,
+arrayLayerCount: 84,
+}
+);
+let renderBundle57 = renderBundleEncoder38.finish(
+{
+label: '\u{1f8d5}\u1120\u0ba6\u05e8\u9a4b\u97e2\u0276\u140e\u{1fc3f}\u0740'
+}
+);
+try {
+computePassEncoder23.setBindGroup(
+1,
+bindGroup4,
+new Uint32Array(3008),
+2590,
+0
+);
+} catch {}
+let promise21 = device5.createComputePipelineAsync(
+{
+label: '\u7bb8\u09a8\u294e\u{1fbcb}\u64e0\u{1fec1}\u0776',
+layout: pipelineLayout9,
+compute: {
+module: shaderModule19,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let commandEncoder64 = device6.createCommandEncoder(
+{
+label: '\u24e1\u53e9\u9122\u51ab',
+}
+);
+try {
+computePassEncoder22.insertDebugMarker(
+'\ufa2a'
+);
+} catch {}
+let imageBitmap20 = await createImageBitmap(offscreenCanvas23);
+let texture74 = device9.createTexture(
+{
+size: {width: 6800, height: 192, depthOrArrayLayers: 161},
+mipLevelCount: 3,
+sampleCount: 1,
+format: 'astc-5x4-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+gpuCanvasContext20.configure(
+{
+device: device9,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'eac-rg11snorm',
+'rg16sint',
+'bgra8unorm',
+'bgra8unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let offscreenCanvas28 = new OffscreenCanvas(523, 264);
+let buffer27 = device1.createBuffer(
+{
+label: '\u0109\u0e7a\u1d7c\u{1f660}\u5331\u{1fb4e}',
+size: 5959,
+usage: GPUBufferUsage.COPY_DST,
+mappedAtCreation: false,
+}
+);
+let querySet55 = device1.createQuerySet({
+label: '\u{1f975}\u{1ff78}\u{1fc89}',
+type: 'occlusion',
+count: 3104,
+});
+let texture75 = device1.createTexture(
+{
+label: '\u0d21\u{1fdda}\u05f4\u5d9f\u{1fbe0}\u39e9\ud1a0\u7136\u21a5',
+size: [374, 1, 467],
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float'
+],
+}
+);
+let renderPassEncoder15 = commandEncoder63.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView12,
+depthLoadOp: 'load',
+depthStoreOp: 'discard',
+},
+occlusionQuerySet: querySet28,
+maxDrawCount: 159392,
+}
+);
+let renderBundleEncoder60 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+'r32uint',
+undefined,
+'rg32uint',
+'r32float',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 831,
+}
+);
+let renderBundle58 = renderBundleEncoder28.finish(
+{
+label: '\u2971\u0155\u51f0\u41be\u00a0\u{1ffd5}\u514a\u0957\u7dbd\u{1fcf9}\u51ef'
+}
+);
+try {
+computePassEncoder10.setPipeline(
+pipeline33
+);
+} catch {}
+try {
+renderPassEncoder15.setViewport(
+17.18,
+39.44,
+5.539,
+2.442,
+0.4497,
+0.7509
+);
+} catch {}
+let pipeline56 = await device1.createComputePipelineAsync(
+{
+label: '\u{1fb29}\u57fe',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule17,
+entryPoint: 'compute0',
+},
+}
+);
+let bindGroupLayout34 = device9.createBindGroupLayout(
+{
+label: '\u0c61\ue4df\u05ac\u{1fb97}\u1606\u{1fc61}\ubfaa\u4e00',
+entries: [
+{
+binding: 1921,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '2d-array' },
+},
+{
+binding: 2626,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let querySet56 = device9.createQuerySet({
+type: 'occlusion',
+count: 3101,
+});
+let texture76 = device9.createTexture(
+{
+label: '\ue95b\u{1fd31}\u0280\u{1f65d}\udaa4\u09d2\u9117\u3a4f\u0e1b\u{1f83e}\u{1ff84}',
+size: [114, 114, 1],
+mipLevelCount: 2,
+format: 'astc-6x6-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let bindGroup9 = device8.createBindGroup({
+label: '\u2f66\u{1f6e5}\u0685\u5ce1\u5a89\u27c2\u4a0e',
+layout: bindGroupLayout32,
+entries: [
+
+],
+});
+let commandEncoder65 = device8.createCommandEncoder(
+{
+label: '\ud2f4\u8164\ub3e5\u059b\u5fd1',
+}
+);
+pseudoSubmit(device8, commandEncoder58);
+try {
+await device8.popErrorScope();
+} catch {}
+try {
+renderBundleEncoder56.insertDebugMarker(
+'\u5a2a'
+);
+} catch {}
+let promise22 = device8.queue.onSubmittedWorkDone();
+let offscreenCanvas29 = new OffscreenCanvas(314, 484);
+let commandEncoder66 = device10.createCommandEncoder(
+{
+label: '\u{1f9f0}\u{1f727}\u8e15',
+}
+);
+let texture77 = device10.createTexture(
+{
+label: '\u0a95\u{1fd48}\u{1fdc4}\uc3bf\u0e4a',
+size: [7641],
+dimension: '1d',
+format: 'r32uint',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'r32uint'
+],
+}
+);
+let textureView53 = texture77.createView(
+{
+label: '\u8520\u2666\u{1f97c}\u0a75\u48e3\ucde6\ue6a0\u071f',
+mipLevelCount: 1,
+}
+);
+let computePassEncoder30 = commandEncoder66.beginComputePass(
+{
+label: '\u{1f859}\u167f'
+}
+);
+try {
+await device10.queue.onSubmittedWorkDone();
+} catch {}
+try {
+await promise22;
+} catch {}
+document.body.prepend(video3);
+try {
+offscreenCanvas28.getContext('webgpu');
+} catch {}
+let commandEncoder67 = device10.createCommandEncoder(
+{
+}
+);
+let texture78 = device10.createTexture(
+{
+label: '\u{1fb75}\u7200\uf589\u0d48\u002d\udddd\u{1f6f3}\u48c1',
+size: [3745],
+dimension: '1d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+device10.addEventListener('uncapturederror', e => { log('device10.uncapturederror'); log(e); e.label = device10.label; });
+} catch {}
+let texture79 = device1.createTexture(
+{
+size: [6436, 5, 1],
+mipLevelCount: 11,
+sampleCount: 1,
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let sampler57 = device1.createSampler(
+{
+label: '\ub01b\ubcd9\u580c\u8e64\u{1fb4f}\u0c25\ud675\u0d0f\ubbf1\u73c4',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 34.633,
+lodMaxClamp: 72.523,
+}
+);
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: 4.975, g: -755.5, b: 247.6, a: 139.9, });
+} catch {}
+try {
+renderBundleEncoder49.setVertexBuffer(
+88,
+undefined,
+1364935253,
+1337309996
+);
+} catch {}
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+let arrayBuffer5 = buffer12.getMappedRange(
+17376,
+15868
+);
+try {
+device1.queue.writeTexture(
+{
+  texture: texture17,
+  mipLevel: 0,
+  origin: { x: 644, y: 1, z: 916 },
+  aspect: 'all',
+},
+new DataView(arrayBuffer1),
+/* required buffer size: 2842405 */{
+offset: 995,
+bytesPerRow: 3974,
+rowsPerImage: 143,
+},
+{width: 935, height: 0, depthOrArrayLayers: 6}
+);
+} catch {}
+let pipeline57 = await device1.createRenderPipelineAsync(
+{
+label: '\ue1a4\u39b7\ubd7c\uf762\udbe7\u0562\u0ce5\ua472\u27a9\u{1fbc7}\u{1ff87}',
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule10,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1348,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 340,
+shaderLocation: 2,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 788,
+shaderLocation: 17,
+},
+{
+format: 'snorm16x4',
+offset: 8,
+shaderLocation: 15,
+},
+{
+format: 'uint32x3',
+offset: 712,
+shaderLocation: 3,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 688,
+shaderLocation: 10,
+},
+{
+format: 'float32',
+offset: 508,
+shaderLocation: 6,
+},
+{
+format: 'sint32x4',
+offset: 580,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x2',
+offset: 716,
+shaderLocation: 1,
+},
+{
+format: 'unorm16x4',
+offset: 396,
+shaderLocation: 11,
+},
+{
+format: 'uint32',
+offset: 4,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x2',
+offset: 792,
+shaderLocation: 0,
+},
+{
+format: 'snorm8x2',
+offset: 606,
+shaderLocation: 5,
+},
+{
+format: 'snorm16x4',
+offset: 684,
+shaderLocation: 12,
+},
+{
+format: 'sint32x3',
+offset: 760,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 48,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 24,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 3716,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 4368,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32',
+offset: 120,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 6884,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 6372,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 6344,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+},
+fragment: {
+module: shaderModule10,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less',
+failOp: 'invert',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater',
+depthFailOp: 'replace',
+passOp: 'replace',
+},
+stencilReadMask: 574,
+stencilWriteMask: 439,
+depthBiasSlopeScale: 18,
+depthBiasClamp: 88,
+},
+}
+);
+let video22 = await videoWithData();
+let imageBitmap21 = await createImageBitmap(img11);
+let canvas17 = document.createElement('canvas');
+let img18 = await imageWithData(164, 107, '#9b666ac9', '#4b4225a3');
+let video23 = await videoWithData();
+let shaderModule22 = device6.createShaderModule(
+{
+label: '\uc14e\u{1fc6b}\u4801\u{1fb69}\u29fb\u{1f829}\uef04\u0c33\u9c68\u084c',
+code: `@group(1) @binding(111)
+var<storage, read_write> local15: array<u32>;
+@group(0) @binding(108)
+var<storage, read_write> i28: array<u32>;
+@group(2) @binding(108)
+var<storage, read_write> i29: array<u32>;
+@group(2) @binding(111)
+var<storage, read_write> type20: array<u32>;
+@group(0) @binding(111)
+var<storage, read_write> i30: array<u32>;
+@group(1) @binding(108)
+var<storage, read_write> type21: array<u32>;
+
+@compute @workgroup_size(8, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(7) f0: vec2<i32>,
+@location(5) f1: vec3<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S24 {
+@location(15) f0: vec3<i32>,
+@location(9) f1: i32,
+@location(8) f2: vec3<f16>,
+@location(5) f3: vec4<f16>,
+@builtin(vertex_index) f4: u32,
+@location(2) f5: vec3<f16>,
+@location(3) f6: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(1) a0: vec3<f32>, a1: S24, @builtin(instance_index) a2: u32, @location(7) a3: vec4<i32>, @location(6) a4: f16, @location(4) a5: f32, @location(0) a6: u32, @location(14) a7: vec2<u32>, @location(12) a8: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let textureView54 = texture57.createView(
+{
+label: '\u{1f8c5}\u{1fd41}\u09bc\u{1fa72}\u9386',
+baseArrayLayer: 0,
+arrayLayerCount: 1,
+}
+);
+let renderBundleEncoder61 = device6.createRenderBundleEncoder(
+{
+label: '\u6180\u688a\u07b0\u{1ff92}\u131a\u04c4\u{1f8d0}',
+colorFormats: [
+'rg32uint',
+'r32float',
+'rgb10a2uint',
+'r32float'
+],
+sampleCount: 300,
+stencilReadOnly: true,
+}
+);
+let adapter12 = await navigator.gpu.requestAdapter(
+{
+powerPreference: 'high-performance',
+}
+);
+let gpuCanvasContext22 = canvas17.getContext('webgpu');
+let bindGroupLayout35 = device6.createBindGroupLayout(
+{
+label: '\u7235\udb04\u52f3\u5d1f\u4604\u093d\udbc0\u7593',
+entries: [
+
+],
+}
+);
+let querySet57 = device6.createQuerySet({
+label: '\u09c8\u{1fb6b}\u097d\u48ca',
+type: 'occlusion',
+count: 704,
+});
+let textureView55 = texture57.createView(
+{
+label: '\u0782\u7ab7\ud32d\u0264\ucb6a\ue7d0\u01f5\u0294\uf924',
+}
+);
+let renderBundle59 = renderBundleEncoder58.finish();
+try {
+renderBundleEncoder61.setVertexBuffer(
+74,
+undefined,
+1670066320,
+1266255063
+);
+} catch {}
+try {
+await buffer23.mapAsync(
+GPUMapMode.WRITE,
+17704,
+10920
+);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let pipelineLayout15 = device1.createPipelineLayout(
+{
+label: '\u0ade\u367a\u7b79\uc7dc\ub2fb\u3026\u{1fd65}\u{1faa4}\u0872\u{1fa6f}',
+bindGroupLayouts: [
+bindGroupLayout14
+]
+}
+);
+let renderBundleEncoder62 = device1.createRenderBundleEncoder(
+{
+label: '\u{1fc13}\udee2\u0b84',
+colorFormats: [
+'r8unorm',
+'rg8sint',
+'rgba16sint',
+'r8uint',
+'r8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 995,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder9.end();
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer16,
+6588,
+new Int16Array(14520),
+5706,
+1792
+);
+} catch {}
+let buffer28 = device6.createBuffer(
+{
+label: '\ua4cd\u{1fa2e}\u{1fafa}\ue061\u0b48\u0b1b\u1c3c\u04a7\u{1fa68}\ufc22\u0667',
+size: 62576,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let commandEncoder68 = device6.createCommandEncoder(
+{
+label: '\uda34\u03d5\ud6d8\ubf54\u0e0c\u9191',
+}
+);
+let textureView56 = texture57.createView(
+{
+label: '\u8aef\u{1fdba}\uf5aa\u052b\u62f0\u37bb\u035a\u{1fc32}\u669a\u{1f75e}',
+}
+);
+let sampler58 = device6.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+lodMinClamp: 94.266,
+lodMaxClamp: 96.068,
+}
+);
+try {
+computePassEncoder22.end();
+} catch {}
+let pipeline58 = device6.createRenderPipeline(
+{
+label: '\u31e4\u{1fd2f}\u{1f6aa}\u8c7d\u{1fb74}\u0ccb\ud9f5\u95b5',
+layout: pipelineLayout13,
+vertex: {
+module: shaderModule22,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1968,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 1000,
+shaderLocation: 7,
+},
+{
+format: 'uint8x4',
+offset: 660,
+shaderLocation: 0,
+},
+{
+format: 'float16x4',
+offset: 204,
+shaderLocation: 5,
+},
+{
+format: 'sint32',
+offset: 1680,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x4',
+offset: 1388,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x2',
+offset: 688,
+shaderLocation: 6,
+},
+{
+format: 'sint8x2',
+offset: 1928,
+shaderLocation: 12,
+},
+{
+format: 'unorm8x4',
+offset: 520,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 964,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x2',
+offset: 592,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 936,
+attributes: [
+{
+format: 'float32x3',
+offset: 216,
+shaderLocation: 2,
+},
+{
+format: 'sint32x4',
+offset: 224,
+shaderLocation: 15,
+},
+{
+format: 'uint8x2',
+offset: 290,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 1228,
+attributes: [
+{
+format: 'uint8x2',
+offset: 726,
+shaderLocation: 3,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x71aa2602,
+},
+fragment: {
+module: shaderModule22,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'always',
+failOp: 'invert',
+depthFailOp: 'replace',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+},
+stencilReadMask: 15,
+stencilWriteMask: 2170,
+depthBias: 86,
+depthBiasSlopeScale: 85,
+depthBiasClamp: 63,
+},
+}
+);
+let canvas18 = document.createElement('canvas');
+let buffer29 = device5.createBuffer(
+{
+label: '\u0d9b\u087f\u9560\u0a17',
+size: 48978,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let sampler59 = device5.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+maxAnisotropy: 1,
+}
+);
+try {
+renderBundleEncoder37.setBindGroup(
+0,
+bindGroup4
+);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+let pipeline59 = device5.createRenderPipeline(
+{
+label: '\u0ff9\ub49a\u0c2e\u{1fc05}\ua786\u5d93\u31be\ucc6a\uc66e\u{1fdcb}',
+layout: pipelineLayout9,
+vertex: {
+module: shaderModule19,
+entryPoint: 'vertex0',
+buffers: [
+
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule19,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.GREEN,
+}
+],
+},
+}
+);
+let texture80 = device4.createTexture(
+{
+label: '\u0ae7\u08ac\uc758\u0d2a\u{1f624}\u2864\u{1ff21}\u2a6d\udec6\u{1ff2c}',
+size: {width: 3420, height: 180, depthOrArrayLayers: 199},
+mipLevelCount: 12,
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x10-unorm'
+],
+}
+);
+let computePassEncoder31 = commandEncoder39.beginComputePass(
+{
+
+}
+);
+let renderBundleEncoder63 = device4.createRenderBundleEncoder(
+{
+label: '\udb48\u7651\u5832\ube38\u1a46\u050d\uc15b',
+colorFormats: [
+undefined,
+'bgra8unorm-srgb',
+'rg32float',
+'rg16float',
+'rgba8sint',
+'rg16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 342,
+}
+);
+let sampler60 = device4.createSampler(
+{
+label: '\u{1f76c}\u0c4d\ubcdb\u8d46',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 48.636,
+lodMaxClamp: 75.262,
+maxAnisotropy: 20,
+}
+);
+let texture81 = device10.createTexture(
+{
+label: '\u0a32\u{1fd5e}',
+size: [1244, 1, 202],
+mipLevelCount: 2,
+dimension: '3d',
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32sint'
+],
+}
+);
+let textureView57 = texture77.createView(
+{
+label: '\u08f9\u53d3\u4d2a\u022b\u{1fef6}\u044e\ubea7\u{1fc25}\u4c49\u0fa8\ud031',
+format: 'r32uint',
+}
+);
+let sampler61 = device10.createSampler(
+{
+label: '\u0454\u247b',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 32.439,
+lodMaxClamp: 44.159,
+compare: 'less',
+}
+);
+let gpuCanvasContext23 = offscreenCanvas29.getContext('webgpu');
+let pipelineLayout16 = device8.createPipelineLayout(
+{
+label: '\u4346\u163d\ud441\u8a81\u0347\u{1f7df}\u50ec\u0d40\u06db',
+bindGroupLayouts: [
+bindGroupLayout30,
+bindGroupLayout32,
+bindGroupLayout32,
+bindGroupLayout30,
+bindGroupLayout31,
+bindGroupLayout30,
+bindGroupLayout32
+]
+}
+);
+let texture82 = device8.createTexture(
+{
+label: '\u{1f659}\u{1fe2a}\u2034\u0522\uab49\u78ab',
+size: [197, 3, 1],
+mipLevelCount: 2,
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8unorm'
+],
+}
+);
+let sampler62 = device8.createSampler(
+{
+label: '\u{1f77d}\ua9a3\u{1fc8f}\u0413\u54e8\u36dc\u{1ffc1}',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 24.372,
+lodMaxClamp: 40.373,
+maxAnisotropy: 15,
+}
+);
+try {
+renderBundleEncoder56.setVertexBuffer(
+52,
+undefined,
+2490807536,
+1391654661
+);
+} catch {}
+try {
+buffer22.destroy();
+} catch {}
+let video24 = await videoWithData();
+let bindGroup10 = device5.createBindGroup({
+layout: bindGroupLayout25,
+entries: [
+{
+binding: 59,
+resource: sampler24
+},
+{
+binding: 378,
+resource: externalTexture7
+}
+],
+});
+let querySet58 = device5.createQuerySet({
+type: 'occlusion',
+count: 1630,
+});
+let sampler63 = device5.createSampler(
+{
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 80.111,
+}
+);
+let pipeline60 = device5.createComputePipeline(
+{
+label: '\u0b3f\u37a3\u0819\ud86f\ud52d\uf566',
+layout: pipelineLayout9,
+compute: {
+module: shaderModule19,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let promise23 = device5.createRenderPipelineAsync(
+{
+label: '\u{1fbe4}\u0c0e\u83fe',
+layout: pipelineLayout9,
+vertex: {
+module: shaderModule16,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1084,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 484,
+shaderLocation: 3,
+},
+{
+format: 'unorm16x4',
+offset: 1060,
+shaderLocation: 1,
+},
+{
+format: 'uint32x3',
+offset: 476,
+shaderLocation: 8,
+},
+{
+format: 'snorm16x2',
+offset: 392,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule16,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+undefined,
+undefined,
+undefined,
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+undefined,
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'replace',
+depthFailOp: 'invert',
+},
+stencilReadMask: 1359,
+stencilWriteMask: 443,
+depthBias: 88,
+depthBiasSlopeScale: 59,
+},
+}
+);
+let video25 = await videoWithData();
+let pipelineLayout17 = device9.createPipelineLayout(
+{
+label: '\u0aa0\udbd8\uf3ad\u09f2\u{1fab0}\u8be1\ua244\u6386',
+bindGroupLayouts: [
+bindGroupLayout34,
+bindGroupLayout34
+]
+}
+);
+let sampler64 = device9.createSampler(
+{
+label: '\u0420\u0192\u605d\ufcc4\u{1fccd}\u092d\u{1fcf1}\uba11\u{1fc91}\u0e91',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 18.384,
+lodMaxClamp: 70.686,
+}
+);
+let pipelineLayout18 = device5.createPipelineLayout(
+{
+label: '\u697c\ude0c\u83e6',
+bindGroupLayouts: [
+
+]
+}
+);
+try {
+computePassEncoder26.setPipeline(
+pipeline36
+);
+} catch {}
+try {
+buffer29.destroy();
+} catch {}
+try {
+await buffer15.mapAsync(
+GPUMapMode.READ,
+0,
+15720
+);
+} catch {}
+let img19 = await imageWithData(7, 207, '#270a66ed', '#29eee68d');
+let bindGroupLayout36 = device10.createBindGroupLayout(
+{
+entries: [
+{
+binding: 329,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '3d' },
+}
+],
+}
+);
+try {
+device10.queue.writeTexture(
+{
+  texture: texture81,
+  mipLevel: 1,
+  origin: { x: 127, y: 0, z: 10 },
+  aspect: 'all',
+},
+new ArrayBuffer(7426477),
+/* required buffer size: 7426477 */{
+offset: 19,
+bytesPerRow: 1937,
+rowsPerImage: 71,
+},
+{width: 473, height: 0, depthOrArrayLayers: 55}
+);
+} catch {}
+document.body.prepend(canvas1);
+gc();
+let texture83 = device4.createTexture(
+{
+label: '\uedd9\u{1ff95}\u{1fa40}\u{1fd47}\u{1feed}\uc867\uc8fc\u0cd5\u5dac\u5571',
+size: {width: 236, height: 168, depthOrArrayLayers: 116},
+mipLevelCount: 2,
+format: 'eac-r11unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'eac-r11unorm',
+'eac-r11unorm',
+'eac-r11unorm'
+],
+}
+);
+let sampler65 = device4.createSampler(
+{
+label: '\u458b\u{1fa94}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 19.744,
+lodMaxClamp: 55.151,
+}
+);
+try {
+commandEncoder55.copyBufferToTexture(
+{
+/* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 47060 */
+offset: 47060,
+buffer: buffer24,
+},
+{
+  texture: texture73,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device4, buffer24);
+} catch {}
+canvas7.width = 912;
+let commandEncoder69 = device1.createCommandEncoder(
+{
+}
+);
+let texture84 = device1.createTexture(
+{
+label: '\u05bb\u9e93\uba9e\u{1fb2e}\u3dbf\u0a1d\u{1fccd}\u0a1c\ub44f\u81dc',
+size: [35, 167, 1],
+mipLevelCount: 7,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderPassEncoder16 = commandEncoder69.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView12,
+depthClearValue: 0.904328166503807,
+depthLoadOp: 'clear',
+depthStoreOp: 'discard',
+depthReadOnly: false,
+stencilClearValue: 5880,
+},
+maxDrawCount: 52888,
+}
+);
+try {
+renderPassEncoder13.setIndexBuffer(
+buffer8,
+'uint16',
+22298,
+3447
+);
+} catch {}
+try {
+renderBundleEncoder47.setVertexBuffer(
+79,
+undefined,
+2814930907
+);
+} catch {}
+try {
+renderBundleEncoder47.pushDebugGroup(
+'\u684b'
+);
+} catch {}
+try {
+computePassEncoder19.insertDebugMarker(
+'\u8534'
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture32,
+  mipLevel: 0,
+  origin: { x: 806, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 185 */{
+offset: 185,
+},
+{width: 488, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise24 = device1.createComputePipelineAsync(
+{
+label: '\u02a9\u{1fa00}',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule13,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let offscreenCanvas30 = new OffscreenCanvas(163, 940);
+let pipelineLayout19 = device9.createPipelineLayout(
+{
+bindGroupLayouts: [
+
+]
+}
+);
+let commandEncoder70 = device9.createCommandEncoder();
+let computePassEncoder32 = commandEncoder70.beginComputePass(
+{
+label: '\u{1fe4a}\u5f00\u{1f8ee}\u{1fb33}\u0f87\u2cc2\u06ad\u9e15\u{1fcf6}\u2e99'
+}
+);
+let commandEncoder71 = device4.createCommandEncoder();
+let texture85 = device4.createTexture(
+{
+size: {width: 576, height: 12, depthOrArrayLayers: 1},
+mipLevelCount: 10,
+dimension: '2d',
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-12x12-unorm'
+],
+}
+);
+let externalTexture8 = device4.importExternalTexture(
+{
+label: '\u5c98\ua7fd\u1ff4\u95ae\u2be3\u7d92\u9368\u{1fbfe}\u21ad\u{1f915}',
+source: video8,
+colorSpace: 'display-p3',
+}
+);
+try {
+device4.queue.writeTexture(
+{
+  texture: texture83,
+  mipLevel: 0,
+  origin: { x: 24, y: 120, z: 43 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer0),
+/* required buffer size: 274231 */{
+offset: 143,
+bytesPerRow: 561,
+rowsPerImage: 48,
+},
+{width: 160, height: 36, depthOrArrayLayers: 11}
+);
+} catch {}
+let renderBundleEncoder64 = device9.createRenderBundleEncoder(
+{
+label: '\u{1f7ed}\ue73c\u91dc\u{1f91c}\u4285\u{1fe66}\u24cf\u2e12\u3daa',
+colorFormats: [
+'rgba32uint',
+'rg8sint',
+'r32sint',
+'r16sint',
+'rg16uint',
+undefined
+],
+sampleCount: 365,
+depthReadOnly: true,
+}
+);
+let video26 = await videoWithData();
+let videoFrame19 = new VideoFrame(imageBitmap6, {timestamp: 0});
+let buffer30 = device5.createBuffer(
+{
+label: '\u080f\u2a3a\ud6b1\u03f1\uf460',
+size: 26701,
+usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+}
+);
+let renderBundleEncoder65 = device5.createRenderBundleEncoder(
+{
+label: '\u0a78\u03e9\u9cea\u07a9\u6455',
+colorFormats: [
+'r32sint'
+],
+sampleCount: 357,
+depthReadOnly: true,
+}
+);
+let sampler66 = device5.createSampler(
+{
+label: '\ucca3\u8974\u7472\u365d\u05a4',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 84.294,
+lodMaxClamp: 93.338,
+compare: 'less',
+}
+);
+try {
+renderBundleEncoder65.setVertexBuffer(
+7,
+buffer13,
+33548
+);
+} catch {}
+try {
+device5.queue.writeBuffer(
+buffer17,
+38796,
+new Int16Array(30276),
+17450,
+840
+);
+} catch {}
+let pipeline61 = device5.createComputePipeline(
+{
+label: '\u51fc\u0da5\u8bb1\uf902\u{1ffe0}\u6b89\u0043\uf087\u0cd4\ue52e',
+layout: pipelineLayout18,
+compute: {
+module: shaderModule19,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+computePassEncoder23.setBindGroup(
+0,
+bindGroup3
+);
+} catch {}
+let gpuCanvasContext24 = offscreenCanvas30.getContext('webgpu');
+let imageData33 = new ImageData(244, 128);
+let pipelineLayout20 = device10.createPipelineLayout(
+{
+label: '\u04e0\ufdb9\u0ceb\uf116',
+bindGroupLayouts: [
+bindGroupLayout36,
+bindGroupLayout36,
+bindGroupLayout36,
+bindGroupLayout36,
+bindGroupLayout36,
+bindGroupLayout36,
+bindGroupLayout36,
+bindGroupLayout36
+]
+}
+);
+let buffer31 = device10.createBuffer(
+{
+size: 16080,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+let computePassEncoder33 = commandEncoder67.beginComputePass(
+{
+label: '\u{1f960}\ub850\ufb6c\uc4b9\u0dad\u0395\u0b58\u1a2c\udb47\u0a0b\u08ee'
+}
+);
+try {
+gpuCanvasContext2.configure(
+{
+device: device10,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+let pipelineLayout21 = device6.createPipelineLayout(
+{
+label: '\u0e05\u67cb\u0387\u2bc3\u92b5\u1f53\u93d8',
+bindGroupLayouts: [
+
+]
+}
+);
+let renderBundle60 = renderBundleEncoder54.finish(
+{
+label: '\ufb54\u0c6a\u{1fc49}\u{1fe70}\u09a9\u05a4\ua76a\u{1fa39}\ud1d4'
+}
+);
+try {
+computePassEncoder24.end();
+} catch {}
+try {
+renderBundleEncoder61.setVertexBuffer(
+55,
+undefined,
+459110992,
+3188943697
+);
+} catch {}
+let pipeline62 = await device6.createComputePipelineAsync(
+{
+label: '\u3912\u1648\u7457\u0e56\u0b71\u31da\u{1fe49}\u86c7\u0f4b\u0dbf',
+layout: pipelineLayout13,
+compute: {
+module: shaderModule22,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageData34 = new ImageData(24, 128);
+let shaderModule23 = device8.createShaderModule(
+{
+label: '\u0c56\u05e5\uc3ed\u7c70\u7aa1\ue9fb\u3202',
+code: `@group(4) @binding(1170)
+var<storage, read_write> global22: array<u32>;
+
+@compute @workgroup_size(1, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@builtin(sample_mask) f0: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(sample_mask) a1: u32, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(17) a0: vec4<f16>, @builtin(instance_index) a1: u32, @location(20) a2: vec4<f32>, @location(4) a3: vec2<u32>, @location(13) a4: vec4<u32>, @location(15) a5: vec3<u32>, @location(0) a6: vec3<u32>, @location(18) a7: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+}
+);
+let texture86 = device8.createTexture(
+{
+label: '\u{1f998}\uc576\u4dee\u67fd\u1726\ue62f\u74cc\uec43',
+size: {width: 6552},
+sampleCount: 1,
+dimension: '1d',
+format: 'rg16uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder66 = device8.createRenderBundleEncoder(
+{
+label: '\u0db0\u0462\ud5a7\uee7e\ubf7a',
+colorFormats: [
+'r8sint',
+'rgba16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 589,
+depthReadOnly: false,
+stencilReadOnly: false,
+}
+);
+try {
+commandEncoder65.copyBufferToTexture(
+{
+/* bytesInLastRow: 380 widthInBlocks: 190 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 38306 */
+offset: 38306,
+buffer: buffer22,
+},
+{
+  texture: texture82,
+  mipLevel: 0,
+  origin: { x: 5, y: 1, z: 0 },
+  aspect: 'all',
+},
+{width: 190, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device8, buffer22);
+} catch {}
+try {
+device8.queue.writeTexture(
+{
+  texture: texture82,
+  mipLevel: 1,
+  origin: { x: 12, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 97 */{
+offset: 97,
+},
+{width: 31, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline63 = device8.createRenderPipeline(
+{
+label: '\uc42e\u0a7e\u0f35\u{1fe32}\ud67b\u941a\u577a',
+layout: 'auto',
+vertex: {
+module: shaderModule23,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1524,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 462,
+shaderLocation: 20,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 184,
+shaderLocation: 17,
+},
+{
+format: 'sint32x2',
+offset: 300,
+shaderLocation: 18,
+},
+{
+format: 'uint32x2',
+offset: 1456,
+shaderLocation: 15,
+},
+{
+format: 'uint8x4',
+offset: 1348,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 9644,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 3812,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 756,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 440,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 428,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule23,
+entryPoint: 'fragment0',
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'zero',
+depthFailOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 1622,
+depthBias: 19,
+depthBiasSlopeScale: 72,
+depthBiasClamp: 30,
+},
+}
+);
+let device11 = await adapter12.requestDevice({
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxColorAttachmentBytesPerSample: 54,
+maxVertexAttributes: 24,
+maxVertexBufferArrayStride: 17136,
+maxStorageTexturesPerShaderStage: 31,
+maxStorageBuffersPerShaderStage: 16,
+maxDynamicStorageBuffersPerPipelineLayout: 44730,
+maxBindingsPerBindGroup: 1325,
+maxTextureDimension1D: 9872,
+maxTextureDimension2D: 8280,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 45722691,
+maxUniformBuffersPerShaderStage: 33,
+maxInterStageShaderVariables: 116,
+maxInterStageShaderComponents: 112,
+maxSamplersPerShaderStage: 18,
+},
+});
+try {
+buffer18.unmap();
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture49,
+  mipLevel: 0,
+  origin: { x: 364, y: 0, z: 93 },
+  aspect: 'all',
+},
+arrayBuffer3,
+/* required buffer size: 43731981 */{
+offset: 481,
+bytesPerRow: 5870,
+rowsPerImage: 298,
+},
+{width: 2820, height: 0, depthOrArrayLayers: 26}
+);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas21,
+  origin: { x: 573, y: 304 },
+  flipY: true,
+},
+{
+  texture: texture73,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let renderBundle61 = renderBundleEncoder64.finish();
+let gpuCanvasContext25 = canvas18.getContext('webgpu');
+let shaderModule24 = device1.createShaderModule(
+{
+label: '\u{1ff67}\u3520\u0e86\u0af6\u6c8b\u8a66\u55c1\u{1fda1}\u3976\ua523\ufdae',
+code: `@group(1) @binding(7532)
+var<storage, read_write> function28: array<u32>;
+@group(3) @binding(1199)
+var<storage, read_write> function29: array<u32>;
+@group(0) @binding(1832)
+var<storage, read_write> global23: array<u32>;
+@group(2) @binding(7532)
+var<storage, read_write> i31: array<u32>;
+@group(2) @binding(5363)
+var<storage, read_write> global24: array<u32>;
+@group(5) @binding(7532)
+var<storage, read_write> global25: array<u32>;
+@group(0) @binding(1199)
+var<storage, read_write> field23: array<u32>;
+@group(4) @binding(7532)
+var<storage, read_write> type22: array<u32>;
+@group(4) @binding(5363)
+var<storage, read_write> global26: array<u32>;
+@group(5) @binding(5363)
+var<storage, read_write> i32: array<u32>;
+@group(3) @binding(1832)
+var<storage, read_write> i33: array<u32>;
+@group(1) @binding(5363)
+var<storage, read_write> type23: array<u32>;
+
+@compute @workgroup_size(6, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S25 {
+@builtin(front_facing) f0: bool,
+@builtin(sample_index) f1: u32,
+@builtin(sample_mask) f2: u32
+}
+struct FragmentOutput0 {
+@location(7) f0: vec4<i32>,
+@location(3) f1: vec2<f32>,
+@location(5) f2: vec3<u32>,
+@location(0) f3: vec3<i32>,
+@location(6) f4: vec3<u32>,
+@location(4) f5: i32,
+@location(1) f6: vec4<f32>,
+@location(2) f7: vec3<f32>,
+@builtin(sample_mask) f8: u32
+}
+
+@fragment
+fn fragment0(a0: S25, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(1) a1: vec3<f16>, @builtin(vertex_index) a2: u32, @location(0) a3: vec4<f16>, @location(7) a4: u32, @location(15) a5: vec3<i32>, @location(9) a6: vec3<f16>, @location(11) a7: vec3<f16>, @location(6) a8: u32, @location(5) a9: vec2<f16>, @location(18) a10: vec2<i32>, @location(4) a11: vec2<i32>, @location(13) a12: vec3<i32>, @location(3) a13: f32, @location(2) a14: vec3<f32>, @location(14) a15: vec4<f32>, @location(10) a16: vec3<i32>, @location(16) a17: vec2<f16>, @location(17) a18: vec2<u32>, @location(8) a19: vec2<f32>, @location(12) a20: vec3<f16>, @location(19) a21: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let textureView58 = texture36.createView(
+{
+label: '\u{1f9e5}\ua8bb\udcce\u0383\u0c58\u{1f957}',
+aspect: 'stencil-only',
+format: 'stencil8',
+baseArrayLayer: 83,
+arrayLayerCount: 8,
+}
+);
+let renderBundle62 = renderBundleEncoder28.finish(
+{
+
+}
+);
+try {
+renderPassEncoder13.setIndexBuffer(
+buffer11,
+'uint32'
+);
+} catch {}
+let arrayBuffer6 = buffer21.getMappedRange(
+80,
+2456
+);
+let pipeline64 = device1.createComputePipeline(
+{
+label: '\u0e6b\u3a11\u{1fac5}\ufea6\u{1fe3c}',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule17,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline65 = device1.createRenderPipeline(
+{
+label: '\u0ceb\ue38c',
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule6,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 3712,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 316,
+shaderLocation: 4,
+},
+{
+format: 'sint16x4',
+offset: 3308,
+shaderLocation: 3,
+},
+{
+format: 'uint8x4',
+offset: 2488,
+shaderLocation: 19,
+},
+{
+format: 'uint8x2',
+offset: 2848,
+shaderLocation: 11,
+},
+{
+format: 'snorm8x2',
+offset: 3526,
+shaderLocation: 10,
+},
+{
+format: 'snorm16x2',
+offset: 2516,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 140,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x4',
+offset: 20,
+shaderLocation: 18,
+},
+{
+format: 'float32x3',
+offset: 24,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 7424,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 2796,
+shaderLocation: 7,
+},
+{
+format: 'snorm8x4',
+offset: 7228,
+shaderLocation: 17,
+},
+{
+format: 'float32x2',
+offset: 5248,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 3116,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 1088,
+shaderLocation: 14,
+},
+{
+format: 'sint8x4',
+offset: 184,
+shaderLocation: 5,
+},
+{
+format: 'unorm8x2',
+offset: 1744,
+shaderLocation: 13,
+},
+{
+format: 'uint16x4',
+offset: 2604,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 5288,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 2272,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x2',
+offset: 20,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x2',
+offset: 4468,
+shaderLocation: 1,
+},
+{
+format: 'sint8x4',
+offset: 4872,
+shaderLocation: 6,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'back',
+unclippedDepth: false,
+},
+multisample: {
+mask: 0xe686d3fa,
+},
+fragment: {
+module: shaderModule6,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'r8uint',
+},
+undefined
+],
+},
+}
+);
+document.body.prepend(video15);
+let shaderModule25 = device9.createShaderModule(
+{
+label: '\u0c20\u6ac9\u{1fea5}\u4779\u26e1\u{1fdb4}',
+code: `@group(1) @binding(2626)
+var<storage, read_write> global27: array<u32>;
+@group(0) @binding(2626)
+var<storage, read_write> i34: array<u32>;
+@group(0) @binding(1921)
+var<storage, read_write> global28: array<u32>;
+@group(1) @binding(1921)
+var<storage, read_write> local16: array<u32>;
+
+@compute @workgroup_size(5, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(2) f0: vec4<f32>,
+@builtin(frag_depth) f1: f32,
+@location(4) f2: vec3<i32>,
+@location(1) f3: i32,
+@location(6) f4: vec2<i32>,
+@location(5) f5: vec2<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+}
+);
+let bindGroupLayout37 = device9.createBindGroupLayout(
+{
+entries: [
+
+],
+}
+);
+let texture87 = device9.createTexture(
+{
+label: '\u{1fb2e}\u0ac9\u0445\ufe12\u{1ff78}\u{1fd63}\u5a25',
+size: {width: 7660},
+dimension: '1d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb',
+'bgra8unorm-srgb'
+],
+}
+);
+let textureView59 = texture76.createView(
+{
+label: '\uc89b\u97e3\u7cb5\u03ed',
+dimension: '2d-array',
+baseMipLevel: 1,
+}
+);
+let renderBundleEncoder67 = device9.createRenderBundleEncoder(
+{
+colorFormats: [
+'bgra8unorm',
+'r32sint',
+'rg11b10ufloat'
+],
+sampleCount: 247,
+stencilReadOnly: true,
+}
+);
+let renderBundle63 = renderBundleEncoder64.finish(
+{
+label: '\u{1fc9e}\u8602\u{1ffbb}\u61d9\u7051\u{1f93c}\u6697'
+}
+);
+let pipeline66 = await device9.createRenderPipelineAsync(
+{
+label: '\ucd2e\u91f5\u{1f6c3}\u{1fb0b}\u{1f9a3}\u02af\u05a1\uc0af',
+layout: pipelineLayout19,
+vertex: {
+module: shaderModule25,
+entryPoint: 'vertex0',
+buffers: [
+
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x41034818,
+},
+fragment: {
+module: shaderModule25,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+},
+stencilReadMask: 2967,
+depthBias: 28,
+depthBiasSlopeScale: 5,
+depthBiasClamp: 62,
+},
+}
+);
+let commandEncoder72 = device11.createCommandEncoder();
+let texture88 = device11.createTexture(
+{
+label: '\u0b61\u{1f894}\u018e\ue6d9\u02f5\u8a18',
+size: [25, 4, 210],
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let sampler67 = device11.createSampler(
+{
+label: '\u{1f601}\u4a65\u{1fb34}\u6e0f\u0316',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 24.888,
+lodMaxClamp: 53.418,
+compare: 'equal',
+}
+);
+let querySet59 = device4.createQuerySet({
+label: '\u0739\u95a5\u8769\u{1fc5f}\u0973\u90e6',
+type: 'occlusion',
+count: 749,
+});
+let sampler68 = device4.createSampler(
+{
+label: '\udd5e\u0ed1\u67d0\ufccf',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 30.853,
+maxAnisotropy: 19,
+}
+);
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let bindGroupLayout38 = device5.createBindGroupLayout(
+{
+label: '\uf52c\ubcad\u090c',
+entries: [
+{
+binding: 7,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+},
+{
+binding: 369,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d-array' },
+},
+{
+binding: 490,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'non-filtering' },
+}
+],
+}
+);
+let commandEncoder73 = device5.createCommandEncoder(
+{
+}
+);
+let sampler69 = device5.createSampler(
+{
+label: '\u8fc1\u{1fc54}\u2871',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 20.027,
+lodMaxClamp: 84.279,
+}
+);
+let promise25 = device5.popErrorScope();
+try {
+device5.queue.writeTexture(
+{
+  texture: texture71,
+  mipLevel: 0,
+  origin: { x: 1384, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 566 */{
+offset: 566,
+rowsPerImage: 205,
+},
+{width: 1681, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let textureView60 = texture73.createView(
+{
+dimension: '2d-array',
+baseMipLevel: 0,
+}
+);
+let renderBundle64 = renderBundleEncoder55.finish(
+{
+label: '\u94b2\u09cc\u0594\u0c47\u3357\u{1fce5}\u8ad1'
+}
+);
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+let querySet60 = device10.createQuerySet({
+label: '\u6999\u{1f915}',
+type: 'occlusion',
+count: 1678,
+});
+let querySet61 = device6.createQuerySet({
+label: '\u{1f7f2}\u00fe\uac85\uc70e',
+type: 'occlusion',
+count: 3538,
+});
+pseudoSubmit(device6, commandEncoder41);
+let texture89 = device6.createTexture(
+{
+label: '\ud967\u233a\u{1fd98}',
+size: [8028, 232, 1],
+mipLevelCount: 6,
+format: 'etc2-rgb8a1unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder34 = commandEncoder64.beginComputePass(
+{
+label: '\u{1fab6}\ud419\u1c42\u05ef'
+}
+);
+let renderBundleEncoder68 = device6.createRenderBundleEncoder(
+{
+label: '\u0ca5\u{1f6a4}\u0e6d\u0d2d\u49fd\u2f2c\u00c3\u02ac\u045a\u0b40',
+colorFormats: [
+'rgba8sint',
+'rgba8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 783,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+await adapter1.requestAdapterInfo();
+} catch {}
+try {
+adapter9.label = '\u0be5\u{1fad6}\u3763\u3307\u0531\u4cfa';
+} catch {}
+let buffer32 = device11.createBuffer(
+{
+label: '\u{1fb39}\u9963\u{1fced}\u0add\u8c2f\u{1ff89}\ud317\ue2ab\u{1ffc8}\u98bb\u8af9',
+size: 13420,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let sampler70 = device11.createSampler(
+{
+label: '\u06c4\u0e1c\ua6c3\u02aa',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 37.227,
+lodMaxClamp: 58.255,
+compare: 'less-equal',
+maxAnisotropy: 12,
+}
+);
+try {
+buffer32.unmap();
+} catch {}
+let offscreenCanvas31 = new OffscreenCanvas(713, 90);
+let videoFrame20 = new VideoFrame(video4, {timestamp: 0});
+let commandEncoder74 = device4.createCommandEncoder(
+{
+label: '\u3b4a\u9e4d\u6987\u3a96\uddf2\u0164\u02eb',
+}
+);
+let renderBundleEncoder69 = device4.createRenderBundleEncoder(
+{
+colorFormats: [
+'bgra8unorm',
+'rg16sint',
+'rgba16sint',
+'rgba8sint',
+'rg16sint',
+undefined
+],
+sampleCount: 684,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle65 = renderBundleEncoder34.finish(
+{
+label: '\u{1f6a9}\u0b93\u50c0\u0e32\u{1fc50}\u{1f8a1}\u{1fe97}\u75ff'
+}
+);
+try {
+commandEncoder50.copyTextureToTexture(
+{
+  texture: texture67,
+  mipLevel: 0,
+  origin: { x: 0, y: 84, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture85,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas15,
+  origin: { x: 77, y: 55 },
+  flipY: false,
+},
+{
+  texture: texture73,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let gpuCanvasContext26 = offscreenCanvas31.getContext('webgpu');
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let renderBundle66 = renderBundleEncoder60.finish(
+{
+label: '\u57f9\ua253'
+}
+);
+try {
+renderPassEncoder13.setVertexBuffer(
+13,
+undefined,
+2968159170,
+701314660
+);
+} catch {}
+let promise26 = device1.popErrorScope();
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+device1.queue.submit([
+]);
+} catch {}
+let pipeline67 = await device1.createRenderPipelineAsync(
+{
+label: '\u4767\u629b\u3a75\ubcaa\u0126\u09b1',
+layout: pipelineLayout15,
+vertex: {
+module: shaderModule18,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 916,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 892,
+shaderLocation: 13,
+},
+{
+format: 'sint16x4',
+offset: 536,
+shaderLocation: 1,
+},
+{
+format: 'sint32x3',
+offset: 744,
+shaderLocation: 10,
+},
+{
+format: 'unorm16x4',
+offset: 404,
+shaderLocation: 3,
+},
+{
+format: 'sint16x4',
+offset: 160,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 580,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 304,
+shaderLocation: 6,
+},
+{
+format: 'sint16x4',
+offset: 492,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 4620,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 164,
+shaderLocation: 5,
+},
+{
+format: 'uint8x4',
+offset: 336,
+shaderLocation: 2,
+},
+{
+format: 'sint32x4',
+offset: 3484,
+shaderLocation: 17,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 1452,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x4',
+offset: 2588,
+shaderLocation: 12,
+},
+{
+format: 'float16x2',
+offset: 1580,
+shaderLocation: 7,
+},
+{
+format: 'snorm8x2',
+offset: 3304,
+shaderLocation: 14,
+},
+{
+format: 'sint32',
+offset: 1764,
+shaderLocation: 18,
+},
+{
+format: 'sint32x4',
+offset: 3512,
+shaderLocation: 16,
+},
+{
+format: 'float32x2',
+offset: 1936,
+shaderLocation: 19,
+},
+{
+format: 'unorm16x2',
+offset: 1420,
+shaderLocation: 4,
+},
+{
+format: 'sint8x4',
+offset: 444,
+shaderLocation: 8,
+},
+{
+format: 'sint32x3',
+offset: 2556,
+shaderLocation: 15,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule18,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.RED,
+},
+{
+format: 'r16float',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+let offscreenCanvas32 = new OffscreenCanvas(117, 933);
+let shaderModule26 = device1.createShaderModule(
+{
+label: '\u09df\u9792\uc302\u239e\u0b56',
+code: `@group(1) @binding(6961)
+var<storage, read_write> function30: array<u32>;
+@group(1) @binding(5460)
+var<storage, read_write> global29: array<u32>;
+
+@compute @workgroup_size(5, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0() -> @location(2) vec3<i32> {
+return vec3<i32>();
+}
+
+struct S26 {
+@location(4) f0: vec4<f32>,
+@builtin(vertex_index) f1: u32,
+@location(2) f2: vec2<f32>,
+@location(17) f3: vec4<u32>,
+@location(9) f4: vec2<f32>,
+@location(18) f5: vec4<i32>,
+@location(8) f6: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(3) a0: f16, @location(1) a1: vec2<f32>, @location(15) a2: f16, @location(16) a3: vec3<f32>, @builtin(instance_index) a4: u32, a5: S26, @location(5) a6: vec3<i32>, @location(13) a7: vec4<i32>, @location(14) a8: i32, @location(11) a9: vec4<f32>, @location(10) a10: f32, @location(7) a11: vec4<u32>, @location(19) a12: vec2<i32>, @location(6) a13: f32, @location(0) a14: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let querySet62 = device1.createQuerySet({
+label: '\u0761\u0568\ued15',
+type: 'occlusion',
+count: 1269,
+});
+try {
+renderBundleEncoder31.setVertexBuffer(
+55,
+undefined,
+194918748,
+921861089
+);
+} catch {}
+try {
+texture52.destroy();
+} catch {}
+try {
+device1.queue.submit([
+]);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer27,
+2692,
+new Float32Array(31425),
+25913,
+108
+);
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+  log('the end')
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/LayoutTests/fast/webgpu/fuzz-273573-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-273573-expected.txt
@@ -1,0 +1,675 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 982x5202
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x5202
+  RenderBlock {HTML} at (0,0) size 785x5202 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x5186
+      RenderText {#text} at (32,137) size 26x17
+        text run at (32,137) width 26: "\x{C1AA}\x{C94}"
+      RenderText {#text} at (57,137) size 87x17
+        text run at (57,137) width 87: "\x{4F78}\x{D83F}\x{DE8B}\x{D83F}\x{DDDC}\x{9E7}\x{C52}\x{63A9}\x{77E1}"
+      RenderText {#text} at (443,137) size 62x17
+        text run at (443,137) width 62: "\x{910F}\x{742A}\x{B92}\x{D83D}\x{DE81}"
+      RenderText {#text} at (504,137) size 65x17
+        text run at (504,137) width 65: "\x{D75}\x{BE26}\x{D83E}\x{DED9}\x{2ABB}"
+      RenderText {#text} at (568,137) size 98x17
+        text run at (568,137) width 98: "\x{A76}\x{44CD}\x{DF6}\x{4F0}\x{1C62}\x{FD8}\x{235A}\x{173E}\x{D83F}\x{DED7}"
+      RenderText {#text} at (665,137) size 72x17
+        text run at (665,137) width 72: "\x{D83E}\x{DD5B}\x{200B}\x{D83D}\x{DFEA}\x{1A46}\x{AB6F}\x{D83F}\x{DF12}"
+      RenderText {#text} at (300,296) size 63x17
+        text run at (300,296) width 15: "\x{34E5}"
+        text run at (315,296) width 11 RTL: "\x{85D}"
+        text run at (325,296) width 38: "\x{F632}\x{B956}\x{FFC}"
+      RenderText {#text} at (362,296) size 123x17
+        text run at (362,296) width 123: "\x{4E06}\x{CECA}\x{D83F}\x{DED1}\x{E430}\x{96AB}\x{85DD}\x{575E}\x{1D9}\x{879E}"
+      RenderText {#text} at (484,296) size 79x17
+        text run at (484,296) width 79: "\x{D83E}\x{DCE2}\x{AD5}\x{8870}\x{20C7}\x{B348}\x{AD31}"
+      RenderText {#text} at (562,296) size 45x17
+        text run at (562,296) width 35: "\x{C6E8}\x{D83E}\x{DC2A}\x{A026}"
+        text run at (596,296) width 11 RTL: "\x{7DA}"
+      RenderText {#text} at (606,296) size 82x17
+        text run at (606,296) width 16: "\x{3FBE}"
+        text run at (621,296) width 10 RTL: "\x{72F}\x{82B}"
+        text run at (630,296) width 58: "\x{91B1}\x{1F7}\x{D83F}\x{DC56}\x{ED0}\x{77B4}"
+      RenderText {#text} at (600,454) size 70x17
+        text run at (600,454) width 70: "\x{9AA}\x{4946}\x{4B32}\x{D83E}\x{DCA5}\x{908}\x{D83F}\x{DF1A}"
+      RenderImage {IMG} at (284,592) size 21x165
+      RenderText {#text} at (305,744) size 80x17
+        text run at (305,744) width 80: "\x{3091}\x{9AD}\x{ABA2}\x{CFD}\x{D83D}\x{DF95}\x{B13}\x{4B0E}"
+      RenderText {#text} at (384,744) size 154x17
+        text run at (384,744) width 63: "\x{C22}\x{4C66}\x{A99C}\x{D83E}\x{DEB0}"
+        text run at (446,744) width 15 RTL: "\x{6FA}"
+        text run at (460,744) width 78: "\x{F675}\x{5712}\x{E343}\x{A88A}\x{4B4}\x{608C}"
+      RenderText {#text} at (553,744) size 36x17
+        text run at (553,744) width 36: "\x{55A7}\x{D83F}\x{DF2E}\x{2DD8}"
+      RenderText {#text} at (588,744) size 107x17
+        text run at (588,744) width 60: "\x{D83E}\x{DC95}\x{16CF}\x{C63A}\x{82D}\x{A2F8}\x{D83D}\x{DFD8}"
+        text run at (647,744) width 12 RTL: "\x{86B}"
+        text run at (658,744) width 37: "\x{A737}\x{D83F}\x{DF22}\x{D83F}\x{DFBF}"
+      RenderText {#text} at (0,744) size 762x181
+        text run at (694,744) width 68: "\x{1401}\x{CD2}\x{B6E4}\x{8940}\x{AF27}"
+        text run at (0,908) width 57: "\x{CAE4}\x{90}\x{8DB9}\x{1EC8}\x{FF00}"
+      RenderText {#text} at (72,908) size 37x17
+        text run at (72,908) width 27: "\x{B66D}\x{592}\x{D83F}\x{DEDD}"
+        text run at (98,908) width 11 RTL: "\x{64A}"
+      RenderText {#text} at (457,908) size 94x17
+        text run at (457,908) width 94: "\x{5D93}\x{D7F}\x{5957}\x{D83E}\x{DE78}\x{51B}\x{E8D}\x{D7C}"
+      RenderText {#text} at (550,908) size 120x17
+        text run at (550,908) width 120: "\x{7195}\x{556F}\x{D83E}\x{DCAE}\x{ED7}\x{D83F}\x{DC74}\x{D83F}\x{DC9A}\x{D83F}\x{DF3F}\x{D83E}\x{DE67}\x{C08D}\x{2E51}"
+      RenderText {#text} at (0,908) size 755x175
+        text run at (669,908) width 86: "\x{D83E}\x{DF48}\x{25CA}\x{5554}\x{4281}\x{D83F}\x{DF60}\x{E4EE}\x{434E}"
+        text run at (0,1066) width 20 RTL: "\x{FD79}"
+        text run at (19,1066) width 26: "\x{CAA}\x{C890}"
+      RenderText {#text} at (44,1066) size 42x17
+        text run at (44,1066) width 42: "\x{C93}\x{D83D}\x{DE93}\x{995}"
+      RenderText {#text} at (385,1066) size 99x17
+        text run at (385,1066) width 99: "\x{140}\x{30B}\x{D83F}\x{DD8B}\x{E03E}\x{D83E}\x{DF2B}\x{75AD}\x{D83E}\x{DCE1}\x{E7C2}\x{CF21}\x{420}"
+      RenderText {#text} at (483,1066) size 22x17
+        text run at (483,1066) width 22: "\x{D83E}\x{DF49}\x{6}"
+      RenderText {#text} at (504,1066) size 108x17
+        text run at (504,1066) width 108: "\x{C24}\x{4EF}\x{D83F}\x{DED8}\x{30C9}\x{6D71}\x{40B1}\x{D83E}\x{DEF4}\x{F888}"
+      RenderText {#text} at (611,1066) size 115x17
+        text run at (611,1066) width 115: "\x{6EDD}\x{D83E}\x{DD93}\x{929}\x{6982}\x{C1A}\x{E97}\x{4E1}\x{2813}\x{3ED}\x{585}"
+      RenderText {#text} at (0,1066) size 751x42
+        text run at (725,1066) width 26: "\x{EFCC}\x{4DA1}"
+        text run at (0,1091) width 44: "\x{13B}\x{D83E}\x{DC1C}\x{55D6}\x{A35}"
+      RenderText {#text} at (0,1501) size 86x17
+        text run at (0,1501) width 8: "\x{663}"
+        text run at (7,1501) width 79: "\x{73A6}\x{D83D}\x{DF18}\x{F3F}\x{B3C}\x{38BB}\x{B45}\x{823}\x{D83F}\x{DC95}"
+      RenderText {#text} at (85,1501) size 63x17
+        text run at (85,1501) width 63: "\x{4592}\x{21E7}\x{8DB}\x{B90B}\x{499}"
+      RenderText {#text} at (147,1501) size 107x17
+        text run at (147,1501) width 22: "\x{D83F}\x{DD08}\x{D840}"
+        text run at (168,1501) width 15 RTL: "\x{8BE}"
+        text run at (182,1501) width 72: "\x{6A31}\x{407}\x{975}\x{D83F}\x{DFC9}\x{8716}\x{D83F}\x{DE6D}"
+      RenderText {#text} at (253,1501) size 32x17
+        text run at (253,1501) width 32: "\x{2D8F}\x{F772}"
+      RenderText {#text} at (284,1501) size 11x17
+        text run at (284,1501) width 11: "\x{517}\x{343}"
+      RenderText {#text} at (294,1501) size 42x17
+        text run at (294,1501) width 42: "\x{DDBE}\x{5A81}\x{8744}"
+      RenderText {#text} at (335,1501) size 29x17
+        text run at (335,1501) width 29: "\x{A2C5}\x{B79D}\x{B9}"
+      RenderText {#text} at (363,1501) size 72x17
+        text run at (363,1501) width 72: "\x{B3A7}\x{E810}\x{AFF5}\x{B583}\x{46FD}"
+      RenderText {#text} at (434,1501) size 81x17
+        text run at (434,1501) width 81: "\x{1A23}\x{991C}\x{FD7}\x{D83F}\x{DEE9}\x{D83E}\x{DC87}\x{BEF1}\x{D83E}\x{DF30}"
+      RenderText {#text} at (514,1501) size 72x17
+        text run at (514,1501) width 72: "\x{BC91}\x{AD3}\x{D4C}\x{95A}\x{C81E}\x{90A}"
+      RenderText {#text} at (585,1501) size 108x17
+        text run at (585,1501) width 37: "\x{648D}\x{D83E}\x{DCFE}\x{EED5}"
+        text run at (621,1501) width 9 RTL: "\x{7D6}"
+        text run at (629,1501) width 64: "\x{FE45}\x{1A75}\x{EBF6}\x{5997}\x{1B95}\x{C3C}"
+      RenderText {#text} at (213,2180) size 110x17
+        text run at (213,2180) width 15: "\x{730E}"
+        text run at (228,2180) width 22 RTL: "\x{893}\x{63B}"
+        text run at (249,2180) width 74: "\x{37B0}\x{D83D}\x{DF13}\x{7144}\x{A748}\x{D83D}\x{DEA3}\x{654}"
+      RenderHTMLCanvas {CANVAS} at (322,1523) size 301x670
+      RenderText {#text} at (622,2180) size 53x17
+        text run at (622,2180) width 23: "\x{EAD5}\x{D5A}"
+        text run at (644,2180) width 24 RTL: "\x{8B8}\x{FBA}"
+        text run at (667,2180) width 8: "\x{FF}"
+      RenderText {#text} at (674,2180) size 46x17
+        text run at (674,2180) width 46: "\x{4E04}\x{4715}\x{2ED7}"
+      RenderText {#text} at (0,2180) size 739x45
+        text run at (719,2180) width 20: "\x{EDB}\x{A016}"
+        text run at (0,2208) width 51: "\x{4EE}\x{D83D}\x{DF66}\x{E14F}\x{25B}\x{F27C}"
+      RenderText {#text} at (50,2208) size 123x17
+        text run at (50,2208) width 12 RTL: "\x{88F}"
+        text run at (61,2208) width 66: "\x{56DE}\x{75E3}\x{8FF1}\x{D83E}\x{DDF9}"
+        text run at (126,2208) width 11 RTL: "\x{803}"
+        text run at (136,2208) width 37: "\x{185E}\x{4350}\x{295}\x{D83D}\x{DF2A}"
+      RenderText {#text} at (172,2208) size 70x17
+        text run at (172,2208) width 51: "\x{2AF}\x{34CD}\x{725A}\x{D83D}\x{DE76}"
+        text run at (222,2208) width 20 RTL: "\x{FD02}"
+      RenderText {#text} at (241,2208) size 126x17
+        text run at (241,2208) width 38: "\x{D665}\x{9AD8}\x{296}"
+        text run at (278,2208) width 12 RTL: "\x{FB37}"
+        text run at (289,2208) width 67: "\x{BEE8}\x{D83F}\x{DE77}\x{D359}\x{9A67}\x{D83F}\x{DE37}"
+        text run at (355,2208) width 12 RTL: "\x{5FC}"
+      RenderText {#text} at (366,2208) size 57x17
+        text run at (366,2208) width 57: "\x{A5ED}\x{C406}\x{162E}\x{9661}"
+      RenderText {#text} at (422,2208) size 64x17
+        text run at (422,2208) width 64: "\x{FFE}\x{3ACD}\x{4A37}\x{EEAE}\x{D83E}\x{DC79}"
+      RenderText {#text} at (485,2208) size 124x17
+        text run at (485,2208) width 124: "\x{A1}\x{55C}\x{F41D}\x{AA95}\x{3A64}\x{F68F}\x{D83D}\x{DF3B}\x{DA00}\x{855B}\x{C24D}\x{447D}"
+      RenderText {#text} at (608,2208) size 122x17
+        text run at (608,2208) width 122: "\x{F315}\x{41E}\x{DD54}\x{D83E}\x{DDE2}\x{D83D}\x{DEE9}\x{5B24}\x{BBB7}\x{A8A2}\x{24F}"
+      RenderText {#text} at (0,2208) size 760x224
+        text run at (729,2208) width 31: "\x{9C9D}\x{BB35}"
+        text run at (0,2415) width 52: "\x{431F}\x{D83E}\x{DFBF}\x{9FE}\x{4545}"
+      RenderText {#text} at (51,2415) size 138x17
+        text run at (51,2415) width 71: "\x{B606}\x{C420}\x{C27D}\x{308}\x{886E}\x{563}"
+        text run at (121,2415) width 14 RTL: "\x{77D}"
+        text run at (134,2415) width 55: "\x{3948}\x{5EF4}\x{A28E}\x{BAB6}"
+      RenderText {#text} at (204,2415) size 114x17
+        text run at (204,2415) width 114: "\x{CFC9}\x{AB02}\x{BFB0}\x{D83F}\x{DE32}\x{3CC0}\x{8AD8}\x{2711}\x{4D25}"
+      RenderText {#text} at (317,2415) size 104x17
+        text run at (317,2415) width 104: "\x{19EE}\x{9E44}\x{E64A}\x{D83E}\x{DC17}\x{D83E}\x{DE59}\x{62A1}\x{1F7}\x{7F8F}"
+      RenderText {#text} at (420,2415) size 46x17
+        text run at (420,2415) width 46: "\x{2458}\x{D83E}\x{DDEF}\x{27C8}"
+      RenderText {#text} at (465,2415) size 28x17
+        text run at (465,2415) width 28: "\x{C985}\x{1645}"
+      RenderImage {IMG} at (492,2227) size 182x201
+      RenderText {#text} at (673,2415) size 61x17
+        text run at (673,2415) width 61: "\x{D83F}\x{DE63}\x{D83D}\x{DEC6}\x{3355}\x{D83E}\x{DF0E}\x{17A6}"
+      RenderText {#text} at (290,2554) size 67x17
+        text run at (290,2554) width 67: "\x{89}\x{4AC3}\x{9A87}\x{E4F1}\x{8154}"
+      RenderText {#text} at (356,2554) size 120x17
+        text run at (356,2554) width 72: "\x{D83E}\x{DE82}\x{1D98}\x{629D}\x{AE61}\x{7BCB}"
+        text run at (427,2554) width 14 RTL: "\x{852}"
+        text run at (440,2554) width 36: "\x{B2BB}\x{28EC}\x{29B1}"
+      RenderText {#text} at (475,2554) size 51x17
+        text run at (475,2554) width 51: "\x{D83D}\x{DF4E}\x{D83F}\x{DC12}\x{634B}\x{6008}"
+      RenderText {#text} at (525,2554) size 118x17
+        text run at (525,2554) width 118: "\x{278}\x{4C70}\x{905}\x{D83E}\x{DD64}\x{D83E}\x{DED5}\x{A441}\x{D83F}\x{DE86}\x{D83E}\x{DFDA}\x{D83F}\x{DFAB}"
+      RenderText {#text} at (0,2554) size 767x175
+        text run at (642,2554) width 71: "\x{2F6C}\x{9192}\x{586B}\x{291}\x{4D45}"
+        text run at (712,2554) width 25 RTL: "\x{FD21}"
+        text run at (736,2554) width 31: "\x{CF1C}\x{8A0B}"
+        text run at (0,2712) width 11: "\x{E4C8}"
+      RenderImage {IMG} at (10,2573) size 295x152
+      RenderText {#text} at (304,2712) size 88x17
+        text run at (304,2712) width 40: "\x{A78E}\x{63A3}\x{C4AF}"
+        text run at (343,2712) width 10 RTL: "\x{843}"
+        text run at (352,2712) width 40: "\x{30B2}\x{AE1B}\x{A810}"
+      RenderText {#text} at (391,2712) size 26x17
+        text run at (391,2712) width 26: "\x{D83D}\x{DEED}\x{98D1}"
+      RenderText {#text} at (416,2712) size 103x17
+        text run at (416,2712) width 103: "\x{C934}\x{C655}\x{1CA}\x{ACA}\x{D83E}\x{DC1C}'\x{D83E}\x{DD9D}\x{D83F}\x{DC62}"
+      RenderText {#text} at (518,2712) size 81x17
+        text run at (518,2712) width 27: "\x{BCE}\x{3CEB}"
+        text run at (544,2712) width 9 RTL: "\x{5E8}"
+        text run at (552,2712) width 47: "\x{397B}\x{F98}\x{A58}\x{2104}"
+      RenderImage {IMG} at (300,2765) size 26x233
+      RenderText {#text} at (626,2985) size 70x17
+        text run at (626,2985) width 55: "\x{D83D}\x{DEF7}\x{83C5}\x{D83E}\x{DDE1}"
+        text run at (681,2985) width 15 RTL: "\x{5D4}\x{846}"
+      RenderText {#text} at (0,2985) size 756x252
+        text run at (695,2985) width 61: "\x{D8E}\x{9EB9}\x{9FD5}\x{D83F}\x{DE5F}"
+        text run at (0,3220) width 53: "\x{88DA}\x{655}\x{D83F}\x{DF38}\x{B757}\x{3D8}\x{FE2A}"
+      RenderText {#text} at (52,3220) size 48x17
+        text run at (52,3220) width 48: "\x{2602}\x{5A15}\x{1797}\x{A38}"
+      RenderText {#text} at (99,3220) size 52x17
+        text run at (99,3220) width 52: "\x{DA07}\x{547E}\x{D83D}\x{DF3C}\x{8CAF}"
+      RenderImage {IMG} at (150,3004) size 247x229
+      RenderText {#text} at (396,3220) size 47x17
+        text run at (396,3220) width 47: "\x{D83F}\x{DC3E}\x{262}\x{3E0D}\x{E7E9}"
+      RenderText {#text} at (442,3220) size 103x17
+        text run at (442,3220) width 27: "\x{D851}\x{5F41}"
+        text run at (468,3220) width 20 RTL: "\x{837}"
+        text run at (487,3220) width 58: "\x{B48}\x{D83E}\x{DCB0}\x{BDCB}\x{B8EC}"
+      RenderText {#text} at (544,3220) size 46x17
+        text run at (544,3220) width 46: "\x{7A6}\x{90EE}\x{548D}\x{B538}"
+      RenderText {#text} at (589,3220) size 60x17
+        text run at (589,3220) width 8: "\x{31F}"
+        text run at (596,3220) width 8 RTL: "\x{676}"
+        text run at (603,3220) width 46: "\x{7053}\x{2F9B}\x{305}\x{657A}"
+      RenderText {#text} at (648,3220) size 105x17
+        text run at (648,3220) width 63: "\x{A6B}\x{AA0}\x{4013}\x{8F6E}\x{A9D1}\x{6DB}"
+        text run at (710,3220) width 6 RTL: "\x{FE97}"
+        text run at (715,3220) width 38: "\x{7754}\x{2FAF}\x{D83D}\x{DF4C}"
+      RenderText {#text} at (0,3220) size 764x47
+        text run at (752,3220) width 12: "\x{2EF8}"
+        text run at (0,3250) width 15: "\x{37A9}"
+      RenderText {#text} at (0,3421) size 56x17
+        text run at (0,3421) width 56: "\x{D83F}\x{DC0D}\x{67DC}\x{6EA3}\x{3A79}"
+      RenderText {#text} at (55,3421) size 67x17
+        text run at (55,3421) width 67: "\x{1}\x{CA89}\x{7852}\x{BDBC}\x{BED}"
+      RenderText {#text} at (0,3834) size 55x17
+        text run at (0,3834) width 55: "\x{3EA}\x{5659}\x{B224}\x{5A3A}"
+      RenderImage {IMG} at (54,3788) size 47x59
+      RenderText {#text} at (100,3834) size 93x17
+        text run at (100,3834) width 93: "\x{7D65}\x{4D20}\x{898}\x{D83F}\x{DE70}\x{B767}\x{90C}\x{4CCF}"
+      RenderText {#text} at (527,3834) size 122x17
+        text run at (527,3834) width 122: "\x{8AA4}\x{A3E}\x{B9F}\x{1F10}\x{E49}\x{D83F}\x{DF44}\x{B78}\x{CE88}\x{19F5}\x{D83D}\x{DEC0}"
+      RenderText {#text} at (648,3834) size 93x17
+        text run at (648,3834) width 67: "\x{DAB}\x{B758}\x{E82}\x{339}\x{D754}\x{98B}"
+        text run at (714,3834) width 12 RTL: "\x{895}"
+        text run at (725,3834) width 16: "\x{B544}"
+      RenderText {#text} at (0,3973) size 117x17
+        text run at (0,3973) width 117: "\x{5DE9}\x{BAC7}\x{615A}\x{443}\x{D83E}\x{DC0B}\x{5AE9}\x{FB8}\x{3E2D}\x{45A8}"
+      RenderImage {IMG} at (116,3920) size 156x66
+      RenderText {#text} at (271,3973) size 111x17
+        text run at (271,3973) width 111: "\x{4456}\x{763D}\x{6858}\x{3197}\x{7B4A}\x{A6C5}\x{13D1}\x{AE2C}"
+      RenderText {#text} at (381,3973) size 82x17
+        text run at (381,3973) width 82: "\x{4907}\x{B652}\x{D83E}\x{DE43}\x{CBD5}\x{C520}\x{459}"
+      RenderImage {IMG} at (462,3859) size 288x127
+      RenderText {#text} at (0,4001) size 120x17
+        text run at (0,4001) width 120: "\x{D83F}\x{DDA7}\x{363}\x{D83E}\x{DC47}\x{5E75}\x{D83F}\x{DE23}\x{1AE}\x{A8E5}\x{D83F}\x{DEF3}\x{48DF}\x{5107}"
+      RenderText {#text} at (119,4001) size 27x17
+        text run at (119,4001) width 27: "\x{E95D}\x{BA46}"
+      RenderText {#text} at (145,4001) size 110x17
+        text run at (145,4001) width 99: "\x{6D9B}\x{D83D}\x{DE24}\x{8BA2}\x{6CE6}\x{E9B}\x{D83E}\x{DFA8}\x{1361}\x{22DE}"
+        text run at (243,4001) width 12 RTL: "\x{621}\x{709}"
+      RenderText {#text} at (254,4001) size 35x17
+        text run at (254,4001) width 35: "\x{D83F}\x{DD69}\x{5660}\x{A0E6}"
+      RenderText {#text} at (288,4001) size 84x17
+        text run at (288,4001) width 84: "\x{6B8D}\x{CD3F}{\x{BA63}\x{D83F}\x{DC58}\x{D83E}\x{DE79}"
+      RenderText {#text} at (371,4001) size 79x17
+        text run at (371,4001) width 79: "\x{6BB9}\x{D83F}\x{DEA4}\x{2C97}\x{2972}\x{1BF}\x{DE85}\x{CFE7}"
+      RenderText {#text} at (449,4001) size 67x17
+        text run at (449,4001) width 67: "\x{EF1}\x{B007}\x{3F51}\x{261D}\x{D83F}\x{DC63}"
+      RenderText {#text} at (515,4001) size 76x17
+        text run at (515,4001) width 44: "\x{98B8}\x{29B}\x{9DD}\x{D83E}\x{DF77}"
+        text run at (558,4001) width 12 RTL: "\x{812}"
+        text run at (569,4001) width 22: "\x{970}\x{4E6C}"
+      RenderText {#text} at (590,4001) size 140x17
+        text run at (590,4001) width 140: "\x{D83D}\x{DFE5}\x{D83E}\x{DC26}\x{61CA}\x{D83E}\x{DE1C}\x{D83E}\x{DC4B}\x{8674}\x{3056}\x{1992}\x{37B8}\x{8F24}"
+      RenderImage {IMG} at (0,4272) size 76x41
+      RenderText {#text} at (76,4300) size 26x17
+        text run at (76,4300) width 26: "\x{E444}\x{8A50}"
+      RenderText {#text} at (101,4300) size 123x17
+        text run at (101,4300) width 123: "\x{6E4}\x{312}\x{D83E}\x{DDBF}\x{D3EF}\x{2A01}\x{8F1B}\x{24D5}\x{D83F}\x{DD89}\x{CE5}\x{4551}"
+      RenderImage {IMG} at (223,4251) size 56x62
+      RenderText {#text} at (278,4300) size 31x17
+        text run at (278,4300) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (308,4300) size 81x17
+        text run at (308,4300) width 81: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (388,4300) size 69x17
+        text run at (388,4300) width 7 RTL: "\x{692}"
+        text run at (394,4300) width 63: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (0,4363) size 298x170
+      RenderText {#text} at (298,4520) size 103x17
+        text run at (298,4520) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (438,4520) size 100x17
+        text run at (438,4520) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (537,4520) size 117x17
+        text run at (537,4520) width 32: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (568,4520) width 10 RTL: "\x{79B}"
+        text run at (577,4520) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (0,4540) size 292x253
+      RenderText {#text} at (292,4780) size 103x17
+        text run at (292,4780) width 103: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (394,4780) size 105x17
+        text run at (394,4780) width 105: "\x{10D}\x{BA96}\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (498,4780) size 102x17
+        text run at (498,4780) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (599,4780) size 116x17
+        text run at (599,4780) width 116: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (0,4811) size 34x17
+        text run at (0,4811) width 34: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (33,4811) size 120x17
+        text run at (33,4811) width 26: "\x{24BF}\x{B00}"
+        text run at (58,4811) width 12 RTL: "\x{5FF}"
+        text run at (69,4811) width 14: "\x{2FA}\x{B13}"
+        text run at (82,4811) width 11 RTL: "\x{8BC}"
+        text run at (92,4811) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (152,4811) size 88x17
+        text run at (152,4811) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (239,4811) size 88x17
+        text run at (239,4811) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (326,4811) size 22x17
+        text run at (326,4811) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (347,4811) size 111x17
+        text run at (347,4811) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (457,4811) size 79x17
+        text run at (457,4811) width 79: "\x{ECB8}\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (535,4811) size 85x17
+        text run at (535,4811) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+      RenderText {#text} at (619,4811) size 100x17
+        text run at (619,4811) width 80: "\x{D83F}\x{DD83}\x{D83F}\x{DD58}\x{6EE2}\x{47A3}\x{10B}\x{2CC7}\x{BC62}"
+        text run at (698,4811) width 10 RTL: "\x{67F}"
+        text run at (707,4811) width 12: "\x{D83F}\x{DC12}"
+      RenderText {#text} at (0,4811) size 752x45
+        text run at (718,4811) width 34: "\x{F24}\x{A756}\x{4864}"
+        text run at (0,4839) width 116: "\x{D83D}\x{DF2C}\x{D83E}\x{DD04}\x{D83D}\x{DFF9}\x{D83E}\x{DD6D}\x{D83D}\x{DF33}\x{9AA9}\x{FF4C}\x{D83E}\x{DEAD}"
+      RenderText {#text} at (115,4839) size 52x17
+        text run at (115,4839) width 27: "\x{84E2}\x{D83E}\x{DCB2}"
+        text run at (141,4839) width 11 RTL: "\x{793}"
+        text run at (151,4839) width 16: "\x{812B}"
+      RenderText {#text} at (166,4839) size 119x17
+        text run at (166,4839) width 119: "\x{CD98}\x{D83E}\x{DEF8}\x{D83E}\x{DDA7}\x{AF08}\x{4EB8}\x{1243}\x{B2E}\x{FF7}"
+      RenderText {#text} at (284,4839) size 96x17
+        text run at (284,4839) width 96: "\x{1E56}\x{DB7F}\x{3BE0}\x{9F86}\x{4C4D}\x{D83F}\x{DCB1}\x{D83E}\x{DD9F}"
+      RenderText {#text} at (379,4839) size 60x17
+        text run at (379,4839) width 16: "\x{AC6C}"
+        text run at (394,4839) width 15 RTL: "\x{84C}"
+        text run at (408,4839) width 31: "\x{3CFB}\x{C01}"
+      RenderText {#text} at (438,4839) size 84x17
+        text run at (438,4839) width 84: "\x{C96F}\x{CFE}\x{D83E}\x{DD4C}\x{2EB1}\x{BFB}\x{D83F}\x{DFDA}"
+      RenderText {#text} at (521,4839) size 74x17
+        text run at (521,4839) width 74: "\x{966}\x{D83D}\x{DE44}\x{F51D}\x{D83E}\x{DF45}\x{F91}\x{2772}\x{D83F}\x{DF3B}"
+      RenderText {#text} at (594,4839) size 89x17
+        text run at (594,4839) width 67: "\x{94A5}\x{8A96}\x{6D75}\x{D83F}\x{DC81}\x{180}"
+        text run at (660,4839) width 12 RTL: "\x{6A6}"
+        text run at (671,4839) width 12: "\x{D83F}\x{DC37}"
+      RenderText {#text} at (682,4839) size 78x17
+        text run at (682,4839) width 58: "\x{EA1}\x{FB1}\x{A34}\x{5543}\x{D83F}\x{DF64}"
+        text run at (739,4839) width 13 RTL: "\x{801}"
+        text run at (751,4839) width 9: "\x{2EE1}"
+      RenderText {#text} at (0,4865) size 34x17
+        text run at (0,4865) width 34: "\x{1498}\x{D83F}\x{DE40}\x{D83E}\x{DC29}"
+      RenderText {#text} at (33,4865) size 23x17
+        text run at (33,4865) width 23: "\x{3040}\x{D83E}\x{DE44}"
+      RenderText {#text} at (55,4865) size 74x17
+        text run at (55,4865) width 74: "\x{D83F}\x{DF07}\x{DE60}\x{958}\x{D83F}\x{DD30}\x{4AC5}\x{3F37}"
+      RenderText {#text} at (128,4865) size 133x17
+        text run at (128,4865) width 133: "\x{7F0}\x{9CF}\x{C47A}\x{D74}\x{161C}\x{1F13}\x{97BB}\x{4FF7}\x{3AEF}\x{D83E}\x{DC98}\x{DDA}"
+      RenderText {#text} at (260,4865) size 111x17
+        text run at (260,4865) width 111: "\x{E60A}\x{5E72}\x{FAFC}\x{A318}\x{960}\x{9825}\x{265E}\x{6633}\x{6C91}"
+      RenderText {#text} at (370,4865) size 109x17
+        text run at (370,4865) width 61: "\x{739A}\x{2679}\x{24C2}\x{4019}"
+        text run at (430,4865) width 12 RTL: "\x{5C9}"
+        text run at (441,4865) width 38: "\x{CEE6}\x{D83E}\x{DF11}\x{A44}"
+      RenderText {#text} at (478,4865) size 32x17
+        text run at (478,4865) width 32: "\x{A89}\x{D83E}\x{DE59}\x{D83E}\x{DE6F}"
+      RenderText {#text} at (509,4865) size 83x17
+        text run at (509,4865) width 68: "\x{C1D6}\x{DC6A}\x{6930}\x{9921}\x{432}\x{ED}"
+        text run at (576,4865) width 5 RTL: "\x{701}"
+        text run at (580,4865) width 12: "\x{C84}"
+      RenderText {#text} at (591,4865) size 98x17
+        text run at (591,4865) width 98: "\x{D83D}\x{DE53}\x{D83F}\x{DC79}\x{C460}\x{BEF2}\x{4C04}\x{156}\x{372}\x{47A}"
+      RenderText {#text} at (688,4865) size 23x17
+        text run at (688,4865) width 23: "\x{D83E}\x{DC7C}\x{D83F}\x{DC5B}"
+      RenderText {#text} at (0,4865) size 756x43
+        text run at (710,4865) width 46: "\x{37FE}\x{9416}\x{9668}"
+        text run at (0,4891) width 54: "\x{E6B0}\x{F1F}\x{E27B}\x{B1B}\x{6F8B}"
+      RenderText {#text} at (53,4891) size 89x17
+        text run at (53,4891) width 89: "\x{533}\x{D83F}\x{DDD9}\x{C481}\x{C5EC}\x{A889}\x{49D9}\x{D83F}\x{DEBB}"
+      RenderText {#text} at (141,4891) size 120x17
+        text run at (141,4891) width 16: "\x{589C}"
+        text run at (156,4891) width 12 RTL: "\x{5CC}"
+        text run at (167,4891) width 49: "\x{1FF}\x{8296}\x{D83F}\x{DD87}\x{C9CD}"
+        text run at (215,4891) width 11 RTL: "\x{5E1}"
+        text run at (225,4891) width 12: "\x{EB97}"
+        text run at (236,4891) width 14 RTL: "\x{8B6}"
+        text run at (249,4891) width 12: "\x{D83E}\x{DE33}"
+      RenderText {#text} at (260,4891) size 70x17
+        text run at (260,4891) width 70: "\x{29E}\x{3AD8}\x{911F}\x{4170}\x{89AC}"
+      RenderText {#text} at (329,4891) size 127x17
+        text run at (329,4891) width 127: "\x{DAE}\x{D83E}\x{DFD0}\x{D676}\x{7A82}\x{D83F}\x{DC92}\x{D33}\x{99C8}\x{D83E}\x{DD52}\x{8FDE}\x{140}"
+      RenderText {#text} at (455,4891) size 145x17
+        text run at (455,4891) width 128: "\x{D83E}\x{DCB1}\x{D83E}\x{DCB7}\x{D83F}\x{DDE3}\x{B97C}\x{C855}\x{CD5B}\x{CF1}\x{C54C}\x{4043}\x{1535}"
+        text run at (587,4891) width 13 RTL: "\x{83D}"
+      RenderText {#text} at (582,4891) size 84x17
+        text run at (582,4891) width 6 RTL: "\x{5D5}"
+        text run at (599,4891) width 67: "\x{5E92}\x{1E8A}\x{9A39}\x{D29}\x{D83F}\x{DEBA}"
+      RenderText {#text} at (665,4891) size 31x17
+        text run at (665,4891) width 31: "\x{47B5}\x{8C8D}"
+      RenderText {#text} at (0,4891) size 764x45
+        text run at (695,4891) width 69: "\x{275C}\x{145}\x{C5C7}\x{F654}\x{DAD7}\x{BDD7}"
+        text run at (0,4919) width 19: "n\x{F047}"
+      RenderText {#text} at (18,4919) size 120x17
+        text run at (18,4919) width 28: "\x{ABB4}\x{AACB}\x{A19}"
+        text run at (45,4919) width 15 RTL: "\x{717}"
+        text run at (59,4919) width 79: "\x{E620}\x{D83E}\x{DC2C}\x{D83D}\x{DE54}\x{2C3}\x{BD07}\x{536}\x{4AFF}"
+      RenderText {#text} at (137,4919) size 63x17
+        text run at (137,4919) width 32: "\x{D83E}\x{DDCC}\x{D83E}\x{DC21}"
+        text run at (168,4919) width 17 RTL: "\x{6BE}\x{769}"
+        text run at (184,4919) width 16: "\x{41BE}"
+      RenderText {#text} at (199,4919) size 41x17
+        text run at (199,4919) width 15 RTL: "\x{808}"
+        text run at (213,4919) width 27: "\x{D83E}\x{DE4B}\x{4961}"
+      RenderText {#text} at (239,4919) size 48x17
+        text run at (239,4919) width 48: "\x{2CE9}\x{E5A6}\x{7C86}\x{10}"
+      RenderText {#text} at (286,4919) size 140x17
+        text run at (286,4919) width 140: "\x{D83F}\x{DE92}\x{E10B}\x{E644}\x{346D}\x{DD9}\x{EC1}\x{1D39}\x{BAE0}\x{CCC}\x{D0A}\x{272D}"
+      RenderText {#text} at (425,4919) size 144x17
+        text run at (425,4919) width 144: "\x{8E33}\x{F5F6}\x{D83E}\x{DD52}\x{542C}\x{AE0C}\x{33F}\x{B49F}\x{D83E}\x{DCA8}\x{DA4}\x{D83F}\x{DC82}\x{6138}"
+      RenderText {#text} at (568,4919) size 102x17
+        text run at (568,4919) width 33: "\x{D83F}\x{DF2D}\x{F4A7}\x{E7C6}"
+        text run at (600,4919) width 10 RTL: "\x{639}"
+        text run at (609,4919) width 27: "\x{FDD}\x{8C02}"
+        text run at (635,4919) width 5 RTL: "\x{627}"
+        text run at (639,4919) width 31: "\x{64C5}\x{3878}"
+      RenderText {#text} at (0,4919) size 768x44
+        text run at (669,4919) width 99: "\x{911D}\x{B0A}\x{D83E}\x{DF5D}\x{530D}\x{D6F0}\x{302}\x{9DF7}\x{D18}"
+        text run at (0,4946) width 15: "\x{B088}\x{EC9}"
+      RenderText {#text} at (14,4946) size 27x17
+        text run at (14,4946) width 12: "\x{D83F}\x{DDBE}"
+        text run at (35,4946) width 6 RTL: "\x{6C0}"
+      RenderText {#text} at (25,4946) size 76x17
+        text run at (25,4946) width 11 RTL: "\x{6D1}"
+        text run at (40,4946) width 61: "\x{B7EC}\x{DC39}\x{73EF}\x{1F90}\x{D83E}\x{DFE6}"
+      RenderText {#text} at (100,4946) size 132x17
+        text run at (100,4946) width 111: "\x{326D}\x{F53}\x{D83E}\x{DCAB}\x{482}\x{D83E}\x{DFFE}\x{B32F}\x{D83F}\x{DD03}\x{5C3E}\x{3D9C}"
+        text run at (210,4946) width 22 RTL: "\x{FCFC}"
+      RenderText {#text} at (231,4946) size 102x17
+        text run at (231,4946) width 77: "\x{8950}\x{4E2A}\x{EDC}\x{D83E}\x{DCD7}\x{D83F}\x{DD84}\x{44E}"
+        text run at (307,4946) width 11 RTL: "\x{848}"
+        text run at (317,4946) width 16: "\x{AF80}"
+      RenderText {#text} at (332,4946) size 129x17
+        text run at (332,4946) width 129: "\x{54D7}\x{E79C}\x{8C16}\x{63C6}\x{F54D}\x{8CEB}\x{8E6}\x{D83E}\x{DD1E}\x{F5BB}\x{AD09}"
+      RenderText {#text} at (460,4946) size 95x17
+        text run at (460,4946) width 95: "\x{D07B}\x{D83D}\x{DEBF}\x{C5}\x{D83E}\x{DCF7}\x{F8}\x{4AC9}\x{6E8E}"
+      RenderText {#text} at (554,4946) size 112x17
+        text run at (554,4946) width 112: "\x{C7FE}\x{AE4D}\x{4827}\x{BA55}\x{62AD}\x{FBA}\x{6065}\x{4EFC}"
+      RenderText {#text} at (0,4946) size 755x45
+        text run at (665,4946) width 90: "\x{10C6}\x{4BF}\x{BBE4}\x{D3B}\x{A0A}\x{B8E}\x{1487}\x{D83F}\x{DC7C}"
+        text run at (0,4974) width 32: "\x{23D}\x{1AA}\x{8F3F}"
+      RenderText {#text} at (31,4974) size 36x17
+        text run at (31,4974) width 36: "\x{328}\x{E96}\x{D83F}\x{DF71}\x{F10F}"
+      RenderText {#text} at (66,4974) size 88x17
+        text run at (66,4974) width 88: "\x{614A}\x{C870}\x{E997}\x{D83F}\x{DE46}\x{2D8B}\x{B80}\x{EFC4}"
+      RenderText {#text} at (153,4974) size 140x17
+        text run at (153,4974) width 140: "\x{496B}\x{D83F}\x{DE84}\x{D3D8}\x{D83D}\x{DF44}\x{1244}\x{D83E}\x{DD7C}\x{3C8A}\x{D73F}\x{E6DF}\x{D83F}\x{DD5E}"
+      RenderText {#text} at (292,4974) size 11x17
+        text run at (292,4974) width 11: "\x{2995}\x{F7D}"
+      RenderText {#text} at (302,4974) size 60x17
+        text run at (302,4974) width 60: "\x{515D}\x{DEA}k\x{D83F}\x{DDE9}\x{D099}"
+      RenderText {#text} at (361,4974) size 83x17
+        text run at (361,4974) width 83: "\x{4936}\x{A04}\x{D83D}\x{DE68}\x{7F8E}\x{5145}\x{3B80}"
+      RenderText {#text} at (443,4974) size 42x17
+        text run at (443,4974) width 42: "\x{B92B}\x{B663}\x{D83F}\x{DF52}"
+      RenderText {#text} at (484,4974) size 32x17
+        text run at (484,4974) width 32: "\x{D83F}\x{DD45}\x{4C8}\x{1500}"
+      RenderText {#text} at (515,4974) size 103x17
+        text run at (515,4974) width 11 RTL: "\x{649}"
+        text run at (525,4974) width 93: "Y\x{E2}\x{D83D}\x{DFCF}\x{BE7}\x{E856}\x{D83D}\x{DF5D}\x{96CF}\x{76BA}"
+      RenderText {#text} at (617,4974) size 71x17
+        text run at (617,4974) width 71: "\x{3190}\x{B978}\x{898}\x{AD2C}\x{CF05}"
+      RenderText {#text} at (687,4974) size 49x17
+        text run at (687,4974) width 49: "\x{D83F}\x{DC2C}\x{DDE0}\x{2E3F}\x{3B9A}"
+      RenderText {#text} at (0,5002) size 78x17
+        text run at (0,5002) width 31: "\x{D83E}\x{DE42}\x{A6E}\x{D9FC}"
+        text run at (30,5002) width 18 RTL: "\x{FC17}"
+        text run at (47,5002) width 31: "\x{24A9}\x{5434}"
+      RenderText {#text} at (77,5002) size 138x17
+        text run at (77,5002) width 138: "\x{8EB0}\x{D83F}\x{DCBB}\x{8B92}\x{4961}\x{D83F}\x{DE5F}\x{815F}\x{1496}\x{75DF}\x{F135}\x{D83E}\x{DCAE}\x{AB94}"
+      RenderText {#text} at (214,5002) size 119x17
+        text run at (214,5002) width 119: "\x{7}\x{F4E}\x{E9C5}\x{D83E}\x{DD16}\x{FF4}\x{C8B2}\x{8885}\x{1181}\x{D83F}\x{DDD6}"
+      RenderText {#text} at (332,5002) size 138x17
+        text run at (332,5002) width 138: "\x{F40D}\x{D83E}\x{DE7B}\x{D83F}\x{DE68}\x{481}\x{1242}\x{BA41}\x{8A50}\x{D83F}\x{DD54}\x{2F2A}\x{D83D}\x{DE49}"
+      RenderText {#text} at (469,5002) size 137x17
+        text run at (469,5002) width 137: "\x{884F}\x{146B}\x{D9C5}\x{D83E}\x{DF3C}\x{40EA}\x{BCD5}\x{5E1B}\x{A59}\x{D83E}\x{DCDD}\x{D83F}\x{DDF0}\x{7C60}"
+      RenderText {#text} at (605,5002) size 119x17
+        text run at (605,5002) width 119: "\x{5BB}\x{D83D}\x{DF58}\x{994}\x{D6F}\x{D83F}\x{DCBF}\x{1E35}\x{DD08}\x{90FE}\x{16AD}\x{B0D1}\x{5E87}"
+      RenderText {#text} at (0,5002) size 758x45
+        text run at (723,5002) width 35: "\x{78F9}\x{D83F}\x{DC10}\x{A0E3}"
+        text run at (0,5030) width 15: "\x{5AFC}"
+      RenderText {#text} at (15,5030) size 130x17
+        text run at (15,5030) width 130: "\x{5084}\x{BECB}\x{6B64}\x{D83E}\x{DC65}\x{D72B}\x{7CD8}\x{D83F}\x{DC17}\x{9C6}\x{D83F}\x{DEF6}\x{7A6}"
+      RenderText {#text} at (144,5030) size 67x17
+        text run at (144,5030) width 67: "\x{21AA}\x{C3A9}\x{32C1}\x{1E22}\x{D00}"
+      RenderText {#text} at (210,5030) size 111x17
+        text run at (210,5030) width 10 RTL: "\x{682}"
+        text run at (219,5030) width 102: "\x{78A3}\x{E49}\x{B61}\x{C2}\x{E55}\x{555}\x{3F5}\x{A4E9}\x{34EC}\x{D83E}\x{DE4D}"
+      RenderText {#text} at (320,5030) size 96x17
+        text run at (320,5030) width 42: "\x{5699}\x{8FFA}\x{F786}"
+        text run at (361,5030) width 9 RTL: "\x{685}"
+        text run at (369,5030) width 47: "\x{1D3F}\x{DB6B}\x{BF05}\x{4083}"
+      RenderText {#text} at (415,5030) size 35x17
+        text run at (415,5030) width 31: "\x{7F14}\x{9D87}"
+        text run at (445,5030) width 5 RTL: "\x{627}"
+      RenderText {#text} at (449,5030) size 53x17
+        text run at (449,5030) width 53: "\x{D83F}\x{DD01}\x{4ED3}\x{60F4}\x{2C4D}"
+      RenderText {#text} at (501,5030) size 52x17
+        text run at (501,5030) width 52: "\x{D404}\x{ADEF}\x{558}\x{D83F}\x{DC9A}"
+      RenderText {#text} at (552,5030) size 73x17
+        text run at (552,5030) width 12: "\x{D83E}\x{DF0D}"
+        text run at (563,5030) width 12 RTL: "\x{5EA}"
+        text run at (574,5030) width 51: "\x{1211}\x{EE55}\x{1C8A}\x{D83F}\x{DEAD}"
+      RenderText {#text} at (0,5030) size 744x42
+        text run at (624,5030) width 120: "\x{D83E}\x{DE97}\x{AFC9}\x{D83F}\x{DC32}\x{D83F}\x{DD2F}\x{20A}\x{F3F1}\x{D83E}\x{DD8F}\x{2E70}\x{3838}"
+        text run at (0,5055) width 11: "\x{D83E}\x{DF9C}"
+      RenderText {#text} at (10,5055) size 121x17
+        text run at (10,5055) width 121: "\x{D83E}\x{DC74}\x{D83D}\x{DF80}\x{FAE}\x{EA64}\x{525}\x{D83F}\x{DF92}\x{D83E}\x{DE4A}\x{4F6}\x{D83F}\x{DE5D}\x{D83E}\x{DF5C}\x{88DC}"
+      RenderText {#text} at (130,5055) size 38x17
+        text run at (130,5055) width 38: "\x{6B58}\x{CF96}\x{168B}"
+      RenderText {#text} at (167,5055) size 108x17
+        text run at (167,5055) width 50: "\x{B850}\x{D83D}\x{DF15}\x{850E}\x{C90}"
+        text run at (216,5055) width 8 RTL: "\x{6C1}"
+        text run at (223,5055) width 52: "\x{D83F}\x{DF5B}\x{6949}\x{4E7E}\x{9BA}"
+      RenderText {#text} at (274,5055) size 110x17
+        text run at (274,5055) width 12: "\x{D83E}\x{DC0E}"
+        text run at (285,5055) width 10 RTL: "\x{7D5}"
+        text run at (294,5055) width 90: "\x{3ADE}\x{D83D}\x{DFBF}\x{55B}\x{D83E}\x{DFD0}\x{F3C9}\x{AFC}\x{D83F}\x{DEA7}\x{FD5}\x{B6C}"
+      RenderText {#text} at (383,5055) size 57x17
+        text run at (383,5055) width 57: "\x{945}\x{5DA4}\x{D83E}\x{DDEE}\x{53A}"
+      RenderText {#text} at (439,5055) size 107x17
+        text run at (439,5055) width 107: "\x{81F7}\x{48AB}\x{2610}\x{6F92}\x{D83E}\x{DC73}\x{8881}\x{45F}\x{F920}"
+      RenderText {#text} at (545,5055) size 128x17
+        text run at (545,5055) width 128: "\x{E4B}\x{DD7}\x{736}\x{F5A}\x{7373}\x{532}\x{D83E}\x{DC9E}\x{D83E}\x{DE64}\x{274A}\x{CBF1}\x{6AA5}"
+      RenderText {#text} at (0,5055) size 751x45
+        text run at (672,5055) width 79: "\x{DEDD}\x{DC4D}\x{D83F}\x{DEBA}\x{D83F}\x{DE46}\x{F56F}\x{141D}\x{BA38}"
+        text run at (0,5083) width 48: "\x{E100}\x{E5A4}\x{E4D8}\x{6679}"
+      RenderText {#text} at (47,5083) size 51x17
+        text run at (47,5083) width 51: "\x{8AC3}\x{5294}\x{E15}\x{F006}"
+      RenderText {#text} at (97,5083) size 123x17
+        text run at (97,5083) width 123: "\x{F769}\x{D83E}\x{DCA1}\x{D83E}\x{DDF9}\x{25AE}\x{72E5}\x{D83E}\x{DCCF}\x{4A8C}\x{D1F0}\x{D83E}\x{DC81}\x{1C7A}"
+      RenderText {#text} at (219,5083) size 118x17
+        text run at (219,5083) width 22: "\x{D83F}\x{DEF5}\x{F8EC}"
+        text run at (240,5083) width 11 RTL: "\x{6D0}"
+        text run at (250,5083) width 16: "\x{487A}"
+        text run at (265,5083) width 7 RTL: "\x{693}"
+        text run at (271,5083) width 66: "\x{F3C}\x{9485}\x{673D}\x{D83E}\x{DCAB}\x{81DF}"
+      RenderText {#text} at (336,5083) size 130x17
+        text run at (336,5083) width 109: "\x{4A16}\x{82C6}\x{643C}\x{D83D}\x{DEB5}\x{135B}\x{DB59}\x{D83F}\x{DF91}\x{EA82}"
+        text run at (444,5083) width 11 RTL: "\x{752}"
+        text run at (454,5083) width 12: "\x{D83E}\x{DC78}"
+      RenderText {#text} at (465,5083) size 22x17
+        text run at (465,5083) width 22: "\x{94EA}\x{227}"
+      RenderText {#text} at (486,5083) size 124x17
+        text run at (486,5083) width 66: "\x{BA4}\x{1557}\x{E7B2}\x{E3DF}\x{D83D}\x{DE1A}"
+        text run at (551,5083) width 18 RTL: "\x{FCFA}"
+        text run at (568,5083) width 42: "\x{82F5}\x{A7BB}\x{C572}"
+      RenderText {#text} at (609,5083) size 105x17
+        text run at (609,5083) width 105: "\x{EDFC}\x{EFEA}\x{99D}\x{BD3D}\x{A907}\x{CBD}\x{D83F}\x{DF12}\x{918}\x{53F}\x{F1}"
+      RenderText {#text} at (713,5083) size 30x17
+        text run at (713,5083) width 23: "\x{AF5}\x{DCE}"
+        text run at (735,5083) width 8 RTL: "\x{84B}"
+      RenderText {#text} at (0,5083) size 758x45
+        text run at (742,5083) width 16: "\x{D83D}\x{DF05}"
+        text run at (0,5111) width 102: "\x{6B6B}\x{A57}\x{D83F}\x{DE71}\x{A8A}\x{FAB9}\x{2E87}\x{E26D}\x{9DC0}"
+      RenderText {#text} at (101,5111) size 127x17
+        text run at (101,5111) width 127: "\x{C1F9}\x{D83F}\x{DE33}\x{F143}\x{815B}\x{D83E}\x{DCFB}\x{AE3E}\x{4D6}\x{246}\x{D83D}\x{DF03}\x{B53D}"
+      RenderText {#text} at (227,5111) size 128x17
+        text run at (227,5111) width 128: "\x{D83E}\x{DCCB}\x{A4F7}\x{3F2}\x{4A5}\x{F49}\x{6D02}\x{2BE1}\x{1DAF}\x{D83E}\x{DE79}\x{3F1D}\x{B2D}"
+      RenderText {#text} at (354,5111) size 44x17
+        text run at (354,5111) width 44: "\x{E6FD}\x{D83E}\x{DCEA}\x{C86}\x{D83D}\x{DFB6}"
+      RenderText {#text} at (397,5111) size 94x17
+        text run at (397,5111) width 94: "\x{8550}\x{315}\x{D83F}\x{DEBE}\x{9D59}\x{A8E0}\x{D29}\x{DD57}\x{3736}"
+      RenderText {#text} at (490,5111) size 40x17
+        text run at (490,5111) width 40: "\x{978}\x{16F}\x{A1C}\x{9FCF}"
+      RenderText {#text} at (529,5111) size 121x17
+        text run at (529,5111) width 121: "\x{445}\x{C7E}\x{49B4}\x{F256}\x{9EB}\x{E2B3}\x{7D5D}\x{D83D}\x{DF3A}\x{D83F}\x{DDB5}\x{F993}"
+      RenderText {#text} at (649,5111) size 90x17
+        text run at (649,5111) width 90: "\x{203}\x{799B}\x{D83F}\x{DF95}\x{6834}\x{4A6E}\x{D83F}\x{DEEA}\x{634E}"
+      RenderText {#text} at (0,5111) size 754x45
+        text run at (738,5111) width 16: "\x{B821}"
+        text run at (0,5139) width 48: "\x{A615}\x{1D6}\x{4E7}\x{E06C}q"
+      RenderText {#text} at (47,5139) size 57x17
+        text run at (47,5139) width 57: "\x{D83E}\x{DEC0}\x{FAA}\x{D83D}\x{DED3}\x{474A}"
+      RenderText {#text} at (103,5139) size 117x17
+        text run at (103,5139) width 117: "\x{F198}\x{27BB}\x{5D7A}\x{AA7}\x{AF9C}\x{1EE4}\x{23C2}\x{35DA}\x{E551}"
+      RenderText {#text} at (219,5139) size 27x17
+        text run at (219,5139) width 27: "\x{5A8F}\x{D67}"
+      RenderText {#text} at (245,5139) size 25x17
+        text run at (245,5139) width 25: "\x{422F}\x{F34}"
+      RenderText {#text} at (269,5139) size 113x17
+        text run at (269,5139) width 113: "\x{4E0B}\x{AD32}\x{9EF}\x{92F2}\x{6147}\x{A0D8}\x{D83E}\x{DDCE}\x{D63F}"
+      RenderText {#text} at (381,5139) size 97x17
+        text run at (381,5139) width 16: "\x{D83E}\x{DF77}\x{2D42}"
+        text run at (396,5139) width 15 RTL: "\x{FC9D}"
+        text run at (410,5139) width 68: "\x{56AB}\x{38D3}\x{32E0}\x{1EF}\x{D6B}"
+      RenderText {#text} at (477,5139) size 20x17
+        text run at (477,5139) width 20: "\x{10}\x{E8A}"
+      RenderText {#text} at (496,5139) size 122x17
+        text run at (496,5139) width 23: "\x{D83E}\x{DC7F}\x{E324}"
+        text run at (518,5139) width 12 RTL: "\x{88A}"
+        text run at (529,5139) width 89: "\x{F2E}\x{9192}\x{B089}\x{E52B}\x{D83E}\x{DE89}\x{D83D}\x{DFBF}\x{8FA8}"
+      RenderText {#text} at (617,5139) size 77x17
+        text run at (617,5139) width 77: "\x{BAB5}\x{D028}\x{E7E}\x{D83F}\x{DC2F}\x{E14}\x{38B9}"
+      RenderText {#text} at (693,5139) size 50x17
+        text run at (693,5139) width 50: "\x{34E}\x{A22F}\x{24F}\x{D83E}\x{DC0E}\x{7F63}"
+      RenderText {#text} at (0,5139) size 758x42
+        text run at (742,5139) width 16: "\x{725E}"
+        text run at (0,5164) width 52: "\x{3512}\x{89F2}\x{E971}\x{F91}"
+        text run at (51,5164) width 10 RTL: "\x{5E4}"
+      RenderText {#text} at (60,5164) size 46x17
+        text run at (60,5164) width 46: "\x{F2C1}\x{570}\x{178}\x{91C7}"
+layer at (8,142) size 16x16
+  RenderVideo {VIDEO} at (0,134) size 16x16
+layer at (24,142) size 16x16
+  RenderVideo {VIDEO} at (16,134) size 16x16
+layer at (151,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (143,0) size 300x150
+layer at (8,167) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,159) size 300x150
+layer at (8,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,317) size 300x150
+layer at (308,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,317) size 300x150
+layer at (8,481) size 284x284
+  RenderVideo {VIDEO} at (0,473) size 284x284
+layer at (546,749) size 16x16
+  RenderVideo {VIDEO} at (537,741) size 17x16
+layer at (65,913) size 16x16
+  RenderVideo {VIDEO} at (56,905) size 17x16
+layer at (116,779) size 349x150
+  RenderHTMLCanvas {CANVAS} at (108,771) size 350x150
+layer at (93,937) size 300x150
+  RenderHTMLCanvas {CANVAS} at (85,929) size 301x150
+layer at (8,1120) size 885x385
+  RenderHTMLCanvas {CANVAS} at (0,1112) size 885x385
+layer at (8,1988) size 213x213
+  RenderVideo {VIDEO} at (0,1980) size 213x213
+layer at (196,2420) size 16x16
+  RenderVideo {VIDEO} at (188,2412) size 17x16
+layer at (8,2448) size 290x127
+  RenderHTMLCanvas {CANVAS} at (0,2440) size 290x127
+layer at (8,2856) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,2848) size 300x150
+layer at (334,2739) size 300x267
+  RenderHTMLCanvas {CANVAS} at (326,2731) size 300x267
+layer at (8,3276) size 974x150
+  RenderHTMLCanvas {CANVAS} at (0,3268) size 974x150
+layer at (8,3447) size 905x349
+  RenderHTMLCanvas {CANVAS} at (0,3439) size 905x349
+layer at (200,3832) size 335x23
+  RenderHTMLCanvas {CANVAS} at (192,3824) size 336x23
+layer at (748,3839) size 16x16
+  RenderVideo {VIDEO} at (740,3831) size 17x16
+layer at (465,4030) size 291x291
+  RenderVideo {VIDEO} at (456,4022) size 292x291
+layer at (408,4328) size 38x213
+  RenderVideo {VIDEO} at (400,4320) size 39x213

--- a/LayoutTests/fast/webgpu/fuzz-273573.html
+++ b/LayoutTests/fast/webgpu/fuzz-273573.html
@@ -1,0 +1,24604 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUCommandEncoder} commandEncoder
+ */
+function pseudoSubmit(device, commandEncoder) {
+  device.pushErrorScope('validation');
+  commandEncoder.clearBuffer(device.createBuffer({size: 0, usage: 0}), 0, 0);
+  device.popErrorScope().then(() => {});
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let device0 = await adapter0.requestDevice({
+label: '\u{1fc65}\ufb7e\u1bf2\u71e7\u0c2f\u03f6\u0862\u0696\u0cc1\ua058\u6115',
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 43,
+maxVertexAttributes: 19,
+maxVertexBufferArrayStride: 35280,
+maxStorageTexturesPerShaderStage: 29,
+maxStorageBuffersPerShaderStage: 27,
+maxDynamicStorageBuffersPerPipelineLayout: 30084,
+maxBindingsPerBindGroup: 8754,
+maxTextureDimension1D: 11229,
+maxTextureDimension2D: 11699,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 199721813,
+maxUniformBuffersPerShaderStage: 35,
+maxInterStageShaderVariables: 49,
+maxInterStageShaderComponents: 119,
+maxSamplersPerShaderStage: 21,
+},
+});
+let video0 = await videoWithData();
+let buffer0 = device0.createBuffer(
+{
+label: '\u2cea\u{1f6df}\u5535\ufa73\u0bd8\ub8fa\u2751\u7f94\u{1f863}',
+size: 11395,
+usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let querySet0 = device0.createQuerySet({
+label: '\u0718\u{1fde6}\uedca\u0f9c\u32a6\u0e6d\u{1fee9}\u03a5\u0133\u{1f80e}\u{1fb19}',
+type: 'occlusion',
+count: 274,
+});
+let texture0 = device0.createTexture(
+{
+label: '\ua5d3\u01b9\u{1f6cd}\u075e\u0047\uc6c3',
+size: {width: 6145},
+dimension: '1d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16float'
+],
+}
+);
+let textureView0 = texture0.createView(
+{
+}
+);
+let videoFrame0 = new VideoFrame(video0, {timestamp: 0});
+try {
+adapter0.label = '\u8679\u{1f9b3}\u020c\u2e10\u{1f97c}\ucee1\ud1c9';
+} catch {}
+let sampler0 = device0.createSampler(
+{
+label: '\ue327\u09a0\u6321\u6a9c\ua9ad\u{1fc56}\u55f1\u0526\u{1f854}\u03e9\u0f53',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMaxClamp: 59.746,
+compare: 'equal',
+}
+);
+let textureView1 = texture0.createView(
+{
+label: '\u{1fd5b}\u6a17\u29a3',
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 366, y: 1, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(48),
+/* required buffer size: 304 */{
+offset: 304,
+},
+{width: 4990, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let buffer1 = device0.createBuffer(
+{
+label: '\ub4cf\u{1fac5}\u5573\u7004\ufe12\u933e\u23e3',
+size: 11420,
+usage: GPUBufferUsage.UNIFORM,
+mappedAtCreation: true,
+}
+);
+let renderBundleEncoder0 = device0.createRenderBundleEncoder(
+{
+label: '\u{1f962}\u{1fabe}',
+colorFormats: [
+'rg32float',
+'r16uint',
+'rg16sint',
+'rgba16sint',
+undefined,
+'rgba8unorm-srgb'
+],
+sampleCount: 675,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder0.setVertexBuffer(
+10,
+buffer0,
+5980,
+4631
+);
+} catch {}
+let bindGroupLayout0 = device0.createBindGroupLayout(
+{
+label: '\u0501\u049d\u043a\u0fc8\u{1f668}\u1ded\u5428\u66ee\u3a64',
+entries: [
+{
+binding: 2242,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+},
+{
+binding: 6973,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '3d' },
+},
+{
+binding: 6956,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+}
+],
+}
+);
+let renderBundle0 = renderBundleEncoder0.finish(
+{
+label: '\u672c\u{1fa51}\u0af1\ub5c6\u{1f727}\u33a8\u23ac\u034f\u46a2'
+}
+);
+let commandEncoder0 = device0.createCommandEncoder(
+{
+label: '\u0ae0\ud2c7',
+}
+);
+let renderBundle1 = renderBundleEncoder0.finish(
+{
+
+}
+);
+let promise0 = device0.popErrorScope();
+let imageData0 = new ImageData(140, 244);
+let videoFrame1 = new VideoFrame(video0, {timestamp: 0});
+let pipelineLayout0 = device0.createPipelineLayout(
+{
+label: '\u7c79\u0af6\ue8b6\u1889\u5b7f',
+bindGroupLayouts: [
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0
+]
+}
+);
+let textureView2 = texture0.createView(
+{
+label: '\uf80a\uef33',
+}
+);
+let computePassEncoder0 = commandEncoder0.beginComputePass(
+{
+
+}
+);
+let renderBundleEncoder1 = device0.createRenderBundleEncoder(
+{
+label: '\ud250\u077c\u3b84\u2b1d\u{1f6c8}\u0f5a\u522b\u0012\u8be8\u34c7\u5f5b',
+colorFormats: [
+'rg16uint',
+'r16float',
+'r8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 784,
+}
+);
+let img0 = await imageWithData(180, 280, '#2093da37', '#41ada33d');
+let shaderModule0 = device0.createShaderModule(
+{
+label: '\u0e92\u8873\u04eb\uc8ce\u9b98\u57ad\u{1fa9a}',
+code: `@group(4) @binding(2242)
+var<storage, read_write> function0: array<u32>;
+@group(0) @binding(6956)
+var<storage, read_write> field0: array<u32>;
+@group(5) @binding(6956)
+var<storage, read_write> i0: array<u32>;
+@group(3) @binding(2242)
+var<storage, read_write> function1: array<u32>;
+@group(5) @binding(2242)
+var<storage, read_write> type0: array<u32>;
+@group(6) @binding(6956)
+var<storage, read_write> i1: array<u32>;
+@group(8) @binding(6973)
+var<storage, read_write> global0: array<u32>;
+@group(7) @binding(2242)
+var<storage, read_write> field1: array<u32>;
+@group(0) @binding(2242)
+var<storage, read_write> i2: array<u32>;
+@group(4) @binding(6973)
+var<storage, read_write> local0: array<u32>;
+@group(2) @binding(6973)
+var<storage, read_write> function2: array<u32>;
+@group(7) @binding(6973)
+var<storage, read_write> i3: array<u32>;
+@group(7) @binding(6956)
+var<storage, read_write> function3: array<u32>;
+@group(6) @binding(6973)
+var<storage, read_write> parameter0: array<u32>;
+@group(6) @binding(2242)
+var<storage, read_write> parameter1: array<u32>;
+@group(2) @binding(6956)
+var<storage, read_write> type1: array<u32>;
+@group(1) @binding(6973)
+var<storage, read_write> type2: array<u32>;
+@group(3) @binding(6956)
+var<storage, read_write> local1: array<u32>;
+@group(0) @binding(6973)
+var<storage, read_write> global1: array<u32>;
+@group(4) @binding(6956)
+var<storage, read_write> type3: array<u32>;
+@group(1) @binding(6956)
+var<storage, read_write> parameter2: array<u32>;
+@group(1) @binding(2242)
+var<storage, read_write> function4: array<u32>;
+@group(3) @binding(6973)
+var<storage, read_write> global2: array<u32>;
+
+@compute @workgroup_size(6, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: vec2<f32>,
+@location(3) f1: u32,
+@builtin(sample_mask) f2: u32,
+@location(1) f3: f32,
+@location(5) f4: vec4<i32>,
+@location(2) f5: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(sample_mask) a2: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S0 {
+@location(2) f0: vec2<u32>,
+@location(12) f1: vec4<u32>,
+@location(10) f2: vec3<i32>,
+@location(4) f3: i32,
+@builtin(vertex_index) f4: u32,
+@location(15) f5: vec4<i32>,
+@location(7) f6: vec3<u32>,
+@location(6) f7: vec2<u32>,
+@location(3) f8: vec2<u32>,
+@location(8) f9: vec3<f32>,
+@location(14) f10: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec4<u32>, @location(13) a1: vec4<u32>, @location(1) a2: vec4<f32>, @location(18) a3: vec2<u32>, @builtin(instance_index) a4: u32, @location(5) a5: f32, @location(9) a6: f32, @location(17) a7: vec3<f32>, a8: S0, @location(16) a9: vec2<u32>, @location(0) a10: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let renderBundleEncoder2 = device0.createRenderBundleEncoder(
+{
+label: '\u2ec7\u{1f653}\u0a1c\u661a\u081a\u000d\u{1f6e4}\u0355',
+colorFormats: [
+'rg16uint',
+undefined,
+'r16uint',
+'rg16uint',
+'r16float',
+'bgra8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 900,
+stencilReadOnly: true,
+}
+);
+let querySet1 = device0.createQuerySet({
+label: '\u{1f9e9}\u0cf4\u9680\u2385\u09e9\u8f5c\u6274\u{1fa68}\u0849\u80c7\u{1f63e}',
+type: 'occlusion',
+count: 1727,
+});
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 17, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(80),
+/* required buffer size: 12495 */{
+offset: 703,
+},
+{width: 5896, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let texture1 = device0.createTexture(
+{
+label: '\u{1f893}\u7e06\u08c3\u{1fa0c}',
+size: [1551, 157, 54],
+mipLevelCount: 5,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'depth16unorm'
+],
+}
+);
+let sampler1 = device0.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 53.273,
+lodMaxClamp: 62.635,
+}
+);
+try {
+buffer1.destroy();
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 263, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint32Array(new ArrayBuffer(64)),
+/* required buffer size: 10810 */{
+offset: 2,
+},
+{width: 5404, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let renderBundle2 = renderBundleEncoder1.finish(
+{
+label: '\u{1f98f}\u2c83\u0835\u0826'
+}
+);
+let externalTexture0 = device0.importExternalTexture(
+{
+label: '\u7c5b\u{1f60c}\u01c4\ud922\u759d',
+source: videoFrame1,
+colorSpace: 'srgb',
+}
+);
+try {
+buffer0.unmap();
+} catch {}
+let querySet2 = device0.createQuerySet({
+label: '\u1c4c\u05b9',
+type: 'occlusion',
+count: 3040,
+});
+let sampler2 = device0.createSampler(
+{
+label: '\u{1fc11}\u8c04\u6a12\u0e6b\u{1ffd2}\ua5d7\ueff5\u004f\u2334\u{1fa14}\u{1fff0}',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 92.224,
+maxAnisotropy: 3,
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture1,
+  mipLevel: 4,
+  origin: { x: 0, y: 4, z: 37 },
+  aspect: 'depth-only',
+},
+new ArrayBuffer(0),
+/* required buffer size: 258935 */{
+offset: 518,
+bytesPerRow: 313,
+rowsPerImage: 55,
+},
+{width: 96, height: 1, depthOrArrayLayers: 16}
+);
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+try {
+await promise1;
+} catch {}
+let videoFrame2 = new VideoFrame(video0, {timestamp: 0});
+let querySet3 = device0.createQuerySet({
+label: '\u{1f953}\u{1f78b}\ud443\u0c9c\u0d12\u0be3\ud280\u3c98\uf2a2\uae30\u{1f6b8}',
+type: 'occlusion',
+count: 3541,
+});
+let renderBundle3 = renderBundleEncoder1.finish(
+{
+
+}
+);
+let sampler3 = device0.createSampler(
+{
+label: '\u56b3\u38ae\u7b7b\u0a1e\u3f3e\ub3ec\u0653\u74b8\u{1f995}\u7637\u3fd0',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 86.159,
+lodMaxClamp: 87.507,
+}
+);
+try {
+renderBundleEncoder2.setVertexBuffer(
+5,
+buffer0
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture1,
+  mipLevel: 2,
+  origin: { x: 0, y: 7, z: 30 },
+  aspect: 'all',
+},
+new BigUint64Array(new ArrayBuffer(64)),
+/* required buffer size: 806032 */{
+offset: 674,
+bytesPerRow: 892,
+rowsPerImage: 41,
+},
+{width: 387, height: 1, depthOrArrayLayers: 23}
+);
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+let pipeline0 = await device0.createComputePipelineAsync(
+{
+label: '\u0d26\u0b7d\u9379\u01e4\u0ed1',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let video1 = await videoWithData();
+let renderBundleEncoder3 = device0.createRenderBundleEncoder(
+{
+label: '\ud5e5\u6f4b\u0395\u241f\u{1f7cc}\u8342',
+colorFormats: [
+'r32uint',
+undefined,
+'rgba8uint',
+'rgba16float',
+'rg8unorm'
+],
+sampleCount: 734,
+}
+);
+let renderBundle4 = renderBundleEncoder2.finish();
+try {
+computePassEncoder0.setPipeline(
+pipeline0
+);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(
+11,
+buffer0
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 436, y: 0, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(0),
+/* required buffer size: 154 */{
+offset: 154,
+},
+{width: 2473, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(941, 675);
+let imageBitmap0 = await createImageBitmap(imageData0);
+let texture2 = device0.createTexture(
+{
+size: [1923, 2, 5],
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundle5 = renderBundleEncoder1.finish(
+{
+label: '\u3fb3\uffc8'
+}
+);
+try {
+renderBundleEncoder3.setVertexBuffer(
+10,
+buffer0
+);
+} catch {}
+let shaderModule1 = device0.createShaderModule(
+{
+code: `@group(2) @binding(2242)
+var<storage, read_write> local2: array<u32>;
+@group(3) @binding(2242)
+var<storage, read_write> field2: array<u32>;
+@group(8) @binding(6956)
+var<storage, read_write> type4: array<u32>;
+@group(5) @binding(6973)
+var<storage, read_write> i4: array<u32>;
+@group(0) @binding(6956)
+var<storage, read_write> i5: array<u32>;
+@group(4) @binding(2242)
+var<storage, read_write> global3: array<u32>;
+@group(5) @binding(6956)
+var<storage, read_write> field3: array<u32>;
+@group(4) @binding(6973)
+var<storage, read_write> local3: array<u32>;
+@group(0) @binding(2242)
+var<storage, read_write> function5: array<u32>;
+@group(7) @binding(2242)
+var<storage, read_write> global4: array<u32>;
+@group(5) @binding(2242)
+var<storage, read_write> field4: array<u32>;
+@group(8) @binding(6973)
+var<storage, read_write> local4: array<u32>;
+@group(7) @binding(6973)
+var<storage, read_write> parameter3: array<u32>;
+@group(6) @binding(2242)
+var<storage, read_write> type5: array<u32>;
+@group(3) @binding(6956)
+var<storage, read_write> type6: array<u32>;
+@group(6) @binding(6973)
+var<storage, read_write> field5: array<u32>;
+@group(1) @binding(6973)
+var<storage, read_write> global5: array<u32>;
+@group(6) @binding(6956)
+var<storage, read_write> i6: array<u32>;
+@group(1) @binding(2242)
+var<storage, read_write> global6: array<u32>;
+@group(2) @binding(6973)
+var<storage, read_write> local5: array<u32>;
+@group(0) @binding(6973)
+var<storage, read_write> global7: array<u32>;
+@group(3) @binding(6973)
+var<storage, read_write> type7: array<u32>;
+
+@compute @workgroup_size(4, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: vec3<f32>,
+@location(1) f1: vec3<u32>,
+@location(3) f2: vec4<f32>,
+@location(5) f3: vec3<f32>,
+@location(7) f4: f32,
+@location(4) f5: vec4<u32>,
+@location(0) f6: u32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(17) a0: vec3<u32>, @location(2) a1: i32, @location(15) a2: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let querySet4 = device0.createQuerySet({
+label: '\ueebe\u88c6\ud549\u116b\udf5a\u0693\u{1fa89}\uc21e\uf412\u7289\u7508',
+type: 'occlusion',
+count: 2874,
+});
+pseudoSubmit(device0, commandEncoder0);
+let textureView3 = texture0.createView(
+{
+label: '\u0446\ued95\u0c80\u6482\u808e\u0757',
+aspect: 'all',
+baseArrayLayer: 0,
+}
+);
+let sampler4 = device0.createSampler(
+{
+label: '\u0ae9\u{1fa59}\u8a60',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 94.207,
+lodMaxClamp: 97.398,
+compare: 'not-equal',
+maxAnisotropy: 1,
+}
+);
+let renderBundle6 = renderBundleEncoder0.finish(
+{
+label: '\u019c\uf653'
+}
+);
+try {
+renderBundleEncoder3.setVertexBuffer(
+4,
+buffer0,
+11156,
+24
+);
+} catch {}
+try {
+await promise2;
+} catch {}
+let renderBundleEncoder4 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg11b10ufloat',
+'rg8unorm',
+'rgba16uint',
+undefined,
+'rg8uint',
+'rgb10a2unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 365,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: { x: 118, y: 1, z: 0 },
+  aspect: 'all',
+},
+new Float32Array(new ArrayBuffer(64)),
+/* required buffer size: 2583033 */{
+offset: 877,
+bytesPerRow: 8843,
+rowsPerImage: 292,
+},
+{width: 1098, height: 0, depthOrArrayLayers: 2}
+);
+} catch {}
+let pipeline1 = await device0.createRenderPipelineAsync(
+{
+label: '\u{1f60e}\u58aa\u0e80\u043e\u{1fcd3}\u0176\u{1f942}\u7794\u308a\ueb86\u{1fb35}',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 16420,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 9276,
+shaderLocation: 0,
+},
+{
+format: 'uint32x3',
+offset: 14048,
+shaderLocation: 12,
+},
+{
+format: 'sint16x4',
+offset: 10924,
+shaderLocation: 15,
+},
+{
+format: 'uint8x2',
+offset: 932,
+shaderLocation: 7,
+},
+{
+format: 'sint8x4',
+offset: 15888,
+shaderLocation: 4,
+},
+{
+format: 'uint8x2',
+offset: 828,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x2',
+offset: 980,
+shaderLocation: 17,
+},
+{
+format: 'unorm16x2',
+offset: 14700,
+shaderLocation: 5,
+},
+{
+format: 'uint32x2',
+offset: 10972,
+shaderLocation: 14,
+},
+{
+format: 'uint8x2',
+offset: 7716,
+shaderLocation: 3,
+},
+{
+format: 'uint8x2',
+offset: 6472,
+shaderLocation: 6,
+},
+{
+format: 'uint8x2',
+offset: 11772,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 35032,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 13136,
+shaderLocation: 2,
+},
+{
+format: 'unorm8x4',
+offset: 32392,
+shaderLocation: 9,
+},
+{
+format: 'sint32x2',
+offset: 23196,
+shaderLocation: 10,
+},
+{
+format: 'uint32x4',
+offset: 15352,
+shaderLocation: 13,
+},
+{
+format: 'unorm8x2',
+offset: 25054,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 6604,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 4704,
+shaderLocation: 8,
+},
+{
+format: 'uint32x3',
+offset: 112,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x84c6f9db,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'keep',
+passOp: 'invert',
+},
+stencilWriteMask: 3212,
+depthBiasSlopeScale: 49,
+depthBiasClamp: 20,
+},
+}
+);
+try {
+adapter0.label = '\u03bd\u9784\u024a\u{1faf5}\u03a1\u{1f7f2}';
+} catch {}
+let texture3 = device0.createTexture(
+{
+label: '\u75df\u2ee5\u{1f75f}\ucbbb\u8423\u809a\u75bf\u00fe\u0e2b\u29da',
+size: {width: 2403, height: 2, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+await promise0;
+} catch {}
+gc();
+let promise3 = navigator.gpu.requestAdapter(
+{
+}
+);
+let renderBundle7 = renderBundleEncoder0.finish(
+{
+label: '\uc427\u{1fa37}\u{1f77a}\u2b9a\u0a23\u0a16\u74ba\u{1f6d2}\u{1fb51}\u0499\u3364'
+}
+);
+let sampler5 = device0.createSampler(
+{
+label: '\u{1f9a8}\u1058\ucc59\u{1fb41}',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 45.878,
+lodMaxClamp: 63.682,
+maxAnisotropy: 15,
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 5,
+  origin: { x: 21, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Float32Array(new ArrayBuffer(24)),
+/* required buffer size: 260 */{
+offset: 260,
+},
+{width: 4, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend(img0);
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+try {
+window.someLabel = externalTexture0.label;
+} catch {}
+let commandEncoder1 = device0.createCommandEncoder(
+{
+label: '\u368c\u9883\u0db0\u0641\u22d7\ud6ff\u{1faf8}\u0ae5\u10c0\u13f9\u3a33',
+}
+);
+let sampler6 = device0.createSampler(
+{
+label: '\uf7f6\u07a8\u1f86\u1d38\u0ff9\ud084\u2148\u35be\u595b\u3fa0\u{1f962}',
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 32.948,
+lodMaxClamp: 57.918,
+}
+);
+document.body.prepend(video0);
+let renderBundle8 = renderBundleEncoder0.finish();
+try {
+renderBundleEncoder3.setVertexBuffer(
+9,
+buffer0,
+10320,
+870
+);
+} catch {}
+gc();
+let imageData1 = new ImageData(120, 188);
+let sampler7 = device0.createSampler(
+{
+addressModeW: 'repeat',
+mipmapFilter: 'linear',
+lodMinClamp: 28.081,
+lodMaxClamp: 48.021,
+}
+);
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+computePassEncoder0.insertDebugMarker(
+'\u84b9'
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 5,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint32Array(new ArrayBuffer(64)),
+/* required buffer size: 496 */{
+offset: 400,
+rowsPerImage: 105,
+},
+{width: 12, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+let renderBundleEncoder5 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba32sint',
+undefined,
+'r32uint',
+'bgra8unorm-srgb',
+'rg32float'
+],
+sampleCount: 464,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder3.setVertexBuffer(
+11,
+buffer0,
+6292,
+4475
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture1,
+  mipLevel: 2,
+  origin: { x: 0, y: 37, z: 10 },
+  aspect: 'all',
+},
+new Int8Array(new ArrayBuffer(40)),
+/* required buffer size: 793 */{
+offset: 793,
+bytesPerRow: 1000,
+},
+{width: 387, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let bindGroupLayout1 = device0.createBindGroupLayout(
+{
+label: '\ua868\u7337\ub65f\u9ee1\u{1fe05}\u0731\u04e6\u68cc\u{1f717}\u{1f8f4}\u{1fd01}',
+entries: [
+{
+binding: 1109,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'storage', minBindingSize: 756003, hasDynamicOffset: false },
+},
+{
+binding: 5018,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+},
+{
+binding: 166,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}
+],
+}
+);
+let texture4 = device0.createTexture(
+{
+label: '\uf35b\uf842\u{1fd63}\u0cfa',
+size: [6049, 1, 28],
+mipLevelCount: 5,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 1,
+  origin: { x: 7, y: 1, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(219255),
+/* required buffer size: 219255 */{
+offset: 267,
+bytesPerRow: 4977,
+rowsPerImage: 44,
+},
+{width: 606, height: 0, depthOrArrayLayers: 2}
+);
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+let pipeline2 = await device0.createComputePipelineAsync(
+{
+label: '\u0103\ub87c\u9280\u0fcd\u025f\u3876\u0329\u01e3',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+await promise4;
+} catch {}
+let commandEncoder2 = device0.createCommandEncoder(
+{
+label: '\ud309\u0b15\u705c\u{1f78f}',
+}
+);
+let querySet5 = device0.createQuerySet({
+label: '\u1751\u99d6\u{1f707}\u2756\u070b\u1b7b\u{1f8c8}\uf5f6\udd53',
+type: 'occlusion',
+count: 941,
+});
+pseudoSubmit(device0, commandEncoder1);
+offscreenCanvas0.height = 858;
+gc();
+let video2 = await videoWithData();
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let bindGroupLayout2 = device0.createBindGroupLayout(
+{
+label: '\u1e79\u50e3\u9971\u0b9c\u3a6b\u007c\u0e0e\u{1f92c}\u7181',
+entries: [
+{
+binding: 1894,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+let buffer2 = device0.createBuffer(
+{
+label: '\u0bf8\ud3f4\u0c70\u{1f77f}\uedf5\u0ccb\ue727\u18d8',
+size: 37670,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let textureView4 = texture3.createView(
+{
+label: '\u{1f6b8}\u{1fa46}\u8f8d\ueaef',
+baseMipLevel: 3,
+}
+);
+let sampler8 = device0.createSampler(
+{
+label: '\u5da7\ub28b\ub2c6',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 97.639,
+lodMaxClamp: 97.918,
+}
+);
+let sampler9 = device0.createSampler(
+{
+label: '\u0901\u12e1\u7743\u{1f77d}\u01f2\ub9a6',
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 21.994,
+lodMaxClamp: 53.935,
+}
+);
+try {
+renderBundleEncoder3.setVertexBuffer(
+7,
+buffer0,
+712,
+1092
+);
+} catch {}
+try {
+commandEncoder2.clearBuffer(
+buffer2,
+3556,
+31540
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+18816,
+new BigUint64Array(20106),
+15263,
+1376
+);
+} catch {}
+let querySet6 = device0.createQuerySet({
+label: '\uf515\u{1fb79}\u0200\u1ea8\u{1fd7d}',
+type: 'occlusion',
+count: 442,
+});
+let sampler10 = device0.createSampler(
+{
+label: '\u6b11\u{1fb68}\uf360\uef06\ue0b8\u{1f649}\ua090',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 97.884,
+lodMaxClamp: 98.800,
+maxAnisotropy: 11,
+}
+);
+let pipeline3 = device0.createRenderPipeline(
+{
+label: '\u5f26\ub5e9\u047e\u084d\u07b0\u{1ffd9}\u03db\ue149\u{1fbcb}',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 6676,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 3368,
+shaderLocation: 17,
+},
+{
+format: 'uint32x2',
+offset: 6248,
+shaderLocation: 14,
+},
+{
+format: 'uint32x2',
+offset: 408,
+shaderLocation: 18,
+},
+{
+format: 'uint16x2',
+offset: 3460,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 13352,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x4',
+offset: 2400,
+shaderLocation: 12,
+},
+{
+format: 'uint8x4',
+offset: 1564,
+shaderLocation: 13,
+},
+{
+format: 'unorm16x4',
+offset: 3228,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x2',
+offset: 3662,
+shaderLocation: 5,
+},
+{
+format: 'unorm8x2',
+offset: 654,
+shaderLocation: 1,
+},
+{
+format: 'unorm16x4',
+offset: 6324,
+shaderLocation: 0,
+},
+{
+format: 'sint8x2',
+offset: 12924,
+shaderLocation: 15,
+},
+{
+format: 'sint32',
+offset: 1384,
+shaderLocation: 4,
+},
+{
+format: 'uint16x4',
+offset: 3752,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 31496,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x2',
+offset: 824,
+shaderLocation: 3,
+},
+{
+format: 'uint8x4',
+offset: 17568,
+shaderLocation: 2,
+},
+{
+format: 'float32x4',
+offset: 15140,
+shaderLocation: 9,
+},
+{
+format: 'uint8x2',
+offset: 9740,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 2260,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 1916,
+shaderLocation: 11,
+},
+{
+format: 'sint32',
+offset: 2000,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'front',
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+{
+format: 'rg8sint',
+writeMask: 0,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'never',
+failOp: 'replace',
+depthFailOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'replace',
+},
+stencilWriteMask: 1295,
+depthBiasSlopeScale: 19,
+depthBiasClamp: 97,
+},
+}
+);
+let offscreenCanvas1 = new OffscreenCanvas(668, 789);
+let sampler11 = device0.createSampler(
+{
+label: '\u0e9b\udf1f\u{1fe39}\u095a\u8345\u54ad\u0d35\u37a7\u2acf\u{1f6e9}\u0a9d',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 94.275,
+lodMaxClamp: 94.669,
+maxAnisotropy: 6,
+}
+);
+try {
+renderBundleEncoder5.setVertexBuffer(
+3,
+buffer0,
+5964,
+4900
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 4,
+  origin: { x: 28, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Int16Array(new ArrayBuffer(24)),
+/* required buffer size: 1462 */{
+offset: 830,
+},
+{width: 79, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let textureView5 = texture4.createView(
+{
+label: '\u96a1\u0d3a\ufbfd\ubc80\u5143\u5253\u0777',
+dimension: '2d',
+aspect: 'depth-only',
+baseMipLevel: 3,
+baseArrayLayer: 18,
+}
+);
+try {
+device0.queue.writeBuffer(
+buffer2,
+16160,
+new BigUint64Array(32124),
+9598,
+1532
+);
+} catch {}
+let buffer3 = device0.createBuffer(
+{
+label: '\u032c\u0fae\u{1f939}\u{1f9af}\u{1f744}',
+size: 58610,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let querySet7 = device0.createQuerySet({
+label: '\u0394\u5d94\ufaae\u6552\u336b\u0201',
+type: 'occlusion',
+count: 1117,
+});
+let texture5 = device0.createTexture(
+{
+label: '\u046e\u{1fd5e}\uf139\u{1fd9b}\u0a1e',
+size: {width: 2263, height: 141, depthOrArrayLayers: 254},
+mipLevelCount: 9,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'depth32float',
+'depth32float'
+],
+}
+);
+let textureView6 = texture0.createView(
+{
+label: '\u{1f9e3}\u85a6\u00e3\u7615',
+aspect: 'all',
+}
+);
+let renderPassEncoder0 = commandEncoder2.beginRenderPass(
+{
+label: '\ud3b2\u{1f876}\u0c93\ueb55\u0d18',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView4,
+depthClearValue: 0.15733808489520262,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+stencilClearValue: 16998,
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet1,
+maxDrawCount: 256168,
+}
+);
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(
+0,
+buffer0
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rgba16float',
+'rgba16float',
+'rgba16float',
+'rgba16float'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let pipeline4 = await device0.createRenderPipelineAsync(
+{
+label: '\u7ce4\u024e\u1ce8\uce2a\u279b\u0102\u0fb4\u{1fe71}\u6336\u6367',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 6544,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 2248,
+shaderLocation: 11,
+},
+{
+format: 'uint32x3',
+offset: 3844,
+shaderLocation: 12,
+},
+{
+format: 'sint32x3',
+offset: 6512,
+shaderLocation: 4,
+},
+{
+format: 'uint8x2',
+offset: 500,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x4',
+offset: 3672,
+shaderLocation: 8,
+},
+{
+format: 'uint32',
+offset: 48,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x2',
+offset: 2364,
+shaderLocation: 0,
+},
+{
+format: 'uint8x2',
+offset: 5444,
+shaderLocation: 6,
+},
+{
+format: 'unorm16x2',
+offset: 1300,
+shaderLocation: 9,
+},
+{
+format: 'float32x4',
+offset: 5624,
+shaderLocation: 17,
+},
+{
+format: 'uint16x2',
+offset: 2184,
+shaderLocation: 2,
+},
+{
+format: 'uint32x2',
+offset: 1488,
+shaderLocation: 18,
+},
+{
+format: 'uint32',
+offset: 6232,
+shaderLocation: 13,
+},
+{
+format: 'sint8x2',
+offset: 3916,
+shaderLocation: 10,
+},
+{
+format: 'float32x2',
+offset: 6180,
+shaderLocation: 1,
+},
+{
+format: 'uint16x4',
+offset: 6008,
+shaderLocation: 16,
+},
+{
+format: 'uint8x2',
+offset: 2684,
+shaderLocation: 14,
+},
+{
+format: 'sint16x2',
+offset: 5856,
+shaderLocation: 15,
+},
+{
+format: 'unorm8x2',
+offset: 894,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+},
+multisample: {
+mask: 0xc197a1d6,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.GREEN,
+},
+{
+format: 'r8uint',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+},
+stencilReadMask: 2709,
+stencilWriteMask: 1981,
+depthBias: 97,
+depthBiasSlopeScale: 12,
+depthBiasClamp: 17,
+},
+}
+);
+let buffer4 = device0.createBuffer(
+{
+label: '\u0aa6\uba12',
+size: 2276,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let commandEncoder3 = device0.createCommandEncoder(
+{
+label: '\u{1f838}\u416b\ua6e1\u8583',
+}
+);
+let renderPassEncoder1 = commandEncoder3.beginRenderPass(
+{
+label: '\ua2a1\u10f1\u7192\u0dc5\u0300\u{1ffb7}\u7032',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView4,
+depthClearValue: 0.832537604223622,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+depthReadOnly: false,
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet1,
+maxDrawCount: 1960,
+}
+);
+let sampler12 = device0.createSampler(
+{
+label: '\u0688\uc61c\u{1f821}\uf3f8\u{1feda}\u{1f65d}\u0c18\u1d00\u063a\uc4d3',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 82.401,
+maxAnisotropy: 12,
+}
+);
+try {
+renderPassEncoder1.setVertexBuffer(
+6,
+buffer0,
+2144
+);
+} catch {}
+document.body.prepend(video1);
+try {
+renderPassEncoder0.beginOcclusionQuery(374);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setViewport(
+298.7,
+0.08654,
+0.3991,
+0.06178,
+0.4545,
+0.9532
+);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(
+3,
+buffer0,
+704,
+5809
+);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+5852,
+new DataView(new ArrayBuffer(1120)),
+100,
+220
+);
+} catch {}
+let pipeline5 = device0.createComputePipeline(
+{
+label: '\u7dfb\uec28\u{1fd92}\u69be',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline6 = await device0.createRenderPipelineAsync(
+{
+label: '\ua803\u{1fab9}\u0354\uece9\u00e4\u4c96',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 8760,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 6904,
+shaderLocation: 15,
+},
+{
+format: 'uint32x4',
+offset: 1840,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 27164,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 21500,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0x4e3281a6,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.RED,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rgba8unorm-srgb',
+},
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'src-alpha',
+dstFactor: 'constant'
+},
+},
+format: 'r16float',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2445,
+stencilWriteMask: 1116,
+depthBias: 91,
+depthBiasSlopeScale: 82,
+depthBiasClamp: 12,
+},
+}
+);
+let gpuCanvasContext1 = offscreenCanvas1.getContext('webgpu');
+let texture6 = device0.createTexture(
+{
+label: '\u0832\u013d',
+size: {width: 100, height: 236, depthOrArrayLayers: 151},
+mipLevelCount: 2,
+dimension: '2d',
+format: 'etc2-rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'etc2-rgba8unorm',
+'etc2-rgba8unorm'
+],
+}
+);
+let renderBundleEncoder6 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8uint',
+'rg16sint',
+'rg16float',
+'rgba16float',
+'r32float',
+'rg16sint',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 449,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+pseudoSubmit(device0, commandEncoder2);
+try {
+renderPassEncoder0.setScissorRect(
+40,
+1,
+9,
+0
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+37252,
+new BigUint64Array(6391),
+3653,
+40
+);
+} catch {}
+let imageBitmap1 = await createImageBitmap(video0);
+let texture7 = device0.createTexture(
+{
+label: '\ue72f\u{1fb14}\uf6b0\u0465\ud58a\u119e\u{1ff7f}\uc3d9\ue8aa\u0d65',
+size: {width: 7472},
+mipLevelCount: 1,
+dimension: '1d',
+format: 'rgba32uint',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundleEncoder7 = device0.createRenderBundleEncoder(
+{
+label: '\u2d63\u{1f621}\ud87d\u0375\u1466\u0f15\ub287\ub51c\u5eb9\u0341',
+colorFormats: [
+'r8uint',
+'rgba8uint',
+'rg16float',
+'rg32uint'
+],
+sampleCount: 425,
+stencilReadOnly: true,
+}
+);
+let renderBundle9 = renderBundleEncoder5.finish(
+{
+label: '\u06cc\u9bf2\u0163\u013e\u6259\u7d11\u3c61\u5dbb\u5eab\u076a\ub4f7'
+}
+);
+let sampler13 = device0.createSampler(
+{
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 65.843,
+lodMaxClamp: 75.680,
+}
+);
+try {
+renderPassEncoder1.setScissorRect(
+101,
+1,
+180,
+0
+);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(
+1237
+);
+} catch {}
+try {
+computePassEncoder0.insertDebugMarker(
+'\u6f1a'
+);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+204,
+0,
+39,
+0
+);
+} catch {}
+try {
+renderBundleEncoder6.pushDebugGroup(
+'\u08b9'
+);
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout(
+{
+label: '\u1fa7\u0112\u0c62\u4f52\u0082',
+entries: [
+{
+binding: 2091,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let commandEncoder4 = device0.createCommandEncoder(
+{
+label: '\u0b0c\ud3f3\ubdce\u94d9',
+}
+);
+pseudoSubmit(device0, commandEncoder3);
+let texture8 = device0.createTexture(
+{
+label: '\u{1f8a5}\u04d1\u7066\u069b',
+size: {width: 111, height: 1, depthOrArrayLayers: 1356},
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rgba8unorm',
+'rgba8unorm-srgb',
+'rgba8unorm-srgb'
+],
+}
+);
+try {
+renderPassEncoder0.setViewport(
+253.0,
+0.6568,
+33.88,
+0.06573,
+0.3723,
+0.7845
+);
+} catch {}
+try {
+commandEncoder4.clearBuffer(
+buffer2,
+14384,
+16788
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let pipelineLayout1 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout2,
+bindGroupLayout3
+]
+}
+);
+let textureView7 = texture1.createView(
+{
+label: '\u0db4\u043e',
+dimension: '2d',
+baseMipLevel: 1,
+mipLevelCount: 1,
+baseArrayLayer: 52,
+}
+);
+try {
+renderPassEncoder0.setBlendConstant({ r: -203.9, g: 848.6, b: -317.5, a: -687.1, });
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(
+188,
+0,
+32,
+0
+);
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+270.0,
+0.4812,
+13.22,
+0.3565,
+0.9318,
+0.9379
+);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+2,
+buffer0,
+3752,
+499
+);
+} catch {}
+try {
+commandEncoder4.clearBuffer(
+buffer2,
+24944,
+11048
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let pipeline7 = await device0.createComputePipelineAsync(
+{
+label: '\u05fd\u812a\u{1ff41}\ud94c',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let computePassEncoder1 = commandEncoder4.beginComputePass(
+{
+label: '\u2ee3\u{1fc56}\u013c\u1a83\u{1f9df}'
+}
+);
+let renderBundle10 = renderBundleEncoder5.finish(
+{
+label: '\u67b5\u06a1\ub474\u0c9a\u0df9\u{1f743}\u0c58\u{1fe22}\ua51f\u15fd'
+}
+);
+let sampler14 = device0.createSampler(
+{
+label: '\ue14e\u922f\u{1f830}\u{1fc68}\ua181\u0c10\uf4d9',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 4.768,
+lodMaxClamp: 83.735,
+maxAnisotropy: 16,
+}
+);
+try {
+renderPassEncoder0.setVertexBuffer(
+9,
+buffer0,
+9256,
+1687
+);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(
+5,
+buffer0,
+6260,
+4588
+);
+} catch {}
+try {
+renderBundleEncoder6.popDebugGroup();
+} catch {}
+let adapter1 = await promise3;
+let offscreenCanvas2 = new OffscreenCanvas(802, 32);
+try {
+offscreenCanvas2.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder5 = device0.createCommandEncoder();
+let querySet8 = device0.createQuerySet({
+label: '\u00e0\u{1fe05}',
+type: 'occlusion',
+count: 815,
+});
+let computePassEncoder2 = commandEncoder5.beginComputePass(
+{
+label: '\ua9d3\u9a87'
+}
+);
+try {
+computePassEncoder2.setPipeline(
+pipeline0
+);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(797);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(
+2673
+);
+} catch {}
+let renderBundleEncoder8 = device0.createRenderBundleEncoder(
+{
+label: '\u0ef2\u{1f7eb}\u0f40\u{1f87a}\u0d35\u{1ff09}\ud700\u5263\ubc88\u05cf',
+colorFormats: [
+'rg8uint',
+undefined,
+'rgba32sint',
+'r8uint',
+'rgba32float',
+'r8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 779,
+stencilReadOnly: true,
+}
+);
+let sampler15 = device0.createSampler(
+{
+label: '\u8d85\u0877\u580d\u{1f9d9}\u{1fcf9}\u08e1\u3449\u{1fa9d}\u3eae\u6534',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 98.640,
+maxAnisotropy: 12,
+}
+);
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture1,
+  mipLevel: 1,
+  origin: { x: 0, y: 31, z: 26 },
+  aspect: 'depth-only',
+},
+new BigInt64Array(new ArrayBuffer(80)),
+/* required buffer size: 2827681 */{
+offset: 945,
+bytesPerRow: 1729,
+rowsPerImage: 86,
+},
+{width: 775, height: 1, depthOrArrayLayers: 20}
+);
+} catch {}
+gc();
+let querySet9 = device0.createQuerySet({
+type: 'occlusion',
+count: 577,
+});
+try {
+renderPassEncoder1.setScissorRect(
+255,
+0,
+18,
+0
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+11204,
+new Int16Array(24086),
+5725,
+8004
+);
+} catch {}
+gc();
+let textureView8 = texture7.createView(
+{
+label: '\u46ec\uc01b\u{1f9df}\u4402\ua28d\ue641',
+aspect: 'all',
+}
+);
+let renderBundle11 = renderBundleEncoder4.finish(
+{
+label: '\u{1fb4b}\u8790\u0afa'
+}
+);
+let sampler16 = device0.createSampler(
+{
+label: '\u{1ffda}\u44af\u{1f97c}\u4a85',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 56.125,
+lodMaxClamp: 99.094,
+}
+);
+let arrayBuffer0 = buffer4.getMappedRange(
+0,
+1976
+);
+try {
+computePassEncoder0.pushDebugGroup(
+'\u{1fdd3}'
+);
+} catch {}
+try {
+computePassEncoder0.popDebugGroup();
+} catch {}
+offscreenCanvas2.width = 3;
+let canvas0 = document.createElement('canvas');
+try {
+device0.queue.label = '\u3ccd\u{1fd09}\u{1fff6}\uaa29\u0c6b\u{1f909}\ufc73\ufa69\u011b';
+} catch {}
+let bindGroup0 = device0.createBindGroup({
+label: '\ue878\u837e\ue68a\u{1fc1f}\u{1f986}\u8021',
+layout: bindGroupLayout3,
+entries: [
+{
+binding: 2091,
+resource: externalTexture0
+}
+],
+});
+let textureView9 = texture3.createView(
+{
+dimension: '2d-array',
+baseMipLevel: 3,
+}
+);
+let sampler17 = device0.createSampler(
+{
+label: '\u1d55\u0da2\u04e8\u36db',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 53.930,
+lodMaxClamp: 78.740,
+maxAnisotropy: 12,
+}
+);
+try {
+computePassEncoder2.setBindGroup(
+10,
+bindGroup0,
+new Uint32Array(6516),
+2938,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: -951.3, g: -41.09, b: -812.8, a: -908.8, });
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+67,
+1,
+127,
+0
+);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(
+11,
+buffer0
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 2194, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer0),
+/* required buffer size: 83 */{
+offset: 83,
+},
+{width: 767, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(37, 809);
+let textureView10 = texture6.createView(
+{
+format: 'etc2-rgba8unorm',
+baseMipLevel: 1,
+baseArrayLayer: 87,
+arrayLayerCount: 47,
+}
+);
+try {
+renderPassEncoder1.setBindGroup(
+9,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+10,
+buffer0,
+3664,
+6615
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(472, 408);
+let pipelineLayout2 = device0.createPipelineLayout(
+{
+label: '\u719a\ub8ec\u064a\ub71d\u0e0d\u{1f985}\u{1f9a6}\u588a',
+bindGroupLayouts: [
+bindGroupLayout0,
+bindGroupLayout2,
+bindGroupLayout0,
+bindGroupLayout1
+]
+}
+);
+let commandEncoder6 = device0.createCommandEncoder();
+let texture9 = device0.createTexture(
+{
+label: '\u94c1\ucf98\u04d1\u0ea0\u0b3c\u0a06',
+size: {width: 7788, height: 1, depthOrArrayLayers: 210},
+mipLevelCount: 3,
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb10a2unorm',
+'rgb10a2unorm',
+'rgb10a2unorm'
+],
+}
+);
+let computePassEncoder3 = commandEncoder6.beginComputePass(
+{
+label: '\u8637\u75af\u8eda\u{1ff7f}\u901f\ub63b\u0e9f\u{1fe50}\u07b9\ud8e4'
+}
+);
+let renderBundleEncoder9 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8unorm-srgb',
+'rgba8unorm-srgb',
+'r32float'
+],
+sampleCount: 289,
+depthReadOnly: true,
+}
+);
+let sampler18 = device0.createSampler(
+{
+label: '\u{1fe41}\u0585\u0358\u7fae\u{1fe36}\u005a\u0c91\u42d1\u0371',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 58.707,
+maxAnisotropy: 11,
+}
+);
+let videoFrame3 = new VideoFrame(video1, {timestamp: 0});
+let commandEncoder7 = device0.createCommandEncoder(
+{
+label: '\u{1f668}\udf31\u8e67\u78e9\u{1fcd1}\u{1fe38}\u0772\ufb51\u{1fcc7}\u21cf',
+}
+);
+let textureView11 = texture2.createView(
+{
+label: '\ue4ec\u0ee5\u{1f84d}\ud35e\u0e39\u2835\ua8dd\u{1f6df}\u0796',
+baseMipLevel: 1,
+mipLevelCount: 4,
+baseArrayLayer: 0,
+}
+);
+let renderBundle12 = renderBundleEncoder2.finish(
+{
+label: '\u6799\u{1fb2b}\u{1f9af}\u0294\u06c3\ucd2a\u{1f6ee}\u8804\u{1fa7a}'
+}
+);
+try {
+computePassEncoder3.setPipeline(
+pipeline0
+);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(
+3384
+);
+} catch {}
+try {
+commandEncoder7.clearBuffer(
+buffer2,
+26368,
+3820
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+externalTexture0.label = '\u6cc2\u0330\u{1fdc4}\u33e6\u091f\u6fa6\u0404';
+} catch {}
+pseudoSubmit(device0, commandEncoder7);
+let renderBundle13 = renderBundleEncoder9.finish();
+try {
+computePassEncoder3.setBindGroup(
+8,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+154,
+0,
+25,
+1
+);
+} catch {}
+try {
+renderBundleEncoder7.pushDebugGroup(
+'\u9a66'
+);
+} catch {}
+let pipeline8 = await device0.createComputePipelineAsync(
+{
+layout: pipelineLayout2,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let img1 = await imageWithData(251, 285, '#3c8ac767', '#3e9f2eda');
+let commandEncoder8 = device0.createCommandEncoder(
+{
+label: '\u0531\u07e6\u{1f922}\ud091\u37be\u8b82',
+}
+);
+let querySet10 = device0.createQuerySet({
+label: '\u0d1c\uffc8\u9c95\u3329\u{1f7eb}',
+type: 'occlusion',
+count: 109,
+});
+let textureView12 = texture6.createView(
+{
+label: '\u0bc8\u{1f819}',
+dimension: '2d',
+baseMipLevel: 1,
+baseArrayLayer: 38,
+}
+);
+let renderBundle14 = renderBundleEncoder4.finish(
+{
+label: '\u0298\u{1fff1}\u0079\u9a63\u0ed2'
+}
+);
+let sampler19 = device0.createSampler(
+{
+label: '\u0e24\u{1faae}\ucbbc\ub6f6\uc911\ud596\u{1ff6d}\u0df4\u01d3\u0d1b\ua753',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+lodMinClamp: 46.742,
+lodMaxClamp: 78.445,
+}
+);
+try {
+renderPassEncoder1.beginOcclusionQuery(1555);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+3,
+buffer0,
+1676,
+2505
+);
+} catch {}
+let shaderModule2 = device0.createShaderModule(
+{
+label: '\u4ad3\u{1fbb6}',
+code: `@group(2) @binding(2242)
+var<storage, read_write> type8: array<u32>;
+@group(2) @binding(6973)
+var<storage, read_write> parameter4: array<u32>;
+@group(0) @binding(6973)
+var<storage, read_write> function6: array<u32>;
+@group(3) @binding(1109)
+var<storage, read_write> field6: array<u32>;
+@group(1) @binding(1894)
+var<storage, read_write> i7: array<u32>;
+@group(0) @binding(6956)
+var<storage, read_write> function7: array<u32>;
+@group(3) @binding(5018)
+var<storage, read_write> parameter5: array<u32>;
+@group(3) @binding(166)
+var<storage, read_write> local6: array<u32>;
+@group(2) @binding(6956)
+var<storage, read_write> field7: array<u32>;
+
+@compute @workgroup_size(7, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: vec2<f32>,
+@location(2) f1: f32,
+@location(1) f2: vec3<u32>,
+@location(0) f3: vec2<i32>,
+@location(3) f4: f32,
+@location(5) f5: i32,
+@location(6) f6: vec4<f32>,
+@location(7) f7: i32,
+@builtin(sample_mask) f8: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(position) a2: vec4<f32>, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S1 {
+@location(14) f0: vec3<f32>,
+@location(5) f1: vec2<u32>,
+@location(1) f2: vec4<f32>,
+@location(15) f3: f16,
+@location(3) f4: vec4<u32>,
+@location(7) f5: vec3<f16>,
+@location(10) f6: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(2) a0: f32, @builtin(instance_index) a1: u32, @location(16) a2: vec4<i32>, @location(9) a3: vec4<f32>, @location(13) a4: vec3<f32>, @builtin(vertex_index) a5: u32, @location(6) a6: vec4<f16>, a7: S1, @location(0) a8: vec4<u32>, @location(17) a9: vec3<i32>, @location(11) a10: i32, @location(12) a11: vec3<u32>, @location(4) a12: vec4<u32>, @location(8) a13: vec2<i32>, @location(18) a14: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+}
+);
+let renderPassEncoder2 = commandEncoder8.beginRenderPass(
+{
+label: '\u{1f779}\u{1f87e}\u{1f81a}\u56e9\u6538',
+colorAttachments: [
+
+],
+depthStencilAttachment: {
+view: textureView4,
+depthClearValue: 0.42470479129491456,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+},
+occlusionQuerySet: querySet9,
+maxDrawCount: 14184,
+}
+);
+try {
+computePassEncoder1.setPipeline(
+pipeline5
+);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(100);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+4,
+buffer0
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageBitmap2 = await createImageBitmap(imageBitmap0);
+try {
+computePassEncoder2.setBindGroup(
+5,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+40,
+0,
+232,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(
+476
+);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+261.6,
+0.9086,
+21.63,
+0.04544,
+0.1062,
+0.9803
+);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+0,
+buffer0,
+7924,
+1182
+);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(
+6,
+buffer0,
+212,
+9207
+);
+} catch {}
+let sampler20 = device0.createSampler(
+{
+label: '\u9522\u{1f6cd}\u1e6a\u{1f9ed}\u05da\u6fcb\u7e48',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 12.162,
+lodMaxClamp: 14.953,
+compare: 'less-equal',
+}
+);
+try {
+renderBundleEncoder6.setBindGroup(
+8,
+bindGroup0
+);
+} catch {}
+try {
+computePassEncoder0.insertDebugMarker(
+'\uf9ce'
+);
+} catch {}
+let pipeline9 = device0.createRenderPipeline(
+{
+label: '\u7b94\u02dd\u{1f7a7}\u{1f864}\u{1f872}\u{1fc39}\u0552\u7d10\u{1fa72}\u3844',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 30256,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 22396,
+shaderLocation: 7,
+},
+{
+format: 'uint32x2',
+offset: 8528,
+shaderLocation: 4,
+},
+{
+format: 'float16x2',
+offset: 8692,
+shaderLocation: 18,
+},
+{
+format: 'unorm16x2',
+offset: 2044,
+shaderLocation: 14,
+},
+{
+format: 'uint8x2',
+offset: 8996,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 12224,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 1504,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x2',
+offset: 8232,
+shaderLocation: 3,
+},
+{
+format: 'uint16x2',
+offset: 17188,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x4',
+offset: 31092,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 31572,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x2',
+offset: 3818,
+shaderLocation: 16,
+},
+{
+format: 'snorm8x4',
+offset: 27164,
+shaderLocation: 1,
+},
+{
+format: 'sint32x2',
+offset: 13140,
+shaderLocation: 11,
+},
+{
+format: 'uint8x4',
+offset: 1240,
+shaderLocation: 0,
+},
+{
+format: 'unorm8x2',
+offset: 1498,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 1640,
+shaderLocation: 15,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 24604,
+shaderLocation: 13,
+},
+{
+format: 'sint32x2',
+offset: 24752,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x4',
+offset: 4928,
+shaderLocation: 10,
+},
+{
+format: 'float32x4',
+offset: 30592,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+multisample: {
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'invert',
+depthFailOp: 'invert',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'invert',
+passOp: 'replace',
+},
+depthBias: 36,
+depthBiasSlopeScale: 83,
+depthBiasClamp: 2,
+},
+}
+);
+try {
+renderPassEncoder1.setScissorRect(
+158,
+1,
+134,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(
+1530
+);
+} catch {}
+try {
+renderPassEncoder1.setViewport(
+166.4,
+0.4016,
+108.3,
+0.4899,
+0.9151,
+0.9951
+);
+} catch {}
+let pipeline10 = await device0.createRenderPipelineAsync(
+{
+label: '\ua23a\ueac4\u06cc\u08b0\u{1ffae}\u{1f8b5}\u1515\u0eea\u{1f998}\u0362',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 3008,
+shaderLocation: 6,
+},
+{
+format: 'sint32x3',
+offset: 34296,
+shaderLocation: 10,
+},
+{
+format: 'sint8x4',
+offset: 5456,
+shaderLocation: 15,
+},
+{
+format: 'uint32x3',
+offset: 23272,
+shaderLocation: 14,
+},
+{
+format: 'uint8x2',
+offset: 32328,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 8360,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x3',
+offset: 468,
+shaderLocation: 2,
+},
+{
+format: 'unorm8x4',
+offset: 4764,
+shaderLocation: 1,
+},
+{
+format: 'unorm16x2',
+offset: 2932,
+shaderLocation: 17,
+},
+{
+format: 'sint32x2',
+offset: 2136,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x4',
+offset: 8160,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 10376,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x2',
+offset: 6826,
+shaderLocation: 7,
+},
+{
+format: 'uint32x3',
+offset: 2908,
+shaderLocation: 18,
+},
+{
+format: 'uint8x2',
+offset: 9866,
+shaderLocation: 13,
+},
+{
+format: 'snorm16x4',
+offset: 8080,
+shaderLocation: 8,
+},
+{
+format: 'uint16x2',
+offset: 612,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 27552,
+attributes: [
+{
+format: 'uint32',
+offset: 23964,
+shaderLocation: 16,
+},
+{
+format: 'uint32x4',
+offset: 4408,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x2',
+offset: 26284,
+shaderLocation: 0,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 23764,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'none',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x2f02d9ca,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r16uint',
+writeMask: 0,
+},
+undefined,
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 4061,
+stencilWriteMask: 2011,
+depthBias: 64,
+depthBiasSlopeScale: 41,
+depthBiasClamp: 100,
+},
+}
+);
+offscreenCanvas1.width = 785;
+let imageData2 = new ImageData(164, 148);
+let commandEncoder9 = device0.createCommandEncoder(
+{
+label: '\u0fdc\u0173\u9927\u0155',
+}
+);
+let renderPassEncoder3 = commandEncoder9.beginRenderPass(
+{
+label: '\u64d4\u031a\u702c\u0d54\u{1fd53}\u5863',
+colorAttachments: [
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView9,
+depthClearValue: 8.408766304582276,
+depthReadOnly: true,
+stencilReadOnly: true,
+},
+maxDrawCount: 15288,
+}
+);
+try {
+computePassEncoder2.setBindGroup(
+6,
+bindGroup0,
+new Uint32Array(1518),
+142,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -900.4, g: 784.8, b: -44.75, a: 359.1, });
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+122,
+1,
+138,
+0
+);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+6,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+4,
+bindGroup0,
+new Uint32Array(1375),
+183,
+0
+);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+gc();
+try {
+adapter1.label = '\u1163\u0e9d\u879d\u2763\u{1fcdd}\u07cb\u{1ff85}\u{1fd30}\u0cee';
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(
+8,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(310);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+141,
+0,
+58,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+3,
+buffer0,
+8420,
+2734
+);
+} catch {}
+try {
+renderBundleEncoder7.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture6,
+  mipLevel: 1,
+  origin: { x: 8, y: 60, z: 20 },
+  aspect: 'all',
+},
+new DataView(arrayBuffer0),
+/* required buffer size: 5068897 */{
+offset: 215,
+bytesPerRow: 378,
+rowsPerImage: 285,
+},
+{width: 20, height: 60, depthOrArrayLayers: 48}
+);
+} catch {}
+let gpuCanvasContext2 = canvas0.getContext('webgpu');
+let texture10 = device0.createTexture(
+{
+label: '\u0502\uba9b\u0efc\u07a3',
+size: [171, 135, 1],
+mipLevelCount: 7,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+71,
+1,
+170,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+5,
+buffer0,
+10040,
+899
+);
+} catch {}
+try {
+commandEncoder6.copyBufferToBuffer(
+buffer4,
+1476,
+buffer2,
+30296,
+100
+);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let bindGroupLayout4 = device0.createBindGroupLayout(
+{
+label: '\u6678\u{1fe02}\u235d\ue680\u0780\u0b0e\u0eec\u{1f7b8}',
+entries: [
+{
+binding: 7623,
+visibility: GPUShaderStage.FRAGMENT,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 2910,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+let commandBuffer0 = commandEncoder6.finish();
+let texture11 = device0.createTexture(
+{
+label: '\uab5e\u898e\u0d15\ue4ee\u0632\u6b3b\u4e17',
+size: [80, 132, 1],
+mipLevelCount: 4,
+sampleCount: 1,
+format: 'etc2-rgb8a1unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+renderPassEncoder3.setScissorRect(
+208,
+1,
+84,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+21.02,
+0.6920,
+211.6,
+0.1108,
+0.4047,
+0.5797
+);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+let pipeline11 = device0.createRenderPipeline(
+{
+label: '\u04bd\u{1fbf9}\u0f3f\u64bd',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 2684,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 11816,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 472,
+shaderLocation: 13,
+},
+{
+format: 'uint8x4',
+offset: 9480,
+shaderLocation: 6,
+},
+{
+format: 'sint32x2',
+offset: 1512,
+shaderLocation: 15,
+},
+{
+format: 'float32',
+offset: 4940,
+shaderLocation: 0,
+},
+{
+format: 'uint32x4',
+offset: 9924,
+shaderLocation: 14,
+},
+{
+format: 'uint32',
+offset: 972,
+shaderLocation: 12,
+},
+{
+format: 'float16x2',
+offset: 8076,
+shaderLocation: 5,
+},
+{
+format: 'snorm8x2',
+offset: 5624,
+shaderLocation: 17,
+},
+{
+format: 'float32x3',
+offset: 76,
+shaderLocation: 8,
+},
+{
+format: 'uint16x2',
+offset: 2020,
+shaderLocation: 16,
+},
+{
+format: 'uint16x4',
+offset: 10388,
+shaderLocation: 3,
+},
+{
+format: 'snorm8x4',
+offset: 5444,
+shaderLocation: 1,
+},
+{
+format: 'uint32x3',
+offset: 508,
+shaderLocation: 7,
+},
+{
+format: 'sint32x2',
+offset: 808,
+shaderLocation: 10,
+},
+{
+format: 'uint16x4',
+offset: 3828,
+shaderLocation: 11,
+},
+{
+format: 'uint16x4',
+offset: 3464,
+shaderLocation: 18,
+},
+{
+format: 'sint16x2',
+offset: 10716,
+shaderLocation: 4,
+},
+{
+format: 'float16x2',
+offset: 2312,
+shaderLocation: 9,
+},
+{
+format: 'uint32x2',
+offset: 8956,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'one-minus-constant',
+dstFactor: 'src'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'src-alpha-saturated',
+dstFactor: 'one-minus-constant'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.GREEN,
+},
+undefined,
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+let gpuCanvasContext3 = offscreenCanvas3.getContext('webgpu');
+try {
+offscreenCanvas4.getContext('bitmaprenderer');
+} catch {}
+let shaderModule3 = device0.createShaderModule(
+{
+label: '\u{1fd39}\ub2da',
+code: `@group(0) @binding(6973)
+var<storage, read_write> global8: array<u32>;
+@group(1) @binding(6973)
+var<storage, read_write> field8: array<u32>;
+@group(8) @binding(6973)
+var<storage, read_write> field9: array<u32>;
+@group(1) @binding(2242)
+var<storage, read_write> type9: array<u32>;
+@group(3) @binding(2242)
+var<storage, read_write> type10: array<u32>;
+@group(7) @binding(6973)
+var<storage, read_write> function8: array<u32>;
+@group(4) @binding(6973)
+var<storage, read_write> field10: array<u32>;
+@group(0) @binding(6956)
+var<storage, read_write> function9: array<u32>;
+@group(8) @binding(6956)
+var<storage, read_write> parameter6: array<u32>;
+@group(6) @binding(6973)
+var<storage, read_write> local7: array<u32>;
+@group(4) @binding(2242)
+var<storage, read_write> type11: array<u32>;
+@group(3) @binding(6973)
+var<storage, read_write> i8: array<u32>;
+@group(8) @binding(2242)
+var<storage, read_write> i9: array<u32>;
+@group(2) @binding(6973)
+var<storage, read_write> parameter7: array<u32>;
+@group(6) @binding(6956)
+var<storage, read_write> local8: array<u32>;
+
+@compute @workgroup_size(6, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(7) f0: vec3<i32>,
+@location(3) f1: vec4<u32>,
+@location(1) f2: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @location(38) a1: vec4<u32>, @builtin(sample_mask) a2: u32, @location(35) a3: vec4<f16>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S2 {
+@location(17) f0: f32,
+@location(11) f1: vec2<i32>,
+@location(3) f2: vec3<i32>
+}
+struct VertexOutput0 {
+@location(35) f0: vec4<f16>,
+@location(41) f1: vec3<i32>,
+@location(44) f2: vec2<f32>,
+@location(24) f3: u32,
+@location(3) f4: f16,
+@location(48) f5: vec2<u32>,
+@builtin(position) f6: vec4<f32>,
+@location(38) f7: vec4<u32>,
+@location(0) f8: u32
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec3<f32>, a1: S2) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let querySet11 = device0.createQuerySet({
+label: '\ua79f\u0b25\u8cbd\u{1f8e7}\u1763\u{1fa5e}\u{1fbc4}\uf76c\u05e8\u7916',
+type: 'occlusion',
+count: 798,
+});
+let textureView13 = texture5.createView(
+{
+label: '\u7e28\u1403\u0dd5\u7982\u0110\u6683\u0051\u0989\u015a\u026f',
+baseMipLevel: 2,
+mipLevelCount: 4,
+baseArrayLayer: 48,
+arrayLayerCount: 73,
+}
+);
+let renderBundle15 = renderBundleEncoder5.finish(
+{
+label: '\u8071\u08a9\u7515'
+}
+);
+try {
+renderPassEncoder3.setBindGroup(
+4,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+183,
+1,
+59,
+0
+);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+4,
+bindGroup0
+);
+} catch {}
+try {
+querySet1.destroy();
+} catch {}
+let pipeline12 = await device0.createRenderPipelineAsync(
+{
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 5472,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 4424,
+shaderLocation: 18,
+},
+{
+format: 'float16x4',
+offset: 4136,
+shaderLocation: 5,
+},
+{
+format: 'uint16x2',
+offset: 1772,
+shaderLocation: 14,
+},
+{
+format: 'snorm8x2',
+offset: 2176,
+shaderLocation: 9,
+},
+{
+format: 'uint32x2',
+offset: 4436,
+shaderLocation: 16,
+},
+{
+format: 'uint16x2',
+offset: 1308,
+shaderLocation: 11,
+},
+{
+format: 'uint32x2',
+offset: 5080,
+shaderLocation: 3,
+},
+{
+format: 'uint16x2',
+offset: 4192,
+shaderLocation: 13,
+},
+{
+format: 'float16x4',
+offset: 3360,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 15392,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 14816,
+shaderLocation: 12,
+},
+{
+format: 'uint16x2',
+offset: 2924,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 2700,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x2',
+offset: 2660,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 6372,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 1120,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 30272,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 4696,
+shaderLocation: 7,
+},
+{
+format: 'sint16x2',
+offset: 156,
+shaderLocation: 15,
+},
+{
+format: 'unorm8x4',
+offset: 26532,
+shaderLocation: 1,
+},
+{
+format: 'sint8x4',
+offset: 3036,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 30280,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x4',
+offset: 6076,
+shaderLocation: 17,
+},
+{
+format: 'float32',
+offset: 3776,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0xa85feab4,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'r32float',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'r8uint',
+writeMask: 0,
+},
+undefined,
+{
+format: 'rgba32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+}
+],
+},
+}
+);
+let texture12 = device0.createTexture(
+{
+label: '\u{1fa71}\u993a',
+size: {width: 2086},
+dimension: '1d',
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundleEncoder10 = device0.createRenderBundleEncoder(
+{
+label: '\u{1fd9c}\u{1f8ae}',
+colorFormats: [
+'rgba16uint',
+'r8sint',
+'rg32sint',
+'rg8unorm'
+],
+sampleCount: 580,
+depthReadOnly: true,
+}
+);
+let renderBundle16 = renderBundleEncoder1.finish(
+{
+label: '\u0169\u{1fdc8}\ua2af\uaf38\u{1f90f}\u3c17\u{1f648}\u{1f7b8}'
+}
+);
+let sampler21 = device0.createSampler(
+{
+label: '\ub1a1\u5c68\uc0e3\u{1ff12}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 85.191,
+maxAnisotropy: 16,
+}
+);
+try {
+renderPassEncoder2.beginOcclusionQuery(305);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+32,
+0,
+265,
+1
+);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(
+5,
+buffer0,
+5668,
+2204
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+computePassEncoder2.setBindGroup(
+0,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+1,
+bindGroup0,
+new Uint32Array(1388),
+218,
+0
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+11,
+buffer0,
+2308
+);
+} catch {}
+let promise5 = device0.createRenderPipelineAsync(
+{
+label: '\u0ff3\u{1f908}\u595a\u{1fda0}\ubb58\udd5a',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 16772,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 15676,
+shaderLocation: 3,
+},
+{
+format: 'unorm16x4',
+offset: 15264,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 31132,
+attributes: [
+{
+format: 'float32x2',
+offset: 10460,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 5664,
+attributes: [
+
+],
+},
+{
+arrayStride: 17648,
+attributes: [
+
+],
+},
+{
+arrayStride: 8128,
+attributes: [
+
+],
+},
+{
+arrayStride: 15328,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 34376,
+attributes: [
+
+],
+},
+{
+arrayStride: 4572,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 9036,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 5860,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule3,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'replace',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 3514,
+stencilWriteMask: 946,
+depthBias: 11,
+depthBiasSlopeScale: 67,
+depthBiasClamp: 83,
+},
+}
+);
+let texture13 = device0.createTexture(
+{
+label: '\u0688\u{1f947}\ud5d3\ua2c5\u07e1\u6a68\u0469\u2367\u0ca2',
+size: {width: 979, height: 1, depthOrArrayLayers: 1316},
+dimension: '3d',
+format: 'rg32float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32float',
+'rg32float'
+],
+}
+);
+try {
+renderPassEncoder2.setBindGroup(
+2,
+bindGroup0,
+new Uint32Array(8086),
+482,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+299,
+1,
+1,
+0
+);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(
+3796
+);
+} catch {}
+try {
+renderPassEncoder1.setViewport(
+112.8,
+0.7447,
+32.93,
+0.1823,
+0.6402,
+0.8164
+);
+} catch {}
+let pipeline13 = await device0.createComputePipelineAsync(
+{
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let canvas1 = document.createElement('canvas');
+let buffer5 = device0.createBuffer(
+{
+label: '\u024c\u091c\u{1fcc1}\u3db8',
+size: 14063,
+usage: GPUBufferUsage.QUERY_RESOLVE,
+}
+);
+let texture14 = device0.createTexture(
+{
+label: '\u0b75\u0a03\u4de7\u027f\u69f6\u7e93\uf2a0\u0965',
+size: {width: 5701},
+dimension: '1d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+}
+);
+let renderBundleEncoder11 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+undefined,
+'rgba8uint',
+'rgb10a2uint',
+'rg16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 124,
+}
+);
+try {
+computePassEncoder2.setBindGroup(
+8,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 309.0, g: 721.6, b: 514.7, a: -696.8, });
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+185,
+1,
+20,
+0
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+20016,
+new Float32Array(23153),
+13371,
+244
+);
+} catch {}
+let pipeline14 = await device0.createComputePipelineAsync(
+{
+label: '\u00f0\u589b\u0166\u{1fbf8}\u{1f953}\u{1fbd5}\u{1f60b}\u{1f6ed}',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let querySet12 = device0.createQuerySet({
+type: 'occlusion',
+count: 2613,
+});
+let renderBundle17 = renderBundleEncoder10.finish(
+{
+label: '\uc355\u29b5\u{1f9b0}\u13a8\u{1fcb6}\ude3b\ud955\u0c59\u14e4'
+}
+);
+try {
+renderPassEncoder3.setStencilReference(
+1663
+);
+} catch {}
+try {
+texture3.destroy();
+} catch {}
+gc();
+let querySet13 = device0.createQuerySet({
+type: 'occlusion',
+count: 3493,
+});
+let renderBundle18 = renderBundleEncoder7.finish();
+try {
+renderPassEncoder2.setBindGroup(
+4,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+112,
+1,
+9,
+0
+);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(
+802
+);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(
+3,
+bindGroup0
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+7360,
+new BigUint64Array(21701),
+6796,
+1864
+);
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+let pipeline15 = device0.createRenderPipeline(
+{
+label: '\u06a0\u{1fdb6}\u{1fc14}\u0abd\u0929\uc025\u0ea6\u868a',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 34940,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 3982,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 29828,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x4',
+offset: 18580,
+shaderLocation: 3,
+},
+{
+format: 'sint32',
+offset: 14452,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 33844,
+attributes: [
+{
+format: 'float16x4',
+offset: 32184,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule3,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+{
+format: 'rgba32uint',
+},
+undefined,
+undefined,
+undefined
+],
+},
+}
+);
+let sampler22 = device0.createSampler(
+{
+label: '\u087e\u03e2\u04e2\u05ad\u{1fa67}\u235c\u0621\u236e',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 17.939,
+lodMaxClamp: 48.479,
+maxAnisotropy: 9,
+}
+);
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+166,
+1,
+95,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.setViewport(
+119.6,
+0.1844,
+91.07,
+0.8110,
+0.5391,
+0.5827
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 1575, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(arrayBuffer0),
+/* required buffer size: 564 */{
+offset: 564,
+},
+{width: 361, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let textureView14 = texture4.createView(
+{
+aspect: 'depth-only',
+baseMipLevel: 3,
+mipLevelCount: 1,
+baseArrayLayer: 3,
+arrayLayerCount: 7,
+}
+);
+let sampler23 = device0.createSampler(
+{
+label: '\u{1f7b4}\u0bb1\u6a1e\u1ba3\u{1fd46}\ube86\ue6a4\u034c',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 21.565,
+lodMaxClamp: 31.418,
+}
+);
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+41,
+0,
+157,
+0
+);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(
+1509
+);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(
+5,
+bindGroup0,
+[]
+);
+} catch {}
+try {
+buffer1.destroy();
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 206, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(0),
+/* required buffer size: 798 */{
+offset: 798,
+},
+{width: 1514, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let commandEncoder10 = device0.createCommandEncoder(
+{
+label: '\u{1f61b}\u053b\u4452',
+}
+);
+let renderBundle19 = renderBundleEncoder8.finish(
+{
+
+}
+);
+let sampler24 = device0.createSampler(
+{
+label: '\u{1f62f}\uf617\ue0dd\ued94\u{1ff3b}\u0681\u{1f7d6}\uec53\u766b\u{1fc2d}\u1635',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 14.796,
+lodMaxClamp: 80.440,
+maxAnisotropy: 11,
+}
+);
+try {
+renderPassEncoder3.setBindGroup(
+1,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(
+8,
+buffer0,
+1792,
+4934
+);
+} catch {}
+try {
+commandEncoder10.clearBuffer(
+buffer2,
+20960,
+8640
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let pipeline16 = await device0.createRenderPipelineAsync(
+{
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 7872,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 964,
+shaderLocation: 1,
+},
+{
+format: 'uint32x2',
+offset: 4560,
+shaderLocation: 5,
+},
+{
+format: 'sint32x4',
+offset: 3168,
+shaderLocation: 11,
+},
+{
+format: 'float16x4',
+offset: 3252,
+shaderLocation: 7,
+},
+{
+format: 'snorm8x2',
+offset: 4644,
+shaderLocation: 6,
+},
+{
+format: 'unorm16x2',
+offset: 7560,
+shaderLocation: 15,
+},
+{
+format: 'snorm8x2',
+offset: 2598,
+shaderLocation: 13,
+},
+{
+format: 'float16x2',
+offset: 844,
+shaderLocation: 14,
+},
+{
+format: 'float16x4',
+offset: 6780,
+shaderLocation: 2,
+},
+{
+format: 'uint16x4',
+offset: 1168,
+shaderLocation: 4,
+},
+{
+format: 'uint32x2',
+offset: 4800,
+shaderLocation: 12,
+},
+{
+format: 'sint16x4',
+offset: 1272,
+shaderLocation: 17,
+},
+{
+format: 'snorm16x2',
+offset: 3624,
+shaderLocation: 10,
+},
+{
+format: 'uint8x4',
+offset: 5896,
+shaderLocation: 0,
+},
+{
+format: 'uint32x4',
+offset: 3960,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x4',
+offset: 5332,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 9148,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 8912,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x4',
+offset: 748,
+shaderLocation: 8,
+},
+{
+format: 'snorm16x2',
+offset: 2732,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 10912,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 26040,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 9648,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 5660,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 2912,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 23532,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 19164,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32',
+offset: 4444,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0xb9c89e80,
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r32sint',
+},
+{
+format: 'rg8uint',
+},
+{
+format: 'r8unorm',
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'src',
+dstFactor: 'zero'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'bgra8unorm',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater-equal',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 1738,
+stencilWriteMask: 1464,
+depthBias: 48,
+depthBiasSlopeScale: 48,
+depthBiasClamp: 70,
+},
+}
+);
+document.body.prepend(img1);
+let videoFrame4 = new VideoFrame(canvas1, {timestamp: 0});
+let querySet14 = device0.createQuerySet({
+label: '\u{1f721}\u01a1\uaf9a\u0ab2\ufb17\u0fb0',
+type: 'occlusion',
+count: 3947,
+});
+let textureView15 = texture12.createView(
+{
+mipLevelCount: 1,
+}
+);
+try {
+renderPassEncoder1.setScissorRect(
+240,
+0,
+59,
+1
+);
+} catch {}
+try {
+commandEncoder4.copyBufferToTexture(
+{
+/* bytesInLastRow: 136 widthInBlocks: 17 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 57632 */
+offset: 57632,
+rowsPerImage: 260,
+buffer: buffer3,
+},
+{
+  texture: texture2,
+  mipLevel: 5,
+  origin: { x: 38, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 17, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+renderBundleEncoder3.insertDebugMarker(
+'\u0579'
+);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer0,
+]);
+} catch {}
+offscreenCanvas2.width = 675;
+let offscreenCanvas5 = new OffscreenCanvas(899, 988);
+let textureView16 = texture4.createView(
+{
+label: '\ub2e0\u06cb\u{1f91d}\u0398\u2b3e\u{1f64c}\ub027\u{1fb96}\u009c',
+dimension: '2d',
+aspect: 'depth-only',
+mipLevelCount: 2,
+baseArrayLayer: 19,
+}
+);
+let renderBundleEncoder12 = device0.createRenderBundleEncoder(
+{
+label: '\u09d7\u6655\u{1fbb3}\u458a\u7663',
+colorFormats: [
+'bgra8unorm-srgb',
+'rg16float'
+],
+sampleCount: 235,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(
+8,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(
+9,
+buffer0,
+5736,
+2136
+);
+} catch {}
+try {
+commandEncoder10.copyBufferToBuffer(
+buffer3,
+48244,
+buffer2,
+812,
+3092
+);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder10.clearBuffer(
+buffer2,
+35156,
+1584
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView17 = texture5.createView(
+{
+dimension: '2d',
+aspect: 'depth-only',
+baseMipLevel: 8,
+baseArrayLayer: 237,
+}
+);
+let renderPassEncoder4 = commandEncoder4.beginRenderPass(
+{
+label: '\u9382\u787b\u{1fe32}\u228f\u4aea',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView9,
+depthClearValue: 0.7472833518551169,
+depthLoadOp: 'clear',
+depthStoreOp: 'discard',
+stencilClearValue: 56633,
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet9,
+maxDrawCount: 411032,
+}
+);
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+commandEncoder10.clearBuffer(
+buffer2,
+18456,
+16280
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let pipeline17 = await device0.createComputePipelineAsync(
+{
+layout: 'auto',
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+},
+}
+);
+let pipeline18 = await device0.createRenderPipelineAsync(
+{
+label: '\u4b63\u0760\ud1fd\ubbd7\u014f',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 28940,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 21576,
+shaderLocation: 2,
+},
+{
+format: 'sint32x2',
+offset: 13484,
+shaderLocation: 10,
+},
+{
+format: 'snorm16x4',
+offset: 24884,
+shaderLocation: 17,
+},
+{
+format: 'uint32x3',
+offset: 4640,
+shaderLocation: 14,
+},
+{
+format: 'float32',
+offset: 16884,
+shaderLocation: 5,
+},
+{
+format: 'uint8x4',
+offset: 1408,
+shaderLocation: 7,
+},
+{
+format: 'float32',
+offset: 6536,
+shaderLocation: 9,
+},
+{
+format: 'uint32x4',
+offset: 25992,
+shaderLocation: 18,
+},
+{
+format: 'sint32',
+offset: 20648,
+shaderLocation: 4,
+},
+{
+format: 'uint16x2',
+offset: 1668,
+shaderLocation: 6,
+},
+{
+format: 'float32x3',
+offset: 13204,
+shaderLocation: 0,
+},
+{
+format: 'uint32x4',
+offset: 18240,
+shaderLocation: 13,
+},
+{
+format: 'float32x4',
+offset: 20060,
+shaderLocation: 8,
+},
+{
+format: 'uint16x2',
+offset: 22528,
+shaderLocation: 16,
+},
+{
+format: 'sint8x2',
+offset: 13530,
+shaderLocation: 15,
+},
+{
+format: 'uint8x4',
+offset: 25272,
+shaderLocation: 3,
+},
+{
+format: 'float16x2',
+offset: 21216,
+shaderLocation: 1,
+},
+{
+format: 'uint32',
+offset: 13100,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 9672,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 4732,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'back',
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+passOp: 'keep',
+},
+stencilBack: {
+compare: 'greater-equal',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 3990,
+stencilWriteMask: 3968,
+depthBias: 93,
+depthBiasSlopeScale: 29,
+},
+}
+);
+let bindGroupLayout5 = device0.createBindGroupLayout(
+{
+label: '\ufbe2\u{1f9e8}\u{1fdbd}\u0ab1\ucd5b\ubc76\u{1fe39}\u{1f9c2}\ub1af',
+entries: [
+{
+binding: 1972,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'storage', minBindingSize: 537287, hasDynamicOffset: false },
+}
+],
+}
+);
+let querySet15 = device0.createQuerySet({
+label: '\ufeca\u620c\u{1fd3a}\u4e17\uc540\ufd43\u0152',
+type: 'occlusion',
+count: 327,
+});
+let textureView18 = texture7.createView(
+{
+label: '\u{1fdcd}\u0d10',
+baseArrayLayer: 0,
+}
+);
+let renderPassEncoder5 = commandEncoder5.beginRenderPass(
+{
+label: '\ud0da\u0560\u617a\ube48\u{1f65a}\ufced\uf49d',
+colorAttachments: [
+
+],
+depthStencilAttachment: {
+view: textureView4,
+depthClearValue: 0.3100994274556048,
+depthLoadOp: 'clear',
+depthStoreOp: 'discard',
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet9,
+maxDrawCount: 320496,
+}
+);
+let renderBundle20 = renderBundleEncoder3.finish(
+{
+label: '\u{1fdac}\u{1f73b}\u138e\ua404\u{1f924}'
+}
+);
+let sampler25 = device0.createSampler(
+{
+label: '\uf702\u5ff2\u73db\u08f9\u6d8f\u3b1c\uab22\u0e96\uec21\u4688',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 47.124,
+lodMaxClamp: 76.591,
+}
+);
+try {
+renderPassEncoder2.beginOcclusionQuery(388);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(
+10,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(
+5,
+buffer0,
+5544,
+5401
+);
+} catch {}
+try {
+gpuCanvasContext3.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let pipeline19 = await device0.createComputePipelineAsync(
+{
+label: '\uc892\u1d43\u{1f787}\u9308\uf34a',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+renderPassEncoder3.setVertexBuffer(
+6,
+buffer0,
+10688,
+385
+);
+} catch {}
+try {
+commandEncoder10.clearBuffer(
+buffer2,
+33132,
+124
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 1741, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Float64Array(new ArrayBuffer(32)),
+/* required buffer size: 343 */{
+offset: 343,
+bytesPerRow: 1124,
+},
+{width: 251, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let textureView19 = texture12.createView(
+{
+label: '\u{1f746}\uca57\ub077\u0b68\u8486',
+}
+);
+let computePassEncoder4 = commandEncoder10.beginComputePass(
+{
+label: '\u3560\u0ed8\u0eb1'
+}
+);
+let renderBundle21 = renderBundleEncoder10.finish(
+{
+label: '\u0b77\u1f82\u75af\u46e1'
+}
+);
+try {
+computePassEncoder4.setBindGroup(
+5,
+bindGroup0,
+new Uint32Array(7697),
+7625,
+0
+);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(
+0,
+buffer0,
+7436,
+262
+);
+} catch {}
+let pipeline20 = device0.createRenderPipeline(
+{
+label: '\u5533\u099b\u0785\u2b22\u0887\u1120\u{1f795}\u5402\ue8d8\u01db\u339c',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 14200,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x4',
+offset: 8584,
+shaderLocation: 18,
+},
+{
+format: 'sint16x4',
+offset: 3932,
+shaderLocation: 11,
+},
+{
+format: 'uint32x4',
+offset: 4240,
+shaderLocation: 4,
+},
+{
+format: 'snorm16x2',
+offset: 5576,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x2',
+offset: 12374,
+shaderLocation: 14,
+},
+{
+format: 'uint32x3',
+offset: 2320,
+shaderLocation: 0,
+},
+{
+format: 'uint32x2',
+offset: 8960,
+shaderLocation: 5,
+},
+{
+format: 'sint32',
+offset: 5184,
+shaderLocation: 8,
+},
+{
+format: 'uint32x4',
+offset: 12408,
+shaderLocation: 3,
+},
+{
+format: 'float16x4',
+offset: 11868,
+shaderLocation: 2,
+},
+{
+format: 'sint16x4',
+offset: 320,
+shaderLocation: 17,
+},
+{
+format: 'float32x3',
+offset: 6248,
+shaderLocation: 1,
+},
+{
+format: 'unorm16x2',
+offset: 2428,
+shaderLocation: 10,
+},
+{
+format: 'sint32',
+offset: 11188,
+shaderLocation: 16,
+},
+{
+format: 'float32x3',
+offset: 13756,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x2',
+offset: 11056,
+shaderLocation: 6,
+},
+{
+format: 'float32x2',
+offset: 3888,
+shaderLocation: 13,
+},
+{
+format: 'float32x2',
+offset: 6696,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 11464,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 18536,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 2436,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 1748,
+shaderLocation: 12,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0xc6f3a08d,
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.ALL,
+},
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'zero',
+dstFactor: 'one-minus-src'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'one',
+dstFactor: 'one-minus-src'
+},
+},
+format: 'rg16float',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilReadMask: 1485,
+stencilWriteMask: 467,
+depthBias: 97,
+depthBiasSlopeScale: 26,
+depthBiasClamp: 90,
+},
+}
+);
+let commandEncoder11 = device0.createCommandEncoder(
+{
+}
+);
+let renderBundle22 = renderBundleEncoder10.finish(
+{
+label: '\u02a9\u030c\uefef\ub353\u526e\u5ee9\ucb94\u5761\u{1fe38}\uea6a\u586a'
+}
+);
+let sampler26 = device0.createSampler(
+{
+label: '\uf263\u0cd1\uba69\u7ad4\u350b\u0e22\u019f\u{1f635}\u8286',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMaxClamp: 18.576,
+compare: 'less',
+}
+);
+try {
+renderPassEncoder4.setBindGroup(
+1,
+bindGroup0,
+new Uint32Array(412),
+166,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+commandEncoder11.copyBufferToBuffer(
+buffer4,
+1936,
+buffer2,
+3548,
+56
+);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder11.copyTextureToTexture(
+{
+  texture: texture5,
+  mipLevel: 1,
+  origin: { x: 609, y: 42, z: 22 },
+  aspect: 'depth-only',
+},
+{
+  texture: texture5,
+  mipLevel: 3,
+  origin: { x: 0, y: 13, z: 32 },
+  aspect: 'all',
+},
+{width: 282, height: 0, depthOrArrayLayers: 200}
+);
+} catch {}
+try {
+commandEncoder11.resolveQuerySet(
+querySet13,
+2269,
+744,
+buffer5,
+5376
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture6,
+  mipLevel: 1,
+  origin: { x: 44, y: 28, z: 27 },
+  aspect: 'all',
+},
+new ArrayBuffer(56),
+/* required buffer size: 559248 */{
+offset: 476,
+bytesPerRow: 83,
+rowsPerImage: 204,
+},
+{width: 4, height: 4, depthOrArrayLayers: 34}
+);
+} catch {}
+document.body.prepend(canvas1);
+let texture15 = device0.createTexture(
+{
+label: '\u9d81\u06b6\u971d\u2996\u082e\u{1f738}\u7bef\ue386\u{1fd3b}',
+size: {width: 9832},
+dimension: '1d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rg32sint'
+],
+}
+);
+let textureView20 = texture13.createView(
+{
+label: '\u{1fc91}\u0591\u01fb',
+baseArrayLayer: 0,
+}
+);
+try {
+computePassEncoder4.setPipeline(
+pipeline19
+);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(316);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(
+3,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder11.pushDebugGroup(
+'\u527c'
+);
+} catch {}
+let pipeline21 = await promise5;
+let commandEncoder12 = device0.createCommandEncoder(
+{
+label: '\uc101\uc8af\uf09e\u{1fc0e}\ua853',
+}
+);
+let renderPassEncoder6 = commandEncoder11.beginRenderPass(
+{
+label: '\u4f62\u0f16\ucf8b\u6bd9\u0925\ue37d\u361a\u3ce9\u7f60',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView9,
+depthClearValue: 0.3194711620806985,
+depthLoadOp: 'clear',
+depthStoreOp: 'discard',
+stencilClearValue: 34101,
+},
+occlusionQuerySet: querySet8,
+maxDrawCount: 193288,
+}
+);
+let renderBundle23 = renderBundleEncoder12.finish();
+try {
+renderPassEncoder3.setBindGroup(
+0,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+7,
+bindGroup0,
+new Uint32Array(9721),
+1980,
+0
+);
+} catch {}
+try {
+renderPassEncoder6.setViewport(
+175.4,
+0.7126,
+94.14,
+0.1422,
+0.1728,
+0.9168
+);
+} catch {}
+try {
+renderBundleEncoder11.insertDebugMarker(
+'\u04cd'
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb',
+'rgba8unorm-srgb'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+20272,
+new Float32Array(64870),
+37525,
+3040
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture11,
+  mipLevel: 1,
+  origin: { x: 0, y: 24, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 822 */{
+offset: 822,
+bytesPerRow: 166,
+rowsPerImage: 30,
+},
+{width: 36, height: 28, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await promise6;
+} catch {}
+offscreenCanvas1.width = 458;
+gc();
+let canvas2 = document.createElement('canvas');
+let commandEncoder13 = device0.createCommandEncoder(
+{
+label: '\u00e6\ua63c\u{1f7ec}',
+}
+);
+let texture16 = device0.createTexture(
+{
+label: '\u49c4\u7f51\u0e7b\u{1f886}\u16a3',
+size: [10316, 2, 1],
+mipLevelCount: 2,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'depth24plus'
+],
+}
+);
+let renderBundle24 = renderBundleEncoder10.finish();
+try {
+computePassEncoder4.setPipeline(
+pipeline17
+);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(
+3,
+buffer0,
+5868,
+1550
+);
+} catch {}
+try {
+commandEncoder12.clearBuffer(
+buffer2,
+28992,
+6880
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder12.resolveQuerySet(
+querySet14,
+2648,
+1220,
+buffer5,
+256
+);
+} catch {}
+canvas1.height = 263;
+gc();
+let commandEncoder14 = device0.createCommandEncoder();
+let textureView21 = texture3.createView(
+{
+label: '\u{1fb77}\uf790\u5e73\u003a\ud904',
+dimension: '2d-array',
+format: 'depth32float',
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+let renderBundleEncoder13 = device0.createRenderBundleEncoder(
+{
+label: '\u1bb4\u069b\u{1f941}\u955d\u{1fad4}\u0a38\u110e',
+colorFormats: [
+'rgba8unorm-srgb'
+],
+sampleCount: 411,
+stencilReadOnly: true,
+}
+);
+let renderBundle25 = renderBundleEncoder7.finish(
+{
+label: '\u{1ffa6}\u{1f9c9}\ude5b\u2e4a\u0b83\u9e03\u56aa\uc8c1\u0388'
+}
+);
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant({ r: -471.0, g: 48.69, b: -826.9, a: 969.1, });
+} catch {}
+let pipeline22 = await device0.createComputePipelineAsync(
+{
+label: '\u{1ff0d}\u9a9c\ub37b\u{1f605}\u2b61\u24aa\u9ca8\u7055\u7db6\u0650\u801e',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let video3 = await videoWithData();
+try {
+canvas1.getContext('webgl2');
+} catch {}
+let bindGroupLayout6 = device0.createBindGroupLayout(
+{
+label: '\u2394\u2892\u{1fc7c}\u{1fb8f}\u{1fbcf}\u6d40\u{1f755}\ue637\u9bf8\u01b9\u0c2e',
+entries: [
+{
+binding: 5112,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 4291,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 4361,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+let texture17 = device0.createTexture(
+{
+size: [2992, 1, 133],
+mipLevelCount: 6,
+sampleCount: 1,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'stencil8',
+'stencil8'
+],
+}
+);
+let textureView22 = texture13.createView(
+{
+label: '\u629b\u4d5e\u007b\u97f5\u0fe2\u02bd\u6b17',
+dimension: '3d',
+}
+);
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: 833.9, g: 364.5, b: 709.3, a: 842.1, });
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(
+7,
+buffer0,
+8880,
+1973
+);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(
+7,
+buffer0,
+1864,
+7686
+);
+} catch {}
+let pipeline23 = await device0.createComputePipelineAsync(
+{
+label: '\u0110\u2f1d\u8a7f\u8e78\u0d22\ub1b3\u{1fa26}\u{1fc9a}',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+},
+}
+);
+let canvas3 = document.createElement('canvas');
+let shaderModule4 = device0.createShaderModule(
+{
+label: '\u0052\ufd97\ua60d\u{1fe46}\u7633\uab6d\u95cb',
+code: `@group(0) @binding(6956)
+var<storage, read_write> global9: array<u32>;
+@group(3) @binding(166)
+var<storage, read_write> parameter8: array<u32>;
+@group(3) @binding(1109)
+var<storage, read_write> function10: array<u32>;
+@group(0) @binding(2242)
+var<storage, read_write> function11: array<u32>;
+@group(3) @binding(5018)
+var<storage, read_write> parameter9: array<u32>;
+@group(2) @binding(6956)
+var<storage, read_write> type12: array<u32>;
+@group(2) @binding(6973)
+var<storage, read_write> function12: array<u32>;
+
+@compute @workgroup_size(1, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(0) f0: vec2<f32>,
+@location(7) f1: vec4<f32>,
+@location(1) f2: vec4<u32>,
+@location(2) f3: vec3<i32>,
+@location(5) f4: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(45) a0: vec4<f32>, @builtin(sample_mask) a1: u32, @builtin(sample_index) a2: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S3 {
+@location(3) f0: vec2<f32>
+}
+struct VertexOutput0 {
+@location(45) f9: vec4<f32>,
+@builtin(position) f10: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec2<f16>, @location(12) a1: vec2<u32>, @location(11) a2: vec3<f32>, @location(15) a3: vec3<f16>, @location(6) a4: u32, @location(17) a5: f32, @location(10) a6: u32, @location(4) a7: vec3<i32>, @location(13) a8: vec3<i32>, @location(5) a9: i32, @builtin(vertex_index) a10: u32, @location(2) a11: vec3<f16>, @location(9) a12: u32, @location(0) a13: vec2<i32>, @location(8) a14: vec4<u32>, @location(1) a15: vec2<u32>, @location(7) a16: f16, @location(18) a17: vec2<f16>, @location(16) a18: vec2<i32>, a19: S3, @builtin(instance_index) a20: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let computePassEncoder5 = commandEncoder12.beginComputePass(
+{
+label: '\ua3e3\u{1f628}\ua934\u7dbc\u670e\u{1fe01}\u{1fd4f}'
+}
+);
+try {
+computePassEncoder5.setBindGroup(
+10,
+bindGroup0,
+new Uint32Array(4956),
+643,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+11,
+buffer0,
+9656,
+826
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+7,
+buffer0
+);
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(
+querySet0,
+43,
+69,
+buffer5,
+4352
+);
+} catch {}
+let gpuCanvasContext4 = canvas3.getContext('webgpu');
+let canvas4 = document.createElement('canvas');
+let videoFrame5 = new VideoFrame(offscreenCanvas5, {timestamp: 0});
+let shaderModule5 = device0.createShaderModule(
+{
+label: '\u64b7\u0ecf',
+code: `@group(3) @binding(5018)
+var<storage, read_write> field11: array<u32>;
+@group(3) @binding(166)
+var<storage, read_write> function13: array<u32>;
+@group(0) @binding(6973)
+var<storage, read_write> type13: array<u32>;
+@group(2) @binding(2242)
+var<storage, read_write> global10: array<u32>;
+@group(2) @binding(6973)
+var<storage, read_write> field12: array<u32>;
+@group(3) @binding(1109)
+var<storage, read_write> function14: array<u32>;
+@group(1) @binding(1894)
+var<storage, read_write> field13: array<u32>;
+@group(0) @binding(2242)
+var<storage, read_write> field14: array<u32>;
+
+@compute @workgroup_size(3, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: vec4<f32>,
+@location(7) f1: vec4<f32>,
+@location(2) f2: vec2<u32>,
+@location(0) f3: u32,
+@location(5) f4: f32,
+@location(3) f5: vec3<f32>,
+@builtin(frag_depth) f6: f32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(front_facing) a1: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(6) a0: f16, @location(4) a1: f32, @location(5) a2: vec3<f32>, @location(13) a3: f16, @location(9) a4: f16, @builtin(instance_index) a5: u32, @location(18) a6: vec2<i32>, @location(3) a7: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let pipelineLayout3 = device0.createPipelineLayout(
+{
+label: '\uc505\u5cba\u0af5\u8e57\u{1f711}\u062e',
+bindGroupLayouts: [
+bindGroupLayout0,
+bindGroupLayout2,
+bindGroupLayout3,
+bindGroupLayout4,
+bindGroupLayout6,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout2,
+bindGroupLayout4,
+bindGroupLayout5,
+bindGroupLayout3
+]
+}
+);
+let querySet16 = device0.createQuerySet({
+label: '\u{1f7bd}\ubb6e\u{1fb35}\ucf54\ud337\u02fe\uf2e8\u14b0\u4c19',
+type: 'occlusion',
+count: 3113,
+});
+let computePassEncoder6 = commandEncoder13.beginComputePass(
+{
+label: '\u4770\uf6ec\u{1f9bb}\uaac1\u05ed\u3cb5\ue7b4\u0db4\u{1fa5e}\u{1f862}'
+}
+);
+let renderPassEncoder7 = commandEncoder14.beginRenderPass(
+{
+label: '\u1419\u3c06\u0458\uad16',
+colorAttachments: [
+
+],
+depthStencilAttachment: {
+view: textureView21,
+depthClearValue: 2.255484187111861,
+depthReadOnly: true,
+stencilClearValue: 34377,
+stencilReadOnly: true,
+},
+maxDrawCount: 23904,
+}
+);
+try {
+computePassEncoder5.setBindGroup(
+6,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(
+400
+);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+8,
+buffer0,
+5180,
+250
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+8,
+buffer0,
+2132,
+5070
+);
+} catch {}
+try {
+commandEncoder10.copyBufferToBuffer(
+buffer3,
+24164,
+buffer2,
+14316,
+14356
+);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder10.clearBuffer(
+buffer2,
+18436,
+8384
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let imageData3 = new ImageData(36, 236);
+let commandEncoder15 = device0.createCommandEncoder(
+{
+label: '\u{1fb02}\ua63c\ueb75\ud82c\u03e4\u{1f7dd}\uea47\u0cff\u77b8\u{1fe79}',
+}
+);
+let querySet17 = device0.createQuerySet({
+label: '\u42e6\u091f\ub1a0\u8a51\u7a9e\u{1fdcf}\ue2b6\u{1fe84}',
+type: 'occlusion',
+count: 2,
+});
+let renderPassEncoder8 = commandEncoder15.beginRenderPass(
+{
+label: '\u4fc4\u{1ff20}\u0288\uc8dd\u{1fb49}\ue68d\u523d\u1ac2\u47f6\ud126',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView4,
+depthLoadOp: 'load',
+depthStoreOp: 'discard',
+stencilClearValue: 50054,
+},
+occlusionQuerySet: querySet16,
+}
+);
+try {
+renderPassEncoder5.setBindGroup(
+1,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(
+1,
+bindGroup0
+);
+} catch {}
+let pipeline24 = await device0.createRenderPipelineAsync(
+{
+label: '\u06fd\uaa34',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 18768,
+attributes: [
+{
+format: 'sint16x4',
+offset: 5476,
+shaderLocation: 8,
+},
+{
+format: 'float32x3',
+offset: 15572,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 28444,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x2',
+offset: 24608,
+shaderLocation: 16,
+},
+{
+format: 'uint32',
+offset: 6728,
+shaderLocation: 5,
+},
+{
+format: 'sint32x3',
+offset: 14228,
+shaderLocation: 11,
+},
+{
+format: 'float32x4',
+offset: 19264,
+shaderLocation: 14,
+},
+{
+format: 'sint32x3',
+offset: 2140,
+shaderLocation: 17,
+},
+{
+format: 'snorm8x2',
+offset: 26512,
+shaderLocation: 9,
+},
+{
+format: 'uint32x3',
+offset: 1764,
+shaderLocation: 3,
+},
+{
+format: 'uint8x2',
+offset: 20608,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x4',
+offset: 14428,
+shaderLocation: 18,
+},
+{
+format: 'snorm8x2',
+offset: 14620,
+shaderLocation: 1,
+},
+{
+format: 'uint8x4',
+offset: 20272,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 28520,
+attributes: [
+{
+format: 'snorm8x4',
+offset: 9912,
+shaderLocation: 2,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 3680,
+shaderLocation: 13,
+},
+{
+format: 'float32',
+offset: 18624,
+shaderLocation: 6,
+},
+{
+format: 'snorm8x2',
+offset: 13498,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 12960,
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 9304,
+shaderLocation: 7,
+},
+{
+format: 'uint32',
+offset: 5040,
+shaderLocation: 12,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'one',
+dstFactor: 'zero'
+},
+},
+format: 'r16float',
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+failOp: 'invert',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'increment-clamp',
+},
+stencilWriteMask: 2150,
+depthBiasSlopeScale: 45,
+depthBiasClamp: 63,
+},
+}
+);
+let querySet18 = device0.createQuerySet({
+label: '\u8540\u0a25',
+type: 'occlusion',
+count: 1781,
+});
+let textureView23 = texture4.createView(
+{
+label: '\u00bc\uf995\u974c',
+dimension: '2d',
+aspect: 'depth-only',
+baseMipLevel: 0,
+mipLevelCount: 2,
+baseArrayLayer: 3,
+}
+);
+let computePassEncoder7 = commandEncoder10.beginComputePass(
+{
+label: '\u{1f812}\u{1f6f7}\u2630\ube6f\uf74a\u1f3b\u14e4\u03fa\u1ee0'
+}
+);
+let renderBundle26 = renderBundleEncoder9.finish(
+{
+label: '\ube62\u{1fc7c}\u0a47\u04f2\u2d67\ua040'
+}
+);
+let pipeline25 = device0.createComputePipeline(
+{
+label: '\u0812\u{1fd43}\u{1fbdb}\u99cd',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let videoFrame6 = new VideoFrame(canvas4, {timestamp: 0});
+let texture18 = gpuCanvasContext3.getCurrentTexture();
+let textureView24 = texture8.createView(
+{
+label: '\uda8a\u0630\u{1f828}\u080d\ufbc2',
+baseMipLevel: 4,
+mipLevelCount: 1,
+}
+);
+try {
+computePassEncoder5.setPipeline(
+pipeline2
+);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(
+4,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 713.8, g: 395.5, b: 912.6, a: 768.4, });
+} catch {}
+try {
+renderPassEncoder1.setViewport(
+232.7,
+0.6214,
+15.95,
+0.1253,
+0.4048,
+0.4080
+);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(
+5,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder11.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb',
+'rgba8unorm-srgb',
+'rg8sint',
+'depth32float'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline26 = device0.createRenderPipeline(
+{
+label: '\u090f\u{1fb24}',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule4,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1460,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 1052,
+shaderLocation: 18,
+},
+{
+format: 'sint32x4',
+offset: 428,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 2536,
+attributes: [
+{
+format: 'float32x3',
+offset: 2440,
+shaderLocation: 11,
+},
+{
+format: 'float32x3',
+offset: 1232,
+shaderLocation: 17,
+},
+{
+format: 'uint8x2',
+offset: 674,
+shaderLocation: 12,
+},
+{
+format: 'uint8x2',
+offset: 882,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 35204,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 27296,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x2',
+offset: 27568,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 24396,
+attributes: [
+{
+format: 'sint16x4',
+offset: 17320,
+shaderLocation: 0,
+},
+{
+format: 'sint16x2',
+offset: 9912,
+shaderLocation: 5,
+},
+{
+format: 'sint8x2',
+offset: 17392,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 32520,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x4',
+offset: 31060,
+shaderLocation: 10,
+},
+{
+format: 'sint16x2',
+offset: 7396,
+shaderLocation: 16,
+},
+{
+format: 'uint16x2',
+offset: 9108,
+shaderLocation: 6,
+},
+{
+format: 'float32',
+offset: 13844,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x4',
+offset: 16628,
+shaderLocation: 14,
+},
+{
+format: 'uint32x2',
+offset: 3752,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 13848,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x4',
+offset: 4792,
+shaderLocation: 3,
+},
+{
+format: 'uint32x4',
+offset: 2192,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule4,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+},
+{
+format: 'rgba16uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+{
+format: 'rgba32uint',
+},
+undefined
+],
+},
+}
+);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+canvas4.getContext('2d');
+} catch {}
+let commandEncoder16 = device0.createCommandEncoder(
+{
+label: '\u530d\u{1f8b6}\u9d4e\u0520\u0d83',
+}
+);
+let texture19 = device0.createTexture(
+{
+label: '\u{1fcbf}\u9318\ucc68\u00fd\u8b24\u0a6e\u{1fff2}',
+size: [7279],
+dimension: '1d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16sint',
+'rgba16sint'
+],
+}
+);
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(
+buffer4,
+1976,
+buffer2,
+21292,
+248
+);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder16.clearBuffer(
+buffer2,
+33140,
+1668
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+renderBundleEncoder11.insertDebugMarker(
+'\u{1f7dc}'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+17080,
+new Float32Array(41627),
+21364,
+3896
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 24, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 739 */{
+offset: 739,
+},
+{width: 1957, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let texture20 = gpuCanvasContext0.getCurrentTexture();
+let renderPassEncoder9 = commandEncoder16.beginRenderPass(
+{
+label: '\u{1ffc9}\u0983\u09ab\u{1fc5c}\uf278',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView21,
+depthClearValue: 8.69555487439714,
+depthLoadOp: 'load',
+depthStoreOp: 'discard',
+stencilClearValue: 36185,
+},
+occlusionQuerySet: querySet8,
+}
+);
+try {
+computePassEncoder5.setPipeline(
+pipeline22
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+5,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+8,
+bindGroup0
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture17,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 20 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer0),
+/* required buffer size: 6940188 */{
+offset: 714,
+bytesPerRow: 431,
+rowsPerImage: 161,
+},
+{width: 374, height: 1, depthOrArrayLayers: 101}
+);
+} catch {}
+let shaderModule6 = device0.createShaderModule(
+{
+label: '\u{1f7ba}\u2a8a\u0c81\u33e3\u0cc2\u{1f74f}\ua8fe\u{1fb17}\u{1f627}',
+code: `@group(3) @binding(166)
+var<storage, read_write> local9: array<u32>;
+@group(2) @binding(6956)
+var<storage, read_write> field15: array<u32>;
+@group(3) @binding(1109)
+var<storage, read_write> function15: array<u32>;
+@group(1) @binding(1894)
+var<storage, read_write> local10: array<u32>;
+@group(2) @binding(2242)
+var<storage, read_write> function16: array<u32>;
+@group(0) @binding(6973)
+var<storage, read_write> i10: array<u32>;
+@group(3) @binding(5018)
+var<storage, read_write> local11: array<u32>;
+@group(0) @binding(6956)
+var<storage, read_write> global11: array<u32>;
+
+@compute @workgroup_size(4, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S4 {
+@location(21) f0: f16,
+@location(29) f1: vec2<f16>,
+@location(12) f2: vec2<i32>,
+@location(33) f3: vec2<f32>,
+@location(35) f4: vec3<f16>,
+@location(46) f5: u32,
+@location(45) f6: vec4<f16>,
+@location(44) f7: vec2<f32>,
+@location(10) f8: vec2<f32>,
+@location(16) f9: vec2<u32>,
+@location(5) f10: vec4<f32>,
+@builtin(sample_index) f11: u32,
+@location(36) f12: vec3<f16>,
+@location(0) f13: vec3<u32>,
+@location(7) f14: vec4<i32>,
+@location(24) f15: vec4<u32>,
+@location(15) f16: vec2<i32>,
+@location(17) f17: i32,
+@location(31) f18: vec3<i32>,
+@location(30) f19: vec4<u32>,
+@location(39) f20: f32,
+@location(34) f21: vec2<f16>
+}
+struct FragmentOutput0 {
+@location(4) f0: vec2<u32>,
+@location(2) f1: vec4<i32>,
+@location(6) f2: f32
+}
+
+@fragment
+fn fragment0(a0: S4, @location(43) a1: f16, @location(32) a2: vec2<u32>, @location(1) a3: f16, @location(23) a4: vec3<f32>, @location(6) a5: vec3<f32>, @location(22) a6: vec3<f16>, @location(18) a7: vec4<i32>, @location(37) a8: u32, @location(4) a9: vec3<f16>, @location(13) a10: vec4<u32>, @builtin(front_facing) a11: bool, @builtin(position) a12: vec4<f32>, @builtin(sample_mask) a13: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(21) f11: f16,
+@location(35) f12: vec3<f16>,
+@location(16) f13: vec2<u32>,
+@location(7) f14: vec4<i32>,
+@location(32) f15: vec2<u32>,
+@location(5) f16: vec4<f32>,
+@location(0) f17: vec3<u32>,
+@location(23) f18: vec3<f32>,
+@location(6) f19: vec3<f32>,
+@location(31) f20: vec3<i32>,
+@location(10) f21: vec2<f32>,
+@builtin(position) f22: vec4<f32>,
+@location(43) f23: f16,
+@location(39) f24: f32,
+@location(34) f25: vec2<f16>,
+@location(30) f26: vec4<u32>,
+@location(4) f27: vec3<f16>,
+@location(46) f28: u32,
+@location(37) f29: u32,
+@location(33) f30: vec2<f32>,
+@location(1) f31: f16,
+@location(13) f32: vec4<u32>,
+@location(12) f33: vec2<i32>,
+@location(36) f34: vec3<f16>,
+@location(18) f35: vec4<i32>,
+@location(15) f36: vec2<i32>,
+@location(29) f37: vec2<f16>,
+@location(24) f38: vec4<u32>,
+@location(17) f39: i32,
+@location(44) f40: vec2<f32>,
+@location(45) f41: vec4<f16>,
+@location(22) f42: vec3<f16>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @builtin(instance_index) a1: u32, @location(16) a2: vec2<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let renderBundle27 = renderBundleEncoder3.finish(
+{
+label: '\ua126\ub765\u{1f8ea}\u76f0\u92c6'
+}
+);
+try {
+computePassEncoder6.setBindGroup(
+0,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(483);
+} catch {}
+try {
+renderPassEncoder6.setViewport(
+272.9,
+0.1286,
+4.027,
+0.8518,
+0.2289,
+0.9659
+);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(
+9,
+bindGroup0
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 4, y: 162 },
+  flipY: true,
+},
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device0.destroy();
+} catch {}
+try {
+computePassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder8.setViewport(
+86.30,
+0.5817,
+173.8,
+0.03585,
+0.1083,
+0.2749
+);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(
+2,
+bindGroup0,
+new Uint32Array(5566),
+1774,
+0
+);
+} catch {}
+try {
+commandEncoder12.resolveQuerySet(
+querySet8,
+356,
+156,
+buffer5,
+9728
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb',
+'r8uint',
+'bgra8unorm-srgb'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+6152,
+new BigUint64Array(324),
+85,
+164
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas3,
+  origin: { x: 68, y: 19 },
+  flipY: true,
+},
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let adapter2 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let offscreenCanvas6 = new OffscreenCanvas(14, 304);
+let video4 = await videoWithData();
+let imageData4 = new ImageData(44, 72);
+try {
+offscreenCanvas5.getContext('webgl');
+} catch {}
+document.body.prepend(video1);
+let promise7 = adapter2.requestAdapterInfo();
+try {
+offscreenCanvas6.getContext('webgl2');
+} catch {}
+let computePassEncoder8 = commandEncoder12.beginComputePass(
+{
+
+}
+);
+let renderBundle28 = renderBundleEncoder10.finish(
+{
+
+}
+);
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(
+140,
+0,
+3,
+0
+);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+9,
+bindGroup0,
+new Uint32Array(6486),
+2404,
+0
+);
+} catch {}
+let canvas5 = document.createElement('canvas');
+let gpuCanvasContext5 = canvas5.getContext('webgpu');
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageBitmap3 = await createImageBitmap(videoFrame1);
+document.body.prepend(img1);
+let offscreenCanvas7 = new OffscreenCanvas(471, 952);
+let videoFrame7 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+let bindGroupLayout7 = device0.createBindGroupLayout(
+{
+label: '\u{1f8cb}\uccff\uffa6\u0b37\u0196\u048d',
+entries: [
+{
+binding: 8113,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+},
+{
+binding: 4418,
+visibility: 0,
+externalTexture: {},
+}
+],
+}
+);
+try {
+renderPassEncoder6.setBlendConstant({ r: 750.5, g: -791.6, b: -0.08069, a: 510.2, });
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+243,
+1,
+33,
+0
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture1,
+  mipLevel: 3,
+  origin: { x: 0, y: 4, z: 26 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 3277525 */{
+offset: 419,
+bytesPerRow: 656,
+rowsPerImage: 185,
+},
+{width: 193, height: 1, depthOrArrayLayers: 28}
+);
+} catch {}
+let pipeline27 = await device0.createRenderPipelineAsync(
+{
+label: '\u013e\ud6f3\u{1f624}\u2872\u{1faf0}\u0959\u{1fbe7}\ue400',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule6,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 5432,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 34664,
+attributes: [
+
+],
+},
+{
+arrayStride: 26892,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 28904,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 20292,
+attributes: [
+
+],
+},
+{
+arrayStride: 24404,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 25944,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 32280,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 21324,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 15880,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+},
+multisample: {
+mask: 0xc3bb141d,
+},
+fragment: {
+module: shaderModule6,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilReadMask: 831,
+stencilWriteMask: 122,
+depthBias: 37,
+depthBiasSlopeScale: 85,
+depthBiasClamp: 49,
+},
+}
+);
+let img2 = await imageWithData(143, 104, '#e9170b07', '#a560d4e5');
+video1.height = 25;
+try {
+offscreenCanvas7.getContext('webgpu');
+} catch {}
+let querySet19 = device0.createQuerySet({
+label: '\u{1faf3}\u{1f6f3}\u157d\u{1f9b8}\u{1fa23}\u7029\u0903',
+type: 'occlusion',
+count: 3309,
+});
+let textureView25 = texture2.createView(
+{
+baseMipLevel: 3,
+mipLevelCount: 2,
+baseArrayLayer: 0,
+}
+);
+let renderBundleEncoder14 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba32float',
+'rg16sint',
+'r32float',
+'bgra8unorm-srgb',
+'r8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 963,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder8.setBindGroup(
+1,
+bindGroup0,
+new Uint32Array(2887),
+289,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+145,
+1,
+43,
+0
+);
+} catch {}
+try {
+renderPassEncoder4.setViewport(
+60.64,
+0.04998,
+183.1,
+0.7947,
+0.7015,
+0.7456
+);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(
+3,
+buffer0,
+5004,
+462
+);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+await promise7;
+} catch {}
+gc();
+let img3 = await imageWithData(168, 149, '#4a979f46', '#1f532b4f');
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let offscreenCanvas8 = new OffscreenCanvas(760, 388);
+try {
+offscreenCanvas8.getContext('webgpu');
+} catch {}
+offscreenCanvas2.width = 144;
+document.body.prepend(img1);
+let offscreenCanvas9 = new OffscreenCanvas(462, 351);
+gc();
+let gpuCanvasContext6 = offscreenCanvas9.getContext('webgpu');
+let gpuCanvasContext7 = canvas2.getContext('webgpu');
+let imageData5 = new ImageData(88, 164);
+let imageData6 = new ImageData(20, 136);
+let videoFrame8 = new VideoFrame(videoFrame6, {timestamp: 0});
+try {
+adapter0.label = '\u0728\uf152\uc87c\u{1fe72}\ua72f\ucef3';
+} catch {}
+let imageData7 = new ImageData(160, 256);
+let canvas6 = document.createElement('canvas');
+let imageBitmap4 = await createImageBitmap(video3);
+gc();
+let canvas7 = document.createElement('canvas');
+try {
+canvas6.getContext('webgl');
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+canvas0.width = 635;
+let adapter3 = await navigator.gpu.requestAdapter(
+{
+}
+);
+try {
+canvas7.getContext('webgpu');
+} catch {}
+let imageData8 = new ImageData(208, 252);
+document.body.prepend(canvas1);
+let imageData9 = new ImageData(240, 120);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let device1 = await adapter2.requestDevice({
+label: '\u{1f691}\u06ea\u91ba\u12f2\ub476\u0bc6\uc73b\u2fba\ud8de\uf280\u0127',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 42,
+maxVertexAttributes: 28,
+maxVertexBufferArrayStride: 62924,
+maxStorageTexturesPerShaderStage: 31,
+maxStorageBuffersPerShaderStage: 35,
+maxDynamicStorageBuffersPerPipelineLayout: 14503,
+maxBindingsPerBindGroup: 6920,
+maxTextureDimension1D: 11698,
+maxTextureDimension2D: 10765,
+maxVertexBuffers: 10,
+maxUniformBufferBindingSize: 100063698,
+maxUniformBuffersPerShaderStage: 19,
+maxInterStageShaderVariables: 109,
+maxInterStageShaderComponents: 63,
+maxSamplersPerShaderStage: 16,
+},
+});
+let promise8 = adapter3.requestAdapterInfo();
+offscreenCanvas1.height = 56;
+let renderBundleEncoder15 = device1.createRenderBundleEncoder(
+{
+label: '\u0f55\u5dca\u7ab9\ud556\u{1ff3a}\u6b61\ubdb7\ud715\u28ad',
+colorFormats: [
+undefined,
+'rg16uint',
+'rg32uint',
+'rg11b10ufloat',
+'rg32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 376,
+stencilReadOnly: true,
+}
+);
+let sampler27 = device1.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 54.809,
+lodMaxClamp: 66.021,
+maxAnisotropy: 5,
+}
+);
+let imageBitmap5 = await createImageBitmap(video2);
+try {
+device1.queue.label = '\u5cf1\u4332\ub1a6';
+} catch {}
+try {
+gpuCanvasContext6.configure(
+{
+device: device1,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm',
+'rgba32float',
+'rgba16uint'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let promise9 = device1.queue.onSubmittedWorkDone();
+canvas3.width = 608;
+let offscreenCanvas10 = new OffscreenCanvas(26, 215);
+let videoFrame9 = new VideoFrame(img2, {timestamp: 0});
+let buffer6 = device1.createBuffer(
+{
+label: '\u1669\u01df\u{1f890}\u8835\u{1f8da}\u0ec2\u0a60\ubdca\u11b0',
+size: 10843,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+mappedAtCreation: false,
+}
+);
+let commandEncoder17 = device1.createCommandEncoder(
+{
+label: '\u06e1\u{1fb1d}\u{1f914}\uc2c4\ud8c8\u7082\ud27f\u{1fc91}\ueffb\u85a4\u2934',
+}
+);
+try {
+renderBundleEncoder15.setIndexBuffer(
+buffer6,
+'uint32'
+);
+} catch {}
+let gpuCanvasContext8 = offscreenCanvas10.getContext('webgpu');
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+try {
+await promise8;
+} catch {}
+let texture21 = device1.createTexture(
+{
+size: {width: 3830},
+dimension: '1d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let promise10 = device1.popErrorScope();
+try {
+buffer6.unmap();
+} catch {}
+let buffer7 = device1.createBuffer(
+{
+label: '\ub3c0\u8f07\u{1f773}\u67d6',
+size: 13394,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+}
+);
+let renderBundle29 = renderBundleEncoder15.finish(
+{
+label: '\uc787\u5b37'
+}
+);
+video3.width = 272;
+canvas4.height = 220;
+gc();
+let imageBitmap6 = await createImageBitmap(offscreenCanvas7);
+let commandEncoder18 = device1.createCommandEncoder(
+{
+}
+);
+let textureView26 = texture21.createView(
+{
+label: '\u{1fa7f}\u0b81\u0246\u{1f8d8}',
+}
+);
+try {
+commandEncoder17.clearBuffer(
+buffer7,
+10796,
+324
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder17.insertDebugMarker(
+'\ud812'
+);
+} catch {}
+let commandEncoder19 = device1.createCommandEncoder(
+{
+label: '\u0e3d\ucca6\u375f\u0580\u{1f9df}\u{1fb18}\u{1f7f3}\uff6b\ubefb\u0311',
+}
+);
+let textureView27 = texture21.createView(
+{
+aspect: 'all',
+}
+);
+let computePassEncoder9 = commandEncoder17.beginComputePass(
+{
+label: '\u{1fd92}\u0147\u0fb7\u9321\uc625\u0b12'
+}
+);
+let sampler28 = device1.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 47.535,
+lodMaxClamp: 59.039,
+compare: 'less',
+maxAnisotropy: 18,
+}
+);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+await promise10;
+} catch {}
+let bindGroupLayout8 = device1.createBindGroupLayout(
+{
+entries: [
+{
+binding: 1617,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 1761,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '3d' },
+}
+],
+}
+);
+let pipelineLayout4 = device1.createPipelineLayout(
+{
+label: '\u{1fdf3}\u3236\u{1fefc}\u2d25\u{1fb8d}\udf13\u0cf2\u0f77\u1f7e\u4767\u{1fb87}',
+bindGroupLayouts: [
+bindGroupLayout8,
+bindGroupLayout8,
+bindGroupLayout8,
+bindGroupLayout8,
+bindGroupLayout8,
+bindGroupLayout8
+]
+}
+);
+let querySet20 = device1.createQuerySet({
+label: '\u5b7f\u{1f992}\ua029\uccb6\ubea0',
+type: 'occlusion',
+count: 2081,
+});
+let renderBundleEncoder16 = device1.createRenderBundleEncoder(
+{
+label: '\u3fc8\ub158\u6837\u08e9\u7c96\u0fa2\u{1fba7}\uf208',
+colorFormats: [
+'r8sint',
+'r32float',
+'bgra8unorm',
+'rg16sint',
+undefined,
+'rgba8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 387,
+stencilReadOnly: true,
+}
+);
+let renderBundle30 = renderBundleEncoder15.finish();
+try {
+commandEncoder18.clearBuffer(
+buffer7,
+228,
+10896
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder19.resolveQuerySet(
+querySet20,
+1253,
+449,
+buffer7,
+6400
+);
+} catch {}
+try {
+await promise9;
+} catch {}
+let querySet21 = device1.createQuerySet({
+type: 'occlusion',
+count: 2133,
+});
+let texture22 = device1.createTexture(
+{
+label: '\u937a\u069d',
+size: [101, 62, 241],
+mipLevelCount: 3,
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8uint'
+],
+}
+);
+let sampler29 = device1.createSampler(
+{
+label: '\u7bca\u024f',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 22.017,
+lodMaxClamp: 48.207,
+}
+);
+try {
+renderBundleEncoder16.setIndexBuffer(
+buffer6,
+'uint32',
+956,
+6361
+);
+} catch {}
+try {
+device1.pushErrorScope('internal');
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+12808,
+new Int16Array(53547),
+3630,
+184
+);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let promise11 = adapter0.requestAdapterInfo();
+let shaderModule7 = device1.createShaderModule(
+{
+label: '\u5a7f\u{1f96c}\u{1f656}\u7969\ua07e\u03d3\u3cb2\u7ece',
+code: `@group(5) @binding(1761)
+var<storage, read_write> type14: array<u32>;
+@group(0) @binding(1761)
+var<storage, read_write> local12: array<u32>;
+@group(1) @binding(1761)
+var<storage, read_write> global12: array<u32>;
+@group(0) @binding(1617)
+var<storage, read_write> field16: array<u32>;
+@group(3) @binding(1761)
+var<storage, read_write> field17: array<u32>;
+@group(4) @binding(1761)
+var<storage, read_write> global13: array<u32>;
+@group(2) @binding(1761)
+var<storage, read_write> i11: array<u32>;
+@group(4) @binding(1617)
+var<storage, read_write> type15: array<u32>;
+@group(1) @binding(1617)
+var<storage, read_write> function17: array<u32>;
+@group(2) @binding(1617)
+var<storage, read_write> i12: array<u32>;
+
+@compute @workgroup_size(1, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S6 {
+@location(42) f0: vec4<f16>,
+@location(90) f1: vec3<f16>,
+@location(45) f2: vec4<i32>,
+@location(65) f3: i32,
+@location(100) f4: vec3<u32>,
+@location(69) f5: vec3<u32>,
+@location(98) f6: vec4<f16>,
+@location(13) f7: vec2<f16>,
+@location(31) f8: i32
+}
+struct FragmentOutput0 {
+@location(2) f0: vec3<f32>,
+@location(7) f1: f32,
+@location(4) f2: i32,
+@location(5) f3: vec2<f32>,
+@location(3) f4: vec2<f32>,
+@location(1) f5: vec2<f32>,
+@location(6) f6: vec4<f32>,
+@location(0) f7: vec4<i32>,
+@builtin(frag_depth) f8: f32
+}
+
+@fragment
+fn fragment0(@location(4) a0: vec3<u32>, @builtin(position) a1: vec4<f32>, @location(68) a2: u32, @location(51) a3: i32, @location(58) a4: vec3<i32>, a5: S6, @location(108) a6: vec2<i32>, @location(26) a7: f32, @location(18) a8: vec4<u32>, @location(101) a9: vec3<f16>, @location(59) a10: vec4<f16>, @location(33) a11: vec4<i32>, @location(46) a12: i32, @location(22) a13: vec3<f16>, @location(84) a14: vec3<i32>, @location(32) a15: vec4<u32>, @builtin(sample_index) a16: u32, @builtin(sample_mask) a17: u32, @builtin(front_facing) a18: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S5 {
+@location(16) f0: vec3<i32>,
+@location(9) f1: vec2<f32>,
+@location(12) f2: vec3<f16>,
+@location(13) f3: vec3<f16>,
+@location(7) f4: vec2<f16>,
+@location(1) f5: vec2<f16>,
+@location(4) f6: vec4<f16>,
+@builtin(instance_index) f7: u32,
+@location(14) f8: vec4<f32>,
+@location(5) f9: vec4<u32>,
+@location(0) f10: vec2<u32>,
+@location(24) f11: vec3<f16>,
+@location(25) f12: vec3<i32>,
+@location(2) f13: vec2<i32>,
+@location(17) f14: vec3<u32>,
+@location(19) f15: vec4<u32>,
+@location(20) f16: vec3<i32>
+}
+struct VertexOutput0 {
+@location(101) f43: vec3<f16>,
+@location(65) f44: i32,
+@location(59) f45: vec4<f16>,
+@location(26) f46: f32,
+@location(68) f47: u32,
+@location(108) f48: vec2<i32>,
+@location(4) f49: vec3<u32>,
+@location(45) f50: vec4<i32>,
+@location(13) f51: vec2<f16>,
+@location(100) f52: vec3<u32>,
+@location(33) f53: vec4<i32>,
+@location(84) f54: vec3<i32>,
+@location(90) f55: vec3<f16>,
+@location(18) f56: vec4<u32>,
+@builtin(position) f57: vec4<f32>,
+@location(42) f58: vec4<f16>,
+@location(58) f59: vec3<i32>,
+@location(32) f60: vec4<u32>,
+@location(98) f61: vec4<f16>,
+@location(51) f62: i32,
+@location(31) f63: i32,
+@location(69) f64: vec3<u32>,
+@location(46) f65: i32,
+@location(22) f66: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec4<i32>, @location(18) a1: vec4<f32>, @location(15) a2: vec4<i32>, @builtin(vertex_index) a3: u32, @location(10) a4: vec3<u32>, a5: S5, @location(6) a6: vec4<f16>, @location(26) a7: vec3<f16>, @location(23) a8: vec2<u32>, @location(27) a9: vec3<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroupLayout9 = device1.createBindGroupLayout(
+{
+label: '\u4e1f\u8193\u02c9',
+entries: [
+{
+binding: 381,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+},
+{
+binding: 746,
+visibility: 0,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let querySet22 = device1.createQuerySet({
+label: '\u{1fb9e}\u05b7\u0224\u6849\u4e22\u684b\u01e8',
+type: 'occlusion',
+count: 1997,
+});
+let sampler30 = device1.createSampler(
+{
+label: '\u9669\u{1fd6e}\u4fd1\ufa73\u0bd1\u{1fa11}\u13a1\u{1f9e6}\u0ea9',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMaxClamp: 64.042,
+}
+);
+try {
+renderBundleEncoder16.setIndexBuffer(
+buffer6,
+'uint32',
+336
+);
+} catch {}
+try {
+commandEncoder18.copyBufferToBuffer(
+buffer6,
+5192,
+buffer7,
+1900,
+2708
+);
+dissociateBuffer(device1, buffer6);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder18.clearBuffer(
+buffer7,
+12640,
+276
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 47, y: 29, z: 37 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 5608439 */{
+offset: 927,
+bytesPerRow: 295,
+rowsPerImage: 132,
+},
+{width: 38, height: 1, depthOrArrayLayers: 145}
+);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let texture23 = device1.createTexture(
+{
+label: '\u{1f7d3}\u463c',
+size: {width: 5100},
+dimension: '1d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let textureView28 = texture23.createView(
+{
+label: '\u009a\u0c07',
+}
+);
+try {
+renderBundleEncoder16.setVertexBuffer(
+1,
+buffer6,
+7720
+);
+} catch {}
+try {
+commandEncoder18.copyBufferToBuffer(
+buffer6,
+4200,
+buffer7,
+7180,
+5740
+);
+dissociateBuffer(device1, buffer6);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder19.clearBuffer(
+buffer7,
+9828,
+692
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 33, y: 52, z: 149 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 1057477 */{
+offset: 201,
+bytesPerRow: 84,
+rowsPerImage: 185,
+},
+{width: 13, height: 7, depthOrArrayLayers: 69}
+);
+} catch {}
+let pipeline28 = device1.createComputePipeline(
+{
+label: '\u0164\u{1f82c}\u45e7\u73ac\ud846\u0055\u1d30',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline29 = await device1.createRenderPipelineAsync(
+{
+label: '\uf1bf\u2b94\u4f22\u{1fc89}\u8888\udb79\u{1f665}\u{1fe8b}\u{1f995}\u8902',
+layout: 'auto',
+vertex: {
+module: shaderModule7,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 18752,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x2',
+offset: 2868,
+shaderLocation: 16,
+},
+{
+format: 'snorm16x4',
+offset: 4868,
+shaderLocation: 24,
+},
+{
+format: 'unorm16x4',
+offset: 15760,
+shaderLocation: 4,
+},
+{
+format: 'sint32x2',
+offset: 692,
+shaderLocation: 3,
+},
+{
+format: 'sint8x2',
+offset: 8634,
+shaderLocation: 27,
+},
+{
+format: 'sint16x4',
+offset: 10740,
+shaderLocation: 25,
+},
+{
+format: 'sint32x2',
+offset: 4896,
+shaderLocation: 20,
+},
+{
+format: 'float32x2',
+offset: 304,
+shaderLocation: 6,
+},
+{
+format: 'uint8x2',
+offset: 18036,
+shaderLocation: 23,
+},
+{
+format: 'unorm16x4',
+offset: 14644,
+shaderLocation: 1,
+},
+{
+format: 'uint32',
+offset: 1016,
+shaderLocation: 17,
+},
+{
+format: 'uint8x4',
+offset: 9216,
+shaderLocation: 10,
+},
+{
+format: 'snorm8x2',
+offset: 1934,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x2',
+offset: 8548,
+shaderLocation: 14,
+},
+{
+format: 'unorm16x2',
+offset: 18184,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x4',
+offset: 6996,
+shaderLocation: 26,
+},
+{
+format: 'sint8x4',
+offset: 9656,
+shaderLocation: 2,
+},
+{
+format: 'float32x2',
+offset: 3452,
+shaderLocation: 12,
+},
+{
+format: 'uint16x4',
+offset: 15976,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 26920,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 1156,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x3',
+offset: 26120,
+shaderLocation: 0,
+},
+{
+format: 'sint32x2',
+offset: 49064,
+shaderLocation: 15,
+},
+{
+format: 'snorm8x2',
+offset: 31750,
+shaderLocation: 13,
+},
+{
+format: 'float32x3',
+offset: 40220,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule7,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+passOp: 'increment-wrap',
+},
+stencilWriteMask: 1158,
+depthBias: 81,
+depthBiasClamp: 99,
+},
+}
+);
+canvas7.width = 891;
+gc();
+let img4 = await imageWithData(65, 83, '#d843c4b1', '#dcbaa9a1');
+try {
+await promise11;
+} catch {}
+let imageData10 = new ImageData(20, 128);
+let bindGroup1 = device1.createBindGroup({
+label: '\u{1ff9f}\u5167\u{1f69e}\u09ad\u1ff1\u0637\u0e4b\u83c9\ua53c\u82c0\u{1f73a}',
+layout: bindGroupLayout9,
+entries: [
+{
+binding: 381,
+resource: sampler27
+},
+{
+binding: 746,
+resource: sampler27
+}
+],
+});
+let commandEncoder20 = device1.createCommandEncoder(
+{
+label: '\u06a6\ubfc2\u{1fa88}',
+}
+);
+let texture24 = device1.createTexture(
+{
+label: '\u{1fbbc}\u050d\u0966\u0c4f\u0a6a\u1455',
+size: {width: 92, height: 71, depthOrArrayLayers: 6},
+mipLevelCount: 4,
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let renderBundle31 = renderBundleEncoder15.finish();
+try {
+renderBundleEncoder16.setBindGroup(
+0,
+bindGroup1
+);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(
+0,
+buffer6,
+8812
+);
+} catch {}
+try {
+commandEncoder19.copyTextureToTexture(
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 33, y: 36, z: 137 },
+  aspect: 'all',
+},
+{
+  texture: texture22,
+  mipLevel: 1,
+  origin: { x: 30, y: 4, z: 0 },
+  aspect: 'all',
+},
+{width: 19, height: 25, depthOrArrayLayers: 76}
+);
+} catch {}
+let promise12 = adapter1.requestDevice({
+label: '\u{1fec8}\u734c\u{1fcfb}\u{1fbba}',
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 35,
+maxVertexAttributes: 19,
+maxVertexBufferArrayStride: 9735,
+maxStorageTexturesPerShaderStage: 42,
+maxStorageBuffersPerShaderStage: 39,
+maxDynamicStorageBuffersPerPipelineLayout: 36997,
+maxBindingsPerBindGroup: 6479,
+maxTextureDimension1D: 11102,
+maxTextureDimension2D: 9485,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 65134441,
+maxUniformBuffersPerShaderStage: 18,
+maxInterStageShaderVariables: 88,
+maxInterStageShaderComponents: 61,
+maxSamplersPerShaderStage: 21,
+},
+});
+let textureView29 = texture23.createView(
+{
+label: '\u2e8a\ue483',
+}
+);
+let computePassEncoder10 = commandEncoder18.beginComputePass(
+{
+
+}
+);
+let sampler31 = device1.createSampler(
+{
+label: '\u598c\ua674\uac36\u{1f8a9}\u222f\u0907\u11a5\u08f7',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 18.021,
+maxAnisotropy: 14,
+}
+);
+try {
+computePassEncoder10.setBindGroup(
+9,
+bindGroup1
+);
+} catch {}
+try {
+commandEncoder19.resolveQuerySet(
+querySet21,
+1865,
+103,
+buffer7,
+8448
+);
+} catch {}
+let commandEncoder21 = device1.createCommandEncoder();
+let renderBundleEncoder17 = device1.createRenderBundleEncoder(
+{
+label: '\u99b1\u{1fa60}\u7fc2\u0db4\u{1f80a}\u0cba\u05f0\u0132\u{1ff16}\u{1ff96}',
+colorFormats: [
+'rgba32float',
+'rgba16float'
+],
+sampleCount: 297,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder16.setIndexBuffer(
+buffer6,
+'uint32'
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+5764,
+new BigUint64Array(61404),
+55099,
+12
+);
+} catch {}
+let promise13 = device1.queue.onSubmittedWorkDone();
+let pipeline30 = device1.createRenderPipeline(
+{
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule7,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'float32x3',
+offset: 40688,
+shaderLocation: 24,
+},
+{
+format: 'sint32x4',
+offset: 29316,
+shaderLocation: 20,
+},
+{
+format: 'sint8x2',
+offset: 62142,
+shaderLocation: 2,
+},
+{
+format: 'float32',
+offset: 26692,
+shaderLocation: 4,
+},
+{
+format: 'unorm16x4',
+offset: 59220,
+shaderLocation: 1,
+},
+{
+format: 'uint32x3',
+offset: 12220,
+shaderLocation: 10,
+},
+{
+format: 'unorm16x2',
+offset: 17792,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x4',
+offset: 22068,
+shaderLocation: 26,
+},
+{
+format: 'sint8x2',
+offset: 22570,
+shaderLocation: 25,
+},
+{
+format: 'sint16x2',
+offset: 23240,
+shaderLocation: 15,
+},
+{
+format: 'uint32x3',
+offset: 43480,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 17388,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x2',
+offset: 12138,
+shaderLocation: 5,
+},
+{
+format: 'uint32x3',
+offset: 11168,
+shaderLocation: 17,
+},
+{
+format: 'sint8x2',
+offset: 5262,
+shaderLocation: 27,
+},
+{
+format: 'sint16x2',
+offset: 16596,
+shaderLocation: 3,
+},
+{
+format: 'float16x4',
+offset: 8716,
+shaderLocation: 18,
+},
+{
+format: 'float32x4',
+offset: 8884,
+shaderLocation: 6,
+},
+{
+format: 'uint16x4',
+offset: 10524,
+shaderLocation: 23,
+},
+{
+format: 'float32x3',
+offset: 7504,
+shaderLocation: 13,
+},
+{
+format: 'uint16x2',
+offset: 12524,
+shaderLocation: 19,
+},
+{
+format: 'unorm8x4',
+offset: 2476,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x2',
+offset: 15804,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 39268,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x2',
+offset: 16564,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 52592,
+attributes: [
+{
+format: 'sint32x3',
+offset: 52004,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule7,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rgba8sint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r8unorm',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'keep',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+},
+stencilReadMask: 1914,
+depthBias: 60,
+depthBiasSlopeScale: 78,
+},
+}
+);
+let pipelineLayout5 = device1.createPipelineLayout(
+{
+label: '\u9599\u0a21\u3918\u{1f600}\u6032\u6204\u035d\u0c8c\u9b56\u{1fdbb}',
+bindGroupLayouts: [
+bindGroupLayout8,
+bindGroupLayout9,
+bindGroupLayout8,
+bindGroupLayout9,
+bindGroupLayout8,
+bindGroupLayout8,
+bindGroupLayout9
+]
+}
+);
+let computePassEncoder11 = commandEncoder19.beginComputePass(
+{
+label: '\ub423\u5bcd\ub806\u015d\u0bec'
+}
+);
+let renderBundle32 = renderBundleEncoder15.finish(
+{
+label: '\u32ef\u24dc\u27b6\u0e19'
+}
+);
+try {
+computePassEncoder11.setBindGroup(
+4,
+bindGroup1,
+new Uint32Array(686),
+561,
+0
+);
+} catch {}
+try {
+commandEncoder21.clearBuffer(
+buffer7,
+10964,
+196
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture22,
+  mipLevel: 1,
+  origin: { x: 24, y: 0, z: 113 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 4709130 */{
+offset: 566,
+bytesPerRow: 224,
+rowsPerImage: 236,
+},
+{width: 21, height: 17, depthOrArrayLayers: 90}
+);
+} catch {}
+let querySet23 = device1.createQuerySet({
+label: '\u7a54\u7f47\udf0d\u3e5f\u0b83\u7ca8\u0fa1\uec1e\u06ea\u525a',
+type: 'occlusion',
+count: 2243,
+});
+let texture25 = device1.createTexture(
+{
+label: '\u6a3f\u990c\uafb7\u0487\u0aca\uae9a\u{1ffcd}\uc0a4\u0137\u973c\u5313',
+size: {width: 153, height: 1, depthOrArrayLayers: 1501},
+mipLevelCount: 8,
+dimension: '3d',
+format: 'rgba32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32uint',
+'rgba32uint'
+],
+}
+);
+try {
+computePassEncoder10.setPipeline(
+pipeline28
+);
+} catch {}
+try {
+commandEncoder21.resolveQuerySet(
+querySet20,
+260,
+81,
+buffer7,
+1280
+);
+} catch {}
+let device2 = await adapter3.requestDevice({
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'shader-f16',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 6,
+maxColorAttachmentBytesPerSample: 42,
+maxVertexAttributes: 17,
+maxVertexBufferArrayStride: 52955,
+maxStorageTexturesPerShaderStage: 26,
+maxStorageBuffersPerShaderStage: 30,
+maxDynamicStorageBuffersPerPipelineLayout: 1019,
+maxBindingsPerBindGroup: 2762,
+maxTextureDimension1D: 9587,
+maxTextureDimension2D: 13178,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 70292620,
+maxUniformBuffersPerShaderStage: 36,
+maxInterStageShaderVariables: 18,
+maxInterStageShaderComponents: 85,
+maxSamplersPerShaderStage: 20,
+},
+});
+let renderBundleEncoder18 = device2.createRenderBundleEncoder(
+{
+label: '\u768a\u0f68\u2eda\u6acd\u0edd',
+colorFormats: [
+'rg16uint',
+'rg32uint',
+undefined,
+'rg16float',
+'rg16uint',
+'rg8uint',
+'rg16float',
+undefined
+],
+sampleCount: 402,
+stencilReadOnly: true,
+}
+);
+try {
+device2.pushErrorScope('internal');
+} catch {}
+try {
+gpuCanvasContext4.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+}
+);
+} catch {}
+let querySet24 = device1.createQuerySet({
+label: '\u{1fe86}\u08a7\u7097\u045b\u0942\u3692\u{1fe67}',
+type: 'occlusion',
+count: 1838,
+});
+let renderBundleEncoder19 = device1.createRenderBundleEncoder(
+{
+label: '\u6557\u{1fcc7}\u2a1c\u0cd6\u0e6e\u1676\u8976\u22a8\u0793\u0e7e\u789f',
+colorFormats: [
+'rg8unorm',
+'rg32float',
+'rgba8sint',
+'r32uint'
+],
+sampleCount: 692,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle33 = renderBundleEncoder15.finish(
+{
+
+}
+);
+try {
+renderBundleEncoder17.setIndexBuffer(
+buffer7,
+'uint16',
+8872,
+3268
+);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(
+5,
+buffer6,
+9172,
+1252
+);
+} catch {}
+try {
+commandEncoder20.clearBuffer(
+buffer7,
+2748,
+2792
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+let pipeline31 = await device1.createComputePipelineAsync(
+{
+label: '\u32b9\u0b0d\u4bb8\uaafe\u04c1\u19d6',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageBitmap7 = await createImageBitmap(img4);
+let renderBundle34 = renderBundleEncoder18.finish(
+{
+label: '\uc3e7\u0afb\ub281\u0fa0\ua611'
+}
+);
+let textureView30 = texture22.createView(
+{
+label: '\u1835\u{1fb63}\ua885\uc6d7\u{1fe5f}\uceed\ua18d\ue7bb\ud970\u591e',
+dimension: '2d',
+baseMipLevel: 1,
+mipLevelCount: 1,
+baseArrayLayer: 122,
+}
+);
+let computePassEncoder12 = commandEncoder21.beginComputePass(
+{
+label: '\u0d66\u{1f708}\u0429'
+}
+);
+try {
+renderBundleEncoder16.setVertexBuffer(
+9,
+buffer6
+);
+} catch {}
+try {
+commandEncoder20.copyTextureToTexture(
+{
+  texture: texture25,
+  mipLevel: 2,
+  origin: { x: 33, y: 1, z: 209 },
+  aspect: 'all',
+},
+{
+  texture: texture25,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 10}
+);
+} catch {}
+let texture26 = device2.createTexture(
+{
+label: '\u0616\u09f8\u9fb9\u{1fa0a}\u15c5\u04d6\u{1fd7e}\u{1f87f}',
+size: [9259],
+dimension: '1d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+
+],
+}
+);
+let sampler32 = device2.createSampler(
+{
+label: '\u{1f61d}\ubeae\ued4a\ubc1f\ufd72\u{1f89c}\u{1fd13}\u6f50\u3968',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 92.263,
+lodMaxClamp: 96.205,
+maxAnisotropy: 12,
+}
+);
+let img5 = await imageWithData(31, 172, '#576ffda3', '#ac8f183a');
+let commandEncoder22 = device2.createCommandEncoder();
+let querySet25 = device2.createQuerySet({
+label: '\ucdf6\uc28f\u4bec\u{1f637}\u0031\u3be7\u{1ff75}\u0e39\u6547\u7847',
+type: 'occlusion',
+count: 3000,
+});
+let commandBuffer1 = commandEncoder22.finish();
+let texture27 = gpuCanvasContext3.getCurrentTexture();
+let renderBundleEncoder20 = device2.createRenderBundleEncoder(
+{
+label: '\u5d53\u{1fb85}\u0f27\u{1fee4}\u287f\ufb30\u{1ff4a}\u75f7\u094d\u040d\u46e6',
+colorFormats: [
+'rgba16float',
+'r32uint',
+'rg8unorm',
+'rg32uint',
+undefined
+],
+sampleCount: 620,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler33 = device2.createSampler(
+{
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 47.786,
+lodMaxClamp: 55.601,
+}
+);
+try {
+await promise13;
+} catch {}
+let bindGroupLayout10 = pipeline28.getBindGroupLayout(3);
+let bindGroup2 = device1.createBindGroup({
+label: '\u03f2\u8ce9\u07ff\u02c1\u6f23\ua3cc\u{1f663}\u0374',
+layout: bindGroupLayout9,
+entries: [
+{
+binding: 381,
+resource: sampler31
+},
+{
+binding: 746,
+resource: sampler27
+}
+],
+});
+let buffer8 = device1.createBuffer(
+{
+label: '\u4d2e\u4205\ubfa4\u0dfb\u{1fb01}\uf049\u0a3b\u0f92\u0d9a\uf0f3',
+size: 34604,
+usage: GPUBufferUsage.UNIFORM,
+}
+);
+let computePassEncoder13 = commandEncoder20.beginComputePass(
+{
+label: '\u0d4d\u544a\u{1f71b}\u0842\uf2e8\ubfd7\u0e39\u0363\u4772\u2a84\u{1fe43}'
+}
+);
+try {
+renderBundleEncoder16.setBindGroup(
+6,
+bindGroup1,
+new Uint32Array(8002),
+1170,
+0
+);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(
+9,
+buffer6,
+6556,
+2901
+);
+} catch {}
+let pipeline32 = device1.createComputePipeline(
+{
+label: '\u2544\uc540\u{1fcd0}\ufdb0\u0b38\u0630\u06aa\u7c7d\u02d9\u{1fd23}',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+adapter0.label = '\ucb03\ubc11\uc46a\u8a70\u{1fed3}\u70cf\u15f7\u{1f614}\u36ad\u1105';
+} catch {}
+let bindGroup3 = device1.createBindGroup({
+label: '\u0ca8\u0509\u063f\u50fd\ud6f8\u0867\u9242\u{1feb6}\u0f3c\u0630\uffc5',
+layout: bindGroupLayout9,
+entries: [
+{
+binding: 746,
+resource: sampler27
+},
+{
+binding: 381,
+resource: sampler30
+}
+],
+});
+let renderBundleEncoder21 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg8sint',
+'rg16sint',
+'bgra8unorm',
+'r32uint',
+'r32uint',
+'rg16float',
+undefined,
+'r8uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 302,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder21.setBindGroup(
+5,
+bindGroup3
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture25,
+  mipLevel: 3,
+  origin: { x: 1, y: 0, z: 16 },
+  aspect: 'all',
+},
+new Int8Array(arrayBuffer0),
+/* required buffer size: 329863 */{
+offset: 733,
+bytesPerRow: 23,
+rowsPerImage: 90,
+},
+{width: 0, height: 0, depthOrArrayLayers: 160}
+);
+} catch {}
+document.body.prepend(img2);
+let imageData11 = new ImageData(208, 172);
+gc();
+try {
+adapter3.label = '\ud992\u7cdd\u{1fceb}\u10bc\u9dc5\ud071\u9adc\u0107\ufaa3\u3ef7\ufd7d';
+} catch {}
+let shaderModule8 = device1.createShaderModule(
+{
+label: '\u3e31\u0de1\u{1fc7e}\u1e46\uc0fe\u9fb2\uf6eb\u004e',
+code: `@group(5) @binding(1761)
+var<storage, read_write> local13: array<u32>;
+@group(6) @binding(746)
+var<storage, read_write> function18: array<u32>;
+@group(4) @binding(1617)
+var<storage, read_write> i13: array<u32>;
+@group(2) @binding(1617)
+var<storage, read_write> function19: array<u32>;
+@group(5) @binding(1617)
+var<storage, read_write> function20: array<u32>;
+@group(3) @binding(746)
+var<storage, read_write> global14: array<u32>;
+@group(6) @binding(381)
+var<storage, read_write> local14: array<u32>;
+@group(1) @binding(746)
+var<storage, read_write> type16: array<u32>;
+@group(0) @binding(1761)
+var<storage, read_write> global15: array<u32>;
+@group(2) @binding(1761)
+var<storage, read_write> field18: array<u32>;
+@group(0) @binding(1617)
+var<storage, read_write> type17: array<u32>;
+
+@compute @workgroup_size(5, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: vec2<i32>,
+@builtin(sample_mask) f1: u32,
+@location(4) f2: vec4<i32>,
+@location(7) f3: vec4<f32>,
+@location(2) f4: vec4<i32>,
+@location(1) f5: vec2<u32>,
+@location(0) f6: f32,
+@location(3) f7: f32,
+@location(5) f8: vec4<f32>,
+@builtin(frag_depth) f9: f32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S7 {
+@location(11) f0: vec3<i32>,
+@location(19) f1: vec4<f16>,
+@location(13) f2: vec2<f16>,
+@location(22) f3: vec4<f16>,
+@location(20) f4: vec4<i32>,
+@builtin(instance_index) f5: u32,
+@location(1) f6: vec3<f16>,
+@builtin(vertex_index) f7: u32,
+@location(23) f8: vec3<u32>,
+@location(9) f9: vec4<f16>,
+@location(7) f10: vec3<i32>,
+@location(15) f11: vec2<i32>,
+@location(17) f12: vec4<f32>,
+@location(16) f13: f32,
+@location(6) f14: vec4<i32>,
+@location(3) f15: vec3<u32>,
+@location(5) f16: vec3<u32>,
+@location(8) f17: vec3<i32>,
+@location(12) f18: vec4<i32>,
+@location(26) f19: vec3<f16>,
+@location(21) f20: i32,
+@location(27) f21: i32,
+@location(18) f22: f16,
+@location(14) f23: vec3<u32>,
+@location(4) f24: vec2<u32>,
+@location(24) f25: vec3<i32>,
+@location(25) f26: vec4<f32>,
+@location(2) f27: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(10) a0: f16, a1: S7, @location(0) a2: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let renderBundle35 = renderBundleEncoder17.finish(
+{
+
+}
+);
+let sampler34 = device1.createSampler(
+{
+label: '\ub777\u0c6a\u4e81',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 31.466,
+maxAnisotropy: 12,
+}
+);
+try {
+renderBundleEncoder21.setBindGroup(
+0,
+bindGroup1
+);
+} catch {}
+try {
+querySet21.destroy();
+} catch {}
+try {
+texture23.destroy();
+} catch {}
+let pipeline33 = await device1.createComputePipelineAsync(
+{
+label: '\u9abb\u05fe\u054d\ub148\u{1fae4}\u0655',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+video4.width = 292;
+let offscreenCanvas11 = new OffscreenCanvas(927, 259);
+let shaderModule9 = device1.createShaderModule(
+{
+label: '\u{1fec9}\u98eb',
+code: `@group(6) @binding(746)
+var<storage, read_write> type18: array<u32>;
+@group(0) @binding(1617)
+var<storage, read_write> i14: array<u32>;
+@group(1) @binding(746)
+var<storage, read_write> field19: array<u32>;
+@group(5) @binding(1761)
+var<storage, read_write> local15: array<u32>;
+@group(4) @binding(1617)
+var<storage, read_write> function21: array<u32>;
+@group(3) @binding(746)
+var<storage, read_write> global16: array<u32>;
+@group(5) @binding(1617)
+var<storage, read_write> local16: array<u32>;
+@group(2) @binding(1761)
+var<storage, read_write> function22: array<u32>;
+@group(4) @binding(1761)
+var<storage, read_write> i15: array<u32>;
+@group(1) @binding(381)
+var<storage, read_write> parameter10: array<u32>;
+@group(3) @binding(381)
+var<storage, read_write> i16: array<u32>;
+@group(2) @binding(1617)
+var<storage, read_write> function23: array<u32>;
+@group(0) @binding(1761)
+var<storage, read_write> function24: array<u32>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S9 {
+@location(40) f0: vec3<f16>,
+@location(43) f1: vec2<u32>,
+@builtin(front_facing) f2: bool,
+@location(47) f3: f16,
+@location(53) f4: vec3<u32>,
+@location(34) f5: i32,
+@location(87) f6: vec4<f32>,
+@location(65) f7: vec2<i32>,
+@location(45) f8: u32,
+@location(32) f9: i32,
+@location(86) f10: u32,
+@location(17) f11: vec3<u32>,
+@builtin(sample_mask) f12: u32,
+@location(71) f13: vec4<u32>,
+@location(8) f14: vec3<f32>,
+@location(102) f15: vec4<u32>,
+@location(57) f16: vec4<f16>,
+@location(14) f17: vec2<f32>,
+@location(33) f18: vec3<f32>,
+@location(84) f19: vec3<f32>,
+@location(92) f20: f16,
+@builtin(sample_index) f21: u32
+}
+struct FragmentOutput0 {
+@location(0) f0: i32,
+@location(6) f1: vec2<f32>,
+@location(7) f2: f32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @location(108) a1: vec3<i32>, @location(46) a2: vec4<f32>, @location(98) a3: vec2<i32>, @location(58) a4: vec2<i32>, a5: S9, @location(101) a6: vec4<f16>, @location(7) a7: f32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S8 {
+@builtin(vertex_index) f0: u32,
+@location(18) f1: vec4<f32>,
+@location(22) f2: vec2<f16>,
+@location(9) f3: vec3<u32>,
+@location(10) f4: vec2<f32>,
+@location(27) f5: vec3<f32>,
+@location(12) f6: vec2<u32>,
+@location(20) f7: vec3<f16>,
+@location(1) f8: f16,
+@location(3) f9: vec4<f16>,
+@location(15) f10: vec4<i32>,
+@location(23) f11: vec2<u32>,
+@location(17) f12: vec2<u32>,
+@location(0) f13: vec4<f16>,
+@location(2) f14: vec4<f16>,
+@location(14) f15: vec3<i32>,
+@location(16) f16: vec3<f16>
+}
+struct VertexOutput0 {
+@location(87) f67: vec4<f32>,
+@builtin(position) f68: vec4<f32>,
+@location(8) f69: vec3<f32>,
+@location(53) f70: vec3<u32>,
+@location(65) f71: vec2<i32>,
+@location(84) f72: vec3<f32>,
+@location(43) f73: vec2<u32>,
+@location(17) f74: vec3<u32>,
+@location(102) f75: vec4<u32>,
+@location(46) f76: vec4<f32>,
+@location(7) f77: f32,
+@location(47) f78: f16,
+@location(58) f79: vec2<i32>,
+@location(57) f80: vec4<f16>,
+@location(86) f81: u32,
+@location(33) f82: vec3<f32>,
+@location(98) f83: vec2<i32>,
+@location(108) f84: vec3<i32>,
+@location(92) f85: f16,
+@location(40) f86: vec3<f16>,
+@location(34) f87: i32,
+@location(101) f88: vec4<f16>,
+@location(14) f89: vec2<f32>,
+@location(71) f90: vec4<u32>,
+@location(45) f91: u32,
+@location(32) f92: i32
+}
+
+@vertex
+fn vertex0(@location(24) a0: vec2<f16>, @location(21) a1: vec2<i32>, @location(26) a2: vec3<f16>, @builtin(instance_index) a3: u32, @location(11) a4: vec3<i32>, @location(6) a5: f32, a6: S8, @location(8) a7: f32, @location(19) a8: vec2<u32>, @location(5) a9: vec4<f32>, @location(13) a10: f32, @location(4) a11: vec4<f16>, @location(25) a12: vec2<f32>, @location(7) a13: vec3<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let querySet26 = device1.createQuerySet({
+label: '\u0cf9\u6915\u{1fdaf}\ud069\u04e0\u{1f995}\u078f\u{1fc8e}\u{1fc7f}\u09da\u{1fd2d}',
+type: 'occlusion',
+count: 1740,
+});
+let textureView31 = texture22.createView(
+{
+baseArrayLayer: 68,
+arrayLayerCount: 73,
+}
+);
+try {
+computePassEncoder13.setBindGroup(
+3,
+bindGroup1
+);
+} catch {}
+try {
+computePassEncoder13.insertDebugMarker(
+'\u{1f653}'
+);
+} catch {}
+let pipeline34 = device1.createRenderPipeline(
+{
+label: '\u98a7\u{1f6bf}\u7dd7\ub1f4\u0e7a\u7205',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule8,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 14552,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 1592,
+shaderLocation: 22,
+},
+{
+format: 'uint16x2',
+offset: 8376,
+shaderLocation: 4,
+},
+{
+format: 'uint16x4',
+offset: 7512,
+shaderLocation: 23,
+},
+{
+format: 'float16x4',
+offset: 6004,
+shaderLocation: 25,
+},
+{
+format: 'snorm8x2',
+offset: 2826,
+shaderLocation: 26,
+},
+{
+format: 'sint8x4',
+offset: 4708,
+shaderLocation: 15,
+},
+{
+format: 'sint16x2',
+offset: 11592,
+shaderLocation: 6,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 5844,
+shaderLocation: 17,
+},
+{
+format: 'sint8x2',
+offset: 6204,
+shaderLocation: 8,
+},
+{
+format: 'sint16x2',
+offset: 14332,
+shaderLocation: 24,
+},
+{
+format: 'unorm8x2',
+offset: 6444,
+shaderLocation: 10,
+},
+{
+format: 'uint8x2',
+offset: 7452,
+shaderLocation: 5,
+},
+{
+format: 'sint16x2',
+offset: 13964,
+shaderLocation: 27,
+},
+{
+format: 'sint32x4',
+offset: 5360,
+shaderLocation: 21,
+},
+{
+format: 'snorm16x4',
+offset: 2356,
+shaderLocation: 13,
+},
+{
+format: 'unorm8x2',
+offset: 7154,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x2',
+offset: 7264,
+shaderLocation: 19,
+},
+{
+format: 'uint16x2',
+offset: 4800,
+shaderLocation: 14,
+},
+{
+format: 'sint32x4',
+offset: 9432,
+shaderLocation: 11,
+},
+{
+format: 'float16x4',
+offset: 156,
+shaderLocation: 1,
+},
+{
+format: 'sint16x2',
+offset: 3052,
+shaderLocation: 7,
+},
+{
+format: 'float32x2',
+offset: 7452,
+shaderLocation: 0,
+},
+{
+format: 'uint32x2',
+offset: 5664,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 17092,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 7928,
+shaderLocation: 20,
+},
+{
+format: 'sint32x4',
+offset: 3280,
+shaderLocation: 12,
+},
+{
+format: 'uint16x4',
+offset: 14920,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x4',
+offset: 8684,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 25980,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 33944,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x4',
+offset: 26336,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule8,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+writeMask: 0,
+},
+{
+format: 'rg8uint',
+},
+{
+format: 'rgba16sint',
+writeMask: 0,
+},
+{
+format: 'r32float',
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'replace',
+passOp: 'replace',
+},
+stencilReadMask: 1130,
+stencilWriteMask: 3261,
+depthBias: 40,
+depthBiasSlopeScale: 18,
+depthBiasClamp: 11,
+},
+}
+);
+let offscreenCanvas12 = new OffscreenCanvas(897, 975);
+let promise14 = adapter1.requestAdapterInfo();
+let commandEncoder23 = device2.createCommandEncoder(
+{
+label: '\u{1fb38}\u2168\uaeb1\u92db\ufc70\u{1fb30}',
+}
+);
+let texture28 = device2.createTexture(
+{
+label: '\u{1fcec}\u{1fb2c}\u0e27\ua55b\u0f30\ua3f1\u0461\u5251\udf45\u{1ff92}\u5ee7',
+size: {width: 11409, height: 2, depthOrArrayLayers: 1},
+mipLevelCount: 10,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+try {
+renderBundleEncoder20.setVertexBuffer(
+3,
+undefined,
+3936400511,
+305646216
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture28,
+  mipLevel: 1,
+  origin: { x: 464, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 617 */{
+offset: 617,
+},
+{width: 4294, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let shaderModule10 = device1.createShaderModule(
+{
+label: '\u7b4e\u03cb',
+code: `@group(3) @binding(1761)
+var<storage, read_write> parameter11: array<u32>;
+@group(2) @binding(1761)
+var<storage, read_write> type19: array<u32>;
+@group(4) @binding(1761)
+var<storage, read_write> global17: array<u32>;
+@group(4) @binding(1617)
+var<storage, read_write> field20: array<u32>;
+@group(2) @binding(1617)
+var<storage, read_write> function25: array<u32>;
+@group(0) @binding(1617)
+var<storage, read_write> type20: array<u32>;
+@group(1) @binding(1617)
+var<storage, read_write> global18: array<u32>;
+@group(3) @binding(1617)
+var<storage, read_write> type21: array<u32>;
+@group(1) @binding(1761)
+var<storage, read_write> local17: array<u32>;
+
+@compute @workgroup_size(7, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(5) f0: vec2<u32>,
+@location(4) f1: vec4<f32>,
+@location(6) f2: vec3<f32>,
+@location(2) f3: vec4<u32>,
+@location(1) f4: vec2<f32>,
+@location(7) f5: u32,
+@builtin(sample_mask) f6: u32,
+@location(0) f7: vec4<f32>,
+@location(3) f8: vec3<f32>,
+@builtin(frag_depth) f9: f32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(front_facing) a2: bool, @builtin(sample_index) a3: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S10 {
+@location(7) f0: vec2<i32>,
+@location(10) f1: u32,
+@location(8) f2: vec2<i32>,
+@location(2) f3: f32,
+@location(4) f4: vec4<u32>,
+@location(17) f5: vec4<u32>,
+@location(6) f6: i32,
+@location(0) f7: vec3<i32>,
+@builtin(instance_index) f8: u32,
+@location(3) f9: vec4<u32>,
+@location(14) f10: vec3<f32>,
+@location(16) f11: vec2<u32>,
+@location(27) f12: vec3<u32>,
+@builtin(vertex_index) f13: u32,
+@location(13) f14: f32,
+@location(9) f15: vec2<f16>,
+@location(19) f16: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec4<f32>, @location(22) a1: vec4<i32>, @location(20) a2: vec3<i32>, @location(23) a3: vec4<i32>, @location(11) a4: vec4<f16>, @location(12) a5: vec2<f32>, a6: S10) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let querySet27 = device1.createQuerySet({
+label: '\u{1fa3a}\uc1f4\uba30\u077e\u982f\ue71c\u3922\ua4f7\u434e',
+type: 'occlusion',
+count: 3988,
+});
+let renderBundleEncoder22 = device1.createRenderBundleEncoder(
+{
+label: '\u{1fa31}\ub888\u6ae0\u0159\u0e10\uc694',
+colorFormats: [
+undefined,
+'rg32float',
+'r32uint',
+'r8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 421,
+stencilReadOnly: true,
+}
+);
+let renderBundle36 = renderBundleEncoder22.finish(
+{
+label: '\u386a\ub79d\u0945\u0a63\u13b4\u0215\uefb4\u{1fc35}\u8f01\u0831'
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+4,
+bindGroup3
+);
+} catch {}
+try {
+computePassEncoder10.end();
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(
+4,
+bindGroup1
+);
+} catch {}
+try {
+commandEncoder18.copyTextureToTexture(
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 1, y: 8, z: 123 },
+  aspect: 'all',
+},
+{
+  texture: texture22,
+  mipLevel: 2,
+  origin: { x: 12, y: 1, z: 117 },
+  aspect: 'all',
+},
+{width: 12, height: 10, depthOrArrayLayers: 115}
+);
+} catch {}
+try {
+renderBundleEncoder19.insertDebugMarker(
+'\u{1fdaa}'
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+2764,
+new BigUint64Array(22915),
+21818,
+880
+);
+} catch {}
+let promise15 = device1.queue.onSubmittedWorkDone();
+canvas3.width = 608;
+let canvas8 = document.createElement('canvas');
+try {
+window.someLabel = externalTexture0.label;
+} catch {}
+pseudoSubmit(device2, commandEncoder23);
+let renderBundleEncoder23 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg16uint',
+'r8uint',
+'r16sint',
+'r32float',
+'rg32sint'
+],
+sampleCount: 816,
+stencilReadOnly: true,
+}
+);
+let sampler35 = device2.createSampler(
+{
+label: '\u063a\u{1f6d4}\u141f',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 1.701,
+lodMaxClamp: 66.452,
+}
+);
+try {
+device2.queue.submit([
+]);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 5704, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 43, y: 16 },
+  flipY: false,
+},
+{
+  texture: texture28,
+  mipLevel: 1,
+  origin: { x: 2595, y: 1, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 7, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+offscreenCanvas11.getContext('webgpu');
+} catch {}
+let querySet28 = device2.createQuerySet({
+label: '\ua457\u6b44\u23a9\u{1f9a9}\u0c7a\u0acf\udfff',
+type: 'occlusion',
+count: 1991,
+});
+let texture29 = device2.createTexture(
+{
+label: '\u{1fd56}\u08c1\u5109\u0dbf\u9eeb\u042f\u0aea\u{1f703}\u091a',
+size: [130, 1, 929],
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView32 = texture27.createView(
+{
+label: '\u{1fe91}\u06c6\ud124\u63fe\u8214\u92de\u049f\udcec\u7ee0\u{1fa81}\u293d',
+baseMipLevel: 0,
+}
+);
+try {
+device2.pushErrorScope('validation');
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 1368, y: 1, z: 0 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer0),
+/* required buffer size: 697 */{
+offset: 697,
+},
+{width: 4316, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend(canvas0);
+try {
+canvas8.getContext('webgl2');
+} catch {}
+let commandEncoder24 = device1.createCommandEncoder(
+{
+label: '\u{1f6c0}\ud8df\u0eaa\u{1f9ab}\ud63a',
+}
+);
+let textureView33 = texture25.createView(
+{
+label: '\u{1f7ce}\u7cb0',
+baseMipLevel: 3,
+mipLevelCount: 4,
+}
+);
+let renderBundle37 = renderBundleEncoder21.finish(
+{
+label: '\u750c\u{1f6e1}\uef01\u0b81\u{1f75f}\u7dc7\u3f74\u0719\u{1fd97}\u03c5'
+}
+);
+let sampler36 = device1.createSampler(
+{
+label: '\udadc\uf6d8\u86d1\u0d2b\ufa50\u018d\uefba\ub7f5',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 2.657,
+lodMaxClamp: 70.097,
+maxAnisotropy: 16,
+}
+);
+try {
+computePassEncoder13.setPipeline(
+pipeline32
+);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(
+9,
+bindGroup2,
+new Uint32Array(7666),
+3775,
+0
+);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(
+buffer7,
+'uint16'
+);
+} catch {}
+try {
+commandEncoder18.copyTextureToTexture(
+{
+  texture: texture22,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 24 },
+  aspect: 'all',
+},
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 45, y: 16, z: 19 },
+  aspect: 'all',
+},
+{width: 5, height: 5, depthOrArrayLayers: 149}
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline35 = await device1.createRenderPipelineAsync(
+{
+label: '\uafe6\ua3bb\ue577\u22b7\u02ea',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule9,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 32968,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 10992,
+shaderLocation: 19,
+},
+{
+format: 'float16x2',
+offset: 26964,
+shaderLocation: 7,
+},
+{
+format: 'snorm8x4',
+offset: 20912,
+shaderLocation: 22,
+},
+{
+format: 'unorm8x2',
+offset: 11504,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x2',
+offset: 5078,
+shaderLocation: 1,
+},
+{
+format: 'unorm8x4',
+offset: 3600,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x2',
+offset: 21324,
+shaderLocation: 10,
+},
+{
+format: 'unorm8x4',
+offset: 17160,
+shaderLocation: 16,
+},
+{
+format: 'sint8x4',
+offset: 5056,
+shaderLocation: 21,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 22252,
+shaderLocation: 20,
+}
+],
+},
+{
+arrayStride: 19684,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 15388,
+shaderLocation: 6,
+},
+{
+format: 'uint8x2',
+offset: 19030,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x4',
+offset: 6428,
+shaderLocation: 18,
+},
+{
+format: 'sint8x4',
+offset: 17188,
+shaderLocation: 11,
+},
+{
+format: 'float32x2',
+offset: 10032,
+shaderLocation: 3,
+},
+{
+format: 'sint16x4',
+offset: 11708,
+shaderLocation: 15,
+},
+{
+format: 'snorm16x4',
+offset: 5928,
+shaderLocation: 26,
+},
+{
+format: 'sint16x4',
+offset: 7780,
+shaderLocation: 14,
+},
+{
+format: 'uint32x2',
+offset: 5652,
+shaderLocation: 23,
+},
+{
+format: 'unorm8x4',
+offset: 7384,
+shaderLocation: 13,
+},
+{
+format: 'float32x4',
+offset: 6656,
+shaderLocation: 24,
+},
+{
+format: 'float32x4',
+offset: 11692,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 15276,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 13192,
+shaderLocation: 5,
+},
+{
+format: 'float32',
+offset: 13464,
+shaderLocation: 27,
+},
+{
+format: 'uint8x2',
+offset: 15000,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 31196,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 2916,
+shaderLocation: 0,
+},
+{
+format: 'uint16x4',
+offset: 4104,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 30652,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 62192,
+attributes: [
+{
+format: 'float16x4',
+offset: 61132,
+shaderLocation: 25,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule9,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+}
+);
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+offscreenCanvas12.getContext('webgl2');
+} catch {}
+let textureView34 = texture27.createView(
+{
+label: '\u9995\u9f8e\uc003\u{1fc5a}\u263d\u{1f8ed}\u3720\u{1f78a}\u007e\u8c19\u{1fddb}',
+}
+);
+let renderBundle38 = renderBundleEncoder18.finish();
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 5704, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas3,
+  origin: { x: 475, y: 74 },
+  flipY: true,
+},
+{
+  texture: texture28,
+  mipLevel: 1,
+  origin: { x: 2092, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 4, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let shaderModule11 = device1.createShaderModule(
+{
+label: '\ua28d\u0f41\u0472\ued07\u044a',
+code: `@group(5) @binding(1761)
+var<storage, read_write> parameter12: array<u32>;
+@group(0) @binding(1617)
+var<storage, read_write> parameter13: array<u32>;
+@group(3) @binding(1761)
+var<storage, read_write> type22: array<u32>;
+@group(4) @binding(1761)
+var<storage, read_write> i17: array<u32>;
+@group(3) @binding(1617)
+var<storage, read_write> local18: array<u32>;
+@group(1) @binding(1617)
+var<storage, read_write> parameter14: array<u32>;
+@group(2) @binding(1617)
+var<storage, read_write> parameter15: array<u32>;
+@group(1) @binding(1761)
+var<storage, read_write> parameter16: array<u32>;
+@group(0) @binding(1761)
+var<storage, read_write> global19: array<u32>;
+@group(4) @binding(1617)
+var<storage, read_write> function26: array<u32>;
+@group(2) @binding(1761)
+var<storage, read_write> parameter17: array<u32>;
+
+@compute @workgroup_size(7, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(5) f0: vec3<f32>,
+@location(3) f1: vec2<f32>,
+@location(0) f2: f32,
+@location(4) f3: vec4<u32>,
+@location(6) f4: vec4<i32>,
+@location(7) f5: vec3<f32>,
+@location(2) f6: u32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @location(97) a1: u32, @location(88) a2: f16, @builtin(sample_index) a3: u32, @location(79) a4: vec4<f16>, @location(105) a5: vec2<i32>, @location(71) a6: vec2<i32>, @location(14) a7: vec4<i32>, @builtin(front_facing) a8: bool, @location(6) a9: vec4<u32>, @location(83) a10: vec4<i32>, @location(10) a11: vec4<f32>, @location(62) a12: vec2<u32>, @location(46) a13: u32, @location(35) a14: f16, @location(31) a15: i32, @location(48) a16: f16, @location(9) a17: f16, @location(55) a18: vec2<u32>, @location(72) a19: u32, @location(81) a20: f16) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S11 {
+@location(24) f0: i32,
+@location(26) f1: u32,
+@location(12) f2: vec4<u32>
+}
+struct VertexOutput0 {
+@location(62) f93: vec2<u32>,
+@location(14) f94: vec4<i32>,
+@location(77) f95: u32,
+@location(40) f96: vec3<f32>,
+@location(79) f97: vec4<f16>,
+@location(9) f98: f16,
+@location(81) f99: f16,
+@location(88) f100: f16,
+@location(10) f101: vec4<f32>,
+@location(57) f102: vec2<i32>,
+@location(6) f103: vec4<u32>,
+@location(97) f104: u32,
+@location(35) f105: f16,
+@location(17) f106: vec4<f16>,
+@location(31) f107: i32,
+@location(49) f108: vec2<f16>,
+@location(87) f109: i32,
+@location(48) f110: f16,
+@location(24) f111: vec4<f16>,
+@builtin(position) f112: vec4<f32>,
+@location(55) f113: vec2<u32>,
+@location(46) f114: u32,
+@location(100) f115: vec3<i32>,
+@location(71) f116: vec2<i32>,
+@location(105) f117: vec2<i32>,
+@location(72) f118: u32,
+@location(34) f119: vec4<i32>,
+@location(70) f120: u32,
+@location(83) f121: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(23) a0: vec4<f16>, a1: S11, @location(4) a2: vec4<u32>, @location(20) a3: vec4<f32>, @location(18) a4: vec3<f32>, @location(22) a5: f32, @location(3) a6: vec4<f16>, @location(21) a7: vec3<u32>, @location(27) a8: u32, @location(6) a9: vec2<f32>, @location(14) a10: vec3<f16>, @location(15) a11: vec3<u32>, @location(25) a12: vec3<i32>, @location(0) a13: vec2<f32>, @location(2) a14: vec2<i32>, @location(13) a15: i32, @location(9) a16: f16, @location(1) a17: vec4<u32>, @location(17) a18: vec3<f16>, @location(7) a19: vec2<i32>, @location(11) a20: vec3<u32>, @location(10) a21: f32, @location(5) a22: vec4<f32>, @builtin(vertex_index) a23: u32, @location(19) a24: vec2<i32>, @builtin(instance_index) a25: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let querySet29 = device1.createQuerySet({
+type: 'occlusion',
+count: 3236,
+});
+let texture30 = device1.createTexture(
+{
+size: [2426],
+dimension: '1d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8snorm'
+],
+}
+);
+let textureView35 = texture30.createView(
+{
+label: '\u5553\u0de5\u4eda\uc761\ua731\ucaeb\u09ed\u0d8a\u33ee',
+}
+);
+let computePassEncoder14 = commandEncoder24.beginComputePass();
+let sampler37 = device1.createSampler(
+{
+label: '\ufb3a\u0b8b\u0b8c\u{1fa51}\u07bb\u078e\ub7b0\ubeae',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 8.350,
+lodMaxClamp: 89.871,
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+7,
+bindGroup2,
+new Uint32Array(3516),
+2862,
+0
+);
+} catch {}
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+await promise15;
+} catch {}
+let videoFrame10 = new VideoFrame(video0, {timestamp: 0});
+let commandEncoder25 = device2.createCommandEncoder(
+{
+}
+);
+let textureView36 = texture29.createView(
+{
+label: '\u7312\u{1fa22}\u{1f77c}',
+dimension: '3d',
+}
+);
+let renderPassEncoder10 = commandEncoder25.beginRenderPass(
+{
+label: '\udfb5\uab2f\ubcaf\u9ea1\u15a3\ud2c0',
+colorAttachments: [
+undefined,
+undefined,
+{
+view: textureView34,
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet25,
+maxDrawCount: 8264,
+}
+);
+let renderBundleEncoder24 = device2.createRenderBundleEncoder(
+{
+label: '\u4ba0\u567d\u{1fe06}\u{1fa91}\u0fd1\u05f5\u0022\u00e4\ue4ab',
+colorFormats: [
+'rgba8unorm',
+'r8sint',
+'rgba16sint',
+'rgba8uint',
+'rg8sint',
+'r32sint',
+'r16uint',
+'rg16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 172,
+stencilReadOnly: true,
+}
+);
+let renderBundle39 = renderBundleEncoder24.finish(
+{
+label: '\u7d8e\ua1a1\u3b6f\ud816\u075f\u0c91\ud5c0\u0c20'
+}
+);
+try {
+renderPassEncoder10.setBlendConstant({ r: 468.4, g: 901.0, b: 699.9, a: -498.9, });
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(
+0,
+1,
+1,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+3217
+);
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+0.5559,
+0.4850,
+0.2959,
+0.2387,
+0.1917,
+0.8760
+);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(
+26,
+undefined,
+983822418,
+1629296485
+);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(
+34,
+undefined,
+2462380781,
+19402705
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 4431, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Int32Array(arrayBuffer0),
+/* required buffer size: 5130 */{
+offset: 502,
+},
+{width: 2314, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let offscreenCanvas13 = new OffscreenCanvas(616, 82);
+let bindGroupLayout11 = device2.createBindGroupLayout(
+{
+entries: [
+{
+binding: 2146,
+visibility: 0,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 830,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+}
+],
+}
+);
+try {
+renderBundleEncoder20.setVertexBuffer(
+69,
+undefined,
+3428155624,
+341503554
+);
+} catch {}
+try {
+device2.pushErrorScope('validation');
+} catch {}
+try {
+device2.queue.submit([
+]);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 44, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap6,
+  origin: { x: 283, y: 448 },
+  flipY: false,
+},
+{
+  texture: texture28,
+  mipLevel: 8,
+  origin: { x: 11, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 22, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let imageBitmap8 = await createImageBitmap(offscreenCanvas4);
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+pseudoSubmit(device2, commandEncoder25);
+try {
+renderPassEncoder10.beginOcclusionQuery(254);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+0.9451,
+0.4690,
+0.04993,
+0.3297,
+0.08227,
+0.2860
+);
+} catch {}
+let commandEncoder26 = device2.createCommandEncoder();
+pseudoSubmit(device2, commandEncoder26);
+let textureView37 = texture27.createView(
+{
+label: '\u0ded\u8ed4\uceba',
+format: 'rgba8unorm',
+}
+);
+let sampler38 = device2.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 45.522,
+lodMaxClamp: 96.932,
+compare: 'always',
+}
+);
+let externalTexture1 = device2.importExternalTexture(
+{
+source: videoFrame2,
+colorSpace: 'srgb',
+}
+);
+try {
+renderPassEncoder10.setBlendConstant({ r: -579.5, g: 959.1, b: -99.73, a: -508.1, });
+} catch {}
+try {
+gpuCanvasContext8.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 5004, y: 0, z: 0 },
+  aspect: 'all',
+},
+new BigInt64Array(new ArrayBuffer(0)),
+/* required buffer size: 71 */{
+offset: 71,
+rowsPerImage: 213,
+},
+{width: 3631, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let gpuCanvasContext9 = offscreenCanvas13.getContext('webgpu');
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+offscreenCanvas8.height = 669;
+let querySet30 = device2.createQuerySet({
+label: '\uf04d\u0cd4\u{1fc92}',
+type: 'occlusion',
+count: 2235,
+});
+let renderBundleEncoder25 = device2.createRenderBundleEncoder(
+{
+label: '\u0eff\uf3d0\u081a\u0d7a\u0930\ue1f7\u18bb\u0480\u3a9d\u3560\u6293',
+colorFormats: [
+'r8uint',
+'rg11b10ufloat',
+'rgba8uint',
+'rgba32sint'
+],
+sampleCount: 112,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder10.setVertexBuffer(
+43,
+undefined,
+3363606373
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 22, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 66, y: 172 },
+  flipY: true,
+},
+{
+  texture: texture28,
+  mipLevel: 9,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 16, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let commandEncoder27 = device1.createCommandEncoder(
+{
+label: '\ued91\u0456\u969c\u0627\u22ac\u09e2\ua955\ud891\u1b05',
+}
+);
+let renderBundleEncoder26 = device1.createRenderBundleEncoder(
+{
+label: '\u{1fe67}\u0e10\u0a5b\u{1fc0a}',
+colorFormats: [
+'r16float',
+'rg32sint',
+'r32sint',
+'rgba8sint',
+'rgba32uint',
+'r16sint'
+],
+sampleCount: 458,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler39 = device1.createSampler(
+{
+label: '\u{1fc51}\uc9cc\u7c3b\u3f5d\u1d99\ud1bf\u0f7d\u1b2d',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 35.802,
+lodMaxClamp: 73.323,
+}
+);
+let renderBundle40 = renderBundleEncoder16.finish(
+{
+label: '\u9517\u{1f818}'
+}
+);
+let sampler40 = device1.createSampler(
+{
+label: '\u{1f70e}\u{1fa37}\uabe4\u588c\u0833\u0f9e',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMaxClamp: 79.929,
+compare: 'less',
+}
+);
+try {
+renderBundleEncoder19.setVertexBuffer(
+5,
+buffer6,
+5932,
+4355
+);
+} catch {}
+try {
+commandEncoder21.copyBufferToBuffer(
+buffer6,
+224,
+buffer7,
+9468,
+436
+);
+dissociateBuffer(device1, buffer6);
+dissociateBuffer(device1, buffer7);
+} catch {}
+let pipeline36 = device1.createComputePipeline(
+{
+label: '\u0741\u3386\ue624\u{1f637}\uaf2e\u49a8',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+},
+}
+);
+let texture31 = device1.createTexture(
+{
+label: '\u17f1\u9fea\ue2a8\u0072\u5b4e\u0e57',
+size: [2043, 1, 146],
+mipLevelCount: 2,
+dimension: '3d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8uint',
+'r8uint',
+'r8uint'
+],
+}
+);
+let textureView38 = texture23.createView(
+{
+label: '\ub2b1\u06a5\u0082',
+baseArrayLayer: 0,
+}
+);
+let renderBundleEncoder27 = device1.createRenderBundleEncoder(
+{
+label: '\u{1fd69}\u9528\u0df5\u14d2',
+colorFormats: [
+undefined,
+'r32float',
+'bgra8unorm',
+'r8unorm',
+'rg8unorm'
+],
+sampleCount: 208,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder27.copyBufferToBuffer(
+buffer6,
+4572,
+buffer7,
+13040,
+28
+);
+dissociateBuffer(device1, buffer6);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder18.resolveQuerySet(
+querySet27,
+3139,
+168,
+buffer7,
+7424
+);
+} catch {}
+let pipeline37 = device1.createComputePipeline(
+{
+label: '\u43f7\u{1f97e}\u{1f8ac}\u1a56\u{1fa60}\u5bcd\u{1fee9}\u{1fb1d}\u0168',
+layout: 'auto',
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let commandEncoder28 = device2.createCommandEncoder(
+{
+label: '\uae3b\uc039\u0d75\u{1fcb1}\u8e90\ua069',
+}
+);
+let textureView39 = texture27.createView(
+{
+label: '\u9410\ud45e\u9b21\u{1fe24}\u792e\u03a4\u0ef1\u0552\u{1feaf}',
+dimension: '2d-array',
+arrayLayerCount: 1,
+}
+);
+let computePassEncoder15 = commandEncoder28.beginComputePass(
+{
+label: '\u5b15\u231d\u4051\u06de\ub634\u067c'
+}
+);
+let renderBundle41 = renderBundleEncoder24.finish(
+{
+label: '\ue2eb\u0316\u02c2\u2f76\u070b'
+}
+);
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+1850
+);
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+0.8973,
+0.5225,
+0.00559,
+0.1307,
+0.6805,
+0.7957
+);
+} catch {}
+let adapter4 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let textureView40 = texture26.createView(
+{
+label: '\u3739\u5a60\u3dc5\u0072\u2002',
+arrayLayerCount: 1,
+}
+);
+let renderBundleEncoder28 = device2.createRenderBundleEncoder(
+{
+label: '\u0a49\u0871\u9e6e\uee0d\u065e\u00fc\u0ae5',
+colorFormats: [
+'rgba8unorm',
+'bgra8unorm'
+],
+sampleCount: 153,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder10.setBlendConstant({ r: 543.0, g: 963.5, b: -922.7, a: -347.3, });
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(
+1,
+0,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+1708
+);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(
+52,
+undefined,
+896720730,
+2448174999
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1426, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img3,
+  origin: { x: 25, y: 16 },
+  flipY: false,
+},
+{
+  texture: texture28,
+  mipLevel: 3,
+  origin: { x: 826, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 91, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+2183
+);
+} catch {}
+let sampler41 = device2.createSampler(
+{
+label: '\u057c\u6bb6\u{1fa4c}\u68d7',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 58.166,
+lodMaxClamp: 81.974,
+}
+);
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: 236.0, g: 488.4, b: -275.6, a: -199.3, });
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+0.5317,
+0.03297,
+0.00965,
+0.4792,
+0.1454,
+0.1604
+);
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let offscreenCanvas14 = new OffscreenCanvas(426, 403);
+let pipelineLayout6 = device2.createPipelineLayout(
+{
+label: '\u{1f6e1}\u9d7f\u{1fc7e}\u0b4c\u07b7',
+bindGroupLayouts: [
+bindGroupLayout11,
+bindGroupLayout11,
+bindGroupLayout11,
+bindGroupLayout11
+]
+}
+);
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(
+1,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+0.3103,
+0.2405,
+0.6614,
+0.3595,
+0.3743,
+0.9063
+);
+} catch {}
+try {
+device2.queue.submit([
+commandBuffer1,
+]);
+} catch {}
+let bindGroupLayout12 = device1.createBindGroupLayout(
+{
+entries: [
+{
+binding: 6076,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'filtering' },
+},
+{
+binding: 4733,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+}
+],
+}
+);
+let querySet31 = device1.createQuerySet({
+label: '\u02ff\u1995\u0e35\u573d\u4a30',
+type: 'occlusion',
+count: 3287,
+});
+let renderBundleEncoder29 = device1.createRenderBundleEncoder(
+{
+label: '\u1c95\u{1faaf}\u{1f6fc}\u0fcc',
+colorFormats: [
+'r32uint',
+undefined,
+'rgba32float',
+'rgba32sint',
+undefined,
+'r32uint'
+],
+sampleCount: 960,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler42 = device1.createSampler(
+{
+label: '\u5613\u9c01\u0ff7\u8aa4\u{1f7e9}\u046d\u300c\u7794',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 38.090,
+lodMaxClamp: 72.157,
+maxAnisotropy: 1,
+}
+);
+try {
+renderBundleEncoder26.setVertexBuffer(
+7,
+buffer6,
+9060,
+371
+);
+} catch {}
+try {
+commandEncoder21.copyTextureToTexture(
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 36, y: 13, z: 109 },
+  aspect: 'all',
+},
+{
+  texture: texture22,
+  mipLevel: 1,
+  origin: { x: 18, y: 12, z: 69 },
+  aspect: 'all',
+},
+{width: 31, height: 6, depthOrArrayLayers: 96}
+);
+} catch {}
+try {
+commandEncoder18.clearBuffer(
+buffer7,
+5868,
+6828
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+computePassEncoder11.insertDebugMarker(
+'\u7e68'
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+10856,
+new DataView(new ArrayBuffer(11651)),
+6898,
+1276
+);
+} catch {}
+let gpuCanvasContext10 = offscreenCanvas14.getContext('webgpu');
+let offscreenCanvas15 = new OffscreenCanvas(746, 1003);
+let shaderModule12 = device2.createShaderModule(
+{
+label: '\u5409\u9b60',
+code: `@group(1) @binding(2146)
+var<storage, read_write> type23: array<u32>;
+@group(0) @binding(2146)
+var<storage, read_write> global20: array<u32>;
+@group(2) @binding(2146)
+var<storage, read_write> type24: array<u32>;
+@group(2) @binding(830)
+var<storage, read_write> parameter18: array<u32>;
+@group(0) @binding(830)
+var<storage, read_write> local19: array<u32>;
+@group(3) @binding(830)
+var<storage, read_write> local20: array<u32>;
+@group(3) @binding(2146)
+var<storage, read_write> field21: array<u32>;
+
+@compute @workgroup_size(7, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(3) f0: vec4<u32>,
+@location(0) f1: u32,
+@location(2) f2: vec3<i32>,
+@location(1) f3: vec2<u32>,
+@location(4) f4: f32,
+@location(7) f5: i32,
+@location(6) f6: vec3<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(13) a0: f32, @location(0) a1: vec2<i32>, @location(9) a2: vec2<f16>, @location(3) a3: vec3<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture32 = gpuCanvasContext8.getCurrentTexture();
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+let querySet32 = device1.createQuerySet({
+label: '\u036b\u8a64\u0120\u{1fb1c}\u05d4\u0097\u07ae\u{1f8e2}\u1847',
+type: 'occlusion',
+count: 1148,
+});
+let texture33 = device1.createTexture(
+{
+label: '\ucffd\ue4fa\u7866\ud405\u{1f941}\u79ce',
+size: {width: 1646, height: 1, depthOrArrayLayers: 872},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16sint',
+'r16sint',
+'r16sint'
+],
+}
+);
+let textureView41 = texture31.createView(
+{
+label: '\u5b40\u0927\u0330\u54b7\ufdab\ue67a\u4d54\u60f9\u{1fef0}',
+dimension: '3d',
+mipLevelCount: 1,
+}
+);
+let renderBundleEncoder30 = device1.createRenderBundleEncoder(
+{
+label: '\u450f\u89fd\u370f\u20e7',
+colorFormats: [
+'rg32float',
+'bgra8unorm-srgb',
+'rg16float',
+'rg16float'
+],
+sampleCount: 665,
+stencilReadOnly: true,
+}
+);
+try {
+commandEncoder27.copyBufferToBuffer(
+buffer6,
+6308,
+buffer7,
+2396,
+1024
+);
+dissociateBuffer(device1, buffer6);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder21.clearBuffer(
+buffer7,
+11560,
+1484
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder21.resolveQuerySet(
+querySet31,
+792,
+825,
+buffer7,
+512
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture25,
+  mipLevel: 4,
+  origin: { x: 8, y: 0, z: 11 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 4775079 */{
+offset: 329,
+bytesPerRow: 250,
+rowsPerImage: 269,
+},
+{width: 0, height: 1, depthOrArrayLayers: 72}
+);
+} catch {}
+let buffer9 = device1.createBuffer(
+{
+label: '\u6340\u{1fe94}\u{1fcf7}\u06b3\u0c67\u0c02\ubc99\ua331\u{1fc60}\u741c',
+size: 44139,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX,
+}
+);
+let sampler43 = device1.createSampler(
+{
+label: '\uaabf\u778b\u{1ff02}\ud472\u0189\u9f10',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 84.029,
+lodMaxClamp: 89.316,
+compare: 'less-equal',
+maxAnisotropy: 4,
+}
+);
+try {
+computePassEncoder13.setPipeline(
+pipeline28
+);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(
+5,
+bindGroup1
+);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(
+8,
+buffer9,
+27616,
+6666
+);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture25,
+  mipLevel: 2,
+  origin: { x: 5, y: 0, z: 6 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 16572585 */{
+offset: 560,
+bytesPerRow: 535,
+rowsPerImage: 177,
+},
+{width: 25, height: 1, depthOrArrayLayers: 176}
+);
+} catch {}
+offscreenCanvas12.width = 764;
+try {
+offscreenCanvas15.getContext('bitmaprenderer');
+} catch {}
+let texture34 = device1.createTexture(
+{
+label: '\ub26a\u34c2\ua6af\u{1ffc6}\u95a3\u0f4c\ubbe2\uf5b0\uef35\uc714\u679f',
+size: {width: 44, height: 32, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'eac-r11unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'eac-r11unorm',
+'eac-r11unorm'
+],
+}
+);
+let sampler44 = device1.createSampler(
+{
+label: '\u0d7d\uef83\u09e4\u0e49\u04cd\ub4c6\u5165\u53e7\u{1fba3}\ub34b\ud701',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 96.105,
+maxAnisotropy: 20,
+}
+);
+try {
+commandEncoder18.copyBufferToBuffer(
+buffer6,
+80,
+buffer7,
+9832,
+1472
+);
+dissociateBuffer(device1, buffer6);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder21.copyTextureToTexture(
+{
+  texture: texture25,
+  mipLevel: 6,
+  origin: { x: 1, y: 0, z: 22 },
+  aspect: 'all',
+},
+{
+  texture: texture25,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 10 },
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder18.resolveQuerySet(
+querySet27,
+580,
+404,
+buffer7,
+9216
+);
+} catch {}
+let buffer10 = device2.createBuffer(
+{
+label: '\u{1ff20}\ub294\u0937\ub529\u04e0\u98b1\u0bb9\ubffc',
+size: 16200,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let renderBundle42 = renderBundleEncoder23.finish();
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+0.3809,
+0.1681,
+0.3215,
+0.8058,
+0.2301,
+0.6958
+);
+} catch {}
+canvas3.height = 978;
+let video5 = await videoWithData();
+let imageBitmap9 = await createImageBitmap(offscreenCanvas0);
+let imageData12 = new ImageData(72, 40);
+try {
+await adapter2.requestAdapterInfo();
+} catch {}
+let commandEncoder29 = device1.createCommandEncoder(
+{
+label: '\u78bb\u05a6\u0138\u0d98\u1fcf',
+}
+);
+let computePassEncoder16 = commandEncoder27.beginComputePass(
+{
+
+}
+);
+let renderPassEncoder11 = commandEncoder18.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView41,
+depthSlice: 30,
+clearValue: { r: 261.8, g: 617.7, b: 794.2, a: 362.0, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 65,
+clearValue: { r: -594.9, g: -586.3, b: -95.55, a: -437.0, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 84,
+clearValue: { r: -136.5, g: -549.9, b: 27.12, a: -147.1, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 74,
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet24,
+maxDrawCount: 16952,
+}
+);
+let renderBundleEncoder31 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba32uint',
+'rg32uint',
+'r16uint',
+'r8unorm'
+],
+sampleCount: 881,
+stencilReadOnly: true,
+}
+);
+let sampler45 = device1.createSampler(
+{
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 98.123,
+lodMaxClamp: 98.796,
+compare: 'never',
+maxAnisotropy: 5,
+}
+);
+try {
+computePassEncoder9.setPipeline(
+pipeline28
+);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(
+5,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(
+976
+);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(
+buffer7,
+'uint16',
+6092,
+3614
+);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(
+2,
+bindGroup2
+);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(
+2,
+bindGroup3,
+new Uint32Array(9842),
+8249,
+0
+);
+} catch {}
+try {
+commandEncoder21.copyBufferToBuffer(
+buffer6,
+7692,
+buffer7,
+1200,
+2424
+);
+dissociateBuffer(device1, buffer6);
+dissociateBuffer(device1, buffer7);
+} catch {}
+let imageBitmap10 = await createImageBitmap(imageData11);
+let textureView42 = texture26.createView(
+{
+}
+);
+let sampler46 = device2.createSampler(
+{
+label: '\u6f60\ub780\u0498\u0b7a\u00d1\ua78f\u05cf',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 28.553,
+lodMaxClamp: 70.077,
+}
+);
+try {
+renderPassEncoder10.setStencilReference(
+590
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+await promise14;
+} catch {}
+let img6 = await imageWithData(292, 258, '#2762e68c', '#7ce8573a');
+try {
+adapter0.label = '\u0809\u2bec\u941b';
+} catch {}
+let commandEncoder30 = device2.createCommandEncoder(
+{
+label: '\u418e\u0afc\u{1fa58}\u{1f95d}\u66e9\ueda1\u{1ff30}\u2dc7\uc0e5',
+}
+);
+let querySet33 = device2.createQuerySet({
+label: '\u0354\u{1fca8}\u9269\u{1fc5d}\u{1f79a}',
+type: 'occlusion',
+count: 1677,
+});
+let textureView43 = texture32.createView(
+{
+baseMipLevel: 0,
+}
+);
+try {
+commandEncoder30.clearBuffer(
+buffer10
+);
+dissociateBuffer(device2, buffer10);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16uint',
+'eac-rg11unorm',
+'rg8snorm',
+'rgba8unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 178, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas12,
+  origin: { x: 338, y: 789 },
+  flipY: false,
+},
+{
+  texture: texture28,
+  mipLevel: 6,
+  origin: { x: 4, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 164, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let offscreenCanvas16 = new OffscreenCanvas(939, 1007);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let img7 = await imageWithData(110, 172, '#ed5fe9d0', '#2f7f43f3');
+let video6 = await videoWithData();
+let videoFrame11 = new VideoFrame(canvas0, {timestamp: 0});
+try {
+device1.label = '\u{1fa25}\u03c5\u8cbe\ubf7d\u04bc\u{1ff36}\uc7eb';
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(
+10,
+bindGroup1,
+new Uint32Array(4288),
+3260,
+0
+);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+9,
+buffer6,
+9240,
+1085
+);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+offscreenCanvas16.height = 120;
+let renderPassEncoder12 = commandEncoder30.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined,
+{
+view: textureView32,
+clearValue: { r: -275.6, g: 579.6, b: -509.9, a: 713.9, },
+loadOp: 'load',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet25,
+maxDrawCount: 42808,
+}
+);
+try {
+renderPassEncoder12.beginOcclusionQuery(2297);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+54,
+undefined,
+2876384182,
+248938124
+);
+} catch {}
+let gpuCanvasContext11 = offscreenCanvas16.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageData13 = new ImageData(192, 8);
+let querySet34 = device1.createQuerySet({
+label: '\ud676\u0bd8\ud118',
+type: 'occlusion',
+count: 1973,
+});
+try {
+renderPassEncoder11.setBindGroup(
+10,
+bindGroup3
+);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(6);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: -68.97, g: -247.0, b: -995.7, a: -611.0, });
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(
+1869
+);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(
+2,
+bindGroup3
+);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(
+1,
+bindGroup1,
+new Uint32Array(7102),
+6544,
+0
+);
+} catch {}
+try {
+commandEncoder29.clearBuffer(
+buffer7,
+8520,
+2428
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+let pipeline38 = await device1.createComputePipelineAsync(
+{
+label: '\u275d\u{1f933}\ue74a\u2c4e\u{1fb63}\uc33a\u4de3\u5c6d\u6b10\u{1fcda}\u45b3',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline39 = device1.createRenderPipeline(
+{
+label: '\uee85\u{1fd85}\u0531',
+layout: pipelineLayout5,
+vertex: {
+module: shaderModule7,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 15380,
+attributes: [
+{
+format: 'sint16x2',
+offset: 14312,
+shaderLocation: 27,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 14028,
+shaderLocation: 6,
+},
+{
+format: 'unorm8x4',
+offset: 13388,
+shaderLocation: 1,
+},
+{
+format: 'uint32x3',
+offset: 11316,
+shaderLocation: 5,
+},
+{
+format: 'sint8x4',
+offset: 11168,
+shaderLocation: 2,
+},
+{
+format: 'sint16x2',
+offset: 13832,
+shaderLocation: 16,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 2776,
+shaderLocation: 12,
+},
+{
+format: 'sint32x3',
+offset: 8064,
+shaderLocation: 3,
+},
+{
+format: 'uint32',
+offset: 2972,
+shaderLocation: 0,
+},
+{
+format: 'uint32',
+offset: 4708,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 57744,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 7424,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 1664,
+shaderLocation: 17,
+},
+{
+format: 'unorm16x4',
+offset: 2744,
+shaderLocation: 14,
+},
+{
+format: 'float32x4',
+offset: 7200,
+shaderLocation: 24,
+},
+{
+format: 'float32x2',
+offset: 5844,
+shaderLocation: 18,
+},
+{
+format: 'sint16x2',
+offset: 2704,
+shaderLocation: 20,
+},
+{
+format: 'float32x2',
+offset: 2256,
+shaderLocation: 26,
+},
+{
+format: 'sint16x4',
+offset: 2292,
+shaderLocation: 25,
+},
+{
+format: 'sint32x3',
+offset: 3820,
+shaderLocation: 15,
+},
+{
+format: 'snorm8x2',
+offset: 6182,
+shaderLocation: 13,
+},
+{
+format: 'float32x3',
+offset: 5804,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x2',
+offset: 1964,
+shaderLocation: 7,
+},
+{
+format: 'uint32x3',
+offset: 1728,
+shaderLocation: 10,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 1100,
+shaderLocation: 9,
+},
+{
+format: 'uint8x2',
+offset: 390,
+shaderLocation: 19,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule7,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16sint',
+writeMask: 0,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'invert',
+},
+stencilWriteMask: 1423,
+depthBias: 66,
+depthBiasSlopeScale: 75,
+depthBiasClamp: 62,
+},
+}
+);
+let adapter5 = await navigator.gpu.requestAdapter();
+try {
+computePassEncoder9.setPipeline(
+pipeline31
+);
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+395.7,
+0.1356,
+99.70,
+0.3858,
+0.06661,
+0.9370
+);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+1,
+buffer6
+);
+} catch {}
+let texture35 = device1.createTexture(
+{
+label: '\u{1fa19}\ude0c\uff2d\u3b05\u5c66\u1d07',
+size: [18, 14, 57],
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rg32sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(
+198,
+0,
+673,
+1
+);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(
+8,
+bindGroup2
+);
+} catch {}
+try {
+commandEncoder29.clearBuffer(
+buffer7,
+13388,
+0
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder21.resolveQuerySet(
+querySet24,
+1474,
+179,
+buffer7,
+3072
+);
+} catch {}
+let pipeline40 = device1.createRenderPipeline(
+{
+label: '\ud9b2\u1ff9\u3fe6\u0780\u7e6b\u{1fe25}',
+layout: pipelineLayout5,
+vertex: {
+module: shaderModule8,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 8152,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 3548,
+shaderLocation: 1,
+},
+{
+format: 'float32x3',
+offset: 4860,
+shaderLocation: 10,
+},
+{
+format: 'snorm8x2',
+offset: 1060,
+shaderLocation: 19,
+},
+{
+format: 'sint32x4',
+offset: 3336,
+shaderLocation: 21,
+}
+],
+},
+{
+arrayStride: 28452,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x2',
+offset: 7934,
+shaderLocation: 7,
+},
+{
+format: 'float32x2',
+offset: 22872,
+shaderLocation: 16,
+},
+{
+format: 'float32x3',
+offset: 11452,
+shaderLocation: 22,
+},
+{
+format: 'float32',
+offset: 19900,
+shaderLocation: 18,
+},
+{
+format: 'sint32',
+offset: 14840,
+shaderLocation: 20,
+},
+{
+format: 'float32',
+offset: 6988,
+shaderLocation: 25,
+},
+{
+format: 'uint32',
+offset: 15340,
+shaderLocation: 2,
+},
+{
+format: 'snorm8x4',
+offset: 10684,
+shaderLocation: 13,
+},
+{
+format: 'uint32x4',
+offset: 12288,
+shaderLocation: 4,
+},
+{
+format: 'sint32',
+offset: 10432,
+shaderLocation: 8,
+},
+{
+format: 'uint8x4',
+offset: 9160,
+shaderLocation: 3,
+},
+{
+format: 'snorm8x2',
+offset: 558,
+shaderLocation: 26,
+},
+{
+format: 'sint32x3',
+offset: 3540,
+shaderLocation: 15,
+},
+{
+format: 'sint8x4',
+offset: 5216,
+shaderLocation: 27,
+},
+{
+format: 'unorm8x4',
+offset: 24876,
+shaderLocation: 17,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 13524,
+shaderLocation: 0,
+},
+{
+format: 'unorm8x2',
+offset: 2004,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 50772,
+attributes: [
+{
+format: 'uint32x4',
+offset: 47048,
+shaderLocation: 14,
+},
+{
+format: 'uint16x2',
+offset: 33596,
+shaderLocation: 5,
+},
+{
+format: 'sint32x4',
+offset: 32616,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 21500,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 1636,
+shaderLocation: 24,
+},
+{
+format: 'sint32x4',
+offset: 14748,
+shaderLocation: 6,
+},
+{
+format: 'uint16x4',
+offset: 4088,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 53668,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 4336,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x84d02996,
+},
+fragment: {
+module: shaderModule8,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16float',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-clamp',
+},
+stencilReadMask: 1746,
+stencilWriteMask: 2497,
+depthBias: 60,
+depthBiasSlopeScale: 10,
+depthBiasClamp: 48,
+},
+}
+);
+let texture36 = device2.createTexture(
+{
+label: '\u81a0\u{1f6cb}',
+size: {width: 196, height: 216, depthOrArrayLayers: 5},
+mipLevelCount: 8,
+format: 'eac-rg11unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView44 = texture36.createView(
+{
+label: '\u0e5c\u{1fab6}\u6b3e\u41d6\u{1f91c}\u09b0\u{1f8f1}',
+baseMipLevel: 3,
+mipLevelCount: 2,
+baseArrayLayer: 2,
+arrayLayerCount: 3,
+}
+);
+try {
+renderPassEncoder10.setBlendConstant({ r: 158.2, g: -874.4, b: -272.2, a: 545.6, });
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+3204
+);
+} catch {}
+try {
+await device2.popErrorScope();
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer10,
+12328,
+new Int16Array(12952),
+801,
+540
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let textureView45 = texture26.createView(
+{
+label: '\uc2ce\ub8f1\uc88b\u{1f783}',
+}
+);
+let renderBundle43 = renderBundleEncoder24.finish(
+{
+label: '\u00f2\ub372\u54af\u9b0c\u08d5\u{1ff5d}\u1877'
+}
+);
+try {
+renderPassEncoder12.setBlendConstant({ r: -645.8, g: 405.0, b: -209.7, a: 63.18, });
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+3477
+);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+39,
+undefined,
+1833028295,
+2267051994
+);
+} catch {}
+let imageData14 = new ImageData(40, 20);
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(2123);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+let promise16 = buffer10.mapAsync(
+GPUMapMode.READ,
+13392,
+1368
+);
+try {
+commandEncoder28.copyTextureToTexture(
+{
+  texture: texture32,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture32,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder28.clearBuffer(
+buffer10
+);
+dissociateBuffer(device2, buffer10);
+} catch {}
+let buffer11 = device2.createBuffer(
+{
+label: '\u3286\u{1ffa4}\ud4e0\u0b55\u9814\u{1f6bb}\uf6e1\u{1fdd5}\u7809\u0ed5',
+size: 64173,
+usage: GPUBufferUsage.MAP_READ,
+}
+);
+try {
+renderPassEncoder10.setBlendConstant({ r: 977.7, g: 301.1, b: 625.4, a: 266.0, });
+} catch {}
+try {
+buffer11.destroy();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 356, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData9,
+  origin: { x: 2, y: 97 },
+  flipY: true,
+},
+{
+  texture: texture28,
+  mipLevel: 5,
+  origin: { x: 119, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 236, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let renderPassEncoder13 = commandEncoder21.beginRenderPass(
+{
+label: '\u8b22\u0d20',
+colorAttachments: [
+undefined,
+{
+view: textureView41,
+depthSlice: 56,
+clearValue: { r: 850.4, g: -671.9, b: 116.7, a: 573.9, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 135,
+clearValue: { r: 631.9, g: -560.6, b: -630.8, a: -641.9, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 58,
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 51,
+clearValue: { r: 16.83, g: 306.6, b: -789.4, a: 3.995, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 100,
+clearValue: { r: 576.7, g: 183.0, b: 380.9, a: 446.1, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 0,
+clearValue: { r: 476.8, g: 552.9, b: 599.5, a: -500.8, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 74,
+clearValue: { r: 445.6, g: 849.1, b: 379.8, a: -877.3, },
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet24,
+maxDrawCount: 19592,
+}
+);
+try {
+renderPassEncoder13.end();
+} catch {}
+try {
+commandEncoder29.copyBufferToBuffer(
+buffer9,
+7116,
+buffer7,
+11276,
+1144
+);
+dissociateBuffer(device1, buffer9);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+5956,
+new Float32Array(7065),
+1636,
+1752
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let shaderModule13 = device1.createShaderModule(
+{
+code: `@group(6) @binding(381)
+var<storage, read_write> local21: array<u32>;
+@group(0) @binding(1761)
+var<storage, read_write> parameter19: array<u32>;
+@group(2) @binding(1617)
+var<storage, read_write> field22: array<u32>;
+@group(3) @binding(381)
+var<storage, read_write> function27: array<u32>;
+@group(2) @binding(1761)
+var<storage, read_write> function28: array<u32>;
+@group(3) @binding(746)
+var<storage, read_write> i18: array<u32>;
+@group(4) @binding(1617)
+var<storage, read_write> function29: array<u32>;
+@group(1) @binding(746)
+var<storage, read_write> global21: array<u32>;
+@group(6) @binding(746)
+var<storage, read_write> parameter20: array<u32>;
+@group(5) @binding(1617)
+var<storage, read_write> global22: array<u32>;
+
+@compute @workgroup_size(6, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool) -> @location(4) i32 {
+return i32();
+}
+
+
+
+@vertex
+fn vertex0(@location(10) a0: vec3<i32>, @builtin(instance_index) a1: u32, @location(4) a2: vec2<u32>, @location(11) a3: vec2<i32>, @location(19) a4: u32, @location(25) a5: vec2<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+try {
+renderPassEncoder11.setBlendConstant({ r: 352.8, g: -238.7, b: -168.9, a: -855.0, });
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(
+551,
+1,
+1112,
+0
+);
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+388.5,
+0.2363,
+148.2,
+0.3814,
+0.7361,
+0.8262
+);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+7,
+buffer6,
+2204
+);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(
+buffer7,
+'uint32',
+9452,
+2138
+);
+} catch {}
+try {
+commandEncoder29.clearBuffer(
+buffer7,
+212,
+108
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+568,
+new DataView(new ArrayBuffer(13844)),
+11844,
+104
+);
+} catch {}
+let pipeline41 = device1.createRenderPipeline(
+{
+label: '\u7144\u7e91\u{1f8c8}\u{1fdfc}\uf7a7',
+layout: pipelineLayout5,
+vertex: {
+module: shaderModule10,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 14784,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x2',
+offset: 9158,
+shaderLocation: 4,
+},
+{
+format: 'uint16x2',
+offset: 4656,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x4',
+offset: 2324,
+shaderLocation: 13,
+},
+{
+format: 'uint32x3',
+offset: 3676,
+shaderLocation: 10,
+},
+{
+format: 'sint32x2',
+offset: 10172,
+shaderLocation: 20,
+},
+{
+format: 'sint16x2',
+offset: 9932,
+shaderLocation: 6,
+},
+{
+format: 'snorm8x4',
+offset: 5596,
+shaderLocation: 14,
+},
+{
+format: 'sint8x2',
+offset: 11782,
+shaderLocation: 0,
+},
+{
+format: 'sint32x3',
+offset: 12132,
+shaderLocation: 7,
+},
+{
+format: 'snorm8x2',
+offset: 13680,
+shaderLocation: 5,
+},
+{
+format: 'uint32x2',
+offset: 2404,
+shaderLocation: 19,
+},
+{
+format: 'uint32x2',
+offset: 7536,
+shaderLocation: 16,
+},
+{
+format: 'sint16x4',
+offset: 6464,
+shaderLocation: 8,
+},
+{
+format: 'float32',
+offset: 6732,
+shaderLocation: 9,
+},
+{
+format: 'uint16x4',
+offset: 14024,
+shaderLocation: 27,
+},
+{
+format: 'sint8x4',
+offset: 10100,
+shaderLocation: 23,
+},
+{
+format: 'sint8x4',
+offset: 1136,
+shaderLocation: 22,
+},
+{
+format: 'snorm16x4',
+offset: 4012,
+shaderLocation: 12,
+},
+{
+format: 'float32x4',
+offset: 5776,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 40552,
+attributes: [
+{
+format: 'snorm16x2',
+offset: 33440,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 172,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x2',
+offset: 68,
+shaderLocation: 17,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule10,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rgba16float',
+writeMask: 0,
+},
+{
+format: 'rg32float',
+writeMask: 0,
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rg8unorm',
+writeMask: GPUColorWrite.BLUE,
+},
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r8uint',
+},
+{
+format: 'rg11b10ufloat',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r8uint',
+writeMask: 0,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+failOp: 'decrement-wrap',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilWriteMask: 596,
+depthBias: 51,
+depthBiasSlopeScale: 34,
+depthBiasClamp: 30,
+},
+}
+);
+let bindGroupLayout13 = device2.createBindGroupLayout(
+{
+label: '\u{1fbf4}\u2f29\ufd0a\uc762\u5cd6\u12ec\u0677\u19a8\ud026\u3114',
+entries: [
+{
+binding: 1202,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+},
+{
+binding: 1665,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'storage', minBindingSize: 699756, hasDynamicOffset: false },
+},
+{
+binding: 1466,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let computePassEncoder17 = commandEncoder28.beginComputePass(
+{
+label: '\u06b3\u3e6a\u7e66\u0eb0\u6001\u670e\u0e21'
+}
+);
+let renderBundleEncoder32 = device2.createRenderBundleEncoder(
+{
+label: '\u{1f81d}\u01ba\u01f6\ubf61\u733e\u0161\u9dc9',
+colorFormats: [
+undefined,
+'rg8unorm',
+'rg16uint',
+'rgba16sint',
+'r8uint',
+'r16float',
+'rg16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 706,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder10.beginOcclusionQuery(2415);
+} catch {}
+let canvas9 = document.createElement('canvas');
+let img8 = await imageWithData(219, 71, '#7800bc88', '#90d5d76f');
+let shaderModule14 = device2.createShaderModule(
+{
+label: '\u06fd\uee7e',
+code: `@group(0) @binding(830)
+var<storage, read_write> type25: array<u32>;
+@group(3) @binding(830)
+var<storage, read_write> function30: array<u32>;
+@group(1) @binding(2146)
+var<storage, read_write> type26: array<u32>;
+@group(3) @binding(2146)
+var<storage, read_write> field23: array<u32>;
+@group(2) @binding(830)
+var<storage, read_write> i19: array<u32>;
+@group(2) @binding(2146)
+var<storage, read_write> type27: array<u32>;
+
+@compute @workgroup_size(6, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S13 {
+@location(1) f0: vec2<f16>,
+@location(4) f1: vec2<f32>,
+@location(3) f2: vec2<f32>,
+@location(2) f3: vec2<f16>,
+@location(12) f4: vec4<u32>
+}
+struct FragmentOutput0 {
+@location(6) f0: vec3<f32>,
+@location(3) f1: vec4<f32>,
+@location(0) f2: f32,
+@location(5) f3: u32,
+@builtin(sample_mask) f4: u32
+}
+
+@fragment
+fn fragment0(@location(14) a0: vec4<i32>, @location(9) a1: vec4<f32>, a2: S13, @location(13) a3: i32, @location(17) a4: vec4<f16>, @location(7) a5: u32, @location(10) a6: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S12 {
+@location(2) f0: vec2<f32>,
+@location(4) f1: vec4<f16>,
+@location(9) f2: vec3<f16>,
+@location(11) f3: i32,
+@builtin(instance_index) f4: u32
+}
+struct VertexOutput0 {
+@location(11) f122: f32,
+@location(15) f123: vec4<i32>,
+@builtin(position) f124: vec4<f32>,
+@location(7) f125: u32,
+@location(4) f126: vec2<f32>,
+@location(10) f127: vec4<f32>,
+@location(9) f128: vec4<f32>,
+@location(17) f129: vec4<f16>,
+@location(3) f130: vec2<f32>,
+@location(2) f131: vec2<f16>,
+@location(12) f132: vec4<u32>,
+@location(1) f133: vec2<f16>,
+@location(13) f134: i32,
+@location(14) f135: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(13) a0: vec2<u32>, @location(8) a1: vec3<f16>, @location(0) a2: vec4<f16>, a3: S12, @builtin(vertex_index) a4: u32, @location(16) a5: vec2<f32>, @location(10) a6: vec3<f16>, @location(3) a7: i32, @location(12) a8: vec2<u32>, @location(5) a9: vec3<u32>, @location(6) a10: vec4<f16>, @location(7) a11: vec3<f32>, @location(1) a12: vec3<u32>, @location(14) a13: vec2<u32>, @location(15) a14: f32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let textureView46 = texture27.createView(
+{
+label: '\u01d5\u3d86',
+dimension: '2d-array',
+}
+);
+let renderBundle44 = renderBundleEncoder24.finish(
+{
+label: '\u8169\uc511\u{1f9e8}\u{1f67c}\u{1f736}\u2c27\u0a69\u13fa\u8b2e\u{1f808}'
+}
+);
+let sampler47 = device2.createSampler(
+{
+label: '\u0749\u0777\u37d1\u0d0b\ub21c\u1521\u0ddf\u8ff1\u{1f8dd}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 74.064,
+lodMaxClamp: 97.878,
+}
+);
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(
+28,
+undefined
+);
+} catch {}
+try {
+buffer11.destroy();
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture28,
+  mipLevel: 4,
+  origin: { x: 22, y: 1, z: 1 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(arrayBuffer0),
+/* required buffer size: 30 */{
+offset: 30,
+rowsPerImage: 299,
+},
+{width: 65, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let computePassEncoder18 = commandEncoder29.beginComputePass(
+{
+label: '\u{1fe2c}\u12c8\u0572\u8ba0\u7d26\u0e6a\ua7a7\u0a20\uc997\ufb54'
+}
+);
+try {
+renderPassEncoder11.setBindGroup(
+2,
+bindGroup3
+);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(
+8,
+buffer6,
+4204,
+5434
+);
+} catch {}
+let gpuCanvasContext12 = canvas9.getContext('webgpu');
+let commandEncoder31 = device1.createCommandEncoder(
+{
+label: '\u{1fa27}\u0da6\u3896\u7807\u0e0b\u0dbc\u2771\u{1f775}',
+}
+);
+let texture37 = device1.createTexture(
+{
+label: '\u0c0a\u3a83\u{1f704}\uc1ea\u7bc4\u01b9\uaa2e\ufcb9\ub336',
+size: {width: 6973},
+dimension: '1d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+let renderBundle45 = renderBundleEncoder16.finish(
+{
+
+}
+);
+try {
+computePassEncoder14.setPipeline(
+pipeline32
+);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(
+3695
+);
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+515.5,
+0.02387,
+698.0,
+0.07739,
+0.02197,
+0.9665
+);
+} catch {}
+try {
+gpuCanvasContext8.configure(
+{
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST,
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+await promise16;
+} catch {}
+let shaderModule15 = device2.createShaderModule(
+{
+code: `@group(2) @binding(2146)
+var<storage, read_write> field24: array<u32>;
+@group(1) @binding(2146)
+var<storage, read_write> function31: array<u32>;
+@group(1) @binding(830)
+var<storage, read_write> global23: array<u32>;
+@group(0) @binding(2146)
+var<storage, read_write> parameter21: array<u32>;
+@group(3) @binding(830)
+var<storage, read_write> global24: array<u32>;
+@group(0) @binding(830)
+var<storage, read_write> local22: array<u32>;
+
+@compute @workgroup_size(4, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(7) f0: vec2<f32>,
+@location(1) f1: vec2<i32>,
+@location(0) f2: vec2<i32>,
+@location(3) f3: i32,
+@location(4) f4: vec2<f32>
+}
+
+@fragment
+fn fragment0(@location(0) a0: f16, @location(4) a1: vec3<f32>, @location(5) a2: f32, @builtin(sample_mask) a3: u32, @builtin(sample_index) a4: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S14 {
+@location(12) f0: vec4<u32>,
+@builtin(vertex_index) f1: u32,
+@location(0) f2: f32,
+@location(10) f3: vec2<i32>,
+@location(16) f4: vec3<f16>,
+@location(3) f5: vec3<u32>,
+@builtin(instance_index) f6: u32,
+@location(15) f7: vec3<i32>,
+@location(1) f8: f32,
+@location(5) f9: vec2<f32>,
+@location(8) f10: vec3<f16>,
+@location(2) f11: f16
+}
+struct VertexOutput0 {
+@builtin(position) f136: vec4<f32>,
+@location(5) f137: f32,
+@location(4) f138: vec3<f32>,
+@location(0) f139: f16
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec3<i32>, a1: S14, @location(13) a2: f32, @location(14) a3: vec3<f16>, @location(6) a4: vec4<i32>, @location(4) a5: vec3<f16>, @location(11) a6: vec2<f16>, @location(9) a7: vec4<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder32 = device2.createCommandEncoder(
+{
+label: '\u3307\u0cde\u7b22\u5ad5\ud79f\u777c\u{1f79f}\u01c0\uf08f',
+}
+);
+let texture38 = device2.createTexture(
+{
+label: '\uc6ca\u6fad\u0e52\ubcf0\u47f5\u{1fc63}\u3853\u7e53',
+size: {width: 1067},
+dimension: '1d',
+format: 'rgba32uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32uint',
+'rgba32uint'
+],
+}
+);
+try {
+renderPassEncoder12.beginOcclusionQuery(1299);
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(
+0,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(
+82,
+undefined,
+102062727
+);
+} catch {}
+let pipeline42 = await device2.createComputePipelineAsync(
+{
+label: '\u00f5\u79ec\u435b\ub046\u{1fc6c}\u0023\u0f4b\u07a3\ucc04\uddc1\u12d0',
+layout: pipelineLayout6,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let texture39 = device2.createTexture(
+{
+label: '\u03cc\u{1fe19}\u459d\u0f51',
+size: {width: 176, height: 199, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rg16sint',
+'rg16sint'
+],
+}
+);
+let renderPassEncoder14 = commandEncoder32.beginRenderPass(
+{
+label: '\u{1f66d}\u1509',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+{
+view: textureView34,
+clearValue: { r: 834.5, g: -593.9, b: -125.3, a: -123.0, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined,
+undefined,
+undefined
+],
+occlusionQuerySet: querySet33,
+maxDrawCount: 143648,
+}
+);
+let renderBundleEncoder33 = device2.createRenderBundleEncoder(
+{
+label: '\u0408\u000b\u04d7\u0e69',
+colorFormats: [
+'r16float',
+'rgba16sint',
+'rg32float',
+'rgba16float',
+'rgba8uint',
+'rgba16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 676,
+depthReadOnly: true,
+}
+);
+let renderBundle46 = renderBundleEncoder28.finish(
+{
+label: '\u94c3\u0faf\u124b'
+}
+);
+try {
+computePassEncoder17.setPipeline(
+pipeline42
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 3475, y: 1, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(666),
+/* required buffer size: 666 */{
+offset: 666,
+},
+{width: 1947, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let promise17 = device2.queue.onSubmittedWorkDone();
+let pipeline43 = await device2.createRenderPipelineAsync(
+{
+label: '\ud12b\ue883\ue814\u0bf2\ud3ad\u{1fbc2}\u61a6\u0b73',
+layout: pipelineLayout6,
+vertex: {
+module: shaderModule15,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 15772,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 43428,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 26432,
+shaderLocation: 10,
+},
+{
+format: 'float16x2',
+offset: 3296,
+shaderLocation: 13,
+},
+{
+format: 'sint8x2',
+offset: 4678,
+shaderLocation: 15,
+},
+{
+format: 'uint32x3',
+offset: 27224,
+shaderLocation: 3,
+},
+{
+format: 'sint16x4',
+offset: 11732,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x2',
+offset: 33756,
+shaderLocation: 8,
+},
+{
+format: 'sint16x4',
+offset: 6396,
+shaderLocation: 7,
+},
+{
+format: 'unorm16x4',
+offset: 9108,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x2',
+offset: 24218,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 40516,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 4904,
+shaderLocation: 11,
+},
+{
+format: 'unorm8x4',
+offset: 19124,
+shaderLocation: 5,
+},
+{
+format: 'float32',
+offset: 17324,
+shaderLocation: 16,
+},
+{
+format: 'snorm8x4',
+offset: 14440,
+shaderLocation: 14,
+},
+{
+format: 'uint32x4',
+offset: 6240,
+shaderLocation: 12,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 30788,
+shaderLocation: 1,
+},
+{
+format: 'float32x3',
+offset: 31012,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 27368,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x4',
+offset: 24852,
+shaderLocation: 6,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule15,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg8sint',
+},
+{
+format: 'r8sint',
+},
+undefined,
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'src-alpha-saturated',
+dstFactor: 'dst'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'zero',
+depthFailOp: 'keep',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'always',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilReadMask: 2537,
+stencilWriteMask: 638,
+depthBias: 40,
+depthBiasClamp: 35,
+},
+}
+);
+let canvas10 = document.createElement('canvas');
+try {
+canvas10.getContext('2d');
+} catch {}
+try {
+await promise17;
+} catch {}
+let adapter6 = await navigator.gpu.requestAdapter();
+let querySet35 = device2.createQuerySet({
+label: '\u5a2a\u5de0\u9718\ua26a\u4721\u0f6c\u516e',
+type: 'occlusion',
+count: 3268,
+});
+let renderBundle47 = renderBundleEncoder32.finish(
+{
+label: '\u{1f76c}\u0c30\u91ba\u085d\uc492\u{1f971}\u43bc\u01fb\uc3a1\u2f28\ud904'
+}
+);
+let sampler48 = device2.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 91.608,
+lodMaxClamp: 97.518,
+maxAnisotropy: 18,
+}
+);
+try {
+renderPassEncoder14.setScissorRect(
+0,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder14.setViewport(
+0.6094,
+0.8887,
+0.1826,
+0.03438,
+0.5336,
+0.7591
+);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+21,
+undefined,
+1791999560,
+1000575790
+);
+} catch {}
+let commandEncoder33 = device1.createCommandEncoder(
+{
+label: '\u{1fa32}\ud283\u0ba5',
+}
+);
+pseudoSubmit(device1, commandEncoder18);
+try {
+renderPassEncoder11.beginOcclusionQuery(885);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+7,
+buffer9,
+40928,
+1489
+);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(
+3,
+bindGroup2
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+5312,
+new Float32Array(26474),
+21306,
+508
+);
+} catch {}
+let video7 = await videoWithData();
+let sampler49 = device2.createSampler(
+{
+label: '\u747e\uab65\u{1fd1a}\ua33d',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 22.922,
+lodMaxClamp: 83.711,
+maxAnisotropy: 6,
+}
+);
+try {
+renderPassEncoder14.setScissorRect(
+1,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder14.setViewport(
+0.8051,
+0.4979,
+0.1046,
+0.3271,
+0.6687,
+0.9493
+);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+let pipeline44 = await device2.createRenderPipelineAsync(
+{
+label: '\uaede\u{1f6ec}\ue691',
+layout: 'auto',
+vertex: {
+module: shaderModule15,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 51660,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 45312,
+shaderLocation: 3,
+},
+{
+format: 'float32x3',
+offset: 41696,
+shaderLocation: 8,
+},
+{
+format: 'float32x4',
+offset: 19832,
+shaderLocation: 2,
+},
+{
+format: 'sint16x4',
+offset: 18356,
+shaderLocation: 10,
+},
+{
+format: 'snorm8x4',
+offset: 41136,
+shaderLocation: 0,
+},
+{
+format: 'sint16x4',
+offset: 40560,
+shaderLocation: 9,
+},
+{
+format: 'snorm8x2',
+offset: 6466,
+shaderLocation: 1,
+},
+{
+format: 'sint16x2',
+offset: 18688,
+shaderLocation: 15,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 11124,
+shaderLocation: 5,
+},
+{
+format: 'float16x2',
+offset: 36232,
+shaderLocation: 16,
+},
+{
+format: 'sint32x2',
+offset: 14924,
+shaderLocation: 6,
+},
+{
+format: 'float32',
+offset: 4848,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 36928,
+shaderLocation: 12,
+},
+{
+format: 'unorm16x4',
+offset: 35616,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 21788,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 2304,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 11960,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 3512,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 5012,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 4046,
+shaderLocation: 13,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'back',
+},
+fragment: {
+module: shaderModule15,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16sint',
+},
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+undefined,
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'rg32float',
+},
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+},
+stencilReadMask: 3551,
+depthBias: 67,
+depthBiasClamp: 49,
+},
+}
+);
+try {
+adapter4.label = '\u96db\u0b41\u{1f835}\u1fa1\u5e96\u59d7\u0251\u007a\u{1faec}\u9a83\uf6d6';
+} catch {}
+let shaderModule16 = device2.createShaderModule(
+{
+label: '\u0c95\u4062\u8a36\u3f33\u056d\u05f7\u7830\ue915',
+code: `@group(0) @binding(830)
+var<storage, read_write> function32: array<u32>;
+@group(1) @binding(830)
+var<storage, read_write> i20: array<u32>;
+@group(3) @binding(2146)
+var<storage, read_write> function33: array<u32>;
+@group(1) @binding(2146)
+var<storage, read_write> type28: array<u32>;
+@group(0) @binding(2146)
+var<storage, read_write> field25: array<u32>;
+@group(3) @binding(830)
+var<storage, read_write> function34: array<u32>;
+@group(2) @binding(2146)
+var<storage, read_write> function35: array<u32>;
+
+@compute @workgroup_size(1, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(2) f0: vec4<u32>,
+@location(7) f1: vec4<u32>,
+@location(1) f2: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(position) a1: vec4<f32>, @builtin(sample_mask) a2: u32, @builtin(sample_index) a3: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S15 {
+@location(5) f0: vec3<u32>,
+@location(11) f1: vec2<f16>,
+@location(4) f2: vec3<u32>,
+@location(16) f3: i32,
+@location(13) f4: vec4<f32>,
+@location(7) f5: vec4<u32>,
+@location(1) f6: vec3<u32>,
+@builtin(vertex_index) f7: u32,
+@location(14) f8: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(12) a0: f32, @location(6) a1: vec4<u32>, @location(15) a2: vec3<u32>, @location(2) a3: vec3<f16>, @location(9) a4: vec3<u32>, @location(8) a5: vec3<i32>, @location(0) a6: i32, @location(10) a7: vec4<i32>, @location(3) a8: i32, a9: S15, @builtin(instance_index) a10: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let querySet36 = device2.createQuerySet({
+label: '\u{1f787}\u0801\u{1f781}\u0b62\u0c3e\u{1fe75}',
+type: 'occlusion',
+count: 2318,
+});
+let renderBundleEncoder34 = device2.createRenderBundleEncoder(
+{
+label: '\uf76e\u7cd1\u3c71\ub3ad\u{1faab}\u03fd',
+colorFormats: [
+'rgba16uint',
+undefined,
+'bgra8unorm-srgb'
+],
+sampleCount: 672,
+}
+);
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(251);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(
+75,
+undefined,
+333460900,
+694232636
+);
+} catch {}
+try {
+commandEncoder28.clearBuffer(
+buffer10
+);
+dissociateBuffer(device2, buffer10);
+} catch {}
+let texture40 = device2.createTexture(
+{
+size: {width: 7224},
+dimension: '1d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderPassEncoder15 = commandEncoder28.beginRenderPass(
+{
+label: '\u0b60\u0ab7\uc3e2\u{1f613}\u{1f946}\u00bb\u0733\u5d7b\u0dce\ub671',
+colorAttachments: [
+{
+view: textureView46,
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+undefined,
+undefined,
+undefined
+],
+occlusionQuerySet: querySet28,
+maxDrawCount: 122088,
+}
+);
+let renderBundle48 = renderBundleEncoder34.finish(
+{
+label: '\u47ac\u027d'
+}
+);
+let sampler50 = device2.createSampler(
+{
+label: '\uebd7\u7eaa\u065b\ucd4d\u01e4\ue2e0',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+lodMinClamp: 21.983,
+lodMaxClamp: 37.593,
+}
+);
+try {
+renderPassEncoder15.beginOcclusionQuery(592);
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: -604.5, g: 679.0, b: -846.6, a: -738.0, });
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(
+4,
+undefined,
+906427180,
+2466850729
+);
+} catch {}
+let pipeline45 = await device2.createComputePipelineAsync(
+{
+layout: 'auto',
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+},
+}
+);
+let promise18 = device2.createRenderPipelineAsync(
+{
+label: '\ucc6a\u{1fff1}\u15e6\udc32\ud596\u2122\u0d92',
+layout: pipelineLayout6,
+vertex: {
+module: shaderModule16,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1176,
+attributes: [
+{
+format: 'snorm16x2',
+offset: 664,
+shaderLocation: 12,
+},
+{
+format: 'snorm16x4',
+offset: 984,
+shaderLocation: 11,
+},
+{
+format: 'sint32',
+offset: 52,
+shaderLocation: 16,
+},
+{
+format: 'sint8x4',
+offset: 156,
+shaderLocation: 10,
+},
+{
+format: 'uint8x2',
+offset: 960,
+shaderLocation: 15,
+},
+{
+format: 'sint16x2',
+offset: 672,
+shaderLocation: 14,
+},
+{
+format: 'uint8x4',
+offset: 468,
+shaderLocation: 4,
+},
+{
+format: 'sint32',
+offset: 384,
+shaderLocation: 0,
+},
+{
+format: 'sint16x2',
+offset: 1140,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 372,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x4',
+offset: 128,
+shaderLocation: 3,
+},
+{
+format: 'snorm16x4',
+offset: 216,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 51268,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 44644,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 37940,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32',
+offset: 22476,
+shaderLocation: 7,
+},
+{
+format: 'uint32x4',
+offset: 28152,
+shaderLocation: 5,
+},
+{
+format: 'uint32x4',
+offset: 728,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 21596,
+attributes: [
+{
+format: 'uint16x4',
+offset: 12004,
+shaderLocation: 1,
+},
+{
+format: 'uint16x2',
+offset: 12728,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'none',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule16,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'rgba16uint',
+},
+{
+format: 'rgb10a2uint',
+writeMask: 0,
+}
+],
+},
+}
+);
+let video8 = await videoWithData();
+let bindGroupLayout14 = device0.createBindGroupLayout(
+{
+label: '\u02fc\u{1fa74}\u0a9a\u{1fc6e}\u{1fcab}\u07a9',
+entries: [
+{
+binding: 4669,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+},
+{
+binding: 1374,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '2d-array' },
+},
+{
+binding: 4729,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'non-filtering' },
+}
+],
+}
+);
+let buffer12 = device0.createBuffer(
+{
+label: '\u2441\u7f97\u4c07',
+size: 7265,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let texture41 = device0.createTexture(
+{
+label: '\u0fa2\uba06\uceac\u009a\udcb4\u0c31\u0ae1\u0832\ue277\u8fe7\ud915',
+size: [4278, 191, 1],
+mipLevelCount: 3,
+format: 'rgba16uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let sampler51 = device0.createSampler(
+{
+label: '\u0771\ud9ba\u2b92\u893d\u0c6d\u9748',
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+maxAnisotropy: 17,
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 4,
+  origin: { x: 4, y: 0, z: 0 },
+  aspect: 'all',
+},
+new DataView(arrayBuffer0),
+/* required buffer size: 360 */{
+offset: 360,
+},
+{width: 98, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img4,
+  origin: { x: 1, y: 35 },
+  flipY: true,
+},
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let querySet37 = device1.createQuerySet({
+label: '\u07ce\ueee4\u{1fc5d}\u{1fc11}\uc9e5\u{1ff27}\u364c\u711d',
+type: 'occlusion',
+count: 2913,
+});
+let renderBundle49 = renderBundleEncoder19.finish();
+let sampler52 = device1.createSampler(
+{
+label: '\u1399\u492e\u23d3\u0cbc\u07f3\u9575\ua234\u082c\u{1feac}\u{1fefb}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 33.991,
+}
+);
+try {
+renderPassEncoder11.setStencilReference(
+3112
+);
+} catch {}
+try {
+querySet34.destroy();
+} catch {}
+try {
+commandEncoder31.resolveQuerySet(
+querySet23,
+91,
+256,
+buffer7,
+2304
+);
+} catch {}
+let video9 = await videoWithData();
+let querySet38 = device2.createQuerySet({
+label: '\u076f\u0daf\u9934\u01e4\u081b\u01f5\u0886\u51d6',
+type: 'occlusion',
+count: 3524,
+});
+let sampler53 = device2.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 37.159,
+lodMaxClamp: 50.766,
+}
+);
+let arrayBuffer1 = buffer10.getMappedRange(
+13520,
+1172
+);
+try {
+buffer10.unmap();
+} catch {}
+let pipeline46 = await device2.createRenderPipelineAsync(
+{
+label: '\ub532\uc13f\u899b\uf36b\u0e29\u035c\u6721',
+layout: pipelineLayout6,
+vertex: {
+module: shaderModule16,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 21848,
+attributes: [
+{
+format: 'uint32',
+offset: 17036,
+shaderLocation: 6,
+},
+{
+format: 'unorm16x4',
+offset: 4804,
+shaderLocation: 12,
+},
+{
+format: 'uint8x4',
+offset: 12612,
+shaderLocation: 7,
+},
+{
+format: 'uint16x2',
+offset: 8964,
+shaderLocation: 1,
+},
+{
+format: 'uint16x2',
+offset: 16268,
+shaderLocation: 5,
+},
+{
+format: 'sint16x2',
+offset: 2096,
+shaderLocation: 3,
+},
+{
+format: 'sint8x4',
+offset: 5752,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 28328,
+attributes: [
+{
+format: 'uint8x2',
+offset: 27674,
+shaderLocation: 9,
+},
+{
+format: 'uint8x2',
+offset: 5232,
+shaderLocation: 15,
+},
+{
+format: 'sint32x3',
+offset: 22308,
+shaderLocation: 14,
+},
+{
+format: 'sint8x4',
+offset: 20108,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 45128,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 44496,
+shaderLocation: 2,
+},
+{
+format: 'unorm8x2',
+offset: 39754,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 22684,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 19360,
+shaderLocation: 0,
+},
+{
+format: 'uint32x4',
+offset: 12344,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x4',
+offset: 24948,
+shaderLocation: 11,
+},
+{
+format: 'sint32x3',
+offset: 43420,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule16,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+{
+format: 'rgb10a2uint',
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'zero',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 1922,
+stencilWriteMask: 2696,
+depthBias: 67,
+depthBiasSlopeScale: 94,
+},
+}
+);
+video6.height = 232;
+let querySet39 = device1.createQuerySet({
+label: '\u{1f658}\u0d2f\u{1f9b3}\u5ccb\u{1f9ad}\u{1ffa2}\u2afb\u1752\u{1fbc4}',
+type: 'occlusion',
+count: 3240,
+});
+let renderPassEncoder16 = commandEncoder33.beginRenderPass(
+{
+label: '\u71d6\u5dcc',
+colorAttachments: [
+{
+view: textureView41,
+depthSlice: 65,
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 79,
+clearValue: { r: -161.4, g: 225.0, b: -796.6, a: 122.1, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 47,
+clearValue: { r: 996.5, g: -880.1, b: -160.1, a: -651.1, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 37,
+clearValue: { r: -830.6, g: 474.6, b: -373.6, a: -821.2, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 20,
+clearValue: { r: 749.2, g: 921.8, b: 613.0, a: 3.563, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 11,
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 115,
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined
+],
+occlusionQuerySet: querySet39,
+maxDrawCount: 264624,
+}
+);
+try {
+computePassEncoder11.setPipeline(
+pipeline28
+);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(
+1622
+);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+5,
+buffer9
+);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder31.copyBufferToBuffer(
+buffer9,
+40556,
+buffer7,
+5084,
+1436
+);
+dissociateBuffer(device1, buffer9);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder31.resolveQuerySet(
+querySet29,
+554,
+1629,
+buffer7,
+0
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout15 = device2.createBindGroupLayout(
+{
+entries: [
+{
+binding: 2684,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '1d' },
+},
+{
+binding: 122,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '2d-array' },
+}
+],
+}
+);
+let pipelineLayout7 = device2.createPipelineLayout(
+{
+label: '\ub370\u06c2\u{1fcb1}\u913e\u6125\u4733',
+bindGroupLayouts: [
+bindGroupLayout15
+]
+}
+);
+let commandEncoder34 = device2.createCommandEncoder();
+let renderBundle50 = renderBundleEncoder24.finish(
+{
+
+}
+);
+let sampler54 = device2.createSampler(
+{
+label: '\u8e60\u{1f63c}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 93.977,
+lodMaxClamp: 96.610,
+maxAnisotropy: 18,
+}
+);
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant({ r: -93.42, g: -54.54, b: -51.60, a: -315.8, });
+} catch {}
+try {
+renderPassEncoder14.setStencilReference(
+1681
+);
+} catch {}
+try {
+renderPassEncoder14.setViewport(
+0.2487,
+0.3459,
+0.3202,
+0.08598,
+0.4112,
+0.4424
+);
+} catch {}
+try {
+renderBundleEncoder25.insertDebugMarker(
+'\ub0bf'
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer10,
+10688,
+new Int16Array(19336),
+1227,
+1856
+);
+} catch {}
+let pipeline47 = device2.createRenderPipeline(
+{
+layout: pipelineLayout6,
+vertex: {
+module: shaderModule16,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 25796,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 19536,
+shaderLocation: 10,
+},
+{
+format: 'uint8x4',
+offset: 5356,
+shaderLocation: 6,
+},
+{
+format: 'sint16x4',
+offset: 8164,
+shaderLocation: 8,
+},
+{
+format: 'uint32',
+offset: 13300,
+shaderLocation: 9,
+},
+{
+format: 'sint32x4',
+offset: 15308,
+shaderLocation: 0,
+},
+{
+format: 'uint32',
+offset: 14104,
+shaderLocation: 4,
+},
+{
+format: 'sint32x4',
+offset: 23760,
+shaderLocation: 16,
+},
+{
+format: 'uint16x2',
+offset: 14364,
+shaderLocation: 5,
+},
+{
+format: 'uint8x4',
+offset: 1888,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x4',
+offset: 10228,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 22960,
+shaderLocation: 2,
+},
+{
+format: 'sint8x4',
+offset: 40724,
+shaderLocation: 3,
+},
+{
+format: 'uint16x4',
+offset: 29960,
+shaderLocation: 1,
+},
+{
+format: 'uint32x4',
+offset: 15008,
+shaderLocation: 15,
+},
+{
+format: 'sint32x3',
+offset: 48388,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 18592,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x2',
+offset: 31940,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 35736,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 37544,
+attributes: [
+
+],
+},
+{
+arrayStride: 2948,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 196,
+shaderLocation: 13,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x8a53635d,
+},
+fragment: {
+module: shaderModule16,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'rgba8uint',
+writeMask: 0,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+passOp: 'invert',
+},
+stencilReadMask: 386,
+stencilWriteMask: 906,
+depthBias: 60,
+depthBiasSlopeScale: 12,
+depthBiasClamp: 33,
+},
+}
+);
+let shaderModule17 = device1.createShaderModule(
+{
+label: '\u{1f8f8}\u01ea\u{1f8df}\u0dfd\ube6b\u{1fc63}\u01d3\u0588\u{1fc2f}\u3da5',
+code: `@group(0) @binding(1761)
+var<storage, read_write> type29: array<u32>;
+@group(4) @binding(1617)
+var<storage, read_write> parameter22: array<u32>;
+@group(0) @binding(1617)
+var<storage, read_write> field26: array<u32>;
+@group(5) @binding(1761)
+var<storage, read_write> global25: array<u32>;
+@group(6) @binding(746)
+var<storage, read_write> function36: array<u32>;
+@group(1) @binding(381)
+var<storage, read_write> global26: array<u32>;
+@group(1) @binding(746)
+var<storage, read_write> local23: array<u32>;
+@group(5) @binding(1617)
+var<storage, read_write> i21: array<u32>;
+@group(3) @binding(746)
+var<storage, read_write> parameter23: array<u32>;
+@group(3) @binding(381)
+var<storage, read_write> local24: array<u32>;
+@group(6) @binding(381)
+var<storage, read_write> function37: array<u32>;
+@group(2) @binding(1761)
+var<storage, read_write> type30: array<u32>;
+@group(2) @binding(1617)
+var<storage, read_write> global27: array<u32>;
+
+@compute @workgroup_size(8, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(0) f0: vec2<f32>,
+@location(7) f1: vec2<f32>,
+@location(5) f2: f32
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(sample_mask) a1: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S16 {
+@location(11) f0: vec4<u32>,
+@location(4) f1: f32,
+@location(3) f2: vec2<f32>,
+@location(22) f3: f16,
+@location(12) f4: vec4<i32>,
+@location(0) f5: vec3<i32>,
+@location(7) f6: vec2<u32>,
+@location(10) f7: vec2<u32>,
+@location(27) f8: f16
+}
+
+@vertex
+fn vertex0(@location(16) a0: vec2<i32>, @location(25) a1: vec2<u32>, @location(1) a2: vec4<f16>, @location(19) a3: vec4<u32>, @builtin(instance_index) a4: u32, @location(21) a5: f32, @location(6) a6: f32, @builtin(vertex_index) a7: u32, @location(14) a8: f32, @location(5) a9: u32, @location(20) a10: vec3<i32>, @location(8) a11: u32, @location(2) a12: vec2<f32>, @location(26) a13: vec4<u32>, @location(23) a14: i32, @location(17) a15: vec4<i32>, @location(15) a16: u32, a17: S16, @location(18) a18: vec3<f16>, @location(24) a19: vec3<u32>, @location(9) a20: vec2<f16>, @location(13) a21: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture42 = device1.createTexture(
+{
+size: {width: 34, height: 1, depthOrArrayLayers: 155},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundle51 = renderBundleEncoder29.finish(
+{
+label: '\udfc0\u{1fb10}\u1741'
+}
+);
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+computePassEncoder16.setPipeline(
+pipeline31
+);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(
+10,
+bindGroup1,
+new Uint32Array(2437),
+1819,
+0
+);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: 4.746, g: -639.4, b: 674.1, a: 276.1, });
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+1,
+buffer9,
+392
+);
+} catch {}
+try {
+commandEncoder31.copyTextureToTexture(
+{
+  texture: texture25,
+  mipLevel: 1,
+  origin: { x: 13, y: 0, z: 30 },
+  aspect: 'all',
+},
+{
+  texture: texture25,
+  mipLevel: 3,
+  origin: { x: 18, y: 0, z: 61 },
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 58}
+);
+} catch {}
+try {
+commandEncoder20.clearBuffer(
+buffer7,
+3312,
+6984
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder31.resolveQuerySet(
+querySet37,
+1142,
+1401,
+buffer7,
+768
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+6332,
+new DataView(new ArrayBuffer(2719)),
+2199,
+36
+);
+} catch {}
+let promise19 = device1.queue.onSubmittedWorkDone();
+let adapter7 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let bindGroupLayout16 = device2.createBindGroupLayout(
+{
+label: '\u01d3\ub6ed\uf0e4\u17bc\ubbef\ufe58\u{1f849}\ua415\u53ae',
+entries: [
+
+],
+}
+);
+let bindGroup4 = device2.createBindGroup({
+label: '\u{1f8c7}\u0479\uc9ae\u0078\u{1fccd}',
+layout: bindGroupLayout16,
+entries: [
+
+],
+});
+let textureView47 = texture26.createView(
+{
+label: '\u76a3\ud6fc',
+}
+);
+try {
+renderBundleEncoder25.setBindGroup(
+0,
+bindGroup4
+);
+} catch {}
+canvas2.width = 79;
+let imageBitmap11 = await createImageBitmap(offscreenCanvas12);
+let commandEncoder35 = device1.createCommandEncoder(
+{
+label: '\u02eb\u{1fa4d}\u{1fb41}',
+}
+);
+let texture43 = device1.createTexture(
+{
+label: '\u09d8\u0865\ueef7\ufea8\u{1f942}\u0a7e\u{1ff0c}\u0319\u727a\u136e\u6168',
+size: {width: 75, height: 7, depthOrArrayLayers: 42},
+mipLevelCount: 5,
+format: 'rgba32sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgba32sint',
+'rgba32sint'
+],
+}
+);
+try {
+renderPassEncoder16.setBlendConstant({ r: 493.5, g: -134.6, b: 401.1, a: -299.2, });
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+1359.4,
+0.8181,
+604.3,
+0.04709,
+0.5218,
+0.8831
+);
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture(
+{
+  texture: texture25,
+  mipLevel: 6,
+  origin: { x: 2, y: 0, z: 23 },
+  aspect: 'all',
+},
+{
+  texture: texture25,
+  mipLevel: 3,
+  origin: { x: 5, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+632,
+new DataView(new ArrayBuffer(40257)),
+26978,
+4220
+);
+} catch {}
+let img9 = await imageWithData(218, 268, '#be24f0fe', '#0e7fb0d6');
+let bindGroup5 = device1.createBindGroup({
+label: '\u9cd0\u7659\u0107\u04b4\ub28c',
+layout: bindGroupLayout9,
+entries: [
+{
+binding: 381,
+resource: sampler31
+},
+{
+binding: 746,
+resource: sampler36
+}
+],
+});
+let commandEncoder36 = device1.createCommandEncoder(
+{
+}
+);
+let externalTexture2 = device1.importExternalTexture(
+{
+label: '\u0348\u0b6c\uada0',
+source: video8,
+colorSpace: 'display-p3',
+}
+);
+try {
+renderPassEncoder16.setScissorRect(
+924,
+0,
+490,
+1
+);
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+1819.7,
+0.3557,
+44.17,
+0.1595,
+0.1500,
+0.5077
+);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+0,
+buffer9,
+6568,
+18770
+);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(
+9,
+bindGroup5
+);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(
+2,
+buffer6,
+8908,
+1629
+);
+} catch {}
+try {
+commandEncoder36.copyTextureToTexture(
+{
+  texture: texture33,
+  mipLevel: 1,
+  origin: { x: 351, y: 0, z: 14 },
+  aspect: 'all',
+},
+{
+  texture: texture33,
+  mipLevel: 3,
+  origin: { x: 20, y: 0, z: 76 },
+  aspect: 'all',
+},
+{width: 176, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture25,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Uint8Array(arrayBuffer1),
+/* required buffer size: 54638 */{
+offset: 454,
+bytesPerRow: 122,
+rowsPerImage: 222,
+},
+{width: 1, height: 1, depthOrArrayLayers: 3}
+);
+} catch {}
+let offscreenCanvas17 = new OffscreenCanvas(98, 53);
+let videoFrame12 = new VideoFrame(canvas7, {timestamp: 0});
+let computePassEncoder19 = commandEncoder35.beginComputePass(
+{
+label: '\u{1fc07}\u6ca4\u{1fd7f}\ude1f\u03fc\u4771\u{1f900}\u{1fa98}'
+}
+);
+let renderBundle52 = renderBundleEncoder30.finish();
+let sampler55 = device1.createSampler(
+{
+label: '\u08d4\u2c6b\ud5c5\u3422\u2411\ud35d\u50ca\u9577\uc27c',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 60.418,
+lodMaxClamp: 67.560,
+compare: 'less',
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder11.setStencilReference(
+1470
+);
+} catch {}
+try {
+renderPassEncoder16.setViewport(
+1859.0,
+0.9608,
+26.46,
+0.02207,
+0.1345,
+0.1363
+);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+66,
+undefined
+);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(
+9,
+buffer9,
+30380
+);
+} catch {}
+try {
+commandEncoder20.clearBuffer(
+buffer7,
+12852,
+4
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+let pipeline48 = await device1.createComputePipelineAsync(
+{
+label: '\u1d30\uc6cf\u3ef6\ufbfa\ub808\u{1fdd1}\u0327\u0e3b\u721d\ua1d8',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule10,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let promise20 = device1.createRenderPipelineAsync(
+{
+label: '\u{1fb2b}\u00d7\u0f68\ud439\uab6b\uca3a\u0c25\u4978\u18fa',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule13,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 59852,
+attributes: [
+{
+format: 'sint32x3',
+offset: 38840,
+shaderLocation: 11,
+},
+{
+format: 'uint16x2',
+offset: 45536,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 6912,
+attributes: [
+
+],
+},
+{
+arrayStride: 61348,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 29820,
+shaderLocation: 25,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32',
+offset: 12580,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 25800,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 41616,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32',
+offset: 26108,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'always',
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+},
+stencilWriteMask: 199,
+depthBiasSlopeScale: 96,
+depthBiasClamp: 56,
+},
+}
+);
+let imageBitmap12 = await createImageBitmap(imageData6);
+let videoFrame13 = new VideoFrame(videoFrame9, {timestamp: 0});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let video10 = await videoWithData();
+let imageBitmap13 = await createImageBitmap(imageData10);
+try {
+offscreenCanvas17.getContext('webgl');
+} catch {}
+let commandEncoder37 = device2.createCommandEncoder();
+let renderPassEncoder17 = commandEncoder37.beginRenderPass(
+{
+label: '\u7021\uec00',
+colorAttachments: [
+undefined,
+{
+view: textureView46,
+clearValue: { r: 502.4, g: -293.9, b: -404.1, a: 779.0, },
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet28,
+maxDrawCount: 89696,
+}
+);
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder34.clearBuffer(
+buffer10
+);
+dissociateBuffer(device2, buffer10);
+} catch {}
+let pipeline49 = await device2.createRenderPipelineAsync(
+{
+layout: 'auto',
+vertex: {
+module: shaderModule12,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 4824,
+attributes: [
+{
+format: 'float32x4',
+offset: 3900,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 25772,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 34900,
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 42556,
+attributes: [
+
+],
+},
+{
+arrayStride: 21040,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x4',
+offset: 20696,
+shaderLocation: 3,
+},
+{
+format: 'float16x4',
+offset: 20024,
+shaderLocation: 9,
+},
+{
+format: 'sint8x2',
+offset: 19968,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'back',
+},
+multisample: {
+count: 4,
+mask: 0x21a86e3e,
+},
+fragment: {
+module: shaderModule12,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16uint',
+writeMask: 0,
+},
+{
+format: 'rg16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+let video11 = await videoWithData();
+let querySet40 = device1.createQuerySet({
+label: '\u{1f9c6}\u0551\u00ea\u032e\u74d8\uc558\u7d6c\u{1fc2f}\u0ec3\ud7cf\u{1fcf2}',
+type: 'occlusion',
+count: 1226,
+});
+let renderBundleEncoder35 = device1.createRenderBundleEncoder(
+{
+label: '\u56ce\u{1fc44}\u1102\u{1fd3d}\u99d7\uaf04\u0501\u0047\u0009',
+colorFormats: [
+undefined,
+undefined,
+'r32float',
+'r8unorm',
+'rgb10a2unorm'
+],
+sampleCount: 861,
+depthReadOnly: true,
+}
+);
+let sampler56 = device1.createSampler(
+{
+label: '\ucd44\u{1ff4e}\u58d1\u0163\uf2b9',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 60.471,
+lodMaxClamp: 62.868,
+}
+);
+try {
+renderPassEncoder16.beginOcclusionQuery(2499);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+5,
+buffer9,
+37964,
+1056
+);
+} catch {}
+let pipeline50 = device1.createComputePipeline(
+{
+label: '\u077d\u{1fc99}',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+},
+}
+);
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let bindGroup6 = device2.createBindGroup({
+layout: bindGroupLayout16,
+entries: [
+
+],
+});
+let texture44 = device2.createTexture(
+{
+label: '\u099c\u67c7',
+size: {width: 172, height: 24, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'eac-rg11unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'eac-rg11unorm'
+],
+}
+);
+let textureView48 = texture40.createView(
+{
+label: '\u0f68\u{1ff2e}\u0f7e\u6ead\u055f\u93c1\u0f79\u086e',
+baseMipLevel: 0,
+}
+);
+let renderBundleEncoder36 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg8sint',
+undefined,
+'r32sint',
+undefined,
+'rg32float',
+'rgba32float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 675,
+stencilReadOnly: true,
+}
+);
+let renderBundle53 = renderBundleEncoder20.finish(
+{
+label: '\ud05f\u0dcd\u{1ff27}\u{1fd57}\uea90\u0799\u{1fa8d}\ud29b'
+}
+);
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant({ r: 752.8, g: -264.9, b: 669.6, a: 444.5, });
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(
+2,
+bindGroup4
+);
+} catch {}
+let pipeline51 = await device2.createComputePipelineAsync(
+{
+label: '\uc334\u0915\u7437\u068d\u{1fef4}',
+layout: 'auto',
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+device2.destroy();
+} catch {}
+let bindGroupLayout17 = device1.createBindGroupLayout(
+{
+label: '\u0c38\uc1c5\u6783\u57e1',
+entries: [
+{
+binding: 2789,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+},
+{
+binding: 4311,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+},
+{
+binding: 2718,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+}
+],
+}
+);
+let textureView49 = texture21.createView(
+{
+label: '\u{1ff02}\u0bc6\u4222\u0ec0\u0759\u4427\u7f68',
+mipLevelCount: 1,
+}
+);
+let computePassEncoder20 = commandEncoder20.beginComputePass(
+{
+label: '\u90c7\u5c5b\ufcc2\u09e8\u0004\ucd71\u{1f801}\u5bd3\u2ddc\ubbfd\u{1fc8d}'
+}
+);
+try {
+renderPassEncoder16.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: 351.6, g: 684.7, b: 252.9, a: 906.4, });
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(
+0,
+bindGroup2
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+928,
+new Float32Array(13669),
+1326,
+2252
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture31,
+  mipLevel: 0,
+  origin: { x: 499, y: 0, z: 41 },
+  aspect: 'all',
+},
+new ArrayBuffer(16),
+/* required buffer size: 23852054 */{
+offset: 254,
+bytesPerRow: 1262,
+rowsPerImage: 300,
+},
+{width: 1012, height: 0, depthOrArrayLayers: 64}
+);
+} catch {}
+let pipeline52 = device1.createComputePipeline(
+{
+label: '\u7bb5\u0a42\uf067\u1392\u7c17\u00d1\u{1fcd2}\ua479\u93dc',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule9,
+entryPoint: 'compute0',
+},
+}
+);
+let offscreenCanvas18 = new OffscreenCanvas(835, 58);
+try {
+device1.queue.label = '\u{1fb1f}\u0bb6\ufd2f\u0d58\ueaa6';
+} catch {}
+let pipelineLayout8 = device1.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout17,
+bindGroupLayout12,
+bindGroupLayout12
+]
+}
+);
+let computePassEncoder21 = commandEncoder31.beginComputePass();
+let renderBundle54 = renderBundleEncoder15.finish(
+{
+
+}
+);
+try {
+renderPassEncoder16.setBindGroup(
+10,
+bindGroup2,
+new Uint32Array(8209),
+4579,
+0
+);
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+825.8,
+0.5086,
+739.7,
+0.1868,
+0.3408,
+0.5201
+);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(
+buffer7,
+'uint16',
+888
+);
+} catch {}
+let pipeline53 = await device1.createComputePipelineAsync(
+{
+layout: pipelineLayout4,
+compute: {
+module: shaderModule13,
+entryPoint: 'compute0',
+},
+}
+);
+let texture45 = device1.createTexture(
+{
+label: '\u30f5\u0aab\ud85a\u5fc6\u{1f713}\u8860\uce40',
+size: [1029, 1, 153],
+mipLevelCount: 11,
+dimension: '3d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba32float'
+],
+}
+);
+let renderBundle55 = renderBundleEncoder27.finish(
+{
+label: '\u1336\u{1f98a}\u{1f61b}\u0f99\u043f\ubdf8\u{1f62a}\u845d\ub0a4\uc837'
+}
+);
+try {
+renderPassEncoder11.setViewport(
+1213.3,
+0.6002,
+647.1,
+0.2517,
+0.8810,
+0.8847
+);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(
+buffer7,
+'uint16',
+10208,
+793
+);
+} catch {}
+try {
+commandEncoder36.copyBufferToBuffer(
+buffer9,
+1972,
+buffer7,
+2476,
+9032
+);
+dissociateBuffer(device1, buffer9);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder36.clearBuffer(
+buffer7,
+10100,
+2040
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture45,
+  mipLevel: 0,
+  origin: { x: 57, y: 0, z: 117 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 61695661 */{
+offset: 85,
+bytesPerRow: 14870,
+rowsPerImage: 122,
+},
+{width: 926, height: 1, depthOrArrayLayers: 35}
+);
+} catch {}
+let gpuCanvasContext13 = offscreenCanvas18.getContext('webgpu');
+let pipelineLayout9 = device1.createPipelineLayout(
+{
+label: '\u039b\u0d29\u3fd5',
+bindGroupLayouts: [
+bindGroupLayout9,
+bindGroupLayout8,
+bindGroupLayout17,
+bindGroupLayout10,
+bindGroupLayout9,
+bindGroupLayout17,
+bindGroupLayout17,
+bindGroupLayout12
+]
+}
+);
+let commandEncoder38 = device1.createCommandEncoder(
+{
+label: '\uc3fb\u35e5\ue784\u992d\u04f7\u4af7',
+}
+);
+let commandBuffer2 = commandEncoder38.finish();
+let texture46 = device1.createTexture(
+{
+label: '\u{1fc62}\u0f31\u{1f965}\u069f\u0a97\udf0d\u834b\u04ac\u{1fca8}\u{1fc28}',
+size: {width: 5024},
+sampleCount: 1,
+dimension: '1d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16float',
+'r16float',
+'r16float'
+],
+}
+);
+let textureView50 = texture43.createView(
+{
+label: '\u{1fb63}\u2e75\u1e0e\u0d48\uabbc\u016e',
+dimension: '2d',
+baseMipLevel: 4,
+baseArrayLayer: 7,
+}
+);
+try {
+computePassEncoder9.insertDebugMarker(
+'\u9991'
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 16, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: canvas8,
+  origin: { x: 108, y: 19 },
+  flipY: true,
+},
+{
+  texture: texture45,
+  mipLevel: 6,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 14, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline54 = device1.createComputePipeline(
+{
+label: '\u8d70\u3257\u021b\ud563\u{1f805}\u{1fa8f}\ub696',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend(canvas5);
+let adapter8 = await navigator.gpu.requestAdapter(
+{
+}
+);
+try {
+await adapter5.requestAdapterInfo();
+} catch {}
+canvas6.width = 285;
+let offscreenCanvas19 = new OffscreenCanvas(244, 948);
+let bindGroup7 = device1.createBindGroup({
+label: '\u0d94\ue255\u5be2\u0cd1\u0c97\uc670',
+layout: bindGroupLayout9,
+entries: [
+{
+binding: 746,
+resource: sampler31
+},
+{
+binding: 381,
+resource: sampler29
+}
+],
+});
+let texture47 = device1.createTexture(
+{
+label: '\u76e4\u{1fbaf}\u{1fd48}\u7da3\u3b71\u84ed\u0b90\u0381',
+size: {width: 80, height: 172, depthOrArrayLayers: 217},
+mipLevelCount: 2,
+format: 'eac-rg11unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'eac-rg11unorm',
+'eac-rg11unorm',
+'eac-rg11unorm'
+],
+}
+);
+let computePassEncoder22 = commandEncoder36.beginComputePass(
+{
+
+}
+);
+try {
+computePassEncoder19.setPipeline(
+pipeline38
+);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(
+6,
+bindGroup7
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture33,
+  mipLevel: 5,
+  origin: { x: 3, y: 0, z: 15 },
+  aspect: 'all',
+},
+new ArrayBuffer(48),
+/* required buffer size: 348042 */{
+offset: 170,
+bytesPerRow: 209,
+rowsPerImage: 208,
+},
+{width: 48, height: 1, depthOrArrayLayers: 9}
+);
+} catch {}
+let imageBitmap14 = await createImageBitmap(videoFrame5);
+let textureView51 = texture35.createView(
+{
+label: '\ub483\uaad0\u{1ffb2}',
+format: 'rg32sint',
+baseMipLevel: 5,
+}
+);
+try {
+computePassEncoder19.setPipeline(
+pipeline53
+);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: -175.1, g: 432.5, b: -838.6, a: 947.6, });
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(
+1879,
+0,
+144,
+0
+);
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+1024.2,
+0.3713,
+733.1,
+0.5570,
+0.2476,
+0.5958
+);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+8,
+buffer9
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 514, height: 1, depthOrArrayLayers: 76}
+*/
+{
+  source: img6,
+  origin: { x: 114, y: 11 },
+  flipY: true,
+},
+{
+  texture: texture45,
+  mipLevel: 1,
+  origin: { x: 262, y: 1, z: 22 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 145, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline55 = device1.createComputePipeline(
+{
+label: '\uf24a\u373c\u{1ff35}\u0919\u7b25\u{1f98c}\ue24f\u3898\u0dab',
+layout: pipelineLayout8,
+compute: {
+module: shaderModule13,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+await promise19;
+} catch {}
+let imageData15 = new ImageData(220, 136);
+try {
+offscreenCanvas19.getContext('2d');
+} catch {}
+let shaderModule18 = device1.createShaderModule(
+{
+label: '\u0c39\u{1f6ce}',
+code: `@group(0) @binding(2789)
+var<storage, read_write> field27: array<u32>;
+@group(2) @binding(4733)
+var<storage, read_write> parameter24: array<u32>;
+@group(1) @binding(6076)
+var<storage, read_write> global28: array<u32>;
+@group(0) @binding(4311)
+var<storage, read_write> function38: array<u32>;
+@group(0) @binding(2718)
+var<storage, read_write> field28: array<u32>;
+
+@compute @workgroup_size(2, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(3) f0: vec4<i32>,
+@location(5) f1: vec2<i32>,
+@location(1) f2: vec2<i32>,
+@location(0) f3: vec4<u32>,
+@location(6) f4: i32
+}
+
+@fragment
+fn fragment0(@location(11) a0: vec4<u32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S17 {
+@builtin(instance_index) f0: u32,
+@location(18) f1: u32,
+@location(17) f2: vec3<f16>,
+@location(6) f3: vec4<u32>,
+@location(11) f4: u32,
+@location(21) f5: vec2<i32>,
+@location(12) f6: vec2<f16>,
+@location(22) f7: vec4<i32>,
+@location(2) f8: f32,
+@location(5) f9: f32,
+@location(14) f10: u32,
+@location(8) f11: i32,
+@location(7) f12: vec2<f32>,
+@location(9) f13: u32,
+@location(13) f14: vec3<f16>,
+@location(23) f15: i32,
+@location(1) f16: f32,
+@location(0) f17: u32,
+@location(20) f18: vec2<u32>
+}
+struct VertexOutput0 {
+@location(7) f140: vec3<f16>,
+@location(11) f141: vec4<u32>,
+@location(57) f142: i32,
+@location(20) f143: f16,
+@location(34) f144: vec3<f16>,
+@location(81) f145: vec3<i32>,
+@builtin(position) f146: vec4<f32>,
+@location(68) f147: u32,
+@location(24) f148: vec3<f16>,
+@location(17) f149: vec2<u32>
+}
+
+@vertex
+fn vertex0(a0: S17, @location(15) a1: vec3<i32>, @location(3) a2: vec4<i32>, @location(25) a3: i32, @builtin(vertex_index) a4: u32, @location(4) a5: vec4<i32>, @location(27) a6: vec2<f16>, @location(26) a7: vec3<f32>, @location(16) a8: vec2<f32>, @location(10) a9: vec3<i32>, @location(24) a10: vec3<u32>, @location(19) a11: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder39 = device1.createCommandEncoder();
+try {
+renderPassEncoder16.setBindGroup(
+8,
+bindGroup3,
+new Uint32Array(2922),
+496,
+0
+);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(
+2620
+);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(
+4,
+buffer9,
+20444,
+14744
+);
+} catch {}
+try {
+commandEncoder39.copyBufferToBuffer(
+buffer6,
+432,
+buffer7,
+7288,
+4576
+);
+dissociateBuffer(device1, buffer6);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder39.clearBuffer(
+buffer7,
+5268,
+4508
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 32, height: 1, depthOrArrayLayers: 4}
+*/
+{
+  source: canvas9,
+  origin: { x: 119, y: 121 },
+  flipY: false,
+},
+{
+  texture: texture45,
+  mipLevel: 5,
+  origin: { x: 4, y: 1, z: 4 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 9, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline56 = await device1.createComputePipelineAsync(
+{
+label: '\u805a\ub2de',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule9,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageData16 = new ImageData(212, 4);
+try {
+window.someLabel = externalTexture2.label;
+} catch {}
+let bindGroup8 = device1.createBindGroup({
+layout: bindGroupLayout17,
+entries: [
+{
+binding: 2718,
+resource: externalTexture2
+},
+{
+binding: 4311,
+resource: {
+buffer: buffer8,
+offset: 6144,
+}
+},
+{
+binding: 2789,
+resource: textureView35
+}
+],
+});
+pseudoSubmit(device1, commandEncoder39);
+try {
+renderPassEncoder11.setBindGroup(
+9,
+bindGroup1
+);
+} catch {}
+let promise21 = adapter5.requestDevice({
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 7,
+maxColorAttachmentBytesPerSample: 45,
+maxVertexAttributes: 28,
+maxVertexBufferArrayStride: 10450,
+maxStorageTexturesPerShaderStage: 41,
+maxStorageBuffersPerShaderStage: 27,
+maxDynamicStorageBuffersPerPipelineLayout: 57915,
+maxBindingsPerBindGroup: 6397,
+maxTextureDimension1D: 13488,
+maxTextureDimension2D: 8245,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 124530526,
+maxUniformBuffersPerShaderStage: 27,
+maxInterStageShaderVariables: 34,
+maxInterStageShaderComponents: 72,
+},
+});
+let computePassEncoder23 = commandEncoder34.beginComputePass(
+{
+
+}
+);
+let renderBundleEncoder37 = device2.createRenderBundleEncoder(
+{
+label: '\u9c35\uaa46\u10fd',
+colorFormats: [
+'rgba32uint',
+'rgb10a2unorm',
+'rg8unorm',
+'r8uint',
+undefined,
+'r16uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 157,
+stencilReadOnly: true,
+}
+);
+let sampler57 = device2.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 3.155,
+lodMaxClamp: 36.955,
+}
+);
+try {
+computePassEncoder23.setBindGroup(
+3,
+bindGroup6,
+new Uint32Array(6439),
+6230,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: -196.9, g: 109.6, b: -423.7, a: 822.4, });
+} catch {}
+let commandEncoder40 = device1.createCommandEncoder();
+let querySet41 = device1.createQuerySet({
+type: 'occlusion',
+count: 3309,
+});
+let computePassEncoder24 = commandEncoder40.beginComputePass(
+{
+label: '\u{1f6f2}\u{1f7fc}\u{1fc19}\uc7b3\u48f8\u0bd1\u5c27'
+}
+);
+let renderBundleEncoder38 = device1.createRenderBundleEncoder(
+{
+label: '\u3a7d\u9ed6\uf3d9',
+colorFormats: [
+'rgba8sint',
+undefined,
+'rg8unorm',
+undefined,
+'rg8unorm',
+'rgba32uint',
+'r8unorm',
+'r8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 704,
+stencilReadOnly: true,
+}
+);
+let sampler58 = device1.createSampler(
+{
+label: '\u2455\u{1f940}\u1169',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 23.985,
+lodMaxClamp: 70.892,
+maxAnisotropy: 6,
+}
+);
+try {
+renderPassEncoder11.setViewport(
+210.7,
+0.3745,
+1226.6,
+0.3232,
+0.8570,
+0.9498
+);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(
+7,
+buffer6,
+8892,
+934
+);
+} catch {}
+let canvas11 = document.createElement('canvas');
+try {
+computePassEncoder18.setBindGroup(
+7,
+bindGroup2
+);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(
+6,
+bindGroup2,
+new Uint32Array(5516),
+210,
+0
+);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(
+8,
+bindGroup3
+);
+} catch {}
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(
+2,
+buffer6
+);
+} catch {}
+let pipeline57 = await device1.createComputePipelineAsync(
+{
+label: '\ubeee\u04fb\uc598\u3852\u95c5\u5e43',
+layout: pipelineLayout8,
+compute: {
+module: shaderModule18,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+gc();
+let video12 = await videoWithData();
+let bindGroupLayout18 = device2.createBindGroupLayout(
+{
+entries: [
+{
+binding: 2710,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '2d' },
+}
+],
+}
+);
+let sampler59 = device2.createSampler(
+{
+label: '\u34f4\u09c1',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 68.949,
+lodMaxClamp: 89.473,
+compare: 'not-equal',
+}
+);
+try {
+renderPassEncoder15.setBlendConstant({ r: 8.220, g: 962.4, b: -619.9, a: -116.3, });
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(
+81,
+undefined,
+3190033315,
+1002774383
+);
+} catch {}
+try {
+gpuCanvasContext13.configure(
+{
+device: device2,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let video13 = await videoWithData();
+let gpuCanvasContext14 = canvas11.getContext('webgpu');
+let video14 = await videoWithData();
+let videoFrame14 = new VideoFrame(imageBitmap6, {timestamp: 0});
+let buffer13 = device1.createBuffer(
+{
+label: '\u{1ff40}\uc1b4\u09da\uf4e1\u173b\u{1fb9a}\u8f96\u0e72',
+size: 1272,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+try {
+computePassEncoder14.setPipeline(
+pipeline50
+);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(
+2573
+);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(
+buffer6,
+'uint16',
+5140,
+957
+);
+} catch {}
+try {
+adapter5.label = '\u359e\u{1fa4e}\u01bd\u{1face}\u84d3';
+} catch {}
+let commandEncoder41 = device1.createCommandEncoder(
+{
+label: '\u953c\u0143',
+}
+);
+let renderPassEncoder18 = commandEncoder41.beginRenderPass(
+{
+label: '\u7495\u701d\u4166\u0b8e\ub300\u0596\uefaa\uce8f\u2bae\ucb2c\u465f',
+colorAttachments: [
+{
+view: textureView41,
+depthSlice: 10,
+clearValue: { r: 864.5, g: -323.7, b: 646.6, a: -261.2, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 37,
+clearValue: { r: 358.5, g: -333.2, b: -404.9, a: 953.3, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 40,
+clearValue: { r: 409.5, g: -846.7, b: 689.5, a: 640.5, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 16,
+clearValue: { r: -280.5, g: 739.1, b: -258.8, a: -879.3, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 132,
+clearValue: { r: -369.4, g: 445.2, b: 570.8, a: 612.0, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 74,
+clearValue: { r: 171.2, g: -849.0, b: 275.0, a: -955.4, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 7,
+clearValue: { r: -919.9, g: 439.0, b: 909.9, a: -898.7, },
+loadOp: 'load',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet31,
+maxDrawCount: 418384,
+}
+);
+try {
+renderPassEncoder16.beginOcclusionQuery(1725);
+} catch {}
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(
+buffer6,
+'uint32'
+);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(
+9,
+buffer9
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let promise22 = navigator.gpu.requestAdapter();
+let imageData17 = new ImageData(80, 144);
+let adapter9 = await navigator.gpu.requestAdapter();
+let offscreenCanvas20 = new OffscreenCanvas(129, 726);
+let renderBundleEncoder39 = device1.createRenderBundleEncoder(
+{
+label: '\u7f53\u{1ffa3}\u0d43\u280e\u61bc',
+colorFormats: [
+'r8unorm',
+'r32sint',
+'r32uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 64,
+}
+);
+try {
+computePassEncoder21.setPipeline(
+pipeline57
+);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(
+2432
+);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(
+buffer6,
+'uint16',
+5310,
+680
+);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+1,
+buffer6,
+4320,
+1704
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+544,
+new BigUint64Array(1000),
+323,
+4
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture45,
+  mipLevel: 3,
+  origin: { x: 105, y: 1, z: 12 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer1),
+/* required buffer size: 98226 */{
+offset: 176,
+bytesPerRow: 185,
+rowsPerImage: 265,
+},
+{width: 1, height: 0, depthOrArrayLayers: 3}
+);
+} catch {}
+let pipeline58 = await device1.createComputePipelineAsync(
+{
+label: '\uddb8\u{1f97c}\u{1fddd}\u840e',
+layout: 'auto',
+compute: {
+module: shaderModule18,
+entryPoint: 'compute0',
+},
+}
+);
+let gpuCanvasContext15 = offscreenCanvas20.getContext('webgpu');
+let imageData18 = new ImageData(68, 192);
+let bindGroupLayout19 = device1.createBindGroupLayout(
+{
+label: '\u{1f835}\u97ec\u967a\u10f2\u3dd1\u0a46\ucffc\u5596\u035c\u011c\u20fb',
+entries: [
+{
+binding: 3578,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+}
+],
+}
+);
+let querySet42 = device1.createQuerySet({
+label: '\u5abc\u03c2\uda2a\u535b\u{1f94a}\u0964\u0b2b\u90e9\ud566\u{1fa5f}',
+type: 'occlusion',
+count: 905,
+});
+let texture48 = device1.createTexture(
+{
+label: '\ud975\u3ec9\u0520',
+size: {width: 1498, height: 1, depthOrArrayLayers: 372},
+dimension: '3d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let textureView52 = texture23.createView(
+{
+baseArrayLayer: 0,
+}
+);
+let sampler60 = device1.createSampler(
+{
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 26.892,
+lodMaxClamp: 62.524,
+}
+);
+try {
+renderPassEncoder16.setBlendConstant({ r: 722.7, g: 927.7, b: 501.8, a: -238.7, });
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+8,
+buffer6,
+5656,
+5153
+);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(
+10,
+bindGroup7
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+5540,
+new Int16Array(9240),
+2681,
+960
+);
+} catch {}
+offscreenCanvas8.height = 367;
+let bindGroup9 = device1.createBindGroup({
+label: '\u9065\u6395\u{1ff57}\u06fc',
+layout: bindGroupLayout19,
+entries: [
+{
+binding: 3578,
+resource: textureView31
+}
+],
+});
+let commandEncoder42 = device1.createCommandEncoder(
+{
+label: '\u{1fa75}\u0150\u938e\u06dc\u0c08\u062c\u6140\u04c0\u0580\u{1f746}',
+}
+);
+let texture49 = device1.createTexture(
+{
+label: '\uea87\u17bf\u0179\u0c07\u24a2\u02fd\u3978\ubfa4\u134d\u17ec',
+size: {width: 10147},
+dimension: '1d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+}
+);
+let computePassEncoder25 = commandEncoder42.beginComputePass();
+try {
+renderPassEncoder18.setBindGroup(
+1,
+bindGroup3,
+new Uint32Array(9104),
+4972,
+0
+);
+} catch {}
+try {
+renderPassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(208);
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(
+1494
+);
+} catch {}
+try {
+gpuCanvasContext11.configure(
+{
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+document.body.prepend(video5);
+let offscreenCanvas21 = new OffscreenCanvas(997, 404);
+let videoFrame15 = new VideoFrame(video4, {timestamp: 0});
+try {
+offscreenCanvas21.getContext('bitmaprenderer');
+} catch {}
+let bindGroup10 = device1.createBindGroup({
+label: '\uf2bf\u3dfb\u{1fe3d}\uf76d\u132e\u926c\u0f4b\u{1fa71}\u5fbc\u68b9\u0d06',
+layout: bindGroupLayout9,
+entries: [
+{
+binding: 746,
+resource: sampler39
+},
+{
+binding: 381,
+resource: sampler42
+}
+],
+});
+let commandEncoder43 = device1.createCommandEncoder(
+{
+}
+);
+let renderPassEncoder19 = commandEncoder43.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView41,
+depthSlice: 139,
+clearValue: { r: 301.6, g: 172.7, b: -203.1, a: -482.5, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 136,
+clearValue: { r: -448.2, g: -432.7, b: 596.1, a: 826.5, },
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet40,
+maxDrawCount: 145408,
+}
+);
+try {
+renderPassEncoder18.setStencilReference(
+3665
+);
+} catch {}
+try {
+renderPassEncoder19.setViewport(
+1468.0,
+0.5249,
+194.7,
+0.1366,
+0.1195,
+0.9728
+);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(
+6,
+buffer6,
+10372,
+274
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 1029, height: 1, depthOrArrayLayers: 153}
+*/
+{
+  source: imageBitmap13,
+  origin: { x: 5, y: 65 },
+  flipY: false,
+},
+{
+  texture: texture45,
+  mipLevel: 0,
+  origin: { x: 235, y: 1, z: 13 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let buffer14 = device1.createBuffer(
+{
+label: '\u5bfa\u6e97\u{1fd0e}',
+size: 65532,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let commandEncoder44 = device1.createCommandEncoder(
+{
+label: '\u0939\u4006\u76bf\u0b46\u00b9\ua2a8\uc08a\uc02e\u9ee5\u66f7',
+}
+);
+let textureView53 = texture37.createView(
+{
+label: '\uba6f\u{1f742}\u0dea\ubd77\ue9ff\u{1fc89}',
+}
+);
+let renderBundle56 = renderBundleEncoder17.finish(
+{
+
+}
+);
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(
+3901
+);
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+1482.2,
+0.2137,
+325.8,
+0.3340,
+0.1075,
+0.5049
+);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(
+16,
+undefined,
+3410285594,
+65274498
+);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(
+6,
+bindGroup7
+);
+} catch {}
+try {
+gpuCanvasContext8.configure(
+{
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8unorm',
+'etc2-rgba8unorm'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+3524,
+new BigUint64Array(31307),
+14551,
+492
+);
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let adapter10 = await promise22;
+try {
+window.someLabel = shaderModule14.label;
+} catch {}
+gc();
+let img10 = await imageWithData(119, 220, '#87d753be', '#02bbdb13');
+let querySet43 = device1.createQuerySet({
+label: '\ua63d\u1102\u9551\ubb27\u057d\u0a6c\u0339\u{1f972}',
+type: 'occlusion',
+count: 1344,
+});
+pseudoSubmit(device1, commandEncoder41);
+let texture50 = device1.createTexture(
+{
+label: '\u0ba9\u{1f805}',
+size: [2566, 162, 1],
+mipLevelCount: 3,
+dimension: '2d',
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth16unorm',
+'depth16unorm',
+'depth16unorm'
+],
+}
+);
+let computePassEncoder26 = commandEncoder44.beginComputePass(
+{
+
+}
+);
+let renderBundle57 = renderBundleEncoder21.finish();
+let sampler61 = device1.createSampler(
+{
+label: '\u7066\ufe4a\u9185\uc8ff',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 20.325,
+maxAnisotropy: 6,
+}
+);
+try {
+computePassEncoder26.setBindGroup(
+0,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(
+7,
+bindGroup3,
+new Uint32Array(7875),
+1638,
+0
+);
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(212);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: -327.6, g: 258.6, b: -737.7, a: 228.9, });
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(
+4,
+bindGroup2
+);
+} catch {}
+try {
+renderBundleEncoder39.setVertexBuffer(
+1,
+buffer6,
+3336,
+2185
+);
+} catch {}
+let renderBundleEncoder40 = device2.createRenderBundleEncoder(
+{
+label: '\u0fc3\u563a',
+colorFormats: [
+'rg16float'
+],
+sampleCount: 309,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder17.setBlendConstant({ r: -477.5, g: 836.3, b: 393.0, a: 880.0, });
+} catch {}
+try {
+gpuCanvasContext4.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+let pipeline59 = device2.createComputePipeline(
+{
+layout: pipelineLayout7,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+let img11 = await imageWithData(85, 281, '#c6c9c36a', '#4287f9a4');
+let commandEncoder45 = device1.createCommandEncoder(
+{
+}
+);
+pseudoSubmit(device1, commandEncoder31);
+let sampler62 = device1.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 21.002,
+lodMaxClamp: 25.461,
+compare: 'less-equal',
+}
+);
+try {
+renderPassEncoder11.setBindGroup(
+0,
+bindGroup9
+);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(1313);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: 876.1, g: -998.1, b: -349.2, a: 777.7, });
+} catch {}
+try {
+renderPassEncoder18.setScissorRect(
+117,
+0,
+405,
+0
+);
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(
+1487
+);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(
+buffer6,
+'uint16',
+7450,
+3211
+);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(
+6,
+buffer6,
+10832,
+4
+);
+} catch {}
+try {
+commandEncoder45.clearBuffer(
+buffer13
+);
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+commandEncoder45.resolveQuerySet(
+querySet43,
+985,
+36,
+buffer7,
+9472
+);
+} catch {}
+try {
+gpuCanvasContext12.configure(
+{
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+3452,
+new DataView(new ArrayBuffer(19362)),
+12445,
+4852
+);
+} catch {}
+let pipeline60 = await device1.createComputePipelineAsync(
+{
+label: '\u{1fbef}\u6ead\u4349\u1eda',
+layout: pipelineLayout8,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let bindGroupLayout20 = device1.createBindGroupLayout(
+{
+label: '\u{1fc1e}\u9d5c\u{1fae9}\ud608\u0663\uf4b6\u842a\u{1fc72}\u{1fa1b}\u0288\u00e4',
+entries: [
+{
+binding: 4411,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '1d' },
+},
+{
+binding: 3068,
+visibility: 0,
+storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '2d' },
+}
+],
+}
+);
+let buffer15 = device1.createBuffer(
+{
+label: '\u8d8c\u{1fbf7}\u{1fcd1}\u{1fe41}\ub9ea\u2432\u99c7\ue218',
+size: 30660,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let commandEncoder46 = device1.createCommandEncoder(
+{
+label: '\ue637\u{1fa6a}\u0d2d',
+}
+);
+let sampler63 = device1.createSampler(
+{
+label: '\u{1fcd4}\ufbc8\u9c30\uc6d0\uafbe\u2cf6\u5741',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+lodMaxClamp: 93.174,
+}
+);
+try {
+renderPassEncoder19.beginOcclusionQuery(950);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder19.setStencilReference(
+2234
+);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(
+buffer6,
+'uint32',
+1744,
+4424
+);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+7,
+buffer6
+);
+} catch {}
+try {
+commandEncoder46.resolveQuerySet(
+querySet20,
+356,
+465,
+buffer7,
+3584
+);
+} catch {}
+let pipeline61 = device1.createRenderPipeline(
+{
+label: '\u9648\u616c\u039d\udc0d\ud9fc\u0a4c\u8cb4',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule7,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 42368,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x2',
+offset: 16412,
+shaderLocation: 16,
+},
+{
+format: 'sint8x2',
+offset: 2206,
+shaderLocation: 3,
+},
+{
+format: 'uint32x3',
+offset: 24848,
+shaderLocation: 23,
+},
+{
+format: 'float32',
+offset: 1680,
+shaderLocation: 6,
+},
+{
+format: 'float32x2',
+offset: 140,
+shaderLocation: 7,
+},
+{
+format: 'uint32x4',
+offset: 20164,
+shaderLocation: 17,
+},
+{
+format: 'sint32x2',
+offset: 39572,
+shaderLocation: 27,
+},
+{
+format: 'unorm8x4',
+offset: 38192,
+shaderLocation: 9,
+},
+{
+format: 'float32x4',
+offset: 3300,
+shaderLocation: 18,
+},
+{
+format: 'snorm8x2',
+offset: 41008,
+shaderLocation: 14,
+},
+{
+format: 'unorm8x4',
+offset: 25496,
+shaderLocation: 1,
+},
+{
+format: 'sint16x4',
+offset: 7824,
+shaderLocation: 20,
+},
+{
+format: 'float16x2',
+offset: 17432,
+shaderLocation: 24,
+},
+{
+format: 'snorm8x2',
+offset: 15872,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 57976,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 35220,
+shaderLocation: 10,
+},
+{
+format: 'sint16x4',
+offset: 17376,
+shaderLocation: 2,
+},
+{
+format: 'snorm8x4',
+offset: 13660,
+shaderLocation: 12,
+},
+{
+format: 'sint32x3',
+offset: 18176,
+shaderLocation: 15,
+},
+{
+format: 'snorm8x4',
+offset: 38092,
+shaderLocation: 26,
+}
+],
+},
+{
+arrayStride: 60068,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 1188,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 35964,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 5480,
+shaderLocation: 19,
+},
+{
+format: 'sint32x3',
+offset: 5692,
+shaderLocation: 25,
+},
+{
+format: 'uint32',
+offset: 29036,
+shaderLocation: 0,
+},
+{
+format: 'unorm16x2',
+offset: 27564,
+shaderLocation: 13,
+}
+],
+}
+]
+},
+primitive: {
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+},
+fragment: {
+module: shaderModule7,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'one-minus-constant',
+dstFactor: 'one-minus-constant'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'constant',
+dstFactor: 'src-alpha-saturated'
+},
+},
+format: 'rg16float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'one-minus-constant',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rg16float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.BLUE,
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'one-minus-src-alpha',
+dstFactor: 'constant'
+},
+},
+format: 'r8unorm',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'keep',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 259,
+stencilWriteMask: 4016,
+depthBias: 10,
+depthBiasSlopeScale: 13,
+depthBiasClamp: 99,
+},
+}
+);
+let textureView54 = texture29.createView(
+{
+label: '\u{1fb9e}\u0744\u2f4c\u7046\u0e50\u9d7d\uee10\u{1fae7}',
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+try {
+computePassEncoder23.end();
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: -991.4, g: -237.7, b: -529.4, a: 394.7, });
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+58,
+undefined
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture32,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(48),
+/* required buffer size: 385 */{
+offset: 385,
+rowsPerImage: 181,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+gc();
+let videoFrame16 = new VideoFrame(imageBitmap14, {timestamp: 0});
+let textureView55 = texture28.createView(
+{
+baseMipLevel: 6,
+mipLevelCount: 3,
+}
+);
+try {
+renderPassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder15.setStencilReference(
+749
+);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(
+17,
+undefined,
+2707289027,
+609772494
+);
+} catch {}
+try {
+querySet25.destroy();
+} catch {}
+try {
+gpuCanvasContext7.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'r32sint',
+'rgb10a2unorm'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 44, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap8,
+  origin: { x: 250, y: 279 },
+  flipY: false,
+},
+{
+  texture: texture28,
+  mipLevel: 8,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 10, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise23 = device2.createRenderPipelineAsync(
+{
+label: '\u027a\ubc7b\u3b59\u028a',
+layout: pipelineLayout7,
+vertex: {
+module: shaderModule14,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 2560,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 1458,
+shaderLocation: 4,
+},
+{
+format: 'sint32x4',
+offset: 1964,
+shaderLocation: 3,
+},
+{
+format: 'uint32x2',
+offset: 180,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 1452,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32',
+offset: 1060,
+shaderLocation: 8,
+},
+{
+format: 'uint8x2',
+offset: 664,
+shaderLocation: 13,
+},
+{
+format: 'snorm8x2',
+offset: 122,
+shaderLocation: 15,
+},
+{
+format: 'uint8x4',
+offset: 24,
+shaderLocation: 14,
+},
+{
+format: 'unorm16x4',
+offset: 488,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 48668,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 27236,
+shaderLocation: 1,
+},
+{
+format: 'uint8x2',
+offset: 28350,
+shaderLocation: 5,
+},
+{
+format: 'sint32x3',
+offset: 23036,
+shaderLocation: 11,
+},
+{
+format: 'snorm8x4',
+offset: 24884,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x2',
+offset: 21684,
+shaderLocation: 9,
+},
+{
+format: 'float16x2',
+offset: 5408,
+shaderLocation: 7,
+},
+{
+format: 'snorm8x2',
+offset: 27800,
+shaderLocation: 16,
+},
+{
+format: 'unorm8x4',
+offset: 15048,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 33844,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 42440,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 42256,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x3cdb97cb,
+},
+fragment: {
+module: shaderModule14,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'dst-alpha',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+undefined,
+undefined,
+{
+format: 'bgra8unorm',
+}
+],
+},
+}
+);
+let imageData19 = new ImageData(24, 120);
+let sampler64 = device1.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 81.589,
+lodMaxClamp: 96.431,
+compare: 'greater-equal',
+}
+);
+try {
+renderPassEncoder18.setBindGroup(
+2,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder11.end();
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(968);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(
+1033,
+1,
+804,
+0
+);
+} catch {}
+try {
+renderPassEncoder18.setViewport(
+478.6,
+0.9177,
+345.2,
+0.01226,
+0.1289,
+0.9064
+);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(
+5,
+buffer9,
+14320,
+25029
+);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(
+5,
+bindGroup1
+);
+} catch {}
+try {
+renderBundleEncoder39.setIndexBuffer(
+buffer7,
+'uint32',
+7544,
+809
+);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(
+9,
+buffer9,
+22520,
+6376
+);
+} catch {}
+try {
+commandEncoder46.copyBufferToTexture(
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 53312 */
+offset: 53312,
+bytesPerRow: 0,
+buffer: buffer14,
+},
+{
+  texture: texture34,
+  mipLevel: 5,
+  origin: { x: 0, y: 4, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture50,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 787 */{
+offset: 787,
+bytesPerRow: 5269,
+},
+{width: 2566, height: 162, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas9,
+  origin: { x: 241, y: 195 },
+  flipY: false,
+},
+{
+  texture: texture45,
+  mipLevel: 10,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline62 = await promise20;
+let adapter11 = await navigator.gpu.requestAdapter(
+{
+}
+);
+try {
+await adapter1.requestAdapterInfo();
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(
+8,
+bindGroup8,
+new Uint32Array(6085),
+5537,
+1
+);
+} catch {}
+try {
+renderPassEncoder18.setViewport(
+792.3,
+0.1806,
+656.0,
+0.3647,
+0.5598,
+0.6950
+);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(
+5,
+buffer9,
+28996,
+5502
+);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(
+7,
+bindGroup2
+);
+} catch {}
+try {
+commandEncoder45.resolveQuerySet(
+querySet22,
+1420,
+515,
+buffer7,
+8448
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+5764,
+new Float32Array(8053),
+7094,
+64
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 514, height: 1, depthOrArrayLayers: 76}
+*/
+{
+  source: imageBitmap7,
+  origin: { x: 14, y: 32 },
+  flipY: true,
+},
+{
+  texture: texture45,
+  mipLevel: 1,
+  origin: { x: 184, y: 0, z: 11 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 23, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let offscreenCanvas22 = new OffscreenCanvas(4, 32);
+let bindGroup11 = device1.createBindGroup({
+label: '\u0222\u{1fdd7}',
+layout: bindGroupLayout9,
+entries: [
+{
+binding: 746,
+resource: sampler29
+},
+{
+binding: 381,
+resource: sampler27
+}
+],
+});
+let texture51 = device1.createTexture(
+{
+label: '\u0161\uf7c1\ueeee\u{1fcb2}\u0d4f',
+size: [187, 1, 861],
+mipLevelCount: 7,
+dimension: '3d',
+format: 'r32float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32float',
+'r32float'
+],
+}
+);
+let sampler65 = device1.createSampler(
+{
+label: '\u{1f69c}\uea39\u48fa\u{1f705}\u{1fd40}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 70.924,
+lodMaxClamp: 82.143,
+}
+);
+try {
+computePassEncoder25.setPipeline(
+pipeline32
+);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder19.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(
+2040
+);
+} catch {}
+try {
+renderPassEncoder18.setViewport(
+1412.7,
+0.1243,
+275.3,
+0.6878,
+0.3850,
+0.9036
+);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(
+7,
+buffer6,
+2132,
+8544
+);
+} catch {}
+try {
+renderBundleEncoder39.setVertexBuffer(
+1,
+buffer9,
+10472,
+20524
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 8, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img8,
+  origin: { x: 126, y: 70 },
+  flipY: true,
+},
+{
+  texture: texture45,
+  mipLevel: 7,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 5, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline63 = await device1.createComputePipelineAsync(
+{
+label: '\uc60c\u32c7\u{1f8b4}\u0e9f\u{1f782}\u8455\u{1f786}\u497a\u0d87\u0a7f\ue1dc',
+layout: pipelineLayout8,
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend(canvas6);
+let video15 = await videoWithData();
+let videoFrame17 = videoFrame3.clone();
+let device3 = await adapter10.requestDevice({
+label: '\u60ca\uea14',
+requiredFeatures: [
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 5,
+maxColorAttachmentBytesPerSample: 41,
+maxVertexAttributes: 26,
+maxVertexBufferArrayStride: 17403,
+maxStorageTexturesPerShaderStage: 10,
+maxStorageBuffersPerShaderStage: 29,
+maxDynamicStorageBuffersPerPipelineLayout: 20665,
+maxBindingsPerBindGroup: 5645,
+maxTextureDimension1D: 12182,
+maxTextureDimension2D: 10549,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 149078710,
+maxUniformBuffersPerShaderStage: 23,
+maxInterStageShaderVariables: 91,
+maxInterStageShaderComponents: 107,
+maxSamplersPerShaderStage: 18,
+},
+});
+let renderPassEncoder20 = commandEncoder45.beginRenderPass(
+{
+label: '\uc70d\u0dd6\u4494\u05c4\u73f8\u068f\u5822\u05ee\u054a\ud233',
+colorAttachments: [
+undefined,
+{
+view: textureView50,
+clearValue: { r: -701.2, g: -907.8, b: -715.0, a: 524.2, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+undefined,
+undefined
+],
+occlusionQuerySet: querySet41,
+}
+);
+let renderBundle58 = renderBundleEncoder38.finish(
+{
+
+}
+);
+try {
+computePassEncoder9.setPipeline(
+pipeline53
+);
+} catch {}
+try {
+renderPassEncoder20.setStencilReference(
+2132
+);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(
+buffer6,
+'uint16',
+1870
+);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(
+4,
+bindGroup7,
+new Uint32Array(2084),
+999,
+0
+);
+} catch {}
+try {
+commandEncoder46.copyBufferToBuffer(
+buffer14,
+58272,
+buffer7,
+3772,
+4144
+);
+dissociateBuffer(device1, buffer14);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+8932,
+new Int16Array(52259),
+3822,
+520
+);
+} catch {}
+let promise24 = device1.queue.onSubmittedWorkDone();
+let pipeline64 = device1.createComputePipeline(
+{
+label: '\u6115\uc342\u030a',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+gc();
+let computePassEncoder27 = commandEncoder46.beginComputePass(
+{
+label: '\u8bd2\u08ec\uad69\udb78'
+}
+);
+try {
+renderPassEncoder20.setBlendConstant({ r: 771.8, g: 576.5, b: -711.8, a: 715.7, });
+} catch {}
+try {
+renderPassEncoder18.setScissorRect(
+2042,
+0,
+1,
+0
+);
+} catch {}
+try {
+computePassEncoder26.pushDebugGroup(
+'\u999c'
+);
+} catch {}
+try {
+device1.queue.submit([
+commandBuffer2,
+]);
+} catch {}
+let promise25 = device1.queue.onSubmittedWorkDone();
+let gpuCanvasContext16 = offscreenCanvas22.getContext('webgpu');
+let video16 = await videoWithData();
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let img12 = await imageWithData(291, 73, '#1c573857', '#9658d428');
+let renderBundleEncoder41 = device3.createRenderBundleEncoder(
+{
+label: '\u{1f61a}\u0199',
+colorFormats: [
+undefined
+],
+sampleCount: 30,
+depthReadOnly: true,
+}
+);
+let bindGroup12 = device1.createBindGroup({
+label: '\u8d0f\u0f23',
+layout: bindGroupLayout19,
+entries: [
+{
+binding: 3578,
+resource: textureView31
+}
+],
+});
+let commandEncoder47 = device1.createCommandEncoder(
+{
+label: '\u{1fdbd}\u{1fba4}\ue82a\u9de2\u00b7\u0b9c\u{1f640}',
+}
+);
+let texture52 = device1.createTexture(
+{
+label: '\u8bc3\u8182\u0dad\u99c0\u{1fd78}\ucfe2\u5a25',
+size: [7004],
+dimension: '1d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8unorm',
+'rg8unorm',
+'rg8unorm'
+],
+}
+);
+let textureView56 = texture47.createView(
+{
+label: '\uba7a\u1767',
+dimension: '2d',
+baseMipLevel: 1,
+baseArrayLayer: 106,
+}
+);
+let renderBundleEncoder42 = device1.createRenderBundleEncoder(
+{
+label: '\u{1fe27}\u{1fdf3}\u0d74',
+colorFormats: [
+'rg8sint',
+'rgba16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 249,
+depthReadOnly: true,
+}
+);
+let renderBundle59 = renderBundleEncoder21.finish(
+{
+label: '\u41f3\u04d6\ub0fd\ue643\u{1ff43}\udc27\u0087\ud18a\u7e36\u03da'
+}
+);
+let sampler66 = device1.createSampler(
+{
+label: '\ub800\u52a2\u962f',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 18.760,
+lodMaxClamp: 43.197,
+}
+);
+try {
+renderPassEncoder18.setBindGroup(
+8,
+bindGroup10
+);
+} catch {}
+try {
+renderPassEncoder20.beginOcclusionQuery(2766);
+} catch {}
+try {
+renderPassEncoder18.setViewport(
+836.3,
+0.1199,
+411.1,
+0.7386,
+0.7273,
+0.7893
+);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(
+41,
+undefined,
+4086428899
+);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(
+0,
+bindGroup1
+);
+} catch {}
+try {
+commandEncoder47.resolveQuerySet(
+querySet42,
+244,
+342,
+buffer7,
+8192
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+9252,
+new BigUint64Array(14529),
+188,
+512
+);
+} catch {}
+let pipeline65 = device1.createRenderPipeline(
+{
+label: '\u0aa5\ud348\u13f0\u2d8d\ued26',
+layout: pipelineLayout8,
+vertex: {
+module: shaderModule9,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 4184,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 324,
+shaderLocation: 25,
+},
+{
+format: 'unorm16x4',
+offset: 2020,
+shaderLocation: 10,
+},
+{
+format: 'unorm8x4',
+offset: 3264,
+shaderLocation: 2,
+},
+{
+format: 'snorm8x2',
+offset: 814,
+shaderLocation: 24,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 3568,
+shaderLocation: 7,
+},
+{
+format: 'float32x4',
+offset: 3564,
+shaderLocation: 13,
+},
+{
+format: 'uint32x3',
+offset: 1508,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x2',
+offset: 2028,
+shaderLocation: 8,
+},
+{
+format: 'float32x2',
+offset: 4096,
+shaderLocation: 4,
+},
+{
+format: 'sint32x4',
+offset: 2340,
+shaderLocation: 14,
+},
+{
+format: 'uint32x4',
+offset: 972,
+shaderLocation: 23,
+},
+{
+format: 'unorm8x4',
+offset: 3024,
+shaderLocation: 20,
+},
+{
+format: 'float32x4',
+offset: 1992,
+shaderLocation: 5,
+},
+{
+format: 'unorm16x2',
+offset: 2500,
+shaderLocation: 18,
+},
+{
+format: 'uint32x2',
+offset: 3552,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 13852,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32',
+offset: 12508,
+shaderLocation: 16,
+},
+{
+format: 'uint8x2',
+offset: 4442,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 41536,
+attributes: [
+{
+format: 'unorm16x4',
+offset: 30188,
+shaderLocation: 26,
+},
+{
+format: 'float32x2',
+offset: 32488,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 2832,
+shaderLocation: 11,
+},
+{
+format: 'float32x3',
+offset: 31620,
+shaderLocation: 22,
+},
+{
+format: 'sint32x3',
+offset: 31556,
+shaderLocation: 21,
+},
+{
+format: 'snorm8x2',
+offset: 18744,
+shaderLocation: 27,
+},
+{
+format: 'sint32x3',
+offset: 17980,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x4',
+offset: 33476,
+shaderLocation: 1,
+},
+{
+format: 'uint8x4',
+offset: 32860,
+shaderLocation: 9,
+},
+{
+format: 'snorm8x2',
+offset: 52240,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 33400,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 264,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule9,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'zero',
+dstFactor: 'one-minus-dst'
+},
+},
+format: 'rg16float',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'dst',
+dstFactor: 'src'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'src-alpha',
+dstFactor: 'src'
+},
+},
+format: 'r8unorm',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'equal',
+depthFailOp: 'increment-clamp',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'never',
+depthFailOp: 'keep',
+passOp: 'zero',
+},
+depthBias: 64,
+depthBiasSlopeScale: 28,
+depthBiasClamp: 76,
+},
+}
+);
+let imageData20 = new ImageData(64, 240);
+let buffer16 = device3.createBuffer(
+{
+size: 5432,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE,
+mappedAtCreation: true,
+}
+);
+let texture53 = device3.createTexture(
+{
+size: {width: 483, height: 1, depthOrArrayLayers: 251},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+let textureView57 = texture53.createView(
+{
+baseMipLevel: 1,
+mipLevelCount: 1,
+}
+);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+await promise25;
+} catch {}
+let arrayBuffer2 = buffer16.getMappedRange(
+0,
+3388
+);
+let bindGroupLayout21 = device1.createBindGroupLayout(
+{
+entries: [
+{
+binding: 6223,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '3d' },
+},
+{
+binding: 10,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+},
+{
+binding: 735,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let textureView58 = texture45.createView(
+{
+baseMipLevel: 4,
+mipLevelCount: 1,
+arrayLayerCount: 1,
+}
+);
+let renderBundle60 = renderBundleEncoder29.finish(
+{
+label: '\udc05\ua6d4\ud82a\u{1f710}\u{1f6db}\u0c8d\u4e2b\u{1fda0}\u0ff3\u02eb'
+}
+);
+try {
+renderPassEncoder18.setViewport(
+335.9,
+0.5404,
+1254.7,
+0.2201,
+0.5575,
+0.6096
+);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(
+5,
+buffer6
+);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(
+buffer6,
+'uint16',
+5756,
+4026
+);
+} catch {}
+try {
+buffer13.destroy();
+} catch {}
+try {
+commandEncoder47.clearBuffer(
+buffer7,
+10784,
+1584
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder47.resolveQuerySet(
+querySet21,
+1138,
+418,
+buffer7,
+7936
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+12272,
+new Int16Array(7894),
+5606,
+308
+);
+} catch {}
+let video17 = await videoWithData();
+let bindGroup13 = device1.createBindGroup({
+label: '\u5f2f\u05c4\u19bb\udfc1\u{1f639}',
+layout: bindGroupLayout17,
+entries: [
+{
+binding: 2789,
+resource: textureView52
+},
+{
+binding: 2718,
+resource: externalTexture2
+},
+{
+binding: 4311,
+resource: {
+buffer: buffer8,
+offset: 26112,
+size: 6884,
+}
+}
+],
+});
+let querySet44 = device1.createQuerySet({
+type: 'occlusion',
+count: 2119,
+});
+let sampler67 = device1.createSampler(
+{
+label: '\u0bbd\u900c\u{1fb9a}\u94af\ud042',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 49.766,
+maxAnisotropy: 12,
+}
+);
+try {
+renderPassEncoder20.setBindGroup(
+5,
+bindGroup13,
+[17920]
+);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(
+1671,
+0,
+348,
+0
+);
+} catch {}
+try {
+renderPassEncoder18.setViewport(
+289.4,
+0.1538,
+150.3,
+0.4702,
+0.03521,
+0.1537
+);
+} catch {}
+let videoFrame18 = new VideoFrame(video3, {timestamp: 0});
+gc();
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let canvas12 = document.createElement('canvas');
+let shaderModule19 = device1.createShaderModule(
+{
+label: '\u07ee\u4e5c\ubd14\u544a\u{1fbbb}\u0417\u3d9c\u{1fb8f}\u0467',
+code: `@group(4) @binding(1617)
+var<storage, read_write> parameter25: array<u32>;
+@group(2) @binding(1761)
+var<storage, read_write> parameter26: array<u32>;
+@group(3) @binding(1617)
+var<storage, read_write> local25: array<u32>;
+@group(3) @binding(1761)
+var<storage, read_write> parameter27: array<u32>;
+@group(1) @binding(1617)
+var<storage, read_write> global29: array<u32>;
+@group(0) @binding(1617)
+var<storage, read_write> function39: array<u32>;
+@group(5) @binding(1617)
+var<storage, read_write> parameter28: array<u32>;
+@group(5) @binding(1761)
+var<storage, read_write> parameter29: array<u32>;
+@group(2) @binding(1617)
+var<storage, read_write> function40: array<u32>;
+
+@compute @workgroup_size(6, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0() {
+
+}
+
+struct S18 {
+@builtin(vertex_index) f0: u32,
+@location(9) f1: vec4<f16>,
+@location(25) f2: vec3<f16>,
+@location(19) f3: vec4<i32>
+}
+
+@vertex
+fn vertex0(a0: S18, @location(13) a1: f32, @builtin(instance_index) a2: u32, @location(1) a3: vec3<f32>, @location(7) a4: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder48 = device1.createCommandEncoder(
+{
+label: '\u2e22\u{1fe60}\u{1f7ec}',
+}
+);
+let texture54 = device1.createTexture(
+{
+size: {width: 98, height: 98, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth32float-stencil8',
+'depth32float-stencil8'
+],
+}
+);
+let renderBundle61 = renderBundleEncoder15.finish(
+{
+
+}
+);
+try {
+renderPassEncoder20.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder47.copyBufferToBuffer(
+buffer14,
+46200,
+buffer13,
+64,
+1188
+);
+dissociateBuffer(device1, buffer14);
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+commandEncoder47.clearBuffer(
+buffer13
+);
+dissociateBuffer(device1, buffer13);
+} catch {}
+let querySet45 = device3.createQuerySet({
+label: '\u{1f741}\uaf54\u8fc0\u7101\u5b1e\u0887\u7033\u{1fc36}',
+type: 'occlusion',
+count: 2793,
+});
+let textureView59 = texture53.createView(
+{
+label: '\uc904\u0534\u3dad\u{1f9bb}\u05c9\u9290\u9aa0\u0cc0\ua5cc',
+baseMipLevel: 1,
+}
+);
+try {
+device3.queue.writeTexture(
+{
+  texture: texture53,
+  mipLevel: 1,
+  origin: { x: 44, y: 0, z: 26 },
+  aspect: 'all',
+},
+new Uint8Array(arrayBuffer2),
+/* required buffer size: 1655509 */{
+offset: 373,
+bytesPerRow: 634,
+rowsPerImage: 261,
+},
+{width: 99, height: 1, depthOrArrayLayers: 11}
+);
+} catch {}
+try {
+await promise24;
+} catch {}
+let querySet46 = device3.createQuerySet({
+label: '\u{1f6cf}\u9a1c',
+type: 'occlusion',
+count: 970,
+});
+let gpuCanvasContext17 = canvas12.getContext('webgpu');
+let imageData21 = new ImageData(124, 136);
+let videoFrame19 = new VideoFrame(offscreenCanvas22, {timestamp: 0});
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let buffer17 = device3.createBuffer(
+{
+size: 63918,
+usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+}
+);
+let commandEncoder49 = device3.createCommandEncoder();
+try {
+device3.queue.writeTexture(
+{
+  texture: texture53,
+  mipLevel: 3,
+  origin: { x: 12, y: 0, z: 3 },
+  aspect: 'all',
+},
+new BigInt64Array(arrayBuffer1),
+/* required buffer size: 190339 */{
+offset: 772,
+bytesPerRow: 413,
+rowsPerImage: 27,
+},
+{width: 43, height: 0, depthOrArrayLayers: 18}
+);
+} catch {}
+video8.width = 93;
+gc();
+let pipelineLayout10 = device1.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout8,
+bindGroupLayout10,
+bindGroupLayout8,
+bindGroupLayout12,
+bindGroupLayout19,
+bindGroupLayout8
+]
+}
+);
+let commandEncoder50 = device1.createCommandEncoder(
+{
+label: '\uea88\u779b\u{1facd}\u{1fe52}\u{1fa66}\u2dc1\uf763\ud4ad',
+}
+);
+let querySet47 = device1.createQuerySet({
+label: '\u30d4\u0f19\ue955',
+type: 'occlusion',
+count: 2998,
+});
+let renderPassEncoder21 = commandEncoder48.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView41,
+depthSlice: 17,
+clearValue: { r: 704.9, g: 37.89, b: -389.0, a: -679.8, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 90,
+clearValue: { r: 802.2, g: 645.6, b: -858.0, a: -672.9, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 127,
+clearValue: { r: 237.5, g: -26.99, b: -874.4, a: -923.0, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 25,
+clearValue: { r: 827.2, g: -415.2, b: 243.7, a: 698.8, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 56,
+clearValue: { r: -276.0, g: -706.8, b: 773.6, a: -10.81, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 138,
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 144,
+clearValue: { r: 666.1, g: -894.8, b: -112.3, a: 48.13, },
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet21,
+maxDrawCount: 151416,
+}
+);
+let renderBundle62 = renderBundleEncoder27.finish(
+{
+label: '\u00ce\u0542\u3c15\u7ff8\u05be\u3869\uec22\u1035\u{1fd50}\u295b\u8ed9'
+}
+);
+try {
+renderPassEncoder18.setBindGroup(
+9,
+bindGroup3
+);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder35.insertDebugMarker(
+'\u{1ff2d}'
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let img13 = await imageWithData(128, 193, '#4f34645a', '#f28c8146');
+let video18 = await videoWithData();
+let imageBitmap15 = await createImageBitmap(imageBitmap4);
+let bindGroupLayout22 = device3.createBindGroupLayout(
+{
+label: '\u0937\ucaf0\u018d\u0c16\u03fa',
+entries: [
+{
+binding: 5591,
+visibility: 0,
+sampler: { type: 'non-filtering' },
+}
+],
+}
+);
+try {
+renderBundleEncoder41.setVertexBuffer(
+93,
+undefined,
+4230068691,
+32210845
+);
+} catch {}
+let buffer18 = device1.createBuffer(
+{
+label: '\u5ac7\u00a3\u86f9\u039c\u{1f86f}\u09e3\u0ed5',
+size: 2612,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let commandEncoder51 = device1.createCommandEncoder();
+let querySet48 = device1.createQuerySet({
+type: 'occlusion',
+count: 2761,
+});
+let textureView60 = texture31.createView(
+{
+label: '\ud787\u{1f6ab}\u{1f894}\ue57f\ua55b\u{1fa4d}\u0389\ud908',
+baseMipLevel: 1,
+}
+);
+try {
+computePassEncoder9.setPipeline(
+pipeline32
+);
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(
+624,
+0,
+1393,
+1
+);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(
+4,
+buffer9,
+22432,
+10118
+);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+commandEncoder51.copyTextureToTexture(
+{
+  texture: texture50,
+  mipLevel: 2,
+  origin: { x: 0, y: 11, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture50,
+  mipLevel: 1,
+  origin: { x: 438, y: 36, z: 1 },
+  aspect: 'depth-only',
+},
+{width: 641, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+computePassEncoder26.popDebugGroup();
+} catch {}
+let img14 = await imageWithData(91, 294, '#d8428a15', '#47fe9723');
+let video19 = await videoWithData();
+let renderBundle63 = renderBundleEncoder41.finish();
+try {
+buffer17.destroy();
+} catch {}
+try {
+commandEncoder49.clearBuffer(
+buffer16,
+2084
+);
+dissociateBuffer(device3, buffer16);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame20 = new VideoFrame(img5, {timestamp: 0});
+let pipelineLayout11 = device3.createPipelineLayout(
+{
+label: '\u0637\u{1fd0c}\uf2a1\u0f06',
+bindGroupLayouts: [
+bindGroupLayout22,
+bindGroupLayout22,
+bindGroupLayout22,
+bindGroupLayout22,
+bindGroupLayout22
+]
+}
+);
+let querySet49 = device3.createQuerySet({
+label: '\u0055\u13e7\u1e5e\u66ca\u{1f700}\u158c',
+type: 'occlusion',
+count: 3561,
+});
+let renderBundle64 = renderBundleEncoder41.finish(
+{
+label: '\ub9aa\u{1ff74}\u93d2\u0660\u{1f83d}\ue33f\uf7b3\ua486\uf9c5'
+}
+);
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(
+2,
+bindGroup8,
+[0]
+);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder19.setStencilReference(
+1507
+);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(
+4,
+buffer9
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+4684,
+new DataView(new ArrayBuffer(47000)),
+26736,
+5808
+);
+} catch {}
+let offscreenCanvas23 = new OffscreenCanvas(60, 539);
+try {
+commandEncoder49.label = '\u0914\ub501\u0203\u371e\u{1fc62}\u{1f787}\u7a65\ue5c2\u5a2e';
+} catch {}
+let commandEncoder52 = device3.createCommandEncoder();
+let renderPassEncoder22 = commandEncoder52.beginRenderPass(
+{
+label: '\u2b25\u0b0e\ua112\u{1fadb}\u02b8\ubc98\u2a97\u053f\u5d9f\u2147\u05a1',
+colorAttachments: [
+{
+view: textureView57,
+depthSlice: 18,
+clearValue: { r: 820.2, g: -507.6, b: -128.8, a: -722.3, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView57,
+depthSlice: 52,
+clearValue: { r: 263.7, g: -303.0, b: -883.2, a: 744.6, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView57,
+depthSlice: 19,
+clearValue: { r: -516.9, g: 439.9, b: -666.9, a: 628.6, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView57,
+depthSlice: 2,
+clearValue: { r: 533.5, g: 517.7, b: -72.66, a: -129.3, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView57,
+depthSlice: 85,
+clearValue: { r: 787.2, g: 806.6, b: -176.6, a: 23.05, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView57,
+depthSlice: 4,
+clearValue: { r: 886.0, g: 362.8, b: -886.3, a: -209.9, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView57,
+depthSlice: 106,
+clearValue: { r: -878.8, g: 962.7, b: -55.77, a: 83.20, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView57,
+depthSlice: 98,
+clearValue: { r: 301.2, g: 204.4, b: -385.2, a: -161.2, },
+loadOp: 'load',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet49,
+maxDrawCount: 63248,
+}
+);
+let renderBundleEncoder43 = device3.createRenderBundleEncoder(
+{
+label: '\u{1fb94}\u6d1d\u0e76\ue96a',
+colorFormats: [
+'rgba8sint',
+'r32sint'
+],
+sampleCount: 224,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder22.executeBundles([]);
+} catch {}
+let commandEncoder53 = device1.createCommandEncoder(
+{
+}
+);
+let querySet50 = device1.createQuerySet({
+type: 'occlusion',
+count: 1058,
+});
+let texture55 = device1.createTexture(
+{
+label: '\u{1f7ac}\uf2f2\u80cc\ua4ca\u{1f9dd}\u{1fe84}',
+size: {width: 77, height: 162, depthOrArrayLayers: 217},
+mipLevelCount: 1,
+dimension: '2d',
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth32float-stencil8'
+],
+}
+);
+let renderPassEncoder23 = commandEncoder51.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView51,
+depthSlice: 0,
+clearValue: { r: -314.5, g: -135.9, b: 566.9, a: -482.9, },
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined,
+undefined,
+undefined
+],
+occlusionQuerySet: querySet31,
+maxDrawCount: 33864,
+}
+);
+let sampler68 = device1.createSampler(
+{
+label: '\u1f55\u0ad1\u26c5\u{1fa8d}\udfe8',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 12.474,
+lodMaxClamp: 20.253,
+compare: 'not-equal',
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+6,
+bindGroup13,
+new Uint32Array(3444),
+995,
+1
+);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(
+8,
+bindGroup9
+);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(
+7,
+bindGroup9
+);
+} catch {}
+let arrayBuffer3 = buffer18.getMappedRange(
+0,
+664
+);
+try {
+commandEncoder50.resolveQuerySet(
+querySet26,
+552,
+102,
+buffer7,
+256
+);
+} catch {}
+let pipeline66 = await device1.createRenderPipelineAsync(
+{
+label: '\u0ac7\u5af4\ub640',
+layout: pipelineLayout5,
+vertex: {
+module: shaderModule10,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 54264,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 8386,
+shaderLocation: 9,
+},
+{
+format: 'sint8x4',
+offset: 52968,
+shaderLocation: 0,
+},
+{
+format: 'sint32x2',
+offset: 8476,
+shaderLocation: 23,
+},
+{
+format: 'sint8x4',
+offset: 3740,
+shaderLocation: 20,
+},
+{
+format: 'uint32',
+offset: 50504,
+shaderLocation: 10,
+},
+{
+format: 'uint8x2',
+offset: 51426,
+shaderLocation: 19,
+},
+{
+format: 'float16x4',
+offset: 12188,
+shaderLocation: 12,
+},
+{
+format: 'sint32x4',
+offset: 7956,
+shaderLocation: 6,
+},
+{
+format: 'uint32x2',
+offset: 23372,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x2',
+offset: 38234,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x2',
+offset: 29664,
+shaderLocation: 13,
+},
+{
+format: 'uint32',
+offset: 47680,
+shaderLocation: 17,
+},
+{
+format: 'sint32',
+offset: 29996,
+shaderLocation: 8,
+},
+{
+format: 'uint8x2',
+offset: 16044,
+shaderLocation: 16,
+},
+{
+format: 'sint32',
+offset: 45196,
+shaderLocation: 22,
+},
+{
+format: 'sint8x4',
+offset: 24772,
+shaderLocation: 7,
+},
+{
+format: 'uint32x2',
+offset: 49908,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 15544,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 6116,
+shaderLocation: 27,
+},
+{
+format: 'unorm8x2',
+offset: 11356,
+shaderLocation: 5,
+},
+{
+format: 'unorm16x2',
+offset: 2788,
+shaderLocation: 14,
+},
+{
+format: 'snorm16x2',
+offset: 11228,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule10,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rgba8unorm-srgb',
+writeMask: GPUColorWrite.ALL,
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+},
+{
+format: 'rg8unorm',
+writeMask: GPUColorWrite.BLUE,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'always',
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'replace',
+},
+stencilReadMask: 2817,
+stencilWriteMask: 2043,
+depthBias: 68,
+depthBiasSlopeScale: 30,
+depthBiasClamp: 99,
+},
+}
+);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+try {
+offscreenCanvas23.getContext('bitmaprenderer');
+} catch {}
+let texture56 = device1.createTexture(
+{
+label: '\u{1f843}\ua152\ueb83\u07d3\ue789\u2cfe\uc864',
+size: {width: 126, height: 1, depthOrArrayLayers: 461},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rg8sint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8sint',
+'rg8sint',
+'rg8sint'
+],
+}
+);
+let textureView61 = texture43.createView(
+{
+dimension: '2d',
+baseMipLevel: 2,
+mipLevelCount: 2,
+baseArrayLayer: 2,
+}
+);
+let renderPassEncoder24 = commandEncoder47.beginRenderPass(
+{
+label: '\u034f\u{1fac8}\u0f0e\u506d\u38c5\ub1d9\u{1f9ae}\u0795',
+colorAttachments: [
+{
+view: textureView41,
+depthSlice: 133,
+clearValue: { r: -938.0, g: 526.3, b: -436.3, a: 932.8, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 11,
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 92,
+clearValue: { r: 589.9, g: 223.8, b: -654.4, a: -389.9, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 74,
+clearValue: { r: 524.0, g: 555.3, b: 922.2, a: 927.1, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 72,
+clearValue: { r: 86.73, g: -132.0, b: -492.9, a: -163.8, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 13,
+clearValue: { r: -660.6, g: 83.38, b: -288.9, a: -147.0, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 94,
+clearValue: { r: -360.1, g: 156.3, b: -638.5, a: -577.6, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 54,
+clearValue: { r: 540.6, g: 854.2, b: -773.8, a: 455.1, },
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet31,
+maxDrawCount: 672,
+}
+);
+let sampler69 = device1.createSampler(
+{
+label: '\u729b\uf9a8\u0a15\u309a\u{1f86c}\u06af\uad5e\u6bf6\u0fdc\u3bfc\ud67c',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 63.798,
+lodMaxClamp: 66.303,
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+0,
+bindGroup5
+);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(
+2,
+bindGroup9
+);
+} catch {}
+try {
+renderPassEncoder23.beginOcclusionQuery(1946);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder19.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder19.setViewport(
+1918.2,
+0.7485,
+49.29,
+0.2357,
+0.4932,
+0.9592
+);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(
+buffer7,
+'uint32'
+);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(
+3,
+buffer6,
+928,
+9796
+);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(
+buffer7,
+'uint32',
+10500,
+1830
+);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(
+3,
+buffer9,
+36040,
+7776
+);
+} catch {}
+try {
+await buffer15.mapAsync(
+GPUMapMode.WRITE,
+0,
+1136
+);
+} catch {}
+try {
+commandEncoder53.copyBufferToBuffer(
+buffer6,
+2072,
+buffer13,
+744,
+144
+);
+dissociateBuffer(device1, buffer6);
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let shaderModule20 = device3.createShaderModule(
+{
+label: '\u0dfa\u0161\ua2a2\u0739\u0a09\u{1fc1e}\u{1fd51}',
+code: `@group(2) @binding(5591)
+var<storage, read_write> type31: array<u32>;
+@group(1) @binding(5591)
+var<storage, read_write> local26: array<u32>;
+
+@compute @workgroup_size(8, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S20 {
+@location(89) f0: vec3<i32>,
+@location(51) f1: vec2<f16>,
+@location(39) f2: vec4<i32>,
+@location(74) f3: vec3<f16>,
+@location(6) f4: vec3<i32>,
+@location(56) f5: vec4<f16>,
+@location(90) f6: vec3<f16>,
+@location(52) f7: vec2<f16>,
+@location(3) f8: u32,
+@location(85) f9: f32,
+@location(46) f10: vec4<f16>,
+@location(1) f11: vec4<u32>,
+@location(5) f12: vec2<i32>,
+@location(80) f13: vec3<f32>,
+@builtin(position) f14: vec4<f32>,
+@location(14) f15: vec3<u32>,
+@location(11) f16: vec2<i32>,
+@location(33) f17: vec3<f16>,
+@location(61) f18: vec4<f32>,
+@location(64) f19: vec2<f32>,
+@location(65) f20: vec4<f16>
+}
+struct FragmentOutput0 {
+@location(2) f0: vec3<f32>,
+@location(0) f1: f32,
+@location(1) f2: vec3<f32>,
+@location(5) f3: u32,
+@location(7) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(4) a0: vec4<f16>, @location(68) a1: i32, @location(63) a2: vec3<f16>, a3: S20, @location(45) a4: u32, @location(34) a5: vec4<i32>, @builtin(sample_index) a6: u32, @builtin(front_facing) a7: bool, @builtin(sample_mask) a8: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S19 {
+@location(12) f0: vec3<i32>,
+@location(11) f1: vec3<u32>,
+@location(17) f2: vec4<i32>,
+@location(6) f3: vec4<f32>,
+@location(25) f4: vec4<f32>,
+@location(3) f5: f16,
+@location(13) f6: vec2<u32>,
+@location(4) f7: vec2<f16>,
+@location(15) f8: i32
+}
+struct VertexOutput0 {
+@location(89) f150: vec3<i32>,
+@location(90) f151: vec3<f16>,
+@location(74) f152: vec3<f16>,
+@location(85) f153: f32,
+@location(65) f154: vec4<f16>,
+@location(5) f155: vec2<i32>,
+@location(6) f156: vec3<i32>,
+@location(4) f157: vec4<f16>,
+@location(39) f158: vec4<i32>,
+@builtin(position) f159: vec4<f32>,
+@location(46) f160: vec4<f16>,
+@location(11) f161: vec2<i32>,
+@location(1) f162: vec4<u32>,
+@location(45) f163: u32,
+@location(61) f164: vec4<f32>,
+@location(80) f165: vec3<f32>,
+@location(14) f166: vec3<u32>,
+@location(68) f167: i32,
+@location(63) f168: vec3<f16>,
+@location(56) f169: vec4<f16>,
+@location(34) f170: vec4<i32>,
+@location(64) f171: vec2<f32>,
+@location(51) f172: vec2<f16>,
+@location(33) f173: vec3<f16>,
+@location(3) f174: u32,
+@location(52) f175: vec2<f16>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(5) a1: vec2<f32>, @location(10) a2: vec3<u32>, @location(24) a3: vec2<u32>, @location(8) a4: f16, a5: S19, @location(21) a6: vec2<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture57 = device3.createTexture(
+{
+label: '\u{1f7e1}\u462b\u092a\u6133\u09f0\ue9df\u8e75\u{1fd1e}',
+size: [8112, 6, 1],
+mipLevelCount: 7,
+dimension: '2d',
+format: 'astc-8x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-8x6-unorm-srgb'
+],
+}
+);
+let computePassEncoder28 = commandEncoder49.beginComputePass();
+let renderBundleEncoder44 = device3.createRenderBundleEncoder(
+{
+colorFormats: [
+'bgra8unorm-srgb',
+'rg11b10ufloat'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 36,
+depthReadOnly: true,
+}
+);
+let sampler70 = device3.createSampler(
+{
+label: '\u9679\u14f7\u9126\u0c9c\ubd35\u0f0f',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 86.824,
+maxAnisotropy: 19,
+}
+);
+try {
+renderPassEncoder22.beginOcclusionQuery(2864);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder22.insertDebugMarker(
+'\u02fa'
+);
+} catch {}
+try {
+gpuCanvasContext5.configure(
+{
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let promise26 = device3.queue.onSubmittedWorkDone();
+let pipeline67 = device3.createRenderPipeline(
+{
+label: '\u4089\u0ed7\u0638\u{1fca7}\u48d0\u065b\u0470\u7acf',
+layout: pipelineLayout11,
+vertex: {
+module: shaderModule20,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 17296,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x3',
+offset: 10316,
+shaderLocation: 21,
+},
+{
+format: 'sint32x3',
+offset: 9756,
+shaderLocation: 12,
+},
+{
+format: 'sint32',
+offset: 4212,
+shaderLocation: 15,
+},
+{
+format: 'uint16x4',
+offset: 10564,
+shaderLocation: 13,
+},
+{
+format: 'uint8x2',
+offset: 8082,
+shaderLocation: 24,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 16380,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 3728,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x4',
+offset: 1068,
+shaderLocation: 3,
+},
+{
+format: 'float16x2',
+offset: 1136,
+shaderLocation: 4,
+},
+{
+format: 'uint32x4',
+offset: 736,
+shaderLocation: 10,
+},
+{
+format: 'sint8x2',
+offset: 1236,
+shaderLocation: 17,
+},
+{
+format: 'uint32x3',
+offset: 492,
+shaderLocation: 11,
+},
+{
+format: 'float32',
+offset: 316,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 4896,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 4184,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 2788,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x4',
+offset: 928,
+shaderLocation: 25,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0xdf549161,
+},
+fragment: {
+module: shaderModule20,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r16float',
+},
+{
+format: 'rg8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+undefined,
+undefined,
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+undefined
+],
+},
+}
+);
+gc();
+let commandEncoder54 = device2.createCommandEncoder(
+{
+label: '\u0598\u57b1\u336d',
+}
+);
+let querySet51 = device2.createQuerySet({
+label: '\u94f1\u2da6\u08bd\uaed7\u{1fee4}\u{1f9e9}\u0985\u{1fc50}\u{1fd6e}',
+type: 'occlusion',
+count: 623,
+});
+let textureView62 = texture29.createView(
+{
+label: '\u{1f794}\u{1ff9d}\u8edb\u0a35\u6925\u{1fcf7}',
+dimension: '3d',
+baseMipLevel: 2,
+}
+);
+let computePassEncoder29 = commandEncoder34.beginComputePass(
+{
+label: '\ucaf0\u0271\u{1f9a9}\u{1f899}\u07ff'
+}
+);
+let sampler71 = device2.createSampler(
+{
+label: '\u{1fd43}\u9898\uc1d6\u3f44\uc784',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 68.817,
+maxAnisotropy: 2,
+}
+);
+try {
+renderPassEncoder17.setScissorRect(
+0,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(
+1,
+bindGroup6
+);
+} catch {}
+document.body.prepend(video0);
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let offscreenCanvas24 = new OffscreenCanvas(680, 811);
+let imageBitmap16 = await createImageBitmap(offscreenCanvas1);
+let imageData22 = new ImageData(8, 84);
+let shaderModule21 = device3.createShaderModule(
+{
+label: '\u{1fbc4}\ua941\u7a9e\u4e66\u{1f9d4}\uf418\u5603\u0f83\u0950\u0776\u0440',
+code: `@group(4) @binding(5591)
+var<storage, read_write> field29: array<u32>;
+@group(0) @binding(5591)
+var<storage, read_write> type32: array<u32>;
+@group(3) @binding(5591)
+var<storage, read_write> field30: array<u32>;
+
+@compute @workgroup_size(5, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S22 {
+@location(64) f0: vec2<i32>
+}
+struct FragmentOutput0 {
+@location(1) f0: vec2<f32>,
+@builtin(frag_depth) f1: f32,
+@location(0) f2: vec2<i32>,
+@location(4) f3: i32,
+@location(7) f4: f32,
+@location(5) f5: vec4<u32>,
+@builtin(sample_mask) f6: u32,
+@location(2) f7: vec2<u32>,
+@location(6) f8: vec3<i32>,
+@location(3) f9: u32
+}
+
+@fragment
+fn fragment0(@location(19) a0: vec4<i32>, @location(43) a1: vec2<f32>, @location(25) a2: vec3<i32>, @location(1) a3: i32, @location(73) a4: f16, @location(33) a5: f16, @location(61) a6: f16, @location(53) a7: vec4<f16>, @location(39) a8: vec4<u32>, @location(62) a9: vec4<i32>, @builtin(sample_index) a10: u32, @location(3) a11: vec4<i32>, @location(40) a12: vec4<f16>, @builtin(position) a13: vec4<f32>, @location(74) a14: vec3<i32>, @location(65) a15: vec2<i32>, a16: S22, @location(88) a17: vec3<i32>, @location(51) a18: vec4<f16>, @location(13) a19: f32, @location(77) a20: vec3<i32>, @location(7) a21: vec2<f32>, @location(17) a22: f16, @builtin(sample_mask) a23: u32, @builtin(front_facing) a24: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S21 {
+@location(24) f0: vec3<f16>,
+@location(17) f1: vec3<f16>,
+@location(3) f2: i32,
+@location(16) f3: vec2<f16>,
+@location(4) f4: vec4<u32>,
+@location(15) f5: vec3<i32>,
+@location(7) f6: vec4<u32>,
+@location(23) f7: f32,
+@location(1) f8: f32,
+@builtin(vertex_index) f9: u32,
+@location(11) f10: f16,
+@location(25) f11: vec3<u32>,
+@location(2) f12: vec3<u32>,
+@location(13) f13: vec3<u32>,
+@location(5) f14: vec2<i32>,
+@builtin(instance_index) f15: u32,
+@location(10) f16: u32
+}
+struct VertexOutput0 {
+@location(65) f176: vec2<i32>,
+@location(73) f177: f16,
+@location(53) f178: vec4<f16>,
+@location(13) f179: f32,
+@location(1) f180: i32,
+@location(25) f181: vec3<i32>,
+@location(7) f182: vec2<f32>,
+@location(19) f183: vec4<i32>,
+@location(88) f184: vec3<i32>,
+@location(39) f185: vec4<u32>,
+@location(77) f186: vec3<i32>,
+@location(74) f187: vec3<i32>,
+@location(62) f188: vec4<i32>,
+@location(33) f189: f16,
+@location(40) f190: vec4<f16>,
+@location(51) f191: vec4<f16>,
+@builtin(position) f192: vec4<f32>,
+@location(64) f193: vec2<i32>,
+@location(61) f194: f16,
+@location(3) f195: vec4<i32>,
+@location(43) f196: vec2<f32>,
+@location(17) f197: f16
+}
+
+@vertex
+fn vertex0(a0: S21, @location(9) a1: f16, @location(19) a2: vec3<u32>, @location(12) a3: i32, @location(0) a4: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+}
+);
+let commandEncoder55 = device3.createCommandEncoder(
+{
+label: '\u2d0d\u{1fa4f}\u{1ff88}\u837d\u{1fba4}\u029c\u0b71\u6703\u{1fc8e}\ufbcb',
+}
+);
+let textureView63 = texture53.createView(
+{
+baseMipLevel: 3,
+mipLevelCount: 1,
+}
+);
+let sampler72 = device3.createSampler(
+{
+label: '\u36ae\u{1facd}\u0be9\u{1fb28}\u08ae',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+lodMaxClamp: 93.650,
+}
+);
+try {
+renderPassEncoder22.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder22.setBlendConstant({ r: -341.2, g: -70.08, b: 933.3, a: 448.1, });
+} catch {}
+try {
+renderPassEncoder22.setScissorRect(
+32,
+0,
+104,
+1
+);
+} catch {}
+try {
+renderPassEncoder22.setStencilReference(
+2824
+);
+} catch {}
+try {
+commandEncoder55.clearBuffer(
+buffer16
+);
+dissociateBuffer(device3, buffer16);
+} catch {}
+try {
+gpuCanvasContext14.configure(
+{
+device: device3,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm',
+'astc-10x6-unorm',
+'rgba16float',
+'rgba16float'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+await promise26;
+} catch {}
+let textureView64 = texture47.createView(
+{
+dimension: '2d-array',
+mipLevelCount: 1,
+baseArrayLayer: 195,
+arrayLayerCount: 15,
+}
+);
+let renderBundle65 = renderBundleEncoder16.finish(
+{
+label: '\u88ac\u{1fd01}\u75db\u748e\ud1fa\u{1fe9c}\u0a07\u7ebd\u05ea\u{1fb09}'
+}
+);
+let sampler73 = device1.createSampler(
+{
+label: '\u0173\u0ce5\u671a\u08a5\uc175\u{1fca7}',
+addressModeV: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 17.651,
+}
+);
+try {
+renderPassEncoder18.beginOcclusionQuery(2794);
+} catch {}
+try {
+renderBundleEncoder39.setBindGroup(
+10,
+bindGroup2
+);
+} catch {}
+try {
+commandEncoder50.copyBufferToBuffer(
+buffer6,
+7476,
+buffer7,
+13128,
+56
+);
+dissociateBuffer(device1, buffer6);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder53.clearBuffer(
+buffer13
+);
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 16, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: imageBitmap9,
+  origin: { x: 486, y: 352 },
+  flipY: false,
+},
+{
+  texture: texture45,
+  mipLevel: 6,
+  origin: { x: 9, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+video14.height = 56;
+let video20 = await videoWithData();
+try {
+offscreenCanvas24.getContext('webgl2');
+} catch {}
+let bindGroupLayout23 = device0.createBindGroupLayout(
+{
+label: '\u60f9\u939d\uaeed\u{1f7eb}\uda1f\u1d37\u{1f8fc}\u{1fd88}\u{1f871}\ub340\u91d4',
+entries: [
+
+],
+}
+);
+let commandEncoder56 = device0.createCommandEncoder();
+try {
+computePassEncoder6.setBindGroup(
+8,
+bindGroup0,
+new Uint32Array(4765),
+4065,
+0
+);
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(
+818
+);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+20.04,
+0.3505,
+93.00,
+0.5415,
+0.3825,
+0.7817
+);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+commandEncoder56.copyBufferToBuffer(
+buffer3,
+9420,
+buffer12,
+4716,
+2200
+);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder56.resolveQuerySet(
+querySet4,
+952,
+514,
+buffer5,
+1792
+);
+} catch {}
+try {
+gpuCanvasContext3.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg16uint',
+'rgba8unorm-srgb',
+'rgba8unorm',
+'rgba8unorm'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+let pipeline68 = device0.createComputePipeline(
+{
+label: '\ufbf6\u07f9\ubcc2\u0ab1\ue077\u{1fcbc}',
+layout: 'auto',
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let img15 = await imageWithData(64, 228, '#1e8294b9', '#4589a6ec');
+let computePassEncoder30 = commandEncoder55.beginComputePass(
+{
+label: '\u1ffc\u0b64\u0c0a\u{1ff9b}\u{1fd32}\ub452'
+}
+);
+try {
+renderPassEncoder22.endOcclusionQuery();
+} catch {}
+let pipeline69 = device3.createRenderPipeline(
+{
+label: '\u8454\u{1fa64}\u0237\ue502\u{1f683}\u62b4',
+layout: pipelineLayout11,
+vertex: {
+module: shaderModule20,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 4664,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 2444,
+shaderLocation: 13,
+},
+{
+format: 'uint16x4',
+offset: 1272,
+shaderLocation: 21,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 32,
+shaderLocation: 25,
+},
+{
+format: 'float32',
+offset: 3884,
+shaderLocation: 4,
+},
+{
+format: 'uint16x2',
+offset: 4496,
+shaderLocation: 11,
+},
+{
+format: 'float32x4',
+offset: 3756,
+shaderLocation: 3,
+},
+{
+format: 'float32x2',
+offset: 2852,
+shaderLocation: 6,
+},
+{
+format: 'uint8x4',
+offset: 3436,
+shaderLocation: 10,
+},
+{
+format: 'sint16x2',
+offset: 2032,
+shaderLocation: 17,
+},
+{
+format: 'uint32x3',
+offset: 1484,
+shaderLocation: 24,
+},
+{
+format: 'sint32',
+offset: 3116,
+shaderLocation: 12,
+},
+{
+format: 'snorm16x4',
+offset: 3516,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 13388,
+attributes: [
+{
+format: 'sint16x4',
+offset: 11392,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 1492,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 872,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule20,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'dst-alpha',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+writeMask: 0,
+},
+{
+format: 'rg11b10ufloat',
+},
+{
+format: 'rg16float',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+{
+format: 'r16uint',
+writeMask: 0,
+},
+undefined
+],
+},
+}
+);
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.prepend(img9);
+try {
+adapter6.label = '\u{1f836}\u{1fc55}\u{1fa19}\u7a5e\u0ce9\u5582\u5fc6\u0fef\u6ef1\u0478\u8303';
+} catch {}
+let renderBundleEncoder45 = device3.createRenderBundleEncoder(
+{
+label: '\u01dd\ufd2c\u{1fafd}',
+colorFormats: [
+undefined,
+'rgba16float',
+'rgba8unorm-srgb',
+'rg32float',
+'rg8uint',
+'rg16uint',
+'bgra8unorm'
+],
+sampleCount: 677,
+depthReadOnly: true,
+stencilReadOnly: false,
+}
+);
+try {
+renderBundleEncoder44.setVertexBuffer(
+56,
+undefined,
+231929598,
+3885358721
+);
+} catch {}
+let canvas13 = document.createElement('canvas');
+let adapter12 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let querySet52 = device3.createQuerySet({
+label: '\u{1fcfc}\u08a7\ueef4\u0837\u0ef4\u0155\u0012\ue563\u0aea\u0fe8\u9a0c',
+type: 'occlusion',
+count: 3240,
+});
+let renderBundle66 = renderBundleEncoder41.finish(
+{
+label: '\u4fe3\u7c9b\u83d3\u{1f94f}\uc65d\u0bb0'
+}
+);
+let sampler74 = device3.createSampler(
+{
+label: '\u1f34\u{1fede}\u{1fae1}\u61b1',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 5.386,
+lodMaxClamp: 6.429,
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder22.setStencilReference(
+3799
+);
+} catch {}
+try {
+gpuCanvasContext12.configure(
+{
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb',
+'stencil8'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let img16 = await imageWithData(83, 291, '#f6b1d65e', '#cb164285');
+let shaderModule22 = device1.createShaderModule(
+{
+label: '\u0970\ucde7\u10dd\uff16\uebb2\ue08f\u0ac2\ue0f1\u{1f6e3}\u9ddd',
+code: `@group(4) @binding(746)
+var<storage, read_write> type33: array<u32>;
+@group(5) @binding(2789)
+var<storage, read_write> global30: array<u32>;
+@group(0) @binding(746)
+var<storage, read_write> type34: array<u32>;
+@group(5) @binding(4311)
+var<storage, read_write> parameter30: array<u32>;
+@group(4) @binding(381)
+var<storage, read_write> field31: array<u32>;
+@group(7) @binding(6076)
+var<storage, read_write> local27: array<u32>;
+@group(6) @binding(4311)
+var<storage, read_write> type35: array<u32>;
+@group(6) @binding(2718)
+var<storage, read_write> field32: array<u32>;
+@group(6) @binding(2789)
+var<storage, read_write> type36: array<u32>;
+@group(2) @binding(2789)
+var<storage, read_write> field33: array<u32>;
+@group(0) @binding(381)
+var<storage, read_write> type37: array<u32>;
+@group(1) @binding(1617)
+var<storage, read_write> i22: array<u32>;
+@group(5) @binding(2718)
+var<storage, read_write> parameter31: array<u32>;
+@group(3) @binding(1761)
+var<storage, read_write> function41: array<u32>;
+@group(2) @binding(2718)
+var<storage, read_write> function42: array<u32>;
+@group(1) @binding(1761)
+var<storage, read_write> i23: array<u32>;
+@group(7) @binding(4733)
+var<storage, read_write> local28: array<u32>;
+
+@compute @workgroup_size(7, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S23 {
+@builtin(sample_index) f0: u32,
+@builtin(sample_mask) f1: u32,
+@builtin(front_facing) f2: bool,
+@builtin(position) f3: vec4<f32>
+}
+struct FragmentOutput0 {
+@location(5) f0: vec4<u32>,
+@location(3) f1: i32,
+@builtin(sample_mask) f2: u32,
+@location(7) f3: i32,
+@location(4) f4: vec3<f32>,
+@location(6) f5: vec3<u32>,
+@builtin(frag_depth) f6: f32,
+@location(1) f7: vec3<u32>
+}
+
+@fragment
+fn fragment0(a0: S23) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(18) a0: vec4<i32>, @location(16) a1: vec2<i32>, @location(12) a2: vec2<u32>, @location(2) a3: f32, @location(9) a4: vec2<f16>, @location(26) a5: vec3<u32>, @location(8) a6: vec4<f16>, @location(25) a7: f32, @location(11) a8: vec4<f32>, @location(22) a9: vec4<f32>, @location(13) a10: vec3<u32>, @location(0) a11: vec4<f32>, @location(3) a12: f16, @location(10) a13: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+}
+);
+let textureView65 = texture33.createView(
+{
+label: '\u{1f6ea}\u8648\u2112\u95c2\uf3f2\u{1fcc4}\u019e\u{1f8c3}\u{1fcaa}',
+aspect: 'all',
+baseMipLevel: 2,
+mipLevelCount: 4,
+}
+);
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant({ r: -312.9, g: 311.6, b: 65.60, a: 183.5, });
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(
+1,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(
+269
+);
+} catch {}
+let bindGroup14 = device3.createBindGroup({
+layout: bindGroupLayout22,
+entries: [
+{
+binding: 5591,
+resource: sampler74
+}
+],
+});
+let texture58 = device3.createTexture(
+{
+label: '\uc432\u7dab',
+size: [80, 8, 157],
+mipLevelCount: 4,
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+renderBundleEncoder43.setBindGroup(
+0,
+bindGroup14,
+new Uint32Array(9575),
+3886,
+0
+);
+} catch {}
+let canvas14 = document.createElement('canvas');
+let shaderModule23 = device3.createShaderModule(
+{
+label: '\u2c58\u21ef',
+code: `@group(1) @binding(5591)
+var<storage, read_write> i24: array<u32>;
+@group(3) @binding(5591)
+var<storage, read_write> i25: array<u32>;
+@group(4) @binding(5591)
+var<storage, read_write> local29: array<u32>;
+@group(2) @binding(5591)
+var<storage, read_write> global31: array<u32>;
+
+@compute @workgroup_size(6, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: u32,
+@location(2) f1: u32,
+@location(1) f2: vec4<u32>,
+@location(0) f3: vec3<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(15) a0: vec3<f32>, @location(11) a1: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture59 = device3.createTexture(
+{
+label: '\u56a5\u6dbb\ufc71\ue5c1\u{1f761}\u036f\u8d05\u{1fa25}\u0c5f\u{1ff3e}\u0ffe',
+size: {width: 3127},
+dimension: '1d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rg11b10ufloat',
+'rg11b10ufloat',
+'rg11b10ufloat'
+],
+}
+);
+let renderBundle67 = renderBundleEncoder41.finish(
+{
+label: '\u{1f992}\uf5ac\u980a'
+}
+);
+try {
+renderPassEncoder22.setBlendConstant({ r: -459.4, g: -139.4, b: 211.4, a: -683.0, });
+} catch {}
+try {
+renderPassEncoder22.setStencilReference(
+1338
+);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(
+2,
+bindGroup14,
+new Uint32Array(1771),
+460,
+0
+);
+} catch {}
+try {
+renderPassEncoder22.pushDebugGroup(
+'\u{1f90c}'
+);
+} catch {}
+let gpuCanvasContext18 = canvas13.getContext('webgpu');
+let canvas15 = document.createElement('canvas');
+try {
+canvas15.getContext('webgpu');
+} catch {}
+let gpuCanvasContext19 = canvas14.getContext('webgpu');
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let imageBitmap17 = await createImageBitmap(offscreenCanvas17);
+let videoFrame21 = new VideoFrame(videoFrame12, {timestamp: 0});
+let buffer19 = device3.createBuffer(
+{
+size: 3516,
+usage: GPUBufferUsage.STORAGE,
+}
+);
+let renderBundle68 = renderBundleEncoder41.finish();
+try {
+computePassEncoder28.end();
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(
+50,
+undefined,
+827442284,
+2486172665
+);
+} catch {}
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+let arrayBuffer4 = buffer16.getMappedRange(
+3392,
+812
+);
+try {
+commandEncoder49.copyTextureToTexture(
+{
+  texture: texture53,
+  mipLevel: 2,
+  origin: { x: 9, y: 0, z: 3 },
+  aspect: 'all',
+},
+{
+  texture: texture53,
+  mipLevel: 1,
+  origin: { x: 148, y: 1, z: 8 },
+  aspect: 'all',
+},
+{width: 45, height: 0, depthOrArrayLayers: 42}
+);
+} catch {}
+let computePassEncoder31 = commandEncoder53.beginComputePass(
+{
+label: '\u02bf\u0e14\u{1f7d8}\uf9fa'
+}
+);
+try {
+renderBundleEncoder42.setIndexBuffer(
+buffer6,
+'uint32',
+4472,
+4888
+);
+} catch {}
+try {
+commandEncoder50.copyBufferToBuffer(
+buffer9,
+24588,
+buffer13,
+992,
+0
+);
+dissociateBuffer(device1, buffer9);
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+8024,
+new BigUint64Array(26711),
+15633,
+224
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 257, height: 1, depthOrArrayLayers: 38}
+*/
+{
+  source: canvas15,
+  origin: { x: 158, y: 15 },
+  flipY: true,
+},
+{
+  texture: texture45,
+  mipLevel: 2,
+  origin: { x: 68, y: 1, z: 11 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 140, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline70 = await device1.createComputePipelineAsync(
+{
+layout: pipelineLayout4,
+compute: {
+module: shaderModule18,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let video21 = await videoWithData();
+let textureView66 = texture25.createView(
+{
+label: '\u6619\ub35a\u01e3',
+format: 'rgba32uint',
+baseMipLevel: 1,
+mipLevelCount: 4,
+baseArrayLayer: 0,
+}
+);
+let renderBundleEncoder46 = device1.createRenderBundleEncoder(
+{
+label: '\u0492\u{1fb9f}\u0f66\u0c32\u{1fc35}\udc12\uc419\u0fb9',
+colorFormats: [
+'r32sint',
+'rgba16uint',
+'rgba16uint',
+'rg11b10ufloat'
+],
+sampleCount: 762,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder21.beginOcclusionQuery(1053);
+} catch {}
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(
+3752
+);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(
+buffer6,
+'uint32',
+3552
+);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(
+8,
+buffer9,
+41640,
+2127
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture33,
+  mipLevel: 1,
+  origin: { x: 570, y: 0, z: 8 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 3894391 */{
+offset: 39,
+bytesPerRow: 218,
+rowsPerImage: 154,
+},
+{width: 74, height: 0, depthOrArrayLayers: 117}
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 8, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas11,
+  origin: { x: 156, y: 114 },
+  flipY: true,
+},
+{
+  texture: texture45,
+  mipLevel: 7,
+  origin: { x: 4, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 4, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let video22 = await videoWithData();
+let bindGroup15 = device3.createBindGroup({
+layout: bindGroupLayout22,
+entries: [
+{
+binding: 5591,
+resource: sampler74
+}
+],
+});
+let commandBuffer3 = commandEncoder49.finish(
+{
+}
+);
+let renderBundle69 = renderBundleEncoder41.finish(
+{
+label: '\u0eff\u0caf\ud5be'
+}
+);
+try {
+renderBundleEncoder43.setBindGroup(
+4,
+bindGroup14,
+new Uint32Array(4959),
+289,
+0
+);
+} catch {}
+try {
+texture57.destroy();
+} catch {}
+let pipeline71 = device3.createRenderPipeline(
+{
+label: '\u0b2f\u0555\u87cf',
+layout: pipelineLayout11,
+vertex: {
+module: shaderModule20,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 4568,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 2012,
+shaderLocation: 24,
+},
+{
+format: 'float32x4',
+offset: 3304,
+shaderLocation: 6,
+},
+{
+format: 'snorm16x4',
+offset: 3132,
+shaderLocation: 8,
+},
+{
+format: 'uint32x4',
+offset: 336,
+shaderLocation: 11,
+},
+{
+format: 'unorm16x2',
+offset: 2588,
+shaderLocation: 3,
+},
+{
+format: 'sint32x4',
+offset: 2428,
+shaderLocation: 17,
+},
+{
+format: 'sint8x4',
+offset: 3060,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 14400,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 13360,
+shaderLocation: 25,
+},
+{
+format: 'sint16x2',
+offset: 8444,
+shaderLocation: 12,
+},
+{
+format: 'float32x2',
+offset: 424,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 96,
+shaderLocation: 21,
+},
+{
+format: 'uint32x3',
+offset: 16392,
+shaderLocation: 13,
+},
+{
+format: 'float32x3',
+offset: 852,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 9168,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 2960,
+attributes: [
+
+],
+},
+{
+arrayStride: 7828,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 492,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 44,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule20,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'constant',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.GREEN,
+},
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'zero',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 2524,
+depthBias: 46,
+depthBiasSlopeScale: 42,
+depthBiasClamp: 24,
+},
+}
+);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let textureView67 = texture33.createView(
+{
+baseMipLevel: 4,
+}
+);
+let computePassEncoder32 = commandEncoder50.beginComputePass(
+{
+label: '\udb7e\u7ffd\u550d\u0f7d\u{1fdee}\ua4f6\u6a73\u06a8\uabac\ud5d2'
+}
+);
+let renderBundle70 = renderBundleEncoder26.finish(
+{
+label: '\u0390\u0ee4\u0bc4\u23bb\u{1f811}\u71db'
+}
+);
+try {
+renderPassEncoder20.setBindGroup(
+3,
+bindGroup9
+);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder20.setScissorRect(
+1,
+1,
+1,
+0
+);
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(
+898
+);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(
+2,
+buffer9
+);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(
+8,
+buffer9,
+24972,
+14020
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline72 = device1.createComputePipeline(
+{
+label: '\u5fbe\u4284\u040a',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule19,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline73 = device1.createRenderPipeline(
+{
+label: '\u0579\u{1fe9e}\uaea7\u0c71\u0f10\u4eb2\uaf42\u02ca\u0f56\u8fb0',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule8,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 32368,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 15412,
+shaderLocation: 26,
+},
+{
+format: 'sint32x3',
+offset: 32144,
+shaderLocation: 24,
+},
+{
+format: 'snorm8x2',
+offset: 13566,
+shaderLocation: 16,
+},
+{
+format: 'unorm8x2',
+offset: 20264,
+shaderLocation: 25,
+},
+{
+format: 'float32x3',
+offset: 5396,
+shaderLocation: 17,
+},
+{
+format: 'float16x2',
+offset: 7636,
+shaderLocation: 1,
+},
+{
+format: 'snorm8x2',
+offset: 6434,
+shaderLocation: 18,
+},
+{
+format: 'sint32x3',
+offset: 29952,
+shaderLocation: 6,
+},
+{
+format: 'uint32',
+offset: 8584,
+shaderLocation: 14,
+},
+{
+format: 'sint8x2',
+offset: 27608,
+shaderLocation: 12,
+},
+{
+format: 'snorm16x4',
+offset: 14120,
+shaderLocation: 13,
+},
+{
+format: 'uint8x4',
+offset: 8632,
+shaderLocation: 5,
+},
+{
+format: 'uint8x2',
+offset: 2458,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 30760,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 23064,
+shaderLocation: 21,
+},
+{
+format: 'uint32x2',
+offset: 19080,
+shaderLocation: 2,
+},
+{
+format: 'sint32x2',
+offset: 3260,
+shaderLocation: 15,
+},
+{
+format: 'snorm16x4',
+offset: 29140,
+shaderLocation: 22,
+},
+{
+format: 'snorm16x4',
+offset: 18172,
+shaderLocation: 10,
+},
+{
+format: 'sint16x2',
+offset: 29708,
+shaderLocation: 27,
+}
+],
+},
+{
+arrayStride: 6704,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32',
+offset: 5148,
+shaderLocation: 20,
+},
+{
+format: 'uint32x4',
+offset: 3948,
+shaderLocation: 23,
+},
+{
+format: 'snorm16x4',
+offset: 1648,
+shaderLocation: 19,
+},
+{
+format: 'sint32x2',
+offset: 5124,
+shaderLocation: 8,
+},
+{
+format: 'sint8x4',
+offset: 4972,
+shaderLocation: 11,
+},
+{
+format: 'uint32x2',
+offset: 2568,
+shaderLocation: 3,
+},
+{
+format: 'sint32x4',
+offset: 5404,
+shaderLocation: 7,
+},
+{
+format: 'float16x2',
+offset: 2224,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 32668,
+attributes: [
+
+],
+},
+{
+arrayStride: 5344,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 37520,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32',
+offset: 4920,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+},
+fragment: {
+module: shaderModule8,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16float',
+writeMask: 0,
+},
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rgba16sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'one-minus-constant',
+dstFactor: 'constant'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.BLUE,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'decrement-clamp',
+passOp: 'invert',
+},
+stencilReadMask: 3019,
+stencilWriteMask: 1592,
+depthBias: 96,
+depthBiasClamp: 48,
+},
+}
+);
+let canvas16 = document.createElement('canvas');
+let adapter13 = await navigator.gpu.requestAdapter();
+let renderBundle71 = renderBundleEncoder17.finish();
+try {
+renderPassEncoder23.setBindGroup(
+5,
+bindGroup12
+);
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(
+2357
+);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(
+7,
+bindGroup9,
+new Uint32Array(2493),
+1648,
+0
+);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(
+8,
+buffer9,
+10140,
+28304
+);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let shaderModule24 = device3.createShaderModule(
+{
+label: '\u0d48\u9484\u{1fa1e}\u6636\u6220\ud626\ua320\u2b6e\u{1f92f}\u{1f693}',
+code: `@group(1) @binding(5591)
+var<storage, read_write> local30: array<u32>;
+@group(4) @binding(5591)
+var<storage, read_write> field34: array<u32>;
+@group(3) @binding(5591)
+var<storage, read_write> i26: array<u32>;
+
+@compute @workgroup_size(8, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(position) a2: vec4<f32>, @builtin(front_facing) a3: bool) {
+
+}
+
+struct S24 {
+@location(21) f0: vec4<f16>,
+@location(8) f1: vec3<f32>,
+@location(11) f2: f32,
+@location(12) f3: vec2<f32>,
+@location(15) f4: f16,
+@location(10) f5: f32,
+@location(18) f6: vec2<f16>,
+@builtin(vertex_index) f7: u32,
+@location(6) f8: vec4<u32>,
+@location(5) f9: vec3<u32>,
+@builtin(instance_index) f10: u32,
+@location(13) f11: vec3<u32>,
+@location(2) f12: vec4<f16>,
+@location(14) f13: vec2<i32>,
+@location(4) f14: i32,
+@location(7) f15: i32,
+@location(0) f16: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(20) a0: vec2<f32>, @location(16) a1: vec3<f32>, @location(24) a2: f16, @location(3) a3: f32, @location(19) a4: vec4<f16>, @location(9) a5: vec2<f32>, @location(17) a6: vec2<f32>, @location(23) a7: f32, @location(25) a8: i32, @location(22) a9: vec4<u32>, a10: S24, @location(1) a11: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+}
+);
+try {
+computePassEncoder30.setBindGroup(
+3,
+bindGroup15,
+new Uint32Array(1195),
+894,
+0
+);
+} catch {}
+try {
+renderPassEncoder22.setViewport(
+22.22,
+0.3629,
+195.4,
+0.1499,
+0.01639,
+0.8627
+);
+} catch {}
+let arrayBuffer5 = buffer16.getMappedRange(
+4208,
+1152
+);
+let img17 = await imageWithData(229, 118, '#4496d6b7', '#6a02bca8');
+let textureView68 = texture58.createView(
+{
+baseMipLevel: 3,
+baseArrayLayer: 51,
+arrayLayerCount: 65,
+}
+);
+let renderBundleEncoder47 = device3.createRenderBundleEncoder(
+{
+label: '\u8160\u0cb9\u48ed\u330f\u5c34',
+colorFormats: [
+'rg8sint',
+'rg32float',
+'rg16float'
+],
+sampleCount: 437,
+stencilReadOnly: false,
+}
+);
+try {
+renderPassEncoder22.setViewport(
+24.04,
+0.3482,
+203.8,
+0.1447,
+0.6197,
+0.8203
+);
+} catch {}
+try {
+renderPassEncoder22.insertDebugMarker(
+'\u{1f997}'
+);
+} catch {}
+let bindGroupLayout24 = device1.createBindGroupLayout(
+{
+label: '\uddf7\uf1f1\u1197\u0276\u7543\ubb68\u09fe\ucf97\u0d92',
+entries: [
+{
+binding: 3503,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+},
+{
+binding: 1455,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'non-filtering' },
+},
+{
+binding: 2804,
+visibility: 0,
+storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '2d-array' },
+}
+],
+}
+);
+try {
+computePassEncoder26.setBindGroup(
+5,
+bindGroup8,
+new Uint32Array(2972),
+343,
+1
+);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(
+8,
+buffer9
+);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(
+7,
+bindGroup1
+);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(
+2,
+buffer6,
+8200,
+503
+);
+} catch {}
+try {
+await buffer14.mapAsync(
+GPUMapMode.WRITE
+);
+} catch {}
+let promise27 = device1.queue.onSubmittedWorkDone();
+let canvas17 = document.createElement('canvas');
+let videoFrame22 = new VideoFrame(canvas16, {timestamp: 0});
+let renderBundle72 = renderBundleEncoder43.finish(
+{
+
+}
+);
+try {
+renderPassEncoder22.setViewport(
+43.53,
+0.7616,
+150.6,
+0.2075,
+0.1055,
+0.4147
+);
+} catch {}
+try {
+renderBundleEncoder47.setBindGroup(
+0,
+bindGroup14
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture53,
+  mipLevel: 3,
+  origin: { x: 4, y: 0, z: 3 },
+  aspect: 'all',
+},
+new ArrayBuffer(385845),
+/* required buffer size: 385845 */{
+offset: 453,
+bytesPerRow: 222,
+rowsPerImage: 217,
+},
+{width: 54, height: 0, depthOrArrayLayers: 9}
+);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+await adapter7.requestAdapterInfo();
+} catch {}
+let device4 = await promise12;
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+let offscreenCanvas25 = new OffscreenCanvas(816, 607);
+let texture60 = device4.createTexture(
+{
+size: {width: 2322, height: 127, depthOrArrayLayers: 39},
+mipLevelCount: 10,
+dimension: '2d',
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb10a2unorm'
+],
+}
+);
+gc();
+let img18 = await imageWithData(90, 192, '#75eafe33', '#343e993c');
+let video23 = await videoWithData();
+let texture61 = device3.createTexture(
+{
+label: '\u{1f629}\u47e1\u07e5\u0dd8\ud36e\u{1fe4b}\u{1f767}\uca7e\uf01b',
+size: [242, 1, 203],
+mipLevelCount: 4,
+sampleCount: 1,
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rg8unorm',
+'rg8unorm',
+'rg8unorm'
+],
+}
+);
+try {
+renderPassEncoder22.setBindGroup(
+4,
+bindGroup15,
+new Uint32Array(4228),
+732,
+0
+);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(
+1,
+bindGroup15,
+new Uint32Array(3543),
+1491,
+0
+);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+canvas14.width = 536;
+try {
+device2.label = '\u4c3f\u31d9';
+} catch {}
+let device5 = await promise21;
+try {
+canvas16.getContext('webgpu');
+} catch {}
+video20.height = 271;
+let renderBundleEncoder48 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg16float',
+'rgb10a2unorm',
+'r32uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 254,
+stencilReadOnly: true,
+}
+);
+let renderBundle73 = renderBundleEncoder21.finish(
+{
+label: '\u0a29\u{1fe57}\u6f29\uaf33\u3edf\u0dc4\u06f2\u0ebd'
+}
+);
+try {
+renderPassEncoder18.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder24.setScissorRect(
+762,
+1,
+759,
+0
+);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(
+1,
+buffer9,
+96,
+34806
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+6204,
+new Float32Array(7240),
+1518,
+1484
+);
+} catch {}
+let promise28 = device1.createComputePipelineAsync(
+{
+label: '\u5796\u3293\ue436\u0688\ub977\uef73\u{1ff40}\ude52',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule9,
+entryPoint: 'compute0',
+},
+}
+);
+let shaderModule25 = device3.createShaderModule(
+{
+label: '\u{1ffc0}\u0cad',
+code: `@group(2) @binding(5591)
+var<storage, read_write> function43: array<u32>;
+@group(4) @binding(5591)
+var<storage, read_write> global32: array<u32>;
+@group(1) @binding(5591)
+var<storage, read_write> local31: array<u32>;
+
+@compute @workgroup_size(4, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(0) f0: i32,
+@location(6) f1: vec4<i32>,
+@location(5) f2: vec3<i32>,
+@location(4) f3: f32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S25 {
+@location(18) f0: vec3<i32>,
+@location(25) f1: i32,
+@builtin(vertex_index) f2: u32,
+@location(12) f3: f32
+}
+
+@vertex
+fn vertex0(@location(16) a0: vec4<i32>, @location(2) a1: vec3<f16>, @location(10) a2: vec3<f32>, @location(23) a3: vec3<f16>, @location(5) a4: vec4<f32>, @location(9) a5: vec4<f16>, @location(15) a6: vec2<i32>, @builtin(instance_index) a7: u32, a8: S25, @location(6) a9: vec3<f16>, @location(20) a10: vec4<f16>, @location(17) a11: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let pipelineLayout12 = device3.createPipelineLayout(
+{
+label: '\u4415\u0fb4\u173a\u5185\u{1f818}\ufebe',
+bindGroupLayouts: [
+bindGroupLayout22,
+bindGroupLayout22,
+bindGroupLayout22,
+bindGroupLayout22
+]
+}
+);
+try {
+renderPassEncoder22.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder22.setViewport(
+235.0,
+0.4302,
+5.670,
+0.07851,
+0.5093,
+0.6020
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture61,
+  mipLevel: 0,
+  origin: { x: 24, y: 0, z: 87 },
+  aspect: 'all',
+},
+new ArrayBuffer(72),
+/* required buffer size: 874419 */{
+offset: 51,
+bytesPerRow: 396,
+rowsPerImage: 32,
+},
+{width: 109, height: 0, depthOrArrayLayers: 70}
+);
+} catch {}
+let pipeline74 = device3.createRenderPipeline(
+{
+label: '\u7ecf\ue6f9',
+layout: pipelineLayout11,
+vertex: {
+module: shaderModule25,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 13916,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32',
+offset: 1132,
+shaderLocation: 25,
+},
+{
+format: 'snorm8x4',
+offset: 9004,
+shaderLocation: 10,
+},
+{
+format: 'unorm16x4',
+offset: 1236,
+shaderLocation: 20,
+},
+{
+format: 'float32x4',
+offset: 9236,
+shaderLocation: 12,
+},
+{
+format: 'sint8x2',
+offset: 7474,
+shaderLocation: 15,
+},
+{
+format: 'snorm8x4',
+offset: 1092,
+shaderLocation: 6,
+},
+{
+format: 'snorm16x4',
+offset: 12352,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x2',
+offset: 8084,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 11972,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 11030,
+shaderLocation: 5,
+},
+{
+format: 'sint16x4',
+offset: 9464,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x4',
+offset: 5028,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 11360,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x2',
+offset: 7128,
+shaderLocation: 16,
+},
+{
+format: 'float16x4',
+offset: 700,
+shaderLocation: 17,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule25,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16sint',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'always',
+failOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'invert',
+},
+stencilReadMask: 3399,
+stencilWriteMask: 3985,
+depthBias: 92,
+depthBiasSlopeScale: 73,
+depthBiasClamp: 35,
+},
+}
+);
+let commandEncoder57 = device5.createCommandEncoder();
+let computePassEncoder33 = commandEncoder57.beginComputePass(
+{
+label: '\u757c\u{1fd34}\u8505\u0c04'
+}
+);
+let promise29 = device5.queue.onSubmittedWorkDone();
+let gpuCanvasContext20 = offscreenCanvas25.getContext('webgpu');
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+try {
+canvas17.getContext('webgl');
+} catch {}
+let renderBundle74 = renderBundleEncoder15.finish(
+{
+label: '\u{1fbc3}\u0148\u9da9\ua1bf\u05b3'
+}
+);
+try {
+renderPassEncoder18.setBindGroup(
+8,
+bindGroup12,
+new Uint32Array(2474),
+2288,
+0
+);
+} catch {}
+try {
+renderPassEncoder21.beginOcclusionQuery(658);
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(
+411,
+0,
+859,
+1
+);
+} catch {}
+try {
+renderPassEncoder18.setViewport(
+501.9,
+0.9260,
+180.3,
+0.02571,
+0.7505,
+0.8855
+);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(
+5,
+buffer6,
+900,
+6054
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture34,
+  mipLevel: 2,
+  origin: { x: 0, y: 4, z: 1 },
+  aspect: 'all',
+},
+new Uint32Array(arrayBuffer1),
+/* required buffer size: 508 */{
+offset: 508,
+bytesPerRow: 224,
+},
+{width: 4, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let device6 = await adapter13.requestDevice({
+label: '\uec6e\ubbde\u46e6\u{1fefd}\u583c\u{1f94c}\u93af',
+requiredLimits: {
+maxBindGroups: 6,
+maxColorAttachmentBytesPerSample: 53,
+maxVertexAttributes: 23,
+maxVertexBufferArrayStride: 58239,
+maxStorageTexturesPerShaderStage: 39,
+maxStorageBuffersPerShaderStage: 37,
+maxDynamicStorageBuffersPerPipelineLayout: 26269,
+maxBindingsPerBindGroup: 3477,
+maxTextureArrayLayers: 256,
+maxTextureDimension1D: 10034,
+maxTextureDimension2D: 10365,
+maxVertexBuffers: 11,
+maxUniformBufferBindingSize: 255911313,
+maxUniformBuffersPerShaderStage: 22,
+maxInterStageShaderVariables: 100,
+maxInterStageShaderComponents: 64,
+},
+});
+try {
+adapter10.label = '\uae33\u6868\u99a4\ueb04\u07c2\u09a8\ua421\u0639\ufa5d\ua97a';
+} catch {}
+let commandEncoder58 = device4.createCommandEncoder(
+{
+label: '\u50fd\u{1f848}\u5c38',
+}
+);
+let commandBuffer4 = commandEncoder58.finish(
+{
+label: '\ube0a\ub9cc\u3d6c',
+}
+);
+let sampler75 = device4.createSampler(
+{
+label: '\u{1fe6f}\u03ad\ue531\u{1f9b2}\u2cdc\u9ba8\u{1ff17}\uee20',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 65.409,
+lodMaxClamp: 98.204,
+maxAnisotropy: 19,
+}
+);
+try {
+gpuCanvasContext12.configure(
+{
+device: device4,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8unorm',
+'rgba16float',
+'rgba16float'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let buffer20 = device1.createBuffer(
+{
+label: '\ua57f\uf418',
+size: 6409,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: false,
+}
+);
+let querySet53 = device1.createQuerySet({
+label: '\u04ce\u{1f93e}\u3c0b\u082a\u1fcb\u{1f985}\u{1f7a5}\u0f6a\uc559',
+type: 'occlusion',
+count: 2185,
+});
+try {
+renderPassEncoder23.setViewport(
+0.04742,
+0.5855,
+0.8926,
+0.07658,
+0.3486,
+0.6165
+);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(
+0,
+buffer9,
+13620,
+13670
+);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(
+1,
+bindGroup1,
+[]
+);
+} catch {}
+let pipeline75 = await device1.createComputePipelineAsync(
+{
+label: '\uaedc\uc028\u4635\u98bb\uca3a\u4909\u{1f723}\u48df\u06f5\u331f',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule19,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let commandEncoder59 = device4.createCommandEncoder(
+{
+label: '\u0f78\u081c\u38f3\u1dde\u0b20\u{1f65c}\uc350\u07e4\u79e8',
+}
+);
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let imageBitmap18 = await createImageBitmap(imageBitmap9);
+let shaderModule26 = device3.createShaderModule(
+{
+code: `@group(3) @binding(5591)
+var<storage, read_write> i27: array<u32>;
+@group(2) @binding(5591)
+var<storage, read_write> function44: array<u32>;
+@group(1) @binding(5591)
+var<storage, read_write> local32: array<u32>;
+@group(0) @binding(5591)
+var<storage, read_write> type38: array<u32>;
+
+@compute @workgroup_size(6, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S27 {
+@location(70) f0: vec4<i32>,
+@location(50) f1: u32,
+@location(37) f2: vec3<i32>,
+@location(83) f3: vec4<i32>,
+@location(23) f4: vec4<f32>,
+@location(1) f5: i32,
+@location(18) f6: vec3<f16>,
+@location(44) f7: vec2<i32>,
+@location(74) f8: vec3<i32>,
+@location(88) f9: vec3<i32>,
+@location(69) f10: u32,
+@location(30) f11: f16,
+@location(19) f12: vec3<i32>,
+@location(59) f13: vec2<u32>
+}
+struct FragmentOutput0 {
+@location(3) f0: vec2<f32>,
+@location(7) f1: vec4<f32>,
+@location(1) f2: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(56) a0: vec3<f16>, @location(79) a1: vec3<f32>, @location(32) a2: i32, @location(7) a3: i32, @location(55) a4: vec2<f16>, @builtin(sample_index) a5: u32, @location(62) a6: vec3<i32>, @location(85) a7: vec3<i32>, @location(4) a8: vec2<f32>, @location(63) a9: vec2<f16>, @location(78) a10: vec3<i32>, @location(68) a11: vec4<f32>, @location(10) a12: i32, @location(36) a13: f16, @location(84) a14: vec4<f16>, @location(31) a15: vec3<f16>, @location(71) a16: f32, @location(29) a17: vec4<f32>, @location(73) a18: vec4<i32>, @builtin(front_facing) a19: bool, @location(28) a20: vec3<f16>, a21: S27, @location(26) a22: vec2<u32>, @location(47) a23: vec4<i32>, @location(38) a24: f32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S26 {
+@location(7) f0: vec3<f16>,
+@location(6) f1: vec3<i32>,
+@location(1) f2: vec4<f32>,
+@location(5) f3: f32,
+@location(15) f4: vec2<u32>,
+@builtin(vertex_index) f5: u32,
+@location(17) f6: vec4<f32>,
+@location(24) f7: vec3<u32>,
+@location(8) f8: vec2<i32>,
+@location(9) f9: f32,
+@location(14) f10: vec4<u32>,
+@location(25) f11: f16,
+@location(13) f12: vec4<u32>,
+@location(10) f13: vec3<i32>,
+@location(2) f14: f16,
+@location(18) f15: vec3<f32>,
+@location(11) f16: i32,
+@location(4) f17: vec3<i32>,
+@location(23) f18: vec2<f16>,
+@location(16) f19: vec4<f32>,
+@location(19) f20: vec3<u32>
+}
+struct VertexOutput0 {
+@location(69) f198: u32,
+@location(37) f199: vec3<i32>,
+@location(68) f200: vec4<f32>,
+@location(56) f201: vec3<f16>,
+@location(73) f202: vec4<i32>,
+@location(36) f203: f16,
+@location(88) f204: vec3<i32>,
+@location(74) f205: vec3<i32>,
+@location(83) f206: vec4<i32>,
+@location(7) f207: i32,
+@location(55) f208: vec2<f16>,
+@location(28) f209: vec3<f16>,
+@location(62) f210: vec3<i32>,
+@location(4) f211: vec2<f32>,
+@location(59) f212: vec2<u32>,
+@location(70) f213: vec4<i32>,
+@location(79) f214: vec3<f32>,
+@location(84) f215: vec4<f16>,
+@location(1) f216: i32,
+@location(6) f217: f32,
+@location(58) f218: u32,
+@location(15) f219: f32,
+@location(50) f220: u32,
+@location(47) f221: vec4<i32>,
+@location(40) f222: u32,
+@location(66) f223: vec3<u32>,
+@location(32) f224: i32,
+@location(19) f225: vec3<i32>,
+@location(78) f226: vec3<i32>,
+@location(26) f227: vec2<u32>,
+@location(18) f228: vec3<f16>,
+@location(63) f229: vec2<f16>,
+@location(44) f230: vec2<i32>,
+@location(42) f231: vec4<f32>,
+@location(71) f232: f32,
+@location(23) f233: vec4<f32>,
+@location(29) f234: vec4<f32>,
+@location(61) f235: vec3<f16>,
+@location(31) f236: vec3<f16>,
+@location(10) f237: i32,
+@location(85) f238: vec3<i32>,
+@location(76) f239: vec2<i32>,
+@builtin(position) f240: vec4<f32>,
+@location(38) f241: f32,
+@location(30) f242: f16
+}
+
+@vertex
+fn vertex0(@location(21) a0: vec4<i32>, a1: S26, @location(0) a2: vec2<f16>, @location(22) a3: vec2<f32>, @location(12) a4: vec3<f32>, @location(20) a5: vec4<u32>, @location(3) a6: vec2<f16>, @builtin(instance_index) a7: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+}
+);
+let bindGroupLayout25 = device3.createBindGroupLayout(
+{
+label: '\uce42\u2157\ub7cc\u0856\ub6fb\u{1fc20}\u0329\u{1fba0}\u{1f7e8}\u{1fb3e}\u04c7',
+entries: [
+
+],
+}
+);
+let renderBundle75 = renderBundleEncoder47.finish(
+{
+label: '\u576f\u03d2\u0127\u3284\ub5e4\u{1ff47}\u1c60'
+}
+);
+try {
+renderPassEncoder22.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder22.setStencilReference(
+3225
+);
+} catch {}
+try {
+device3.queue.submit([
+commandBuffer3,
+]);
+} catch {}
+let texture62 = device5.createTexture(
+{
+label: '\u8ef0\ua8ba\ud400\u{1ff81}\u{1f891}\u5971\uce71\u0ff4\u073d\u10e0\uf022',
+size: [6157, 46, 152],
+mipLevelCount: 7,
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'r16uint',
+'r16uint',
+'r16uint'
+],
+}
+);
+let textureView69 = texture62.createView(
+{
+label: '\u9b55\u{1f9bc}\ucb8a\u{1ff76}\u4951\u{1fcc2}\ud00e\u0314\ue204\u{1fda5}\u7d38',
+dimension: '2d',
+baseMipLevel: 3,
+mipLevelCount: 1,
+baseArrayLayer: 15,
+arrayLayerCount: 1,
+}
+);
+try {
+device5.addEventListener('uncapturederror', e => { log('device5.uncapturederror'); log(e); e.label = device5.label; });
+} catch {}
+let querySet54 = device3.createQuerySet({
+label: '\ufd7f\u{1fef0}\u{1fd50}\u1179\ucd71\u7ec1\ucbd5',
+type: 'occlusion',
+count: 940,
+});
+let renderBundleEncoder49 = device3.createRenderBundleEncoder(
+{
+label: '\u5044\u0bb9\u7842',
+colorFormats: [
+'r32float',
+'r32float',
+'rg16sint',
+'bgra8unorm-srgb',
+'r32sint',
+'rg32sint',
+'r8sint'
+],
+sampleCount: 15,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder22.setViewport(
+65.06,
+0.09930,
+32.00,
+0.6494,
+0.2682,
+0.8931
+);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(
+1,
+bindGroup15
+);
+} catch {}
+try {
+gpuCanvasContext13.configure(
+{
+device: device3,
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture62,
+  mipLevel: 4,
+  origin: { x: 31, y: 1, z: 9 },
+  aspect: 'all',
+},
+new Int32Array(arrayBuffer2),
+/* required buffer size: 3266542 */{
+offset: 622,
+bytesPerRow: 648,
+rowsPerImage: 42,
+},
+{width: 256, height: 0, depthOrArrayLayers: 121}
+);
+} catch {}
+let querySet55 = device5.createQuerySet({
+label: '\u{1f895}\u{1fa34}\u2c9b\u{1ff09}\u5e26\ue1d8\u62af',
+type: 'occlusion',
+count: 2349,
+});
+try {
+querySet55.destroy();
+} catch {}
+let texture63 = device4.createTexture(
+{
+label: '\u0f3b\u{1fbed}\u{1f6e3}\u05b2\u5f67\ue56e',
+size: [196, 1, 1643],
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let texture64 = gpuCanvasContext13.getCurrentTexture();
+try {
+device4.queue.submit([
+commandBuffer4,
+]);
+} catch {}
+pseudoSubmit(device3, commandEncoder55);
+let renderBundle76 = renderBundleEncoder41.finish(
+{
+label: '\u06d0\ue156\u{1ff5d}\u{1f772}\u{1fc18}\u01b0\u0bc1\u{1fa2f}'
+}
+);
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline76 = await device3.createRenderPipelineAsync(
+{
+label: '\u{1f687}\u2329\ud238\uf37f',
+layout: pipelineLayout12,
+vertex: {
+module: shaderModule21,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 13324,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 1780,
+shaderLocation: 0,
+},
+{
+format: 'uint8x4',
+offset: 3652,
+shaderLocation: 25,
+},
+{
+format: 'sint8x4',
+offset: 8052,
+shaderLocation: 5,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 2648,
+shaderLocation: 1,
+},
+{
+format: 'sint16x2',
+offset: 3980,
+shaderLocation: 3,
+},
+{
+format: 'sint32x2',
+offset: 11220,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x4',
+offset: 12384,
+shaderLocation: 23,
+},
+{
+format: 'uint16x4',
+offset: 12644,
+shaderLocation: 10,
+},
+{
+format: 'sint16x2',
+offset: 3716,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x4',
+offset: 2964,
+shaderLocation: 17,
+},
+{
+format: 'uint32x2',
+offset: 9468,
+shaderLocation: 7,
+},
+{
+format: 'float16x2',
+offset: 5348,
+shaderLocation: 16,
+},
+{
+format: 'uint16x4',
+offset: 5844,
+shaderLocation: 4,
+},
+{
+format: 'unorm16x4',
+offset: 11244,
+shaderLocation: 9,
+},
+{
+format: 'uint16x4',
+offset: 7968,
+shaderLocation: 19,
+},
+{
+format: 'float32',
+offset: 7712,
+shaderLocation: 24,
+}
+],
+},
+{
+arrayStride: 9088,
+attributes: [
+{
+format: 'uint32x3',
+offset: 7224,
+shaderLocation: 13,
+},
+{
+format: 'uint16x4',
+offset: 216,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 6704,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32',
+offset: 6108,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule21,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'rg16sint',
+},
+{
+format: 'rg32float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r8uint',
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'less',
+failOp: 'replace',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'always',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilWriteMask: 2475,
+depthBias: 93,
+depthBiasSlopeScale: 21,
+depthBiasClamp: 32,
+},
+}
+);
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let offscreenCanvas26 = new OffscreenCanvas(1023, 645);
+try {
+offscreenCanvas26.getContext('webgpu');
+} catch {}
+let querySet56 = device4.createQuerySet({
+type: 'occlusion',
+count: 1255,
+});
+let commandBuffer5 = commandEncoder59.finish(
+{
+}
+);
+let renderBundleEncoder50 = device4.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8sint',
+undefined,
+'rgba16uint',
+'bgra8unorm',
+'rg8sint',
+'r16uint',
+'rg16float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 136,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder50.setVertexBuffer(
+27,
+undefined,
+804053297,
+2730796036
+);
+} catch {}
+try {
+await promise29;
+} catch {}
+let video24 = await videoWithData();
+try {
+renderBundleEncoder50.setVertexBuffer(
+16,
+undefined,
+2369133106,
+1256595744
+);
+} catch {}
+try {
+device4.queue.submit([
+commandBuffer5,
+]);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture64,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(2),
+/* required buffer size: 2 */{
+offset: 2,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await promise27;
+} catch {}
+try {
+await adapter12.requestAdapterInfo();
+} catch {}
+let commandEncoder60 = device3.createCommandEncoder(
+{
+label: '\ud6b3\u{1f94f}\ub807\u3a16\u0b62',
+}
+);
+let textureView70 = texture57.createView(
+{
+label: '\u9438\ue91f',
+baseMipLevel: 5,
+mipLevelCount: 1,
+}
+);
+let computePassEncoder34 = commandEncoder60.beginComputePass();
+try {
+renderPassEncoder22.setViewport(
+3.305,
+0.8628,
+14.42,
+0.1065,
+0.6632,
+0.6829
+);
+} catch {}
+try {
+renderPassEncoder22.insertDebugMarker(
+'\uda1a'
+);
+} catch {}
+let pipeline77 = device3.createComputePipeline(
+{
+label: '\u0ed9\u{1f62f}',
+layout: pipelineLayout12,
+compute: {
+module: shaderModule23,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let commandEncoder61 = device6.createCommandEncoder(
+{
+}
+);
+let computePassEncoder35 = commandEncoder61.beginComputePass(
+{
+
+}
+);
+let renderBundleEncoder51 = device6.createRenderBundleEncoder(
+{
+label: '\u7ca8\u0bd0\ub5a1\u07d0\u{1fd57}\u0c5a',
+colorFormats: [
+'r8unorm',
+'rg16uint',
+'rg32float',
+'r16sint',
+'r32float',
+'bgra8unorm',
+undefined,
+'rg32sint'
+],
+sampleCount: 19,
+depthReadOnly: true,
+}
+);
+try {
+computePassEncoder35.end();
+} catch {}
+try {
+device6.label = '\ud41d\u{1fbd8}\u0dcc\u0959\u0d4b\u{1f98f}\u023f\u{1faa7}\udf96';
+} catch {}
+let querySet57 = device6.createQuerySet({
+label: '\u0994\u0f58\u7298',
+type: 'occlusion',
+count: 1334,
+});
+let renderBundle77 = renderBundleEncoder51.finish(
+{
+label: '\u7b5a\uab4b\u07bf\u018e'
+}
+);
+let sampler76 = device6.createSampler(
+{
+label: '\ud2c8\ue8ea\u2ddc\u59c1\u5de1',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 61.914,
+lodMaxClamp: 76.169,
+maxAnisotropy: 4,
+}
+);
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let pipelineLayout13 = device1.createPipelineLayout(
+{
+label: '\ua7b3\u58a0\u{1f93f}\u0ff1\u{1f8ab}\u3efe\u0d3c',
+bindGroupLayouts: [
+bindGroupLayout12
+]
+}
+);
+let buffer21 = device1.createBuffer(
+{
+label: '\ue92c\u136c\u9256\u{1fa43}\u00f7',
+size: 47154,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let commandEncoder62 = device1.createCommandEncoder(
+{
+label: '\u{1feff}\u00ae\ub7e4\u4571\u31ea',
+}
+);
+let querySet58 = device1.createQuerySet({
+label: '\u0363\u0ae8\u{1fa65}\u79b4\u433c\u{1f72c}\u41b2\ue9ff',
+type: 'occlusion',
+count: 3446,
+});
+try {
+renderPassEncoder18.beginOcclusionQuery(2009);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(
+1,
+buffer6,
+6156,
+2207
+);
+} catch {}
+try {
+commandEncoder62.clearBuffer(
+buffer13
+);
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+commandEncoder62.resolveQuerySet(
+querySet50,
+983,
+13,
+buffer7,
+7424
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+488,
+new BigUint64Array(36464),
+26373,
+96
+);
+} catch {}
+let pipeline78 = await promise28;
+try {
+device1.destroy();
+} catch {}
+let canvas18 = document.createElement('canvas');
+let imageData23 = new ImageData(16, 32);
+try {
+device4.queue.writeTexture(
+{
+  texture: texture64,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(756),
+/* required buffer size: 756 */{
+offset: 756,
+bytesPerRow: 32,
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+gc();
+let commandBuffer6 = commandEncoder61.finish(
+{
+label: '\u{1ff14}\u0431\u8a29\u{1f668}\u{1f85d}\ub432\ud6f1',
+}
+);
+let texture65 = device6.createTexture(
+{
+label: '\u{1fadf}\u1229\u{1f83c}',
+size: [192, 1, 113],
+mipLevelCount: 7,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'depth32float',
+'depth32float'
+],
+}
+);
+let renderBundle78 = renderBundleEncoder51.finish(
+{
+label: '\u{1fa9a}\ue070\u8a8f\u5bda\uf13a\u3193'
+}
+);
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let canvas19 = document.createElement('canvas');
+let imageData24 = new ImageData(176, 48);
+let promise30 = adapter11.requestDevice({
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 52,
+maxVertexBufferArrayStride: 39820,
+maxStorageTexturesPerShaderStage: 43,
+maxStorageBuffersPerShaderStage: 21,
+maxDynamicStorageBuffersPerPipelineLayout: 37079,
+maxBindingsPerBindGroup: 5673,
+maxTextureDimension1D: 14014,
+maxTextureDimension2D: 14739,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 192112610,
+maxUniformBuffersPerShaderStage: 26,
+maxInterStageShaderComponents: 97,
+},
+});
+let renderBundle79 = renderBundleEncoder51.finish(
+{
+label: '\u069f\u6cdd\u{1febd}\u{1f943}\u25e5\u{1f9a4}\u{1f8f4}\u0609\u8d57\uc1ca'
+}
+);
+let sampler77 = device6.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+lodMinClamp: 22.921,
+}
+);
+let querySet59 = device5.createQuerySet({
+label: '\u2376\u11f0\u{1f782}\ubcce\u{1fd06}',
+type: 'occlusion',
+count: 965,
+});
+let renderBundleEncoder52 = device5.createRenderBundleEncoder(
+{
+label: '\u{1fca8}\ua77d\u0002\u2b4f\u7124\uc376\ud19a\u04da',
+colorFormats: [
+'rgba16uint',
+undefined,
+'rg16float',
+'rg32float'
+],
+sampleCount: 745,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+offscreenCanvas1.width = 198;
+let offscreenCanvas27 = new OffscreenCanvas(774, 65);
+let imageBitmap19 = await createImageBitmap(imageBitmap17);
+let textureView71 = texture62.createView(
+{
+label: '\u06cf\ufff4\u053d\ub26a\ud8ba\ubf50\u006e',
+dimension: '2d',
+aspect: 'all',
+baseMipLevel: 4,
+mipLevelCount: 2,
+baseArrayLayer: 49,
+}
+);
+let imageData25 = new ImageData(108, 184);
+try {
+canvas18.getContext('webgl2');
+} catch {}
+let buffer22 = device5.createBuffer(
+{
+label: '\u{1fc9c}\uf34c\u{1faff}\u32a9\ua45b\ua989',
+size: 59817,
+usage: GPUBufferUsage.VERTEX,
+mappedAtCreation: false,
+}
+);
+let textureView72 = texture62.createView(
+{
+label: '\u{1fc3e}\u0779\ua492',
+dimension: '2d-array',
+baseMipLevel: 5,
+baseArrayLayer: 93,
+arrayLayerCount: 52,
+}
+);
+let sampler78 = device5.createSampler(
+{
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 68.798,
+lodMaxClamp: 97.842,
+}
+);
+let promise31 = device5.queue.onSubmittedWorkDone();
+try {
+await promise31;
+} catch {}
+let commandEncoder63 = device3.createCommandEncoder(
+{
+label: '\u{1f992}\u29cf\ua5cb\u3561\u{1f989}\u0434\uf7d3\ud0a6\u{1f8ea}',
+}
+);
+let renderBundle80 = renderBundleEncoder49.finish();
+try {
+computePassEncoder34.setPipeline(
+pipeline77
+);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(
+4,
+bindGroup14
+);
+} catch {}
+try {
+device3.pushErrorScope('out-of-memory');
+} catch {}
+let arrayBuffer6 = buffer16.getMappedRange(
+5360,
+32
+);
+let gpuCanvasContext21 = canvas19.getContext('webgpu');
+let gpuCanvasContext22 = offscreenCanvas27.getContext('webgpu');
+document.body.prepend(video9);
+let bindGroup16 = device3.createBindGroup({
+label: '\u2eed\udf8d\u145b\u6645\u15ee\u9042\ud4f1\u45f7',
+layout: bindGroupLayout25,
+entries: [
+
+],
+});
+let texture66 = device3.createTexture(
+{
+label: '\ud69b\u0d4f\u{1f846}\u8beb\u0388\uf5f7',
+size: {width: 3590, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgb9e5ufloat',
+'rgb9e5ufloat'
+],
+}
+);
+try {
+renderBundleEncoder44.setBindGroup(
+1,
+bindGroup15,
+new Uint32Array(6359),
+4474,
+0
+);
+} catch {}
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+commandEncoder63.clearBuffer(
+buffer16
+);
+dissociateBuffer(device3, buffer16);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture53,
+  mipLevel: 1,
+  origin: { x: 1, y: 1, z: 8 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer2),
+/* required buffer size: 10086714 */{
+offset: 714,
+bytesPerRow: 984,
+rowsPerImage: 125,
+},
+{width: 240, height: 0, depthOrArrayLayers: 83}
+);
+} catch {}
+let imageData26 = new ImageData(216, 256);
+try {
+adapter13.label = '\ua12c\u{1fd28}\u50b5\u01d9\u{1f80f}\u1df6\u4587\u4eae\ub9db\u044f';
+} catch {}
+let texture67 = device3.createTexture(
+{
+label: '\u61c0\u8b52\u0e84\u520f',
+size: [5807],
+dimension: '1d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let computePassEncoder36 = commandEncoder63.beginComputePass(
+{
+label: '\u0446\u6d5d\ufa30\u3bd5\u3a83\u{1fc91}\u{1fb92}'
+}
+);
+let renderBundleEncoder53 = device3.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg32float',
+'rg8sint',
+'r16sint',
+'rg32uint',
+'r32float',
+'rg16uint',
+'r16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 873,
+depthReadOnly: true,
+}
+);
+let sampler79 = device3.createSampler(
+{
+label: '\u{1fbc6}\ue872\u044e\ucbf8\u84ec\ub829\u{1f956}\u1ec9\u071b\u7238',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 80.305,
+lodMaxClamp: 90.756,
+}
+);
+try {
+renderBundleEncoder44.setBindGroup(
+4,
+bindGroup16
+);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(
+4,
+bindGroup16,
+new Uint32Array(9861),
+9548,
+0
+);
+} catch {}
+let pipeline79 = device3.createRenderPipeline(
+{
+label: '\u{1fa1e}\u9f07\u{1f786}\uf0f2\u02ae\u1152\ufa0e\u3e78',
+layout: pipelineLayout11,
+vertex: {
+module: shaderModule24,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 2328,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 1852,
+shaderLocation: 19,
+},
+{
+format: 'float16x4',
+offset: 1860,
+shaderLocation: 12,
+},
+{
+format: 'uint32',
+offset: 2140,
+shaderLocation: 13,
+},
+{
+format: 'sint8x2',
+offset: 2188,
+shaderLocation: 25,
+},
+{
+format: 'float32x4',
+offset: 1304,
+shaderLocation: 15,
+},
+{
+format: 'uint32',
+offset: 2036,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 940,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 350,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x2',
+offset: 114,
+shaderLocation: 2,
+},
+{
+format: 'unorm8x2',
+offset: 62,
+shaderLocation: 16,
+},
+{
+format: 'float32x2',
+offset: 56,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 5852,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x3',
+offset: 5704,
+shaderLocation: 6,
+},
+{
+format: 'unorm8x2',
+offset: 2550,
+shaderLocation: 9,
+},
+{
+format: 'sint32x4',
+offset: 4052,
+shaderLocation: 4,
+},
+{
+format: 'sint32x4',
+offset: 48,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x2',
+offset: 4600,
+shaderLocation: 24,
+},
+{
+format: 'float32x3',
+offset: 4988,
+shaderLocation: 20,
+},
+{
+format: 'unorm8x2',
+offset: 5400,
+shaderLocation: 3,
+},
+{
+format: 'snorm8x2',
+offset: 5674,
+shaderLocation: 8,
+},
+{
+format: 'snorm16x2',
+offset: 3608,
+shaderLocation: 21,
+},
+{
+format: 'uint32',
+offset: 472,
+shaderLocation: 1,
+},
+{
+format: 'sint8x2',
+offset: 2170,
+shaderLocation: 14,
+},
+{
+format: 'float32x4',
+offset: 3640,
+shaderLocation: 11,
+},
+{
+format: 'float32x3',
+offset: 1756,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 16608,
+attributes: [
+{
+format: 'unorm8x4',
+offset: 2972,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 15700,
+attributes: [
+{
+format: 'uint32x4',
+offset: 9384,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 8508,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 10004,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 10772,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 540,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 64,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+},
+}
+);
+let imageData27 = new ImageData(168, 200);
+try {
+adapter8.label = '\u05aa\u{1f60b}\uc2ce';
+} catch {}
+let promise32 = adapter7.requestDevice({
+label: '\u0b08\u{1f741}\u{1f8c4}\u881f\u{1ffcc}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 8,
+maxColorAttachmentBytesPerSample: 60,
+maxVertexAttributes: 25,
+maxVertexBufferArrayStride: 61581,
+maxStorageTexturesPerShaderStage: 9,
+maxStorageBuffersPerShaderStage: 16,
+maxDynamicStorageBuffersPerPipelineLayout: 54859,
+maxBindingsPerBindGroup: 1339,
+maxTextureDimension1D: 10039,
+maxTextureDimension2D: 13759,
+minStorageBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 59862826,
+maxUniformBuffersPerShaderStage: 36,
+maxInterStageShaderVariables: 41,
+maxInterStageShaderComponents: 82,
+maxSamplersPerShaderStage: 20,
+},
+});
+let commandEncoder64 = device4.createCommandEncoder(
+{
+label: '\uee97\ud4d3\u0544',
+}
+);
+let imageBitmap20 = await createImageBitmap(imageData4);
+let texture68 = device4.createTexture(
+{
+label: '\u0c6b\uaba6\u{1fba8}\u0436',
+size: [90, 1, 979],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'r16uint',
+'r16uint',
+'r16uint'
+],
+}
+);
+let textureView73 = texture60.createView(
+{
+label: '\u92c0\u684d\u01a7\ucc42\udbd3\u61bc\u3489\u05c0\u0cb3\u0c1b\ud7b6',
+dimension: '2d',
+baseMipLevel: 4,
+mipLevelCount: 5,
+baseArrayLayer: 34,
+}
+);
+try {
+renderBundleEncoder50.insertDebugMarker(
+'\u{1f80e}'
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture64,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer0),
+/* required buffer size: 853 */{
+offset: 853,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let renderBundleEncoder54 = device3.createRenderBundleEncoder(
+{
+colorFormats: [
+'bgra8unorm-srgb'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 595,
+depthReadOnly: true,
+}
+);
+let renderBundle81 = renderBundleEncoder47.finish(
+{
+label: '\u{1fde1}\uf188\u3659\uabba\udd37\uafdb\u0a17\u{1fbad}\u6bfe\udae6'
+}
+);
+let sampler80 = device3.createSampler(
+{
+label: '\u00a5\u69cd\u0ef9\u6688\u0af5',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'linear',
+lodMinClamp: 22.247,
+lodMaxClamp: 67.655,
+compare: 'equal',
+}
+);
+try {
+renderPassEncoder22.beginOcclusionQuery(3222);
+} catch {}
+try {
+renderPassEncoder22.setStencilReference(
+1430
+);
+} catch {}
+try {
+renderPassEncoder22.setViewport(
+57.12,
+0.2184,
+3.962,
+0.4658,
+0.5526,
+0.6117
+);
+} catch {}
+gc();
+try {
+renderBundleEncoder52.setVertexBuffer(
+2,
+buffer22,
+21108
+);
+} catch {}
+let commandBuffer7 = commandEncoder64.finish(
+{
+label: '\u{1f6fe}\u0b26\ub563\u1fb9\u{1ff3d}\u{1fd6d}\uf863\u0f08\u67e3',
+}
+);
+let sampler81 = device4.createSampler(
+{
+label: '\u21c9\u5230\u1f88\u080e',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 29.107,
+lodMaxClamp: 53.519,
+}
+);
+try {
+gpuCanvasContext9.configure(
+{
+device: device4,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-12x10-unorm-srgb',
+'astc-10x5-unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture64,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Float32Array(new ArrayBuffer(32)),
+/* required buffer size: 57 */{
+offset: 57,
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+texture6.label = '\u63f4\u0213\u{1f652}\u2d83\u{1f99c}';
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture69 = device4.createTexture(
+{
+label: '\u{1ffb1}\u549c\u0f87\ufff3\u0098\u0743\u9cef\u0c1c\ubdb1\u0c89',
+size: [876, 10, 1],
+mipLevelCount: 2,
+format: 'astc-12x10-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+gpuCanvasContext1.configure(
+{
+device: device4,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm',
+'bgra8unorm',
+'bgra8unorm-srgb',
+'astc-4x4-unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let renderBundleEncoder55 = device6.createRenderBundleEncoder(
+{
+label: '\u994b\u{1f714}\u0d97',
+colorFormats: [
+'rg16sint',
+'r32sint',
+'rgba8unorm-srgb',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 921,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+gpuCanvasContext22.unconfigure();
+} catch {}
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+document.body.prepend(canvas14);
+let imageBitmap21 = await createImageBitmap(img2);
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let img19 = await imageWithData(175, 114, '#a05b0d77', '#c2a1d588');
+let renderBundleEncoder56 = device5.createRenderBundleEncoder(
+{
+label: '\u0eda\ub49c\u4883\u69cb\ufcf5',
+colorFormats: [
+undefined,
+'rg16sint',
+'rg32float',
+'r16uint',
+'bgra8unorm-srgb'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 534,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+try {
+gpuCanvasContext12.configure(
+{
+device: device5,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture62,
+  mipLevel: 4,
+  origin: { x: 101, y: 1, z: 4 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer0),
+/* required buffer size: 4366119 */{
+offset: 827,
+bytesPerRow: 698,
+rowsPerImage: 53,
+},
+{width: 241, height: 0, depthOrArrayLayers: 119}
+);
+} catch {}
+try {
+await device5.queue.onSubmittedWorkDone();
+} catch {}
+let imageBitmap22 = await createImageBitmap(imageBitmap0);
+let commandEncoder65 = device4.createCommandEncoder(
+{
+label: '\u099e\uf946\u3956\u{1f70e}',
+}
+);
+let texture70 = device4.createTexture(
+{
+label: '\u02e7\ubbf3\u{1f893}\u{1f73c}\u1e21\u5ac1\ud133\u0f6b',
+size: [2514, 170, 47],
+mipLevelCount: 12,
+format: 'astc-6x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-6x5-unorm',
+'astc-6x5-unorm-srgb',
+'astc-6x5-unorm'
+],
+}
+);
+try {
+commandEncoder65.copyTextureToTexture(
+{
+  texture: texture70,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 27 },
+  aspect: 'all',
+},
+{
+  texture: texture70,
+  mipLevel: 5,
+  origin: { x: 18, y: 0, z: 20 },
+  aspect: 'all',
+},
+{width: 48, height: 0, depthOrArrayLayers: 6}
+);
+} catch {}
+let imageBitmap23 = await createImageBitmap(video14);
+let imageData28 = new ImageData(20, 84);
+try {
+querySet57.destroy();
+} catch {}
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+let imageData29 = new ImageData(216, 100);
+let commandEncoder66 = device5.createCommandEncoder(
+{
+label: '\u07d6\u205c\uc3ce\u{1fe9c}\u{1fc4f}\u68a5',
+}
+);
+let texture71 = device5.createTexture(
+{
+size: {width: 208, height: 8, depthOrArrayLayers: 248},
+mipLevelCount: 7,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView74 = texture62.createView(
+{
+label: '\ub943\udcef\u9529\u095e\u{1f94e}\u08bf\uac75\u{1fa54}\u7d17',
+baseMipLevel: 2,
+mipLevelCount: 1,
+baseArrayLayer: 89,
+arrayLayerCount: 52,
+}
+);
+let renderBundleEncoder57 = device5.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgb10a2uint',
+'rgba32uint',
+'rg32sint',
+undefined,
+'rg16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 776,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let querySet60 = device6.createQuerySet({
+label: '\uc003\u3f41\u456d\ua307\u08e5\u99cf\u6dc9\ufec2',
+type: 'occlusion',
+count: 672,
+});
+let sampler82 = device6.createSampler(
+{
+mipmapFilter: 'nearest',
+lodMinClamp: 95.870,
+lodMaxClamp: 97.506,
+compare: 'less',
+}
+);
+try {
+renderBundleEncoder55.setVertexBuffer(
+26,
+undefined,
+1756171434,
+1322601241
+);
+} catch {}
+try {
+device6.pushErrorScope('internal');
+} catch {}
+let promise33 = device6.queue.onSubmittedWorkDone();
+let canvas20 = document.createElement('canvas');
+let querySet61 = device6.createQuerySet({
+label: '\u0aeb\uf548\u{1f676}\u01f0',
+type: 'occlusion',
+count: 2498,
+});
+let renderBundle82 = renderBundleEncoder55.finish(
+{
+label: '\u0d88\u8007\u0446\u0846\u4e01'
+}
+);
+try {
+canvas20.getContext('webgl');
+} catch {}
+let adapter14 = await navigator.gpu.requestAdapter(
+{
+}
+);
+try {
+window.someLabel = device4.label;
+} catch {}
+let texture72 = device4.createTexture(
+{
+label: '\u7ec5\u0513',
+size: [240, 12, 44],
+mipLevelCount: 3,
+dimension: '2d',
+format: 'astc-12x12-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-12x12-unorm-srgb',
+'astc-12x12-unorm'
+],
+}
+);
+let textureView75 = texture64.createView(
+{
+label: '\uc1ad\u01fd',
+}
+);
+try {
+commandEncoder65.copyTextureToTexture(
+{
+  texture: texture64,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture64,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+adapter6.label = '\u09b3\ud43a\ua62a\u9dbc\u0d9b';
+} catch {}
+try {
+window.someLabel = querySet57.label;
+} catch {}
+let texture73 = device6.createTexture(
+{
+label: '\u{1fd4a}\ua5ee',
+size: {width: 186, height: 1, depthOrArrayLayers: 1393},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder58 = device6.createRenderBundleEncoder(
+{
+colorFormats: [
+undefined
+],
+sampleCount: 963,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler83 = device6.createSampler(
+{
+label: '\u0d16\u0a2a\u3b09\u0c3b\u{1f95c}\uab46\u08bf',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 54.559,
+lodMaxClamp: 64.048,
+}
+);
+let imageData30 = new ImageData(200, 172);
+let commandBuffer8 = commandEncoder66.finish(
+{
+label: '\u1049\u{1ff9b}\u{1fa84}\u4e3f\u0f70\u2006',
+}
+);
+let renderBundleEncoder59 = device5.createRenderBundleEncoder(
+{
+label: '\u01ac\u30bf\u056f',
+colorFormats: [
+'rg32float',
+'rgba8uint',
+'bgra8unorm',
+'rg32sint',
+'r8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 638,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle83 = renderBundleEncoder57.finish(
+{
+label: '\u190a\ubc93\ub517\u50ab\u{1fc9e}\u6c0c\u0475'
+}
+);
+let canvas21 = document.createElement('canvas');
+let bindGroup17 = device3.createBindGroup({
+label: '\uc527\u08b1\u0ab7\uc742\u{1f6c0}',
+layout: bindGroupLayout22,
+entries: [
+{
+binding: 5591,
+resource: sampler74
+}
+],
+});
+let texture74 = device3.createTexture(
+{
+label: '\u8616\u813c\u0b6c\uad49\u51fd\u43aa',
+size: {width: 3194, height: 1, depthOrArrayLayers: 231},
+mipLevelCount: 7,
+dimension: '2d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8unorm',
+'rgba8unorm'
+],
+}
+);
+let textureView76 = texture58.createView(
+{
+label: '\uedae\u0f8e\u9fb6\ub53d\u0aec',
+dimension: '2d',
+aspect: 'all',
+baseMipLevel: 3,
+baseArrayLayer: 124,
+arrayLayerCount: 1,
+}
+);
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(
+/*
+{width: 199, height: 1, depthOrArrayLayers: 231}
+*/
+{
+  source: imageData27,
+  origin: { x: 56, y: 26 },
+  flipY: true,
+},
+{
+  texture: texture74,
+  mipLevel: 4,
+  origin: { x: 9, y: 0, z: 186 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 108, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline80 = device3.createComputePipeline(
+{
+layout: pipelineLayout12,
+compute: {
+module: shaderModule26,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+await promise33;
+} catch {}
+let commandEncoder67 = device4.createCommandEncoder();
+let textureView77 = texture63.createView(
+{
+label: '\u524d\u0633\u{1f6e1}\u03fe\uda76\u{1fe3c}\u87ec\u{1fa58}\u{1faee}\uece4\u0475',
+format: 'rg32sint',
+baseMipLevel: 3,
+}
+);
+let renderPassEncoder25 = commandEncoder67.beginRenderPass(
+{
+label: '\u06b9\ubb87\uf39a\u3fa9\u8603',
+colorAttachments: [
+{
+view: textureView75,
+clearValue: { r: -880.1, g: -395.9, b: -101.1, a: -409.8, },
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+maxDrawCount: 63176,
+}
+);
+try {
+renderPassEncoder25.setBlendConstant({ r: 886.3, g: -28.22, b: 569.3, a: -808.1, });
+} catch {}
+try {
+commandEncoder65.copyTextureToTexture(
+{
+  texture: texture64,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture64,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext17.configure(
+{
+device: device4,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let texture75 = device6.createTexture(
+{
+label: '\u0a16\u05ed\u0b56\u0f8d\u30c7',
+size: [6354],
+dimension: '1d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'r16sint',
+'r16sint',
+'r16sint'
+],
+}
+);
+let sampler84 = device6.createSampler(
+{
+label: '\u090f\ueb5e',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 51.481,
+lodMaxClamp: 65.105,
+maxAnisotropy: 19,
+}
+);
+try {
+gpuCanvasContext0.configure(
+{
+device: device6,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16float',
+'stencil8'
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let adapter15 = await navigator.gpu.requestAdapter();
+let videoFrame23 = new VideoFrame(videoFrame10, {timestamp: 0});
+try {
+canvas21.getContext('2d');
+} catch {}
+let commandEncoder68 = device5.createCommandEncoder(
+{
+label: '\u06d5\u{1fe3b}\u6790\u0ded\uc82c\u2c5b',
+}
+);
+let texture76 = device5.createTexture(
+{
+label: '\uf7e0\u07a7',
+size: [1168, 6, 154],
+mipLevelCount: 11,
+format: 'astc-8x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-8x6-unorm-srgb',
+'astc-8x6-unorm'
+],
+}
+);
+let sampler85 = device5.createSampler(
+{
+label: '\u0f20\u13cd\u{1faa1}\u{1fa2b}\u{1fe55}\u5785',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 88.654,
+maxAnisotropy: 9,
+}
+);
+let externalTexture3 = device5.importExternalTexture(
+{
+label: '\u{1f724}\u025b\u0bcc\u7ec6\u{1fdee}\ue3be',
+source: videoFrame6,
+colorSpace: 'display-p3',
+}
+);
+try {
+buffer22.destroy();
+} catch {}
+try {
+buffer22.unmap();
+} catch {}
+let querySet62 = device1.createQuerySet({
+label: '\ud9cd\ud5e7\uc308',
+type: 'occlusion',
+count: 1212,
+});
+let sampler86 = device1.createSampler(
+{
+label: '\u{1fa14}\u188f',
+addressModeU: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 37.457,
+lodMaxClamp: 86.485,
+}
+);
+try {
+computePassEncoder20.setBindGroup(
+8,
+bindGroup3,
+new Uint32Array(5605),
+1300,
+0
+);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(
+6,
+bindGroup2,
+new Uint32Array(970),
+795,
+0
+);
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(
+1,
+0,
+0,
+1
+);
+} catch {}
+try {
+renderPassEncoder24.setViewport(
+345.0,
+0.1685,
+880.1,
+0.4451,
+0.5906,
+0.8346
+);
+} catch {}
+let pipeline81 = await device1.createRenderPipelineAsync(
+{
+label: '\u7764\u1474\u{1f89d}\u4bb5\u9742',
+layout: pipelineLayout9,
+vertex: {
+module: shaderModule13,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 23848,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 8624,
+shaderLocation: 11,
+},
+{
+format: 'uint8x2',
+offset: 536,
+shaderLocation: 25,
+}
+],
+},
+{
+arrayStride: 37440,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 52328,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x3',
+offset: 27408,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 6748,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 5144,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 34412,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 9216,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 3628,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule13,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16sint',
+},
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'keep',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilReadMask: 2822,
+stencilWriteMask: 3988,
+depthBias: 1,
+depthBiasSlopeScale: 36,
+depthBiasClamp: 35,
+},
+}
+);
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let renderPassEncoder26 = commandEncoder68.beginRenderPass(
+{
+label: '\u{1ff70}\u00e4\u5745\u{1feaa}',
+colorAttachments: [
+{
+view: textureView69,
+clearValue: { r: 464.3, g: 167.6, b: 907.4, a: -23.61, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined
+],
+occlusionQuerySet: querySet55,
+maxDrawCount: 14456,
+}
+);
+try {
+renderPassEncoder26.beginOcclusionQuery(2254);
+} catch {}
+try {
+renderPassEncoder26.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder26.setStencilReference(
+718
+);
+} catch {}
+try {
+renderPassEncoder26.setViewport(
+320.8,
+0.1238,
+24.38,
+2.411,
+0.9736,
+0.9983
+);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(
+6,
+buffer22,
+9564,
+7037
+);
+} catch {}
+let canvas22 = document.createElement('canvas');
+let canvas23 = document.createElement('canvas');
+try {
+canvas23.getContext('webgpu');
+} catch {}
+let bindGroupLayout26 = device5.createBindGroupLayout(
+{
+label: '\u8db6\u93aa\u5d29\u1804\u0ef4\ub3cc\u0356',
+entries: [
+{
+binding: 2341,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+},
+{
+binding: 651,
+visibility: 0,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let pipelineLayout14 = device5.createPipelineLayout(
+{
+label: '\u{1fda5}\u012d\uae9c\u{1f9f6}',
+bindGroupLayouts: [
+
+]
+}
+);
+let texture77 = device5.createTexture(
+{
+label: '\uf504\u92c4\u088b\u0a72\u9622\u0142\u{1f722}\u{1fbca}\u5326',
+size: {width: 2143, height: 205, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+sampleCount: 1,
+format: 'rg16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg16uint',
+'rg16uint',
+'rg16uint'
+],
+}
+);
+let textureView78 = texture62.createView(
+{
+label: '\ufff4\u{1fb0f}\u57c1\ua36c\u{1f66a}\u{1f7bf}\uea0f',
+baseMipLevel: 1,
+baseArrayLayer: 14,
+arrayLayerCount: 53,
+}
+);
+let renderBundleEncoder60 = device5.createRenderBundleEncoder(
+{
+label: '\u{1f71e}\u89a5\uf4e2\u0e73\u3edc\u0575\u{1fd53}\u669a\u0561',
+colorFormats: [
+'rgba8unorm-srgb',
+'r8uint',
+undefined
+],
+sampleCount: 668,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder26.beginOcclusionQuery(2281);
+} catch {}
+try {
+renderPassEncoder26.setBlendConstant({ r: 803.8, g: 715.0, b: -603.5, a: 194.3, });
+} catch {}
+try {
+renderBundleEncoder60.setVertexBuffer(
+7,
+buffer22,
+8828,
+9865
+);
+} catch {}
+let offscreenCanvas28 = new OffscreenCanvas(854, 814);
+let commandBuffer9 = commandEncoder65.finish(
+{
+}
+);
+let renderBundleEncoder61 = device4.createRenderBundleEncoder(
+{
+label: '\ub97c\u8ccc\uaf93\u0d4d\ud391',
+colorFormats: [
+'rgba32uint',
+undefined,
+'rgba8unorm',
+'r32sint',
+'r16sint',
+undefined,
+undefined
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 630,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle84 = renderBundleEncoder61.finish();
+let commandEncoder69 = device3.createCommandEncoder(
+{
+label: '\u8d52\ua030\ucf22\u{1fac2}\u5c2c',
+}
+);
+let querySet63 = device3.createQuerySet({
+label: '\u0d34\u077a\u249e\u{1ff5f}',
+type: 'occlusion',
+count: 2255,
+});
+let textureView79 = texture74.createView(
+{
+label: '\u0613\u09f3\u0749\ud3d7\u{1f969}\u951f\u{1f6bc}',
+dimension: '2d',
+baseMipLevel: 4,
+mipLevelCount: 2,
+baseArrayLayer: 57,
+}
+);
+let renderBundleEncoder62 = device3.createRenderBundleEncoder(
+{
+label: '\u{1fe1e}\u{1fc4c}\u8547\uec81\u0d04\u8bfb',
+colorFormats: [
+'rg16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 809,
+}
+);
+let renderBundle85 = renderBundleEncoder45.finish();
+try {
+computePassEncoder34.setBindGroup(
+1,
+bindGroup16,
+[]
+);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(
+1,
+bindGroup17
+);
+} catch {}
+try {
+renderPassEncoder22.setBlendConstant({ r: -495.8, g: -945.6, b: 763.9, a: 904.2, });
+} catch {}
+try {
+renderPassEncoder22.setStencilReference(
+1068
+);
+} catch {}
+try {
+renderPassEncoder22.setViewport(
+91.58,
+0.6262,
+64.86,
+0.1153,
+0.4366,
+0.9529
+);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+try {
+gpuCanvasContext11.configure(
+{
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb10a2unorm',
+'rgba8unorm',
+'astc-5x5-unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let gpuCanvasContext23 = offscreenCanvas28.getContext('webgpu');
+let video25 = await videoWithData();
+let imageBitmap24 = await createImageBitmap(imageBitmap4);
+try {
+await adapter3.requestAdapterInfo();
+} catch {}
+let video26 = await videoWithData();
+let gpuCanvasContext24 = canvas22.getContext('webgpu');
+video8.height = 22;
+let offscreenCanvas29 = new OffscreenCanvas(201, 1024);
+let canvas24 = document.createElement('canvas');
+let querySet64 = device4.createQuerySet({
+type: 'occlusion',
+count: 2475,
+});
+let sampler87 = device4.createSampler(
+{
+label: '\u0b4b\u0172\uca00\u1f35\u6c5a',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 33.777,
+lodMaxClamp: 88.440,
+}
+);
+try {
+renderPassEncoder25.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder25.setScissorRect(
+0,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder25.setViewport(
+0.6640,
+0.3313,
+0.2317,
+0.03291,
+0.8249,
+0.8461
+);
+} catch {}
+let texture78 = device5.createTexture(
+{
+label: '\u01c7\u{1fcea}\u335e\u2011\u8531\u{1ff4f}\u0bb5\uc6d4\u{1fd1f}',
+size: [252, 132, 113],
+mipLevelCount: 3,
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundle86 = renderBundleEncoder60.finish();
+try {
+renderPassEncoder26.setViewport(
+74.78,
+2.426,
+362.3,
+2.282,
+0.8784,
+0.9799
+);
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(
+1,
+buffer22,
+41536,
+10032
+);
+} catch {}
+let commandEncoder70 = device6.createCommandEncoder(
+{
+label: '\u{1f8ab}\u{1fd73}\u{1fc07}\u074c\u{1fb14}\ubd55\u{1fe02}\uc14a\ucc5b\u22b8\u088b',
+}
+);
+let renderBundle87 = renderBundleEncoder58.finish(
+{
+label: '\u24c4\u7c96\u0f88\u{1f919}\ube64\u{1ff7f}\u{1f6d7}'
+}
+);
+try {
+canvas24.getContext('webgpu');
+} catch {}
+let querySet65 = device6.createQuerySet({
+label: '\u0bfd\u57a1\u2e77\u{1f8e2}\u51b8\u{1f601}\u{1f708}\ub004',
+type: 'occlusion',
+count: 1974,
+});
+let video27 = await videoWithData();
+let renderBundle88 = renderBundleEncoder58.finish(
+{
+label: '\uc360\u509c\u{1f65b}\u0978'
+}
+);
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+let canvas25 = document.createElement('canvas');
+let videoFrame24 = new VideoFrame(img6, {timestamp: 0});
+let buffer23 = device5.createBuffer(
+{
+label: '\u5120\u{1f7c2}\u2f84\u4825',
+size: 9431,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let renderBundle89 = renderBundleEncoder57.finish(
+{
+label: '\u0fd2\u74d9\uac77\u{1fe55}'
+}
+);
+let imageBitmap25 = await createImageBitmap(imageBitmap2);
+let bindGroup18 = device3.createBindGroup({
+label: '\u{1ff21}\uba2a\u08e9\u93c0\u0fcc\u{1fb3f}\u06d1\u{1f642}',
+layout: bindGroupLayout22,
+entries: [
+{
+binding: 5591,
+resource: sampler74
+}
+],
+});
+let buffer24 = device3.createBuffer(
+{
+label: '\u{1f8c0}\u0c5d\u{1fac1}\u{1fc5c}\u{1f7d6}\ube7c\u9343\u69fa\u{1fa53}',
+size: 56433,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let renderBundle90 = renderBundleEncoder49.finish();
+try {
+renderPassEncoder22.setViewport(
+34.28,
+0.9376,
+80.92,
+0.05387,
+0.3194,
+0.8757
+);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer16,
+4476,
+new Int16Array(39312),
+385,
+400
+);
+} catch {}
+offscreenCanvas18.width = 775;
+let textureView80 = texture75.createView(
+{
+label: '\u{1f630}\u5fd0\ufa08\u6c60\u9d9a\u{1fe61}\u5459',
+}
+);
+let computePassEncoder37 = commandEncoder70.beginComputePass(
+{
+label: '\ub4b7\u{1f72d}\u{1f686}\u03b8\u8706\u{1f863}\u4dd3'
+}
+);
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+  log('the end')
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -633,8 +633,8 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
 
         if (zeroColorTargets) {
             mtlDescriptor.defaultRasterSampleCount = textureView.sampleCount();
-            mtlDescriptor.renderTargetWidth = textureView.width();
-            mtlDescriptor.renderTargetHeight = textureView.height();
+            mtlDescriptor.renderTargetWidth = metalDepthStencilTexture.width;
+            mtlDescriptor.renderTargetHeight = metalDepthStencilTexture.height;
         }
     }
 

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -132,7 +132,7 @@ public:
     static bool isStencilOnlyFormat(MTLPixelFormat);
     bool shouldStopCaptureAfterSubmit();
     id<MTLBuffer> placeholderBuffer() const;
-    id<MTLTexture> placeholderTexture() const;
+    id<MTLTexture> placeholderTexture(WGPUTextureFormat) const;
     bool isDestroyed() const;
     NSString *errorValidatingTextureCreation(const WGPUTextureDescriptor&, const Vector<WGPUTextureFormat>& viewFormats);
 
@@ -187,6 +187,7 @@ private:
 
     id<MTLBuffer> m_placeholderBuffer { nil };
     id<MTLTexture> m_placeholderTexture { nil };
+    id<MTLTexture> m_placeholderDepthStencilTexture { nil };
 
     const Ref<Adapter> m_adapter;
 #if HAVE(COREVIDEO_METAL_SUPPORT)

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -200,6 +200,8 @@ Device::Device(id<MTLDevice> device, id<MTLCommandQueue> defaultQueue, HardwareC
     desc.storageMode = MTLStorageModeShared;
     desc.usage = MTLTextureUsageShaderRead | MTLTextureUsageRenderTarget;
     m_placeholderTexture = [m_device newTextureWithDescriptor:desc];
+    desc.pixelFormat = MTLPixelFormatDepth32Float_Stencil8;
+    m_placeholderDepthStencilTexture = [m_device newTextureWithDescriptor:desc];
 }
 
 Device::Device(Adapter& adapter)
@@ -290,9 +292,9 @@ id<MTLBuffer> Device::placeholderBuffer() const
     return m_placeholderBuffer;
 }
 
-id<MTLTexture> Device::placeholderTexture() const
+id<MTLTexture> Device::placeholderTexture(WGPUTextureFormat format) const
 {
-    return m_placeholderTexture;
+    return Texture::isDepthOrStencilFormat(format) ? m_placeholderDepthStencilTexture : m_placeholderTexture;
 }
 
 Queue& Device::getQueue()

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -96,8 +96,6 @@ RenderPassEncoder::RenderPassEncoder(id<MTLRenderCommandEncoder> renderCommandEn
             continue;
 
         auto& texture = fromAPI(attachment.view);
-        m_renderTargetWidth = texture.width();
-        m_renderTargetHeight = texture.height();
         texture.setPreviouslyCleared();
         addResourceToActiveResources(texture, BindGroupEntryUsage::Attachment);
 
@@ -110,6 +108,8 @@ RenderPassEncoder::RenderPassEncoder(id<MTLRenderCommandEncoder> renderCommandEn
 
         texture.setCommandEncoder(parentEncoder);
         id<MTLTexture> textureToClear = texture.texture();
+        m_renderTargetWidth = textureToClear.width;
+        m_renderTargetHeight = textureToClear.height;
         if (!textureToClear)
             continue;
         TextureAndClearColor *textureWithClearColor = [[TextureAndClearColor alloc] initWithTexture:textureToClear];
@@ -129,12 +129,12 @@ RenderPassEncoder::RenderPassEncoder(id<MTLRenderCommandEncoder> renderCommandEn
         auto& textureView = fromAPI(attachment->view);
         textureView.setPreviouslyCleared();
         textureView.setCommandEncoder(parentEncoder);
+        id<MTLTexture> depthTexture = textureView.isDestroyed() ? nil : textureView.texture();
         if (textureView.width() && !m_renderTargetWidth) {
-            m_renderTargetWidth = textureView.width();
-            m_renderTargetHeight = textureView.height();
+            m_renderTargetWidth = depthTexture.width;
+            m_renderTargetHeight = depthTexture.height;
         }
 
-        id<MTLTexture> depthTexture = textureView.texture();
         m_depthClearValue = attachment->depthStoreOp == WGPUStoreOp_Discard ? 0 : quantizedDepthValue(attachment->depthClearValue, textureView.format());
         if (!Device::isStencilOnlyFormat(depthTexture.pixelFormat)) {
             m_clearDepthAttachment = depthTexture && attachment->depthStoreOp == WGPUStoreOp_Discard && attachment->depthLoadOp == WGPULoadOp_Load;
@@ -544,12 +544,12 @@ void RenderPassEncoder::drawIndexed(uint32_t indexCount, uint32_t instanceCount,
         return;
 
     auto firstIndexOffsetInBytes = firstIndex * indexSizeInBytes;
-    id<MTLBuffer> indexBuffer = m_indexBuffer->buffer();
     if (NSString* error = errorValidatingDrawIndexed()) {
         makeInvalid(error);
         return;
     }
 
+    id<MTLBuffer> indexBuffer = m_indexBuffer.get() ? m_indexBuffer->buffer() : nil;
     if (firstIndexOffsetInBytes + indexCount * indexSizeInBytes > m_indexBufferSize) {
         makeInvalid(@"Values to drawIndexed are invalid");
         return;

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -3212,7 +3212,7 @@ void Texture::destroy()
 {
     // https://gpuweb.github.io/gpuweb/#dom-gputexture-destroy
     if (!m_canvasBacking)
-        m_texture = m_device->placeholderTexture();
+        m_texture = m_device->placeholderTexture(format());
     m_destroyed = true;
     for (auto& view : m_textureViews) {
         if (view.get())

--- a/Source/WebGPU/WebGPU/TextureView.h
+++ b/Source/WebGPU/WebGPU/TextureView.h
@@ -58,7 +58,7 @@ public:
 
     bool isValid() const;
 
-    id<MTLTexture> texture() const { return m_texture; }
+    id<MTLTexture> texture() const;
     id<MTLTexture> parentTexture() const;
     const WGPUTextureViewDescriptor& descriptor() const { return m_descriptor; }
     const std::optional<WGPUExtent3D>& renderExtent() const { return m_renderExtent; }

--- a/Source/WebGPU/WebGPU/TextureView.mm
+++ b/Source/WebGPU/WebGPU/TextureView.mm
@@ -100,6 +100,11 @@ WGPUTextureUsageFlags TextureView::usage() const
     return m_parentTexture->usage();
 }
 
+id<MTLTexture> TextureView::texture() const
+{
+    return isDestroyed() ? parentTexture() : m_texture;
+}
+
 uint32_t TextureView::sampleCount() const
 {
     return m_parentTexture->sampleCount();
@@ -162,7 +167,7 @@ bool TextureView::isValid() const
 
 void TextureView::destroy()
 {
-    m_texture = m_device->placeholderTexture();
+    m_texture = m_device->placeholderTexture(format());
     if (m_commandEncoder && !m_parentTexture->isCanvasBacking())
         m_commandEncoder.get()->makeSubmitInvalid();
 


### PR DESCRIPTION
#### 7328ea1a6d2a83ce883c443780f6e916dbc56f28
<pre>
[WebGPU] Destroyed texture should not be used as depth stencil attachments
<a href="https://bugs.webkit.org/show_bug.cgi?id=273323">https://bugs.webkit.org/show_bug.cgi?id=273323</a>
&lt;radar://127115893&gt;

Reviewed by Tadeu Zagallo.

Destroyed textures are 1x1 bgra8unorm textures, there is no
benefit to having those set as a depth stencil attachment.

Any draw commands will make the command encoder invalid when a
destroyed texture is used during a draw command, so there is
no change in behavior.

* LayoutTests/TestExpectations:
* LayoutTests/fast/webgpu/fuzz-273323-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-273323.html: Added.
* LayoutTests/fast/webgpu/fuzz-273573-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-273573.html: Added.
Add regression tests.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::beginRenderPass):
* Source/WebGPU/WebGPU/Device.h:
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::Device):
(WebGPU::Device::placeholderTexture const):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::m_maxDrawCount):
(WebGPU::RenderPassEncoder::drawIndexed):
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::destroy):
* Source/WebGPU/WebGPU/TextureView.h:
(WebGPU::TextureView::texture const): Deleted.
* Source/WebGPU/WebGPU/TextureView.mm:
(WebGPU::TextureView::texture const):
(WebGPU::TextureView::destroy):

Canonical link: <a href="https://commits.webkit.org/278326@main">https://commits.webkit.org/278326@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5faf0fb92554942d86080c000b3764db77547eef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50193 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29484 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53451 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/883 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/487 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40958 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27159 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43198 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22056 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24582 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/449 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8571 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46569 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/510 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55035 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25289 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48358 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26550 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43383 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47377 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11010 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27413 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26282 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->