### PR TITLE
Leaked 2D contexts might consume all OS global GPU resources

### DIFF
--- a/LayoutTests/fast/canvas/image-buffer-backend-count-limit-expected.txt
+++ b/LayoutTests/fast/canvas/image-buffer-backend-count-limit-expected.txt
@@ -1,0 +1,10 @@
+Test creates many 2D contexts and checks when they are not created accelerated anymore
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Effective rendering mode switches to Unaccelerated at instance: 1000
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/image-buffer-backend-count-limit.html
+++ b/LayoutTests/fast/canvas/image-buffer-backend-count-limit.html
@@ -1,0 +1,64 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true ] -->
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("Test creates many 2D contexts and checks when they are not created accelerated anymore")
+
+function pixelsEqual(a, b) {
+    for (let i = 0; i < 4; ++i) {
+        if (a[i] != b[i])
+            return false;
+    }
+    return true;
+}
+
+var transparentBlack = [0, 0, 0, 0];
+var lime = [0, 255, 0, 255];
+var imageData;
+var context;
+function runTest() {
+    if (typeof CanvasRenderingContext2D.prototype.getEffectiveRenderingModeForTesting === "undefined") {
+        testFailed("Need effective rendering mode API");
+        return;
+    }
+    let canvases = [];
+    for (let i = 0; i < 15000; ++i) {
+        let canvas = document.createElement('canvas');
+        canvases.push(canvas)
+        canvas.height = 100;
+        canvas.width = 100;
+        context = canvas.getContext("2d");
+        if (!context) {
+            testFailed(`Context ${i} not created`);
+            return;
+        }
+        context.fillStyle = "lime";
+        context.fillRect(0, 0, canvas.width, canvas.height);
+        imageData = context.getImageData(0, 0, 1, 1);
+        if (!imageData) {
+            testFailed("Context failed to allocate imageData");
+            return;
+        } else if (pixelsEqual(imageData.data, transparentBlack)) {
+            testFailed("Context was lost");
+            return;
+        } else if (!pixelsEqual(imageData.data, lime)) {
+            shouldBe("imageData.data", "lime");
+            return;
+        }
+        let renderingMode = context.getEffectiveRenderingModeForTesting();
+        if (renderingMode != "Accelerated") {
+            testPassed(`Effective rendering mode switches to ${renderingMode} at instance: ${i}`);
+            canvases.length = 0;
+            delete context;
+            delete canvas;
+            gc();
+            return;
+        }
+    }
+    testFailed(`All ${i} contexts accelerated. Currently unexpected`);
+}
+runTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3915,6 +3915,8 @@ imported/w3c/web-platform-tests/svg/text/reftests/transform-dynamic-change.html 
 
 # Cairo doesn't support hardware acceleration, this test will pass once we switch to Skia.
 fast/canvas/canvas-will-read-frequently.html [ Failure ]
+# Accelerated canvases not implemented for Cairo.
+fast/canvas/image-buffer-backend-count-limit.html [ Skip ]
 
 # End: Common failures between GTK and WPE.
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2852,3 +2852,6 @@ http/tests/media/hls/hls-webvtt-style.html [ Pass Timeout ]
 [ Ventura Debug ] imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-mode.html [ Skip ]
 
 webkit.org/b/273577 [ Ventura ] http/tests/media/hls/track-webvtt-multitracks.html [ Skip ]
+
+# Limiting accelerated canvases not implemented for WK1
+fast/canvas/image-buffer-backend-count-limit.html [ Skip ]

--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -416,6 +416,9 @@ webgl/webgl-worker.html [ Skip ]
 # Accelerated canvas isn't supported yet
 fast/canvas/canvas-will-read-frequently.html [ Skip ]
 
+# Limiting accelerated canvases not implemented for WK1
+fast/canvas/image-buffer-backend-count-limit.html [ Skip ]
+
 #//////////////////////////////////////////////////////////////////////////////////////////
 # These areas are not implemented well on WinCairo
 #//////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebKit/GPUProcess/RemoteSharedResourceCache.h
+++ b/Source/WebKit/GPUProcess/RemoteSharedResourceCache.h
@@ -32,13 +32,14 @@
 #include "ThreadSafeObjectHeap.h"
 #include <WebCore/ImageBuffer.h>
 #include <WebCore/RenderingResourceIdentifier.h>
+#include <atomic>
 #include <wtf/FastMalloc.h>
 #include <wtf/Ref.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebKit {
 
-// Class holding GPU process resources per Web Process.
+// Class holding GPU process resources per WebContent process.
 // Thread-safe.
 class RemoteSharedResourceCache final : public ThreadSafeRefCounted<RemoteSharedResourceCache>, IPC::MessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
@@ -48,6 +49,10 @@ public:
 
     void addSerializedImageBuffer(WebCore::RenderingResourceIdentifier, Ref<WebCore::ImageBuffer>);
     RefPtr<WebCore::ImageBuffer> takeSerializedImageBuffer(WebCore::RenderingResourceIdentifier);
+
+    void didAddAcceleratedImageBuffer();
+    void didTakeAcceleratedImageBuffer();
+    WebCore::RenderingMode adjustAcceleratedImageBufferRenderingMode(WebCore::RenderingPurpose) const;
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
@@ -59,8 +64,8 @@ private:
     void releaseSerializedImageBuffer(WebCore::RenderingResourceIdentifier);
 
     IPC::ThreadSafeObjectHeap<RemoteSerializedImageBufferIdentifier, RefPtr<WebCore::ImageBuffer>> m_serializedImageBuffers;
+    std::atomic<size_t> m_acceleratedImageBufferCount { 0 };
 };
-
 
 } // namespace WebKit
 


### PR DESCRIPTION
#### 78038e7ea408ff3a2869d9394ba4dff327492d9c
<pre>
Leaked 2D contexts might consume all OS global GPU resources
<a href="https://bugs.webkit.org/show_bug.cgi?id=273326">https://bugs.webkit.org/show_bug.cgi?id=273326</a>
<a href="https://rdar.apple.com/95930955">rdar://95930955</a>

Reviewed by Matt Woodrow.

Limit all the GPUP accelerated image buffers to certain numbers:
 - 30000 total limit
 - 3000 layer tile, 2D Context backing stores limit per WP
 - 1000 2D Context backing stores limit per WP

Store the per-WP limit to the RemoteSharedResourceCache. This is shared
with all the RemoteRenderingBackend instances of a particular WP:
main thread rendering and Web Worker rendering.

If GPUP allocates unlimited amount of accelerated image buffers, the
allocations cause all of system IOSurface handles. The failures are
handled ok in GPUP code, but might cause problems in other parts of the
WebKit as well as in other processes. The underlying CGContexts will
also run into per-process Metal object count limits.

* LayoutTests/fast/canvas/image-buffer-backend-count-limit-expected.txt: Added.
* LayoutTests/fast/canvas/image-buffer-backend-count-limit.html: Added.
* Source/WebKit/GPUProcess/RemoteSharedResourceCache.cpp:
(WebKit::RemoteSharedResourceCache::didAddAcceleratedImageBuffer):
(WebKit::RemoteSharedResourceCache::didTakeAcceleratedImageBuffer):
(WebKit::RemoteSharedResourceCache::adjustAcceleratedImageBufferRenderingMode const):
* Source/WebKit/GPUProcess/RemoteSharedResourceCache.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::didCreateImageBuffer):
(WebKit::RemoteRenderingBackend::allocateImageBuffer):
(WebKit::RemoteRenderingBackend::releaseImageBuffer):
(WebKit::RemoteRenderingBackend::takeImageBuffer):

Canonical link: <a href="https://commits.webkit.org/278304@main">https://commits.webkit.org/278304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6be92f6f7b4998cdb1c2a3266be9d4d119638f4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29311 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53265 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/699 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/268 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40794 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43028 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21926 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24341 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/268 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8392 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46390 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/315 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54847 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25116 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/294 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48188 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 262 flakes 63 failures; Uploaded test results; 7 flakes 52 failures; Compiled WebKit; Running layout-tests-repeat-failures-without-change") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26374 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43228 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47252 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10995 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27236 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26103 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->