### PR TITLE
Simplify ContextMenuContextData serialization

### DIFF
--- a/Source/WebCore/editing/cocoa/AttributedString.h
+++ b/Source/WebCore/editing/cocoa/AttributedString.h
@@ -150,6 +150,7 @@ struct WEBCORE_EXPORT AttributedString {
     static bool rangesAreSafe(const String&, const Vector<std::pair<Range, HashMap<String, AttributeValue>>>&);
     RetainPtr<NSDictionary> documentAttributesAsNSDictionary() const;
     RetainPtr<NSAttributedString> nsAttributedString() const;
+    bool isNull() const;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/editing/cocoa/AttributedString.mm
+++ b/Source/WebCore/editing/cocoa/AttributedString.mm
@@ -230,6 +230,11 @@ static RetainPtr<NSDictionary> toNSDictionary(const HashMap<String, AttributedSt
     return result;
 }
 
+bool AttributedString::isNull() const
+{
+    return string.isNull();
+}
+
 RetainPtr<NSDictionary> AttributedString::documentAttributesAsNSDictionary() const
 {
     if (!documentAttributes)

--- a/Source/WebKit/Shared/ContextMenuContextData.cpp
+++ b/Source/WebKit/Shared/ContextMenuContextData.cpp
@@ -139,7 +139,7 @@ ContextMenuContextData::ContextMenuContextData(WebCore::ContextMenuContext::Type
     , String&& selectedText
 #if ENABLE(SERVICE_CONTROLS)
     , std::optional<WebCore::ShareableBitmapHandle>&& controlledImageHandle
-    , Vector<uint8_t>&& controlledSelectionData
+    , WebCore::AttributedString&& controlledSelection
     , Vector<String>&& selectedTelephoneNumbers
     , bool selectionIsEditable
     , WebCore::IntRect&& controlledImageBounds
@@ -160,7 +160,7 @@ ContextMenuContextData::ContextMenuContextData(WebCore::ContextMenuContext::Type
     , m_selectedText(WTFMove(selectedText))
     , m_hasEntireImage(hasEntireImage)
 #if ENABLE(SERVICE_CONTROLS)
-    , m_controlledSelectionData(WTFMove(controlledSelectionData))
+    , m_controlledSelection(WTFMove(controlledSelection))
     , m_selectedTelephoneNumbers(WTFMove(selectedTelephoneNumbers))
     , m_selectionIsEditable(selectionIsEditable)
     , m_controlledImageBounds(WTFMove(controlledImageBounds))
@@ -185,7 +185,7 @@ ContextMenuContextData::ContextMenuContextData(WebCore::ContextMenuContext::Type
 #if ENABLE(SERVICE_CONTROLS)
 bool ContextMenuContextData::controlledDataIsEditable() const
 {
-    if (!m_controlledSelectionData.isEmpty() || m_controlledImage || !m_controlledImageAttachmentID.isNull())
+    if (!m_controlledSelection.isNull() || m_controlledImage || !m_controlledImageAttachmentID.isNull())
         return m_selectionIsEditable;
 
     return false;

--- a/Source/WebKit/Shared/ContextMenuContextData.h
+++ b/Source/WebKit/Shared/ContextMenuContextData.h
@@ -33,6 +33,10 @@
 #include <WebCore/ContextMenuContext.h>
 #include <WebCore/ElementContext.h>
 
+#if ENABLE(SERVICE_CONTROLS)
+#include <WebCore/AttributedString.h>
+#endif
+
 namespace IPC {
 class Decoder;
 class Encoder;
@@ -54,7 +58,7 @@ public:
         , String&& selectedText
 #if ENABLE(SERVICE_CONTROLS)
         , std::optional<WebCore::ShareableBitmapHandle>&& controlledImageHandle
-        , Vector<uint8_t>&& controlledSelectionData
+        , WebCore::AttributedString&& controlledSelection
         , Vector<String>&& selectedTelephoneNumbers
         , bool selectionIsEditable
         , WebCore::IntRect&& controlledImageBounds
@@ -80,10 +84,10 @@ public:
     bool hasEntireImage() const { return m_hasEntireImage; }
 
 #if ENABLE(SERVICE_CONTROLS)
-    ContextMenuContextData(const WebCore::IntPoint& menuLocation, const Vector<uint8_t>& selectionData, const Vector<String>& selectedTelephoneNumbers, bool isEditable)
+    ContextMenuContextData(const WebCore::IntPoint& menuLocation, WebCore::AttributedString&& controlledSelection, const Vector<String>& selectedTelephoneNumbers, bool isEditable)
         : m_type(Type::ServicesMenu)
         , m_menuLocation(menuLocation)
-        , m_controlledSelectionData(selectionData)
+        , m_controlledSelection(WTFMove(controlledSelection))
         , m_selectedTelephoneNumbers(selectedTelephoneNumbers)
         , m_selectionIsEditable(isEditable)
     {
@@ -104,7 +108,7 @@ public:
     WebCore::ShareableBitmap* controlledImage() const { return m_controlledImage.get(); }
     std::optional<WebCore::ShareableBitmap::Handle> createControlledImageReadOnlyHandle() const;
 
-    const Vector<uint8_t>& controlledSelectionData() const { return m_controlledSelectionData; }
+    const WebCore::AttributedString& controlledSelection() const { return m_controlledSelection; }
     const Vector<String>& selectedTelephoneNumbers() const { return m_selectedTelephoneNumbers; }
 
     bool selectionIsEditable() const { return m_selectionIsEditable; }
@@ -141,7 +145,7 @@ private:
     void setImage(WebCore::Image&);
     
     RefPtr<WebCore::ShareableBitmap> m_controlledImage;
-    Vector<uint8_t> m_controlledSelectionData;
+    WebCore::AttributedString m_controlledSelection;
     Vector<String> m_selectedTelephoneNumbers;
     bool m_selectionIsEditable;
     WebCore::IntRect m_controlledImageBounds;

--- a/Source/WebKit/Shared/ContextMenuContextData.serialization.in
+++ b/Source/WebKit/Shared/ContextMenuContextData.serialization.in
@@ -30,7 +30,7 @@ class WebKit::ContextMenuContextData {
     String selectedText();
 #if ENABLE(SERVICE_CONTROLS)
     std::optional<WebCore::ShareableBitmapHandle> createControlledImageReadOnlyHandle();
-    Vector<uint8_t> controlledSelectionData();
+    WebCore::AttributedString controlledSelection();
     Vector<String> selectedTelephoneNumbers();
     bool selectionIsEditable();
     WebCore::IntRect controlledImageBounds();

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -251,12 +251,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         }
         items = @[ itemProvider.get() ];
         
-    } else if (!m_context.controlledSelectionData().isEmpty()) {
-        auto selectionData = adoptNS([[NSData alloc] initWithBytes:static_cast<const void*>(m_context.controlledSelectionData().data()) length:m_context.controlledSelectionData().size()]);
-        auto selection = adoptNS([[NSAttributedString alloc] initWithRTFD:selectionData.get() documentAttributes:nil]);
-
+    } else if (RetainPtr selection = m_context.controlledSelection().nsAttributedString())
         items = @[ selection.get() ];
-    } else if (isPDFAttachment) {
+    else if (isPDFAttachment) {
         itemProvider = adoptNS([[NSItemProvider alloc] initWithItem:attachment->associatedElementNSData() typeIdentifier:attachment->utiType()]);
         items = @[ itemProvider.get() ];
     } else {

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -759,14 +759,12 @@ void WebPage::handleSelectionServiceClick(FrameSelection& selection, const Vecto
     if (!range)
         return;
 
-    auto attributedSelection = attributedString(*range).nsAttributedString();
-    if (!attributedSelection)
+    auto selectionString = attributedString(*range);
+    if (selectionString.isNull())
         return;
 
-    NSData *selectionData = [attributedSelection RTFDFromRange:NSMakeRange(0, [attributedSelection length]) documentAttributes:@{ }];
-
     flushPendingEditorStateUpdate();
-    send(Messages::WebPageProxy::ShowContextMenu(ContextMenuContextData(point, makeVector(selectionData), phoneNumbers, selection.selection().isContentEditable()), UserData()));
+    send(Messages::WebPageProxy::ShowContextMenu(ContextMenuContextData(point, WTFMove(selectionString), phoneNumbers, selection.selection().isContentEditable()), UserData()));
 }
 
 void WebPage::handleImageServiceClick(const IntPoint& point, Image& image, HTMLImageElement& element)


### PR DESCRIPTION
#### c1fefa0bb16a18b82461ac3111b56f3395e7a1b7
<pre>
Simplify ContextMenuContextData serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=273329">https://bugs.webkit.org/show_bug.cgi?id=273329</a>
<a href="https://rdar.apple.com/124958882">rdar://124958882</a>

Reviewed by Wenson Hsieh.

Instead of taking an AttributedString, extracting an NSAttributedString,
extracting an NSData, serializing the data, then reconstructing the
NSAttributedString on the other side, just serialize the AttributedString
then do one extraction operation to get an NSAttributedString.

* Source/WebCore/editing/cocoa/AttributedString.h:
* Source/WebKit/Shared/ContextMenuContextData.cpp:
(WebKit::ContextMenuContextData::ContextMenuContextData):
(WebKit::ContextMenuContextData::controlledDataIsEditable const):
* Source/WebKit/Shared/ContextMenuContextData.h:
(WebKit::ContextMenuContextData::ContextMenuContextData):
(WebKit::ContextMenuContextData::controlledSelection const):
(WebKit::ContextMenuContextData::controlledSelectionData const): Deleted.
* Source/WebKit/Shared/ContextMenuContextData.serialization.in:
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::WebContextMenuProxyMac::setupServicesMenu):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::handleSelectionServiceClick):

Canonical link: <a href="https://commits.webkit.org/278074@main">https://commits.webkit.org/278074@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5cb55b4b3693af7101587a0b7dfdedd7a513d451

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49402 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28684 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52437 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/52641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/75 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51706 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26304 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/52641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42555 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/52641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23686 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43738 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7771 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45604 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44240 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54153 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24484 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20673 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47686 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25756 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46689 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26595 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7100 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25479 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->