### PR TITLE
[Unified Text Replacement] Undo-ing a replacement session can sometimes result in incorrect text

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm
@@ -46,52 +46,6 @@
 
 namespace WebKit {
 
-static std::optional<std::tuple<WebCore::Node&, WebCore::DocumentMarker&>> findReplacementMarkerByUUID(WebCore::Document& document, const WTF::UUID& replacementUUID)
-{
-    RefPtr<WebCore::Node> targetNode;
-    WeakPtr<WebCore::DocumentMarker> targetMarker;
-
-    document.markers().forEachOfTypes({ WebCore::DocumentMarker::Type::UnifiedTextReplacement }, [&replacementUUID, &targetNode, &targetMarker] (auto& node, auto& marker) mutable {
-        auto data = std::get<WebCore::DocumentMarker::UnifiedTextReplacementData>(marker.data());
-        if (data.uuid != replacementUUID)
-            return false;
-
-        targetNode = &node;
-        targetMarker = &marker;
-
-        return true;
-    });
-
-    if (targetNode && targetMarker)
-        return { { *targetNode, *targetMarker } };
-
-    return std::nullopt;
-}
-
-static std::optional<std::tuple<WebCore::Node&, WebCore::DocumentMarker&>> findReplacementMarkerContainingRange(WebCore::Document& document, const WebCore::SimpleRange& range)
-{
-    RefPtr<WebCore::Node> targetNode;
-    WeakPtr<WebCore::DocumentMarker> targetMarker;
-
-    document.markers().forEachOfTypes({ WebCore::DocumentMarker::Type::UnifiedTextReplacement }, [&range, &targetNode, &targetMarker] (auto& node, auto& marker) mutable {
-        auto data = std::get<WebCore::DocumentMarker::UnifiedTextReplacementData>(marker.data());
-
-        auto markerRange = WebCore::makeSimpleRange(node, marker);
-        if (!WebCore::contains(WebCore::TreeType::ComposedTree, markerRange, range))
-            return false;
-
-        targetNode = &node;
-        targetMarker = &marker;
-
-        return true;
-    });
-
-    if (targetNode && targetMarker)
-        return { { *targetNode, *targetMarker } };
-
-    return std::nullopt;
-}
-
 UnifiedTextReplacementController::UnifiedTextReplacementController(WebPage& webPage)
     : m_webPage(webPage)
 {
@@ -223,7 +177,7 @@ void UnifiedTextReplacementController::textReplacementSessionDidUpdateStateForRe
     if (state != WebTextReplacementData::State::Committed && state != WebTextReplacementData::State::Reverted && state != WebTextReplacementData::State::Active)
         return;
 
-    auto nodeAndMarker = findReplacementMarkerByUUID(*document, replacement.uuid);
+    auto nodeAndMarker = findReplacementMarkerByUUID(*sessionRange, replacement.uuid);
     if (!nodeAndMarker) {
         ASSERT_NOT_REACHED();
         return;
@@ -280,30 +234,23 @@ void UnifiedTextReplacementController::didEndTextReplacementSession(const WTF::U
         return;
     }
 
-    // FIXME: Associate the markers with a specific session, and only modify the markers which belong
-    // to this session.
+    auto& markers = document->markers();
 
-    if (!accepted) {
-        Vector<std::pair<WebCore::SimpleRange, String>> replacements;
+    markers.forEach<WebCore::DocumentMarkerController::IterationDirection::Backwards>(*sessionRange, { WebCore::DocumentMarker::Type::UnifiedTextReplacement }, [&](auto& node, auto& marker) {
+        auto data = std::get<WebCore::DocumentMarker::UnifiedTextReplacementData>(marker.data());
 
-        document->markers().forEachOfTypes({ WebCore::DocumentMarker::Type::UnifiedTextReplacement }, [&replacements] (auto& node, auto& marker) {
-            auto data = std::get<WebCore::DocumentMarker::UnifiedTextReplacementData>(marker.data());
-            if (data.state == WebCore::DocumentMarker::UnifiedTextReplacementData::State::Reverted)
-                return false;
+        auto offsetRange = WebCore::OffsetRange { marker.startOffset(), marker.endOffset() };
+        markers.removeMarkers(node, offsetRange, { WebCore::DocumentMarker::Type::UnifiedTextReplacement });
 
-            auto rangeToReplace = makeSimpleRange(node, marker);
-            replacements.append({ rangeToReplace, data.originalText });
+        auto rangeToReplace = makeSimpleRange(node, marker);
 
-            return false;
-        });
+        if (!accepted && data.state != WebCore::DocumentMarker::UnifiedTextReplacementData::State::Reverted)
+            replaceContentsOfRangeInSession(uuid, rangeToReplace, data.originalText);
 
-        for (const auto& [range, text] : replacements)
-            replaceContentsOfRangeInSession(uuid, range, text);
-    }
+        return false;
+    });
 
     document->selection().setSelection({ *sessionRange });
-
-    document->markers().removeMarkers({ WebCore::DocumentMarker::Type::UnifiedTextReplacement });
 
     m_replacementTypes.remove(uuid);
     m_contextRanges.remove(uuid);
@@ -403,51 +350,42 @@ void UnifiedTextReplacementController::textReplacementSessionPerformEditActionFo
         return;
     }
 
-    Vector<Ref<WebCore::Node>> sessionNodes;
-    for (Ref node : intersectingNodes(*sessionRange))
-        sessionNodes.append(node);
+    auto& markers = document.markers();
 
-    for (auto nodeIterator = sessionNodes.rbegin(); nodeIterator != sessionNodes.rend(); ++nodeIterator) {
-        auto node = *nodeIterator;
-        auto markers = document.markers().markersFor(node, { WebCore::DocumentMarker::Type::UnifiedTextReplacement });
+    markers.forEach<WebCore::DocumentMarkerController::IterationDirection::Backwards>(*sessionRange, { WebCore::DocumentMarker::Type::UnifiedTextReplacement }, [&](auto& node, auto& marker) {
+        auto rangeToReplace = WebCore::makeSimpleRange(node, marker);
 
-        for (auto markerIterator = markers.rbegin(); markerIterator != markers.rend(); ++markerIterator) {
-            auto marker = *markerIterator;
-            if (!marker)
-                continue;
+        auto currentText = WebCore::plainText(rangeToReplace);
 
-            auto rangeToReplace = makeSimpleRange(node, *marker);
+        auto oldData = std::get<WebCore::DocumentMarker::UnifiedTextReplacementData>(marker.data());
+        auto previousText = oldData.originalText;
+        auto offsetRange = WebCore::OffsetRange { marker.startOffset(), marker.endOffset() };
 
-            auto currentText = WebCore::plainText(rangeToReplace);
+        markers.removeMarkers(node, offsetRange, { WebCore::DocumentMarker::Type::UnifiedTextReplacement });
 
-            auto oldData = std::get<WebCore::DocumentMarker::UnifiedTextReplacementData>(marker->data());
-            auto previousText = oldData.originalText;
-            auto offsetRange = WebCore::OffsetRange { marker->startOffset(), marker->endOffset() };
+        auto newState = [&] {
+            switch (action) {
+            case WebTextReplacementData::EditAction::Undo:
+                return WebCore::DocumentMarker::UnifiedTextReplacementData::State::Reverted;
 
-            document.markers().removeMarkers(node, offsetRange, { WebCore::DocumentMarker::Type::UnifiedTextReplacement });
+            case WebTextReplacementData::EditAction::Redo:
+                return WebCore::DocumentMarker::UnifiedTextReplacementData::State::Pending;
 
-            auto newState = [&] {
-                switch (action) {
-                case WebTextReplacementData::EditAction::Undo:
-                    return WebCore::DocumentMarker::UnifiedTextReplacementData::State::Reverted;
+            default:
+                ASSERT_NOT_REACHED();
+                return WebCore::DocumentMarker::UnifiedTextReplacementData::State::Pending;
+            }
+        }();
 
-                case WebTextReplacementData::EditAction::Redo:
-                    return WebCore::DocumentMarker::UnifiedTextReplacementData::State::Pending;
+        replaceContentsOfRangeInSession(uuid, rangeToReplace, previousText);
 
-                default:
-                    ASSERT_NOT_REACHED();
-                    return WebCore::DocumentMarker::UnifiedTextReplacementData::State::Pending;
-                }
-            }();
+        auto newData = WebCore::DocumentMarker::UnifiedTextReplacementData { currentText, oldData.uuid, uuid, newState };
+        auto newOffsetRange = WebCore::OffsetRange { offsetRange.start, offsetRange.end + previousText.length() - currentText.length() };
 
-            replaceContentsOfRangeInSession(uuid, rangeToReplace, previousText);
+        markers.addMarker(node, WebCore::DocumentMarker { WebCore::DocumentMarker::Type::UnifiedTextReplacement, newOffsetRange, WTFMove(newData) });
 
-            auto newData = WebCore::DocumentMarker::UnifiedTextReplacementData { currentText, oldData.uuid, uuid, newState };
-            auto newOffsetRange = WebCore::OffsetRange { offsetRange.start, offsetRange.end + previousText.length() - currentText.length() };
-
-            document.markers().addMarker(node, WebCore::DocumentMarker { WebCore::DocumentMarker::Type::UnifiedTextReplacement, newOffsetRange, WTFMove(newData) });
-        }
-    }
+        return false;
+    });
 }
 
 void UnifiedTextReplacementController::textReplacementSessionPerformEditActionForRichText(WebCore::Document& document, const WTF::UUID& uuid, WebTextReplacementData::EditAction action)
@@ -555,7 +493,7 @@ void UnifiedTextReplacementController::updateStateForSelectedReplacementIfNeeded
     if (!document->selection().isCaret())
         return;
 
-    auto nodeAndMarker = findReplacementMarkerContainingRange(*document, *selectionRange);
+    auto nodeAndMarker = findReplacementMarkerContainingRange(*selectionRange);
     if (!nodeAndMarker)
         return;
 
@@ -592,6 +530,64 @@ RefPtr<WebCore::Document> UnifiedTextReplacementController::document() const
     }
 
     return frame->document();
+}
+
+std::optional<std::tuple<WebCore::Node&, WebCore::DocumentMarker&>> UnifiedTextReplacementController::findReplacementMarkerByUUID(const WebCore::SimpleRange& outerRange, const WTF::UUID& replacementUUID)
+{
+    RefPtr document = this->document();
+    if (!document) {
+        ASSERT_NOT_REACHED();
+        return std::nullopt;
+    }
+
+    RefPtr<WebCore::Node> targetNode;
+    WeakPtr<WebCore::DocumentMarker> targetMarker;
+
+    document->markers().forEach(outerRange, { WebCore::DocumentMarker::Type::UnifiedTextReplacement }, [&replacementUUID, &targetNode, &targetMarker] (auto& node, auto& marker) mutable {
+        auto data = std::get<WebCore::DocumentMarker::UnifiedTextReplacementData>(marker.data());
+        if (data.uuid != replacementUUID)
+            return false;
+
+        targetNode = &node;
+        targetMarker = &marker;
+
+        return true;
+    });
+
+    if (targetNode && targetMarker)
+        return { { *targetNode, *targetMarker } };
+
+    return std::nullopt;
+}
+
+std::optional<std::tuple<WebCore::Node&, WebCore::DocumentMarker&>> UnifiedTextReplacementController::findReplacementMarkerContainingRange(const WebCore::SimpleRange& range)
+{
+    RefPtr document = this->document();
+    if (!document) {
+        ASSERT_NOT_REACHED();
+        return std::nullopt;
+    }
+
+    RefPtr<WebCore::Node> targetNode;
+    WeakPtr<WebCore::DocumentMarker> targetMarker;
+
+    document->markers().forEach(range, { WebCore::DocumentMarker::Type::UnifiedTextReplacement }, [&range, &targetNode, &targetMarker] (auto& node, auto& marker) mutable {
+        auto data = std::get<WebCore::DocumentMarker::UnifiedTextReplacementData>(marker.data());
+
+        auto markerRange = WebCore::makeSimpleRange(node, marker);
+        if (!WebCore::contains(WebCore::TreeType::ComposedTree, markerRange, range))
+            return false;
+
+        targetNode = &node;
+        targetMarker = &marker;
+
+        return true;
+    });
+
+    if (targetNode && targetMarker)
+        return { { *targetNode, *targetMarker } };
+
+    return std::nullopt;
 }
 
 void UnifiedTextReplacementController::replaceContentsOfRangeInSessionInternal(const WTF::UUID& uuid, const WebCore::SimpleRange& range, WTF::Function<void(WebCore::Editor&)>&& replacementOperation)

--- a/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
+++ b/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
@@ -40,6 +40,7 @@
 namespace WebCore {
 struct TextIndicatorData;
 enum class TextIndicatorOption : uint16_t;
+class DocumentMarker;
 class Editor;
 }
 
@@ -77,6 +78,9 @@ public:
     std::optional<WebCore::SimpleRange> contextRangeForSessionWithUUID(const WTF::UUID&) const;
 
 private:
+    std::optional<std::tuple<WebCore::Node&, WebCore::DocumentMarker&>> findReplacementMarkerContainingRange(const WebCore::SimpleRange&);
+    std::optional<std::tuple<WebCore::Node&, WebCore::DocumentMarker&>> findReplacementMarkerByUUID(const WebCore::SimpleRange& outerRange, const WTF::UUID& replacementUUID);
+
     void replaceContentsOfRangeInSessionInternal(const WTF::UUID&, const WebCore::SimpleRange&, WTF::Function<void(WebCore::Editor&)>&&);
     void replaceContentsOfRangeInSession(const WTF::UUID&, const WebCore::SimpleRange&, const String&);
     void replaceContentsOfRangeInSession(const WTF::UUID&, const WebCore::SimpleRange&, WebCore::DocumentFragment&);


### PR DESCRIPTION
#### 677afac9fefb30712341b5b909db687479ec7f53
<pre>
[Unified Text Replacement] Undo-ing a replacement session can sometimes result in incorrect text
<a href="https://bugs.webkit.org/show_bug.cgi?id=273331">https://bugs.webkit.org/show_bug.cgi?id=273331</a>
<a href="https://rdar.apple.com/127123467">rdar://127123467</a>

Reviewed by Aditya Keerthi.

When undo-ing a text replacement session, the original text may not be restored correctly. This is
because in `didEndTextReplacementSession`, the markers were being iterated from the beginning and
then their ranges were replaced with the original text. However, if the original text was a different
length than the marker range length, the replacement of the subsequent markers will end up using an
out-of-date replacement range.

Fix by iterating the markers backwards, since the replacement range of prior markers will never be
affected in this case.

Also perform a minor refactor to share more common logic.

* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::DocumentMarkerController::forEach&lt;DocumentMarkerController::IterationMode::Forward&gt;):
(WebCore::DocumentMarkerController::forEach&lt;DocumentMarkerController::IterationMode::Reversed&gt;):
(WebCore::DocumentMarkerController::forEachOfTypes):
(WebCore::DocumentMarkerController::forEach): Deleted.
* Source/WebCore/dom/DocumentMarkerController.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm:
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidUpdateStateForReplacement):
(WebKit::UnifiedTextReplacementController::didEndTextReplacementSession):
(WebKit::UnifiedTextReplacementController::textReplacementSessionPerformEditActionForPlainText):
(WebKit::UnifiedTextReplacementController::updateStateForSelectedReplacementIfNeeded):
(WebKit::UnifiedTextReplacementController::findReplacementMarkerByUUID):
(WebKit::UnifiedTextReplacementController::findReplacementMarkerContainingRange):
(WebKit::findReplacementMarkerByUUID): Deleted.
(WebKit::findReplacementMarkerContainingRange): Deleted.
* Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h:

Canonical link: <a href="https://commits.webkit.org/278069@main">https://commits.webkit.org/278069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/405296ceaa07f46884dbebd52d90dcd3e98e63be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52386 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/52573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/25 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51657 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26255 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/52573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51453 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26182 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42508 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/52573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23637 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43691 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7721 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44195 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54104 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24434 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20620 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47643 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-visibility-hidden-child.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25706 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42715 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46636 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/10850 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26545 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7096 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25430 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->