### PR TITLE
mlc.ai Web LLM WebGPU demo doesn't work in Safari

### DIFF
--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h
@@ -37,7 +37,7 @@
 
 namespace WebCore::WebGPU {
 
-class Buffer : public RefCounted<Buffer>, public CanMakeWeakPtr<Buffer> {
+class Buffer : public ThreadSafeRefCounted<Buffer>, public CanMakeWeakPtr<Buffer> {
 public:
     virtual ~Buffer() = default;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUDevice.h
@@ -77,7 +77,7 @@ class Surface;
 class Texture;
 struct TextureDescriptor;
 
-class Device : public RefCounted<Device>, public CanMakeWeakPtr<Device> {
+class Device : public ThreadSafeRefCounted<Device>, public CanMakeWeakPtr<Device> {
 public:
     virtual ~Device() = default;
 

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -439,15 +439,11 @@ bool Device::popErrorScope(CompletionHandler<void(WGPUErrorType, String&&)>&& ca
     }
 
     auto scope = m_errorScopeStack.takeLast();
+    if (scope.error)
+        callback(scope.error->type, WTFMove(scope.error->message));
+    else
+        callback(WGPUErrorType_NoError, { });
 
-    instance().scheduleWork([scope = WTFMove(scope), callback = WTFMove(callback)]() mutable {
-        if (scope.error)
-            callback(scope.error->type, WTFMove(scope.error->message));
-        else
-            callback(WGPUErrorType_NoError, { });
-    });
-
-    // FIXME: Make sure this is the right thing to return.
     return true;
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
@@ -69,6 +69,11 @@ void RemoteBuffer::mapAsync(WebCore::WebGPU::MapModeFlags mapModeFlags, WebCore:
     });
 }
 
+void RemoteBuffer::map(WebCore::WebGPU::MapModeFlags mapModeFlags, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&& callback)
+{
+    return mapAsync(mapModeFlags, offset, size, WTFMove(callback));
+}
+
 void RemoteBuffer::getMappedRange(WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&& callback)
 {
     auto mappedRange = m_backing->getMappedRange(offset, size);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
@@ -80,6 +80,7 @@ private:
 
     void getMappedRange(WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> sizeForMap, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
     void mapAsync(WebCore::WebGPU::MapModeFlags, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> sizeForMap, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
+    void map(WebCore::WebGPU::MapModeFlags, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> sizeForMap, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
     void unmap(Vector<uint8_t>&&);
 
     void destroy();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.messages.in
@@ -26,6 +26,7 @@
 messages -> RemoteBuffer NotRefCounted Stream {
     void GetMappedRange(WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size) -> (std::optional<Vector<uint8_t>> data) Synchronous
     void MapAsync(WebCore::WebGPU::MapModeFlags mapModeFlags, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size) -> (std::optional<Vector<uint8_t>> data)
+    void Map(WebCore::WebGPU::MapModeFlags mapModeFlags, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size) -> (std::optional<Vector<uint8_t>> data) Synchronous NotStreamEncodableReply
     void Unmap(Vector<uint8_t> data)
     void Destroy()
     void Destruct()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
@@ -312,6 +312,15 @@ void RemoteDevice::createRenderPipelineAsync(const WebGPU::RenderPipelineDescrip
     });
 }
 
+void RemoteDevice::createComputePipelineAsyncSync(const WebGPU::ComputePipelineDescriptor& descriptor, WebGPUIdentifier identifier, CompletionHandler<void(bool, String&&)>&& callback)
+{
+    return createComputePipelineAsync(descriptor, identifier, WTFMove(callback));
+}
+void RemoteDevice::createRenderPipelineAsyncSync(const WebGPU::RenderPipelineDescriptor& descriptor, WebGPUIdentifier identifier, CompletionHandler<void(bool, String&&)>&& callback)
+{
+    return createRenderPipelineAsync(descriptor, identifier, WTFMove(callback));
+}
+
 void RemoteDevice::createCommandEncoder(const std::optional<WebGPU::CommandEncoderDescriptor>& descriptor, WebGPUIdentifier identifier)
 {
     std::optional<WebCore::WebGPU::CommandEncoderDescriptor> convertedDescriptor;
@@ -369,6 +378,11 @@ void RemoteDevice::popErrorScope(CompletionHandler<void(bool, std::optional<WebG
             callback(success, { WebGPU::InternalError { internalError->message() } });
         });
     });
+}
+
+void RemoteDevice::popErrorScopeSync(CompletionHandler<void(bool, std::optional<WebGPU::Error>&&)>&& callback)
+{
+    return popErrorScope(WTFMove(callback));
 }
 
 void RemoteDevice::resolveUncapturedErrorEvent(CompletionHandler<void(bool, std::optional<WebGPU::Error>&&)>&& callback)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
@@ -133,6 +133,8 @@ private:
     void createRenderPipeline(const WebGPU::RenderPipelineDescriptor&, WebGPUIdentifier);
     void createComputePipelineAsync(const WebGPU::ComputePipelineDescriptor&, WebGPUIdentifier, CompletionHandler<void(bool, String&&)>&&);
     void createRenderPipelineAsync(const WebGPU::RenderPipelineDescriptor&, WebGPUIdentifier, CompletionHandler<void(bool, String&&)>&&);
+    void createComputePipelineAsyncSync(const WebGPU::ComputePipelineDescriptor&, WebGPUIdentifier, CompletionHandler<void(bool, String&&)>&&);
+    void createRenderPipelineAsyncSync(const WebGPU::RenderPipelineDescriptor&, WebGPUIdentifier, CompletionHandler<void(bool, String&&)>&&);
 
     void createCommandEncoder(const std::optional<WebGPU::CommandEncoderDescriptor>&, WebGPUIdentifier);
     void createRenderBundleEncoder(const WebGPU::RenderBundleEncoderDescriptor&, WebGPUIdentifier);
@@ -141,6 +143,7 @@ private:
 
     void pushErrorScope(WebCore::WebGPU::ErrorFilter);
     void popErrorScope(CompletionHandler<void(bool, std::optional<WebGPU::Error>&&)>&&);
+    void popErrorScopeSync(CompletionHandler<void(bool, std::optional<WebGPU::Error>&&)>&&);
     void resolveUncapturedErrorEvent(CompletionHandler<void(bool, std::optional<WebGPU::Error>&&)>&&);
     void resolveDeviceLostPromise(CompletionHandler<void(WebCore::WebGPU::DeviceLostReason)>&&);
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in
@@ -37,11 +37,14 @@ messages -> RemoteDevice NotRefCounted Stream {
     void CreateRenderPipeline(WebKit::WebGPU::RenderPipelineDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
     void CreateComputePipelineAsync(WebKit::WebGPU::ComputePipelineDescriptor descriptor, WebKit::WebGPUIdentifier identifier) -> (bool success, String error)
     void CreateRenderPipelineAsync(WebKit::WebGPU::RenderPipelineDescriptor descriptor, WebKit::WebGPUIdentifier identifier) -> (bool success, String error)
+    void CreateComputePipelineAsyncSync(WebKit::WebGPU::ComputePipelineDescriptor descriptor, WebKit::WebGPUIdentifier identifier) -> (bool success, String error) Synchronous NotStreamEncodableReply
+    void CreateRenderPipelineAsyncSync(WebKit::WebGPU::RenderPipelineDescriptor descriptor, WebKit::WebGPUIdentifier identifier) -> (bool success, String error) Synchronous NotStreamEncodableReply
     void CreateCommandEncoder(std::optional<WebKit::WebGPU::CommandEncoderDescriptor> descriptor, WebKit::WebGPUIdentifier identifier)
     void CreateRenderBundleEncoder(WebKit::WebGPU::RenderBundleEncoderDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
     void CreateQuerySet(WebKit::WebGPU::QuerySetDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
     void PushErrorScope(WebCore::WebGPU::ErrorFilter errorFilter)
     void PopErrorScope() -> (bool success, std::optional<WebKit::WebGPU::Error> error)
+    void PopErrorScopeSync() -> (bool success, std::optional<WebKit::WebGPU::Error> error) Synchronous NotStreamEncodableReply
     void ResolveUncapturedErrorEvent() -> (bool hasUncapturedError, std::optional<WebKit::WebGPU::Error> error)
     void ResolveDeviceLostPromise() -> (WebCore::WebGPU::DeviceLostReason reason)
     void SetLabel(String label)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.cpp
@@ -75,6 +75,11 @@ void RemoteShaderModule::compilationInfo(CompletionHandler<void(Vector<WebGPU::C
     });
 }
 
+void RemoteShaderModule::compilationInfoSync(CompletionHandler<void(Vector<WebGPU::CompilationMessage>&&)>&& callback)
+{
+    return compilationInfo(WTFMove(callback));
+}
+
 void RemoteShaderModule::setLabel(String&& label)
 {
     m_backing->setLabel(WTFMove(label));

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h
@@ -77,6 +77,7 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void compilationInfo(CompletionHandler<void(Vector<WebGPU::CompilationMessage>&&)>&&);
+    void compilationInfoSync(CompletionHandler<void(Vector<WebGPU::CompilationMessage>&&)>&&);
 
     void setLabel(String&&);
     void destruct();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.messages.in
@@ -25,6 +25,7 @@
 
 messages -> RemoteShaderModule NotRefCounted Stream {
     void CompilationInfo() -> (Vector<WebKit::WebGPU::CompilationMessage> messages)
+    void CompilationInfoSync() -> (Vector<WebKit::WebGPU::CompilationMessage> messages) Synchronous NotStreamEncodableReply
     void SetLabel(String label)
     void Destruct()
 }

--- a/Source/WebKit/Shared/WebGPU/WebGPUConvertToBackingContext.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUConvertToBackingContext.h
@@ -199,7 +199,7 @@ struct VertexAttribute;
 struct VertexBufferLayout;
 struct VertexState;
 
-class ConvertToBackingContext : public RefCounted<ConvertToBackingContext> {
+class ConvertToBackingContext : public ThreadSafeRefCounted<ConvertToBackingContext> {
 public:
     virtual ~ConvertToBackingContext() = default;
 


### PR DESCRIPTION
#### 7296bf185f627a35ca58ef24a7b9d6e7ae90e785
<pre>
mlc.ai Web LLM WebGPU demo doesn&apos;t work in Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=266793#add_comment">https://bugs.webkit.org/show_bug.cgi?id=266793#add_comment</a>
&lt;radar://108093665&gt;

Reviewed by NOBODY (OOPS!).

Any IPC call using sendWithAsyncReply from a worker was
impacted by a delayed dispatch leading to hangs or incorrect
results if the website used its own internal timeout.

Workaround this for now but converting these messages to
sync messages when not on the main thread.

* Source/WebCore/Modules/WebGPU/GPUBuffer.cpp:
(WebCore::GPUBuffer::mapAsync):
* Source/WebCore/Modules/WebGPU/GPUDevice.cpp:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUDevice.h:
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::popErrorScope):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp:
(WebKit::RemoteBuffer::map):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp:
(WebKit::RemoteDevice::createComputePipelineAsyncSync):
(WebKit::RemoteDevice::createRenderPipelineAsyncSync):
(WebKit::RemoteDevice::popErrorScopeSync):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.cpp:
(WebKit::RemoteShaderModule::compilationInfoSync):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.messages.in:
* Source/WebKit/Shared/WebGPU/WebGPUConvertToBackingContext.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp:
(WebKit::WebGPU::RemoteBufferProxy::mapAsync):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp:
(WebKit::WebGPU::RemoteDeviceProxy::createComputePipelineAsync):
(WebKit::WebGPU::RemoteDeviceProxy::createRenderPipelineAsync):
(WebKit::WebGPU::RemoteDeviceProxy::popErrorScope):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.cpp:
(WebKit::WebGPU::RemoteShaderModuleProxy::compilationInfo):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7296bf185f627a35ca58ef24a7b9d6e7ae90e785

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52586 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/22 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51654 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34647 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26252 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40306 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26179 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42510 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21422 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23634 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43693 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7718 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45546 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44197 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54101 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24431 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20617 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47640 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25703 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42717 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46633 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26542 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25427 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->