### PR TITLE
Content Scripts running in subframe without mainframe permission fail to work properly.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIStorageCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIStorageCocoa.mm
@@ -54,11 +54,6 @@ void WebExtensionContext::storageGet(WebPageProxyIdentifier webPageProxyIdentifi
 {
     auto callingAPIName = makeString("browser.storage."_s, toAPIString(dataType), ".get()"_s);
 
-    if (!extensionCanAccessWebPage(webPageProxyIdentifier)) {
-        completionHandler(toWebExtensionError(callingAPIName, nil, @"access not allowed"));
-        return;
-    }
-
     auto storage = storageForType(dataType);
     [storage getValuesForKeys:createNSArray(keys).get() completionHandler:makeBlockPtr([callingAPIName, completionHandler = WTFMove(completionHandler)](NSDictionary<NSString *, NSString *> *values, NSString *errorMessage) mutable {
         if (errorMessage)
@@ -72,11 +67,6 @@ void WebExtensionContext::storageGetBytesInUse(WebPageProxyIdentifier webPagePro
 {
     auto callingAPIName = makeString("browser.storage."_s, toAPIString(dataType), ".getBytesInUse()"_s);
 
-    if (!extensionCanAccessWebPage(webPageProxyIdentifier)) {
-        completionHandler(toWebExtensionError(callingAPIName, nil, @"access not allowed"));
-        return;
-    }
-
     auto storage = storageForType(dataType);
     [storage getStorageSizeForKeys:createNSArray(keys).get() completionHandler:makeBlockPtr([callingAPIName, completionHandler = WTFMove(completionHandler)](size_t size, NSString *errorMessage) mutable {
         if (errorMessage)
@@ -89,11 +79,6 @@ void WebExtensionContext::storageGetBytesInUse(WebPageProxyIdentifier webPagePro
 void WebExtensionContext::storageSet(WebPageProxyIdentifier webPageProxyIdentifier, WebExtensionDataType dataType, const String& dataJSON, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
     auto callingAPIName = makeString("browser.storage."_s, toAPIString(dataType), ".set()"_s);
-
-    if (!extensionCanAccessWebPage(webPageProxyIdentifier)) {
-        completionHandler(toWebExtensionError(callingAPIName, nil, @"access not allowed"));
-        return;
-    }
 
     NSDictionary *data = parseJSON(dataJSON);
 
@@ -136,11 +121,6 @@ void WebExtensionContext::storageRemove(WebPageProxyIdentifier webPageProxyIdent
 {
     auto callingAPIName = makeString("browser.storage."_s, toAPIString(dataType), ".remove()"_s);
 
-    if (!extensionCanAccessWebPage(webPageProxyIdentifier)) {
-        completionHandler(toWebExtensionError(callingAPIName, nil, @"access not allowed"));
-        return;
-    }
-
     [storageForType(dataType) getValuesForKeys:createNSArray(keys).get() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, callingAPIName, keys, dataType, completionHandler = WTFMove(completionHandler)](NSDictionary<NSString *, NSString *> *oldValuesAndKeys, NSString *errorMessage) mutable {
         if (errorMessage) {
             completionHandler(toWebExtensionError(callingAPIName, nil, errorMessage));
@@ -164,11 +144,6 @@ void WebExtensionContext::storageClear(WebPageProxyIdentifier webPageProxyIdenti
 {
     auto callingAPIName = makeString("browser.storage."_s, toAPIString(dataType), ".clear()"_s);
 
-    if (!extensionCanAccessWebPage(webPageProxyIdentifier)) {
-        completionHandler(toWebExtensionError(callingAPIName, nil, @"access not allowed"));
-        return;
-    }
-
     [storageForType(dataType) getValuesForKeys:@[ ] completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, callingAPIName, dataType, completionHandler = WTFMove(completionHandler)](NSDictionary<NSString *, NSString *> *oldValuesAndKeys, NSString *errorMessage) mutable {
         if (errorMessage) {
             completionHandler(toWebExtensionError(callingAPIName, nil, errorMessage));
@@ -190,13 +165,6 @@ void WebExtensionContext::storageClear(WebPageProxyIdentifier webPageProxyIdenti
 
 void WebExtensionContext::storageSetAccessLevel(WebPageProxyIdentifier webPageProxyIdentifier, WebExtensionDataType dataType, const WebExtensionStorageAccessLevel accessLevel, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
-    static NSString * const callingAPIName = @"browser.storage.session.setAccessLevel()";
-
-    if (!extensionCanAccessWebPage(webPageProxyIdentifier)) {
-        completionHandler(toWebExtensionError(callingAPIName, nil, @"access not allowed"));
-        return;
-    }
-
     setSessionStorageAllowedInContentScripts(accessLevel == WebExtensionStorageAccessLevel::TrustedAndUntrustedContexts);
 
     completionHandler({ });

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -466,11 +466,6 @@ void WebExtensionContext::tabsSendMessage(WebExtensionTabIdentifier tabIdentifie
         return;
     }
 
-    if (!tab->extensionHasPermission()) {
-        completionHandler(toWebExtensionError(apiName, nil, @"this extension does not have access to this tab"));
-        return;
-    }
-
     auto targetContentWorldType = isURLForThisExtension(tab->url()) ? WebExtensionContentWorldType::Main : WebExtensionContentWorldType::ContentScript;
 
     auto processes = tab->processes(WebExtensionEventListenerType::RuntimeOnMessage, targetContentWorldType);
@@ -494,11 +489,6 @@ void WebExtensionContext::tabsConnect(WebExtensionTabIdentifier tabIdentifier, W
     RefPtr tab = getTab(tabIdentifier);
     if (!tab) {
         completionHandler(toWebExtensionError(apiName, nil, @"tab not found"));
-        return;
-    }
-
-    if (!tab->extensionHasPermission()) {
-        completionHandler(toWebExtensionError(apiName, nil, @"this extension does not have access to this tab"));
         return;
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -484,27 +484,6 @@ bool WebExtensionContext::isURLForThisExtension(const URL& url) const
     return url.isValid() && protocolHostAndPortAreEqual(baseURL(), url);
 }
 
-bool WebExtensionContext::extensionCanAccessWebPage(WebPageProxyIdentifier webPageProxyIdentifier)
-{
-    RefPtr page = WebProcessProxy::webPage(webPageProxyIdentifier);
-    if (page && isURLForThisExtension(URL { page->pageLoadState().activeURL() }))
-        return true;
-
-    RefPtr tab = getTab(webPageProxyIdentifier);
-    if (!tab) {
-        // FIXME: <https://webkit.org/b/268030> Tab isn't found in the list of opened tabs.
-        return true;
-    }
-
-    if (tab->extensionHasPermission())
-        return true;
-
-    RELEASE_LOG_ERROR(Extensions, "Access to this tab is not allowed for this extension");
-
-    ASSERT_NOT_REACHED();
-    return false;
-}
-
 void WebExtensionContext::setUniqueIdentifier(String&& uniqueIdentifier)
 {
     ASSERT(!isLoaded());

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -283,7 +283,6 @@ public:
     void setBaseURL(URL&&);
 
     bool isURLForThisExtension(const URL&) const;
-    bool extensionCanAccessWebPage(WebPageProxyIdentifier);
 
     bool hasCustomUniqueIdentifier() const { return m_customUniqueIdentifier; }
 


### PR DESCRIPTION
#### 3b5714016d2450752f2d89e2068d44bcbae9945c
<pre>
Content Scripts running in subframe without mainframe permission fail to work properly.
<a href="https://webkit.org/b/270218">https://webkit.org/b/270218</a>
<a href="https://rdar.apple.com/problem/123750228">rdar://problem/123750228</a>

Reviewed by Brian Weinstein.

Allow sending a message to a tab even if the extension does not have permissions for
the main frame. The other browsers don&apos;t reject with an error in this case, the message
is just dropped on the floor later on in processes() when the listeners are checked.

Also allows subframes with content scripts to access storage if the main frame does not
have host permission. This was being blocked by a permission check, but that required main
frame host permissions. This is already covered in a permissive way for frames by the
isStorageMessageAllowed() check that happens when a storage IPC message is received.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIStorageCocoa.mm:
(WebKit::WebExtensionContext::storageGet): Removed extensionCanAccessWebPage() call.
(WebKit::WebExtensionContext::storageGetBytesInUse): Ditto.
(WebKit::WebExtensionContext::storageSet): Ditto.
(WebKit::WebExtensionContext::storageRemove): Ditto.
(WebKit::WebExtensionContext::storageClear): Ditto.
(WebKit::WebExtensionContext::storageSetAccessLevel): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsSendMessage): Removed permission check / error.
(WebKit::WebExtensionContext::tabsConnect): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::extensionCanAccessWebPage): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, SendMessageFromSubframe)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, ConnectFromSubframe)): Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIStorage, StorageFromSubframe)): Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundToSubframe)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, ConnectToSubframe)): Added.

Canonical link: <a href="https://commits.webkit.org/278066@main">https://commits.webkit.org/278066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce8d03c7dd6a7bcf206d4e661e99b2e8c1bf71eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52411 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/52617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/51 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51682 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26280 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/52617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51478 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42529 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/52617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23660 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43712 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7746 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45572 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44217 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54129 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24459 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20643 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47664 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25731 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46657 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26570 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7094 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25455 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->