### PR TITLE
[visionOS] After returning to element fullscreen from LMK fullscreen, unable to re-enter LMK fullscreen

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -1244,7 +1244,8 @@ void VideoPresentationManagerProxy::failedToEnterFullscreen(PlaybackSessionConte
 
 void VideoPresentationManagerProxy::didCleanupFullscreen(PlaybackSessionContextIdentifier contextId)
 {
-    if (!m_page)
+    RefPtr page = m_page.get();
+    if (!page)
         return;
 
     auto& [model, interface] = ensureModelAndInterface(contextId);
@@ -1267,12 +1268,14 @@ void VideoPresentationManagerProxy::didCleanupFullscreen(PlaybackSessionContextI
         model->setLayerHostView(nullptr);
     }
 
-    m_page->send(Messages::VideoPresentationManager::DidCleanupFullscreen(contextId));
+    page->send(Messages::VideoPresentationManager::DidCleanupFullscreen(contextId));
 
     if (!hasMode(HTMLMediaElementEnums::VideoFullscreenModeInWindow)) {
         interface->setMode(HTMLMediaElementEnums::VideoFullscreenModeNone, false);
         removeClientForContext(contextId);
     }
+
+    page->didCleanupFullscreen(contextId);
 }
 
 void VideoPresentationManagerProxy::setVideoLayerFrame(PlaybackSessionContextIdentifier contextId, WebCore::FloatRect frame)

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -730,6 +730,7 @@ public:
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     virtual void didEnterFullscreen() = 0;
     virtual void didExitFullscreen() = 0;
+    virtual void didCleanupFullscreen() = 0;
 #endif
 
 #if PLATFORM(GTK) || PLATFORM(WPE)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7615,6 +7615,11 @@ void WebPageProxy::didExitFullscreen(PlaybackSessionContextIdentifier identifier
     }
 }
 
+void WebPageProxy::didCleanupFullscreen(PlaybackSessionContextIdentifier)
+{
+    protectedPageClient()->didCleanupFullscreen();
+}
+
 void WebPageProxy::failedToEnterFullscreen(PlaybackSessionContextIdentifier identifier)
 {
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2147,6 +2147,7 @@ public:
     void failedToEnterFullscreen(PlaybackSessionContextIdentifier);
     void didEnterFullscreen(PlaybackSessionContextIdentifier);
     void didExitFullscreen(PlaybackSessionContextIdentifier);
+    void didCleanupFullscreen(PlaybackSessionContextIdentifier);
     void didChangePlaybackRate(PlaybackSessionContextIdentifier);
     void didChangeCurrentTime(PlaybackSessionContextIdentifier);
 #else

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -340,6 +340,7 @@ private:
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     void didEnterFullscreen() final { };
     void didExitFullscreen() final;
+    void didCleanupFullscreen() final;
 #endif
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -1105,6 +1105,13 @@ void PageClientImpl::didExitFullscreen()
 #endif
 }
 
+void PageClientImpl::didCleanupFullscreen()
+{
+#if ENABLE(FULLSCREEN_API)
+    [[webView() fullScreenWindowController] didCleanupFullscreen];
+#endif
+}
+
 #endif // ENABLE(VIDEO_PRESENTATION_MODE)
 
 #if ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h
@@ -60,6 +60,9 @@ NS_ASSUME_NONNULL_BEGIN
 #if PLATFORM(VISION)
 - (void)hideCustomControls:(BOOL)hidden;
 #endif
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+- (void)configureEnvironmentPickerButtonView;
+#endif
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
@@ -51,6 +51,7 @@
 - (void)webViewDidRemoveFromSuperviewWhileInFullscreen;
 - (void)videoControlsManagerDidChange;
 - (void)didExitFullscreen;
+- (void)didCleanupFullscreen;
 
 #if PLATFORM(VISION)
 - (void)toggleSceneDimming;

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -1942,6 +1942,14 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 #endif
 }
 
+- (void)didCleanupFullscreen
+{
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    if (self.isFullScreen)
+        [_fullscreenViewController configureEnvironmentPickerButtonView];
+#endif
+}
+
 @end
 
 #if PLATFORM(VISION) && ENABLE(QUICKLOOK_FULLSCREEN)

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -316,6 +316,7 @@ private:
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     void didEnterFullscreen() final { }
     void didExitFullscreen() final { }
+    void didCleanupFullscreen() final { }
 #endif
 
     NSView *m_view;


### PR DESCRIPTION
#### 44488b037c9b367b57bd00943194c42b46c20eee
<pre>
[visionOS] After returning to element fullscreen from LMK fullscreen, unable to re-enter LMK fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=273344">https://bugs.webkit.org/show_bug.cgi?id=273344</a>
<a href="https://rdar.apple.com/127137182">rdar://127137182</a>

Reviewed by Eric Carlson.

When exiting LinearMediaKit fullscreen the VideoPresentationInterfaceLMK and its
LMPlayableViewController are destroyed, but WKFullScreenViewController still has a reference to a
UIView created by the LMPlayableViewController. Since the LMPlayableViewController and its
Playable-conforming delegate no longer exist, the view has no delegate to notify when the user
interacts with it. This results in an inability to re-enter LinearMediaKit fullscreen after
previously exiting from it to element fullscreen.

Resolved this by plumbing a &quot;didCleanupFullscreen&quot; call from VideoPresentationInterfaceIOS to
WKFullScreenViewController. When this method is called and the VC is still in fullscreen mode,
WKFullScreenViewController is told to remove the old _environmentPickerButtonView and create a new
one (which will re-ensure a VideoPresentationInterfaceLMK and LMPlayableViewController).

* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::didCleanupFullscreen):
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCleanupFullscreen):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::didCleanupFullscreen):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController videoControlsManagerDidChange]):
(-[WKFullScreenViewController configureEnvironmentPickerButtonView]):
(-[WKFullScreenViewController _configureEnvironmentPickerButtonViewWithPlayableViewController:]): Deleted.
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController didCleanupFullscreen]):
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:

Canonical link: <a href="https://commits.webkit.org/278089@main">https://commits.webkit.org/278089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9983645d9f078e53e2817ab173bd9702ba14d199

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52675 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/109 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26338 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40353 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26264 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42592 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21470 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23720 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7805 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45637 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54187 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24518 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20711 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47718 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25790 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42795 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46727 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10862 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26629 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25513 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->