### PR TITLE
Add some root frame utility functions

### DIFF
--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -69,6 +69,9 @@ public:
     Frame& mainFrame() const { return m_mainFrame.get(); }
     bool isMainFrame() const { return this == m_mainFrame.ptr(); }
     virtual bool isRootFrame() const = 0;
+#if ASSERT_ENABLED
+    static bool isRootFrameIdentifier(FrameIdentifier);
+#endif
 
     WEBCORE_EXPORT void detachFromPage();
 
@@ -113,7 +116,7 @@ private:
     mutable FrameTree m_treeNode;
     Ref<WindowProxy> m_windowProxy;
     WeakPtr<HTMLFrameOwnerElement, WeakPtrImplWithEventTargetData> m_ownerElement;
-    WeakRef<Frame> m_mainFrame;
+    const WeakRef<Frame> m_mainFrame;
     const Ref<Settings> m_settings;
     FrameType m_frameType;
     mutable UniqueRef<NavigationScheduler> m_navigationScheduler;

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -35,6 +35,7 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/HashSet.h>
 #include <wtf/UniqueRef.h>
+#include <wtf/WeakRef.h>
 
 #if PLATFORM(IOS_FAMILY)
 #include "Timer.h"
@@ -169,7 +170,8 @@ public:
     CheckedRef<const ScriptController> checkedScript() const;
     void resetScript();
 
-    WEBCORE_EXPORT bool isRootFrame() const final;
+    bool isRootFrame() const final { return m_rootFrame.ptr() == this; }
+    const LocalFrame& rootFrame() const { return m_rootFrame.get(); }
 
     WEBCORE_EXPORT RenderView* contentRenderer() const; // Root of the render tree for the document contained in this frame.
 
@@ -376,7 +378,6 @@ private:
     unsigned m_navigationDisableCount { 0 };
     unsigned m_selfOnlyRefCount { 0 };
     bool m_hasHadUserInteraction { false };
-    const bool m_isRootFrame { false };
 
 #if ENABLE(WINDOW_PROXY_PROPERTY_ACCESS_NOTIFICATION)
     OptionSet<WindowProxyProperty> m_accessedWindowProxyPropertiesViaOpener;
@@ -384,6 +385,7 @@ private:
 
     FloatSize m_overrideScreenSize;
 
+    const WeakRef<const LocalFrame> m_rootFrame;
     UniqueRef<EventHandler> m_eventHandler;
     HashSet<RegistrableDomain> m_storageAccessExceptionDomains;
 };


### PR DESCRIPTION
#### 63eb54f1aee4398784db80b00a80669cd679ef70
<pre>
Add some root frame utility functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=273348">https://bugs.webkit.org/show_bug.cgi?id=273348</a>
<a href="https://rdar.apple.com/127142451">rdar://127142451</a>

Reviewed by Simon Fraser.

Frame has the ability to query if it is the main frame and the ability to quickly
get the main frame without traversing the frame tree to find it.  It does this by
storing a WeakRef of the main frame and comparing or dereferencing it.  This has
been useful for many years.

LocalFrame already had the ability to quickly query if it is a root frame.  With
site isolation off and all the frames in the same process, this is the same as
being the main frame.  With site isolation on, though, frames can be in different
processes so a root frame is the root of a subtree of LocalFrames with either no
parent (if it is also the main frame) or a RemoteFrame parent if its parent&apos;s
contents are in another process.

With <a href="https://github.com/WebKit/WebKit/pull/27300">https://github.com/WebKit/WebKit/pull/27300</a> we introduce the need to quickly
get the root frame of a particular LocalFrame.  We implement that in this PR the
same way we have long ago with the main frame: by storing a WeakRef.

In that same PR, we will benefit by having the ability to assert that a particular
FrameIdentifier is from a root frame to prevent future developers from forgetting
a call to rootFrame and messing up the scroll tree.  For that purpose we introduce
Frame::isRootFrameIdentifier which requires some extra bookkeeping that isn&apos;t
necessary in release builds with ASSERT_ENABLED set to false.

* Source/WebCore/page/Frame.cpp:
(WebCore::allFrames):
(WebCore::Frame::Frame):
(WebCore::Frame::~Frame):
(WebCore::Frame::isRootFrameIdentifier):
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::rootFrame):
(WebCore::LocalFrame::LocalFrame):
(WebCore::isRootFrame): Deleted.
(WebCore::LocalFrame::isRootFrame const): Deleted.
* Source/WebCore/page/LocalFrame.h:

Canonical link: <a href="https://commits.webkit.org/278133@main">https://commits.webkit.org/278133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/832d8e5f408b965c2fcf2a55ce607a05ca821b0a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49381 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52414 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52620 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/54 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34678 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26283 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40316 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42536 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21432 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23665 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43720 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7749 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45594 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54132 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24462 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20647 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47671 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25734 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46679 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26573 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7132 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25458 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->