### PR TITLE
Do not expect link filtering domains returned from WebPrivacy to contain a protocol

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
@@ -232,7 +232,7 @@ TEST(AdvancedPrivacyProtections, RemoveTrackingQueryParametersWhenNavigatingWith
 TEST(AdvancedPrivacyProtections, RemoveTrackingQueryParametersByDomain)
 {
     [TestProtocol registerWithScheme:@"https"];
-    QueryParameterRequestSwizzler swizzler { @[ @"foo", @"bar", @"baz" ], @[ @"http://a.com", @"", @"" ], @[ @"", @"", @"" ] };
+    QueryParameterRequestSwizzler swizzler { @[ @"foo", @"bar", @"baz" ], @[ @"a.com", @"", @"" ], @[ @"", @"", @"" ] };
 
     auto webView = createWebViewWithAdvancedPrivacyProtections();
     auto url = [NSURL URLWithString:@"https://b.com/bundle-file/simple.html?foo=10&garply=20&bar=30&baz=40"];
@@ -262,7 +262,7 @@ TEST(AdvancedPrivacyProtections, RemoveTrackingQueryParametersByPath)
 TEST(AdvancedPrivacyProtections, RemoveTrackingQueryParametersByDomainAndPath)
 {
     [TestProtocol registerWithScheme:@"https"];
-    QueryParameterRequestSwizzler swizzler { @[ @"foo", @"bar", @"baz" ], @[ @"http://a.com", @"", @"" ], @[ @"/abc/", @"", @"" ] };
+    QueryParameterRequestSwizzler swizzler { @[ @"foo", @"bar", @"baz" ], @[ @"a.com", @"", @"" ], @[ @"/abc/", @"", @"" ] };
 
     auto webView = createWebViewWithAdvancedPrivacyProtections();
     auto url = [NSURL URLWithString:@"https://b.com/bundle-file/simple.html?foo=10&garply=20&bar=30&baz=40"];


### PR DESCRIPTION
#### 2cb63f8cc4d9a706916cb94617cd4ecb81e9ce5c
<pre>
Do not expect link filtering domains returned from WebPrivacy to contain a protocol
<a href="https://bugs.webkit.org/show_bug.cgi?id=273349">https://bugs.webkit.org/show_bug.cgi?id=273349</a>
<a href="https://rdar.apple.com/127143043">rdar://127143043</a>

Reviewed by Matthew Finkel and Wenson Hsieh.

WebKit should no longer expect the domain returned from WebPrivacy to contain a protocol. Append one
here so the URL parser works correctly.

* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::LinkDecorationFilteringController::updateStrings):
(WebKit::requestLinkDecorationFilteringData):
* Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm:
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, RemoveTrackingQueryParametersByDomain)):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, RemoveTrackingQueryParametersByDomainAndPath)):

Canonical link: <a href="https://commits.webkit.org/278068@main">https://commits.webkit.org/278068@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0917b4af40d3f62a200846c85458ce3dcc677c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49385 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52418 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/52624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/58 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51689 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34682 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26287 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/52624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51485 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42534 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/52624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23667 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43718 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7753 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45579 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44222 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54136 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24466 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47670 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25738 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42742 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46664 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/26577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7095 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25462 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->