### PR TITLE
Factor out stateNodeForID calls in AsyncScrollingCoordinator

### DIFF
--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
@@ -98,6 +98,8 @@ protected:
 
     bool eventTrackingRegionsDirty() const { return m_eventTrackingRegionsDirty; }
     WEBCORE_EXPORT LocalFrameView* frameViewForScrollingNode(ScrollingNodeID) const;
+    RefPtr<ScrollingStateNode> stateNodeForNodeID(ScrollingNodeID) const;
+    RefPtr<ScrollingStateNode> stateNodeForScrollableArea(const ScrollableArea&) const;
 
 private:
     bool isAsyncScrollingCoordinator() const override { return true; }


### PR DESCRIPTION
#### 70994f6c7424e77819499f8dca387982a93cf0b1
<pre>
Factor out stateNodeForID calls in AsyncScrollingCoordinator
<a href="https://bugs.webkit.org/show_bug.cgi?id=273347">https://bugs.webkit.org/show_bug.cgi?id=273347</a>
<a href="https://rdar.apple.com/127142962">rdar://127142962</a>

Reviewed by Alex Christensen.

In anticipation of <a href="https://github.com/WebKit/WebKit/pull/27300">https://github.com/WebKit/WebKit/pull/27300</a> factor out use of stateNodeForID in
AsyncScrollingCoordinator.

* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::stateNodeForNodeID const):
(WebCore::AsyncScrollingCoordinator::frameViewLayoutUpdated):
(WebCore::AsyncScrollingCoordinator::frameViewVisualViewportChanged):
(WebCore::AsyncScrollingCoordinator::frameViewWillBeDetached):
(WebCore::AsyncScrollingCoordinator::updateIsMonitoringWheelEventsForFrameView):
(WebCore::AsyncScrollingCoordinator::frameViewRootLayerDidChange):
(WebCore::AsyncScrollingCoordinator::requestStartKeyboardScrollAnimation):
(WebCore::AsyncScrollingCoordinator::requestStopKeyboardScrollAnimation):
(WebCore::AsyncScrollingCoordinator::requestScrollToPosition):
(WebCore::AsyncScrollingCoordinator::stopAnimatedScroll):
(WebCore::AsyncScrollingCoordinator::setScrollbarLayoutDirection):
(WebCore::AsyncScrollingCoordinator::setMouseIsOverScrollbar):
(WebCore::AsyncScrollingCoordinator::setMouseIsOverContentArea):
(WebCore::AsyncScrollingCoordinator::setMouseMovedInContentArea):
(WebCore::AsyncScrollingCoordinator::setLayerHostingContextIdentifierForFrameHostingNode):
(WebCore::AsyncScrollingCoordinator::setScrollbarEnabled):
(WebCore::AsyncScrollingCoordinator::frameViewForScrollingNode const):
(WebCore::AsyncScrollingCoordinator::scrollableAreaScrollbarLayerDidChange):
(WebCore::AsyncScrollingCoordinator::parentOfNode const):
(WebCore::AsyncScrollingCoordinator::childrenOfNode const):
(WebCore::AsyncScrollingCoordinator::ensureRootStateNodeForFrameView):
(WebCore::AsyncScrollingCoordinator::setNodeLayers):
(WebCore::AsyncScrollingCoordinator::setFrameScrollingNodeState):
(WebCore::AsyncScrollingCoordinator::setScrollingNodeScrollableAreaGeometry):
(WebCore::AsyncScrollingCoordinator::setViewportConstraintedNodeConstraints):
(WebCore::AsyncScrollingCoordinator::setPositionedNodeConstraints):
(WebCore::AsyncScrollingCoordinator::setRelatedOverflowScrollingNodes):
(WebCore::AsyncScrollingCoordinator::setSynchronousScrollingReasons):
(WebCore::AsyncScrollingCoordinator::synchronousScrollingReasons const):
(WebCore::AsyncScrollingCoordinator::updateScrollSnapPropertiesWithFrameView):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h:

Canonical link: <a href="https://commits.webkit.org/278157@main">https://commits.webkit.org/278157@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b57dacac560e283ff2e16adda5bf398c3d1994e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52843 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/277 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51906 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26506 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40488 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51701 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26427 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21603 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23876 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43904 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7972 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45791 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44410 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54420 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20861 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47859 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25955 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46890 "Found 1 new API test failure: /TestWTF:WTF_ParkingLot.UnparkOneOneFast (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10898 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26801 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25680 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->