### PR TITLE
[JSC] Disable StopIfNecessaryTimer on WebKit main thread

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -2587,6 +2587,11 @@ void Heap::setEdenActivityCallback(RefPtr<GCActivityCallback>&& callback)
     m_edenActivityCallback = WTFMove(callback);
 }
 
+void Heap::disableStopIfNecessaryTimer()
+{
+    m_stopIfNecessaryTimer->disable();
+}
+
 bool Heap::useGenerationalGC()
 {
     return Options::useGenerationalGC() && !VM::isInMiniMode();

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -330,6 +330,7 @@ public:
 
     JS_EXPORT_PRIVATE void setFullActivityCallback(RefPtr<GCActivityCallback>&&);
     JS_EXPORT_PRIVATE void setEdenActivityCallback(RefPtr<GCActivityCallback>&&);
+    JS_EXPORT_PRIVATE void disableStopIfNecessaryTimer();
 
     JS_EXPORT_PRIVATE void setGarbageCollectionTimerEnabled(bool);
     JS_EXPORT_PRIVATE void scheduleOpportunisticFullCollection();

--- a/Source/JavaScriptCore/heap/StopIfNecessaryTimer.cpp
+++ b/Source/JavaScriptCore/heap/StopIfNecessaryTimer.cpp
@@ -45,11 +45,20 @@ void StopIfNecessaryTimer::doWork(VM& vm)
 
 void StopIfNecessaryTimer::scheduleSoon()
 {
+    if (m_isDisabled)
+        return;
+
     if (isScheduled()) {
         WTF::loadLoadFence();
         return;
     }
     setTimeUntilFire(0_s);
+}
+
+
+void StopIfNecessaryTimer::disable()
+{
+    m_isDisabled = true;
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/heap/StopIfNecessaryTimer.h
+++ b/Source/JavaScriptCore/heap/StopIfNecessaryTimer.h
@@ -39,6 +39,11 @@ public:
     void doWork(VM&) final;
     
     void scheduleSoon();
+
+    void disable();
+
+private:
+    bool m_isDisabled { false };
 };
 
 } // namespace JSC

--- a/Source/WebCore/bindings/js/CommonVM.cpp
+++ b/Source/WebCore/bindings/js/CommonVM.cpp
@@ -69,6 +69,7 @@ JSC::VM& commonVMSlow()
 #if !PLATFORM(IOS_FAMILY)
     vm.heap.setFullActivityCallback(OpportunisticTaskScheduler::FullGCActivityCallback::create(vm.heap));
     vm.heap.setEdenActivityCallback(OpportunisticTaskScheduler::EdenGCActivityCallback::create(vm.heap));
+    vm.heap.disableStopIfNecessaryTimer(); // Because opportunistic task scheduler and GC timer exists, we do not need StopIfNecessaryTimer.
 #endif
 
     g_commonVMOrNull = &vm;


### PR DESCRIPTION
#### c1d30237589d2fa3fea2e0a76029783d73c2fac4
<pre>
[JSC] Disable StopIfNecessaryTimer on WebKit main thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=273354">https://bugs.webkit.org/show_bug.cgi?id=273354</a>
<a href="https://rdar.apple.com/127152132">rdar://127152132</a>

Reviewed by Keith Miller.

Because we have opportunistic task scheduler and GC timer, we do not need to have StopIfNecessaryTimer
in the main thread VM of WebKit.

* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::disableStopIfNecessaryTimer):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/heap/StopIfNecessaryTimer.cpp:
(JSC::StopIfNecessaryTimer::scheduleSoon):
(JSC::StopIfNecessaryTimer::disable):
* Source/JavaScriptCore/heap/StopIfNecessaryTimer.h:
* Source/WebCore/bindings/js/CommonVM.cpp:
(WebCore::commonVMSlow):

Canonical link: <a href="https://commits.webkit.org/278115@main">https://commits.webkit.org/278115@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea05835759ebcb5af4b9bcd662216e0c73d79dd0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52440 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52644 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/78 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51709 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26307 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40333 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51505 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26234 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42561 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21449 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23690 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43744 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7774 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/42709 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45607 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44246 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54156 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/48993 "Found 4 new JSC stress test failures: microbenchmarks/super-get-by-val-with-this-monomorphic.js.ftl-eager-no-cjit, stress/caller-and-arguments-properties-for-functions-that-dont-have-them.js.ftl-eager-no-cjit, stress/poly-setter-combo.js.ftl-eager-no-cjit, stress/proxy-get-set-correct-receiver.js.ftl-eager-no-cjit (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24487 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20676 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47690 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25759 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42765 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46693 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26598 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56388 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7120 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25482 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11580 "Passed tests") | 
<!--EWS-Status-Bubble-End-->