### PR TITLE
Introduce JS promises to TestRunner.idl

### DIFF
--- a/LayoutTests/fast/loader/window-open-to-invalid-url-calls-policy-delegate.html
+++ b/LayoutTests/fast/loader/window-open-to-invalid-url-calls-policy-delegate.html
@@ -14,11 +14,10 @@ if (window.testRunner) {
 <p>Note, this test must be run in DumpRenderTree.</p>
 <script>
 window.open("http://A=a&B=b", "_top");
-window.setTimeout(function() {
+window.setTimeout(async function () {
     if (window.testRunner) {
-        testRunner.flushConsoleLogs(function() {
-            testRunner.notifyDone();
-        });
+        await testRunner.flushConsoleLogs();
+        testRunner.notifyDone();
     }
 }, 0);
 </script>

--- a/LayoutTests/http/tests/resourceLoadStatistics/prune-statistics.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/prune-statistics.html
@@ -50,40 +50,46 @@
             setEnableFeature(false, finishJSTest);
     }
 
-    function initializeStatisticsAndRunTests(step) {
+    async function initializeStatisticsAndRunTests(step) {
         switch (step) {
             // Non-prevalent without user interaction to be pruned first.
             case 1:
-                testRunner.setStatisticsLastSeen(urlsToBePruned[0].url, olderTimestamp, function() { initializeStatisticsAndRunTests(2); });
+                await testRunner.setStatisticsLastSeen(urlsToBePruned[0].url, olderTimestamp);
+                initializeStatisticsAndRunTests(2);
                 break;
             case 2:
-                testRunner.setStatisticsLastSeen(urlsToBePruned[1].url, newerTimestamp, function() { initializeStatisticsAndRunTests(3); });
+                await testRunner.setStatisticsLastSeen(urlsToBePruned[1].url, newerTimestamp);
+                initializeStatisticsAndRunTests(3);
                 break;
             // Prevalent without user interaction to be pruned second.
             case 3:
                 testRunner.setStatisticsPrevalentResource(urlsToBePruned[2].url, true, function() { initializeStatisticsAndRunTests(4); });
                 break;
             case 4:
-                testRunner.setStatisticsLastSeen(urlsToBePruned[2].url, olderTimestamp, function() { initializeStatisticsAndRunTests(5); });
+                await testRunner.setStatisticsLastSeen(urlsToBePruned[2].url, olderTimestamp);
+                initializeStatisticsAndRunTests(5);
                 break;
             case 5:
                 testRunner.setStatisticsPrevalentResource(urlsToBePruned[3].url, true, function() { initializeStatisticsAndRunTests(6); });
                 break;
             case 6:
-                testRunner.setStatisticsLastSeen(urlsToBePruned[3].url, newerTimestamp, function() { initializeStatisticsAndRunTests(7); });
+                await testRunner.setStatisticsLastSeen(urlsToBePruned[3].url, newerTimestamp);
+                initializeStatisticsAndRunTests(7);
                 break;
             // Non-prevalent with user interaction to be pruned third.
             case 7:
                 testRunner.setStatisticsHasHadUserInteraction(urlsToBePruned[4].url, true, function() { initializeStatisticsAndRunTests(8); });
                 break;
             case 8:
-                testRunner.setStatisticsLastSeen(urlsToBePruned[4].url, olderTimestamp, function() { initializeStatisticsAndRunTests(9); });
+                await testRunner.setStatisticsLastSeen(urlsToBePruned[4].url, olderTimestamp);
+                initializeStatisticsAndRunTests(9);
                 break;
             case 9:
                 testRunner.setStatisticsHasHadUserInteraction(urlsToBePruned[5].url, true, function() { initializeStatisticsAndRunTests(10); });
                 break;
             case 10:
-                testRunner.setStatisticsLastSeen(urlsToBePruned[5].url, newerTimestamp, function() { initializeStatisticsAndRunTests(11); });
+                await testRunner.setStatisticsLastSeen(urlsToBePruned[5].url, newerTimestamp);
+                initializeStatisticsAndRunTests(11);
                 break;
             // Prevalent with user interaction to be pruned last.
             case 11:
@@ -93,7 +99,8 @@
                 testRunner.setStatisticsHasHadUserInteraction(urlsToBePruned[6].url, true, function() { initializeStatisticsAndRunTests(13); });
                 break;
             case 13:
-                testRunner.setStatisticsLastSeen(urlsToBePruned[6].url, olderTimestamp, function() { initializeStatisticsAndRunTests(14); });
+                await testRunner.setStatisticsLastSeen(urlsToBePruned[6].url, olderTimestamp);
+                initializeStatisticsAndRunTests(14);
                 break;
             case 14:
                 testRunner.setStatisticsPrevalentResource(urlsToBePruned[7].url, true, function() { initializeStatisticsAndRunTests(15); });
@@ -102,7 +109,8 @@
                 testRunner.setStatisticsHasHadUserInteraction(urlsToBePruned[7].url, true, function() { initializeStatisticsAndRunTests(16); });
                 break;
             case 16:
-                testRunner.setStatisticsLastSeen(urlsToBePruned[7].url, newerTimestamp, function() { initializeStatisticsAndRunTests(17); });
+                await testRunner.setStatisticsLastSeen(urlsToBePruned[7].url, newerTimestamp);
+                initializeStatisticsAndRunTests(17);
                 break;
             case 17:
                 checkIfPrevalentAccordingToInitialExpectation(0, urlsToBePruned.length);
@@ -131,10 +139,9 @@
     function runTest() {
         fillerUrl = "http://127.0." + currentTest + ".1:8000/temp";
         testRunner.setStatisticsPrevalentResource(fillerUrl, true, function() {
-            testRunner.setStatisticsHasHadUserInteraction(fillerUrl, true, function() {
-                testRunner.setStatisticsLastSeen(fillerUrl, newestTimestamp, function() {
-                    testRunner.statisticsProcessStatisticsAndDataRecords();
-                });
+            testRunner.setStatisticsHasHadUserInteraction(fillerUrl, true, async function () {
+                await testRunner.setStatisticsLastSeen(fillerUrl, newestTimestamp);
+                testRunner.statisticsProcessStatisticsAndDataRecords();
             });
         });
     }

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -316,7 +316,7 @@ interface TestRunner {
     undefined installStatisticsDidScanDataRecordsCallback(object callback);
     undefined setStatisticsDebugMode(boolean value, object completionHandler);
     undefined setStatisticsPrevalentResourceForDebugMode(DOMString hostName, object completionHandler);
-    undefined setStatisticsLastSeen(DOMString hostName, double seconds, object completionHandler);
+    Promise<undefined> setStatisticsLastSeen(DOMString hostName, double seconds);
     undefined setStatisticsMergeStatistic(DOMString hostName, DOMString topFrameDomain1, DOMString topFrameDomain2, double lastSeen, boolean hadUserInteraction, double mostRecentUserInteraction, boolean isGrandfathered, boolean isPrevalent, boolean isVeryPrevalent, unsigned long dataRecordsRemoved, object completionHandler);
     undefined setStatisticsExpiredStatistic(DOMString hostName, unsigned long numberOfOperatingDaysPassed, boolean hadUserInteraction, boolean isScheduledForAllButCookieDataRemoval, boolean isPrevalent, object completionHandler);
     undefined setStatisticsPrevalentResource(DOMString hostName, boolean value, object completionHandler);
@@ -459,5 +459,5 @@ interface TestRunner {
     undefined generateTestReport(DOMString message, DOMString group);
 
     undefined getAndClearReportedWindowProxyAccessDomains(object callback);
-    undefined flushConsoleLogs(object callback);
+    Promise<undefined> flushConsoleLogs();
 };


### PR DESCRIPTION
#### 7fb21c92649c22834f37c7672df7fc794e092102
<pre>
Introduce JS promises to TestRunner.idl
<a href="https://bugs.webkit.org/show_bug.cgi?id=273355">https://bugs.webkit.org/show_bug.cgi?id=273355</a>

Reviewed by Alan Baradlay.

This is pretty simple use of JSObjectMakeDeferredPromise with only a resolve function and no reject function,
but it works and allows us to have more modern async tests.

* LayoutTests/fast/loader/window-open-to-invalid-url-calls-policy-delegate.html:
* LayoutTests/http/tests/resourceLoadStatistics/prune-statistics.html:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/CodeGeneratorTestRunner.pm:
(_generateImplementationFile):
(_returnExpression):
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:

Canonical link: <a href="https://commits.webkit.org/278076@main">https://commits.webkit.org/278076@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54eee2e618c9dddfbf424a934c637bb76b9cafd7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52648 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/82 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51713 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34707 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26311 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40329 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51509 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26239 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42562 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21445 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23695 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43745 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7778 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45612 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44247 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54160 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24491 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20680 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47692 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25763 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42766 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46696 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26602 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7101 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25486 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->