### PR TITLE
[Buildstream SDK] Update GTK and gst-plugin-dav1d

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1196,6 +1196,10 @@ imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.
 
 imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.worker.html [ Pass ]
 
+# Colorimetry-related failures, to be fixed by proper av01 codec string parsing/handling.
+imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?av1 [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?av1 [ Failure ]
+
 # Our MP3 decoder is not yet spec-compliant (reverse decoding, mostly).
 imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?mp3 [ Failure ]
 imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?mp3 [ Failure ]

--- a/Tools/buildstream/elements/freedesktop-sdk.bst
+++ b/Tools/buildstream/elements/freedesktop-sdk.bst
@@ -24,3 +24,4 @@ config:
     bootstrap_build_arch: '%{bootstrap_build_arch}'
   overrides:
     components/dav1d.bst: sdk/dav1d.bst
+    components/pango.bst: sdk/pango.bst

--- a/Tools/buildstream/elements/sdk/gst-plugin-dav1d.bst
+++ b/Tools/buildstream/elements/sdk/gst-plugin-dav1d.bst
@@ -36,7 +36,7 @@ sources:
 - kind: git_repo
   url: gitlab_freedesktop_org:gstreamer/gst-plugins-rs.git
   track: main
-  ref: gstreamer-1.23.1-158-g168af88edab195505767c92b90e70792b0c83e5c
+  ref: gstreamer-1.23.1-174-ga87eaa4b7909bff400d1272c83f86db5a72598c1
 - kind: local
   path: files/gst-plugin-dav1d/Cargo.lock
 - kind: local

--- a/Tools/buildstream/elements/sdk/gtk.bst
+++ b/Tools/buildstream/elements/sdk/gtk.bst
@@ -3,10 +3,12 @@ sources:
 - kind: git_repo
   url: gitlab_gnome_org:GNOME/gtk.git
   track: 4.*
-  ref: 4.14.1-0-gc648bb7b19bede75d3af4acaed468b922269ed05
+  ref: 4.15.0-0-g1a3c5cf420392f76998974f54edc899e526b524d
 build-depends:
 - sdk-build-depends/sassc.bst
 - freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
+- freedesktop-sdk.bst:components/shaderc.bst
+- freedesktop-sdk.bst:components/vulkan-headers.bst
 
 depends:
 - freedesktop-sdk.bst:components/at-spi2-core.bst
@@ -27,7 +29,6 @@ depends:
 
 variables:
   meson-local: >-
-    -Dvulkan=disabled
     -Dbuild-tests=false
     -Dbuild-testsuite=false
 public:

--- a/Tools/buildstream/elements/sdk/pango.bst
+++ b/Tools/buildstream/elements/sdk/pango.bst
@@ -1,0 +1,43 @@
+kind: meson
+
+build-depends:
+- freedesktop-sdk.bst:components/gobject-introspection.bst
+- freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
+- freedesktop-sdk.bst:components/gtk-doc.bst
+
+depends:
+- freedesktop-sdk.bst:bootstrap-import.bst
+- freedesktop-sdk.bst:components/cairo.bst
+- freedesktop-sdk.bst:components/harfbuzz.bst
+- freedesktop-sdk.bst:components/fontconfig.bst
+- freedesktop-sdk.bst:components/fribidi.bst
+- freedesktop-sdk.bst:components/json-glib.bst
+- freedesktop-sdk.bst:components/libthai.bst
+- freedesktop-sdk.bst:components/xorg-lib-xft.bst
+
+public:
+  bst:
+    split-rules:
+      devel:
+        (>):
+        - '%{libdir}/libpango-1.0.so'
+        - '%{libdir}/libpangoft2-1.0.so'
+        - '%{libdir}/libpangocairo-1.0.so'
+        - '%{libdir}/libpangoxft-1.0.so'
+
+  cpe:
+    ignored:
+    - CVE-2019-1010238
+
+# Those are the defaults which we explicitly match.
+variables:
+  meson-local: >-
+    -Dgtk_doc=false
+    -Dintrospection=enabled
+    -Dinstall-tests=false
+
+sources:
+- kind: git_repo
+  url: gitlab_gnome_org:GNOME/pango.git
+  track: 1.52.*
+  ref: 1.52.2-0-g7fe0a98f6180069732aa819fb5f1f2fa4f5d10f1


### PR DESCRIPTION
#### c99c18cd6894b42a18739abb2cff0a06b32cb783
<pre>
[Buildstream SDK] Update GTK and gst-plugin-dav1d
<a href="https://bugs.webkit.org/show_bug.cgi?id=273356">https://bugs.webkit.org/show_bug.cgi?id=273356</a>

Reviewed by Adrian Perez de Castro.

Update to GTK 4.15, which depends on Pango 1.52, not shipped by upstream SDK, so we need a local
override. The gst-plugin-dav1d was also update to latest development version including an additional
colorimetry-related patch.

* LayoutTests/platform/glib/TestExpectations:
* Tools/buildstream/elements/freedesktop-sdk.bst:
* Tools/buildstream/elements/sdk/gst-plugin-dav1d.bst:
* Tools/buildstream/elements/sdk/gtk.bst:
* Tools/buildstream/elements/sdk/pango.bst: Added.

Canonical link: <a href="https://commits.webkit.org/278079@main">https://commits.webkit.org/278079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f8e658fb8f5fbee95f408d18621fd7b619e4367

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28695 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52448 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52652 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/86 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51717 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26315 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40331 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51513 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26242 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42569 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21447 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23698 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43751 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7782 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45615 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44257 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54164 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24495 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20684 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47696 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25767 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42772 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46701 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26606 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7105 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25490 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->