### PR TITLE
Expand use of WKBundlePagePostMessageWithAsyncReply in WebKitTestRunner

### DIFF
--- a/Tools/WebKitTestRunner/DictionaryFunctions.h
+++ b/Tools/WebKitTestRunner/DictionaryFunctions.h
@@ -29,29 +29,6 @@
 
 namespace WTR {
 
-WKDictionaryRef dictionaryValue(WKTypeRef);
-
-bool booleanValue(WKTypeRef);
-bool booleanValue(const WKRetainPtr<WKTypeRef>&);
-
-double doubleValue(WKTypeRef);
-std::optional<double> optionalDoubleValue(WKTypeRef);
-
-WKStringRef stringValue(WKTypeRef);
-WTF::String toWTFString(WKTypeRef);
-
-uint64_t uint64Value(WKTypeRef);
-uint64_t uint64Value(const WKRetainPtr<WKTypeRef>&);
-
-WKTypeRef value(WKDictionaryRef, const char* key);
-
-bool booleanValue(WKDictionaryRef, const char* key);
-double doubleValue(WKDictionaryRef, const char* key);
-WKStringRef stringValue(WKDictionaryRef, const char* key);
-uint64_t uint64Value(WKDictionaryRef, const char* key);
-
-std::optional<double> optionalDoubleValue(WKDictionaryRef, const char* key);
-
 template<typename T> void setValue(const WKRetainPtr<WKMutableDictionaryRef>&, const char* key, const WKRetainPtr<T>& value);
 void setValue(const WKRetainPtr<WKMutableDictionaryRef>&, const char* key, bool value);
 void setValue(const WKRetainPtr<WKMutableDictionaryRef>&, const char* key, const char* value);
@@ -78,6 +55,11 @@ inline bool booleanValue(const WKRetainPtr<WKTypeRef>& value)
 inline WKDictionaryRef dictionaryValue(WKTypeRef value)
 {
     return value && WKGetTypeID(value) == WKDictionaryGetTypeID() ? static_cast<WKDictionaryRef>(value) : nullptr;
+}
+
+inline WKArrayRef arrayValue(WKTypeRef value)
+{
+    return value && WKGetTypeID(value) == WKArrayGetTypeID() ? static_cast<WKArrayRef>(value) : nullptr;
 }
 
 inline double doubleValue(WKTypeRef value)

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -246,16 +246,6 @@ void InjectedBundle::didReceiveMessageToPage(WKBundlePageRef page, WKStringRef m
         return;
     }
 
-    if (WKStringIsEqualToUTF8CString(messageName, "CallRemoveChromeInputFieldCallback")) {
-        m_testRunner->callRemoveChromeInputFieldCallback();
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "CallSetBackingScaleFactorCallback")) {
-        m_testRunner->callSetBackingScaleFactorCallback();
-        return;
-    }
-
     if (WKStringIsEqualToUTF8CString(messageName, "CallDidBeginSwipeCallback")) {
         m_testRunner->callDidBeginSwipeCallback();
         return;
@@ -273,11 +263,6 @@ void InjectedBundle::didReceiveMessageToPage(WKBundlePageRef page, WKStringRef m
 
     if (WKStringIsEqualToUTF8CString(messageName, "CallDidRemoveSwipeSnapshotCallback")) {
         m_testRunner->callDidRemoveSwipeSnapshotCallback();
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "CallDidRemoveAllSessionCredentialsCallback")) {
-        m_testRunner->callDidRemoveAllSessionCredentialsCallback();
         return;
     }
 
@@ -313,16 +298,6 @@ void InjectedBundle::didReceiveMessageToPage(WKBundlePageRef page, WKStringRef m
 
     if (WKStringIsEqualToUTF8CString(messageName, "WebsiteDataScanForRegistrableDomainsFinished")) {
         m_testRunner->statisticsDidScanDataRecordsCallback();
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "CallDidSetAppBoundDomains")) {
-        m_testRunner->didSetAppBoundDomainsCallback();
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "CallDidSetManagedDomains")) {
-        m_testRunner->didSetManagedDomainsCallback();
         return;
     }
 
@@ -496,16 +471,6 @@ void InjectedBundle::outputText(StringView output, IsFinalTestOutput isFinalTest
 void InjectedBundle::postNewBeforeUnloadReturnValue(bool value)
 {
     postPageMessage("BeforeUnloadReturnValue", value);
-}
-
-void InjectedBundle::postRemoveChromeInputField()
-{
-    postPageMessage("RemoveChromeInputField");
-}
-
-void InjectedBundle::postSetBackingScaleFactor(double backingScaleFactor)
-{
-    postPageMessage("SetBackingScaleFactor", adoptWK(WKDoubleCreate(backingScaleFactor)));
 }
 
 void InjectedBundle::postSetWindowIsKey(bool isKey)

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
@@ -82,8 +82,6 @@ public:
     void outputText(StringView, IsFinalTestOutput = IsFinalTestOutput::No);
     void dumpToStdErr(const String&);
     void postNewBeforeUnloadReturnValue(bool);
-    void postRemoveChromeInputField();
-    void postSetBackingScaleFactor(double);
     void postSetWindowIsKey(bool);
     void postSetViewSize(double width, double height);
     void postSimulateWebNotificationClick(WKDataRef notificationID);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -279,9 +279,6 @@ public:
 
     void setViewSize(double width, double height);
 
-    void callRemoveChromeInputFieldCallback();
-    void callSetBackingScaleFactorCallback();
-
     static void overridePreference(JSStringRef preference, JSStringRef value);
 
     // Cookies testing
@@ -487,7 +484,6 @@ public:
     void setUseSeparateServiceWorkerProcess(bool);
 
     void removeAllSessionCredentials(JSContextRef, JSValueRef);
-    void callDidRemoveAllSessionCredentialsCallback();
     
     void getApplicationManifestThen(JSContextRef, JSValueRef);
 
@@ -511,10 +507,7 @@ public:
     bool hasAppBoundSession();
     void clearAppBoundSession();
     void setAppBoundDomains(JSContextRef, JSValueRef originArray, JSValueRef callback);
-    void didSetAppBoundDomainsCallback();
-
     void setManagedDomains(JSContextRef, JSValueRef originArray, JSValueRef callback);
-    void didSetManagedDomainsCallback();
 
     bool didLoadAppInitiatedRequest();
     bool didLoadNonAppInitiatedRequest();

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -273,8 +273,8 @@ public:
     void setStatisticsToSameSiteStrictCookies(WKStringRef hostName, CompletionHandler<void(WKTypeRef)>&&);
     void setStatisticsFirstPartyHostCNAMEDomain(WKStringRef firstPartyURLString, WKStringRef cnameURLString, CompletionHandler<void(WKTypeRef)>&&);
     void setStatisticsThirdPartyCNAMEDomain(WKStringRef cnameURLString, CompletionHandler<void(WKTypeRef)>&&);
-    void setAppBoundDomains(WKArrayRef originURLs);
-    void setManagedDomains(WKArrayRef originURLs);
+    void setAppBoundDomains(WKArrayRef originURLs, CompletionHandler<void(WKTypeRef)>&&);
+    void setManagedDomains(WKArrayRef originURLs, CompletionHandler<void(WKTypeRef)>&&);
     void statisticsResetToConsistentState();
 
     void removeAllCookies(CompletionHandler<void(WKTypeRef)>&&);
@@ -312,7 +312,7 @@ public:
     void resetStoragePersistedState();
     void clearStorage();
 
-    void removeAllSessionCredentials();
+    void removeAllSessionCredentials(CompletionHandler<void(WKTypeRef)>&&);
 
     void clearIndexedDatabases();
     void clearLocalStorage();
@@ -386,10 +386,6 @@ public:
     void markPrivateClickMeasurementsAsExpiredForTesting();
     void setPCMFraudPreventionValuesForTesting(WKStringRef unlinkableToken, WKStringRef secretToken, WKStringRef signature, WKStringRef keyID);
     void setPrivateClickMeasurementAppBundleIDForTesting(WKStringRef);
-
-    void didSetAppBoundDomains() const;
-
-    void didSetManagedDomains() const;
 
     WKURLRef currentTestURL() const;
 

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -387,18 +387,6 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         return;
     }
 
-    if (WKStringIsEqualToUTF8CString(messageName, "RemoveChromeInputField")) {
-        TestController::singleton().mainWebView()->removeChromeInputField();
-        postPageMessage("CallRemoveChromeInputFieldCallback");
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "SetBackingScaleFactor")) {
-        WKPageSetCustomBackingScaleFactor(TestController::singleton().mainWebView()->page(), doubleValue(messageBody));
-        postPageMessage("CallSetBackingScaleFactorCallback");
-        return;
-    }
-
     if (WKStringIsEqualToUTF8CString(messageName, "SimulateWebNotificationClick")) {
         WKDataRef notificationID = dataValue(messageBody);
         TestController::singleton().simulateWebNotificationClick(notificationID);
@@ -682,23 +670,6 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
 
     if (WKStringIsEqualToUTF8CString(messageName, "DumpPolicyDelegateCallbacks")) {
         TestController::singleton().dumpPolicyDelegateCallbacks();
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "RemoveAllSessionCredentials")) {
-        TestController::singleton().removeAllSessionCredentials();
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "SetAppBoundDomains")) {
-        ASSERT(WKGetTypeID(messageBody) == WKArrayGetTypeID());
-        TestController::singleton().setAppBoundDomains(static_cast<WKArrayRef>(messageBody));
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "SetManagedDomains")) {
-        ASSERT(WKGetTypeID(messageBody) == WKArrayGetTypeID());
-        TestController::singleton().setManagedDomains(static_cast<WKArrayRef>(messageBody));
         return;
     }
 
@@ -1490,21 +1461,6 @@ void TestInvocation::didRemoveSwipeSnapshot()
 void TestInvocation::notifyDownloadDone()
 {
     postPageMessage("NotifyDownloadDone");
-}
-
-void TestInvocation::didRemoveAllSessionCredentials()
-{
-    postPageMessage("CallDidRemoveAllSessionCredentialsCallback");
-}
-
-void TestInvocation::didSetAppBoundDomains()
-{
-    postPageMessage("CallDidSetAppBoundDomains");
-}
-
-void TestInvocation::didSetManagedDomains()
-{
-    postPageMessage("CallDidSetManagedDomains");
 }
 
 void TestInvocation::dumpResourceLoadStatistics()

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -72,12 +72,6 @@ public:
 
     void notifyDownloadDone();
 
-    void didRemoveAllSessionCredentials();
-
-    void didSetAppBoundDomains();
-
-    void didSetManagedDomains();
-
     void dumpResourceLoadStatistics();
 
     bool canOpenWindows() const { return m_canOpenWindows; }

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -60,6 +60,7 @@
 #import <WebKit/_WKWebsiteDataStoreConfiguration.h>
 #import <pal/spi/cocoa/LaunchServicesSPI.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/CompletionHandler.h>
 #import <wtf/MainThread.h>
 #import <wtf/RunLoop.h>
 #import <wtf/UniqueRef.h>
@@ -504,12 +505,12 @@ unsigned TestController::imageCountInGeneralPasteboard() const
     return imagesArray.count;
 }
 
-void TestController::removeAllSessionCredentials()
+void TestController::removeAllSessionCredentials(CompletionHandler<void(WKTypeRef)>&& completionHandler)
 {
     auto types = adoptNS([[NSSet alloc] initWithObjects:_WKWebsiteDataTypeCredentials, nil]);
-    [[globalWebViewConfiguration() websiteDataStore] removeDataOfTypes:types.get() modifiedSince:[NSDate distantPast] completionHandler:^() {
-        m_currentInvocation->didRemoveAllSessionCredentials();
-    }];
+    [[globalWebViewConfiguration() websiteDataStore] removeDataOfTypes:types.get() modifiedSince:[NSDate distantPast] completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)] () mutable {
+        completionHandler(nullptr);
+    }).get()];
 }
 
 bool TestController::didLoadAppInitiatedRequest()


### PR DESCRIPTION
#### 375cdc397ac2d646c8f43ed094ce1d2a18790005
<pre>
Expand use of WKBundlePagePostMessageWithAsyncReply in WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=273359">https://bugs.webkit.org/show_bug.cgi?id=273359</a>
<a href="https://rdar.apple.com/127169842">rdar://127169842</a>

Reviewed by Charlie Wolfe.

Not only does it reduce boilerplate code, but it also works better with site isolation
by sending the reply to the originating process instead of the main frame process.

* Tools/WebKitTestRunner/DictionaryFunctions.h:
(WTR::arrayValue):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::didReceiveMessageToPage):
(WTR::InjectedBundle::postRemoveChromeInputField): Deleted.
(WTR::InjectedBundle::postSetBackingScaleFactor): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::removeChromeInputField):
(WTR::TestRunner::setBackingScaleFactor):
(WTR::TestRunner::removeAllSessionCredentials):
(WTR::TestRunner::setAppBoundDomains):
(WTR::TestRunner::setManagedDomains):
(WTR::TestRunner::callRemoveChromeInputFieldCallback): Deleted.
(WTR::TestRunner::callSetBackingScaleFactorCallback): Deleted.
(WTR::TestRunner::callDidRemoveAllSessionCredentialsCallback): Deleted.
(WTR::TestRunner::didSetAppBoundDomainsCallback): Deleted.
(WTR::TestRunner::didSetManagedDomainsCallback): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::didReceiveAsyncMessageFromInjectedBundle):
(WTR::TestController::removeAllSessionCredentials):
(WTR::TestController::setAppBoundDomains):
(WTR::TestController::setManagedDomains):
(WTR::AppBoundDomainsCallbackContext::AppBoundDomainsCallbackContext): Deleted.
(WTR::didSetAppBoundDomainsCallback): Deleted.
(WTR::ManagedDomainsCallbackContext::ManagedDomainsCallbackContext): Deleted.
(WTR::didSetManagedDomainsCallback): Deleted.
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):
(WTR::TestInvocation::didRemoveAllSessionCredentials): Deleted.
(WTR::TestInvocation::didSetAppBoundDomains): Deleted.
(WTR::TestInvocation::didSetManagedDomains): Deleted.
* Tools/WebKitTestRunner/TestInvocation.h:
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::removeAllSessionCredentials):

Canonical link: <a href="https://commits.webkit.org/278105@main">https://commits.webkit.org/278105@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6f1f14dc8c0f224e56988462a8415abbbdb79ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52668 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/102 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51733 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34727 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26331 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40347 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51529 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26257 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42583 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21464 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23713 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43765 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7798 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45630 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54180 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24511 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20699 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47712 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25783 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42786 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46721 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26622 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7112 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25506 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->