### PR TITLE
Switch the ConnectionMap lock to os_unfair_lock

### DIFF
--- a/Source/WTF/wtf/Locker.h
+++ b/Source/WTF/wtf/Locker.h
@@ -58,7 +58,7 @@ template<typename T> class DropLockForScope;
 using AdoptLockTag = std::adopt_lock_t;
 constexpr AdoptLockTag AdoptLock;
 
-template<typename T>
+template<typename T, typename = void>
 class [[nodiscard]] Locker : public AbstractLocker { // NOLINT
 public:
     explicit Locker(T& lockable) : m_lockable(&lockable) { lock(); }

--- a/Source/WTF/wtf/PlatformEnableCocoa.h
+++ b/Source/WTF/wtf/PlatformEnableCocoa.h
@@ -1017,3 +1017,7 @@
 #if !defined(ENABLE_QUICKLOOK_SANDBOX_RESTRICTIONS) && PLATFORM(IOS)
 #define ENABLE_QUICKLOOK_SANDBOX_RESTRICTIONS 1
 #endif
+
+#if __has_include(<os/lock.h>) && !defined(ENABLE_UNFAIR_LOCK)
+#define ENABLE_UNFAIR_LOCK 1
+#endif


### PR DESCRIPTION
#### d4b4c478068cdfd2b2ffe86a776be750779351ba
<pre>
Switch the ConnectionMap lock to os_unfair_lock
<a href="https://rdar.apple.com/127171137">rdar://127171137</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=273360">https://bugs.webkit.org/show_bug.cgi?id=273360</a>

Reviewed by Chris Dumez.

The ConnectionMap is accessed from multiple threads (obviously, since it&apos;s guarded with a lock)
Sometimes, a background thread accessing it is really low priority. e.g. The &quot;Log Queue&quot; thread.

In these cases, the extremely low priority background thread can be preempted while holding the lock.
Which causes the main thread to hang when also trying to acquire it, such as when tearing down a Connection.

This situation was radically improved in <a href="https://commits.webkit.org/278072@main">https://commits.webkit.org/278072@main</a> by holding the lock for
a significantly lower amount of time, protecting just the memory reads of a hash lookup.

But the fundamental problem still exists - Because our standard WTF Lock &quot;spinlock&quot; doesn&apos;t participate in
donation, aren&apos;t priority inheriting, etc...  The fundamental problem still exists.

So this patch introduces WTF::UnfairLock to wrap os_unfair_lock, and switches the ConnectionMap lock to use
it on platforms that support it.

It maintains all the decorations for thread safety analysis, etc.
It also removes some bits from the Connection class itself to reduce the chance that a client can hog the lock
for longer than necessary going forward.

* Source/WTF/wtf/Lock.h:
* Source/WTF/wtf/Locker.h:
* Source/WTF/wtf/PlatformEnableCocoa.h:
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::WTF_REQUIRES_LOCK):
(IPC::Connection::connection):
(IPC::Connection::connectionMap): Deleted.
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::send):

Canonical link: <a href="https://commits.webkit.org/278088@main">https://commits.webkit.org/278088@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46584aa7afc4ff801d5978d5faed03fa8b6453c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49434 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52470 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52673 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/107 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34732 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26336 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40354 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26262 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42594 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21471 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23718 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43776 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7803 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/42739 "Found 6 new JSC stress test failures: stress/proxy-basic.js.ftl-eager-no-cjit, stress/proxy-revoke.js.ftl-eager-no-cjit, stress/reflect-set-proxy-set.js.ftl-eager-no-cjit, stress/reflect-set-receiver-proxy-set.js.ftl-eager-no-cjit, stress/super-get-by-id.js.ftl-eager-no-cjit, stress/v8-typedarray-resizablearraybuffer-array-methods.js.ftl-eager-no-cjit (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45635 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44278 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54185 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/48927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24516 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20706 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47719 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25788 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42794 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46729 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10861 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26627 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56417 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25511 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11587 "Passed tests") | 
<!--EWS-Status-Bubble-End-->