### PR TITLE
Writing suggestions sometimes show up in the middle of previous paragraphs in `textarea`s

### DIFF
--- a/LayoutTests/editing/input/mac/writing-suggestions-textarea-multiple-lines-expected.txt
+++ b/LayoutTests/editing/input/mac/writing-suggestions-textarea-multiple-lines-expected.txt
@@ -1,0 +1,20 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x326
+  RenderBlock {HTML} at (0,0) size 800x326
+    RenderBody {BODY} at (8,8) size 784x310
+      RenderText {#text} at (0,0) size 0x0
+      RenderText {#text} at (0,0) size 0x0
+layer at (8,8) size 306x306 clip at (9,9) size 304x304
+  RenderTextControl {TEXTAREA} at (0,0) size 306x306 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (3,3) size 300x54
+      RenderText {#text} at (0,0) size 106x18
+        text run at (0,0) width 106: "good morning."
+        text run at (105,0) width 1: " "
+      RenderBR {BR} at (0,18) size 0x18
+      RenderText {#text} at (0,36) size 44x18
+        text run at (0,36) width 44: "My na"
+      RenderInline (generated) at (43,36) size 40x18 [color=color(srgb 0 0 0 / 0.5)]
+        RenderText at (43,36) size 40x18
+          text run at (43,36) width 40: "me is"
+caret: position 5 of child 2 {#text} of child 0 {DIV} of {#document-fragment} of child 1 {TEXTAREA} of body

--- a/LayoutTests/editing/input/mac/writing-suggestions-textarea-multiple-lines.html
+++ b/LayoutTests/editing/input/mac/writing-suggestions-textarea-multiple-lines.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+textarea {
+    font-size: 16px;
+    width: 300px;
+    height: 300px;
+    caret-color: transparent;
+}
+</style>
+</head>
+<body>
+<textarea id="textarea">good morning.
+</textarea>
+<script>
+addEventListener("load", async () => {
+    const editor = document.getElementById('textarea');
+
+    const shadowRoot = internals.shadowRoot(editor);
+
+    shadowRoot.childNodes[0].appendChild(document.createTextNode("My na"));
+
+    editor.focus();
+    editor.selectionStart = 20;
+    editor.selectionEnd = 20;
+    testRunner.waitUntilDone();
+
+    await UIHelper.setInlinePrediction("name is", 2);
+    await UIHelper.ensurePresentationUpdate();
+
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1908,5 +1908,6 @@ webkit.org/b/272685 [ Ventura+ x86_64 ] imported/w3c/web-platform-tests/svg/pain
 
 # Inline predictions are only supported on Sonoma and later.
 [ Monterey Ventura ] editing/input/mac/show-inline-prediction-with-adjacent-text.html [ Skip ]
+[ Monterey Ventura ] editing/input/mac/writing-suggestions-textarea-multiple-lines.html [ Skip ]
 
 webkit.org/b/273012 [ Ventura+ x86_64 ] imported/w3c/web-platform-tests/svg/painting/reftests/percentage.svg [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -304,19 +304,19 @@ void RenderTreeUpdater::GeneratedContent::updateWritingSuggestionsRenderer(Rende
         return;
     }
 
-    auto* firstChildText = dynamicDowncast<RenderText>(renderer.firstChild());
-    if (!firstChildText) {
+    CheckedPtr nodeBeforeWritingSuggestionsTextRenderer = dynamicDowncast<RenderText>(nodeBeforeWritingSuggestions->renderer());
+    if (!nodeBeforeWritingSuggestionsTextRenderer) {
         destroyWritingSuggestionsIfNeeded();
         return;
     }
 
-    auto textWithoutSuggestion = firstChildText->text();
+    auto textWithoutSuggestion = nodeBeforeWritingSuggestionsTextRenderer->text();
 
     auto offset = writingSuggestionData->offset();
     auto prefix = textWithoutSuggestion.substring(0, offset);
     auto suffix = textWithoutSuggestion.substring(offset);
 
-    firstChildText->setText(prefix);
+    nodeBeforeWritingSuggestionsTextRenderer->setText(prefix);
 
     auto newStyle = RenderStyle::clone(*style);
     if (auto writingSuggestionsRenderer = editor.writingSuggestionRenderer()) {
@@ -363,7 +363,7 @@ void RenderTreeUpdater::GeneratedContent::updateWritingSuggestionsRenderer(Rende
         editor.setWritingSuggestionRenderer(*newWritingSuggestionsRenderer.get());
         m_updater.m_builder.attach(renderer, WTFMove(newWritingSuggestionsRenderer), rendererAfterWritingSuggestions.get());
 
-        auto* prefixNode = firstChildText->textNode();
+        auto* prefixNode = nodeBeforeWritingSuggestionsTextRenderer->textNode();
         if (!prefixNode) {
             ASSERT_NOT_REACHED();
             destroyWritingSuggestionsIfNeeded();


### PR DESCRIPTION
#### 7685053aabfc692b2b35b2b6885eaa2af68da6ef
<pre>
Writing suggestions sometimes show up in the middle of previous paragraphs in `textarea`s
<a href="https://bugs.webkit.org/show_bug.cgi?id=273365">https://bugs.webkit.org/show_bug.cgi?id=273365</a>
<a href="https://rdar.apple.com/127129683">rdar://127129683</a>

Reviewed by Wenson Hsieh.

The logic that inserts the writing suggestions renderer was incorrectly assuming that the renderer
which corresponds to the node before the writing suggestion would always just be the first text
child node of the current renderer. While this is true for trivial `contenteditable` `div`s, which
have several `RenderBlock`s, and one `RenderText` per block, this is not true for `textarea`s,
which can and do have multiple `RenderText`s per block, nor is this true in the general case of
arbitrary HTML.

Since the node before the writing suggestions renderer is known already, its renderer is the correct
one to use, and doesn&apos;t make any assumptions about the number of children of a renderer.

* LayoutTests/editing/input/mac/writing-suggestions-textarea-multiple-lines-expected.txt: Added.
* LayoutTests/editing/input/mac/writing-suggestions-textarea-multiple-lines.html: Added.
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
(WebCore::RenderTreeUpdater::GeneratedContent::updateWritingSuggestionsRenderer):

Canonical link: <a href="https://commits.webkit.org/278140@main">https://commits.webkit.org/278140@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a5fc47d96322b99313aa8a1b42ad67261fed30d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49551 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52598 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52793 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/227 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51855 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26455 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40456 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51651 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26375 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42690 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21571 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23835 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43873 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7922 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45749 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44378 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54369 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24636 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20820 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47827 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25905 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46848 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10888 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26749 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25629 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->