### PR TITLE
[Buildstream SDK] Backport GTK startup assert fix

### DIFF
--- a/Tools/buildstream/elements/sdk/gtk.bst
+++ b/Tools/buildstream/elements/sdk/gtk.bst
@@ -4,6 +4,8 @@ sources:
   url: gitlab_gnome_org:GNOME/gtk.git
   track: 4.*
   ref: 4.15.0-0-g1a3c5cf420392f76998974f54edc899e526b524d
+- kind: patch
+  path: patches/gtk/0001-wayland-Consistently-handle-enum-type.patch
 build-depends:
 - sdk-build-depends/sassc.bst
 - freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst

--- a/Tools/buildstream/patches/gtk/0001-wayland-Consistently-handle-enum-type.patch
+++ b/Tools/buildstream/patches/gtk/0001-wayland-Consistently-handle-enum-type.patch
@@ -1,0 +1,35 @@
+From 007e7c68dce68c2dcced89a1af4759f1956d9ab7 Mon Sep 17 00:00:00 2001
+From: Alice Mikhaylenko <alicem@gnome.org>
+Date: Mon, 22 Apr 2024 17:18:11 +0400
+Subject: [PATCH] wayland: Consistently handle enum type
+
+Fixes https://gitlab.gnome.org/GNOME/gtk/-/issues/6649
+---
+ gdk/wayland/gdkdisplay-wayland.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/gdk/wayland/gdkdisplay-wayland.c b/gdk/wayland/gdkdisplay-wayland.c
+index 70107360fe..bd260967e6 100644
+--- a/gdk/wayland/gdkdisplay-wayland.c
++++ b/gdk/wayland/gdkdisplay-wayland.c
+@@ -1917,6 +1917,7 @@ apply_portal_setting (TranslationEntry *entry,
+       entry->fallback.s = g_intern_string (g_variant_get_string (value, NULL));
+       break;
+     case G_TYPE_INT:
++    case G_TYPE_ENUM:
+       entry->fallback.i = g_variant_get_int32 (value);
+       break;
+     case G_TYPE_BOOLEAN:
+@@ -2166,6 +2167,9 @@ set_value_from_entry (GdkDisplay       *display,
+         case G_TYPE_BOOLEAN:
+           g_value_set_boolean (value, entry->fallback.b);
+           break;
++        case G_TYPE_ENUM:
++          g_value_set_enum (value, entry->fallback.i);
++          break;
+         case G_TYPE_NONE:
+           if (g_str_equal (entry->setting, "gtk-fontconfig-timestamp"))
+             g_value_set_uint (value, (guint)entry->fallback.i);
+-- 
+2.44.0
+


### PR DESCRIPTION
#### b8a213ced45bbdf0de563464a143039162ac9276
<pre>
[Buildstream SDK] Backport GTK startup assert fix
<a href="https://bugs.webkit.org/show_bug.cgi?id=273370">https://bugs.webkit.org/show_bug.cgi?id=273370</a>

Unreviewed, backport a GTK patch fixing an assert being raised at startup in Wayland.

* Tools/buildstream/elements/sdk/gtk.bst:
* Tools/buildstream/patches/gtk/0001-wayland-Consistently-handle-enum-type.patch: Added.

Canonical link: <a href="https://commits.webkit.org/278086@main">https://commits.webkit.org/278086@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a621a946015a8dd8544bbb026e0b79f2a113f201

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52689 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/123 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51754 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26352 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51550 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26280 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/21486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23738 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7819 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45654 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/44295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54201 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24532 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25804 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26643 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7107 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25527 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->