### PR TITLE
[visionOS] AVPlayerLayer goes blank when transitioning to LinearMediaKit fullscreen

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -370,7 +370,6 @@ private:
     std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics(AVPlayerLayer*) const;
 
     void setVideoReceiverEndpoint(const VideoReceiverEndpoint&) final;
-    void clearVideoReceiverEndpoint();
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
     const String& defaultSpatialTrackingLabel() const;
@@ -381,6 +380,8 @@ private:
 
     void updateSpatialTrackingLabel();
 #endif
+
+    void isInFullscreenOrPictureInPictureChanged(bool) final;
 
     RetainPtr<AVURLAsset> m_avAsset;
     RetainPtr<AVPlayer> m_avPlayer;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -4081,7 +4081,7 @@ void MediaPlayerPrivateAVFoundationObjC::setVideoReceiverEndpoint(const VideoRec
     assertIsMainThread();
 
     if (!endpoint) {
-        clearVideoReceiverEndpoint();
+        [m_videoLayer setPlayer:m_avPlayer.get()];
         return;
     }
 
@@ -4092,23 +4092,22 @@ void MediaPlayerPrivateAVFoundationObjC::setVideoReceiverEndpoint(const VideoRec
 
     m_videoTarget = adoptCF(videoTarget);
     [m_avPlayer addVideoTarget:m_videoTarget.get()];
-    [m_videoLayer setPlayer:nil];
 #else
     UNUSED_PARAM(endpoint);
 #endif
 }
 
-void MediaPlayerPrivateAVFoundationObjC::clearVideoReceiverEndpoint()
+void MediaPlayerPrivateAVFoundationObjC::isInFullscreenOrPictureInPictureChanged(bool isInFullscreenOrPictureInPicture)
 {
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     assertIsMainThread();
 
-    RetainPtr videoTarget = std::exchange(m_videoTarget, nullptr);
-    if (!videoTarget)
-        return;
-
-    [m_videoLayer setPlayer:m_avPlayer.get()];
-    [m_avPlayer removeVideoTarget:videoTarget.get()];
+    if (isInFullscreenOrPictureInPicture)
+        [m_videoLayer setPlayer:nil];
+    else if (RetainPtr videoTarget = std::exchange(m_videoTarget, nullptr))
+        [m_avPlayer removeVideoTarget:videoTarget.get()];
+#else
+    UNUSED_PARAM(isInFullscreenOrPictureInPicture);
 #endif
 }
 


### PR DESCRIPTION
#### d6c40da0535c2a51f51a07747750b4bdc101a28b
<pre>
[visionOS] AVPlayerLayer goes blank when transitioning to LinearMediaKit fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=273373">https://bugs.webkit.org/show_bug.cgi?id=273373</a>
<a href="https://rdar.apple.com/127199127">rdar://127199127</a>

Reviewed by Jer Noble.

When transitioning to LinearMediaKit fullscreen during AVPlayer-based playback,
MediaPlayerPrivateAVFoundationObjC would immediately remove the AVPlayer from its AVPlayerLayer,
causing the layer to go blank. Resolved this by deferring removal of the AVPlayer until the
fullscreen transition completes. Conversely, deferred removing the FigVideoTarget from the AVPlayer
until the transition back to inline completes.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::setVideoReceiverEndpoint):
(WebCore::MediaPlayerPrivateAVFoundationObjC::isInFullscreenOrPictureInPictureChanged):
(WebCore::MediaPlayerPrivateAVFoundationObjC::clearVideoReceiverEndpoint): Deleted.

Canonical link: <a href="https://commits.webkit.org/278092@main">https://commits.webkit.org/278092@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8950362685fb345017a529588e6e0fea631b1cf1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49459 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52698 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/132 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51763 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34758 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26361 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40377 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51559 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26288 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42615 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21495 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23746 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43799 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7828 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45662 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44303 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54210 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24541 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20732 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47744 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25813 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46758 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10865 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26652 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25536 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->