### PR TITLE
Drop StringImpl::characters8() / characters16()

### DIFF
--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -723,9 +723,9 @@ public:
         unsigned size = m_length;
         const void* payload;
         if (m_is8Bit)
-            payload = impl->characters8();
+            payload = impl->span8().data();
         else {
-            payload = impl->characters16();
+            payload = impl->span16().data();
             size *= 2;
         }
 

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -1181,7 +1181,7 @@ void FastStringifier<CharType>::append(JSValue value)
             if (needComma)
                 m_buffer[m_length++] = ',';
             m_buffer[m_length] = '"';
-            auto* characters = name.characters8();
+            auto characters = name.span8();
             for (unsigned i = 0; i < nameLength; ++i) {
                 auto character = characters[i];
                 if (UNLIKELY(WTF::escapedFormsForJSON[character])) {

--- a/Source/JavaScriptCore/runtime/JSString.cpp
+++ b/Source/JavaScriptCore/runtime/JSString.cpp
@@ -76,9 +76,9 @@ void JSString::dumpToStream(const JSCell* cell, PrintStream& out)
     } else {
         if (WTF::StringImpl* ourImpl = bitwise_cast<StringImpl*>(pointer)) {
             if (ourImpl->is8Bit())
-                out.printf("[8 %p]", ourImpl->characters8());
+                out.printf("[8 %p]", ourImpl->span8().data());
             else
-                out.printf("[16 %p]", ourImpl->characters16());
+                out.printf("[16 %p]", ourImpl->span16().data());
         }
     }
     out.printf(">");

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -1356,12 +1356,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSplitFast, (JSGlobalObject* globalObject
     StringImpl* separatorImpl = separator.impl();
 
     if (separatorLength == 1) {
-        UChar separatorCharacter;
-        if (separatorImpl->is8Bit())
-            separatorCharacter = separatorImpl->characters8()[0];
-        else
-            separatorCharacter = separatorImpl->characters16()[0];
-
+        UChar separatorCharacter = separatorImpl->at(0);
         if (stringImpl->is8Bit()) {
             if (splitStringByOneCharacterImpl<LChar>(result, stringImpl, separatorCharacter, limit))
                 RELEASE_AND_RETURN(scope, JSValue::encode(cacheAndCreateArray()));

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -680,6 +680,12 @@ std::span<T, Extent> spanReinterpretCast(std::span<U, Extent> span)
 }
 
 template<typename T, std::size_t Extent>
+std::span<T, Extent> spanConstCast(std::span<const T, Extent> span)
+{
+    return std::span<T, Extent> { const_cast<T*>(span.data()), span.size() };
+}
+
+template<typename T, std::size_t Extent>
 std::span<const uint8_t, Extent == std::dynamic_extent ? std::dynamic_extent: Extent * sizeof(T)> asBytes(std::span<T, Extent> span)
 {
     return std::span<const uint8_t, Extent == std::dynamic_extent ? std::dynamic_extent: Extent * sizeof(T)> { reinterpret_cast<const uint8_t*>(span.data()), span.size_bytes() };
@@ -775,6 +781,7 @@ using WTF::roundUpToMultipleOf;
 using WTF::roundUpToMultipleOfNonPowerOfTwo;
 using WTF::roundDownToMultipleOf;
 using WTF::safeCast;
+using WTF::spanConstCast;
 using WTF::spanReinterpretCast;
 using WTF::tryBinarySearch;
 using WTF::valueOrCompute;

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -2544,14 +2544,14 @@ template<typename CharacterType> std::optional<URLParser::LCharBuffer> URLParser
     if (domain.containsOnlyASCII() && !subdomainStartsWithXNDashDash(domain)) {
         size_t length = domain.length();
         if (domain.is8Bit()) {
-            const LChar* characters = domain.characters8();
+            auto characters = domain.span8();
             ascii.appendUsingFunctor(length, [&](size_t i) {
                 if (UNLIKELY(isASCIIUpper(characters[i])))
                     syntaxViolation(iteratorForSyntaxViolationPosition);
                 return toASCIILower(characters[i]);
             });
         } else {
-            const UChar* characters = domain.characters16();
+            auto characters = domain.span16();
             ascii.appendUsingFunctor(length, [&](size_t i) {
                 if (UNLIKELY(isASCIIUpper(characters[i])))
                     syntaxViolation(iteratorForSyntaxViolationPosition);

--- a/Source/WTF/wtf/text/AtomString.cpp
+++ b/Source/WTF/wtf/text/AtomString.cpp
@@ -48,7 +48,7 @@ ALWAYS_INLINE AtomString AtomString::convertASCIICase() const
     unsigned length;
     const unsigned localBufferSize = 100;
     if (impl->is8Bit() && (length = impl->length()) <= localBufferSize) {
-        const LChar* characters = impl->characters8();
+        auto characters = impl->span8();
         unsigned failingIndex;
         for (unsigned i = 0; i < length; ++i) {
             if (type == CaseConvertType::Lower ? UNLIKELY(isASCIIUpper(characters[i])) : LIKELY(isASCIILower(characters[i]))) {

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -135,8 +135,8 @@ struct HashedUTF8CharactersTranslator {
 
         auto charactersLatin1 = spanReinterpretCast<const LChar>(characters.characters);
         if (string->is8Bit())
-            return WTF::equal(string->characters8(), charactersLatin1);
-        return WTF::equal(string->characters16(), charactersLatin1);
+            return WTF::equal(string->span8().data(), charactersLatin1);
+        return WTF::equal(string->span16().data(), charactersLatin1);
     }
 
     static void translate(AtomStringTable::StringEntry& location, const HashedUTF8Characters& characters, unsigned hash)

--- a/Source/WTF/wtf/text/StringBuilder.cpp
+++ b/Source/WTF/wtf/text/StringBuilder.cpp
@@ -93,9 +93,9 @@ void StringBuilder::shrink(unsigned newLength)
         }
         // Allocate a fresh buffer, with a copy of the characters we are keeping.
         if (m_buffer->is8Bit())
-            allocateBuffer<LChar>(m_buffer->characters<LChar>(), newLength);
+            allocateBuffer<LChar>(m_buffer->span8().data(), newLength);
         else
-            allocateBuffer<UChar>(m_buffer->characters<UChar>(), newLength);
+            allocateBuffer<UChar>(m_buffer->span16().data(), newLength);
         return;
     }
 
@@ -144,7 +144,7 @@ UChar* StringBuilder::extendBufferForAppendingWithUpconvert(unsigned requiredLen
         allocateBuffer<UChar>(characters<LChar>(), expandedCapacity(capacity(), requiredLength));
         if (UNLIKELY(hasOverflowed()))
             return nullptr;
-        return const_cast<UChar*>(m_buffer->characters<UChar>()) + std::exchange(m_length, requiredLength);
+        return const_cast<UChar*>(m_buffer->span16().data()) + std::exchange(m_length, requiredLength);
     }
     return extendBufferForAppending<UChar>(requiredLength);
 }

--- a/Source/WTF/wtf/text/StringBuilder.h
+++ b/Source/WTF/wtf/text/StringBuilder.h
@@ -158,11 +158,11 @@ inline void StringBuilder::append(UChar character)
 {
     if (m_buffer && m_length < m_buffer->length() && m_string.isNull()) {
         if (!m_buffer->is8Bit()) {
-            const_cast<UChar*>(m_buffer->characters<UChar>())[m_length++] = character;
+            spanConstCast(m_buffer->span16())[m_length++] = character;
             return;
         }
         if (isLatin1(character)) {
-            const_cast<LChar*>(m_buffer->characters<LChar>())[m_length++] = static_cast<LChar>(character);
+            spanConstCast(m_buffer->span8())[m_length++] = static_cast<LChar>(character);
             return;
         }
     }
@@ -173,9 +173,9 @@ inline void StringBuilder::append(LChar character)
 {
     if (m_buffer && m_length < m_buffer->length() && m_string.isNull()) {
         if (m_buffer->is8Bit())
-            const_cast<LChar*>(m_buffer->characters<LChar>())[m_length++] = character;
+            spanConstCast(m_buffer->span8())[m_length++] = character;
         else
-            const_cast<UChar*>(m_buffer->characters<UChar>())[m_length++] = character;
+            spanConstCast(m_buffer->span16())[m_length++] = character;
         return;
     }
     append(WTF::span(character));
@@ -292,7 +292,7 @@ template<typename CharacterType> inline const CharacterType* StringBuilder::char
         return nullptr;
     if (!m_string.isNull())
         return m_string.span<CharacterType>().data();
-    return m_buffer->characters<CharacterType>();
+    return m_buffer->span<CharacterType>().data();
 }
 
 template<typename... StringTypeAdapters> void StringBuilder::appendFromAdapters(StringTypeAdapters... adapters)

--- a/Source/WTF/wtf/text/StringBuilderInternals.h
+++ b/Source/WTF/wtf/text/StringBuilderInternals.h
@@ -75,7 +75,7 @@ template<typename CharacterType> CharacterType* StringBuilder::extendBufferForAp
 {
     if (m_buffer && requiredLength <= m_buffer->length()) {
         m_string = { };
-        return const_cast<CharacterType*>(m_buffer->characters<CharacterType>()) + std::exchange(m_length, requiredLength);
+        return const_cast<CharacterType*>(m_buffer->span<CharacterType>().data()) + std::exchange(m_length, requiredLength);
     }
     return extendBufferForAppendingSlowCase<CharacterType>(requiredLength);
 }
@@ -88,7 +88,7 @@ template<typename CharacterType> CharacterType* StringBuilder::extendBufferForAp
     reallocateBuffer(expandedCapacity(capacity(), requiredLength));
     if (UNLIKELY(hasOverflowed()))
         return nullptr;
-    return const_cast<CharacterType*>(m_buffer->characters<CharacterType>()) + std::exchange(m_length, requiredLength);
+    return const_cast<CharacterType*>(m_buffer->span<CharacterType>().data()) + std::exchange(m_length, requiredLength);
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -443,7 +443,7 @@ inline UChar String::characterAt(unsigned index) const
 {
     if (!m_impl || index >= m_impl->length())
         return 0;
-    return m_impl->is8Bit() ? m_impl->characters8()[index] : m_impl->characters16()[index];
+    return m_impl->at(index);
 }
 
 inline String WARN_UNUSED_RETURN makeStringByReplacingAll(const String& string, UChar target, UChar replacement)

--- a/Source/WebCore/css/parser/CSSTokenizerInputStream.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizerInputStream.cpp
@@ -44,11 +44,11 @@ void CSSTokenizerInputStream::advanceUntilNonWhitespace()
 {
     // Using ASCII whitespace here rather than CSS space since we don't do preprocessing
     if (m_string->is8Bit()) {
-        const LChar* characters = m_string->characters8();
+        auto characters = m_string->span8();
         while (m_offset < m_stringLength && isASCIIWhitespace(characters[m_offset]))
             ++m_offset;
     } else {
-        const UChar* characters = m_string->characters16();
+        auto characters = m_string->span16();
         while (m_offset < m_stringLength && isASCIIWhitespace(characters[m_offset]))
             ++m_offset;
     }

--- a/Source/WebCore/css/parser/CSSTokenizerInputStream.h
+++ b/Source/WebCore/css/parser/CSSTokenizerInputStream.h
@@ -73,11 +73,11 @@ public:
     unsigned skipWhilePredicate(unsigned offset)
     {
         if (m_string->is8Bit()) {
-            const LChar* characters8 = m_string->characters8();
+            auto characters8 = m_string->span8();
             while ((m_offset + offset) < m_stringLength && characterPredicate(characters8[m_offset + offset]))
                 ++offset;
         } else {
-            const UChar* characters16 = m_string->characters16();
+            auto characters16 = m_string->span16();
             while ((m_offset + offset) < m_stringLength && characterPredicate(characters16[m_offset + offset]))
                 ++offset;
         }

--- a/Source/WebCore/dom/DatasetDOMStringMap.cpp
+++ b/Source/WebCore/dom/DatasetDOMStringMap.cpp
@@ -93,16 +93,15 @@ static inline AtomString convertPropertyNameToAttributeName(const StringImpl& na
 
     buffer.append(std::span { dataPrefix });
 
-    const CharacterType* characters = name.characters<CharacterType>();
-    for (unsigned i = 0; i < length; ++i) {
-        CharacterType character = characters[i];
+    auto characters = name.span<CharacterType>();
+    for (auto character : characters) {
         if (isASCIIUpper(character)) {
             buffer.append('-');
             buffer.append(toASCIILower(character));
         } else
             buffer.append(character);
     }
-    return AtomString(buffer.span());
+    return buffer.span();
 }
 
 static AtomString convertPropertyNameToAttributeName(const String& name)

--- a/Source/WebCore/platform/text/SegmentedString.h
+++ b/Source/WebCore/platform/text/SegmentedString.h
@@ -169,9 +169,9 @@ inline SegmentedString::Substring::Substring(String&& passedString)
     if (length) {
         is8Bit = underlyingString.impl()->is8Bit();
         if (is8Bit)
-            currentCharacter8 = underlyingString.impl()->characters8();
+            currentCharacter8 = underlyingString.impl()->span8().data();
         else
-            currentCharacter16 = underlyingString.impl()->characters16();
+            currentCharacter16 = underlyingString.impl()->span16().data();
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
@@ -46,16 +46,16 @@ TEST(WTF, StringImplCreationFromLiteral)
     auto programmaticString = StringImpl::createWithoutCopying(span(programmaticStringData));
     ASSERT_EQ(strlen(programmaticStringData), programmaticString->length());
     ASSERT_TRUE(equal(programmaticString.get(), StringView::fromLatin1(programmaticStringData)));
-    ASSERT_EQ(programmaticStringData, reinterpret_cast<const char*>(programmaticString->characters8()));
+    ASSERT_EQ(programmaticStringData, reinterpret_cast<const char*>(programmaticString->span8().data()));
     ASSERT_TRUE(programmaticString->is8Bit());
 
     // AtomStringImpl from createWithoutCopying should use the same underlying string.
     auto atomStringWithTemplate = AtomStringImpl::add(stringWithTemplate.ptr());
     ASSERT_TRUE(atomStringWithTemplate->is8Bit());
-    ASSERT_EQ(atomStringWithTemplate->characters8(), stringWithTemplate->characters8());
+    ASSERT_EQ(atomStringWithTemplate->span8().data(), stringWithTemplate->span8().data());
     auto atomicProgrammaticString = AtomStringImpl::add(programmaticString.ptr());
     ASSERT_TRUE(atomicProgrammaticString->is8Bit());
-    ASSERT_EQ(atomicProgrammaticString->characters8(), programmaticString->characters8());
+    ASSERT_EQ(atomicProgrammaticString->span8().data(), programmaticString->span8().data());
 }
 
 TEST(WTF, StringImplReplaceWithLiteral)
@@ -643,7 +643,7 @@ TEST(WTF, StringImplStaticToAtomString)
     ASSERT_TRUE(original.isStatic());
 
     ASSERT_TRUE(atomic->is8Bit());
-    ASSERT_EQ(atomic->characters8(), original.characters8());
+    ASSERT_EQ(atomic->span8().data(), original.span8().data());
 
     auto result2 = AtomStringImpl::lookUp(&original);
     ASSERT_TRUE(result2);
@@ -774,7 +774,7 @@ TEST(WTF, ExternalStringImplCreate8bit)
         ASSERT_FALSE(external->isSymbol());
         ASSERT_FALSE(external->isAtom());
         ASSERT_EQ(external->length(), bufferStringLength);
-        ASSERT_EQ(external->characters8(), buffer);
+        ASSERT_EQ(external->span8().data(), buffer);
     }
 
     ASSERT_TRUE(freeFunctionCalled);
@@ -796,7 +796,7 @@ TEST(WTF, ExternalStringImplCreate16bit)
         ASSERT_FALSE(external->isSymbol());
         ASSERT_FALSE(external->isAtom());
         ASSERT_EQ(external->length(), bufferStringLength);
-        ASSERT_EQ(external->characters16(), buffer);
+        ASSERT_EQ(external->span16().data(), buffer);
     }
 
     ASSERT_TRUE(freeFunctionCalled);
@@ -825,7 +825,7 @@ TEST(WTF, ExternalStringAtom)
         ASSERT_FALSE(external->isSymbol());
         ASSERT_TRUE(external->is8Bit());
         ASSERT_EQ(external->length(), bufferStringLength);
-        ASSERT_EQ(external->characters8(), buffer);
+        ASSERT_EQ(external->span8().data(), buffer);
 
         auto result = AtomStringImpl::lookUp(external.ptr());
         ASSERT_FALSE(result);
@@ -836,7 +836,7 @@ TEST(WTF, ExternalStringAtom)
         ASSERT_FALSE(atomic->isSymbol());
         ASSERT_TRUE(atomic->is8Bit());
         ASSERT_EQ(atomic->length(), external->length());
-        ASSERT_EQ(atomic->characters8(), external->characters8());
+        ASSERT_EQ(atomic->span8().data(), external->span8().data());
 
         auto result2 = AtomStringImpl::lookUp(external.ptr());
         ASSERT_TRUE(result2);

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
@@ -329,7 +329,8 @@ static RetainPtr<dispatch_data_t> dataFromString(String&& s)
 {
     auto impl = s.releaseImpl();
     ASSERT(impl->is8Bit());
-    return adoptNS(dispatch_data_create(impl->characters8(), impl->length(), dispatch_get_main_queue(), ^{
+    auto characters = impl->span8();
+    return adoptNS(dispatch_data_create(characters.data(), characters.size(), dispatch_get_main_queue(), ^{
         (void)impl;
     }));
 }


### PR DESCRIPTION
#### 67a879c31de358001ebd9ab1006d534c14bd8de5
<pre>
Drop StringImpl::characters8() / characters16()
<a href="https://bugs.webkit.org/show_bug.cgi?id=273376">https://bugs.webkit.org/show_bug.cgi?id=273376</a>

Reviewed by Darin Adler.

Drop StringImpl::characters8() / characters16() in favor of span equivalents.

* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::CachedUniquedStringImplBase::encode):
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::FastStringifier&lt;CharType&gt;::append):
* Source/JavaScriptCore/runtime/JSString.cpp:
(JSC::JSString::dumpToStream):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/WTF/wtf/StdLibExtras.h:
(WTF::spanConstCast):
* Source/WTF/wtf/URLParser.cpp:
(WTF::URLParser::domainToASCII):
* Source/WTF/wtf/text/AtomString.cpp:
(WTF::AtomString::convertASCIICase const):
* Source/WTF/wtf/text/AtomStringImpl.cpp:
(WTF::HashAndUTF8CharactersTranslator::equal):
* Source/WTF/wtf/text/StringBuilder.cpp:
(WTF::StringBuilder::shrink):
(WTF::StringBuilder::extendBufferForAppendingWithUpconvert):
* Source/WTF/wtf/text/StringBuilder.h:
(WTF::StringBuilder::append):
(WTF::StringBuilder::characters const):
* Source/WTF/wtf/text/StringBuilderInternals.h:
(WTF::StringBuilder::extendBufferForAppending):
(WTF::StringBuilder::extendBufferForAppendingSlowCase):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::simplifyMatchedCharactersToSpace):
(WTF::StringImpl::find):
(WTF::equalInner):
(WTF::equalInternal):
(WTF::equal):
(WTF::equalIgnoringNullity):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::span8 const):
(WTF::StringImpl::span16 const):
(WTF::StringImpl::span&lt;LChar&gt; const):
(WTF::StringImpl::span&lt;UChar&gt; const):
(WTF::StringImpl::containsOnlyLatin1 const):
(WTF::StringImpl::removeCharactersImpl):
(WTF::StringImpl::removeCharacters):
(WTF::StringImpl::characters8 const): Deleted.
(WTF::StringImpl::characters16 const): Deleted.
(WTF::StringImpl::span const): Deleted.
(WTF::StringImpl::characters&lt;LChar&gt; const): Deleted.
(WTF::StringImpl::characters&lt;UChar&gt; const): Deleted.
* Source/WTF/wtf/text/WTFString.h:
(WTF::String::characterAt const):
* Source/WTF/wtf/text/cf/StringImplCF.cpp:
(WTF::StringImpl::createCFString):
* Source/WTF/wtf/unicode/UTF8Conversion.cpp:
(WTF::Unicode::equalUTF16WithUTF8):
(WTF::Unicode::equalLatin1WithUTF8):
* Source/WTF/wtf/unicode/UTF8Conversion.h:
* Source/WebCore/css/parser/CSSTokenizerInputStream.cpp:
(WebCore::CSSTokenizerInputStream::advanceUntilNonWhitespace):
* Source/WebCore/css/parser/CSSTokenizerInputStream.h:
(WebCore::CSSTokenizerInputStream::characterPredicate):
* Source/WebCore/dom/DatasetDOMStringMap.cpp:
(WebCore::convertPropertyNameToAttributeName):
* Source/WebCore/platform/text/SegmentedString.h:
(WebCore::SegmentedString::Substring::Substring):

Canonical link: <a href="https://commits.webkit.org/278108@main">https://commits.webkit.org/278108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a5c2e98b788621d607b215a7188d9a6ff644f69

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49476 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28758 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52715 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/149 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51780 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26378 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40389 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51576 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42626 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21507 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23761 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43809 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7845 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/42788 "Found 6 new JSC stress test failures: microbenchmarks/super-get-by-val-with-this-polymorphic.js.ftl-eager-no-cjit, stress/proxy-get-set-correct-receiver.js.ftl-eager-no-cjit, stress/proxy-has-property.js.ftl-eager-no-cjit, stress/proxy-own-keys.js.ftl-eager-no-cjit, stress/typedarray-defineOwnProperty-error.js.ftl-eager-no-cjit, stress/v8-typedarray-resizablearraybuffer.js.ftl-eager-no-cjit (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45675 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44315 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54227 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/48969 "Found 3 new JSC stress test failures: stress/poly-proto-using-inheritance.js.ftl-eager-no-cjit, stress/proxy-get-missing-handler-inline-cache.js.ftl-eager-no-cjit, stress/super-get-by-id.js.ftl-eager-no-cjit (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24559 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20743 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47758 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25830 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42815 "Build is in progress. Recent messages:") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46774 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26670 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56459 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7115 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25553 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11599 "Passed tests") | 
<!--EWS-Status-Bubble-End-->