### PR TITLE
[view-transitions] Assertion due to unbalanced begin/end transparency layers

### DIFF
--- a/LayoutTests/fast/css/view-transitions-nested-transparency-layers-expected.html
+++ b/LayoutTests/fast/css/view-transitions-nested-transparency-layers-expected.html
@@ -1,0 +1,10 @@
+<style>
+    .target {
+        width: 100px;
+        height: 100px;
+        contain: paint;
+        background: blue;
+        opacity: 0.5;
+    }
+</style>
+<div class="target"></div>

--- a/LayoutTests/fast/css/view-transitions-nested-transparency-layers.html
+++ b/LayoutTests/fast/css/view-transitions-nested-transparency-layers.html
@@ -1,0 +1,30 @@
+<html class="reftest-wait">
+<meta name="fuzzy" content="maxDifference=1; totalPixels=10000">
+<script>
+    function finishTest() {
+        document.documentElement.classList.remove("reftest-wait");
+    }
+    async function startTest() {
+        document.startViewTransition(() => requestAnimationFrame(() => requestAnimationFrame(finishTest)));
+    }
+    onload = () => requestAnimationFrame(() => requestAnimationFrame(startTest));
+</script>
+<style>
+    .parent {
+        width: 100px;
+        height: 100px;
+        opacity: 0.5;
+    }
+    .target {
+        width: 100px;
+        height: 100px;
+        contain: paint;
+        background: blue;
+        opacity: 0.5;
+        view-transition-name: target;
+    }
+    html::view-transition-group(target) { animation-duration: 300s; }
+    html::view-transition-new(target) { animation: unset; opacity: 0; }
+    html::view-transition-old(target) { animation: unset; opacity: 1; }
+</style>
+<div class="parent"><div class="target"></div></div>

--- a/LayoutTests/fast/css/view-transitions-unbalanced-transparency-layers-assertion-expected.txt
+++ b/LayoutTests/fast/css/view-transitions-unbalanced-transparency-layers-assertion-expected.txt
@@ -1,0 +1,2 @@
+Test passes if there is no assertion or crash.
+

--- a/LayoutTests/fast/css/view-transitions-unbalanced-transparency-layers-assertion.html
+++ b/LayoutTests/fast/css/view-transitions-unbalanced-transparency-layers-assertion.html
@@ -1,0 +1,15 @@
+Test passes if there is no assertion or crash.
+<head>
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+    </script>
+    <style>
+        * { opacity: 0.75 }
+    </style>
+</head>
+<body onload="document.startViewTransition()">
+    <div>
+        <li style="view-transition-name: a0">
+    </div>
+</body>

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1110,7 +1110,7 @@ private:
     void collectEventRegionForFragments(const LayerFragments&, GraphicsContext&, const LayerPaintingInfo&, OptionSet<PaintBehavior>);
     void collectAccessibilityRegionsForFragments(const LayerFragments&, GraphicsContext&, const LayerPaintingInfo&, OptionSet<PaintBehavior>);
 
-    RenderLayer* transparentPaintingAncestor();
+    RenderLayer* transparentPaintingAncestor(const LayerPaintingInfo&);
     void beginTransparencyLayers(GraphicsContext&, const LayerPaintingInfo&, const LayoutRect& dirtyRect);
 
     struct HitLayer {


### PR DESCRIPTION
#### aaecbac76dbf8704715a9859be1852db13c34817
<pre>
[view-transitions] Assertion due to unbalanced begin/end transparency layers
<a href="https://bugs.webkit.org/show_bug.cgi?id=273377">https://bugs.webkit.org/show_bug.cgi?id=273377</a>
<a href="https://rdar.apple.com/126279004">rdar://126279004</a>

Reviewed by Matt Woodrow.

Transparency layers were being applied for render layers that we are not painting.

* LayoutTests/fast/css/view-transitions-nested-transparency-layers-expected.html: Added.
* LayoutTests/fast/css/view-transitions-nested-transparency-layers.html: Added.
* LayoutTests/fast/css/view-transitions-unbalanced-transparency-layers-assertion-expected.txt: Added.
* LayoutTests/fast/css/view-transitions-unbalanced-transparency-layers-assertion.html: Added.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::transparentPaintingAncestor): Stop at root layer.
(WebCore::RenderLayer::beginTransparencyLayers): Pass LayerPaintingInfo in to transparentPaintingAncestor.
(WebCore::RenderLayer::paintLayerWithEffects): Stop at root layer.
* Source/WebCore/rendering/RenderLayer.h: Change private beginTransparencyLayers function to
take LayerPaintingInfo argument.

Canonical link: <a href="https://commits.webkit.org/278096@main">https://commits.webkit.org/278096@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d3130cd3e9c9c7792dbb49b29020f53ffb1c847

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28750 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52504 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52707 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/141 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26370 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40381 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26295 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42619 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21499 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23753 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43803 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7837 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45669 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54219 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24550 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20736 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47748 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25822 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46762 "Found 4 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/menulist, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/listbox, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/value/basic (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26661 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7109 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25545 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->