### PR TITLE
[iOS] Rebaseline several pasteboard-related layout tests

### DIFF
--- a/LayoutTests/editing/async-clipboard/clipboard-write-basic-expected.txt
+++ b/LayoutTests/editing/async-clipboard/clipboard-write-basic-expected.txt
@@ -9,7 +9,8 @@ PASS firstItem.types is ['text/plain', 'text/uri-list']
 PASS getType("text/plain") resolved to "The quick brown fox jumped over the lazy dog."
 PASS getType("text/uri-list") resolved to "https://www.apple.com/"
 Testing secondItem:
-PASS secondItem.types is ['text/uri-list', 'text/html']
+PASS secondItem.types.includes('text/uri-list') is true
+PASS secondItem.types.includes('text/html') is true
 PASS getType("text/uri-list") resolved to "https://webkit.org/"
 PASS fragment.querySelector('a').href is "https://webkit.org/"
 Testing thirdItem:

--- a/LayoutTests/editing/async-clipboard/clipboard-write-basic.html
+++ b/LayoutTests/editing/async-clipboard/clipboard-write-basic.html
@@ -48,7 +48,8 @@
                 await checkClipboardItemString(firstItem, "text/uri-list", "https://www.apple.com/");
 
                 debug("Testing secondItem:");
-                shouldBe("secondItem.types", "['text/uri-list', 'text/html']");
+                shouldBeTrue("secondItem.types.includes('text/uri-list')");
+                shouldBeTrue("secondItem.types.includes('text/html')");
                 await checkClipboardItemString(secondItem, "text/uri-list", "https://webkit.org/");
                 fragment = await loadDocument(await secondItem.getType("text/html"));
                 shouldBeEqualToString("fragment.querySelector('a').href", "https://webkit.org/");

--- a/LayoutTests/editing/async-clipboard/sanitize-when-reading-markup-expected.txt
+++ b/LayoutTests/editing/async-clipboard/sanitize-when-reading-markup-expected.txt
@@ -7,12 +7,12 @@ PASS Wrote markup to the clipboard.
 PASS finishedCopying became true
 PASS Read items from the clipboard.
 PASS items.length is 2
-PASS items[0].types is ['text/html']
+PASS items[0].types.includes('text/html') is true
 PASS fragment1.documentElement.textContent is "Hello world 1"
 PASS fragment1.querySelector('p') is non-null.
 PASS fragment1.querySelector('script') is null
 PASS fragment1.querySelector('p').onclick is null
-PASS items[1].types is ['text/html']
+PASS items[1].types.includes('text/html') is true
 PASS fragment2.documentElement.textContent is "Hello world 2"
 PASS fragment2.querySelector('span') is non-null.
 PASS fragment2.querySelector('p') is null

--- a/LayoutTests/editing/async-clipboard/sanitize-when-reading-markup.html
+++ b/LayoutTests/editing/async-clipboard/sanitize-when-reading-markup.html
@@ -33,14 +33,14 @@
                     testPassed("Read items from the clipboard.");
                     shouldBe("items.length", "2");
 
-                    shouldBe("items[0].types", "['text/html']");
+                    shouldBeTrue("items[0].types.includes('text/html')");
                     fragment1 = await loadDocument(await items[0].getType("text/html"));
                     shouldBeEqualToString("fragment1.documentElement.textContent", "Hello world 1");
                     shouldBeNonNull("fragment1.querySelector('p')");
                     shouldBeNull("fragment1.querySelector('script')");
                     shouldBeNull("fragment1.querySelector('p').onclick");
 
-                    shouldBe("items[1].types", "['text/html']");
+                    shouldBeTrue("items[1].types.includes('text/html')");
                     fragment2 = await loadDocument(await items[1].getType("text/html"));
                     shouldBeEqualToString("fragment2.documentElement.textContent", "Hello world 2");
                     shouldBeNonNull("fragment2.querySelector('span')");

--- a/LayoutTests/editing/pasteboard/data-transfer-set-data-sanitize-url-when-copying-in-null-origin-expected.txt
+++ b/LayoutTests/editing/pasteboard/data-transfer-set-data-sanitize-url-when-copying-in-null-origin-expected.txt
@@ -5,11 +5,15 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 PASS urlReadInSameDocument is "http://webkit.org/b/🤔?x=8 + 6<"
 PASS htmlReadInSameDocument is "testing"
-PASS JSON.stringify(typesInSameDocument) is "[\"text/uri-list\",\"text/html\"]"
-PASS JSON.stringify(itemsInSameDocument) is "[{\"kind\":\"string\",\"type\":\"text/uri-list\"},{\"kind\":\"string\",\"type\":\"text/html\"}]"
+PASS typesInSameDocument.includes("text/uri-list") is true
+PASS typesInSameDocument.includes("text/html") is true
+PASS JSON.stringify(itemsInSameDocument[0]) is "{\"kind\":\"string\",\"type\":\"text/uri-list\"}"
+PASS JSON.stringify(itemsInSameDocument[1]) is "{\"kind\":\"string\",\"type\":\"text/html\"}"
 PASS event.clipboardData.getData("url") is "http://webkit.org/b/%F0%9F%A4%94?x=8%20+%206%3C"
-PASS JSON.stringify(event.clipboardData.types) is "[\"text/uri-list\",\"text/html\"]"
-PASS JSON.stringify(Array.from(event.clipboardData.items).map((item) => ({kind: item.kind, type: item.type}))) is "[{\"kind\":\"string\",\"type\":\"text/uri-list\"},{\"kind\":\"string\",\"type\":\"text/html\"}]"
+PASS event.clipboardData.types.includes("text/uri-list") is true
+PASS event.clipboardData.types.includes("text/html") is true
+PASS JSON.stringify(pastedItems[0]) is "{\"kind\":\"string\",\"type\":\"text/uri-list\"}"
+PASS JSON.stringify(pastedItems[1]) is "{\"kind\":\"string\",\"type\":\"text/html\"}"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/editing/pasteboard/data-transfer-set-data-sanitize-url-when-copying-in-null-origin.html
+++ b/LayoutTests/editing/pasteboard/data-transfer-set-data-sanitize-url-when-copying-in-null-origin.html
@@ -58,9 +58,11 @@ onmessage = (event) => {
     htmlReadInSameDocument = event.data.html;
     shouldBeEqualToString('htmlReadInSameDocument', "testing");
     typesInSameDocument = event.data.types;
-    shouldBeEqualToString('JSON.stringify(typesInSameDocument)', '["text/uri-list","text/html"]');
+    shouldBeTrue('typesInSameDocument.includes("text/uri-list")');
+    shouldBeTrue('typesInSameDocument.includes("text/html")');
     itemsInSameDocument = event.data.items;
-    shouldBeEqualToString('JSON.stringify(itemsInSameDocument)', '[{"kind":"string","type":"text/uri-list"},{"kind":"string","type":"text/html"}]');
+    shouldBeEqualToString('JSON.stringify(itemsInSameDocument[0])', '{"kind":"string","type":"text/uri-list"}');
+    shouldBeEqualToString('JSON.stringify(itemsInSameDocument[1])', '{"kind":"string","type":"text/html"}');
     document.getElementById('destination').focus();
     if (window.testRunner)
         document.execCommand('paste');
@@ -68,9 +70,11 @@ onmessage = (event) => {
 
 function doPaste(event) {
     shouldBeEqualToString('event.clipboardData.getData("url")', (new URL(originalURL)).href);
-    shouldBeEqualToString('JSON.stringify(event.clipboardData.types)', '["text/uri-list","text/html"]');
-    shouldBeEqualToString('JSON.stringify(Array.from(event.clipboardData.items).map((item) => ({kind: item.kind, type: item.type})))',
-        '[{"kind":"string","type":"text/uri-list"},{"kind":"string","type":"text/html"}]');
+    shouldBeTrue('event.clipboardData.types.includes("text/uri-list")');
+    shouldBeTrue('event.clipboardData.types.includes("text/html")');
+    pastedItems = [...event.clipboardData.items].map(item => ({ kind: item.kind, type: item.type }));
+    shouldBeEqualToString('JSON.stringify(pastedItems[0])', '{"kind":"string","type":"text/uri-list"}');
+    shouldBeEqualToString('JSON.stringify(pastedItems[1])', '{"kind":"string","type":"text/html"}');
     document.getElementById('destination').remove();
     finishJSTest();
 }

--- a/LayoutTests/editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying-expected.txt
+++ b/LayoutTests/editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying-expected.txt
@@ -3,9 +3,9 @@ This tests getData strips away secrets and dangerous code when copying HTML in a
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS JSON.stringify(typesInSameDocument) is "[\"text/html\"]"
+PASS typesInSameDocument.includes("text/html") is true
 PASS htmlInSameDocument is "<meta content=\"secret\"><b onmouseover=\"dangerousCode()\">hello</b><!-- secret-->, world<script>dangerousCode()</script>"
-PASS JSON.stringify(itemsInSameDocument) is "[{\"kind\":\"string\",\"type\":\"text/html\"}]"
+PASS JSON.stringify(itemsInSameDocument[0]) is "{\"kind\":\"string\",\"type\":\"text/html\"}"
 PASS htmlInAnotherDocument.includes("secret") is false
 PASS htmlInAnotherDocument.includes("dangerousCode") is false
 PASS b = (new DOMParser).parseFromString(htmlInAnotherDocument, "text/html").querySelector("b"); b.textContent is "hello"

--- a/LayoutTests/editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying-in-null-origin-expected.txt
+++ b/LayoutTests/editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying-in-null-origin-expected.txt
@@ -3,15 +3,15 @@ This tests getData strips away secrets and dangerous code when copying inside a 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS JSON.stringify(typesInNullOrigin) is "[\"text/html\"]"
+PASS typesInNullOrigin.includes("text/html") is true
 PASS htmlInNullOrigin.includes("secret") is false
 PASS htmlInNullOrigin.includes("dangerousCode") is false
 PASS b = (new DOMParser).parseFromString(htmlInNullOrigin, "text/html").querySelector("b"); b.textContent is "hello"
 PASS b.parentNode.textContent is "hello, world"
-PASS JSON.stringify(itemsInNullOrigin) is "[{\"kind\":\"string\",\"type\":\"text/html\"}]"
+PASS JSON.stringify(itemsInNullOrigin[0]) is "{\"kind\":\"string\",\"type\":\"text/html\"}"
 PASS event.clipboardData.getData("text/html") is "<meta content=\"secret\"><b onmouseover=\"dangerousCode()\">hello</b><!-- secret-->, world<script>dangerousCode()</script>"
-PASS JSON.stringify(event.clipboardData.types) is "[\"text/html\"]"
-PASS JSON.stringify(Array.from(event.clipboardData.items).map((item) => ({kind: item.kind, type: item.type}))) is "[{\"kind\":\"string\",\"type\":\"text/html\"}]"
+PASS event.clipboardData.types.includes("text/html") is true
+PASS JSON.stringify(pastedItems[0]) is "{\"kind\":\"string\",\"type\":\"text/html\"}"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying-in-null-origin.html
+++ b/LayoutTests/editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying-in-null-origin.html
@@ -22,13 +22,15 @@ function runTest() {
     document.execCommand('copy');
 }
 
+let container = document.getElementById('container');
+
 var originalHTML = '<meta content="secret"><b onmouseover="dangerousCode()">hello</b><!-- secret-->, world<script>dangerousCode()</scr' + 'ipt>';
 function doCopy(event) {
     event.clipboardData.setData('text/html', originalHTML);
     event.preventDefault();
 
     const iframe = document.createElement('iframe');
-    document.getElementById('container').insertBefore(iframe, iframe.lastChild);
+    container.insertBefore(iframe, iframe.lastChild);
     iframe.src = `data:text/html;charset=utf-8,<!DOCTYPE html>
     <div id="destination" onpaste="doPaste(event)" contenteditable>2. Paste here</div>
     <script>
@@ -51,7 +53,7 @@ function doCopy(event) {
 
 onmessage = (event) => {
     typesInNullOrigin = event.data.types;
-    shouldBeEqualToString('JSON.stringify(typesInNullOrigin)', '["text/html"]');
+    shouldBeTrue('typesInNullOrigin.includes("text/html")');
 
     htmlInNullOrigin = event.data.html;
     shouldBeFalse('htmlInNullOrigin.includes("secret")');
@@ -60,7 +62,7 @@ onmessage = (event) => {
     shouldBeEqualToString('b.parentNode.textContent', 'hello, world');
 
     itemsInNullOrigin = event.data.items;
-    shouldBeEqualToString('JSON.stringify(itemsInNullOrigin)', '[{"kind":"string","type":"text/html"}]');
+    shouldBeEqualToString('JSON.stringify(itemsInNullOrigin[0])', '{"kind":"string","type":"text/html"}');
     document.getElementById('destination').focus();
     if (window.testRunner)
         document.execCommand('paste');
@@ -68,10 +70,10 @@ onmessage = (event) => {
 
 function doPaste(event) {
     shouldBeEqualToString('event.clipboardData.getData("text/html")', originalHTML);
-    shouldBeEqualToString('JSON.stringify(event.clipboardData.types)', '["text/html"]');
-    shouldBeEqualToString('JSON.stringify(Array.from(event.clipboardData.items).map((item) => ({kind: item.kind, type: item.type})))',
-        '[{"kind":"string","type":"text/html"}]');
-    document.getElementById('container').remove();
+    shouldBeTrue('event.clipboardData.types.includes("text/html")');
+    pastedItems = [...event.clipboardData.items].map(item => ({kind: item.kind, type: item.type}));
+    shouldBeEqualToString('JSON.stringify(pastedItems[0])', '{"kind":"string","type":"text/html"}');
+    container.style.display = "none";
     finishJSTest();
 }
 

--- a/LayoutTests/editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying.html
+++ b/LayoutTests/editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying.html
@@ -64,13 +64,13 @@ function doCopy(event) {
 
 onmessage = (event) => {
     typesInSameDocument = event.data.types;
-    shouldBeEqualToString('JSON.stringify(typesInSameDocument)', '["text/html"]');
+    shouldBeTrue('typesInSameDocument.includes("text/html")');
     htmlInSameDocument = event.data.html;
     originalHTML = event.data.originalHTML;
     shouldBeEqualToString('htmlInSameDocument', originalHTML);
 
     itemsInSameDocument = event.data.items;
-    shouldBeEqualToString('JSON.stringify(itemsInSameDocument)', '[{"kind":"string","type":"text/html"}]');
+    shouldBeEqualToString('JSON.stringify(itemsInSameDocument[0])', '{"kind":"string","type":"text/html"}');
 
     document.getElementById('destination').focus();
     if (window.testRunner)

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -6942,12 +6942,6 @@ webkit.org/b/271018 imported/w3c/web-platform-tests/svg/painting/reftests/marker
 
 webkit.org/b/271178 media/now-playing-webaudio.html [ Pass Failure ]
 
-# rdar://124417777 (REGRESSION (iOS 17.4): 5 editing / paste-related layout tests are constantly failing.)
-editing/async-clipboard/clipboard-write-basic.html [ Pass Failure ]
-editing/async-clipboard/sanitize-when-reading-markup.html [ Pass Failure ]
-editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying-in-null-origin.html [ Pass Failure ]
-editing/pasteboard/data-transfer-set-data-sanitize-url-when-copying-in-null-origin.html [ Pass Failure ]
-editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying.html [ Pass Failure ]
 # rdar://124971386 (REGRESSION (iOS 17.4): 2 imported WPT css-box/margin-trim/computed-margin-values layout tests are consistently failing.)
 imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-child-with-border.html [ Pass Failure ]
 imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-self-collapsing-nested.html [ Pass Failure ]


### PR DESCRIPTION
#### ebc755bc85449255bef9b771927f073adb8eac9f
<pre>
[iOS] Rebaseline several pasteboard-related layout tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=273378">https://bugs.webkit.org/show_bug.cgi?id=273378</a>
<a href="https://rdar.apple.com/124417777">rdar://124417777</a>

Reviewed by Richard Robinson.

Rebaseline several layout tests in `editing/async-clipboard` and `editing/pasteboard` after system
changes (in UIKit). In iOS 17.4+, UIKit now automatically publishes `public.utf8-plain-text` on the
pasteboard as long as `public.html` is written.

The value of the plain text type is either a value explicitly written to the pasteboard, or (if no
value was specified) the text content of a document derived from loading the HTML data (by using
UIFoundation). As such, we make these tests pass in both cases where the system does (or doesn&apos;t)
automatically write plain text on behalf of the pasteboard client when HTML data is written.

* LayoutTests/editing/async-clipboard/clipboard-write-basic-expected.txt:
* LayoutTests/editing/async-clipboard/clipboard-write-basic.html:
* LayoutTests/editing/async-clipboard/sanitize-when-reading-markup-expected.txt:
* LayoutTests/editing/async-clipboard/sanitize-when-reading-markup.html:
* LayoutTests/editing/pasteboard/data-transfer-set-data-sanitize-url-when-copying-in-null-origin-expected.txt:
* LayoutTests/editing/pasteboard/data-transfer-set-data-sanitize-url-when-copying-in-null-origin.html:
* LayoutTests/editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying-expected.txt:
* LayoutTests/editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying-in-null-origin-expected.txt:
* LayoutTests/editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying-in-null-origin.html:
* LayoutTests/editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/278095@main">https://commits.webkit.org/278095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c59c2aec9a38b6281f8fe3edbdf9a8f8495aff35

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52505 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52708 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/142 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26371 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40384 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26296 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42621 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21502 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23754 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43805 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7838 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45670 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54220 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24551 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20737 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47750 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25823 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46764 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10867 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26662 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25546 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->