### PR TITLE
Add byteCast for conversions between different byte-sized types

### DIFF
--- a/Source/JavaScriptCore/API/JSStringRef.cpp
+++ b/Source/JavaScriptCore/API/JSStringRef.cpp
@@ -98,7 +98,7 @@ size_t JSStringGetUTF8CString(JSStringRef string, char* buffer, size_t bufferSiz
     if (!string || !buffer || !bufferSize)
         return 0;
 
-    std::span<char8_t> target { reinterpret_cast<char8_t*>(buffer), bufferSize - 1 };
+    std::span<char8_t> target { byteCast<char8_t>(buffer), bufferSize - 1 };
     WTF::Unicode::ConversionResult<char8_t> result;
     if (string->is8Bit())
         result = WTF::Unicode::convert(string->span8(), target);

--- a/Source/JavaScriptCore/assembler/MacroAssemblerPrinter.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerPrinter.cpp
@@ -125,7 +125,7 @@ void printMemory(PrintStream& out, Context& context)
         break;
     }
     case Memory::AddressType::AbsoluteAddress: {
-        ptr = reinterpret_cast<uint8_t*>(const_cast<void*>(memory.u.absoluteAddress.m_ptr));
+        ptr = static_cast<uint8_t*>(const_cast<void*>(memory.u.absoluteAddress.m_ptr));
         break;
     }
     }

--- a/Source/JavaScriptCore/assembler/ProbeFrame.h
+++ b/Source/JavaScriptCore/assembler/ProbeFrame.h
@@ -36,7 +36,7 @@ namespace Probe {
 class Frame {
 public:
     Frame(void* frameBase, Stack& stack)
-        : m_frameBase { reinterpret_cast<uint8_t*>(frameBase) }
+        : m_frameBase { static_cast<uint8_t*>(frameBase) }
         , m_stack { stack }
     { }
 

--- a/Source/JavaScriptCore/bytecode/UnlinkedMetadataTableInlines.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedMetadataTableInlines.h
@@ -131,7 +131,7 @@ ALWAYS_INLINE RefPtr<MetadataTable> UnlinkedMetadataTable::link()
         MetadataStatistics::numberOfCopiesFromLinking++;
         MetadataStatistics::linkingCopyMemory += sizeof(LinkingData) + totalSize;
 #endif
-        buffer = reinterpret_cast<uint8_t*>(MetadataTableMalloc::malloc(sizeof(LinkingData) + totalSize));
+        buffer = static_cast<uint8_t*>(MetadataTableMalloc::malloc(sizeof(LinkingData) + totalSize));
         memcpy(buffer + valueProfileSize + sizeof(LinkingData), m_rawBuffer + valueProfileSize + sizeof(LinkingData), offsetTableSize);
     }
     // FIXME: Is this needed since we'll clear the data in the CodeBlock Constructor... Plus I could see caching value profiles being profitable.

--- a/Source/JavaScriptCore/runtime/Identifier.h
+++ b/Source/JavaScriptCore/runtime/Identifier.h
@@ -147,7 +147,7 @@ public:
     friend bool operator==(const Identifier&, const char*);
 
     static bool equal(const StringImpl*, const LChar*);
-    static inline bool equal(const StringImpl* a, const char* b) { return Identifier::equal(a, reinterpret_cast<const LChar*>(b)); };
+    static inline bool equal(const StringImpl* a, const char* b) { return Identifier::equal(a, byteCast<LChar>(b)); };
     static bool equal(const StringImpl*, std::span<const LChar>);
     static bool equal(const StringImpl*, std::span<const UChar>);
     static bool equal(const StringImpl* a, const StringImpl* b) { return ::equal(a, b); }
@@ -234,7 +234,7 @@ inline bool operator==(const Identifier& a, const LChar* b)
 
 inline bool operator==(const Identifier& a, const char* b)
 {
-    return Identifier::equal(a, reinterpret_cast<const LChar*>(b));
+    return Identifier::equal(a, byteCast<LChar>(b));
 }
 
 inline bool Identifier::equal(const StringImpl* r, const LChar* s)

--- a/Source/JavaScriptCore/runtime/IntlCollator.cpp
+++ b/Source/JavaScriptCore/runtime/IntlCollator.cpp
@@ -301,8 +301,8 @@ UCollationResult IntlCollator::compareStrings(JSGlobalObject* globalObject, Stri
         }
 
         if (x.is8Bit() && y.is8Bit() && x.containsOnlyASCII() && y.containsOnlyASCII()) {
-            auto xCharacters = spanReinterpretCast<const char>(x.span8());
-            auto yCharacters = spanReinterpretCast<const char>(y.span8());
+            auto xCharacters = byteCast<char>(x.span8());
+            auto yCharacters = byteCast<char>(y.span8());
             return ucol_strcollUTF8(m_collator.get(), xCharacters.data(), xCharacters.size(), yCharacters.data(), yCharacters.size(), &status);
         }
 

--- a/Source/JavaScriptCore/runtime/IntlLocale.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocale.cpp
@@ -178,7 +178,7 @@ bool LocaleIDBuilder::setKeywordValue(ASCIILiteral key, StringView value)
 
     ASSERT(value.containsOnlyASCII());
     Vector<char, 32> rawValue(value.length() + 1);
-    value.getCharacters(reinterpret_cast<LChar*>(rawValue.data()));
+    value.getCharacters(byteCast<LChar>(rawValue.data()));
     rawValue[value.length()] = '\0';
 
     UErrorCode status = U_ZERO_ERROR;

--- a/Source/JavaScriptCore/runtime/NumberPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/NumberPrototype.cpp
@@ -354,7 +354,7 @@ static String toStringWithRadixInternal(int32_t number, unsigned radix)
     do {
         uint32_t index = positiveNumber % radix;
         ASSERT(index < sizeof(radixDigits));
-        *--p = static_cast<LChar>(radixDigits[index]);
+        *--p = radixDigits[index];
         positiveNumber /= radix;
     } while (positiveNumber);
 

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -598,7 +598,7 @@ struct Segment {
     uint8_t& byte(uint32_t pos)
     {
         ASSERT(pos < sizeInBytes);
-        return *reinterpret_cast<uint8_t*>(reinterpret_cast<char*>(this) + sizeof(Segment) + pos);
+        return *(reinterpret_cast<uint8_t*>(this) + sizeof(Segment) + pos);
     }
 
     static void destroy(Segment*);

--- a/Source/JavaScriptCore/wasm/WasmMemory.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemory.cpp
@@ -411,7 +411,7 @@ bool Memory::fill(uint32_t offset, uint8_t targetValue, uint32_t count)
     if (offset + count > m_handle->size())
         return false;
 
-    memset(reinterpret_cast<uint8_t*>(basePointer()) + offset, targetValue, count);
+    memset(static_cast<uint8_t*>(basePointer()) + offset, targetValue, count);
     return true;
 }
 
@@ -429,7 +429,7 @@ bool Memory::copy(uint32_t dstAddress, uint32_t srcAddress, uint32_t count)
     if (!count)
         return true;
 
-    uint8_t* base = reinterpret_cast<uint8_t*>(basePointer());
+    uint8_t* base = static_cast<uint8_t*>(basePointer());
     // Source and destination areas might overlap, so using memmove.
     memmove(base + dstAddress, base + srcAddress, count);
     return true;
@@ -446,7 +446,7 @@ bool Memory::init(uint32_t offset, const uint8_t* data, uint32_t length)
     if (!length)
         return true;
 
-    memcpy(reinterpret_cast<uint8_t*>(basePointer()) + offset, data, length);
+    memcpy(static_cast<uint8_t*>(basePointer()) + offset, data, length);
     return true;
 }
 

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -2119,7 +2119,7 @@ void indentForNestingLevel(PrintStream& out, unsigned nestingDepth)
 
 void dumpUChar32(PrintStream& out, char32_t c)
 {
-    if (c >= ' '&& c <= 0xff)
+    if (c >= ' ' && c <= 0xff)
         out.printf("'%c'", static_cast<char>(c));
     else
         out.printf("0x%04x", c);

--- a/Source/WTF/wtf/FastFloat.cpp
+++ b/Source/WTF/wtf/FastFloat.cpp
@@ -33,16 +33,18 @@ namespace WTF {
 double parseDouble(std::span<const LChar> string, size_t& parsedLength)
 {
     double doubleValue = 0;
-    auto result = fast_float::from_chars(reinterpret_cast<const char*>(string.data()), reinterpret_cast<const char*>(string.data()) + string.size(), doubleValue);
-    parsedLength = result.ptr - reinterpret_cast<const char*>(string.data());
+    auto stringData = byteCast<char>(string.data());
+    auto result = fast_float::from_chars(stringData, stringData + string.size(), doubleValue);
+    parsedLength = result.ptr - stringData;
     return doubleValue;
 }
 
 double parseDouble(std::span<const UChar> string, size_t& parsedLength)
 {
     double doubleValue = 0;
-    auto result = fast_float::from_chars(reinterpret_cast<const char16_t*>(string.data()), reinterpret_cast<const char16_t*>(string.data()) + string.size(), doubleValue);
-    parsedLength = result.ptr - reinterpret_cast<const char16_t*>(string.data());
+    auto stringData = reinterpret_cast<const char16_t*>(string.data());
+    auto result = fast_float::from_chars(stringData, stringData + string.size(), doubleValue);
+    parsedLength = result.ptr - stringData;
     return doubleValue;
 }
 

--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -57,7 +57,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     return std::filesystem::u8path(path.utf8().data());
 ALLOW_DEPRECATED_DECLARATIONS_END
 #else
-    return { std::u8string(reinterpret_cast<const char8_t*>(path.utf8().data())) };
+    return { std::u8string(byteCast<char8_t>(path.utf8().data())) };
 #endif
 }
 

--- a/Source/WTF/wtf/PageBlock.h
+++ b/Source/WTF/wtf/PageBlock.h
@@ -75,7 +75,7 @@ public:
     PageBlock(void*, size_t, bool hasGuardPages);
     
     void* base() const { return m_base; }
-    void* end() const { return reinterpret_cast<uint8_t*>(m_base) + size(); }
+    void* end() const { return static_cast<uint8_t*>(m_base) + size(); }
     size_t size() const { return m_size; }
 
     operator bool() const { return !!m_realBase; }

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -204,7 +204,7 @@ const char* Thread::normalizeThreadName(const char* threadName)
 #endif
     auto characters = result.span8();
     ASSERT(characters[characters.size()] == '\0');
-    return reinterpret_cast<const char*>(characters.data());
+    return byteCast<char>(characters.data());
 #endif
 }
 

--- a/Source/WTF/wtf/cf/VectorCF.h
+++ b/Source/WTF/wtf/cf/VectorCF.h
@@ -162,7 +162,7 @@ template<typename MapLambdaType> Vector<typename LambdaTypeTraits<MapLambdaType>
 
 inline std::span<const uint8_t> span(CFDataRef data)
 {
-    return { reinterpret_cast<const uint8_t*>(CFDataGetBytePtr(data)), Checked<size_t>(CFDataGetLength(data)) };
+    return { static_cast<const uint8_t*>(CFDataGetBytePtr(data)), Checked<size_t>(CFDataGetLength(data)) };
 }
 
 inline Vector<uint8_t> makeVector(CFDataRef data)

--- a/Source/WTF/wtf/persistence/PersistentCoders.cpp
+++ b/Source/WTF/wtf/persistence/PersistentCoders.cpp
@@ -81,7 +81,7 @@ std::optional<CString> Coder<CString>::decodeForPersistence(Decoder& decoder)
 
     char* buffer;
     CString string = CString::newUninitialized(*length, buffer);
-    if (!decoder.decodeFixedLengthData({ reinterpret_cast<uint8_t*>(buffer), *length }))
+    if (!decoder.decodeFixedLengthData({ byteCast<uint8_t>(buffer), *length }))
         return std::nullopt;
 
     return string;

--- a/Source/WTF/wtf/text/AtomStringImpl.h
+++ b/Source/WTF/wtf/text/AtomStringImpl.h
@@ -89,9 +89,8 @@ inline RefPtr<AtomStringImpl> AtomStringImpl::lookUp(StringImpl* string)
 
 ALWAYS_INLINE RefPtr<AtomStringImpl> AtomStringImpl::add(std::span<const char> characters)
 {
-    return add({ reinterpret_cast<const LChar*>(characters.data()), characters.size() });
+    return add(byteCast<LChar>(characters));
 }
-
 
 ALWAYS_INLINE RefPtr<AtomStringImpl> AtomStringImpl::add(StringImpl* string)
 {

--- a/Source/WTF/wtf/text/StringBuilder.h
+++ b/Source/WTF/wtf/text/StringBuilder.h
@@ -63,7 +63,7 @@ public:
     void append(const char*) = delete; // Pass ASCIILiteral or span instead.
     void append(UChar);
     void append(LChar);
-    void append(char character) { append(static_cast<LChar>(character)); }
+    void append(char character) { append(byteCast<LChar>(character)); }
 
     // FIXME: Add a StringTypeAdapter so we can append one string builder to another with variadic append.
     void append(const StringBuilder&);

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -50,7 +50,7 @@ inline std::span<const UChar> span(const UChar& character)
 
 inline std::span<const LChar> span8(const char* string)
 {
-    return { reinterpret_cast<const LChar*>(string), string ? strlen(string) : 0 };
+    return { byteCast<LChar>(string), string ? strlen(string) : 0 };
 }
 
 inline std::span<const char> span(const char* string)
@@ -197,8 +197,8 @@ ALWAYS_INLINE bool equal(const LChar* aLChar, std::span<const LChar> bLChar)
     ASSERT(bLChar.size() <= std::numeric_limits<unsigned>::max());
     unsigned length = bLChar.size();
 
-    const char* a = reinterpret_cast<const char*>(aLChar);
-    const char* b = reinterpret_cast<const char*>(bLChar.data());
+    const char* a = byteCast<char>(aLChar);
+    const char* b = byteCast<char>(bLChar.data());
 
     unsigned wordLength = length >> 2;
     for (unsigned i = 0; i != wordLength; ++i) {
@@ -211,8 +211,8 @@ ALWAYS_INLINE bool equal(const LChar* aLChar, std::span<const LChar> bLChar)
     length &= 3;
 
     if (length) {
-        const LChar* aRemainder = reinterpret_cast<const LChar*>(a);
-        const LChar* bRemainder = reinterpret_cast<const LChar*>(b);
+        const LChar* aRemainder = byteCast<LChar>(a);
+        const LChar* bRemainder = byteCast<LChar>(b);
 
         for (unsigned i = 0; i <  length; ++i) {
             if (aRemainder[i] != bRemainder[i])
@@ -839,7 +839,7 @@ template<typename CharacterType> inline bool equalLettersIgnoringASCIICase(std::
 
 template<typename CharacterType> inline bool equalLettersIgnoringASCIICase(std::span<const CharacterType> characters, std::span<const char> lowercaseLetters)
 {
-    return equalLettersIgnoringASCIICase(characters, { reinterpret_cast<const LChar*>(lowercaseLetters.data()), lowercaseLetters.size() });
+    return equalLettersIgnoringASCIICase(characters, byteCast<LChar>(lowercaseLetters));
 }
 
 template<typename CharacterType> inline bool equalLettersIgnoringASCIICase(std::span<const CharacterType> characters, ASCIILiteral lowercaseLetters)

--- a/Source/WTF/wtf/text/StringConcatenate.h
+++ b/Source/WTF/wtf/text/StringConcatenate.h
@@ -132,7 +132,7 @@ public:
 private:
     static unsigned computeLength(const LChar* characters)
     {
-        return stringLength(std::strlen(reinterpret_cast<const char*>(characters)));
+        return stringLength(std::strlen(byteCast<char>(characters)));
     }
 
     const LChar* m_characters;
@@ -345,7 +345,7 @@ template<typename UnderlyingElementType> struct PaddingSpecification {
 
 template<typename UnderlyingElementType> PaddingSpecification<UnderlyingElementType> pad(char character, unsigned length, UnderlyingElementType element)
 {
-    return { static_cast<LChar>(character), length, element };
+    return { byteCast<LChar>(character), length, element };
 }
 
 template<typename UnderlyingElementType> class StringTypeAdapter<PaddingSpecification<UnderlyingElementType>> {

--- a/Source/WTF/wtf/text/StringConcatenateNumbers.h
+++ b/Source/WTF/wtf/text/StringConcatenateNumbers.h
@@ -80,7 +80,7 @@ public:
     template<typename CharacterType> void writeTo(CharacterType* destination) const { StringImpl::copyCharacters(destination, span()); }
 
 private:
-    std::span<const LChar> span() const { return { reinterpret_cast<const LChar*>(&m_buffer[0]), m_length }; }
+    std::span<const LChar> span() const { return { byteCast<LChar>(&m_buffer[0]), m_length }; }
 
     NumberToStringBuffer m_buffer;
     unsigned m_length;
@@ -106,7 +106,7 @@ public:
     }
 
     unsigned length() const { return m_length; }
-    const LChar* buffer() const { return reinterpret_cast<const LChar*>(&m_buffer[0]); }
+    const LChar* buffer() const { return byteCast<LChar>(&m_buffer[0]); }
     std::span<const LChar> span() const { return { buffer(), length() }; }
 
 private:
@@ -141,7 +141,7 @@ public:
     } 
 
     unsigned length() const { return m_length; }
-    const LChar* buffer() const { return reinterpret_cast<const LChar*>(&m_buffer[0]); }
+    const LChar* buffer() const { return byteCast<LChar>(&m_buffer[0]); }
     std::span<const LChar> span() const { return { buffer(), length() }; }
 
 private:

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -998,8 +998,8 @@ ALWAYS_INLINE static bool equalInner(const StringImpl& string, unsigned start, s
     ASSERT(start + matchString.size() <= string.length());
 
     if (string.is8Bit())
-        return equal(string.span8().data() + start, spanReinterpretCast<const LChar>(matchString));
-    return equal(string.span16().data() + start, spanReinterpretCast<const LChar>(matchString));
+        return equal(string.span8().data() + start, byteCast<LChar>(matchString));
+    return equal(string.span16().data() + start, byteCast<LChar>(matchString));
 }
 
 ALWAYS_INLINE static bool equalInner(const StringImpl& string, unsigned start, StringView matchString)

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -249,7 +249,7 @@ public:
 
     WTF_EXPORT_PRIVATE static Ref<StringImpl> create(std::span<const UChar>);
     WTF_EXPORT_PRIVATE static Ref<StringImpl> create(std::span<const LChar>);
-    ALWAYS_INLINE static Ref<StringImpl> create(std::span<const char> characters) { return create({ reinterpret_cast<const LChar*>(characters.data()), characters.size() }); }
+    ALWAYS_INLINE static Ref<StringImpl> create(std::span<const char> characters) { return create(byteCast<LChar>(characters)); }
     WTF_EXPORT_PRIVATE static Ref<StringImpl> create8BitIfPossible(std::span<const UChar>);
 
     // Not using create() naming to encourage developers to call create(ASCIILiteral) when they have a string literal.
@@ -261,7 +261,7 @@ public:
 
     static Ref<StringImpl> createWithoutCopying(std::span<const UChar> characters) { return characters.empty() ?  Ref { *empty() } : createWithoutCopyingNonEmpty(characters); }
     static Ref<StringImpl> createWithoutCopying(std::span<const LChar> characters) { return characters.empty() ? Ref { *empty() } : createWithoutCopyingNonEmpty(characters); }
-    ALWAYS_INLINE static Ref<StringImpl> createWithoutCopying(std::span<const char> characters) { return createWithoutCopying({ reinterpret_cast<const LChar*>(characters.data()), characters.size() }); }
+    ALWAYS_INLINE static Ref<StringImpl> createWithoutCopying(std::span<const char> characters) { return createWithoutCopying(byteCast<LChar>(characters)); }
 
     WTF_EXPORT_PRIVATE static Ref<StringImpl> createUninitialized(size_t length, LChar*&);
     WTF_EXPORT_PRIVATE static Ref<StringImpl> createUninitialized(size_t length, UChar*&);
@@ -272,9 +272,8 @@ public:
 
     static Ref<StringImpl> createStaticStringImpl(std::span<const char> characters)
     {
-        std::span lcharSpan { reinterpret_cast<const LChar*>(characters.data()), characters.size() };
-        ASSERT(charactersAreAllASCII(lcharSpan));
-        return createStaticStringImpl(lcharSpan);
+        ASSERT(charactersAreAllASCII(byteCast<LChar>(characters)));
+        return createStaticStringImpl(byteCast<LChar>(characters));
     }
     WTF_EXPORT_PRIVATE static Ref<StringImpl> createStaticStringImpl(std::span<const LChar>);
     WTF_EXPORT_PRIVATE static Ref<StringImpl> createStaticStringImpl(std::span<const UChar>);
@@ -493,7 +492,7 @@ public:
 
     WTF_EXPORT_PRIVATE Ref<StringImpl> replace(UChar, UChar);
     WTF_EXPORT_PRIVATE Ref<StringImpl> replace(UChar, StringView);
-    ALWAYS_INLINE Ref<StringImpl> replace(UChar pattern, std::span<const char> replacement) { return replace(pattern, { reinterpret_cast<const LChar*>(replacement.data()), replacement.size() }); }
+    ALWAYS_INLINE Ref<StringImpl> replace(UChar pattern, std::span<const char> replacement) { return replace(pattern, byteCast<LChar>(replacement)); }
     WTF_EXPORT_PRIVATE Ref<StringImpl> replace(UChar, std::span<const LChar>);
     Ref<StringImpl> replace(UChar, std::span<const UChar>);
     WTF_EXPORT_PRIVATE Ref<StringImpl> replace(StringView, StringView);
@@ -605,13 +604,13 @@ template<> struct ValueCheck<StringImpl*> {
 
 WTF_EXPORT_PRIVATE bool equal(const StringImpl*, const StringImpl*);
 WTF_EXPORT_PRIVATE bool equal(const StringImpl*, const LChar*);
-inline bool equal(const StringImpl* a, const char* b) { return equal(a, reinterpret_cast<const LChar*>(b)); }
+inline bool equal(const StringImpl* a, const char* b) { return equal(a, byteCast<LChar>(b)); }
 WTF_EXPORT_PRIVATE bool equal(const StringImpl*, std::span<const LChar>);
 WTF_EXPORT_PRIVATE bool equal(const StringImpl*, std::span<const UChar>);
 ALWAYS_INLINE bool equal(const StringImpl* a, ASCIILiteral b) { return equal(a, b.span8()); }
-inline bool equal(const StringImpl* a, std::span<const char> b) { return equal(a, { reinterpret_cast<const LChar*>(b.data()), b.size() }); }
+inline bool equal(const StringImpl* a, std::span<const char> b) { return equal(a, byteCast<LChar>(b)); }
 inline bool equal(const LChar* a, StringImpl* b) { return equal(b, a); }
-inline bool equal(const char* a, StringImpl* b) { return equal(b, reinterpret_cast<const LChar*>(a)); }
+inline bool equal(const char* a, StringImpl* b) { return equal(b, byteCast<LChar>(a)); }
 WTF_EXPORT_PRIVATE bool equal(const StringImpl& a, const StringImpl& b);
 
 WTF_EXPORT_PRIVATE bool equalIgnoringNullity(StringImpl*, StringImpl*);
@@ -741,7 +740,7 @@ inline size_t StringImpl::find(LChar character, size_t start)
 
 ALWAYS_INLINE size_t StringImpl::find(char character, size_t start)
 {
-    return find(static_cast<LChar>(character), start);
+    return find(byteCast<LChar>(character), start);
 }
 
 inline size_t StringImpl::find(UChar character, size_t start)

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -154,7 +154,7 @@ public:
 
     size_t find(UChar, unsigned start = 0) const;
     size_t find(LChar, unsigned start = 0) const;
-    ALWAYS_INLINE size_t find(char c, unsigned start = 0) const { return find(static_cast<LChar>(c), start); }
+    ALWAYS_INLINE size_t find(char c, unsigned start = 0) const { return find(byteCast<LChar>(c), start); }
     template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, UChar>>* = nullptr>
     size_t find(CodeUnitMatchFunction&&, unsigned start = 0) const;
     ALWAYS_INLINE size_t find(ASCIILiteral literal, unsigned start = 0) const { return find(literal.span8(), start); }
@@ -412,7 +412,7 @@ inline StringView::StringView(const char* characters)
 
 inline StringView::StringView(std::span<const char> characters)
 {
-    initialize(std::span { reinterpret_cast<const LChar*>(characters.data()), characters.size() });
+    initialize(byteCast<LChar>(characters));
 }
 
 inline StringView::StringView(const void* characters, unsigned length, bool is8bit)
@@ -776,7 +776,7 @@ inline bool equal(StringView a, const LChar* b)
     if (a.isEmpty())
         return !b;
 
-    auto bSpan = span8(reinterpret_cast<const char*>(b));
+    auto bSpan = span8(byteCast<char>(b));
     if (a.length() != bSpan.size())
         return false;
 

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -51,7 +51,7 @@ String::String(std::span<const LChar> characters)
 }
 
 String::String(std::span<const char> characters)
-    : m_impl(characters.data() ? RefPtr { StringImpl::create(spanReinterpretCast<const uint8_t>(characters)) } : nullptr)
+    : m_impl(characters.data() ? RefPtr { StringImpl::create(byteCast<uint8_t>(characters)) } : nullptr)
 {
 }
 

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -263,16 +263,16 @@ public:
 
     // String::fromUTF8 will return a null string if the input data contains invalid UTF-8 sequences.
     WTF_EXPORT_PRIVATE static String fromUTF8(std::span<const char8_t>);
-    static String fromUTF8(std::span<const LChar> characters) { return fromUTF8({ reinterpret_cast<const char8_t*>(characters.data()), characters.size() }); }
-    static String fromUTF8(std::span<const char> characters) { return fromUTF8({ reinterpret_cast<const char8_t*>(characters.data()), characters.size() }); }
+    static String fromUTF8(std::span<const LChar> characters) { return fromUTF8(byteCast<char8_t>(characters)); }
+    static String fromUTF8(std::span<const char> characters) { return fromUTF8(byteCast<char8_t>(characters)); }
     static String fromUTF8(const char* string) { return fromUTF8(WTF::span8(string)); }
     static String fromUTF8ReplacingInvalidSequences(std::span<const char8_t>);
-    static String fromUTF8ReplacingInvalidSequences(std::span<const LChar> characters) { return fromUTF8ReplacingInvalidSequences({ reinterpret_cast<const char8_t*>(characters.data()), characters.size() }); }
+    static String fromUTF8ReplacingInvalidSequences(std::span<const LChar> characters) { return fromUTF8ReplacingInvalidSequences(byteCast<char8_t>(characters)); }
 
     // Tries to convert the passed in string to UTF-8, but will fall back to Latin-1 if the string is not valid UTF-8.
     WTF_EXPORT_PRIVATE static String fromUTF8WithLatin1Fallback(std::span<const char8_t>);
-    static String fromUTF8WithLatin1Fallback(std::span<const LChar> characters) { return fromUTF8WithLatin1Fallback({ reinterpret_cast<const char8_t*>(characters.data()), characters.size() }); }
-    static String fromUTF8WithLatin1Fallback(std::span<const char> characters) { return fromUTF8WithLatin1Fallback({ reinterpret_cast<const char8_t*>(characters.data()), characters.size() }); }
+    static String fromUTF8WithLatin1Fallback(std::span<const LChar> characters) { return fromUTF8WithLatin1Fallback(byteCast<char8_t>(characters)); }
+    static String fromUTF8WithLatin1Fallback(std::span<const char> characters) { return fromUTF8WithLatin1Fallback(byteCast<char8_t>(characters)); }
 
     WTF_EXPORT_PRIVATE static String fromCodePoint(char32_t codePoint);
 

--- a/Source/WTF/wtf/text/cf/AtomStringImplCF.cpp
+++ b/Source/WTF/wtf/text/cf/AtomStringImplCF.cpp
@@ -40,7 +40,7 @@ RefPtr<AtomStringImpl> AtomStringImpl::add(CFStringRef string)
 
     size_t length = CFStringGetLength(string);
 
-    if (const LChar* ptr = reinterpret_cast<const LChar*>(CFStringGetCStringPtr(string, kCFStringEncodingISOLatin1)))
+    if (const LChar* ptr = byteCast<LChar>(CFStringGetCStringPtr(string, kCFStringEncodingISOLatin1)))
         return add(std::span { ptr, length });
 
     if (const UniChar* ptr = CFStringGetCharactersPtr(string))

--- a/Source/WTF/wtf/unicode/Collator.h
+++ b/Source/WTF/wtf/unicode/Collator.h
@@ -46,7 +46,7 @@ public:
     explicit Collator(const char* = nullptr, bool = false) { }
 
     WTF_EXPORT_PRIVATE static int collate(StringView, StringView);
-    WTF_EXPORT_PRIVATE static int collateUTF8(const char*, const char*);
+    WTF_EXPORT_PRIVATE static int collate(const char8_t*, const char8_t*);
 };
 
 #else
@@ -61,7 +61,7 @@ public:
     WTF_EXPORT_PRIVATE ~Collator();
 
     WTF_EXPORT_PRIVATE int collate(StringView, StringView) const;
-    WTF_EXPORT_PRIVATE int collateUTF8(const char*, const char*) const;
+    WTF_EXPORT_PRIVATE int collate(const char8_t*, const char8_t*) const;
 
 private:
     char* m_locale;

--- a/Source/WTF/wtf/unicode/CollatorDefault.cpp
+++ b/Source/WTF/wtf/unicode/CollatorDefault.cpp
@@ -51,9 +51,9 @@ int Collator::collate(StringView a, StringView b) const
     return 0;
 }
 
-int Collator::collateUTF8(const char* a, const char* b) const
+int Collator::collate(const char8_t* a, const char8_t* b) const
 {
-    return collate(String::fromUTF8(a), String::fromUTF8(b));
+    return collate(String::fromUTF8(byteCast<char>(a)), String::fromUTF8(byteCast<char>(b)));
 }
 
 }

--- a/Source/WTF/wtf/unicode/icu/CollatorICU.cpp
+++ b/Source/WTF/wtf/unicode/icu/CollatorICU.cpp
@@ -253,17 +253,17 @@ int Collator::collate(StringView a, StringView b) const
     return result;
 }
 
-static UCharIterator createIteratorUTF8(const char* string)
+static UCharIterator createIterator(const char8_t* string)
 {
     UCharIterator iterator;
-    uiter_setUTF8(&iterator, string, strlen(string));
+    uiter_setUTF8(&iterator, byteCast<char>(string), strlen(byteCast<char>(string)));
     return iterator;
 }
 
-int Collator::collateUTF8(const char* a, const char* b) const
+int Collator::collate(const char8_t* a, const char8_t* b) const
 {
-    UCharIterator iteratorA = createIteratorUTF8(a);
-    UCharIterator iteratorB = createIteratorUTF8(b);
+    UCharIterator iteratorA = createIterator(a);
+    UCharIterator iteratorB = createIterator(b);
     UErrorCode status = U_ZERO_ERROR;
     int result = ucol_strcollIter(m_collator, &iteratorA, &iteratorB, &status);
     ASSERT(U_SUCCESS(status));

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -253,7 +253,7 @@ static void getImageBytesFromVideoFrame(const RefPtr<VideoFrame>& videoFrame, Im
     auto sizeInBytes = rows * CVPixelBufferGetBytesPerRow(pixelBuffer);
 
     CVPixelBufferLockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
-    callback({ reinterpret_cast<uint8_t*>(CVPixelBufferGetBaseAddress(pixelBuffer)), sizeInBytes }, rows);
+    callback({ static_cast<uint8_t*>(CVPixelBufferGetBaseAddress(pixelBuffer)), sizeInBytes }, rows);
     CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
 }
 #endif

--- a/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp
@@ -194,7 +194,7 @@ std::optional<Vector<Ref<SharedBuffer>>> InitDataRegistry::extractKeyIDsCenc(con
 #if USE(GSTREAMER)
 bool isPlayReadySanitizedInitializationData(const SharedBuffer& buffer)
 {
-    auto* protectionData = reinterpret_cast<const char*>(buffer.span().data());
+    auto* protectionData = byteCast<char>(buffer.span().data());
     size_t protectionDataLength = buffer.size();
 
     // The protection data starts with a 10-byte PlayReady version

--- a/Source/WebCore/PAL/pal/text/EncodingTables.cpp
+++ b/Source/WebCore/PAL/pal/text/EncodingTables.cpp
@@ -1079,7 +1079,7 @@ const std::array<std::pair<uint16_t, UChar>, 7724>& jis0208()
                 icuInput[1] = 0xA1 + j;
 
                 UChar* output = &icuOutput;
-                const char* input = reinterpret_cast<const char*>(icuInput);
+                const char* input = byteCast<char>(&icuInput[0]);
                 ucnv_toUnicode(icuConverter.get(), &output, output + 1, &input, input + sizeof(icuInput), nullptr, true, &error);
                 ASSERT(!error);
                 if (icuOutput != 0xFFFD) {
@@ -1885,7 +1885,7 @@ const std::array<std::pair<uint16_t, UChar>, 6067>& jis0212()
                 icuInput[2] = 0xA1 + j;
 
                 UChar* output = &icuOutput;
-                const char* input = reinterpret_cast<const char*>(icuInput);
+                const char* input = byteCast<char>(&icuInput[0]);
                 ucnv_toUnicode(icuConverter.get(), &output, output + 1, &input, input + sizeof(icuInput), nullptr, true, &error);
                 ASSERT(!error);
                 if (icuOutput != 0xFFFD) {
@@ -4909,7 +4909,7 @@ const std::array<std::pair<uint16_t, char32_t>, 18590>& big5()
                 icuInput[0] = lead;
                 icuInput[1] = trail + offset;
                 UChar* output = &icuOutput;
-                const char* input = reinterpret_cast<const char*>(icuInput);
+                const char* input = byteCast<char>(&icuInput[0]);
                 ucnv_toUnicode(icuConverter.get(), &output, output + 1, &input, input + sizeof(icuInput), nullptr, true, &error);
                 ASSERT(!error);
                 (*array)[arrayIndex++] = { pointer, icuOutput };
@@ -7077,7 +7077,7 @@ const std::array<std::pair<uint16_t, UChar>, 17048>& eucKR()
         ASSERT(U_SUCCESS(error));
         auto getPair = [icuConverter = WTFMove(icuConverter)] (uint16_t pointer) -> std::optional<std::pair<uint16_t, UChar>> {
             std::array<uint8_t, 2> icuInput { static_cast<uint8_t>(pointer / 190u + 0x81), static_cast<uint8_t>(pointer % 190u + 0x41) };
-            const char* input = reinterpret_cast<const char*>(icuInput.data());
+            const char* input = byteCast<char>(icuInput.data());
             UChar icuOutput[2];
             UChar* output = icuOutput;
             UErrorCode error = U_ZERO_ERROR;
@@ -8620,7 +8620,7 @@ const std::array<UChar, 23940>& gb18030()
             icuInput[1] += (icuInput[1] < 0x3F) ? 0x40 : 0x41;
             UChar icuOutput { 0 };
             UChar* output = &icuOutput;
-            const char* input = reinterpret_cast<const char*>(icuInput);
+            const char* input = byteCast<char>(&icuInput[0]);
             ucnv_toUnicode(icuConverter.get(), &output, output + 1, &input, input + sizeof(icuInput), nullptr, true, &error);
             ASSERT(!error);
             ASSERT(icuOutput != 0xFFFD);

--- a/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
@@ -255,7 +255,7 @@ String TextCodecCJK::eucJPDecode(std::span<const uint8_t> bytes, bool flush, boo
             return SawError::Yes;
         }
         if (isASCII(byte)) {
-            result.append(static_cast<char>(byte));
+            result.append(byteCast<char>(byte));
             return SawError::No;
         }
         if (byte == 0x8E || byte == 0x8F || (byte >= 0xA1 && byte <= 0xFE)) {
@@ -1177,7 +1177,7 @@ String TextCodecCJK::big5Decode(std::span<const uint8_t> bytes, bool flush, bool
             return SawError::Yes;
         }
         if (isASCII(byte)) {
-            result.append(static_cast<char>(byte));
+            result.append(byteCast<char>(byte));
             return SawError::No;
         }
         if (byte >= 0x81 && byte <= 0xFE) {

--- a/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
@@ -229,7 +229,7 @@ String TextCodecICU::decode(std::span<const uint8_t> bytes, bool flush, bool sto
 
     UChar buffer[ConversionBufferSize];
     UChar* bufferLimit = buffer + ConversionBufferSize;
-    const char* source = reinterpret_cast<const char*>(bytes.data());
+    const char* source = byteCast<char>(bytes.data());
     const char* sourceLimit = source + bytes.size();
     int32_t* offsets = nullptr;
     UErrorCode err = U_ZERO_ERROR;
@@ -313,7 +313,7 @@ Vector<uint8_t> TextCodecICU::encode(StringView string, UnencodableHandling hand
         char* targetLimit = target + ConversionBufferSize;
         error = U_ZERO_ERROR;
         ucnv_fromUnicode(m_converter.get(), &target, targetLimit, &source, sourceLimit, 0, true, &error);
-        result.append(std::span(reinterpret_cast<uint8_t*>(buffer), target - buffer));
+        result.append(std::span(byteCast<uint8_t>(&buffer[0]), target - buffer));
     } while (needsToGrowToProduceBuffer(error));
     return result;
 }

--- a/Source/WebCore/PAL/pal/text/TextEncodingDetectorICU.cpp
+++ b/Source/WebCore/PAL/pal/text/TextEncodingDetectorICU.cpp
@@ -46,7 +46,7 @@ bool detectTextEncoding(std::span<const uint8_t> data, const char* hintEncodingN
     if (U_FAILURE(status))
         return false;
     ucsdet_enableInputFilter(detector, true);
-    ucsdet_setText(detector, reinterpret_cast<const char*>(data.data()), static_cast<int32_t>(data.size()), &status);
+    ucsdet_setText(detector, byteCast<char>(data.data()), static_cast<int32_t>(data.size()), &status);
     if (U_FAILURE(status))
         return false;
 

--- a/Source/WebCore/css/process-css-pseudo-selectors.py
+++ b/Source/WebCore/css/process-css-pseudo-selectors.py
@@ -437,7 +437,7 @@ class GPerfOutputGenerator:
         writer.write_block("""
         static inline const SelectorPseudoClassOrCompatibilityPseudoElementEntry* findPseudoClassAndCompatibilityElementName(std::span<const LChar> characters)
         {
-            return SelectorPseudoClassAndCompatibilityElementMapHash::in_word_set(reinterpret_cast<const char*>(characters.data()), characters.size());
+            return SelectorPseudoClassAndCompatibilityElementMapHash::in_word_set(byteCast<char>(characters.data()), characters.size());
         }""")
 
         writer.write_block(f"""
@@ -477,7 +477,7 @@ class GPerfOutputGenerator:
         writer.write_block("""
             static inline std::optional<CSSSelector::PseudoElement> findPseudoElementName(std::span<const LChar> characters)
             {
-                if (const SelectorPseudoTypeEntry* entry = SelectorPseudoElementMapHash::in_word_set(reinterpret_cast<const char*>(characters.data()), characters.size()))
+                if (auto entry = SelectorPseudoElementMapHash::in_word_set(byteCast<char>(characters.data()), characters.size()))
                     return entry->type;
                 return std::nullopt;
             }""")

--- a/Source/WebCore/html/track/VTTScanner.h
+++ b/Source/WebCore/html/track/VTTScanner.h
@@ -160,7 +160,7 @@ inline size_t VTTScanner::Run::length() const
 template<unsigned charactersCount>
 inline bool VTTScanner::scan(const char (&characters)[charactersCount])
 {
-    return scan({ reinterpret_cast<const LChar*>(characters), charactersCount - 1 });
+    return scan({ byteCast<LChar>(&characters[0]), charactersCount - 1 });
 }
 
 template<bool characterPredicate(UChar)>

--- a/Source/WebCore/html/track/WebVTTTokenizer.cpp
+++ b/Source/WebCore/html/track/WebVTTTokenizer.cpp
@@ -56,11 +56,6 @@ namespace WebCore {
         goto stateName; \
     } while (false)
 
-template<unsigned charactersCount> ALWAYS_INLINE bool equalLiteral(const StringBuilder& s, const char (&characters)[charactersCount])
-{
-    return equal(s, reinterpret_cast<const LChar*>(characters), charactersCount - 1);
-}
-
 static void addNewClass(StringBuilder& classes, const StringBuilder& newClass)
 {
     if (!classes.isEmpty())

--- a/Source/WebCore/platform/SharedBufferChunkReader.cpp
+++ b/Source/WebCore/platform/SharedBufferChunkReader.cpp
@@ -96,7 +96,7 @@ bool SharedBufferChunkReader::nextChunk(Vector<uint8_t>& chunk, bool includeSepa
         if (++m_iteratorCurrent == m_iteratorEnd) {
             m_segment = nullptr;
             if (m_separatorIndex > 0)
-                chunk.append(std::span { reinterpret_cast<const uint8_t*>(m_separator.data()), m_separatorIndex });
+                chunk.append(byteCast<uint8_t>(m_separator.subspan(0, m_separatorIndex)));
             return !chunk.isEmpty();
         }
         m_segment = m_iteratorCurrent->segment->span().data();

--- a/Source/WebCore/platform/graphics/MIMESniffer.cpp
+++ b/Source/WebCore/platform/graphics/MIMESniffer.cpp
@@ -35,7 +35,7 @@ namespace MIMESniffer {
 template<std::size_t N>
 constexpr auto span8(const char(&p)[N])
 {
-    return std::span<const uint8_t, N - 1>(reinterpret_cast<const uint8_t*>(p), N - 1);
+    return std::span<const uint8_t, N - 1>(byteCast<uint8_t>(&p[0]), N - 1);
 }
 
 static bool hasSignatureForMP4(std::span<const uint8_t> sequence)

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -86,10 +86,10 @@ bool GraphicsContextGLANGLE::initialize()
     if (!platformInitializeContext())
         return false;
 
-    String extensionsString = String::fromLatin1(reinterpret_cast<const char*>(GL_GetString(GL_EXTENSIONS)));
+    String extensionsString = String::fromLatin1(byteCast<char>(GL_GetString(GL_EXTENSIONS)));
     for (auto& extension : extensionsString.split(' '))
         m_availableExtensions.add(extension);
-    extensionsString = String::fromLatin1(reinterpret_cast<const char*>(GL_GetString(GL_REQUESTABLE_EXTENSIONS_ANGLE)));
+    extensionsString = String::fromLatin1(byteCast<char>(GL_GetString(GL_REQUESTABLE_EXTENSIONS_ANGLE)));
     for (auto& extension : extensionsString.split(' '))
         m_requestableExtensions.add(extension);
 
@@ -1353,7 +1353,7 @@ String GraphicsContextGLANGLE::getString(GCGLenum name)
     if (!makeContextCurrent())
         return String();
 
-    return String::fromLatin1(reinterpret_cast<const char*>(GL_GetString(name)));
+    return String::fromLatin1(byteCast<char>(GL_GetString(name)));
 }
 
 void GraphicsContextGLANGLE::hint(GCGLenum target, GCGLenum mode)

--- a/Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm
+++ b/Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm
@@ -131,7 +131,7 @@ RefPtr<ShareableBitmap> ShareableBitmap::createFromImagePixels(NativeImage& imag
     if (!pixels)
         return nullptr;
 
-    const auto* bytes = reinterpret_cast<const uint8_t*>(CFDataGetBytePtr(pixels.get()));
+    const auto* bytes = byteCast<uint8_t>(CFDataGetBytePtr(pixels.get()));
     CheckedUint32 sizeInBytes = CFDataGetLength(pixels.get());
     if (!bytes || !sizeInBytes || sizeInBytes.hasOverflowed())
         return nullptr;

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -103,11 +103,11 @@ VariationDefaultsMap defaultVariationValues(CTFontRef font, ShouldLocalizeAxisNa
         if (rawMinimumValue > rawMaximumValue)
             std::swap(rawMinimumValue, rawMaximumValue);
 
-        auto b1 = rawAxisIdentifier >> 24;
-        auto b2 = (rawAxisIdentifier & 0xFF0000) >> 16;
-        auto b3 = (rawAxisIdentifier & 0xFF00) >> 8;
-        auto b4 = rawAxisIdentifier & 0xFF;
-        FontTag resultKey = {{ static_cast<char>(b1), static_cast<char>(b2), static_cast<char>(b3), static_cast<char>(b4) }};
+        char b1 = rawAxisIdentifier >> 24;
+        char b2 = (rawAxisIdentifier & 0xFF0000) >> 16;
+        char b3 = (rawAxisIdentifier & 0xFF00) >> 8;
+        char b4 = rawAxisIdentifier & 0xFF;
+        FontTag resultKey = { { b1, b2, b3, b4 } };
         VariationDefaults resultValues = { axisName, rawDefaultValue, rawMinimumValue, rawMaximumValue };
         result.set(resultKey, resultValues);
     }

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
@@ -379,7 +379,7 @@ Ref<WebCoreDecompressionSession::DecodingPromise> WebCoreDecompressionSession::d
             auto durationInUs = duration.toTimeScale(1000000);
             DecodingPromise::Producer producer;
             auto promise = producer.promise();
-            m_videoDecoder->decode({ { reinterpret_cast<uint8_t*>(data), size }, true, presentationTimeInUs.timeValue(), durationInUs.timeValue() }, [weakThis = ThreadSafeWeakPtr { *this }, this, duration = PAL::toCMTime(duration), producer = WTFMove(producer)](String&&) {
+            m_videoDecoder->decode({ { byteCast<uint8_t>(data), size }, true, presentationTimeInUs.timeValue(), durationInUs.timeValue() }, [weakThis = ThreadSafeWeakPtr { *this }, this, duration = PAL::toCMTime(duration), producer = WTFMove(producer)](String&&) {
                 RefPtr protectedThis = weakThis.get();
                 if (!protectedThis || isInvalidated()) {
                     producer.reject(0);

--- a/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
@@ -287,7 +287,7 @@ bool parseOpusPrivateData(std::span<const uint8_t> codecPrivateData, SharedBuffe
     //
     //     This is an 8-octet (64-bit) field that allows codec
     //     identification and is human readable.
-    if (strncmp("OpusHead", reinterpret_cast<const char*>(codecPrivateData.data()), 8))
+    if (strncmp("OpusHead", byteCast<char>(codecPrivateData.data()), 8))
         return false;
 
     // 2. Version (8 bits, unsigned):

--- a/Source/WebCore/platform/graphics/cpu/arm/filters/FEBlendNeonApplier.cpp
+++ b/Source/WebCore/platform/graphics/cpu/arm/filters/FEBlendNeonApplier.cpp
@@ -110,9 +110,9 @@ public:
 
 void FEBlendNeonApplier::applyPlatform(unsigned char* srcPixelArrayA, unsigned char* srcPixelArrayB, unsigned char* dstPixelArray, unsigned colorArrayLength) const
 {
-    uint8_t* sourcePixelA = reinterpret_cast<uint8_t*>(srcPixelArrayA);
-    uint8_t* sourcePixelB = reinterpret_cast<uint8_t*>(srcPixelArrayB);
-    uint8_t* destinationPixel = reinterpret_cast<uint8_t*>(dstPixelArray);
+    uint8_t* sourcePixelA = byteCast<uint8_t>(srcPixelArrayA);
+    uint8_t* sourcePixelB = byteCast<uint8_t>(srcPixelArrayB);
+    uint8_t* destinationPixel = byteCast<uint8_t>(dstPixelArray);
 
     uint16x8_t sixteenConst255 = vdupq_n_u16(255);
     uint16x8_t sixteenConstOne = vdupq_n_u16(1);

--- a/Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm
@@ -91,7 +91,7 @@ CertificateInfo ResourceResponse::platformCertificateInfo(std::span<const std::b
     auto trust = checked_cf_cast<SecTrustRef>(trustValue);
 
     if (trust && auditToken.size()) {
-        auto data = adoptCF(CFDataCreate(nullptr, reinterpret_cast<const uint8_t*>(auditToken.data()), auditToken.size()));
+        auto data = adoptCF(CFDataCreate(nullptr, byteCast<uint8_t>(auditToken.data()), auditToken.size()));
         SecTrustSetClientAuditToken(trust, data.get());
     }
 

--- a/Source/WebCore/workers/ScriptBuffer.cpp
+++ b/Source/WebCore/workers/ScriptBuffer.cpp
@@ -72,7 +72,7 @@ String ScriptBuffer::toString() const
 
     StringBuilder builder;
     m_buffer.get()->forEachSegment([&](auto segment) {
-        builder.append(spanReinterpretCast<const char8_t>(segment));
+        builder.append(byteCast<char8_t>(segment));
     });
     return builder.toString();
 }
@@ -87,7 +87,7 @@ void ScriptBuffer::append(const String& string)
     if (string.isEmpty())
         return;
     auto result = string.tryGetUTF8([&](std::span<const char> span) -> bool {
-        m_buffer.append(spanReinterpretCast<const uint8_t>(span));
+        m_buffer.append(byteCast<char8_t>(span));
         return true;
     });
     RELEASE_ASSERT(result);

--- a/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
+++ b/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
@@ -109,7 +109,7 @@ static xmlDocPtr docLoaderFunc(const xmlChar* uri,
     case XSLT_LOAD_DOCUMENT: {
         xsltTransformContextPtr context = (xsltTransformContextPtr)ctxt;
         xmlChar* base = xmlNodeGetBase(context->document->doc, context->node);
-        URL url(URL({ }, String::fromLatin1(reinterpret_cast<const char*>(base))), String::fromLatin1(reinterpret_cast<const char*>(uri)));
+        URL url(URL({ }, String::fromLatin1(byteCast<char>(base))), String::fromLatin1(byteCast<char>(uri)));
         xmlFree(base);
         ResourceError error;
         ResourceResponse response;
@@ -147,8 +147,8 @@ static xmlDocPtr docLoaderFunc(const xmlChar* uri,
 
         // We don't specify an encoding here. Neither Gecko nor WinIE respects
         // the encoding specified in the HTTP headers.
-        auto dataSpan = data->span();
-        return xmlReadMemory(reinterpret_cast<const char*>(dataSpan.data()), dataSpan.size(), (const char*)uri, nullptr, options);
+        auto dataSpan = byteCast<char>(data->span());
+        return xmlReadMemory(dataSpan.data(), dataSpan.size(), byteCast<char>(uri), nullptr, options);
     }
     case XSLT_LOAD_STYLESHEET:
         return globalProcessor->xslStylesheet()->locateStylesheetSubResource(((xsltStylesheetPtr)ctxt)->doc, uri);
@@ -171,7 +171,7 @@ static int writeToStringBuilder(void* context, const char* buffer, int length)
     auto& builder = *static_cast<StringBuilder*>(context);
     if (!length)
         return 0;
-    auto checkedString = WTF::Unicode::checkUTF8({ reinterpret_cast<const char8_t*>(buffer), static_cast<size_t>(length) });
+    auto checkedString = WTF::Unicode::checkUTF8({ byteCast<char8_t>(buffer), static_cast<size_t>(length) });
     if (checkedString.characters.empty())
         return -1;
     builder.append(checkedString);
@@ -308,7 +308,7 @@ bool XSLTProcessor::transformToString(Node& sourceNode, String& mimeType, String
 
     xmlChar* origMethod = sheet->method;
     if (!origMethod && mimeType == textHTMLContentTypeAtom())
-        sheet->method = reinterpret_cast<xmlChar*>(const_cast<char*>("html"));
+        sheet->method = byteCast<xmlChar>(const_cast<char*>("html"));
 
     bool success = false;
     bool shouldFreeSourceDoc = false;
@@ -352,7 +352,7 @@ bool XSLTProcessor::transformToString(Node& sourceNode, String& mimeType, String
 
         if ((success = saveResultToString(resultDoc, sheet, resultString))) {
             mimeType = resultMIMEType(resultDoc, sheet);
-            resultEncoding = String::fromLatin1(reinterpret_cast<const char*>(resultDoc->encoding));
+            resultEncoding = String::fromLatin1(byteCast<char>(resultDoc->encoding));
         }
         xmlFreeDoc(resultDoc);
     }

--- a/Source/WebCore/xml/XSLTUnicodeSort.cpp
+++ b/Source/WebCore/xml/XSLTUnicodeSort.cpp
@@ -129,7 +129,7 @@ void xsltUnicodeSortFunction(xsltTransformContextPtr ctxt, xmlNodePtr *sorts, in
     // The implementation of Collator should be lenient, and accept both "en-US" and "en_US", for example.
     // This lets an author specify sorting rules, e.g. "de_DE@collation=phonebook", which isn't
     // possible with language alone.
-    Collator collator(comp->has_lang ? reinterpret_cast<const char*>(comp->lang) : "en", comp->lower_first);
+    Collator collator(comp->has_lang ? byteCast<char>(comp->lang) : "en", comp->lower_first);
 
     /* Shell's sort of node-set */
     for (incr = len / 2; incr > 0; incr /= 2) {
@@ -160,7 +160,7 @@ void xsltUnicodeSortFunction(xsltTransformContextPtr ctxt, xmlNodePtr *sorts, in
                             tst = 1;
                         else tst = -1;
                     } else
-                        tst = collator.collateUTF8(reinterpret_cast<const char*>(results[j]->stringval), reinterpret_cast<const char*>(results[j + incr]->stringval));
+                        tst = collator.collate(byteCast<char8_t>(results[j]->stringval), byteCast<char8_t>(results[j + incr]->stringval));
                     if (desc[0])
                         tst = -tst;
                 }
@@ -210,7 +210,7 @@ void xsltUnicodeSortFunction(xsltTransformContextPtr ctxt, xmlNodePtr *sorts, in
                                     tst = 1;
                                 else tst = -1;
                             } else
-                                tst = collator.collateUTF8(reinterpret_cast<const char*>(res[j]->stringval), reinterpret_cast<const char*>(res[j + incr]->stringval));
+                                tst = collator.collate(byteCast<char8_t>(res[j]->stringval), byteCast<char8_t>(res[j + incr]->stringval));
                             if (desc[depth])
                                 tst = -tst;
                         }

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -607,8 +607,8 @@ RefPtr<XMLParserContext> XMLParserContext::createMemoryParser(xmlSAXHandlerPtr h
     parser->sax2 = 1;
     parser->instate = XML_PARSER_CONTENT; // We are parsing a CONTENT
     parser->depth = 0;
-    parser->str_xml = xmlDictLookup(parser->dict, reinterpret_cast<xmlChar*>(const_cast<char*>("xml")), 3);
-    parser->str_xmlns = xmlDictLookup(parser->dict, reinterpret_cast<xmlChar*>(const_cast<char*>("xmlns")), 5);
+    parser->str_xml = xmlDictLookup(parser->dict, byteCast<xmlChar>(const_cast<char*>("xml")), 3);
+    parser->str_xmlns = xmlDictLookup(parser->dict, byteCast<xmlChar>(const_cast<char*>("xmlns")), 5);
     parser->str_xml_ns = xmlDictLookup(parser->dict, XML_XML_NAMESPACE, 36);
     parser->_private = userData;
 
@@ -698,22 +698,22 @@ void XMLDocumentParser::doWrite(const String& parseString)
 
 static inline String toString(const xmlChar* string, size_t size)
 {
-    return String::fromUTF8({ reinterpret_cast<const char*>(string), size });
+    return String::fromUTF8({ byteCast<char>(string), size });
 }
 
 static inline String toString(const xmlChar* string)
 {
-    return String::fromUTF8(reinterpret_cast<const char*>(string));
+    return String::fromUTF8(byteCast<char>(string));
 }
 
 static inline AtomString toAtomString(const xmlChar* string, size_t size)
 {
-    return AtomString::fromUTF8({ reinterpret_cast<const char*>(string), size });
+    return AtomString::fromUTF8({ byteCast<char>(string), size });
 }
 
 static inline AtomString toAtomString(const xmlChar* string)
 {
-    return AtomString::fromUTF8(reinterpret_cast<const char*>(string));
+    return AtomString::fromUTF8(byteCast<char>(string));
 }
 
 struct _xmlSAX2Namespace {
@@ -1142,23 +1142,23 @@ static void normalErrorHandler(void* closure, const char* message, ...)
 // Using a static entity and marking it XML_INTERNAL_PREDEFINED_ENTITY is
 // a hack to avoid malloc/free. Using a global variable like this could cause trouble
 // if libxml implementation details were to change
-static xmlChar sharedXHTMLEntityResult[9] = {0, 0, 0, 0, 0, 0, 0, 0, 0};
+static std::array<xmlChar, 9> sharedXHTMLEntityResult = { };
 
 static xmlEntityPtr sharedXHTMLEntity()
 {
     static xmlEntity entity;
     if (!entity.type) {
         entity.type = XML_ENTITY_DECL;
-        entity.orig = sharedXHTMLEntityResult;
-        entity.content = sharedXHTMLEntityResult;
+        entity.orig = sharedXHTMLEntityResult.data();
+        entity.content = sharedXHTMLEntityResult.data();
         entity.etype = XML_INTERNAL_PREDEFINED_ENTITY;
     }
     return &entity;
 }
 
-static size_t convertUTF16EntityToUTF8(std::span<const UChar> utf16Entity, char* target, size_t targetSize)
+static size_t convertUTF16EntityToUTF8(std::span<const UChar> utf16Entity, std::span<char8_t> target)
 {
-    auto result = WTF::Unicode::convert(utf16Entity, { reinterpret_cast<char8_t*>(target), targetSize });
+    auto result = WTF::Unicode::convert(utf16Entity, target);
     if (result.code != WTF::Unicode::ConversionResultCode::Success)
         return 0;
 
@@ -1170,13 +1170,12 @@ static size_t convertUTF16EntityToUTF8(std::span<const UChar> utf16Entity, char*
 
 static xmlEntityPtr getXHTMLEntity(const xmlChar* name)
 {
-    auto decodedEntity = decodeNamedHTMLEntityForXMLParser(reinterpret_cast<const char*>(name));
+    auto decodedEntity = decodeNamedHTMLEntityForXMLParser(byteCast<char>(name));
     if (decodedEntity.failed())
         return nullptr;
 
     auto utf16DecodedEntity = decodedEntity.span();
 
-    constexpr size_t kSharedXhtmlEntityResultLength = std::size(sharedXHTMLEntityResult);
     size_t entityLengthInUTF8;
     // Unlike HTML parser, XML parser parses the content of named
     // entities. So we need to escape '&' and '<'.
@@ -1207,12 +1206,11 @@ static xmlEntityPtr getXHTMLEntity(const xmlChar* name)
         entityLengthInUTF8 = 8;
     } else {
         ASSERT(utf16DecodedEntity.size() <= 4);
-        entityLengthInUTF8 = convertUTF16EntityToUTF8(utf16DecodedEntity,
-            reinterpret_cast<char*>(sharedXHTMLEntityResult), kSharedXhtmlEntityResultLength);
+        entityLengthInUTF8 = convertUTF16EntityToUTF8(utf16DecodedEntity, byteCast<char8_t>(std::span { sharedXHTMLEntityResult }));
         if (!entityLengthInUTF8)
             return 0;
     }
-    ASSERT(entityLengthInUTF8 <= kSharedXhtmlEntityResultLength);
+    ASSERT(entityLengthInUTF8 <= sharedXHTMLEntityResult.size());
 
     xmlEntityPtr entity = sharedXHTMLEntity();
     entity->length = entityLengthInUTF8;
@@ -1377,7 +1375,7 @@ xmlDocPtr xmlDocPtrForString(CachedResourceLoader& cachedResourceLoader, const S
     // good error messages.
 
     const bool is8Bit = source.is8Bit();
-    auto characters = is8Bit ? spanReinterpretCast<const char>(source.span8()) : spanReinterpretCast<const char>(source.span16());
+    auto characters = is8Bit ? byteCast<char>(source.span8()) : spanReinterpretCast<const char>(source.span16());
     size_t sizeInBytes = source.length() * (is8Bit ? sizeof(LChar) : sizeof(UChar));
     const char* encoding = is8Bit ? "iso-8859-1" : nativeEndianUTF16Encoding();
 
@@ -1476,7 +1474,7 @@ using AttributeParseState = std::optional<HashMap<String, String>>;
 
 static void attributesStartElementNsHandler(void* closure, const xmlChar* xmlLocalName, const xmlChar* /*xmlPrefix*/, const xmlChar* /*xmlURI*/, int /*numNamespaces*/, const xmlChar** /*namespaces*/, int numAttributes, int /*numDefaulted*/, const xmlChar** libxmlAttributes)
 {
-    if (strcmp(reinterpret_cast<const char*>(xmlLocalName), "attrs") != 0)
+    if (strcmp(byteCast<char>(xmlLocalName), "attrs"))
         return;
 
     auto& state = *static_cast<AttributeParseState*>(static_cast<xmlParserCtxtPtr>(closure)->_private);

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -448,7 +448,7 @@ Device::ExternalTextureData Device::createExternalTextureFromPixelBuffer(CVPixel
             if (!mtlTexture)
                 return { };
 
-            uint8_t *imageBytes = reinterpret_cast<uint8_t*>(CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, plane));
+            uint8_t *imageBytes = static_cast<uint8_t*>(CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, plane));
             int bytesPerRow = CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, plane);
 
             [mtlTexture replaceRegion:MTLRegionMake2D(0, 0, width, height) mipmapLevel:0 withBytes:imageBytes bytesPerRow:bytesPerRow];

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -965,7 +965,7 @@
         assertIsCurrent(workQueue());
         Vector<uint8_t, 4> data(dataSize, 0);
         m_context->getBufferSubData(target, static_cast<GCGLintptr>(offset), data);
-        completionHandler(std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size()));
+        completionHandler(byteCast<uint8_t>(data.span()));
     }
     void blitFramebuffer(int32_t srcX0, int32_t srcY0, int32_t srcX1, int32_t srcY1, int32_t dstX0, int32_t dstY0, int32_t dstX1, int32_t dstY1, uint32_t mask, uint32_t filter)
     {

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1513,13 +1513,13 @@ void NetworkConnectionToWebProcess::logOnBehalfOfWebContent(std::span<const uint
     // os_log_hook on sender side sends a null category and subsystem when logging to OS_LOG_DEFAULT.
     auto osLog = OSObjectPtr<os_log_t>();
     if (isNullTerminated(logSubsystem) && isNullTerminated(logCategory)) {
-        auto subsystem = reinterpret_cast<const char*>(logSubsystem.data());
-        auto category = reinterpret_cast<const char*>(logCategory.data());
+        auto subsystem = byteCast<char>(logSubsystem.data());
+        auto category = byteCast<char>(logCategory.data());
         osLog = adoptOSObject(os_log_create(subsystem, category));
     }
 
     auto osLogPointer = osLog.get() ? osLog.get() : OS_LOG_DEFAULT;
-    auto logData = reinterpret_cast<const char*>(logString.data());
+    auto logData = byteCast<char>(logString.data());
 
 #if HAVE(OS_SIGNPOST)
     if (WTFSignpostHandleIndirectLog(osLogPointer, pid, logData))

--- a/Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.cpp
@@ -95,7 +95,7 @@ void LibWebRTCSocketClient::setOption(int option, int value)
 void LibWebRTCSocketClient::signalReadPacket(rtc::AsyncPacketSocket* socket, const char* value, size_t length, const rtc::SocketAddress& address, const rtc::PacketTime& packetTime)
 {
     ASSERT_UNUSED(socket, m_socket.get() == socket);
-    std::span data(reinterpret_cast<const uint8_t*>(value), length);
+    std::span data(byteCast<uint8_t>(value), length);
     m_connection->send(Messages::LibWebRTCNetwork::SignalReadPacket(m_identifier, data, RTCNetwork::IPAddress(address.ipaddr()), address.port(), packetTime), 0);
 }
 

--- a/Source/WebKit/Shared/API/c/WKString.cpp
+++ b/Source/WebKit/Shared/API/c/WKString.cpp
@@ -79,7 +79,7 @@ size_t WKStringGetUTF8CStringImpl(WKStringRef stringRef, char* buffer, size_t bu
 
     auto string = WebKit::toImpl(stringRef)->stringView();
 
-    std::span<char8_t> target { reinterpret_cast<char8_t*>(buffer), bufferSize - 1 };
+    std::span<char8_t> target { byteCast<char8_t>(buffer), bufferSize - 1 };
     WTF::Unicode::ConversionResult<char8_t> result;
     if (string.is8Bit())
         result = WTF::Unicode::convert(string.span8(), target);

--- a/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
@@ -49,7 +49,7 @@ std::unique_ptr<SandboxExtensionImpl> SandboxExtensionImpl::create(const char* p
 }
 
 SandboxExtensionImpl::SandboxExtensionImpl(std::span<const uint8_t> serializedFormat)
-    : m_token { strndup(reinterpret_cast<const char*>(serializedFormat.data()), serializedFormat.size()) }
+    : m_token { strndup(byteCast<char>(serializedFormat.data()), serializedFormat.size()) }
 {
     ASSERT(!serializedFormat.empty());
 }

--- a/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
+++ b/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
@@ -151,7 +151,7 @@ public:
     HistoryEntryDataEncoder& operator<<(const Vector<char>& value)
     {
         *this << static_cast<uint64_t>(value.size());
-        encodeFixedLengthData(spanReinterpretCast<const uint8_t>(value.span()), 1);
+        encodeFixedLengthData(byteCast<uint8_t>(value.span()), 1);
 
         return *this;
     }
@@ -508,7 +508,7 @@ RefPtr<API::Data> encodeLegacySessionState(const SessionState& sessionState)
     if (!CFPropertyListWrite(stateDictionary.get(), writeStream.get(), kCFPropertyListBinaryFormat_v1_0, 0, nullptr))
         return nullptr;
 
-    auto data = adoptCF(static_cast<CFDataRef>(CFWriteStreamCopyProperty(writeStream.get(), kCFStreamPropertyDataWritten)));
+    auto data = adoptCF(checked_cf_cast<CFDataRef>(CFWriteStreamCopyProperty(writeStream.get(), kCFStreamPropertyDataWritten)));
 
     CFIndex length = CFDataGetLength(data.get());
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
@@ -80,7 +80,7 @@ void LibWebRTCSocket::signalReadPacket(std::span<const uint8_t> data, rtc::Socke
         return;
 
     m_remoteAddress = WTFMove(address);
-    SignalReadPacket(this, reinterpret_cast<const char*>(data.data()), data.size(), m_remoteAddress, timestamp);
+    SignalReadPacket(this, byteCast<char>(data.data()), data.size(), m_remoteAddress, timestamp);
 }
 
 void LibWebRTCSocket::signalSentPacket(int64_t rtcPacketID, int64_t sendTimeMs)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4552,10 +4552,7 @@ void WebPage::getWebArchiveOfFrame(std::optional<FrameIdentifier> frameID, Compl
 void WebPage::getAccessibilityTreeData(CompletionHandler<void(const std::optional<IPC::SharedBufferReference>&)>&& callback)
 {
     IPC::SharedBufferReference dataBuffer;
-
 #if PLATFORM(COCOA)
-    RetainPtr<CFDataRef> data;
-
     if (auto treeData = m_page->accessibilityTreeData()) {
         auto stream = adoptCF(CFWriteStreamCreateWithAllocatedBuffers(0, 0));
         CFWriteStreamOpen(stream.get());
@@ -4568,13 +4565,12 @@ void WebPage::getAccessibilityTreeData(CompletionHandler<void(const std::optiona
         writeTreeToStream(treeData->liveTree);
         writeTreeToStream(treeData->isolatedTree);
 
-        data = adoptCF(static_cast<CFDataRef>(CFWriteStreamCopyProperty(stream.get(), kCFStreamPropertyDataWritten)));
+        auto data = adoptCF(checked_cf_cast<CFDataRef>(CFWriteStreamCopyProperty(stream.get(), kCFStreamPropertyDataWritten)));
         CFWriteStreamClose(stream.get());
 
         dataBuffer = IPC::SharedBufferReference(SharedBuffer::create(data.get()));
     }
 #endif
-
     callback(dataBuffer);
 }
 

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -873,7 +873,7 @@ static void registerLogHook()
             char* messageString = os_log_copy_message_string(&msg);
             if (!messageString)
                 return;
-            std::span logString(reinterpret_cast<uint8_t*>(messageString), strlen(messageString) + 1);
+            std::span logString(byteCast<uint8_t>(messageString), strlen(messageString) + 1);
 
             auto connectionID = WebProcess::singleton().networkProcessConnectionID();
             if (connectionID)

--- a/Source/WebKitLegacy/mac/Misc/WebNSDataExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebNSDataExtras.mm
@@ -36,7 +36,7 @@
 
 #define CHANNEL_TAG_LENGTH 7
 
-    const char* p = reinterpret_cast<const char*>(bytes);
+    const char* p = byteCast<char>(bytes);
     int remaining = std::min<NSUInteger>(length, WEB_GUESS_MIME_TYPE_PEEK_LENGTH) - (CHANNEL_TAG_LENGTH - 1);
 
     BOOL foundRDF = false;

--- a/Tools/TestWebKitAPI/Tests/WTF/StdLibExtrasTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StdLibExtrasTests.cpp
@@ -132,7 +132,6 @@ TEST(WTF_StdLibExtras, MakeUniqueFunctionLocalTypeCompiles)
     auto c = makeUnique<LocalClass>();
 }
 
-
 TEST(WTF_StdLibExtras, RoundUpToMultipleOfWorks)
 {
     EXPECT_EQ(2u, roundUpToMultipleOf(static_cast<uint8_t>(2), static_cast<uint8_t>(1)));
@@ -179,6 +178,32 @@ TEST(WTF_StdLibExtras, RoundUpToMultipleOfNonPowerOfTwoWorks)
     EXPECT_TRUE(roundUpToMultipleOfNonPowerOfTwo(CheckedSize { WTF::ResultOverflowed }, CheckedSize { 78 }).hasOverflowed());
     EXPECT_TRUE(roundUpToMultipleOfNonPowerOfTwo(CheckedSize { 78 }, CheckedSize { WTF::ResultOverflowed }).hasOverflowed());
 
+}
+
+TEST(WTF_StdLibExtras, ByteCast)
+{
+    uint8_t u8 = 0;
+    const uint8_t cu8 = 0;
+    std::span su8 = { &u8, 1 };
+    std::span scu8 = { &cu8, 1 };
+    static_assert(std::same_as<char, decltype(byteCast<char>(u8))>);
+    static_assert(std::same_as<char8_t, decltype(byteCast<char8_t>(u8))>);
+    static_assert(std::same_as<std::byte, decltype(byteCast<std::byte>(u8))>);
+    static_assert(std::same_as<char, decltype(byteCast<char>(cu8))>);
+    static_assert(std::same_as<char8_t, decltype(byteCast<char8_t>(cu8))>);
+    static_assert(std::same_as<std::byte, decltype(byteCast<std::byte>(cu8))>);
+    static_assert(std::same_as<char*, decltype(byteCast<char>(&u8))>);
+    static_assert(std::same_as<char8_t*, decltype(byteCast<char8_t>(&u8))>);
+    static_assert(std::same_as<std::byte*, decltype(byteCast<std::byte>(&u8))>);
+    static_assert(std::same_as<const char*, decltype(byteCast<char>(&cu8))>);
+    static_assert(std::same_as<const char8_t*, decltype(byteCast<char8_t>(&cu8))>);
+    static_assert(std::same_as<const std::byte*, decltype(byteCast<std::byte>(&cu8))>);
+    static_assert(std::same_as<std::span<char>, decltype(byteCast<char>(su8))>);
+    static_assert(std::same_as<std::span<char8_t>, decltype(byteCast<char8_t>(su8))>);
+    static_assert(std::same_as<std::span<std::byte>, decltype(byteCast<std::byte>(su8))>);
+    static_assert(std::same_as<std::span<const char>, decltype(byteCast<char>(scu8))>);
+    static_assert(std::same_as<std::span<const char8_t>, decltype(byteCast<char8_t>(scu8))>);
+    static_assert(std::same_as<std::span<const std::byte>, decltype(byteCast<std::byte>(scu8))>);
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp
@@ -38,14 +38,13 @@
 
 namespace TestWebKitAPI {
 
-static void expectBuilderContent(StringView expected, const StringBuilder& builder)
+static String builderContent(const StringBuilder& builder)
 {
     // Not using builder.toString() or builder.toStringPreserveCapacity() because they all
     // change internal state of builder.
     if (builder.is8Bit())
-        EXPECT_EQ(expected, String(builder.span<LChar>()));
-    else
-        EXPECT_EQ(expected, String(builder.span<UChar>()));
+        return builder.span<LChar>();
+    return builder.span<UChar>();
 }
 
 void expectEmpty(const StringBuilder& builder)
@@ -65,24 +64,24 @@ TEST(StringBuilderTest, Append)
 {
     StringBuilder builder;
     builder.append(String("0123456789"_s));
-    expectBuilderContent("0123456789"_s, builder);
+    EXPECT_EQ("0123456789"_s, builderContent(builder));
     builder.append("abcd"_s);
-    expectBuilderContent("0123456789abcd"_s, builder);
+    EXPECT_EQ("0123456789abcd"_s, builderContent(builder));
     builder.append(std::span { reinterpret_cast<const LChar*>("efgh"), 3 });
-    expectBuilderContent("0123456789abcdefg"_s, builder);
+    EXPECT_EQ("0123456789abcdefg"_s, builderContent(builder));
     builder.append(""_s);
-    expectBuilderContent("0123456789abcdefg"_s, builder);
+    EXPECT_EQ("0123456789abcdefg"_s, builderContent(builder));
     builder.append('#');
-    expectBuilderContent("0123456789abcdefg#"_s, builder);
+    EXPECT_EQ("0123456789abcdefg#"_s, builderContent(builder));
 
     builder.toString(); // Test after reifyString().
     StringBuilder builder1;
     builder.append(""_span);
-    expectBuilderContent("0123456789abcdefg#"_s, builder);
+    EXPECT_EQ("0123456789abcdefg#"_s, builderContent(builder));
     builder1.append(builder.span<LChar>());
     builder1.append("XYZ"_s);
     builder.append(builder1.span<LChar>());
-    expectBuilderContent("0123456789abcdefg#0123456789abcdefg#XYZ"_s, builder);
+    EXPECT_EQ("0123456789abcdefg#0123456789abcdefg#XYZ"_s, builderContent(builder));
 
     StringBuilder builder2;
     builder2.reserveCapacity(100);
@@ -102,7 +101,7 @@ TEST(StringBuilderTest, Append)
     builderForUChar32Append.append(U'A');
     EXPECT_EQ(3U, builderForUChar32Append.length());
     const UChar resultArray[] = { U16_LEAD(frakturAChar), U16_TRAIL(frakturAChar), 'A' };
-    expectBuilderContent(String({ resultArray, std::size(resultArray) }), builderForUChar32Append);
+    EXPECT_EQ(String({ resultArray, std::size(resultArray) }), builderContent(builderForUChar32Append));
     {
         StringBuilder builder;
         StringBuilder builder2;
@@ -116,7 +115,7 @@ TEST(StringBuilderTest, Append)
         builder.append(std::span { data });
         EXPECT_EQ(4U, builder.length());
         const UChar resultArray[] = { U16_LEAD(frakturAChar), U16_TRAIL(frakturAChar), U16_LEAD(frakturAChar), U16_TRAIL(frakturAChar) };
-        expectBuilderContent(String({ resultArray, std::size(resultArray) }), builder);
+        EXPECT_EQ(String({ resultArray, std::size(resultArray) }), builderContent(builder));
     }
 }
 
@@ -131,7 +130,7 @@ TEST(StringBuilderTest, AppendIntMin)
     std::string expectedString;
     stringStream >> expectedString;
 
-    expectBuilderContent(String::fromLatin1(expectedString.c_str()), builder);
+    EXPECT_EQ(String::fromLatin1(expectedString.c_str()), builderContent(builder));
 }
 
 TEST(StringBuilderTest, VariadicAppend)
@@ -139,52 +138,52 @@ TEST(StringBuilderTest, VariadicAppend)
     {
         StringBuilder builder;
         builder.append(String("0123456789"_s));
-        expectBuilderContent("0123456789"_s, builder);
+        EXPECT_EQ("0123456789"_s, builderContent(builder));
         builder.append("abcd"_s);
-        expectBuilderContent("0123456789abcd"_s, builder);
+        EXPECT_EQ("0123456789abcd"_s, builderContent(builder));
         builder.append('e');
-        expectBuilderContent("0123456789abcde"_s, builder);
+        EXPECT_EQ("0123456789abcde"_s, builderContent(builder));
         builder.append(""_s);
-        expectBuilderContent("0123456789abcde"_s, builder);
+        EXPECT_EQ("0123456789abcde"_s, builderContent(builder));
     }
 
     {
         StringBuilder builder;
         builder.append(String("0123456789"_s), "abcd"_s, 'e', ""_s);
-        expectBuilderContent("0123456789abcde"_s, builder);
+        EXPECT_EQ("0123456789abcde"_s, builderContent(builder));
         builder.append(String("A"_s), "B"_s, 'C', ""_s);
-        expectBuilderContent("0123456789abcdeABC"_s, builder);
+        EXPECT_EQ("0123456789abcdeABC"_s, builderContent(builder));
     }
 
     {
         StringBuilder builder;
         builder.append(String("0123456789"_s), "abcd"_s, bullseye, ""_s);
-        expectBuilderContent(makeString("0123456789abcd"_s, String({ &bullseye, 1 })), builder);
+        EXPECT_EQ(makeString("0123456789abcd"_s, bullseye), builderContent(builder));
         builder.append(String("A"_s), "B"_s, 'C', ""_s);
-        expectBuilderContent(makeString("0123456789abcd"_s, String({ &bullseye, 1 }), "ABC"_s), builder);
+        EXPECT_EQ(makeString("0123456789abcd"_s, bullseye, "ABC"_s), builderContent(builder));
     }
 
     {
         // Test where we upconvert the StringBuilder from 8-bit to 16-bit, and don't fit in the existing capacity.
         StringBuilder builder;
         builder.append(String("0123456789"_s), "abcd"_s, 'e', ""_s);
-        expectBuilderContent("0123456789abcde"_s, builder);
+        EXPECT_EQ("0123456789abcde"_s, builderContent(builder));
         EXPECT_TRUE(builder.is8Bit());
         EXPECT_LT(builder.capacity(), builder.length() + 3);
         builder.append(String("A"_s), "B"_s, bullseye, ""_s);
-        expectBuilderContent(makeString("0123456789abcdeAB"_s, String({ &bullseye, 1 })), builder);
+        EXPECT_EQ(makeString("0123456789abcdeAB"_s, bullseye), builderContent(builder));
     }
 
     {
         // Test where we upconvert the StringBuilder from 8-bit to 16-bit, but would have fit in the capacity if the upconvert wasn't necessary.
         StringBuilder builder;
         builder.append(String("0123456789"_s), "abcd"_s, 'e', ""_s);
-        expectBuilderContent("0123456789abcde"_s, builder);
+        EXPECT_EQ("0123456789abcde"_s, builderContent(builder));
         builder.reserveCapacity(32);
         EXPECT_TRUE(builder.is8Bit());
         EXPECT_GE(builder.capacity(), builder.length() + 3);
         builder.append(String("A"_s), "B"_s, bullseye, ""_s);
-        expectBuilderContent(makeString("0123456789abcdeAB"_s, String({ &bullseye, 1 })), builder);
+        EXPECT_EQ(makeString("0123456789abcdeAB"_s, bullseye), builderContent(builder));
     }
 }
 
@@ -291,15 +290,15 @@ TEST(StringBuilderTest, Resize)
     builder.append("0123456789"_s);
     builder.shrink(10);
     EXPECT_EQ(10U, builder.length());
-    expectBuilderContent("0123456789"_s, builder);
+    EXPECT_EQ("0123456789"_s, builderContent(builder));
     builder.shrink(8);
     EXPECT_EQ(8U, builder.length());
-    expectBuilderContent("01234567"_s, builder);
+    EXPECT_EQ("01234567"_s, builderContent(builder));
 
     builder.toString();
     builder.shrink(7);
     EXPECT_EQ(7U, builder.length());
-    expectBuilderContent("0123456"_s, builder);
+    EXPECT_EQ("0123456"_s, builderContent(builder));
     builder.shrink(0);
     expectEmpty(builder);
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
@@ -108,8 +108,7 @@ TEST(WTF, StringImplEqualIgnoringASCIICaseBasic)
     auto b = StringImpl::create("ABCDEFG"_s);
     auto c = StringImpl::create("abcdefg"_s);
     constexpr auto d = "aBcDeFG"_s;
-    constexpr size_t zeroLength = 0; // LLVM bug workaround.
-    auto empty = StringImpl::create(std::span { reinterpret_cast<const LChar*>(""), zeroLength });
+    auto empty = StringImpl::create(""_span);
     auto shorter = StringImpl::create("abcdef"_s);
     auto different = StringImpl::create("abcrefg"_s);
 
@@ -152,9 +151,8 @@ TEST(WTF, StringImplEqualIgnoringASCIICaseWithNull)
 
 TEST(WTF, StringImplEqualIgnoringASCIICaseWithEmpty)
 {
-    constexpr size_t zeroLength = 0; // LLVM bug workaround.
-    auto a = StringImpl::create(std::span { reinterpret_cast<const LChar*>(""), zeroLength });
-    auto b = StringImpl::create(std::span { reinterpret_cast<const LChar*>(""), zeroLength });
+    auto a = StringImpl::create(""_span);
+    auto b = StringImpl::create(""_span);
     ASSERT_TRUE(equalIgnoringASCIICase(a.ptr(), b.ptr()));
     ASSERT_TRUE(equalIgnoringASCIICase(b.ptr(), a.ptr()));
 }
@@ -332,8 +330,7 @@ TEST(WTF, StringImplFindIgnoringASCIICaseOnNull)
 TEST(WTF, StringImplFindIgnoringASCIICaseOnEmpty)
 {
     auto reference = stringFromUTF8("ABCÉEFG");
-    constexpr size_t zeroLength = 0; // LLVM bug workaround.
-    auto empty = StringImpl::create({ reinterpret_cast<const LChar*>(""), zeroLength });
+    auto empty = StringImpl::create(""_span);
     EXPECT_EQ(static_cast<size_t>(0), reference->findIgnoringASCIICase(empty.ptr()));
     EXPECT_EQ(static_cast<size_t>(0), reference->findIgnoringASCIICase(empty.ptr(), 0));
     EXPECT_EQ(static_cast<size_t>(3), reference->findIgnoringASCIICase(empty.ptr(), 3));
@@ -409,16 +406,14 @@ TEST(WTF, StringImplStartsWithIgnoringASCIICaseWithNull)
     auto reference = StringImpl::create("aBcDeFG"_s);
     ASSERT_FALSE(reference->startsWithIgnoringASCIICase(StringView { }));
 
-    constexpr size_t zeroLength = 0; // LLVM bug workaround.
-    auto empty = StringImpl::create(std::span { reinterpret_cast<const LChar*>(""), zeroLength });
+    auto empty = StringImpl::create(""_span);
     ASSERT_FALSE(empty->startsWithIgnoringASCIICase(StringView { }));
 }
 
 TEST(WTF, StringImplStartsWithIgnoringASCIICaseWithEmpty)
 {
     auto reference = StringImpl::create("aBcDeFG"_s);
-    constexpr size_t zeroLength = 0; // LLVM bug workaround.
-    auto empty = StringImpl::create(std::span { reinterpret_cast<const LChar*>(""), zeroLength });
+    auto empty = StringImpl::create(""_span);
     ASSERT_TRUE(reference->startsWithIgnoringASCIICase(empty.ptr()));
     ASSERT_TRUE(reference->startsWithIgnoringASCIICase(*empty.ptr()));
     ASSERT_TRUE(empty->startsWithIgnoringASCIICase(empty.ptr()));
@@ -500,16 +495,14 @@ TEST(WTF, StringImplEndsWithIgnoringASCIICaseWithNull)
     auto reference = StringImpl::create("aBcDeFG"_s);
     ASSERT_FALSE(reference->endsWithIgnoringASCIICase(StringView { }));
 
-    constexpr size_t zeroLength = 0; // LLVM bug workaround.
-    auto empty = StringImpl::create(std::span { reinterpret_cast<const LChar*>(""), zeroLength });
+    auto empty = StringImpl::create(""_span);
     ASSERT_FALSE(empty->endsWithIgnoringASCIICase(StringView { }));
 }
 
 TEST(WTF, StringImplEndsWithIgnoringASCIICaseWithEmpty)
 {
     auto reference = StringImpl::create("aBcDeFG"_s);
-    constexpr size_t zeroLength = 0; // LLVM bug workaround.
-    auto empty = StringImpl::create(std::span { reinterpret_cast<const LChar*>(""), zeroLength });
+    auto empty = StringImpl::create(""_span);
     ASSERT_TRUE(reference->endsWithIgnoringASCIICase(empty.ptr()));
     ASSERT_TRUE(reference->endsWithIgnoringASCIICase(*empty.ptr()));
     ASSERT_TRUE(empty->endsWithIgnoringASCIICase(empty.ptr()));

--- a/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
@@ -338,8 +338,7 @@ TEST(WTF, StringViewEqualIgnoringASCIICaseBasic)
     RefPtr<StringImpl> b = StringImpl::create("ABCDEFG"_s);
     RefPtr<StringImpl> c = StringImpl::create("abcdefg"_s);
     constexpr auto d = "aBcDeFG"_s;
-    constexpr size_t zeroLength = 0; // LLVM bug workaround.
-    RefPtr<StringImpl> empty = StringImpl::create(std::span { reinterpret_cast<const LChar*>(""), zeroLength });
+    RefPtr<StringImpl> empty = StringImpl::create(""_span);
     RefPtr<StringImpl> shorter = StringImpl::create("abcdef"_s);
     RefPtr<StringImpl> different = StringImpl::create("abcrefg"_s);
 
@@ -384,9 +383,8 @@ TEST(WTF, StringViewEqualIgnoringASCIICaseBasic)
 
 TEST(WTF, StringViewEqualIgnoringASCIICaseWithEmpty)
 {
-    constexpr size_t zeroLength = 0; // LLVM bug workaround.
-    RefPtr<StringImpl> a = StringImpl::create(std::span { reinterpret_cast<const LChar*>(""), zeroLength });
-    RefPtr<StringImpl> b = StringImpl::create(std::span { reinterpret_cast<const LChar*>(""), zeroLength });
+    RefPtr<StringImpl> a = StringImpl::create(""_span);
+    RefPtr<StringImpl> b = StringImpl::create(""_span);
     StringView stringViewA(*a.get());
     StringView stringViewB(*b.get());
     ASSERT_TRUE(equalIgnoringASCIICase(stringViewA, stringViewB));

--- a/Tools/TestWebKitAPI/Tests/WebCore/CBORWriterTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CBORWriterTest.cpp
@@ -43,7 +43,7 @@ bool eq(const Vector<uint8_t>& cbor, const CString& expect)
 {
     if (cbor.size() != expect.length())
         return false;
-    return !memcmp(cbor.data(), reinterpret_cast<const uint8_t*>(expect.data()), cbor.size());
+    return !memcmp(cbor.data(), expect.data(), cbor.size());
 }
 
 bool eq(const Vector<uint8_t>& cbor, const uint8_t* expect, const size_t expectLength)

--- a/Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp
@@ -238,7 +238,7 @@ TEST_F(FragmentedSharedBufferTest, getSomeData)
     checkBuffer(gh2.span().data(), gh2.size(), "gh");
     checkBuffer(ghijkl.span().data(), ghijkl.size(), "ghijkl");
     EXPECT_EQ(gh1.size(), gh2.size());
-    checkBufferWithLength(gh1.span().data(), gh1.size(), reinterpret_cast<const char*>(gh2.span().data()), gh2.size());
+    checkBufferWithLength(gh1.span().data(), gh1.size(), byteCast<char>(gh2.span().data()), gh2.size());
     checkBuffer(l.span().data(), l.size(), "l");
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PDFLinkReferrer.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PDFLinkReferrer.mm
@@ -77,15 +77,15 @@ TEST(WebKit, PDFLinkReferrer)
         connection.receiveHTTPRequest([=](Vector<char>&& requestBytes) {
             requestBytes.append('\0');
             // Look for a referer header.
-            const auto* currentLine = reinterpret_cast<const char*>(requestBytes.data());
+            const auto* currentLine = byteCast<char>(requestBytes.data());
             while (currentLine) {
                 EXPECT_NE(strncasecmp(currentLine, "referer:", 8), 0);
                 const char* nextLine = strchr(currentLine, '\n');
                 currentLine = nextLine ? nextLine + 1 : 0;
             }
             constexpr auto responseHeader =
-            "HTTP/1.1 200 OK\r\n"
-            "Content-Length: 0\r\n\r\n"_s;
+                "HTTP/1.1 200 OK\r\n"
+                "Content-Length: 0\r\n\r\n"_s;
             connection.send(responseHeader);
         });
     });

--- a/Tools/TestWebKitAPI/cocoa/CGImagePixelReader.cpp
+++ b/Tools/TestWebKitAPI/cocoa/CGImagePixelReader.cpp
@@ -51,7 +51,7 @@ bool CGImagePixelReader::isTransparentBlack(unsigned x, unsigned y) const
 
 Color CGImagePixelReader::at(unsigned x, unsigned y) const
 {
-    auto* data = reinterpret_cast<uint8_t*>(CGBitmapContextGetData(m_context.get()));
+    auto* data = static_cast<uint8_t*>(CGBitmapContextGetData(m_context.get()));
     auto offset = 4 * (width() * y + x);
     return makeFromComponentsClampingExceptAlpha<SRGBA<uint8_t>>(data[offset], data[offset + 1], data[offset + 2], data[offset + 3]);
 }

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
@@ -84,7 +84,7 @@ static RetainPtr<nw_protocol_definition_t> proxyDefinition(HTTPServer::Protocol 
                     break;
                 }
                 case State::DidRequestCredentials:
-                    EXPECT_TRUE(strnstr(reinterpret_cast<const char*>(buffer), "Proxy-Authorization: Basic dGVzdHVzZXI6dGVzdHBhc3N3b3Jk\r\n", bufferLength));
+                    EXPECT_TRUE(strnstr(byteCast<char>(buffer), "Proxy-Authorization: Basic dGVzdHVzZXI6dGVzdHBhc3N3b3Jk\r\n", bufferLength));
                     FALLTHROUGH;
                 case State::WillNotRequestCredentials: {
                     const char* negotiationResponse = ""
@@ -557,7 +557,7 @@ void Connection::webSocketHandshake(CompletionHandler<void()>&& connectionHandle
 
             const auto webSocketKeyGUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"_span;
             SHA1 sha1;
-            sha1.addBytes(std::span { reinterpret_cast<const uint8_t*>(keyBegin), static_cast<size_t>(keyEnd - keyBegin) });
+            sha1.addBytes(byteCast<uint8_t>(std::span { keyBegin, keyEnd }));
             sha1.addBytes(webSocketKeyGUID);
             SHA1::Digest hash;
             sha1.computeHash(hash);


### PR DESCRIPTION
#### dbd9819325e88d1d46f1662949df2edd3bba2666
<pre>
Add byteCast for conversions between different byte-sized types
<a href="https://bugs.webkit.org/show_bug.cgi?id=273380">https://bugs.webkit.org/show_bug.cgi?id=273380</a>
<a href="https://rdar.apple.com/127209334">rdar://127209334</a>

Reviewed by Chris Dumez.

* Source/JavaScriptCore/API/JSStringRef.cpp:
(JSStringGetUTF8CString): Use byteCast.

* Source/JavaScriptCore/assembler/MacroAssemblerPrinter.cpp:
(JSC::Printer::printMemory): Use static_cast instead of reinterpret_cast.
* Source/JavaScriptCore/assembler/ProbeFrame.h:
(JSC::Probe::Frame::Frame): Ditto.
* Source/JavaScriptCore/bytecode/UnlinkedMetadataTableInlines.h:
(JSC::UnlinkedMetadataTable::link): Ditto.

* Source/JavaScriptCore/runtime/Identifier.h:
(JSC::Identifier::equal): Use byteCast.
(JSC::operator==): Ditto.
* Source/JavaScriptCore/runtime/IntlCollator.cpp:
(JSC::IntlCollator::compareStrings const): Ditto.
* Source/JavaScriptCore/runtime/IntlLocale.cpp:
(JSC::LocaleIDBuilder::setKeywordValue): Ditto.

* Source/JavaScriptCore/runtime/NumberPrototype.cpp:
(JSC::toStringWithRadixInternal): Removed unneeded static_cast.

* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::Segment::byte): Removed unneeded reinterpret_cast.

* Source/JavaScriptCore/wasm/WasmMemory.cpp:
(JSC::Wasm::Memory::fill): Use static_cast instead of reinterpret_cast.
(JSC::Wasm::Memory::copy): Ditto.
(JSC::Wasm::Memory::init): Ditto.

* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::dumpUChar32): Tweaked formatting.

* Source/WTF/wtf/FastFloat.cpp:
(WTF::parseDouble): Use byteCast.
* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::toStdFileSystemPath): Ditto.
(WTF::FileSystemImpl::fromStdFileSystemPath): Ditto.

* Source/WTF/wtf/PageBlock.h:
(WTF::PageBlock::end const): Use static_cast instead of reinterpret_cast.

* Source/WTF/wtf/StdLibExtras.h: Added byteCast.

* Source/WTF/wtf/Threading.cpp:
(WTF::Thread::normalizeThreadName): Use byteCast.

* Source/WTF/wtf/URLHelpers.cpp:
(WTF::URLHelpers::userVisibleURL): Use span instead of dataAsUInt8Ptr.
* Source/WTF/wtf/cf/URLCF.cpp:
(WTF::URL::createCFURL const): Ditto.

* Source/WTF/wtf/cf/VectorCF.h:
(WTF::span): Use static_cast instead of reinterpret_cast.

* Source/WTF/wtf/persistence/PersistentCoders.cpp:
(WTF::Persistence::Coder&lt;CString&gt;::encodeForPersistence): Use span
instead of dataAsUInt8Ptr.
(WTF::Persistence::Coder&lt;CString&gt;::decodeForPersistence): Use byteCast.

* Source/WTF/wtf/text/AtomStringImpl.h: Use byteCast.
* Source/WTF/wtf/text/CString.h: Ditto.
* Source/WTF/wtf/text/StringBuilder.h:
(WTF::StringBuilder::append): Ditto.
* Source/WTF/wtf/text/StringCommon.h: Ditto.
* Source/WTF/wtf/text/StringConcatenate.h: Ditto.
* Source/WTF/wtf/text/StringConcatenateNumbers.h: Ditto.
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::equalInner): Ditto.
* Source/WTF/wtf/text/StringImpl.h: Ditto.
* Source/WTF/wtf/text/StringView.h: Ditto.
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::String): Ditto.
(WTF::String::fromUTF8): Ditto.
* Source/WTF/wtf/text/WTFString.h: Ditto.
* Source/WTF/wtf/text/cf/AtomStringImplCF.cpp:
(WTF::AtomStringImpl::add): Ditto.

* Source/WTF/wtf/unicode/Collator.h: Use char8_t instead of UTF8 in the
name for the collate function that takes null-terminated strings.
* Source/WTF/wtf/unicode/CollatorDefault.cpp:
(WTF::Collator::collate const): Use byteCast.
* Source/WTF/wtf/unicode/icu/CollatorICU.cpp:
(WTF::createIterator): Use byteCast.
(WTF::Collator::collate const): Use createIterator.

* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::getImageBytesFromVideoFrame): Use static_cast instead of reinterpret_cast.

* Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp:
(WebCore::isPlayReadySanitizedInitializationData): Use byteCast.
* Source/WebCore/PAL/pal/text/EncodingTables.cpp:
(PAL::jis0208): Ditto.
(PAL::jis0212): Ditto.
(PAL::big5): Ditto.
(PAL::eucKR): Ditto.
(PAL::gb18030): Ditto.
* Source/WebCore/PAL/pal/text/TextCodecCJK.cpp:
(PAL::TextCodecCJK::eucJPDecode): Ditto.
(PAL::TextCodecCJK::big5Decode): Ditto.
* Source/WebCore/PAL/pal/text/TextCodecICU.cpp:
(PAL::TextCodecICU::decode): Ditto.
(PAL::TextCodecICU::encode const): Ditto.
* Source/WebCore/PAL/pal/text/TextEncodingDetectorICU.cpp:
(PAL::detectTextEncoding): Ditto.
* Source/WebCore/css/process-css-pseudo-selectors.py: Ditto.
* Source/WebCore/html/track/VTTScanner.h:
(WebCore::VTTScanner::scan): Ditto.

* Source/WebCore/html/track/WebVTTTokenizer.cpp:
(WebCore::equalLiteral): Deleted.

* Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm:
(WebCore::showText): Use span instead of dataAsUInt8Ptr.

* Source/WebCore/platform/SharedBuffer.h: Deleted dataAsCharPtr.

* Source/WebCore/platform/SharedBufferChunkReader.cpp:
(WebCore::SharedBufferChunkReader::nextChunk): Use byteCast.
* Source/WebCore/platform/graphics/MIMESniffer.cpp:
(WebCore::MIMESniffer::span8): Ditto.
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::initialize): Ditto.
(WebCore::GraphicsContextGLANGLE::getString): Ditto.
* Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm:
(WebCore::ShareableBitmap::createFromImagePixels): Ditto.

* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::defaultVariationValues): Use assignment instead of static_cast.

* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm:
(WebCore::WebCoreDecompressionSession::decodeSample): Use byteCast.
* Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm:
(WebCore::parseOpusPrivateData): Ditto.
* Source/WebCore/platform/graphics/cpu/arm/filters/FEBlendNeonApplier.cpp:
(WebCore::FEBlendNeonApplier::applyPlatform const): Ditto.
* Source/WebCore/platform/image-decoders/ScalableImageDecoder.cpp:
(WebCore::ScalableImageDecoder::create): Ditto.

* Source/WebCore/platform/network/cf/ResourceRequestCFNet.h:
(WebCore::httpHeaderValueUsingSuitableEncoding): Use span instead of
dataAsUInt8Ptr.
* Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm:
(WebCore::ResourceResponse::platformCertificateInfo const): Ditto.

* Source/WebCore/workers/ScriptBuffer.cpp:
(WebCore::ScriptBuffer::toString const): Use byteCast.
(WebCore::ScriptBuffer::append): Ditto. Also fixed a mistake where this was
using uint8_t instead of char8_t.

* Source/WebCore/xml/XSLTProcessorLibxslt.cpp:
(WebCore::docLoaderFunc): Use byteCast.
(WebCore::writeToStringBuilder): Ditto.
(WebCore::XSLTProcessor::transformToString): Ditto.
* Source/WebCore/xml/XSLTUnicodeSort.cpp:
(WebCore::xsltUnicodeSortFunction): Ditto.
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLParserContext::createMemoryParser): Use byteCast.
(WebCore::toString): Ditto.
(WebCore::toAtomString): Ditto.
(WebCore::sharedXHTMLEntity): Ditto.
(WebCore::convertUTF16EntityToUTF8): Ditto.
(WebCore::getXHTMLEntity): Ditto.
(WebCore::xmlDocPtrForString): Ditto.
(WebCore::attributesStartElementNsHandler): Ditto.
* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createExternalTextureFromPixelBuffer const): Ditto.
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
(getBufferSubData): Ditto.
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::logOnBehalfOfWebContent): Ditto.
* Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.cpp:
(WebKit::LibWebRTCSocketClient::signalReadPacket): Ditto.
* Source/WebKit/Shared/API/c/WKString.cpp:
(WKStringGetUTF8CStringImpl): Ditto.

* Source/WebKit/Shared/API/c/cf/WKURLCF.mm:
(WKURLCopyCFURL): Use span instead of dataAsUInt8Ptr.
* Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm:
(WebKit::SandboxExtensionImpl::SandboxExtensionImpl): Ditto.

* Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp:
(WebKit::HistoryEntryDataEncoder::operator&lt;&lt;): Use byteCast.
(WebKit::encodeLegacySessionState): Use checked_cf_cast.

* Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp:
(WebKit::HistoryEntryDataEncoder::operator&lt;&lt;): Use byteCast.
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp:
(WebKit::LibWebRTCSocket::signalReadPacket): Ditto.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::getAccessibilityTreeData): Use checked_cf_cast.

* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::registerLogHook): Use byteCast.
* Source/WebKitLegacy/mac/Misc/WebNSDataExtras.mm:
(-[NSData _webkit_guessedMIMETypeForXML]): Ditto.

* Tools/TestWebKitAPI/Tests/WTF/StdLibExtrasTests.cpp:
(TestWebKitAPI::TEST(WTF_StdLibExtras, ByteCast)): Added some tests.

* Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp: Rewrite tests so it&apos;s easier
to see which one failed. Did not use byteCast here.

* Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp:
(TestWebKitAPI::TEST(WTF, StringImplEqualIgnoringASCIICaseBasic)): Ditto.
(TestWebKitAPI::TEST(WTF, StringImplEqualIgnoringASCIICaseWithEmpty)): Ditto.
(TestWebKitAPI::TEST(WTF, StringImplFindIgnoringASCIICaseOnEmpty)): Ditto.
(TestWebKitAPI::TEST(WTF, StringImplStartsWithIgnoringASCIICaseWithNull)): Ditto.
(TestWebKitAPI::TEST(WTF, StringImplStartsWithIgnoringASCIICaseWithEmpty)): Ditto.
(TestWebKitAPI::TEST(WTF, StringImplEndsWithIgnoringASCIICaseWithNull)): Ditto.
(TestWebKitAPI::TEST(WTF, StringImplEndsWithIgnoringASCIICaseWithEmpty)): Ditto.
* Tools/TestWebKitAPI/Tests/WTF/StringView.cpp:
(TestWebKitAPI::TEST(WTF, StringViewEqualIgnoringASCIICaseBasic)): Ditto.
(TestWebKitAPI::TEST(WTF, StringViewEqualIgnoringASCIICaseWithEmpty)): Ditto.

* Tools/TestWebKitAPI/Tests/WebCore/CBORWriterTest.cpp:
(TestWebKitAPI::eq): Remomved unneeded reinterpret_cast.

* Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp:
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, getSomeData)): Use byteCast
and span instead of dataAsCharPtr.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/PDFLinkReferrer.mm:
(TEST(WebKit, PDFLinkReferrer)): Use byteCast.

* Tools/TestWebKitAPI/cocoa/CGImagePixelReader.cpp:
(TestWebKitAPI::CGImagePixelReader::at const): Use static_cast instead of
reinterpret_cast.

* Tools/TestWebKitAPI/cocoa/HTTPServer.mm:
(TestWebKitAPI::proxyDefinition): Use byteCast.
(TestWebKitAPI::Connection::webSocketHandshake): Ditto.

Canonical link: <a href="https://commits.webkit.org/279338@main">https://commits.webkit.org/279338@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c704904e024c47d73332159b5934541dab5fad31

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53200 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5688 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56479 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3923 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55505 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39791 "Failed to compile WebKit") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3661 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43128 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2550 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55298 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/30569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45931 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24258 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3258 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2082 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/46556 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3414 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58075 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52713 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28343 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3378 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50530 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29561 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46153 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49846 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30481 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65018 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7819 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29317 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12372 "Found 6 new JSC stress test failures: stress/spread-non-array.js.no-llint, wasm.yaml/wasm/function-tests/add-12.js.wasm-eager, wasm.yaml/wasm/function-tests/br-if-as-return.js.wasm-eager, wasm.yaml/wasm/function-tests/brTableAsIf.js.wasm-eager, wasm.yaml/wasm/function-tests/dead-call.js.wasm-eager, wasm.yaml/wasm/regress/242294.js.wasm-eager (failure)") | 
<!--EWS-Status-Bubble-End-->