### PR TITLE
Use ASCIILiteral in JSC assembler macros

### DIFF
--- a/Source/JavaScriptCore/assembler/ARM64Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64Assembler.h
@@ -216,10 +216,10 @@ public:
     static constexpr FPRegisterID lastFPRegister() { return ARM64Registers::q31; }
     static constexpr unsigned numberOfFPRegisters() { return lastFPRegister() - firstFPRegister() + 1; }
 
-    static const char* gprName(RegisterID id)
+    static ASCIILiteral gprName(RegisterID id)
     {
         ASSERT(id >= firstRegister() && id <= lastRegister());
-        static const char* const nameForRegister[numberOfRegisters()] = {
+        static constexpr ASCIILiteral nameForRegister[numberOfRegisters()] = {
 #define REGISTER_NAME(id, name, r, cs) name,
         FOR_EACH_GP_REGISTER(REGISTER_NAME)
 #undef REGISTER_NAME
@@ -227,10 +227,10 @@ public:
         return nameForRegister[id];
     }
 
-    static const char* sprName(SPRegisterID id)
+    static ASCIILiteral sprName(SPRegisterID id)
     {
         ASSERT(id >= firstSPRegister() && id <= lastSPRegister());
-        static const char* const nameForRegister[numberOfSPRegisters()] = {
+        static constexpr ASCIILiteral nameForRegister[numberOfSPRegisters()] = {
 #define REGISTER_NAME(id, name) name,
         FOR_EACH_SP_REGISTER(REGISTER_NAME)
 #undef REGISTER_NAME
@@ -238,10 +238,10 @@ public:
         return nameForRegister[id];
     }
 
-    static const char* fprName(FPRegisterID id)
+    static ASCIILiteral fprName(FPRegisterID id)
     {
         ASSERT(id >= firstFPRegister() && id <= lastFPRegister());
-        static const char* const nameForRegister[numberOfFPRegisters()] = {
+        static constexpr ASCIILiteral nameForRegister[numberOfFPRegisters()] = {
 #define REGISTER_NAME(id, name, r, cs) name,
         FOR_EACH_FP_REGISTER(REGISTER_NAME)
 #undef REGISTER_NAME

--- a/Source/JavaScriptCore/assembler/ARM64Registers.h
+++ b/Source/JavaScriptCore/assembler/ARM64Registers.h
@@ -44,134 +44,134 @@
 #if !OS(DARWIN)
 #define FOR_EACH_GP_REGISTER(macro)                             \
     /* Parameter/result registers. */                           \
-    macro(x0,  "x0",  0, 0)                                     \
-    macro(x1,  "x1",  0, 0)                                     \
-    macro(x2,  "x2",  0, 0)                                     \
-    macro(x3,  "x3",  0, 0)                                     \
-    macro(x4,  "x4",  0, 0)                                     \
-    macro(x5,  "x5",  0, 0)                                     \
-    macro(x6,  "x6",  0, 0)                                     \
-    macro(x7,  "x7",  0, 0)                                     \
+    macro(x0,  "x0"_s,  0, 0)                                     \
+    macro(x1,  "x1"_s,  0, 0)                                     \
+    macro(x2,  "x2"_s,  0, 0)                                     \
+    macro(x3,  "x3"_s,  0, 0)                                     \
+    macro(x4,  "x4"_s,  0, 0)                                     \
+    macro(x5,  "x5"_s,  0, 0)                                     \
+    macro(x6,  "x6"_s,  0, 0)                                     \
+    macro(x7,  "x7"_s,  0, 0)                                     \
     /* Indirect result location register. */                    \
-    macro(x8,  "x8",  0, 0)                                     \
+    macro(x8,  "x8"_s,  0, 0)                                     \
     /* Temporary registers. */                                  \
-    macro(x9,  "x9",  0, 0)                                     \
-    macro(x10, "x10", 0, 0)                                     \
-    macro(x11, "x11", 0, 0)                                     \
-    macro(x12, "x12", 0, 0)                                     \
-    macro(x13, "x13", 0, 0)                                     \
-    macro(x14, "x14", 0, 0)                                     \
-    macro(x15, "x15", 0, 0)                                     \
+    macro(x9,  "x9"_s,  0, 0)                                     \
+    macro(x10, "x10"_s, 0, 0)                                     \
+    macro(x11, "x11"_s, 0, 0)                                     \
+    macro(x12, "x12"_s, 0, 0)                                     \
+    macro(x13, "x13"_s, 0, 0)                                     \
+    macro(x14, "x14"_s, 0, 0)                                     \
+    macro(x15, "x15"_s, 0, 0)                                     \
     /* Intra-procedure-call scratch registers (temporary). */   \
-    macro(x16, "x16", 0, 0)                                     \
-    macro(x17, "x17", 0, 0)                                     \
+    macro(x16, "x16"_s, 0, 0)                                     \
+    macro(x17, "x17"_s, 0, 0)                                     \
     /* Platform Register (temporary). */                        \
-    macro(x18, "x18", 0, 0)                                     \
+    macro(x18, "x18"_s, 0, 0)                                     \
     /* Callee-saved. */                                         \
-    macro(x19, "x19", 0, 1)                                     \
-    macro(x20, "x20", 0, 1)                                     \
-    macro(x21, "x21", 0, 1)                                     \
-    macro(x22, "x22", 0, 1)                                     \
-    macro(x23, "x23", 0, 1)                                     \
-    macro(x24, "x24", 0, 1)                                     \
-    macro(x25, "x25", 0, 1)                                     \
-    macro(x26, "x26", 0, 1)                                     \
-    macro(x27, "x27", 0, 1)                                     \
-    macro(x28, "x28", 0, 1)                                     \
+    macro(x19, "x19"_s, 0, 1)                                     \
+    macro(x20, "x20"_s, 0, 1)                                     \
+    macro(x21, "x21"_s, 0, 1)                                     \
+    macro(x22, "x22"_s, 0, 1)                                     \
+    macro(x23, "x23"_s, 0, 1)                                     \
+    macro(x24, "x24"_s, 0, 1)                                     \
+    macro(x25, "x25"_s, 0, 1)                                     \
+    macro(x26, "x26"_s, 0, 1)                                     \
+    macro(x27, "x27"_s, 0, 1)                                     \
+    macro(x28, "x28"_s, 0, 1)                                     \
     /* Special. */                                              \
-    macro(fp,  "fp",  0, 1)                                     \
-    macro(lr,  "lr",  1, 0)                                     \
-    macro(sp,  "sp",  0, 0)
+    macro(fp,  "fp"_s,  0, 1)                                     \
+    macro(lr,  "lr"_s,  1, 0)                                     \
+    macro(sp,  "sp"_s,  0, 0)
 #else
 #define FOR_EACH_GP_REGISTER(macro)                             \
     /* Parameter/result registers. */                           \
-    macro(x0,  "x0",  0, 0)                                     \
-    macro(x1,  "x1",  0, 0)                                     \
-    macro(x2,  "x2",  0, 0)                                     \
-    macro(x3,  "x3",  0, 0)                                     \
-    macro(x4,  "x4",  0, 0)                                     \
-    macro(x5,  "x5",  0, 0)                                     \
-    macro(x6,  "x6",  0, 0)                                     \
-    macro(x7,  "x7",  0, 0)                                     \
+    macro(x0,  "x0"_s,  0, 0)                                     \
+    macro(x1,  "x1"_s,  0, 0)                                     \
+    macro(x2,  "x2"_s,  0, 0)                                     \
+    macro(x3,  "x3"_s,  0, 0)                                     \
+    macro(x4,  "x4"_s,  0, 0)                                     \
+    macro(x5,  "x5"_s,  0, 0)                                     \
+    macro(x6,  "x6"_s,  0, 0)                                     \
+    macro(x7,  "x7"_s,  0, 0)                                     \
     /* Indirect result location register. */                    \
-    macro(x8,  "x8",  0, 0)                                     \
+    macro(x8,  "x8"_s,  0, 0)                                     \
     /* Temporary registers. */                                  \
-    macro(x9,  "x9",  0, 0)                                     \
-    macro(x10, "x10", 0, 0)                                     \
-    macro(x11, "x11", 0, 0)                                     \
-    macro(x12, "x12", 0, 0)                                     \
-    macro(x13, "x13", 0, 0)                                     \
-    macro(x14, "x14", 0, 0)                                     \
-    macro(x15, "x15", 0, 0)                                     \
+    macro(x9,  "x9"_s,  0, 0)                                     \
+    macro(x10, "x10"_s, 0, 0)                                     \
+    macro(x11, "x11"_s, 0, 0)                                     \
+    macro(x12, "x12"_s, 0, 0)                                     \
+    macro(x13, "x13"_s, 0, 0)                                     \
+    macro(x14, "x14"_s, 0, 0)                                     \
+    macro(x15, "x15"_s, 0, 0)                                     \
     /* Intra-procedure-call scratch registers (temporary). */   \
-    macro(x16, "x16", 0, 0)                                     \
-    macro(x17, "x17", 0, 0)                                     \
+    macro(x16, "x16"_s, 0, 0)                                     \
+    macro(x17, "x17"_s, 0, 0)                                     \
     /* Platform Register (temporary). */                        \
-    macro(x18, "x18", 1, 0)                                     \
+    macro(x18, "x18"_s, 1, 0)                                     \
     /* Callee-saved. */                                         \
-    macro(x19, "x19", 0, 1)                                     \
-    macro(x20, "x20", 0, 1)                                     \
-    macro(x21, "x21", 0, 1)                                     \
-    macro(x22, "x22", 0, 1)                                     \
-    macro(x23, "x23", 0, 1)                                     \
-    macro(x24, "x24", 0, 1)                                     \
-    macro(x25, "x25", 0, 1)                                     \
-    macro(x26, "x26", 0, 1)                                     \
-    macro(x27, "x27", 0, 1)                                     \
-    macro(x28, "x28", 0, 1)                                     \
+    macro(x19, "x19"_s, 0, 1)                                     \
+    macro(x20, "x20"_s, 0, 1)                                     \
+    macro(x21, "x21"_s, 0, 1)                                     \
+    macro(x22, "x22"_s, 0, 1)                                     \
+    macro(x23, "x23"_s, 0, 1)                                     \
+    macro(x24, "x24"_s, 0, 1)                                     \
+    macro(x25, "x25"_s, 0, 1)                                     \
+    macro(x26, "x26"_s, 0, 1)                                     \
+    macro(x27, "x27"_s, 0, 1)                                     \
+    macro(x28, "x28"_s, 0, 1)                                     \
     /* Special. */                                              \
-    macro(fp,  "fp",  0, 1)                                     \
-    macro(lr,  "lr",  1, 0)                                     \
-    macro(sp,  "sp",  0, 0)
+    macro(fp,  "fp"_s,  0, 1)                                     \
+    macro(lr,  "lr"_s,  1, 0)                                     \
+    macro(sp,  "sp"_s,  0, 0)
 #endif
 
 #define FOR_EACH_REGISTER_ALIAS(macro)          \
-    macro(ip0, "ip0", x16)                      \
-    macro(ip1, "ip1", x17)                      \
-    macro(x29, "x29", fp)                       \
-    macro(x30, "x30", lr)                       \
-    macro(zr,  "zr",  0x3f)
+    macro(ip0, "ip0"_s, x16)                      \
+    macro(ip1, "ip1"_s, x17)                      \
+    macro(x29, "x29"_s, fp)                       \
+    macro(x30, "x30"_s, lr)                       \
+    macro(zr,  "zr"_s,  0x3f)
 
 #define FOR_EACH_SP_REGISTER(macro)             \
-    macro(pc,   "pc")                           \
-    macro(nzcv, "nzcv")                         \
-    macro(fpsr, "fpsr")
+    macro(pc,   "pc"_s)                           \
+    macro(nzcv, "nzcv"_s)                         \
+    macro(fpsr, "fpsr"_s)
 
 #define FOR_EACH_FP_REGISTER(macro)             \
     /* Parameter/result registers. */           \
-    macro(q0,  "q0",  0, 0)                     \
-    macro(q1,  "q1",  0, 0)                     \
-    macro(q2,  "q2",  0, 0)                     \
-    macro(q3,  "q3",  0, 0)                     \
-    macro(q4,  "q4",  0, 0)                     \
-    macro(q5,  "q5",  0, 0)                     \
-    macro(q6,  "q6",  0, 0)                     \
-    macro(q7,  "q7",  0, 0)                     \
+    macro(q0,  "q0"_s,  0, 0)                     \
+    macro(q1,  "q1"_s,  0, 0)                     \
+    macro(q2,  "q2"_s,  0, 0)                     \
+    macro(q3,  "q3"_s,  0, 0)                     \
+    macro(q4,  "q4"_s,  0, 0)                     \
+    macro(q5,  "q5"_s,  0, 0)                     \
+    macro(q6,  "q6"_s,  0, 0)                     \
+    macro(q7,  "q7"_s,  0, 0)                     \
     /* Callee-saved (up to 64-bits only!). */   \
-    macro(q8,  "q8",  0, 1)                     \
-    macro(q9,  "q9",  0, 1)                     \
-    macro(q10, "q10", 0, 1)                     \
-    macro(q11, "q11", 0, 1)                     \
-    macro(q12, "q12", 0, 1)                     \
-    macro(q13, "q13", 0, 1)                     \
-    macro(q14, "q14", 0, 1)                     \
-    macro(q15, "q15", 0, 1)                     \
+    macro(q8,  "q8"_s,  0, 1)                     \
+    macro(q9,  "q9"_s,  0, 1)                     \
+    macro(q10, "q10"_s, 0, 1)                     \
+    macro(q11, "q11"_s, 0, 1)                     \
+    macro(q12, "q12"_s, 0, 1)                     \
+    macro(q13, "q13"_s, 0, 1)                     \
+    macro(q14, "q14"_s, 0, 1)                     \
+    macro(q15, "q15"_s, 0, 1)                     \
     /* Temporary registers. */                  \
-    macro(q16, "q16", 0, 0)                     \
-    macro(q17, "q17", 0, 0)                     \
-    macro(q18, "q18", 0, 0)                     \
-    macro(q19, "q19", 0, 0)                     \
-    macro(q20, "q20", 0, 0)                     \
-    macro(q21, "q21", 0, 0)                     \
-    macro(q22, "q22", 0, 0)                     \
-    macro(q23, "q23", 0, 0)                     \
-    macro(q24, "q24", 0, 0)                     \
-    macro(q25, "q25", 0, 0)                     \
-    macro(q26, "q26", 0, 0)                     \
-    macro(q27, "q27", 0, 0)                     \
-    macro(q28, "q28", 0, 0)                     \
-    macro(q29, "q29", 0, 0)                     \
-    macro(q30, "q30", 0, 0)                     \
-    macro(q31, "q31", 0, 0)
+    macro(q16, "q16"_s, 0, 0)                     \
+    macro(q17, "q17"_s, 0, 0)                     \
+    macro(q18, "q18"_s, 0, 0)                     \
+    macro(q19, "q19"_s, 0, 0)                     \
+    macro(q20, "q20"_s, 0, 0)                     \
+    macro(q21, "q21"_s, 0, 0)                     \
+    macro(q22, "q22"_s, 0, 0)                     \
+    macro(q23, "q23"_s, 0, 0)                     \
+    macro(q24, "q24"_s, 0, 0)                     \
+    macro(q25, "q25"_s, 0, 0)                     \
+    macro(q26, "q26"_s, 0, 0)                     \
+    macro(q27, "q27"_s, 0, 0)                     \
+    macro(q28, "q28"_s, 0, 0)                     \
+    macro(q29, "q29"_s, 0, 0)                     \
+    macro(q30, "q30"_s, 0, 0)                     \
+    macro(q31, "q31"_s, 0, 0)
 
 #endif // CPU(ARM64)

--- a/Source/JavaScriptCore/assembler/ARMv7Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARMv7Assembler.h
@@ -363,10 +363,10 @@ public:
 #endif
     static constexpr unsigned numberOfFPRegisters() { return lastFPRegister() - firstFPRegister() + 1; }
 
-    static const char* gprName(RegisterID id)
+    static ASCIILiteral gprName(RegisterID id)
     {
         ASSERT(id >= firstRegister() && id <= lastRegister());
-        static const char* const nameForRegister[numberOfRegisters()] = {
+        static constexpr ASCIILiteral nameForRegister[numberOfRegisters()] = {
 #define REGISTER_NAME(id, name, r, cs) name,
         FOR_EACH_GP_REGISTER(REGISTER_NAME)
 #undef REGISTER_NAME        
@@ -374,10 +374,10 @@ public:
         return nameForRegister[id];
     }
 
-    static const char* sprName(SPRegisterID id)
+    static ASCIILiteral sprName(SPRegisterID id)
     {
         ASSERT(id >= firstSPRegister() && id <= lastSPRegister());
-        static const char* const nameForRegister[numberOfSPRegisters()] = {
+        static constexpr ASCIILiteral nameForRegister[numberOfSPRegisters()] = {
 #define REGISTER_NAME(id, name) name,
         FOR_EACH_SP_REGISTER(REGISTER_NAME)
 #undef REGISTER_NAME
@@ -385,10 +385,10 @@ public:
         return nameForRegister[id];
     }
 
-    static const char* fprName(FPRegisterID id)
+    static ASCIILiteral fprName(FPRegisterID id)
     {
         ASSERT(id >= firstFPRegister() && id <= lastFPRegister());
-        static const char* const nameForRegister[numberOfFPRegisters()] = {
+        static constexpr ASCIILiteral nameForRegister[numberOfFPRegisters()] = {
 #define REGISTER_NAME(id, name, r, cs) name,
         FOR_EACH_FP_DOUBLE_REGISTER(REGISTER_NAME)
 #undef REGISTER_NAME

--- a/Source/JavaScriptCore/assembler/ARMv7Registers.h
+++ b/Source/JavaScriptCore/assembler/ARMv7Registers.h
@@ -40,161 +40,161 @@
 
 #if !OS(DARWIN)
 #define FOR_EACH_GP_REGISTER(macro)             \
-    macro(r0,  "r0",  0, 0)                     \
-    macro(r1,  "r1",  0, 0)                     \
-    macro(r2,  "r2",  0, 0)                     \
-    macro(r3,  "r3",  0, 0)                     \
-    macro(r4,  "r4",  0, 1)                     \
-    macro(r5,  "r5",  0, 1)                     \
-    macro(r6,  "r6",  0, 1)                     \
-    macro(r7,  "r7",  0, 0)                     \
-    macro(r8,  "r8",  0, 1)                     \
-    macro(r9,  "r9",  0, 1)                     \
-    macro(r10, "r10", 0, 1)                     \
-    macro(r11, "r11", 0, 1)                     \
-    macro(r12, "ip",  0, 0)                     \
-    macro(r13, "sp",  0, 0)                     \
-    macro(r14, "lr",  1, 0)                     \
-    macro(r15, "pc",  1, 0)
+    macro(r0,  "r0"_s,  0, 0)                     \
+    macro(r1,  "r1"_s,  0, 0)                     \
+    macro(r2,  "r2"_s,  0, 0)                     \
+    macro(r3,  "r3"_s,  0, 0)                     \
+    macro(r4,  "r4"_s,  0, 1)                     \
+    macro(r5,  "r5"_s,  0, 1)                     \
+    macro(r6,  "r6"_s,  0, 1)                     \
+    macro(r7,  "r7"_s,  0, 0)                     \
+    macro(r8,  "r8"_s,  0, 1)                     \
+    macro(r9,  "r9"_s,  0, 1)                     \
+    macro(r10, "r10"_s, 0, 1)                     \
+    macro(r11, "r11"_s, 0, 1)                     \
+    macro(r12, "ip"_s,  0, 0)                     \
+    macro(r13, "sp"_s,  0, 0)                     \
+    macro(r14, "lr"_s,  1, 0)                     \
+    macro(r15, "pc"_s,  1, 0)
 #else
 #define FOR_EACH_GP_REGISTER(macro)             \
-    macro(r0,  "r0",  0, 0)                     \
-    macro(r1,  "r1",  0, 0)                     \
-    macro(r2,  "r2",  0, 0)                     \
-    macro(r3,  "r3",  0, 0)                     \
-    macro(r4,  "r4",  0, 1)                     \
-    macro(r5,  "r5",  0, 1)                     \
-    macro(r6,  "r6",  0, 1)                     \
-    macro(r7,  "r7",  0, 0)                     \
-    macro(r8,  "r8",  0, 1)                     \
-    macro(r9,  "r9",  0, 0)                     \
-    macro(r10, "r10", 0, 1)                     \
-    macro(r11, "r11", 0, 1)                     \
-    macro(r12, "ip",  0, 0)                     \
-    macro(r13, "sp",  0, 0)                     \
-    macro(r14, "lr",  1, 0)                     \
-    macro(r15, "pc",  1, 0)
+    macro(r0,  "r0"_s,  0, 0)                     \
+    macro(r1,  "r1"_s,  0, 0)                     \
+    macro(r2,  "r2"_s,  0, 0)                     \
+    macro(r3,  "r3"_s,  0, 0)                     \
+    macro(r4,  "r4"_s,  0, 1)                     \
+    macro(r5,  "r5"_s,  0, 1)                     \
+    macro(r6,  "r6"_s,  0, 1)                     \
+    macro(r7,  "r7"_s,  0, 0)                     \
+    macro(r8,  "r8"_s,  0, 1)                     \
+    macro(r9,  "r9"_s,  0, 0)                     \
+    macro(r10, "r10"_s, 0, 1)                     \
+    macro(r11, "r11"_s, 0, 1)                     \
+    macro(r12, "ip"_s,  0, 0)                     \
+    macro(r13, "sp"_s,  0, 0)                     \
+    macro(r14, "lr"_s,  1, 0)                     \
+    macro(r15, "pc"_s,  1, 0)
 #endif
 
 #define FOR_EACH_REGISTER_ALIAS(macro)          \
-    macro(fp, "fp", r7)                         \
-    macro(sb, "sb", r9)                         \
-    macro(sl, "sl", r10)                        \
-    macro(ip, "ip", r12)                        \
-    macro(sp, "sp", r13)                        \
-    macro(lr, "lr", r14)                        \
-    macro(pc, "pc", r15)
+    macro(fp, "fp"_s, r7)                         \
+    macro(sb, "sb"_s, r9)                         \
+    macro(sl, "sl"_s, r10)                        \
+    macro(ip, "ip"_s, r12)                        \
+    macro(sp, "sp"_s, r13)                        \
+    macro(lr, "lr"_s, r14)                        \
+    macro(pc, "pc"_s, r15)
 
 #define FOR_EACH_SP_REGISTER(macro)             \
-    macro(apsr,  "apsr")                        \
-    macro(fpscr, "fpscr")
+    macro(apsr,  "apsr"_s)                        \
+    macro(fpscr, "fpscr"_s)
 
 #define FOR_EACH_FP_SINGLE_REGISTER(macro)      \
-    macro(s0,  "s0",  0, 0)                     \
-    macro(s1,  "s1",  0, 0)                     \
-    macro(s2,  "s2",  0, 0)                     \
-    macro(s3,  "s3",  0, 0)                     \
-    macro(s4,  "s4",  0, 0)                     \
-    macro(s5,  "s5",  0, 0)                     \
-    macro(s6,  "s6",  0, 0)                     \
-    macro(s7,  "s7",  0, 0)                     \
-    macro(s8,  "s8",  0, 0)                     \
-    macro(s9,  "s9",  0, 0)                     \
-    macro(s10, "s10", 0, 0)                     \
-    macro(s11, "s11", 0, 0)                     \
-    macro(s12, "s12", 0, 0)                     \
-    macro(s13, "s13", 0, 0)                     \
-    macro(s14, "s14", 0, 0)                     \
-    macro(s15, "s15", 0, 0)                     \
-    macro(s16, "s16", 0, 1)                     \
-    macro(s17, "s17", 0, 1)                     \
-    macro(s18, "s18", 0, 1)                     \
-    macro(s19, "s19", 0, 1)                     \
-    macro(s20, "s20", 0, 1)                     \
-    macro(s21, "s21", 0, 1)                     \
-    macro(s22, "s22", 0, 1)                     \
-    macro(s23, "s23", 0, 1)                     \
-    macro(s24, "s24", 0, 1)                     \
-    macro(s25, "s25", 0, 1)                     \
-    macro(s26, "s26", 0, 1)                     \
-    macro(s27, "s27", 0, 1)                     \
-    macro(s28, "s28", 0, 1)                     \
-    macro(s29, "s29", 0, 1)                     \
-    macro(s30, "s30", 0, 1)                     \
-    macro(s31, "s31", 0, 1)
+    macro(s0,  "s0"_s,  0, 0)                     \
+    macro(s1,  "s1"_s,  0, 0)                     \
+    macro(s2,  "s2"_s,  0, 0)                     \
+    macro(s3,  "s3"_s,  0, 0)                     \
+    macro(s4,  "s4"_s,  0, 0)                     \
+    macro(s5,  "s5"_s,  0, 0)                     \
+    macro(s6,  "s6"_s,  0, 0)                     \
+    macro(s7,  "s7"_s,  0, 0)                     \
+    macro(s8,  "s8"_s,  0, 0)                     \
+    macro(s9,  "s9"_s,  0, 0)                     \
+    macro(s10, "s10"_s, 0, 0)                     \
+    macro(s11, "s11"_s, 0, 0)                     \
+    macro(s12, "s12"_s, 0, 0)                     \
+    macro(s13, "s13"_s, 0, 0)                     \
+    macro(s14, "s14"_s, 0, 0)                     \
+    macro(s15, "s15"_s, 0, 0)                     \
+    macro(s16, "s16"_s, 0, 1)                     \
+    macro(s17, "s17"_s, 0, 1)                     \
+    macro(s18, "s18"_s, 0, 1)                     \
+    macro(s19, "s19"_s, 0, 1)                     \
+    macro(s20, "s20"_s, 0, 1)                     \
+    macro(s21, "s21"_s, 0, 1)                     \
+    macro(s22, "s22"_s, 0, 1)                     \
+    macro(s23, "s23"_s, 0, 1)                     \
+    macro(s24, "s24"_s, 0, 1)                     \
+    macro(s25, "s25"_s, 0, 1)                     \
+    macro(s26, "s26"_s, 0, 1)                     \
+    macro(s27, "s27"_s, 0, 1)                     \
+    macro(s28, "s28"_s, 0, 1)                     \
+    macro(s29, "s29"_s, 0, 1)                     \
+    macro(s30, "s30"_s, 0, 1)                     \
+    macro(s31, "s31"_s, 0, 1)
 
 #if CPU(ARM_NEON) || CPU(ARM_VFP_V3_D32)
 #define FOR_EACH_FP_DOUBLE_REGISTER(macro)      \
-    macro(d0,  "d0",  0, 0)                     \
-    macro(d1,  "d1",  0, 0)                     \
-    macro(d2,  "d2",  0, 0)                     \
-    macro(d3,  "d3",  0, 0)                     \
-    macro(d4,  "d4",  0, 0)                     \
-    macro(d5,  "d5",  0, 0)                     \
-    macro(d6,  "d6",  0, 0)                     \
-    macro(d7,  "d7",  0, 0)                     \
-    macro(d8,  "d8",  0, 1)                     \
-    macro(d9,  "d9",  0, 1)                     \
-    macro(d10, "d10", 0, 1)                     \
-    macro(d11, "d11", 0, 1)                     \
-    macro(d12, "d12", 0, 1)                     \
-    macro(d13, "d13", 0, 1)                     \
-    macro(d14, "d14", 0, 1)                     \
-    macro(d15, "d15", 0, 1)                     \
-    macro(d16, "d16", 0, 0)                     \
-    macro(d17, "d17", 0, 0)                     \
-    macro(d18, "d18", 0, 0)                     \
-    macro(d19, "d19", 0, 0)                     \
-    macro(d20, "d20", 0, 0)                     \
-    macro(d21, "d21", 0, 0)                     \
-    macro(d22, "d22", 0, 0)                     \
-    macro(d23, "d23", 0, 0)                     \
-    macro(d24, "d24", 0, 0)                     \
-    macro(d25, "d25", 0, 0)                     \
-    macro(d26, "d26", 0, 0)                     \
-    macro(d27, "d27", 0, 0)                     \
-    macro(d28, "d28", 0, 0)                     \
-    macro(d29, "d29", 0, 0)                     \
-    macro(d30, "d30", 0, 0)                     \
-    macro(d31, "d31", 0, 0)
+    macro(d0,  "d0"_s,  0, 0)                     \
+    macro(d1,  "d1"_s,  0, 0)                     \
+    macro(d2,  "d2"_s,  0, 0)                     \
+    macro(d3,  "d3"_s,  0, 0)                     \
+    macro(d4,  "d4"_s,  0, 0)                     \
+    macro(d5,  "d5"_s,  0, 0)                     \
+    macro(d6,  "d6"_s,  0, 0)                     \
+    macro(d7,  "d7"_s,  0, 0)                     \
+    macro(d8,  "d8"_s,  0, 1)                     \
+    macro(d9,  "d9"_s,  0, 1)                     \
+    macro(d10, "d10"_s, 0, 1)                     \
+    macro(d11, "d11"_s, 0, 1)                     \
+    macro(d12, "d12"_s, 0, 1)                     \
+    macro(d13, "d13"_s, 0, 1)                     \
+    macro(d14, "d14"_s, 0, 1)                     \
+    macro(d15, "d15"_s, 0, 1)                     \
+    macro(d16, "d16"_s, 0, 0)                     \
+    macro(d17, "d17"_s, 0, 0)                     \
+    macro(d18, "d18"_s, 0, 0)                     \
+    macro(d19, "d19"_s, 0, 0)                     \
+    macro(d20, "d20"_s, 0, 0)                     \
+    macro(d21, "d21"_s, 0, 0)                     \
+    macro(d22, "d22"_s, 0, 0)                     \
+    macro(d23, "d23"_s, 0, 0)                     \
+    macro(d24, "d24"_s, 0, 0)                     \
+    macro(d25, "d25"_s, 0, 0)                     \
+    macro(d26, "d26"_s, 0, 0)                     \
+    macro(d27, "d27"_s, 0, 0)                     \
+    macro(d28, "d28"_s, 0, 0)                     \
+    macro(d29, "d29"_s, 0, 0)                     \
+    macro(d30, "d30"_s, 0, 0)                     \
+    macro(d31, "d31"_s, 0, 0)
 #else
 #define FOR_EACH_FP_DOUBLE_REGISTER(macro)      \
-    macro(d0,  "d0",  0, 0)                     \
-    macro(d1,  "d1",  0, 0)                     \
-    macro(d2,  "d2",  0, 0)                     \
-    macro(d3,  "d3",  0, 0)                     \
-    macro(d4,  "d4",  0, 0)                     \
-    macro(d5,  "d5",  0, 0)                     \
-    macro(d6,  "d6",  0, 0)                     \
-    macro(d7,  "d7",  0, 0)                     \
-    macro(d8,  "d8",  0, 1)                     \
-    macro(d9,  "d9",  0, 1)                     \
-    macro(d10, "d10", 0, 1)                     \
-    macro(d11, "d11", 0, 1)                     \
-    macro(d12, "d12", 0, 1)                     \
-    macro(d13, "d13", 0, 1)                     \
-    macro(d14, "d14", 0, 1)                     \
-    macro(d15, "d15", 0, 1)
+    macro(d0,  "d0"_s,  0, 0)                     \
+    macro(d1,  "d1"_s,  0, 0)                     \
+    macro(d2,  "d2"_s,  0, 0)                     \
+    macro(d3,  "d3"_s,  0, 0)                     \
+    macro(d4,  "d4"_s,  0, 0)                     \
+    macro(d5,  "d5"_s,  0, 0)                     \
+    macro(d6,  "d6"_s,  0, 0)                     \
+    macro(d7,  "d7"_s,  0, 0)                     \
+    macro(d8,  "d8"_s,  0, 1)                     \
+    macro(d9,  "d9"_s,  0, 1)                     \
+    macro(d10, "d10"_s, 0, 1)                     \
+    macro(d11, "d11"_s, 0, 1)                     \
+    macro(d12, "d12"_s, 0, 1)                     \
+    macro(d13, "d13"_s, 0, 1)                     \
+    macro(d14, "d14"_s, 0, 1)                     \
+    macro(d15, "d15"_s, 0, 1)
 #endif
 
 #if CPU(ARM_NEON)
 #define FOR_EACH_FP_QUAD_REGISTER(macro)        \
-    macro(q0, "q0", 0, 0)                       \
-    macro(q1, "q1", 0, 0)                       \
-    macro(q2, "q2", 0, 0)                       \
-    macro(q3, "q3", 0, 0)                       \
-    macro(q4, "q4", 0, 1)                       \
-    macro(q5, "q5", 0, 1)                       \
-    macro(q6, "q6", 0, 1)                       \
-    macro(q7, "q7", 0, 1)                       \
-    macro(q8, "q8", 0, 0)                       \
-    macro(q9, "q9", 0, 0)                       \
-    macro(q10, "q10", 0, 0)                     \
-    macro(q11, "q11", 0, 0)                     \
-    macro(q12, "q12", 0, 0)                     \
-    macro(q13, "q13", 0, 0)                     \
-    macro(q14, "q14", 0, 0)                     \
-    macro(q15, "q15", 0, 0)
+    macro(q0, "q0"_s, 0, 0)                       \
+    macro(q1, "q1"_s, 0, 0)                       \
+    macro(q2, "q2"_s, 0, 0)                       \
+    macro(q3, "q3"_s, 0, 0)                       \
+    macro(q4, "q4"_s, 0, 1)                       \
+    macro(q5, "q5"_s, 0, 1)                       \
+    macro(q6, "q6"_s, 0, 1)                       \
+    macro(q7, "q7"_s, 0, 1)                       \
+    macro(q8, "q8"_s, 0, 0)                       \
+    macro(q9, "q9"_s, 0, 0)                       \
+    macro(q10, "q10"_s, 0, 0)                     \
+    macro(q11, "q11"_s, 0, 0)                     \
+    macro(q12, "q12"_s, 0, 0)                     \
+    macro(q13, "q13"_s, 0, 0)                     \
+    macro(q14, "q14"_s, 0, 0)                     \
+    macro(q15, "q15"_s, 0, 0)
 #endif
 
 #endif // CPU(ARM_THUMB2)

--- a/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
@@ -117,17 +117,17 @@ public:
     static constexpr RegisterID firstRegister() { return AssemblerType::firstRegister(); }
     static constexpr RegisterID lastRegister() { return AssemblerType::lastRegister(); }
     static constexpr unsigned numberOfRegisters() { return AssemblerType::numberOfRegisters(); }
-    static const char* gprName(RegisterID id) { return AssemblerType::gprName(id); }
+    static ASCIILiteral gprName(RegisterID id) { return AssemblerType::gprName(id); }
 
     static constexpr SPRegisterID firstSPRegister() { return AssemblerType::firstSPRegister(); }
     static constexpr SPRegisterID lastSPRegister() { return AssemblerType::lastSPRegister(); }
     static constexpr unsigned numberOfSPRegisters() { return AssemblerType::numberOfSPRegisters(); }
-    static const char* sprName(SPRegisterID id) { return AssemblerType::sprName(id); }
+    static ASCIILiteral sprName(SPRegisterID id) { return AssemblerType::sprName(id); }
 
     static constexpr FPRegisterID firstFPRegister() { return AssemblerType::firstFPRegister(); }
     static constexpr FPRegisterID lastFPRegister() { return AssemblerType::lastFPRegister(); }
     static constexpr unsigned numberOfFPRegisters() { return AssemblerType::numberOfFPRegisters(); }
-    static const char* fprName(FPRegisterID id) { return AssemblerType::fprName(id); }
+    static ASCIILiteral fprName(FPRegisterID id) { return AssemblerType::fprName(id); }
 
     // Section 1: MacroAssembler operand types
     //

--- a/Source/JavaScriptCore/assembler/MacroAssemblerPrinter.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerPrinter.cpp
@@ -62,18 +62,18 @@ void printAllRegisters(PrintStream& out, Context& context)
 
     for (auto id = MacroAssembler::firstRegister(); id <= MacroAssembler::lastRegister(); id = nextID(id)) {
         intptr_t value = static_cast<intptr_t>(cpu.gpr(id));
-        INDENT; out.printf("    %6s: " INTPTR_HEX_VALUE_FORMAT "  %" PRIdPTR "\n", cpu.gprName(id), value, value);
+        INDENT; out.printf("    %6s: " INTPTR_HEX_VALUE_FORMAT "  %" PRIdPTR "\n", cpu.gprName(id).characters(), value, value);
     }
     for (auto id = MacroAssembler::firstSPRegister(); id <= MacroAssembler::lastSPRegister(); id = nextID(id)) {
         intptr_t value = static_cast<intptr_t>(cpu.spr(id));
-        INDENT; out.printf("    %6s: " INTPTR_HEX_VALUE_FORMAT "  %" PRIdPTR "\n", cpu.sprName(id), value, value);
+        INDENT; out.printf("    %6s: " INTPTR_HEX_VALUE_FORMAT "  %" PRIdPTR "\n", cpu.sprName(id).characters(), value, value);
     }
     #undef INTPTR_HEX_VALUE_FORMAT
 
     for (auto id = MacroAssembler::firstFPRegister(); id <= MacroAssembler::lastFPRegister(); id = nextID(id)) {
         uint64_t u = bitwise_cast<uint64_t>(cpu.fpr(id));
         double d = cpu.fpr(id);
-        INDENT; out.printf("    %6s: 0x%016" PRIx64 "  %.13g\n", cpu.fprName(id), u, d);
+        INDENT; out.printf("    %6s: 0x%016" PRIx64 "  %.13g\n", cpu.fprName(id).characters(), u, d);
     }
 
     INDENT; out.print("}\n");

--- a/Source/JavaScriptCore/assembler/ProbeContext.h
+++ b/Source/JavaScriptCore/assembler/ProbeContext.h
@@ -39,9 +39,9 @@ struct CPUState {
     using SPRegisterID = MacroAssembler::SPRegisterID;
     using FPRegisterID = MacroAssembler::FPRegisterID;
 
-    static inline const char* gprName(RegisterID id) { return MacroAssembler::gprName(id); }
-    static inline const char* sprName(SPRegisterID id) { return MacroAssembler::sprName(id); }
-    static inline const char* fprName(FPRegisterID id) { return MacroAssembler::fprName(id); }
+    static ASCIILiteral gprName(RegisterID id) { return MacroAssembler::gprName(id); }
+    static ASCIILiteral sprName(SPRegisterID id) { return MacroAssembler::sprName(id); }
+    static ASCIILiteral fprName(FPRegisterID id) { return MacroAssembler::fprName(id); }
     inline UCPURegister& gpr(RegisterID);
     inline UCPURegister& spr(SPRegisterID);
     template<SavedFPWidth = SavedFPWidth::DontSaveVectors> inline double& fpr(FPRegisterID);
@@ -240,9 +240,9 @@ public:
 #if CPU(X86_64) || CPU(ARM64)
     v128_t& vector(FPRegisterID id) { return cpu.vector(id); }
 #endif
-    const char* gprName(RegisterID id) { return cpu.gprName(id); }
-    const char* sprName(SPRegisterID id) { return cpu.sprName(id); }
-    const char* fprName(FPRegisterID id) { return cpu.fprName(id); }
+    ASCIILiteral gprName(RegisterID id) { return cpu.gprName(id); }
+    ASCIILiteral sprName(SPRegisterID id) { return cpu.sprName(id); }
+    ASCIILiteral fprName(FPRegisterID id) { return cpu.fprName(id); }
 
     template<typename T> T gpr(RegisterID id) const { return cpu.gpr<T>(id); }
     template<typename T> T spr(SPRegisterID id) const { return cpu.spr<T>(id); }

--- a/Source/JavaScriptCore/assembler/RISCV64Assembler.h
+++ b/Source/JavaScriptCore/assembler/RISCV64Assembler.h
@@ -1490,10 +1490,10 @@ public:
     static constexpr FPRegisterID lastFPRegister() { return RISCV64Registers::f31; }
     static constexpr unsigned numberOfFPRegisters() { return lastFPRegister() - firstFPRegister() + 1; }
 
-    static const char* gprName(RegisterID id)
+    static ASCIILiteral gprName(RegisterID id)
     {
         ASSERT(id >= firstRegister() && id <= lastRegister());
-        static const char* const nameForRegister[numberOfRegisters()] = {
+        static constexpr ASCIILiteral nameForRegister[numberOfRegisters()] = {
 #define REGISTER_NAME(id, name, r, cs) name,
             FOR_EACH_GP_REGISTER(REGISTER_NAME)
 #undef REGISTER_NAME
@@ -1501,10 +1501,10 @@ public:
         return nameForRegister[id];
     }
 
-    static const char* sprName(SPRegisterID id)
+    static ASCIILiteral sprName(SPRegisterID id)
     {
         ASSERT(id >= firstSPRegister() && id <= lastSPRegister());
-        static const char* const nameForRegister[numberOfSPRegisters()] = {
+        static constexpr ASCIILiteral nameForRegister[numberOfSPRegisters()] = {
 #define REGISTER_NAME(id, name) name,
             FOR_EACH_SP_REGISTER(REGISTER_NAME)
 #undef REGISTER_NAME
@@ -1512,10 +1512,10 @@ public:
         return nameForRegister[id];
     }
 
-    static const char* fprName(FPRegisterID id)
+    static ASCIILiteral fprName(FPRegisterID id)
     {
         ASSERT(id >= firstFPRegister() && id <= lastFPRegister());
-        static const char* const nameForRegister[numberOfFPRegisters()] = {
+        static constexpr ASCIILiteral nameForRegister[numberOfFPRegisters()] = {
 #define REGISTER_NAME(id, name, r, cs) name,
             FOR_EACH_FP_REGISTER(REGISTER_NAME)
 #undef REGISTER_NAME

--- a/Source/JavaScriptCore/assembler/RISCV64Registers.h
+++ b/Source/JavaScriptCore/assembler/RISCV64Registers.h
@@ -36,83 +36,83 @@
 #define RegisterNames RISCV64Registers
 
 #define FOR_EACH_GP_REGISTER(macro)    \
-    macro(x0, "x0", 1, 0)              \
-    macro(x1, "x1", 1, 0)              \
-    macro(x2, "x2", 1, 1)              \
-    macro(x3, "x3", 1, 0)              \
-    macro(x4, "x4", 1, 0)              \
-    macro(x5, "x5", 0, 0)              \
-    macro(x6, "x6", 0, 0)              \
-    macro(x7, "x7", 0, 0)              \
-    macro(x8, "x8", 1, 1)              \
-    macro(x9, "x9", 0, 1)              \
-    macro(x10, "x10", 0, 0)            \
-    macro(x11, "x11", 0, 0)            \
-    macro(x12, "x12", 0, 0)            \
-    macro(x13, "x13", 0, 0)            \
-    macro(x14, "x14", 0, 0)            \
-    macro(x15, "x15", 0, 0)            \
-    macro(x16, "x16", 0, 0)            \
-    macro(x17, "x17", 0, 0)            \
-    macro(x18, "x18", 0, 1)            \
-    macro(x19, "x19", 0, 1)            \
-    macro(x20, "x20", 0, 1)            \
-    macro(x21, "x21", 0, 1)            \
-    macro(x22, "x22", 0, 1)            \
-    macro(x23, "x23", 0, 1)            \
-    macro(x24, "x24", 0, 1)            \
-    macro(x25, "x25", 0, 1)            \
-    macro(x26, "x26", 0, 1)            \
-    macro(x27, "x27", 0, 1)            \
-    macro(x28, "x28", 0, 0)            \
-    macro(x29, "x29", 0, 0)            \
+    macro(x0, "x0"_s, 1, 0)              \
+    macro(x1, "x1"_s, 1, 0)              \
+    macro(x2, "x2"_s, 1, 1)              \
+    macro(x3, "x3"_s, 1, 0)              \
+    macro(x4, "x4"_s, 1, 0)              \
+    macro(x5, "x5"_s, 0, 0)              \
+    macro(x6, "x6"_s, 0, 0)              \
+    macro(x7, "x7"_s, 0, 0)              \
+    macro(x8, "x8"_s, 1, 1)              \
+    macro(x9, "x9"_s, 0, 1)              \
+    macro(x10, "x10"_s, 0, 0)            \
+    macro(x11, "x11"_s, 0, 0)            \
+    macro(x12, "x12"_s, 0, 0)            \
+    macro(x13, "x13"_s, 0, 0)            \
+    macro(x14, "x14"_s, 0, 0)            \
+    macro(x15, "x15"_s, 0, 0)            \
+    macro(x16, "x16"_s, 0, 0)            \
+    macro(x17, "x17"_s, 0, 0)            \
+    macro(x18, "x18"_s, 0, 1)            \
+    macro(x19, "x19"_s, 0, 1)            \
+    macro(x20, "x20"_s, 0, 1)            \
+    macro(x21, "x21"_s, 0, 1)            \
+    macro(x22, "x22"_s, 0, 1)            \
+    macro(x23, "x23"_s, 0, 1)            \
+    macro(x24, "x24"_s, 0, 1)            \
+    macro(x25, "x25"_s, 0, 1)            \
+    macro(x26, "x26"_s, 0, 1)            \
+    macro(x27, "x27"_s, 0, 1)            \
+    macro(x28, "x28"_s, 0, 0)            \
+    macro(x29, "x29"_s, 0, 0)            \
 /* MacroAssembler scratch registers */ \
-    macro(x30, "x30", 0, 0)            \
-    macro(x31, "x31", 0, 0)
+    macro(x30, "x30"_s, 0, 0)            \
+    macro(x31, "x31"_s, 0, 0)
 
 #define FOR_EACH_REGISTER_ALIAS(macro) \
-    macro(zero, "zero", x0)            \
-    macro(ra, "ra", x1)                \
-    macro(sp, "sp", x2)                \
-    macro(gp, "gp", x3)                \
-    macro(tp, "tp", x4)                \
-    macro(fp, "fp", x8)
+    macro(zero, "zero"_s, x0)            \
+    macro(ra, "ra"_s, x1)                \
+    macro(sp, "sp"_s, x2)                \
+    macro(gp, "gp"_s, x3)                \
+    macro(tp, "tp"_s, x4)                \
+    macro(fp, "fp"_s, x8)
 
 #define FOR_EACH_SP_REGISTER(macro) \
-    macro(pc, "pc")
+    macro(pc, "pc"_s)
 
 #define FOR_EACH_FP_REGISTER(macro) \
-    macro(f0, "f0", 0, 0)           \
-    macro(f1, "f1", 0, 0)           \
-    macro(f2, "f2", 0, 0)           \
-    macro(f3, "f3", 0, 0)           \
-    macro(f4, "f4", 0, 0)           \
-    macro(f5, "f5", 0, 0)           \
-    macro(f6, "f6", 0, 0)           \
-    macro(f7, "f7", 0, 0)           \
-    macro(f8, "f8", 0, 1)           \
-    macro(f9, "f9", 0, 1)           \
-    macro(f10, "f10", 0, 0)         \
-    macro(f11, "f11", 0, 0)         \
-    macro(f12, "f12", 0, 0)         \
-    macro(f13, "f13", 0, 0)         \
-    macro(f14, "f14", 0, 0)         \
-    macro(f15, "f15", 0, 0)         \
-    macro(f16, "f16", 0, 0)         \
-    macro(f17, "f17", 0, 0)         \
-    macro(f18, "f18", 0, 1)         \
-    macro(f19, "f19", 0, 1)         \
-    macro(f20, "f20", 0, 1)         \
-    macro(f21, "f21", 0, 1)         \
-    macro(f22, "f22", 0, 1)         \
-    macro(f23, "f23", 0, 1)         \
-    macro(f24, "f24", 0, 1)         \
-    macro(f25, "f25", 0, 1)         \
-    macro(f26, "f26", 0, 1)         \
-    macro(f27, "f27", 0, 1)         \
-    macro(f28, "f28", 0, 0)         \
-    macro(f29, "f29", 0, 0)         \
-    macro(f30, "f30", 0, 0)         \
-    macro(f31, "f31", 0, 0)
+    macro(f0, "f0"_s, 0, 0)           \
+    macro(f1, "f1"_s, 0, 0)           \
+    macro(f2, "f2"_s, 0, 0)           \
+    macro(f3, "f3"_s, 0, 0)           \
+    macro(f4, "f4"_s, 0, 0)           \
+    macro(f5, "f5"_s, 0, 0)           \
+    macro(f6, "f6"_s, 0, 0)           \
+    macro(f7, "f7"_s, 0, 0)           \
+    macro(f8, "f8"_s, 0, 1)           \
+    macro(f9, "f9"_s, 0, 1)           \
+    macro(f10, "f10"_s, 0, 0)         \
+    macro(f11, "f11"_s, 0, 0)         \
+    macro(f12, "f12"_s, 0, 0)         \
+    macro(f13, "f13"_s, 0, 0)         \
+    macro(f14, "f14"_s, 0, 0)         \
+    macro(f15, "f15"_s, 0, 0)         \
+    macro(f16, "f16"_s, 0, 0)         \
+    macro(f17, "f17"_s, 0, 0)         \
+    macro(f18, "f18"_s, 0, 1)         \
+    macro(f19, "f19"_s, 0, 1)         \
+    macro(f20, "f20"_s, 0, 1)         \
+    macro(f21, "f21"_s, 0, 1)         \
+    macro(f22, "f22"_s, 0, 1)         \
+    macro(f23, "f23"_s, 0, 1)         \
+    macro(f24, "f24"_s, 0, 1)         \
+    macro(f25, "f25"_s, 0, 1)         \
+    macro(f26, "f26"_s, 0, 1)         \
+    macro(f27, "f27"_s, 0, 1)         \
+    macro(f28, "f28"_s, 0, 0)         \
+    macro(f29, "f29"_s, 0, 0)         \
+    macro(f30, "f30"_s, 0, 0)         \
+    macro(f31, "f31"_s, 0, 0)
 
 #endif // CPU(RISCV64)

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -104,10 +104,10 @@ public:
     }
     static constexpr unsigned numberOfFPRegisters() { return lastFPRegister() - firstFPRegister() + 1; }
     
-    static const char* gprName(RegisterID id)
+    static ASCIILiteral gprName(RegisterID id)
     {
         ASSERT(id >= firstRegister() && id <= lastRegister());
-        static const char* const nameForRegister[numberOfRegisters()] = {
+        static constexpr ASCIILiteral nameForRegister[numberOfRegisters()] = {
 #define REGISTER_NAME(id, name, res, cs) name,
         FOR_EACH_GP_REGISTER(REGISTER_NAME)
 #undef REGISTER_NAME
@@ -115,10 +115,10 @@ public:
         return nameForRegister[id];
     }
 
-    static const char* sprName(SPRegisterID id)
+    static ASCIILiteral sprName(SPRegisterID id)
     {
         ASSERT(id >= firstSPRegister() && id <= lastSPRegister());
-        static const char* const nameForRegister[numberOfSPRegisters()] = {
+        static constexpr ASCIILiteral const nameForRegister[numberOfSPRegisters()] = {
 #define REGISTER_NAME(id, name, res, cs) name,
         FOR_EACH_SP_REGISTER(REGISTER_NAME)
 #undef REGISTER_NAME
@@ -126,10 +126,10 @@ public:
         return nameForRegister[id];
     }
     
-    static const char* fprName(FPRegisterID reg)
+    static ASCIILiteral fprName(FPRegisterID reg)
     {
         ASSERT(reg >= firstFPRegister() && reg <= lastFPRegister());
-        static const char* const nameForRegister[numberOfFPRegisters()] = {
+        static constexpr ASCIILiteral nameForRegister[numberOfFPRegisters()] = {
 #define REGISTER_NAME(id, name, res, cs) name,
         FOR_EACH_FP_REGISTER(REGISTER_NAME)
 #undef REGISTER_NAME

--- a/Source/JavaScriptCore/assembler/X86Registers.h
+++ b/Source/JavaScriptCore/assembler/X86Registers.h
@@ -37,27 +37,27 @@
     FOR_EACH_FP_REGISTER(macro)
 
 #define FOR_EACH_GP_REGISTER(macro)             \
-    macro(eax, "eax", 0, 0)                     \
-    macro(ecx, "ecx", 0, 0)                     \
-    macro(edx, "edx", 0, 0)                     \
-    macro(ebx, "ebx", 0, 1)                     \
-    macro(esp, "esp", 0, 0)                     \
-    macro(ebp, "ebp", 0, 1)                     \
-    macro(esi, "esi", 0, 1)                     \
-    macro(edi, "edi", 0, 1)
+    macro(eax, "eax"_s, 0, 0)                     \
+    macro(ecx, "ecx"_s, 0, 0)                     \
+    macro(edx, "edx"_s, 0, 0)                     \
+    macro(ebx, "ebx"_s, 0, 1)                     \
+    macro(esp, "esp"_s, 0, 0)                     \
+    macro(ebp, "ebp"_s, 0, 1)                     \
+    macro(esi, "esi"_s, 0, 1)                     \
+    macro(edi, "edi"_s, 0, 1)
 
 #define FOR_EACH_FP_REGISTER(macro)             \
-    macro(xmm0, "xmm0", 0, 0)                   \
-    macro(xmm1, "xmm1", 0, 0)                   \
-    macro(xmm2, "xmm2", 0, 0)                   \
-    macro(xmm3, "xmm3", 0, 0)                   \
-    macro(xmm4, "xmm4", 0, 0)                   \
-    macro(xmm5, "xmm5", 0, 0)                   \
-    macro(xmm6, "xmm6", 0, 0)                   \
-    macro(xmm7, "xmm7", 0, 0)
+    macro(xmm0, "xmm0"_s, 0, 0)                   \
+    macro(xmm1, "xmm1"_s, 0, 0)                   \
+    macro(xmm2, "xmm2"_s, 0, 0)                   \
+    macro(xmm3, "xmm3"_s, 0, 0)                   \
+    macro(xmm4, "xmm4"_s, 0, 0)                   \
+    macro(xmm5, "xmm5"_s, 0, 0)                   \
+    macro(xmm6, "xmm6"_s, 0, 0)                   \
+    macro(xmm7, "xmm7"_s, 0, 0)
 
 #define FOR_EACH_SP_REGISTER(macro)             \
-    macro(eip,    "eip",    0, 0)               \
-    macro(eflags, "eflags", 0, 0)
+    macro(eip,    "eip"_s,    0, 0)               \
+    macro(eflags, "eflags"_s, 0, 0)
 
 #endif

--- a/Source/JavaScriptCore/assembler/X86_64Registers.h
+++ b/Source/JavaScriptCore/assembler/X86_64Registers.h
@@ -36,65 +36,65 @@
 #if !OS(WINDOWS)
 
 #define FOR_EACH_GP_REGISTER(macro)             \
-    macro(eax, "rax", 0, 0)                     \
-    macro(ecx, "rcx", 0, 0)                     \
-    macro(edx, "rdx", 0, 0)                     \
-    macro(ebx, "rbx", 0, 1)                     \
-    macro(esp, "rsp", 0, 0)                     \
-    macro(ebp, "rbp", 0, 1)                     \
-    macro(esi, "rsi", 0, 0)                     \
-    macro(edi, "rdi", 0, 0)                     \
-    macro(r8,  "r8",  0, 0)                     \
-    macro(r9,  "r9",  0, 0)                     \
-    macro(r10, "r10", 0, 0)                     \
-    macro(r11, "r11", 0, 0)                     \
-    macro(r12, "r12", 0, 1)                     \
-    macro(r13, "r13", 0, 1)                     \
-    macro(r14, "r14", 0, 1)                     \
-    macro(r15, "r15", 0, 1)
+    macro(eax, "rax"_s, 0, 0)                     \
+    macro(ecx, "rcx"_s, 0, 0)                     \
+    macro(edx, "rdx"_s, 0, 0)                     \
+    macro(ebx, "rbx"_s, 0, 1)                     \
+    macro(esp, "rsp"_s, 0, 0)                     \
+    macro(ebp, "rbp"_s, 0, 1)                     \
+    macro(esi, "rsi"_s, 0, 0)                     \
+    macro(edi, "rdi"_s, 0, 0)                     \
+    macro(r8,  "r8"_s,  0, 0)                     \
+    macro(r9,  "r9"_s,  0, 0)                     \
+    macro(r10, "r10"_s, 0, 0)                     \
+    macro(r11, "r11"_s, 0, 0)                     \
+    macro(r12, "r12"_s, 0, 1)                     \
+    macro(r13, "r13"_s, 0, 1)                     \
+    macro(r14, "r14"_s, 0, 1)                     \
+    macro(r15, "r15"_s, 0, 1)
 
 #else // OS(WINDOWS)
 
 #define FOR_EACH_GP_REGISTER(macro)             \
-    macro(eax, "rax", 0, 0)                     \
-    macro(ecx, "rcx", 0, 0)                     \
-    macro(edx, "rdx", 0, 0)                     \
-    macro(ebx, "rbx", 0, 1)                     \
-    macro(esp, "rsp", 0, 0)                     \
-    macro(ebp, "rbp", 0, 1)                     \
-    macro(esi, "rsi", 0, 1)                     \
-    macro(edi, "rdi", 0, 1)                     \
-    macro(r8,  "r8",  0, 0)                     \
-    macro(r9,  "r9",  0, 0)                     \
-    macro(r10, "r10", 0, 0)                     \
-    macro(r11, "r11", 0, 0)                     \
-    macro(r12, "r12", 0, 1)                     \
-    macro(r13, "r13", 0, 1)                     \
-    macro(r14, "r14", 0, 1)                     \
-    macro(r15, "r15", 0, 1)
+    macro(eax, "rax"_s, 0, 0)                     \
+    macro(ecx, "rcx"_s, 0, 0)                     \
+    macro(edx, "rdx"_s, 0, 0)                     \
+    macro(ebx, "rbx"_s, 0, 1)                     \
+    macro(esp, "rsp"_s, 0, 0)                     \
+    macro(ebp, "rbp"_s, 0, 1)                     \
+    macro(esi, "rsi"_s, 0, 1)                     \
+    macro(edi, "rdi"_s, 0, 1)                     \
+    macro(r8,  "r8"_s,  0, 0)                     \
+    macro(r9,  "r9"_s,  0, 0)                     \
+    macro(r10, "r10"_s, 0, 0)                     \
+    macro(r11, "r11"_s, 0, 0)                     \
+    macro(r12, "r12"_s, 0, 1)                     \
+    macro(r13, "r13"_s, 0, 1)                     \
+    macro(r14, "r14"_s, 0, 1)                     \
+    macro(r15, "r15"_s, 0, 1)
 
 #endif // !OS(WINDOWS)
 
 #define FOR_EACH_FP_REGISTER(macro)             \
-    macro(xmm0,  "xmm0",  0, 0)                  \
-    macro(xmm1,  "xmm1",  0, 0)                  \
-    macro(xmm2,  "xmm2",  0, 0)                  \
-    macro(xmm3,  "xmm3",  0, 0)                  \
-    macro(xmm4,  "xmm4",  0, 0)                  \
-    macro(xmm5,  "xmm5",  0, 0)                  \
-    macro(xmm6,  "xmm6",  0, 0)                  \
-    macro(xmm7,  "xmm7",  0, 0)                  \
-    macro(xmm8,  "xmm8",  0, 0)                  \
-    macro(xmm9,  "xmm9",  0, 0)                  \
-    macro(xmm10, "xmm10", 0, 0)                  \
-    macro(xmm11, "xmm11", 0, 0)                  \
-    macro(xmm12, "xmm12", 0, 0)                  \
-    macro(xmm13, "xmm13", 0, 0)                  \
-    macro(xmm14, "xmm14", 0, 0)                  \
-    macro(xmm15, "xmm15", 0, 0)
+    macro(xmm0,  "xmm0"_s,  0, 0)                  \
+    macro(xmm1,  "xmm1"_s,  0, 0)                  \
+    macro(xmm2,  "xmm2"_s,  0, 0)                  \
+    macro(xmm3,  "xmm3"_s,  0, 0)                  \
+    macro(xmm4,  "xmm4"_s,  0, 0)                  \
+    macro(xmm5,  "xmm5"_s,  0, 0)                  \
+    macro(xmm6,  "xmm6"_s,  0, 0)                  \
+    macro(xmm7,  "xmm7"_s,  0, 0)                  \
+    macro(xmm8,  "xmm8"_s,  0, 0)                  \
+    macro(xmm9,  "xmm9"_s,  0, 0)                  \
+    macro(xmm10, "xmm10"_s, 0, 0)                  \
+    macro(xmm11, "xmm11"_s, 0, 0)                  \
+    macro(xmm12, "xmm12"_s, 0, 0)                  \
+    macro(xmm13, "xmm13"_s, 0, 0)                  \
+    macro(xmm14, "xmm14"_s, 0, 0)                  \
+    macro(xmm15, "xmm15"_s, 0, 0)
 
 #define FOR_EACH_SP_REGISTER(macro)             \
-    macro(eip,    "eip",    0, 0)               \
-    macro(eflags, "eflags", 0, 0)
+    macro(eip,    "eip"_s,    0, 0)               \
+    macro(eflags, "eflags"_s, 0, 0)
 
 #endif // CPU(X86_64)

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -1839,7 +1839,7 @@ void SpeculativeJIT::dump(const char* label)
 #endif
             ) {
             ASSERT(info.gpr() != InvalidGPRReg);
-            dataLogF(":%s\n", GPRInfo::debugName(info.gpr()));
+            dataLogF(":%s\n", GPRInfo::debugName(info.gpr()).characters());
         } else
             dataLogF("\n");
     }

--- a/Source/JavaScriptCore/dfg/DFGVariableEvent.cpp
+++ b/Source/JavaScriptCore/dfg/DFGVariableEvent.cpp
@@ -76,13 +76,13 @@ void VariableEvent::dumpFillInfo(const char* name, PrintStream& out) const
 {
     out.print(name, "(", id(), ", ");
     if (dataFormat() == DataFormatDouble)
-        out.printf("%s", FPRInfo::debugName(fpr()));
+        out.printf("%s", FPRInfo::debugName(fpr()).characters());
 #if USE(JSVALUE32_64)
     else if (dataFormat() & DataFormatJS)
-        out.printf("%s:%s", GPRInfo::debugName(tagGPR()), GPRInfo::debugName(payloadGPR()));
+        out.printf("%s:%s", GPRInfo::debugName(tagGPR()).characters(), GPRInfo::debugName(payloadGPR()).characters());
 #endif
     else
-        out.printf("%s", GPRInfo::debugName(gpr()));
+        out.printf("%s", GPRInfo::debugName(gpr()).characters());
     out.printf(", %s)", dataFormatToString(dataFormat()));
 }
 

--- a/Source/JavaScriptCore/jit/FPRInfo.h
+++ b/Source/JavaScriptCore/jit/FPRInfo.h
@@ -96,7 +96,7 @@ public:
         return (FPRReg)index;
     }
 
-    static const char* debugName(FPRReg reg)
+    static ASCIILiteral debugName(FPRReg reg)
     {
         ASSERT(reg != InvalidFPRReg);
         return MacroAssembler::fprName(reg);
@@ -168,7 +168,7 @@ public:
         return static_cast<FPRReg>(index);
     }
 
-    static const char* debugName(FPRReg reg)
+    static ASCIILiteral debugName(FPRReg reg)
     {
         ASSERT(reg != InvalidFPRReg);
         return MacroAssembler::fprName(reg);
@@ -264,7 +264,7 @@ public:
         return static_cast<FPRReg>(index);
     }
 
-    static const char* debugName(FPRReg reg)
+    static ASCIILiteral debugName(FPRReg reg)
     {
         ASSERT(reg != InvalidFPRReg);
         return MacroAssembler::fprName(reg);
@@ -361,7 +361,7 @@ public:
         return indexForRegister[reg];
     }
 
-    static const char* debugName(FPRReg reg)
+    static ASCIILiteral debugName(FPRReg reg)
     {
         ASSERT(reg != InvalidFPRReg);
         return MacroAssembler::fprName(reg);

--- a/Source/JavaScriptCore/jit/GPRInfo.h
+++ b/Source/JavaScriptCore/jit/GPRInfo.h
@@ -390,7 +390,7 @@ public:
         return indexForRegister[reg];
     }
 
-    static const char* debugName(GPRReg reg)
+    static ASCIILiteral debugName(GPRReg reg)
     {
         ASSERT(reg != InvalidGPRReg);
         return MacroAssembler::gprName(reg);
@@ -535,7 +535,7 @@ public:
         return indexForRegister[reg];
     }
 
-    static const char* debugName(GPRReg reg)
+    static ASCIILiteral debugName(GPRReg reg)
     {
         ASSERT(reg != InvalidGPRReg);
         return MacroAssembler::gprName(reg);
@@ -631,7 +631,7 @@ public:
         return result;
     }
 
-    static const char* debugName(GPRReg reg)
+    static ASCIILiteral debugName(GPRReg reg)
     {
         ASSERT(reg != InvalidGPRReg);
         return MacroAssembler::gprName(reg);
@@ -751,7 +751,7 @@ public:
         return toRegister(index);
     }
 
-    static const char* debugName(GPRReg reg)
+    static ASCIILiteral debugName(GPRReg reg)
     {
         ASSERT(reg != InvalidGPRReg);
         return MacroAssembler::gprName(reg);
@@ -878,7 +878,7 @@ public:
         return indexForRegister[reg];
     }
 
-    static const char* debugName(GPRReg reg)
+    static ASCIILiteral debugName(GPRReg reg)
     {
         ASSERT(reg != InvalidGPRReg);
         return MacroAssembler::gprName(reg);

--- a/Source/JavaScriptCore/jit/Reg.cpp
+++ b/Source/JavaScriptCore/jit/Reg.cpp
@@ -33,7 +33,7 @@
 
 namespace JSC {
 
-const char* Reg::debugName() const
+ASCIILiteral Reg::debugName() const
 {
     if (!*this)
         return nullptr;

--- a/Source/JavaScriptCore/jit/Reg.h
+++ b/Source/JavaScriptCore/jit/Reg.h
@@ -164,7 +164,7 @@ public:
         return m_index;
     }
 
-    const char* debugName() const;
+    ASCIILiteral debugName() const;
 
     void dump(PrintStream&) const;
 


### PR DESCRIPTION
#### b1f35bb4f49588153a2b874b84079c6ebe2d22e5
<pre>
Use ASCIILiteral in JSC assembler macros
<a href="https://bugs.webkit.org/show_bug.cgi?id=273383">https://bugs.webkit.org/show_bug.cgi?id=273383</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/assembler/ARM64Assembler.h:
(JSC::ARM64Assembler::gprName):
(JSC::ARM64Assembler::sprName):
(JSC::ARM64Assembler::fprName):
* Source/JavaScriptCore/assembler/ARM64Registers.h:
* Source/JavaScriptCore/assembler/ARMv7Assembler.h:
(JSC::ARMv7Assembler::gprName):
(JSC::ARMv7Assembler::sprName):
(JSC::ARMv7Assembler::fprName):
* Source/JavaScriptCore/assembler/ARMv7Registers.h:
* Source/JavaScriptCore/assembler/AbstractMacroAssembler.h:
(JSC::AbstractMacroAssembler::gprName):
(JSC::AbstractMacroAssembler::sprName):
(JSC::AbstractMacroAssembler::fprName):
* Source/JavaScriptCore/assembler/RISCV64Assembler.h:
(JSC::RISCV64Assembler::gprName):
(JSC::RISCV64Assembler::sprName):
(JSC::RISCV64Assembler::fprName):
* Source/JavaScriptCore/assembler/RISCV64Registers.h:
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::gprName):
(JSC::X86Assembler::sprName):
(JSC::X86Assembler::fprName):
* Source/JavaScriptCore/assembler/X86Registers.h:
* Source/JavaScriptCore/assembler/X86_64Registers.h:

Canonical link: <a href="https://commits.webkit.org/278114@main">https://commits.webkit.org/278114@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40f080a3cf800e230d56b6d583baf2abd0b0d65d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49549 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52791 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/225 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26453 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40455 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51649 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26368 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21570 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23832 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7920 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/42863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45746 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/44381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54367 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/49043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24634 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20819 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47826 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25903 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46846 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26747 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56531 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7119 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25627 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11620 "Passed tests") | 
<!--EWS-Status-Bubble-End-->