### PR TITLE
[build.webkit.org] [GTK][WPE] Add new buildbots for Ubuntu 24.04

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -430,7 +430,7 @@
                     "workernames": ["gtk-linux-bot-22"]
                   },
                   {
-                    "name": "GTK-Linux-64-bit-Release-Ubuntu-2004-Build", "factory": "NoInstallDependenciesBuildFactory",
+                    "name": "GTK-Linux-64-bit-Release-Ubuntu-2204-Build", "factory": "NoInstallDependenciesBuildFactory",
                     "platform": "gtk", "configuration": "release", "architectures": ["x86_64"],
                     "additionalArguments": ["--no-experimental-features"],
                     "workernames": ["gtk-linux-bot-11"]
@@ -442,9 +442,8 @@
                     "workernames": ["gtk-linux-bot-21"]
                   },
                   {
-                    "name": "GTK-Linux-64bit-Release-Packaging-Nightly-Ubuntu2004", "factory": "BuildAndGenerateMiniBrowserBundleFactory",
+                    "name": "GTK-Linux-64bit-Release-Packaging-Nightly-Ubuntu2204", "factory": "BuildAndGenerateMiniBrowserBundleFactory",
                     "platform": "gtk", "configuration": "release", "architectures": ["x86_64"],
-                    "additionalArguments": ["--no-bubblewrap-sandbox"],
                     "workernames": ["gtk-linux-bot-17"]
                   },
                   {
@@ -558,7 +557,7 @@
                     "workernames": ["wpe-linux-bot-6"]
                   },
                   {
-                    "name": "WPE-Linux-64bit-Release-Packaging-Nightly-Ubuntu2004", "factory": "BuildAndGenerateMiniBrowserBundleFactory",
+                    "name": "WPE-Linux-64bit-Release-Packaging-Nightly-Ubuntu2204", "factory": "BuildAndGenerateMiniBrowserBundleFactory",
                     "platform": "wpe", "configuration": "release", "architectures": ["x86_64"],
                     "additionalArguments": ["--no-bubblewrap-sandbox", "--cmakeargs=-DENABLE_WPE_QT_API=OFF"],
                     "workernames": ["wpe-linux-bot-8"]
@@ -570,7 +569,7 @@
                     "workernames": ["wpe-linux-bot-9"]
                   },
                   {
-                    "name": "WPE-Linux-64-bit-Release-Ubuntu-2004-Build", "factory": "NoInstallDependenciesBuildFactory",
+                    "name": "WPE-Linux-64-bit-Release-Ubuntu-2204-Build", "factory": "NoInstallDependenciesBuildFactory",
                     "platform": "wpe", "configuration": "release", "architectures": ["x86_64"],
                     "additionalArguments": ["--no-experimental-features"],
                     "workernames": ["wpe-linux-bot-10"]
@@ -645,10 +644,10 @@
                                      "GTK-Linux-64-bit-Release-Clang-Build",
                                      "GTK-Linux-64-bit-Release-Debian-11-Build",
                                      "GTK-Linux-64-bit-Release-Debian-Stable-Build",
-                                     "GTK-Linux-64-bit-Release-Ubuntu-2004-Build",
+                                     "GTK-Linux-64-bit-Release-Ubuntu-2204-Build",
                                      "GTK-Linux-64-bit-Release-Ubuntu-LTS-Build",
                                      "GTK-Linux-64-bit-Release-GTK4-Tests",
-                                     "WPE-Linux-64-bit-Release-Ubuntu-2004-Build",
+                                     "WPE-Linux-64-bit-Release-Ubuntu-2204-Build",
                                      "WPE-Linux-64-bit-Release-Ubuntu-LTS-Build",
                                      "WPE-Linux-RPi4-32bits-Mesa-Release-Perf-Build",
                                      "WPE-Linux-RPi4-64bits-Mesa-Release-Perf-Build",
@@ -843,8 +842,8 @@
                   },
                   { "type": "Nightly", "name": "NightlyScheduler", "change_filter": "main_filter",
                     "branch": "main", "hour": 22, "minute": 0,
-                    "builderNames": ["GTK-Linux-64bit-Release-Packaging-Nightly-Ubuntu2004",
-                                     "WPE-Linux-64bit-Release-Packaging-Nightly-Ubuntu2004"]
+                    "builderNames": ["GTK-Linux-64bit-Release-Packaging-Nightly-Ubuntu2204",
+                                     "WPE-Linux-64bit-Release-Packaging-Nightly-Ubuntu2204"]
                   }
                 ]
 }

--- a/Tools/CISupport/build-webkit-org/factories_unittest.py
+++ b/Tools/CISupport/build-webkit-org/factories_unittest.py
@@ -1046,7 +1046,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-stale-build-files',
             'compile-webkit'
         ],
-        'GTK-Linux-64-bit-Release-Ubuntu-2004-Build': [
+        'GTK-Linux-64-bit-Release-Ubuntu-2204-Build': [
             'configure-build',
             'configuration',
             'clean-and-update-working-directory',
@@ -1057,7 +1057,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-stale-build-files',
             'compile-webkit'
         ],
-        'GTK-Linux-64bit-Release-Packaging-Nightly-Ubuntu2004': [
+        'GTK-Linux-64bit-Release-Packaging-Nightly-Ubuntu2204': [
             'configure-build',
             'configuration',
             'clean-and-update-working-directory',
@@ -1435,7 +1435,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'extract-built-product',
             'webdriver-test'
         ],
-        'WPE-Linux-64bit-Release-Packaging-Nightly-Ubuntu2004': [
+        'WPE-Linux-64bit-Release-Packaging-Nightly-Ubuntu2204': [
             'configure-build',
             'configuration',
             'clean-and-update-working-directory',
@@ -1471,7 +1471,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-stale-build-files',
             'compile-webkit'
         ],
-        'WPE-Linux-64-bit-Release-Ubuntu-2004-Build': [
+        'WPE-Linux-64-bit-Release-Ubuntu-2204-Build': [
             'configure-build',
             'configuration',
             'clean-and-update-working-directory',

--- a/Tools/glib/dependencies/apt
+++ b/Tools/glib/dependencies/apt
@@ -111,6 +111,7 @@ PACKAGES=(
     libssl-dev
     libtool-bin
     libxml-libxml-perl
+    meson
     nasm
     python3-setuptools
     uuid-dev

--- a/Tools/jhbuild/jhbuild-minimal.modules
+++ b/Tools/jhbuild/jhbuild-minimal.modules
@@ -75,14 +75,16 @@
   <repository type="tarball" name="gnupg.org"
       href="https://www.gnupg.org/ftp/gcrypt/"/>
 
-  <!-- meson 0.62.0  required to build gstreamer-1.22.7 -->
-  <distutils id="meson" python3="1">
-    <branch module="mesonbuild/meson"
-            version="0.62.2"
-            tag="0.62.2"
-            checkoutdir="meson-${version}"
-            repo="github.com"/>
-  </distutils>
+  <!-- meson 0.62.2 required to build gstreamer-1.22.7 -->
+  <if condition-check="require-meson">
+    <distutils id="meson" python3="1">
+      <branch module="mesonbuild/meson"
+              version="0.62.2"
+              tag="0.62.2"
+              checkoutdir="meson-${version}"
+              repo="github.com"/>
+    </distutils>
+  </if>
 
 <!-- This moduleset is used when the environment variable WEBKIT_JHBUILD_MODULESET=minimal is set -->
 <!-- Its intended to allow building WebKit using as much as libraries from your distribution as possible -->

--- a/Tools/jhbuild/jhbuild-wrapper
+++ b/Tools/jhbuild/jhbuild-wrapper
@@ -24,7 +24,7 @@ import shlex
 import subprocess
 import sys
 
-jhbuild_revision = '048920f64d82779eef88158455bfd1d160a3be1a'
+jhbuild_revision = '388cbc7a5a79566534441702c7f599973a05f3c9'
 
 def determine_platform():
     if '--gtk' in sys.argv:

--- a/Tools/jhbuild/jhbuildrc_common.py
+++ b/Tools/jhbuild/jhbuildrc_common.py
@@ -19,7 +19,7 @@ import multiprocessing
 import sys
 import os
 import platform
-
+import subprocess
 
 script_dir = None
 
@@ -33,6 +33,20 @@ def script_path(*args):
 
 def top_level_path(*args):
     return os.path.join(*((os.path.join(os.path.dirname(__file__), '..', '..'),) + args))
+
+
+def meson_version():
+    try:
+        result = subprocess.run(['meson', '--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+        if result.returncode == 0:
+            version = result.stdout.strip()
+            major, minor, revision = version.split(".")
+            return int(major) * 100 + int(minor) * 10 + int(revision)
+        else:
+            return None
+    except FileNotFoundError:
+        return none
 
 
 def init(jhbuildrc_globals, jhbuild_platform):
@@ -100,3 +114,7 @@ def init(jhbuildrc_globals, jhbuild_platform):
         jhbuild_enable_thunder = os.environ['JHBUILD_ENABLE_THUNDER'].lower()
         if jhbuild_enable_thunder == 'yes' or jhbuild_enable_thunder == '1' or jhbuild_enable_thunder == 'true':
             jhbuildrc_globals['conditions'].add('Thunder')
+
+    REQUIRED_MESON_VERSION = 622
+    if meson_version() < REQUIRED_MESON_VERSION:
+        conditions.add('require-meson')


### PR DESCRIPTION
#### 4237fe6baabe351e022f35db3deaac8e41117e95
<pre>
[build.webkit.org] [GTK][WPE] Add new buildbots for Ubuntu 24.04
<a href="https://bugs.webkit.org/show_bug.cgi?id=273384">https://bugs.webkit.org/show_bug.cgi?id=273384</a>

Reviewed by Carlos Alberto Lopez Perez.

Now Ubuntu LTS build bots build Ubuntu 24.04 and there&apos;s a specific
entry for Ubuntu 22.04. The Ubuntu 20.04 bots have been removed.

* Tools/CISupport/build-webkit-org/config.json:
* Tools/CISupport/build-webkit-org/factories_unittest.py:
(TestExpectedBuildSteps):
* Tools/glib/dependencies/apt:
* Tools/jhbuild/jhbuild-minimal.modules:
* Tools/jhbuild/jhbuild-wrapper:
* Tools/jhbuild/jhbuildrc_common.py:
(meson_version):
(init):

Canonical link: <a href="https://commits.webkit.org/278510@main">https://commits.webkit.org/278510@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8bbcaf108e180fca4b6025984b52d340ff3ba2b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50816 "Failed to checkout and rebase branch from PR 27858") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30113 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54075 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1507 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53119 "Failed to checkout and rebase branch from PR 27858") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1157 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/52915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/27763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/43778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/22527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/1034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9257 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/1096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55669 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25918 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/50837 "Failed to checkout and rebase branch from PR 27858") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27175 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/43856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28043 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7351 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26907 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->