### PR TITLE
Generate serialization of Font-related classes

### DIFF
--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -108,7 +108,7 @@ struct FontPlatformDataAttributes {
         { }
 #endif
 
-#if USE(WIN)
+#if PLATFORM(WIN)
     FontPlatformDataAttributes(float size, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, bool syntheticBold, bool syntheticOblique, LOGFONT font)
         : m_size(size)
         , m_orientation(orientation)
@@ -117,6 +117,18 @@ struct FontPlatformDataAttributes {
         , m_syntheticBold(syntheticBold)
         , m_syntheticOblique(syntheticOblique)
         , m_font(font)
+        { }
+#endif
+
+#if USE(SKIA)
+    FontPlatformDataAttributes(float size, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, bool syntheticBold, bool syntheticOblique, Vector<hb_feature_t>&& features)
+        : m_size(size)
+        , m_orientation(orientation)
+        , m_widthVariant(widthVariant)
+        , m_textRenderingMode(textRenderingMode)
+        , m_syntheticBold(syntheticBold)
+        , m_syntheticOblique(syntheticOblique)
+        , m_features(WTFMove(features))
         { }
 #endif
 

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -359,7 +359,6 @@ $(PROJECT_DIR)/Shared/WebCompiledContentRuleListData.serialization.in
 $(PROJECT_DIR)/Shared/WebConnection.messages.in
 $(PROJECT_DIR)/Shared/WebContextMenuItemData.serialization.in
 $(PROJECT_DIR)/Shared/WebCoreArgumentCoders.serialization.in
-$(PROJECT_DIR)/Shared/WebCoreFont.serialization.in
 $(PROJECT_DIR)/Shared/WebEvent.serialization.in
 $(PROJECT_DIR)/Shared/WebExtensionContextParameters.serialization.in
 $(PROJECT_DIR)/Shared/WebExtensionControllerParameters.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -673,7 +673,6 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/WebBackForwardListCounts.serialization.in \
 	Shared/WebContextMenuItemData.serialization.in \
 	Shared/WebCoreArgumentCoders.serialization.in \
-	Shared/WebCoreFont.serialization.in \
 	Shared/WebEvent.serialization.in \
 	Shared/WebFindOptions.serialization.in \
 	Shared/WebFoundTextRange.serialization.in \

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -105,6 +105,8 @@ list(APPEND WebKit_SERIALIZATION_IN_FILES
     Shared/glib/InputMethodState.serialization.in
     Shared/glib/UserMessage.serialization.in
 
+    Shared/harfbuzz/ArgumentCodersHarfBuzz.serialization.in
+
     Shared/skia/CoreIPCSkColorSpace.serialization.in
 
     Shared/soup/WebCoreArgumentCodersSoup.serialization.in

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -36,13 +36,7 @@
 #include <skia/core/SkColorSpace.h>
 #endif
 
-#if PLATFORM(GTK)
-#include "ArgumentCodersGtk.h"
-#endif
-
 namespace WebCore {
-
-class Font;
 class FontPlatformData;
 
 } // namespace WebCore
@@ -50,20 +44,13 @@ class FontPlatformData;
 namespace IPC {
 
 #if !USE(CORE_TEXT)
-template<> struct ArgumentCoder<WebCore::Font> {
-    static void encode(Encoder&, const WebCore::Font&);
-    static std::optional<Ref<WebCore::Font>> decode(Decoder&);
-    static void encodePlatformData(Encoder&, const WebCore::Font&);
-    static std::optional<WebCore::FontPlatformData> decodePlatformData(Decoder&);
+template<> struct ArgumentCoder<WebCore::FontPlatformData> {
+    static void encode(Encoder&, const WebCore::FontPlatformData&);
+    static std::optional<WebCore::FontPlatformData> decode(Decoder&);
 };
+#endif
 
-template<> struct ArgumentCoder<WebCore::FontPlatformDataAttributes> {
-    static void encode(Encoder&, const WebCore::FontPlatformDataAttributes&);
-    static std::optional<WebCore::FontPlatformDataAttributes> decode(Decoder&);
-    static void encodePlatformData(Encoder&, const WebCore::FontPlatformDataAttributes&);
-    static WARN_UNUSED_RETURN bool decodePlatformData(Decoder&, WebCore::FontPlatformDataAttributes&);
-};
-
+#if OS(WINDOWS)
 template<> struct ArgumentCoder<WebCore::FontCustomPlatformData> {
     static void encode(Encoder&, const WebCore::FontCustomPlatformData&);
     static std::optional<Ref<WebCore::FontCustomPlatformData>> decode(Decoder&);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3909,12 +3909,32 @@ header: <WebCore/FontAttributes.h>
     Natural
 };
 
-#if USE(CORE_TEXT)
 [RefCounted] class WebCore::Font {
     WebCore::FontInternalAttributes attributes();
     WebCore::FontPlatformData platformData();
 }
+
+header: <WebCore/FontPlatformData.h>
+[CustomHeader] struct WebCore::FontPlatformDataAttributes {
+    float m_size;
+    WebCore::FontOrientation m_orientation;
+    WebCore::FontWidthVariant m_widthVariant;
+    WebCore::TextRenderingMode m_textRenderingMode;
+    bool m_syntheticBold;
+    bool m_syntheticOblique;
+#if USE(CORE_TEXT)
+    RetainPtr<CFDictionaryRef> m_attributes;
+    CTFontDescriptorOptions m_options;
+    RetainPtr<CFStringRef> m_url;
+    RetainPtr<CFStringRef> m_psName;
 #endif
+#if PLATFORM(WIN)
+    LOGFONT m_font;
+#endif
+#if USE(SKIA)
+    Vector<hb_feature_t> m_features;
+#endif
+};
 
 [CustomHeader] struct WebCore::FontAttributes {
     RefPtr<WebCore::Font> font

--- a/Source/WebKit/Shared/freetype/WebCoreArgumentCodersFreeType.cpp
+++ b/Source/WebKit/Shared/freetype/WebCoreArgumentCodersFreeType.cpp
@@ -32,26 +32,15 @@
 
 namespace IPC {
 
-void ArgumentCoder<WebCore::Font>::encodePlatformData(Encoder&, const WebCore::Font&)
+void ArgumentCoder<WebCore::FontPlatformData>::encode(Encoder&, const WebCore::FontPlatformData&)
 {
     ASSERT_NOT_REACHED();
 }
 
-std::optional<WebCore::FontPlatformData> ArgumentCoder<WebCore::Font>::decodePlatformData(Decoder&)
+std::optional<WebCore::FontPlatformData> ArgumentCoder<WebCore::FontPlatformData>::decode(Decoder&)
 {
     ASSERT_NOT_REACHED();
     return std::nullopt;
-}
-
-void ArgumentCoder<WebCore::FontPlatformData::Attributes>::encodePlatformData(Encoder&, const WebCore::FontPlatformData::Attributes&)
-{
-    ASSERT_NOT_REACHED();
-}
-
-bool ArgumentCoder<WebCore::FontPlatformData::Attributes>::decodePlatformData(Decoder&, WebCore::FontPlatformData::Attributes&)
-{
-    ASSERT_NOT_REACHED();
-    return false;
 }
 
 } // namespace IPC

--- a/Source/WebKit/Shared/harfbuzz/ArgumentCodersHarfBuzz.serialization.in
+++ b/Source/WebKit/Shared/harfbuzz/ArgumentCodersHarfBuzz.serialization.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Apple Inc. All rights reserved.
+# Copyright (C) 2024 Igalia, S.L.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -20,20 +20,16 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-header: <WebCore/FontPlatformData.h>
+#if USE(SKIA)
 
-#if USE(CORE_TEXT)
-[CustomHeader] struct WebCore::FontPlatformDataAttributes {
-    float m_size;
-    WebCore::FontOrientation m_orientation;
-    WebCore::FontWidthVariant m_widthVariant;
-    WebCore::TextRenderingMode m_textRenderingMode;
-    bool m_syntheticBold;
-    bool m_syntheticOblique;
-    RetainPtr<CFDictionaryRef> m_attributes;
-    CTFontDescriptorOptions m_options;
-    RetainPtr<CFStringRef> m_url;
-    RetainPtr<CFStringRef> m_psName;
-};
-#endif
+using hb_tag_t = uint32_t;
 
+header: <hb.h>
+[CustomHeader] struct hb_feature_t {
+     hb_tag_t tag;
+     uint32_t value;
+     unsigned int start;
+     unsigned int end;
+}
+
+#endif // USE(SKIA)

--- a/Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.cpp
+++ b/Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.cpp
@@ -34,26 +34,15 @@
 
 namespace IPC {
 
-void ArgumentCoder<WebCore::Font>::encodePlatformData(Encoder&, const WebCore::Font&)
+void ArgumentCoder<WebCore::FontPlatformData>::encode(Encoder&, const WebCore::FontPlatformData&)
 {
     ASSERT_NOT_REACHED();
 }
 
-std::optional<WebCore::FontPlatformData> ArgumentCoder<WebCore::Font>::decodePlatformData(Decoder&)
+std::optional<WebCore::FontPlatformData> ArgumentCoder<WebCore::FontPlatformData>::decode(Decoder&)
 {
     ASSERT_NOT_REACHED();
     return std::nullopt;
-}
-
-void ArgumentCoder<WebCore::FontPlatformData::Attributes>::encodePlatformData(Encoder&, const WebCore::FontPlatformData::Attributes&)
-{
-    ASSERT_NOT_REACHED();
-}
-
-bool ArgumentCoder<WebCore::FontPlatformData::Attributes>::decodePlatformData(Decoder&, WebCore::FontPlatformData::Attributes&)
-{
-    ASSERT_NOT_REACHED();
-    return false;
 }
 
 void ArgumentCoder<sk_sp<SkColorSpace>>::encode(Encoder& encoder, const sk_sp<SkColorSpace>& colorSpace)

--- a/Source/WebKit/Shared/win/WebCoreArgumentCodersWin.cpp
+++ b/Source/WebKit/Shared/win/WebCoreArgumentCodersWin.cpp
@@ -47,9 +47,8 @@ template<> struct ArgumentCoder<LOGFONT> {
     }
 };
 
-void ArgumentCoder<Font>::encodePlatformData(Encoder& encoder, const Font& font)
+void ArgumentCoder<FontPlatformData>::encode(Encoder& encoder, const FontPlatformData& platformData)
 {
-    const auto& platformData = font.platformData();
     encoder << platformData.size();
     encoder << platformData.syntheticBold();
     encoder << platformData.syntheticOblique();
@@ -66,7 +65,7 @@ void ArgumentCoder<Font>::encodePlatformData(Encoder& encoder, const Font& font)
     encoder << logFont;
 }
 
-std::optional<FontPlatformData> ArgumentCoder<Font>::decodePlatformData(Decoder& decoder)
+std::optional<FontPlatformData> ArgumentCoder<FontPlatformData>::decode(Decoder& decoder)
 {
     std::optional<float> size;
     decoder >> size;
@@ -120,22 +119,5 @@ std::optional<FontPlatformData> ArgumentCoder<Font>::decodePlatformData(Decoder&
 
     return FontPlatformData(WTFMove(gdiFont), *size, *syntheticBold, *syntheticOblique, fontCustomPlatformData.get());
 }
-
-void ArgumentCoder<WebCore::FontPlatformData::Attributes>::encodePlatformData(Encoder& encoder, const WebCore::FontPlatformData::Attributes& data)
-{
-    encoder << data.m_font;
-}
-
-bool ArgumentCoder<WebCore::FontPlatformData::Attributes>::decodePlatformData(Decoder& decoder, WebCore::FontPlatformData::Attributes& data)
-{
-    std::optional<LOGFONT> logFont;
-    decoder >> logFont;
-    if (!logFont)
-        return false;
-
-    data.m_font = *logFont;
-    return true;
-}
-
 
 } // namespace IPC


### PR DESCRIPTION
#### 46242d56a9aeff31338c137c4d8bc324d3f6935c
<pre>
Generate serialization of Font-related classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=273389">https://bugs.webkit.org/show_bug.cgi?id=273389</a>

Reviewed by NOBODY (OOPS!).

WebCoreFont.serialization.in contents can be moved to
WebCoreArgumentCoders.serialization.in because they can also
be used in other platforms than Cocoa. The generator for Font
can be also reused with the appropriate ifdef&apos;s for different
platforms. As a result most serializers can be generated.

The only ones left are FontCustomPlatformData, which right
now is only needed for Windows, as Linux ports don&apos;t implement
GPU process support yet, and FontPlatformData, which is a no-op.

* Source/WebCore/platform/graphics/FontPlatformData.h:
(WebCore::FontPlatformDataAttributes::FontPlatformDataAttributes):
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;WebCore::Font&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;Font&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;WebCore::FontPlatformDataAttributes&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;FontPlatformDataAttributes&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/freetype/WebCoreArgumentCodersFreeType.cpp:
(IPC::ArgumentCoder&lt;WebCore::FontPlatformData&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::FontPlatformData&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::Font&gt;::encodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;WebCore::Font&gt;::decodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;WebCore::FontPlatformData::Attributes&gt;::encodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;WebCore::FontPlatformData::Attributes&gt;::decodePlatformData): Deleted.
* Source/WebKit/Shared/harfbuzz/ArgumentCodersHarfBuzz.serialization.in: Renamed from Source/WebKit/Shared/WebCoreFont.serialization.in.
* Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.cpp:
(IPC::ArgumentCoder&lt;WebCore::FontPlatformData&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::FontPlatformData&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::Font&gt;::encodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;WebCore::Font&gt;::decodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;WebCore::FontPlatformData::Attributes&gt;::encodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;WebCore::FontPlatformData::Attributes&gt;::decodePlatformData): Deleted.
* Source/WebKit/Shared/win/WebCoreArgumentCodersWin.cpp:
(IPC::ArgumentCoder&lt;FontPlatformData&gt;::encode):
(IPC::ArgumentCoder&lt;FontPlatformData&gt;::decode):
(IPC::ArgumentCoder&lt;Font&gt;::encodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;Font&gt;::decodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;WebCore::FontPlatformData::Attributes&gt;::encodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;WebCore::FontPlatformData::Attributes&gt;::decodePlatformData): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46242d56a9aeff31338c137c4d8bc324d3f6935c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52550 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52751 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/185 "Hash 46242d56 for PR 27861 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51816 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26414 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40420 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51612 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26333 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42657 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21539 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23793 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43841 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7881 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45707 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44345 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54266 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24595 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20772 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47790 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25866 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42829 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46811 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26706 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25589 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->