### PR TITLE
[JSC] Extract WatchpointSet collection from AccessCase

### DIFF
--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -307,45 +307,7 @@ JSObject* AccessCase::alternateBaseImpl() const
 
 Ref<AccessCase> AccessCase::cloneImpl() const
 {
-    auto result = adoptRef(*new AccessCase(*this));
-    result->resetState();
-    return result;
-}
-
-Vector<WatchpointSet*, 2> AccessCase::commit(VM& vm)
-{
-    // It's fine to commit something that is already committed. That arises when we switch to using
-    // newly allocated watchpoints. When it happens, it's not efficient - but we think that's OK
-    // because most AccessCases have no extra watchpoints anyway.
-
-    Vector<WatchpointSet*, 2> result;
-    Structure* structure = this->structure();
-    auto append = [&] (auto* set) {
-        ASSERT(set->isStillValid());
-        result.append(set);
-    };
-
-    if (m_identifier) {
-        if ((structure && structure->needImpurePropertyWatchpoint())
-            || m_conditionSet.needImpurePropertyWatchpoint()
-            || (m_polyProtoAccessChain && m_polyProtoAccessChain->needImpurePropertyWatchpoint(vm)))
-            append(vm.ensureWatchpointSetForImpureProperty(m_identifier.uid()));
-    }
-
-    if (additionalSet())
-        append(additionalSet());
-
-    if (structure
-        && structure->hasRareData()
-        && structure->rareData()->hasSharedPolyProtoWatchpoint()
-        && structure->rareData()->sharedPolyProtoWatchpoint()->isStillValid()) {
-        WatchpointSet* set = structure->rareData()->sharedPolyProtoWatchpoint()->inflate();
-        append(set);
-    }
-
-    m_state = Committed;
-
-    return result;
+    return adoptRef(*new AccessCase(*this));
 }
 
 bool AccessCase::guardedByStructureCheckSkippingConstantIdentifierCheck() const
@@ -1212,8 +1174,6 @@ void AccessCase::dump(PrintStream& out) const
     Indenter indent;
     CommaPrinter comma;
 
-    out.print(comma, m_state);
-
     out.print(comma, "ident = '"_s, m_identifier, "'"_s);
     if (isValidOffset(m_offset))
         out.print(comma, "offset = "_s, m_offset);
@@ -1442,7 +1402,6 @@ void AccessCase::checkConsistency(StructureStubInfo& stubInfo)
 
 bool AccessCase::canBeShared(const AccessCase& lhs, const AccessCase& rhs)
 {
-    // We do not care m_state.
     // And we say "false" if either of them have m_polyProtoAccessChain.
     if (lhs.m_polyProtoAccessChain || rhs.m_polyProtoAccessChain)
         return false;

--- a/Source/JavaScriptCore/bytecode/GetterSetterAccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/GetterSetterAccessCase.cpp
@@ -72,9 +72,7 @@ GetterSetterAccessCase::GetterSetterAccessCase(const GetterSetterAccessCase& oth
 
 Ref<AccessCase> GetterSetterAccessCase::cloneImpl() const
 {
-    auto result = adoptRef(*new GetterSetterAccessCase(*this));
-    result->resetState();
-    return result;
+    return adoptRef(*new GetterSetterAccessCase(*this));
 }
 
 bool GetterSetterAccessCase::hasAlternateBaseImpl() const

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -804,11 +804,6 @@ static bool doesJSCalls(AccessCase::AccessType type)
     return false;
 }
 
-void InlineCacheCompiler::installWatchpoint(CodeBlock* codeBlock, const ObjectPropertyCondition& condition)
-{
-    WatchpointsOnStructureStubInfo::ensureReferenceAndInstallWatchpoint(m_watchpoints, codeBlock, m_stubInfo, condition);
-}
-
 void InlineCacheCompiler::restoreScratch()
 {
     m_allocator->restoreReusedRegistersByPopping(*m_jit, m_preservedReusedRegisterState);
@@ -1530,8 +1525,6 @@ void InlineCacheCompiler::generateWithGuard(AccessCase& accessCase, CCallHelpers
 
     accessCase.checkConsistency(*m_stubInfo);
 
-    accessCase.m_state = AccessCase::Generated;
-
     JSGlobalObject* globalObject = m_globalObject;
     CCallHelpers& jit = *m_jit;
     JIT_COMMENT(jit, "Begin generateWithGuard");
@@ -1553,11 +1546,11 @@ void InlineCacheCompiler::generateWithGuard(AccessCase& accessCase, CCallHelpers
     }
 
     auto emitDefaultGuard = [&] () {
-        if (accessCase.m_polyProtoAccessChain) {
+        if (accessCase.polyProtoAccessChain()) {
             ASSERT(!accessCase.viaGlobalProxy());
             GPRReg baseForAccessGPR = m_scratchGPR;
             jit.move(baseGPR, baseForAccessGPR);
-            accessCase.m_polyProtoAccessChain->forEach(vm, accessCase.structure(), [&] (Structure* structure, bool atEnd) {
+            accessCase.polyProtoAccessChain()->forEach(vm, accessCase.structure(), [&](Structure* structure, bool atEnd) {
                 fallThrough.append(
                     jit.branchStructure(
                         CCallHelpers::NotEqual,
@@ -2727,10 +2720,7 @@ void InlineCacheCompiler::generateWithGuard(AccessCase& accessCase, CCallHelpers
 void InlineCacheCompiler::generate(AccessCase& accessCase)
 {
     RELEASE_ASSERT(m_stubInfo->hasConstantIdentifier);
-    accessCase.m_state = AccessCase::Generated;
-
     accessCase.checkConsistency(*m_stubInfo);
-
     generateImpl(accessCase);
 }
 
@@ -2738,8 +2728,6 @@ void InlineCacheCompiler::generateImpl(AccessCase& accessCase)
 {
     SuperSamplerScope superSamplerScope(false);
     dataLogLnIf(InlineCacheCompilerInternal::verbose, "\n\nGenerating code for: ", accessCase);
-
-    ASSERT(accessCase.m_state == AccessCase::Generated); // We rely on the callers setting this for us.
 
     CCallHelpers& jit = *m_jit;
     VM& vm = m_vm;
@@ -2751,10 +2739,10 @@ void InlineCacheCompiler::generateImpl(AccessCase& accessCase)
     GPRReg scratchGPR = m_scratchGPR;
 
     for (const ObjectPropertyCondition& condition : accessCase.m_conditionSet) {
-        RELEASE_ASSERT(!accessCase.m_polyProtoAccessChain);
+        RELEASE_ASSERT(!accessCase.polyProtoAccessChain());
 
         if (condition.isWatchableAssumingImpurePropertyWatchpoint(PropertyCondition::WatchabilityEffort::EnsureWatchability)) {
-            installWatchpoint(codeBlock, condition);
+            WatchpointsOnStructureStubInfo::ensureReferenceAndInstallWatchpoint(m_watchpoints, codeBlock, m_stubInfo, condition);
             continue;
         }
 
@@ -2826,7 +2814,7 @@ void InlineCacheCompiler::generateImpl(AccessCase& accessCase)
         GPRReg receiverGPR = baseGPR;
         GPRReg propertyOwnerGPR;
 
-        if (accessCase.m_polyProtoAccessChain) {
+        if (accessCase.polyProtoAccessChain()) {
             // This isn't pretty, but we know we got here via generateWithGuard,
             // and it left the baseForAccess inside scratchGPR. We could re-derive the base,
             // but it'd require emitting the same code to load the base twice.
@@ -4022,20 +4010,6 @@ void InlineCacheCompiler::emitIntrinsicGetter(IntrinsicGetterAccessCase& accessC
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-static void commit(const GCSafeConcurrentJSLocker&, VM& vm, std::unique_ptr<WatchpointsOnStructureStubInfo>& watchpoints, CodeBlock* codeBlock, StructureStubInfo& stubInfo, AccessCase& accessCase)
-{
-    // NOTE: We currently assume that this is relatively rare. It mainly arises for accesses to
-    // properties on DOM nodes. For sure we cache many DOM node accesses, but even in
-    // Real Pages (TM), we appear to spend most of our time caching accesses to properties on
-    // vanilla objects or exotic objects from within JSC (like Arguments, those are super popular).
-    // Those common kinds of JSC object accesses don't hit this case.
-
-    for (WatchpointSet* set : accessCase.commit(vm)) {
-        Watchpoint* watchpoint = WatchpointsOnStructureStubInfo::ensureReferenceAndAddWatchpoint(watchpoints, codeBlock, &stubInfo);
-        set->add(watchpoint);
-    }
-}
-
 static inline bool canUseMegamorphicPutFastPath(Structure* structure)
 {
     while (true) {
@@ -4068,7 +4042,37 @@ enum class HandlerICType : uint8_t {
     MegamorphicById,
 };
 
-AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSLocker& locker, PolymorphicAccess& poly, CodeBlock* codeBlock)
+static Vector<WatchpointSet*, 3> collectAdditionalWatchpoints(VM& vm, AccessCase& accessCase)
+{
+    // It's fine to commit something that is already committed. That arises when we switch to using
+    // newly allocated watchpoints. When it happens, it's not efficient - but we think that's OK
+    // because most AccessCases have no extra watchpoints anyway.
+
+    Vector<WatchpointSet*, 3> result;
+    Structure* structure = accessCase.structure();
+
+    if (accessCase.identifier()) {
+        if ((structure && structure->needImpurePropertyWatchpoint())
+            || accessCase.conditionSet().needImpurePropertyWatchpoint()
+            || (accessCase.polyProtoAccessChain() && accessCase.polyProtoAccessChain()->needImpurePropertyWatchpoint(vm)))
+            result.append(vm.ensureWatchpointSetForImpureProperty(accessCase.identifier().uid()));
+    }
+
+    if (WatchpointSet* set  = accessCase.additionalSet())
+        result.append(set);
+
+    if (structure
+        && structure->hasRareData()
+        && structure->rareData()->hasSharedPolyProtoWatchpoint()
+        && structure->rareData()->sharedPolyProtoWatchpoint()->isStillValid()) {
+        WatchpointSet* set = structure->rareData()->sharedPolyProtoWatchpoint()->inflate();
+        result.append(set);
+    }
+
+    return result;
+}
+
+AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSLocker&, PolymorphicAccess& poly, CodeBlock* codeBlock)
 {
     SuperSamplerScope superSamplerScope(false);
 
@@ -4079,6 +4083,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
     // m_list in-place because we may still fail, in which case we want the PolymorphicAccess object
     // to be unmutated. For sure, we want it to hang onto any data structures that may be referenced
     // from the code of the current stub (aka previous).
+    Vector<WatchpointSet*, 8> additionalWatchpointSets;
     PolymorphicAccess::ListType cases;
     cases.reserveInitialCapacity(poly.m_list.size());
     unsigned srcIndex = 0;
@@ -4086,6 +4091,12 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
         [&] () {
             if (!someCase->couldStillSucceed())
                 return;
+
+            auto sets = collectAdditionalWatchpoints(vm(), *someCase);
+            for (auto* set : sets) {
+                if (!set->isStillValid())
+                    return;
+            }
 
             // Figure out if this is replaced by any later case. Given two cases A and B where A
             // comes first in the case list, we know that A would have triggered first if we had
@@ -4107,11 +4118,12 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
             // If the case had been generated, then we have to keep the original in m_list in case we
             // fail to regenerate. That case may have data structures that are used by the code that it
             // had generated. If the case had not been generated, then we want to remove it from m_list.
-            bool isGeneratedAndDoesJSCalls = someCase->state() == AccessCase::Generated && doesJSCalls(someCase->type());
-            if (isGeneratedAndDoesJSCalls)
+            if (doesJSCalls(someCase->type()))
                 cases.append(someCase->clone());
             else
                 cases.append(someCase);
+
+            additionalWatchpointSets.appendVector(sets);
         }();
         ++srcIndex;
     }
@@ -4433,7 +4445,15 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
         } else
             allGuardedByStructureCheck &= entry->guardedByStructureCheckSkippingConstantIdentifierCheck();
 
-        commit(locker, vm(), m_watchpoints, codeBlock, *m_stubInfo, *entry);
+        // NOTE: We currently assume that this is relatively rare. It mainly arises for accesses to
+        // properties on DOM nodes. For sure we cache many DOM node accesses, but even in
+        // Real Pages (TM), we appear to spend most of our time caching accesses to properties on
+        // vanilla objects or exotic objects from within JSC (like Arguments, those are super popular).
+        // Those common kinds of JSC object accesses don't hit this case.
+        for (WatchpointSet* set : additionalWatchpointSets) {
+            Watchpoint* watchpoint = WatchpointsOnStructureStubInfo::ensureReferenceAndAddWatchpoint(m_watchpoints, codeBlock, m_stubInfo);
+            set->add(watchpoint);
+        }
 
         keys[index] = entry;
         ++index;
@@ -4747,9 +4767,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
 PolymorphicAccess::PolymorphicAccess() = default;
 PolymorphicAccess::~PolymorphicAccess() = default;
 
-AccessGenerationResult PolymorphicAccess::addCases(
-    const GCSafeConcurrentJSLocker& locker, VM& vm, CodeBlock* codeBlock, StructureStubInfo& stubInfo,
-    Vector<RefPtr<AccessCase>, 2> originalCasesToAdd)
+AccessGenerationResult PolymorphicAccess::addCases(const GCSafeConcurrentJSLocker&, VM& vm, CodeBlock*, StructureStubInfo& stubInfo, Vector<RefPtr<AccessCase>, 2> originalCasesToAdd)
 {
     SuperSamplerScope superSamplerScope(false);
 
@@ -4831,7 +4849,7 @@ AccessGenerationResult PolymorphicAccess::addCases(
     // Now add things to the new list. Note that at this point, we will still have old cases that
     // may be replaced by the new ones. That's fine. We will sort that out when we regenerate.
     for (auto& caseToAdd : casesToAdd) {
-        commit(locker, vm, m_watchpoints, codeBlock, stubInfo, *caseToAdd);
+        collectAdditionalWatchpoints(vm, *caseToAdd);
         m_list.append(WTFMove(caseToAdd));
     }
 
@@ -4952,23 +4970,6 @@ void printInternal(PrintStream& out, AccessCase::AccessType type)
 
 #undef JSC_DEFINE_ACCESS_TYPE_CASE
     }
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
-void printInternal(PrintStream& out, AccessCase::State state)
-{
-    switch (state) {
-    case AccessCase::Primordial:
-        out.print("Primordial");
-        return;
-    case AccessCase::Committed:
-        out.print("Committed");
-        return;
-    case AccessCase::Generated:
-        out.print("Generated");
-        return;
-    }
-
     RELEASE_ASSERT_NOT_REACHED();
 }
 

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
@@ -238,8 +238,6 @@ public:
     {
     }
 
-    void installWatchpoint(CodeBlock*, const ObjectPropertyCondition&);
-
     void restoreScratch();
     void succeed();
 
@@ -367,7 +365,6 @@ namespace WTF {
 
 void printInternal(PrintStream&, JSC::AccessGenerationResult::Kind);
 void printInternal(PrintStream&, JSC::AccessCase::AccessType);
-void printInternal(PrintStream&, JSC::AccessCase::State);
 void printInternal(PrintStream&, JSC::AccessType);
 
 } // namespace WTF

--- a/Source/JavaScriptCore/bytecode/InstanceOfAccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/InstanceOfAccessCase.cpp
@@ -48,9 +48,7 @@ void InstanceOfAccessCase::dumpImpl(PrintStream& out, CommaPrinter& comma, Inden
 
 Ref<AccessCase> InstanceOfAccessCase::cloneImpl() const
 {
-    auto result = adoptRef(*new InstanceOfAccessCase(*this));
-    result->resetState();
-    return result;
+    return adoptRef(*new InstanceOfAccessCase(*this));
 }
 
 InstanceOfAccessCase::InstanceOfAccessCase(

--- a/Source/JavaScriptCore/bytecode/IntrinsicGetterAccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/IntrinsicGetterAccessCase.cpp
@@ -47,9 +47,7 @@ Ref<AccessCase> IntrinsicGetterAccessCase::create(VM& vm, JSCell* owner, Cacheab
 
 Ref<AccessCase> IntrinsicGetterAccessCase::cloneImpl() const
 {
-    auto result = adoptRef(*new IntrinsicGetterAccessCase(*this));
-    result->resetState();
-    return result;
+    return adoptRef(*new IntrinsicGetterAccessCase(*this));
 }
 
 bool IntrinsicGetterAccessCase::doesCalls() const

--- a/Source/JavaScriptCore/bytecode/ModuleNamespaceAccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/ModuleNamespaceAccessCase.cpp
@@ -52,9 +52,7 @@ Ref<AccessCase> ModuleNamespaceAccessCase::create(VM& vm, JSCell* owner, Cacheab
 
 Ref<AccessCase> ModuleNamespaceAccessCase::cloneImpl() const
 {
-    auto result = adoptRef(*new ModuleNamespaceAccessCase(*this));
-    result->resetState();
-    return result;
+    return adoptRef(*new ModuleNamespaceAccessCase(*this));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/ProxyObjectAccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/ProxyObjectAccessCase.cpp
@@ -56,9 +56,7 @@ Ref<AccessCase> ProxyObjectAccessCase::create(VM& vm, JSCell* owner, AccessType 
 
 Ref<AccessCase> ProxyObjectAccessCase::cloneImpl() const
 {
-    auto result = adoptRef(*new ProxyObjectAccessCase(*this));
-    result->resetState();
-    return result;
+    return adoptRef(*new ProxyObjectAccessCase(*this));
 }
 
 void ProxyObjectAccessCase::dumpImpl(PrintStream& out, CommaPrinter& comma, Indenter& indent) const

--- a/Source/JavaScriptCore/bytecode/ProxyableAccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/ProxyableAccessCase.cpp
@@ -46,9 +46,7 @@ Ref<AccessCase> ProxyableAccessCase::create(VM& vm, JSCell* owner, AccessType ty
 
 Ref<AccessCase> ProxyableAccessCase::cloneImpl() const
 {
-    auto result = adoptRef(*new ProxyableAccessCase(*this));
-    result->resetState();
-    return result;
+    return adoptRef(*new ProxyableAccessCase(*this));
 }
 
 void ProxyableAccessCase::dumpImpl(PrintStream& out, CommaPrinter& comma, Indenter& indent) const


### PR DESCRIPTION
#### d5408df0618d2f1bfbba7b5bd3ab8f3f1d52d44c
<pre>
[JSC] Extract WatchpointSet collection from AccessCase
<a href="https://bugs.webkit.org/show_bug.cgi?id=273392">https://bugs.webkit.org/show_bug.cgi?id=273392</a>
<a href="https://rdar.apple.com/127220534">rdar://127220534</a>

Reviewed by Keith Miller.

This patch changes how watchpoint set are registered in IC.

1. We will always clone AccessCase holding CallLinkInfo for simplicity. This is rare and this wipes AccessCase::State completely.
2. We stop registering watchpoint set at addCases. It only materializes watchpoint set for the future invalidation. We collect them
   when actually generating code. And we stop generating code for AccessCase which already holds invalid watchpoint set.
   By doing this approach, now we can list up all the watchpoint set we would like to see in InlineCacheCompiler&apos;s regenerate function.
   And AccessCase becomes much more just an immutable feedback data.

This is important step towards Handler IC. Now we gather all watchpoint set registrations into InlineCacheCompiler::regenerate.
Next step is redesign of these watchpoint set to put them into IC code instead of StructureStubInfo. And then, Handler IC will share the
same set of watchpoint set when sharing code.

* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::commit): Deleted.
* Source/JavaScriptCore/bytecode/AccessCase.h:
(JSC::AccessCase::polyProtoAccessChain const):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::generateWithGuard):
(JSC::InlineCacheCompiler::generateImpl):
(JSC::collectAdditionalWatchpoints):
(JSC::InlineCacheCompiler::regenerate):
(JSC::PolymorphicAccess::addCases):
(JSC::InlineCacheCompiler::installWatchpoint): Deleted.
(JSC::commit): Deleted.
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.h:

Canonical link: <a href="https://commits.webkit.org/278113@main">https://commits.webkit.org/278113@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25f34a37d0e25434ee558de6123fdf76a8476ca6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49531 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28813 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52770 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/209 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34831 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40441 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51631 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42678 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21556 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23825 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43860 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7900 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/42846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45731 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54346 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/49026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24615 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20798 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47813 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25886 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46836 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26727 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56514 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7118 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25608 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11615 "Passed tests") | 
<!--EWS-Status-Bubble-End-->