### PR TITLE
[WebXR] Fixes due to Update ANGLE to 2024-04-26

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -682,17 +682,16 @@ GCGLExternalImage GraphicsContextGLCocoa::createExternalImage(ExternalImageSourc
     }
 
     // Create an EGLImage out of the MTLTexture
-#if PLATFORM(IOS_FAMILY_SIMULATOR)
-    UNUSED_VARIABLE(internalFormat);
-    const EGLint attributes[] = { EGL_METAL_TEXTURE_ARRAY_SLICE_ANGLE, layer, EGL_NONE };
+    Vector<EGLint, 6> attributes;
+    attributes.appendList({ EGL_METAL_TEXTURE_ARRAY_SLICE_ANGLE, layer });
+#if !PLATFORM(IOS_FAMILY_SIMULATOR)
+    if (internalFormat != EGL_NONE)
+        attributes.appendList({ EGL_TEXTURE_INTERNAL_FORMAT_ANGLE, static_cast<EGLint>(internalFormat) });
 #else
-    const EGLint attributes[] = {
-        EGL_METAL_TEXTURE_ARRAY_SLICE_ANGLE, layer,
-        EGL_TEXTURE_INTERNAL_FORMAT_ANGLE, static_cast<EGLint>(internalFormat),
-        EGL_NONE
-    };
+    UNUSED_VARIABLE(internalFormat);
 #endif
-    auto eglImage = EGL_CreateImageKHR(platformDisplay(), EGL_NO_CONTEXT, EGL_METAL_TEXTURE_ANGLE, reinterpret_cast<EGLClientBuffer>(texture.get()), attributes);
+    attributes.appendList({ EGL_NONE, EGL_NONE });
+    auto eglImage = EGL_CreateImageKHR(platformDisplay(), EGL_NO_CONTEXT, EGL_METAL_TEXTURE_ANGLE, reinterpret_cast<EGLClientBuffer>(texture.get()), attributes.data());
     if (!eglImage) {
         addError(GCGLErrorCode::InvalidOperation);
         return { };


### PR DESCRIPTION
#### 40a587be57369f415bf7ed68ecc2f0354bdd90de
<pre>
[WebXR] Fixes due to Update ANGLE to 2024-04-26
<a href="https://bugs.webkit.org/show_bug.cgi?id=273391">https://bugs.webkit.org/show_bug.cgi?id=273391</a>
<a href="https://rdar.apple.com/127219301">rdar://127219301</a>

Reviewed by Cameron McCormack.

Upstream ANGLE change for overriding internal image format for externally
attached images will fail if EGL_TEXTURE_INTERNAL_FORMAT_ANGLE is
EGL_NONE. Change createExternalImage to skip passing
EGL_TEXTURE_INTERNAL_FORMAT_ANGLE if EGL_NONE is passed for internalFormat.

* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::createExternalImage):

Canonical link: <a href="https://commits.webkit.org/278149@main">https://commits.webkit.org/278149@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5e6c7fbbfd5da5e8fed9e01ca5f14d2d3930df5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52709 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52902 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/336 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51965 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26565 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51760 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/26476 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8031 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/44458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54479 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24747 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/26014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/26862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7142 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/25739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->