### PR TITLE
[IFC][Integration] Layout boxes should have a renderer backpointer

### DIFF
--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.h
@@ -76,10 +76,6 @@ public:
 
     bool contains(const RenderElement&) const;
 
-    size_t boxCount() const { return m_renderers.size(); }
-
-    const auto& renderers() const { return m_renderers; }
-
 private:
     Layout::InitialContainingBlock& initialContainingBlock();
 
@@ -91,9 +87,6 @@ private:
     void insertChild(UniqueRef<Layout::Box>, RenderObject&, const RenderObject* beforeChild = nullptr);
 
     RenderBlock& m_rootRenderer;
-    Vector<SingleThreadWeakPtr<RenderObject>, 1> m_renderers;
-
-    HashMap<CheckedRef<const Layout::Box>, SingleThreadWeakPtr<RenderObject>> m_boxToRendererMap;
 };
 
 #if ENABLE(TREE_DEBUGGING)

--- a/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
+++ b/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
@@ -28,6 +28,7 @@
 
 #include "FlexFormattingConstraints.h"
 #include "FlexFormattingContext.h"
+#include "FormattingContextBoxIterator.h"
 #include "HitTestLocation.h"
 #include "HitTestRequest.h"
 #include "HitTestResult.h"
@@ -162,9 +163,8 @@ void FlexLayout::layout()
     auto relayoutFlexItems = [&] {
         // Flex items need to be laid out now with their final size (and through setOverridingLogicalWidth/Height)
         // Note that they may re-size themselves.
-        for (auto& renderObject : m_boxTree.renderers()) {
-            auto& renderer = downcast<RenderBox>(*renderObject);
-            auto& layoutBox = *renderer.layoutBox();
+        for (auto& layoutBox : formattingContextBoxes(flexBox())) {
+            auto& renderer = downcast<RenderBox>(*layoutBox.rendererForIntegration());
             auto borderBox = Layout::BoxGeometry::borderBoxRect(layoutState().geometryForBox(layoutBox));
 
             renderer.setWidth(LayoutUnit { });
@@ -186,9 +186,8 @@ void FlexLayout::layout()
 
 void FlexLayout::updateRenderers()
 {
-    for (auto& renderObject : m_boxTree.renderers()) {
-        auto& renderer = downcast<RenderBox>(*renderObject);
-        auto& layoutBox = *renderer.layoutBox();
+    for (auto& layoutBox : formattingContextBoxes(flexBox())) {
+        auto& renderer = downcast<RenderBox>(*layoutBox.rendererForIntegration());
         auto& flexItemGeometry = layoutState().geometryForBox(layoutBox);
         auto borderBox = Layout::BoxGeometry::borderBoxRect(flexItemGeometry);
         renderer.setLocation(borderBox.topLeft());

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -29,6 +29,7 @@
 #include "BlockFormattingState.h"
 #include "BlockLayoutState.h"
 #include "EventRegion.h"
+#include "FormattingContextBoxIterator.h"
 #include "HitTestLocation.h"
 #include "HitTestRequest.h"
 #include "HitTestResult.h"
@@ -469,8 +470,7 @@ void LineLayout::updateRenderTreePositions(const Vector<LineAdjustment>& lineAdj
         }
     }
 
-    for (auto& renderObject : m_boxTree.renderers()) {
-        auto& layoutBox = *renderObject->layoutBox();
+    for (auto& layoutBox : formattingContextBoxes(rootLayoutBox())) {
         if (!layoutBox.isFloatingPositioned() && !layoutBox.isOutOfFlowPositioned())
             continue;
         if (layoutBox.isLineBreakBox())
@@ -1064,8 +1064,7 @@ void LineLayout::shiftLinesBy(LayoutUnit blockShift)
         }
     }
 
-    for (auto& object : m_boxTree.renderers()) {
-        Layout::Box& layoutBox = *object->layoutBox();
+    for (auto& layoutBox : formattingContextBoxes(rootLayoutBox())) {
         if (layoutBox.isOutOfFlowPositioned() && layoutBox.style().hasStaticBlockPosition(isHorizontalWritingMode)) {
             CheckedRef renderer = downcast<RenderLayerModelObject>(m_boxTree.rendererForLayoutBox(layoutBox));
             if (!renderer->layer())

--- a/Source/WebCore/layout/layouttree/FormattingContextBoxIterator.h
+++ b/Source/WebCore/layout/layouttree/FormattingContextBoxIterator.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "LayoutDescendantIterator.h"
+
+namespace WebCore {
+namespace Layout {
+
+class FormattingContextBoxIterator : public LayoutDescendantIterator<Box> {
+public:
+    FormattingContextBoxIterator(const ElementBox& root)
+        : LayoutDescendantIterator<Layout::Box>(root)
+    {
+    }
+
+    enum FirstTag { First };
+    FormattingContextBoxIterator(const ElementBox& root, FirstTag)
+        : LayoutDescendantIterator<Box>(root, Traversal::firstWithin<Box>(root))
+    {
+    }
+
+    FormattingContextBoxIterator& operator++()
+    {
+        if (get().establishesFormattingContext())
+            traverseNextSkippingChildren();
+        else
+            traverseNext();
+        return *this;
+    }
+};
+
+class FormattingContextBoxIteratorAdapter {
+public:
+    FormattingContextBoxIteratorAdapter(const ElementBox& root)
+        : m_root(root)
+    {
+    }
+    FormattingContextBoxIterator begin() { return { m_root, FormattingContextBoxIterator::First }; }
+    FormattingContextBoxIterator end() { return { m_root }; }
+
+private:
+    const ElementBox& m_root;
+};
+
+inline FormattingContextBoxIteratorAdapter formattingContextBoxes(const ElementBox& root)
+{
+    ASSERT(root.establishesFormattingContext());
+    return { root };
+}
+
+
+}
+}

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -32,6 +32,7 @@
 #include "LayoutInitialContainingBlock.h"
 #include "LayoutPhase.h"
 #include "LayoutState.h"
+#include "RenderObject.h"
 #include "RenderStyleInlines.h"
 #include "Shape.h"
 #include <wtf/IsoMallocInlines.h>
@@ -56,6 +57,8 @@ Box::~Box()
 {
     if (UNLIKELY(m_hasRareData))
         removeRareData();
+    if (m_renderer)
+        m_renderer->clearLayoutBox();
 }
 
 UniqueRef<Box> Box::removeFromParent()

--- a/Source/WebCore/layout/layouttree/LayoutBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutBox.h
@@ -34,6 +34,7 @@
 namespace WebCore {
 
 class Shape;
+class RenderObject;
 
 namespace Layout {
 
@@ -194,6 +195,9 @@ public:
     BoxGeometry* cachedGeometryForLayoutState(const LayoutState&) const;
     void setCachedGeometryForLayoutState(LayoutState&, std::unique_ptr<BoxGeometry>) const;
 
+    RenderObject* rendererForIntegration() const { return m_renderer.get(); }
+    void setRendererForIntegration(RenderObject* renderer) { m_renderer = renderer; }
+
     UniqueRef<Box> removeFromParent();
 
 protected:
@@ -236,7 +240,7 @@ private:
     RenderStyle m_style;
 
     CheckedPtr<ElementBox> m_parent;
-    
+
     std::unique_ptr<Box> m_nextSibling;
     CheckedPtr<Box> m_previousSibling;
 
@@ -244,6 +248,7 @@ private:
     mutable WeakPtr<LayoutState> m_cachedLayoutState;
     mutable std::unique_ptr<BoxGeometry> m_cachedGeometryForLayoutState;
 
+    CheckedPtr<RenderObject> m_renderer;
 };
 
 inline bool Box::isContainingBlockForInFlow() const

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -160,6 +160,7 @@ RenderObject::RenderObject(Type type, Node& node, OptionSet<TypeFlag> typeFlags,
 
 RenderObject::~RenderObject()
 {
+    clearLayoutBox();
     checkedView()->didDestroyRenderer();
     ASSERT(!m_hasAXObject);
 #ifndef NDEBUG
@@ -176,10 +177,17 @@ CheckedRef<RenderView> RenderObject::checkedView() const
 void RenderObject::setLayoutBox(Layout::Box& box)
 {
     m_layoutBox = &box;
+    m_layoutBox->setRendererForIntegration(this);
 }
 
 void RenderObject::clearLayoutBox()
 {
+    if (!m_layoutBox)
+        return;
+
+    ASSERT(m_layoutBox->rendererForIntegration() == this);
+
+    m_layoutBox->setRendererForIntegration(nullptr);
     m_layoutBox = nullptr;
 }
 


### PR DESCRIPTION
#### 292d42429ba215465a1e89f01981f3a92e742446
<pre>
[IFC][Integration] Layout boxes should have a renderer backpointer
<a href="https://bugs.webkit.org/show_bug.cgi?id=273395">https://bugs.webkit.org/show_bug.cgi?id=273395</a>
<a href="https://rdar.apple.com/127226407">rdar://127226407</a>

Reviewed by Alan Baradlay.

Currently we are using an awkward layout box -&gt; renderer map in BoxTree. We can simplify things,
save memory and improve performance by getting rid of it.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp:
(WebCore::LayoutIntegration::BoxTree::~BoxTree):
(WebCore::LayoutIntegration::BoxTree::buildTreeForInlineContent):
(WebCore::LayoutIntegration::BoxTree::buildTreeForFlexContent):
(WebCore::LayoutIntegration::BoxTree::insertChild):
(WebCore::LayoutIntegration::BoxTree::insert):
(WebCore::LayoutIntegration::BoxTree::remove):
(WebCore::LayoutIntegration::BoxTree::contains const):
(WebCore::LayoutIntegration::BoxTree::rendererForLayoutBox):
(WebCore::LayoutIntegration::BoxTree::rendererForLayoutBox const):
(WebCore::LayoutIntegration::BoxTree::hasRendererForLayoutBox const):
* Source/WebCore/layout/integration/LayoutIntegrationBoxTree.h:
(WebCore::LayoutIntegration::BoxTree::boxCount const): Deleted.
(WebCore::LayoutIntegration::BoxTree::renderers const): Deleted.
* Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp:
(WebCore::LayoutIntegration::FlexLayout::layout):
(WebCore::LayoutIntegration::FlexLayout::updateRenderers):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::updateRenderTreePositions):

Since we don&apos;t have a renderer list anymore, traverse the boxes in the formatting context instead.

(WebCore::LayoutIntegration::LineLayout::shiftLinesBy):
* Source/WebCore/layout/layouttree/FormattingContextBoxIterator.h: Added.
(WebCore::Layout::FormattingContextBoxIterator::FormattingContextBoxIterator):
(WebCore::Layout::FormattingContextBoxIterator::operator++):
(WebCore::Layout::FormattingContextBoxIteratorAdapter::FormattingContextBoxIteratorAdapter):
(WebCore::Layout::FormattingContextBoxIteratorAdapter::begin):
(WebCore::Layout::FormattingContextBoxIteratorAdapter::end):
(WebCore::Layout::formattingContextBoxes):

Add a iterator for traversing all boxes in a formatting context.

* Source/WebCore/layout/layouttree/LayoutBox.cpp:
(WebCore::Layout::Box::~Box):
* Source/WebCore/layout/layouttree/LayoutBox.h:
(WebCore::Layout::Box::rendererForIntegration const):
(WebCore::Layout::Box::setRendererForIntegration):
* Source/WebCore/layout/layouttree/LayoutIterator.h:
(WebCore::Layout::LayoutBoxTraversal::nextSkippingChildren):
(WebCore::Layout::Traversal::nextSkippingChildren):
(WebCore::Layout::LayoutIterator&lt;T&gt;::traverseNextSkippingChildren):
(WebCore::Layout::LayoutIterator&lt;T&gt;::operator const):
(WebCore::Layout:: const):
(WebCore::Layout::LayoutIterator&lt;T&gt;::get const):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::~RenderObject):
(WebCore::RenderObject::setLayoutBox):
(WebCore::RenderObject::clearLayoutBox):

Canonical link: <a href="https://commits.webkit.org/278104@main">https://commits.webkit.org/278104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26820b15d11b0857f893e2716aa6a633d0d9dd11

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52752 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/186 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51817 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34813 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26415 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40419 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26332 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42656 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21538 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23792 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43840 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7882 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45706 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44344 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54267 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24596 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20773 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47791 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25867 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46810 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10873 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26707 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25590 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->