### PR TITLE
Implement trusted types enforcement on eval

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-eval-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-eval-expected.txt
@@ -1,20 +1,26 @@
 
-FAIL eval(string) in dedicated worker assert_throws_js: function "_ => eval("2")" did not throw
-FAIL indirect eval(string) in dedicated worker assert_throws_js: function "_ => eval?.("2")" did not throw
+PASS eval(string) in dedicated worker
+PASS indirect eval(string) in dedicated worker
 PASS eval(TrustedScript) in dedicated worker
 PASS indirect eval(TrustedScript) in dedicated worker
-FAIL eval(string) with default policy in dedicated worker assert_equals: expected 5 but got 2
-FAIL indirect eval(string) with default policy in dedicated worker assert_equals: expected 5 but got 2
-FAIL eval(string) in service worker assert_throws_js: function "_ => eval("2")" did not throw
-FAIL indirect eval(string) in service worker assert_throws_js: function "_ => eval?.("2")" did not throw
+PASS eval(string) with default policy in dedicated worker
+PASS indirect eval(string) with default policy in dedicated worker
+PASS eval(string) with default policy mutation in dedicated worker
+PASS indirect eval(string) with default policy mutation in dedicated worker
+PASS eval(string) in service worker
+PASS indirect eval(string) in service worker
+PASS eval(string) in shared worker
+PASS indirect eval(string) in shared worker
+PASS eval(TrustedScript) in shared worker
 PASS eval(TrustedScript) in service worker
 PASS indirect eval(TrustedScript) in service worker
-FAIL eval(string) with default policy in service worker assert_equals: expected 5 but got 2
-FAIL eval(string) in shared worker assert_throws_js: function "_ => eval("2")" did not throw
-FAIL indirect eval(string) with default policy in service worker assert_equals: expected 5 but got 2
-FAIL indirect eval(string) in shared worker assert_throws_js: function "_ => eval?.("2")" did not throw
-PASS eval(TrustedScript) in shared worker
+PASS eval(string) with default policy in service worker
+PASS indirect eval(string) with default policy in service worker
 PASS indirect eval(TrustedScript) in shared worker
-FAIL eval(string) with default policy in shared worker assert_equals: expected 5 but got 2
-FAIL indirect eval(string) with default policy in shared worker assert_equals: expected 5 but got 2
+PASS eval(string) with default policy in shared worker
+PASS indirect eval(string) with default policy in shared worker
+PASS eval(string) with default policy mutation in shared worker
+PASS indirect eval(string) with default policy mutation in shared worker
+PASS eval(string) with default policy mutation in service worker
+PASS indirect eval(string) with default policy mutation in service worker
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-importScripts-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-importScripts-expected.txt
@@ -6,9 +6,9 @@ PASS importScripts with two URLs, both trusted, in dedicated worker
 PASS importScripts with two URLs, both strings, in dedicated worker
 PASS importScripts with two URLs, one trusted, in dedicated worker
 PASS importScripts with untrusted URLs and default policy works in dedicated worker
-PASS importScripts with one trusted and one untrusted URLs and default policy works in dedicated worker
 PASS importScripts with TrustedScriptURL works in service worker
 PASS importScripts with untrusted URLs throws in service worker
+PASS importScripts with one trusted and one untrusted URLs and default policy works in dedicated worker
 PASS null is not a trusted script URL throws in service worker
 PASS importScripts with two URLs, both trusted, in service worker
 PASS importScripts with two URLs, both strings, in service worker

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/csp-block-eval-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/csp-block-eval-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 
 PASS eval with plain string throws (both block).
 PASS eval with TrustedScript throws (script-src blocks).

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy-expected.txt
@@ -1,8 +1,8 @@
 
 PASS eval of TrustedScript works.
 PASS indirect eval of TrustedScript works.
-FAIL eval of string works. assert_equals: expected 5 but got 2
+PASS eval of string works.
 PASS eval of !TrustedScript and !string works.
 PASS Function constructor of TrustedScript works.
-FAIL Function constructor of string works. assert_equals: expected 5 but got 2
+PASS Function constructor of string works.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy-mutate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy-mutate-expected.txt
@@ -1,0 +1,5 @@
+
+PASS eval of string where default policy mutates value throws.
+PASS indirect eval of string where default policy mutates value throws.
+FAIL Function constructor with string where default policy mutates value throws. assert_throws_js: function "_ => new Function('return 1+1')" did not throw
+

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy-mutate.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy-mutate.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
+<html>
+<head>
+  <script nonce="abc" src="/resources/testharness.js"></script>
+  <script nonce="abc" src="/resources/testharnessreport.js"></script>
+  <script nonce="abc" src="support/helper.sub.js"></script>
+  <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'">
+</head>
+<body>
+<script>
+  trustedTypes.createPolicy("default", {createScript: s => s.replace("1", "4")});
+
+  test(t => {
+    assert_throws_js(EvalError, _ => eval('1+1'));
+  }, "eval of string where default policy mutates value throws.");
+
+  test(t => {
+    assert_throws_js(EvalError, _ => eval?.('1+1'));
+  }, "indirect eval of string where default policy mutates value throws.");
+
+  test(t => {
+    assert_throws_js(EvalError, _ => new Function('return 1+1'));
+  }, "Function constructor with string where default policy mutates value throws.");
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy.html
@@ -8,7 +8,7 @@
 </head>
 <body>
 <script>
-  trustedTypes.createPolicy("default", {createScript: s => s.replace("1", "4")});
+  trustedTypes.createPolicy("default", {createScript: s => s});
   const p = trustedTypes.createPolicy("p", {createScript: s => s});
 
   test(t => {
@@ -20,7 +20,7 @@
   }, "indirect eval of TrustedScript works.");
 
   test(t => {
-    assert_equals(eval('1+1'), 5); // '1+1' becomes '4+1'.
+    assert_equals(eval('1+1'), 2);
   }, "eval of string works.");
 
   test(t => {
@@ -35,7 +35,7 @@
   }, "Function constructor of TrustedScript works.");
 
   test(t => {
-    assert_equals(new Function('return 1+1')(), 5);
+    assert_equals(new Function('return 1+1')(), 2);
   }, "Function constructor of string works.");
 </script>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-no-default-policy-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-no-default-policy-expected.txt
@@ -1,8 +1,10 @@
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 
 PASS eval of TrustedScript works.
 PASS indirect eval of TrustedScript works.
-FAIL eval of string fails. assert_throws_js: function "_ => eval('1+1')" did not throw
-FAIL indirect eval of string fails. assert_throws_js: function "_ => eval?.('1+1')" did not throw
+PASS eval of string fails.
+PASS indirect eval of string fails.
 PASS eval of !TrustedScript and !string works.
 PASS Function constructor of TrustedScript works.
 FAIL Function constructor of string fails. assert_throws_js: function "_ => new Function('return 1+1')()" did not throw

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-permissive-csp-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-permissive-csp-expected.txt
@@ -1,17 +1,15 @@
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 
-FAIL eval with plain string with Trusted Types and permissive CSP throws (no type). assert_throws_js: function "_ => {
-      eval('a="hello there"');
-    }" did not throw
-FAIL indirect eval with plain string with Trusted Types and permissive CSP throws (no type). assert_throws_js: function "_ => {
-      eval?.('a="hello there"');
-    }" did not throw
+PASS eval with plain string with Trusted Types and permissive CSP throws (no type).
+PASS indirect eval with plain string with Trusted Types and permissive CSP throws (no type).
 FAIL Function constructor with plain string with Trusted Types and permissive CSP throws (no type). assert_throws_js: function "_ => {
       new Function('a="hello there"');
     }" did not throw
 PASS eval with TrustedScript and permissive CSP works.
 PASS indirect eval with TrustedScript and permissive CSP works.
 PASS new Function with TrustedScript and permissive CSP works.
-FAIL eval with default policy and permissive CSP still obeys default policy. assert_equals: expected "Hello a cat untrusted string" but got "Hello transformed untrusted string"
-FAIL indirect eval with default policy and permissive CSP still obeys default policy. assert_equals: expected "Hello a cat untrusted string" but got "Hello transformed untrusted string"
-FAIL new Function with default policy and permissive CSP still obeys default policy. assert_equals: expected "Hello a cat untrusted string" but got "Hello transformed untrusted string"
+PASS eval with plain string with Trusted Types and permissive CSP works with default policy.
+PASS indirect eval with plain string with Trusted Types and permissive CSP works with default policy.
+PASS new Function with plain string default policy and permissive CSP works with default policy.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-permissive-csp.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-permissive-csp.html
@@ -51,20 +51,20 @@
     assert_equals(s, "Hello a cat string");
   }, "new Function with TrustedScript and permissive CSP works.");
 
-  trustedTypes.createPolicy("default", { createScript: createScriptJS }, true);
+  trustedTypes.createPolicy("default", { createScript: (s) => s });
   test(t => {
-    let s = eval('"Hello transformed untrusted string"');
-    assert_equals(s, "Hello a cat untrusted string");
-  }, "eval with default policy and permissive CSP still obeys default policy.");
+    let s = eval('1+1');
+    assert_equals(s, 2);
+  }, "eval with plain string with Trusted Types and permissive CSP works with default policy.");
 
   test(t => {
-    let s = eval?.('"Hello transformed untrusted string"');
-    assert_equals(s, "Hello a cat untrusted string");
-  }, "indirect eval with default policy and permissive CSP still obeys default policy.");
+    let s = eval?.('1+1');
+    assert_equals(s, 2);
+  }, "indirect eval with plain string with Trusted Types and permissive CSP works with default policy.");
 
   test(t => {
-    let s = new Function('return "Hello transformed untrusted string"')();
-    assert_equals(s, "Hello a cat untrusted string");
-  }, "new Function with default policy and permissive CSP still obeys default policy.");
+    let s = new Function('return 1+1')();
+    assert_equals(s, 2);
+  }, "new Function with plain string default policy and permissive CSP works with default policy.");
 </script>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/support/WorkerGlobalScope-eval.https.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/support/WorkerGlobalScope-eval.https.js
@@ -39,10 +39,16 @@ trustedTypes.createPolicy("default", {
   createScript: x => x.replace("2", "5")
 });
 test(t => {
-  assert_equals(eval("2"), 5);
+  assert_equals(eval("4"), 4);
 }, "eval(string) with default policy in " + worker_type);
 test(t => {
-  assert_equals(eval?.("2"), 5);
+  assert_equals(eval?.("4"), 4);
 }, "indirect eval(string) with default policy in " + worker_type);
+test(t => {
+  assert_throws_js(EvalError, _ => eval("2"));
+}, "eval(string) with default policy mutation in " + worker_type);
+test(t => {
+  assert_throws_js(EvalError, _ => eval?.("2"));
+}, "indirect eval(string) with default policy mutation in " + worker_type);
 
 done();

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-expected.txt
@@ -1,6 +1,7 @@
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: Refused to load because it does not appear in the object-src directive of the Content Security Policy.
 CONSOLE MESSAGE: Refused to load because it does not appear in the object-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Refused to load because it does not appear in the object-src directive of the Content Security Policy.
 
 
 PASS Trusted Type violation report: evaluating a string.

--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.cpp
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.cpp
@@ -59,6 +59,7 @@ const GlobalObjectMethodTable* JSAPIGlobalObject::globalObjectMethodTable()
         nullptr, // instantiateStreaming
         nullptr, // deriveShadowRealmGlobalObject
         &codeForEval,
+        &canCompileStrings,
     };
     return &table;
 }

--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
@@ -78,6 +78,7 @@ const GlobalObjectMethodTable* JSAPIGlobalObject::globalObjectMethodTable()
         nullptr, // instantiateStreaming
         &deriveShadowRealmGlobalObject,
         &codeForEval,
+        &canCompileStrings,
     };
     return &table;
 };

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -945,7 +945,8 @@ const GlobalObjectMethodTable GlobalObject::s_globalObjectMethodTable = {
     nullptr, // compileStreaming
     nullptr, // instantinateStreaming
     &deriveShadowRealmGlobalObject,
-    &codeForEval
+    &codeForEval,
+    &canCompileStrings,
 };
 
 GlobalObject::GlobalObject(VM& vm, Structure* structure)

--- a/Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h
+++ b/Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h
@@ -38,6 +38,7 @@ class Microtask;
 class RuntimeFlags;
 class SourceOrigin;
 
+enum class CompilationType;
 enum class ScriptExecutionStatus;
 
 enum class JSPromiseRejectionOperation : unsigned {
@@ -71,6 +72,7 @@ struct GlobalObjectMethodTable {
     JSPromise* (*instantiateStreaming)(JSGlobalObject*, JSValue, JSObject*);
     JSGlobalObject* (*deriveShadowRealmGlobalObject)(JSGlobalObject*);
     String (*codeForEval)(JSGlobalObject*, JSValue);
+    bool (*canCompileStrings)(JSGlobalObject*, CompilationType, String, JSValue);
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -611,7 +611,8 @@ const GlobalObjectMethodTable* JSGlobalObject::baseGlobalObjectMethodTable()
         nullptr, // compileStreaming
         nullptr, // instantiateStreaming
         &deriveShadowRealmGlobalObject,
-        &codeForEval
+        &codeForEval,
+        &canCompileStrings,
     };
     return &table;
 };

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -121,6 +121,12 @@ enum class ScriptExecutionStatus {
 
 enum class BindingCreationContext : bool { Global, Eval };
 
+enum class CompilationType {
+    Function,
+    DirectEval,
+    IndirectEval,
+};
+
 constexpr bool typeExposedByDefault = true;
 
 #define DEFINE_STANDARD_BUILTIN(macro, upperName, lowerName) macro(upperName, lowerName, lowerName, JS ## upperName, upperName, object, typeExposedByDefault)
@@ -551,6 +557,7 @@ public:
 
     bool m_evalEnabled { true };
     bool m_webAssemblyEnabled { true };
+    bool m_requiresTrustedTypes { true };
     bool m_needsSiteSpecificQuirks { false };
     unsigned m_globalLexicalBindingEpoch { 1 };
     ScopeOffset m_lastStaticGlobalOffset;
@@ -923,6 +930,7 @@ public:
     static ScriptExecutionStatus scriptExecutionStatus(JSGlobalObject*, JSObject*) { return ScriptExecutionStatus::Running; }
     static void reportViolationForUnsafeEval(JSGlobalObject*, JSString*) { }
     static String codeForEval(JSGlobalObject*, JSValue) { return nullString(); }
+    static bool canCompileStrings(JSGlobalObject*, CompilationType, String, JSValue) { return true; }
 
     inline JSObject* arrayBufferPrototype(ArrayBufferSharingMode) const;
     inline Structure* arrayBufferStructure(ArrayBufferSharingMode) const;
@@ -1023,6 +1031,7 @@ public:
 
     bool evalEnabled() const { return m_evalEnabled; }
     bool webAssemblyEnabled() const { return m_webAssemblyEnabled; }
+    bool requiresTrustedTypes() const { return m_requiresTrustedTypes; }
     const String& evalDisabledErrorMessage() const { return m_evalDisabledErrorMessage; }
     const String& webAssemblyDisabledErrorMessage() const { return m_webAssemblyDisabledErrorMessage; }
     void setEvalEnabled(bool enabled, const String& errorMessage = String())
@@ -1034,6 +1043,10 @@ public:
     {
         m_webAssemblyEnabled = enabled;
         m_webAssemblyDisabledErrorMessage = errorMessage;
+    }
+    void setRequiresTrustedTypes(bool required)
+    {
+        m_requiresTrustedTypes = required;
     }
 
 #if ASSERT_ENABLED

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -372,6 +372,24 @@ ScriptExecutionContext* JSDOMGlobalObject::scriptExecutionContext() const
     return nullptr;
 }
 
+bool JSDOMGlobalObject::canCompileStrings(JSGlobalObject* globalObject, CompilationType compilationType, String codeString, JSValue bodyArgument)
+{
+    VM& vm = globalObject->vm();
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+
+    auto& thisObject = static_cast<JSDOMGlobalObject&>(*globalObject);
+    auto* scriptExecutionContext = thisObject.scriptExecutionContext();
+
+    auto result = canCompile(*scriptExecutionContext, compilationType, codeString, bodyArgument);
+
+    if (result.hasException()) {
+        propagateException(*globalObject, throwScope, result.releaseException());
+        RETURN_IF_EXCEPTION(throwScope, false);
+    }
+
+    return result.releaseReturnValue();
+}
+
 template<typename Visitor>
 void JSDOMGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.h
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.h
@@ -79,6 +79,8 @@ public:
 
     ScriptExecutionContext* scriptExecutionContext() const;
 
+    static bool canCompileStrings(JSC::JSGlobalObject*, JSC::CompilationType, String, JSC::JSValue);
+
     // https://tc39.es/ecma262/#sec-agent-clusters
     String agentClusterID() const;
     static String defaultAgentClusterID();

--- a/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
@@ -36,6 +36,7 @@
 #include "HTMLFrameOwnerElement.h"
 #include "InspectorController.h"
 #include "JSDOMBindingSecurity.h"
+#include "JSDOMExceptionHandling.h"
 #include "JSDOMWindowCustom.h"
 #include "JSDocument.h"
 #include "JSFetchResponse.h"
@@ -52,6 +53,7 @@
 #include "ScriptModuleLoader.h"
 #include "SecurityOrigin.h"
 #include "Settings.h"
+#include "TrustedType.h"
 #include "WebCoreJSClientData.h"
 #include <JavaScriptCore/CodeBlock.h>
 #include <JavaScriptCore/DeferredWorkTimer.h>
@@ -105,7 +107,8 @@ const GlobalObjectMethodTable* JSDOMWindowBase::globalObjectMethodTable()
         nullptr,
 #endif
         deriveShadowRealmGlobalObject,
-        codeForEval
+        codeForEval,
+        canCompileStrings
     };
     return &table;
 };
@@ -307,6 +310,11 @@ String JSDOMWindowBase::codeForEval(JSGlobalObject* globalObject, JSValue value)
         return script->toString();
 
     return nullString();
+}
+
+bool JSDOMWindowBase::canCompileStrings(JSGlobalObject* globalObject, CompilationType compilationType, String codeString, JSValue bodyArgument)
+{
+    return JSDOMGlobalObject::canCompileStrings(globalObject, compilationType, codeString, bodyArgument);
 }
 
 void JSDOMWindowBase::willRemoveFromWindowProxy()

--- a/Source/WebCore/bindings/js/JSDOMWindowBase.h
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.h
@@ -81,6 +81,7 @@ public:
     static JSC::ScriptExecutionStatus scriptExecutionStatus(JSC::JSGlobalObject*, JSC::JSObject*);
     static void reportViolationForUnsafeEval(JSC::JSGlobalObject*, JSC::JSString*);
     static String codeForEval(JSC::JSGlobalObject*, JSC::JSValue);
+    static bool canCompileStrings(JSC::JSGlobalObject*, JSC::CompilationType, String, JSC::JSValue);
 
     void printErrorMessage(const String&) const;
 

--- a/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.cpp
+++ b/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.cpp
@@ -72,6 +72,7 @@ const GlobalObjectMethodTable* JSShadowRealmGlobalScopeBase::globalObjectMethodT
 #endif
         &deriveShadowRealmGlobalObject,
         &codeForEval,
+        &canCompileStrings,
     };
     return &table;
 };
@@ -157,6 +158,11 @@ void JSShadowRealmGlobalScopeBase::reportViolationForUnsafeEval(JSC::JSGlobalObj
 String JSShadowRealmGlobalScopeBase::codeForEval(JSC::JSGlobalObject* globalObject, JSC::JSValue value)
 {
     return JSGlobalObject::codeForEval(globalObject, value);
+}
+
+bool JSShadowRealmGlobalScopeBase::canCompileStrings(JSC::JSGlobalObject* globalObject, JSC::CompilationType compilationType, String codeString, JSC::JSValue bodyArgument)
+{
+    return JSGlobalObject::canCompileStrings(globalObject, compilationType, codeString, bodyArgument);
 }
 
 void JSShadowRealmGlobalScopeBase::queueMicrotaskToEventLoop(JSGlobalObject& object, Ref<JSC::Microtask>&& task)

--- a/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.h
+++ b/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.h
@@ -56,6 +56,7 @@ private:
     static void queueMicrotaskToEventLoop(JSC::JSGlobalObject&, Ref<JSC::Microtask>&&);
     static void reportViolationForUnsafeEval(JSC::JSGlobalObject*, JSC::JSString*);
     static String codeForEval(JSC::JSGlobalObject*, JSC::JSValue);
+    static bool canCompileStrings(JSC::JSGlobalObject*, JSC::CompilationType, String, JSC::JSValue);
 
 protected:
     JSShadowRealmGlobalScopeBase(JSC::VM&, JSC::Structure*, RefPtr<ShadowRealmGlobalScope>&&);

--- a/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp
+++ b/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp
@@ -30,9 +30,11 @@
 
 #include "DOMWrapperWorld.h"
 #include "EventLoop.h"
+#include "JSDOMExceptionHandling.h"
 #include "JSDOMGuardedObject.h"
 #include "JSMicrotaskCallback.h"
 #include "JSTrustedScript.h"
+#include "TrustedType.h"
 #include "WorkerGlobalScope.h"
 #include "WorkerThread.h"
 #include <JavaScriptCore/GlobalObjectMethodTable.h>
@@ -75,6 +77,7 @@ const GlobalObjectMethodTable* JSWorkerGlobalScopeBase::globalObjectMethodTable(
 #endif
         deriveShadowRealmGlobalObject,
         codeForEval,
+        canCompileStrings,
     };
     return &table;
 };
@@ -154,6 +157,11 @@ String JSWorkerGlobalScopeBase::codeForEval(JSC::JSGlobalObject* globalObject, J
         return script->toString();
 
     return nullString();
+}
+
+bool JSWorkerGlobalScopeBase::canCompileStrings(JSC::JSGlobalObject* globalObject, JSC::CompilationType compilationType, String codeString, JSC::JSValue bodyArgument)
+{
+    return JSDOMGlobalObject::canCompileStrings(globalObject, compilationType, codeString, bodyArgument);
 }
 
 void JSWorkerGlobalScopeBase::queueMicrotaskToEventLoop(JSGlobalObject& object, Ref<JSC::Microtask>&& task)

--- a/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.h
+++ b/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.h
@@ -59,6 +59,7 @@ public:
     static void queueMicrotaskToEventLoop(JSC::JSGlobalObject&, Ref<JSC::Microtask>&&);
     static void reportViolationForUnsafeEval(JSC::JSGlobalObject*, JSC::JSString*);
     static String codeForEval(JSC::JSGlobalObject*, JSC::JSValue);
+    static bool canCompileStrings(JSC::JSGlobalObject*, JSC::CompilationType, String, JSC::JSValue);
 
 protected:
     JSWorkerGlobalScopeBase(JSC::VM&, JSC::Structure*, RefPtr<WorkerGlobalScope>&&);

--- a/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.cpp
+++ b/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.cpp
@@ -70,6 +70,7 @@ const GlobalObjectMethodTable* JSWorkletGlobalScopeBase::globalObjectMethodTable
 #endif
         deriveShadowRealmGlobalObject,
         codeForEval,
+        canCompileStrings,
     };
     return &table;
 };
@@ -123,6 +124,11 @@ void JSWorkletGlobalScopeBase::reportViolationForUnsafeEval(JSC::JSGlobalObject*
 String JSWorkletGlobalScopeBase::codeForEval(JSC::JSGlobalObject* globalObject, JSC::JSValue value)
 {
     return JSGlobalObject::codeForEval(globalObject, value);
+}
+
+bool JSWorkletGlobalScopeBase::canCompileStrings(JSC::JSGlobalObject* globalObject, JSC::CompilationType compilationType, String codeString, JSC::JSValue bodyArgument)
+{
+    return JSGlobalObject::canCompileStrings(globalObject, compilationType, codeString, bodyArgument);
 }
 
 bool JSWorkletGlobalScopeBase::supportsRichSourceInfo(const JSGlobalObject* object)

--- a/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.h
+++ b/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.h
@@ -60,6 +60,7 @@ public:
     static void queueMicrotaskToEventLoop(JSC::JSGlobalObject&, Ref<JSC::Microtask>&&);
     static void reportViolationForUnsafeEval(JSC::JSGlobalObject*, JSC::JSString*);
     static String codeForEval(JSC::JSGlobalObject*, JSC::JSValue);
+    static bool canCompileStrings(JSC::JSGlobalObject*, JSC::CompilationType, String, JSC::JSValue);
 
 protected:
     JSWorkletGlobalScopeBase(JSC::VM&, JSC::Structure*, RefPtr<WorkletGlobalScope>&&);

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -453,6 +453,14 @@ void ScriptController::setWebAssemblyEnabled(bool value, const String& errorMess
     jsWindowProxy->window()->setWebAssemblyEnabled(value, errorMessage);
 }
 
+void ScriptController::setRequiresTrustedTypes(bool required)
+{
+    auto* proxy = windowProxy().existingJSWindowProxy(mainThreadNormalWorld());
+    if (!proxy)
+        return;
+    proxy->window()->setRequiresTrustedTypes(required);
+}
+
 bool ScriptController::canAccessFromCurrentOrigin(LocalFrame* frame, Document& accessingDocument)
 {
     auto* lexicalGlobalObject = JSExecState::currentState();

--- a/Source/WebCore/bindings/js/ScriptController.h
+++ b/Source/WebCore/bindings/js/ScriptController.h
@@ -130,6 +130,7 @@ public:
 
     void setEvalEnabled(bool, const String& errorMessage = String());
     void setWebAssemblyEnabled(bool, const String& errorMessage = String());
+    void setRequiresTrustedTypes(bool);
 
     static bool canAccessFromCurrentOrigin(LocalFrame*, Document& accessingDocument);
     WEBCORE_EXPORT bool canExecuteScripts(ReasonForCallingCanExecuteScripts);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4240,6 +4240,15 @@ void Document::disableWebAssembly(const String& errorMessage)
     frame->checkedScript()->setWebAssemblyEnabled(false, errorMessage);
 }
 
+void Document::setRequiresTrustedTypes(bool required)
+{
+    RefPtr frame = this->frame();
+    if (!frame)
+        return;
+
+    frame->checkedScript()->setRequiresTrustedTypes(required);
+}
+
 IDBClient::IDBConnectionProxy* Document::idbConnectionProxy()
 {
     if (!m_idbConnectionProxy) {

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -845,6 +845,7 @@ public:
 
     void disableEval(const String& errorMessage) final;
     void disableWebAssembly(const String& errorMessage) final;
+    void setRequiresTrustedTypes(bool required) final;
 
     IDBClient::IDBConnectionProxy* idbConnectionProxy() final;
     StorageConnection* storageConnection();

--- a/Source/WebCore/dom/EmptyScriptExecutionContext.h
+++ b/Source/WebCore/dom/EmptyScriptExecutionContext.h
@@ -61,6 +61,7 @@ public:
 
     void disableEval(const String&) final { };
     void disableWebAssembly(const String&) final { };
+    void setRequiresTrustedTypes(bool) final { };
 
     IDBClient::IDBConnectionProxy* idbConnectionProxy() final { return nullptr; }
     SocketProvider* socketProvider() final { return nullptr; }

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -136,6 +136,7 @@ public:
 
     virtual void disableEval(const String& errorMessage) = 0;
     virtual void disableWebAssembly(const String& errorMessage) = 0;
+    virtual void setRequiresTrustedTypes(bool required) = 0;
 
     virtual IDBClient::IDBConnectionProxy* idbConnectionProxy() = 0;
 

--- a/Source/WebCore/dom/TrustedType.cpp
+++ b/Source/WebCore/dom/TrustedType.cpp
@@ -30,6 +30,7 @@
 #include "Document.h"
 #include "HTMLScriptElement.h"
 #include "JSDOMExceptionHandling.h"
+#include "JSTrustedScript.h"
 #include "LocalDOMWindow.h"
 #include "Node.h"
 #include "SVGNames.h"
@@ -324,6 +325,24 @@ ExceptionOr<RefPtr<Text>> processNodeOrStringAsTrustedType(Ref<Document> documen
         text = Text::create(document, std::get<RefPtr<TrustedScript>>(variant)->toString());
 
     return text;
+}
+
+ExceptionOr<bool> canCompile(ScriptExecutionContext& scriptExecutionContext, JSC::CompilationType compilationType, String codeString, JSC::JSValue bodyArgument)
+{
+    VM& vm = scriptExecutionContext.vm();
+
+    if (bodyArgument.isObject())
+        return JSTrustedScript::toWrapped(vm, bodyArgument) ? true : false;
+
+    ASSERT(bodyArgument.isString());
+
+    auto sink = compilationType == CompilationType::Function ? "Function"_s : "eval"_s;
+
+    auto stringValueHolder = trustedTypeCompliantString(TrustedType::TrustedScript, scriptExecutionContext, codeString, sink);
+    if (stringValueHolder.hasException())
+        return stringValueHolder.releaseException();
+
+    return codeString == stringValueHolder.releaseReturnValue();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/TrustedType.h
+++ b/Source/WebCore/dom/TrustedType.h
@@ -30,6 +30,14 @@
 #include "TrustedScript.h"
 #include "TrustedScriptURL.h"
 
+namespace JSC {
+
+class JSValue;
+
+enum class CompilationType;
+
+} // namespace JSC
+
 namespace WebCore {
 
 class Document;
@@ -68,4 +76,7 @@ ExceptionOr<String> trustedTypeCompliantString(ScriptExecutionContext&, std::var
 ExceptionOr<RefPtr<Text>> processNodeOrStringAsTrustedType(Ref<Document>, RefPtr<Node> parent, std::variant<RefPtr<Node>, String, RefPtr<TrustedScript>>);
 
 WEBCORE_EXPORT AttributeTypeAndSink trustedTypeForAttribute(const String& elementName, const String& attributeName, const String& elementNamespace, const String& attributeNamespace);
+
+ExceptionOr<bool> canCompile(ScriptExecutionContext&, JSC::CompilationType, String codeString, JSC::JSValue bodyArgument);
+
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
@@ -97,6 +97,11 @@ void WorkerOrWorkletGlobalScope::disableWebAssembly(const String& errorMessage)
     m_script->disableWebAssembly(errorMessage);
 }
 
+void WorkerOrWorkletGlobalScope::setRequiresTrustedTypes(bool required)
+{
+    m_script->setRequiresTrustedTypes(required);
+}
+
 bool WorkerOrWorkletGlobalScope::isJSExecutionForbidden() const
 {
     return !m_script || m_script->isExecutionForbidden();

--- a/Source/WebCore/workers/WorkerOrWorkletGlobalScope.h
+++ b/Source/WebCore/workers/WorkerOrWorkletGlobalScope.h
@@ -99,6 +99,7 @@ private:
     // ScriptExecutionContext.
     void disableEval(const String& errorMessage) final;
     void disableWebAssembly(const String& errorMessage) final;
+    void setRequiresTrustedTypes(bool required) final;
 
     // EventTarget.
     ScriptExecutionContext* scriptExecutionContext() const final { return const_cast<WorkerOrWorkletGlobalScope*>(this); }

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
@@ -203,6 +203,14 @@ void WorkerOrWorkletScriptController::disableWebAssembly(const String& errorMess
     m_globalScopeWrapper->setWebAssemblyEnabled(false, errorMessage);
 }
 
+void WorkerOrWorkletScriptController::setRequiresTrustedTypes(bool required)
+{
+    initScriptIfNeeded();
+    JSLockHolder lock { vm() };
+
+    m_globalScopeWrapper->setRequiresTrustedTypes(required);
+}
+
 void WorkerOrWorkletScriptController::evaluate(const ScriptSourceCode& sourceCode, String* returnedExceptionMessage)
 {
     if (isExecutionForbidden())

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.h
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.h
@@ -95,6 +95,7 @@ public:
 
     void disableEval(const String& errorMessage);
     void disableWebAssembly(const String& errorMessage);
+    void setRequiresTrustedTypes(bool required);
 
     void evaluate(const ScriptSourceCode&, String* returnedExceptionMessage = nullptr);
     void evaluate(const ScriptSourceCode&, NakedPtr<JSC::Exception>& returnedException, String* returnedExceptionMessage = nullptr);


### PR DESCRIPTION
#### 7a4725b0e7299c17437ca3c94836d430bd741aac
<pre>
Implement trusted types enforcement on eval
<a href="https://bugs.webkit.org/show_bug.cgi?id=273185">https://bugs.webkit.org/show_bug.cgi?id=273185</a>

Reviewed by Darin Adler and Justin Michaud.

This patch introduces a new canCompileStrings function to the global object method table.
This function is used in eval for enforcement of trusted types.
It also updates the associated tests to match the latest spec.

A follow up patch will update the Function constructor to use this.

See <a href="https://tc39.es/proposal-dynamic-code-brand-checks">https://tc39.es/proposal-dynamic-code-brand-checks</a>

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-eval-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-importScripts-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/csp-block-eval-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy-mutate-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy-mutate.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-no-default-policy-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-permissive-csp-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-permissive-csp.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/support/WorkerGlobalScope-eval.https.js:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-expected.txt: Added.
* Source/JavaScriptCore/API/JSAPIGlobalObject.cpp:
(JSC::JSAPIGlobalObject::globalObjectMethodTable):
* Source/JavaScriptCore/API/JSAPIGlobalObject.mm:
(JSC::JSAPIGlobalObject::globalObjectMethodTable):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::eval):
* Source/JavaScriptCore/jsc.cpp:
* Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::baseGlobalObjectMethodTable):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::canCompileStrings):
(JSC::JSGlobalObject::requiresTrustedTypes const):
(JSC::JSGlobalObject::setRequiresTrustedTypes):
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::JSDOMGlobalObject::canCompileStrings):
* Source/WebCore/bindings/js/JSDOMGlobalObject.h:
* Source/WebCore/bindings/js/JSDOMWindowBase.cpp:
(WebCore::JSDOMWindowBase::globalObjectMethodTable):
(WebCore::JSDOMWindowBase::canCompileStrings):
* Source/WebCore/bindings/js/JSDOMWindowBase.h:
* Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.cpp:
(WebCore::JSShadowRealmGlobalScopeBase::globalObjectMethodTable):
(WebCore::JSShadowRealmGlobalScopeBase::canCompileStrings):
* Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.h:
* Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp:
(WebCore::JSWorkerGlobalScopeBase::globalObjectMethodTable):
(WebCore::JSWorkerGlobalScopeBase::canCompileStrings):
* Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.h:
* Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.cpp:
(WebCore::JSWorkletGlobalScopeBase::globalObjectMethodTable):
(WebCore::JSWorkletGlobalScopeBase::canCompileStrings):
* Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.h:
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::setRequiresTrustedTypes):
* Source/WebCore/bindings/js/ScriptController.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setRequiresTrustedTypes):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/EmptyScriptExecutionContext.h:
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/dom/TrustedType.cpp:
(WebCore::canCompile):
* Source/WebCore/dom/TrustedType.h:
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::didCreateWindowProxy const):
(WebCore::ContentSecurityPolicy::applyPolicyToScriptExecutionContext):
* Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp:
(WebCore::WorkerOrWorkletGlobalScope::setRequiresTrustedTypes):
* Source/WebCore/workers/WorkerOrWorkletGlobalScope.h:
* Source/WebCore/workers/WorkerOrWorkletScriptController.cpp:
(WebCore::WorkerOrWorkletScriptController::setRequiresTrustedTypes):
* Source/WebCore/workers/WorkerOrWorkletScriptController.h:

Canonical link: <a href="https://commits.webkit.org/279473@main">https://commits.webkit.org/279473@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a9411137fcd14ec56631a6701232112f27e0843

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6015 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56789 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4235 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55815 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4026 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43377 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2776 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55607 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31064 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46260 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24514 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27910 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3563 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2391 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/46869 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49667 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3735 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58384 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/53024 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28667 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3744 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50783 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29873 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46429 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50123 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11678 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30802 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65329 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29645 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12451 "Passed tests") | 
<!--EWS-Status-Bubble-End-->