### PR TITLE
[GStreamer] Video encoder configuration using codec strings

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1196,10 +1196,6 @@ imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.
 
 imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.worker.html [ Pass ]
 
-# Colorimetry-related failures, to be fixed by proper av01 codec string parsing/handling.
-imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?av1 [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?av1 [ Failure ]
-
 # Our MP3 decoder is not yet spec-compliant (reverse decoding, mostly).
 imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?mp3 [ Failure ]
 imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?mp3 [ Failure ]

--- a/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
@@ -71,6 +71,43 @@ std::pair<const char*, const char*> GStreamerCodecUtilities::parseH264ProfileAnd
     return { profile, level };
 }
 
+static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> h264CapsFromCodecString(const String& codecString)
+{
+    auto outputCaps = adoptGRef(gst_caps_new_empty_simple("video/x-h264"));
+    // FIXME: Set level on caps too?
+    auto [gstProfile, _] = GStreamerCodecUtilities::parseH264ProfileAndLevel(codecString);
+    if (gstProfile)
+        gst_caps_set_simple(outputCaps.get(), "profile", G_TYPE_STRING, gstProfile, nullptr);
+
+    StringBuilder formatBuilder;
+    auto profile = StringView::fromLatin1(gstProfile);
+    auto isY444 = profile.findIgnoringASCIICase("high-4:4:4"_s) != notFound;
+    auto isY422 = profile.findIgnoringASCIICase("high-4:2:2"_s) != notFound;
+    auto isY420 = profile.findIgnoringASCIICase("high-10"_s) != notFound;
+    if (isY444)
+        formatBuilder.append("Y444"_s);
+    else if (isY422)
+        formatBuilder.append("I422"_s);
+    else if (isY420)
+        formatBuilder.append("Y420"_s);
+    else
+        formatBuilder.append("I420"_s);
+
+    if (isY444 || isY422 || isY420) {
+#if G_BYTE_ORDER == G_LITTLE_ENDIAN
+        auto endianness = "LE"_s;
+#else
+        auto endianness = "BE"_s;
+#endif
+        formatBuilder.append("_10"_s, endianness);
+    }
+
+    auto pixelFormat = formatBuilder.toString();
+    GST_DEBUG("Setting pixel format %s for profile %s", pixelFormat.ascii().data(), gstProfile);
+    auto inputCaps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, pixelFormat.ascii().data(), nullptr));
+    return { inputCaps, outputCaps };
+}
+
 const char* GStreamerCodecUtilities::parseHEVCProfile(const String& codec)
 {
     ensureDebugCategoryInitialized();
@@ -105,7 +142,45 @@ const char* GStreamerCodecUtilities::parseHEVCProfile(const String& codec)
     return gst_codec_utils_h265_get_profile(profileTierLevel, sizeof(profileTierLevel));
 }
 
-static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> vpxCapsFromCodecString(const String& codecString, unsigned width, unsigned height, int framerateNumerator, int framerateDenominator)
+static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> h265CapsFromCodecString(const String& codecString)
+{
+    auto outputCaps = adoptGRef(gst_caps_new_empty_simple("video/x-h265"));
+    auto gstProfile = GStreamerCodecUtilities::parseHEVCProfile(codecString);
+    if (gstProfile)
+        gst_caps_set_simple(outputCaps.get(), "profile", G_TYPE_STRING, gstProfile, nullptr);
+
+    StringBuilder formatBuilder;
+    auto profile = StringView::fromLatin1(gstProfile);
+    auto isY444 = profile.findIgnoringASCIICase("-444"_s) != notFound;
+    auto isY422 = profile.findIgnoringASCIICase("-422"_s) != notFound;
+    if (isY444)
+        formatBuilder.append("Y444"_s);
+    else if (isY422)
+        formatBuilder.append("I422"_s);
+    else
+        formatBuilder.append("I420"_s);
+
+    if (isY444 || isY422) {
+#if G_BYTE_ORDER == G_LITTLE_ENDIAN
+        auto endianness = "LE"_s;
+#else
+        auto endianness = "BE"_s;
+#endif
+        auto is12Bits = profile.findIgnoringASCIICase("-12"_s) != notFound;
+        auto is10Bits = profile.findIgnoringASCIICase("-10"_s) != notFound;
+        if (is10Bits)
+            formatBuilder.append("_10"_s, endianness);
+        else if (is12Bits)
+            formatBuilder.append("_12"_s, endianness);
+    }
+
+    auto pixelFormat = formatBuilder.toString();
+    GST_DEBUG("Setting pixel format %s for profile %s", pixelFormat.ascii().data(), gstProfile);
+    auto inputCaps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, pixelFormat.ascii().data(), nullptr));
+    return { inputCaps, outputCaps };
+}
+
+static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> vpxCapsFromCodecString(const String& codecString)
 {
     auto parameters = parseVPCodecParameters(codecString);
     if (!parameters)
@@ -126,8 +201,11 @@ static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> vpxCapsFromCodecString(cons
         yuvFormat = "Y444";
     StringBuilder formatBuilder;
     formatBuilder.append(yuvFormat);
-    if (parameters->bitDepth > 8) {
-        formatBuilder.append('_', parameters->bitDepth);
+    if (parameters->bitDepth > 8 || parameters->profile == 2) {
+        if (parameters->bitDepth > 8)
+            formatBuilder.append('_', parameters->bitDepth);
+        else
+            formatBuilder.append("_10"_s);
 #if G_BYTE_ORDER == G_LITTLE_ENDIAN
         formatBuilder.append("LE"_s);
 #else
@@ -138,7 +216,8 @@ static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> vpxCapsFromCodecString(cons
     auto formatString = formatBuilder.toString();
     auto format = gst_video_format_from_string(formatString.ascii().data());
     GstVideoInfo info;
-    gst_video_info_set_format(&info, format, width, height);
+    // Setting a random size here, it is overridden later on.
+    gst_video_info_set_format(&info, format, 320, 240);
 
     if (parameters->videoFullRangeFlag == VPConfigurationRange::FullRange)
         GST_VIDEO_INFO_COLORIMETRY(&info).range = GST_VIDEO_COLOR_RANGE_0_255;
@@ -222,12 +301,10 @@ static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> vpxCapsFromCodecString(cons
     }
     inputCaps = adoptGRef(gst_video_info_to_caps(&info));
 
-    gst_caps_set_simple(inputCaps.get(), "framerate", GST_TYPE_FRACTION, framerateNumerator, framerateDenominator, nullptr);
-
     return { inputCaps, outputCaps };
 }
 
-static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> av1CapsFromCodecString(const String& codecString, unsigned width, unsigned height, int framerateNumerator, int framerateDenominator)
+static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> av1CapsFromCodecString(const String& codecString)
 {
     auto configurationRecord = parseAV1CodecParameters(codecString);
     if (!configurationRecord)
@@ -283,7 +360,8 @@ static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> av1CapsFromCodecString(cons
     auto formatString = formatBuilder.toString();
     auto format = gst_video_format_from_string(formatString.ascii().data());
     GstVideoInfo info;
-    gst_video_info_set_format(&info, format, width, height);
+    // Setting a random size here, it is overridden later on.
+    gst_video_info_set_format(&info, format, 320, 240);
 
     if (configurationRecord->videoFullRangeFlag == AV1ConfigurationRange::FullRange)
         GST_VIDEO_INFO_COLORIMETRY(&info).range = GST_VIDEO_COLOR_RANGE_0_255;
@@ -423,22 +501,56 @@ static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> av1CapsFromCodecString(cons
         gst_caps_set_simple(outputCaps.get(), "chroma-format", G_TYPE_STRING, chromaFormat, nullptr);
 
     auto inputCaps = adoptGRef(gst_video_info_to_caps(&info));
-    gst_caps_set_simple(inputCaps.get(), "framerate", GST_TYPE_FRACTION, framerateNumerator, framerateDenominator, nullptr);
     GST_DEBUG("Codec %s maps to input %" GST_PTR_FORMAT " and output %" GST_PTR_FORMAT, codecString.ascii().data(), inputCaps.get(), outputCaps.get());
     return { inputCaps, outputCaps };
 }
 
-std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> GStreamerCodecUtilities::capsFromCodecString(const String& codecString, unsigned width, unsigned height, int framerateNumerator, int framerateDenominator)
+std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> GStreamerCodecUtilities::capsFromCodecString(const String& codecString, std::optional<IntSize> size, std::optional<double> frameRate)
 {
     ensureDebugCategoryInitialized();
-    if (codecString.startsWith("vp8"_s) || codecString.startsWith("vp08"_s) || codecString.startsWith("vp9"_s) || codecString.startsWith("vp09"_s))
-        return vpxCapsFromCodecString(codecString, width, height, framerateNumerator, framerateDenominator);
 
-    if (codecString.startsWith("av01"_s))
-        return av1CapsFromCodecString(codecString, width, height, framerateNumerator, framerateDenominator);
+    auto completeCaps = [&](GRefPtr<GstCaps>&& caps) -> GRefPtr<GstCaps> {
+        if (!caps)
+            return nullptr;
 
-    if (codecString.startsWith("avc1"_s))
-        return { nullptr, nullptr };
+        if (frameRate) {
+            int framerateNumerator, framerateDenominator;
+            gst_util_double_to_fraction(*frameRate, &framerateNumerator, &framerateDenominator);
+            gst_caps_set_simple(caps.get(), "framerate", GST_TYPE_FRACTION, framerateNumerator, framerateDenominator, nullptr);
+        } else if (!gst_caps_is_any(caps.get()) && !gst_caps_is_empty(caps.get())) {
+            auto structure = gst_caps_get_structure(caps.get(), 0);
+            gst_structure_remove_field(structure, "framerate");
+        }
+
+        if (size)
+            gst_caps_set_simple(caps.get(), "width", G_TYPE_INT, size->width(), "height", G_TYPE_INT, size->height(), nullptr);
+        else if (!gst_caps_is_any(caps.get()) && !gst_caps_is_empty(caps.get())) {
+            auto structure = gst_caps_get_structure(caps.get(), 0);
+            gst_structure_remove_fields(structure, "width", "height", nullptr);
+        }
+        return caps;
+    };
+
+    if (codecString.startsWith("vp8"_s) || codecString.startsWith("vp08"_s) || codecString.startsWith("vp9"_s) || codecString.startsWith("vp09"_s)) {
+        auto [inputCaps, outputCaps] = vpxCapsFromCodecString(codecString);
+        return { completeCaps(WTFMove(inputCaps)), completeCaps(WTFMove(outputCaps)) };
+    }
+
+    if (codecString.startsWith("av01"_s)) {
+        auto [inputCaps, outputCaps] = av1CapsFromCodecString(codecString);
+        return { completeCaps(WTFMove(inputCaps)), completeCaps(WTFMove(outputCaps)) };
+    }
+
+    if (codecString.startsWith("avc1"_s)) {
+        auto [inputCaps, outputCaps] = h264CapsFromCodecString(codecString);
+        return { completeCaps(WTFMove(inputCaps)), completeCaps(WTFMove(outputCaps)) };
+    }
+
+    if (codecString.startsWith("hvc1"_s) || codecString.startsWith("hev1"_s)) {
+        auto [inputCaps, outputCaps] = h265CapsFromCodecString(codecString);
+        return { completeCaps(WTFMove(inputCaps)), completeCaps(WTFMove(outputCaps)) };
+    }
+
     return { nullptr, nullptr };
 }
 

--- a/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.h
@@ -22,7 +22,7 @@
 #if USE(GSTREAMER)
 
 #include "GRefPtrGStreamer.h"
-
+#include "IntSize.h"
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -31,7 +31,7 @@ namespace GStreamerCodecUtilities {
 
 std::pair<const char*, const char*> parseH264ProfileAndLevel(const String& codec);
 const char* parseHEVCProfile(const String& codec);
-std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> capsFromCodecString(const String&, unsigned width, unsigned height, int framerateNumerator, int framerateDenominator);
+std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> capsFromCodecString(const String&, std::optional<IntSize> = std::nullopt, std::optional<double> frameRate = std::nullopt);
 
 } // namespace GStreamerCodecUtilities
 

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.h
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.h
@@ -86,7 +86,7 @@ private:
     std::optional<uint32_t> m_bitRates[MaxSpatialLayers][MaxTemporalLayers];
 };
 
-bool videoEncoderSupportsFormat(WebKitVideoEncoder*, const GRefPtr<GstCaps>&);
-bool videoEncoderSetFormat(WebKitVideoEncoder*, GRefPtr<GstCaps>&&, const String& = emptyString());
+bool videoEncoderSupportsCodec(WebKitVideoEncoder*, const String&);
+bool videoEncoderSetCodec(WebKitVideoEncoder*, const String&, std::optional<WebCore::IntSize> = std::nullopt, std::optional<double> frameRate = std::nullopt);
 void videoEncoderSetBitRateAllocation(WebKitVideoEncoder*, RefPtr<WebKitVideoEncoderBitRateAllocation>&&);
 void teardownVideoEncoderSingleton();

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
@@ -23,6 +23,7 @@
 #if USE(GSTREAMER_TRANSCODER)
 
 #include "ContentType.h"
+#include "GStreamerCodecUtilities.h"
 #include "GStreamerCommon.h"
 #include "GStreamerMediaStreamSource.h"
 #include "GStreamerRegistryScanner.h"
@@ -240,28 +241,12 @@ GRefPtr<GstEncodingContainerProfile> MediaRecorderPrivateBackend::containerProfi
         gst_encoding_profile_set_element_properties(GST_ENCODING_PROFILE(profile.get()), gst_structure_from_string("element-properties-map, map={[mp4mux,fragment-duration=1000,fragment-mode=0,streamable=0,force-create-timecode-trak=1]}", nullptr));
 
     auto codecs = contentType.codecs();
-    // TODO: Handle profiles.
     if (selectedTracks.videoTrack) {
-        String videoCapsName;
-        if (codecs.contains("vp8"_s))
-            videoCapsName = "video/x-vp8"_s;
-        else if (codecs.contains("vp9"_s))
-            videoCapsName = "video/x-vp9"_s;
-        else if (codecs.contains("av1"_s))
-            videoCapsName = "video/x-av1"_s;
-        else if (codecs.findIf([](auto& codec) { return codec.startsWith("avc1"_s); }) != notFound)
-            videoCapsName = "video/x-h264"_s;
-        else if (containerType.endsWith("webm"_s))
-            videoCapsName = "video/x-vp8"_s;
-        else if (containerType.endsWith("mp4"_s))
-            videoCapsName = "video/x-h264"_s;
-        else {
-            GST_WARNING("Video codec for %s not supported", contentType.raw().utf8().data());
-            return nullptr;
-        }
-
-        RELEASE_ASSERT(!videoCapsName.isEmpty());
-        auto videoCaps = adoptGRef(gst_caps_new_empty_simple(videoCapsName.utf8().data()));
+        if (codecs.isEmpty())
+            m_videoCodec = "avc1.4d002a"_s;
+        else
+            m_videoCodec = codecs.first();
+        auto [_, videoCaps] = GStreamerCodecUtilities::capsFromCodecString(m_videoCodec);
         GST_DEBUG("Creating video encoding profile for caps %" GST_PTR_FORMAT, videoCaps.get());
         m_videoEncodingProfile = adoptGRef(GST_ENCODING_PROFILE(gst_encoding_video_profile_new(videoCaps.get(), nullptr, nullptr, 1)));
         gst_encoding_container_profile_add_profile(profile.get(), m_videoEncodingProfile.get());
@@ -341,8 +326,7 @@ void MediaRecorderPrivateBackend::setSink(GstElement* element)
 
 void MediaRecorderPrivateBackend::configureVideoEncoder(GstElement* element)
 {
-    auto format = adoptGRef(gst_encoding_profile_get_format(GST_ENCODING_PROFILE(m_videoEncodingProfile.get())));
-    g_object_set(element, "format", format.get(), nullptr);
+    videoEncoderSetCodec(WEBKIT_VIDEO_ENCODER(element), m_videoCodec);
 
     auto bitrate = [options = m_options]() -> unsigned {
         if (options.videoBitsPerSecond)

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.h
@@ -73,6 +73,7 @@ private:
 
     GRefPtr<GstEncodingProfile> m_audioEncodingProfile;
     GRefPtr<GstEncodingProfile> m_videoEncodingProfile;
+    String m_videoCodec;
     GRefPtr<GstTranscoder> m_transcoder;
     GRefPtr<GstTranscoderSignalAdapter> m_signalAdapter;
     GRefPtr<GstElement> m_pipeline;

--- a/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp
@@ -108,7 +108,7 @@ TEST_F(GStreamerTest, capsFromCodecString)
     using namespace GStreamerCodecUtilities;
 
 #define TEST_CAPS_FROM_CODEC(codecString, expectedInputFormat, expectedOutputCaps) G_STMT_START { \
-        auto [input, output] = capsFromCodecString(codecString, 320, 240, 30, 1); \
+        auto [input, output] = capsFromCodecString(codecString);        \
         auto inputStructure = gst_caps_get_structure(input.get(), 0);   \
         const char* inputFormat = gst_structure_get_string(inputStructure, "format"); \
         ASSERT_STREQ(inputFormat, expectedInputFormat);                 \
@@ -117,7 +117,7 @@ TEST_F(GStreamerTest, capsFromCodecString)
     } G_STMT_END
 
 #define TEST_CAPS_FROM_CODEC_FULL(codecString, expectedInputCaps, expectedOutputCaps) G_STMT_START { \
-        auto [input, output] = capsFromCodecString(codecString, 320, 240, 30, 1); \
+        auto [input, output] = capsFromCodecString(codecString);        \
         GUniquePtr<char> inputCaps(gst_caps_to_string(input.get()));    \
         ASSERT_STREQ(inputCaps.get(), expectedInputCaps);               \
         GUniquePtr<char> outputCaps(gst_caps_to_string(output.get()));  \
@@ -146,23 +146,23 @@ TEST_F(GStreamerTest, capsFromCodecString)
     TEST_CAPS_FROM_CODEC("av01.0.00M.10.0.112"_s, "I420_10LE", "video/x-av1, profile=(string)main, bit-depth-luma=(uint)10, bit-depth-chroma=(uint)10, chroma-format=(string)4:2:0");
 
     // AV1 colorimetry.
-    TEST_CAPS_FROM_CODEC_FULL("av01.0.00M.10.0.110.01"_s, "video/x-raw, format=(string)I420_10LE, width=(int)320, height=(int)240, interlace-mode=(string)progressive, pixel-aspect-ratio=(fraction)1/1, chroma-site=(string)jpeg, colorimetry=(string)bt709, framerate=(fraction)30/1", "video/x-av1, profile=(string)main, bit-depth-luma=(uint)10, bit-depth-chroma=(uint)10, chroma-format=(string)4:2:0");
-    TEST_CAPS_FROM_CODEC_FULL("av01.0.00M.10.0.110.09"_s, "video/x-raw, format=(string)I420_10LE, width=(int)320, height=(int)240, interlace-mode=(string)progressive, pixel-aspect-ratio=(fraction)1/1, chroma-site=(string)jpeg, colorimetry=(string)2:3:5:7, framerate=(fraction)30/1", "video/x-av1, profile=(string)main, bit-depth-luma=(uint)10, bit-depth-chroma=(uint)10, chroma-format=(string)4:2:0");
+    TEST_CAPS_FROM_CODEC_FULL("av01.0.00M.10.0.110.01"_s, "video/x-raw, format=(string)I420_10LE, interlace-mode=(string)progressive, pixel-aspect-ratio=(fraction)1/1, chroma-site=(string)jpeg, colorimetry=(string)bt709", "video/x-av1, profile=(string)main, bit-depth-luma=(uint)10, bit-depth-chroma=(uint)10, chroma-format=(string)4:2:0");
+    TEST_CAPS_FROM_CODEC_FULL("av01.0.00M.10.0.110.09"_s, "video/x-raw, format=(string)I420_10LE, interlace-mode=(string)progressive, pixel-aspect-ratio=(fraction)1/1, chroma-site=(string)jpeg, colorimetry=(string)2:3:5:7", "video/x-av1, profile=(string)main, bit-depth-luma=(uint)10, bit-depth-chroma=(uint)10, chroma-format=(string)4:2:0");
 
     // AV1 bt709 transfer characteristics.
-    TEST_CAPS_FROM_CODEC_FULL("av01.0.00M.10.0.110.01.01"_s, "video/x-raw, format=(string)I420_10LE, width=(int)320, height=(int)240, interlace-mode=(string)progressive, pixel-aspect-ratio=(fraction)1/1, chroma-site=(string)jpeg, colorimetry=(string)bt709, framerate=(fraction)30/1", "video/x-av1, profile=(string)main, bit-depth-luma=(uint)10, bit-depth-chroma=(uint)10, chroma-format=(string)4:2:0");
-    TEST_CAPS_FROM_CODEC_FULL("av01.0.00M.10.0.110.01.04"_s, "video/x-raw, format=(string)I420_10LE, width=(int)320, height=(int)240, interlace-mode=(string)progressive, pixel-aspect-ratio=(fraction)1/1, chroma-site=(string)jpeg, colorimetry=(string)bt709, framerate=(fraction)30/1", "video/x-av1, profile=(string)main, bit-depth-luma=(uint)10, bit-depth-chroma=(uint)10, chroma-format=(string)4:2:0");
+    TEST_CAPS_FROM_CODEC_FULL("av01.0.00M.10.0.110.01.01"_s, "video/x-raw, format=(string)I420_10LE, interlace-mode=(string)progressive, pixel-aspect-ratio=(fraction)1/1, chroma-site=(string)jpeg, colorimetry=(string)bt709", "video/x-av1, profile=(string)main, bit-depth-luma=(uint)10, bit-depth-chroma=(uint)10, chroma-format=(string)4:2:0");
+    TEST_CAPS_FROM_CODEC_FULL("av01.0.00M.10.0.110.01.04"_s, "video/x-raw, format=(string)I420_10LE, interlace-mode=(string)progressive, pixel-aspect-ratio=(fraction)1/1, chroma-site=(string)jpeg, colorimetry=(string)bt709", "video/x-av1, profile=(string)main, bit-depth-luma=(uint)10, bit-depth-chroma=(uint)10, chroma-format=(string)4:2:0");
 
     // AV1 custom transfer characteristics.
-    TEST_CAPS_FROM_CODEC_FULL("av01.0.00M.10.0.110.01.06"_s, "video/x-raw, format=(string)I420_10LE, width=(int)320, height=(int)240, interlace-mode=(string)progressive, pixel-aspect-ratio=(fraction)1/1, chroma-site=(string)jpeg, colorimetry=(string)2:3:16:1, framerate=(fraction)30/1", "video/x-av1, profile=(string)main, bit-depth-luma=(uint)10, bit-depth-chroma=(uint)10, chroma-format=(string)4:2:0");
-    TEST_CAPS_FROM_CODEC_FULL("av01.0.00M.10.0.110.01.13"_s, "video/x-raw, format=(string)I420_10LE, width=(int)320, height=(int)240, interlace-mode=(string)progressive, pixel-aspect-ratio=(fraction)1/1, chroma-site=(string)jpeg, colorimetry=(string)2:3:0:1, framerate=(fraction)30/1", "video/x-av1, profile=(string)main, bit-depth-luma=(uint)10, bit-depth-chroma=(uint)10, chroma-format=(string)4:2:0");
-    TEST_CAPS_FROM_CODEC_FULL("av01.0.00M.10.0.110.01.14"_s, "video/x-raw, format=(string)I420_10LE, width=(int)320, height=(int)240, interlace-mode=(string)progressive, pixel-aspect-ratio=(fraction)1/1, chroma-site=(string)jpeg, colorimetry=(string)2:3:13:1, framerate=(fraction)30/1", "video/x-av1, profile=(string)main, bit-depth-luma=(uint)10, bit-depth-chroma=(uint)10, chroma-format=(string)4:2:0");
-    TEST_CAPS_FROM_CODEC_FULL("av01.0.00M.10.0.110.01.15"_s, "video/x-raw, format=(string)I420_10LE, width=(int)320, height=(int)240, interlace-mode=(string)progressive, pixel-aspect-ratio=(fraction)1/1, chroma-site=(string)jpeg, colorimetry=(string)2:3:11:1, framerate=(fraction)30/1", "video/x-av1, profile=(string)main, bit-depth-luma=(uint)10, bit-depth-chroma=(uint)10, chroma-format=(string)4:2:0");
-    TEST_CAPS_FROM_CODEC_FULL("av01.0.00M.10.0.110.01.16"_s, "video/x-raw, format=(string)I420_10LE, width=(int)320, height=(int)240, interlace-mode=(string)progressive, pixel-aspect-ratio=(fraction)1/1, chroma-site=(string)jpeg, colorimetry=(string)2:3:14:1, framerate=(fraction)30/1", "video/x-av1, profile=(string)main, bit-depth-luma=(uint)10, bit-depth-chroma=(uint)10, chroma-format=(string)4:2:0");
+    TEST_CAPS_FROM_CODEC_FULL("av01.0.00M.10.0.110.01.06"_s, "video/x-raw, format=(string)I420_10LE, interlace-mode=(string)progressive, pixel-aspect-ratio=(fraction)1/1, chroma-site=(string)jpeg, colorimetry=(string)2:3:16:1", "video/x-av1, profile=(string)main, bit-depth-luma=(uint)10, bit-depth-chroma=(uint)10, chroma-format=(string)4:2:0");
+    TEST_CAPS_FROM_CODEC_FULL("av01.0.00M.10.0.110.01.13"_s, "video/x-raw, format=(string)I420_10LE, interlace-mode=(string)progressive, pixel-aspect-ratio=(fraction)1/1, chroma-site=(string)jpeg, colorimetry=(string)2:3:0:1", "video/x-av1, profile=(string)main, bit-depth-luma=(uint)10, bit-depth-chroma=(uint)10, chroma-format=(string)4:2:0");
+    TEST_CAPS_FROM_CODEC_FULL("av01.0.00M.10.0.110.01.14"_s, "video/x-raw, format=(string)I420_10LE, interlace-mode=(string)progressive, pixel-aspect-ratio=(fraction)1/1, chroma-site=(string)jpeg, colorimetry=(string)2:3:13:1", "video/x-av1, profile=(string)main, bit-depth-luma=(uint)10, bit-depth-chroma=(uint)10, chroma-format=(string)4:2:0");
+    TEST_CAPS_FROM_CODEC_FULL("av01.0.00M.10.0.110.01.15"_s, "video/x-raw, format=(string)I420_10LE, interlace-mode=(string)progressive, pixel-aspect-ratio=(fraction)1/1, chroma-site=(string)jpeg, colorimetry=(string)2:3:11:1", "video/x-av1, profile=(string)main, bit-depth-luma=(uint)10, bit-depth-chroma=(uint)10, chroma-format=(string)4:2:0");
+    TEST_CAPS_FROM_CODEC_FULL("av01.0.00M.10.0.110.01.16"_s, "video/x-raw, format=(string)I420_10LE, interlace-mode=(string)progressive, pixel-aspect-ratio=(fraction)1/1, chroma-site=(string)jpeg, colorimetry=(string)2:3:14:1", "video/x-av1, profile=(string)main, bit-depth-luma=(uint)10, bit-depth-chroma=(uint)10, chroma-format=(string)4:2:0");
 
     // AV1 video full range flag.
-    TEST_CAPS_FROM_CODEC_FULL("av01.0.00M.10.0.110.01.01.00.0"_s, "video/x-raw, format=(string)I420_10LE, width=(int)320, height=(int)240, interlace-mode=(string)progressive, pixel-aspect-ratio=(fraction)1/1, chroma-site=(string)jpeg, colorimetry=(string)2:1:5:1, framerate=(fraction)30/1", "video/x-av1, profile=(string)main, bit-depth-luma=(uint)10, bit-depth-chroma=(uint)10, chroma-format=(string)4:2:0");
-    TEST_CAPS_FROM_CODEC_FULL("av01.0.00M.10.0.110.01.01.00.1"_s, "video/x-raw, format=(string)I420_10LE, width=(int)320, height=(int)240, interlace-mode=(string)progressive, pixel-aspect-ratio=(fraction)1/1, chroma-site=(string)jpeg, colorimetry=(string)1:1:5:1, framerate=(fraction)30/1", "video/x-av1, profile=(string)main, bit-depth-luma=(uint)10, bit-depth-chroma=(uint)10, chroma-format=(string)4:2:0");
+    TEST_CAPS_FROM_CODEC_FULL("av01.0.00M.10.0.110.01.01.00.0"_s, "video/x-raw, format=(string)I420_10LE, interlace-mode=(string)progressive, pixel-aspect-ratio=(fraction)1/1, chroma-site=(string)jpeg, colorimetry=(string)2:1:5:1", "video/x-av1, profile=(string)main, bit-depth-luma=(uint)10, bit-depth-chroma=(uint)10, chroma-format=(string)4:2:0");
+    TEST_CAPS_FROM_CODEC_FULL("av01.0.00M.10.0.110.01.01.00.1"_s, "video/x-raw, format=(string)I420_10LE, interlace-mode=(string)progressive, pixel-aspect-ratio=(fraction)1/1, chroma-site=(string)jpeg, colorimetry=(string)1:1:5:1", "video/x-av1, profile=(string)main, bit-depth-luma=(uint)10, bit-depth-chroma=(uint)10, chroma-format=(string)4:2:0");
 
 #undef TEST_CAPS_FROM_CODEC
 #undef TEST_CAPS_FROM_CODEC_FULL


### PR DESCRIPTION
#### a65cb6426ce7d364e4f0c462533bf67e5d0abb5f
<pre>
[GStreamer] Video encoder configuration using codec strings
<a href="https://bugs.webkit.org/show_bug.cgi?id=273398">https://bugs.webkit.org/show_bug.cgi?id=273398</a>

Reviewed by Xabier Rodriguez-Calvar.

The video encoder used to be configurable with output caps, but that wasn&apos;t sufficient so later on
it was extended with some support for codec string handling, which made the code more complex. By
dropping GstCaps configuration support and by relying only on codec string parsing, the input/output
caps logic is now decided in the GStreamerCodecUtilities. So modules making use of codec
strings (MediaRecorder, WebCodecs) pass their configuration directly to the encoder. For WebRTC we
forge a codec string according to the negotiated video encoding-name. Later on for simulcast the
codec strings from the RtpSender parameters will be leveraged.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::fillVideoRtpCapabilities):
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp:
(WebCore::GStreamerInternalVideoEncoder::initialize):
* Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp:
(WebCore::h264CapsFromCodecString):
(WebCore::h265CapsFromCodecString):
(WebCore::vpxCapsFromCodecString):
(WebCore::av1CapsFromCodecString):
(WebCore::GStreamerCodecUtilities::capsFromCodecString):
* Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.h:
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(videoEncoderGetProperty):
(videoEncoderSetEncoder):
(videoEncoderFindForCodec):
(videoEncoderSupportsCodec):
(videoEncoderSetCodec):
(videoEncoderSetProperty):
(webkit_video_encoder_class_init):
(videoEncoderSupportsFormat): Deleted.
(videoEncoderSetFormat): Deleted.
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.h:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp:
(WebCore::MediaRecorderPrivateBackend::containerProfile):
(WebCore::MediaRecorderPrivateBackend::configureVideoEncoder):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingVideoSourceGStreamer::setPayloadType):
* Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/278266@main">https://commits.webkit.org/278266@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4e98e1a77f991cf100b2685ddce00bc35737d85

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50029 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53272 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/706 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52330 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35420 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/275 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52127 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26899 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21931 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24324 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/283 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8399 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46371 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/330 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54854 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25123 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48194 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26381 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43243 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/10967 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/27244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26110 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->