### PR TITLE
[IFC][Integration] Remove BoxTree::layoutBoxForRenderer/rendererForLayoutBox

### DIFF
--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.h
@@ -63,17 +63,6 @@ public:
     const Layout::ElementBox& rootLayoutBox() const;
     Layout::ElementBox& rootLayoutBox();
 
-    const Layout::Box& layoutBoxForRenderer(const RenderObject&) const;
-    Layout::Box& layoutBoxForRenderer(const RenderObject&);
-
-    const Layout::ElementBox& layoutBoxForRenderer(const RenderElement&) const;
-    Layout::ElementBox& layoutBoxForRenderer(const RenderElement&);
-
-    const RenderObject& rendererForLayoutBox(const Layout::Box&) const;
-    RenderObject& rendererForLayoutBox(const Layout::Box&);
-
-    bool hasRendererForLayoutBox(const Layout::Box&) const;
-
     bool contains(const RenderElement&) const;
 
 private:

--- a/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
+++ b/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
@@ -98,7 +98,7 @@ void FlexLayout::updateFormattingRootGeometryAndInvalidate()
 void FlexLayout::updateFlexItemDimensions(const RenderBlock& flexItem, LayoutUnit, LayoutUnit)
 {
     auto& rootGeometry = layoutState().geometryForBox(flexBox());
-    auto& layoutBox = m_boxTree.layoutBoxForRenderer(flexItem);
+    auto& layoutBox = *flexItem.layoutBox();
     auto& boxGeometry = layoutState().ensureGeometryForBox(layoutBox);
     auto& style = flexItem.style();
 

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPath.h
@@ -93,12 +93,12 @@ public:
 
     const RenderObject& renderer() const
     {
-        return m_inlineContent->rendererForLayoutBox(box().layoutBox());
+        return *box().layoutBox().rendererForIntegration();
     }
 
     bool hasRenderer() const
     {
-        return m_inlineContent->hasRendererForLayoutBox(box().layoutBox());
+        return !!box().layoutBox().rendererForIntegration();
     }
 
     const RenderBlockFlow& formattingContextRoot() const

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -72,7 +72,7 @@ void BoxGeometryUpdater::updateListMarkerDimensions(const RenderListMarker& list
     if (intrinsicWidthMode)
         return;
 
-    auto& layoutBox = boxTree().layoutBoxForRenderer(listMarker);
+    auto& layoutBox = *listMarker.layoutBox();
     if (layoutBox.isListMarkerOutside()) {
         auto* ancestor = listMarker.containingBlock();
         auto offsetFromParentListItem = [&] {
@@ -218,7 +218,7 @@ static inline LayoutSize scrollbarLogicalSize(const RenderBox& renderer)
 
 void BoxGeometryUpdater::updateLayoutBoxDimensions(const RenderBox& renderBox, std::optional<Layout::IntrinsicWidthMode> intrinsicWidthMode)
 {
-    auto& layoutBox = boxTree().layoutBoxForRenderer(renderBox);
+    auto& layoutBox = const_cast<Layout::ElementBox&>(*renderBox.layoutBox());
     auto isLeftToRightInlineDirection = renderBox.parent()->style().isLeftToRightDirection();
     auto blockFlowDirection = writingModeToBlockFlowDirection(renderBox.parent()->style().writingMode());
     auto isHorizontalWritingMode = blockFlowDirection == BlockFlowDirection::TopToBottom || blockFlowDirection == BlockFlowDirection::BottomToTop;
@@ -293,7 +293,7 @@ void BoxGeometryUpdater::updateLayoutBoxDimensions(const RenderBox& renderBox, s
 void BoxGeometryUpdater::updateLineBreakBoxDimensions(const RenderLineBreak& lineBreakBox)
 {
     // This is just a box geometry reset (see InlineFormattingContext::layoutInFlowContent).
-    auto& boxGeometry = layoutState().ensureGeometryForBox(boxTree().layoutBoxForRenderer(lineBreakBox));
+    auto& boxGeometry = layoutState().ensureGeometryForBox(*lineBreakBox.layoutBox());
 
     boxGeometry.setHorizontalMargin({ });
     boxGeometry.setBorder({ });
@@ -306,7 +306,7 @@ void BoxGeometryUpdater::updateLineBreakBoxDimensions(const RenderLineBreak& lin
 
 void BoxGeometryUpdater::updateInlineBoxDimensions(const RenderInline& renderInline, std::optional<Layout::IntrinsicWidthMode> intrinsicWidthMode)
 {
-    auto& boxGeometry = layoutState().ensureGeometryForBox(boxTree().layoutBoxForRenderer(renderInline));
+    auto& boxGeometry = layoutState().ensureGeometryForBox(*renderInline.layoutBox());
 
     // Check if this renderer is part of a continuation and adjust horizontal margin/border/padding accordingly.
     auto shouldNotRetainBorderPaddingAndMarginStart = renderInline.isContinuation();

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp
@@ -90,16 +90,6 @@ IteratorRange<const InlineDisplay::Box*> InlineContent::boxesForRect(const Layou
     return { &boxes[firstBox], &boxes[lastBox] + 1 };
 }
 
-const RenderObject& InlineContent::rendererForLayoutBox(const Layout::Box& layoutBox) const
-{
-    return lineLayout().rendererForLayoutBox(layoutBox);
-}
-
-bool InlineContent::hasRendererForLayoutBox(const Layout::Box& layoutBox) const
-{
-    return lineLayout().hasRendererForLayoutBox(layoutBox);
-}
-
 const RenderBlockFlow& InlineContent::formattingContextRoot() const
 {
     return lineLayout().flow();

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
@@ -77,10 +77,7 @@ struct InlineContent : public CanMakeWeakPtr<InlineContent> {
     void shrinkToFit();
 
     const LineLayout& lineLayout() const { return *m_lineLayout; }
-    const RenderObject& rendererForLayoutBox(const Layout::Box&) const;
     const RenderBlockFlow& formattingContextRoot() const;
-
-    bool hasRendererForLayoutBox(const Layout::Box&) const;
 
     size_t indexForBox(const InlineDisplay::Box&) const;
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
@@ -236,7 +236,7 @@ void InlineContentBuilder::adjustDisplayLines(InlineContent& inlineContent, size
             }
 
             if (box.isAtomicInlineLevelBox()) {
-                auto& renderer = downcast<RenderBox>(m_boxTree.rendererForLayoutBox(box.layoutBox()));
+                auto& renderer = downcast<RenderBox>(*box.layoutBox().rendererForIntegration());
                 if (!renderer.hasSelfPaintingLayer()) {
                     auto childInkOverflow = renderer.logicalVisualOverflowRectForPropagation(&renderer.parent()->style());
                     childInkOverflow.move(box.left(), box.top());
@@ -249,7 +249,7 @@ void InlineContentBuilder::adjustDisplayLines(InlineContent& inlineContent, size
             }
 
             if (box.isInlineBox()) {
-                if (!downcast<RenderElement>(m_boxTree.rendererForLayoutBox(box.layoutBox())).hasSelfPaintingLayer())
+                if (!downcast<RenderElement>(*box.layoutBox().rendererForIntegration()).hasSelfPaintingLayer())
                     inkOverflowRect.unite(box.inkOverflow());
             }
         }
@@ -291,7 +291,7 @@ void InlineContentBuilder::computeIsFirstIsLastBoxAndBidiReorderingForInlineCont
         }
         auto& layoutBox = displayBox.layoutBox();
         if (is<Layout::InlineTextBox>(layoutBox) && displayBox.bidiLevel() != UBIDI_DEFAULT_LTR)
-            downcast<RenderText>(m_boxTree.rendererForLayoutBox(layoutBox)).setNeedsVisualReordering();
+            downcast<RenderText>(*layoutBox.rendererForIntegration()).setNeedsVisualReordering();
 
         if (lastDisplayBoxForLayoutBoxIndexes.set(&layoutBox, index).isNewEntry)
             displayBox.setIsFirstForLayoutBox(true);

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
@@ -97,7 +97,7 @@ void InlineContentPainter::paintDisplayBox(const InlineDisplay::Box& box)
         return;
     }
 
-    if (auto* renderer = dynamicDowncast<RenderBox>(m_boxTree.rendererForLayoutBox(box.layoutBox())); renderer && renderer->isReplacedOrInlineBlock()) {
+    if (auto* renderer = dynamicDowncast<RenderBox>(box.layoutBox().rendererForIntegration()); renderer && renderer->isReplacedOrInlineBlock()) {
         if (m_paintInfo.shouldPaintWithinRoot(*renderer)) {
             // FIXME: Painting should not require a non-const renderer.
             const_cast<RenderBox*>(renderer)->paintAsInlineBlock(m_paintInfo, flippedContentOffsetIfNeeded(*renderer));
@@ -153,7 +153,7 @@ LayoutPoint InlineContentPainter::flippedContentOffsetIfNeeded(const RenderBox& 
 
 LayerPaintScope::LayerPaintScope(const BoxTree& boxTree, const RenderInline* layerRenderer)
     : m_boxTree(boxTree)
-    , m_layerInlineBox(layerRenderer ? &boxTree.layoutBoxForRenderer(*layerRenderer) : nullptr)
+    , m_layerInlineBox(layerRenderer ? layerRenderer->layoutBox() : nullptr)
 {
 }
 
@@ -185,7 +185,7 @@ bool LayerPaintScope::includes(const InlineDisplay::Box& box)
     if (box.isRootInlineBox() || box.isText() || box.isLineBreak())
         return true;
 
-    auto* renderer = dynamicDowncast<RenderLayerModelObject>(m_boxTree.rendererForLayoutBox(box.layoutBox()));
+    auto* renderer = dynamicDowncast<RenderLayerModelObject>(box.layoutBox().rendererForIntegration());
     bool hasSelfPaintingLayer = renderer && renderer->hasSelfPaintingLayer();
 
     if (hasSelfPaintingLayer && box.isNonRootInlineBox())

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
@@ -121,8 +121,6 @@ public:
     InlineIterator::LineBoxIterator firstLineBox() const;
     InlineIterator::LineBoxIterator lastLineBox() const;
 
-    const RenderObject& rendererForLayoutBox(const Layout::Box&) const;
-    bool hasRendererForLayoutBox(const Layout::Box&) const;
     const RenderBlockFlow& flow() const { return downcast<RenderBlockFlow>(m_boxTree.rootRenderer()); }
     RenderBlockFlow& flow() { return downcast<RenderBlockFlow>(m_boxTree.rootRenderer()); }
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp
@@ -63,7 +63,7 @@ std::pair<Vector<LineAdjustment>, std::optional<size_t>> computeAdjustmentsForPa
         if (!floatBox.layoutBox())
             continue;
 
-        auto& renderer = downcast<RenderBox>(inlineContent.rendererForLayoutBox(*floatBox.layoutBox()));
+        auto& renderer = downcast<RenderBox>(*floatBox.layoutBox()->rendererForIntegration());
         bool isUsplittable = renderer.isUnsplittableForPagination() || renderer.style().breakInside() == BreakInside::Avoid;
 
         auto placedByLine = floatBox.placedByLine();

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -39,6 +39,7 @@
 #include "InlineIteratorTextBox.h"
 #include "InlineIteratorTextBoxInlines.h"
 #include "InlineRunAndOffset.h"
+#include "LayoutInlineTextBox.h"
 #include "LayoutIntegrationLineLayout.h"
 #include "LineSelection.h"
 #include "LocalFrame.h"
@@ -272,6 +273,16 @@ RenderText::~RenderText()
 {
     // Do not add any code here. Add it to willBeDestroyed() instead.
     ASSERT(!originalTextMap().contains(this));
+}
+
+Layout::InlineTextBox* RenderText::layoutBox()
+{
+    return downcast<Layout::InlineTextBox>(RenderObject::layoutBox());
+}
+
+const Layout::InlineTextBox* RenderText::layoutBox() const
+{
+    return downcast<Layout::InlineTextBox>(RenderObject::layoutBox());
 }
 
 ASCIILiteral RenderText::renderName() const
@@ -1683,7 +1694,7 @@ void RenderText::secureText(UChar maskingCharacter)
         characters[revealedCharactersOffset] = characterToReveal;
 }
 
-static void invalidateLineLayoutPathOnContentChangeIfNeeded(const RenderText& renderer, size_t offset, int delta)
+static void invalidateLineLayoutPathOnContentChangeIfNeeded(RenderText& renderer, size_t offset, int delta)
 {
     auto* container = LayoutIntegration::LineLayout::blockContainer(renderer);
     if (!container)

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -36,6 +36,10 @@ class LegacyInlineTextBox;
 struct GlyphOverflow;
 struct WordTrailingSpace;
 
+namespace Layout {
+class InlineTextBox;
+}
+
 namespace LayoutIntegration {
 class LineLayout;
 }
@@ -48,6 +52,9 @@ public:
     RenderText(Type, Document&, const String&);
 
     virtual ~RenderText();
+
+    Layout::InlineTextBox* layoutBox();
+    const Layout::InlineTextBox* layoutBox() const;
 
     WEBCORE_EXPORT Text* textNode() const;
 


### PR DESCRIPTION
#### 3a591537a16cef9f11a37f3220807774720aba8c
<pre>
[IFC][Integration] Remove BoxTree::layoutBoxForRenderer/rendererForLayoutBox
<a href="https://bugs.webkit.org/show_bug.cgi?id=273408">https://bugs.webkit.org/show_bug.cgi?id=273408</a>
<a href="https://rdar.apple.com/problem/127236477">rdar://problem/127236477</a>

Reviewed by Alan Baradlay.

Use the direct accessors instead.

* Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp:
(WebCore::LayoutIntegration::BoxTree::insertChild):
(WebCore::LayoutIntegration::BoxTree::updateContent):
(WebCore::LayoutIntegration::BoxTree::insert):
(WebCore::LayoutIntegration::showInlineContent):
(WebCore::LayoutIntegration::BoxTree::layoutBoxForRenderer): Deleted.
(WebCore::LayoutIntegration::BoxTree::layoutBoxForRenderer const): Deleted.
(WebCore::LayoutIntegration::BoxTree::rendererForLayoutBox): Deleted.
(WebCore::LayoutIntegration::BoxTree::rendererForLayoutBox const): Deleted.
(WebCore::LayoutIntegration::BoxTree::hasRendererForLayoutBox const): Deleted.
* Source/WebCore/layout/integration/LayoutIntegrationBoxTree.h:
* Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp:
(WebCore::LayoutIntegration::FlexLayout::updateFlexItemDimensions):
* Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPath.h:
(WebCore::InlineIterator::BoxModernPath::renderer const):
(WebCore::InlineIterator::BoxModernPath::hasRenderer const):
* Source/WebCore/layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.cpp:
(WebCore::LayoutIntegration::BoxGeometryUpdater::updateListMarkerDimensions):
(WebCore::LayoutIntegration::BoxGeometryUpdater::updateLayoutBoxDimensions):
(WebCore::LayoutIntegration::BoxGeometryUpdater::updateLineBreakBoxDimensions):
(WebCore::LayoutIntegration::BoxGeometryUpdater::updateInlineBoxDimensions):
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp:
(WebCore::LayoutIntegration::InlineContent::rendererForLayoutBox const): Deleted.
(WebCore::LayoutIntegration::InlineContent::hasRendererForLayoutBox const): Deleted.
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h:
(WebCore::LayoutIntegration::InlineContent::lineLayout const):
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp:
(WebCore::LayoutIntegration::InlineContentBuilder::adjustDisplayLines const):
(WebCore::LayoutIntegration::InlineContentBuilder::computeIsFirstIsLastBoxAndBidiReorderingForInlineContent const):
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp:
(WebCore::LayoutIntegration::InlineContentPainter::paintDisplayBox):
(WebCore::LayoutIntegration::LayerPaintScope::LayerPaintScope):
(WebCore::LayoutIntegration::LayerPaintScope::includes):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::contains const):
(WebCore::LayoutIntegration::LineLayout::updateRenderTreePositions):
(WebCore::LayoutIntegration::LineLayout::textBoxesFor const):
(WebCore::LayoutIntegration::LineLayout::boxFor const):
(WebCore::LayoutIntegration::LineLayout::firstInlineBoxFor const):
(WebCore::LayoutIntegration::LineLayout::firstInlineBoxRect const):
(WebCore::LayoutIntegration::LineLayout::enclosingBorderBoxRectFor const):
(WebCore::LayoutIntegration::LineLayout::visualOverflowBoundingBoxRectFor const):
(WebCore::LayoutIntegration::LineLayout::collectInlineBoxRects const):
(WebCore::LayoutIntegration::LineLayout::hitTest):
(WebCore::LayoutIntegration::LineLayout::shiftLinesBy):
(WebCore::LayoutIntegration::LineLayout::removedFromTree):
(WebCore::LayoutIntegration::LineLayout::updateTextContent):
(WebCore::LayoutIntegration::LineLayout::rendererForLayoutBox const): Deleted.
(WebCore::LayoutIntegration::LineLayout::hasRendererForLayoutBox const): Deleted.
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp:
(WebCore::LayoutIntegration::computeAdjustmentsForPagination):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::layoutBox):
(WebCore::RenderText::layoutBox const):
(WebCore::invalidateLineLayoutPathOnContentChangeIfNeeded):
* Source/WebCore/rendering/RenderText.h:

Canonical link: <a href="https://commits.webkit.org/278160@main">https://commits.webkit.org/278160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8e7a403f74354fb02fa027f8549cd5484bb677c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28966 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52727 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52920 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/354 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51983 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34986 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26583 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40533 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51778 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26493 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21653 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out; 1 api test failed or timed out; Compiled WebKit (warnings); 1 api test failed or timed out; Passed API tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23935 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43967 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8049 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44471 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54498 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24765 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20920 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26032 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10899 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26880 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25757 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->