### PR TITLE
Reduce use of `const char*` in <wtf/DateMath.h>

### DIFF
--- a/Source/JavaScriptCore/runtime/JSDateMath.cpp
+++ b/Source/JavaScriptCore/runtime/JSDateMath.cpp
@@ -451,11 +451,11 @@ double DateCache::parseDate(JSGlobalObject* globalObject, VM& vm, const String& 
         return std::numeric_limits<double>::quiet_NaN();
     }
 
-    auto parseDateImpl = [this] (const char* dateString) {
+    auto parseDateImpl = [this] (const CString& dateString) {
         bool isLocalTime;
-        double value = WTF::parseES5DateFromNullTerminatedCharacters(dateString, isLocalTime);
+        double value = WTF::parseES5DateFromNullTerminatedCharacters(dateString.data(), isLocalTime);
         if (std::isnan(value))
-            value = WTF::parseDateFromNullTerminatedCharacters(dateString, isLocalTime);
+            value = WTF::parseDate(dateString.span(), isLocalTime);
 
         if (isLocalTime && std::isfinite(value))
             value -= localTimeOffset(static_cast<int64_t>(value), WTF::LocalTime).offset;
@@ -463,8 +463,7 @@ double DateCache::parseDate(JSGlobalObject* globalObject, VM& vm, const String& 
         return value;
     };
 
-    auto dateUTF8 = expectedString.value();
-    double value = parseDateImpl(dateUTF8.data());
+    double value = parseDateImpl(expectedString.value());
     m_cachedDateString = date;
     m_cachedDateStringValue = value;
     return value;

--- a/Source/WTF/wtf/DateMath.cpp
+++ b/Source/WTF/wtf/DateMath.cpp
@@ -416,11 +416,11 @@ static const struct KnownZone {
     { "pdt", -420 }
 };
 
-inline static void skipSpacesAndComments(const char*& s)
+inline static void skipSpacesAndComments(std::span<const LChar>& s)
 {
     int nesting = 0;
-    char ch;
-    while ((ch = *s)) {
+    while (!s.empty()) {
+        auto ch = s.front();
         if (!isUnicodeCompatibleASCIIWhitespace(ch)) {
             if (ch == '(')
                 nesting++;
@@ -429,20 +429,19 @@ inline static void skipSpacesAndComments(const char*& s)
             else if (nesting == 0)
                 break;
         }
-        s++;
+        s = s.subspan(1);
     }
 }
 
 // returns 0-11 (Jan-Dec); -1 on failure
-static int findMonth(const char* monthStr)
+static int findMonth(std::span<const LChar> monthStr)
 {
-    ASSERT(monthStr);
+    if (monthStr.size() < 3)
+        return -1;
+
     char needle[4];
-    for (int i = 0; i < 3; ++i) {
-        if (!*monthStr)
-            return -1;
-        needle[i] = static_cast<char>(toASCIILower(*monthStr++));
-    }
+    for (unsigned i = 0; i < 3; ++i)
+        needle[i] = static_cast<char>(toASCIILower(monthStr[i]));
     needle[3] = '\0';
     const char *haystack = "janfebmaraprmayjunjulaugsepoctnovdec";
     const char *str = strstr(haystack, needle);
@@ -454,22 +453,47 @@ static int findMonth(const char* monthStr)
     return -1;
 }
 
+// FIXME: Port call sites to the overload taking in a span and remove.
 static bool parseInt(const char* string, char** stopPosition, int base, int* result)
 {
     long longResult = strtol(string, stopPosition, base);
     // Avoid the use of errno as it is not available on Windows CE
     if (string == *stopPosition || longResult <= std::numeric_limits<int>::min() || longResult >= std::numeric_limits<int>::max())
         return false;
-    *result = static_cast<int>(longResult);
+    *result = longResult;
     return true;
 }
 
+static bool parseInt(std::span<const LChar>& string, int base, int* result)
+{
+    char* stopPosition;
+    long longResult = strtol(reinterpret_cast<const char*>(string.data()), &stopPosition, base);
+    // Avoid the use of errno as it is not available on Windows CE
+    if (string.data() == reinterpret_cast<const LChar*>(stopPosition) || longResult <= std::numeric_limits<int>::min() || longResult >= std::numeric_limits<int>::max())
+        return false;
+    string = string.subspan(reinterpret_cast<const LChar*>(stopPosition) - string.data());
+    *result = longResult;
+    return true;
+}
+
+// FIXME: Port call sites to the overload taking in a span and remove.
 static bool parseLong(const char* string, char** stopPosition, int base, long* result)
 {
     *result = strtol(string, stopPosition, base);
     // Avoid the use of errno as it is not available on Windows CE
     if (string == *stopPosition || *result == std::numeric_limits<long>::min() || *result == std::numeric_limits<long>::max())
         return false;
+    return true;
+}
+
+static bool parseLong(std::span<const LChar>& string, int base, long* result)
+{
+    char* stopPosition;
+    *result = strtol(reinterpret_cast<const char*>(string.data()), &stopPosition, base);
+    // Avoid the use of errno as it is not available on Windows CE
+    if (string.data() == reinterpret_cast<const LChar*>(stopPosition) || *result == std::numeric_limits<long>::min() || *result == std::numeric_limits<long>::max())
+        return false;
+    string = string.subspan(reinterpret_cast<const LChar*>(stopPosition) - string.data());
     return true;
 }
 
@@ -692,7 +716,7 @@ double parseES5DateFromNullTerminatedCharacters(const char* dateString, bool& is
 }
 
 // Odd case where 'exec' is allowed to be 0, to accomodate a caller in WebCore.
-double parseDateFromNullTerminatedCharacters(const char* dateString, bool& isLocalTime)
+double parseDate(std::span<const LChar> dateString, bool& isLocalTime)
 {
     isLocalTime = true;
     int offset = 0;
@@ -715,33 +739,31 @@ double parseDateFromNullTerminatedCharacters(const char* dateString, bool& isLoc
     skipSpacesAndComments(dateString);
 
     long month = -1;
-    const char *wordStart = dateString;
+    auto wordStart = dateString;
     // Check contents of first words if not number
-    while (*dateString && !isASCIIDigit(*dateString)) {
-        if (isUnicodeCompatibleASCIIWhitespace(*dateString) || *dateString == '(') {
-            if (dateString - wordStart >= 3)
+    while (!dateString.empty() && !isASCIIDigit(dateString.front())) {
+        if (isUnicodeCompatibleASCIIWhitespace(dateString.front()) || dateString.front() == '(') {
+            if (dateString.data() - wordStart.data() >= 3)
                 month = findMonth(wordStart);
             skipSpacesAndComments(dateString);
             wordStart = dateString;
         } else
-           dateString++;
+            dateString = dateString.subspan(1);
     }
 
     // Missing delimiter between month and day (like "January29")?
-    if (month == -1 && wordStart != dateString)
+    if (month == -1 && wordStart.data() != dateString.data())
         month = findMonth(wordStart);
 
     skipSpacesAndComments(dateString);
 
-    if (!*dateString)
+    if (dateString.empty())
         return std::numeric_limits<double>::quiet_NaN();
 
     // ' 09-Nov-99 23:12:40 GMT'
-    char* newPosStr;
     long day;
-    if (!parseLong(dateString, &newPosStr, 10, &day))
+    if (!parseLong(dateString, 10, &day))
         return std::numeric_limits<double>::quiet_NaN();
-    dateString = newPosStr;
 
     if (day < 0)
         return std::numeric_limits<double>::quiet_NaN();
@@ -749,70 +771,72 @@ double parseDateFromNullTerminatedCharacters(const char* dateString, bool& isLoc
     std::optional<int> year;
     if (day > 31) {
         // ### where is the boundary and what happens below?
-        if (*dateString != '/')
+        if (dateString.empty() || dateString.front() != '/')
             return std::numeric_limits<double>::quiet_NaN();
+        dateString = dateString.subspan(1);
         // looks like a YYYY/MM/DD date
-        if (!*++dateString)
+        if (dateString.empty())
             return std::numeric_limits<double>::quiet_NaN();
         if (day <= std::numeric_limits<int>::min() || day >= std::numeric_limits<int>::max())
             return std::numeric_limits<double>::quiet_NaN();
         year = static_cast<int>(day);
-        if (!parseLong(dateString, &newPosStr, 10, &month))
+        if (!parseLong(dateString, 10, &month))
             return std::numeric_limits<double>::quiet_NaN();
         month -= 1;
-        dateString = newPosStr;
-        if (*dateString++ != '/' || !*dateString)
+        if (dateString.empty() || dateString.front() != '/')
             return std::numeric_limits<double>::quiet_NaN();
-        if (!parseLong(dateString, &newPosStr, 10, &day))
+        dateString = dateString.subspan(1);
+        if (dateString.empty())
             return std::numeric_limits<double>::quiet_NaN();
-        dateString = newPosStr;
-    } else if (*dateString == '/' && month == -1) {
-        dateString++;
+        if (!parseLong(dateString, 10, &day))
+            return std::numeric_limits<double>::quiet_NaN();
+    } else if (!dateString.empty() && dateString.front() == '/' && month == -1) {
+        dateString = dateString.subspan(1);
         // This looks like a MM/DD/YYYY date, not an RFC date.
         month = day - 1; // 0-based
-        if (!parseLong(dateString, &newPosStr, 10, &day))
+        if (!parseLong(dateString, 10, &day))
             return std::numeric_limits<double>::quiet_NaN();
         if (day < 1 || day > 31)
             return std::numeric_limits<double>::quiet_NaN();
-        dateString = newPosStr;
-        if (*dateString == '/')
-            dateString++;
-        if (!*dateString)
+        if (!dateString.empty() && dateString.front() == '/')
+            dateString = dateString.subspan(1);
+        if (dateString.empty())
             return std::numeric_limits<double>::quiet_NaN();
      } else {
-        if (*dateString == '-')
-            dateString++;
+        if (!dateString.empty() && dateString.front() == '-')
+            dateString = dateString.subspan(1);
 
         skipSpacesAndComments(dateString);
 
-        if (*dateString == ',')
-            dateString++;
+        if (!dateString.empty() && dateString.front() == ',')
+            dateString = dateString.subspan(1);
 
         if (month == -1) { // not found yet
             month = findMonth(dateString);
             if (month == -1)
                 return std::numeric_limits<double>::quiet_NaN();
 
-            while (*dateString && *dateString != '-' && *dateString != ',' && !isUnicodeCompatibleASCIIWhitespace(*dateString))
-                dateString++;
+            while (!dateString.empty() && dateString.front() != '-' && dateString.front() != ',' && !isUnicodeCompatibleASCIIWhitespace(dateString.front()))
+                dateString = dateString.subspan(1);
 
-            if (!*dateString)
+            if (dateString.empty())
                 return std::numeric_limits<double>::quiet_NaN();
 
             // '-99 23:12:40 GMT'
-            if (*dateString != '-' && *dateString != '/' && *dateString != ',' && !isUnicodeCompatibleASCIIWhitespace(*dateString))
+            if (dateString.front() != '-' && dateString.front() != '/' && dateString.front() != ',' && !isUnicodeCompatibleASCIIWhitespace(dateString.front()))
                 return std::numeric_limits<double>::quiet_NaN();
-            dateString++;
+            dateString = dateString.subspan(1);
         }
     }
 
     if (month < 0 || month > 11)
         return std::numeric_limits<double>::quiet_NaN();
 
+    auto newPosStr = dateString;
     // '99 23:12:40 GMT'
-    if (*dateString && !year) {
+    if (!dateString.empty() && !year) {
         int result = 0;
-        if (!parseInt(dateString, &newPosStr, 10, &result))
+        if (!parseInt(newPosStr, 10, &result))
             return std::numeric_limits<double>::quiet_NaN();
         year = result;
     }
@@ -821,63 +845,63 @@ double parseDateFromNullTerminatedCharacters(const char* dateString, bool& isLoc
     long hour = 0;
     long minute = 0;
     long second = 0;
-    if (!*newPosStr)
+    if (newPosStr.empty())
         dateString = newPosStr;
     else {
         // ' 23:12:40 GMT'
-        if (!(isUnicodeCompatibleASCIIWhitespace(*newPosStr) || *newPosStr == ',')) {
-            if (*newPosStr != ':')
+        if (!(isUnicodeCompatibleASCIIWhitespace(newPosStr.front()) || newPosStr.front() == ',')) {
+            if (newPosStr.front() != ':')
                 return std::numeric_limits<double>::quiet_NaN();
             // There was no year; the number was the hour.
             year = std::nullopt;
         } else {
             // in the normal case (we parsed the year), advance to the next number
             // ' at 23:12:40 GMT'
-            if (isUnicodeCompatibleASCIIWhitespace(newPosStr[0]) && isASCIIAlphaCaselessEqual(newPosStr[1], 'a') && isASCIIAlphaCaselessEqual(newPosStr[2], 't'))
-                newPosStr += 3;
+            if (newPosStr.size() >= 3 && isUnicodeCompatibleASCIIWhitespace(newPosStr[0]) && isASCIIAlphaCaselessEqual(newPosStr[1], 'a') && isASCIIAlphaCaselessEqual(newPosStr[2], 't'))
+                newPosStr = newPosStr.subspan(3);
             else
-                ++newPosStr; // space or comma
+                newPosStr = newPosStr.subspan(1); // space or comma
             dateString = newPosStr;
             skipSpacesAndComments(dateString);
         }
 
-        parseLong(dateString, &newPosStr, 10, &hour);
+        newPosStr = dateString;
+        parseLong(newPosStr, 10, &hour);
         // Do not check for errno here since we want to continue
         // even if errno was set becasue we are still looking
         // for the timezone!
 
         // Read a number? If not, this might be a timezone name.
-        if (newPosStr != dateString) {
+        if (newPosStr.data() != dateString.data()) {
             dateString = newPosStr;
 
             if (hour < 0 || hour > 23)
                 return std::numeric_limits<double>::quiet_NaN();
 
-            if (!*dateString)
+            if (dateString.empty())
                 return std::numeric_limits<double>::quiet_NaN();
 
             // ':12:40 GMT'
-            if (*dateString++ != ':')
+            if (dateString.front() != ':')
                 return std::numeric_limits<double>::quiet_NaN();
 
-            if (!parseLong(dateString, &newPosStr, 10, &minute))
+            dateString = dateString.subspan(1); // skip ':'.
+            if (!parseLong(dateString, 10, &minute))
                 return std::numeric_limits<double>::quiet_NaN();
-            dateString = newPosStr;
 
             if (minute < 0 || minute > 59)
                 return std::numeric_limits<double>::quiet_NaN();
 
             // ':40 GMT'
-            if (*dateString && *dateString != ':' && !isUnicodeCompatibleASCIIWhitespace(*dateString))
+            if (!dateString.empty() && dateString.front() != ':' && !isUnicodeCompatibleASCIIWhitespace(dateString.front()))
                 return std::numeric_limits<double>::quiet_NaN();
 
             // seconds are optional in rfc822 + rfc2822
-            if (*dateString ==':') {
-                dateString++;
+            if (!dateString.empty() && dateString.front() == ':') {
+                dateString = dateString.subspan(1);
 
-                if (!parseLong(dateString, &newPosStr, 10, &second))
+                if (!parseLong(dateString, 10, &second))
                     return std::numeric_limits<double>::quiet_NaN();
-                dateString = newPosStr;
 
                 if (second < 0 || second > 59)
                     return std::numeric_limits<double>::quiet_NaN();
@@ -885,64 +909,61 @@ double parseDateFromNullTerminatedCharacters(const char* dateString, bool& isLoc
 
             skipSpacesAndComments(dateString);
 
-            if (startsWithLettersIgnoringASCIICase(StringView::fromLatin1(dateString), "am"_s)) {
+            if (startsWithLettersIgnoringASCIICase(StringView(dateString), "am"_s)) {
                 if (hour > 12)
                     return std::numeric_limits<double>::quiet_NaN();
                 if (hour == 12)
                     hour = 0;
-                dateString += 2;
+                dateString = dateString.subspan(2);
                 skipSpacesAndComments(dateString);
-            } else if (startsWithLettersIgnoringASCIICase(StringView::fromLatin1(dateString), "pm"_s)) {
+            } else if (startsWithLettersIgnoringASCIICase(StringView(dateString), "pm"_s)) {
                 if (hour > 12)
                     return std::numeric_limits<double>::quiet_NaN();
                 if (hour != 12)
                     hour += 12;
-                dateString += 2;
+                dateString = dateString.subspan(2);
                 skipSpacesAndComments(dateString);
             }
         }
     }
     
     // The year may be after the time but before the time zone.
-    if (isASCIIDigit(*dateString) && !year) {
+    if (!dateString.empty() && isASCIIDigit(dateString.front()) && !year) {
         int result = 0;
-        if (!parseInt(dateString, &newPosStr, 10, &result))
+        if (!parseInt(dateString, 10, &result))
             return std::numeric_limits<double>::quiet_NaN();
         year = result;
-        dateString = newPosStr;
         skipSpacesAndComments(dateString);
     }
 
     // Don't fail if the time zone is missing. 
     // Some websites omit the time zone (4275206).
-    if (*dateString) {
-        if (startsWithLettersIgnoringASCIICase(StringView ::fromLatin1(dateString), "gmt"_s) || startsWithLettersIgnoringASCIICase(StringView::fromLatin1(dateString), "utc"_s)) {
-            dateString += 3;
+    if (!dateString.empty()) {
+        if (startsWithLettersIgnoringASCIICase(StringView(dateString), "gmt"_s) || startsWithLettersIgnoringASCIICase(StringView(dateString), "utc"_s)) {
+            dateString = dateString.subspan(3);
             isLocalTime = false;
         }
 
-        if (*dateString == '+' || *dateString == '-') {
+        if (!dateString.empty() && (dateString.front() == '+' || dateString.front() == '-')) {
             int o;
-            if (!parseInt(dateString, &newPosStr, 10, &o))
+            if (!parseInt(dateString, 10, &o))
                 return std::numeric_limits<double>::quiet_NaN();
-            dateString = newPosStr;
 
             if (o < -9959 || o > 9959)
                 return std::numeric_limits<double>::quiet_NaN();
 
             int sgn = (o < 0) ? -1 : 1;
             o = std::abs(o);
-            if (*dateString != ':') {
+            if (dateString.empty() || dateString.front() != ':') {
                 if (o >= 24)
                     offset = ((o / 100) * 60 + (o % 100)) * sgn;
                 else
                     offset = o * 60 * sgn;
             } else { // GMT+05:00
-                ++dateString; // skip the ':'
+                dateString = dateString.subspan(1); // skip the ':'
                 int o2;
-                if (!parseInt(dateString, &newPosStr, 10, &o2))
+                if (!parseInt(dateString, 10, &o2))
                     return std::numeric_limits<double>::quiet_NaN();
-                dateString = newPosStr;
                 offset = (o * 60 + o2) * sgn;
             }
             isLocalTime = false;
@@ -950,10 +971,10 @@ double parseDateFromNullTerminatedCharacters(const char* dateString, bool& isLoc
             for (auto& knownZone : knownZones) {
                 // Since the passed-in length is used for both strings, the following checks that
                 // dateString has the time zone name as a prefix, not that it is equal.
-                auto length = strlen(knownZone.tzName);
-                if (equalLettersIgnoringASCIICase(dateString, { knownZone.tzName, length })) {
+                auto tzName = span8(knownZone.tzName);
+                if (dateString.size() >= tzName.size() && equalLettersIgnoringASCIICase(dateString.data(), tzName)) {
                     offset = knownZone.tzOffset;
-                    dateString += length;
+                    dateString = dateString.subspan(tzName.size());
                     isLocalTime = false;
                     break;
                 }
@@ -963,17 +984,16 @@ double parseDateFromNullTerminatedCharacters(const char* dateString, bool& isLoc
 
     skipSpacesAndComments(dateString);
 
-    if (*dateString && !year) {
+    if (!dateString.empty() && !year) {
         int result = 0;
-        if (!parseInt(dateString, &newPosStr, 10, &result))
+        if (!parseInt(dateString, 10, &result))
             return std::numeric_limits<double>::quiet_NaN();
         year = result;
-        dateString = newPosStr;
         skipSpacesAndComments(dateString);
     }
 
     // Trailing garbage
-    if (*dateString)
+    if (!dateString.empty())
         return std::numeric_limits<double>::quiet_NaN();
 
     // Y2K: Handle 2 digit years.
@@ -1001,10 +1021,10 @@ double parseDateFromNullTerminatedCharacters(const char* dateString, bool& isLoc
     return ymdhmsToMilliseconds(year.value(), month + 1, day, hour, minute, second, 0) - offset * (secondsPerMinute * msPerSecond);
 }
 
-double parseDateFromNullTerminatedCharacters(const char* dateString)
+double parseDate(std::span<const LChar> dateString)
 {
     bool isLocalTime;
-    double value = parseDateFromNullTerminatedCharacters(dateString, isLocalTime);
+    double value = parseDate(dateString, isLocalTime);
 
     if (isLocalTime)
         value -= calculateLocalTimeOffset(value, LocalTime).offset;

--- a/Source/WTF/wtf/DateMath.h
+++ b/Source/WTF/wtf/DateMath.h
@@ -78,8 +78,8 @@ int equivalentYearForDST(int year);
 
 // Not really math related, but this is currently the only shared place to put these.
 WTF_EXPORT_PRIVATE double parseES5DateFromNullTerminatedCharacters(const char* dateString, bool& isLocalTime);
-WTF_EXPORT_PRIVATE double parseDateFromNullTerminatedCharacters(const char* dateString);
-WTF_EXPORT_PRIVATE double parseDateFromNullTerminatedCharacters(const char* dateString, bool& isLocalTime);
+WTF_EXPORT_PRIVATE double parseDate(std::span<const LChar> dateString);
+WTF_EXPORT_PRIVATE double parseDate(std::span<const LChar> dateString, bool& isLocalTime);
 // dayOfWeek: [0, 6] 0 being Monday, day: [1, 31], month: [0, 11], year: ex: 2011, hours: [0, 23], minutes: [0, 59], seconds: [0, 59], utcOffset: [-720,720]. 
 WTF_EXPORT_PRIVATE String makeRFC2822DateString(unsigned dayOfWeek, unsigned day, unsigned month, unsigned year, unsigned hours, unsigned minutes, unsigned seconds, int utcOffset);
 
@@ -525,7 +525,7 @@ using WTF::msToDays;
 using WTF::msToHours;
 using WTF::msToMinutes;
 using WTF::msToYear;
-using WTF::parseDateFromNullTerminatedCharacters;
+using WTF::parseDate;
 using WTF::secondsPerDay;
 using WTF::secondsPerMinute;
 using WTF::setTimeZoneOverride;

--- a/Source/WebCore/platform/network/HTTPParsers.cpp
+++ b/Source/WebCore/platform/network/HTTPParsers.cpp
@@ -321,7 +321,7 @@ static String trimInputSample(std::span<const CharType> input)
 
 std::optional<WallTime> parseHTTPDate(const String& value)
 {
-    double dateInMillisecondsSinceEpoch = parseDateFromNullTerminatedCharacters(value.utf8().data());
+    double dateInMillisecondsSinceEpoch = parseDate(value.utf8().span());
     if (!std::isfinite(dateInMillisecondsSinceEpoch))
         return std::nullopt;
     // This assumes system_clock epoch equals Unix epoch which is true for all implementations but unspecified.

--- a/Source/WebCore/platform/network/curl/CookieUtil.cpp
+++ b/Source/WebCore/platform/network/curl/CookieUtil.cpp
@@ -80,9 +80,9 @@ bool domainMatch(const String& cookieDomain, const String& host)
     return false;
 }
 
-static std::optional<double> parseExpiresMS(const char* expires)
+static std::optional<double> parseExpiresMS(std::span<const LChar> expires)
 {
-    double tmp = parseDateFromNullTerminatedCharacters(expires);
+    double tmp = parseDate(expires);
     if (isnan(tmp))
         return { };
 
@@ -129,7 +129,7 @@ static void parseCookieAttributes(const String& attribute, bool& hasMaxAge, Cook
             result.expires = std::nullopt;
         }
     } else if (equalLettersIgnoringASCIICase(attributeName, "expires"_s) && !hasMaxAge) {
-        if (auto expiryTime = parseExpiresMS(attributeValue.utf8().data())) {
+        if (auto expiryTime = parseExpiresMS(attributeValue.utf8().span())) {
             result.expires = expiryTime.value();
             result.session = false;
         } else if (!hasMaxAge) {


### PR DESCRIPTION
#### 511e5fff44f9949be51d903a8d1f9c851d2864e0
<pre>
Reduce use of `const char*` in &lt;wtf/DateMath.h&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=273409">https://bugs.webkit.org/show_bug.cgi?id=273409</a>

Reviewed by Darin Adler.

Reduce use of `const char*` in &lt;wtf/DateMath.h&gt; by leveraging std::span.

* Source/JavaScriptCore/runtime/JSDateMath.cpp:
(JSC::DateCache::parseDate):
* Source/WTF/wtf/DateMath.cpp:
(WTF::skipSpacesAndComments):
(WTF::findMonth):
(WTF::parseInt):
(WTF::parseLong):
(WTF::parseDate):
(WTF::parseDateFromNullTerminatedCharacters): Deleted.
* Source/WTF/wtf/DateMath.h:
* Source/WebCore/platform/network/HTTPParsers.cpp:
(WebCore::parseHTTPDate):
* Source/WebCore/platform/network/curl/CookieUtil.cpp:
(WebCore::CookieUtil::parseExpiresMS):
(WebCore::CookieUtil::parseCookieAttributes):

Canonical link: <a href="https://commits.webkit.org/278153@main">https://commits.webkit.org/278153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/305c5c2945b03c8ad44ca31670cabac1714f821f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52893 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/327 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51956 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26556 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26470 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21638 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23914 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43951 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8022 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/42966 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44455 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54470 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/49146 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24738 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20899 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26005 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26853 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56633 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7145 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/25730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11637 "Passed tests") | 
<!--EWS-Status-Bubble-End-->