### PR TITLE
Implement trusted types enforcement on Function constructor

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-clips-sample.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-clips-sample.https-expected.txt
@@ -1,7 +1,5 @@
 
 PASS Unsafe eval violation sample is clipped to 40 characters.
-FAIL Function constructor - the other kind of eval - is clipped. assert_throws_js: function "_ => {
-      new Function("a", "b", "return '1234567890123456789012345678901234567890';");
-    }" did not throw
+FAIL Function constructor - the other kind of eval - is clipped. assert_equals: expected "Function|(a,b) {return '12345678901234567890123" but got "Function|function anonymous(a,b) {return '12345"
 PASS Trusted Types violation sample is clipped to 40 characters excluded the sink name.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy-mutate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy-mutate-expected.txt
@@ -1,8 +1,8 @@
 
 PASS eval of string where default policy mutates value throws.
 PASS indirect eval of string where default policy mutates value throws.
-FAIL Function constructor with string where default policy mutates value throws. assert_throws_js: function "_ => new Function('return 1+1')" did not throw
-FAIL AsyncFunction constructor with string where default policy mutates value throws. assert_throws_js: function "_ => new AsyncFunction('return 1+1')" did not throw
-FAIL GeneratorFunction constructor with string where default policy mutates value throws. assert_throws_js: function "_ => new GeneratorFunction('return 1+1')" did not throw
-FAIL AsyncGeneratorFunction constructor with string where default policy mutates value throws. assert_throws_js: function "_ => new AsyncGeneratorFunction('return 1+1')" did not throw
+PASS Function constructor with string where default policy mutates value throws.
+PASS AsyncFunction constructor with string where default policy mutates value throws.
+PASS GeneratorFunction constructor with string where default policy mutates value throws.
+PASS AsyncGeneratorFunction constructor with string where default policy mutates value throws.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-no-default-policy-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-no-default-policy-expected.txt
@@ -1,5 +1,11 @@
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 
 PASS eval of TrustedScript works.
 PASS indirect eval of TrustedScript works.
@@ -7,11 +13,11 @@ PASS eval of string fails.
 PASS indirect eval of string fails.
 PASS eval of !TrustedScript and !string works.
 PASS Function constructor of TrustedScript works.
-FAIL Function constructor of string fails. assert_throws_js: function "_ => new Function('return 1+1')()" did not throw
+PASS Function constructor of string fails.
 PASS Function constructor of all TrustedScripts works.
-FAIL Function constructor of all strings fails. assert_throws_js: function "_ => new Function('val', 'return val+1')(1)" did not throw
-FAIL Function constructor of string and TrustedScript fails. assert_throws_js: function "_ => new Function('val', p.createScript('return val+1'))(1)" did not throw
-FAIL AsyncFunction constructor of string fails. assert_throws_js: function "_ => new AsyncFunction('return 1+1')()" did not throw
-FAIL GeneratorFunction constructor of string fails. assert_throws_js: function "_ => new GeneratorFunction('return 1+1')()" did not throw
-FAIL AsyncGeneratorFunction constructor of string fails. assert_throws_js: function "_ => new AsyncGeneratorFunction('return 1+1')()" did not throw
+PASS Function constructor of all strings fails.
+PASS Function constructor of string and TrustedScript fails.
+PASS AsyncFunction constructor of string fails.
+PASS GeneratorFunction constructor of string fails.
+PASS AsyncGeneratorFunction constructor of string fails.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor-expected.txt
@@ -1,67 +1,131 @@
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 
-FAIL Function constructor with mixed plain and trusted strings, mask #0 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "Function")" did not throw
-FAIL AsyncFunction constructor with mixed plain and trusted strings, mask #0 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncFunction")" did not throw
-FAIL GeneratorFunction constructor with mixed plain and trusted strings, mask #0 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "GeneratorFunction")" did not throw
-FAIL AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #0 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncGeneratorFunction")" did not throw
-FAIL Function constructor with mixed plain and trusted strings, mask #1 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "Function")" did not throw
-FAIL AsyncFunction constructor with mixed plain and trusted strings, mask #1 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncFunction")" did not throw
-FAIL GeneratorFunction constructor with mixed plain and trusted strings, mask #1 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "GeneratorFunction")" did not throw
-FAIL AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #1 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncGeneratorFunction")" did not throw
-FAIL Function constructor with mixed plain and trusted strings, mask #2 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "Function")" did not throw
-FAIL AsyncFunction constructor with mixed plain and trusted strings, mask #2 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncFunction")" did not throw
-FAIL GeneratorFunction constructor with mixed plain and trusted strings, mask #2 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "GeneratorFunction")" did not throw
-FAIL AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #2 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncGeneratorFunction")" did not throw
-FAIL Function constructor with mixed plain and trusted strings, mask #3 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "Function")" did not throw
-FAIL AsyncFunction constructor with mixed plain and trusted strings, mask #3 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncFunction")" did not throw
-FAIL GeneratorFunction constructor with mixed plain and trusted strings, mask #3 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "GeneratorFunction")" did not throw
-FAIL AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #3 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncGeneratorFunction")" did not throw
-FAIL Function constructor with mixed plain and trusted strings, mask #4 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "Function")" did not throw
-FAIL AsyncFunction constructor with mixed plain and trusted strings, mask #4 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncFunction")" did not throw
-FAIL GeneratorFunction constructor with mixed plain and trusted strings, mask #4 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "GeneratorFunction")" did not throw
-FAIL AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #4 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncGeneratorFunction")" did not throw
-FAIL Function constructor with mixed plain and trusted strings, mask #5 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "Function")" did not throw
-FAIL AsyncFunction constructor with mixed plain and trusted strings, mask #5 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncFunction")" did not throw
-FAIL GeneratorFunction constructor with mixed plain and trusted strings, mask #5 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "GeneratorFunction")" did not throw
-FAIL AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #5 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncGeneratorFunction")" did not throw
-FAIL Function constructor with mixed plain and trusted strings, mask #6 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "Function")" did not throw
-FAIL AsyncFunction constructor with mixed plain and trusted strings, mask #6 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncFunction")" did not throw
-FAIL GeneratorFunction constructor with mixed plain and trusted strings, mask #6 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "GeneratorFunction")" did not throw
-FAIL AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #6 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncGeneratorFunction")" did not throw
-FAIL Function constructor with mixed plain and trusted strings, mask #7 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "Function")" did not throw
-FAIL AsyncFunction constructor with mixed plain and trusted strings, mask #7 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncFunction")" did not throw
-FAIL GeneratorFunction constructor with mixed plain and trusted strings, mask #7 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "GeneratorFunction")" did not throw
-FAIL AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #7 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncGeneratorFunction")" did not throw
-FAIL Function constructor with mixed plain and trusted strings, mask #8 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "Function")" did not throw
-FAIL AsyncFunction constructor with mixed plain and trusted strings, mask #8 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncFunction")" did not throw
-FAIL GeneratorFunction constructor with mixed plain and trusted strings, mask #8 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "GeneratorFunction")" did not throw
-FAIL AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #8 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncGeneratorFunction")" did not throw
-FAIL Function constructor with mixed plain and trusted strings, mask #9 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "Function")" did not throw
-FAIL AsyncFunction constructor with mixed plain and trusted strings, mask #9 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncFunction")" did not throw
-FAIL GeneratorFunction constructor with mixed plain and trusted strings, mask #9 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "GeneratorFunction")" did not throw
-FAIL AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #9 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncGeneratorFunction")" did not throw
-FAIL Function constructor with mixed plain and trusted strings, mask #10 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "Function")" did not throw
-FAIL AsyncFunction constructor with mixed plain and trusted strings, mask #10 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncFunction")" did not throw
-FAIL GeneratorFunction constructor with mixed plain and trusted strings, mask #10 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "GeneratorFunction")" did not throw
-FAIL AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #10 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncGeneratorFunction")" did not throw
-FAIL Function constructor with mixed plain and trusted strings, mask #11 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "Function")" did not throw
-FAIL AsyncFunction constructor with mixed plain and trusted strings, mask #11 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncFunction")" did not throw
-FAIL GeneratorFunction constructor with mixed plain and trusted strings, mask #11 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "GeneratorFunction")" did not throw
-FAIL AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #11 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncGeneratorFunction")" did not throw
-FAIL Function constructor with mixed plain and trusted strings, mask #12 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "Function")" did not throw
-FAIL AsyncFunction constructor with mixed plain and trusted strings, mask #12 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncFunction")" did not throw
-FAIL GeneratorFunction constructor with mixed plain and trusted strings, mask #12 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "GeneratorFunction")" did not throw
-FAIL AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #12 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncGeneratorFunction")" did not throw
-FAIL Function constructor with mixed plain and trusted strings, mask #13 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "Function")" did not throw
-FAIL AsyncFunction constructor with mixed plain and trusted strings, mask #13 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncFunction")" did not throw
-FAIL GeneratorFunction constructor with mixed plain and trusted strings, mask #13 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "GeneratorFunction")" did not throw
-FAIL AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #13 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncGeneratorFunction")" did not throw
-FAIL Function constructor with mixed plain and trusted strings, mask #14 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "Function")" did not throw
-FAIL AsyncFunction constructor with mixed plain and trusted strings, mask #14 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncFunction")" did not throw
-FAIL GeneratorFunction constructor with mixed plain and trusted strings, mask #14 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "GeneratorFunction")" did not throw
-FAIL AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #14 assert_throws_js: function "_ => new_function_with_maybe_trusted_args(mask, "AsyncGeneratorFunction")" did not throw
+PASS Function constructor with mixed plain and trusted strings, mask #0
+PASS AsyncFunction constructor with mixed plain and trusted strings, mask #0
+PASS GeneratorFunction constructor with mixed plain and trusted strings, mask #0
+PASS AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #0
+PASS Function constructor with mixed plain and trusted strings, mask #1
+PASS AsyncFunction constructor with mixed plain and trusted strings, mask #1
+PASS GeneratorFunction constructor with mixed plain and trusted strings, mask #1
+PASS AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #1
+PASS Function constructor with mixed plain and trusted strings, mask #2
+PASS AsyncFunction constructor with mixed plain and trusted strings, mask #2
+PASS GeneratorFunction constructor with mixed plain and trusted strings, mask #2
+PASS AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #2
+PASS Function constructor with mixed plain and trusted strings, mask #3
+PASS AsyncFunction constructor with mixed plain and trusted strings, mask #3
+PASS GeneratorFunction constructor with mixed plain and trusted strings, mask #3
+PASS AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #3
+PASS Function constructor with mixed plain and trusted strings, mask #4
+PASS AsyncFunction constructor with mixed plain and trusted strings, mask #4
+PASS GeneratorFunction constructor with mixed plain and trusted strings, mask #4
+PASS AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #4
+PASS Function constructor with mixed plain and trusted strings, mask #5
+PASS AsyncFunction constructor with mixed plain and trusted strings, mask #5
+PASS GeneratorFunction constructor with mixed plain and trusted strings, mask #5
+PASS AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #5
+PASS Function constructor with mixed plain and trusted strings, mask #6
+PASS AsyncFunction constructor with mixed plain and trusted strings, mask #6
+PASS GeneratorFunction constructor with mixed plain and trusted strings, mask #6
+PASS AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #6
+PASS Function constructor with mixed plain and trusted strings, mask #7
+PASS AsyncFunction constructor with mixed plain and trusted strings, mask #7
+PASS GeneratorFunction constructor with mixed plain and trusted strings, mask #7
+PASS AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #7
+PASS Function constructor with mixed plain and trusted strings, mask #8
+PASS AsyncFunction constructor with mixed plain and trusted strings, mask #8
+PASS GeneratorFunction constructor with mixed plain and trusted strings, mask #8
+PASS AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #8
+PASS Function constructor with mixed plain and trusted strings, mask #9
+PASS AsyncFunction constructor with mixed plain and trusted strings, mask #9
+PASS GeneratorFunction constructor with mixed plain and trusted strings, mask #9
+PASS AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #9
+PASS Function constructor with mixed plain and trusted strings, mask #10
+PASS AsyncFunction constructor with mixed plain and trusted strings, mask #10
+PASS GeneratorFunction constructor with mixed plain and trusted strings, mask #10
+PASS AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #10
+PASS Function constructor with mixed plain and trusted strings, mask #11
+PASS AsyncFunction constructor with mixed plain and trusted strings, mask #11
+PASS GeneratorFunction constructor with mixed plain and trusted strings, mask #11
+PASS AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #11
+PASS Function constructor with mixed plain and trusted strings, mask #12
+PASS AsyncFunction constructor with mixed plain and trusted strings, mask #12
+PASS GeneratorFunction constructor with mixed plain and trusted strings, mask #12
+PASS AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #12
+PASS Function constructor with mixed plain and trusted strings, mask #13
+PASS AsyncFunction constructor with mixed plain and trusted strings, mask #13
+PASS GeneratorFunction constructor with mixed plain and trusted strings, mask #13
+PASS AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #13
+PASS Function constructor with mixed plain and trusted strings, mask #14
+PASS AsyncFunction constructor with mixed plain and trusted strings, mask #14
+PASS GeneratorFunction constructor with mixed plain and trusted strings, mask #14
+PASS AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #14
 PASS Function constructor with mixed plain and trusted strings, mask #15
-FAIL Function constructor with trusted strings, and a forged toString() for the one at index 0 assert_throws_js: function "_ => new Function(...mixed_args)" did not throw
-FAIL Function constructor with trusted strings, and a forged toString() for the one at index 1 assert_throws_js: function "_ => new Function(...mixed_args)" did not throw
-FAIL Function constructor with trusted strings, and a forged toString() for the one at index 2 assert_throws_js: function "_ => new Function(...mixed_args)" did not throw
-FAIL Function constructor with trusted strings, and a forged toString() for the one at index 3 assert_throws_js: function "_ => new Function(...mixed_args)" did not throw
+PASS Function constructor with trusted strings, and a forged toString() for the one at index 0
+PASS Function constructor with trusted strings, and a forged toString() for the one at index 1
+PASS Function constructor with trusted strings, and a forged toString() for the one at index 2
+PASS Function constructor with trusted strings, and a forged toString() for the one at index 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
 <html>
 <head>
   <link rel="help" href="https://w3c.github.io/webappsec-csp/#can-compile-strings">

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-permissive-csp-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-permissive-csp-expected.txt
@@ -1,11 +1,10 @@
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 
 PASS eval with plain string with Trusted Types and permissive CSP throws (no type).
 PASS indirect eval with plain string with Trusted Types and permissive CSP throws (no type).
-FAIL Function constructor with plain string with Trusted Types and permissive CSP throws (no type). assert_throws_js: function "_ => {
-      new Function('a="hello there"');
-    }" did not throw
+PASS Function constructor with plain string with Trusted Types and permissive CSP throws (no type).
 PASS eval with TrustedScript and permissive CSP works.
 PASS indirect eval with TrustedScript and permissive CSP works.
 PASS new Function with TrustedScript and permissive CSP works.

--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.cpp
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.cpp
@@ -60,6 +60,7 @@ const GlobalObjectMethodTable* JSAPIGlobalObject::globalObjectMethodTable()
         nullptr, // deriveShadowRealmGlobalObject
         &codeForEval,
         &canCompileStrings,
+        &trustedScriptStructure,
     };
     return &table;
 }

--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
@@ -80,6 +80,7 @@ const GlobalObjectMethodTable* JSAPIGlobalObject::globalObjectMethodTable()
         &deriveShadowRealmGlobalObject,
         &codeForEval,
         &canCompileStrings,
+        &trustedScriptStructure,
     };
     return &table;
 };

--- a/Source/JavaScriptCore/debugger/DebuggerEvalEnabler.h
+++ b/Source/JavaScriptCore/debugger/DebuggerEvalEnabler.h
@@ -46,8 +46,11 @@ public:
         UNUSED_PARAM(mode);
         if (globalObject) {
             m_evalWasDisabled = !globalObject->evalEnabled();
+            m_trustedTypesWereRequired = globalObject->requiresTrustedTypes();
             if (m_evalWasDisabled)
                 globalObject->setEvalEnabled(true, globalObject->evalDisabledErrorMessage());
+            if (m_trustedTypesWereRequired)
+                globalObject->setRequiresTrustedTypes(false);
 #if ASSERT_ENABLED
             if (m_mode == Mode::EvalOnGlobalObjectAtDebuggerEntry)
                 globalObject->setGlobalObjectAtDebuggerEntry(globalObject);
@@ -61,6 +64,8 @@ public:
             JSGlobalObject* globalObject = m_globalObject;
             if (m_evalWasDisabled)
                 globalObject->setEvalEnabled(false, globalObject->evalDisabledErrorMessage());
+            if (m_trustedTypesWereRequired)
+                globalObject->setRequiresTrustedTypes(true);
 #if ASSERT_ENABLED
             if (m_mode == Mode::EvalOnGlobalObjectAtDebuggerEntry)
                 globalObject->setGlobalObjectAtDebuggerEntry(nullptr);
@@ -71,6 +76,7 @@ public:
 private:
     JSGlobalObject* const m_globalObject;
     bool m_evalWasDisabled { false };
+    bool m_trustedTypesWereRequired { false };
 #if ASSERT_ENABLED
     DebuggerEvalEnabler::Mode m_mode;
 #endif

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -123,29 +123,42 @@ JSValue eval(CallFrame* callFrame, JSValue thisValue, JSScope* callerScopeChain,
         return jsUndefined();
 
     JSValue program = callFrame->argument(0);
-    JSString* programString = nullptr;
-    if (LIKELY(program.isString()))
-        programString = asString(program);
-    else if (Options::useTrustedTypes()) {
-        auto code = globalObject->globalObjectMethodTable()->codeForEval(globalObject, program);
-        if (!code.isNull())
-            programString = jsString(vm, code);
+    String programSource;
+    bool isTrusted = false;
+    if (LIKELY(program.isString())) {
+        programSource = program.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, JSValue());
+    } else if (Options::useTrustedTypes() && program.isObject()) {
+        auto* structure = globalObject->trustedScriptStructure();
+        if (structure == asObject(program)->structure()) {
+            programSource = program.toWTFString(globalObject);
+            RETURN_IF_EXCEPTION(scope, { });
+            isTrusted = true;
+        } else {
+            auto code = globalObject->globalObjectMethodTable()->codeForEval(globalObject, program);
+            RETURN_IF_EXCEPTION(scope, { });
+            if (!code.isNull()) {
+                programSource = code;
+                isTrusted = true;
+            }
+        }
     }
 
-    if (!programString)
+    if (programSource.isNull())
         return program;
 
-    auto programSource = programString->value(globalObject);
-    RETURN_IF_EXCEPTION(scope, JSValue());
-
-    if (Options::useTrustedTypes() && globalObject->requiresTrustedTypes() && !globalObject->globalObjectMethodTable()->canCompileStrings(globalObject, CompilationType::DirectEval, programSource, program)) {
-        throwException(globalObject, scope, createEvalError(globalObject, "Refused to evaluate a string as JavaScript because this document requires a 'Trusted Type' assignment."_s));
-        return { };
+    if (Options::useTrustedTypes() && globalObject->requiresTrustedTypes() && !isTrusted) {
+        bool canCompileStrings = globalObject->globalObjectMethodTable()->canCompileStrings(globalObject, CompilationType::DirectEval, programSource, *vm.emptyList);
+        RETURN_IF_EXCEPTION(scope, { });
+        if (!canCompileStrings) {
+            throwException(globalObject, scope, createEvalError(globalObject, "Refused to evaluate a string as JavaScript because this document requires a 'Trusted Type' assignment."_s));
+            return { };
+        }
     }
 
     TopCallFrameSetter topCallFrame(vm, callFrame);
     if (!globalObject->evalEnabled()) {
-        globalObject->globalObjectMethodTable()->reportViolationForUnsafeEval(globalObject, programString);
+        globalObject->globalObjectMethodTable()->reportViolationForUnsafeEval(globalObject, programSource);
         throwException(globalObject, scope, createEvalError(globalObject, globalObject->evalDisabledErrorMessage()));
         return { };
     }
@@ -172,13 +185,13 @@ JSValue eval(CallFrame* callFrame, JSValue thisValue, JSScope* callerScopeChain,
     DirectEvalExecutable* eval = callerBaselineCodeBlock->directEvalCodeCache().tryGet(programSource, bytecodeIndex);
     if (!eval) {
         if (!(lexicallyScopedFeatures & StrictModeLexicallyScopedFeature)) {
-            if (programSource->is8Bit()) {
-                LiteralParser preparser(globalObject, programSource->span8(), SloppyJSON, callerBaselineCodeBlock);
+            if (programSource.is8Bit()) {
+                LiteralParser preparser(globalObject, programSource.span8(), SloppyJSON, callerBaselineCodeBlock);
                 if (JSValue parsedObject = preparser.tryLiteralParse())
                     RELEASE_AND_RETURN(scope, parsedObject);
 
             } else {
-                LiteralParser preparser(globalObject, programSource->span16(), SloppyJSON, callerBaselineCodeBlock);
+                LiteralParser preparser(globalObject, programSource.span16(), SloppyJSON, callerBaselineCodeBlock);
                 if (JSValue parsedObject = preparser.tryLiteralParse())
                     RELEASE_AND_RETURN(scope, parsedObject);
 

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -956,6 +956,7 @@ const GlobalObjectMethodTable GlobalObject::s_globalObjectMethodTable = {
     &deriveShadowRealmGlobalObject,
     &codeForEval,
     &canCompileStrings,
+    &trustedScriptStructure,
 };
 
 GlobalObject::GlobalObject(VM& vm, Structure* structure)

--- a/Source/JavaScriptCore/runtime/DirectEvalExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/DirectEvalExecutable.cpp
@@ -41,7 +41,7 @@ DirectEvalExecutable* DirectEvalExecutable::create(JSGlobalObject* globalObject,
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (!globalObject->evalEnabled()) {
-        globalObject->globalObjectMethodTable()->reportViolationForUnsafeEval(globalObject, source.provider() ? jsNontrivialString(vm, source.provider()->source().toString()) : nullptr);
+        globalObject->globalObjectMethodTable()->reportViolationForUnsafeEval(globalObject, source.provider() ? source.provider()->source().toString() : nullString());
         throwException(globalObject, scope, createEvalError(globalObject, globalObject->evalDisabledErrorMessage()));
         return nullptr;
     }

--- a/Source/JavaScriptCore/runtime/FunctionConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionConstructor.cpp
@@ -146,9 +146,31 @@ JSObject* constructFunction(JSGlobalObject* globalObject, const ArgList& args, c
     auto code = stringifyFunction(globalObject, args, functionName, functionConstructionMode, scope, functionConstructorParametersEndPosition);
     EXCEPTION_ASSERT(!!scope.exception() == code.isNull());
 
+    if (Options::useTrustedTypes() && globalObject->requiresTrustedTypes()) {
+        bool isTrusted = true;
+        auto* structure = globalObject->trustedScriptStructure();
+        for (size_t i = 0; i < args.size(); i++) {
+            auto arg = args.at(i);
+
+            if (!arg.isObject() || structure != asObject(arg)->structure()) {
+                isTrusted = false;
+                break;
+            }
+        }
+
+        if (!isTrusted) {
+            bool canCompileStrings = globalObject->globalObjectMethodTable()->canCompileStrings(globalObject, CompilationType::Function, code, args);
+            RETURN_IF_EXCEPTION(scope, { });
+            if (!canCompileStrings) {
+                throwException(globalObject, scope, createEvalError(globalObject, "Refused to evaluate a string as JavaScript because this document requires a 'Trusted Type' assignment."_s));
+                return nullptr;
+            }
+        }
+    }
+
     if (UNLIKELY(!globalObject->evalEnabled())) {
         scope.clearException();
-        globalObject->globalObjectMethodTable()->reportViolationForUnsafeEval(globalObject, !code.isNull() ? jsNontrivialString(vm, WTFMove(code)) : nullptr);
+        globalObject->globalObjectMethodTable()->reportViolationForUnsafeEval(globalObject, !code.isNull() ? WTFMove(code) : nullString());
         throwException(globalObject, scope, createEvalError(globalObject, globalObject->evalDisabledErrorMessage()));
         return nullptr;
     }

--- a/Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h
+++ b/Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h
@@ -37,6 +37,7 @@ class JSValue;
 class Microtask;
 class RuntimeFlags;
 class SourceOrigin;
+class Structure;
 
 enum class CompilationType;
 enum class ScriptExecutionStatus;
@@ -66,13 +67,14 @@ struct GlobalObjectMethodTable {
     JSObject* (*currentScriptExecutionOwner)(JSGlobalObject*);
 
     ScriptExecutionStatus (*scriptExecutionStatus)(JSGlobalObject*, JSObject* scriptExecutionOwner);
-    void (*reportViolationForUnsafeEval)(JSGlobalObject*, JSString*);
+    void (*reportViolationForUnsafeEval)(JSGlobalObject*, const String&);
     String (*defaultLanguage)();
     JSPromise* (*compileStreaming)(JSGlobalObject*, JSValue);
     JSPromise* (*instantiateStreaming)(JSGlobalObject*, JSValue, JSObject*);
     JSGlobalObject* (*deriveShadowRealmGlobalObject)(JSGlobalObject*);
     String (*codeForEval)(JSGlobalObject*, JSValue);
-    bool (*canCompileStrings)(JSGlobalObject*, CompilationType, String, JSValue);
+    bool (*canCompileStrings)(JSGlobalObject*, CompilationType, String, const ArgList&);
+    Structure* (*trustedScriptStructure)(JSGlobalObject*);
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/IndirectEvalExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/IndirectEvalExecutable.cpp
@@ -42,7 +42,7 @@ inline IndirectEvalExecutable* IndirectEvalExecutable::createImpl(JSGlobalObject
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (!globalObject->evalEnabled()) {
-        globalObject->globalObjectMethodTable()->reportViolationForUnsafeEval(globalObject, source.provider() ? jsNontrivialString(vm, source.provider()->source().toString()) : nullptr);
+        globalObject->globalObjectMethodTable()->reportViolationForUnsafeEval(globalObject, source.provider() ? source.provider()->source().toString() : nullString());
         throwException(globalObject, scope, createEvalError(globalObject, globalObject->evalDisabledErrorMessage()));
         return nullptr;
     }

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -630,6 +630,7 @@ const GlobalObjectMethodTable* JSGlobalObject::baseGlobalObjectMethodTable()
         &deriveShadowRealmGlobalObject,
         &codeForEval,
         &canCompileStrings,
+        &trustedScriptStructure,
     };
     return &table;
 };
@@ -1075,6 +1076,8 @@ void JSGlobalObject::init(VM& vm)
     m_regExpMatchesArrayStructure.set(vm, this, createRegExpMatchesArrayStructure(vm, this));
     m_regExpMatchesArrayWithIndicesStructure.set(vm, this, createRegExpMatchesArrayWithIndicesStructure(vm, this));
     m_regExpMatchesIndicesArrayStructure.set(vm, this, createRegExpMatchesIndicesArrayStructure(vm, this));
+
+    m_trustedScriptStructure.setMayBeNull(vm, this, globalObjectMethodTable()->trustedScriptStructure(this));
 
     m_moduleRecordStructure.initLater(
         [] (const Initializer<Structure>& init) {
@@ -2670,6 +2673,7 @@ void JSGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitFunctionStructures(thisObject->m_builtinFunctions);
     visitFunctionStructures(thisObject->m_ordinaryFunctions);
     visitor.append(thisObject->m_boundFunctionStructure);
+    visitor.append(thisObject->m_trustedScriptStructure);
 
     thisObject->m_customGetterFunctionStructure.visit(visitor);
     thisObject->m_customSetterFunctionStructure.visit(visitor);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -367,6 +367,7 @@ public:
     WriteBarrierStructureID m_regExpMatchesArrayWithIndicesStructure;
     WriteBarrierStructureID m_regExpMatchesIndicesArrayStructure;
     LazyProperty<JSGlobalObject, Structure> m_regExpStringIteratorStructure;
+    WriteBarrierStructureID m_trustedScriptStructure;
 
     LazyProperty<JSGlobalObject, Structure> m_customGetterFunctionStructure;
     LazyProperty<JSGlobalObject, Structure> m_customSetterFunctionStructure;
@@ -863,7 +864,7 @@ public:
     Structure* asyncGeneratorFunctionStructure() const { return m_asyncGeneratorFunctionStructure.get(); }
     Structure* iteratorStructure() const { return m_iteratorStructure.get(); }
     Structure* iteratorHelperStructure() const { return m_iteratorHelperStructure.get(); }
-    Structure* arrayIteratorStructure() const { return m_arrayIteratorStructure.get(); }    
+    Structure* arrayIteratorStructure() const { return m_arrayIteratorStructure.get(); }
     Structure* mapIteratorStructure() const { return m_mapIteratorStructure.get(); }
     Structure* setIteratorStructure() const { return m_setIteratorStructure.get(); }
     Structure* wrapForValidIteratorStructure() const { return m_wrapForValidIteratorStructure.get(this); }
@@ -902,6 +903,7 @@ public:
     Structure* segmentIteratorStructure() { return m_segmentIteratorStructure.get(this); }
     Structure* segmenterStructure() { return m_segmenterStructure.get(this); }
     Structure* segmentsStructure() { return m_segmentsStructure.get(this); }
+    Structure* trustedScriptStructure() { return m_trustedScriptStructure.get(); }
 
     JSObject* dateTimeFormatConstructor() { return m_dateTimeFormatStructure.constructor(this); }
     JSObject* dateTimeFormatPrototype() { return m_dateTimeFormatStructure.prototype(this); }
@@ -969,9 +971,10 @@ public:
     static void reportUncaughtExceptionAtEventLoop(JSGlobalObject*, Exception*);
     static JSObject* currentScriptExecutionOwner(JSGlobalObject* global) { return global; }
     static ScriptExecutionStatus scriptExecutionStatus(JSGlobalObject*, JSObject*) { return ScriptExecutionStatus::Running; }
-    static void reportViolationForUnsafeEval(JSGlobalObject*, JSString*) { }
+    static void reportViolationForUnsafeEval(JSGlobalObject*, const String&) { }
     static String codeForEval(JSGlobalObject*, JSValue) { return nullString(); }
-    static bool canCompileStrings(JSGlobalObject*, CompilationType, String, JSValue) { return true; }
+    static bool canCompileStrings(JSGlobalObject*, CompilationType, String, const ArgList&) { return true; }
+    static Structure* trustedScriptStructure(JSGlobalObject*) { return nullptr; }
 
     inline JSObject* arrayBufferPrototype(ArrayBufferSharingMode) const;
     inline Structure* arrayBufferStructure(ArrayBufferSharingMode) const;
@@ -1067,8 +1070,7 @@ public:
     JS_EXPORT_PRIVATE void queueMicrotask(Ref<Microtask>&&);
     JS_EXPORT_PRIVATE void queueMicrotask(JSValue job, JSValue, JSValue, JSValue, JSValue);
 
-    static void reportViolationForUnsafeEval(const JSGlobalObject*, JSString*) { }
-    static String codeForEval(const JSGlobalObject*, JSValue) { return nullString(); }
+    static void reportViolationForUnsafeEval(const JSGlobalObject*, const String&) { }
 
     bool evalEnabled() const { return m_evalEnabled; }
     bool webAssemblyEnabled() const { return m_webAssemblyEnabled; }

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -670,7 +670,6 @@ dom/TextDecoderStreamDecoder.h
 dom/Traversal.cpp
 dom/TreeScope.cpp
 dom/TreeWalker.cpp
-dom/TrustedType.cpp
 dom/ViewTransition.cpp
 dom/ViewTransitionTypeSet.cpp
 dom/VisitedLinkState.cpp

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -49,6 +49,7 @@
 #include "JSReadableStream.h"
 #include "JSShadowRealmGlobalScope.h"
 #include "JSShadowRealmGlobalScopeBase.h"
+#include "JSTrustedScript.h"
 #include "JSWorkerGlobalScope.h"
 #include "JSWorkletGlobalScope.h"
 #include "JSWritableStream.h"
@@ -372,7 +373,17 @@ ScriptExecutionContext* JSDOMGlobalObject::scriptExecutionContext() const
     return nullptr;
 }
 
-bool JSDOMGlobalObject::canCompileStrings(JSGlobalObject* globalObject, CompilationType compilationType, String codeString, JSValue bodyArgument)
+String JSDOMGlobalObject::codeForEval(JSGlobalObject* globalObject, JSValue value)
+{
+    VM& vm = globalObject->vm();
+
+    if (auto* script = JSTrustedScript::toWrapped(vm, value))
+        return script->toString();
+
+    return String();
+}
+
+bool JSDOMGlobalObject::canCompileStrings(JSGlobalObject* globalObject, CompilationType compilationType, String codeString, const ArgList& args)
 {
     VM& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
@@ -380,14 +391,24 @@ bool JSDOMGlobalObject::canCompileStrings(JSGlobalObject* globalObject, Compilat
     auto& thisObject = static_cast<JSDOMGlobalObject&>(*globalObject);
     auto* scriptExecutionContext = thisObject.scriptExecutionContext();
 
-    auto result = canCompile(*scriptExecutionContext, compilationType, codeString, bodyArgument);
+    auto result = canCompile(*scriptExecutionContext, compilationType, codeString, args);
 
     if (result.hasException()) {
-        propagateException(*globalObject, throwScope, result.releaseException());
-        RETURN_IF_EXCEPTION(throwScope, false);
+        // https://w3c.github.io/webappsec-csp/#can-compile-strings
+        // Step 2.7. If the algorithm throws an error, throw an EvalError.
+        // This clears the existing exceptions and returns false, where the caller throws an EvalError.
+        throwScope.clearException();
+        return false;
     }
 
     return result.releaseReturnValue();
+}
+
+Structure* JSDOMGlobalObject::trustedScriptStructure(JSGlobalObject* globalObject)
+{
+    auto& thisObject = static_cast<JSDOMGlobalObject&>(*globalObject);
+
+    return getDOMStructure<JSTrustedScript>(globalObject->vm(), thisObject);
 }
 
 template<typename Visitor>

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.h
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.h
@@ -85,7 +85,9 @@ public:
 
     ScriptExecutionContext* scriptExecutionContext() const;
 
-    static bool canCompileStrings(JSC::JSGlobalObject*, JSC::CompilationType, String, JSC::JSValue);
+    static String codeForEval(JSC::JSGlobalObject*, JSC::JSValue);
+    static bool canCompileStrings(JSC::JSGlobalObject*, JSC::CompilationType, String, const JSC::ArgList&);
+    static JSC::Structure* trustedScriptStructure(JSC::JSGlobalObject*);
 
     // https://tc39.es/ecma262/#sec-agent-clusters
     String agentClusterID() const;

--- a/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
@@ -108,7 +108,8 @@ const GlobalObjectMethodTable* JSDOMWindowBase::globalObjectMethodTable()
 #endif
         deriveShadowRealmGlobalObject,
         codeForEval,
-        canCompileStrings
+        canCompileStrings,
+        trustedScriptStructure,
     };
     return &table;
 };
@@ -280,7 +281,7 @@ JSC::ScriptExecutionStatus JSDOMWindowBase::scriptExecutionStatus(JSC::JSGlobalO
     return jsCast<JSDocument*>(owner)->wrapped().jscScriptExecutionStatus();
 }
 
-void JSDOMWindowBase::reportViolationForUnsafeEval(JSGlobalObject* object, JSString* source)
+void JSDOMWindowBase::reportViolationForUnsafeEval(JSGlobalObject* object, const String& source)
 {
     const JSDOMWindowBase* thisObject = static_cast<const JSDOMWindowBase*>(object);
     CheckedPtr<ContentSecurityPolicy> contentSecurityPolicy;
@@ -296,25 +297,7 @@ void JSDOMWindowBase::reportViolationForUnsafeEval(JSGlobalObject* object, JSStr
     if (!contentSecurityPolicy)
         return;
 
-    String sourceString;
-    if (source)
-        sourceString = source->tryGetValue();
-    contentSecurityPolicy->allowEval(object, LogToConsole::No, sourceString);
-}
-
-String JSDOMWindowBase::codeForEval(JSGlobalObject* globalObject, JSValue value)
-{
-    VM& vm = globalObject->vm();
-
-    if (auto* script = JSTrustedScript::toWrapped(vm, value))
-        return script->toString();
-
-    return nullString();
-}
-
-bool JSDOMWindowBase::canCompileStrings(JSGlobalObject* globalObject, CompilationType compilationType, String codeString, JSValue bodyArgument)
-{
-    return JSDOMGlobalObject::canCompileStrings(globalObject, compilationType, codeString, bodyArgument);
+    contentSecurityPolicy->allowEval(object, LogToConsole::No, source);
 }
 
 void JSDOMWindowBase::willRemoveFromWindowProxy()

--- a/Source/WebCore/bindings/js/JSDOMWindowBase.h
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.h
@@ -31,6 +31,7 @@
 #include <JavaScriptCore/Lookup.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorInlines.h>
+#include <JavaScriptCore/Structure.h>
 #include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/WriteBarrier.h>
 #include <cstddef>
@@ -79,9 +80,7 @@ public:
     static void queueMicrotaskToEventLoop(JSC::JSGlobalObject&, Ref<JSC::Microtask>&&);
     static JSC::JSObject* currentScriptExecutionOwner(JSC::JSGlobalObject*);
     static JSC::ScriptExecutionStatus scriptExecutionStatus(JSC::JSGlobalObject*, JSC::JSObject*);
-    static void reportViolationForUnsafeEval(JSC::JSGlobalObject*, JSC::JSString*);
-    static String codeForEval(JSC::JSGlobalObject*, JSC::JSValue);
-    static bool canCompileStrings(JSC::JSGlobalObject*, JSC::CompilationType, String, JSC::JSValue);
+    static void reportViolationForUnsafeEval(JSC::JSGlobalObject*, const String&);
 
     void printErrorMessage(const String&) const;
 

--- a/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.cpp
+++ b/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.cpp
@@ -73,6 +73,7 @@ const GlobalObjectMethodTable* JSShadowRealmGlobalScopeBase::globalObjectMethodT
         &deriveShadowRealmGlobalObject,
         &codeForEval,
         &canCompileStrings,
+        &trustedScriptStructure,
     };
     return &table;
 };
@@ -149,20 +150,10 @@ JSC::ScriptExecutionStatus JSShadowRealmGlobalScopeBase::scriptExecutionStatus(J
     return incubating->globalObjectMethodTable()->scriptExecutionStatus(incubating, owner);
 }
 
-void JSShadowRealmGlobalScopeBase::reportViolationForUnsafeEval(JSC::JSGlobalObject* globalObject, JSC::JSString* msg)
+void JSShadowRealmGlobalScopeBase::reportViolationForUnsafeEval(JSC::JSGlobalObject* globalObject, const String& msg)
 {
     auto incubating = jsCast<JSShadowRealmGlobalScopeBase*>(globalObject)->incubatingRealm();
     incubating->globalObjectMethodTable()->reportViolationForUnsafeEval(incubating, msg);
-}
-
-String JSShadowRealmGlobalScopeBase::codeForEval(JSC::JSGlobalObject* globalObject, JSC::JSValue value)
-{
-    return JSGlobalObject::codeForEval(globalObject, value);
-}
-
-bool JSShadowRealmGlobalScopeBase::canCompileStrings(JSC::JSGlobalObject* globalObject, JSC::CompilationType compilationType, String codeString, JSC::JSValue bodyArgument)
-{
-    return JSGlobalObject::canCompileStrings(globalObject, compilationType, codeString, bodyArgument);
 }
 
 void JSShadowRealmGlobalScopeBase::queueMicrotaskToEventLoop(JSGlobalObject& object, Ref<JSC::Microtask>&& task)

--- a/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.h
+++ b/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.h
@@ -54,9 +54,7 @@ private:
     static JSC::RuntimeFlags javaScriptRuntimeFlags(const JSC::JSGlobalObject*);
     static JSC::ScriptExecutionStatus scriptExecutionStatus(JSC::JSGlobalObject*, JSC::JSObject*);
     static void queueMicrotaskToEventLoop(JSC::JSGlobalObject&, Ref<JSC::Microtask>&&);
-    static void reportViolationForUnsafeEval(JSC::JSGlobalObject*, JSC::JSString*);
-    static String codeForEval(JSC::JSGlobalObject*, JSC::JSValue);
-    static bool canCompileStrings(JSC::JSGlobalObject*, JSC::CompilationType, String, JSC::JSValue);
+    static void reportViolationForUnsafeEval(JSC::JSGlobalObject*, const String&);
 
 protected:
     JSShadowRealmGlobalScopeBase(JSC::VM&, JSC::Structure*, RefPtr<ShadowRealmGlobalScope>&&);

--- a/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp
+++ b/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp
@@ -78,6 +78,7 @@ const GlobalObjectMethodTable* JSWorkerGlobalScopeBase::globalObjectMethodTable(
         deriveShadowRealmGlobalObject,
         codeForEval,
         canCompileStrings,
+        trustedScriptStructure,
     };
     return &table;
 };
@@ -144,24 +145,9 @@ JSC::ScriptExecutionStatus JSWorkerGlobalScopeBase::scriptExecutionStatus(JSC::J
     return jsCast<JSWorkerGlobalScopeBase*>(globalObject)->scriptExecutionContext()->jscScriptExecutionStatus();
 }
 
-void JSWorkerGlobalScopeBase::reportViolationForUnsafeEval(JSC::JSGlobalObject* globalObject, JSC::JSString* source)
+void JSWorkerGlobalScopeBase::reportViolationForUnsafeEval(JSC::JSGlobalObject* globalObject, const String& source)
 {
     return JSGlobalObject::reportViolationForUnsafeEval(globalObject, source);
-}
-
-String JSWorkerGlobalScopeBase::codeForEval(JSC::JSGlobalObject* globalObject, JSC::JSValue value)
-{
-    VM& vm = globalObject->vm();
-
-    if (auto* script = JSTrustedScript::toWrapped(vm, value))
-        return script->toString();
-
-    return nullString();
-}
-
-bool JSWorkerGlobalScopeBase::canCompileStrings(JSC::JSGlobalObject* globalObject, JSC::CompilationType compilationType, String codeString, JSC::JSValue bodyArgument)
-{
-    return JSDOMGlobalObject::canCompileStrings(globalObject, compilationType, codeString, bodyArgument);
 }
 
 void JSWorkerGlobalScopeBase::queueMicrotaskToEventLoop(JSGlobalObject& object, Ref<JSC::Microtask>&& task)

--- a/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.h
+++ b/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.h
@@ -57,9 +57,7 @@ public:
     static JSC::RuntimeFlags javaScriptRuntimeFlags(const JSC::JSGlobalObject*);
     static JSC::ScriptExecutionStatus scriptExecutionStatus(JSC::JSGlobalObject*, JSC::JSObject*);
     static void queueMicrotaskToEventLoop(JSC::JSGlobalObject&, Ref<JSC::Microtask>&&);
-    static void reportViolationForUnsafeEval(JSC::JSGlobalObject*, JSC::JSString*);
-    static String codeForEval(JSC::JSGlobalObject*, JSC::JSValue);
-    static bool canCompileStrings(JSC::JSGlobalObject*, JSC::CompilationType, String, JSC::JSValue);
+    static void reportViolationForUnsafeEval(JSC::JSGlobalObject*, const String&);
 
 protected:
     JSWorkerGlobalScopeBase(JSC::VM&, JSC::Structure*, RefPtr<WorkerGlobalScope>&&);

--- a/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.cpp
+++ b/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.cpp
@@ -71,6 +71,7 @@ const GlobalObjectMethodTable* JSWorkletGlobalScopeBase::globalObjectMethodTable
         deriveShadowRealmGlobalObject,
         codeForEval,
         canCompileStrings,
+        trustedScriptStructure,
     };
     return &table;
 };
@@ -116,19 +117,9 @@ JSC::ScriptExecutionStatus JSWorkletGlobalScopeBase::scriptExecutionStatus(JSC::
     return jsCast<JSWorkletGlobalScopeBase*>(globalObject)->scriptExecutionContext()->jscScriptExecutionStatus();
 }
 
-void JSWorkletGlobalScopeBase::reportViolationForUnsafeEval(JSC::JSGlobalObject* globalObject, JSC::JSString* source)
+void JSWorkletGlobalScopeBase::reportViolationForUnsafeEval(JSC::JSGlobalObject* globalObject, const String& source)
 {
     return JSGlobalObject::reportViolationForUnsafeEval(globalObject, source);
-}
-
-String JSWorkletGlobalScopeBase::codeForEval(JSC::JSGlobalObject* globalObject, JSC::JSValue value)
-{
-    return JSGlobalObject::codeForEval(globalObject, value);
-}
-
-bool JSWorkletGlobalScopeBase::canCompileStrings(JSC::JSGlobalObject* globalObject, JSC::CompilationType compilationType, String codeString, JSC::JSValue bodyArgument)
-{
-    return JSGlobalObject::canCompileStrings(globalObject, compilationType, codeString, bodyArgument);
 }
 
 bool JSWorkletGlobalScopeBase::supportsRichSourceInfo(const JSGlobalObject* object)

--- a/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.h
+++ b/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.h
@@ -58,9 +58,7 @@ public:
     static JSC::RuntimeFlags javaScriptRuntimeFlags(const JSC::JSGlobalObject*);
     static JSC::ScriptExecutionStatus scriptExecutionStatus(JSC::JSGlobalObject*, JSC::JSObject*);
     static void queueMicrotaskToEventLoop(JSC::JSGlobalObject&, Ref<JSC::Microtask>&&);
-    static void reportViolationForUnsafeEval(JSC::JSGlobalObject*, JSC::JSString*);
-    static String codeForEval(JSC::JSGlobalObject*, JSC::JSValue);
-    static bool canCompileStrings(JSC::JSGlobalObject*, JSC::CompilationType, String, JSC::JSValue);
+    static void reportViolationForUnsafeEval(JSC::JSGlobalObject*, const String&);
 
 protected:
     JSWorkletGlobalScopeBase(JSC::VM&, JSC::Structure*, RefPtr<WorkletGlobalScope>&&);

--- a/Source/WebCore/dom/TrustedType.cpp
+++ b/Source/WebCore/dom/TrustedType.cpp
@@ -38,6 +38,7 @@
 #include "WindowOrWorkerGlobalScopeTrustedTypes.h"
 #include "WorkerGlobalScope.h"
 #include "XLinkNames.h"
+#include <JavaScriptCore/ArgList.h>
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSCJSValueInlines.h>
@@ -302,12 +303,40 @@ ExceptionOr<String> requireTrustedTypesForPreNavigationCheckPasses(ScriptExecuti
         : nullString());
 }
 
-ExceptionOr<bool> canCompile(ScriptExecutionContext& scriptExecutionContext, JSC::CompilationType compilationType, String codeString, JSC::JSValue bodyArgument)
+ExceptionOr<bool> canCompile(ScriptExecutionContext& scriptExecutionContext, JSC::CompilationType compilationType, String codeString, const JSC::ArgList& args)
 {
-    if (bodyArgument.isObject())
-        return JSTrustedScript::toWrapped(scriptExecutionContext.vm(), bodyArgument) ? true : false;
+    if (compilationType == CompilationType::Function) {
+        VM& vm = scriptExecutionContext.vm();
+        auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ASSERT(bodyArgument.isString());
+        bool isTrusted = true;
+
+        for (size_t i = 0; i < args.size(); i++) {
+            auto arg = args.at(i);
+            if (!arg.isObject()) {
+                isTrusted = false;
+                break;
+            }
+            if (auto trustedScript = JSTrustedScript::toWrapped(vm, arg)) {
+                if (!trustedScript) {
+                    isTrusted = false;
+                    break;
+                }
+                auto argString = arg.toWTFString(scriptExecutionContext.globalObject());
+                RETURN_IF_EXCEPTION(scope, Exception { ExceptionCode::ExistingExceptionError });
+                if (trustedScript->toString() != argString) {
+                    isTrusted = false;
+                    break;
+                }
+            } else {
+                isTrusted = false;
+                break;
+            }
+        }
+
+        if (isTrusted)
+            return true;
+    }
 
     auto sink = compilationType == CompilationType::Function ? "Function"_s : "eval"_s;
 

--- a/Source/WebCore/dom/TrustedType.h
+++ b/Source/WebCore/dom/TrustedType.h
@@ -32,7 +32,7 @@
 
 namespace JSC {
 
-class JSValue;
+class ArgList;
 
 enum class CompilationType;
 
@@ -72,6 +72,6 @@ ExceptionOr<String> trustedTypeCompliantString(ScriptExecutionContext&, std::var
 
 WEBCORE_EXPORT AttributeTypeAndSink trustedTypeForAttribute(const String& elementName, const String& attributeName, const String& elementNamespace, const String& attributeNamespace);
 
-ExceptionOr<bool> canCompile(ScriptExecutionContext&, JSC::CompilationType, String codeString, JSC::JSValue bodyArgument);
+ExceptionOr<bool> canCompile(ScriptExecutionContext&, JSC::CompilationType, String codeString, const JSC::ArgList& args);
 
 } // namespace WebCore


### PR DESCRIPTION
#### 152e920a5ac26047b9103bd750367343205e7752
<pre>
Implement trusted types enforcement on Function constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=273187">https://bugs.webkit.org/show_bug.cgi?id=273187</a>

Reviewed by Yusuke Suzuki.

This patch adds trusted types enforcement to the Function constructor as well as updating the eval implementation.

The canCompileStrings global method table function no longer takes a JSValue argument,
this is because it is now only called for untrusted input from eval.

The implementation of TT enforcement for both direct and indirect eval is updated to do more work in JSC.
The structure of the TrustedScript type is used by JSC to determine if an object should be evaluated,
rather than always calling codeForEval. Only if the structures don&apos;t match is codeForEval called, this can happen
if someone changes the instance properties such as for polyfills.

The canCompileStrings call is now only done if the input is known
to be untrusted (raw string rather than TrustedScript argument).

The Function constructor is now also updated such that when TT enforcement is enabled through CSP, similar logic
comparing the arguments to the TrustedScript structure is used.
If not all of the arguments match the structure then they&apos;re not trusted so we fallback to calling canCompileStrings,
with a new ArgList atgument.

The ArgList is used to check if the arguments are modified trusted script objects, which are accepted providing the
stringifier isn&apos;t modified.

DebuggerEvalEnabler is also updated to disable trusted types and re-enable it, so that
web inspector can continue working on sites with TT enforced.

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-clips-sample.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy-mutate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-no-default-policy-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-permissive-csp-expected.txt:
* Source/JavaScriptCore/API/JSAPIGlobalObject.cpp:
(JSC::JSAPIGlobalObject::globalObjectMethodTable):
* Source/JavaScriptCore/API/JSAPIGlobalObject.mm:
(JSC::JSAPIGlobalObject::globalObjectMethodTable):
* Source/JavaScriptCore/debugger/DebuggerEvalEnabler.h:
(JSC::DebuggerEvalEnabler::DebuggerEvalEnabler):
(JSC::DebuggerEvalEnabler::~DebuggerEvalEnabler):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::eval):
* Source/JavaScriptCore/jsc.cpp:
* Source/JavaScriptCore/runtime/DirectEvalExecutable.cpp:
(JSC::DirectEvalExecutable::create):
* Source/JavaScriptCore/runtime/FunctionConstructor.cpp:
(JSC::constructFunction):
* Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h:
* Source/JavaScriptCore/runtime/IndirectEvalExecutable.cpp:
(JSC::IndirectEvalExecutable::createImpl):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::baseGlobalObjectMethodTable):
(JSC::JSGlobalObject::init):
(JSC::JSGlobalObject::visitChildrenImpl):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::arrayIteratorStructure const):
(JSC::JSGlobalObject::trustedScriptStructure):
(JSC::JSGlobalObject::reportViolationForUnsafeEval):
(JSC::JSGlobalObject::canCompileStrings):
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::JSDOMGlobalObject::codeForEval):
(WebCore::JSDOMGlobalObject::canCompileStrings):
(WebCore::JSDOMGlobalObject::trustedScriptStructure):
* Source/WebCore/bindings/js/JSDOMGlobalObject.h:
* Source/WebCore/bindings/js/JSDOMWindowBase.cpp:
(WebCore::JSDOMWindowBase::globalObjectMethodTable):
(WebCore::JSDOMWindowBase::reportViolationForUnsafeEval):
(WebCore::JSDOMWindowBase::codeForEval): Deleted.
(WebCore::JSDOMWindowBase::canCompileStrings): Deleted.
* Source/WebCore/bindings/js/JSDOMWindowBase.h:
* Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.cpp:
(WebCore::JSShadowRealmGlobalScopeBase::globalObjectMethodTable):
(WebCore::JSShadowRealmGlobalScopeBase::reportViolationForUnsafeEval):
(WebCore::JSShadowRealmGlobalScopeBase::codeForEval): Deleted.
(WebCore::JSShadowRealmGlobalScopeBase::canCompileStrings): Deleted.
* Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.h:
* Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp:
(WebCore::JSWorkerGlobalScopeBase::globalObjectMethodTable):
(WebCore::JSWorkerGlobalScopeBase::reportViolationForUnsafeEval):
(WebCore::JSWorkerGlobalScopeBase::codeForEval): Deleted.
(WebCore::JSWorkerGlobalScopeBase::canCompileStrings): Deleted.
* Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.h:
* Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.cpp:
(WebCore::JSWorkletGlobalScopeBase::globalObjectMethodTable):
(WebCore::JSWorkletGlobalScopeBase::reportViolationForUnsafeEval):
(WebCore::JSWorkletGlobalScopeBase::codeForEval): Deleted.
(WebCore::JSWorkletGlobalScopeBase::canCompileStrings): Deleted.
* Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.h:
* Source/WebCore/dom/TrustedType.cpp:
(WebCore::canCompile):
* Source/WebCore/dom/TrustedType.h:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations: Remove TrustedType.cpp because the file has been fixed.

Canonical link: <a href="https://commits.webkit.org/287909@main">https://commits.webkit.org/287909@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b844e0180ed9190e3e293cf040b286b2a6028632

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85784 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32241 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83365 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8594 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63442 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21210 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84324 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/543 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73955 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43740 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/442 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28117 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30699 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/74234 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87219 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/80313 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8485 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6031 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71752 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8664 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69789 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70987 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17676 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15037 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13946 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/102720 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8446 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13970 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24966 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8283 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11803 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10091 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->