### PR TITLE
Replace StringContext IDL extended attribute with union types

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5522,6 +5522,7 @@ webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html [ Skip ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-report-only.html [ Skip ]
 webkit.org/b/274519 imported/w3c/web-platform-tests/trusted-types/HTMLScriptElement-in-xhtml-document.tentative.https.xhtml [ Skip ]
+webkit.org/b/274519 imported/w3c/web-platform-tests/trusted-types/Document-write-exception-order.xhtml [ Skip ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-importScripts.html [ Pass Failure ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-navigation.html [ Pass Failure ]
 webkit.org/b/274088 imported/w3c/web-platform-tests/trusted-types/Element-setAttribute-respects-Elements-node-documents-globals-CSP.html [ Pass Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Document-write-exception-order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Document-write-exception-order-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+
+PASS `document.write(string)` throws TypeError
+PASS `document.write(TrustedHTML)` throws InvalidStateError
+PASS `document.write(string)` w/ default policy throws InvalidStateError
+

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Document-write-exception-order.xhtml
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Document-write-exception-order.xhtml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="support/helper.sub.js"></script>
+
+  <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script';" />
+</head>
+<body>
+<script>
+  test(t => {
+    const old = document.body.innerText;
+    assert_throws_js(TypeError, _ => {
+      document.write('A string');
+    });
+    assert_equals(document.body.innerText, old);
+  }, "`document.write(string)` throws TypeError");
+
+  let p = createHTML_policy(window, 1);
+  test(t => {
+    const old = document.body.innerText;
+    assert_throws_dom("InvalidStateError", _ => {
+      document.write(p.createHTML('A string'));
+    });
+    assert_equals(document.body.innerText, old);
+  }, "`document.write(TrustedHTML)` throws InvalidStateError");
+
+  let default_policy = trustedTypes.createPolicy('default',
+      { createHTML: createHTMLJS }, true );
+
+  test(t => {
+    const old = document.body.innerText;
+    assert_throws_dom("InvalidStateError", _ => {
+      document.write('A string');
+    });
+    assert_equals(document.body.innerText, old);
+  }, "`document.write(string)` w/ default policy throws InvalidStateError");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-insertAdjacentHTML-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-insertAdjacentHTML-expected.txt
@@ -6,9 +6,12 @@ CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the followin
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 
 PASS insertAdjacentHTML with html assigned via policy (successful HTML transformation).
+PASS insertAdjacentHTML(TrustedHTML) throws SyntaxError DOMException when position invalid.
 PASS `insertAdjacentHTML(string)` throws.
+PASS `insertAdjacentHTML(string)` still throws TypeError when position invalid.
 PASS `insertAdjacentHTML(null)` throws.
 PASS `insertAdjacentHTML(string)` assigned via default policy (successful HTML transformation).
 PASS `insertAdjacentHTML(null)` assigned via default policy does not throw.

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-insertAdjacentHTML.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-insertAdjacentHTML.html
@@ -40,6 +40,24 @@
       container.firstChild.remove();
   }, "insertAdjacentHTML with html assigned via policy (successful HTML transformation).");
 
+  test(t => {
+    let p = createHTML_policy(window, 1);
+    var d = document.createElement('div');
+    container.appendChild(d);
+
+    assert_throws_dom("SyntaxError", _ => {
+      d.insertAdjacentHTML('invalid', p.createHTML("<p>Fail</p>"));
+    });
+
+    assert_equals(d.previousSibling, null);
+    assert_equals(d.firstChild, null);
+    assert_equals(d.lastChild, null);
+    assert_equals(d.nextSibling, null);
+
+    while (container.firstChild)
+      container.firstChild.remove();
+  }, "insertAdjacentHTML(TrustedHTML) throws SyntaxError DOMException when position invalid.");
+
   // String assignments throw.
   test(t => {
     var d = document.createElement('div');
@@ -66,6 +84,23 @@
     while (container.firstChild)
       container.firstChild.remove();
   }, "`insertAdjacentHTML(string)` throws.");
+
+  test(t => {
+    var d = document.createElement('div');
+    container.appendChild(d);
+
+    assert_throws_js(TypeError, _ => {
+      d.insertAdjacentHTML('invalid', "<p>Fail</p>");
+    });
+
+    assert_equals(d.previousSibling, null);
+    assert_equals(d.firstChild, null);
+    assert_equals(d.lastChild, null);
+    assert_equals(d.nextSibling, null);
+
+    while (container.firstChild)
+      container.firstChild.remove();
+  }, "`insertAdjacentHTML(string)` still throws TypeError when position invalid.");
 
   // Null assignment throws.
   test(t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-outerHTML-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-outerHTML-expected.txt
@@ -1,8 +1,11 @@
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 
 PASS outerHTML with html assigned via policy (successful HTML transformation).
+PASS `outerHTML = TrustedHTML` throws NoModificationAllowedError when parent is a document.
 PASS `outerHTML = string` throws.
+PASS `outerHTML = string` throws TypeError even when parent is a document.
 PASS `outerHTML = null` throws.
 PASS `outerHTML = string` assigned via default policy (successful HTML transformation).
 PASS `outerHTML = null` assigned via default policy does not throw

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-outerHTML.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-outerHTML.html
@@ -26,6 +26,13 @@
       container.firstChild.remove();
   }, "outerHTML with html assigned via policy (successful HTML transformation).");
 
+  test(t => {
+    let p = createHTML_policy(window, 1);
+    assert_throws_dom("NoModificationAllowedError", _ => {
+      document.documentElement.outerHTML = p.createHTML('<p>Content</p>');
+    });
+  }, "`outerHTML = TrustedHTML` throws NoModificationAllowedError when parent is a document.");
+
   // String assignments throw.
   test(t => {
     var d = document.createElement('div');
@@ -37,6 +44,12 @@
     while (container.firstChild)
       container.firstChild.remove();
   }, "`outerHTML = string` throws.");
+
+  test(t => {
+    assert_throws_js(TypeError, _ => {
+      document.documentElement.outerHTML = '<p>Content</p>';
+    });
+  }, "`outerHTML = string` throws TypeError even when parent is a document.");
 
   // Null assignment throws.
   test(t => {

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -468,7 +468,7 @@ public:
     void setShouldNotFireMutationEvents(bool fire) { m_shouldNotFireMutationEvents = fire; }
 
     void setMarkupUnsafe(const String&, OptionSet<ParserContentPolicy>);
-    static Ref<Document> parseHTMLUnsafe(Document&, const String&);
+    static ExceptionOr<Ref<Document>> parseHTMLUnsafe(Document&, std::variant<RefPtr<TrustedHTML>, String>&&);
 
     Element* elementForAccessKey(const String& key);
     void invalidateAccessKeyCache();

--- a/Source/WebCore/dom/Document.idl
+++ b/Source/WebCore/dom/Document.idl
@@ -41,7 +41,7 @@ typedef (HTMLScriptElement or SVGScriptElement) HTMLOrSVGScriptElement;
 ] interface Document : Node {
     [CallWith=CurrentDocument] constructor();
 
-    [CallWith=CurrentDocument, EnabledBySetting=DeclarativeShadowRootsParserAPIsEnabled] static Document parseHTMLUnsafe(HTMLString html);
+    [CallWith=CurrentDocument, EnabledBySetting=DeclarativeShadowRootsParserAPIsEnabled] static Document parseHTMLUnsafe((TrustedHTML or DOMString) html);
 
     [SameObject, ImplementedAs=fragmentDirectiveForBindings, EnabledBySetting=ScrollToTextFragmentFeatureDetectionEnabled] readonly attribute FragmentDirective fragmentDirective;
     [SameObject] readonly attribute DOMImplementation implementation;
@@ -103,5 +103,3 @@ Document includes GlobalEventHandlers;
 Document includes DocumentAndElementEventHandlers;
 Document includes FontFaceSource;
 Document includes XPathEvaluatorBase;
-
-typedef [StringContext=TrustedHTML] DOMString HTMLString;

--- a/Source/WebCore/dom/Element+DOMParsing.idl
+++ b/Source/WebCore/dom/Element+DOMParsing.idl
@@ -25,8 +25,6 @@
 
 // https://w3c.github.io/DOM-Parsing/#extensions-to-the-element-interface
 partial interface Element {
-    [CEReactions=Needed] attribute [LegacyNullToEmptyString] HTMLString outerHTML;
-    [CEReactions=Needed] undefined insertAdjacentHTML(DOMString position, HTMLString text);
+    [CEReactions=Needed] attribute (TrustedHTML or [LegacyNullToEmptyString] DOMString)  outerHTML;
+    [CEReactions=Needed] undefined insertAdjacentHTML(DOMString position, (TrustedHTML or DOMString) text);
 };
-
-typedef [StringContext=TrustedHTML] DOMString HTMLString;

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3926,9 +3926,14 @@ ExceptionOr<void> Element::replaceChildrenWithMarkup(const String& markup, Optio
     return replaceChildrenWithFragment(container, fragment.releaseReturnValue());
 }
 
-ExceptionOr<void> Element::setHTMLUnsafe(const String& html)
+ExceptionOr<void> Element::setHTMLUnsafe(std::variant<RefPtr<TrustedHTML>, String>&& html)
 {
-    return replaceChildrenWithMarkup(html, { ParserContentPolicy::AllowDeclarativeShadowRoots, ParserContentPolicy::AlwaysParseAsHTML });
+    auto stringValueHolder = trustedTypeCompliantString(*document().scriptExecutionContext(), WTFMove(html), "Element setHTMLUnsafe"_s);
+
+    if (stringValueHolder.hasException())
+        return stringValueHolder.releaseException();
+
+    return replaceChildrenWithMarkup(stringValueHolder.releaseReturnValue(), { ParserContentPolicy::AllowDeclarativeShadowRoots, ParserContentPolicy::AlwaysParseAsHTML });
 }
 
 String Element::getHTML(GetHTMLOptions&& options) const
@@ -3955,8 +3960,13 @@ String Element::outerHTML() const
     return serializeFragment(*this, SerializedNodes::SubtreeIncludingNode, nullptr, ResolveURLs::NoExcludingURLsForPrivacy);
 }
 
-ExceptionOr<void> Element::setOuterHTML(const String& html)
+ExceptionOr<void> Element::setOuterHTML(std::variant<RefPtr<TrustedHTML>, String>&& html)
 {
+    auto stringValueHolder = trustedTypeCompliantString(*document().scriptExecutionContext(), WTFMove(html), "Element outerHTML"_s);
+
+    if (stringValueHolder.hasException())
+        return stringValueHolder.releaseException();
+
     // The specification allows setting outerHTML on an Element whose parent is a DocumentFragment and Gecko supports this.
     // https://w3c.github.io/DOM-Parsing/#dom-element-outerhtml
     RefPtr parent = parentElement();
@@ -3969,7 +3979,7 @@ ExceptionOr<void> Element::setOuterHTML(const String& html)
     RefPtr previous = previousSibling();
     RefPtr next = nextSibling();
 
-    auto fragment = createFragmentForInnerOuterHTML(*parent, html, { ParserContentPolicy::AllowScriptingContent });
+    auto fragment = createFragmentForInnerOuterHTML(*parent, stringValueHolder.releaseReturnValue(), { ParserContentPolicy::AllowScriptingContent });
     if (fragment.hasException())
         return fragment.releaseException();
 
@@ -3991,9 +4001,14 @@ ExceptionOr<void> Element::setOuterHTML(const String& html)
     return { };
 }
 
-ExceptionOr<void> Element::setInnerHTML(const String& markup)
+ExceptionOr<void> Element::setInnerHTML(std::variant<RefPtr<TrustedHTML>, String>&& html)
 {
-    return replaceChildrenWithMarkup(markup, { });
+    auto stringValueHolder = trustedTypeCompliantString(*document().scriptExecutionContext(), WTFMove(html), "Element innerHTML"_s);
+
+    if (stringValueHolder.hasException())
+        return stringValueHolder.releaseException();
+
+    return replaceChildrenWithMarkup(stringValueHolder.releaseReturnValue(), { });
 }
 
 String Element::innerText()
@@ -5501,9 +5516,14 @@ ExceptionOr<void> Element::insertAdjacentHTML(const String& where, const String&
     return { };
 }
 
-ExceptionOr<void> Element::insertAdjacentHTML(const String& where, const String& markup)
+ExceptionOr<void> Element::insertAdjacentHTML(const String& where, std::variant<RefPtr<TrustedHTML>, String>&& markup)
 {
-    return insertAdjacentHTML(where, markup, nullptr);
+    auto stringValueHolder = trustedTypeCompliantString(*document().scriptExecutionContext(), WTFMove(markup), "Element insertAdjacentHTML"_s);
+
+    if (stringValueHolder.hasException())
+        return stringValueHolder.releaseException();
+
+    return insertAdjacentHTML(where, stringValueHolder.releaseReturnValue(), nullptr);
 }
 
 ExceptionOr<void> Element::insertAdjacentText(const String& where, String&& text)

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -448,7 +448,7 @@ public:
     ExceptionOr<void> insertAdjacentHTML(const String& where, const String& html, NodeVector* addedNodes);
 
     WEBCORE_EXPORT ExceptionOr<Element*> insertAdjacentElement(const String& where, Element& newChild);
-    WEBCORE_EXPORT ExceptionOr<void> insertAdjacentHTML(const String& where, const String& html);
+    WEBCORE_EXPORT ExceptionOr<void> insertAdjacentHTML(const String& where, std::variant<RefPtr<TrustedHTML>, String>&&);
     WEBCORE_EXPORT ExceptionOr<void> insertAdjacentText(const String& where, String&& text);
 
     using Node::computedStyle;
@@ -521,13 +521,13 @@ public:
     virtual void blur();
     virtual void runFocusingStepsForAutofocus();
 
-    ExceptionOr<void> setHTMLUnsafe(const String&);
+    ExceptionOr<void> setHTMLUnsafe(std::variant<RefPtr<TrustedHTML>, String>&&);
     String getHTML(GetHTMLOptions&&) const;
 
     WEBCORE_EXPORT String innerHTML() const;
     WEBCORE_EXPORT String outerHTML() const;
-    WEBCORE_EXPORT ExceptionOr<void> setInnerHTML(const String&);
-    WEBCORE_EXPORT ExceptionOr<void> setOuterHTML(const String&);
+    WEBCORE_EXPORT ExceptionOr<void> setInnerHTML(std::variant<RefPtr<TrustedHTML>, String>&&);
+    WEBCORE_EXPORT ExceptionOr<void> setOuterHTML(std::variant<RefPtr<TrustedHTML>, String>&&);
     WEBCORE_EXPORT String innerText();
     WEBCORE_EXPORT String outerText();
  

--- a/Source/WebCore/dom/InnerHTML.idl
+++ b/Source/WebCore/dom/InnerHTML.idl
@@ -23,13 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://w3c.github.io/DOM-Parsing/#the-innerhtml-mixin
 // https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-parsing-and-serialization
 
 interface mixin InnerHTML {
-    [CEReactions=Needed, EnabledBySetting=DeclarativeShadowRootsParserAPIsEnabled] undefined setHTMLUnsafe(HTMLString html);
+    [CEReactions=Needed, EnabledBySetting=DeclarativeShadowRootsParserAPIsEnabled] undefined setHTMLUnsafe((TrustedHTML or DOMString) html);
     [CEReactions=NotNeeded, EnabledBySetting=DeclarativeShadowRootsSerializerAPIsEnabled] DOMString getHTML(optional GetHTMLOptions options = {});
-    [CEReactions=Needed] attribute [LegacyNullToEmptyString] HTMLString innerHTML;
+    [CEReactions=Needed] attribute (TrustedHTML or [LegacyNullToEmptyString] DOMString) innerHTML;
 };
-
-typedef [StringContext=TrustedHTML] DOMString HTMLString;

--- a/Source/WebCore/dom/Range+DOMParsing.idl
+++ b/Source/WebCore/dom/Range+DOMParsing.idl
@@ -25,7 +25,5 @@
 
 // https://w3c.github.io/DOM-Parsing/#extensions-to-the-range-interface
 partial interface Range {
-    [CEReactions=Needed, NewObject] DocumentFragment createContextualFragment(HTMLString fragment);
+    [CEReactions=Needed, NewObject] DocumentFragment createContextualFragment((TrustedHTML or DOMString) fragment);
 };
-
-typedef [StringContext=TrustedHTML] DOMString HTMLString;

--- a/Source/WebCore/dom/Range.h
+++ b/Source/WebCore/dom/Range.h
@@ -37,6 +37,7 @@ class DocumentFragment;
 class LocalDOMWindow;
 class NodeWithIndex;
 class Text;
+class TrustedHTML;
 
 struct SimpleRange;
 
@@ -90,7 +91,7 @@ public:
     Ref<DOMRectList> getClientRects() const;
     Ref<DOMRect> getBoundingClientRect() const;
 
-    WEBCORE_EXPORT ExceptionOr<Ref<DocumentFragment>> createContextualFragment(const String& fragment);
+    WEBCORE_EXPORT ExceptionOr<Ref<DocumentFragment>> createContextualFragment(std::variant<RefPtr<TrustedHTML>, String>&& fragment);
 
     // Expand range to a unit (word or sentence or block or document) boundary.
     // Please refer to https://bugs.webkit.org/show_bug.cgi?id=27632 comment #5 for details.

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -39,6 +39,7 @@ namespace WebCore {
 class HTMLSlotElement;
 class SlotAssignment;
 class StyleSheetList;
+class TrustedHTML;
 class WebAnimation;
 
 enum class ParserContentPolicy : uint8_t;
@@ -97,11 +98,11 @@ public:
     RefPtr<Element> protectedHost() const { return m_host.get(); }
     void setHost(WeakPtr<Element, WeakPtrImplWithEventTargetData>&& host) { m_host = WTFMove(host); }
 
-    ExceptionOr<void> setHTMLUnsafe(const String&);
+    ExceptionOr<void> setHTMLUnsafe(std::variant<RefPtr<TrustedHTML>, String>&&);
     String getHTML(GetHTMLOptions&&) const;
 
     String innerHTML() const;
-    ExceptionOr<void> setInnerHTML(const String&);
+    ExceptionOr<void> setInnerHTML(std::variant<RefPtr<TrustedHTML>, String>&&);
 
     Ref<Node> cloneNodeInternal(Document&, CloningOperation) override;
 

--- a/Source/WebCore/dom/TrustedType.cpp
+++ b/Source/WebCore/dom/TrustedType.cpp
@@ -188,6 +188,19 @@ ExceptionOr<String> trustedTypeCompliantString(TrustedType expectedType, ScriptE
     return stringValue;
 }
 
+ExceptionOr<String> trustedTypeCompliantString(ScriptExecutionContext& scriptExecutionContext, std::variant<RefPtr<TrustedHTML>, String>&& input, const String& sink)
+{
+    return WTF::switchOn(
+        WTFMove(input),
+        [&scriptExecutionContext, &sink](const String& string) -> ExceptionOr<String> {
+            return trustedTypeCompliantString(TrustedType::TrustedHTML, scriptExecutionContext, string, sink);
+        },
+        [](const RefPtr<TrustedHTML>& html) -> ExceptionOr<String> {
+            return html->toString();
+        }
+    );
+}
+
 ExceptionOr<String> trustedTypeCompliantString(ScriptExecutionContext& scriptExecutionContext, std::variant<RefPtr<TrustedScript>, String>&& input, const String& sink)
 {
     return WTF::switchOn(

--- a/Source/WebCore/dom/TrustedType.h
+++ b/Source/WebCore/dom/TrustedType.h
@@ -59,6 +59,8 @@ WEBCORE_EXPORT ExceptionOr<String> trustedTypeCompliantString(TrustedType, Scrip
 
 WEBCORE_EXPORT ExceptionOr<String> requireTrustedTypesForPreNavigationCheckPasses(ScriptExecutionContext&, const String& urlString);
 
+ExceptionOr<String> trustedTypeCompliantString(ScriptExecutionContext&, std::variant<RefPtr<TrustedHTML>, String>&&, const String& sink);
+
 ExceptionOr<String> trustedTypeCompliantString(ScriptExecutionContext&, std::variant<RefPtr<TrustedScript>, String>&&, const String& sink);
 
 ExceptionOr<String> trustedTypeCompliantString(ScriptExecutionContext&, std::variant<RefPtr<TrustedScriptURL>, String>&&, const String& sink);

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -41,6 +41,7 @@
 #include "ScriptController.h"
 #include "ScriptableDocumentParser.h"
 #include "Settings.h"
+#include "TrustedType.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -188,6 +189,22 @@ const AtomString& HTMLIFrameElement::loadingForBindings() const
 void HTMLIFrameElement::setLoadingForBindings(const AtomString& value)
 {
     setAttributeWithoutSynchronization(loadingAttr, value);
+}
+
+String HTMLIFrameElement::srcdoc() const
+{
+    return attributeWithoutSynchronization(srcdocAttr);
+}
+
+ExceptionOr<void> HTMLIFrameElement::setSrcdoc(std::variant<RefPtr<TrustedHTML>, String>&& value)
+{
+    auto stringValueHolder = trustedTypeCompliantString(*document().scriptExecutionContext(), WTFMove(value), "HTMLIFrameElement srcdoc"_s);
+
+    if (stringValueHolder.hasException())
+        return stringValueHolder.releaseException();
+
+    setAttributeWithoutSynchronization(srcdocAttr, AtomString { stringValueHolder.releaseReturnValue() });
+    return { };
 }
 
 static bool isFrameLazyLoadable(const Document& document, const URL& url, const AtomString& loadingAttributeValue)

--- a/Source/WebCore/html/HTMLIFrameElement.h
+++ b/Source/WebCore/html/HTMLIFrameElement.h
@@ -31,6 +31,7 @@ namespace WebCore {
 class DOMTokenList;
 class LazyLoadFrameObserver;
 class RenderIFrame;
+class TrustedHTML;
 
 class HTMLIFrameElement final : public HTMLFrameElementBase {
     WTF_MAKE_ISO_ALLOCATED(HTMLIFrameElement);
@@ -47,6 +48,9 @@ public:
 
     const AtomString& loadingForBindings() const;
     void setLoadingForBindings(const AtomString&);
+
+    String srcdoc() const;
+    ExceptionOr<void> setSrcdoc(std::variant<RefPtr<TrustedHTML>, String>&&);
 
     LazyLoadFrameObserver& lazyLoadFrameObserver();
 

--- a/Source/WebCore/html/HTMLIFrameElement.idl
+++ b/Source/WebCore/html/HTMLIFrameElement.idl
@@ -25,7 +25,7 @@
     JSGenerateToNativeObject
 ] interface HTMLIFrameElement : HTMLElement {
     [Reflect, URL, CEReactions=NotNeeded] attribute USVString src;
-    [Reflect, CEReactions=NotNeeded] attribute HTMLString srcdoc;
+    [CEReactions=NotNeeded] attribute (TrustedHTML or DOMString) srcdoc;
     [Reflect, CEReactions=NotNeeded] attribute DOMString name;
     [SameObject, PutForwards=value] readonly attribute DOMTokenList sandbox;
     [Reflect, CEReactions=NotNeeded] attribute DOMString allow;
@@ -49,5 +49,3 @@
     [Reflect, CEReactions=NotNeeded] attribute [LegacyNullToEmptyString] DOMString marginWidth;
 
 };
-
-typedef [StringContext=TrustedHTML] DOMString HTMLString;

--- a/Source/WebCore/workers/Worker.h
+++ b/Source/WebCore/workers/Worker.h
@@ -50,6 +50,7 @@ namespace WebCore {
 class RTCRtpScriptTransform;
 class RTCRtpScriptTransformer;
 class ScriptExecutionContext;
+class TrustedScriptURL;
 class WorkerGlobalScopeProxy;
 class WorkerScriptLoader;
 
@@ -63,7 +64,7 @@ public:
     using AbstractWorker::WeakValueType;
     using AbstractWorker::WeakPtrImplType;
 
-    static ExceptionOr<Ref<Worker>> create(ScriptExecutionContext&, JSC::RuntimeFlags, const String& url, WorkerOptions&&);
+    static ExceptionOr<Ref<Worker>> create(ScriptExecutionContext&, JSC::RuntimeFlags, std::variant<RefPtr<TrustedScriptURL>, String>&&, WorkerOptions&&);
     virtual ~Worker();
 
     // ActiveDOMObject.

--- a/Source/WebCore/workers/Worker.idl
+++ b/Source/WebCore/workers/Worker.idl
@@ -28,7 +28,7 @@
     ActiveDOMObject,
     Exposed=(Window,DedicatedWorker)
 ] interface Worker : EventTarget {
-    [CallWith=CurrentScriptExecutionContext&RuntimeFlags] constructor(ScriptURLString scriptUrl, optional WorkerOptions options);
+    [CallWith=CurrentScriptExecutionContext&RuntimeFlags] constructor((TrustedScriptURL or USVString) scriptURL, optional WorkerOptions options);
 
     undefined terminate();
 
@@ -39,5 +39,3 @@
 };
 
 Worker includes AbstractWorker;
-
-typedef [StringContext=TrustedScriptURL] USVString ScriptURLString;

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -60,6 +60,7 @@ class ReportingScope;
 class ScheduledAction;
 class ScriptBuffer;
 class ScriptBufferSourceProvider;
+class TrustedScriptURL;
 class WorkerCacheStorageConnection;
 class WorkerClient;
 class WorkerFileSystemStorageConnection;
@@ -118,7 +119,7 @@ public:
     WorkerLocation& location() const;
     void close();
 
-    virtual ExceptionOr<void> importScripts(const FixedVector<String>& urls);
+    virtual ExceptionOr<void> importScripts(const FixedVector<std::variant<RefPtr<TrustedScriptURL>, String>>& urls);
     WorkerNavigator& navigator();
 
     void setIsOnline(bool);

--- a/Source/WebCore/workers/WorkerGlobalScope.idl
+++ b/Source/WebCore/workers/WorkerGlobalScope.idl
@@ -33,7 +33,7 @@
     readonly attribute WorkerGlobalScope self;
     readonly attribute WorkerLocation location;
     readonly attribute WorkerNavigator navigator;
-    undefined importScripts(ScriptURLString... urls);
+    undefined importScripts((TrustedScriptURL or USVString)... urls);
 
     attribute OnErrorEventHandler onerror;
     // FIXME: Implement 'onlanguagechange'.
@@ -46,5 +46,3 @@
 
 WorkerGlobalScope includes WindowOrWorkerGlobalScope;
 WorkerGlobalScope includes FontFaceSource;
-
-typedef [StringContext=TrustedScriptURL] USVString ScriptURLString;

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.h
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.h
@@ -47,6 +47,7 @@ namespace WebCore {
 class DeferredPromise;
 class NavigatorBase;
 class ServiceWorker;
+class TrustedScriptURL;
 
 enum class ServiceWorkerUpdateViaCache : uint8_t;
 enum class WorkerType : bool;
@@ -69,7 +70,7 @@ public:
     ReadyPromise& ready();
 
     using RegistrationOptions = ServiceWorkerRegistrationOptions;
-    void addRegistration(const String& scriptURL, const RegistrationOptions&, Ref<DeferredPromise>&&);
+    void addRegistration(std::variant<RefPtr<TrustedScriptURL>, String>&&, const RegistrationOptions&, Ref<DeferredPromise>&&);
     void unregisterRegistration(ServiceWorkerRegistrationIdentifier, DOMPromiseDeferred<IDLBoolean>&&);
     void updateRegistration(const URL& scopeURL, const URL& scriptURL, WorkerType, RefPtr<DeferredPromise>&&);
 

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.idl
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.idl
@@ -36,7 +36,7 @@
     readonly attribute ServiceWorker? controller;
     readonly attribute Promise<ServiceWorkerRegistration> ready;
 
-    [NewObject, ImplementedAs=addRegistration] Promise<ServiceWorkerRegistration> register(ScriptURLString scriptURL, optional RegistrationOptions options);
+    [NewObject, ImplementedAs=addRegistration] Promise<ServiceWorkerRegistration> register((TrustedScriptURL or USVString) scriptURL, optional RegistrationOptions options);
     [NewObject] Promise<any> getRegistration(optional USVString clientURL = "");
     [NewObject] Promise<sequence<ServiceWorkerRegistration>> getRegistrations();
 
@@ -53,5 +53,3 @@ dictionary RegistrationOptions {
     WorkerType type = "classic";
     ServiceWorkerUpdateViaCache updateViaCache = "imports";
 };
-
-typedef [StringContext=TrustedScriptURL] USVString ScriptURLString;

--- a/Source/WebCore/workers/shared/SharedWorker.h
+++ b/Source/WebCore/workers/shared/SharedWorker.h
@@ -37,13 +37,14 @@ namespace WebCore {
 
 class MessagePort;
 class ResourceError;
+class TrustedScriptURL;
 
 struct WorkerOptions;
 
 class SharedWorker final : public AbstractWorker, public ActiveDOMObject, public Identified<SharedWorkerObjectIdentifier> {
     WTF_MAKE_ISO_ALLOCATED(SharedWorker);
 public:
-    static ExceptionOr<Ref<SharedWorker>> create(Document&, String&& scriptURL, std::optional<std::variant<String, WorkerOptions>>&&);
+    static ExceptionOr<Ref<SharedWorker>> create(Document&, std::variant<RefPtr<TrustedScriptURL>, String>&&, std::optional<std::variant<String, WorkerOptions>>&&);
     ~SharedWorker();
 
     void ref() const final { AbstractWorker::ref(); }

--- a/Source/WebCore/workers/shared/SharedWorker.idl
+++ b/Source/WebCore/workers/shared/SharedWorker.idl
@@ -28,10 +28,9 @@
     Exposed=Window
 ]
 interface SharedWorker : EventTarget {
-  [CallWith=CurrentDocument] constructor(ScriptURLString scriptURL, optional (DOMString or WorkerOptions) options);
+  [CallWith=CurrentDocument] constructor((TrustedScriptURL or USVString) scriptURL, optional (DOMString or WorkerOptions) options);
 
   readonly attribute MessagePort port;
 };
 SharedWorker includes AbstractWorker;
 
-typedef [StringContext=TrustedScriptURL] USVString ScriptURLString;

--- a/Source/WebCore/xml/DOMParser.h
+++ b/Source/WebCore/xml/DOMParser.h
@@ -26,13 +26,14 @@ namespace WebCore {
 class Document;
 class WeakPtrImplWithEventTargetData;
 class Settings;
+class TrustedHTML;
 
 class DOMParser : public RefCounted<DOMParser> {
 public:
     static Ref<DOMParser> create(Document& contextDocument);
     ~DOMParser();
 
-    ExceptionOr<Ref<Document>> parseFromString(const String&, const AtomString& contentType);
+    ExceptionOr<Ref<Document>> parseFromString(std::variant<RefPtr<TrustedHTML>, String>&&, const AtomString& contentType);
 
 private:
     explicit DOMParser(Document& contextDocument);

--- a/Source/WebCore/xml/DOMParser.idl
+++ b/Source/WebCore/xml/DOMParser.idl
@@ -22,7 +22,5 @@
 ] interface DOMParser {
     [CallWith=CurrentDocument] constructor();
 
-    [NewObject] Document parseFromString(HTMLString string, [AtomString] DOMString contentType);
+    [NewObject] Document parseFromString((TrustedHTML or DOMString) string, [AtomString] DOMString contentType);
 };
-
-typedef [StringContext=TrustedHTML] DOMString HTMLString;


### PR DESCRIPTION
#### 3b35a19d0a910ba3376525d9dae67fe6b4d5016f
<pre>
Replace StringContext IDL extended attribute with union types
<a href="https://bugs.webkit.org/show_bug.cgi?id=273412">https://bugs.webkit.org/show_bug.cgi?id=273412</a>

Reviewed by Darin Adler.

This patch replaces most usages of the StringContext IDL extended attribute,
with union types and updates to the callsites to do the trusted type enforcement.

Follow up patches will address HTML timer functions, Document write(ln) and the StringContext code generator changes.

* Source/WebCore/dom/Document+HTML.idl:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::parseHTMLUnsafe):
(WebCore::Document::write):
(WebCore::Document::writeln):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Document.idl:
* Source/WebCore/dom/Element+DOMParsing.idl:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setHTMLUnsafe):
(WebCore::Element::setOuterHTML):
(WebCore::Element::setInnerHTML):
(WebCore::Element::insertAdjacentHTML):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/InnerHTML.idl:
* Source/WebCore/dom/Range+DOMParsing.idl:
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::createContextualFragment):
* Source/WebCore/dom/Range.h:
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::setHTMLUnsafe):
(WebCore::ShadowRoot::setInnerHTML):
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/dom/TrustedType.cpp:
(WebCore::trustedTypeCompliantString):
* Source/WebCore/dom/TrustedType.h:
* Source/WebCore/html/HTMLIFrameElement.cpp:
(WebCore::HTMLIFrameElement::srcdoc const):
(WebCore::HTMLIFrameElement::setSrcdoc):
* Source/WebCore/html/HTMLIFrameElement.h:
* Source/WebCore/html/HTMLIFrameElement.idl:
* Source/WebCore/workers/Worker.cpp:
(WebCore::Worker::create):
* Source/WebCore/workers/Worker.h:
* Source/WebCore/workers/Worker.idl:
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::importScripts):
* Source/WebCore/workers/WorkerGlobalScope.h:
* Source/WebCore/workers/WorkerGlobalScope.idl:
* Source/WebCore/workers/service/ServiceWorkerContainer.cpp:
(WebCore::ServiceWorkerContainer::addRegistration):
* Source/WebCore/workers/service/ServiceWorkerContainer.h:
* Source/WebCore/workers/service/ServiceWorkerContainer.idl:
* Source/WebCore/workers/shared/SharedWorker.cpp:
(WebCore::SharedWorker::create):
* Source/WebCore/workers/shared/SharedWorker.h:
* Source/WebCore/workers/shared/SharedWorker.idl:
* Source/WebCore/xml/DOMParser.cpp:
(WebCore::DOMParser::parseFromString):
* Source/WebCore/xml/DOMParser.h:
* Source/WebCore/xml/DOMParser.idl:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/Document-write-exception-order-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/Document-write-exception-order.xhtml: Added.
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-insertAdjacentHTML-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-insertAdjacentHTML.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-outerHTML-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-outerHTML.html:
* LayoutTests/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/279313@main">https://commits.webkit.org/279313@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6774a5f3af0a50b6917aeccf624cadfdcd187c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5576 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56368 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3812 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55394 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3539 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43054 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2466 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55187 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30183 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45828 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24182 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27187 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3156 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1971 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49039 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57963 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3262 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50456 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29450 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46054 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11585 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30369 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29204 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->