### PR TITLE
pral.com.pk - Double bounce animation compared to other browsers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/shadow-root-insertion-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/shadow-root-insertion-expected.txt
@@ -1,0 +1,3 @@
+
+PASS addition of a shadow root should not cancel in-flight transitions
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/shadow-root-insertion.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/shadow-root-insertion.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Transitions: behavior when a shadow root is inserted while transitioning</title>
+<meta name="assert" content="Checks the addition of a shadow root does not affect an in-flight transition">
+<link rel="help" href="https://drafts.csswg.org/css-transitions/">
+
+<script src="/resources/testharness.js" type="text/javascript"></script>
+<script src="/resources/testharnessreport.js" type="text/javascript"></script>
+<script src="./support/helper.js" type="text/javascript"></script>
+
+</head>
+<body>
+<div id="log"></div>
+<script>
+test(t => {
+  // Start a 100s transition 50% of the way through
+  const div = addDiv(t, {
+    style: 'transition: height 100s -50s linear; height: 0px',
+  });
+  getComputedStyle(div).height;
+  div.style.height = '100px';
+  assert_equals(
+    getComputedStyle(div).height,
+    '50px',
+    'Transition should be initially 50% complete'
+  );
+
+  // Add a shadow root
+  div.attachShadow({ mode: "open" });
+
+  // The transition on the height property should not have been canceled
+  assert_equals(
+    getComputedStyle(div).height,
+    '50px',
+    'Transition should not have been canceled'
+  );
+}, 'addition of a shadow root should not cancel in-flight transitions');
+</script>
+
+</body>
+</html>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2867,7 +2867,7 @@ void Element::addShadowRoot(Ref<ShadowRoot>&& newShadowRoot)
         WidgetHierarchyUpdatesSuspensionScope suspendWidgetHierarchyUpdates;
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
         if (renderer() || hasDisplayContents())
-            RenderTreeUpdater::tearDownRenderers(*this);
+            RenderTreeUpdater::tearDownRenderersForShadowRootInsertion(*this);
 
         ensureElementRareData().setShadowRoot(WTFMove(newShadowRoot));
 

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.h
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.h
@@ -49,6 +49,7 @@ public:
     void commit(std::unique_ptr<Style::Update>);
 
     static void tearDownRenderers(Element&);
+    static void tearDownRenderersForShadowRootInsertion(Element&);
     static void tearDownRenderersAfterSlotChange(Element& host);
     static void tearDownRenderer(Text&);
 
@@ -92,7 +93,8 @@ private:
     void popParentsToDepth(unsigned depth);
 
     // FIXME: Use OptionSet.
-    enum class TeardownType { Full, FullAfterSlotChange, RendererUpdate, RendererUpdateCancelingAnimations };
+    enum class TeardownType { Full, FullAfterSlotOrShadowRootChange, RendererUpdate, RendererUpdateCancelingAnimations };
+    static void tearDownRenderers(Element&, TeardownType);
     static void tearDownRenderers(Element&, TeardownType, RenderTreeBuilder&);
     static void tearDownTextRenderer(Text&, const ContainerNode* root, RenderTreeBuilder&);
     static void tearDownLeftoverChildrenOfComposedTree(Element&, RenderTreeBuilder&);


### PR DESCRIPTION
#### 19c5bd914bfa1fb024e81ef201480315edd4bb7d
<pre>
pral.com.pk - Double bounce animation compared to other browsers
<a href="https://bugs.webkit.org/show_bug.cgi?id=273364">https://bugs.webkit.org/show_bug.cgi?id=273364</a>
<a href="https://rdar.apple.com/127188948">rdar://127188948</a>

Reviewed by Antti Koivisto.

The site pral.com.pk has a list of images under their &quot;ISO CERTIFICATIONS&quot; section that are badges with text
rendered within the raster image. Those images run a transition when hovered. After a short while, the transition
is restarted, and this only happens in Safari, and only the first time a given image is hovered.

WebKit in Safari supports text recognition within images, performed asynchronously, and when text is detected
a user-agent shadow root is inserted within the &lt;img&gt; element to show additional UI. The addition of a shadow root
triggers a full renderer rebuild and this has the side effect of canceling all running style-originated animations
on that element.

This explains why the transition appears to restart, because the initial transition is canceled once text recognition
succeeds, and since the cursor is still over the image, a new transition immediately starts. Since the user-agent
shadow root remains attached, hovering over the image a second time does not exhibit the behavior.

We fixed a similar issue in the past with 240582@main to deal with a slot change while a transition is running on an
element and introduced a dedicated `TeardownType` value that distinguishes a full rebuild from a rebuild resulting
from a slot change.

We follow the same approach for the case where a shadow root is inserted, adding a new `tearDownRenderersForShadowRootInsertion()`
method which will call the same logic as `tearDownRenderersAfterSlotChange()`, with an inverse assertion as to whether
the provided element has a shadow root attached. This prompted some refactoring of `tearDownRenderers()` as well since
there is a lot of shared code with the aforementioned methods.

We test this with a new WPT test that would fail prior to this change but already works in Chrome and Firefox.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/shadow-root-insertion-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/shadow-root-insertion.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::addShadowRoot):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::tearDownRenderers):
(WebCore::RenderTreeUpdater::tearDownRenderersForShadowRootInsertion):
(WebCore::RenderTreeUpdater::tearDownRenderersAfterSlotChange):
* Source/WebCore/rendering/updating/RenderTreeUpdater.h:

Canonical link: <a href="https://commits.webkit.org/278156@main">https://commits.webkit.org/278156@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbf105aed9066fa252c996f61e07616e7d8a7866

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52910 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/344 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51973 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26573 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/51768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/26484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/21646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/23926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8039 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/44463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54487 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24755 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20909 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/26022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26870 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7146 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/25747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->