### PR TITLE
Add quirk for TripAdvisor to support mixed content in their Panorama feature

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1845,4 +1845,23 @@ bool Quirks::needsGetElementsByNameQuirk() const
 #endif
 }
 
+bool Quirks::needsRelaxedCorsMixedContentCheckQuirk() const
+{
+    if (!needsQuirks())
+        return false;
+
+    if (m_needsRelaxedCorsMixedContentCheckQuirk)
+        return *m_needsRelaxedCorsMixedContentCheckQuirk;
+
+    m_needsRelaxedCorsMixedContentCheckQuirk = false;
+
+    auto host = m_document->url().host();
+
+    // FIXME: Remove this quirk when <rdar://127247321> is complete
+    if (host == "tripadvisor.com"_s || host.endsWith(".tripadvisor.com"_s))
+        m_needsRelaxedCorsMixedContentCheckQuirk = true;
+
+    return *m_needsRelaxedCorsMixedContentCheckQuirk;
+}
+
 }

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -190,6 +190,7 @@ public:
     WEBCORE_EXPORT bool shouldUseEphemeralPartitionedStorageForDOMCookies(const URL&) const;
 
     bool needsGetElementsByNameQuirk() const;
+    bool needsRelaxedCorsMixedContentCheckQuirk() const;
 
 private:
     bool needsQuirks() const;
@@ -262,6 +263,7 @@ private:
     mutable std::optional<bool> m_needsDisableDOMPasteAccessQuirk;
     mutable std::optional<bool> m_shouldDisableElementFullscreen;
     mutable std::optional<bool> m_shouldIgnorePlaysInlineRequirementQuirk;
+    mutable std::optional<bool> m_needsRelaxedCorsMixedContentCheckQuirk;
 
     Vector<RegistrableDomain> m_subFrameDomainsForStorageAccessQuirk;
 };


### PR DESCRIPTION
#### 0a2730dd7efa7b0fceccec9ae9b3f5d14acebd7f
<pre>
Add quirk for TripAdvisor to support mixed content in their Panorama feature
<a href="https://bugs.webkit.org/show_bug.cgi?id=273425">https://bugs.webkit.org/show_bug.cgi?id=273425</a>
&lt;<a href="https://rdar.apple.com/112851939">rdar://112851939</a>&gt;

Reviewed by Matthew Finkel.

Add a quirk to allow TripAdvisor.com&apos;s Panorama feature to work despite their use of mixed
content in conjunction with crossorigin=&quot;&quot; style. This brings Safari behavior in line with
Chrome, which performs the insecure content upgrade (even though the specification indicates
this should not happen).

* Source/WebCore/loader/MixedContentChecker.cpp:
(WebCore::destinationIsImageAudioOrVideo):
(WebCore::MixedContentChecker::shouldUpgradeInsecureContent):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsRelaxedCorsMixedContentCheckQuirk const):
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/278170@main">https://commits.webkit.org/278170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15d690906a97fc16591f42efaec32b4afc4f4816

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49590 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52832 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/266 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51894 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34895 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40481 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51690 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26411 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42717 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21596 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23864 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43901 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7961 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45782 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44406 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54409 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24675 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20851 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25944 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26788 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7153 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25669 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->