### PR TITLE
ToPropertyKeyOrNumber incorrectly says it doesn't return a number in AI

### DIFF
--- a/JSTests/stress/ToPropertyKeyOrNumber-AI-should-include-number.js
+++ b/JSTests/stress/ToPropertyKeyOrNumber-AI-should-include-number.js
@@ -1,0 +1,12 @@
+//@ requireOptions("--jitPolicyScale=0", "--useConcurrentJIT=0")
+
+function opt() {
+  function f(){
+  }((Error)[flag?0:(WebAssembly)])++
+}
+flag=true
+try{opt()}catch{}
+flag=false
+try{opt()}catch{}
+flag=true
+try{opt()}catch{}

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3000,7 +3000,10 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
 
         clobberWorld();
 
-        setTypeForNode(node, SpecString | SpecSymbol);
+        SpeculatedType type = SpecString | SpecSymbol;
+        if (node->op() == ToPropertyKeyOrNumber)
+            type |= SpecBytecodeNumber;
+        setTypeForNode(node, type);
         break;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -15967,7 +15967,7 @@ void SpeculativeJIT::compileToPropertyKeyOrNumber(Node* node)
 
     addSlowPathGenerator(slowPathCall(slowCases, this, operationToPropertyKeyOrNumber, resultRegs, LinkableConstant::globalObject(*this, node), argumentRegs));
 
-    jsValueResult(resultRegs, node, DataFormatJSCell, UseChildrenCalledExplicitly);
+    jsValueResult(resultRegs, node, DataFormatJS, UseChildrenCalledExplicitly);
 }
 
 void SpeculativeJIT::compileToNumeric(Node* node)


### PR DESCRIPTION
#### f8e2f45c2312e66f34db314a2ca054d0adaac66e
<pre>
ToPropertyKeyOrNumber incorrectly says it doesn&apos;t return a number in AI
<a href="https://bugs.webkit.org/show_bug.cgi?id=273429">https://bugs.webkit.org/show_bug.cgi?id=273429</a>
<a href="https://rdar.apple.com/127225001">rdar://127225001</a>

Reviewed by Yusuke Suzuki.

Right now ToPropertyKeyOrNumber falls through to ToPropertyKey, which says it always
returns `SpecString | SpecSymbol`. This is obviously wrong.

* JSTests/stress/ToPropertyKeyOrNumber-AI-should-include-number.js: Added.
(opt.f):
(opt):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/278136@main">https://commits.webkit.org/278136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3c0b40c1dda8460a820299e5f8cc3798703946b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52632 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52827 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/261 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26490 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51685 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26406 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/21598 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23857 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43896 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7956 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/42900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44401 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54404 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/49080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24670 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20841 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25939 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10887 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26783 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56567 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25664 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11629 "Passed tests") | 
<!--EWS-Status-Bubble-End-->