### PR TITLE
Generate serialization of Skia Font implementation

### DIFF
--- a/Source/WebCore/platform/graphics/FontCustomPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontCustomPlatformData.h
@@ -57,7 +57,7 @@ enum class FontTechnology : uint8_t;
 template <typename T> class FontTaggedSettings;
 typedef FontTaggedSettings<int> FontFeatureSettings;
 
-#if USE(CORE_TEXT)
+#if USE(CORE_TEXT) || USE(SKIA)
 struct FontCustomPlatformSerializedData {
     Vector<uint8_t> fontFaceData;
     String itemInCollection;
@@ -90,7 +90,7 @@ public:
 
     FontPlatformData fontPlatformData(const FontDescription&, bool bold, bool italic, const FontCreationContext&);
 
-#if USE(CORE_TEXT)
+#if USE(CORE_TEXT) || USE(SKIA)
     WEBCORE_EXPORT FontCustomPlatformSerializedData serializedData() const;
     WEBCORE_EXPORT static std::optional<Ref<FontCustomPlatformData>> tryMakeFromSerializationData(FontCustomPlatformSerializedData&&, bool);
 #endif

--- a/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
@@ -140,4 +140,19 @@ bool FontCustomPlatformData::supportsTechnology(const FontTechnology&)
     return true;
 }
 
+std::optional<Ref<FontCustomPlatformData>> FontCustomPlatformData::tryMakeFromSerializationData(FontCustomPlatformSerializedData&& data, bool)
+{
+    auto buffer = SharedBuffer::create(WTFMove(data.fontFaceData));
+    RefPtr fontCustomPlatformData = FontCustomPlatformData::create(buffer, data.itemInCollection);
+    if (!fontCustomPlatformData)
+        return std::nullopt;
+    fontCustomPlatformData->m_renderingResourceIdentifier = data.renderingResourceIdentifier;
+    return fontCustomPlatformData.releaseNonNull();
+}
+
+FontCustomPlatformSerializedData FontCustomPlatformData::serializedData() const
+{
+    return FontCustomPlatformSerializedData { { creationData.fontFaceData->span() }, creationData.itemInCollection, m_renderingResourceIdentifier };
+}
+
 }

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -373,7 +373,7 @@ void RemoteRenderingBackend::cacheFont(const Font::Attributes& fontAttributes, F
     m_remoteResourceCache.cacheFont(WTFMove(font));
 }
 
-#if PLATFORM(COCOA)
+#if PLATFORM(COCOA) || USE(SKIA)
 void RemoteRenderingBackend::cacheFontCustomPlatformData(WebCore::FontCustomPlatformSerializedData&& fontCustomPlatformSerializedData)
 {
     ASSERT(!RunLoop::isMain());
@@ -620,6 +620,11 @@ void RemoteRenderingBackend::terminateWebProcess(ASCIILiteral message)
 bool RemoteRenderingBackend::shouldUseLockdownFontParser() const
 {
     return m_gpuConnectionToWebProcess->isLockdownSafeFontParserEnabled() && m_gpuConnectionToWebProcess->isLockdownModeEnabled() && PAL::canLoad_CoreText_CTFontManagerCreateMemorySafeFontDescriptorFromData();
+}
+#elif USE(SKIA)
+bool RemoteRenderingBackend::shouldUseLockdownFontParser() const
+{
+    return false;
 }
 #endif
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -145,7 +145,7 @@ private:
     void cacheGradient(Ref<WebCore::Gradient>&&);
     void cacheFilter(Ref<WebCore::Filter>&&);
     void cacheFont(const WebCore::Font::Attributes&, WebCore::FontPlatformDataAttributes, std::optional<WebCore::RenderingResourceIdentifier>);
-#if PLATFORM(COCOA)
+#if PLATFORM(COCOA) || USE(SKIA)
     void cacheFontCustomPlatformData(WebCore::FontCustomPlatformSerializedData&&);
 #else
     void cacheFontCustomPlatformData(Ref<WebCore::FontCustomPlatformData>&&);
@@ -184,7 +184,7 @@ private:
 
     Ref<ShapeDetection::ObjectHeap> protectedShapeDetectionObjectHeap() const;
 
-#if PLATFORM(COCOA)
+#if PLATFORM(COCOA) || USE(SKIA)
     bool shouldUseLockdownFontParser() const;
 #endif
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -29,10 +29,10 @@ messages -> RemoteRenderingBackend NotRefCounted Stream {
     DestroyGetPixelBufferSharedMemory()
     CacheNativeImage(WebCore::ShareableBitmapHandle handle, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) NotStreamEncodable
     CacheFont(struct WebCore::FontInternalAttributes data, struct WebCore::FontPlatformDataAttributes platformData, std::optional<WebCore::RenderingResourceIdentifier> renderingResourceIdentifier) NotStreamEncodable
-#if PLATFORM(COCOA)
+#if PLATFORM(COCOA) || USE(SKIA)
     CacheFontCustomPlatformData(struct WebCore::FontCustomPlatformSerializedData fontCustomPlatformData) NotStreamEncodable
 #endif
-#if !PLATFORM(COCOA)
+#if !PLATFORM(COCOA) && !USE(SKIA)
     CacheFontCustomPlatformData(Ref<WebCore::FontCustomPlatformData> customPlatformData) NotStreamEncodable
 #endif
     CacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs> decomposedGlyphs)

--- a/Source/WebKit/Platform/Skia.cmake
+++ b/Source/WebKit/Platform/Skia.cmake
@@ -11,8 +11,13 @@ list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
 )
 
 list(APPEND WebKit_SERIALIZATION_IN_FILES
+    Shared/WebCoreFont.serialization.in
+
+    Shared/harfbuzz/WebCoreArgumentCodersHarfBuzz.serialization.in
+
     Shared/skia/CoreIPCSkColorSpace.serialization.in
     Shared/skia/CoreIPCSkData.serialization.in
+    Shared/skia/WebCoreArgumentCodersSkia.serialization.in
 )
 
 list(APPEND WebKit_LIBRARIES

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -36,7 +36,7 @@ namespace IPC {
 using namespace WebCore;
 using namespace WebKit;
 
-#if !USE(CORE_TEXT)
+#if !USE(CORE_TEXT) && !USE(SKIA)
 void ArgumentCoder<WebCore::Font>::encode(Encoder& encoder, const WebCore::Font& font)
 {
     encoder << font.attributes();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -52,7 +52,7 @@ class FontPlatformData;
 
 namespace IPC {
 
-#if !USE(CORE_TEXT)
+#if !USE(CORE_TEXT) && !USE(SKIA)
 template<> struct ArgumentCoder<WebCore::Font> {
     static void encode(Encoder&, const WebCore::Font&);
     static std::optional<Ref<WebCore::Font>> decode(Decoder&);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4271,27 +4271,6 @@ header: <WebCore/FontAttributes.h>
     bool hasMultipleFonts
 };
 
-#if USE(CORE_TEXT)
-using WebCore::FontPlatformData::IPCData = std::variant<WebCore::FontPlatformSerializedData, WebCore::FontPlatformSerializedCreationData>;
-#endif
-
-#if USE(CORE_TEXT)
-[RefCounted] class WebCore::Font {
-    WebCore::FontInternalAttributes attributes();
-    WebCore::FontPlatformData platformData();
-}
-
-[CreateUsing=fromIPCData] class WebCore::FontPlatformData {
-    float size();
-    WebCore::FontOrientation orientation();
-    WebCore::FontWidthVariant widthVariant();
-    WebCore::TextRenderingMode textRenderingMode();
-    bool syntheticBold();
-    bool syntheticOblique();
-    WebCore::FontPlatformData::IPCData toIPCData();
-}
-#endif
-
 header: <WebCore/WritingDirection.h>
 enum class WebCore::WritingDirection : uint8_t {
     Natural,

--- a/Source/WebKit/Shared/harfbuzz/WebCoreArgumentCodersHarfBuzz.serialization.in
+++ b/Source/WebKit/Shared/harfbuzz/WebCoreArgumentCodersHarfBuzz.serialization.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Apple Inc. All rights reserved.
+# Copyright (C) 2024 Igalia, S.L.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -20,40 +20,16 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#if USE(CORE_TEXT) || USE(SKIA)
-using WebCore::FontPlatformData::IPCData = std::variant<WebCore::FontPlatformSerializedData, WebCore::FontPlatformSerializedCreationData>;
-#endif
-
-[RefCounted] class WebCore::Font {
-    WebCore::FontInternalAttributes attributes();
-    WebCore::FontPlatformData platformData();
-}
-
-[CreateUsing=fromIPCData] class WebCore::FontPlatformData {
-    float size();
-    WebCore::FontOrientation orientation();
-    WebCore::FontWidthVariant widthVariant();
-    WebCore::TextRenderingMode textRenderingMode();
-    bool syntheticBold();
-    bool syntheticOblique();
-    WebCore::FontPlatformData::IPCData toIPCData();
-}
-
-header: <WebCore/FontPlatformData.h>
-[CustomHeader] struct WebCore::FontPlatformDataAttributes {
-    float m_size;
-    WebCore::FontOrientation m_orientation;
-    WebCore::FontWidthVariant m_widthVariant;
-    WebCore::TextRenderingMode m_textRenderingMode;
-    bool m_syntheticBold;
-    bool m_syntheticOblique;
-#if USE(CORE_TEXT)
-    RetainPtr<CFDictionaryRef> m_attributes;
-    CTFontDescriptorOptions m_options;
-    RetainPtr<CFStringRef> m_url;
-    RetainPtr<CFStringRef> m_psName;
-#endif
 #if USE(SKIA)
-    Vector<hb_feature_t> m_features;
-#endif
-};
+
+using hb_tag_t = uint32_t;
+
+header: <hb.h>
+[CustomHeader] struct hb_feature_t {
+     hb_tag_t tag;
+     uint32_t value;
+     unsigned start;
+     unsigned end;
+}
+
+#endif // USE(SKIA)

--- a/Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.cpp
+++ b/Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.cpp
@@ -35,28 +35,6 @@
 
 namespace IPC {
 
-void ArgumentCoder<WebCore::Font>::encodePlatformData(Encoder&, const WebCore::Font&)
-{
-    ASSERT_NOT_REACHED();
-}
-
-std::optional<WebCore::FontPlatformData> ArgumentCoder<WebCore::Font>::decodePlatformData(Decoder&)
-{
-    ASSERT_NOT_REACHED();
-    return std::nullopt;
-}
-
-void ArgumentCoder<WebCore::FontPlatformData::Attributes>::encodePlatformData(Encoder&, const WebCore::FontPlatformData::Attributes&)
-{
-    ASSERT_NOT_REACHED();
-}
-
-bool ArgumentCoder<WebCore::FontPlatformData::Attributes>::decodePlatformData(Decoder&, WebCore::FontPlatformData::Attributes&)
-{
-    ASSERT_NOT_REACHED();
-    return false;
-}
-
 void ArgumentCoder<sk_sp<SkColorSpace>>::encode(Encoder& encoder, const sk_sp<SkColorSpace>& colorSpace)
 {
     encoder << WebKit::CoreIPCSkColorSpace(colorSpace);

--- a/Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.serialization.in
+++ b/Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.serialization.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Apple Inc. All rights reserved.
+# Copyright (C) 2024 Sony Interactive Entertainment Inc.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -20,40 +20,24 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#if USE(CORE_TEXT) || USE(SKIA)
-using WebCore::FontPlatformData::IPCData = std::variant<WebCore::FontPlatformSerializedData, WebCore::FontPlatformSerializedCreationData>;
-#endif
-
-[RefCounted] class WebCore::Font {
-    WebCore::FontInternalAttributes attributes();
-    WebCore::FontPlatformData platformData();
-}
-
-[CreateUsing=fromIPCData] class WebCore::FontPlatformData {
-    float size();
-    WebCore::FontOrientation orientation();
-    WebCore::FontWidthVariant widthVariant();
-    WebCore::TextRenderingMode textRenderingMode();
-    bool syntheticBold();
-    bool syntheticOblique();
-    WebCore::FontPlatformData::IPCData toIPCData();
-}
+#if USE(SKIA)
 
 header: <WebCore/FontPlatformData.h>
-[CustomHeader] struct WebCore::FontPlatformDataAttributes {
-    float m_size;
-    WebCore::FontOrientation m_orientation;
-    WebCore::FontWidthVariant m_widthVariant;
-    WebCore::TextRenderingMode m_textRenderingMode;
-    bool m_syntheticBold;
-    bool m_syntheticOblique;
-#if USE(CORE_TEXT)
-    RetainPtr<CFDictionaryRef> m_attributes;
-    CTFontDescriptorOptions m_options;
-    RetainPtr<CFStringRef> m_url;
-    RetainPtr<CFStringRef> m_psName;
-#endif
-#if USE(SKIA)
-    Vector<hb_feature_t> m_features;
-#endif
+[CustomHeader] struct WebCore::FontPlatformSerializedCreationData {
+    Vector<uint8_t> fontFaceData;
+    String itemInCollection;
 };
+
+header: <WebCore/FontPlatformData.h>
+[CustomHeader] struct WebCore::FontPlatformSerializedData {
+    sk_sp<SkData> typefaceData;
+};
+
+header: <WebCore/FontCustomPlatformData.h>
+[CustomHeader] struct WebCore::FontCustomPlatformSerializedData {
+    Vector<uint8_t> fontFaceData;
+    String itemInCollection;
+    WebCore::RenderingResourceIdentifier renderingResourceIdentifier;
+};
+
+#endif

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -378,7 +378,7 @@ void RemoteRenderingBackendProxy::cacheFont(const WebCore::Font::Attributes& fon
 void RemoteRenderingBackendProxy::cacheFontCustomPlatformData(Ref<const FontCustomPlatformData>&& customPlatformData)
 {
     Ref<FontCustomPlatformData> data = adoptRef(const_cast<FontCustomPlatformData&>(customPlatformData.leakRef()));
-#if PLATFORM(COCOA)
+#if PLATFORM(COCOA) || USE(SKIA)
     send(Messages::RemoteRenderingBackend::CacheFontCustomPlatformData(data->serializedData()));
 #else
     send(Messages::RemoteRenderingBackend::CacheFontCustomPlatformData(WTFMove(data)));


### PR DESCRIPTION
#### aa1e67cc9e681eb2e8fea487a9bef1e542983ec6
<pre>
Generate serialization of Skia Font implementation
<a href="https://bugs.webkit.org/show_bug.cgi?id=273445">https://bugs.webkit.org/show_bug.cgi?id=273445</a>

Reviewed by Alex Christensen.

Add `WebCoreArgumentCodersSkia.serialization.in` which generates serialization
of Skia&apos;s font implementation. Follow along with the CoreText implementation
to reuse as much of their implementation as possible.

* Source/WebCore/platform/graphics/FontCustomPlatformData.h:
* Source/WebCore/platform/graphics/FontPlatformData.h:
(WebCore::FontPlatformDataAttributes::FontPlatformDataAttributes):
* Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp:
(WebCore::FontCustomPlatformData::tryMakeFromSerializationData):
(WebCore::FontCustomPlatformData::serializedData const):
* Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp:
(WebCore::FontPlatformData::FontPlatformData):
(WebCore::FontPlatformData::platformDataInit):
(WebCore::FontPlatformData::fromIPCData):
(WebCore::FontPlatformData::toIPCData const):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::shouldUseLockdownFontParser const):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/Platform/Skia.cmake:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebCoreFont.serialization.in:
* Source/WebKit/Shared/harfbuzz/WebCoreArgumentCodersHarfBuzz.serialization.in: Copied from Source\WebKit\Shared\WebCoreFont.serialization.in.
* Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.cpp:
(IPC::ArgumentCoder&lt;WebCore::Font&gt;::encodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;WebCore::Font&gt;::decodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;WebCore::FontPlatformData::Attributes&gt;::encodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;WebCore::FontPlatformData::Attributes&gt;::decodePlatformData): Deleted.
* Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.serialization.in: Copied from Source\WebKit\Shared\WebCoreFont.serialization.in.
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::cacheFontCustomPlatformData):

Canonical link: <a href="https://commits.webkit.org/286581@main">https://commits.webkit.org/286581@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00da610979da0b8a8e55ff53d96ef95587708e09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29297 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80926 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27667 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78508 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59902 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18018 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49804 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40234 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47199 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23090 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25989 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68327 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23422 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82364 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3767 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2465 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68114 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3920 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65570 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67428 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16815 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11389 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9490 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3714 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6523 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3737 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7167 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5495 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->