### PR TITLE
[Unified Text Replacement] Remove unused `WebTextReplacementData::State::Committed` enum case

### DIFF
--- a/Source/WebKit/Shared/UnifiedTextReplacement.serialization.in
+++ b/Source/WebKit/Shared/UnifiedTextReplacement.serialization.in
@@ -25,7 +25,6 @@ header: "WebTextReplacementData.h"
 [CustomHeader] enum class WebKit::WebTextReplacementDataState : uint8_t {
     Pending,
     Active,
-    Committed,
     Reverted,
     Invalid
 };

--- a/Source/WebKit/Shared/WebTextReplacementData.h
+++ b/Source/WebKit/Shared/WebTextReplacementData.h
@@ -37,7 +37,6 @@ namespace WebKit {
 enum class WebTextReplacementDataState : uint8_t {
     Pending,
     Active,
-    Committed,
     Reverted,
     Invalid,
 };

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm
@@ -179,20 +179,16 @@ void UnifiedTextReplacementController::textReplacementSessionDidUpdateStateForRe
         return;
     }
 
-    if (state != WebTextReplacementData::State::Committed && state != WebTextReplacementData::State::Reverted && state != WebTextReplacementData::State::Active)
-        return;
-
     auto nodeAndMarker = findReplacementMarkerByUUID(*sessionRange, replacement.uuid);
-    if (!nodeAndMarker) {
-        ASSERT_NOT_REACHED();
+    if (!nodeAndMarker)
         return;
-    }
 
     auto& [node, marker] = *nodeAndMarker;
 
     auto rangeToReplace = WebCore::makeSimpleRange(node, marker);
 
-    if (state == WebTextReplacementData::State::Active) {
+    switch (state) {
+    case WebTextReplacementData::State::Active: {
         document->selection().setSelection({ rangeToReplace });
 
         auto rect = document->view()->contentsToRootView(WebCore::unionRect(WebCore::RenderObject::absoluteTextRects(rangeToReplace)));
@@ -201,26 +197,20 @@ void UnifiedTextReplacementController::textReplacementSessionDidUpdateStateForRe
         return;
     }
 
-    auto data = std::get<WebCore::DocumentMarker::UnifiedTextReplacementData>(marker.data());
+    case WebTextReplacementData::State::Reverted: {
+        auto data = std::get<WebCore::DocumentMarker::UnifiedTextReplacementData>(marker.data());
 
-    auto offsetRange = WebCore::OffsetRange { marker.startOffset(), marker.endOffset() };
-    document->markers().removeMarkers(node, offsetRange, { WebCore::DocumentMarker::Type::UnifiedTextReplacement });
+        auto offsetRange = WebCore::OffsetRange { marker.startOffset(), marker.endOffset() };
+        document->markers().removeMarkers(node, offsetRange, { WebCore::DocumentMarker::Type::UnifiedTextReplacement });
 
-    auto newText = [&] {
-        switch (state) {
-        case WebTextReplacementData::State::Committed:
-            return replacement.replacement;
+        replaceContentsOfRangeInSession(uuid, rangeToReplace, data.originalText);
 
-        case WebTextReplacementData::State::Reverted:
-            return data.originalText;
+        return;
+    }
 
-        default:
-            ASSERT_NOT_REACHED();
-            return nullString();
-        }
-    }();
-
-    replaceContentsOfRangeInSession(uuid, rangeToReplace, newText);
+    default:
+        return;
+    }
 }
 
 void UnifiedTextReplacementController::didEndTextReplacementSession(const WTF::UUID& uuid, bool accepted)


### PR DESCRIPTION
#### e769ed8cf322a2ae21245b424526c13bd62ecd21
<pre>
[Unified Text Replacement] Remove unused `WebTextReplacementData::State::Committed` enum case
<a href="https://bugs.webkit.org/show_bug.cgi?id=273446">https://bugs.webkit.org/show_bug.cgi?id=273446</a>
<a href="https://rdar.apple.com/127235440">rdar://127235440</a>

Reviewed by Abrar Rahman Protyasha.

* Source/WebKit/Shared/UnifiedTextReplacement.serialization.in:
* Source/WebKit/Shared/WebTextReplacementData.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm:
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidUpdateStateForReplacement):

Canonical link: <a href="https://commits.webkit.org/278137@main">https://commits.webkit.org/278137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/388f423bdd8786b8416b15638775d86464c223a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49613 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28899 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/52662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/52855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26518 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/52855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26435 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/52662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/52855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/23884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/52662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-skia~~](https://ews-build.webkit.org/#/builders/52/builds/7984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/52662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/54432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/24699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/54432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/25967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/52662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/54432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/26813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7135 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/25692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->