### PR TITLE
Remove TestRunner::forceImmediateCompletion

### DIFF
--- a/LayoutTests/fast/events/beforeunload-dom-manipulation-crash.html
+++ b/LayoutTests/fast/events/beforeunload-dom-manipulation-crash.html
@@ -16,7 +16,7 @@ function runTest() {
 function nextStep() {
     document.head.appendChild(del);
     if (window.testRunner)
-        testRunner.forceImmediateCompletion();
+        testRunner.notifyDone();
 }
 </script>
 </head>

--- a/LayoutTests/http/tests/navigation/unfreeze-layer-tree-after-stopping-load.html
+++ b/LayoutTests/http/tests/navigation/unfreeze-layer-tree-after-stopping-load.html
@@ -11,6 +11,6 @@ document.querySelector("video").play().catch(() => { });
 if (testRunner.stopLoading)
     testRunner.stopLoading();
 
-requestAnimationFrame(() => testRunner.forceImmediateCompletion());
+requestAnimationFrame(() => testRunner.notifyDone());
 </script>
 </body>

--- a/LayoutTests/resources/testharnessreport.js
+++ b/LayoutTests/resources/testharnessreport.js
@@ -148,7 +148,7 @@ if (self.testRunner) {
         // Wait for any other completion callbacks, which may eliminate test elements
         // from the page and therefore reduce the output.
         setTimeout(function () {
-            testRunner.forceImmediateCompletion();
+            testRunner.notifyDone();
         }, 0);
     });
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -124,9 +124,6 @@ interface TestRunner {
     undefined displayOnLoadFinish();
     undefined dontForceRepaint();
 
-    // Failed load condition testing
-    undefined forceImmediateCompletion();
-
     // Printing
     boolean isPageBoxVisible(long pageIndex);
 

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -302,7 +302,7 @@ void InjectedBundle::didReceiveMessageToPage(WKBundlePageRef page, WKStringRef m
     }
 
     if (WKStringIsEqualToUTF8CString(messageName, "ForceImmediateCompletion")) {
-        m_testRunner->forceImmediateCompletion();
+        m_testRunner->notifyDone();
         return;
     }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -261,18 +261,6 @@ void TestRunner::notifyDone()
     setWaitUntilDone(false);
 }
 
-void TestRunner::forceImmediateCompletion()
-{
-    auto& injectedBundle = InjectedBundle::singleton();
-    if (!injectedBundle.isTestRunning())
-        return;
-
-    if (shouldWaitUntilDone() && injectedBundle.page())
-        injectedBundle.page()->dump(m_forceRepaint);
-
-    setWaitUntilDone(false);
-}
-
 void TestRunner::setShouldDumpFrameLoadCallbacks(bool value)
 {
     postSynchronousMessage("SetDumpFrameLoadCallbacks", value);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -175,9 +175,6 @@ public:
     void setQuota(uint64_t);
     void setOriginQuotaRatioEnabled(bool);
 
-    // Failed load condition testing
-    void forceImmediateCompletion();
-
     // Printing
     bool isPageBoxVisible(JSContextRef, int pageIndex);
     bool isPrinting() { return m_isPrinting; }


### PR DESCRIPTION
#### d0d1d8f61ab20e0f2114f881f2ef924c498af840
<pre>
Remove TestRunner::forceImmediateCompletion
<a href="https://bugs.webkit.org/show_bug.cgi?id=273449">https://bugs.webkit.org/show_bug.cgi?id=273449</a>
<a href="https://rdar.apple.com/127260272">rdar://127260272</a>

Reviewed by NOBODY (OOPS!).

It does the same thing as TestRunner::notifyDone, except for some site isolation stuff
which I&apos;m currently working on make work better with site isolation.  This PR will make
that a little simpler.

* LayoutTests/fast/events/beforeunload-dom-manipulation-crash.html:
* LayoutTests/http/tests/navigation/unfreeze-layer-tree-after-stopping-load.html:
* LayoutTests/resources/testharnessreport.js:
(self.testRunner.add_completion_callback):
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::didReceiveMessageToPage):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::forceImmediateCompletion): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0d1d8f61ab20e0f2114f881f2ef924c498af840

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49614 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28900 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52856 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/290 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51919 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34919 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26519 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40502 "Found 9 new test failures: http/tests/navigation/unfreeze-layer-tree-after-stopping-load.html, http/wpt/cross-origin-opener-policy/non-secure-to-secure-context-navigation.https.html, http/wpt/cross-origin-opener-policy/single-request-to-server.html, http/wpt/service-workers/service-worker-spinning-fetch.https.html, imported/w3c/web-platform-tests/css/selectors/invalidation/media-loading-pseudo-classes-in-has.html, imported/w3c/web-platform-tests/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/img-replaced-box-while-loading.html, imported/w3c/web-platform-tests/service-workers/service-worker/opaque-script.https.html, imported/w3c/web-platform-tests/service-workers/service-worker/postmessage-to-client-message-queue.https.html, imported/w3c/web-platform-tests/service-workers/service-worker/respond-with-body-accessed-response.https.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51714 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26442 "Found 2 new test failures: http/tests/navigation/unfreeze-layer-tree-after-stopping-load.html, http/wpt/cross-origin-opener-policy/header-parsing-with-report-to.https.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42729 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21619 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23892 "Found 60 new test failures: imported/w3c/web-platform-tests/html/cross-origin-opener-policy/blob-popup.https.html, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coep-blob-popup.https.html, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coep-navigate-popup.https.html?0-1, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coep-navigate-popup.https.html?2-3, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coep-navigate-popup.https.html?4-last, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coep-with-cross-origin.https.html, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coep-with-same-origin.https.html, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coep-with-same-site.https.html, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coop-csp-sandbox-navigate.https.html, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coop-csp-sandbox.https.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43920 "Found 9 new test failures: http/tests/navigation/unfreeze-layer-tree-after-stopping-load.html, imported/w3c/web-platform-tests/clipboard-apis/feature-policy/clipboard-write/clipboard-write-enabled-by-feature-policy-attribute-cross-origin-tentative.https.sub.html, imported/w3c/web-platform-tests/clipboard-apis/feature-policy/clipboard-write/clipboard-write-enabled-by-feature-policy-cross-origin-tentative.https.sub.html, imported/w3c/web-platform-tests/clipboard-apis/feature-policy/clipboard-write/clipboard-write-enabled-on-self-origin-by-feature-policy.tentative.https.sub.html, imported/w3c/web-platform-tests/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/img-replaced-box-while-loading.html, imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-back-forward.html, imported/w3c/web-platform-tests/navigation-api/navigate-event/same-url-replace-cross-document.html, imported/w3c/web-platform-tests/navigation-api/navigate-event/same-url-replace-same-document.html, imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-not-fully-active.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7985 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45803 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44425 "Found 60 new test failures: http/tests/cache/disk-cache/disk-cache-vary.html, http/tests/navigation/unfreeze-layer-tree-after-stopping-load.html, http/wpt/cross-origin-opener-policy/header-parsing-with-report-to.https.html, http/wpt/cross-origin-opener-policy/non-secure-to-secure-context-navigation.https.html, http/wpt/cross-origin-opener-policy/single-request-to-server.html, http/wpt/service-workers/service-worker-spinning-fetch.https.html, imported/w3c/web-platform-tests/fetch/api/basic/request-upload.any.worker.html, imported/w3c/web-platform-tests/fetch/api/basic/scheme-about.any.worker.html, imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.fillStyle.parse.hsl-clamp-4.html, imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-ImageBitmap.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54433 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24700 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20869 "Found 60 new test failures: fast/forms/password-scrolled-after-caps-lock-toggled.html, http/tests/navigation/unfreeze-layer-tree-after-stopping-load.html, http/wpt/cross-origin-opener-policy/header-parsing-with-report-to.https.html, http/wpt/cross-origin-opener-policy/non-secure-to-secure-context-navigation.https.html, http/wpt/cross-origin-opener-policy/single-request-to-server.html, http/wpt/service-workers/service-worker-spinning-fetch.https.html, imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-offscreen-child.html, imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-rendering-invalidation.html, imported/w3c/web-platform-tests/editing/other/delete-in-child-of-html.tentative.html?designMode=on&method=backspace, imported/w3c/web-platform-tests/editing/other/typing-around-link-element-at-collapsed-selection.tentative.html?target=DesignMode&parent=b&child=i ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47867 "Found 8 new test failures: http/tests/navigation/unfreeze-layer-tree-after-stopping-load.html, http/wpt/cross-origin-opener-policy/single-request-to-server.html, imported/w3c/web-platform-tests/css/selectors/invalidation/media-loading-pseudo-classes-in-has.html, imported/w3c/web-platform-tests/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/img-replaced-box-while-loading.html, imported/w3c/web-platform-tests/service-workers/service-worker/embed-and-object-are-not-intercepted.https.html, imported/w3c/web-platform-tests/service-workers/service-worker/opaque-script.https.html, imported/w3c/web-platform-tests/service-workers/service-worker/postmessage-to-client-message-queue.https.html, imported/w3c/web-platform-tests/service-workers/service-worker/respond-with-body-accessed-response.https.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25968 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42866 "Exiting early after 10 failures. 110 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46892 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26814 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25693 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->