### PR TITLE
[JSC] JIT stub should hold Watchpoint and WatchpointSet

### DIFF
--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
@@ -156,7 +156,6 @@ private:
 
     ListType m_list;
     RefPtr<PolymorphicAccessJITStubRoutine> m_stubRoutine;
-    std::unique_ptr<WatchpointsOnStructureStubInfo> m_watchpoints;
 };
 
 class InlineCacheHandler final : public RefCounted<InlineCacheHandler> {
@@ -167,9 +166,9 @@ public:
     static ptrdiff_t offsetOfJumpTarget() { return OBJECT_OFFSETOF(InlineCacheHandler, m_jumpTarget); }
     static ptrdiff_t offsetOfNext() { return OBJECT_OFFSETOF(InlineCacheHandler, m_next); }
 
-    static Ref<InlineCacheHandler> create(Ref<PolymorphicAccessJITStubRoutine>&& stubRoutine, std::unique_ptr<WatchpointsOnStructureStubInfo>&& watchpoints)
+    static Ref<InlineCacheHandler> create(Ref<PolymorphicAccessJITStubRoutine>&& stubRoutine, std::unique_ptr<StructureStubInfoClearingWatchpoint>&& watchpoint)
     {
-        return adoptRef(*new InlineCacheHandler(WTFMove(stubRoutine), WTFMove(watchpoints)));
+        return adoptRef(*new InlineCacheHandler(WTFMove(stubRoutine), WTFMove(watchpoint)));
     }
 
     CodePtr<JITStubRoutinePtrTag> callTarget() const { return m_callTarget; }
@@ -194,14 +193,14 @@ public:
 
 private:
     InlineCacheHandler() = default;
-    InlineCacheHandler(Ref<PolymorphicAccessJITStubRoutine>&&, std::unique_ptr<WatchpointsOnStructureStubInfo>&&);
+    InlineCacheHandler(Ref<PolymorphicAccessJITStubRoutine>&&, std::unique_ptr<StructureStubInfoClearingWatchpoint>&&);
 
     static Ref<InlineCacheHandler> createSlowPath(VM&, AccessType);
 
     CodePtr<JITStubRoutinePtrTag> m_callTarget;
     CodePtr<JITStubRoutinePtrTag> m_jumpTarget;
     RefPtr<PolymorphicAccessJITStubRoutine> m_stubRoutine;
-    std::unique_ptr<WatchpointsOnStructureStubInfo> m_watchpoints;
+    std::unique_ptr<StructureStubInfoClearingWatchpoint> m_watchpoint;
     RefPtr<InlineCacheHandler> m_next;
 };
 
@@ -343,10 +342,10 @@ private:
     MacroAssembler::JumpList m_failAndRepatch;
     MacroAssembler::JumpList m_failAndIgnore;
     ScratchRegisterAllocator::PreservedState m_preservedReusedRegisterState;
-    std::unique_ptr<WatchpointsOnStructureStubInfo> m_watchpoints;
     GPRReg m_scratchGPR { InvalidGPRReg };
     FPRReg m_scratchFPR { InvalidFPRReg };
     Vector<StructureID> m_weakStructures;
+    Vector<ObjectPropertyCondition> m_conditions;
     Bag<OptimizingCallLinkInfo> m_callLinkInfos;
     ScalarRegisterSet m_liveRegistersToPreserveAtExceptionHandlingCallSite;
     ScalarRegisterSet m_liveRegistersForCall;

--- a/Source/JavaScriptCore/bytecode/Watchpoint.h
+++ b/Source/JavaScriptCore/bytecode/Watchpoint.h
@@ -93,7 +93,8 @@ class WatchpointSet;
 #if ENABLE(JIT)
 #define JSC_WATCHPOINT_TYPES_WITHOUT_DFG(macro) \
     JSC_WATCHPOINT_TYPES_WITHOUT_JIT(macro) \
-    macro(StructureTransitionStructureStubClearing, StructureTransitionStructureStubClearingWatchpoint)
+    macro(StructureTransitionStructureStubClearing, StructureTransitionStructureStubClearingWatchpoint) \
+    macro(StructureStubInfoClearing, StructureStubInfoClearingWatchpoint)
 
 #if ENABLE(DFG_JIT)
 #define JSC_WATCHPOINT_TYPES(macro) \

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
@@ -41,6 +41,7 @@ class AccessCase;
 class CallLinkInfo;
 class JITStubRoutineSet;
 class OptimizingCallLinkInfo;
+class WatchpointsOnStructureStubInfo;
 
 // Use this stub routine if you know that your code might be on stack when
 // either GC or other kinds of stub deletion happen. Basicaly, if your stub
@@ -93,6 +94,7 @@ public:
     friend class JITStubRoutine;
 
     PolymorphicAccessJITStubRoutine(Type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, VM&, FixedVector<RefPtr<AccessCase>>&&, FixedVector<StructureID>&&, JSCell* owner);
+    ~PolymorphicAccessJITStubRoutine();
 
     const FixedVector<RefPtr<AccessCase>>& cases() const { return m_cases; }
     const FixedVector<StructureID>& weakStructures() const { return m_weakStructures; }
@@ -108,6 +110,11 @@ public:
 
     void addedToSharedJITStubSet();
 
+    const WatchpointsOnStructureStubInfo* watchpoints() const { return m_watchpoints.get(); }
+    void setWatchpoints(std::unique_ptr<WatchpointsOnStructureStubInfo>&&);
+    WatchpointSet& watchpointSet() { return m_watchpointSet.get(); }
+    void invalidate();
+
 protected:
     void observeZeroRefCountImpl();
 
@@ -116,6 +123,8 @@ private:
     FixedVector<RefPtr<AccessCase>> m_cases;
     FixedVector<StructureID> m_weakStructures;
     FixedVector<Identifier> m_identifiers;
+    Ref<WatchpointSet> m_watchpointSet;
+    std::unique_ptr<WatchpointsOnStructureStubInfo> m_watchpoints;
 };
 
 // Use this if you want to mark one additional object during GC if your stub


### PR DESCRIPTION
#### 159f9e46d6bb256c1de1ed39f66935ccaf987734
<pre>
[JSC] JIT stub should hold Watchpoint and WatchpointSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=273454">https://bugs.webkit.org/show_bug.cgi?id=273454</a>
<a href="https://rdar.apple.com/127262594">rdar://127262594</a>

Reviewed by Keith Miller.

Previously, our approach is

1. Collecting WatchpointSet throughout IC
2. Watch them and holding watchpoints in StructureStubInfo (or its owining data structures)
3. When WatchpointSet fires, clearing StructureStubInfo.

Instead, the new approach is

1. Collecting WatchpointSet throughout IC
2. Watch them and holding watchpoints in IC JIT Stub
3. IC JIT Stub also holds WatchpointSet
4. StructureStubInfo watches (3)&apos;s WatchpointSet instead.
5. When WatchpointSet fires, invalidating (3)&apos;s IC JIT Stub&apos;s WatchpointSet.
6. Because of (5), WatchpointSet fires, and clearing StructureStubInfo.

In this way, we can have one WatchpointSet managed by IC JIT Stub. And each *potentially multiple* StructureStubInfo can monitor this condition
by inserting Watchpoint into this set. In this way, we can share one IC JIT Stub with multiple StructureStubInfo even if the IC has watchpoints.
This is the work towards Handler IC.

* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheHandler::InlineCacheHandler):
(JSC::m_watchpoint):
(JSC::InlineCacheCompiler::generateImpl):
(JSC::InlineCacheCompiler::regenerate):
(JSC::m_watchpoints): Deleted.
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.h:
* Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.cpp:
(JSC::StructureStubInfoClearingWatchpoint::fireInternal):
(JSC::StructureTransitionStructureStubClearingWatchpoint::fireInternal):
(JSC::WatchpointsOnStructureStubInfo::ensureReferenceAndInstallWatchpoint):
(JSC::WatchpointsOnStructureStubInfo::ensureReferenceAndAddWatchpoint):
(JSC::AdaptiveValueStructureStubClearingWatchpoint::handleFire):
(JSC::WatchpointsOnStructureStubInfo::isValid const): Deleted.
* Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h:
* Source/JavaScriptCore/bytecode/Watchpoint.h:
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp:
(JSC::PolymorphicAccessJITStubRoutine::PolymorphicAccessJITStubRoutine):
(JSC::PolymorphicAccessJITStubRoutine::setWatchpoints):
(JSC::PolymorphicAccessJITStubRoutine::invalidate):
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h:
(JSC::PolymorphicAccessJITStubRoutine::watchpoints const):
(JSC::PolymorphicAccessJITStubRoutine::watchpointSet):

Canonical link: <a href="https://commits.webkit.org/278148@main">https://commits.webkit.org/278148@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d38e18fa8da5c1319a54c08734c88bd0c5e8106

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49658 "Failed to checkout and rebase branch from PR 27908") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28946 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/52707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/52900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26563 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/52900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51758 "Failed to checkout and rebase branch from PR 27908") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/26475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/52707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/52900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/23918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/52707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8029 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/42973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/52707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54477 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/49153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/24745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/26012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/52707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/26860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56640 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7140 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/25737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/11640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->