### PR TITLE
[build-webkit-org] JSC tests are not showing failure count in status

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -759,9 +759,6 @@ class RunJavaScriptCoreTests(TestWithFailureCount, CustomFlagsMixin):
         ]
         self.build.addStepsAfterCurrentStep(steps_to_add)
 
-        self.failedTestCount = self.countFailures()
-        self.failedTestPluralSuffix = "" if self.failedTestCount == 1 else "s"
-
         return super().run()
 
     def countFailures(self):
@@ -781,6 +778,12 @@ class RunJavaScriptCoreTests(TestWithFailureCount, CustomFlagsMixin):
             count += int(match.group(1))
 
         return count
+
+    def evaluateCommand(self, cmd):
+        self.failedTestCount = self.countFailures()
+        self.failedTestPluralSuffix = "" if self.failedTestCount == 1 else "s"
+
+        return super().evaluateCommand(cmd)
 
 
 class RunTest262Tests(TestWithFailureCount, CustomFlagsMixin):


### PR DESCRIPTION
#### 8ad9f4dc1d9218e5b8ccf8f754b0547725cee285
<pre>
[build-webkit-org] JSC tests are not showing failure count in status
<a href="https://bugs.webkit.org/show_bug.cgi?id=273453">https://bugs.webkit.org/show_bug.cgi?id=273453</a>
<a href="https://rdar.apple.com/problem/127261773">rdar://problem/127261773</a>

Reviewed by Jonathan Bedard.

Move the order of operations so that self.failedTestCount is populated before getResultSummary.

* Tools/CISupport/build-webkit-org/steps.py:
(RunJavaScriptCoreTests.run):
(RunJavaScriptCoreTests.evaluateCommand):

Canonical link: <a href="https://commits.webkit.org/278172@main">https://commits.webkit.org/278172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05256d17002cde57b8c5e8d29ee264aaaa47bc94

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28918 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52874 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/308 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51937 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34939 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26537 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40503 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51732 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42743 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21620 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23900 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43930 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8003 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45808 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44434 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54451 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24719 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20887 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47877 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/49658 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25986 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46904 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26834 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7154 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25711 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->