### PR TITLE
Re-import css/css-transitions WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/CSSTransition-effect.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/CSSTransition-effect.tentative.html
@@ -85,12 +85,13 @@ promise_test(async t => {
   div.style.left = '150px';
 
   // This will run style update.
-  assert_equals(div.getAnimations().length, 1);
+  const animations = div.getAnimations();
+  assert_equals(animations.length, 1);
 
-  const new_transition = div.getAnimations()[0];
+  const new_transition = animations[0];
   await new_transition.ready;
 
-  assert_equals(getComputedStyle(div).left, '100px');
+  assert_not_equals(getComputedStyle(div).left, '150px');
 }, 'After setting a transition\'s effect to null, a new transition can be started');
 
 // This is a regression test for https://crbug.com/992668, where Chromium would

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/starting-style-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/starting-style-parsing-expected.txt
@@ -1,0 +1,7 @@
+
+FAIL @starting-style is valid assert_equals: expected "@starting-style {\n}" but got "@starting-style  {\n}"
+PASS @starting-style div is not valid
+PASS @starting-style () is not valid
+PASS @starting-style ( {} is not valid
+PASS @starting-style } is not valid
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/starting-style-parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/starting-style-parsing.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<title>@starting-style: parsing</title>
+<link rel="help" href="https://drafts.csswg.org/css-transitions-2/#at-ruledef-starting-style">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<main id=main></main>
+<script>
+  function test_valid(actual, expected) {
+    if (expected === undefined)
+      expected = actual;
+    test(t => {
+      t.add_cleanup(() => main.replaceChildren());
+      let style = document.createElement('style');
+      style.textContent = `${actual}{}`;
+      main.append(style);
+      assert_equals(style.sheet.rules.length, 1);
+      let rule = style.sheet.rules[0];
+      assert_equals(rule.cssText, `${expected} {\n}`);
+    }, `${actual} is valid`);
+  }
+
+  function test_invalid(actual) {
+    test(t => {
+      t.add_cleanup(() => main.replaceChildren());
+      let style = document.createElement('style');
+      style.textContent = `${actual}{}`;
+      main.append(style);
+      assert_equals(style.sheet.rules.length, 0);
+    }, `${actual} is not valid`);
+  }
+
+  test_valid('@starting-style');
+
+  test_invalid('@starting-style div');
+  test_invalid('@starting-style ()');
+  test_invalid('@starting-style ( {}');
+  test_invalid('@starting-style }');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/starting-style-parsing.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-behavior.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-computed.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-delay-computed.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/w3c-import.log
@@ -74,6 +74,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/root-color-transition-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/root-color-transition.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-of-transitions-001.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-adjustment.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-cascade.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-name-defining-rules.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-rule-basic.html


### PR DESCRIPTION
#### e2ac4828cf48421940986b2a73c003eb8f00643e
<pre>
Re-import css/css-transitions WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=273439">https://bugs.webkit.org/show_bug.cgi?id=273439</a>
<a href="https://rdar.apple.com/127264296">rdar://127264296</a>

Reviewed by Matt Woodrow.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/8c6b479fae23badbb86e9c993f5b5fbb66e16905">https://github.com/web-platform-tests/wpt/commit/8c6b479fae23badbb86e9c993f5b5fbb66e16905</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/CSSTransition-effect.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/starting-style-parsing-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/starting-style-parsing.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/278143@main">https://commits.webkit.org/278143@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c56d571c03014a99cff1b0e11747ce6af14b48b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28925 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52686 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/52879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26542 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/52879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51737 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26456 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/52879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/23903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-skia~~](https://ews-build.webkit.org/#/builders/52/builds/8008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/44438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54456 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/24724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/25991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10892 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/26839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/25716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->