### PR TITLE
Add additional testing for NSTextSelectionRect/NSTextPlaceholder.

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextPlaceholderTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextPlaceholderTests.mm
@@ -37,6 +37,16 @@
 
 #if PLATFORM(MAC)
 #import <pal/spi/mac/NSTextInputContextSPI.h>
+
+// FIXME: Remove this after rdar://126379463 lands
+@interface WKTextSelectionRect : NSObject
+
+@property (nonatomic, readonly) NSRect rect;
+@property (nonatomic, readonly) NSWritingDirection writingDirection;
+@property (nonatomic, readonly) BOOL isVertical;
+@property (nonatomic, readonly) NSAffineTransform *transform;
+
+@end
 #endif
 
 RetainPtr<WKWebView> createWebViewForNSTextPlaceholder()
@@ -55,6 +65,7 @@ TEST(NSTextPlaceholder, InsertTextPlaceholder)
     [(id<NSTextInputClient_Async_staging_126696059>)webView.get() insertTextPlaceholderWithSize:CGSizeMake(50, 100) completionHandler:^(NSTextPlaceholder * placeholder) {
         EXPECT_WK_STREQ("<div style=\"display: inline-block; vertical-align: top; visibility: hidden !important; width: 50px; height: 100px;\"></div>Test<script>document.body.focus()</script>", [webView stringByEvaluatingJavaScript:@"document.body.innerHTML"]);
         isDone = true;
+        EXPECT_TRUE(CGSizeEqualToSize([(WKTextSelectionRect *)[[placeholder rects] firstObject] rect].size, CGSizeMake(50, 100)));
     }];
     TestWebKitAPI::Util::run(&isDone);
 }
@@ -66,6 +77,7 @@ TEST(NSTextPlaceholder, InsertAndRemoveTextPlaceholderWithoutIncomingText)
     __block bool isDone = false;
     [(id<NSTextInputClient_Async_staging_126696059>)webView.get() insertTextPlaceholderWithSize:CGSizeMake(50, 100) completionHandler:^(NSTextPlaceholder *placeholder) {
         EXPECT_WK_STREQ("<div style=\"display: inline-block; vertical-align: top; visibility: hidden !important; width: 50px; height: 100px;\"></div>Test<script>document.body.focus()</script>", [webView stringByEvaluatingJavaScript:@"document.body.innerHTML"]);
+        EXPECT_TRUE(CGSizeEqualToSize([(WKTextSelectionRect *)[[placeholder rects] firstObject] rect].size, CGSizeMake(50, 100)));
         [(id<NSTextInputClient_Async_staging_126696059>)webView.get() removeTextPlaceholder:placeholder willInsertText:NO completionHandler:^{
             EXPECT_WK_STREQ("Test<script>document.body.focus()</script>", [webView stringByEvaluatingJavaScript:@"document.body.innerHTML"]);
             isDone = true;
@@ -81,6 +93,7 @@ TEST(NSTextPlaceholder, InsertAndRemoveTextPlaceholderWithIncomingText)
     __block bool isDone = false;
     [(id<NSTextInputClient_Async_staging_126696059>)webView.get() insertTextPlaceholderWithSize:CGSizeMake(50, 100) completionHandler:^(NSTextPlaceholder *placeholder) {
         EXPECT_WK_STREQ("<div style=\"display: inline-block; vertical-align: top; visibility: hidden !important; width: 50px; height: 100px;\"></div>Test<script>document.body.focus()</script>", [webView stringByEvaluatingJavaScript:@"document.body.innerHTML"]);
+        EXPECT_TRUE(CGSizeEqualToSize([(WKTextSelectionRect *)[[placeholder rects] firstObject] rect].size, CGSizeMake(50, 100)));
         [(id<NSTextInputClient_Async_staging_126696059>)webView.get() removeTextPlaceholder:placeholder willInsertText:YES completionHandler:^{
             EXPECT_WK_STREQ("Test<script>document.body.focus()</script>", [webView stringByEvaluatingJavaScript:@"document.body.innerHTML"]);
             isDone = true;


### PR DESCRIPTION
#### 69188a655c86a9f0e49e9ec9275002b14d836ffe
<pre>
Add additional testing for NSTextSelectionRect/NSTextPlaceholder.
<a href="https://rdar.apple.com/127265259">rdar://127265259</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=273461">https://bugs.webkit.org/show_bug.cgi?id=273461</a>

Reviewed by Aditya Keerthi.

Additional testing of NSTextSelectionRect and the rect property
ensure that we implemented this correctly.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextPlaceholderTests.mm:
(TEST(NSTextPlaceholder, InsertTextPlaceholder)):
(TEST(NSTextPlaceholder, InsertAndRemoveTextPlaceholderWithoutIncomingText)):
(TEST(NSTextPlaceholder, InsertAndRemoveTextPlaceholderWithIncomingText)):

Canonical link: <a href="https://commits.webkit.org/278301@main">https://commits.webkit.org/278301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc4a25ddf0802d8fe061c666d9d140ced685ca0b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2380 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53341 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running compile-webkit") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/773 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52395 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35639 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/337 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40893 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52190 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/27102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43109 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21983 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24522 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/349 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8467 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/399 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54929 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25187 "Build is being retried. Recent messages:compiling") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48289 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26444 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43296 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47301 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27313 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7245 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26176 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->