### PR TITLE
Update ScriptExecutionContext::forEachActiveDOMObject() to ref the ActiveDOMObjects

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -89,6 +89,10 @@ public:
 
     virtual ~GPUDevice();
 
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     String label() const;
     void setLabel(String&&);
 
@@ -136,15 +140,11 @@ public:
     void removeBufferToUnmap(GPUBuffer&);
     void addBufferToUnmap(GPUBuffer&);
 
-    using RefCounted::ref;
-    using RefCounted::deref;
-
     WeakPtr<GPUExternalTexture> takeExternalTextureForVideoElement(const HTMLVideoElement&);
 
 private:
     GPUDevice(ScriptExecutionContext*, Ref<WebGPU::Device>&&);
 
-    // ActiveDOMObject.
     // FIXME: We probably need to override more methods to make this work properly.
     RefPtr<GPUPipelineLayout> createAutoPipelineLayout();
 

--- a/Source/WebCore/Modules/applepay/ApplePaySession.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySession.h
@@ -64,6 +64,10 @@ public:
     static ExceptionOr<Ref<ApplePaySession>> create(Document&, unsigned version, ApplePayPaymentRequest&&);
     virtual ~ApplePaySession();
 
+    // ActiveDOMObject.
+    void ref() const final { PaymentSession::ref(); }
+    void deref() const final { PaymentSession::deref(); }
+
     static constexpr auto STATUS_SUCCESS = ApplePayPaymentAuthorizationResult::Success;
     static constexpr auto STATUS_FAILURE = ApplePayPaymentAuthorizationResult::Failure;
     static constexpr auto STATUS_INVALID_BILLING_POSTAL_ADDRESS = ApplePayPaymentAuthorizationResult::InvalidBillingPostalAddress;
@@ -96,9 +100,6 @@ public:
     ExceptionOr<void> completePayment(unsigned short status);
 
     const ApplePaySessionPaymentRequest& paymentRequest() const { return m_paymentRequest; }
-
-    using PaymentSession::ref;
-    using PaymentSession::deref;
 
 private:
     ApplePaySession(Document&, unsigned version, ApplePaySessionPaymentRequest&&);

--- a/Source/WebCore/Modules/applepay/ApplePaySetupWebCore.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySetupWebCore.h
@@ -51,6 +51,10 @@ public:
     using BeginPromise = DOMPromiseDeferred<IDLBoolean>;
     void begin(Document&, Vector<Ref<ApplePaySetupFeature>>&&, BeginPromise&&);
 
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
 private:
     ApplePaySetup(ScriptExecutionContext&, ApplePaySetupConfiguration&&);
 

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.h
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.h
@@ -52,8 +52,9 @@ public:
     Type type() const;
     State state() const;
 
-    using RefCounted<DOMAudioSession>::ref;
-    using RefCounted<DOMAudioSession>::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
     explicit DOMAudioSession(ScriptExecutionContext*);

--- a/Source/WebCore/Modules/cache/DOMCache.h
+++ b/Source/WebCore/Modules/cache/DOMCache.h
@@ -40,6 +40,10 @@ public:
     static Ref<DOMCache> create(ScriptExecutionContext&, String&&, DOMCacheIdentifier, Ref<CacheStorageConnection>&&);
     ~DOMCache();
 
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     using RequestInfo = FetchRequest::Info;
 
     using KeysPromise = DOMPromiseDeferred<IDLSequence<IDLInterface<FetchRequest>>>;

--- a/Source/WebCore/Modules/cache/DOMCacheStorage.h
+++ b/Source/WebCore/Modules/cache/DOMCacheStorage.h
@@ -39,6 +39,10 @@ public:
     static Ref<DOMCacheStorage> create(ScriptExecutionContext&, Ref<CacheStorageConnection>&&);
     ~DOMCacheStorage();
 
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     using KeysPromise = DOMPromiseDeferred<IDLSequence<IDLDOMString>>;
 
     void match(DOMCache::RequestInfo&&, MultiCacheQueryOptions&&, Ref<DeferredPromise>&&);

--- a/Source/WebCore/Modules/cookie-store/CookieStore.h
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.h
@@ -61,8 +61,9 @@ public:
     void remove(String&& name, Ref<DeferredPromise>&&);
     void remove(CookieStoreDeleteOptions&&, Ref<DeferredPromise>&&);
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     using EventTarget::weakPtrFactory;
     using EventTarget::WeakValueType;

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
@@ -71,8 +71,10 @@ public:
     using CDMInstanceSessionClient::weakPtrFactory;
     using CDMInstanceSessionClient::WeakValueType;
     using CDMInstanceSessionClient::WeakPtrImplType;
-    using RefCounted<MediaKeySession>::ref;
-    using RefCounted<MediaKeySession>::deref;
+
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     bool isClosed() const { return m_closed; }
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.h
@@ -48,6 +48,10 @@ public:
     static Ref<MediaKeySystemAccess> create(Document&, const String& keySystem, MediaKeySystemConfiguration&&, Ref<CDM>&&);
     ~MediaKeySystemAccess();
 
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     const String& keySystem() const { return m_keySystem; }
     const MediaKeySystemConfiguration& getConfiguration() const { return *m_configuration; }
     void createMediaKeys(Document&, Ref<DeferredPromise>&&);

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.h
@@ -48,6 +48,10 @@ public:
     WEBCORE_EXPORT static Ref<MediaKeySystemRequest> create(Document&, const String& keySystem, Ref<DeferredPromise>&&);
     virtual ~MediaKeySystemRequest();
 
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void setAllowCallback(CompletionHandler<void(Ref<DeferredPromise>&&)>&& callback) { m_allowCompletionHandler = WTFMove(callback); }
     WEBCORE_EXPORT void start();
 
@@ -62,6 +66,7 @@ public:
 private:
     MediaKeySystemRequest(Document&, const String& keySystem, Ref<DeferredPromise>&&);
 
+    // ActiveDOMObject.
     void stop() final;
 
     String m_keySystem;

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
@@ -60,8 +60,9 @@ public:
     void generateKeyRequest(const String& mimeType, Ref<Uint8Array>&& initData);
     RefPtr<ArrayBuffer> cachedKeyForKeyId(const String& keyId) const;
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
     WebKitMediaKeySession(Document&, WebKitMediaKeys&, const String& keySystem);

--- a/Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.h
+++ b/Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.h
@@ -42,8 +42,11 @@ class FileSystemDirectoryReader final : public ScriptWrappable, public ActiveDOM
     WTF_MAKE_ISO_ALLOCATED(FileSystemDirectoryReader);
 public:
     static Ref<FileSystemDirectoryReader> create(ScriptExecutionContext&, FileSystemDirectoryEntry&);
-
     ~FileSystemDirectoryReader();
+
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     void readEntries(ScriptExecutionContext&, Ref<FileSystemEntriesCallback>&&, RefPtr<ErrorCallback>&&);
 

--- a/Source/WebCore/Modules/entriesapi/FileSystemEntry.h
+++ b/Source/WebCore/Modules/entriesapi/FileSystemEntry.h
@@ -41,6 +41,10 @@ class FileSystemEntry : public ScriptWrappable, public ActiveDOMObject, public R
 public:
     virtual ~FileSystemEntry();
 
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     virtual bool isFile() const { return false; }
     virtual bool isDirectory() const { return false; }
 

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.h
@@ -77,6 +77,10 @@ public:
 
     String contentType() const { return m_headers->fastGet(HTTPHeaderName::ContentType); }
 
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
 protected:
     FetchBodyOwner(ScriptExecutionContext*, std::optional<FetchBody>&&, Ref<FetchHeaders>&&);
 
@@ -92,7 +96,7 @@ protected:
     void setBody(FetchBody&& body) { m_body = WTFMove(body); }
     ExceptionOr<void> createReadableStream(JSC::JSGlobalObject&);
 
-    // ActiveDOMObject API
+    // ActiveDOMObject.
     void stop() override;
 
     void setDisturbed() { m_isDisturbed = true; }

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemHandle.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemHandle.h
@@ -42,6 +42,9 @@ class FileSystemHandle : public ActiveDOMObject, public ThreadSafeRefCountedAndC
 public:
     virtual ~FileSystemHandle();
 
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
+
     enum class Kind : uint8_t {
         File,
         Directory
@@ -60,7 +63,7 @@ protected:
     FileSystemStorageConnection& connection() { return m_connection.get(); }
 
 private:
-    // ActiveDOMObject
+    // ActiveDOMObject.
     void stop() final;
 
     Kind m_kind { Kind::File };

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.h
@@ -49,6 +49,9 @@ public:
     static Ref<FileSystemSyncAccessHandle> create(ScriptExecutionContext&, FileSystemFileHandle&, FileSystemSyncAccessHandleIdentifier, FileHandle&&, uint64_t capacity);
     ~FileSystemSyncAccessHandle();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     ExceptionOr<void> truncate(unsigned long long size);
     ExceptionOr<unsigned long long> getSize();
     ExceptionOr<void> flush();
@@ -64,7 +67,7 @@ private:
     void closeInternal(ShouldNotifyBackend);
     bool requestSpaceForWrite(uint64_t writeOffset, uint64_t writeLength);
 
-    // ActiveDOMObject
+    // ActiveDOMObject.
     void stop() final;
 
     Ref<FileSystemFileHandle> m_source;

--- a/Source/WebCore/Modules/gamepad/GamepadHapticActuator.h
+++ b/Source/WebCore/Modules/gamepad/GamepadHapticActuator.h
@@ -50,6 +50,9 @@ public:
     static Ref<GamepadHapticActuator> create(Document*, Type, Gamepad&);
     ~GamepadHapticActuator();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     Type type() const { return m_type; }
     bool canPlayEffectType(EffectType) const;
     void playEffect(EffectType, GamepadEffectParameters&&, Ref<DeferredPromise>&&);

--- a/Source/WebCore/Modules/geolocation/Geolocation.h
+++ b/Source/WebCore/Modules/geolocation/Geolocation.h
@@ -59,6 +59,10 @@ public:
     static Ref<Geolocation> create(Navigator&);
     WEBCORE_EXPORT ~Geolocation();
 
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     WEBCORE_EXPORT void resetAllGeolocationPermission();
     Document* document() const { return downcast<Document>(scriptExecutionContext()); }
 
@@ -83,7 +87,7 @@ private:
 
     GeolocationPosition* lastPosition();
 
-    // ActiveDOMObject
+    // ActiveDOMObject.
     void stop() override;
     void suspend(ReasonForSuspension) override;
     void resume() override;

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.h
@@ -80,8 +80,9 @@ public:
     void refEventTarget() final { ThreadSafeRefCounted<IDBDatabase>::ref(); }
     void derefEventTarget() final { ThreadSafeRefCounted<IDBDatabase>::deref(); }
 
-    using ThreadSafeRefCounted<IDBDatabase>::ref;
-    using ThreadSafeRefCounted<IDBDatabase>::deref;
+    // ActiveDOMObject.
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
 
     IDBDatabaseInfo& info() { return m_info; }
     IDBDatabaseConnectionIdentifier databaseConnectionIdentifier() const { return m_databaseConnectionIdentifier; }

--- a/Source/WebCore/Modules/indexeddb/IDBDatabaseNameAndVersionRequest.h
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabaseNameAndVersionRequest.h
@@ -53,8 +53,9 @@ public:
 
     const IDBResourceIdentifier& resourceIdentifier() const;
 
-    using ThreadSafeRefCounted<IDBDatabaseNameAndVersionRequest>::ref;
-    using ThreadSafeRefCounted<IDBDatabaseNameAndVersionRequest>::deref;
+    // ActiveDOMObject.
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
 
     void complete(std::optional<Vector<IDBDatabaseNameAndVersion>>&&);
 

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.cpp
@@ -420,12 +420,12 @@ void IDBIndex::markAsDeleted()
     m_deleted = true;
 }
 
-void IDBIndex::ref()
+void IDBIndex::ref() const
 {
     m_objectStore.ref();
 }
 
-void IDBIndex::deref()
+void IDBIndex::deref() const
 {
     m_objectStore.deref();
 }

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.h
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.h
@@ -81,8 +81,9 @@ public:
     void markAsDeleted();
     bool isDeleted() const { return m_deleted; }
 
-    void ref();
-    void deref();
+    // ActiveDOMObject.
+    void ref() const final;
+    void deref() const final;
 
     WebCoreOpaqueRoot opaqueRoot();
 

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
@@ -762,12 +762,12 @@ void IDBObjectStore::renameReferencedIndex(IDBIndex& index, const String& newNam
     m_referencedIndexes.set(newName, m_referencedIndexes.take(index.info().name()));
 }
 
-void IDBObjectStore::ref()
+void IDBObjectStore::ref() const
 {
     m_transaction.ref();
 }
 
-void IDBObjectStore::deref()
+void IDBObjectStore::deref() const
 {
     m_transaction.deref();
 }

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.h
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.h
@@ -108,8 +108,9 @@ public:
 
     void rollbackForVersionChangeAbort();
 
-    void ref();
-    void deref();
+    // ActiveDOMObject.
+    void ref() const final;
+    void deref() const final;
 
     template<typename Visitor> void visitReferencedIndexes(Visitor&) const;
     void renameReferencedIndex(IDBIndex&, const String& newName);

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.h
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.h
@@ -102,8 +102,9 @@ public:
 
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
 
-    using ThreadSafeRefCounted::ref;
-    using ThreadSafeRefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
 
     void completeRequestAndDispatchEvent(const IDBResultData&);
 

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.h
@@ -91,9 +91,6 @@ public:
     using EventTarget::dispatchEvent;
     void dispatchEvent(Event&) final;
 
-    using ThreadSafeRefCounted<IDBTransaction>::ref;
-    using ThreadSafeRefCounted<IDBTransaction>::deref;
-
     const IDBTransactionInfo& info() const { return m_info; }
     IDBDatabase& database() { return m_database.get(); }
     const IDBDatabase& database() const { return m_database.get(); }
@@ -156,6 +153,8 @@ public:
 
     // ActiveDOMObject.
     void stop() final;
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
 
 private:
     IDBTransaction(IDBDatabase&, const IDBTransactionInfo&, IDBOpenDBRequest*);

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
@@ -66,8 +66,9 @@ public:
     RecordingState state() const { return m_state; }
     const String& mimeType() const { return m_options.mimeType; }
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
     
     ExceptionOr<void> startRecording(std::optional<unsigned>);
     void stopRecording();
@@ -97,7 +98,7 @@ private:
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::MediaRecorder; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
 
-    // ActiveDOMObject API.
+    // ActiveDOMObject.
     void suspend(ReasonForSuspension) final;
     void stop() final;
     bool virtualHasPendingActivity() const final;

--- a/Source/WebCore/Modules/mediasession/MediaSession.h
+++ b/Source/WebCore/Modules/mediasession/MediaSession.h
@@ -80,6 +80,10 @@ public:
     static Ref<MediaSession> create(Navigator&);
     ~MediaSession();
 
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     MediaMetadata* metadata() const { return m_metadata.get(); };
     void setMetadata(RefPtr<MediaMetadata>&&);
     void metadataUpdated();
@@ -147,7 +151,7 @@ private:
     void notifyActionHandlerObservers();
     void notifyReadyStateObservers();
 
-    // ActiveDOMObject
+    // ActiveDOMObject.
     void suspend(ReasonForSuspension) final;
     void stop() final;
     bool virtualHasPendingActivity() const final;

--- a/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h
+++ b/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h
@@ -68,8 +68,10 @@ public:
     using MediaSessionCoordinatorClient::weakPtrFactory;
     using MediaSessionCoordinatorClient::WeakValueType;
     using MediaSessionCoordinatorClient::WeakPtrImplType;
-    using RefCounted::ref;
-    using RefCounted::deref;
+
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     struct PlaySessionCommand {
         std::optional<double> atTime;
@@ -87,7 +89,7 @@ private:
     ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
     void eventListenersDidChange() final;
 
-    // ActiveDOMObject
+    // ActiveDOMObject.
     bool virtualHasPendingActivity() const final;
 
     // MediaSessionObserver

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -87,8 +87,10 @@ public:
     using CanMakeWeakPtr<MediaSource>::weakPtrFactory;
     using CanMakeWeakPtr<MediaSource>::WeakValueType;
     using CanMakeWeakPtr<MediaSource>::WeakPtrImplType;
-    using RefCounted::ref;
-    using RefCounted::deref;
+
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     static bool enabledForContext(ScriptExecutionContext&);
 
@@ -191,6 +193,7 @@ private:
     // ActiveDOMObject.
     void stop() final;
     bool virtualHasPendingActivity() const final;
+
     static bool isTypeSupported(ScriptExecutionContext&, const String& type, Vector<ContentType>&& contentTypesRequiringHardwareSupport);
 
     void setPrivateAndOpen(Ref<MediaSourcePrivate>&&);

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -79,8 +79,10 @@ public:
     using CanMakeWeakPtr<SourceBuffer>::weakPtrFactory;
     using CanMakeWeakPtr<SourceBuffer>::WeakValueType;
     using CanMakeWeakPtr<SourceBuffer>::WeakPtrImplType;
-    using RefCounted::ref;
-    using RefCounted::deref;
+
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     static bool enabledForContext(ScriptExecutionContext&);
 

--- a/Source/WebCore/Modules/mediasource/SourceBufferList.h
+++ b/Source/WebCore/Modules/mediasource/SourceBufferList.h
@@ -69,8 +69,9 @@ public:
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::SourceBufferList; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
 
-    using RefCounted<SourceBufferList>::ref;
-    using RefCounted<SourceBufferList>::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
     explicit SourceBufferList(ScriptExecutionContext*);

--- a/Source/WebCore/Modules/mediastream/ImageCapture.h
+++ b/Source/WebCore/Modules/mediastream/ImageCapture.h
@@ -48,6 +48,10 @@ public:
 
     ~ImageCapture();
 
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void takePhoto(PhotoSettings&&, DOMPromiseDeferred<IDLInterface<Blob>>&&);
     void getPhotoCapabilities(DOMPromiseDeferred<IDLDictionary<PhotoCapabilities>>&&);
     void getPhotoSettings(DOMPromiseDeferred<IDLDictionary<PhotoSettings>>&&);

--- a/Source/WebCore/Modules/mediastream/MediaDevices.h
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.h
@@ -94,8 +94,9 @@ public:
     String deviceIdToPersistentId(const String& deviceId) const { return m_audioOutputDeviceIdToPersistentId.get(deviceId); }
     String hashedGroupId(const String& groupId);
 
-    using RefCounted<MediaDevices>::ref;
-    using RefCounted<MediaDevices>::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
     explicit MediaDevices(Document&);

--- a/Source/WebCore/Modules/mediastream/MediaStream.h
+++ b/Source/WebCore/Modules/mediastream/MediaStream.h
@@ -97,8 +97,9 @@ public:
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::MediaStream; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
 
-    using RefCounted<MediaStream>::ref;
-    using RefCounted<MediaStream>::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     void addTrackFromPlatform(Ref<MediaStreamTrack>&&);
 
@@ -135,7 +136,7 @@ private:
     // MediaCanStartListener
     void mediaCanStart(Document&) final;
 
-    // ActiveDOMObject API.
+    // ActiveDOMObject.
     void stop() final;
     bool virtualHasPendingActivity() const final;
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -157,8 +157,9 @@ public:
     void addObserver(Observer&);
     void removeObserver(Observer&);
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     void setIdForTesting(String&& id) { m_private->setIdForTesting(WTFMove(id)); }
 
@@ -193,7 +194,7 @@ private:
 
     void configureTrackRendering();
 
-    // ActiveDOMObject API.
+    // ActiveDOMObject.
     void stop() final { stopTrack(); }
     void suspend(ReasonForSuspension) final;
     bool virtualHasPendingActivity() const final;

--- a/Source/WebCore/Modules/mediastream/RTCDTMFSender.h
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFSender.h
@@ -50,12 +50,14 @@ public:
 
     ExceptionOr<void> insertDTMF(const String& tones, size_t duration, size_t interToneGap);
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
     RTCDTMFSender(ScriptExecutionContext&, RTCRtpSender&, std::unique_ptr<RTCDTMFSenderBackend>&&);
 
+    // ActiveDOMObject.
     void stop() final;
 
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::RTCDTMFSender; }

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.h
@@ -86,8 +86,9 @@ public:
     bool canDetach() const;
     std::unique_ptr<DetachedRTCDataChannel> detach();
 
-    using RefCounted<RTCDataChannel>::ref;
-    using RefCounted<RTCDataChannel>::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     WEBCORE_EXPORT static std::unique_ptr<RTCDataChannelHandler> handlerFromIdentifier(RTCDataChannelLocalIdentifier);
     void fireOpenEventIfNeeded();
@@ -106,7 +107,7 @@ private:
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 
-    // ActiveDOMObject API
+    // ActiveDOMObject.
     void stop() final;
     bool virtualHasPendingActivity() const final;
 

--- a/Source/WebCore/Modules/mediastream/RTCDtlsTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCDtlsTransport.h
@@ -45,8 +45,9 @@ public:
     static Ref<RTCDtlsTransport> create(ScriptExecutionContext&, UniqueRef<RTCDtlsTransportBackend>&&, Ref<RTCIceTransport>&&);
     ~RTCDtlsTransport();
 
-    using RefCounted<RTCDtlsTransport>::ref;
-    using RefCounted<RTCDtlsTransport>::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     RTCIceTransport& iceTransport() { return m_iceTransport.get(); }
     RTCDtlsTransportState state() { return m_state; }

--- a/Source/WebCore/Modules/mediastream/RTCIceTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCIceTransport.h
@@ -59,8 +59,9 @@ public:
     const RTCIceTransportBackend& backend() const { return m_backend.get(); }
     RefPtr<RTCPeerConnection> connection() const { return m_connection.get(); }
 
-    using RefCounted<RTCIceTransport>::ref;
-    using RefCounted<RTCIceTransport>::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     struct CandidatePair {
         RefPtr<RTCIceCandidate> local;
@@ -77,7 +78,7 @@ private:
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 
-    // ActiveDOMObject
+    // ActiveDOMObject.
     void stop() final;
     bool virtualHasPendingActivity() const final;
 

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -166,8 +166,9 @@ public:
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::RTCPeerConnection; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     // Used for testing with a mock
     WEBCORE_EXPORT void emulatePlatformEvent(const String& action);

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
@@ -75,8 +75,9 @@ public:
 
     bool hasKey(uint64_t) const;
 
-    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref;
-    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref;
+    // ActiveDOMObject.
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
 private:
     RTCRtpSFrameTransform(ScriptExecutionContext&, Options);

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.h
@@ -50,6 +50,10 @@ public:
     static ExceptionOr<Ref<RTCRtpScriptTransform>> create(JSC::JSGlobalObject&, Worker&, JSC::JSValue, Vector<JSC::Strong<JSC::JSObject>>&&);
     ~RTCRtpScriptTransform();
 
+    // ActiveDOMObject.
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
+
     void setTransformer(RTCRtpScriptTransformer&);
 
     bool isAttached() const { return m_isAttached; }

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h
@@ -61,6 +61,10 @@ public:
     static ExceptionOr<Ref<RTCRtpScriptTransformer>> create(ScriptExecutionContext&, MessageWithMessagePorts&&);
     ~RTCRtpScriptTransformer();
 
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     ReadableStream& readable();
     ExceptionOr<Ref<WritableStream>> writable();
     JSC::JSValue options(JSC::JSGlobalObject&);
@@ -77,7 +81,7 @@ public:
 private:
     RTCRtpScriptTransformer(ScriptExecutionContext&, Ref<SerializedScriptValue>&&, Vector<Ref<MessagePort>>&&, Ref<ReadableStream>&&, Ref<SimpleReadableStreamSource>&&);
 
-    // ActiveDOMObject
+    // ActiveDOMObject.
     void stop() final { stopPendingActivity(); }
 
     void stopPendingActivity() { auto pendingActivity = WTFMove(m_pendingActivity); }

--- a/Source/WebCore/Modules/mediastream/RTCSctpTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCSctpTransport.h
@@ -41,8 +41,9 @@ public:
     static Ref<RTCSctpTransport> create(ScriptExecutionContext&, UniqueRef<RTCSctpTransportBackend>&&, Ref<RTCDtlsTransport>&&);
     ~RTCSctpTransport();
 
-    using RefCounted<RTCSctpTransport>::ref;
-    using RefCounted<RTCSctpTransport>::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     RTCDtlsTransport& transport() { return m_transport.get(); }
     RTCSctpTransportState state() const { return m_state; }

--- a/Source/WebCore/Modules/mediastream/UserMediaRequest.h
+++ b/Source/WebCore/Modules/mediastream/UserMediaRequest.h
@@ -61,6 +61,10 @@ public:
     static Ref<UserMediaRequest> create(Document&, MediaStreamRequest&&, TrackConstraints&&, TrackConstraints&&, DOMPromiseDeferred<IDLInterface<MediaStream>>&&);
     virtual ~UserMediaRequest();
 
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void start();
 
     WEBCORE_EXPORT void setAllowedMediaDeviceUIDs(const String& audioDeviceUID, const String& videoDeviceUID);
@@ -83,6 +87,7 @@ public:
 private:
     UserMediaRequest(Document&, MediaStreamRequest&&, TrackConstraints&&, TrackConstraints&&, DOMPromiseDeferred<IDLInterface<MediaStream>>&&);
 
+    // ActiveDOMObject.
     void stop() final;
 
     Vector<String> m_videoDeviceUIDs;

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -64,6 +64,10 @@ public:
     static Ref<HTMLModelElement> create(const QualifiedName&, Document&);
     virtual ~HTMLModelElement();
 
+    // ActiveDOMObject.
+    void ref() const final { HTMLElement::ref(); }
+    void deref() const final { HTMLElement::deref(); }
+
     void sourcesChanged();
     const URL& currentSrc() const { return m_sourceURL; }
     bool complete() const { return m_dataComplete; }
@@ -139,7 +143,7 @@ private:
 
     HTMLModelElement& readyPromiseResolve();
 
-    // ActiveDOMObject
+    // ActiveDOMObject.
     bool virtualHasPendingActivity() const final;
 
     // DOM overrides.

--- a/Source/WebCore/Modules/notifications/Notification.h
+++ b/Source/WebCore/Modules/notifications/Notification.h
@@ -119,8 +119,9 @@ public:
     WEBCORE_EXPORT NotificationData data() const;
     RefPtr<NotificationResources> resources() const { return m_resources; }
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     void markAsShown();
     void showSoon();

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.h
@@ -103,8 +103,10 @@ public:
     void cancel();
 
     using MethodIdentifier = std::variant<String, URL>;
-    using RefCounted<PaymentRequest>::ref;
-    using RefCounted<PaymentRequest>::deref;
+
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
     struct Method {

--- a/Source/WebCore/Modules/paymentrequest/PaymentResponse.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentResponse.h
@@ -92,8 +92,9 @@ public:
     bool hasRetryPromise() const { return !!m_retryPromise; }
     void settleRetryPromise(ExceptionOr<void>&& = { });
 
-    using RefCounted<PaymentResponse>::ref;
-    using RefCounted<PaymentResponse>::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
     PaymentResponse(ScriptExecutionContext*, PaymentRequest&);

--- a/Source/WebCore/Modules/permissions/PermissionStatus.h
+++ b/Source/WebCore/Modules/permissions/PermissionStatus.h
@@ -50,8 +50,9 @@ public:
 
     void stateChanged(PermissionState);
 
-    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref;
-    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref;
+    // ActiveDOMObject.
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
 private:
     PermissionStatus(ScriptExecutionContext&, PermissionState, PermissionDescriptor, PermissionQuerySource, SingleThreadWeakPtr<Page>&&);

--- a/Source/WebCore/Modules/pictureinpicture/PictureInPictureWindow.h
+++ b/Source/WebCore/Modules/pictureinpicture/PictureInPictureWindow.h
@@ -49,13 +49,14 @@ public:
     void setSize(const IntSize&);
     void close();
 
-    using RefCounted<PictureInPictureWindow>::ref;
-    using RefCounted<PictureInPictureWindow>::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
     PictureInPictureWindow(Document&);
 
-    // EventTarget
+    // EventTarget.
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
     enum EventTargetInterfaceType eventTargetInterface() const override { return EventTargetInterfaceType::PictureInPictureWindow; };

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
@@ -72,17 +72,15 @@ public:
 
     void invalidate();
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     WebCoreOpaqueRoot opaqueRootConcurrently() const;
     Node* ownerNode() const;
 
 private:
     explicit RemotePlayback(HTMLMediaElement&);
-
-    void refEventTarget() final { ref(); }
-    void derefEventTarget() final { deref(); }
 
     void setState(State);
     void establishConnection();
@@ -91,6 +89,8 @@ private:
     // EventTarget.
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::RemotePlayback; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    void refEventTarget() final { ref(); }
+    void derefEventTarget() final { deref(); }
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger.get(); }

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.h
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.h
@@ -45,8 +45,9 @@ public:
         return sentinel;
     }
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     bool released() const { return m_wasReleased; }
     WakeLockType type() const { return m_type; }
@@ -56,10 +57,10 @@ public:
 private:
     WakeLockSentinel(Document&, WakeLockType);
 
-    // ActiveDOMObject
+    // ActiveDOMObject.
     bool virtualHasPendingActivity() const final;
 
-    // EventTarget
+    // EventTarget.
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::WakeLockSentinel; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() final { RefCounted::ref(); }

--- a/Source/WebCore/Modules/speech/SpeechRecognition.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognition.h
@@ -61,8 +61,9 @@ public:
     void stopRecognition();
     void abortRecognition();
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     virtual ~SpeechRecognition();
 

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.h
@@ -48,8 +48,9 @@ public:
     static Ref<SpeechSynthesis> create(ScriptExecutionContext&);
     virtual ~SpeechSynthesis();
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     bool pending() const;
     bool speaking() const;

--- a/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
@@ -69,8 +69,9 @@ public:
     MonotonicTime startTime() const { return m_platformUtterance->startTime(); }
     void setStartTime(MonotonicTime startTime) { m_platformUtterance->setStartTime(startTime); }
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     PlatformSpeechSynthesisUtterance* platformUtterance() const { return m_platformUtterance.get(); }
 

--- a/Source/WebCore/Modules/web-locks/WebLockManager.h
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.h
@@ -47,6 +47,10 @@ public:
     static Ref<WebLockManager> create(NavigatorBase&);
     ~WebLockManager();
 
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     struct Options {
         WebLockMode mode { WebLockMode::Exclusive };
         bool ifAvailable { false };

--- a/Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp
@@ -116,12 +116,12 @@ void AudioDestinationNode::renderQuantum(AudioBus* destinationBus, size_t number
         workletGlobalScope->handlePostRenderTasks(m_currentSampleFrame);
 }
 
-void AudioDestinationNode::ref()
+void AudioDestinationNode::ref() const
 {
     context().ref();
 }
 
-void AudioDestinationNode::deref()
+void AudioDestinationNode::deref() const
 {
     context().deref();
 }

--- a/Source/WebCore/Modules/webaudio/AudioDestinationNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioDestinationNode.h
@@ -55,8 +55,8 @@ public:
     virtual void restartRendering() { }
 
     // AudioDestinationNodes are owned by the BaseAudioContext so we forward the refcounting to its BaseAudioContext.
-    void ref() final;
-    void deref() final;
+    void ref() const final;
+    void deref() const final;
 
 protected:
     AudioDestinationNode(BaseAudioContext&, float sampleRate);

--- a/Source/WebCore/Modules/webaudio/AudioNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioNode.h
@@ -94,8 +94,8 @@ public:
     NodeType nodeType() const { return m_nodeType; }
 
     // Can be called from main thread or context's audio thread.
-    virtual void ref();
-    virtual void deref();
+    virtual void ref() const;
+    virtual void deref() const;
     void incrementConnectionCount();
     void decrementConnectionCount();
 
@@ -205,7 +205,8 @@ protected:
     void addOutput(unsigned numberOfChannels);
 
     void markNodeForDeletionIfNecessary();
-    void derefWithLock();
+    void unmarkNodeForDeletionIfNecessary();
+    void derefWithLock() const;
 
     struct DefaultAudioNodeOptions {
         unsigned channelCount;
@@ -255,7 +256,7 @@ private:
 
     // Ref-counting
     // start out with normal refCount == 1 (like WTF::RefCounted class).
-    std::atomic<int> m_normalRefCount { 1 };
+    mutable std::atomic<int> m_normalRefCount { 1 };
     std::atomic<int> m_connectionRefCount { 0 };
     
     bool m_isMarkedForDeletion { false };

--- a/Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.h
@@ -36,6 +36,10 @@ namespace WebCore {
 class AudioScheduledSourceNode : public AudioNode, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(AudioScheduledSourceNode);
 public:
+    // ActiveDOMObject.
+    void ref() const final { AudioNode::ref(); }
+    void deref() const final { AudioNode::deref(); }
+
     // These are the possible states an AudioScheduledSourceNode can be in:
     //
     // UNSCHEDULED_STATE - Initial playback state. Created, but not yet scheduled.
@@ -77,7 +81,9 @@ protected:
     // Called when we have no more sound to play or the noteOff() time has been reached.
     virtual void finish();
 
+    // ActiveDOMObject.
     bool virtualHasPendingActivity() const final;
+
     void eventListenersDidChange() final;
 
     bool requiresTailProcessing() const final { return false; }

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.h
@@ -57,6 +57,10 @@ public:
     static ExceptionOr<Ref<AudioWorkletNode>> create(JSC::JSGlobalObject&, BaseAudioContext&, String&& name, AudioWorkletNodeOptions&&);
     ~AudioWorkletNode();
 
+    // ActiveDOMObject.
+    void ref() const final { AudioNode::ref(); }
+    void deref() const final { AudioNode::deref(); }
+
     AudioParamMap& parameters() { return m_parameters.get(); }
     MessagePort& port() { return m_port.get(); }
 

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -710,6 +710,15 @@ void BaseAudioContext::markForDeletion(AudioNode& node)
     removeAutomaticPullNode(node);
 }
 
+void BaseAudioContext::unmarkForDeletion(AudioNode& node)
+{
+    ASSERT(isGraphOwner());
+    ASSERT_WITH_MESSAGE(node.nodeType() != AudioNode::NodeTypeDestination, "Destination node is owned by the BaseAudioContext");
+
+    m_nodesToDelete.removeFirst(&node);
+    m_nodesMarkedForDeletion.removeFirst(&node);
+}
+
 void BaseAudioContext::scheduleNodeDeletion()
 {
     bool isGood = m_isInitialized && isGraphOwner();

--- a/Source/WebCore/Modules/webaudio/ScriptProcessorNode.h
+++ b/Source/WebCore/Modules/webaudio/ScriptProcessorNode.h
@@ -56,6 +56,10 @@ public:
 
     virtual ~ScriptProcessorNode();
 
+    // ActiveDOMObject.
+    void ref() const final { AudioNode::ref(); }
+    void deref() const final { AudioNode::deref(); }
+
     // AudioNode
     void process(size_t framesToProcess) override;
     void initialize() override;
@@ -73,7 +77,9 @@ private:
 
     ScriptProcessorNode(BaseAudioContext&, size_t bufferSize, unsigned numberOfInputChannels, unsigned numberOfOutputChannels);
 
+    // ActiveDOMObject.
     bool virtualHasPendingActivity() const final;
+
     void eventListenersDidChange() final;
     void fireProcessEvent(unsigned bufferIndex);
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
@@ -71,13 +71,14 @@ public:
 
     static void isConfigSupported(ScriptExecutionContext&, WebCodecsAudioDecoderConfig&&, Ref<DeferredPromise>&&);
 
-    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref;
-    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref;
+    // ActiveDOMObject.
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
 private:
     WebCodecsAudioDecoder(ScriptExecutionContext&, Init&&);
 
-    // ActiveDOMObject API.
+    // ActiveDOMObject.
     void stop() final;
     void suspend(ReasonForSuspension) final;
     bool virtualHasPendingActivity() const final;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h
@@ -71,18 +71,19 @@ public:
 
     static void isConfigSupported(ScriptExecutionContext&, WebCodecsAudioEncoderConfig&&, Ref<DeferredPromise>&&);
 
-    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref;
-    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref;
+    // ActiveDOMObject.
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
 private:
     WebCodecsAudioEncoder(ScriptExecutionContext&, Init&&);
 
-    // ActiveDOMObject API.
+    // ActiveDOMObject.
     void stop() final;
     void suspend(ReasonForSuspension) final;
     bool virtualHasPendingActivity() const final;
 
-    // EventTarget
+    // EventTarget.
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::WebCodecsAudioEncoder; }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
@@ -69,18 +69,19 @@ public:
 
     static void isConfigSupported(ScriptExecutionContext&, WebCodecsVideoDecoderConfig&&, Ref<DeferredPromise>&&);
 
-    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref;
-    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref;
+    // ActiveDOMObject.
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
 private:
     WebCodecsVideoDecoder(ScriptExecutionContext&, Init&&);
 
-    // ActiveDOMObject API.
+    // ActiveDOMObject.
     void stop() final;
     void suspend(ReasonForSuspension) final;
     bool virtualHasPendingActivity() const final;
 
-    // EventTarget
+    // EventTarget.
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::WebCodecsVideoDecoder; }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
@@ -70,13 +70,14 @@ public:
 
     static void isConfigSupported(ScriptExecutionContext&, WebCodecsVideoEncoderConfig&&, Ref<DeferredPromise>&&);
 
-    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref;
-    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref;
+    // ActiveDOMObject.
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
 private:
     WebCodecsVideoEncoder(ScriptExecutionContext&, Init&&);
 
-    // ActiveDOMObject API.
+    // ActiveDOMObject.
     void stop() final;
     void suspend(ReasonForSuspension) final;
     bool virtualHasPendingActivity() const final;

--- a/Source/WebCore/Modules/webdatabase/DatabaseContext.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseContext.h
@@ -47,6 +47,10 @@ class SecurityOriginData;
 
 class DatabaseContext final : public ThreadSafeRefCounted<DatabaseContext>, private ActiveDOMObject {
 public:
+    // ActiveDOMObject.
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
+
     virtual ~DatabaseContext();
 
     DatabaseThread* existingDatabaseThread() const { return m_databaseThread.get(); }
@@ -72,6 +76,8 @@ private:
     void stopDatabases() { stopDatabases(nullptr); }
 
     void contextDestroyed() override;
+
+    // ActiveDOMObject.
     void stop() override;
 
     RefPtr<DatabaseThread> m_databaseThread;

--- a/Source/WebCore/Modules/websockets/WebSocket.h
+++ b/Source/WebCore/Modules/websockets/WebSocket.h
@@ -94,8 +94,9 @@ public:
 
     ScriptExecutionContext* scriptExecutionContext() const final;
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
     explicit WebSocket(ScriptExecutionContext&);
@@ -103,6 +104,8 @@ private:
     void dispatchErrorEventIfNeeded();
 
     void contextDestroyed() final;
+
+    // ActiveDOMObject.
     void suspend(ReasonForSuspension) final;
     void resume() final;
     void stop() final;

--- a/Source/WebCore/Modules/webtransport/WebTransport.h
+++ b/Source/WebCore/Modules/webtransport/WebTransport.h
@@ -65,6 +65,10 @@ public:
     static ExceptionOr<Ref<WebTransport>> create(ScriptExecutionContext&, String&&, WebTransportOptions&&);
     ~WebTransport();
 
+    // ActiveDOMObject.
+    void ref() const final { WebTransportSessionClient::ref(); }
+    void deref() const final { WebTransportSessionClient::deref(); }
+
     void getStats(Ref<DeferredPromise>&&);
     DOMPromise& ready();
     WebTransportReliabilityMode reliability();
@@ -86,6 +90,7 @@ private:
     void initializeOverHTTP(SocketProvider&, ScriptExecutionContext&, URL&&, bool dedicated, bool http3Only, WebTransportCongestionControl, Vector<WebTransportHash>&&);
     void cleanup(Ref<DOMException>&&, std::optional<WebTransportCloseInfo>&&);
 
+    // ActiveDOMObject.
     bool virtualHasPendingActivity() const final;
 
     void receiveDatagram(std::span<const uint8_t>) final;

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -64,8 +64,9 @@ public:
     static Ref<WebXRSession> create(Document&, WebXRSystem&, XRSessionMode, PlatformXR::Device&, FeatureList&&);
     virtual ~WebXRSession();
 
-    using RefCounted<WebXRSession>::ref;
-    using RefCounted<WebXRSession>::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     using PlatformXR::TrackingAndRenderingClient::weakPtrFactory;
     using PlatformXR::TrackingAndRenderingClient::WeakValueType;
@@ -114,7 +115,7 @@ private:
     void refEventTarget() override { ref(); }
     void derefEventTarget() override { deref(); }
 
-    // ActiveDOMObject
+    // ActiveDOMObject.
     void stop() override;
 
     // PlatformXR::TrackingAndRenderingClient

--- a/Source/WebCore/Modules/webxr/WebXRSystem.h
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.h
@@ -65,8 +65,9 @@ public:
     static Ref<WebXRSystem> create(Navigator&);
     ~WebXRSystem();
 
-    using RefCounted<WebXRSystem>::ref;
-    using RefCounted<WebXRSystem>::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     void isSessionSupported(XRSessionMode, IsSessionSupportedPromise&&);
     void requestSession(Document&, XRSessionMode, const XRSessionInit&, RequestSessionPromise&&);

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -163,8 +163,9 @@ public:
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     void contextDestroyed() final;
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 protected:
     explicit WebAnimation(Document&);

--- a/Source/WebCore/css/CSSFontFace.h
+++ b/Source/WebCore/css/CSSFontFace.h
@@ -211,8 +211,8 @@ public:
     virtual void fontStateChanged(CSSFontFace&, CSSFontFace::Status /*oldState*/, CSSFontFace::Status /*newState*/) { }
     virtual void fontPropertyChanged(CSSFontFace&, CSSValueList* /*oldFamilies*/ = nullptr) { }
     virtual void updateStyleIfNeeded(CSSFontFace&) { }
-    virtual void ref() = 0;
-    virtual void deref() = 0;
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
 };
 
 }

--- a/Source/WebCore/css/CSSFontFaceSet.h
+++ b/Source/WebCore/css/CSSFontFaceSet.h
@@ -98,8 +98,8 @@ public:
     ExceptionOr<Vector<std::reference_wrapper<CSSFontFace>>> matchingFacesExcludingPreinstalledFonts(const String& font, const String& text);
 
     // CSSFontFaceClient needs to be able to be held in a RefPtr.
-    void ref() final { RefCounted::ref(); }
-    void deref() final { RefCounted::deref(); }
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
     // FIXME: Should this be implemented?
     void updateStyleIfNeeded(CSSFontFace&) final { }
 

--- a/Source/WebCore/css/CSSFontSelector.h
+++ b/Source/WebCore/css/CSSFontSelector.h
@@ -56,6 +56,9 @@ public:
     using FontSelector::WeakValueType;
     using FontSelector::WeakPtrImplType;
 
+    using FontSelector::ref;
+    using FontSelector::deref;
+
     static Ref<CSSFontSelector> create(ScriptExecutionContext&);
     virtual ~CSSFontSelector();
 
@@ -96,8 +99,8 @@ public:
     void updateStyleIfNeeded();
 
     // CSSFontFaceClient needs to be able to be held in a RefPtr.
-    void ref() final { FontSelector::ref(); }
-    void deref() final { FontSelector::deref(); }
+    void ref() const final { FontSelector::ref(); }
+    void deref() const final { FontSelector::deref(); }
 
 private:
     explicit CSSFontSelector(ScriptExecutionContext&);

--- a/Source/WebCore/css/CSSSegmentedFontFace.h
+++ b/Source/WebCore/css/CSSSegmentedFontFace.h
@@ -56,8 +56,8 @@ public:
     Vector<Ref<CSSFontFace>, 1>& constituentFaces() { return m_fontFaces; }
 
     // CSSFontFaceClient needs to be able to be held in a RefPtr.
-    void ref() final { RefCounted<CSSSegmentedFontFace>::ref(); }
-    void deref() final { RefCounted<CSSSegmentedFontFace>::deref(); }
+    void ref() const final { RefCounted<CSSSegmentedFontFace>::ref(); }
+    void deref() const final { RefCounted<CSSSegmentedFontFace>::deref(); }
 
 private:
     CSSSegmentedFontFace();

--- a/Source/WebCore/css/FontFace.h
+++ b/Source/WebCore/css/FontFace.h
@@ -54,6 +54,9 @@ public:
         String display;
         String sizeAdjust;
     };
+
+    using RefCounted::ref;
+    using RefCounted::deref;
     
     using Source = std::variant<String, RefPtr<JSC::ArrayBuffer>, RefPtr<JSC::ArrayBufferView>>;
     static Ref<FontFace> create(ScriptExecutionContext&, const String& family, Source&&, const Descriptors&);
@@ -91,8 +94,9 @@ public:
 
     void fontStateChanged(CSSFontFace&, CSSFontFace::Status oldState, CSSFontFace::Status newState) final;
 
-    void ref() final { RefCounted::ref(); }
-    void deref() final { RefCounted::deref(); }
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
     explicit FontFace(CSSFontSelector&);

--- a/Source/WebCore/css/FontFaceSet.h
+++ b/Source/WebCore/css/FontFaceSet.h
@@ -75,8 +75,9 @@ public:
     };
     Iterator createIterator(ScriptExecutionContext*) { return Iterator(*this); }
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
     struct PendingPromise : RefCounted<PendingPromise> {

--- a/Source/WebCore/css/MediaQueryList.h
+++ b/Source/WebCore/css/MediaQueryList.h
@@ -51,8 +51,9 @@ public:
 
     void detachFromMatcher();
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
     MediaQueryList(Document&, MediaQueryMatcher&, MQ::MediaQueryList&&, bool matches);

--- a/Source/WebCore/dom/ActiveDOMObject.h
+++ b/Source/WebCore/dom/ActiveDOMObject.h
@@ -70,6 +70,9 @@ public:
     virtual void suspend(ReasonForSuspension);
     virtual void resume();
 
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
+
     // This function must not have a side effect of creating an ActiveDOMObject.
     // That means it must not result in calls to arbitrary JavaScript.
     // It can, however, have a side effect of deleting an ActiveDOMObject.

--- a/Source/WebCore/dom/BroadcastChannel.h
+++ b/Source/WebCore/dom/BroadcastChannel.h
@@ -53,8 +53,9 @@ public:
     }
     ~BroadcastChannel();
 
-    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref;
-    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref;
+    // ActiveDOMObject.
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
     BroadcastChannelIdentifier identifier() const;
     String name() const;
@@ -78,7 +79,7 @@ private:
     void derefEventTarget() final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
     void eventListenersDidChange() final;
 
-    // ActiveDOMObject
+    // ActiveDOMObject.
     bool virtualHasPendingActivity() const final;
     void stop() final { close(); }
 

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -55,8 +55,9 @@ public:
     static Ref<MessagePort> create(ScriptExecutionContext&, const MessagePortIdentifier& local, const MessagePortIdentifier& remote);
     WEBCORE_EXPORT virtual ~MessagePort();
 
-    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref;
-    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref;
+    // ActiveDOMObject.
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue message, StructuredSerializeOptions&&);
 
@@ -102,7 +103,7 @@ private:
     bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) final;
     bool removeEventListener(const AtomString& eventType, EventListener&, const EventListenerOptions&) final;
 
-    // ActiveDOMObject
+    // ActiveDOMObject.
     void contextDestroyed() final;
     void stop() final { close(); }
     bool virtualHasPendingActivity() const final;

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -287,14 +287,14 @@ void ScriptExecutionContext::forEachActiveDOMObject(const Function<ShouldContinu
     SetForScope activeDOMObjectAdditionForbiddenScope(m_activeDOMObjectAdditionForbidden, true);
 
     // Make a frozen copy of the objects so we can iterate while new ones might be destroyed.
-    auto possibleActiveDOMObjects = copyToVector(m_activeDOMObjects);
+    auto possibleActiveDOMObjects = copyToVectorOf<RefPtr<ActiveDOMObject>>(m_activeDOMObjects);
 
-    for (auto* activeDOMObject : possibleActiveDOMObjects) {
+    for (auto& activeDOMObject : possibleActiveDOMObjects) {
         // Check if this object was deleted already. If so, just skip it.
         // Calling contains on a possibly-already-deleted object is OK because we guarantee
         // no new object can be added, so even if a new object ends up allocated with the
         // same address, that will be *after* this function exits.
-        if (!m_activeDOMObjects.contains(activeDOMObject))
+        if (!m_activeDOMObjects.contains(activeDOMObject.get()))
             continue;
 
         if (apply(*activeDOMObject) == ShouldContinue::No)

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -421,7 +421,7 @@ private:
     std::unique_ptr<Vector<std::unique_ptr<PendingException>>> m_pendingExceptions;
     std::unique_ptr<RejectedPromiseTracker> m_rejectedPromiseTracker;
 
-    std::unique_ptr<PublicURLManager> m_publicURLManager;
+    RefPtr<PublicURLManager> m_publicURLManager;
 
     RefPtr<DatabaseContext> m_databaseContext;
 

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -136,6 +136,10 @@ public:
     static Ref<ViewTransition> create(Document&, RefPtr<ViewTransitionUpdateCallback>&&);
     ~ViewTransition();
 
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void skipTransition();
     void skipViewTransition(ExceptionOr<JSC::JSValue>&&);
     void callUpdateCallback();
@@ -170,6 +174,7 @@ private:
     ExceptionOr<void> updatePseudoElementStyles();
     void setupDynamicStyleSheet(const AtomString&, const CapturedElement&);
 
+    // ActiveDOMObject.
     void stop() final;
 
     OrderedNamedElementsMap m_namedElements;

--- a/Source/WebCore/fileapi/Blob.h
+++ b/Source/WebCore/fileapi/Blob.h
@@ -111,6 +111,10 @@ public:
     static bool isNormalizedContentType(const CString&);
 #endif
 
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     // URLRegistrable
     URLRegistry& registry() const override;
 

--- a/Source/WebCore/fileapi/FileReader.h
+++ b/Source/WebCore/fileapi/FileReader.h
@@ -75,8 +75,9 @@ public:
     FileReaderLoader::ReadType readType() const { return m_readType; }
     std::optional<std::variant<String, RefPtr<JSC::ArrayBuffer>>> result() const;
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
     explicit FileReader(ScriptExecutionContext&);

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -75,10 +75,10 @@ class CanvasBase {
 public:
     virtual ~CanvasBase();
 
-    virtual void refCanvasBase() = 0;
-    virtual void derefCanvasBase() = 0;
-    void ref() { refCanvasBase(); }
-    void deref() { derefCanvasBase(); }
+    virtual void refCanvasBase() const = 0;
+    virtual void derefCanvasBase() const = 0;
+    void ref() const { refCanvasBase(); }
+    void deref() const { derefCanvasBase(); }
 
     virtual bool isHTMLCanvasElement() const { return false; }
     virtual bool isOffscreenCanvas() const { return false; }

--- a/Source/WebCore/html/CustomPaintCanvas.h
+++ b/Source/WebCore/html/CustomPaintCanvas.h
@@ -80,8 +80,8 @@ public:
 private:
     CustomPaintCanvas(ScriptExecutionContext&, unsigned width, unsigned height);
 
-    void refCanvasBase() final { ref(); }
-    void derefCanvasBase() final { deref(); }
+    void refCanvasBase() const final { ref(); }
+    void derefCanvasBase() const final { deref(); }
     ScriptExecutionContext* canvasBaseScriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
     void replayDisplayListImpl(GraphicsContext& target) const;
 

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -140,8 +140,9 @@ public:
     void queueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) final;
     void dispatchEvent(Event&) final;
 
-    using HTMLElement::ref;
-    using HTMLElement::deref;
+    // ActiveDOMObject.
+    void ref() const final { HTMLElement::ref(); }
+    void deref() const final { HTMLElement::deref(); }
 
 private:
     HTMLCanvasElement(const QualifiedName&, Document&);
@@ -175,8 +176,8 @@ private:
 
     bool isGPUBased() const;
 
-    void refCanvasBase() final { HTMLElement::ref(); }
-    void derefCanvasBase() final { HTMLElement::deref(); }
+    void refCanvasBase() const final { HTMLElement::ref(); }
+    void derefCanvasBase() const final { HTMLElement::deref(); }
 
     ScriptExecutionContext* canvasBaseScriptExecutionContext() const final { return HTMLElement::scriptExecutionContext(); }
 

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -63,8 +63,9 @@ public:
 
     virtual ~HTMLImageElement();
 
-    using HTMLElement::ref;
-    using HTMLElement::deref;
+    // ActiveDOMObject.
+    void ref() const final { HTMLElement::ref(); }
+    void deref() const final { HTMLElement::deref(); }
 
     void formOwnerRemovedFromTree(const Node& formRoot);
 

--- a/Source/WebCore/html/HTMLMarqueeElement.h
+++ b/Source/WebCore/html/HTMLMarqueeElement.h
@@ -34,6 +34,10 @@ class HTMLMarqueeElement final : public HTMLElement, public ActiveDOMObject {
 public:
     static Ref<HTMLMarqueeElement> create(const QualifiedName&, Document&);
 
+    // ActiveDOMObject.
+    void ref() const final { HTMLElement::ref(); }
+    void deref() const final { HTMLElement::deref(); }
+
     int minimumDelay() const;
 
     WEBCORE_EXPORT void start();
@@ -57,6 +61,7 @@ private:
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
 
+    // ActiveDOMObject.
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
     void suspend(ReasonForSuspension) final;
     void resume() final;

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -173,6 +173,10 @@ public:
     using CanMakeWeakPtr<HTMLMediaElement, WeakPtrFactoryInitialization::Eager>::WeakValueType;
     using CanMakeWeakPtr<HTMLMediaElement, WeakPtrFactoryInitialization::Eager>::WeakPtrImplType;
 
+    // ActiveDOMObject.
+    void ref() const final { HTMLElement::ref(); }
+    void deref() const final { HTMLElement::deref(); }
+
     MediaPlayer* player() const { return m_player.get(); }
     RefPtr<MediaPlayer> protectedPlayer() const { return m_player; }
     WEBCORE_EXPORT std::optional<MediaPlayerIdentifier> playerIdentifier() const;
@@ -760,7 +764,7 @@ private:
     void setFullscreenMode(VideoFullscreenMode);
     void willStopBeingFullscreenElement() override;
 
-    // ActiveDOMObject API.
+    // ActiveDOMObject.
     void suspend(ReasonForSuspension) override;
     void resume() override;
     void stop() override;

--- a/Source/WebCore/html/HTMLSourceElement.h
+++ b/Source/WebCore/html/HTMLSourceElement.h
@@ -44,8 +44,9 @@ public:
     static Ref<HTMLSourceElement> create(Document&);
     static Ref<HTMLSourceElement> create(const QualifiedName&, Document&);
 
-    using HTMLElement::ref;
-    using HTMLElement::deref;
+    // ActiveDOMObject.
+    void ref() const final { HTMLElement::ref(); }
+    void deref() const final { HTMLElement::deref(); }
 
     void scheduleErrorEvent();
     void cancelPendingErrorEvent();

--- a/Source/WebCore/html/HTMLTrackElement.h
+++ b/Source/WebCore/html/HTMLTrackElement.h
@@ -42,6 +42,10 @@ class HTMLTrackElement final : public HTMLElement, public ActiveDOMObject, publi
 public:
     static Ref<HTMLTrackElement> create(const QualifiedName&, Document&);
 
+    // ActiveDOMObject.
+    void ref() const final { HTMLElement::ref(); }
+    void deref() const final { HTMLElement::deref(); }
+
     using HTMLElement::scriptExecutionContext;
 
     const AtomString& kind();

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -736,6 +736,10 @@ private:
 class PendingImageBitmap final : public RefCounted<PendingImageBitmap>, public ActiveDOMObject, public FileReaderLoaderClient {
     WTF_MAKE_FAST_ALLOCATED;
 public:
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     static void fetch(ScriptExecutionContext& scriptExecutionContext, RefPtr<Blob>&& blob, ImageBitmapOptions&& options, std::optional<IntRect> rect, ImageBitmap::ImageBitmapCompletionHandler&& completionHandler)
     {
         if (scriptExecutionContext.activeDOMObjectsAreStopped()) {

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -157,9 +157,11 @@ public:
 
     void queueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) final;
     void dispatchEvent(Event&) final;
-    using RefCounted::ref;
-    using RefCounted::deref;
     bool isDetached() const { return m_detached; };
+
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
     OffscreenCanvas(ScriptExecutionContext&, IntSize, RefPtr<OffscreenCanvasPlaceholderData>);
@@ -170,11 +172,11 @@ private:
     ScriptExecutionContext* canvasBaseScriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
 
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::OffscreenCanvas; }
-    void refEventTarget() final { ref(); }
-    void derefEventTarget() final { deref(); }
+    void refEventTarget() final { RefCounted::ref(); }
+    void derefEventTarget() final { RefCounted::deref(); }
 
-    void refCanvasBase() final { ref(); }
-    void derefCanvasBase() final { deref(); }
+    void refCanvasBase() const final { RefCounted::ref(); }
+    void derefCanvasBase() const final { RefCounted::deref(); }
 
     void setSize(const IntSize&) final;
 

--- a/Source/WebCore/html/PublicURLManager.cpp
+++ b/Source/WebCore/html/PublicURLManager.cpp
@@ -35,9 +35,9 @@
 
 namespace WebCore {
 
-std::unique_ptr<PublicURLManager> PublicURLManager::create(ScriptExecutionContext* context)
+Ref<PublicURLManager> PublicURLManager::create(ScriptExecutionContext* context)
 {
-    auto publicURLManager = makeUnique<PublicURLManager>(context);
+    Ref publicURLManager = adoptRef(*new PublicURLManager(context));
     publicURLManager->suspendIfNeeded();
     return publicURLManager;
 }

--- a/Source/WebCore/html/PublicURLManager.h
+++ b/Source/WebCore/html/PublicURLManager.h
@@ -37,18 +37,22 @@ class SecurityOrigin;
 class URLRegistry;
 class URLRegistrable;
 
-class PublicURLManager final : public ActiveDOMObject {
+class PublicURLManager final : public RefCounted<PublicURLManager>, public ActiveDOMObject {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    explicit PublicURLManager(ScriptExecutionContext*);
+    static Ref<PublicURLManager> create(ScriptExecutionContext*);
 
-    static std::unique_ptr<PublicURLManager> create(ScriptExecutionContext*);
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     void registerURL(const URL&, URLRegistrable&);
     void revoke(const URL&);
 
 private:
-    // ActiveDOMObject API.
+    explicit PublicURLManager(ScriptExecutionContext*);
+
+    // ActiveDOMObject.
     void stop() override;
     
     bool m_isStopped { false };

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
@@ -77,12 +77,12 @@ CanvasRenderingContext::~CanvasRenderingContext()
     instances().remove(this);
 }
 
-void CanvasRenderingContext::ref()
+void CanvasRenderingContext::ref() const
 {
     m_canvas.refCanvasBase();
 }
 
-void CanvasRenderingContext::deref()
+void CanvasRenderingContext::deref() const
 {
     m_canvas.derefCanvasBase();
 }

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -59,8 +59,8 @@ public:
     static HashSet<CanvasRenderingContext*>& instances() WTF_REQUIRES_LOCK(instancesLock());
     static Lock& instancesLock() WTF_RETURNS_LOCK(s_instancesLock);
 
-    WEBCORE_EXPORT void ref();
-    WEBCORE_EXPORT void deref();
+    WEBCORE_EXPORT void ref() const;
+    WEBCORE_EXPORT void deref() const;
 
     CanvasBase& canvasBase() const { return m_canvas; }
 

--- a/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h
@@ -36,6 +36,9 @@ class HTMLCanvasElement;
 class GPUBasedCanvasRenderingContext : public CanvasRenderingContext, public ActiveDOMObject {
     WTF_MAKE_ISO_NONALLOCATABLE(GPUBasedCanvasRenderingContext);
 public:
+    // ActiveDOMObject.
+    void ref() const final { CanvasRenderingContext::ref(); }
+    void deref() const final { CanvasRenderingContext::deref(); }
 
     bool isGPUBased() const override { return true; }
     bool isAccelerated() const override { return true; }

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -128,8 +128,9 @@ public:
 
     virtual MediaTime startTimeVariance() const { return MediaTime::zeroTime(); }
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     const std::optional<Vector<String>>& styleSheets() const { return m_styleSheets; }
 

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -119,8 +119,9 @@ public:
 
     String toJSONString() const;
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     virtual void recalculateStyles() { m_displayTreeNeedsUpdate = true; }
     virtual void setFontSize(int fontSize, bool important);

--- a/Source/WebCore/html/track/TrackListBase.h
+++ b/Source/WebCore/html/track/TrackListBase.h
@@ -65,10 +65,12 @@ public:
     virtual void remove(TrackID, bool scheduleEvent = true);
     virtual RefPtr<TrackBase> find(TrackID) const;
 
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     // EventTarget
     enum EventTargetInterfaceType eventTargetInterface() const override = 0;
-    using RefCounted<TrackListBase>::ref;
-    using RefCounted<TrackListBase>::deref;
     ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
 
     void didMoveToNewDocument(Document&);

--- a/Source/WebCore/page/DOMTimer.h
+++ b/Source/WebCore/page/DOMTimer.h
@@ -48,6 +48,10 @@ class DOMTimer final : public RefCounted<DOMTimer>, public ActiveDOMObject, publ
 public:
     WEBCORE_EXPORT virtual ~DOMTimer();
 
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     static Seconds defaultMinimumInterval() { return 4_ms; }
     static Seconds defaultAlignmentInterval() { return 0_s; }
     static Seconds defaultAlignmentIntervalInLowPowerOrThermallyMitigatedMode() { return 30_ms; }
@@ -79,7 +83,7 @@ private:
 
     void fired();
 
-    // ActiveDOMObject API.
+    // ActiveDOMObject.
     void stop() final;
 
     void makeImminentlyScheduledWorkScopeIfPossible(ScriptExecutionContext&);

--- a/Source/WebCore/page/EventSource.h
+++ b/Source/WebCore/page/EventSource.h
@@ -72,8 +72,9 @@ public:
 
     void close();
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
     EventSource(ScriptExecutionContext&, const URL&, const Init&);

--- a/Source/WebCore/page/ScreenOrientation.h
+++ b/Source/WebCore/page/ScreenOrientation.h
@@ -56,8 +56,9 @@ public:
     Type type() const;
     uint16_t angle() const;
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
     ScreenOrientation(Document*);
@@ -80,7 +81,7 @@ private:
     void derefEventTarget() final { RefCounted::deref(); }
     void eventListenersDidChange() final;
 
-    // ActiveDOMObject
+    // ActiveDOMObject.
     bool virtualHasPendingActivity() const final;
     void suspend(ReasonForSuspension) final;
     void resume() final;

--- a/Source/WebCore/workers/Worker.h
+++ b/Source/WebCore/workers/Worker.h
@@ -66,6 +66,10 @@ public:
     static ExceptionOr<Ref<Worker>> create(ScriptExecutionContext&, JSC::RuntimeFlags, const String& url, WorkerOptions&&);
     virtual ~Worker();
 
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue message, StructuredSerializeOptions&&);
 
     void terminate();

--- a/Source/WebCore/workers/WorkerAnimationController.h
+++ b/Source/WebCore/workers/WorkerAnimationController.h
@@ -48,12 +48,14 @@ public:
     int requestAnimationFrame(Ref<RequestAnimationFrameCallback>&&);
     void cancelAnimationFrame(int);
 
-    using ThreadSafeRefCounted::ref;
-    using ThreadSafeRefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
 
 private:
     WorkerAnimationController(WorkerGlobalScope&);
 
+    // ActiveDOMObject.
     bool virtualHasPendingActivity() const final;
     void stop() final;
     void suspend(ReasonForSuspension) final;

--- a/Source/WebCore/workers/service/ServiceWorker.h
+++ b/Source/WebCore/workers/service/ServiceWorker.h
@@ -65,8 +65,9 @@ public:
     ServiceWorkerRegistrationIdentifier registrationIdentifier() const { return m_data.registrationIdentifier; }
     WorkerType workerType() const { return m_data.type; }
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     const ServiceWorkerData& data() const { return m_data; }
 

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
@@ -106,6 +106,16 @@ void ServiceWorkerContainer::derefEventTarget()
     m_navigator.deref();
 }
 
+void ServiceWorkerContainer::ref() const
+{
+    m_navigator.ref();
+}
+
+void ServiceWorkerContainer::deref() const
+{
+    m_navigator.deref();
+}
+
 auto ServiceWorkerContainer::ready() -> ReadyPromise&
 {
     if (!m_readyPromise) {

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.h
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.h
@@ -59,6 +59,10 @@ public:
 
     ~ServiceWorkerContainer();
 
+    // ActiveDOMObject.
+    void ref() const final;
+    void deref() const final;
+
     ServiceWorker* controller() const;
 
     using ReadyPromise = DOMPromiseProxy<IDLInterface<ServiceWorkerRegistration>>;
@@ -134,6 +138,8 @@ private:
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::ServiceWorkerContainer; }
     void refEventTarget() final;
     void derefEventTarget() final;
+
+    // ActiveDOMObject.
     void stop() final;
 
     void notifyRegistrationIsSettled(const ServiceWorkerRegistrationKey&);

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.h
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.h
@@ -86,8 +86,8 @@ public:
     void getPushSubscription(DOMPromiseDeferred<IDLNullable<IDLInterface<PushSubscription>>>&&);
     void getPushPermissionState(DOMPromiseDeferred<IDLEnumeration<PushPermissionState>>&&);
 
-    void ref() const final { RefCounted::ref(); };
-    void deref() const final { RefCounted::deref(); };
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     const ServiceWorkerRegistrationData& data() const { return m_registrationData; }
 

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.h
@@ -67,8 +67,9 @@ public:
 
     void updateInformation(const BackgroundFetchInformation&);
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
     BackgroundFetchRegistration(ScriptExecutionContext&, BackgroundFetchInformation&&);

--- a/Source/WebCore/workers/shared/SharedWorker.h
+++ b/Source/WebCore/workers/shared/SharedWorker.h
@@ -46,6 +46,9 @@ public:
     static ExceptionOr<Ref<SharedWorker>> create(Document&, String&& scriptURL, std::optional<std::variant<String, WorkerOptions>>&&);
     ~SharedWorker();
 
+    void ref() const final { AbstractWorker::ref(); }
+    void deref() const final { AbstractWorker::deref(); }
+
     static SharedWorker* fromIdentifier(SharedWorkerObjectIdentifier);
     MessagePort& port() const { return m_port.get(); }
 
@@ -67,7 +70,6 @@ private:
     bool virtualHasPendingActivity() const final;
     void suspend(ReasonForSuspension) final;
     void resume() final;
-
 
     SharedWorkerKey m_key;
     Ref<MessagePort> m_port;

--- a/Source/WebCore/worklets/Worklet.h
+++ b/Source/WebCore/worklets/Worklet.h
@@ -45,6 +45,10 @@ class Worklet : public RefCounted<Worklet>, public ScriptWrappable, public CanMa
     WTF_MAKE_ISO_ALLOCATED(Worklet);
 public:
     virtual ~Worklet();
+
+    // ActiveDOMOject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
     
     virtual void addModule(const String& moduleURL, WorkletOptions&&, DOMPromiseDeferred<void>&&);
 

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -129,8 +129,9 @@ public:
 
     const ResourceResponse& resourceResponse() const { return m_response; }
 
-    using RefCounted<XMLHttpRequest>::ref;
-    using RefCounted<XMLHttpRequest>::deref;
+    // ActiveDOMObject.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     size_t memoryCost() const;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h
@@ -91,6 +91,10 @@ public:
     RefPtr<WebFrame> documentFrame();
     RefPtr<WebFrame> htmlIFrameElementContentFrame();
 
+    // ActiveDOMObject.
+    void ref() const final { API::ObjectImpl<API::Object::Type::BundleNodeHandle>::ref(); }
+    void deref() const final { API::ObjectImpl<API::Object::Type::BundleNodeHandle>::deref(); }
+
 private:
     static Ref<InjectedBundleNodeHandle> create(WebCore::Node&);
     InjectedBundleNodeHandle(WebCore::Node&);


### PR DESCRIPTION
#### 838fda3a50a10849e651dba7342361c364fc364e
<pre>
Update ScriptExecutionContext::forEachActiveDOMObject() to ref the ActiveDOMObjects
<a href="https://bugs.webkit.org/show_bug.cgi?id=273462">https://bugs.webkit.org/show_bug.cgi?id=273462</a>

Reviewed by Ryosuke Niwa.

Update ScriptExecutionContext::forEachActiveDOMObject() to ref the ActiveDOMObjects,
to avoid bugs like Bug 273451.

Also fix an issue with AudioNode where the node could get deleted if ref&apos;d after the
node has been marked for deletion. When an AudioNode&apos;s ref-count reaches 0, we mark it for
deletion, so that the BaseAudioContext will eventually destroy it. During this time, the
AudioNode is still registered as an ActiveDOMObject with the ScriptExecutionContext, which
may thus ref it. When a Node gets ref&apos;d we now unmark it for deletion until its ref-count
reaches 0 again.

* Source/WebCore/Modules/WebGPU/GPUDevice.h:
* Source/WebCore/Modules/applepay/ApplePaySession.h:
* Source/WebCore/Modules/applepay/ApplePaySetupWebCore.h:
* Source/WebCore/Modules/audiosession/DOMAudioSession.h:
* Source/WebCore/Modules/cache/DOMCache.h:
* Source/WebCore/Modules/cache/DOMCacheStorage.h:
* Source/WebCore/Modules/cookie-store/CookieStore.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.h:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h:
* Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.h:
* Source/WebCore/Modules/entriesapi/FileSystemEntry.h:
* Source/WebCore/Modules/fetch/FetchBodyOwner.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemHandle.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.h:
* Source/WebCore/Modules/gamepad/GamepadHapticActuator.h:
* Source/WebCore/Modules/geolocation/Geolocation.h:
* Source/WebCore/Modules/indexeddb/IDBActiveDOMObject.h:
* Source/WebCore/Modules/indexeddb/IDBIndex.h:
* Source/WebCore/Modules/indexeddb/IDBObjectStore.h:
* Source/WebCore/Modules/mediarecorder/MediaRecorder.h:
* Source/WebCore/Modules/mediasession/MediaSession.h:
* Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h:
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/Modules/mediasource/SourceBufferList.h:
* Source/WebCore/Modules/mediastream/ImageCapture.h:
* Source/WebCore/Modules/mediastream/MediaDevices.h:
* Source/WebCore/Modules/mediastream/MediaStream.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/RTCDTMFSender.h:
* Source/WebCore/Modules/mediastream/RTCDataChannel.h:
* Source/WebCore/Modules/mediastream/RTCDtlsTransport.h:
* Source/WebCore/Modules/mediastream/RTCIceTransport.h:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.h:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h:
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.h:
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h:
* Source/WebCore/Modules/mediastream/RTCSctpTransport.h:
* Source/WebCore/Modules/mediastream/UserMediaRequest.h:
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/notifications/Notification.h:
* Source/WebCore/Modules/paymentrequest/PaymentRequest.h:
* Source/WebCore/Modules/paymentrequest/PaymentResponse.h:
* Source/WebCore/Modules/permissions/PermissionStatus.h:
* Source/WebCore/Modules/pictureinpicture/PictureInPictureWindow.h:
* Source/WebCore/Modules/remoteplayback/RemotePlayback.h:
* Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.h:
* Source/WebCore/Modules/speech/SpeechRecognition.h:
* Source/WebCore/Modules/speech/SpeechSynthesis.h:
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h:
* Source/WebCore/Modules/web-locks/WebLockManager.h:
* Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.h:
* Source/WebCore/Modules/webaudio/AudioWorkletNode.h:
* Source/WebCore/Modules/webaudio/BaseAudioContext.h:
* Source/WebCore/Modules/webaudio/ScriptProcessorNode.h:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h:
* Source/WebCore/Modules/webdatabase/DatabaseContext.h:
* Source/WebCore/Modules/websockets/WebSocket.h:
* Source/WebCore/Modules/webtransport/WebTransport.h:
* Source/WebCore/Modules/webxr/WebXRSession.h:
* Source/WebCore/Modules/webxr/WebXRSystem.h:
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/css/CSSFontSelector.h:
* Source/WebCore/css/FontFace.h:
* Source/WebCore/css/FontFaceSet.h:
* Source/WebCore/css/MediaQueryList.h:
* Source/WebCore/dom/ActiveDOMObject.h:
* Source/WebCore/dom/BroadcastChannel.h:
* Source/WebCore/dom/MessagePort.h:
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::forEachActiveDOMObject const):
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/dom/ViewTransition.h:
* Source/WebCore/fileapi/Blob.h:
* Source/WebCore/fileapi/FileReader.h:
* Source/WebCore/html/CanvasBase.h:
(WebCore::CanvasBase::ref const):
(WebCore::CanvasBase::deref const):
(WebCore::CanvasBase::ref): Deleted.
(WebCore::CanvasBase::deref): Deleted.
* Source/WebCore/html/CustomPaintCanvas.h:
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLMarqueeElement.h:
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLSourceElement.h:
* Source/WebCore/html/HTMLTrackElement.h:
* Source/WebCore/html/ImageBitmap.cpp:
* Source/WebCore/html/OffscreenCanvas.h:
* Source/WebCore/html/PublicURLManager.cpp:
(WebCore::PublicURLManager::create):
* Source/WebCore/html/PublicURLManager.h:
* Source/WebCore/html/canvas/CanvasRenderingContext.cpp:
(WebCore::CanvasRenderingContext::ref const):
(WebCore::CanvasRenderingContext::deref const):
(WebCore::CanvasRenderingContext::ref): Deleted.
(WebCore::CanvasRenderingContext::deref): Deleted.
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
* Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h:
* Source/WebCore/html/track/TextTrack.h:
* Source/WebCore/html/track/TextTrackCue.h:
* Source/WebCore/html/track/TrackListBase.h:
* Source/WebCore/page/DOMTimer.h:
* Source/WebCore/page/EventSource.h:
* Source/WebCore/page/ScreenOrientation.h:
* Source/WebCore/workers/Worker.h:
* Source/WebCore/workers/WorkerAnimationController.h:
* Source/WebCore/workers/service/ServiceWorker.h:
* Source/WebCore/workers/service/ServiceWorkerContainer.cpp:
(WebCore::ServiceWorkerContainer::refActiveDOMObject):
(WebCore::ServiceWorkerContainer::derefActiveDOMObject):
* Source/WebCore/workers/service/ServiceWorkerContainer.h:
* Source/WebCore/workers/service/ServiceWorkerRegistration.h:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.h:
* Source/WebCore/workers/shared/SharedWorker.h:
* Source/WebCore/worklets/Worklet.h:
* Source/WebCore/xml/XMLHttpRequest.h:

Canonical link: <a href="https://commits.webkit.org/278273@main">https://commits.webkit.org/278273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/203b95cfb5bed27b5a25a114d8aa544aa89b9ce4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50006 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53249 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/683 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52307 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/252 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40787 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52104 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43013 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21919 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24347 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/258 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8376 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46405 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54831 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25100 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/242 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48176 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26358 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43217 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47214 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27220 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7223 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26087 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->