### PR TITLE
Change order of version in Comment

### DIFF
--- a/Source/WebDriver/glib/WebDriverServiceGLib.cpp
+++ b/Source/WebDriver/glib/WebDriverServiceGLib.cpp
@@ -66,7 +66,7 @@ static bool parseVersion(const String& version, uint64_t& major, uint64_t& minor
 
 bool WebDriverService::platformCompareBrowserVersions(const String& requiredVersion, const String& proposedVersion)
 {
-    // We require clients to use format major.micro.minor as version string.
+    // We require clients to use format major.minor.micro as version string.
     uint64_t requiredMajor, requiredMinor, requiredMicro;
     if (!parseVersion(requiredVersion, requiredMajor, requiredMinor, requiredMicro))
         return false;


### PR DESCRIPTION
#### 2836255ac9e925898dce931b9539c5ac3f41e0ae
<pre>
Change order of version in Comment

Change order of version in Comment
<a href="https://bugs.webkit.org/show_bug.cgi?id=273465">https://bugs.webkit.org/show_bug.cgi?id=273465</a>

Reviewed by Carlos Garcia Campos.

“major.micro.minor” to “major.minor.micro”

* Source/WebDriver/glib/WebDriverServiceGLib.cpp:
(WebDriver::WebDriverService::platformCompareBrowserVersions):

Canonical link: <a href="https://commits.webkit.org/278167@main">https://commits.webkit.org/278167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/285946429e081ea92a8e6dc4f6ee2b293583bcf3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49676 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52918 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/352 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26581 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40529 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26491 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21649 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23933 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43963 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8047 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45839 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44467 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Skipped layout-tests; 16 flakes") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54496 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24763 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20917 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47908 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26030 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46933 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10907 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26878 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25755 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->