### PR TITLE
[WPE] WPE Platform: Fix touch events propagation

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
@@ -174,6 +174,7 @@ View::View(struct wpe_view_backend* backend, WPEDisplay* display, const API::Pag
             case WPE_EVENT_TOUCH_CANCEL: {
                 // FIXME: gestures
 #if ENABLE(TOUCH_EVENTS)
+                webView.m_touchEvents.set(wpe_event_touch_get_sequence_id(event), event);
                 auto points = webView.touchPointsForEvent(event);
                 webView.m_touchEvents.remove(wpe_event_touch_get_sequence_id(event));
                 webView.page().handleTouchEvent(NativeWebTouchEvent(event, WTFMove(points)));

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.h
@@ -174,7 +174,7 @@ private:
 #if ENABLE(TOUCH_EVENTS)
     std::unique_ptr<WebKit::TouchGestureController> m_touchGestureController;
 #if ENABLE(WPE_PLATFORM)
-    HashMap<uint32_t, GRefPtr<WPEEvent>> m_touchEvents;
+    HashMap<uint32_t, GRefPtr<WPEEvent>, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_touchEvents;
 #endif
 #endif
     std::unique_ptr<WebKit::PageClientImpl> m_pageClient;


### PR DESCRIPTION
#### a0949547e09cbf06a9c924c0e2f142792fca34da
<pre>
[WPE] WPE Platform: Fix touch events propagation
<a href="https://bugs.webkit.org/show_bug.cgi?id=273468">https://bugs.webkit.org/show_bug.cgi?id=273468</a>

Reviewed by Carlos Garcia Campos.

This change makes it possible to store events with sequence id == 0
in the HashMap thus allowing them to be propagated.
This change also takes touch points of UP/CANCEL events into account
so that those events are propagated correctly as well.

* Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp:
(WKWPE::m_backend):
* Source/WebKit/UIProcess/API/wpe/WPEWebView.h:

Canonical link: <a href="https://commits.webkit.org/278161@main">https://commits.webkit.org/278161@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7661f293f20032cbfdab7d1d7a8fcb7fdb128d03

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52927 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/361 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26590 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51785 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/26503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/21659 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/23945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8056 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/44478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54507 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24772 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20926 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26039 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26887 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7149 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25764 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->