### PR TITLE
[WPE] Decrease schedule input notification for gamepad

### DIFF
--- a/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.cpp
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.cpp
@@ -39,7 +39,7 @@
 namespace WebCore {
 
 static const Seconds connectionDelayInterval { 500_ms };
-static const Seconds inputNotificationDelay { 50_ms };
+static const Seconds inputNotificationDelay { 5_ms };
 
 GamepadProviderLibWPE& GamepadProviderLibWPE::singleton()
 {


### PR DESCRIPTION
#### 0a5f00bcb38798100c8c8cc56f4946dc01786dd7
<pre>
[WPE] Decrease schedule input notification for gamepad
<a href="https://bugs.webkit.org/show_bug.cgi?id=273470">https://bugs.webkit.org/show_bug.cgi?id=273470</a>

Reviewed by Philippe Normand.

Decrease schedule input notification for gamepad from 50ms to 5ms.

Original author: mbhatt627 (<a href="https://github.com/mbhatt627)">https://github.com/mbhatt627)</a>
See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1325">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1325</a>

* Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.cpp:

Canonical link: <a href="https://commits.webkit.org/278162@main">https://commits.webkit.org/278162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e751af4fbe667cd1ce65e1d33a0605d2485200df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49687 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52929 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/363 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51992 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34995 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26592 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40539 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51787 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26502 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21660 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23944 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43978 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8058 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45861 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44489 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54509 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24774 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20929 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47920 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26041 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10905 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26889 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25766 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->