### PR TITLE
[GTK][WPE] Support GL_EXT_packed_depth_stencil as well

### DIFF
--- a/Source/WebCore/platform/graphics/egl/GLContext.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContext.cpp
@@ -541,7 +541,8 @@ const GLContext::GLExtensions& GLContext::glExtensions() const
         m_glExtensions.OES_texture_npot = isExtensionSupported(extensionsString, "GL_OES_texture_npot");
         m_glExtensions.EXT_unpack_subimage = isExtensionSupported(extensionsString, "GL_EXT_unpack_subimage");
         m_glExtensions.APPLE_sync = isExtensionSupported(extensionsString, "GL_APPLE_sync");
-        m_glExtensions.OES_packed_depth_stencil = isExtensionSupported(extensionsString, "GL_OES_packed_depth_stencil");
+        m_glExtensions.EXT_or_OES_packed_depth_stencil = isExtensionSupported(extensionsString, "GL_OES_packed_depth_stencil")
+            || isExtensionSupported(extensionsString, "GL_EXT_packed_depth_stencil");
     });
     return m_glExtensions;
 }

--- a/Source/WebCore/platform/graphics/egl/GLContext.h
+++ b/Source/WebCore/platform/graphics/egl/GLContext.h
@@ -77,7 +77,7 @@ public:
         bool OES_texture_npot { false };
         bool EXT_unpack_subimage { false };
         bool APPLE_sync { false };
-        bool OES_packed_depth_stencil { false };
+        bool EXT_or_OES_packed_depth_stencil { false };
     };
     const GLExtensions& glExtensions() const;
 

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -52,10 +52,12 @@ static const GLenum s_pixelDataType = GL_UNSIGNED_BYTE;
 #endif
 
 // On GLES3, the format we want for packed depth stencil is GL_DEPTH24_STENCIL8, but when added through
-// the extension this format is called GL_DEPTH24_STENCIL8_OES. In any case they hold the same value 0x88F0
-// so we can just use the first one.
+// the extension this format is called GL_DEPTH24_STENCIL8_{OES,EXT}. In any case they hold the same
+// value 0x88F0 so we can just use the first one.
 // These definitions may not exist if this is a GLES1/2 context without the GL_OES_packed_depth_stencil
-// extension. We need to define the one we want to use in order to build on every case.
+// or the GL_EXT_packed_depth_stencil extensions. We need to define the one we want to use in order to
+// build on every case.
+
 #ifndef GL_DEPTH24_STENCIL8
 #define GL_DEPTH24_STENCIL8 0x88F0
 #endif


### PR DESCRIPTION
#### 2619323a38a446d84736f0ad052ea1baf2097473
<pre>
[GTK][WPE] Support GL_EXT_packed_depth_stencil as well
<a href="https://bugs.webkit.org/show_bug.cgi?id=273473">https://bugs.webkit.org/show_bug.cgi?id=273473</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/platform/graphics/egl/GLContext.cpp:
(WebCore::GLContext::glExtensions const): Also check for
GL_EXT_packed_depth_stencil.
* Source/WebCore/platform/graphics/egl/GLContext.h: Rename flag
OES_packed_depth_stencil to EXT_or_OES_packed_depth_stencil.
* Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp: Update
comment to mention GL_EXT_packed_depth_stencil as well.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2619323a38a446d84736f0ad052ea1baf2097473

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49688 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28976 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52737 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52930 "Hash 2619323a for PR 27925 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/364 "Hash 2619323a for PR 27925 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51993 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26593 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/52930 "Hash 2619323a for PR 27925 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51788 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/26511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/52930 "Hash 2619323a for PR 27925 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23946 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43976 "Passed tests") | [❌ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8059 "Hash 2619323a for PR 27925 does not build (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44480 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54510 "Hash 2619323a for PR 27925 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24775 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/54510 "Hash 2619323a for PR 27925 does not build (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26042 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/54510 "Hash 2619323a for PR 27925 does not build (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26890 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25767 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->