### PR TITLE
[GStreamer][EME] Reworked the reference counting of sessions

### DIFF
--- a/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
+++ b/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
@@ -509,7 +509,7 @@ void CDMInstanceSessionClearKey::updateLicense(const String& sessionId, LicenseT
     if (parseLicenseReleaseAcknowledgementFormat(*root)) {
         LOG(EME, "EME - ClearKey - session %s release acknowledged, clearing all known keys", sessionId.utf8().data());
         parentInstance().unrefAllKeysFrom(m_keyStore);
-        m_keyStore.unrefAllKeys();
+        m_keyStore.clear();
         dispatchCallback(true, std::nullopt, SuccessValue::Succeeded);
         return;
     }
@@ -566,7 +566,7 @@ void CDMInstanceSessionClearKey::removeSessionData(const String& sessionId, Lice
         auto rootObject = JSON::Object::create();
         {
             auto array = JSON::Array::create();
-            for (const auto& key : m_keyStore) {
+            for (const auto& key : m_keyStore.values()) {
                 ASSERT(key->id().size() <= std::numeric_limits<unsigned>::max());
                 array->pushString(base64URLEncodeToString(key->id().data(), key->id().size()));
             }
@@ -578,7 +578,7 @@ void CDMInstanceSessionClearKey::removeSessionData(const String& sessionId, Lice
         message = SharedBuffer::create(messageString.utf8().span());
     }
 
-    m_keyStore.unrefAllKeys();
+    m_keyStore.clear();
     dispatchCallback(WTFMove(keyStatusVector), Ref<SharedBuffer>(*message), SuccessValue::Succeeded);
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -640,10 +640,9 @@ void CDMInstanceSessionThunder::closeSession(const String& sessionID, CloseSessi
         opencdm_session_close(m_session->get());
         m_session = BoxPtr<OpenCDMSession>();
         auto instance = cdmInstanceThunder();
-        if (instance) {
+        if (instance)
             instance->unrefAllKeysFrom(m_keyStore);
-            m_keyStore.unrefAllKeys();
-        }
+        m_keyStore.clear();
     }
 
     callback();


### PR DESCRIPTION
#### 38d5868c5f9757b5e845f5d3125f690b712de396
<pre>
[GStreamer][EME] Reworked the reference counting of sessions
<a href="https://bugs.webkit.org/show_bug.cgi?id=273490">https://bugs.webkit.org/show_bug.cgi?id=273490</a>

Reviewed by Philippe Normand.

Now they are properly accounted for and disposed.

A fly-by is fixing the name of for the isKeyAvailable methods to make them code-style compliant.

* Source/WebCore/platform/encryptedmedia/CDMProxy.cpp:
(WebCore::KeyHandle::takeValueIfDifferent):
(WebCore::keyStoreBaseNextID):
(WebCore::ReferenceAwareKeyStore::unrefAllKeysFrom):
(WebCore::ReferenceAwareKeyStore::merge):
(WebCore::CDMProxy::tryWaitForKeyHandle const):
(WebCore::CDMProxy::isKeyAvailableUnlocked const):
(WebCore::CDMProxy::isKeyAvailable const):
(WebCore::CDMProxy::getOrWaitForKeyHandle const):
(WebCore::KeyStore::containsKeyID const): Deleted.
(WebCore::KeyStore::merge): Deleted.
(WebCore::KeyStore::allKeysAs const): Deleted.
(WebCore::KeyStore::addKeys): Deleted.
(WebCore::KeyStore::add): Deleted.
(WebCore::KeyStore::unrefAllKeysFrom): Deleted.
(WebCore::KeyStore::unrefAllKeys): Deleted.
(WebCore::KeyStore::unref): Deleted.
(WebCore::KeyStore::keyHandle const): Deleted.
(WebCore::KeyStore::convertToJSKeyStatusVector const): Deleted.
(WebCore::CDMProxy::keyAvailableUnlocked const): Deleted.
(WebCore::CDMProxy::keyAvailable const): Deleted.
* Source/WebCore/platform/encryptedmedia/CDMProxy.h:
(WebCore::KeyHandle::status const):
(WebCore::KeyHandle::operator==):
(WebCore::KeyHandle::KeyHandle):
(WebCore::KeyStoreBase::KeyStoreBase):
(WebCore::KeyStoreBase::add):
(WebCore::KeyStoreBase::addKeys):
(WebCore::KeyStoreBase::remove):
(WebCore::KeyStoreBase::clear):
(WebCore::KeyStoreBase::containsKeyID const):
(WebCore::KeyStoreBase::keyHandle const):
(WebCore::KeyStoreBase::allKeysAs const):
(WebCore::KeyStoreBase::convertToJSKeyStatusVector const):
(WebCore::KeyStoreBase::numKeys const):
(WebCore::KeyStoreBase::values const):
(WebCore::KeyStoreBase::id const):
(WebCore::ReferenceAwareKeyHandle::createFrom):
(WebCore::ReferenceAwareKeyHandle::updateKeyFrom):
(WebCore::ReferenceAwareKeyHandle::hasReferences const):
(WebCore::ReferenceAwareKeyHandle::ReferenceAwareKeyHandle):
(WebCore::ReferenceAwareKeyHandle::removeReference):
(WebCore::KeyHandle::mergeKeyInto): Deleted.
(WebCore::KeyHandle::operator&lt;): Deleted.
(WebCore::KeyHandle::addSessionReference): Deleted.
(WebCore::KeyHandle::removeSessionReference): Deleted.
(WebCore::KeyHandle::numSessionReferences const): Deleted.
(WebCore::KeyHandle::hasReferences const): Deleted.
(WebCore::KeyStore::hasKeys const): Deleted.
(WebCore::KeyStore::numKeys const): Deleted.
(WebCore::KeyStore::isEmpty const): Deleted.
(WebCore::KeyStore::addSessionReferenceTo const): Deleted.
(WebCore::KeyStore::removeSessionReferenceFrom const): Deleted.
(WebCore::KeyStore::begin): Deleted.
(WebCore::KeyStore::begin const): Deleted.
(WebCore::KeyStore::end): Deleted.
(WebCore::KeyStore::end const): Deleted.
(WebCore::KeyStore::rbegin): Deleted.
(WebCore::KeyStore::rbegin const): Deleted.
(WebCore::KeyStore::rend): Deleted.
(WebCore::KeyStore::rend const): Deleted.
* Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp:
(WebCore::CDMInstanceSessionClearKey::updateLicense):
(WebCore::CDMInstanceSessionClearKey::removeSessionData):
* Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp:
(WebCore::CDMInstanceSessionThunder::closeSession):

Canonical link: <a href="https://commits.webkit.org/278272@main">https://commits.webkit.org/278272@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/baa6d497eeb033b215f0355a0efce025598184f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53262 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/696 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52320 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/265 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40793 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26907 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43021 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21925 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24337 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/261 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8389 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46388 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54844 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25113 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48184 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26371 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43221 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10976 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3; Checked out pull request; Reviewed by Philippe Normand; Running compile-webkit") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27233 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26100 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->