### PR TITLE
Harden PropertySlot::setValue by asserting the attribute's accessor status

### DIFF
--- a/Source/JavaScriptCore/runtime/PropertySlot.h
+++ b/Source/JavaScriptCore/runtime/PropertySlot.h
@@ -210,7 +210,7 @@ public:
 
     void setValue(JSObject* slotBase, unsigned attributes, JSValue value)
     {
-        ASSERT(attributes == attributesForStructure(attributes));
+        ASSERT(attributes == attributesForStructure(attributes) && (!attributes & PropertyAttribute::Accessor));
         
         m_data.value = JSValue::encode(value);
         m_attributes = attributes;
@@ -224,7 +224,7 @@ public:
     
     void setValue(JSObject* slotBase, unsigned attributes, JSValue value, PropertyOffset offset)
     {
-        ASSERT(attributes == attributesForStructure(attributes));
+        ASSERT(attributes == attributesForStructure(attributes) && (!attributes & PropertyAttribute::Accessor));
         
         ASSERT(value);
         m_data.value = JSValue::encode(value);
@@ -240,7 +240,7 @@ public:
 
     void setValue(JSString*, unsigned attributes, JSValue value)
     {
-        ASSERT(attributes == attributesForStructure(attributes));
+        ASSERT(attributes == attributesForStructure(attributes) && (!attributes & PropertyAttribute::Accessor));
         
         ASSERT(value);
         m_data.value = JSValue::encode(value);


### PR DESCRIPTION
#### e782390de5561161b142931d28ba8b89816736e6
<pre>
Harden PropertySlot::setValue by asserting the attribute&apos;s accessor status
<a href="https://bugs.webkit.org/show_bug.cgi?id=273492">https://bugs.webkit.org/show_bug.cgi?id=273492</a>
<a href="https://rdar.apple.com/120777717">rdar://120777717</a>

Reviewed by NOBODY (OOPS!).

This makes sure that e.g. GetterSetter objects cannot be used with setValue, which previously
had had the potential to leak structures in the presence of another bug.

* Source/JavaScriptCore/runtime/PropertySlot.h:
(JSC::PropertySlot::setValue):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e782390de5561161b142931d28ba8b89816736e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52949 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/383 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26612 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40558 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51807 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26530 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21679 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23973 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/44003 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8078 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43026 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45885 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44510 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54530 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/49203 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24795 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20960 "Found 60 new test failures: accessibility/ARIA-reflection.html, accessibility/accessibility-crash-focused-element-change.html, accessibility/accessibility-crash-setattribute.html, accessibility/combobox/aria-combobox-control-owns-elements.html, accessibility/combobox/aria-combobox-hierarchy.html, accessibility/combobox/aria-combobox-no-owns.html, accessibility/combobox/mac/aria-combobox-activedescendant.html, accessibility/combobox/mac/combobox-activedescendant-notifications.html, accessibility/combobox/mac/combobox-value.html, accessibility/custom-elements/autocomplete.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47936 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26061 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26909 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56689 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25786 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11648 "Passed tests") | 
<!--EWS-Status-Bubble-End-->