### PR TITLE
REGRESSION (274826@main): [ iOS ] imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm is a constant failure (attempt #2)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive-expected.txt
@@ -1,4 +1,4 @@
 
 PASS XMLHttpRequest: setRequestHeader() - headers that differ in case
-FAIL XMLHttpRequest: setRequestHeader() - headers that differ in case 1 assert_regexp_match: expected object "/content-TYPE/" but got "Host: localhost:8800\nContent-Type: x/x\nConnection: keep-alive\nTHIS-IS-A-TEST: 1, 2\nAccept: */*\nUser-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)\nReferer: http://localhost:8800/xhr/setrequestheader-case-insensitive.htm\nAccept-Language: en-US,en;q=0.9\nAccept-Encoding: gzip, deflate\n\n"
+FAIL XMLHttpRequest: setRequestHeader() - headers that differ in case 1 assert_equals: expected ["content-TYPE"] but got ["Content-Type"]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm
@@ -26,8 +26,10 @@
         client.setRequestHeader("THIS-is-A-test", "2")
         client.setRequestHeader("content-TYPE", "x/x")
         client.send()
-        assert_regexp_match(client.responseText, /content-TYPE/)
-        assert_regexp_match(client.responseText, /THIS-IS-A-TEST: 1, 2/)
+        const contentTypeHeader = client.responseText.match(/content-TYPE/gi)
+        const thisIsATestHeader = client.responseText.match(/THIS-IS-A-TEST: 1, 2/gi)
+        assert_equals(contentTypeHeader, ["content-TYPE"])
+        assert_equals(thisIsATestHeader, ["THIS-IS-A-TEST: 1, 2"])
       })
     </script>
   </body>

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive-expected.txt
@@ -1,4 +1,0 @@
-
-PASS XMLHttpRequest: setRequestHeader() - headers that differ in case
-FAIL XMLHttpRequest: setRequestHeader() - headers that differ in case 1 assert_regexp_match: expected object "/content-TYPE/" but got "Host: localhost:8800\nContent-Type: x/x\nConnection: keep-alive\nTHIS-IS-A-TEST: 1, 2\nAccept: */*\nUser-Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148\nReferer: http://localhost:8800/xhr/setrequestheader-case-insensitive.htm\nAccept-Language: en-US,en;q=0.9\nAccept-Encoding: gzip, deflate\n\n"
-


### PR DESCRIPTION
#### bcd24645d410ec20291616c58bcb902ce11bc7fb
<pre>
REGRESSION (274826@main): [ iOS ] imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm is a constant failure (attempt #2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=273498">https://bugs.webkit.org/show_bug.cgi?id=273498</a>
<a href="https://rdar.apple.com/127299045">rdar://127299045</a>

Reviewed by Anne van Kesteren and Sam Sneddon.

Second attempt. This change modifies the test such that it now only compares
the relevant header substrings, instead of matching the entire header content.

* LayoutTests/imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm:

Canonical link: <a href="https://commits.webkit.org/278282@main">https://commits.webkit.org/278282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4db68187f71d8db4eba6314d4639c9294c653500

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/1985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53022 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/456 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40618 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51876 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26611 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42835 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21734 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24049 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19 "Found 1 new test failure: http/tests/media/hls/track-webvtt-multitracks.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8149 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43101 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45962 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54603 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24870 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/25 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48004 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26130 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42965 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47030 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26985 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7230 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25856 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->