### PR TITLE
Decoupling from-font resolution from FontCascadeFonts::primaryFont

### DIFF
--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -370,7 +370,7 @@ static Ref<CSSValue> fontSizeAdjustFromStyle(const RenderStyle& style)
         return CSSPrimitiveValue::create(CSSValueNone);
 
     auto metric = fontSizeAdjust.metric;
-    auto value = fontSizeAdjust.isFromFont() ? fontSizeAdjust.resolve(style.computedFontSize(), style.metricsOfPrimaryFont()) : fontSizeAdjust.value.asOptional();
+    auto value = fontSizeAdjust.shouldResolveFromFont() ? fontSizeAdjust.resolve(style.computedFontSize(), style.metricsOfPrimaryFont()) : fontSizeAdjust.value.asOptional();
     if (metric == FontSizeAdjust::Metric::ExHeight)
         return CSSPrimitiveValue::create(*value);
 

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -373,7 +373,9 @@ private:
 inline const Font& FontCascade::primaryFont() const
 {
     ASSERT(m_fonts);
-    return protectedFonts()->primaryFont(m_fontDescription);
+    auto& font = protectedFonts()->primaryFont(m_fontDescription);
+    m_fontDescription.resolveFontSizeAdjustFromFontIfNeeded(font);
+    return font;
 }
 
 inline const FontRanges& FontCascade::fallbackRangesAt(unsigned index) const

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.cpp
@@ -147,4 +147,14 @@ FontSmoothingMode FontCascadeDescription::usedFontSmoothing() const
     return fontSmoothingMode;
 }
 
+void FontCascadeDescription::resolveFontSizeAdjustFromFontIfNeeded(const Font& font)
+{
+    const auto& fontSizeAdjust = this->fontSizeAdjust();
+    if (!fontSizeAdjust.shouldResolveFromFont())
+        return;
+
+    auto aspectValue = fontSizeAdjust.resolve(computedSize(), font.fontMetrics());
+    setFontSizeAdjust({ fontSizeAdjust.metric, FontSizeAdjust::ValueType::FromFont, aspectValue });
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.h
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.h
@@ -45,6 +45,8 @@ typedef FontFamilySpecificationNull FontFamilyPlatformSpecification;
 
 typedef std::variant<AtomString, FontFamilyPlatformSpecification> FontFamilySpecification;
 
+class Font;
+
 class FontCascadeDescription : public FontDescription {
 public:
     WEBCORE_EXPORT FontCascadeDescription();
@@ -117,6 +119,8 @@ public:
             && m_isAbsoluteSize == other.m_isAbsoluteSize;
     }
 #endif
+
+    WEBCORE_EXPORT void resolveFontSizeAdjustFromFontIfNeeded(const Font&);
 
     // Initial values for font properties.
     static std::optional<FontSelectionValue> initialItalic() { return std::nullopt; }

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -74,7 +74,7 @@ public:
     WidthCache& widthCache() { return m_widthCache; }
     const WidthCache& widthCache() const { return m_widthCache; }
 
-    const Font& primaryFont(FontCascadeDescription&);
+    const Font& primaryFont(const FontCascadeDescription&);
     WEBCORE_EXPORT const FontRanges& realizeFallbackRangesAt(const FontCascadeDescription&, unsigned fallbackIndex);
 
     void pruneSystemFallbacks();
@@ -144,7 +144,7 @@ inline bool FontCascadeFonts::canTakeFixedPitchFastContentMeasuring(const FontCa
     return m_canTakeFixedPitchFastContentMeasuring == TriState::True;
 }
 
-inline const Font& FontCascadeFonts::primaryFont(FontCascadeDescription& description)
+inline const Font& FontCascadeFonts::primaryFont(const FontCascadeDescription& description)
 {
     ASSERT(m_thread ? m_thread->ptr() == &Thread::current() : isMainThread());
     if (!m_cachedPrimaryFont) {
@@ -164,14 +164,8 @@ inline const Font& FontCascadeFonts::primaryFont(FontCascadeDescription& descrip
                 }
             }
         }
-
-        ASSERT(m_cachedPrimaryFont);
-        auto fontSizeAdjust = description.fontSizeAdjust();
-        if (fontSizeAdjust.isFromFont()) {
-            auto aspectValue = fontSizeAdjust.resolve(description.computedSize(), m_cachedPrimaryFont->fontMetrics());
-            description.setFontSizeAdjust({ fontSizeAdjust.metric, FontSizeAdjust::ValueType::FromFont, aspectValue });
-        }
     }
+    ASSERT(m_cachedPrimaryFont);
     return *m_cachedPrimaryFont;
 }
 

--- a/Source/WebCore/platform/graphics/FontSizeAdjust.h
+++ b/Source/WebCore/platform/graphics/FontSizeAdjust.h
@@ -71,6 +71,7 @@ struct FontSizeAdjust {
 
     bool isNone() const { return !value && type != ValueType::FromFont; }
     bool isFromFont() const { return type == ValueType::FromFont; }
+    bool shouldResolveFromFont() const { return isFromFont() && !value; }
 
     Metric metric { Metric::ExHeight };
     ValueType type { ValueType::Number };


### PR DESCRIPTION
#### 44d3464ef15e7080e9de1350c0daaa66ac4e315a
<pre>
Decoupling from-font resolution from FontCascadeFonts::primaryFont
<a href="https://bugs.webkit.org/show_bug.cgi?id=273339">https://bugs.webkit.org/show_bug.cgi?id=273339</a>
<a href="https://rdar.apple.com/127132471">rdar://127132471</a>

Reviewed by Brent Fulgham.

font-size-adjust from-font resolution was fixed by [1]. It now works correctly and
it uses the primary font for resolution. However, this patch changed FontCascadeFonts::primaryFont
to receive a mutable (non-const) FontCascadeDescription object, such that it could resolve the
from-font reference after the primary font is resolved.

This means that now FontCascadeFonts::primaryFont does two different things:
a) resolving and caching a font as the primary font
b) resolving from-font according to the primary font if necessary

The (a) part of primaryFont doesn&apos;t require a mutable FontCascadeDescription.
We can update FontCascadeDescription to have a method for resolving font-size-adjust
from-font at the point where we own a mutable FontCascadeDescription instead.

This allows us to compute the primaryFont itself from places where we only have access
to a const FontCascadeDescription. This is for example, required for solving
<a href="https://bugs.webkit.org/show_bug.cgi?id=273233">https://bugs.webkit.org/show_bug.cgi?id=273233</a>, where we need to access to primaryFont
from FontCascadeFonts::glyphDataForVariant

This patch should have no side effects, as it is a preparation
for solving 273233.

[1] <a href="https://commits.webkit.org/269041@main">https://commits.webkit.org/269041@main</a>

* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::fontSizeAdjustFromStyle):
* Source/WebCore/platform/graphics/FontCascade.h:
(WebCore::FontCascade::primaryFont const):
* Source/WebCore/platform/graphics/FontCascadeDescription.cpp:
(WebCore::FontCascadeDescription::resolveFontSizeAdjustFromFontIfNeeded):
* Source/WebCore/platform/graphics/FontCascadeDescription.h:
* Source/WebCore/platform/graphics/FontCascadeFonts.h:
(WebCore::FontCascadeFonts::primaryFont):
* Source/WebCore/platform/graphics/FontSizeAdjust.h:
(WebCore::FontSizeAdjust::shouldResolveFromFont const):

Canonical link: <a href="https://commits.webkit.org/278219@main">https://commits.webkit.org/278219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23ed051f8cdda0a49790d06a50fbcf66229aa5e8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52787 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52978 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/412 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52041 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26641 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40600 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51836 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26556 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42818 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21701 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23997 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/44024 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8108 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45924 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44531 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54559 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24824 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20997 "Build is being retried. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests running") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47975 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-visibility-hidden-child.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26090 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42936 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47002 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10942 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26938 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25815 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->