### PR TITLE
Web Inspector: Top or bottom of Web Inspector is cut off on short viewports

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleDrawer.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleDrawer.js
@@ -154,7 +154,7 @@ WI.ConsoleDrawer = class ConsoleDrawer extends WI.ContentBrowser
     _updateDrawerHeight(height)
     {
         const minimumHeight = 64;
-        const maximumHeight = this.element.parentNode.offsetHeight - 100;
+        const maximumHeight = this.element.parentNode.offsetHeight - WI.TabBrowser.MinimumHeight - WI.QuickConsole.MinimumHeight;
 
         let heightCSSValue = Number.constrain(height, minimumHeight, maximumHeight) + "px";
         if (this.element.style.height === heightCSSValue)

--- a/Source/WebInspectorUI/UserInterface/Views/QuickConsole.js
+++ b/Source/WebInspectorUI/UserInterface/Views/QuickConsole.js
@@ -467,3 +467,5 @@ WI.QuickConsole = class QuickConsole extends WI.View
         this.element.classList.toggle("showing-log", WI.isShowingConsoleTab() || WI.isShowingSplitConsole());
     }
 };
+
+WI.QuickConsole.MinimumHeight = 30; /* Keep in sync with `--console-prompt-min-height` */

--- a/Source/WebInspectorUI/UserInterface/Views/Variables.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Variables.css
@@ -105,7 +105,7 @@
     --yellow-highlight-text-color: var(--text-color);
 
     --console-secondary-text-color: hsla(0, 0%, 0%, 0.33);
-    --console-prompt-min-height: 30px;
+    --console-prompt-min-height: 30px; /* Keep in sync with `WI.QuickConsole.MinimumHeight` */
 
     --message-text-view-font-size: 16px;
     --message-text-view-large-font-size: 28px;


### PR DESCRIPTION
#### 2a15afd431a01ae3aeb4a971e919a0669ace0399
<pre>
Web Inspector: Top or bottom of Web Inspector is cut off on short viewports
<a href="https://bugs.webkit.org/show_bug.cgi?id=273506">https://bugs.webkit.org/show_bug.cgi?id=273506</a>
<a href="https://rdar.apple.com/117272735">rdar://117272735</a>

Reviewed by Devin Rousso.

The Console Drawer was allowed to be resized to an arbitrarily capped maximum height
of `&lt;div id=&quot;main&quot;&gt;` that did not take into account the minimum height defined
by the Tab Browser or the space taken up by the Quick Console.

Their common container is an absolutely-positioned flex container
that has its overflow hidden by `overflow: hidden` on the Web Inspector `&lt;body&gt;`.

So when the Console Drawer was oversized, it pushed either the Quick Console
or the top of the Tab bar beyond the visible viewport, depending on the successive
layout operations (CSS and programmatic) that occur during Web Inspector launch.

The patch sets a maximum height for the Console Drawer that is calculated explicitly.

* Source/WebInspectorUI/UserInterface/Views/ConsoleDrawer.js:
(WI.ConsoleDrawer.prototype._updateDrawerHeight):
* Source/WebInspectorUI/UserInterface/Views/QuickConsole.js:
* Source/WebInspectorUI/UserInterface/Views/Variables.css:
(:root):

Canonical link: <a href="https://commits.webkit.org/278208@main">https://commits.webkit.org/278208@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/774d9c3f3f7121e786695130229f118df9fb8bfd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29137 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53093 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/527 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/94 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40673 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51948 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26693 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21798 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24126 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/82 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8220 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46149 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/120 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54674 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24944 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/92 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48060 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26201 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43049 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47091 "Found 5 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/listbox, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/value/basic, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /TestWebCore:Color.P3ConversionToSRGB, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/menulist (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10933 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27062 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25929 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->