### PR TITLE
[resultsdbpy] Suppress 1-off failures on the dashboard

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/dashboard.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/dashboard.js
@@ -46,13 +46,14 @@ class Dashboard {
         });
     }
 
-    constructor(title, suite, parameters, warnAfter=null, expireAfter=null) {
+    constructor(title, suite, parameters, warnAfter=null, expireAfter=null, sequentialFailures=null) {
         this.title = title;
         this.suite = suite;
         this.parameters = parameters;
 
         this.warnAfter = warnAfter ? warnAfter : 12;
         this.expireAfter = expireAfter ? expireAfter : 7*24;
+        this.sequentialFailures = sequentialFailures ? 2;
 
         this.willFilterExpected = false;
 
@@ -379,10 +380,18 @@ class Dashboard {
             if (latestResult.uuid / 100 < now - this.expireAfter * 60 * 60)
                 continue;
 
-            // For now, do the easy thing and only consider the latest run
-            // In the future, we can consider more sophisticated algorithms
-            const latestStatus = this.failureForBuild(latestResult);
-            let configStatus = latestStatus;
+            // Check the first few statuses, in an attempt to supress 1-off failures
+            let configStatus = this.failureForBuild(latestResult);
+            let i = 2;
+            while (!this.showPassing && i <= this.sequentialFailures && i <= this.requestData[key].length) {
+                const result = this.requestData[key][this.requestData[key].length - i][1];
+                const statusForResult = this.failureForBuild(result);
+                if (statusForResult >= Expectations.stringToStateId('PASS')) {
+                    configStatus = statusForResult;
+                    break;
+                }
+                ++i;
+            }
             
             if (latestResult.uuid / 100 < now - this.warnAfter * 60 * 60)
                 configStatus = Math.min(configStatus, Expectations.stringToStateId('WARNING'));;

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/search.html
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/search.html
@@ -53,12 +53,14 @@ DASHBOARD_QUERY.forEach(query => {
     delete parameters.suite;
     delete parameters.warnAfter;
     delete parameters.expireAfter;
+    delete parameters.sequentialFailures;
     dashboards.push(new Dashboard(
         query.title ? query.title : '?',
         query.suite,
         parameters,
         query.warnAfter,
         query.expireAfter,
+        query.sequentialFailures,
     ));
 });
 


### PR DESCRIPTION
#### a7ad665e79a035b8cf5fb38a153dacd2f4bc7701
<pre>
[resultsdbpy] Suppress 1-off failures on the dashboard
<a href="https://bugs.webkit.org/show_bug.cgi?id=273508">https://bugs.webkit.org/show_bug.cgi?id=273508</a>
<a href="https://rdar.apple.com/127307180">rdar://127307180</a>

Reviewed by NOBODY (OOPS!).

Some queues have infrequent 1-off failures. While these failures don&apos;t impact
our ability to detect regressions when investigating the queue specifically, they
can cloud dashboards query dozens of queues.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/dashboard.js:
(Dashboard.prototype.setTilesFromData): Check a certain number of builds, controlled
by sequentialFailures (which is 2 by default). Only consider a build to be failing if
all builds within the sequentialFailures have not passed.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/search.html: Pass
sequentialFailures to Dashboard.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7ad665e79a035b8cf5fb38a153dacd2f4bc7701

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52984 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/418 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52047 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35051 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26647 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40590 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51842 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26559 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42827 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21702 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/49598 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23999 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/44028 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8114 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45925 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44543 "Build is being retried. Recent messages:OS: Monterey (12.6.8), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests running") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54566 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24830 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20993 "Build is being retried. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests running") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47961 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/49768 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26096 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42951 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47004 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26944 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25821 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->