### PR TITLE
[CMake] Centralize Skia build in WebKit

### DIFF
--- a/Source/WebKit/Platform/Skia.cmake
+++ b/Source/WebKit/Platform/Skia.cmake
@@ -1,0 +1,19 @@
+list(APPEND WebKit_SOURCES
+    Shared/API/c/skia/WKImageSkia.cpp
+
+    Shared/skia/WebCoreArgumentCodersSkia.cpp
+
+    UIProcess/Automation/skia/WebAutomationSessionSkia.cpp
+)
+
+list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
+    "${WEBKIT_DIR}/Shared/skia"
+)
+
+list(APPEND WebKit_SERIALIZATION_IN_FILES
+    Shared/skia/CoreIPCSkColorSpace.serialization.in
+)
+
+list(APPEND WebKit_LIBRARIES
+    Skia
+)

--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -9,6 +9,10 @@ if (ENABLE_MODERN_MEDIA_CONTROLS)
     include(ModernMediaControlsGResources.cmake)
 endif ()
 
+if (USE_SKIA)
+    include(Platform/Skia.cmake)
+endif ()
+
 set(WebKit_OUTPUT_NAME webkit${WEBKITGTK_API_INFIX}gtk-${WEBKITGTK_API_VERSION})
 set(WebProcess_OUTPUT_NAME WebKitWebProcess)
 set(NetworkProcess_OUTPUT_NAME WebKitNetworkProcess)
@@ -69,8 +73,6 @@ list(APPEND WebKit_SERIALIZATION_IN_FILES
     Shared/glib/UserMessage.serialization.in
 
     Shared/gtk/ArgumentCodersGtk.serialization.in
-
-    Shared/skia/CoreIPCSkColorSpace.serialization.in
 
     Shared/soup/WebCoreArgumentCodersSoup.serialization.in
 )
@@ -283,7 +285,6 @@ list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBKIT_DIR}/Shared/glib"
     "${WEBKIT_DIR}/Shared/gtk"
     "${WEBKIT_DIR}/Shared/linux"
-    "${WEBKIT_DIR}/Shared/skia"
     "${WEBKIT_DIR}/Shared/soup"
     "${WEBKIT_DIR}/UIProcess/API/C/cairo"
     "${WEBKIT_DIR}/UIProcess/API/C/glib"

--- a/Source/WebKit/PlatformPlayStation.cmake
+++ b/Source/WebKit/PlatformPlayStation.cmake
@@ -155,13 +155,7 @@ if (USE_CAIRO)
         Shared/API/c/cairo/WKImageCairo.h
     )
 elseif (USE_SKIA)
-    list(APPEND WebKit_SOURCES
-        Shared/skia/WebCoreArgumentCodersSkia.cpp
-    )
-
-    list(APPEND WebKit_LIBRARIES
-        Skia
-    )
+    include(Platform/Skia.cmake)
 endif ()
 
 if (USE_COORDINATED_GRAPHICS)

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -14,6 +14,10 @@ if (ENABLE_MODERN_MEDIA_CONTROLS)
     include(ModernMediaControlsGResources.cmake)
 endif ()
 
+if (USE_SKIA)
+    include(Platform/Skia.cmake)
+endif ()
+
 set(WebKit_OUTPUT_NAME WPEWebKit-${WPE_API_VERSION})
 set(WebProcess_OUTPUT_NAME WPEWebProcess)
 set(NetworkProcess_OUTPUT_NAME WPENetworkProcess)
@@ -104,8 +108,6 @@ list(APPEND WebKit_SERIALIZATION_IN_FILES
     Shared/glib/DMABufRendererBufferMode.serialization.in
     Shared/glib/InputMethodState.serialization.in
     Shared/glib/UserMessage.serialization.in
-
-    Shared/skia/CoreIPCSkColorSpace.serialization.in
 
     Shared/soup/WebCoreArgumentCodersSoup.serialization.in
 )
@@ -383,7 +385,6 @@ list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBKIT_DIR}/Shared/Extensions"
     "${WEBKIT_DIR}/Shared/glib"
     "${WEBKIT_DIR}/Shared/libwpe"
-    "${WEBKIT_DIR}/Shared/skia"
     "${WEBKIT_DIR}/Shared/soup"
     "${WEBKIT_DIR}/Shared/wpe"
     "${WEBKIT_DIR}/UIProcess/API/C/cairo"

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -74,8 +74,6 @@ Shared/API/glib/WebKitURIRequest.cpp @no-unify
 Shared/API/glib/WebKitURIResponse.cpp @no-unify
 Shared/API/glib/WebKitUserMessage.cpp @no-unify
 
-Shared/API/c/skia/WKImageSkia.cpp
-
 Shared/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
 Shared/CoordinatedGraphics/SimpleViewportController.cpp
 
@@ -102,8 +100,6 @@ Shared/gtk/WebEventFactory.cpp
 Shared/linux/WebMemorySamplerLinux.cpp
 
 Shared/soup/WebErrorsSoup.cpp
-
-Shared/skia/WebCoreArgumentCodersSkia.cpp
 
 Shared/unix/AuxiliaryProcessMain.cpp
 
@@ -228,7 +224,6 @@ UIProcess/API/soup/HTTPCookieStoreSoup.cpp
 
 UIProcess/Automation/cairo/WebAutomationSessionCairo.cpp
 UIProcess/Automation/gtk/WebAutomationSessionGtk.cpp @no-unify
-UIProcess/Automation/skia/WebAutomationSessionSkia.cpp
 
 UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
 

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -96,8 +96,6 @@ Shared/linux/WebMemorySamplerLinux.cpp
 
 Shared/soup/WebErrorsSoup.cpp
 
-Shared/skia/WebCoreArgumentCodersSkia.cpp
-
 Shared/unix/AuxiliaryProcessMain.cpp
 
 Shared/wpe/GRefPtrWPE.cpp @no-unify
@@ -122,8 +120,6 @@ UIProcess/API/C/glib/WKTextCheckerGLib.cpp
 
 UIProcess/API/C/wpe/WKView.cpp
 UIProcess/API/C/wpe/WKPagePrivateWPE.cpp
-
-Shared/API/c/skia/WKImageSkia.cpp
 
 Shared/API/c/wpe/WKEventWPE.cpp
 
@@ -216,7 +212,6 @@ UIProcess/API/wpe/WebKitWebViewWPE.cpp @no-unify
 UIProcess/API/wpe/WPEWebView.cpp @no-unify
 
 UIProcess/Automation/libwpe/WebAutomationSessionLibWPE.cpp
-UIProcess/Automation/skia/WebAutomationSessionSkia.cpp
 
 UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
 


### PR DESCRIPTION
#### 13023ae113eb6be6c43faa82f90a16ecea5f4c33
<pre>
[CMake] Centralize Skia build in WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=273512">https://bugs.webkit.org/show_bug.cgi?id=273512</a>

Reviewed by Michael Catanzaro.

Centralize the CMake definitions of Skia for the `WebKit` target into
`Platform/Skia.cmake`.

* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformPlayStation.cmake:
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/Platform/Skia.cmake: Added.
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:

Canonical link: <a href="https://commits.webkit.org/278191@main">https://commits.webkit.org/278191@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bee3385cf0d68484335f473ec2f718fbc2b68a87

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29037 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52991 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/425 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35058 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40603 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26566 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21706 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24006 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8121 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45939 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44537 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests running") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54573 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24837 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20998 "Build is being retried. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests running") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47976 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26103 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42943 "") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47010 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26951 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7171 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25828 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->