### PR TITLE
[webkitpy] Remove build version requirement for simulated device match.

### DIFF
--- a/Tools/Scripts/webkitpy/xcode/simulated_device.py
+++ b/Tools/Scripts/webkitpy/xcode/simulated_device.py
@@ -297,7 +297,7 @@ class SimulatedDeviceManager(object):
         assert device_identifier is not None
 
         for device in cls.available_devices(host):
-            if device.platform_device.name == name and device.platform_device.device_type == device_type and device.platform_device.build_version == runtime.build_version:
+            if device.platform_device.name == name and device.platform_device.device_type == device_type:
                 device.platform_device._delete()
                 break
 
@@ -307,7 +307,7 @@ class SimulatedDeviceManager(object):
         # We just added a device, so our list of _available_devices needs to be re-synced.
         cls.populate_available_devices(host)
         for device in cls.available_devices(host):
-            if device.platform_device.name == name and device.platform_device.device_type == device_type and device.platform_device.build_version == runtime.build_version:
+            if device.platform_device.name == name and device.platform_device.device_type == device_type:
                 device.platform_device.managed_by_script = True
                 return device
         return None


### PR DESCRIPTION
#### 35339e704b5d6701b244ee5cd7f71adbe8b3b2cd
<pre>
[webkitpy] Remove build version requirement for simulated device match.
<a href="https://bugs.webkit.org/show_bug.cgi?id=273515">https://bugs.webkit.org/show_bug.cgi?id=273515</a>
<a href="https://rdar.apple.com/127187171">rdar://127187171</a>

Reviewed by Sam Sneddon.

My recent changes in 277884@main fixed a bug where the wrong type of device was being
booted when running tests in OS simulators. As part of those changes, I added a check
to verify that the build versions matched the request. This caused run-webkit-tests to
not use mounted runtimes, even if the simulator was already booted.

This PR removes the heuristics that check if the device is using the same build version
as default, and instead only checks for device type matching the request.

* Tools/Scripts/webkitpy/xcode/simulated_device.py:
(SimulatedDeviceManager._create_or_find_device_for_request): Remove build_version check.

Canonical link: <a href="https://commits.webkit.org/278414@main">https://commits.webkit.org/278414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c4a8284654440bc0d6c39de94e8c20fc6952155

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49835 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2082 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53079 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/513 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52137 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35156 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40659 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51934 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26677 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42893 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21784 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/49689 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24106 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/74 "Found 1 new test failure: http/tests/media/hls/track-webvtt-multitracks.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8206 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46108 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/104 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54660 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24930 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/81 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48046 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26187 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43033 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47072 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27047 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7302 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25915 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->