### PR TITLE
Remove current macOS (mac-sonoma) from baseline search path

### DIFF
--- a/Tools/Scripts/webkitpy/port/mac.py
+++ b/Tools/Scripts/webkitpy/port/mac.py
@@ -123,9 +123,13 @@ class MacPort(DarwinPort):
 
         expectations = []
         for version in versions_to_fallback:
-            version_name = version_name_map.to_name(version, platform=self.port_name)
-            if version_name:
-                standardized_version_name = version_name.lower().replace(' ', '')
+            if version == MacPort.CURRENT_VERSION:
+                version_name = None
+            else:
+                version_name = version_name_map.to_name(version, platform=self.port_name)
+                if version_name:
+                    standardized_version_name = version_name.lower().replace(' ', '')
+
             apple_name = None
             if apple_additions():
                 apple_name = version_name_map.to_name(version, platform=self.port_name, table=INTERNAL_TABLE)

--- a/Tools/Scripts/webkitpy/port/mac_unittest.py
+++ b/Tools/Scripts/webkitpy/port/mac_unittest.py
@@ -189,10 +189,8 @@ class MacTest(darwin_testcase.DarwinTest):
 
     def test_sonoma_baseline_search_path(self):
         search_path = self.make_port(port_name='macos-sonoma').default_baseline_search_path()
-        self.assertEqual(search_path[0], '/mock-checkout/LayoutTests/platform/mac-sonoma-wk1')
-        self.assertEqual(search_path[1], '/mock-checkout/LayoutTests/platform/mac-sonoma')
-        self.assertEqual(search_path[2], '/mock-checkout/LayoutTests/platform/mac-wk1')
-        self.assertEqual(search_path[3], '/mock-checkout/LayoutTests/platform/mac')
+        self.assertEqual(search_path[0], '/mock-checkout/LayoutTests/platform/mac-wk1')
+        self.assertEqual(search_path[1], '/mock-checkout/LayoutTests/platform/mac')
 
     def test_factory_with_future_version(self):
         port = self.make_port(options=MockOptions(webkit_test_runner=True), os_version=MacTest.FUTURE_VERSION, os_name='mac', port_name='mac')


### PR DESCRIPTION
#### 42db1bee0ebaa7a64103cbe43082bcbd7c1b0552
<pre>
Remove current macOS (mac-sonoma) from baseline search path
<a href="https://bugs.webkit.org/show_bug.cgi?id=273509">https://bugs.webkit.org/show_bug.cgi?id=273509</a>

Reviewed by Jonathan Bedard.

Per policy, we put all current macOS baselines in `mac` rather than
`mac-sonoma`. Rather than relying on policy to enforce this, we should
just remove `mac-sonoma` from the baseline search path, therefore
meaning its baseline search path ends with `mac`.

We&apos;re not currently changing the baseline search path when
apple_additions exists, so if that defines a version name for current
macOS it will remain in the search path.

* Tools/Scripts/webkitpy/port/mac.py:
(MacPort.default_baseline_search_path):
* Tools/Scripts/webkitpy/port/mac_unittest.py:
(MacTest.test_sonoma_baseline_search_path):

Canonical link: <a href="https://commits.webkit.org/278241@main">https://commits.webkit.org/278241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6471a221446901524b5a3901d8acc0a87e6b045f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53141 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/575 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52199 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35288 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/143 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40712 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26801 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42934 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21837 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/49751 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24230 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/155 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8268 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/201 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54722 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24992 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/139 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48100 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26249 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47140 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10956 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27111 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25979 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->