### PR TITLE
[JSC] ASSERTION FAILED: pos >= negativePositionOffest in char32_t JSC::Yarr::Interpreter<unsigned char>::InputStream::readChecked(unsigned int)

### DIFF
--- a/JSTests/stress/regexp-lookbehind.js
+++ b/JSTests/stress/regexp-lookbehind.js
@@ -228,3 +228,7 @@ testRegExp(/(?<=(^v|\sv?|Rev)+)(?:(?:\d+)\.){2}(?:\d+)/, "Rev v v1.0.123", ["1.0
 
 // Test 96
 testRegExp(/(?<=(ab*?))c/i, "Xbc", null);
+testRegExp(/(?<!(ab*?))c/i, "A", null);
+testRegExp(/(?<!(AB*?))c/, "A", null);
+testRegExp(/(?<!(ab*))c/i, "A", null);
+testRegExp(/(?<!(AB*))c/, "A", null);

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2010 Peter Varga (pvarga@inf.u-szeged.hu), University of Szeged
  *
  * Redistribution and use in source and binary forms, with or without
@@ -764,6 +764,11 @@ public:
                 break;
             }
             // matchDirection Backward
+            unsigned position = input.getPos();
+
+            if (position < term.inputPosition)
+                break;
+
             if ((backTrack->matchAmount < term.atom.quantityMaxCount) && input.tryUncheckInput(1)) {
                 ++backTrack->matchAmount;
                 if (checkCasedCharacter(term, term.inputPosition))
@@ -1306,15 +1311,15 @@ public:
         ASSERT(term.type == ByteTerm::Type::ParentheticalAssertionBegin);
         ASSERT(term.atom.quantityMaxCount == 1);
 
+        if (term.matchDirection() == Backward) {
+            BackTrackInfoParentheticalAssertion* backTrack = reinterpret_cast<BackTrackInfoParentheticalAssertion*>(context->frame + term.frameLocation);
+            input.setPos(backTrack->begin);
+        }
+
         // We've failed to match parens; if they are inverted, this is win!
         if (term.invert()) {
             context->term += term.atom.parenthesesWidth;
             return true;
-        }
-
-        if (term.matchDirection() == Backward) {
-            BackTrackInfoParentheticalAssertion* backTrack = reinterpret_cast<BackTrackInfoParentheticalAssertion*>(context->frame + term.frameLocation);
-            input.setPos(backTrack->begin);
         }
 
         return false;


### PR DESCRIPTION
#### a330a52f59a8827e50aa2cababb19946e95b89d5
<pre>
[JSC] ASSERTION FAILED: pos &gt;= negativePositionOffest in char32_t JSC::Yarr::Interpreter&lt;unsigned char&gt;::InputStream::readChecked(unsigned int)
<a href="https://bugs.webkit.org/show_bug.cgi?id=273426">https://bugs.webkit.org/show_bug.cgi?id=273426</a>
<a href="https://rdar.apple.com/127013077">rdar://127013077</a>

Reviewed by Keith Miller.

Added the same position version offest check to backtrackPatternCasedCharacter() that existed in backtrackPatternCharacter().
Also fixed the restoration of the offest for a negative lookbehind assertion.

Updated test.

* JSTests/stress/regexp-lookbehind.js:
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::backtrackPatternCasedCharacter):
(JSC::Yarr::Interpreter::backtrackParentheticalAssertionBegin):

Canonical link: <a href="https://commits.webkit.org/278204@main">https://commits.webkit.org/278204@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e686731cc1c1ea56c6a4d51a067f96260c16dddc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/1998 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53035 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/469 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/35 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40630 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51889 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26621 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21747 "Found 1 new API test failure: /TestWebCore:Color.P3ConversionToSRGB (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24077 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/33 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8162 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/43114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45975 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54616 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/49286 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/34 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48015 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26143 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42973 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47042 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10928 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26998 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56770 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25871 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11663 "Passed tests") | 
<!--EWS-Status-Bubble-End-->