### PR TITLE
[git-webkit] Support bugzilla URLs with angle brackets

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
@@ -44,8 +44,8 @@ requests = webkitcorepy.CallByNeed(lambda: __import__('requests'))
 class Tracker(GenericTracker):
     ROOT_RE = re.compile(r'\Ahttps?://(?P<domain>\S+)\Z')
     RE_TEMPLATES = [
-        r'\Ahttps?://{}/show_bug.cgi\?id=(?P<id>\d+)\Z',
-        r'\A{}/show_bug.cgi\?id=(?P<id>\d+)\Z',
+        r'\A<?https?://{}/show_bug.cgi\?id=(?P<id>\d+)>?\Z',
+        r'\A<?{}/show_bug.cgi\?id=(?P<id>\d+)>?\Z',
     ]
     NAME = 'Bugzilla'
     DEFAULT_TIMEOUT = 30

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
@@ -41,10 +41,10 @@ class Tracker(GenericTracker):
     ISSUE_LINK_RE = re.compile(r'#(?P<id>\d+)')
     USERNAME_RE = re.compile(r'(^|\s|\'|")@(?P<username>[^\s"\'<>]+)')
     RE_TEMPLATES = [
-        r'\Ahttps?://github.{}/{}/{}/issues/(?P<id>\d+)\Z',
-        r'\Agithub.{}/{}/{}/issues/(?P<id>\d+)\Z',
-        r'\Ahttps?://api.github.{}/repos/{}/{}/issues/(?P<id>\d+)\Z',
-        r'\Aapi.github.{}/repos/{}/{}/issues/(?P<id>\d+)\Z',
+        r'\A<?https?://github.{}/{}/{}/issues/(?P<id>\d+)>?\Z',
+        r'\A<?github.{}/{}/{}/issues/(?P<id>\d+)>?\Z',
+        r'\A<?https?://api.github.{}/repos/{}/{}/issues/(?P<id>\d+)>?\Z',
+        r'\A<?api.github.{}/repos/{}/{}/issues/(?P<id>\d+)>?\Z',
     ]
     REFRESH_TOKEN_PROMPT = "Is your API token out of date? Run 'git-webkit setup' to refresh credentials\n"
     DEFAULT_COMPONENT_COLOR = 'FFFFFF'

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
@@ -96,6 +96,13 @@ class TestBugzilla(unittest.TestCase):
         )
         self.assertEqual(tracker.from_string('http://bugs.other.com/show_bug.cgi?id=1234'), None)
 
+    def test_link_brackets(self):
+        tracker = bugzilla.Tracker(self.URL)
+        self.assertEqual(
+            tracker.from_string('<http://bugs.example.com/show_bug.cgi?id=1234>').link,
+            'https://bugs.example.com/show_bug.cgi?id=1234',
+        )
+
     def test_title(self):
         with mocks.Bugzilla(self.URL.split('://')[1], issues=mocks.ISSUES):
             tracker = bugzilla.Tracker(self.URL)

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py
@@ -80,6 +80,17 @@ class TestGitHub(unittest.TestCase):
         )
         self.assertEqual(tracker.from_string('https://github.example.com/Apple/Swift/issues/1234'), None)
 
+    def test_link_brackets(self):
+        tracker = github.Tracker(self.URL)
+        self.assertEqual(
+            tracker.from_string('<http://github.example.com/WebKit/WebKit/issues/1234>').link,
+            'https://github.example.com/WebKit/WebKit/issues/1234',
+        )
+        self.assertEqual(
+            tracker.from_string('<http://api.github.example.com/repos/WebKit/WebKit/issues/1234>').link,
+            'https://github.example.com/WebKit/WebKit/issues/1234',
+        )
+
     def test_title(self):
         with mocks.GitHub(self.URL.split('://')[1], issues=mocks.ISSUES):
             tracker = github.Tracker(self.URL)


### PR DESCRIPTION
#### 91bf9214d6c9734e86fc36ff9931395025ef0bc2
<pre>
[git-webkit] Support bugzilla URLs with angle brackets
<a href="https://bugs.webkit.org/show_bug.cgi?id=267114">https://bugs.webkit.org/show_bug.cgi?id=267114</a>
<a href="https://rdar.apple.com/120504061">rdar://120504061</a>

Reviewed by Ryan Haddad.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker): Add optional angle brackets to regex.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py:
(Tracker): Add optional angle brackets to regex.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py:
(TestBugzilla.test_link_brackets):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py:
(TestGitHub.test_link_brackets):

Canonical link: <a href="https://commits.webkit.org/278189@main">https://commits.webkit.org/278189@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ec66bf49c3e83c57e8e348c978ca319b35bcc7b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29057 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/1979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53012 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/447 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52073 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35085 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51870 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/26603 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/1979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21732 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/49625 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24046 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/1979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8140 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/1979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54594 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24861 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/22 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26122 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/1979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26975 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7168 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25849 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->