### PR TITLE
[WTF] Add PollResult::Yield to AutomaticThread

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -234,7 +234,7 @@ public:
     }
     
 private:
-    PollResult poll(const AbstractLocker& locker) final
+    PollResult poll(const AbstractLocker& locker, unsigned) final
     {
         if (m_heap.m_threadShouldStop) {
             m_heap.notifyThreadStopping(locker);

--- a/Source/JavaScriptCore/jit/JITWorklist.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklist.cpp
@@ -96,15 +96,7 @@ CompilationResult JITWorklist::enqueue(Ref<JITPlan> plan)
     ASSERT(m_plans.find(plan->key()) == m_plans.end());
     m_plans.add(plan->key(), plan.copyRef());
     m_queues[static_cast<unsigned>(plan->tier())].append(WTFMove(plan));
-
-    // Notify when some of thread is waiting.
-    for (auto& thread : m_threads) {
-        if (thread->state() == JITWorklistThread::State::NotCompiling) {
-            m_planEnqueued->notifyOne(locker);
-            break;
-        }
-    }
-
+    m_planEnqueued->notifyOne(locker);
     return CompilationDeferred;
 }
 

--- a/Source/JavaScriptCore/jit/JITWorklistThread.h
+++ b/Source/JavaScriptCore/jit/JITWorklistThread.h
@@ -55,7 +55,7 @@ public:
     State state() const { return m_state; }
 
 private:
-    PollResult poll(const AbstractLocker&) final;
+    PollResult poll(const AbstractLocker&, unsigned spinCount) final;
     WorkResult work() final;
 
     void threadDidStart() final;

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -275,6 +275,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Int32, priorityDeltaOfDFGCompilerThreads, computePriorityDeltaOfWorkerThreads(-1, 0), Normal, nullptr) \
     v(Int32, priorityDeltaOfFTLCompilerThreads, computePriorityDeltaOfWorkerThreads(-2, 0), Normal, nullptr) \
     v(Int32, priorityDeltaOfWasmCompilerThreads, computePriorityDeltaOfWorkerThreads(-1, 0), Normal, nullptr) \
+    v(Unsigned, spinCountForWorklistThreads, 40, Normal, nullptr) \
     \
     v(Bool, useProfiler, false, Normal, nullptr) \
     v(Bool, dumpProfilerDataAtExit, false, Normal, nullptr) \

--- a/Source/JavaScriptCore/runtime/VMTraps.cpp
+++ b/Source/JavaScriptCore/runtime/VMTraps.cpp
@@ -264,7 +264,7 @@ public:
     VMTraps& traps() { return m_vm.traps(); }
 
 private:
-    PollResult poll(const AbstractLocker&) final
+    PollResult poll(const AbstractLocker&, unsigned) final
     {
         if (traps().m_isShuttingDown)
             return PollResult::Stop;

--- a/Source/JavaScriptCore/wasm/WasmWorklist.cpp
+++ b/Source/JavaScriptCore/wasm/WasmWorklist.cpp
@@ -78,7 +78,7 @@ private:
 
     }
 
-    PollResult poll(const AbstractLocker&) final
+    PollResult poll(const AbstractLocker&, unsigned) final
     {
         auto& queue = worklist.m_queue;
         synchronize.notifyAll();

--- a/Source/WTF/wtf/AutomaticThread.h
+++ b/Source/WTF/wtf/AutomaticThread.h
@@ -161,8 +161,8 @@ protected:
     //     }
     // }
     
-    enum class PollResult { Work, Stop, Wait };
-    virtual PollResult poll(const AbstractLocker&) = 0;
+    enum class PollResult { Work, Stop, Wait, Yield };
+    virtual PollResult poll(const AbstractLocker&, unsigned spinCount) = 0;
     
     enum class WorkResult { Continue, Stop };
     virtual WorkResult work() = 0;

--- a/Source/WTF/wtf/ParallelHelperPool.cpp
+++ b/Source/WTF/wtf/ParallelHelperPool.cpp
@@ -182,7 +182,7 @@ public:
     }
 
 private:
-    PollResult poll(const AbstractLocker&) final
+    PollResult poll(const AbstractLocker&, unsigned) final
     {
         if (m_pool.m_isDying)
             return PollResult::Stop;

--- a/Source/WTF/wtf/WorkerPool.cpp
+++ b/Source/WTF/wtf/WorkerPool.cpp
@@ -38,7 +38,7 @@ public:
     {
     }
 
-    PollResult poll(const AbstractLocker&) final
+    PollResult poll(const AbstractLocker&, unsigned) final
     {
         if (m_pool.m_tasks.isEmpty())
             return PollResult::Wait;


### PR DESCRIPTION
#### 4303f0ab0a33fb56a0c6a05d2bf645d070670fea
<pre>
[WTF] Add PollResult::Yield to AutomaticThread
<a href="https://bugs.webkit.org/show_bug.cgi?id=273535">https://bugs.webkit.org/show_bug.cgi?id=273535</a>
<a href="https://rdar.apple.com/127338855">rdar://127338855</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/heap/Heap.cpp:
* Source/JavaScriptCore/jit/JITWorklist.cpp:
(JSC::JITWorklist::enqueue):
* Source/JavaScriptCore/jit/JITWorklistThread.cpp:
(JSC::JITWorklistThread::poll):
(JSC::JITWorklistThread::threadDidStart):
* Source/JavaScriptCore/jit/JITWorklistThread.h:
* Source/JavaScriptCore/runtime/VMTraps.cpp:
* Source/JavaScriptCore/wasm/WasmWorklist.cpp:
* Source/WTF/wtf/AutomaticThread.cpp:
(WTF::AutomaticThread::start):
* Source/WTF/wtf/AutomaticThread.h:
* Source/WTF/wtf/ParallelHelperPool.cpp:
* Source/WTF/wtf/WorkerPool.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4303f0ab0a33fb56a0c6a05d2bf645d070670fea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49821 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53066 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/500 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/67 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51920 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26663 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42864 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21771 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24088 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/56 "Found 1 new test failure: http/tests/media/hls/track-webvtt-multitracks.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8193 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43145 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46093 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/72 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54647 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/49317 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24916 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/60 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48034 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26174 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42999 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27032 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56801 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25902 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11669 "Passed tests") | 
<!--EWS-Status-Bubble-End-->