### PR TITLE
[view-transitions] https://spotify-astro-transitions.vercel.app glitches due to incorrect layer position with overflow:hidden ancestor.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-ancestor-clipped-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-ancestor-clipped-expected.html
@@ -1,0 +1,34 @@
+<!doctype HTML>
+<html>
+<head>
+<style>
+html {
+  background: lightpink;
+}
+div {
+  position: relative;
+  width: 200px;
+  height: 200px;
+}
+
+.outer {
+  background-color: blue;
+  box-shadow: -50px -50px 0px 0px rgba(0,0,0,1);
+  left: 100px;
+  top: 100px;
+}
+
+.inner {
+  background-color: red;
+  left: 50px;
+  top: 50px;
+}
+
+</style>
+</head>
+<body>
+</body>
+<div class="outer">
+  <div class="inner"></div>
+</div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-ancestor-clipped-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-ancestor-clipped-ref.html
@@ -1,0 +1,34 @@
+<!doctype HTML>
+<html>
+<head>
+<style>
+html {
+  background: lightpink;
+}
+div {
+  position: relative;
+  width: 200px;
+  height: 200px;
+}
+
+.outer {
+  background-color: blue;
+  box-shadow: -50px -50px 0px 0px rgba(0,0,0,1);
+  left: 100px;
+  top: 100px;
+}
+
+.inner {
+  background-color: red;
+  left: 50px;
+  top: 50px;
+}
+
+</style>
+</head>
+<body>
+</body>
+<div class="outer">
+  <div class="inner"></div>
+</div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-ancestor-clipped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-ancestor-clipped.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>View transitions: capture opacity elements</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<link rel="author" href="mailto:mattwoodrow@apple.com">
+<link rel="match" href="new-content-ancestor-clipped-ref.html">
+<script src="/common/reftest-wait.js"></script>
+<style>
+.outer {
+  background-color: blue;
+  overflow: hidden;
+  box-shadow: -50px -50px 0px 0px rgba(0,0,0,1);
+  position: relative;
+  left: 100px;
+  top: 100px;
+  width: 200px;
+  height: 200px;
+  view-transition-name: outer;
+}
+.inner {
+  background-color: red;
+  position: relative;
+  left: 50px;
+  top: 50px;
+  width: 200px;
+  height: 200px;
+  view-transition-name: inner;
+}
+/* We're verifying what we capture, so just display the new contents for 5 minutes.  */
+html::view-transition-group(*) { animation-duration: 300s; }
+html::view-transition-new(*) { animation: unset; opacity: 1; }
+html::view-transition-old(*) { animation: unset; opacity: 0; }
+/* hide the root so we show transition background to ensure we're in a transition */
+html::view-transition-group(root) { animation: unset; opacity: 0; }
+html::view-transition { background: lightpink; }
+</style>
+<div class="outer">
+  <div class="inner"></div>
+</div>
+<script>
+failIfNot(document.startViewTransition, "Missing document.startViewTransition");
+
+async function runTest() {
+  let t = document.startViewTransition(() => {
+    requestAnimationFrame(() => requestAnimationFrame(takeScreenshot));
+  });
+}
+onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>
+

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1417,15 +1417,13 @@ void RenderLayerBacking::updateGeometry(const RenderLayer* compositedAncestor)
     ASSERT(compositedAncestor == m_owningLayer.ancestorCompositingLayer());
     LayoutRect parentGraphicsLayerRect = computeParentGraphicsLayerRect(compositedAncestor);
 
-    // If our content is being used in a view-transition, then all positioning
-    // is handled using a synthesized 'transform' property on the wrapping
-    // ::view-transition-new element. Move the parent graphics layer rect to our
-    // position so that layer positions are computed relative to our origin.
+    // If our content is being used in a view-transition, then all positioning is handled using a synthesized 'transform' property on the wrapping
+    // ::view-transition-new element. Set the parent graphics layer rect to that of the pseudo, adjusted into coordinates of the parent layer.
     if (renderer().capturedInViewTransition() && renderer().element()) {
         if (RefPtr activeViewTransition = renderer().document().activeViewTransition()) {
             if (CheckedPtr viewTransitionCapture = activeViewTransition->viewTransitionNewPseudoForCapturedElement(renderer())) {
                 ComputedOffsets computedOffsets(m_owningLayer, compositedAncestor, viewTransitionCapture->captureOverflowRect(), { }, { });
-                parentGraphicsLayerRect.move(computedOffsets.fromParentGraphicsLayer());
+                parentGraphicsLayerRect = { { computedOffsets.fromParentGraphicsLayer().width(), computedOffsets.fromParentGraphicsLayer().height() }, viewTransitionCapture->captureOverflowRect().size() };
             }
         }
     }


### PR DESCRIPTION
#### 84e133272f1e3d267014c0b78953c25750b3ed9b
<pre>
[view-transitions] <a href="https://spotify-astro-transitions.vercel.app">https://spotify-astro-transitions.vercel.app</a> glitches due to incorrect layer position with overflow:hidden ancestor.
<a href="https://bugs.webkit.org/show_bug.cgi?id=273537">https://bugs.webkit.org/show_bug.cgi?id=273537</a>
&lt;<a href="https://rdar.apple.com/127340912">rdar://127340912</a>&gt;

Reviewed by Tim Nguyen.

Rather than just moving the existing parent graphics layer rect (which isn&apos;t relevant, since this layer will be reparented),
use the rect that the pseudo (to which this layer will be reparented) represents directly. It still needs to be moved into the coordinate
space of the current compositing ancestor, since that&apos;s what the following code expects.

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-ancestor-clipped-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-ancestor-clipped-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-ancestor-clipped.html: Added.
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateGeometry):

Canonical link: <a href="https://commits.webkit.org/278230@main">https://commits.webkit.org/278230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc37f789ec49f2dabf16cb4ce7dcb23eee62ad9d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53071 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/505 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52129 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35164 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/72 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40649 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51925 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26682 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42875 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; 65 api tests failed or timed out; Running re-run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21773 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24115 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/67 "Found 1 new test failure: http/tests/media/hls/track-webvtt-multitracks.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8198 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46113 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/87 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54652 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24921 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/65 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48039 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43018 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47077 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10948 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27037 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25907 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->