### PR TITLE
[iOS] Unable to autofill username-only pages in WKWebView

### DIFF
--- a/Source/WebCore/editing/cocoa/AutofillElements.cpp
+++ b/Source/WebCore/editing/cocoa/AutofillElements.cpp
@@ -102,6 +102,11 @@ std::optional<AutofillElements> AutofillElements::computeAutofillElements(Ref<HT
         }
     }
 
+    // Handle the case where a username field appears separately from a password field.
+    auto autofillData = start->autofillData();
+    if (toAutofillFieldName(autofillData.fieldName) == AutofillFieldName::Username)
+        return {{ WTFMove(start), nullptr, nullptr }};
+
     return std::nullopt;
 }
 

--- a/Tools/TestWebKitAPI/Tests/ios/WKWebViewAutofillTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/WKWebViewAutofillTests.mm
@@ -178,6 +178,22 @@ TEST(WKWebViewAutoFillTests, StandalonePasswordField)
     EXPECT_FALSE([webView acceptsAutoFillLoginCredentials]);
 }
 
+TEST(WKWebViewAutoFillTests, StandaloneUsernameField)
+{
+    auto webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    [webView synchronouslyLoadHTMLString:@"<input id='username' autocomplete='username'>"];
+    [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"username.focus()"];
+    EXPECT_TRUE([webView acceptsAutoFillLoginCredentials]);
+
+    auto credentialSuggestion = [UITextAutofillSuggestion autofillSuggestionWithUsername:@"frederik" password:@"famos"];
+    [[webView _autofillInputView] insertTextSuggestion:credentialSuggestion];
+
+    EXPECT_WK_STREQ("frederik", [webView stringByEvaluatingJavaScript:@"username.value"]);
+
+    [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"document.activeElement.blur()"];
+    EXPECT_FALSE([webView acceptsAutoFillLoginCredentials]);
+}
+
 TEST(WKWebViewAutoFillTests, StandaloneTextField)
 {
     auto webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);


### PR DESCRIPTION
#### 926918ec35d91e1c20a16e5e43ce483fc06e3bad
<pre>
[iOS] Unable to autofill username-only pages in WKWebView
<a href="https://bugs.webkit.org/show_bug.cgi?id=273538">https://bugs.webkit.org/show_bug.cgi?id=273538</a>
<a href="https://rdar.apple.com/126970887">rdar://126970887</a>

Reviewed by Wenson Hsieh and Abrar Rahman Protyasha.

As a result of UIKit / AutoFillUI changes in iOS 17.4, username autofill is now
displayed as a suggestion in the keyboard candidates bar on pages that separate
out their username and password fields, like yahoo.com. Previously, this
autofill flow was only available to pages that contained both a username and
password field together.

However, the introduction of standalone username support was a consequence of
other feature work, and never explicitly tested in WKWebView. Due to the way
autofill text suggestions are set up in WebKit, attempting to autofill a
standalone username field, simply drops the content.

Specifically, `AutofillElements::computeAutofillElements` returns `std::nullopt`
if no password field is present. This means that when a username is autofilled
using `-[WKContentView insertTextSuggestion:]` and
`WebPageProxy::autofillLoginCredentials`, the data is simply dropped by an
early return in `WebPage::autofillLoginCredentials`.

Fix by updating `AutofillElements::computeAutofillElements` to handle the
username-only case.

* Source/WebCore/editing/cocoa/AutofillElements.cpp:
(WebCore::AutofillElements::computeAutofillElements):

Support for autofilling specific fields is already present in
`AutofillElements::autofill`, which null checks each individual autofill
element, including the username field.

However, this method currently returns no elements in the case where only a
username field is present. Update to return the username field in the case
where the `autocomplete` value is &quot;username&quot;. This restriction corresponds to
the specification of `UITextContentTypeUsername` on the UI process side.

* Tools/TestWebKitAPI/Tests/ios/WKWebViewAutofillTests.mm:
(TestWebKitAPI::TEST(WKWebViewAutoFillTests, StandaloneUsernameField)):

Canonical link: <a href="https://commits.webkit.org/278215@main">https://commits.webkit.org/278215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49e3792e061c28dabbc84e14813781aa1abaed6a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49838 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29125 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2072 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53081 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/515 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52139 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40661 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51936 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26680 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42879 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3; Running apply-patch; Checked out pull request; Running run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21786 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24112 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/71 "Found 1 new test failure: http/tests/media/hls/track-webvtt-multitracks.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8208 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46111 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/98 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54662 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24932 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/78 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48048 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-visibility-hidden-child.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26189 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43027 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47076 "Found 5 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/listbox, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/value/basic, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /TestWebCore:Color.P3ConversionToSRGB, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/menulist (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10940 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27051 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25917 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->