### PR TITLE
REGRESSION(278148@main): random crashes under JSC::WatchpointSet::fireAllWatchpoints

### DIFF
--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
@@ -112,7 +112,7 @@ public:
 
     const WatchpointsOnStructureStubInfo* watchpoints() const { return m_watchpoints.get(); }
     void setWatchpoints(std::unique_ptr<WatchpointsOnStructureStubInfo>&&);
-    WatchpointSet& watchpointSet() { return m_watchpointSet.get(); }
+    WatchpointSet& watchpointSet() { return *m_watchpointSet.get(); }
     void invalidate();
 
 protected:
@@ -123,7 +123,7 @@ private:
     FixedVector<RefPtr<AccessCase>> m_cases;
     FixedVector<StructureID> m_weakStructures;
     FixedVector<Identifier> m_identifiers;
-    Ref<WatchpointSet> m_watchpointSet;
+    RefPtr<WatchpointSet> m_watchpointSet;
     std::unique_ptr<WatchpointsOnStructureStubInfo> m_watchpoints;
 };
 


### PR DESCRIPTION
#### 1d96c3185c84598869508e1ac51538952efb7912
<pre>
REGRESSION(278148@main): random crashes under JSC::WatchpointSet::fireAllWatchpoints
<a href="https://bugs.webkit.org/show_bug.cgi?id=273467">https://bugs.webkit.org/show_bug.cgi?id=273467</a>
<a href="https://rdar.apple.com/127346958">rdar://127346958</a>

Reviewed by Justin Michaud, Keith Miller and Mark Lam.

PolymorphicAccessJITStubRoutine::invalidate clears StructureStubInfo, and this
may deref PolymorphicAccessJITStubRoutine itself held by InlineCacheHandler.
But at the same time, PolymorphicAccessJITStubRoutine is half-GC-managed, so this `invalidate` function can be called
when PolymorphicAccessJITStubRoutine&apos;s refCount is zero, and will be destroyed by GC.

So, in this patch,

1. We just clear WatchpointSet when PolymorphicAccessJITStubRoutine&apos;s refCount becomes zero.
2. Inside PolymorphicAccessJITStubRoutine::invalidate, we just capture WatchpointSet and fire them all instead of keeping PolymorphicAccessJITStubRoutine alive.

* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp:
(JSC::PolymorphicAccessJITStubRoutine::invalidate):

Canonical link: <a href="https://commits.webkit.org/278223@main">https://commits.webkit.org/278223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f16c14afbe14ebf39eb73bb93d304e8b62e25692

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2168 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53130 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/564 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/132 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40710 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51985 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26747 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21835 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24181 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/144 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8257 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43209 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46229 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/191 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54711 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/49382 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24981 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/128 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48093 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26238 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43113 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47134 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27100 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56865 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7193 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25968 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11686 "Passed tests") | 
<!--EWS-Status-Bubble-End-->