### PR TITLE
[JSC] Threading Concurrency::MainThread in isWatchableAssumingImpurePropertyWatchpoint

### DIFF
--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -974,7 +974,7 @@ bool AccessCase::couldStillSucceed() const
 {
     for (const ObjectPropertyCondition& condition : m_conditionSet) {
         if (condition.condition().kind() == PropertyCondition::Equivalence) {
-            if (!condition.isWatchableAssumingImpurePropertyWatchpoint(PropertyCondition::WatchabilityEffort::EnsureWatchability))
+            if (!condition.isWatchableAssumingImpurePropertyWatchpoint(PropertyCondition::WatchabilityEffort::EnsureWatchability, Concurrency::MainThread))
                 return false;
         } else {
             if (!condition.structureEnsuresValidityAssumingImpurePropertyWatchpoint(Concurrency::MainThread))

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -2741,7 +2741,7 @@ void InlineCacheCompiler::generateImpl(AccessCase& accessCase)
     for (const ObjectPropertyCondition& condition : accessCase.m_conditionSet) {
         RELEASE_ASSERT(!accessCase.polyProtoAccessChain());
 
-        if (condition.isWatchableAssumingImpurePropertyWatchpoint(PropertyCondition::WatchabilityEffort::EnsureWatchability)) {
+        if (condition.isWatchableAssumingImpurePropertyWatchpoint(PropertyCondition::WatchabilityEffort::EnsureWatchability, Concurrency::MainThread)) {
             m_conditions.append(condition);
             continue;
         }

--- a/Source/JavaScriptCore/bytecode/ObjectPropertyCondition.cpp
+++ b/Source/JavaScriptCore/bytecode/ObjectPropertyCondition.cpp
@@ -107,14 +107,25 @@ bool ObjectPropertyCondition::structureEnsuresValidity(Concurrency concurrency) 
     return structureEnsuresValidity(concurrency, m_object->structure());
 }
 
-bool ObjectPropertyCondition::isWatchableAssumingImpurePropertyWatchpoint(
-    Structure* structure, PropertyCondition::WatchabilityEffort effort) const
+bool ObjectPropertyCondition::isWatchableAssumingImpurePropertyWatchpoint(Structure* structure, PropertyCondition::WatchabilityEffort effort, Concurrency concurrency) const
+{
+    return m_condition.isWatchableAssumingImpurePropertyWatchpoint(structure, m_object, effort, concurrency);
+}
+
+bool ObjectPropertyCondition::isWatchableAssumingImpurePropertyWatchpoint(Structure* structure, PropertyCondition::WatchabilityEffort effort) const
 {
     return m_condition.isWatchableAssumingImpurePropertyWatchpoint(structure, m_object, effort);
 }
 
-bool ObjectPropertyCondition::isWatchableAssumingImpurePropertyWatchpoint(
-    PropertyCondition::WatchabilityEffort effort) const
+bool ObjectPropertyCondition::isWatchableAssumingImpurePropertyWatchpoint(PropertyCondition::WatchabilityEffort effort, Concurrency concurrency) const
+{
+    if (!*this)
+        return false;
+
+    return isWatchableAssumingImpurePropertyWatchpoint(m_object->structure(), effort, concurrency);
+}
+
+bool ObjectPropertyCondition::isWatchableAssumingImpurePropertyWatchpoint(PropertyCondition::WatchabilityEffort effort) const
 {
     if (!*this)
         return false;

--- a/Source/JavaScriptCore/bytecode/ObjectPropertyCondition.h
+++ b/Source/JavaScriptCore/bytecode/ObjectPropertyCondition.h
@@ -257,11 +257,10 @@ public:
     
     // This means that it's still valid and we could enforce validity by setting a transition
     // watchpoint on the structure and possibly an impure property watchpoint.
-    bool isWatchableAssumingImpurePropertyWatchpoint(
-        Structure*,
-        PropertyCondition::WatchabilityEffort) const;
-    bool isWatchableAssumingImpurePropertyWatchpoint(
-        PropertyCondition::WatchabilityEffort) const;
+    bool isWatchableAssumingImpurePropertyWatchpoint(Structure*, PropertyCondition::WatchabilityEffort, Concurrency) const;
+    bool isWatchableAssumingImpurePropertyWatchpoint(PropertyCondition::WatchabilityEffort, Concurrency) const;
+    bool isWatchableAssumingImpurePropertyWatchpoint(Structure*, PropertyCondition::WatchabilityEffort) const;
+    bool isWatchableAssumingImpurePropertyWatchpoint(PropertyCondition::WatchabilityEffort) const;
 
     // This means that it's still valid and we could enforce validity by setting a transition
     // watchpoint on the structure, and a value change watchpoint if we're Equivalence.

--- a/Source/JavaScriptCore/bytecode/PropertyCondition.cpp
+++ b/Source/JavaScriptCore/bytecode/PropertyCondition.cpp
@@ -467,11 +467,14 @@ bool PropertyCondition::isWatchableWhenValid(Structure* structure, WatchabilityE
     return true;
 }
 
-bool PropertyCondition::isWatchableAssumingImpurePropertyWatchpoint(
-    Structure* structure, JSObject* base, WatchabilityEffort effort) const
+bool PropertyCondition::isWatchableAssumingImpurePropertyWatchpoint(Structure* structure, JSObject* base, WatchabilityEffort effort, Concurrency concurrency) const
 {
-    return isStillValidAssumingImpurePropertyWatchpoint(watchabilityToConcurrency(effort), structure, base)
-        && isWatchableWhenValid(structure, effort, watchabilityToConcurrency(effort));
+    return isStillValidAssumingImpurePropertyWatchpoint(concurrency, structure, base) && isWatchableWhenValid(structure, effort, concurrency);
+}
+
+bool PropertyCondition::isWatchableAssumingImpurePropertyWatchpoint(Structure* structure, JSObject* base, WatchabilityEffort effort) const
+{
+    return isWatchableAssumingImpurePropertyWatchpoint(structure, base, effort, watchabilityToConcurrency(effort));
 }
 
 bool PropertyCondition::isWatchable(Structure* structure, JSObject* base, WatchabilityEffort effort) const

--- a/Source/JavaScriptCore/bytecode/PropertyCondition.h
+++ b/Source/JavaScriptCore/bytecode/PropertyCondition.h
@@ -326,8 +326,8 @@ public:
     
     // This means that it's still valid and we could enforce validity by setting a transition
     // watchpoint on the structure and possibly an impure property watchpoint.
-    bool isWatchableAssumingImpurePropertyWatchpoint(
-        Structure*, JSObject* base, WatchabilityEffort) const;
+    bool isWatchableAssumingImpurePropertyWatchpoint(Structure*, JSObject*, WatchabilityEffort) const;
+    bool isWatchableAssumingImpurePropertyWatchpoint(Structure*, JSObject*, WatchabilityEffort, Concurrency) const;
     
     // This means that it's still valid and we could enforce validity by setting a transition
     // watchpoint on the structure.


### PR DESCRIPTION
#### 14cbb53aba694170b8552181b637f263df97df4f
<pre>
[JSC] Threading Concurrency::MainThread in isWatchableAssumingImpurePropertyWatchpoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=273540">https://bugs.webkit.org/show_bug.cgi?id=273540</a>
<a href="https://rdar.apple.com/127348006">rdar://127348006</a>

Reviewed by Justin Michaud.

We should thread Concurrency::MainThread when calling isWatchableAssumingImpurePropertyWatchpoint from main thread code.

* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::couldStillSucceed const):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::generateImpl):
* Source/JavaScriptCore/bytecode/ObjectPropertyCondition.cpp:
(JSC::ObjectPropertyCondition::isWatchableAssumingImpurePropertyWatchpoint const):
* Source/JavaScriptCore/bytecode/ObjectPropertyCondition.h:
* Source/JavaScriptCore/bytecode/PropertyCondition.cpp:
(JSC::PropertyCondition::isWatchableAssumingImpurePropertyWatchpoint const):
* Source/JavaScriptCore/bytecode/PropertyCondition.h:

Canonical link: <a href="https://commits.webkit.org/278213@main">https://commits.webkit.org/278213@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36c98720a6f8a2c83511f05746ccd5db7f6fd312

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49842 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2106 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53085 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/519 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40665 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51940 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26685 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42889 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21790 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24118 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/86 "Found 1 new test failure: http/tests/media/hls/track-webvtt-multitracks.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8212 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43164 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); Running jscore-test") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46124 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/126 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54666 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/49336 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24936 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/85 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-screenx-screeny.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48052 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26193 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43055 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47082 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27054 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56820 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7184 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25921 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11676 "Passed tests") | 
<!--EWS-Status-Bubble-End-->